### PR TITLE
fix: resolve Chrome mobile edit drawer fullscreen and toolbar layout

### DIFF
--- a/apps/frontend/src/components/timeline/message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/message-edit-form.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useId, useMemo } from "react"
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useId, useMemo } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { Expand } from "lucide-react"
@@ -49,8 +49,23 @@ export function MessageEditForm({
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
   const richEditorRef = useRef<RichEditorHandle>(null)
   const mobileActionBarRef = useRef<HTMLDivElement>(null)
+  const drawerContentRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
   const instructionsId = useId()
+  // Clear Vaul's cached inline styles when toggling expansion or toolbar so our
+  // CSS classes take effect. Vaul's keyboard handling sets inline style.height
+  // which overrides class-based heights in Chrome and prevents flex recalculation
+  // when children change size. Since we use dvh units (which already account for
+  // the virtual keyboard), Vaul's height adjustments are redundant.
+  useLayoutEffect(() => {
+    const el = drawerContentRef.current
+    if (!el) return
+    el.style.height = ""
+    el.style.maxHeight = ""
+    el.style.bottom = ""
+    // Force reflow so Chrome's compositing layer updates
+    void el.offsetHeight
+  }, [mobileExpanded, formatOpen])
 
   useEffect(() => {
     if (isMobile) return // vaul handles Escape via onOpenChange
@@ -169,7 +184,10 @@ export function MessageEditForm({
           if (!open) setTimeout(onCancel, 300)
         }}
       >
-        <DrawerContent className={mobileExpanded ? "h-[100dvh] max-h-[100dvh]" : "max-h-[85dvh]"}>
+        <DrawerContent
+          ref={drawerContentRef}
+          className={mobileExpanded ? "!h-[100dvh] rounded-t-none" : "max-h-[85dvh]"}
+        >
           <DrawerTitle className="sr-only">Edit message</DrawerTitle>
           <p id={instructionsId} className="sr-only">
             {screenReaderInstructions}


### PR DESCRIPTION
## Problem

The mobile message edit drawer (Vaul-based) had two Chrome-specific regressions:

1. **Fullscreen mode broken** — The expand button toggled its icon but the drawer didn't actually expand. The editor stayed at its default height.
2. **Toolbar covered the editor** — Opening the formatting toolbar pushed content down instead of shrinking the editor area, covering the bottom of the message being edited.

Both worked correctly in Firefox.

## Solution

The root cause is Vaul's virtual keyboard handling. Vaul listens to the Visual Viewport API and sets inline `style.height` (pixel values) on the drawer element when the keyboard opens. Chrome fires these viewport resize events more aggressively than Firefox, leaving cached inline heights that:

- **Override CSS class-based heights** — When `mobileExpanded` toggled, the new CSS class (`h-[100dvh]`) couldn't override Vaul's inline `style.height: 600px`.
- **Prevent flex recalculation** — Combined with `will-change: transform` (which promotes the element to a GPU compositing layer), Chrome skipped re-running flex layout when the toolbar appeared, since it had a "resolved" pixel height and saw no reason to invalidate.

### How it works

A `useLayoutEffect` clears Vaul's cached inline styles (`height`, `maxHeight`, `bottom`) and forces a synchronous reflow whenever expansion or toolbar state changes. This runs after Vaul's own effects (child effects execute before parent effects), ensuring our cleanup takes precedence.

For fullscreen, the height class uses `!important` (`!h-[100dvh]`) to override any inline styles Vaul may re-apply after our cleanup.

Since the project already uses `dvh` units (which natively account for the virtual keyboard on all modern mobile browsers), Vaul's own keyboard height management is redundant.

### Key design decisions

**1. `useLayoutEffect` over `useEffect`**

Must run synchronously before paint to avoid a flash where stale inline styles are visible for one frame.

**2. `!important` only on the fullscreen class**

The default state keeps the original `max-h-[85dvh]` (content-sized, capped) so the drawer naturally fits its content. Only the fullscreen state needs `!important` to definitively override Vaul's inline styles.

**3. Clearing styles rather than setting them**

Clearing lets CSS classes take over naturally. Setting inline styles would fight with Vaul's own style management and risk breaking drag-to-dismiss and other Vaul behaviors.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/components/timeline/message-edit-form.tsx` | Add `useLayoutEffect` to clear Vaul's cached inline styles on expansion/toolbar toggle; use `!important` on fullscreen height; add ref to DrawerContent |

## Test plan

- [x] Existing unit tests pass (6/6)
- [x] Lint and typecheck pass
- [ ] Manual: Chrome mobile — open edit drawer, toggle formatting toolbar, verify editor shrinks
- [ ] Manual: Chrome mobile — expand to fullscreen, verify drawer fills viewport
- [ ] Manual: Firefox mobile — verify both behaviors still work
- [ ] Manual: Verify drawer swipe-to-dismiss still works in both states

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
