### PR TITLE
feat: auto-redirect single-workspace users from workspace picker

### DIFF
--- a/apps/frontend/src/pages/workspace-select.test.tsx
+++ b/apps/frontend/src/pages/workspace-select.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom"
+import { render, screen } from "@/test"
+import { WorkspaceSelectPage } from "./workspace-select"
+import type { Workspace } from "@threa/types"
+
+const mockUseAuth = vi.fn()
+const mockUseWorkspaces = vi.fn()
+const mockUseCreateWorkspace = vi.fn()
+
+vi.mock("@/auth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock("@/hooks", () => ({
+  useWorkspaces: () => mockUseWorkspaces(),
+  useCreateWorkspace: () => mockUseCreateWorkspace(),
+}))
+
+function WorkspaceRouteProbe() {
+  const { workspaceId } = useParams()
+  return <div data-testid="workspace-route">{workspaceId}</div>
+}
+
+function makeWorkspace(id: string, name: string): Workspace {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase(),
+    createdBy: "user_1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/workspaces"]}>
+      <Routes>
+        <Route path="/workspaces" element={<WorkspaceSelectPage />} />
+        <Route path="/w/:workspaceId" element={<WorkspaceRouteProbe />} />
+        <Route path="/login" element={<div data-testid="login-route">login</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("WorkspaceSelectPage", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseWorkspaces.mockReset()
+    mockUseCreateWorkspace.mockReset()
+
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "user_1",
+        email: "kris@example.com",
+        name: "Kris",
+        workosUserId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      loading: false,
+      error: null,
+    })
+
+    mockUseCreateWorkspace.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    })
+  })
+
+  it("should redirect to the only workspace when user has one workspace", async () => {
+    mockUseWorkspaces.mockReturnValue({
+      data: [makeWorkspace("workspace_1", "Solo")],
+      isLoading: false,
+      error: null,
+    })
+
+    renderPage()
+
+    expect(await screen.findByTestId("workspace-route")).toHaveTextContent("workspace_1")
+  })
+
+  it("should show workspace picker when user has multiple workspaces", () => {
+    mockUseWorkspaces.mockReturnValue({
+      data: [makeWorkspace("workspace_1", "Alpha"), makeWorkspace("workspace_2", "Beta")],
+      isLoading: false,
+      error: null,
+    })
+
+    renderPage()
+
+    expect(screen.getByText("Select a workspace to continue")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Alpha" })).toHaveAttribute("href", "/w/workspace_1")
+    expect(screen.getByRole("link", { name: "Beta" })).toHaveAttribute("href", "/w/workspace_2")
+  })
+})

--- a/apps/frontend/src/pages/workspace-select.tsx
+++ b/apps/frontend/src/pages/workspace-select.tsx
@@ -52,6 +52,10 @@ export function WorkspaceSelectPage() {
     )
   }
 
+  if (workspaces?.length === 1) {
+    return <Navigate to={`/w/${workspaces[0].id}`} replace />
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="flex flex-col items-center gap-8">


### PR DESCRIPTION
## Problem

Users who belong to exactly one workspace currently land on `/workspaces` and must perform an unnecessary extra click to enter that workspace.

## Solution

Add a single-workspace redirect in `WorkspaceSelectPage` so users with exactly one workspace are immediately navigated to `/w/:workspaceId`.

### How it works

1. `WorkspaceSelectPage` still handles auth/loading/error states first.
2. After data loads, it checks `workspaces?.length === 1`.
3. When true, it returns `<Navigate to={`/w/${workspaces[0].id}`} replace />`.
4. For multiple workspaces, the existing picker UI is preserved unchanged.

### Key design decisions

**1. Implement redirect in the workspace selection page, not by expanding route wiring**

Keeping the logic in `WorkspaceSelectPage` reuses existing auth/loading/error handling and avoids introducing a second source of truth for workspace list state in routing code.

**2. Add focused page tests for behavior branches**

Tests cover both the new single-workspace redirect and existing multi-workspace picker behavior to prevent regressions in navigation flow.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/pages/workspace-select.test.tsx` | Verifies redirect behavior for single workspace and picker behavior for multiple workspaces. |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/pages/workspace-select.tsx` | Added single-workspace redirect to `/w/:workspaceId` after successful workspace load. |

## Deleted files (if any)

None.

## Test plan

- [x] `bun run --cwd apps/frontend test:watch --run src/pages/workspace-select.test.tsx`
- [x] `bun run --cwd apps/frontend typecheck`
- [ ] Manual verify in browser: single-workspace account goes `/` -> `/w/:workspaceId`; multi-workspace account still sees picker.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
