### PR TITLE
fix: cron tick determinism and ensureSchedule created flag

### DIFF
--- a/apps/backend/src/lib/queue/cron-repository.test.ts
+++ b/apps/backend/src/lib/queue/cron-repository.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test, vi } from "bun:test"
+import type { QueryResult, QueryResultRow } from "pg"
+import type { Querier } from "../../db"
+import { CronRepository } from "./cron-repository"
+
+interface EnsureScheduleRow extends QueryResultRow {
+  id: string
+  queue_name: string
+  interval_seconds: number
+  payload: unknown
+  workspace_id: string | null
+  next_tick_needed_at: Date
+  enabled: boolean
+  created_at: Date
+  updated_at: Date
+  created: boolean
+}
+
+function createEnsureScheduleRow(created: boolean): EnsureScheduleRow {
+  return {
+    id: "cron_01",
+    queue_name: "memo.batch.check",
+    interval_seconds: 30,
+    payload: { workspaceId: "system" },
+    workspace_id: null,
+    next_tick_needed_at: new Date("2026-02-09T10:00:00.000Z"),
+    enabled: true,
+    created_at: new Date("2026-02-09T09:59:00.000Z"),
+    updated_at: new Date("2026-02-09T09:59:00.000Z"),
+    created,
+  }
+}
+
+function createQuerierWithRow(row: EnsureScheduleRow): Querier {
+  const query = vi.fn(async () => {
+    return {
+      rows: [row],
+      rowCount: 1,
+    } as QueryResult<EnsureScheduleRow>
+  })
+
+  return {
+    query: query as Querier["query"],
+  }
+}
+
+describe("CronRepository.ensureSchedule", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("should return created=true when database reports inserted row", async () => {
+    const db = createQuerierWithRow(createEnsureScheduleRow(true))
+
+    const result = await CronRepository.ensureSchedule(db, {
+      id: "cron_01",
+      queueName: "memo.batch.check",
+      intervalSeconds: 30,
+      payload: { workspaceId: "system" },
+      workspaceId: null,
+    })
+
+    expect(result.created).toBe(true)
+  })
+
+  test("should return created=false when database reports existing row", async () => {
+    const db = createQuerierWithRow(createEnsureScheduleRow(false))
+
+    const result = await CronRepository.ensureSchedule(db, {
+      id: "cron_01",
+      queueName: "memo.batch.check",
+      intervalSeconds: 30,
+      payload: { workspaceId: "system" },
+      workspaceId: null,
+    })
+
+    expect(result.created).toBe(false)
+  })
+})

--- a/apps/backend/src/lib/queue/cron-repository.ts
+++ b/apps/backend/src/lib/queue/cron-repository.ts
@@ -160,7 +160,7 @@ export const CronRepository = {
     db: Querier,
     params: CreateScheduleParams
   ): Promise<{ schedule: CronSchedule; created: boolean }> {
-    const result = await db.query<CronScheduleRow & { xmax: string }>(
+    const result = await db.query<CronScheduleRow & { created: boolean }>(
       sql`
         INSERT INTO cron_schedules (
           id, queue_name, interval_seconds, payload, workspace_id
@@ -188,8 +188,7 @@ export const CronRepository = {
     )
 
     const row = result.rows[0]
-    // xmax = 0 means INSERT (new row), xmax > 0 means UPDATE (existing row)
-    const created = row.xmax === "0"
+    const created = row.created
 
     return {
       schedule: mapRowToSchedule(row),

--- a/apps/backend/src/lib/queue/schedule-manager.test.ts
+++ b/apps/backend/src/lib/queue/schedule-manager.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from "bun:test"
+import type { Pool } from "pg"
+import { ScheduleManager } from "./schedule-manager"
+import { CronRepository, type CronSchedule } from "./cron-repository"
+
+interface ScheduleManagerInternals {
+  generateTicks: () => Promise<void>
+}
+
+function createSchedule(overrides: Partial<CronSchedule> = {}): CronSchedule {
+  return {
+    id: "cron_test_1",
+    queueName: "memo.batch.check",
+    intervalSeconds: 30,
+    payload: { workspaceId: "system" },
+    workspaceId: null,
+    nextTickNeededAt: new Date("2026-02-09T10:00:00.000Z"),
+    enabled: true,
+    createdAt: new Date("2026-02-09T09:59:00.000Z"),
+    updatedAt: new Date("2026-02-09T09:59:00.000Z"),
+    ...overrides,
+  }
+}
+
+describe("ScheduleManager", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("should create ticks using deterministic nextTickNeededAt timestamps", async () => {
+    const schedule = createSchedule()
+    const pool = {} as Pool
+
+    vi.spyOn(CronRepository, "findSchedulesNeedingTicks").mockResolvedValue([schedule])
+    const createTicksSpy = vi.spyOn(CronRepository, "createTicks").mockResolvedValue([])
+    const randomSpy = vi.spyOn(Math, "random")
+
+    const manager = new ScheduleManager(pool, {
+      lookaheadSeconds: 60,
+      batchSize: 100,
+      intervalMs: 1000,
+    })
+
+    await (manager as unknown as ScheduleManagerInternals).generateTicks()
+
+    expect(randomSpy).not.toHaveBeenCalled()
+    expect(createTicksSpy).toHaveBeenCalledWith(pool, {
+      schedules: [
+        {
+          scheduleId: schedule.id,
+          queueName: schedule.queueName,
+          payload: schedule.payload,
+          workspaceId: schedule.workspaceId,
+          executeAt: schedule.nextTickNeededAt,
+          intervalSeconds: schedule.intervalSeconds,
+        },
+      ],
+    })
+  })
+
+  test("should not create ticks when no schedules need generation", async () => {
+    const pool = {} as Pool
+    vi.spyOn(CronRepository, "findSchedulesNeedingTicks").mockResolvedValue([])
+    const createTicksSpy = vi.spyOn(CronRepository, "createTicks").mockResolvedValue([])
+
+    const manager = new ScheduleManager(pool, {
+      lookaheadSeconds: 60,
+      batchSize: 100,
+      intervalMs: 1000,
+    })
+
+    await (manager as unknown as ScheduleManagerInternals).generateTicks()
+
+    expect(createTicksSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

The distributed cron implementation had two correctness issues:

1. `ScheduleManager` generated `executeAt` with per-node random jitter, which makes the execution timestamp non-canonical across nodes and can break deterministic tick coordination.
2. `CronRepository.ensureSchedule()` returned `(xmax = 0) AS created` but read `row.xmax` in TypeScript, so the `created` flag could be incorrect.

## Solution

Made cron tick generation deterministic and fixed created-flag mapping in the upsert path.

### How it works

1. `ScheduleManager.generateTicks()` now uses `schedule.nextTickNeededAt` directly for `executeAt`.
2. `CronRepository.ensureSchedule()` now reads the SQL alias `created` from `RETURNING (xmax = 0) AS created`.
3. Added targeted unit tests to lock both behaviors.

### Key design decisions

**1. Remove jitter in schedule-manager tick generation**

The schedule row already defines the canonical due timestamp (`next_tick_needed_at`). Using that exact timestamp ensures consistent `(schedule_id, execute_at)` values across nodes and aligns with deterministic coordination.

**2. Treat SQL aliases as the source of truth for upsert metadata**

Instead of mixing aliasing and system-column reads, the repository now consumes the explicit `created` alias returned by SQL. This keeps the contract clear and avoids silent flag mismatches.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/lib/queue/schedule-manager.test.ts` | Verifies deterministic tick generation and no `Math.random()` usage. |
| `apps/backend/src/lib/queue/cron-repository.test.ts` | Verifies `ensureSchedule().created` for insert vs conflict-update paths. |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/lib/queue/schedule-manager.ts` | Removed random jitter and set `executeAt` to `nextTickNeededAt`. |
| `apps/backend/src/lib/queue/cron-repository.ts` | Fixed `ensureSchedule()` to read the returned `created` alias. |

## Deleted files (if any)

None.

## Test plan

- [x] `bun test apps/backend/src/lib/queue/schedule-manager.test.ts`
- [x] `bun test apps/backend/src/lib/queue/cron-repository.test.ts`
- [x] `bun run --cwd apps/backend typecheck`
- [ ] Manual verification steps

---

🤖 _PR by Claude Code_
