### PR TITLE
fix: pre-fetch stream bootstrap on push notification for instant messages

### DIFF
--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -26,12 +26,8 @@ precacheAndRoute(self.__WB_MANIFEST)
 /** Cache name for pre-fetched bootstrap responses triggered by push notifications. */
 const PUSH_BOOTSTRAP_CACHE = "push-bootstrap"
 
-/**
- * Synchronous set of bootstrap URL pathnames that have been pre-fetched.
- * Lets the fetch interceptor skip `respondWith` entirely when no cache entry
- * exists, so the browser handles the request natively with zero SW overhead.
- */
-const prefetchedBootstrapPaths = new Set<string>()
+/** Regex matching stream bootstrap API paths. */
+const BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/streams\/[^/]+\/bootstrap$/
 
 /**
  * Pre-fetch the stream bootstrap API and store the response in the Cache API
@@ -47,20 +43,22 @@ async function prefetchStreamBootstrap(workspaceId: string, streamId: string): P
 
   const cache = await caches.open(PUSH_BOOTSTRAP_CACHE)
   await cache.put(url, response)
-  prefetchedBootstrapPaths.add(url)
 }
 
 /**
  * Fetch interceptor: serve pre-fetched bootstrap responses from the push cache.
  * Entries are one-shot — deleted after being served so subsequent fetches hit the network.
  *
- * Uses `prefetchedBootstrapPaths` as a synchronous guard so we only call
- * `respondWith` when a cache entry actually exists. Requests without a
- * pre-fetched entry fall through to the browser's native fetch with no SW overhead.
+ * Uses a regex guard (not an in-memory Set) because mobile browsers terminate
+ * the SW between push receipt and notification tap — any in-memory state would
+ * be lost, orphaning the cache entry. The Cache API is persistent and is the
+ * sole source of truth. The per-request cost of a regex test + async cache miss
+ * is sub-millisecond — negligible compared to the network round-trip it replaces
+ * on a cache hit.
  */
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url)
-  if (!prefetchedBootstrapPaths.has(url.pathname)) return
+  if (!BOOTSTRAP_PATH_RE.test(url.pathname)) return
 
   event.respondWith(
     (async () => {
@@ -68,12 +66,10 @@ self.addEventListener("fetch", (event) => {
       const cached = await cache.match(event.request.url)
       if (cached) {
         // One-shot: serve and delete so the next fetch gets fresh data
-        prefetchedBootstrapPaths.delete(url.pathname)
         void cache.delete(event.request.url)
         return cached
       }
-      // Guard was stale (e.g. cache evicted) — clean up and fall through to network
-      prefetchedBootstrapPaths.delete(url.pathname)
+      // No pre-fetched data — pass through to network
       return fetch(event.request)
     })()
   )


### PR DESCRIPTION
## Problem

When receiving a push notification on mobile (especially on cell data), tapping it navigates to the stream but there's a 1-4 second delay before messages appear. This is because the stream bootstrap API call only fires when the stream view mounts — the user stares at an empty message list while waiting for the network round-trip.

If 5 messages arrived (grouped into one notification), or 10 messages arrived where only 1 triggered a notification, none of them are visible until the bootstrap fetch completes.

## Solution

Pre-fetch the stream bootstrap data in the service worker when a push notification arrives, so it's already cached when the user taps the notification.

### How it works

```
Push arrives → SW shows notification → SW pre-fetches /api/.../bootstrap → Cache API stores response
                                                            ↓
User taps notification → App navigates to stream → useStreamBootstrap fires fetch()
                                                            ↓
                                              SW fetch interceptor serves cached response → Instant render
                                                            ↓
                                              useStreamSocket mounts → invalidates bootstrap → Background refetch
```

1. **On push receipt:** After displaying the notification, the SW fetches the stream bootstrap API (using same-origin cookies) and stores the response in a dedicated Cache API store (`push-bootstrap`).

2. **On notification tap:** The app navigates to the stream and `useStreamBootstrap` fires its `queryFn`, which calls `fetch()`. The SW's fetch event interceptor matches the bootstrap URL pattern, finds the pre-cached response, serves it instantly, and deletes the cache entry (one-shot).

3. **Background refresh:** `useStreamSocket` detects that bootstrap data already exists in the TanStack cache and invalidates it, triggering a silent background refetch for full consistency.

### Key design decisions

**1. Cache API + fetch interceptor (zero frontend changes)**

The entire fix lives in the service worker. By using the Cache API and a fetch event interceptor, the pre-fetched response is served transparently — the React code, TanStack Query hooks, and API client are completely unaware. This avoids touching the critical bootstrap path.

**2. One-shot cache entries**

Cache entries are deleted immediately after being served. This ensures subsequent fetches (like the background refetch from socket invalidation) always hit the network and get fresh data.

**3. Best-effort pre-fetch**

The pre-fetch is wrapped in a `.catch(() => {})` — if it fails (auth expired, network error, timeout), the notification still displays normally and the standard bootstrap flow takes over. The pre-fetch never blocks or degrades the notification experience.

**4. Each push overwrites the cache for its stream**

If 5 messages arrive in quick succession for the same stream, each push re-fetches the bootstrap (which includes all recent messages). The last pre-fetch wins, containing all 5 messages. When the user taps the grouped notification, all messages are there.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/sw.ts` | Added `prefetchStreamBootstrap()` function, Cache API fetch interceptor for bootstrap URLs, and pre-fetch call in the push event handler |

## Test plan

- [x] TypeScript typecheck passes (full monorepo)
- [x] ESLint passes
- [x] Frontend builds successfully (including SW compilation)
- [ ] Manual: receive push notification on mobile → tap → verify messages appear instantly
- [ ] Manual: receive multiple notifications for same stream → tap grouped notification → verify all messages present
- [ ] Manual: verify normal (non-notification) stream navigation still works as before
- [ ] Manual: verify pre-fetch failure (e.g. airplane mode between push and tap) falls back to normal fetch gracefully

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
