### PR TITLE
fix: retain editor focus when opening inline message edit

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -337,12 +337,10 @@ export function RichEditor({
     }
   }, [editor, mentionables, getMentionType, toEmoji])
 
-  // Focus editor on mount
-  useEffect(() => {
-    if (editor && !editor.isDestroyed) {
-      editor.commands.focus("end")
-    }
-  }, [editor])
+  // TipTap's autofocus option (line 184) handles initial focus.
+  // No additional focus-on-mount effect needed — the redundant focus()
+  // dispatch caused a view update that raced with toolbar rendering,
+  // briefly dropping focus in autoFocus editors (e.g. inline edit).
 
   // Copy handler: serialize selection to markdown
   useEffect(() => {
@@ -372,10 +370,13 @@ export function RichEditor({
     }
   }, [editor])
 
-  // Re-focus after disabled changes (e.g., after sending)
+  // Re-focus after disabled transitions (e.g., after sending)
+  // Track previous value so this only fires on true→false transitions, not on mount.
+  const prevDisabledRef = useRef(disabled)
   useEffect(() => {
-    if (!disabled && editor && !editor.isDestroyed) {
-      // Small delay to ensure editor is re-enabled
+    const wasDisabled = prevDisabledRef.current
+    prevDisabledRef.current = disabled
+    if (wasDisabled && !disabled && editor && !editor.isDestroyed) {
       const timer = setTimeout(() => focus(), 0)
       return () => clearTimeout(timer)
     }

--- a/apps/frontend/src/components/timeline/message-context-menu.tsx
+++ b/apps/frontend/src/components/timeline/message-context-menu.tsx
@@ -36,7 +36,14 @@ export function MessageContextMenu({ context }: MessageContextMenuProps) {
           <EllipsisVertical className="h-3.5 w-3.5" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-[200px]">
+      <DropdownMenuContent
+        align="end"
+        className="min-w-[200px]"
+        // Prevent Radix from restoring focus to the trigger button on close.
+        // Without this, selecting "Edit message" focuses the editor via autoFocus,
+        // then Radix's cleanup steals focus back to the trigger button.
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         {actions.map((action, index) => (
           <ActionItem
             key={action.id}


### PR DESCRIPTION
## Problem

When opening a message for inline editing via the context menu, the editor briefly receives focus (cursor visible, floating toolbar appears) then immediately loses it. The message is still editable thanks to the type-anywhere feature catching keystrokes, but the visual jank — cursor appearing then disappearing — is noticeable.

## Solution

The root cause is Radix UI's `DropdownMenu` default behavior: when the menu closes, it restores focus to its trigger button. This focus restoration fires *after* TipTap's `autofocus: "end"` has already focused the editor, overriding it.

### Key design decisions

**1. Prevent Radix auto-focus restoration on menu close**

Added `onCloseAutoFocus={(e) => e.preventDefault()}` to `DropdownMenuContent` in the message context menu. This is the standard Radix pattern for action menus where the selected action changes the UI state (e.g. mounting an editor). Without this, every action that focuses something new (edit, delete dialog) would fight with Radix for focus.

**2. Remove redundant focus-on-mount useEffect in RichEditor**

There was a `useEffect([editor])` that unconditionally called `editor.commands.focus("end")` on mount — regardless of the `autoFocus` prop. This was redundant with TipTap's built-in `autofocus: "end"` option and also a latent bug (it focused editors even when `autoFocus={false}`).

**3. Guard disabled-change re-focus to actual transitions**

The re-focus effect (`useEffect([disabled, editor, focus])`) previously fired on initial mount because `disabled` starts as `false`. Now it tracks the previous value via a ref and only fires on actual `true→false` transitions — the intended use case (re-focus after send completes).

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/components/timeline/message-context-menu.tsx` | Add `onCloseAutoFocus` to prevent Radix stealing focus on close |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Remove redundant focus-on-mount effect; guard disabled re-focus to transitions only |

## Test plan

- [x] 758 frontend unit/integration tests pass
- [x] TypeScript typecheck clean
- [x] Manual verification: edit form retains focus with visible cursor and floating toolbar after clicking "Edit message"
- [x] Manual verification: Escape cancels edit and returns focus to zone editor

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
