### PR TITLE
fix(THR-73): address AI cost tracking review feedback

### DIFF
--- a/apps/backend/scripts/test-cost-capture.ts
+++ b/apps/backend/scripts/test-cost-capture.ts
@@ -1,11 +1,11 @@
 /**
  * Test script to verify OpenRouter cost capture is working.
- * Run with: bun src/lib/ai/test-cost-capture.ts
+ * Run with: bun scripts/test-cost-capture.ts
  *
  * This makes real API calls to OpenRouter and logs the cost data.
  */
 
-import { createAI } from "./ai"
+import { createAI } from "../src/lib/ai/ai"
 import { z } from "zod"
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY

--- a/apps/backend/src/agents/persona-agent.ts
+++ b/apps/backend/src/agents/persona-agent.ts
@@ -321,6 +321,7 @@ export class PersonaAgent {
             lastProcessedSequence: session.lastSeenSequence ?? initialSequence,
             enabledTools: persona.enabledTools,
             workspaceId, // For cost tracking
+            invokingUserId, // For cost attribution to the human user
           },
           callbacks
         )

--- a/apps/backend/src/db/migrations/023_ai_usage_indexes.sql
+++ b/apps/backend/src/db/migrations/023_ai_usage_indexes.sql
@@ -1,0 +1,9 @@
+-- Add composite index for efficient user usage queries
+-- Used by AIUsageRepository.getUserUsage and getUsageByUser
+CREATE INDEX idx_ai_usage_workspace_user_created
+ON ai_usage_records(workspace_id, user_id, created_at DESC);
+
+-- Add CHECK constraint to ensure origin values are valid
+-- Complements application-level validation
+ALTER TABLE ai_usage_records
+ADD CONSTRAINT chk_ai_usage_origin CHECK (origin IN ('system', 'user'));

--- a/apps/backend/src/lib/ai/ai.test.ts
+++ b/apps/backend/src/lib/ai/ai.test.ts
@@ -130,37 +130,50 @@ describe("OpenRouter response fixtures", () => {
   // They document the expected response structure for cost tracking
 
   it("should have generateText fixture with cost data", () => {
-    const { providerMetadata } = fixtures.generateText
-
-    expect(providerMetadata.openrouter).toBeDefined()
-    expect(providerMetadata.openrouter.usage).toBeDefined()
-    expect(providerMetadata.openrouter.usage.cost).toBe(0.0000036)
-    expect(providerMetadata.openrouter.usage.promptTokens).toBe(16)
-    expect(providerMetadata.openrouter.usage.completionTokens).toBe(2)
-    expect(providerMetadata.openrouter.usage.totalTokens).toBe(18)
+    expect(fixtures.generateText.providerMetadata).toMatchObject({
+      openrouter: {
+        usage: {
+          cost: 0.0000036,
+          promptTokens: 16,
+          completionTokens: 2,
+          totalTokens: 18,
+        },
+      },
+    })
   })
 
   it("should have generateObject fixture with cost data", () => {
-    const { providerMetadata } = fixtures.generateObject
-
-    expect(providerMetadata.openrouter.usage.cost).toBe(0.00001545)
-    expect(providerMetadata.openrouter.usage.promptTokens).toBe(59)
-    expect(providerMetadata.openrouter.usage.completionTokens).toBe(11)
-    expect(providerMetadata.openrouter.usage.totalTokens).toBe(70)
+    expect(fixtures.generateObject.providerMetadata).toMatchObject({
+      openrouter: {
+        usage: {
+          cost: 0.00001545,
+          promptTokens: 59,
+          completionTokens: 11,
+          totalTokens: 70,
+        },
+      },
+    })
   })
 
   it("should have embed fixture with tokens and cost", () => {
-    const { usage, providerMetadata } = fixtures.embed
-
-    // Embedding models have different usage shape (just 'tokens', no prompt/completion split)
-    expect(usage.tokens).toBe(4)
-    expect(providerMetadata.openrouter.usage.cost).toBe(8e-8)
+    expect(fixtures.embed).toMatchObject({
+      usage: { tokens: 4 },
+      providerMetadata: {
+        openrouter: {
+          usage: { cost: 8e-8 },
+        },
+      },
+    })
   })
 
   it("should have embedMany fixture with tokens and cost", () => {
-    const { usage, providerMetadata } = fixtures.embedMany
-
-    expect(usage.tokens).toBe(3)
-    expect(providerMetadata.openrouter.usage.cost).toBe(6e-8)
+    expect(fixtures.embedMany).toMatchObject({
+      usage: { tokens: 3 },
+      providerMetadata: {
+        openrouter: {
+          usage: { cost: 6e-8 },
+        },
+      },
+    })
   })
 })

--- a/apps/backend/src/lib/ai/cost-tracking-callback.ts
+++ b/apps/backend/src/lib/ai/cost-tracking-callback.ts
@@ -1,0 +1,150 @@
+/**
+ * Cost Tracking Callback for LangChain
+ *
+ * Automatically records AI usage costs when LLM calls complete.
+ * This eliminates the "do thing then call other thing" drift pattern
+ * by baking cost recording into the callback chain.
+ *
+ * Usage:
+ * ```typescript
+ * const result = await costTracker.runWithTracking(async () => {
+ *   return compiledGraph.invoke(input, {
+ *     callbacks: [
+ *       ...getLangfuseCallbacks({ ... }),
+ *       ...getCostTrackingCallbacks({
+ *         costRecorder,
+ *         workspaceId,
+ *         functionId: "companion-response",
+ *         origin: "user",
+ *         getCapturedUsage: () => costTracker.getCapturedUsage(),
+ *       }),
+ *     ],
+ *   })
+ * })
+ * // Cost recording happens automatically - no manual step needed!
+ * ```
+ */
+
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base"
+import type { LLMResult } from "@langchain/core/outputs"
+import type { CostRecorder, AIOrigin, UsageWithCost } from "./ai"
+import type { CapturedUsage } from "./openrouter-cost-interceptor"
+import { logger } from "../logger"
+
+export interface CostTrackingCallbackParams {
+  /** Cost recorder instance to persist usage data */
+  costRecorder: CostRecorder
+  /** Workspace ID - required for cost attribution */
+  workspaceId: string
+  /** Optional user ID - the human who initiated this action (for user-origin calls) */
+  userId?: string
+  /** Optional session ID for grouping related calls */
+  sessionId?: string
+  /** Function ID for categorizing the operation */
+  functionId: string
+  /** Origin of the call - system or user initiated */
+  origin: AIOrigin
+  /** Function to get captured usage from CostTracker */
+  getCapturedUsage: () => CapturedUsage
+}
+
+/**
+ * LangChain callback handler that automatically records costs when LLM calls complete.
+ *
+ * The callback reads usage data from the CostTracker (via getCapturedUsage) and
+ * records it to the database when handleLLMEnd fires.
+ */
+export class CostTrackingCallback extends BaseCallbackHandler {
+  name = "cost-tracking"
+
+  constructor(private params: CostTrackingCallbackParams) {
+    super()
+  }
+
+  async handleLLMEnd(output: LLMResult): Promise<void> {
+    const usage = this.params.getCapturedUsage()
+
+    // Only record if there's actual cost or usage
+    if (usage.cost === 0 && usage.totalTokens === 0) {
+      return
+    }
+
+    // Extract model from LLM output if available
+    const model = (output.llmOutput?.model as string) ?? (output.llmOutput?.modelName as string) ?? "unknown"
+
+    try {
+      await this.params.costRecorder.recordUsage({
+        workspaceId: this.params.workspaceId,
+        userId: this.params.userId,
+        sessionId: this.params.sessionId,
+        functionId: this.params.functionId,
+        model,
+        provider: "openrouter",
+        origin: this.params.origin,
+        usage: {
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          totalTokens: usage.totalTokens,
+          cost: usage.cost,
+        } satisfies UsageWithCost,
+      })
+
+      logger.debug(
+        {
+          workspaceId: this.params.workspaceId,
+          sessionId: this.params.sessionId,
+          functionId: this.params.functionId,
+          model,
+          cost: usage.cost,
+          totalTokens: usage.totalTokens,
+        },
+        "Cost tracking callback recorded usage"
+      )
+    } catch (error) {
+      logger.error(
+        {
+          error,
+          workspaceId: this.params.workspaceId,
+          sessionId: this.params.sessionId,
+          functionId: this.params.functionId,
+        },
+        "Failed to record usage in cost tracking callback"
+      )
+    }
+  }
+}
+
+/**
+ * Create cost tracking callbacks array for LangChain/LangGraph.
+ *
+ * Returns empty array if no costRecorder is provided, allowing safe spreading:
+ * ```typescript
+ * callbacks: [
+ *   ...getLangfuseCallbacks({ ... }),
+ *   ...getCostTrackingCallbacks({ ... }), // safe even if no costRecorder
+ * ]
+ * ```
+ *
+ * @param params - Parameters for cost tracking (costRecorder can be undefined)
+ * @returns Array with CostTrackingCallback, or empty array if no costRecorder
+ */
+export function getCostTrackingCallbacks(
+  params: Partial<CostTrackingCallbackParams> & { workspaceId?: string }
+): CostTrackingCallback[] {
+  // Return empty array if essential params are missing
+  if (!params.costRecorder || !params.workspaceId || !params.functionId || !params.getCapturedUsage) {
+    return []
+  }
+
+  return [
+    new CostTrackingCallback({
+      costRecorder: params.costRecorder,
+      workspaceId: params.workspaceId,
+      userId: params.userId,
+      sessionId: params.sessionId,
+      functionId: params.functionId,
+      origin: params.origin ?? "system",
+      getCapturedUsage: params.getCapturedUsage,
+    }),
+  ]
+}

--- a/apps/backend/src/lib/ai/openrouter-cost-interceptor.ts
+++ b/apps/backend/src/lib/ai/openrouter-cost-interceptor.ts
@@ -3,6 +3,9 @@
  *
  * Captures cost and token usage from OpenRouter API responses for LangChain calls.
  * Uses AsyncLocalStorage to track costs per-request in a thread-safe manner.
+ *
+ * The CostTracker class owns its AsyncLocalStorage instance to avoid singleton
+ * violations (INV-9). Each AI wrapper instance creates its own CostTracker.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks"
@@ -24,114 +27,167 @@ interface CostStore {
   }
 }
 
-const costStorage = new AsyncLocalStorage<CostStore>()
-
 type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 /**
- * Create a fetch wrapper that captures OpenRouter cost from responses.
- * This can be passed to LangChain's ChatOpenAI configuration.
- */
-export function createCostCapturingFetch(originalFetch: FetchFunction = fetch): FetchFunction {
-  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const response = await originalFetch(input, init)
-
-    // Only process OpenRouter responses
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
-    if (!url.includes("openrouter.ai")) {
-      return response
-    }
-
-    // Check if we're in a tracking context
-    const store = costStorage.getStore()
-    if (!store) {
-      return response
-    }
-
-    try {
-      // Clone response to read body without consuming it
-      const cloned = response.clone()
-      const text = await cloned.text()
-
-      // Handle streaming responses (SSE format)
-      if (text.startsWith("data:")) {
-        // For streaming, we need to find the final chunk with usage info
-        const lines = text.split("\n")
-        for (const line of lines.reverse()) {
-          if (line.startsWith("data:") && line !== "data: [DONE]") {
-            try {
-              const data = JSON.parse(line.slice(5).trim())
-              if (data.usage) {
-                store.cost += data.usage.cost ?? 0
-                store.tokens.prompt += data.usage.prompt_tokens ?? 0
-                store.tokens.completion += data.usage.completion_tokens ?? 0
-                store.tokens.total += data.usage.total_tokens ?? 0
-                break
-              }
-            } catch {
-              // Not valid JSON, skip
-            }
-          }
-        }
-      } else {
-        // Non-streaming response
-        const body = JSON.parse(text)
-        if (body.usage) {
-          store.cost += body.usage.cost ?? 0
-          store.tokens.prompt += body.usage.prompt_tokens ?? 0
-          store.tokens.completion += body.usage.completion_tokens ?? 0
-          store.tokens.total += body.usage.total_tokens ?? 0
-        }
-      }
-    } catch (error) {
-      logger.warn({ error }, "Failed to extract cost from OpenRouter response")
-    }
-
-    return response
-  }
-}
-
-/**
- * Run a function with cost tracking enabled.
- * Returns the result along with captured usage data.
+ * CostTracker provides thread-safe cost tracking for OpenRouter API calls.
+ *
+ * Each instance owns its own AsyncLocalStorage, avoiding singleton violations.
+ * Use runWithTracking() to establish a tracking context, then getCapturedUsage()
+ * to read accumulated costs (e.g., from a LangChain callback).
  *
  * @example
- * const { result, usage } = await withCostTracking(async () => {
- *   return compiledGraph.invoke(input, config)
+ * const tracker = new CostTracker()
+ * const result = await tracker.runWithTracking(async () => {
+ *   return compiledGraph.invoke(input, {
+ *     callbacks: [
+ *       ...getCostTrackingCallbacks({
+ *         getCapturedUsage: () => tracker.getCapturedUsage(),
+ *         // ... other params
+ *       }),
+ *     ],
+ *   })
  * })
- * console.log(`Cost: $${usage.cost}`)
  */
-export async function withCostTracking<T>(fn: () => Promise<T>): Promise<{ result: T; usage: CapturedUsage }> {
-  const store: CostStore = {
-    cost: 0,
-    tokens: { prompt: 0, completion: 0, total: 0 },
+export class CostTracker {
+  private storage = new AsyncLocalStorage<CostStore>()
+
+  /**
+   * Create a fetch wrapper that captures OpenRouter cost from responses.
+   * Pass this to LangChain's ChatOpenAI configuration.
+   */
+  createInterceptingFetch(originalFetch: FetchFunction = fetch): FetchFunction {
+    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const response = await originalFetch(input, init)
+
+      // Only process OpenRouter responses
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+      if (!url.includes("openrouter.ai")) {
+        return response
+      }
+
+      // Check if we're in a tracking context
+      const store = this.storage.getStore()
+      if (!store) {
+        return response
+      }
+
+      try {
+        // Clone response to read body without consuming it
+        const cloned = response.clone()
+        const text = await cloned.text()
+
+        // Handle streaming responses (SSE format)
+        if (text.startsWith("data:")) {
+          // For streaming, we need to find the final chunk with usage info
+          const lines = text.split("\n")
+          for (const line of lines.reverse()) {
+            if (line.startsWith("data:") && line !== "data: [DONE]") {
+              try {
+                const data = JSON.parse(line.slice(5).trim())
+                if (data.usage) {
+                  store.cost += data.usage.cost ?? 0
+                  store.tokens.prompt += data.usage.prompt_tokens ?? 0
+                  store.tokens.completion += data.usage.completion_tokens ?? 0
+                  store.tokens.total += data.usage.total_tokens ?? 0
+                  break
+                }
+              } catch {
+                // Not valid JSON, skip
+              }
+            }
+          }
+        } else {
+          // Non-streaming response
+          const body = JSON.parse(text)
+          if (body.usage) {
+            store.cost += body.usage.cost ?? 0
+            store.tokens.prompt += body.usage.prompt_tokens ?? 0
+            store.tokens.completion += body.usage.completion_tokens ?? 0
+            store.tokens.total += body.usage.total_tokens ?? 0
+          }
+        }
+      } catch (error) {
+        logger.warn({ error }, "Failed to extract cost from OpenRouter response")
+      }
+
+      return response
+    }
   }
 
-  const result = await costStorage.run(store, fn)
+  /**
+   * Run a function with cost tracking enabled.
+   * The tracking context is available to getCapturedUsage() and the intercepting fetch.
+   */
+  async runWithTracking<T>(fn: () => Promise<T>): Promise<T> {
+    const store: CostStore = {
+      cost: 0,
+      tokens: { prompt: 0, completion: 0, total: 0 },
+    }
 
-  return {
-    result,
-    usage: {
+    return this.storage.run(store, fn)
+  }
+
+  /**
+   * Get the current accumulated usage, if in a tracking context.
+   * Returns zeros if not in a tracking context.
+   *
+   * This is designed to be passed to CostTrackingCallback via getCapturedUsage.
+   */
+  getCapturedUsage(): CapturedUsage {
+    const store = this.storage.getStore()
+    if (!store) {
+      return { cost: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+    }
+
+    return {
       cost: store.cost,
       promptTokens: store.tokens.prompt,
       completionTokens: store.tokens.completion,
       totalTokens: store.tokens.total,
+    }
+  }
+}
+
+/**
+ * Legacy singleton for backward compatibility.
+ * @deprecated Will be removed once all callers migrate to CostTracker class.
+ */
+const legacyTracker = new CostTracker()
+
+/**
+ * @deprecated Use CostTracker.createInterceptingFetch() instead.
+ * This function exists for backward compatibility during migration.
+ */
+export function createCostCapturingFetch(originalFetch: FetchFunction = fetch): FetchFunction {
+  return legacyTracker.createInterceptingFetch(originalFetch)
+}
+
+/**
+ * @deprecated Use CostTracker.runWithTracking() instead.
+ * This function exists for backward compatibility during migration.
+ */
+export async function withCostTracking<T>(fn: () => Promise<T>): Promise<{ result: T; usage: CapturedUsage }> {
+  const usageBefore = legacyTracker.getCapturedUsage()
+  const result = await legacyTracker.runWithTracking(fn)
+  const usageAfter = legacyTracker.getCapturedUsage()
+
+  return {
+    result,
+    usage: {
+      cost: usageAfter.cost - usageBefore.cost,
+      promptTokens: usageAfter.promptTokens - usageBefore.promptTokens,
+      completionTokens: usageAfter.completionTokens - usageBefore.completionTokens,
+      totalTokens: usageAfter.totalTokens - usageBefore.totalTokens,
     },
   }
 }
 
 /**
- * Get the current cost tracking store, if in a tracking context.
- * Useful for checking accumulated costs mid-execution.
+ * @deprecated Use CostTracker.getCapturedUsage() instead.
  */
 export function getCurrentUsage(): CapturedUsage | null {
-  const store = costStorage.getStore()
-  if (!store) return null
-
-  return {
-    cost: store.cost,
-    promptTokens: store.tokens.prompt,
-    completionTokens: store.tokens.completion,
-    totalTokens: store.tokens.total,
-  }
+  const usage = legacyTracker.getCapturedUsage()
+  if (usage.cost === 0 && usage.totalTokens === 0) return null
+  return usage
 }

--- a/apps/backend/src/lib/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/lib/boundary-extraction/llm-extractor.test.ts
@@ -68,6 +68,7 @@ function createMockContext(overrides: Partial<ExtractionContext> = {}): Extracti
     recentMessages: [createMockMessage()],
     activeConversations: [],
     streamType: "scratchpad",
+    workspaceId: "wsp_test123",
     ...overrides,
   }
 }

--- a/apps/backend/src/lib/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/lib/boundary-extraction/llm-extractor.ts
@@ -94,7 +94,7 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
             activeConversationCount: context.activeConversations.length,
           },
         },
-        context: context.workspaceId ? { workspaceId: context.workspaceId, origin: "system" } : undefined,
+        context: { workspaceId: context.workspaceId, origin: "system" },
       })
 
       return this.validateResult(value, context)

--- a/apps/backend/src/lib/boundary-extraction/types.ts
+++ b/apps/backend/src/lib/boundary-extraction/types.ts
@@ -17,8 +17,8 @@ export interface ExtractionContext {
   streamType: string
   /** For threads: conversations containing the parent message (in the parent channel) */
   parentMessageConversations?: ConversationSummary[]
-  /** Optional workspaceId for cost tracking */
-  workspaceId?: string
+  /** Workspace ID for cost tracking - required for cost attribution */
+  workspaceId: string
 }
 
 export interface CompletenessUpdate {

--- a/apps/backend/src/services/ai-budget-service.ts
+++ b/apps/backend/src/services/ai-budget-service.ts
@@ -26,17 +26,18 @@ const HARD_LIMIT_THRESHOLD = 1.0 // 100% - block non-essential features
 /**
  * Model degradation mappings.
  * Maps expensive models to cheaper alternatives when over budget.
+ * Uses full model IDs with provider prefix to match the format used in AI calls.
  */
 const MODEL_DEGRADATION_MAP: Record<string, string> = {
   // Claude models - degrade to Haiku
-  "anthropic/claude-sonnet-4-20250514": "anthropic/claude-haiku-4.5",
-  "anthropic/claude-sonnet-4.5": "anthropic/claude-haiku-4.5",
-  "anthropic/claude-sonnet-4": "anthropic/claude-haiku-4.5",
+  "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:anthropic/claude-haiku-4.5",
+  "openrouter:anthropic/claude-sonnet-4.5": "openrouter:anthropic/claude-haiku-4.5",
+  "openrouter:anthropic/claude-sonnet-4": "openrouter:anthropic/claude-haiku-4.5",
 
   // OpenAI models - degrade to mini
-  "openai/gpt-4o": "openai/gpt-4o-mini",
-  "openai/gpt-5": "openai/gpt-5-mini",
-  "openai/gpt-5-turbo": "openai/gpt-5-mini",
+  "openrouter:openai/gpt-4o": "openrouter:openai/gpt-4o-mini",
+  "openrouter:openai/gpt-5": "openrouter:openai/gpt-5-mini",
+  "openrouter:openai/gpt-5-turbo": "openrouter:openai/gpt-5-mini",
 }
 
 export interface BudgetStatus {

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -7,10 +7,12 @@ export interface EmbeddingServiceConfig {
   model?: string
 }
 
-/** Optional context for cost tracking */
+/** Context for cost tracking and telemetry */
 export interface EmbeddingContext {
   workspaceId: string
   userId?: string
+  /** Custom function ID for telemetry (e.g., "search-query", "message-embedding") */
+  functionId?: string
 }
 
 /** Interface for embedding service implementations */
@@ -43,7 +45,7 @@ export class EmbeddingService implements EmbeddingServiceLike {
     const { value } = await this.ai.embed({
       model: this.modelId,
       value: text,
-      telemetry: { functionId: "embedding-single" },
+      telemetry: { functionId: context?.functionId ?? "embedding-single" },
       context: costContext,
     })
     return value
@@ -64,7 +66,7 @@ export class EmbeddingService implements EmbeddingServiceLike {
     const { value } = await this.ai.embedMany({
       model: this.modelId,
       values: texts,
-      telemetry: { functionId: "embedding-batch", metadata: { count: texts.length } },
+      telemetry: { functionId: context?.functionId ?? "embedding-batch", metadata: { count: texts.length } },
       context: costContext,
     })
     return value

--- a/apps/backend/src/services/memo-service.ts
+++ b/apps/backend/src/services/memo-service.ts
@@ -172,7 +172,10 @@ export class MemoService implements MemoServiceLike {
       status: MemoStatuses.ACTIVE,
     })
 
-    const embedding = await this.embeddingService.embed(memo.abstract, { workspaceId })
+    const embedding = await this.embeddingService.embed(memo.abstract, {
+      workspaceId,
+      functionId: "memo-embedding",
+    })
     await MemoRepository.updateEmbedding(client, memo.id, embedding)
 
     await OutboxRepository.insert(client, "memo:created", {
@@ -282,7 +285,10 @@ export class MemoService implements MemoServiceLike {
       status: MemoStatuses.ACTIVE,
     })
 
-    const embedding = await this.embeddingService.embed(memo.abstract, { workspaceId })
+    const embedding = await this.embeddingService.embed(memo.abstract, {
+      workspaceId,
+      functionId: "memo-embedding",
+    })
     await MemoRepository.updateEmbedding(client, memo.id, embedding)
 
     await OutboxRepository.insert(client, "memo:created", {
@@ -332,7 +338,10 @@ export class MemoService implements MemoServiceLike {
       version: existingMemo.version + 1,
     })
 
-    const embedding = await this.embeddingService.embed(newMemo.abstract, { workspaceId })
+    const embedding = await this.embeddingService.embed(newMemo.abstract, {
+      workspaceId,
+      functionId: "memo-embedding",
+    })
     await MemoRepository.updateEmbedding(client, newMemo.id, embedding)
 
     await OutboxRepository.insert(client, "memo:revised", {

--- a/apps/backend/src/services/search-service.ts
+++ b/apps/backend/src/services/search-service.ts
@@ -58,7 +58,7 @@ export class SearchService {
     let embedding: number[] = []
     if (query.trim()) {
       try {
-        embedding = await this.embeddingService.embed(query, { workspaceId })
+        embedding = await this.embeddingService.embed(query, { workspaceId, functionId: "search-query" })
       } catch (error) {
         logger.warn({ error }, "Failed to generate embedding, falling back to keyword-only search")
       }

--- a/apps/backend/src/workers/embedding-worker.ts
+++ b/apps/backend/src/workers/embedding-worker.ts
@@ -46,7 +46,10 @@ export function createEmbeddingWorker(deps: EmbeddingWorkerDeps): JobHandler<Emb
       }
 
       // Generate embedding (with cost tracking context)
-      const embedding = await embeddingService.embed(message.content, { workspaceId })
+      const embedding = await embeddingService.embed(message.content, {
+        workspaceId,
+        functionId: "message-embedding",
+      })
 
       // Store embedding
       await MessageRepository.updateEmbedding(client, messageId, embedding)

--- a/apps/frontend/src/pages/ai-usage-admin.tsx
+++ b/apps/frontend/src/pages/ai-usage-admin.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo, useEffect } from "react"
 import { useParams, Link } from "react-router-dom"
 import { ArrowLeft, DollarSign, Bot, Cog } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -253,6 +253,19 @@ function BudgetSettings({
   const updateBudget = useUpdateAIBudget(workspaceId)
   const [localBudget, setLocalBudget] = useState<string>(budget?.monthlyBudgetUsd?.toString() ?? "50")
   const [localHardLimit, setLocalHardLimit] = useState<string>(budget?.hardLimitPercent?.toString() ?? "100")
+
+  // Sync local state when server budget changes
+  useEffect(() => {
+    if (budget?.monthlyBudgetUsd !== undefined) {
+      setLocalBudget(budget.monthlyBudgetUsd.toString())
+    }
+  }, [budget?.monthlyBudgetUsd])
+
+  useEffect(() => {
+    if (budget?.hardLimitPercent !== undefined) {
+      setLocalHardLimit(budget.hardLimitPercent.toString())
+    }
+  }, [budget?.hardLimitPercent])
 
   const handleUpdate = useCallback(
     (updates: UpdateAIBudgetInput) => {


### PR DESCRIPTION
**Linear:** [THR-73](https://linear.app/threa/issue/THR-73)

## Problem

PR #66 introduced AI cost tracking but had several issues identified in review:
- Singleton pattern in cost interceptor violated INV-9
- Manual cost recording was drift-prone (easy to forget)
- Race condition in budget updates (select-then-update)
- Missing userId propagation for assistant cost attribution
- Fire-and-forget alert check could miss transaction

## Solution

### Callback-based cost recording

Created `CostTrackingCallback` that automatically records costs when `handleLLMEnd` fires:

```typescript
const result = await costTracker.runWithTracking(async () => {
  return compiledGraph.invoke(input, {
    callbacks: [
      ...getLangfuseCallbacks({ ... }),
      ...getCostTrackingCallbacks({
        costRecorder, workspaceId, userId, sessionId,
        functionId: "companion-response", origin: "user",
        getCapturedUsage: () => costTracker.getCapturedUsage(),
      }),
    ],
  })
})
// No manual recordUsage() call needed\!
```

### Key changes

1. **CostTracker class** - Owns AsyncLocalStorage, no module-level singleton
2. **Atomic budget updates** - Added `upsertPartial` using COALESCE for race-free updates
3. **userId propagation** - Added `invokingUserId` through companion-runner to persona-agent
4. **Await alert check** - Changed fire-and-forget to awaited within transaction
5. **functionId for embeddings** - Distinguishes search-query, message-embedding, memo-embedding

## New files

| File | Purpose |
|------|---------|
| `lib/ai/cost-tracking-callback.ts` | LangChain callback for auto cost recording |
| `db/migrations/023_ai_usage_indexes.sql` | Composite index + CHECK constraint |
| `scripts/test-cost-capture.ts` | Moved from lib/ai/ |

## Modified files

| File | Change |
|------|--------|
| `lib/ai/openrouter-cost-interceptor.ts` | Refactored to CostTracker class |
| `lib/ai/ai.ts` | Export CostTracker, getCostTrackingCallbacks |
| `agents/companion-runner.ts` | Use callback-based cost recording |
| `agents/persona-agent.ts` | Pass invokingUserId |
| `handlers/ai-usage-handlers.ts` | Use upsertPartial for atomicity |
| `repositories/ai-budget-repository.ts` | Add upsertPartial method |
| `services/ai-cost-service.ts` | Await alert check, remove dead code |
| `services/ai-budget-service.ts` | Add openrouter: prefix to model map |
| `services/embedding-service.ts` | Add functionId parameter |
| `services/search-service.ts` | Pass search-query functionId |
| `services/memo-service.ts` | Pass memo-embedding functionId |
| `workers/embedding-worker.ts` | Pass message-embedding functionId |
| `lib/boundary-extraction/types.ts` | Make workspaceId required |
| `lib/boundary-extraction/llm-extractor.ts` | Remove workspaceId conditional |
| `lib/memo/classifier.ts` | Make workspaceId required |
| `lib/memo/memorizer.ts` | Make workspaceId required |
| `lib/ai/ai.test.ts` | Fix assert chains (INV-24) |
| `frontend/pages/ai-usage-admin.tsx` | Add useEffect for state sync |

## Test plan

- [x] Unit tests pass
- [x] Assistant usage shows correctly in UI (verified user_id populated)
- [x] Budget updates work atomically

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
