### PR TITLE
feat: live progress on agent session cards

### DIFF
--- a/apps/backend/src/lib/trace-emitter.ts
+++ b/apps/backend/src/lib/trace-emitter.ts
@@ -38,6 +38,7 @@ export class TraceEmitter {
  */
 export class SessionTrace {
   private stepNumber = 0
+  private messageCount = 0
   private readonly sessionRoom: string
   private readonly streamRoom: string
   private readonly channelRoom: string | null
@@ -64,6 +65,7 @@ export class SessionTrace {
    */
   async startStep(params: { stepType: AgentStepType; content?: string }): Promise<ActiveStep> {
     this.stepNumber++
+    if (params.stepType === "message_sent") this.messageCount++
     const now = new Date()
 
     // Persist step row (started, not yet completed)
@@ -108,6 +110,7 @@ export class SessionTrace {
       triggerMessageId: this.params.triggerMessageId,
       personaName: this.params.personaName,
       stepCount: stepNumber,
+      messageCount: this.messageCount,
       currentStepType: stepType,
       threadStreamId: this.params.channelStreamId ? this.params.streamId : undefined,
     }

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -148,11 +148,14 @@ export function EventList({
     return item.event.id === firstUnreadEventId
   }
 
-  // Build sessionId → stepCount lookup from agentActivity (keyed by triggerMessageId)
-  const sessionStepCounts = new Map<string, number>()
+  // Build sessionId → live counts lookup from agentActivity (keyed by triggerMessageId)
+  const sessionLiveCounts = new Map<string, { stepCount: number; messageCount: number }>()
   if (agentActivity) {
     for (const activity of agentActivity.values()) {
-      sessionStepCounts.set(activity.sessionId, activity.stepCount)
+      sessionLiveCounts.set(activity.sessionId, {
+        stepCount: activity.stepCount,
+        messageCount: activity.messageCount,
+      })
     }
   }
 
@@ -179,7 +182,7 @@ export function EventList({
               <CommandEvent events={item.events} />
             ) : item.type === "session_group" ? (
               hideSessionCards ? null : (
-                <AgentSessionEvent events={item.events} liveStepCount={sessionStepCounts.get(item.sessionId)} />
+                <AgentSessionEvent events={item.events} liveCounts={sessionLiveCounts.get(item.sessionId)} />
               )
             ) : (
               <EventItem
@@ -187,7 +190,7 @@ export function EventList({
                 workspaceId={workspaceId}
                 streamId={streamId}
                 highlightMessageId={highlightMessageId}
-                agentActivity={agentActivity}
+                agentActivity={hideSessionCards ? agentActivity : undefined}
               />
             )}
           </div>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -93,10 +93,10 @@ export function StreamContent({
     { enabled: !isDraft }
   )
 
-  // In channels, agent responses go to threads — show inline activity on trigger messages
-  // and hide session cards (they belong in the thread). Other stream types show session cards directly.
+  // Track live agent session progress for all stream types (step/message counts on session cards).
+  // In channels, session cards are hidden (responses go to threads) and inline activity shows on trigger messages instead.
   const isChannel = stream?.type === StreamTypes.CHANNEL
-  const agentActivity = useAgentActivity(events, isChannel ? socket : null)
+  const agentActivity = useAgentActivity(events, socket)
 
   const { scrollContainerRef, handleScroll } = useScrollBehavior({
     isLoading,
@@ -165,7 +165,7 @@ export function StreamContent({
             highlightMessageId={highlightMessageId}
             firstUnreadEventId={dividerEventId}
             isDividerFading={isDividerFading}
-            agentActivity={isChannel ? agentActivity : undefined}
+            agentActivity={agentActivity}
             hideSessionCards={isChannel}
           />
         )}

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -17,6 +17,7 @@ export interface MessageAgentActivity {
   personaName: string
   currentStepType: AgentStepType | null
   stepCount: number
+  messageCount: number
   /** Thread stream ID for channel mentions - allows linking directly to thread */
   threadStreamId?: string
 }
@@ -29,6 +30,7 @@ interface ProgressEntry {
   personaName: string
   currentStepType: AgentStepType | null
   stepCount: number
+  messageCount: number
   threadStreamId?: string
 }
 
@@ -109,6 +111,7 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
         personaName: payload.personaName,
         currentStepType: null,
         stepCount: 0,
+        messageCount: 0,
         threadStreamId: payload.threadStreamId,
       })
       return next
@@ -124,6 +127,7 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
         personaName: payload.personaName,
         currentStepType: payload.currentStepType,
         stepCount: payload.stepCount,
+        messageCount: payload.messageCount,
         threadStreamId: payload.threadStreamId,
       })
       return next
@@ -166,6 +170,7 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
         personaName: progress?.personaName ?? session.personaName,
         currentStepType: progress?.currentStepType ?? null,
         stepCount: progress?.stepCount ?? 0,
+        messageCount: progress?.messageCount ?? 0,
         threadStreamId: progress?.threadStreamId,
       })
     }
@@ -178,6 +183,7 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
         personaName: progress.personaName,
         currentStepType: progress.currentStepType,
         stepCount: progress.stepCount,
+        messageCount: progress.messageCount,
         threadStreamId: progress.threadStreamId,
       })
     }

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -73,6 +73,7 @@ export interface AgentSessionProgressPayload {
   triggerMessageId: string
   personaName: string
   stepCount: number
+  messageCount: number
   currentStepType: AgentStepType
   /** Thread stream ID for channel mentions - allows frontend to link directly to thread */
   threadStreamId?: string


### PR DESCRIPTION
## Problem

When the companion agent is running, the agent session card in the message timeline shows only "Ariadne is working..." with a blank subtitle. No progress information is displayed until the session completes, at which point it shows the full summary ("3 steps • 3.9s • 1 message sent"). This makes the running state feel unresponsive.

## Solution

Show live step and message counts on the session card while the agent is running. Duration is intentionally excluded during execution (it was visually noisy with constant updates) and only appears on completion.

**Running state:** `Ariadne is working...` / `2 steps • 1 message sent`
**Completed state:** `Session complete` / `3 steps • 3.9s • 1 message sent` _(unchanged)_

### How it works

1. Backend `SessionTrace` tracks `messageCount` (incremented when a `message_sent` step starts) and includes it in the `agent_session:progress` socket payload alongside the existing `stepCount`
2. Frontend `useAgentActivity` hook stores both counts from progress events
3. The session card component always shows both counts while running, defaulting to 0

### Key design decisions

**1. Enable socket subscription for all stream types**

Previously, `useAgentActivity` only received the socket for channel views (`isChannel ? socket : null`). This was because the hook was originally designed for channel inline indicators. Now it subscribes for all stream types so scratchpads/threads get live session card updates too.

**2. Separate concerns for inline indicators vs session cards**

The `agentActivity` data serves two purposes: session card live counts and inline "Ariadne is thinking" labels on trigger messages. Inline labels remain channel-only (where session cards are hidden), while session cards get live counts everywhere. This is enforced in `EventList` by only forwarding `agentActivity` to `EventItem` when `hideSessionCards` is true.

**3. Count messages at step start time**

`messageCount` increments when a `message_sent` step starts, not when it completes. This is slightly ahead of reality but acceptable for a progress indicator — the message is about to be sent.

## Modified files

| File | Change |
|------|--------|
| `packages/types/src/agent-trace.ts` | Add `messageCount` to `AgentSessionProgressPayload` |
| `apps/backend/src/lib/trace-emitter.ts` | Track and emit `messageCount` in progress payload |
| `apps/frontend/src/hooks/use-agent-activity.ts` | Store `messageCount` from socket events |
| `apps/frontend/src/components/timeline/event-list.tsx` | Pass `liveCounts` object; scope inline indicators to channels only |
| `apps/frontend/src/components/timeline/agent-session-event.tsx` | Accept `liveCounts`, always show steps + messages while running |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Enable socket for all stream types, pass activity to `EventList` always |

## Test plan

- [x] TypeScript compilation passes (no new errors)
- [ ] Manual: trigger agent session in scratchpad, verify card shows live step/message counts
- [ ] Manual: verify completed state still shows duration
- [ ] Manual: verify channel inline indicators still work (not shown in scratchpads)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
