### PR TITLE
refactor: consolidate code-review skill from 6 agents to 1

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -147,10 +147,11 @@ First, fetch the old comment body:
 gh api repos/<OWNER>/<REPO>/issues/comments/[ID] --jq '.body'
 ```
 
-Then update it to preserve the old review in a collapsible block:
+Then update it to preserve the old review in a collapsible block (use heredoc to avoid quoting issues):
 
 ```bash
-gh api repos/<OWNER>/<REPO>/issues/comments/[ID] -X PATCH -f body='<!-- unified-review:superseded -->
+gh api repos/<OWNER>/<REPO>/issues/comments/[ID] -X PATCH -f body="$(cat <<'EOFBODY'
+<!-- unified-review:superseded -->
 **[New review available here](NEW_COMMENT_URL)**
 
 <details>
@@ -158,7 +159,9 @@ gh api repos/<OWNER>/<REPO>/issues/comments/[ID] -X PATCH -f body='<!-- unified-
 
 [OLD_COMMENT_BODY goes here, with the <!-- unified-review --> marker removed]
 
-</details>'
+</details>
+EOFBODY
+)"
 ```
 
 **Final Output** - Return ONLY this structured summary:


### PR DESCRIPTION
## Summary

- Consolidates 6 parallel review agents into a single Sonnet 4.5 agent
- Single agent reviews from all 6 perspectives (code, security, testing, performance, accessibility, reactivity)
- Agent posts comment directly to GitHub instead of passing content back
- Adds confidence score (1-7) to rate overall PR quality

## Why

The previous approach spawned 6 parallel agents, each doing their own code exploration. This consumed ~30% of token quota per review. The new approach:

- One code exploration pass instead of six
- Shared context across all review perspectives
- Only structured summary returned to orchestrator (~10 lines vs full reports)
- Uses Sonnet 4.5 (cheaper than Opus)

## Test plan

- [ ] Run `/code-review` on this PR to verify it works
- [ ] Verify comment is posted with confidence score
- [ ] Compare token usage to previous approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)