### PR TITLE
fix: quick switcher paste now inserts at cursor instead of replacing

### DIFF
--- a/apps/frontend/src/components/quick-switcher/rich-input.tsx
+++ b/apps/frontend/src/components/quick-switcher/rich-input.tsx
@@ -58,8 +58,6 @@ export const STREAM_TRIGGERS: TriggerType[] = ["statusFilter", "filterType"]
 export interface RichInputProps {
   value: string
   onChange: (value: string) => void
-  /** Called when text is pasted, with the normalized pasted text */
-  onPaste?: (text: string) => void
   /** Called when Enter is pressed and no suggestion popover is open.
    *  withModifier is true if Cmd/Ctrl was held (for "open in new tab" behavior).
    */
@@ -103,7 +101,6 @@ export const RichInput = forwardRef<RichInputRef, RichInputProps>(function RichI
   {
     value,
     onChange,
-    onPaste,
     onSubmit,
     onPopoverActiveChange,
     triggers = [],
@@ -276,26 +273,6 @@ export const RichInput = forwardRef<RichInputRef, RichInputProps>(function RichI
           }
           // No onSubmit handler - let event bubble to parent for handling
           return false
-        }
-        return false
-      },
-      handlePaste: (_view, event) => {
-        // Paste as plain text with prefix normalization
-        const text = event.clipboardData?.getData("text/plain")
-        if (text && onPaste) {
-          event.preventDefault()
-          // Normalize multiple mode prefixes to one: "?? food" → "? food", "> > cmd" → "> cmd"
-          // But keep the prefix so mode detection works (pasting "food" should switch to stream mode)
-          const normalized = text
-            .replace(/^([?>][\s?>]*)+/, (match) => {
-              const prefix = match.trim()[0]
-              return prefix ? `${prefix} ` : ""
-            })
-            .trimEnd()
-          // Call onPaste with full normalized text (including any prefix)
-          // Parent handles mode switching based on prefix
-          onPaste(normalized)
-          return true
         }
         return false
       },


### PR DESCRIPTION
## Problem

The quick switcher had two related paste/input bugs:

1. **Paste replaced entire input instead of inserting at cursor** - When pasting text in search or command mode, the entire query was replaced with the pasted content. For example, if you had `? Hello` and wanted to paste `, world` at the end, you'd get `? , world` instead of `? Hello, world`.

2. **Cursor jumped to end on mode switch** - When typing `>` or `?` to switch modes, or removing a prefix, the cursor would jump to the end of the input, which was jarring UX.

Root causes:
- We were hijacking paste events with `handlePaste` in `rich-input.tsx` and calling `onPaste(normalized)` which replaced the entire query via `setQuery(text)`
- An effect in `quick-switcher.tsx` called `focus("end")` whenever the mode changed

## Solution

Let TipTap handle paste natively (insert at cursor) and apply normalization in `onChange` instead.

### Key design decisions

**1. Remove paste hijacking entirely**

Instead of intercepting paste events to normalize content and manage mode switching, we now let TipTap handle paste like any native text input. The normalization logic moved to `onChange` where it applies to all text changes uniformly.

**2. Normalize in onChange, not on paste**

Two normalizations happen on every text change:
- Remove redundant prefixes: `"? ? foo"` → `"? foo"` (handles select-all + paste of prefixed text)
- Ensure space after prefix: `"?foo"` → `"? foo"` (TipTap strips trailing whitespace from `"? "`)

**3. Remove mode-change focus effect**

The effect that refocused the input on mode change was originally needed when we had separate input components for different modes. Since we now use `RichInput` for all modes, this effect only caused cursor jumping and was removed.

## Modified files

| File | Change |
|------|--------|
| `rich-input.tsx` | Remove `onPaste` prop and `handlePaste` handler |
| `quick-switcher.tsx` | Remove `onPaste` prop, remove mode-change focus effect, enhance `onChange` normalization |
| `quick-switcher.integration.test.tsx` | Update existing paste test, add 5 new tests for paste behavior |

## Test plan

- [x] All 69 integration tests pass
- [x] All 33 unit tests pass
- [x] Manual testing: paste inserts at cursor in all modes
- [x] Manual testing: cursor stays in place when typing mode prefix
- [x] Manual testing: redundant prefix normalization works (`? ? foo` → `? foo`)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
