### PR TITLE
feat(THR-50): add region display in workspace settings and creation flow

### DIFF
--- a/.claude/plans/THR-50-multi-region-workspace-handling.md
+++ b/.claude/plans/THR-50-multi-region-workspace-handling.md
@@ -1,0 +1,72 @@
+# THR-50: Multi-Region Workspace Handling — UI & Docs
+
+## Goal
+
+Complete the remaining THR-50 requirements: surface the workspace's data region in the UI so users can see where their data lives, and document how region migration would work if needed. The core multi-region infrastructure (workspace router, control plane, backend-common, KV-cached routing) was already shipped.
+
+## What Was Built
+
+### Region display name utility
+
+A thin frontend utility that maps AWS-style region IDs (`eu-north-1`) to human-friendly labels ("Europe (Stockholm)"). Falls back to the raw ID for unknown regions.
+
+**Files:**
+- `apps/frontend/src/lib/regions.ts` — `REGION_LABELS` map and `formatRegion()` function
+
+### General tab in workspace settings
+
+Replaced the placeholder text in the workspace settings General tab with a `GeneralTab` component that shows workspace metadata. Uses the cache-only observer pattern (same as `UsersTab`) to read from the workspace bootstrap cache.
+
+Displays:
+- **Name** — read-only text
+- **Data region** — formatted label with descriptive note; conditionally rendered (hidden when `workspace.region` is undefined for old workspaces)
+- **Created** — preference-aware formatted date via `useFormattedDate()`
+
+**Files:**
+- `apps/frontend/src/components/workspace-settings/general-tab.tsx` — new component
+- `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx` — import and render `GeneralTab` in place of placeholder
+
+### Region picker display names
+
+Updated the workspace creation region picker to show formatted region names instead of raw IDs.
+
+**Files:**
+- `apps/frontend/src/pages/workspace-select.tsx` — `{region}` → `{formatRegion(region)}`
+
+### Region migration design doc
+
+Lightweight design sketch documenting how workspace migration between regions would work. Covers why/what/how/risks/not-in-scope. Not a runbook — future reference for if/when migration tooling is needed.
+
+**Files:**
+- `docs/region-migration.md` — design sketch
+
+## Design Decisions
+
+### Cache-only observer for GeneralTab data access
+
+**Chose:** Same `useQuery` with `enabled: false` + `staleTime: Infinity` pattern used by `UsersTab`
+**Why:** Workspace bootstrap data is already loaded and cached. No need for a separate fetch. Follows the established cache-only observer pattern documented in CLAUDE.md.
+
+### Conditional region rendering
+
+**Chose:** `{workspace?.region && (...)}` — region section not rendered when region is undefined
+**Why:** Old workspaces created before multi-region may not have a region field. Graceful omission is better than showing "Unknown" or a dash.
+
+### Region labels as a frontend-only map
+
+**Chose:** Simple `Record<string, string>` in a frontend utility file
+**Why:** Region IDs are stable AWS identifiers. No need for a backend endpoint or shared package type. The map is tiny and display-only. New regions just need a line added to the map; unknown regions fall back to the raw ID.
+
+## What's NOT Included
+
+- **Workspace name editing** — the General tab shows the name read-only. Editing is a separate feature.
+- **Region migration tooling** — only the design doc is included. No CLI, admin UI, or automated scripts.
+- **Region selection after creation** — workspaces cannot change region through the UI. The migration doc covers the manual process.
+
+## Status
+
+- [x] Region display name utility (`formatRegion`)
+- [x] General tab in workspace settings
+- [x] Region picker uses display names
+- [x] Region migration design doc
+- [x] Typecheck passes

--- a/apps/frontend/src/components/workspace-settings/general-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/general-tab.tsx
@@ -1,0 +1,47 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useFormattedDate } from "@/hooks"
+import { formatRegion } from "@/lib/regions"
+import type { WorkspaceBootstrap } from "@threa/types"
+
+interface GeneralTabProps {
+  workspaceId: string
+}
+
+export function GeneralTab({ workspaceId }: GeneralTabProps) {
+  const queryClient = useQueryClient()
+  const { formatDate } = useFormattedDate()
+
+  const { data: bootstrapData } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+  })
+
+  const workspace = bootstrapData?.workspace
+
+  return (
+    <div className="space-y-4 p-1">
+      <div>
+        <h3 className="text-sm font-medium">Name</h3>
+        <p className="text-sm text-muted-foreground">{workspace?.name ?? "—"}</p>
+      </div>
+
+      {workspace?.region && (
+        <div>
+          <h3 className="text-sm font-medium">Data region</h3>
+          <p className="text-sm text-muted-foreground">{formatRegion(workspace.region)}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Where your workspace data is stored</p>
+        </div>
+      )}
+
+      <div>
+        <h3 className="text-sm font-medium">Created</h3>
+        <p className="text-sm text-muted-foreground">
+          {workspace?.createdAt ? formatDate(new Date(workspace.createdAt)) : "—"}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { ResponsiveTabs } from "@/components/ui/responsive-tabs"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
+import { GeneralTab } from "./general-tab"
 import { UsersTab } from "./users-tab"
 
 const WORKSPACE_SETTINGS_TABS = ["general", "users"] as const
@@ -68,9 +69,7 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
 
           <div className="flex-1 overflow-y-auto mt-4 pb-4 sm:pb-6">
             <TabsContent value="general" className="mt-0">
-              <div className="space-y-4 p-1">
-                <p className="text-sm text-muted-foreground">Workspace general settings will be available here.</p>
-              </div>
+              <GeneralTab workspaceId={workspaceId} />
             </TabsContent>
             <TabsContent value="users" className="mt-0">
               <UsersTab workspaceId={workspaceId} />

--- a/apps/frontend/src/lib/regions.ts
+++ b/apps/frontend/src/lib/regions.ts
@@ -1,0 +1,9 @@
+const REGION_LABELS: Record<string, string> = {
+  "eu-north-1": "Europe (Stockholm)",
+  "us-east-1": "US East (Virginia)",
+  local: "Local",
+}
+
+export function formatRegion(regionId: string): string {
+  return REGION_LABELS[regionId] ?? regionId
+}

--- a/apps/frontend/src/pages/workspace-select.tsx
+++ b/apps/frontend/src/pages/workspace-select.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ThreaLogo } from "@/components/threa-logo"
 import { ApiError } from "@/api/client"
+import { formatRegion } from "@/lib/regions"
 
 function getCreateWorkspaceErrorMessage(error: unknown): string | null {
   if (!error) return null
@@ -150,7 +151,7 @@ export function WorkspaceSelectPage() {
               <SelectContent>
                 {regions.map((region) => (
                   <SelectItem key={region} value={region}>
-                    {region}
+                    {formatRegion(region)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/docs/region-migration.md
+++ b/docs/region-migration.md
@@ -1,0 +1,43 @@
+# Region Migration Design Sketch
+
+How workspace migration between regions would work if needed. This is a design sketch, not a runbook — no tooling exists yet.
+
+## Why migrate
+
+- Data residency requirements change (e.g. a team moves from EU to US, or a new regulation applies)
+- Latency — workspace creator picked a distant region
+- Compliance — organizational policy mandates a specific region
+
+## Data to move
+
+All workspace-scoped data lives in three stores:
+
+1. **PostgreSQL** — all rows with the workspace's `workspace_id` across every table (messages, streams, events, users, personas, etc.)
+2. **S3** — file uploads in the regional bucket under the workspace prefix
+3. **Cloudflare KV** — the `workspace:<slug>` → `{ region, workspaceId }` routing entry
+
+## Approach
+
+Export/import with a workspace write-lock:
+
+1. **Pause workspace** — set a maintenance flag in the control plane; the workspace router returns 503 for the workspace. Connected clients see a "migrating" state.
+2. **Dump workspace data** — export all workspace-scoped rows from the source region's PostgreSQL. Use `COPY` or `pg_dump` with a workspace filter.
+3. **Transfer S3 objects** — copy the workspace prefix from the source bucket to the target region's bucket.
+4. **Import to target region** — load the PostgreSQL dump into the target region's database. Verify row counts match.
+5. **Update routing** — update the control plane's workspace record with the new region, then update the Cloudflare KV entry so the workspace router sends traffic to the new region.
+6. **Resume workspace** — clear the maintenance flag. Clients reconnect via the workspace router, which now routes to the new region.
+7. **Cleanup** — after a verification period, delete source data (PostgreSQL rows, S3 objects).
+
+## Risks
+
+- **Downtime** — workspace is unavailable during migration. Duration depends on data volume.
+- **Event ordering** — outbox events in flight during the pause could be lost. Drain the outbox before dumping.
+- **Invitation shadows** — the control plane stores invitation records globally. These reference `workspace_id` and don't need to move, but the `region` field on the workspace record must be updated.
+- **Socket reconnection** — clients will lose their WebSocket connection. The existing reconnect-and-rebootstrap flow handles this, but users will see a brief interruption.
+- **Cross-references** — if any future feature stores cross-workspace references, those would break during migration. Currently all data is workspace-scoped so this is not an issue.
+
+## Not in scope yet
+
+- **Live migration** — zero-downtime migration with dual-write and cutover. Significantly more complex.
+- **Automated tooling** — CLI or admin UI to trigger migration. Would need to orchestrate all the steps above.
+- **Partial migration** — moving only some streams or data subsets. Not meaningful given the workspace-scoped data model.


### PR DESCRIPTION
**Linear:** [THR-50](https://linear.app/threa/issue/THR-50)

## Problem

THR-50 multi-region infrastructure is complete (workspace router, control plane, backend-common, KV-cached routing), but two gaps remain:

1. Users can't see where their workspace data is stored — `Workspace.region` exists in the domain type but nothing in the UI displays it
2. No documentation for how workspace region migration would work

## Solution

Surface the data region in the workspace settings General tab and the workspace creation region picker, plus add a migration design doc.

### Key design decisions

**1. Conditional region rendering**

The region section in General tab only renders when `workspace.region` is defined. Old workspaces created before multi-region won't show a region row rather than displaying "Unknown".

**2. Cache-only observer for General tab**

Uses the same `useQuery` with `enabled: false` + `staleTime: Infinity` pattern as `UsersTab` — reads workspace metadata from the existing bootstrap cache without triggering a fetch.

**3. Frontend-only region label map**

Region IDs are stable AWS identifiers. A simple `Record<string, string>` in a frontend utility is sufficient. Unknown regions fall back to the raw ID string.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/lib/regions.ts` | `formatRegion()` utility — maps region IDs to human-friendly labels |
| `apps/frontend/src/components/workspace-settings/general-tab.tsx` | General tab showing workspace name, data region, and creation date |
| `docs/region-migration.md` | Design sketch for how workspace region migration would work |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx` | Import and render `GeneralTab` in place of placeholder text |
| `apps/frontend/src/pages/workspace-select.tsx` | Use `formatRegion()` in region picker instead of raw IDs |

## Test plan

- [x] `bun run typecheck` passes
- [x] Lint and prettier pass
- [ ] Open workspace settings → General tab shows name, formatted region, and created date
- [ ] Region picker in workspace creation shows formatted names (e.g. "Europe (Stockholm)" not "eu-north-1")
- [ ] Workspaces without `region` field don't render the region row

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
