### PR TITLE
fix: increase AI token limits and add outbox listener keepalive

### DIFF
--- a/apps/backend/src/lib/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/lib/boundary-extraction/llm-extractor.ts
@@ -85,7 +85,7 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
           { role: "system", content: SYSTEM_PROMPT },
           { role: "user", content: prompt },
         ],
-        maxTokens: 500,
+        maxTokens: 1000,
         temperature: 0.2,
         telemetry: {
           functionId: "boundary-extraction",

--- a/apps/backend/src/lib/memo/classifier.ts
+++ b/apps/backend/src/lib/memo/classifier.ts
@@ -145,7 +145,7 @@ export class MemoClassifier {
         { role: "system", content: MESSAGE_SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      maxTokens: 200,
+      maxTokens: 500,
       temperature: 0.1,
       telemetry: {
         functionId: "memo-classify-message",
@@ -189,7 +189,7 @@ export class MemoClassifier {
         { role: "system", content: CONVERSATION_SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      maxTokens: 300,
+      maxTokens: 600,
       temperature: 0.1,
       telemetry: {
         functionId: "memo-classify-conversation",

--- a/apps/backend/src/lib/memo/memorizer.ts
+++ b/apps/backend/src/lib/memo/memorizer.ts
@@ -130,7 +130,7 @@ export class Memorizer {
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      maxTokens: 500,
+      maxTokens: 800,
       temperature: 0.3,
       telemetry: {
         functionId: "memorize-message",
@@ -172,7 +172,7 @@ export class Memorizer {
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      maxTokens: 700,
+      maxTokens: 1200,
       temperature: 0.3,
       telemetry: {
         functionId: "memorize-conversation",
@@ -222,7 +222,7 @@ export class Memorizer {
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      maxTokens: 700,
+      maxTokens: 1200,
       temperature: 0.3,
       telemetry: {
         functionId: "revise-memo",

--- a/apps/backend/src/services/stream-naming-service.ts
+++ b/apps/backend/src/services/stream-naming-service.ts
@@ -95,7 +95,7 @@ export class StreamNamingService {
             { role: "system", content: systemPrompt },
             { role: "user", content: conversationText },
           ],
-          maxTokens: 100,
+          maxTokens: 300,
           temperature: 0.3,
           telemetry: {
             functionId: "stream-naming",


### PR DESCRIPTION
## Problem

Two issues were causing degraded AI functionality and noisy error logs:

1. **AI output truncation**: Token limits were too restrictive across multiple AI services. Models with reasoning tokens (like GPT-5-mini) consume output tokens for internal reasoning before generating actual content. With limits like 100-200 tokens, responses were being cut off mid-JSON, causing parse failures and empty outputs.

2. **Database connection timeouts**: PostgreSQL's `idle_session_timeout` (60s) was killing LISTEN connections used by OutboxListeners. These long-lived connections for NOTIFY/LISTEN appeared "idle" to PostgreSQL despite being actively waiting for notifications, causing repeated disconnection errors every ~60 seconds.

## Solution

### 1. Increased AI token limits

Raised `maxTokens` across all AI services to accommodate reasoning tokens:

| Service | Function | Before | After |
|---------|----------|--------|-------|
| classifier.ts | classifyMessage | 200 | 500 |
| classifier.ts | classifyConversation | 300 | 600 |
| llm-extractor.ts | boundary extraction | 500 | 1000 |
| memorizer.ts | memorizeMessage | 500 | 800 |
| memorizer.ts | memorizeConversation | 700 | 1200 |
| memorizer.ts | reviseMemo | 700 | 1200 |
| stream-naming-service.ts | naming | 100 | 300 |

### 2. Added keepalive mechanism to OutboxListener

Instead of relying on PostgreSQL server configuration (which we can't control in managed database services), implemented an application-level keepalive that sends `SELECT 1` every 30 seconds to prevent idle timeout.

**Key design decisions:**

**Application-level keepalive over server config**
- Works with any PostgreSQL deployment (managed services like RDS, Cloud SQL)
- No dependency on DBA configuration
- Self-healing: if keepalive fails, error triggers automatic reconnection

**30-second keepalive interval**
- Safely under the common 60-second idle timeout
- Low overhead (simple `SELECT 1` query)
- Configurable via `keepaliveMs` option

## Modified files

| File | Change |
|------|--------|
| `apps/backend/src/lib/memo/classifier.ts` | Increased maxTokens: 200→500, 300→600 |
| `apps/backend/src/lib/memo/memorizer.ts` | Increased maxTokens: 500→800, 700→1200 |
| `apps/backend/src/lib/boundary-extraction/llm-extractor.ts` | Increased maxTokens: 500→1000 |
| `apps/backend/src/services/stream-naming-service.ts` | Increased maxTokens: 100→300 |
| `apps/backend/src/lib/outbox-listener.ts` | Added keepalive mechanism with configurable interval |

## Test plan

- [x] Manual verification: No more truncated JSON responses in AI calls
- [x] Manual verification: No more idle-session timeout errors in logs
- [x] Keepalive fires every 30s, preventing 60s timeout from triggering

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
