### PR TITLE
feat: add colored glow to sidebar urgency strips on mobile

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -33,8 +33,8 @@ export function UrgencyStrip({ urgency }: { urgency: UrgencyLevel }) {
         <div
           className="absolute inset-y-0 left-0 pointer-events-none"
           style={{
-            width: "2.5rem",
-            background: `linear-gradient(to right, ${color.replace(")", " / 0.22)")}, ${color.replace(")", " / 0.06)")} 40%, transparent)`,
+            width: "4rem",
+            background: `linear-gradient(to right, ${color.replace(")", " / 0.4)")}, ${color.replace(")", " / 0.15)")} 50%, transparent)`,
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- The desktop collapsed sidebar has a blurred glow strip (blue/red/golden) indicating unread activity — this was hidden on mobile via `!isMobile`
- Added a gradient wash to the `UrgencyStrip` component that bleeds rightward from the colored strip into each sidebar item row
- Works for all three urgency types: blue (activity), red (mentions), golden (AI) on both light and dark themes

## Test plan
- [ ] Open sidebar on mobile — items with unread activity show colored glow wash from left edge
- [ ] Verify blue glow for unread messages, red for mentions, gold for AI responses
- [ ] Check dark mode renders the glow with appropriate visibility
- [ ] Verify desktop sidebar still looks correct (glow enhances existing collapsed strip)
- [ ] Confirm quiet/read items show no glow (transparent strip, no gradient child)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced urgency indicator styling with improved visual prominence. Urgency levels now display with gradient glow effects and computed color states for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->