### PR TITLE
feat(THR-7): add stream context enrichment for companion agent

### DIFF
--- a/apps/backend/src/agents/context-builder.ts
+++ b/apps/backend/src/agents/context-builder.ts
@@ -1,0 +1,260 @@
+import type { PoolClient } from "pg"
+import type { StreamType } from "@threa/types"
+import { StreamTypes } from "@threa/types"
+import type { Stream } from "../repositories/stream-repository"
+import { StreamRepository } from "../repositories/stream-repository"
+import { StreamMemberRepository } from "../repositories/stream-member-repository"
+import { MessageRepository, type Message } from "../repositories/message-repository"
+import { UserRepository, type User } from "../repositories/user-repository"
+
+/**
+ * A participant in a stream (user or persona).
+ */
+export interface Participant {
+  id: string
+  name: string
+  role?: string
+}
+
+/**
+ * Info about a message in the thread hierarchy.
+ */
+export interface AnchorMessage {
+  id: string
+  content: string
+  authorName: string
+}
+
+/**
+ * Position in thread hierarchy for nested threads.
+ */
+export interface ThreadPathEntry {
+  streamId: string
+  displayName: string | null
+  anchorMessage: AnchorMessage | null
+}
+
+/**
+ * Context about the stream for the companion agent.
+ * Different stream types populate different fields.
+ */
+export interface StreamContext {
+  streamType: StreamType
+  streamInfo: {
+    name: string | null
+    description: string | null
+    slug: string | null
+  }
+  /** Participants in the stream (for channels, DMs). Scratchpads don't need this. */
+  participants?: Participant[]
+  /** Conversation history - messages in chronological order */
+  conversationHistory: Message[]
+  /** For threads: path from current thread up to root channel */
+  threadContext?: {
+    depth: number
+    path: ThreadPathEntry[]
+  }
+}
+
+const MAX_CONTEXT_MESSAGES = 20
+
+/**
+ * Build stream context for the companion agent.
+ * Returns stream-type-specific context for enriching the system prompt.
+ */
+export async function buildStreamContext(
+  client: PoolClient,
+  streamId: string,
+  _triggerMessageId: string
+): Promise<StreamContext | null> {
+  const stream = await StreamRepository.findById(client, streamId)
+  if (!stream) return null
+
+  switch (stream.type) {
+    case StreamTypes.SCRATCHPAD:
+      return buildScratchpadContext(client, stream)
+
+    case StreamTypes.CHANNEL:
+      return buildChannelContext(client, stream)
+
+    case StreamTypes.THREAD:
+      return buildThreadContext(client, stream)
+
+    case StreamTypes.DM:
+      return buildDmContext(client, stream)
+
+    default:
+      return buildScratchpadContext(client, stream)
+  }
+}
+
+/**
+ * Scratchpad context: personal, solo-first. Conversation history is primary context.
+ */
+async function buildScratchpadContext(client: PoolClient, stream: Stream): Promise<StreamContext> {
+  const messages = await MessageRepository.list(client, stream.id, { limit: MAX_CONTEXT_MESSAGES })
+
+  return {
+    streamType: stream.type,
+    streamInfo: {
+      name: stream.displayName,
+      description: stream.description,
+      slug: stream.slug,
+    },
+    conversationHistory: messages,
+  }
+}
+
+/**
+ * Channel context: collaborative. Includes members, slug, and conversation.
+ */
+async function buildChannelContext(client: PoolClient, stream: Stream): Promise<StreamContext> {
+  const [messages, members] = await Promise.all([
+    MessageRepository.list(client, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
+    StreamMemberRepository.list(client, { streamId: stream.id }),
+  ])
+
+  const participants = await resolveParticipants(
+    client,
+    members.map((m) => m.userId)
+  )
+
+  return {
+    streamType: stream.type,
+    streamInfo: {
+      name: stream.displayName,
+      description: stream.description,
+      slug: stream.slug,
+    },
+    participants,
+    conversationHistory: messages,
+  }
+}
+
+/**
+ * DM context: two-party. Like channels but focused.
+ */
+async function buildDmContext(client: PoolClient, stream: Stream): Promise<StreamContext> {
+  const [messages, members] = await Promise.all([
+    MessageRepository.list(client, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
+    StreamMemberRepository.list(client, { streamId: stream.id }),
+  ])
+
+  const participants = await resolveParticipants(
+    client,
+    members.map((m) => m.userId)
+  )
+
+  return {
+    streamType: stream.type,
+    streamInfo: {
+      name: stream.displayName,
+      description: stream.description,
+      slug: stream.slug,
+    },
+    participants,
+    conversationHistory: messages,
+  }
+}
+
+/**
+ * Thread context: nested discussions. Traverses hierarchy to root.
+ */
+async function buildThreadContext(client: PoolClient, stream: Stream): Promise<StreamContext> {
+  const messages = await MessageRepository.list(client, stream.id, { limit: MAX_CONTEXT_MESSAGES })
+
+  // Build thread path from current thread up to root
+  const threadPath = await buildThreadPath(client, stream)
+
+  return {
+    streamType: stream.type,
+    streamInfo: {
+      name: stream.displayName,
+      description: stream.description,
+      slug: stream.slug,
+    },
+    conversationHistory: messages,
+    threadContext: {
+      depth: threadPath.length,
+      path: threadPath,
+    },
+  }
+}
+
+/**
+ * Build the path from a thread up to its root (channel/scratchpad).
+ * Returns entries in order from root to current thread.
+ */
+async function buildThreadPath(client: PoolClient, stream: Stream): Promise<ThreadPathEntry[]> {
+  const path: ThreadPathEntry[] = []
+  let current: Stream | null = stream
+
+  while (current) {
+    let anchorMessage: AnchorMessage | null = null
+
+    // If this is a thread spawned from a message, get that message
+    if (current.parentMessageId) {
+      const message = await MessageRepository.findById(client, current.parentMessageId)
+      if (message) {
+        const authorName = await resolveAuthorName(client, message.authorId, message.authorType)
+        anchorMessage = {
+          id: message.id,
+          content: message.content.slice(0, 200), // Truncate for context
+          authorName,
+        }
+      }
+    }
+
+    path.unshift({
+      streamId: current.id,
+      displayName: current.displayName,
+      anchorMessage,
+    })
+
+    // Traverse up
+    if (current.parentStreamId) {
+      current = await StreamRepository.findById(client, current.parentStreamId)
+    } else {
+      current = null
+    }
+  }
+
+  return path
+}
+
+/**
+ * Resolve user IDs to participant info.
+ */
+async function resolveParticipants(client: PoolClient, userIds: string[]): Promise<Participant[]> {
+  const participants: Participant[] = []
+
+  for (const userId of userIds) {
+    const user = await UserRepository.findById(client, userId)
+    if (user) {
+      participants.push({
+        id: user.id,
+        name: user.name,
+      })
+    }
+  }
+
+  return participants
+}
+
+/**
+ * Resolve author name for a message.
+ */
+async function resolveAuthorName(
+  client: PoolClient,
+  authorId: string,
+  authorType: "user" | "persona"
+): Promise<string> {
+  if (authorType === "user") {
+    const user = await UserRepository.findById(client, authorId)
+    return user?.name ?? "Unknown"
+  }
+
+  // For personas, we'd need to look up the persona
+  // For now, return a placeholder
+  return "Assistant"
+}

--- a/apps/backend/tests/integration/context-builder.test.ts
+++ b/apps/backend/tests/integration/context-builder.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Context Builder Integration Tests
+ *
+ * Tests verify:
+ * 1. Scratchpad context includes conversation history
+ * 2. Channel context includes members and conversation
+ * 3. Thread context includes hierarchy path
+ * 4. DM context includes both participants
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction } from "../../src/db"
+import { UserRepository } from "../../src/repositories/user-repository"
+import { WorkspaceRepository } from "../../src/repositories/workspace-repository"
+import { StreamRepository } from "../../src/repositories/stream-repository"
+import { StreamMemberRepository } from "../../src/repositories/stream-member-repository"
+import { MessageRepository } from "../../src/repositories/message-repository"
+import { buildStreamContext } from "../../src/agents/context-builder"
+import { setupTestDatabase } from "./setup"
+import { userId, workspaceId, streamId, messageId } from "../../src/lib/id"
+import { StreamTypes, Visibilities } from "@threa/types"
+
+describe("Context Builder", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  describe("Scratchpad Context", () => {
+    test("should include conversation history", async () => {
+      await withTransaction(pool, async (client) => {
+        const ownerId = userId()
+        const wsId = workspaceId()
+        const scratchpadId = streamId()
+
+        await UserRepository.insert(client, {
+          id: ownerId,
+          email: `scratchpad-ctx-${ownerId}@test.com`,
+          name: "Scratchpad Owner",
+          workosUserId: `workos_${ownerId}`,
+        })
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Context Test Workspace",
+          slug: `ctx-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+
+        await StreamRepository.insert(client, {
+          id: scratchpadId,
+          workspaceId: wsId,
+          type: StreamTypes.SCRATCHPAD,
+          displayName: "My Scratchpad",
+          description: "Personal notes",
+          visibility: Visibilities.PRIVATE,
+          createdBy: ownerId,
+        })
+
+        // Add some messages
+        const msg1Id = messageId()
+        const msg2Id = messageId()
+        await MessageRepository.insert(client, {
+          id: msg1Id,
+          streamId: scratchpadId,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Hello world",
+        })
+        await MessageRepository.insert(client, {
+          id: msg2Id,
+          streamId: scratchpadId,
+          sequence: BigInt(2),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Second message",
+        })
+
+        const context = await buildStreamContext(client, scratchpadId, msg2Id)
+
+        expect(context).not.toBeNull()
+        expect(context!.streamType).toBe(StreamTypes.SCRATCHPAD)
+        expect(context!.streamInfo.name).toBe("My Scratchpad")
+        expect(context!.streamInfo.description).toBe("Personal notes")
+        expect(context!.conversationHistory).toHaveLength(2)
+        expect(context!.conversationHistory[0].content).toBe("Hello world")
+        expect(context!.conversationHistory[1].content).toBe("Second message")
+        expect(context!.participants).toBeUndefined()
+      })
+    })
+  })
+
+  describe("Channel Context", () => {
+    test("should include members and conversation", async () => {
+      await withTransaction(pool, async (client) => {
+        const ownerId = userId()
+        const memberId = userId()
+        const wsId = workspaceId()
+        const channelId = streamId()
+
+        await UserRepository.insert(client, {
+          id: ownerId,
+          email: `channel-ctx-owner-${ownerId}@test.com`,
+          name: "Channel Owner",
+          workosUserId: `workos_${ownerId}`,
+        })
+        await UserRepository.insert(client, {
+          id: memberId,
+          email: `channel-ctx-member-${memberId}@test.com`,
+          name: "Channel Member",
+          workosUserId: `workos_${memberId}`,
+        })
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Channel Context Workspace",
+          slug: `channel-ctx-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+
+        await StreamRepository.insert(client, {
+          id: channelId,
+          workspaceId: wsId,
+          type: StreamTypes.CHANNEL,
+          displayName: "General",
+          slug: "general",
+          description: "General discussion",
+          visibility: Visibilities.PUBLIC,
+          createdBy: ownerId,
+        })
+
+        // Add members
+        await StreamMemberRepository.insert(client, channelId, ownerId)
+        await StreamMemberRepository.insert(client, channelId, memberId)
+
+        // Add a message
+        const msgId = messageId()
+        await MessageRepository.insert(client, {
+          id: msgId,
+          streamId: channelId,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Welcome to the channel!",
+        })
+
+        const context = await buildStreamContext(client, channelId, msgId)
+
+        expect(context).not.toBeNull()
+        expect(context!.streamType).toBe(StreamTypes.CHANNEL)
+        expect(context!.streamInfo.name).toBe("General")
+        expect(context!.streamInfo.slug).toBe("general")
+        expect(context!.streamInfo.description).toBe("General discussion")
+        expect(context!.conversationHistory).toHaveLength(1)
+        expect(context!.participants).toHaveLength(2)
+
+        const participantNames = context!.participants!.map((p) => p.name).sort()
+        expect(participantNames).toEqual(["Channel Member", "Channel Owner"])
+      })
+    })
+  })
+
+  describe("Thread Context", () => {
+    test("should include thread hierarchy path", async () => {
+      await withTransaction(pool, async (client) => {
+        const ownerId = userId()
+        const wsId = workspaceId()
+        const channelId = streamId()
+        const threadId = streamId()
+
+        await UserRepository.insert(client, {
+          id: ownerId,
+          email: `thread-ctx-${ownerId}@test.com`,
+          name: "Thread Owner",
+          workosUserId: `workos_${ownerId}`,
+        })
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Thread Context Workspace",
+          slug: `thread-ctx-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+
+        // Create channel
+        await StreamRepository.insert(client, {
+          id: channelId,
+          workspaceId: wsId,
+          type: StreamTypes.CHANNEL,
+          displayName: "Discussions",
+          slug: "discussions",
+          visibility: Visibilities.PUBLIC,
+          createdBy: ownerId,
+        })
+
+        // Add parent message
+        const parentMsgId = messageId()
+        await MessageRepository.insert(client, {
+          id: parentMsgId,
+          streamId: channelId,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "This is the parent message that spawned the thread",
+        })
+
+        // Create thread from channel
+        await StreamRepository.insert(client, {
+          id: threadId,
+          workspaceId: wsId,
+          type: StreamTypes.THREAD,
+          displayName: "Thread Discussion",
+          visibility: Visibilities.PRIVATE,
+          parentStreamId: channelId,
+          parentMessageId: parentMsgId,
+          rootStreamId: channelId,
+          createdBy: ownerId,
+        })
+
+        // Add thread message
+        const threadMsgId = messageId()
+        await MessageRepository.insert(client, {
+          id: threadMsgId,
+          streamId: threadId,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Reply in thread",
+        })
+
+        const context = await buildStreamContext(client, threadId, threadMsgId)
+
+        expect(context).not.toBeNull()
+        expect(context!.streamType).toBe(StreamTypes.THREAD)
+        expect(context!.streamInfo.name).toBe("Thread Discussion")
+        expect(context!.conversationHistory).toHaveLength(1)
+        expect(context!.threadContext).toBeDefined()
+        expect(context!.threadContext!.depth).toBe(2)
+        expect(context!.threadContext!.path).toHaveLength(2)
+
+        // Root should be channel
+        expect(context!.threadContext!.path[0].streamId).toBe(channelId)
+        expect(context!.threadContext!.path[0].displayName).toBe("Discussions")
+
+        // Current should be thread
+        expect(context!.threadContext!.path[1].streamId).toBe(threadId)
+        expect(context!.threadContext!.path[1].displayName).toBe("Thread Discussion")
+        expect(context!.threadContext!.path[1].anchorMessage).toBeDefined()
+        expect(context!.threadContext!.path[1].anchorMessage!.content).toContain("parent message")
+      })
+    })
+
+    test("should handle deeply nested threads", async () => {
+      await withTransaction(pool, async (client) => {
+        const ownerId = userId()
+        const wsId = workspaceId()
+        const channelId = streamId()
+        const thread1Id = streamId()
+        const thread2Id = streamId()
+
+        await UserRepository.insert(client, {
+          id: ownerId,
+          email: `deep-thread-ctx-${ownerId}@test.com`,
+          name: "Deep Thread Owner",
+          workosUserId: `workos_${ownerId}`,
+        })
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Deep Thread Context Workspace",
+          slug: `deep-thread-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+
+        // Create channel -> thread1 -> thread2
+        await StreamRepository.insert(client, {
+          id: channelId,
+          workspaceId: wsId,
+          type: StreamTypes.CHANNEL,
+          displayName: "Root Channel",
+          slug: "root",
+          visibility: Visibilities.PUBLIC,
+          createdBy: ownerId,
+        })
+
+        const msg1Id = messageId()
+        await MessageRepository.insert(client, {
+          id: msg1Id,
+          streamId: channelId,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "First level message",
+        })
+
+        await StreamRepository.insert(client, {
+          id: thread1Id,
+          workspaceId: wsId,
+          type: StreamTypes.THREAD,
+          displayName: "Thread Level 1",
+          visibility: Visibilities.PRIVATE,
+          parentStreamId: channelId,
+          parentMessageId: msg1Id,
+          rootStreamId: channelId,
+          createdBy: ownerId,
+        })
+
+        const msg2Id = messageId()
+        await MessageRepository.insert(client, {
+          id: msg2Id,
+          streamId: thread1Id,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Second level message",
+        })
+
+        await StreamRepository.insert(client, {
+          id: thread2Id,
+          workspaceId: wsId,
+          type: StreamTypes.THREAD,
+          displayName: "Thread Level 2",
+          visibility: Visibilities.PRIVATE,
+          parentStreamId: thread1Id,
+          parentMessageId: msg2Id,
+          rootStreamId: channelId,
+          createdBy: ownerId,
+        })
+
+        const msg3Id = messageId()
+        await MessageRepository.insert(client, {
+          id: msg3Id,
+          streamId: thread2Id,
+          sequence: BigInt(1),
+          authorId: ownerId,
+          authorType: "user",
+          content: "Third level message",
+        })
+
+        const context = await buildStreamContext(client, thread2Id, msg3Id)
+
+        expect(context).not.toBeNull()
+        expect(context!.threadContext!.depth).toBe(3)
+        expect(context!.threadContext!.path).toHaveLength(3)
+        expect(context!.threadContext!.path[0].displayName).toBe("Root Channel")
+        expect(context!.threadContext!.path[1].displayName).toBe("Thread Level 1")
+        expect(context!.threadContext!.path[2].displayName).toBe("Thread Level 2")
+      })
+    })
+  })
+
+  describe("DM Context", () => {
+    test("should include both participants", async () => {
+      await withTransaction(pool, async (client) => {
+        const user1Id = userId()
+        const user2Id = userId()
+        const wsId = workspaceId()
+        const dmId = streamId()
+
+        await UserRepository.insert(client, {
+          id: user1Id,
+          email: `dm-ctx-user1-${user1Id}@test.com`,
+          name: "Alice",
+          workosUserId: `workos_${user1Id}`,
+        })
+        await UserRepository.insert(client, {
+          id: user2Id,
+          email: `dm-ctx-user2-${user2Id}@test.com`,
+          name: "Bob",
+          workosUserId: `workos_${user2Id}`,
+        })
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "DM Context Workspace",
+          slug: `dm-ctx-ws-${wsId}`,
+          createdBy: user1Id,
+        })
+
+        await StreamRepository.insert(client, {
+          id: dmId,
+          workspaceId: wsId,
+          type: StreamTypes.DM,
+          visibility: Visibilities.PRIVATE,
+          createdBy: user1Id,
+        })
+
+        // Add both as members
+        await StreamMemberRepository.insert(client, dmId, user1Id)
+        await StreamMemberRepository.insert(client, dmId, user2Id)
+
+        // Add messages
+        const msgId = messageId()
+        await MessageRepository.insert(client, {
+          id: msgId,
+          streamId: dmId,
+          sequence: BigInt(1),
+          authorId: user1Id,
+          authorType: "user",
+          content: "Hey Bob!",
+        })
+
+        const context = await buildStreamContext(client, dmId, msgId)
+
+        expect(context).not.toBeNull()
+        expect(context!.streamType).toBe(StreamTypes.DM)
+        expect(context!.conversationHistory).toHaveLength(1)
+        expect(context!.participants).toHaveLength(2)
+
+        const participantNames = context!.participants!.map((p) => p.name).sort()
+        expect(participantNames).toEqual(["Alice", "Bob"])
+      })
+    })
+  })
+
+  describe("Non-existent Stream", () => {
+    test("should return null for non-existent stream", async () => {
+      await withTransaction(pool, async (client) => {
+        const context = await buildStreamContext(client, "stream_nonexistent", "msg_nonexistent")
+        expect(context).toBeNull()
+      })
+    })
+  })
+})


### PR DESCRIPTION
**Linear:** [THR-7](https://linear.app/threa/issue/THR-7)

## Problem

The companion agent receives minimal context about the stream it's responding in - just `type`, `displayName`, and `description`. This isn't enough for the agent to provide contextually appropriate responses.

Different stream types have different context requirements:
- **Scratchpads** are personal, solo-first - context is primarily the conversation itself
- **Channels** are collaborative - members and channel purpose matter
- **Threads** exist in a graph - parent context and position in hierarchy matters
- **DMs** are two-party - participant awareness is important

## Solution

Implement a new `context-builder.ts` module that builds stream-type-specific context, and update `buildSystemPrompt` to produce rich, contextually appropriate system prompts.

### How it works

```
Message arrives
    ↓
buildStreamContext(client, streamId, messageId)
    ↓
Switch on stream type:
├── Scratchpad → conversation history only
├── Channel → members + conversation + slug
├── Thread → traverse hierarchy to root
└── DM → both participants + conversation
    ↓
buildSystemPrompt(persona, context)
    ↓
Stream-type-specific prompt section
```

### Key design decisions

**1. Context builder as separate module**

Extracted context building into its own module (`context-builder.ts`) rather than keeping it inline in the companion agent. This makes the logic reusable if other agents need context, and keeps the companion agent focused on orchestration.

**2. Thread hierarchy traversal**

For threads, we traverse upward from the current thread to the root (channel/scratchpad), collecting anchor messages at each level. This gives the agent full awareness of where it is in the conversation graph.

**3. Participant resolution**

For channels and DMs, we resolve member user IDs to names. This gives the agent awareness of who's in the conversation without leaking internal IDs into prompts.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/agents/context-builder.ts` | Stream-type-specific context building with `StreamContext` interface |
| `apps/backend/tests/integration/context-builder.test.ts` | Integration tests covering all stream types |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/agents/companion-agent.ts` | Use context builder, produce stream-type-specific prompts |

## Test plan

- [x] Scratchpad context includes conversation history (integration test)
- [x] Channel context includes members and slug (integration test)
- [x] Thread context includes hierarchy path with anchor messages (integration test)
- [x] Deeply nested threads maintain correct path (integration test)
- [x] DM context includes both participants (integration test)
- [x] Non-existent stream returns null (integration test)
- [x] All 110 existing integration tests pass

## Not included

Phase 4 (Thread Summaries) was marked as optional in the spec and is deferred for future work.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
