### PR TITLE
fix: improve mobile keyboard viewport handling and scroll containment

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Threa</title>
 
     <!-- Primary Meta Tags -->

--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -103,8 +103,10 @@ export function AppShell({ sidebar, children }: AppShellProps) {
     onResizeEnd: stopResizing,
   })
 
-  // Track visual viewport for keyboard-aware layout on mobile
-  const visualViewport = useVisualViewport(isMobile)
+  // Track visual viewport for keyboard-aware layout on mobile.
+  // Sets --viewport-height CSS variable imperatively for smooth tracking;
+  // returns a boolean for conditional rendering (safe-area padding).
+  const isKeyboardOpen = useVisualViewport(isMobile)
 
   const isCollapsed = state === "collapsed"
   const isPreview = state === "preview"
@@ -132,8 +134,8 @@ export function AppShell({ sidebar, children }: AppShellProps) {
 
   return (
     <div
-      className="flex h-dvh w-screen flex-col overflow-hidden"
-      style={visualViewport ? { height: `${visualViewport.height}px` } : undefined}
+      className="flex w-screen flex-col overflow-hidden"
+      style={{ height: "var(--viewport-height, 100dvh)" }}
     >
       {/* Topbar - spans full width */}
       <Topbar isPinned={isMobile ? isOpen : isPinned} onToggleSidebar={togglePinned} />
@@ -289,7 +291,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
         {/* Main content area — safe-area padding for notched devices when keyboard is closed */}
         <main
           className="flex flex-1 flex-col overflow-hidden"
-          style={!visualViewport ? { paddingBottom: "env(safe-area-inset-bottom)" } : undefined}
+          style={!isKeyboardOpen ? { paddingBottom: "env(safe-area-inset-bottom)" } : undefined}
         >
           {children}
         </main>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -168,7 +168,7 @@ export function StreamContent({
 
   return (
     <div className="flex h-full flex-col">
-      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden mb-4" onScroll={handleScroll}>
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden overscroll-y-contain mb-4" onScroll={handleScroll}>
         {/* Show parent message for threads */}
         {isThread && parentMessage && parentStreamId && (
           <ThreadParentMessage

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -109,6 +109,6 @@ export { useResizeDrag } from "./use-resize-drag"
 
 export { useTypeToFocus, focusAtEnd } from "./use-type-to-focus"
 
-export { useVisualViewport, type VisualViewportState } from "./use-visual-viewport"
+export { useVisualViewport } from "./use-visual-viewport"
 
 export { useIsMobile, MOBILE_BREAKPOINT } from "./use-mobile"

--- a/apps/frontend/src/hooks/use-scroll-behavior.ts
+++ b/apps/frontend/src/hooks/use-scroll-behavior.ts
@@ -55,6 +55,26 @@ export function useScrollBehavior({
     }
   }, [isLoading, itemCount, scrollToBottom])
 
+  // Auto-scroll to bottom when the container shrinks (e.g. mobile keyboard opens).
+  // This keeps the latest messages visible instead of being pushed off-screen.
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+
+    let prevHeight = el.clientHeight
+
+    const observer = new ResizeObserver(() => {
+      const newHeight = el.clientHeight
+      if (newHeight < prevHeight && shouldAutoScroll.current) {
+        el.scrollTop = el.scrollHeight
+      }
+      prevHeight = newHeight
+    })
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   const handleScroll = useCallback(() => {
     if (!scrollContainerRef.current) return
 

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -1,57 +1,138 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 
-export interface VisualViewportState {
-  /** Visual viewport height in px (shrinks when keyboard opens) */
-  height: number
-}
-
-/** Threshold in px — if visual viewport is this much smaller than layout viewport, keyboard is open */
+/** Threshold in px — if viewport height is this much smaller than baseline, keyboard is open */
 const KEYBOARD_THRESHOLD = 100
 
+/** How long to poll visualViewport after focus changes to catch keyboard animation (ms) */
+const POLL_DURATION = 600
+
 /**
- * Tracks `window.visualViewport` to detect on-screen keyboard.
- * Returns null when the keyboard is closed (or on desktop / unavailable API).
+ * Tracks the on-screen keyboard state on mobile devices.
  *
- * When the keyboard opens on mobile, the visual viewport shrinks while
- * the layout viewport stays the same. We use this delta to adjust the
- * app shell height so the message input stays above the keyboard.
+ * Sets a `--viewport-height` CSS custom property on `<html>` imperatively
+ * (bypassing React state) for smooth height tracking. Falls back to `100dvh`
+ * when the keyboard is closed.
+ *
+ * Detection strategy (layered to handle browser differences):
+ * 1. Primary: visualViewport.height < window.innerHeight (Chrome, Safari)
+ * 2. Fallback: visualViewport.height < baselineHeight (Firefox Android,
+ *    which resizes both viewports together when the keyboard opens)
+ *
+ * Also polls `visualViewport` during input focus transitions to catch
+ * keyboard animation frames that may not emit discrete resize events.
  */
-export function useVisualViewport(enabled: boolean): VisualViewportState | null {
-  const [state, setState] = useState<VisualViewportState | null>(null)
+export function useVisualViewport(enabled: boolean): boolean {
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+  const rafId = useRef(0)
+  // Baseline height = innerHeight when keyboard is known to be closed.
+  // Used as fallback for browsers that resize both viewports together (Firefox).
+  const baseHeight = useRef(typeof window !== "undefined" ? window.innerHeight : 0)
 
   useEffect(() => {
-    if (!enabled || !window.visualViewport) return
+    if (!enabled) return
 
     const vv = window.visualViewport
-    let rafId = 0
+    const docEl = document.documentElement
+
+    // Reset baseline on mount
+    baseHeight.current = window.innerHeight
 
     const update = () => {
-      const keyboardOpen = vv.height < window.innerHeight - KEYBOARD_THRESHOLD
+      const vvHeight = vv ? vv.height : window.innerHeight
+
+      // Primary: visual viewport smaller than layout viewport (Chrome, Safari)
+      let keyboardOpen = vv ? vv.height < window.innerHeight - KEYBOARD_THRESHOLD : false
+
+      // Fallback: viewport shrank from baseline (Firefox resizes both together)
+      if (!keyboardOpen) {
+        keyboardOpen = vvHeight < baseHeight.current - KEYBOARD_THRESHOLD
+      }
+
+      // Update baseline when keyboard is confirmed closed
+      if (!keyboardOpen) {
+        baseHeight.current = window.innerHeight
+      }
+
       if (keyboardOpen) {
-        setState((prev) => (prev?.height === vv.height ? prev : { height: vv.height }))
+        docEl.style.setProperty("--viewport-height", `${vvHeight}px`)
       } else {
-        setState((prev) => (prev === null ? prev : null))
+        docEl.style.removeProperty("--viewport-height")
+      }
+
+      // Only update React state when the boolean actually changes
+      setIsKeyboardOpen((prev) => (prev !== keyboardOpen ? keyboardOpen : prev))
+
+      // Pin page scroll to prevent iOS visual viewport panning
+      if (vv && vv.offsetTop > 0) {
+        window.scrollTo(0, 0)
       }
     }
 
-    // Coalesce scroll events via rAF to avoid per-tick JS execution
+    // Poll every frame for a duration to catch keyboard open/close animation
+    const pollForDuration = (ms: number) => {
+      cancelAnimationFrame(rafId.current)
+      const start = performance.now()
+      const poll = () => {
+        update()
+        if (performance.now() - start < ms) {
+          rafId.current = requestAnimationFrame(poll)
+        }
+      }
+      rafId.current = requestAnimationFrame(poll)
+    }
+
+    // Coalesce viewport scroll events via rAF
     const onScroll = () => {
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(update)
+      cancelAnimationFrame(rafId.current)
+      rafId.current = requestAnimationFrame(update)
+    }
+
+    // Start polling when an editable element receives focus (keyboard about to open)
+    const onFocusIn = (e: FocusEvent) => {
+      if (e.target instanceof HTMLElement && isEditable(e.target)) {
+        pollForDuration(POLL_DURATION)
+      }
+    }
+
+    // Poll when focus leaves an editable element (keyboard about to close)
+    const onFocusOut = (e: FocusEvent) => {
+      if (e.target instanceof HTMLElement && isEditable(e.target)) {
+        pollForDuration(POLL_DURATION)
+      }
     }
 
     // Set initial state
     update()
 
-    vv.addEventListener("resize", update)
-    vv.addEventListener("scroll", onScroll)
+    // Listen to visualViewport events (primary detection for Chrome/Safari)
+    if (vv) {
+      vv.addEventListener("resize", update)
+      vv.addEventListener("scroll", onScroll)
+    }
+    // Also listen to window resize (Firefox fires this when keyboard changes innerHeight)
+    window.addEventListener("resize", update)
+    document.addEventListener("focusin", onFocusIn)
+    document.addEventListener("focusout", onFocusOut)
 
     return () => {
-      cancelAnimationFrame(rafId)
-      vv.removeEventListener("resize", update)
-      vv.removeEventListener("scroll", onScroll)
+      cancelAnimationFrame(rafId.current)
+      if (vv) {
+        vv.removeEventListener("resize", update)
+        vv.removeEventListener("scroll", onScroll)
+      }
+      window.removeEventListener("resize", update)
+      document.removeEventListener("focusin", onFocusIn)
+      document.removeEventListener("focusout", onFocusOut)
+      docEl.style.removeProperty("--viewport-height")
     }
   }, [enabled])
 
-  return enabled ? state : null
+  return enabled ? isKeyboardOpen : false
+}
+
+function isEditable(el: HTMLElement): boolean {
+  const tag = el.tagName
+  if (tag === "INPUT" || tag === "TEXTAREA") return true
+  if (el.isContentEditable) return true
+  return false
 }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -13,7 +13,16 @@
  */
 
 @layer base {
-  /* Disable double-tap zoom on mobile — the app is not zoomable */
+  /* Disable double-tap zoom on mobile — the app is not zoomable.
+     Lock html/body scroll to prevent mobile browsers from scrolling
+     the page-level viewport when the keyboard is open (which lets the
+     message input slide past the top of the screen). */
+  html,
+  body {
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
   html {
     touch-action: manipulation;
   }


### PR DESCRIPTION
## Summary
- Rewrite `useVisualViewport` to set `--viewport-height` CSS custom property imperatively (no React state for height) with baseline tracking for Firefox Android compatibility
- Lock `html`/`body` overflow and add `overscroll-y-contain` to prevent scrolling past the message input on mobile
- Add ResizeObserver-based auto-scroll in `useScrollBehavior` to keep latest messages visible when keyboard opens
- Add `interactive-widget=resizes-content` viewport meta for native keyboard layout on Chrome 108+ / Safari 18.4+

Stacked on #184.

## Test plan
- [ ] Open a stream on mobile, tap the message input — keyboard should open and input stays above it
- [ ] With keyboard open, try scrolling down — should not be able to scroll the input past the top of the screen
- [ ] Latest messages should remain visible when keyboard opens (auto-scroll to bottom)
- [ ] Desktop behavior unchanged
- [ ] Test on Firefox Android and Chrome Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced mobile keyboard detection with automatic scroll adjustments to keep content visible when keyboard appears.

* **Bug Fixes**
  * Improved viewport handling for more stable layout when mobile keyboard opens and closes.
  * Fixed scroll container behavior to prevent unwanted page scrolling on mobile devices.

* **Improvements**
  * Optimized viewport management for better mobile experience across different devices and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->