### PR TITLE
Use bun install instead of npm install in Claude Code Web setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "command": "[ -f /tmp/.claude-code-web ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; (npm install --prefer-offline 2>/dev/null || npm install) }; exit 0",
+        "command": "[ -f /tmp/.claude-code-web ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; bun install }; exit 0",
         "timeout": 180
       }
     ]

--- a/docs/claude-code-web.md
+++ b/docs/claude-code-web.md
@@ -19,13 +19,9 @@ The `.claude/settings.json` SessionStart hook runs after clone and:
 
 - Copies `.env.claude-code-web` to `.env` (if not already present)
 - Runs `docker compose up -d --wait` to start PostgreSQL 17 with pgvector and MinIO
-- Runs `npm install` (bun install fails due to the proxy not supporting HTTPS CONNECT)
+- Runs `bun install`
 
 This uses the same `docker-compose.yml` and ports as local dev (Postgres 5454, MinIO 9099).
-
-## Dependency Installation
-
-`bun install` fails in the sandbox due to the HTTP proxy not supporting HTTPS CONNECT tunneling. The SessionStart hook uses `npm install` as a fallback instead.
 
 ## Environment
 


### PR DESCRIPTION
## Summary
Updates the Claude Code Web sandbox setup to use `bun install` for dependency installation instead of falling back to `npm install`.

## Changes
- Updated `.claude/settings.json` SessionStart hook to run `bun install` directly instead of attempting `npm install` as a fallback
- Removed the "Dependency Installation" section from `docs/claude-code-web.md` that documented the `bun install` proxy limitation
- Updated documentation to reflect that `bun install` is now the standard dependency installation method

## Details
The previous implementation worked around an HTTP proxy limitation that prevented `bun install` from working in the sandbox environment. This change assumes that limitation has been resolved, allowing `bun install` to be used directly as the primary (and only) dependency installation method. This simplifies the setup process and removes the need for npm as a fallback.

https://claude.ai/code/session_01UuzsZBSEPkTZPj8X9z8h7m