### PR TITLE
fix: scratchpad renaming and sidebar categorization

### DIFF
--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -135,6 +135,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/streams", ...authed, stream.create)
   app.post("/api/workspaces/:workspaceId/streams/read-all", ...authed, workspace.markAllAsRead)
   app.get("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.get)
+  app.patch("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.update)
   app.get("/api/workspaces/:workspaceId/streams/:streamId/bootstrap", ...authed, stream.bootstrap)
   app.patch("/api/workspaces/:workspaceId/streams/:streamId/companion", ...authed, stream.updateCompanionMode)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/pin", ...authed, stream.pin)

--- a/apps/frontend/src/hooks/use-socket-events.ts
+++ b/apps/frontend/src/hooks/use-socket-events.ts
@@ -120,14 +120,14 @@ export function useSocketEvents(workspaceId: string) {
         return { ...old, stream: payload.stream }
       })
 
-      // Update workspace bootstrap cache (sidebar)
+      // Update workspace bootstrap cache (sidebar) - merge to preserve lastMessagePreview
       queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (old: unknown) => {
         if (!old || typeof old !== "object") return old
         const bootstrap = old as { streams?: Stream[] }
         if (!bootstrap.streams) return old
         return {
           ...bootstrap,
-          streams: bootstrap.streams.map((s) => (s.id === payload.stream.id ? payload.stream : s)),
+          streams: bootstrap.streams.map((s) => (s.id === payload.stream.id ? { ...s, ...payload.stream } : s)),
         }
       })
 
@@ -173,10 +173,10 @@ export function useSocketEvents(workspaceId: string) {
         if (!bootstrap.streams) return old
         // Only add if not already present
         if (bootstrap.streams.some((s) => s.id === payload.stream.id)) {
-          // Update existing entry
+          // Update existing entry - merge to preserve lastMessagePreview
           return {
             ...bootstrap,
-            streams: bootstrap.streams.map((s) => (s.id === payload.stream.id ? payload.stream : s)),
+            streams: bootstrap.streams.map((s) => (s.id === payload.stream.id ? { ...s, ...payload.stream } : s)),
           }
         }
         return {

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -191,7 +191,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         if (!wsBootstrap.streams) return old
         return {
           ...wsBootstrap,
-          streams: wsBootstrap.streams.map((s) => (s.id === streamId ? updatedStream : s)),
+          streams: wsBootstrap.streams.map((s) => (s.id === streamId ? { ...s, ...updatedStream } : s)),
         }
       })
     },


### PR DESCRIPTION
## Problem

Renaming a scratchpad via the UI didn't work:

1. **Missing backend route**: The PATCH endpoint for `/api/workspaces/:workspaceId/streams/:streamId` was never registered, causing 404 errors
2. **Cache corruption on rename**: After fixing the route, renamed scratchpads would jump from "Recent" to "Everything else" in the sidebar until page refresh

## Solution

### 1. Register missing PATCH route

The handler existed in `stream-handlers.ts` but was never wired up in `routes.ts`.

### 2. Preserve `lastMessagePreview` when updating stream cache

The sidebar's Smart view categorizes streams into "Recent" based on `lastMessagePreview.createdAt`. The bug:

1. User renames scratchpad → API returns stream without `lastMessagePreview` (not included in PATCH response)
2. Cache update **replaced** the entire stream object, losing the preview
3. Without `lastMessagePreview`, categorization falls through to "Everything else"
4. Refresh works because bootstrap endpoint includes the full `StreamWithPreview`

Fixed by **merging** instead of replacing: `{ ...existingStream, ...updatedStream }`

This preserves fields like `lastMessagePreview` that only come from the workspace bootstrap endpoint.

## Modified files

| File | Change |
|------|--------|
| `apps/backend/src/routes.ts` | Register missing PATCH route for stream updates |
| `apps/frontend/src/hooks/use-stream-or-draft.ts` | Merge stream data in rename callback to preserve `lastMessagePreview` |
| `apps/frontend/src/hooks/use-socket-events.ts` | Merge stream data in `stream:updated` and `stream:unarchived` socket handlers |

## Test plan

- [x] Rename a scratchpad → stays in "Recent" section
- [x] Rename works without 404 error
- [x] Page refresh shows same state (no flash/jump)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
