### PR TITLE
fix: don't pin sidebar when clicking items in preview mode

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -87,7 +87,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
     isResizing,
     urgencyBlocks,
     setHovering,
-    pin,
     collapse,
     togglePinned,
     startResizing,
@@ -114,13 +113,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
       setHovering(false)
     }
   }, [setHovering, isMobile])
-
-  // Click on sidebar pins it (from preview or collapsed) - on mobile this just keeps it open
-  const handleSidebarClick = useCallback(() => {
-    if (!isPinned && !isMobile) {
-      pin()
-    }
-  }, [isPinned, pin, isMobile])
 
   // Close backdrop on mobile
   const handleBackdropClick = useCallback(() => {
@@ -267,7 +259,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             }}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            onClick={handleSidebarClick}
             role="navigation"
             aria-label="Sidebar navigation"
           >

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -73,8 +73,6 @@ interface SidebarContextValue {
   hidePreview: () => void
   /** Toggle between collapsed and pinned */
   togglePinned: () => void
-  /** Pin the sidebar (from preview or collapsed) */
-  pin: () => void
   /** Collapse the sidebar (from pinned) */
   collapse: () => void
   /** Set hovering state */
@@ -225,16 +223,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     })
   }, [clearHideTimeout, isMobile, updatePersistedState])
 
-  // Pin the sidebar (or show preview on mobile)
-  const pin = useCallback(() => {
-    clearHideTimeout()
-    const next = isMobile ? "preview" : "pinned"
-    setState(next)
-    if (!isMobile) {
-      updatePersistedState({ openState: "open" })
-    }
-  }, [clearHideTimeout, isMobile, updatePersistedState])
-
   // Collapse the sidebar
   const collapse = useCallback(() => {
     clearHideTimeout()
@@ -382,7 +370,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
         showPreview,
         hidePreview,
         togglePinned,
-        pin,
         collapse,
         setHovering,
         startResizing,

--- a/tests/browser/sidebar-preview.spec.ts
+++ b/tests/browser/sidebar-preview.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test"
+
+/**
+ * Tests that the sidebar preview mode works like Notion's sidebar:
+ * hovering near the left edge shows a preview, clicking inside it
+ * does NOT pin it open, and moving the mouse away collapses it.
+ *
+ * Pinning only happens via the explicit "Pin sidebar" topbar button.
+ */
+
+test.describe("Sidebar Preview Behavior", () => {
+  const testId = Date.now().toString(36)
+
+  async function loginAsAlice(page: import("@playwright/test").Page) {
+    await page.goto("/login")
+    await page.getByRole("button", { name: "Sign in with WorkOS" }).click()
+    await page.getByRole("button", { name: /Alice Anderson/ }).click()
+    await expect(page.getByText(/Welcome|Select a stream/)).toBeVisible()
+
+    const workspaceInput = page.getByPlaceholder("New workspace name")
+    if (await workspaceInput.isVisible()) {
+      await workspaceInput.fill(`Sidebar Preview ${testId}`)
+      await page.getByRole("button", { name: "Create Workspace" }).click()
+    }
+
+    await expect(page.getByRole("button", { name: "+ New Scratchpad" })).toBeVisible({ timeout: 10000 })
+  }
+
+  async function switchToAllView(page: import("@playwright/test").Page) {
+    const allButton = page.getByRole("button", { name: "All" })
+    await allButton.waitFor({ state: "visible", timeout: 3000 }).catch(() => {})
+    if (await allButton.isVisible()) {
+      await allButton.click()
+      await expect(page.getByRole("heading", { name: "Channels", level: 3 })).toBeVisible({ timeout: 5000 })
+    }
+  }
+
+  async function createChannel(page: import("@playwright/test").Page, channelName: string) {
+    page.once("dialog", async (dialog) => {
+      await dialog.accept(channelName)
+    })
+    await page.getByRole("button", { name: "+ New Channel" }).click()
+    await expect(page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({ timeout: 5000 })
+    await switchToAllView(page)
+    await expect(page.getByRole("link", { name: `#${channelName}` })).toBeVisible({ timeout: 5000 })
+  }
+
+  /** Hover near the left edge to trigger sidebar preview from collapsed state */
+  async function hoverToPreview(page: import("@playwright/test").Page) {
+    const viewport = page.viewportSize()!
+    await page.mouse.move(15, viewport.height / 2)
+  }
+
+  /** Move mouse to center of viewport (away from sidebar) */
+  async function moveAwayFromSidebar(page: import("@playwright/test").Page) {
+    const viewport = page.viewportSize()!
+    await page.mouse.move(viewport.width / 2, viewport.height / 2)
+  }
+
+  test("should not pin sidebar when clicking a channel in preview mode", async ({ page }) => {
+    await loginAsAlice(page)
+
+    const sidebar = page.getByRole("navigation", { name: "Sidebar navigation" })
+
+    // Set up: create a channel while sidebar is pinned
+    const channelName = `preview-test-${testId}`
+    await createChannel(page, channelName)
+
+    // Navigate away so the channel link becomes clickable in sidebar
+    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
+    await expect(page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({ timeout: 5000 })
+
+    // Collapse the sidebar via topbar
+    await page.getByRole("button", { name: "Collapse sidebar" }).click()
+    await expect(sidebar).toHaveCSS("width", "6px", { timeout: 3000 })
+
+    // Hover near left edge to trigger preview
+    await hoverToPreview(page)
+    await expect(sidebar).not.toHaveCSS("width", "6px", { timeout: 3000 })
+
+    // Click the channel link inside the previewed sidebar
+    await page.getByRole("link", { name: `#${channelName}` }).click()
+
+    // Sidebar should still be visible (mouse is over it)
+    await expect(sidebar).not.toHaveCSS("width", "6px")
+
+    // Move mouse away from sidebar
+    await moveAwayFromSidebar(page)
+
+    // Sidebar should collapse (proves it was preview, not pinned)
+    await expect(sidebar).toHaveCSS("width", "6px", { timeout: 3000 })
+  })
+
+  test("topbar pin button should still pin the sidebar", async ({ page }) => {
+    await loginAsAlice(page)
+
+    const sidebar = page.getByRole("navigation", { name: "Sidebar navigation" })
+
+    // Sidebar starts pinned
+    await expect(sidebar).not.toHaveCSS("width", "6px")
+
+    // Collapse via topbar
+    await page.getByRole("button", { name: "Collapse sidebar" }).click()
+    await expect(sidebar).toHaveCSS("width", "6px", { timeout: 3000 })
+
+    // Pin via topbar
+    await page.getByRole("button", { name: "Pin sidebar" }).click()
+    await expect(sidebar).not.toHaveCSS("width", "6px", { timeout: 3000 })
+
+    // Move mouse away - sidebar should stay open because it's pinned
+    await moveAwayFromSidebar(page)
+    await page.waitForTimeout(500)
+    await expect(sidebar).not.toHaveCSS("width", "6px")
+  })
+})


### PR DESCRIPTION
## Problem

Clicking anywhere inside the sidebar while it was in preview mode (hover-triggered overlay) would pin it open. This made the preview mode essentially useless — you couldn't quickly peek at the sidebar to click a channel and have it auto-collapse when you moved the mouse away.

## Solution

Remove the click-to-pin behavior on the sidebar `<aside>` element. The sidebar now behaves like Notion's sidebar:

1. **Collapsed** — hover near the left edge to preview
2. **Preview** — click channels, search, anything — sidebar stays in preview as long as the mouse is over it
3. **Collapses** — when the mouse leaves the sidebar area
4. **Pin explicitly** — only the topbar toggle button pins the sidebar open

### Key design decisions

**1. Remove click handler entirely rather than filtering specific interactions**

The simplest fix: remove `handleSidebarClick` and its `onClick` binding. No need to distinguish "intentional pin click" from "incidental interaction click" — if the user wants to pin, the topbar button is the explicit affordance.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/components/layout/app-shell.tsx` | Removed `handleSidebarClick` callback, its `onClick` binding on `<aside>`, and the unused `pin` destructuring |

## New files

| File | Purpose |
|------|---------|
| `tests/browser/sidebar-preview.spec.ts` | Playwright E2E tests verifying preview-mode click doesn't pin, and topbar pin button still works |

## Test plan

- [x] `should not pin sidebar when clicking a channel in preview mode` — collapses sidebar, hovers to preview, clicks channel, moves mouse away, verifies collapse
- [x] `topbar pin button should still pin the sidebar` — verifies explicit pin via topbar keeps sidebar open when mouse leaves

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
