### PR TITLE
feat: add create-pr skill for Claude Code

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: create-pr
+description: Create a well-structured pull request with proper description, design decisions, and file changes. Use when asked to create a PR, open a PR, or submit changes for review.
+---
+
+# Create Pull Request
+
+Create a pull request with a comprehensive description that explains the problem, solution, design decisions, and changes.
+
+## Instructions
+
+### 1. Gather context
+
+Run these commands in parallel to understand the current state:
+
+```bash
+# Current branch
+git branch --show-current
+
+# Check if tracking remote
+git status -sb
+
+# All commits on this branch (not on main)
+git log main..HEAD --oneline
+
+# Full diff from main
+git diff main...HEAD --stat
+```
+
+### 2. Analyze the changes
+
+For each commit, understand:
+- What problem does it solve?
+- What design decisions were made?
+- What alternatives were considered?
+
+Read relevant files if needed:
+- Task docs in `tasks/` or `docs/plans/`
+- Work notes if they exist
+- The actual code changes
+
+### 3. Structure the PR description
+
+The PR must include these sections:
+
+```markdown
+## Problem
+
+[What issue or limitation exists? Why does this change need to happen?]
+
+## Solution
+
+[High-level description of the approach taken]
+
+### How it works
+
+[Architecture diagram or flow explanation if applicable]
+
+### Key design decisions
+
+[For each significant decision:]
+**1. [Decision title]**
+
+[What was chosen and why. Include alternatives considered if relevant.]
+
+## New files
+
+| File | Purpose |
+|------|---------|
+| `path/to/file.ts` | Brief description |
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `path/to/file.ts` | What changed |
+
+## Deleted files (if any)
+
+| File | Reason |
+|------|--------|
+| `path/to/file.ts` | Why removed |
+
+## Test plan
+
+- [x] Completed tests
+- [ ] Manual verification steps
+```
+
+### 4. Create the PR
+
+```bash
+# Push branch if needed
+git push -u origin $(git branch --show-current)
+
+# Create PR (write body to temp file first to avoid heredoc issues)
+gh pr create --base main --title "[type]: [short description]" --body-file /tmp/claude/pr-body.md
+```
+
+If `gh pr create` fails with GraphQL errors, use the API directly:
+```bash
+gh api repos/{owner}/{repo}/pulls --method POST \
+  -f title="[type]: [short description]" \
+  -f head="$(git branch --show-current)" \
+  -f base="main" \
+  -f body="$(cat /tmp/claude/pr-body.md)"
+```
+
+### 5. Return the PR URL
+
+Always provide the PR URL to the user when done.
+
+## PR Title Conventions
+
+Use conventional commit format:
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `refactor:` - Code restructuring without behavior change
+- `docs:` - Documentation only
+- `test:` - Test additions/changes
+- `chore:` - Maintenance tasks
+
+## Examples
+
+**User says:** "Create a PR"
+**Action:** Analyze current branch, gather context from task docs, create comprehensive PR
+
+**User says:** "Open a PR for this feature"
+**Action:** Same as above, ensuring all design decisions are documented
+
+**User says:** "Submit this for review"
+**Action:** Create PR, return URL for user to review
+
+## Important Notes
+
+- Never create a PR with an empty or minimal description
+- Always explain the "why" not just the "what"
+- Include divergences from original plans if applicable
+- Reference task docs or issues when relevant


### PR DESCRIPTION
## Problem

PRs were being created with minimal or empty descriptions, requiring manual intervention to add proper context. A good PR should explain the problem being solved, design decisions, and what changed - not just list files.

## Solution

A Claude Code skill that guides the agent through creating comprehensive PRs with structured descriptions.

### How it works

When invoked (e.g., "create a PR"), the skill instructs Claude to:

1. **Gather context** - Run git commands to understand branch state, commits, and diff
2. **Analyze changes** - Read task docs, work notes, and code to understand the "why"
3. **Structure description** - Follow a template with Problem, Solution, Design Decisions, File tables
4. **Create PR** - Push and create via `gh` CLI or API fallback
5. **Return URL** - Always provide the PR link

### Key design decisions

**1. Template-based structure**

Forces consistent PR format across all contributions:
- Problem/Solution framing (explains the "why")
- Design decisions section (captures reasoning)
- File tables (quick overview of changes)
- Test plan (verification checklist)

**2. API fallback for PR creation**

`gh pr create` sometimes fails with GraphQL errors. The skill includes a fallback using `gh api` directly to avoid these issues.

**3. Temp file for PR body**

Heredocs in bash fail under certain sandbox restrictions. Writing to `/tmp/claude/pr-body.md` first avoids these issues.

## New files

| File | Purpose |
|------|---------|
| `.claude/skills/create-pr/SKILL.md` | Skill definition with instructions and examples |

## Test plan

- [x] Skill file created with proper YAML frontmatter
- [ ] Verify skill appears in `/skills` list
- [ ] Test with "create a PR" on a feature branch