### PR TITLE
fix: avoid mobile composer overlap with tappable toasts

### DIFF
--- a/apps/frontend/src/components/ui/sonner.test.tsx
+++ b/apps/frontend/src/components/ui/sonner.test.tsx
@@ -33,32 +33,39 @@ vi.mock("sonner", async () => {
       const visibleToasts = props.id
         ? mockState.toasts.filter((activeToast) => activeToast.toasterId === props.id)
         : mockState.toasts.filter((activeToast) => !activeToast.toasterId)
+      const possiblePositions = Array.from(
+        new Set([
+          defaultPosition,
+          ...visibleToasts.filter((activeToast) => activeToast.position).map((activeToast) => activeToast.position!),
+        ])
+      )
 
       return (
         <section ref={ref} data-testid="sonner-root" data-position={props.position} className={props.className}>
-          <ol
-            data-sonner-toaster=""
-            data-y-position={defaultPosition.split("-")[0]}
-            data-x-position={defaultPosition.split("-")[1]}
-          >
-            {visibleToasts.map((activeToast, index) => {
-              const position = activeToast.position ?? defaultPosition
-              const [y, x] = position.split("-")
-              return (
-                <li
-                  key={activeToast.id}
-                  data-sonner-toast=""
-                  data-index={index}
-                  data-y-position={y}
-                  data-x-position={x}
-                  data-dismissible={activeToast.dismissible === false ? "false" : "true"}
-                >
-                  <span>{activeToast.id}</span>
-                  <button type="button">Action</button>
-                </li>
-              )
-            })}
-          </ol>
+          {possiblePositions.map((position, positionIndex) => {
+            const [y, x] = position.split("-")
+            const toastsAtPosition = visibleToasts.filter(
+              (activeToast) => (!activeToast.position && positionIndex === 0) || activeToast.position === position
+            )
+
+            return (
+              <ol key={position} data-sonner-toaster="" data-y-position={y} data-x-position={x}>
+                {toastsAtPosition.map((activeToast, index) => (
+                  <li
+                    key={activeToast.id}
+                    data-sonner-toast=""
+                    data-index={index}
+                    data-y-position={y}
+                    data-x-position={x}
+                    data-dismissible={activeToast.dismissible === false ? "false" : "true"}
+                  >
+                    <span>{activeToast.id}</span>
+                    <button type="button">Action</button>
+                  </li>
+                ))}
+              </ol>
+            )
+          })}
         </section>
       )
     }
@@ -122,5 +129,20 @@ describe("Toaster", () => {
     await user.click(screen.getByText("toast_1"))
 
     expect(mockState.dismissToast).not.toHaveBeenCalled()
+  })
+
+  it("dismisses the correct toast when multiple positions are active", async () => {
+    const user = userEvent.setup()
+    mockState.toasts = [
+      { id: "top_1", position: "top-center" },
+      { id: "bottom_1", position: "bottom-right" },
+      { id: "top_2", position: "top-center" },
+    ]
+
+    render(<Toaster />)
+    await user.click(screen.getByText("top_2"))
+
+    expect(mockState.dismissToast).toHaveBeenCalledWith("top_2")
+    expect(mockState.dismissToast).not.toHaveBeenCalledWith("top_1")
   })
 })

--- a/apps/frontend/src/components/ui/sonner.tsx
+++ b/apps/frontend/src/components/ui/sonner.tsx
@@ -1,24 +1,46 @@
 import { useEffect, useMemo, useRef } from "react"
 import { CircleCheck, Info, LoaderCircle, OctagonX, TriangleAlert } from "lucide-react"
-import { Toaster as Sonner, toast, useSonner } from "sonner"
+import { Toaster as Sonner, toast, useSonner, type ToastT } from "sonner"
 import { usePreferences } from "@/contexts"
 import { useIsMobile } from "@/hooks/use-mobile"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 type ToastPosition = NonNullable<ToasterProps["position"]>
+type SonnerToast = Pick<ToastT, "id" | "position" | "toasterId">
 
 const MOBILE_TOAST_POSITION: ToastPosition = "top-center"
 const DESKTOP_TOAST_POSITION: ToastPosition = "bottom-right"
+
+function groupToastsByPosition(toasts: SonnerToast[], defaultPosition: ToastPosition) {
+  const toastsByPosition = new Map<ToastPosition, SonnerToast[]>()
+
+  for (const activeToast of toasts) {
+    const position = (activeToast.position ?? defaultPosition) as ToastPosition
+    const existingToasts = toastsByPosition.get(position)
+    if (existingToasts) {
+      existingToasts.push(activeToast)
+    } else {
+      toastsByPosition.set(position, [activeToast])
+    }
+  }
+
+  return toastsByPosition
+}
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { resolvedTheme } = usePreferences()
   const isMobile = useIsMobile()
   const { toasts } = useSonner()
   const toasterRef = useRef<HTMLElement | null>(null)
+  const interactionStateRef = useRef<{ filteredToasts: SonnerToast[]; defaultPosition: ToastPosition }>({
+    filteredToasts: [],
+    defaultPosition: DESKTOP_TOAST_POSITION,
+  })
+  const toastIdByElementRef = useRef(new WeakMap<HTMLElement, SonnerToast["id"]>())
 
   const defaultPosition: ToastPosition = props.position ?? (isMobile ? MOBILE_TOAST_POSITION : DESKTOP_TOAST_POSITION)
 
-  const filteredToasts = useMemo(() => {
+  const filteredToasts = useMemo<SonnerToast[]>(() => {
     if (props.id) {
       return toasts.filter((activeToast) => activeToast.toasterId === props.id)
     }
@@ -26,8 +48,58 @@ const Toaster = ({ ...props }: ToasterProps) => {
   }, [props.id, toasts])
 
   useEffect(() => {
+    interactionStateRef.current = { filteredToasts, defaultPosition }
+
     const root = toasterRef.current
     if (!root) return
+    const nextToastIdMap = new WeakMap<HTMLElement, SonnerToast["id"]>()
+    const toastsByPosition = groupToastsByPosition(filteredToasts, defaultPosition)
+
+    for (const [position, toastsAtPosition] of toastsByPosition) {
+      const [y, x] = position.split("-")
+      const domToastsAtPosition = root.querySelectorAll<HTMLElement>(
+        `[data-sonner-toaster][data-y-position="${y}"][data-x-position="${x}"] [data-sonner-toast]`
+      )
+
+      domToastsAtPosition.forEach((domToast) => {
+        const indexRaw = domToast.dataset.index
+        if (!indexRaw) return
+
+        const index = Number.parseInt(indexRaw, 10)
+        if (!Number.isFinite(index)) return
+
+        const toastForIndex = toastsAtPosition[index]
+        if (!toastForIndex) return
+
+        nextToastIdMap.set(domToast, toastForIndex.id)
+      })
+    }
+
+    toastIdByElementRef.current = nextToastIdMap
+  }, [defaultPosition, filteredToasts])
+
+  useEffect(() => {
+    const root = toasterRef.current
+    if (!root) return
+
+    const resolveToastIdFromDataset = (toastElement: HTMLElement) => {
+      const indexRaw = toastElement.dataset.index
+      const y = toastElement.dataset.yPosition
+      const x = toastElement.dataset.xPosition
+      if (!indexRaw || !y || !x) return undefined
+
+      const index = Number.parseInt(indexRaw, 10)
+      if (!Number.isFinite(index)) return undefined
+
+      const clickedPosition = `${y}-${x}` as ToastPosition
+      const { filteredToasts: currentFilteredToasts, defaultPosition: currentDefaultPosition } =
+        interactionStateRef.current
+      const toastsAtPosition = currentFilteredToasts.filter(
+        (activeToast) => (activeToast.position ?? currentDefaultPosition) === clickedPosition
+      )
+
+      return toastsAtPosition[index]?.id
+    }
 
     const handleToastClick = (event: MouseEvent) => {
       const target = event.target
@@ -39,27 +111,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
       const toastElement = target.closest<HTMLElement>("[data-sonner-toast]")
       if (!toastElement || toastElement.dataset.dismissible === "false") return
 
-      const indexRaw = toastElement.dataset.index
-      const y = toastElement.dataset.yPosition
-      const x = toastElement.dataset.xPosition
-      if (!indexRaw || !y || !x) return
+      const mappedToastId = toastIdByElementRef.current.get(toastElement) ?? resolveToastIdFromDataset(toastElement)
+      if (mappedToastId === undefined) return
 
-      const index = Number.parseInt(indexRaw, 10)
-      if (!Number.isFinite(index)) return
-
-      const clickedPosition = `${y}-${x}` as ToastPosition
-      const toastsAtPosition = filteredToasts.filter(
-        (activeToast) => (activeToast.position ?? defaultPosition) === clickedPosition
-      )
-      const clickedToast = toastsAtPosition[index]
-      if (!clickedToast) return
-
-      toast.dismiss(clickedToast.id)
+      toast.dismiss(mappedToastId)
     }
 
     root.addEventListener("click", handleToastClick)
     return () => root.removeEventListener("click", handleToastClick)
-  }, [defaultPosition, filteredToasts])
+  }, [])
 
   return (
     <Sonner


### PR DESCRIPTION
## Problem

On mobile, toast notifications were rendered near the bottom of the viewport, which can overlap the message composer and block one of the most important actions in the app. The current UX also lacked a simple tap-to-dismiss path for users who want to clear toasts quickly.

## Solution

Updated the shared frontend toaster wrapper to make toast behavior mobile-aware and dismissible by tap.

### How it works

1. The toaster now resolves a default position based on breakpoint:
   - mobile: `top-center`
   - desktop: `bottom-right`
2. Mobile toasts now use safe-area-aware offsets so they sit below notches and status bars.
3. A delegated click handler on the toaster root maps the clicked toast DOM node to the active Sonner toast id and calls `toast.dismiss(id)`.
4. Clicks on interactive controls (`button`, links, form controls, role button) are ignored so action/cancel/close controls keep their existing behavior.
5. Non-dismissible toasts are explicitly ignored by the tap handler.

### Key design decisions

**1. Move mobile toasts to `top-center` instead of tweaking bottom offsets**

A top position removes overlap risk with the message composer entirely, including cases where keyboard/safe-area changes alter bottom layout.

**2. Implement dismiss-on-tap in the shared toaster wrapper**

Using delegated handling in the wrapper avoids touching every toast call site and keeps behavior consistent across the app.

**3. Preserve toast actions and non-dismissible semantics**

The handler filters interactive targets and checks `data-dismissible` to prevent accidental dismissals and preserve current UX contracts.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/components/ui/sonner.test.tsx` | Adds focused tests for mobile positioning and tap-to-dismiss behavior. |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/ui/sonner.tsx` | Added mobile-aware default placement, safe-area mobile offsets, delegated tap-to-dismiss logic, and dismissibility cursor styling. |

## Deleted files

None.

## Test plan

- [x] `bunx vitest run src/components/ui/sonner.test.tsx` (from `apps/frontend`)
- [x] `bun run --cwd apps/frontend typecheck`
- [x] Pre-commit hooks passed (lint + typecheck suites)
- [ ] Manual on-device check: trigger success/error toast on mobile and verify it appears at top and tap on body dismisses it without blocking composer input

---

🤖 _PR by Codex_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toasts now position by device (top-center on mobile, bottom-right on desktop).
  * Click-to-dismiss enabled for dismissible toasts; cursor indicates dismissible items.

* **Bug Fixes**
  * Action button clicks no longer dismiss toasts.
  * Non-dismissible toasts are preserved when clicked.

* **Tests**
  * Added comprehensive tests covering positioning, dismissal behavior, and interaction edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->