### PR TITLE
fix: prevent workspace picker flicker during cache seed refresh

### DIFF
--- a/apps/frontend/src/pages/workspace-select.test.tsx
+++ b/apps/frontend/src/pages/workspace-select.test.tsx
@@ -142,7 +142,7 @@ describe("WorkspaceSelectPage", () => {
     expect(await screen.findByTestId("setup-route")).toBeInTheDocument()
   })
 
-  it("should not auto-redirect while seeded data is being refreshed", () => {
+  it("should show loading state (not picker) while seeded data is being refreshed", () => {
     mockUseWorkspaces.mockReturnValue({
       workspaces: [makeWorkspace("workspace_1", "Solo")],
       pendingInvitations: [],
@@ -153,7 +153,8 @@ describe("WorkspaceSelectPage", () => {
 
     renderPage()
 
-    expect(screen.getByText("Select a workspace to continue")).toBeInTheDocument()
+    expect(screen.getByText("Loading...")).toBeInTheDocument()
+    expect(screen.queryByText("Select a workspace to continue")).not.toBeInTheDocument()
   })
 
   it("should show workspace picker when user has multiple workspaces", () => {

--- a/apps/frontend/src/pages/workspace-select.tsx
+++ b/apps/frontend/src/pages/workspace-select.tsx
@@ -89,8 +89,22 @@ export function WorkspaceSelectPage() {
   // Only auto-redirect when there are no pending invitations and no accept in flight.
   // Wait for seeded data to be replaced by a real fetch — seeded cache has
   // pendingInvitations: [] which would cause a false redirect if a real invitation exists.
-  if (workspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId && !isRefreshingSeed) {
+  const willLikelyRedirect = workspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId
+  if (willLikelyRedirect && !isRefreshingSeed) {
     return <Navigate to={`/w/${workspaces[0].id}`} replace />
+  }
+
+  // Show loading state (not the full picker) while seed data is being confirmed.
+  // Without this, the full workspace picker UI flashes briefly before the redirect.
+  if (willLikelyRedirect && isRefreshingSeed) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-4">
+          <ThreaLogo size="lg" className="animate-pulse" />
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary

- Show a loading spinner instead of the full workspace picker UI while seeded data is being confirmed by a real fetch, preventing a visible flash of `loading → picker → redirect` for single-workspace users
- Extract `willLikelyRedirect` condition to share between the redirect and loading state branches
- Scope the `isRefreshingSeed` guard to seeded data only, so normal background refetches don't suppress auto-redirect

## Test plan

- [ ] Install PWA, kill app, reopen — single-workspace user sees `loading → redirect` with no picker flash
- [ ] Multi-workspace user still sees the full picker immediately
- [ ] User with pending invitations sees invitations after seed refresh completes
- [ ] Existing workspace-select tests pass (`bun run test`)

https://claude.ai/code/session_01X4nSoEM1yjhdzU4QjWAM3C