### PR TITLE
Make Ariadne's prompts concise and direct

### DIFF
--- a/apps/backend/src/db/migrations/20260319072852_ariadne_concise_system_prompt.sql
+++ b/apps/backend/src/db/migrations/20260319072852_ariadne_concise_system_prompt.sql
@@ -1,0 +1,6 @@
+-- Update Ariadne's base system prompt to be more concise and direct
+UPDATE personas
+SET system_prompt = 'You are Ariadne, an AI thinking companion in Threa. You help users explore ideas, think through problems, and make decisions. You have access to their previous conversations and knowledge base through the GAM (General Agentic Memory) system.
+
+Keep responses short and direct. Default to a few sentences unless the user asks for depth. Be warm but not wordy — say what matters and stop. Ask clarifying questions rather than guessing at length.'
+WHERE id = 'persona_system_ariadne';

--- a/apps/backend/src/features/agents/companion/prompt/stream-context-sections.ts
+++ b/apps/backend/src/features/agents/companion/prompt/stream-context-sections.ts
@@ -12,28 +12,14 @@ export function buildScratchpadPrompt(context: StreamContext, workspaceResearchE
   if (context.streamInfo.name) {
     section += ` called "${context.streamInfo.name}"`
   }
-  section += ". This is a private, personal space for notes and thinking."
+  section += ". This is a private space for notes and thinking."
 
   if (context.streamInfo.description) {
     section += `\n\nDescription: ${context.streamInfo.description}`
   }
 
-  section += `
-
-## Workspace Knowledge Access
-
-You have access to the user's workspace knowledge through the GAM (General Agentic Memory) system:
-- Their other scratchpads and notes
-- Channels they're a member of
-- DMs they're participating in
-- Memos (summarized knowledge) from past conversations
-
-`
-
   if (workspaceResearchEnabled) {
-    section += `Use the \`workspace_research\` tool when you need this additional context. If a "Retrieved Knowledge" section appears below, it contains information found relevant to this conversation. You can reference this knowledge naturally without explicitly citing sources unless the user asks where information came from.`
-  } else {
-    section += `Workspace research is not available in this run, so rely on the active conversation context and ask follow-up questions when needed.`
+    section += `\n\nYou can use the \`workspace_research\` tool to retrieve relevant knowledge from past conversations, scratchpads, and memos. Reference retrieved knowledge naturally without citing sources unless asked.`
   }
 
   return section
@@ -53,7 +39,7 @@ export function buildChannelPrompt(context: StreamContext): string {
   if (context.streamInfo.slug) {
     section += ` (#${context.streamInfo.slug})`
   }
-  section += ". This is a collaborative space where team members can discuss topics together."
+  section += ". This is a collaborative team space."
 
   if (context.streamInfo.description) {
     section += `\n\nChannel description: ${context.streamInfo.description}`
@@ -80,7 +66,7 @@ export function buildThreadPrompt(context: StreamContext): string {
   if (context.streamInfo.name) {
     section += ` called "${context.streamInfo.name}"`
   }
-  section += ". This is a focused discussion branching from a parent conversation."
+  section += ". This is a focused thread branching from a parent conversation."
 
   if (context.streamInfo.description) {
     section += `\n\nThread description: ${context.streamInfo.description}`
@@ -124,7 +110,7 @@ export function buildDmPrompt(context: StreamContext): string {
     const names = context.participants.map((p) => p.name).join(" and ")
     section += ` between ${names}`
   }
-  section += ". This is a private, focused conversation between two people."
+  section += "."
 
   if (context.streamInfo.description) {
     section += `\n\nDescription: ${context.streamInfo.description}`

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -60,24 +60,19 @@ Key behaviors:
 - Call send_message to deliver your response. You can call it multiple times for multi-part responses.
 - If you have nothing to add (e.g., the question was already answered), simply don't call send_message.
 - If new messages arrive while you're processing, you'll see them and can incorporate them in your response.
-- Be helpful, concise, and conversational.`
+
+## Response Style
+
+Be brief. Default to 1–3 sentences. Match the depth to what was asked — a simple question gets a simple answer. Only go longer when the topic genuinely requires it (step-by-step instructions, complex analysis the user requested, etc.). Avoid preamble, filler, and restating what the user said. Be friendly and warm in tone, but don't pad with extra words.`
 
   if (workspaceResearchEnabled) {
     prompt += `
 
 ## Workspace Research
 
-You have a \`workspace_research\` tool to retrieve relevant workspace memory (messages, memos, and attachments) for this conversation.
+You have a \`workspace_research\` tool to retrieve relevant workspace memory (messages, memos, and attachments).
 
-When to use workspace_research:
-- When you need additional background from past workspace conversations
-- Before answering if you are unsure whether prior context exists
-- When the user asks about previous decisions, conversations, or shared files
-- For scratchpad planning/problem-solving prompts, prefer checking memory early before finalizing your answer
-
-After calling it:
-- Incorporate the retrieved context naturally into your response
-- Preserve important source-backed details when sending your message`
+Use it when the user asks about past conversations, decisions, or shared files, or when you suspect relevant prior context exists. Incorporate retrieved context naturally into your response.`
   }
 
   prompt += `


### PR DESCRIPTION
Add explicit brevity instructions to the Response Style section so Ariadne
defaults to 1-3 sentences and only goes longer when depth is genuinely needed.
Trim verbose stream context descriptions and consolidate workspace research
instructions. Update base system prompt via migration to reinforce short,
warm-but-not-wordy behavior.

https://claude.ai/code/session_01YKxdGKpwyy1W5vaCpEr962