### PR TITLE
fix: restore desktop sidebar account menu trigger

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
@@ -3,11 +3,12 @@ import { describe, expect, it, beforeEach, vi } from "vitest"
 import { render, screen, userEvent } from "@/test"
 import { SidebarFooter } from "./sidebar-footer"
 
-const { logout, openSettings, collapseOnMobile, setSearchParams } = vi.hoisted(() => ({
+const { logout, openSettings, collapseOnMobile, setSearchParams, isMobile } = vi.hoisted(() => ({
   logout: vi.fn(),
   openSettings: vi.fn(),
   collapseOnMobile: vi.fn(),
   setSearchParams: vi.fn(),
+  isMobile: { value: true },
 }))
 
 vi.mock("react-router-dom", () => ({
@@ -50,7 +51,7 @@ vi.mock("@/contexts", async (importOriginal) => {
 })
 
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => true,
+  useIsMobile: () => isMobile.value,
 }))
 
 vi.mock("@/components/ui/drawer", () => ({
@@ -72,6 +73,7 @@ describe("SidebarFooter", () => {
     openSettings.mockReset()
     collapseOnMobile.mockReset()
     setSearchParams.mockReset()
+    isMobile.value = true
   })
 
   it("opens the mobile account drawer on tap and exposes the same actions", async () => {
@@ -107,5 +109,36 @@ describe("SidebarFooter", () => {
 
     expect(openSettings).toHaveBeenCalledWith("appearance")
     expect(collapseOnMobile).toHaveBeenCalled()
+  })
+
+  it("opens the desktop dropdown from the account row trigger", async () => {
+    isMobile.value = false
+    const user = userEvent.setup()
+
+    render(
+      <SidebarFooter
+        workspaceId="workspace_1"
+        currentUser={{
+          id: "user_1",
+          workspaceId: "workspace_1",
+          workosUserId: "workos_user_1",
+          email: "kris@example.com",
+          role: "user",
+          slug: "kris",
+          name: "Kris",
+          description: null,
+          avatarUrl: null,
+          timezone: "Europe/Stockholm",
+          locale: "en-SE",
+          setupCompleted: true,
+          joinedAt: "2026-03-03T10:00:00Z",
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /kris/i }))
+    await user.click(screen.getByText("Settings"))
+
+    expect(openSettings).toHaveBeenCalledWith("appearance")
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { forwardRef, useCallback, useMemo, useState, type ComponentPropsWithoutRef } from "react"
 import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
 import { useAuth } from "@/auth"
@@ -15,31 +15,36 @@ interface SidebarFooterProps {
   currentUser: User | null
 }
 
-interface SidebarFooterTriggerProps {
+interface SidebarFooterTriggerProps extends Omit<ComponentPropsWithoutRef<"button">, "children"> {
   avatarSrc?: string | null
   currentUser: User
-  onClick?: () => void
 }
 
-function SidebarFooterTrigger({ avatarSrc, currentUser, onClick }: SidebarFooterTriggerProps) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-        "hover:bg-muted/50"
-      )}
-      onClick={onClick}
-    >
-      <Avatar className="h-7 w-7">
-        {avatarSrc && <AvatarImage src={avatarSrc} alt={currentUser.name} />}
-        <AvatarFallback className="text-[10px]">{getInitials(currentUser.name)}</AvatarFallback>
-      </Avatar>
-      <span className="truncate flex-1 text-left">{currentUser.name}</span>
-      <ChevronUp className="h-4 w-4 text-muted-foreground shrink-0" />
-    </button>
-  )
-}
+const SidebarFooterTrigger = forwardRef<HTMLButtonElement, SidebarFooterTriggerProps>(
+  ({ avatarSrc, currentUser, className, type = "button", ...buttonProps }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          "w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+          "hover:bg-muted/50",
+          className
+        )}
+        {...buttonProps}
+      >
+        <Avatar className="h-7 w-7">
+          {avatarSrc && <AvatarImage src={avatarSrc} alt={currentUser.name} />}
+          <AvatarFallback className="text-[10px]">{getInitials(currentUser.name)}</AvatarFallback>
+        </Avatar>
+        <span className="truncate flex-1 text-left">{currentUser.name}</span>
+        <ChevronUp className="h-4 w-4 text-muted-foreground shrink-0" />
+      </button>
+    )
+  }
+)
+
+SidebarFooterTrigger.displayName = "SidebarFooterTrigger"
 
 function SidebarFooterHeader({ avatarSrc, currentUser }: { avatarSrc?: string | null; currentUser: User }) {
   return (


### PR DESCRIPTION
## Problem

The sidebar account row (user name/avatar at the bottom of the sidebar) stopped opening its dropdown menu on desktop after the mobile-friendly sidebar update. Mobile behavior still worked via the drawer path, but desktop clicks produced no menu.

## Solution

Make the desktop account-row trigger compatible with Radix `DropdownMenuTrigger` by forwarding its ref and native button props.

### How it works

- `SidebarActionMenu` uses `DropdownMenuTrigger asChild`.
- Radix expects the child to accept forwarded `ref` and trigger props (pointer/keyboard handlers and data attributes).
- The previous `SidebarFooterTrigger` was a plain component that only accepted `onClick`, so Radix handlers were not attached.
- The trigger is now `forwardRef<HTMLButtonElement, ...>` and spreads incoming button props onto the underlying `<button>`.

### Key design decisions

**1. Keep behavior split by device and only fix desktop trigger contract**

Mobile already used the drawer and worked correctly, so the patch only changes the desktop trigger wiring. This keeps the change minimal and avoids touching drawer behavior.

**2. Add a focused regression test for desktop footer menu opening**

The existing test covered mobile only. A new desktop test now asserts that clicking the account row exposes and executes a dropdown action (`Settings`), preventing regressions in trigger wiring.

## New files

None.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | Converted footer trigger to `forwardRef`, widened props to native button props, and passed Radix trigger props/ref through to the real button. |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx` | Added desktop-mode test for opening/selecting the account dropdown and made the mobile hook mock switchable between mobile/desktop paths. |

## Deleted files (if any)

None.

## Test plan

- [x] `bun run --cwd apps/frontend test:watch --run src/components/layout/sidebar/sidebar-actions.test.tsx src/components/layout/sidebar/sidebar-footer.test.tsx`
- [x] `bun run --cwd apps/frontend typecheck`
- [ ] Manual verification in desktop browser (account row opens dropdown in sidebar)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for mobile and desktop sidebar footer behavior to ensure responsive layouts work correctly.

* **Refactor**
  * Improved sidebar footer component to better support responsive design and component composition patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->