### PR TITLE
fix: allow omitted reasoning in memo message classification schema

### DIFF
--- a/apps/backend/src/lib/ai/text-utils.test.ts
+++ b/apps/backend/src/lib/ai/text-utils.test.ts
@@ -70,7 +70,7 @@ describe("stripMarkdownFences", () => {
   test("converts snake_case to camelCase", async () => {
     const input = '{"is_gem": false, "knowledge_type": null}'
     const result = await stripMarkdownFences({ text: input })
-    expect(result).toBe('{"isGem":false,"knowledgeType":null,"confidence":0.5}')
+    expect(result).toBe('{"isGem":false,"knowledgeType":null,"reasoning":null,"confidence":0.5}')
   })
 
   test("maps classification field to isKnowledgeWorthy", async () => {

--- a/apps/backend/src/lib/ai/text-utils.ts
+++ b/apps/backend/src/lib/ai/text-utils.ts
@@ -61,6 +61,11 @@ function addDefaults(obj: Record<string, unknown>): Record<string, unknown> {
     }
   }
 
+  // Message classification often omits reasoning when isGem is false; default to null
+  if ("isGem" in obj && !("reasoning" in obj)) {
+    obj.reasoning = null
+  }
+
   // Default confidence if missing
   if (!("confidence" in obj)) {
     obj.confidence = 0.5

--- a/apps/backend/src/lib/memo/config.ts
+++ b/apps/backend/src/lib/memo/config.ts
@@ -34,7 +34,8 @@ export const MEMO_TEMPERATURES = {
 /**
  * Schema for message classification output.
  * OpenAI's strict mode requires ALL properties in `required`,
- * so we use `.nullable()` instead of `.optional()`.
+ * so we use `.nullable()` instead of `.optional()` for fields the model must emit.
+ * reasoning uses `.nullish()` because some models omit it when isGem is false.
  */
 export const messageClassificationSchema = z.object({
   isGem: z.boolean().describe("Whether this message is a standalone gem worth memorizing"),
@@ -43,7 +44,7 @@ export const messageClassificationSchema = z.object({
     .nullable()
     .describe(`Type of knowledge if isGem is true: ${KNOWLEDGE_TYPES.map((t) => `"${t}"`).join(" | ")}`),
   confidence: z.number().min(0).max(1).nullable().describe("Confidence in this classification (0.0 to 1.0)"),
-  reasoning: z.string().nullable().describe("Brief explanation of the classification decision"),
+  reasoning: z.string().nullish().describe("Brief explanation of the classification decision"),
 })
 
 export type MessageClassificationOutput = z.infer<typeof messageClassificationSchema>


### PR DESCRIPTION
## Problem

Memo batch processing fails when the classifier model returns a payload that omits the `reasoning` field. For example, `openai/gpt-oss-120b` returns `{"isGem":false,"knowledgeType":null,"confidence":0.5}` with no `reasoning` key. The schema used `z.string().nullable()`, which allows `string | null` but not `undefined`, so validation raised `NoObjectGeneratedError: Invalid input: expected string, received undefined` and the whole memo batch failed for that message.

## Solution

Relax the schema and harden the repair path so that omitted `reasoning` is accepted and defaulted.

### How it works

1. **Schema** (`messageClassificationSchema`): `reasoning` is now `z.string().nullish()` so the key may be missing or `null`. The classifier already normalizes with `value.reasoning ?? ""`, so downstream behavior is unchanged.
2. **Repair** (`addDefaults` in text-utils): For message-classification-shaped objects (`"isGem" in obj`), if `reasoning` is missing, set `obj.reasoning = null` before the AI SDK validates. That way validation sees a present key even when the model omits it.
3. **Tests**: The snake_case text-utils test expectation is updated to include `"reasoning":null` in the normalized output for that shape.

### Key design decisions

**1. Relax schema instead of only repair**

Making `reasoning` optional in the schema (`nullish`) matches real model behavior: some models skip explanation when `isGem` is false. Relying only on repair would leave validation fragile if repair ran after validation or on a different code path.

**2. Default reasoning in repair for message-classification shape**

`addDefaults` already handled `knowledgeType` and `confidence` for that shape. Adding `reasoning` there keeps all “model sometimes omits this” handling in one place and ensures the string we pass to the SDK always has the key when we’re in the message-classification case.

**3. No change to classifier output type**

`MessageClassification.reasoning` stays `string`. The classifier continues to use `value.reasoning ?? ""`, so callers still receive a string and no other code needs updates.

## Modified files

| File | Change |
| ------ | ------ |
| `apps/backend/src/lib/memo/config.ts` | `reasoning`: `z.string().nullable()` → `z.string().nullish()`, comment updated |
| `apps/backend/src/lib/ai/text-utils.ts` | In `addDefaults`, set `reasoning = null` when missing for objects with `isGem` |
| `apps/backend/src/lib/ai/text-utils.test.ts` | Snake_case test expectation updated to include `"reasoning":null` |

## Test plan

- [x] `bun test src/lib/ai/text-utils.test.ts` — all 16 tests pass
- [x] Manual: memo batch with a message that previously triggered the error (e.g. model omitting `reasoning`) now completes successfully

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
