### PR TITLE
feat: add outbox retention lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ PORT=3001
 # Logging
 LOG_LEVEL=info
 
+# Outbox retention lifecycle (optional)
+# OUTBOX_RETENTION_INTERVAL_MS=300000
+# OUTBOX_RETENTION_WINDOW_MS=604800000
+# OUTBOX_RETENTION_BATCH_SIZE=1000
+# OUTBOX_RETENTION_MAX_BATCHES_PER_RUN=10
+
 # S3 Storage (uses MinIO locally via docker-compose)
 S3_BUCKET=threa-uploads
 S3_REGION=us-east-1

--- a/apps/backend/src/db/migrations/20260209160355_outbox_retention_indexes.sql
+++ b/apps/backend/src/db/migrations/20260209160355_outbox_retention_indexes.sql
@@ -1,0 +1,5 @@
+-- Outbox retention support indexes
+-- Enables efficient watermark + retention window cleanup scans
+
+CREATE INDEX IF NOT EXISTS idx_outbox_retention_cutoff
+    ON outbox (created_at, id);

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -1,5 +1,6 @@
 export { OutboxDispatcher, type OutboxHandler, type OutboxDispatcherConfig } from "./dispatcher"
 export { BroadcastHandler, type BroadcastHandlerConfig } from "./broadcast-handler"
+export { OutboxRetentionWorker, type OutboxRetentionWorkerConfig } from "./retention-worker"
 export { parseMessageCreatedPayload, type NormalizedMessageCreatedPayload } from "./payload-parsers"
 export {
   OutboxRepository,

--- a/apps/backend/src/lib/outbox/retention-worker.ts
+++ b/apps/backend/src/lib/outbox/retention-worker.ts
@@ -1,0 +1,137 @@
+import type { Pool } from "pg"
+import { Ticker } from "../queue/ticker"
+import { logger } from "../logger"
+import { OutboxRepository } from "./repository"
+
+export interface OutboxRetentionWorkerConfig {
+  listenerIds: string[]
+  intervalMs: number
+  retentionMs: number
+  batchSize: number
+  maxBatchesPerRun: number
+}
+
+const DEFAULT_CONFIG: Omit<OutboxRetentionWorkerConfig, "listenerIds"> = {
+  intervalMs: 300000,
+  retentionMs: 7 * 24 * 60 * 60 * 1000,
+  batchSize: 1000,
+  maxBatchesPerRun: 10,
+}
+
+/**
+ * Periodically purges outbox rows that are:
+ * 1) Older than retention window, and
+ * 2) At or below the minimum listener cursor.
+ */
+export class OutboxRetentionWorker {
+  private readonly ticker: Ticker
+  private readonly config: OutboxRetentionWorkerConfig
+
+  constructor(
+    private readonly pool: Pool,
+    config: Partial<Omit<OutboxRetentionWorkerConfig, "listenerIds">> & Pick<OutboxRetentionWorkerConfig, "listenerIds">
+  ) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      listenerIds: [...new Set(config.listenerIds)],
+    }
+
+    if (this.config.listenerIds.length === 0) {
+      throw new Error("OutboxRetentionWorker requires at least one listener ID")
+    }
+
+    if (this.config.intervalMs <= 0) {
+      throw new Error(`OutboxRetentionWorker intervalMs must be > 0, got ${this.config.intervalMs}`)
+    }
+
+    if (this.config.retentionMs <= 0) {
+      throw new Error(`OutboxRetentionWorker retentionMs must be > 0, got ${this.config.retentionMs}`)
+    }
+
+    if (this.config.batchSize <= 0) {
+      throw new Error(`OutboxRetentionWorker batchSize must be > 0, got ${this.config.batchSize}`)
+    }
+
+    if (this.config.maxBatchesPerRun <= 0) {
+      throw new Error(`OutboxRetentionWorker maxBatchesPerRun must be > 0, got ${this.config.maxBatchesPerRun}`)
+    }
+
+    this.ticker = new Ticker({
+      name: "outbox-retention",
+      intervalMs: this.config.intervalMs,
+      maxConcurrency: 1,
+    })
+  }
+
+  start(): void {
+    this.ticker.start(() => this.cleanup())
+    logger.info(
+      {
+        intervalMs: this.config.intervalMs,
+        retentionMs: this.config.retentionMs,
+        batchSize: this.config.batchSize,
+        maxBatchesPerRun: this.config.maxBatchesPerRun,
+        listenerIds: this.config.listenerIds,
+      },
+      "OutboxRetentionWorker started"
+    )
+  }
+
+  async stop(): Promise<void> {
+    this.ticker.stop()
+    await this.ticker.drain()
+    logger.info("OutboxRetentionWorker stopped")
+  }
+
+  isRunning(): boolean {
+    return this.ticker.isRunning()
+  }
+
+  private async cleanup(): Promise<void> {
+    try {
+      const retentionCutoff = new Date(Date.now() - this.config.retentionMs)
+      const watermark = await OutboxRepository.getRetentionWatermark(this.pool, this.config.listenerIds)
+
+      if (watermark === null || watermark <= 0n) {
+        return
+      }
+
+      let totalDeleted = 0
+      let batches = 0
+
+      while (batches < this.config.maxBatchesPerRun) {
+        const deleted = await OutboxRepository.deleteRetainedEvents(this.pool, {
+          maxEventId: watermark,
+          createdBefore: retentionCutoff,
+          limit: this.config.batchSize,
+        })
+
+        if (deleted === 0) {
+          break
+        }
+
+        totalDeleted += deleted
+        batches += 1
+
+        if (deleted < this.config.batchSize) {
+          break
+        }
+      }
+
+      if (totalDeleted > 0) {
+        logger.info(
+          {
+            deleted: totalDeleted,
+            batches,
+            watermark: watermark.toString(),
+            retentionCutoff: retentionCutoff.toISOString(),
+          },
+          "Outbox retention cleanup completed"
+        )
+      }
+    } catch (err) {
+      logger.error({ err }, "Outbox retention cleanup failed")
+    }
+  }
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -46,7 +46,7 @@ import {
 } from "./features/conversations"
 import { UserPreferencesService } from "./features/user-preferences"
 import { createS3Storage } from "./lib/storage/s3-client"
-import { OutboxDispatcher, BroadcastHandler } from "./lib/outbox"
+import { OutboxDispatcher, BroadcastHandler, OutboxRetentionWorker } from "./lib/outbox"
 import {
   CompanionHandler,
   MentionInvokeHandler,
@@ -503,33 +503,37 @@ export async function startServer(): Promise<ServerInstance> {
   const commandHandler = new CommandHandler(pool, jobQueue)
   const mentionInvokeHandler = new MentionInvokeHandler(pool, jobQueue)
   const attachmentUploadedHandler = new AttachmentUploadedHandler(pool, jobQueue)
+  const outboxHandlers = [
+    broadcastHandler,
+    companionHandler,
+    namingHandler,
+    emojiUsageHandler,
+    embeddingHandler,
+    boundaryExtractionHandler,
+    memoAccumulatorHandler,
+    commandHandler,
+    mentionInvokeHandler,
+    attachmentUploadedHandler,
+  ]
 
-  // Ensure listeners exist in database
-  await broadcastHandler.ensureListener()
-  await companionHandler.ensureListener()
-  await namingHandler.ensureListener()
-  await emojiUsageHandler.ensureListener()
-  await embeddingHandler.ensureListener()
-  await boundaryExtractionHandler.ensureListener()
-  await memoAccumulatorHandler.ensureListener()
-  await commandHandler.ensureListener()
-  await mentionInvokeHandler.ensureListener()
-  await attachmentUploadedHandler.ensureListener()
+  // Ensure listeners exist in database, then register all handlers
+  for (const handler of outboxHandlers) {
+    await handler.ensureListener()
+    outboxDispatcher.register(handler)
+  }
 
-  // Register all handlers with dispatcher
-  outboxDispatcher.register(broadcastHandler)
-  outboxDispatcher.register(companionHandler)
-  outboxDispatcher.register(namingHandler)
-  outboxDispatcher.register(emojiUsageHandler)
-  outboxDispatcher.register(embeddingHandler)
-  outboxDispatcher.register(boundaryExtractionHandler)
-  outboxDispatcher.register(memoAccumulatorHandler)
-  outboxDispatcher.register(commandHandler)
-  outboxDispatcher.register(mentionInvokeHandler)
-  outboxDispatcher.register(attachmentUploadedHandler)
+  // Outbox retention lifecycle - purge rows safe for all active listeners
+  const outboxRetentionWorker = new OutboxRetentionWorker(pool, {
+    listenerIds: outboxHandlers.map((handler) => handler.listenerId),
+    intervalMs: Number(process.env.OUTBOX_RETENTION_INTERVAL_MS) || 300000,
+    retentionMs: Number(process.env.OUTBOX_RETENTION_WINDOW_MS) || 7 * 24 * 60 * 60 * 1000,
+    batchSize: Number(process.env.OUTBOX_RETENTION_BATCH_SIZE) || 1000,
+    maxBatchesPerRun: Number(process.env.OUTBOX_RETENTION_MAX_BATCHES_PER_RUN) || 10,
+  })
 
   // Start single LISTEN connection that notifies all handlers
   await outboxDispatcher.start()
+  outboxRetentionWorker.start()
 
   const orphanSessionCleanup = createOrphanSessionCleanup(pools.main)
   orphanSessionCleanup.start()
@@ -558,6 +562,7 @@ export async function startServer(): Promise<ServerInstance> {
     agentSessionMetrics.stop()
     await scheduleManager.stop()
     await cleanupWorker.stop()
+    await outboxRetentionWorker.stop()
     await outboxDispatcher.stop()
     await jobQueue.stop()
     logger.info("Closing socket.io...")

--- a/apps/backend/tests/integration/outbox-repository.test.ts
+++ b/apps/backend/tests/integration/outbox-repository.test.ts
@@ -80,4 +80,119 @@ describe("OutboxRepository", () => {
       })
     })
   })
+
+  describe("OutboxRepository.getRetentionWatermark", () => {
+    test("should return minimum cursor when all listeners exist", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const listenerA = `test_listener_a_${crypto.randomUUID()}`
+        const listenerB = `test_listener_b_${crypto.randomUUID()}`
+
+        await client.query("INSERT INTO outbox_listeners (listener_id, last_processed_id) VALUES ($1, $2), ($3, $4)", [
+          listenerA,
+          "42",
+          listenerB,
+          "7",
+        ])
+
+        const watermark = await OutboxRepository.getRetentionWatermark(client, [listenerA, listenerB])
+        expect(watermark).toBe(7n)
+      })
+    })
+
+    test("should return null when any listener is missing", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const existingListener = `test_listener_existing_${crypto.randomUUID()}`
+        const missingListener = `test_listener_missing_${crypto.randomUUID()}`
+
+        await client.query("INSERT INTO outbox_listeners (listener_id, last_processed_id) VALUES ($1, $2)", [
+          existingListener,
+          "100",
+        ])
+
+        const watermark = await OutboxRepository.getRetentionWatermark(client, [existingListener, missingListener])
+        expect(watermark).toBeNull()
+      })
+    })
+  })
+
+  describe("OutboxRepository.deleteRetainedEvents", () => {
+    const testEventPayload = (streamId: string) => ({
+      workspaceId: "ws_test",
+      streamId,
+      event: {
+        id: `evt_test_${Date.now()}_${Math.random()}`,
+        streamId,
+        sequence: 1n,
+        eventType: "message_created" as const,
+        payload: { messageId: `msg_test_${Date.now()}`, content: "test" },
+        actorId: "usr_test",
+        actorType: "user" as const,
+        createdAt: new Date(),
+      },
+    })
+
+    test("should delete only rows at or below watermark and older than cutoff", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const baselineResult = await client.query("SELECT COALESCE(MAX(id), 0) as max_id FROM outbox")
+        const baselineId = BigInt(baselineResult.rows[0].max_id)
+
+        const first = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_1"))
+        const second = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_2"))
+        const third = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_3"))
+
+        const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+        await client.query("UPDATE outbox SET created_at = $1 WHERE id > $2", [oldDate, baselineId.toString()])
+
+        const deleted = await OutboxRepository.deleteRetainedEvents(client, {
+          maxEventId: second.id,
+          createdBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          limit: 100,
+        })
+
+        const remaining = await OutboxRepository.fetchAfterId(client, baselineId, 10)
+        const want = {
+          deleted: 2,
+          remainingEventIds: [third.id],
+          remainingEventTypes: ["message:created"],
+        }
+
+        expect({
+          deleted,
+          remainingEventIds: remaining.map((event) => event.id),
+          remainingEventTypes: remaining.map((event) => event.eventType),
+        }).toEqual(want)
+      })
+    })
+
+    test("should respect batch limit", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const baselineResult = await client.query("SELECT COALESCE(MAX(id), 0) as max_id FROM outbox")
+        const baselineId = BigInt(baselineResult.rows[0].max_id)
+
+        let latestId = baselineId
+        for (let i = 0; i < 5; i++) {
+          const inserted = await OutboxRepository.insert(client, "message:created", testEventPayload(`stream_${i}`))
+          latestId = inserted.id
+        }
+
+        const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+        await client.query("UPDATE outbox SET created_at = $1 WHERE id > $2", [oldDate, baselineId.toString()])
+
+        const deleted = await OutboxRepository.deleteRetainedEvents(client, {
+          maxEventId: latestId,
+          createdBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          limit: 2,
+        })
+
+        const remaining = await OutboxRepository.fetchAfterId(client, baselineId, 10)
+        expect({
+          deleted,
+          remainingCount: remaining.length,
+        }).toEqual({
+          deleted: 2,
+          remainingCount: 3,
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Problem

The outbox table had no retention lifecycle. It was append-only with no purge/archive strategy, so table and index growth were unbounded over time.

## Solution

Add a watermark-based outbox retention worker that periodically purges rows only when they are safe to delete:
- safe for all registered outbox listeners (at or below min listener cursor)
- older than a configured retention window
- deleted in bounded batches

### How it works

1. Startup wiring builds a single list of active outbox handlers.
2. Those listener IDs are passed to `OutboxRetentionWorker`.
3. On each interval, worker computes retention cutoff (`now - retentionMs`) and listener watermark (`MIN(last_processed_id)`).
4. Worker deletes events where `id <= watermark` and `created_at < cutoff` in batches until exhausted or `maxBatchesPerRun` is reached.
5. Worker runs independently of dispatching and is stopped during graceful shutdown.

### Key design decisions

**1. Watermark safety over aggressive cleanup**

Retention uses the minimum cursor across all active listeners and returns `null` if any expected listener row is missing. This avoids deleting rows a lagging/missing listener still needs.

**2. Bounded batched deletes**

Cleanup uses configurable `batchSize` and `maxBatchesPerRun` to keep transactions short and avoid long table locks.

**3. Explicit startup listener set**

Server now derives listener IDs from the registered handler list, ensuring retention logic and runtime listeners stay aligned.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/lib/outbox/retention-worker.ts` | Periodic watermark+window retention worker for outbox cleanup |
| `apps/backend/src/db/migrations/20260209160355_outbox_retention_indexes.sql` | Adds outbox retention index for cutoff/id scans |

## Modified files

| File | Change |
| --- | --- |
| `.env.example` | Adds optional outbox retention env knobs |
| `apps/backend/src/lib/outbox/index.ts` | Exports retention worker |
| `apps/backend/src/lib/outbox/repository.ts` | Adds retention watermark and batched delete APIs |
| `apps/backend/src/server.ts` | Wires retention worker start/stop and listener ID source |
| `apps/backend/tests/integration/outbox-repository.test.ts` | Adds integration tests for watermark and delete semantics |

## Deleted files (if any)

None.

## Test plan

- [x] `cd apps/backend && bun test tests/integration/outbox-repository.test.ts`
- [x] `cd apps/backend && bun run typecheck`
- [x] `cd apps/backend && bun run lint` (passes with pre-existing warnings in unrelated files)
- [ ] Manual verification in a long-running dev environment (observe periodic outbox cleanup logs)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
