### PR TITLE
fix: prevent style button touch pass-through on mobile

### DIFF
--- a/apps/frontend/src/components/editor/editor-action-bar.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.tsx
@@ -105,7 +105,9 @@ export function EditorActionBar({
         </Tooltip>
       )}
 
-      {/* Format toggle */}
+      {/* Format toggle — split: pointerdown only prevents blur, click toggles toolbar.
+         Firing the toggle on pointerdown would cause the newly-appeared toolbar buttons
+         to receive the subsequent pointerup/click, inadvertently activating a mark. */}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -115,8 +117,8 @@ export function EditorActionBar({
             aria-label="Formatting"
             aria-pressed={formatOpen}
             className={cn("h-7 w-7 shrink-0", formatOpen && "bg-accent text-accent-foreground")}
-            onPointerDown={handlePointerAction(() => onFormatOpenChange(!formatOpen))}
-            onClick={handleKeyboardClick(() => onFormatOpenChange(!formatOpen))}
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => onFormatOpenChange(!formatOpen)}
             disabled={disabled}
           >
             <span className="text-[13px] font-bold leading-none tracking-tight">Aa</span>


### PR DESCRIPTION
## Problem

On mobile, tapping the Aa (Format) button to open the formatting toolbar would inadvertently activate a toolbar button (typically Strikethrough or Italic). The touch event "passed through" to the newly-rendered toolbar buttons beneath the finger.

This was previously fixed in PR #213 but regressed when PR #210 applied the `handlePointerAction`/`handleKeyboardClick` pattern uniformly to all action bar buttons — including the Format toggle, which needs special treatment.

## Solution

Special-case the Format toggle button so it no longer fires `onFormatOpenChange` on `pointerdown`. Instead:

- **`onPointerDown`** → only calls `preventDefault()` (prevents editor blur, keeps virtual keyboard open)
- **`onClick`** → toggles `formatOpen` (fires after `pointerup`, when the touch cycle is complete)

This ensures the toolbar doesn't render until the full touch event cycle finishes, so there's no target underneath the finger to receive a stray `pointerup`/`click`.

### Key design decisions

**1. Split pointerdown vs click for the Format button only**

Other action bar buttons (Emoji, Mention, Expand) correctly use `handlePointerAction` to fire on `pointerdown` — they don't cause new UI to appear under the tap point, so pass-through isn't an issue. The Format toggle is unique because it reveals a toolbar row directly adjacent to the button.

**2. Restoring the PR #213 approach**

PR #213 originally solved this exact problem with the same split-handler technique. Rather than inventing a new approach (e.g. delayed rendering, pointer capture, touch-action CSS), this restores the proven fix.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/editor/editor-action-bar.tsx` | Format toggle button: `onPointerDown` only prevents default, `onClick` toggles toolbar |

## Test plan

- [ ] On mobile (or touch simulator): tap Aa to open toolbar — no formatting mark should activate
- [ ] Tap Aa again to close toolbar — should toggle cleanly
- [ ] Editor focus and virtual keyboard should remain active throughout
- [ ] Desktop: Format toggle still works via mouse click and keyboard

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
