### PR TITLE
fix: toggle message editor trigger icons

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -1,11 +1,16 @@
 import { useRef, useState, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from "react"
 import { useEditor, EditorContent } from "@tiptap/react"
+import type { PluginKey } from "@tiptap/pm/state"
 import { useParams } from "react-router-dom"
 import { createEditorExtensions } from "./editor-extensions"
 import { EditorBehaviors, isSuggestionActive } from "./editor-behaviors"
 import { EditorToolbar } from "./editor-toolbar"
 import { serializeToMarkdown, parseMarkdown, type MentionTypeLookup } from "./editor-markdown"
 import { useMentionSuggestion, useChannelSuggestion, useCommandSuggestion, useEmojiSuggestion } from "./triggers"
+import { MentionPluginKey } from "./triggers/mention-extension"
+import { CommandPluginKey } from "./triggers/command-extension"
+import { EmojiPluginKey } from "./triggers/emoji-extension"
+import { shouldRemoveTriggerOnToggle, type SuggestionPluginState } from "./trigger-toggle"
 import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { cn } from "@/lib/utils"
@@ -473,18 +478,47 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     }
   }, [disabled, editor, focus])
 
-  // Callbacks for formatting toolbar trigger buttons
+  // Trigger icon behavior:
+  // - First click inserts trigger character and opens suggestion popup.
+  // - Second click (while still empty) removes that trigger character.
+  const handleTriggerClick = useCallback(
+    (trigger: string, pluginKey: PluginKey) => {
+      if (!editor) return
+
+      const { selection } = editor.state
+      const suggestionState = pluginKey.getState(editor.state) as SuggestionPluginState | null
+
+      if (
+        shouldRemoveTriggerOnToggle(trigger, suggestionState, {
+          from: selection.from,
+          to: selection.to,
+          empty: selection.empty,
+        })
+      ) {
+        editor
+          .chain()
+          .focus()
+          .deleteRange({ from: selection.from - trigger.length, to: selection.from })
+          .run()
+        return
+      }
+
+      editor.chain().focus().insertContent(trigger).run()
+    },
+    [editor]
+  )
+
   const handleMentionClick = useCallback(() => {
-    editor?.chain().focus().insertContent("@").run()
-  }, [editor])
+    handleTriggerClick("@", MentionPluginKey)
+  }, [handleTriggerClick])
 
   const handleSlashClick = useCallback(() => {
-    editor?.chain().focus().insertContent("/").run()
-  }, [editor])
+    handleTriggerClick("/", CommandPluginKey)
+  }, [handleTriggerClick])
 
   const handleEmojiClick = useCallback(() => {
-    editor?.chain().focus().insertContent(":").run()
-  }, [editor])
+    handleTriggerClick(":", EmojiPluginKey)
+  }, [handleTriggerClick])
 
   // Expose imperative handle for parent to trigger insert actions
   useImperativeHandle(

--- a/apps/frontend/src/components/editor/trigger-toggle.test.ts
+++ b/apps/frontend/src/components/editor/trigger-toggle.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+import { shouldRemoveTriggerOnToggle, type SuggestionPluginState, type TriggerSelection } from "./trigger-toggle"
+
+function createSuggestionState(overrides?: Partial<SuggestionPluginState>): SuggestionPluginState {
+  return {
+    active: true,
+    range: { from: 10, to: 11 },
+    query: "",
+    text: ":",
+    ...overrides,
+  }
+}
+
+function createSelection(overrides?: Partial<TriggerSelection>): TriggerSelection {
+  return {
+    from: 11,
+    to: 11,
+    empty: true,
+    ...overrides,
+  }
+}
+
+describe("shouldRemoveTriggerOnToggle", () => {
+  it("returns true when trigger suggestion is active with an empty query", () => {
+    const result = shouldRemoveTriggerOnToggle(":", createSuggestionState(), createSelection())
+    expect(result).toBe(true)
+  })
+
+  it("returns false when suggestion query is not empty", () => {
+    const result = shouldRemoveTriggerOnToggle(":", createSuggestionState({ query: "sm" }), createSelection())
+    expect(result).toBe(false)
+  })
+
+  it("returns false when suggestion is inactive", () => {
+    const result = shouldRemoveTriggerOnToggle(":", createSuggestionState({ active: false }), createSelection())
+    expect(result).toBe(false)
+  })
+
+  it("returns false when selection is not empty", () => {
+    const result = shouldRemoveTriggerOnToggle(
+      ":",
+      createSuggestionState(),
+      createSelection({
+        from: 10,
+        to: 11,
+        empty: false,
+      })
+    )
+    expect(result).toBe(false)
+  })
+
+  it("returns false when trigger text does not match", () => {
+    const result = shouldRemoveTriggerOnToggle(":", createSuggestionState({ text: "@" }), createSelection())
+    expect(result).toBe(false)
+  })
+})

--- a/apps/frontend/src/components/editor/trigger-toggle.ts
+++ b/apps/frontend/src/components/editor/trigger-toggle.ts
@@ -1,0 +1,33 @@
+export interface SuggestionPluginState {
+  active: boolean
+  range: {
+    from: number
+    to: number
+  }
+  query: string | null
+  text: string | null
+}
+
+export interface TriggerSelection {
+  from: number
+  to: number
+  empty: boolean
+}
+
+/**
+ * Detects a second click on a trigger button while its empty suggestion is active.
+ * In that state, the click should remove the inserted trigger character instead of inserting another one.
+ */
+export function shouldRemoveTriggerOnToggle(
+  trigger: string,
+  suggestionState: SuggestionPluginState | null | undefined,
+  selection: TriggerSelection
+): boolean {
+  if (!trigger || !selection.empty) return false
+  if (!suggestionState?.active) return false
+  if (suggestionState.query !== "") return false
+  if (suggestionState.text !== trigger) return false
+  if (suggestionState.range.to !== selection.from) return false
+  if (suggestionState.range.from !== selection.from - trigger.length) return false
+  return true
+}


### PR DESCRIPTION
## Problem

In the message composer, clicking the emoji/mention/command trigger icons always inserted another trigger character (`:`, `@`, `/`).

That made the interaction one-sided:
- First click correctly opened suggestions by inserting the trigger.
- Second click (intended as a close/cancel action) inserted a duplicate trigger instead of removing the original when no item had been selected.

## Solution

Implemented toggle behavior for trigger icons in the rich editor:
- First click inserts trigger text and opens suggestion UI.
- Second click removes the trigger text when the corresponding suggestion is still active with an empty query.

### How it works

1. On icon click, read the current TipTap suggestion plugin state (`mention`, `slashCommand`, `emoji`).
2. If state indicates an active empty suggestion for that exact trigger at the cursor, delete the just-inserted trigger range.
3. Otherwise, insert the trigger character as before.

### Key design decisions

**1. Use TipTap plugin state as source of truth**

The toggle decision uses live suggestion plugin state (`active`, `query`, `text`, `range`) instead of introducing extra local UI flags. This keeps behavior aligned with real editor state and avoids desync between toolbar and editor internals.

**2. Extract toggle predicate into a pure helper**

`shouldRemoveTriggerOnToggle` was added as a separate utility so the removal condition is explicit, reusable, and unit-testable.

**3. Keep patch scope minimal**

Only trigger icon click handlers were changed. Typing behavior, suggestion rendering, and command/emoji insertion flows were left untouched.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/components/editor/trigger-toggle.ts` | Encapsulates trigger-toggle removal condition based on suggestion state + cursor selection. |
| `apps/frontend/src/components/editor/trigger-toggle.test.ts` | Unit tests for trigger-toggle edge cases and expected behavior. |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Replaced direct trigger insertion with plugin-aware toggle handler for emoji, mention, and command toolbar actions. |

## Deleted files (if any)

None.

## Test plan

- [x] `bun run --cwd apps/frontend test:watch src/components/editor/trigger-toggle.test.ts`
- [x] `bun run --cwd apps/frontend test:watch src/components/composer/message-composer.test.tsx`
- [x] Pre-commit checks (via hooks): lint + monorepo typecheck
- [ ] Manual verification in the message composer UI:
  - Click emoji icon once inserts `:`
  - Click emoji icon again removes `:` when no emoji is selected
  - Same behavior for mention (`@`) and command (`/`)

---

🤖 _PR by Codex_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor triggers for mentions, slash commands, and emojis now support toggle behavior—clicking an empty trigger removes it instead of duplicating.

* **Tests**
  * Added test coverage for trigger toggle functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->