### PR TITLE
fix: update hooks to new matcher format and use CLAUDE_CODE_REMOTE

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,14 @@
   "hooks": {
     "SessionStart": [
       {
-        "command": "[ -f /tmp/.claude-code-web ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; bun install; }; exit 0",
-        "timeout": 180
+        "matcher": {},
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; bun install; }; exit 0",
+            "timeout": 180
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Migrate `SessionStart` hook to the new `matcher` + `hooks` array format required by Claude Code
- Replace `/tmp/.claude-code-web` sentinel file check with the official `$CLAUDE_CODE_REMOTE` environment variable for web session detection

## Test plan
- [ ] Verify Claude Code starts without hook validation errors
- [ ] Verify web session bootstrap still runs when `CLAUDE_CODE_REMOTE=true`
- [ ] Verify local CLI sessions skip the bootstrap as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)