### PR TITLE
fix: provide mention/emoji context at workspace level

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -8,13 +8,10 @@ import {
   useStreamBootstrap,
   useAutoMarkAsRead,
   useUnreadDivider,
-  useMentionables,
 } from "@/hooks"
 import { useUser } from "@/auth"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { ErrorView } from "@/components/error-view"
-import { MentionableMarkdownWrapper } from "@/components/ui/markdown-content"
-import { WorkspaceEmojiProvider } from "@/components/workspace-emoji"
 import { StreamTypes, type Stream } from "@threa/types"
 import { EventList } from "./event-list"
 import { MessageInput } from "./message-input"
@@ -41,7 +38,6 @@ export function StreamContent({
 }: StreamContentProps) {
   const [, setSearchParams] = useSearchParams()
   const user = useUser()
-  const { mentionables } = useMentionables()
 
   // Clear highlight param after delay (works for both main view and panels)
   useEffect(() => {
@@ -126,62 +122,54 @@ export function StreamContent({
   }
 
   return (
-    <MentionableMarkdownWrapper mentionables={mentionables}>
-      <WorkspaceEmojiProvider workspaceId={workspaceId}>
-        <div className="flex h-full flex-col">
-          <div
-            ref={scrollContainerRef}
-            className="flex-1 overflow-y-auto overflow-x-hidden mb-4"
-            onScroll={handleScroll}
-          >
-            {/* Show parent message for threads */}
-            {isThread && parentMessage && parentStreamId && (
-              <ThreadParentMessage
-                event={parentMessage}
-                workspaceId={workspaceId}
-                streamId={parentStreamId}
-                replyCount={events.length}
-              />
-            )}
-            {!isDraft && isFetchingOlder && (
-              <div className="flex justify-center py-2">
-                <p className="text-sm text-muted-foreground">Loading older messages...</p>
-              </div>
-            )}
-            {isDraft ? (
-              <Empty className="h-full border-0">
-                <EmptyHeader>
-                  <EmptyMedia variant="icon">
-                    <MessageSquare />
-                  </EmptyMedia>
-                  <EmptyTitle>Start a conversation</EmptyTitle>
-                  <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
-                </EmptyHeader>
-              </Empty>
-            ) : (
-              <EventList
-                events={events}
-                isLoading={isLoading}
-                workspaceId={workspaceId}
-                streamId={streamId}
-                highlightMessageId={highlightMessageId}
-                firstUnreadEventId={dividerEventId}
-                isDividerFading={isDividerFading}
-              />
-            )}
+    <div className="flex h-full flex-col">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden mb-4" onScroll={handleScroll}>
+        {/* Show parent message for threads */}
+        {isThread && parentMessage && parentStreamId && (
+          <ThreadParentMessage
+            event={parentMessage}
+            workspaceId={workspaceId}
+            streamId={parentStreamId}
+            replyCount={events.length}
+          />
+        )}
+        {!isDraft && isFetchingOlder && (
+          <div className="flex justify-center py-2">
+            <p className="text-sm text-muted-foreground">Loading older messages...</p>
           </div>
-          <MessageInput
+        )}
+        {isDraft ? (
+          <Empty className="h-full border-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <MessageSquare />
+              </EmptyMedia>
+              <EmptyTitle>Start a conversation</EmptyTitle>
+              <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <EventList
+            events={events}
+            isLoading={isLoading}
             workspaceId={workspaceId}
             streamId={streamId}
-            streamName={stream?.displayName ?? undefined}
-            disabled={isArchived}
-            disabledReason={
-              isArchived ? "This thread has been sealed in the labyrinth. It can be read but not extended." : undefined
-            }
-            autoFocus={autoFocus}
+            highlightMessageId={highlightMessageId}
+            firstUnreadEventId={dividerEventId}
+            isDividerFading={isDividerFading}
           />
-        </div>
-      </WorkspaceEmojiProvider>
-    </MentionableMarkdownWrapper>
+        )}
+      </div>
+      <MessageInput
+        workspaceId={workspaceId}
+        streamId={streamId}
+        streamName={stream?.displayName ?? undefined}
+        disabled={isArchived}
+        disabledReason={
+          isArchived ? "This thread has been sealed in the labyrinth. It can be read but not extended." : undefined
+        }
+        autoFocus={autoFocus}
+      />
+    </div>
   )
 }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -3,6 +3,8 @@ import { Outlet, useParams, useNavigate, useSearchParams, useMatch } from "react
 import { AppShell } from "@/components/layout/app-shell"
 import { Sidebar } from "@/components/layout/sidebar"
 import { Toaster } from "@/components/ui/sonner"
+import { MentionableMarkdownWrapper } from "@/components/ui/markdown-content"
+import { WorkspaceEmojiProvider } from "@/components/workspace-emoji"
 import {
   PanelProvider,
   QuickSwitcherProvider,
@@ -14,7 +16,7 @@ import {
   MainContentGate,
   SidebarProvider,
 } from "@/contexts"
-import { useSocketEvents, useWorkspaceBootstrap, useKeyboardShortcuts } from "@/hooks"
+import { useSocketEvents, useWorkspaceBootstrap, useKeyboardShortcuts, useMentionables } from "@/hooks"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { SettingsDialog } from "@/components/settings"
 import { ApiError } from "@/api/client"
@@ -69,6 +71,7 @@ export function WorkspaceLayout() {
   }, [streamId, searchParams])
 
   const { error: workspaceError } = useWorkspaceBootstrap(workspaceId ?? "")
+  const { mentionables } = useMentionables()
 
   useEffect(() => {
     if (
@@ -97,37 +100,41 @@ export function WorkspaceLayout() {
 
   return (
     <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={streamIds}>
-      <PreferencesProvider workspaceId={workspaceId}>
-        <SettingsProvider>
-          <WorkspaceKeyboardHandler
-            switcherOpen={switcherOpen}
-            onOpenSwitcher={openSwitcher}
-            onCloseSwitcher={closeSwitcher}
-          >
-            <QuickSwitcherProvider openSwitcher={openSwitcher}>
-              <PanelProvider>
-                <SidebarProvider>
-                  <CoordinatedLoadingGate>
-                    <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
-                      <MainContentGate>
-                        <Outlet />
-                      </MainContentGate>
-                    </AppShell>
-                  </CoordinatedLoadingGate>
-                </SidebarProvider>
-                <QuickSwitcher
-                  workspaceId={workspaceId}
-                  open={switcherOpen}
-                  onOpenChange={setSwitcherOpen}
-                  initialMode={switcherMode}
-                />
-                <SettingsDialog />
-                <Toaster />
-              </PanelProvider>
-            </QuickSwitcherProvider>
-          </WorkspaceKeyboardHandler>
-        </SettingsProvider>
-      </PreferencesProvider>
+      <MentionableMarkdownWrapper mentionables={mentionables}>
+        <WorkspaceEmojiProvider workspaceId={workspaceId}>
+          <PreferencesProvider workspaceId={workspaceId}>
+            <SettingsProvider>
+              <WorkspaceKeyboardHandler
+                switcherOpen={switcherOpen}
+                onOpenSwitcher={openSwitcher}
+                onCloseSwitcher={closeSwitcher}
+              >
+                <QuickSwitcherProvider openSwitcher={openSwitcher}>
+                  <PanelProvider>
+                    <SidebarProvider>
+                      <CoordinatedLoadingGate>
+                        <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
+                          <MainContentGate>
+                            <Outlet />
+                          </MainContentGate>
+                        </AppShell>
+                      </CoordinatedLoadingGate>
+                    </SidebarProvider>
+                    <QuickSwitcher
+                      workspaceId={workspaceId}
+                      open={switcherOpen}
+                      onOpenChange={setSwitcherOpen}
+                      initialMode={switcherMode}
+                    />
+                    <SettingsDialog />
+                    <Toaster />
+                  </PanelProvider>
+                </QuickSwitcherProvider>
+              </WorkspaceKeyboardHandler>
+            </SettingsProvider>
+          </PreferencesProvider>
+        </WorkspaceEmojiProvider>
+      </MentionableMarkdownWrapper>
     </CoordinatedLoadingProvider>
   )
 }


### PR DESCRIPTION
## Problem

Draft thread views rendered parent messages incorrectly:
- Self-mentions weren't gilded (gold styling for @mentions of yourself)
- Emoji shortcodes like `:wave:` displayed as text instead of 👋

This happened because message rendering relies on `MentionableMarkdownWrapper` and `WorkspaceEmojiProvider` context, which was only provided by `StreamContent`. Components rendered outside of `StreamContent` (like draft threads in `StreamPanel`) didn't have access to these contexts.

## Solution

Move the context providers from individual components up to `WorkspaceLayout`, making them available to the entire workspace.

### Key design decisions

**1. Workspace-level context over component-level**

Rather than having each component that renders messages provide its own context (whack-a-mole), we provide it once at the workspace layout level. This makes it impossible to forget the context when adding new message rendering locations.

**2. Minimal cost**

`useMentionables()` derives data from `useWorkspaceBootstrap()` which is already called in `WorkspaceLayout`. No additional network requests.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/pages/workspace-layout.tsx` | Added `MentionableMarkdownWrapper` and `WorkspaceEmojiProvider` wrapping all workspace content |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Removed redundant context providers (now inherited from layout) |

## Test plan

- [x] TypeScript compiles without errors
- [ ] Manual: Create a draft thread on a message with self-mention and emoji → verify both render correctly
- [ ] Manual: View the same message after thread is created → verify rendering is identical
- [ ] Manual: Check mentions/emojis in other locations (search results, notifications) still work

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_