### PR TITLE
fix: preserve FileList before input reset to unblock Chrome file picker

### DIFF
--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -51,13 +51,15 @@ export function useAttachments(workspaceId: string): UseAttachmentsReturn {
 
   const handleFileSelect = useCallback(
     async (e: ChangeEvent<HTMLInputElement>) => {
-      const files = e.target.files
-      if (!files || files.length === 0) return
+      // Convert to array before resetting value — Chrome clears the FileList in-place
+      // when input.value is reset, so the reference would be empty if captured after.
+      const files = Array.from(e.target.files ?? [])
+      if (files.length === 0) return
 
       // Reset input so same file can be selected again
       e.target.value = ""
 
-      for (const file of Array.from(files)) {
+      for (const file of files) {
         const tempId = `temp_${Date.now()}_${Math.random().toString(36).slice(2)}`
 
         // Add as uploading


### PR DESCRIPTION
## Problem

File uploads via the file picker were silently broken in Chrome (both mobile and desktop). Selecting files through the picker appeared to work — the dialog opened, the user could select files — but nothing was uploaded afterward. Paste and drop uploads were unaffected.

Firefox worked correctly throughout.

## Solution

Convert `e.target.files` to a plain `Array` before resetting the input value, so the selected files are captured in an independent data structure before Chrome can clear the underlying `FileList`.

### How it works

Chrome's `FileList` (returned by `input.files`) is a **live object** backed by the input element. When `input.value = ""` is called to allow re-selecting the same file, Chrome clears that object **in-place**. Any variable that holds a reference to the same `FileList` object is now empty.

Firefox snapshots the `FileList` on access, so its reference survives the reset. This explains why the bug was Chrome-only.

The previous code:
```ts
const files = e.target.files      // reference to live FileList
e.target.value = ""               // Chrome clears FileList in-place
for (const file of Array.from(files)) { ... }   // iterates empty list
```

The fix:
```ts
const files = Array.from(e.target.files ?? [])  // snapshot before reset
e.target.value = ""               // safe to reset now
for (const file of files) { ... }              // iterates the snapshot
```

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/hooks/use-attachments.ts` | Convert `FileList` to `Array` before resetting input value in `handleFileSelect` |

## Test plan

- [ ] Open file picker via the paperclip button in Chrome — files should upload
- [ ] Open file picker via the paperclip button in Chrome on mobile — files should upload
- [ ] Verify paste and drop uploads are unaffected
- [ ] Verify re-selecting the same file still works (input reset path)
- [ ] Verify in Firefox still works

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file attachment handling to ensure selected files remain stable and accessible after the attachment dialog closes, improving reliability on Chrome browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->