### PR TITLE
feat: add LAN mode for mobile dev over WiFi

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -597,7 +597,7 @@ export async function startServer(): Promise<ServerInstance> {
   pushSessionCleanup.start()
 
   await new Promise<void>((resolve) => {
-    server.listen(config.port, () => {
+    server.listen(config.port, "0.0.0.0", () => {
       logger.info({ port: config.port }, "Server started")
       resolve()
     })

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -133,7 +133,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject)
-    server.listen(config.port, () => {
+    server.listen(config.port, "0.0.0.0", () => {
       server.removeListener("error", reject)
       logger.info({ port: config.port }, "Control plane started")
       resolve()

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -53,7 +53,11 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
         const config = await api.get<WorkspaceConfig>(`/api/workspaces/${workspaceId}/config`)
         if (cancelled) return
 
-        newSocket = io(config.wsUrl, {
+        // In dev, the router returns ws://localhost:PORT but we may be accessing
+        // from a different host (e.g. phone over WiFi). Rewrite to match the actual host.
+        const wsUrl = import.meta.env.DEV ? config.wsUrl.replace("localhost", window.location.hostname) : config.wsUrl
+
+        newSocket = io(wsUrl, {
           path: "/socket.io/",
           withCredentials: true,
           autoConnect: true,

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
   },
   server: {
+    host: "0.0.0.0",
     port: frontendPort,
     hmr: isE2ETest ? false : undefined,
     proxy: {

--- a/apps/workspace-router/wrangler.toml
+++ b/apps/workspace-router/wrangler.toml
@@ -13,3 +13,4 @@ INTERNAL_API_KEY = "dev-internal-key"
 
 [dev]
 port = 3001
+ip = "0.0.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "dev": "bun scripts/dev.ts",
+    "dev:lan": "LAN_MODE=true bun scripts/dev.ts",
     "dev:test": "bun scripts/dev-test.ts",
     "dev:backend": "bun --hot apps/backend/src/index.ts",
     "dev:frontend": "bun run --cwd apps/frontend dev",

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -142,7 +142,8 @@ export class WorkosAuthService implements AuthService {
         cookiePassword: this.cookiePassword,
       })
 
-      return await session.getLogoutUrl()
+      const returnTo = new URL(this.redirectUri).origin
+      return await session.getLogoutUrl({ returnTo })
     } catch (error) {
       logger.error({ err: error }, "Failed to get logout URL")
       return null

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
 
 const POSTGRES_HOST = "localhost"
@@ -311,19 +312,45 @@ async function main() {
     }
   }
 
+  // LAN mode: bind to WiFi IP so the app is reachable from phones
+  const lanMode = process.env.LAN_MODE === "true" || process.argv.includes("--lan")
+  let lanIp: string | undefined
+
+  if (lanMode) {
+    lanIp = Object.values(os.networkInterfaces())
+      .flat()
+      .find((i) => i && i.family === "IPv4" && !i.internal)?.address
+
+    if (!lanIp) {
+      console.error("LAN_MODE enabled but no LAN IP found — are you connected to WiFi?")
+      process.exit(1)
+    }
+
+    console.log(`LAN mode: http://${lanIp}:3000`)
+  }
+
+  const corsOrigins = ["http://localhost:3000", "http://localhost:5173", "http://127.0.0.1:5173"]
+  if (lanIp) corsOrigins.push(`http://${lanIp}:3000`)
+
+  const cpEnvOverrides: Record<string, string> = {}
+  if (lanIp && cpEnv.WORKOS_REDIRECT_URI) {
+    cpEnvOverrides.WORKOS_REDIRECT_URI = cpEnv.WORKOS_REDIRECT_URI.replace("localhost", lanIp)
+  }
+
   const controlPlane = Bun.spawn(["bun", "--hot", "apps/control-plane/src/index.ts"], {
     stdout: "inherit",
     stderr: "inherit",
     env: {
       ...process.env,
       ...cpEnv,
+      ...cpEnvOverrides,
       FAST_SHUTDOWN: "true",
       PORT: "3003",
       DATABASE_URL: cpDbUrl,
       USE_STUB_AUTH: useStubAuth,
       INTERNAL_API_KEY: cpEnv.INTERNAL_API_KEY ?? "dev-internal-key",
       REGIONS: JSON.stringify({ local: { internalUrl: "http://localhost:3002" } }),
-      CORS_ALLOWED_ORIGINS: "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173",
+      CORS_ALLOWED_ORIGINS: corsOrigins.join(","),
       WORKSPACE_CREATION_SKIP_INVITE: "true",
     },
   })
@@ -340,6 +367,7 @@ async function main() {
       USE_STUB_AUTH: useStubAuth,
       CONTROL_PLANE_URL: "http://localhost:3003",
       INTERNAL_API_KEY: backendEnv.INTERNAL_API_KEY ?? "dev-internal-key",
+      CORS_ALLOWED_ORIGINS: corsOrigins.join(","),
       REGION: "local",
     },
   })


### PR DESCRIPTION
## Summary
- Bind all four services (frontend, backend, control-plane, workspace-router) to `0.0.0.0` so they're reachable over the local network
- Add `LAN_MODE` flag to the dev script that auto-detects the WiFi IP and overrides `WORKOS_REDIRECT_URI`, CORS origins, and the frontend WebSocket URL — keeping `.env` files untouched
- Add `bun run dev:lan` convenience script
- Pass `returnTo` on WorkOS logout so the user is redirected back to the correct origin

## Usage
```sh
bun run dev:lan
# or
LAN_MODE=true bun run dev
```

Then open `http://<lan-ip>:3000` on your phone. The LAN IP is logged at startup.

> **Note:** The LAN IP must also be registered as a redirect URI in the WorkOS dashboard (`http://<lan-ip>:3000/api/auth/callback`).

## Test plan
- [ ] `bun run dev` still works as before (localhost-only, no LAN changes)
- [ ] `bun run dev:lan` detects LAN IP, logs it, and overrides CORS + redirect URI
- [ ] Phone can reach the app at `http://<lan-ip>:3000`
- [ ] Login via WorkOS redirects back to the LAN IP
- [ ] Logout redirects back to the LAN IP (not localhost)
- [ ] WebSocket connects successfully from phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `dev:lan` development script enabling local area network access during development
  * Backend and frontend services now accessible from other machines on the local network
  * WebSocket connections properly resolved in development environments

* **Chores**
  * Updated CORS and network binding configurations for multi-interface support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->