### PR TITLE
fix: stabilize browser e2e setup/activity/sidebar flakiness

### DIFF
--- a/tests/browser/sidebar-updates.spec.ts
+++ b/tests/browser/sidebar-updates.spec.ts
@@ -157,13 +157,16 @@ test.describe("Sidebar Updates", () => {
       const scratchpadLink = page.locator(`a[href*="/s/${streamId}"]`).first()
       await expect(scratchpadLink).toBeVisible({ timeout: 10000 })
 
+      // Wait for sidebar preview text to reflect the companion response.
+      // Read text content directly (instead of nested visibility checks) to avoid hover rendering races.
       await expect
         .poll(
           async () => {
             await scratchpadLink.hover()
-            return scratchpadLink.getByText(/stub response/i).isVisible()
+            const previewText = ((await scratchpadLink.textContent()) ?? "").toLowerCase()
+            return previewText.includes("stub response")
           },
-          { timeout: 30000 }
+          { timeout: 45000 }
         )
         .toBeTruthy()
     })


### PR DESCRIPTION
**Linear:** N/A

## Problem

Recent `Browser E2E Tests` failures were clustered around four areas:

- Invitation setup intermittently stuck with disabled `Complete Setup`.
- Activity-feed mention-clearing assertions relied on fixed sleeps.
- Sidebar companion-preview checks were sensitive to hover/render timing.
- Message-send-mode failures in recent runs were from tooltip/visibility timing (not app behavior regressions).

The goal was to reduce flaky assertions while fixing real product behavior where needed.

## Solution

- Fixed a real setup race in member setup slug checking.
- Replaced timing-based activity-feed assertions with state-based polling.
- Hardened sidebar companion-preview assertion logic against transient UI rendering races.

### How it works

1. `MemberSetupPage` now always invalidates prior slug checks before processing a new value, including blank slug transitions.
2. Blank slug submissions no longer get blocked by stale `checking/taken` state; backend still owns final slug generation/validation.
3. Activity-feed tests poll workspace bootstrap unread/mention/activity counts until read-state settles, then assert UI badges clear.
4. Sidebar test polls the stream link text content for companion preview text with hover + extended timeout, instead of nested visibility-only checks.

### Key design decisions

**1. Treat member-setup disablement as a product bug, not just a test issue**

The setup button disablement came from stale async slug checks overwriting current state. Fixing this in production code prevents real user friction under load and removes a root cause behind invitation-flow failures.

**2. Prefer state-driven waits over sleep-based timing**

`waitForTimeout` introduces CI-dependent races. Polling canonical state (counts for activity/read) makes assertions deterministic and aligned with actual behavior.

**3. Keep sidebar assertion user-visible but less fragile**

The sidebar check still validates user-visible preview content, but uses link text polling rather than brittle nested visibility checks that are sensitive to hover/transitions.

## New files

None.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/pages/member-setup.tsx` | Fixed stale slug-check invalidation race; trim slug before submit; allow blank-slug submit path while checks are pending. |
| `tests/browser/activity-feed.spec.ts` | Added read-state polling helper and removed fixed sleeps for mention/activity clear assertions. |
| `tests/browser/sidebar-updates.spec.ts` | Made companion preview assertion poll link text content with hover and extended timeout. |

## Deleted files

None.

## Test plan

- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bunx playwright test tests/browser/sidebar-updates.spec.ts --grep "should update sidebar preview when agent responds in scratchpad while navigated away" --repeat-each=10 --workers=4 --retries=0`
- [x] `bunx playwright test tests/browser/activity-feed.spec.ts tests/browser/sidebar-updates.spec.ts --grep "should show mention badge and activity feed when @mentioned by another user|should update sidebar preview when agent responds in scratchpad while navigated away" --repeat-each=10 --workers=4 --retries=0`
- [x] `bunx playwright test tests/browser/invitation-flow.spec.ts --repeat-each=10 --workers=4 --retries=0`
- [x] `bun run test:browser` (131 successful tests, 0 failing tests)
