### PR TITLE
feat(THR-53): click anywhere in hoverable area to rename scratchpad

### DIFF
--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -71,19 +71,15 @@ export function StreamPage() {
               autoFocus
             />
           ) : isScratchpad ? (
-            <div className="group inline-flex items-center gap-1 rounded-md px-2 py-1 -ml-2 hover:bg-accent/50 hover:outline hover:outline-1 hover:outline-border cursor-pointer transition-colors">
+            <div
+              className="group inline-flex items-center gap-1 rounded-md px-2 py-1 -ml-2 hover:bg-accent/50 hover:outline hover:outline-1 hover:outline-border cursor-pointer transition-colors"
+              onClick={handleStartRename}
+            >
               <h1 className="font-semibold">
                 {streamName}
                 {isDraft && <span className="ml-2 text-xs font-normal text-muted-foreground">(draft)</span>}
               </h1>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
-                onClick={handleStartRename}
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </Button>
+              <Pencil className="h-3.5 w-3.5 opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
           ) : (
             <h1 className="font-semibold">{streamName}</h1>


### PR DESCRIPTION
**Linear:** [THR-53](https://linear.app/threa/issue/THR-53)

## Problem

To rename a scratchpad, users must click the small pencil icon that appears on hover. The container already shows a highlight (background + outline) and has `cursor-pointer`, which suggests the entire area is clickable—but only the icon triggers edit mode.

## Solution

Move the `onClick` handler from the pencil button to the container div, making the entire highlighted area clickable.

### Key design decisions

**1. Remove Button wrapper around pencil icon**

Since the whole container is now clickable, the Button wrapper is unnecessary. The icon remains with the same hover opacity transition as a visual affordance.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/pages/stream.tsx` | Move onClick to container, simplify pencil icon |

## Test plan

- [x] Click on scratchpad name text → enters edit mode
- [x] Click on pencil icon → enters edit mode  
- [x] Click anywhere in highlighted area → enters edit mode
- [x] Hover still shows highlight and pencil icon
- [x] Edit mode works as before (Enter saves, Escape cancels, blur saves)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
