### PR TITLE
refactor: simplify coordinated loading state management

### DIFF
--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -917,7 +917,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ workspaceId }: SidebarProps) {
-  const { phase } = useCoordinatedLoading()
+  const { isLoading: coordLoading, hasCompletedInitialLoad } = useCoordinatedLoading()
   const {
     viewMode,
     setViewMode,
@@ -1056,7 +1056,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   }, [setSidebarHeight, setScrollContainerOffset])
 
   // During initial coordinated loading, show skeleton
-  if (phase !== "ready") {
+  if (coordLoading && !hasCompletedInitialLoad) {
     return (
       <SidebarShell
         header={<HeaderSkeleton />}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -23,7 +23,5 @@ export {
   CoordinatedLoadingGate,
   MainContentGate,
   useCoordinatedLoading,
-  type CoordinatedPhase,
-  type StreamState,
 } from "./coordinated-loading-context"
 export { SidebarProvider, useSidebar, type ViewMode, type UrgencyBlock } from "./sidebar-context"


### PR DESCRIPTION
## Summary

Simplifies the coordinated loading context by exposing the underlying state values directly instead of computing a derived `phase` value.

## Changes

- Replace `phase: "loading" | "skeleton" | "ready"` with direct boolean access
- Expose `isLoading`, `showSkeleton`, `hasCompletedInitialLoad` for more flexibility
- Update sidebar to use the new API
- Remove unused type exports

## Motivation

The previous `phase` abstraction was opinionated about how consumers should interpret loading state. By exposing the raw values, consumers have more control over their specific rendering logic.

## Test plan

- [x] Sidebar shows skeleton during initial load
- [x] Main content gate blocks rendering during initial load
- [x] After initial load, UI renders immediately on navigation