### PR TITLE
test: validate code review skill catches leaky abstractions

### DIFF
--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -917,7 +917,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ workspaceId }: SidebarProps) {
-  const { phase } = useCoordinatedLoading()
+  const { isLoading: coordLoading, hasCompletedInitialLoad } = useCoordinatedLoading()
   const {
     viewMode,
     setViewMode,
@@ -1056,7 +1056,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   }, [setSidebarHeight, setScrollContainerOffset])
 
   // During initial coordinated loading, show skeleton
-  if (phase !== "ready") {
+  if (coordLoading && !hasCompletedInitialLoad) {
     return (
       <SidebarShell
         header={<HeaderSkeleton />}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -23,7 +23,5 @@ export {
   CoordinatedLoadingGate,
   MainContentGate,
   useCoordinatedLoading,
-  type CoordinatedPhase,
-  type StreamState,
 } from "./coordinated-loading-context"
 export { SidebarProvider, useSidebar, type ViewMode, type UrgencyBlock } from "./sidebar-context"


### PR DESCRIPTION
## Purpose

This is a test PR to validate that the updated `/code-review` skill correctly catches leaky abstractions.

## What this PR does

Intentionally introduces a leaky abstraction in `CoordinatedLoadingContext`:

**Leaky API (this PR):**
```typescript
interface CoordinatedLoadingContextValue {
  isLoading: boolean
  showSkeleton: boolean
  hasCompletedInitialLoad: boolean
  // ...
}
```

**Clean API (what it should be):**
```typescript
interface CoordinatedLoadingContextValue {
  phase: "loading" | "skeleton" | "ready"
  // ...
}
```

## Expected outcome

Agent #6 (Abstraction Design) should flag this PR with feedback like:
> "Leaky abstraction: Context exposes implementation details. Consumers must combine `isLoading`, `showSkeleton`, `hasCompletedInitialLoad` with complex boolean logic. Suggest using `phase: 'loading' | 'skeleton' | 'ready'` instead."

## After testing

This PR will be closed without merging.