### PR TITLE
Update Ariadne default model from Haiku 4.5 to Sonnet 4.6

### DIFF
--- a/apps/backend/src/db/migrations/20260319120000_ariadne_default_model_sonnet_4_6.sql
+++ b/apps/backend/src/db/migrations/20260319120000_ariadne_default_model_sonnet_4_6.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Update Ariadne default model to Claude Sonnet 4.6
+-- =============================================================================
+
+-- Update column default
+ALTER TABLE personas
+ALTER COLUMN model SET DEFAULT 'openrouter:anthropic/claude-sonnet-4.6';
+
+-- Update existing Ariadne persona
+UPDATE personas
+SET model = 'openrouter:anthropic/claude-sonnet-4.6'
+WHERE id = 'persona_system_ariadne';

--- a/apps/backend/src/features/ai-usage/budget-service.ts
+++ b/apps/backend/src/features/ai-usage/budget-service.ts
@@ -30,6 +30,7 @@ const SOFT_LIMIT_THRESHOLD = 0.8 // 80% - start degrading models
  */
 const MODEL_DEGRADATION_MAP: Record<string, string> = {
   // Claude models - degrade to Haiku
+  "openrouter:anthropic/claude-sonnet-4.6": "openrouter:anthropic/claude-haiku-4.5",
   "openrouter:anthropic/claude-sonnet-4-20250514": "openrouter:anthropic/claude-haiku-4.5",
   "openrouter:anthropic/claude-sonnet-4.5": "openrouter:anthropic/claude-haiku-4.5",
   "openrouter:anthropic/claude-sonnet-4": "openrouter:anthropic/claude-haiku-4.5",

--- a/apps/backend/src/lib/ai/models.yaml
+++ b/apps/backend/src/lib/ai/models.yaml
@@ -7,6 +7,11 @@
 
 models:
   # Anthropic Claude models
+  openrouter:anthropic/claude-sonnet-4.6:
+    name: Claude Sonnet 4.6
+    inputModalities: [text, image]
+    outputModalities: [text]
+
   openrouter:anthropic/claude-sonnet-4.5:
     name: Claude Sonnet 4.5
     inputModalities: [text, image]

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -32,6 +32,26 @@ All models use `provider:modelPath` format:
 
 ## Inference Models
 
+### openrouter:anthropic/claude-sonnet-4.6
+
+**Name:** Claude Sonnet 4.6
+
+**Description:** Latest high-quality reasoning model from Anthropic's Claude 4.6 generation. Successor to Claude Sonnet 4.5 with improved capabilities.
+
+**Typical cost:** ~$3.00 per 1M input tokens, ~$15.00 per 1M output tokens
+
+**When to use:**
+
+- Complex reasoning and generation
+- Multi-turn agent conversations
+- Nuanced text generation requiring high quality
+- Default Ariadne companion persona model
+- Tasks where quality justifies higher cost
+
+**Use instead of:** `claude-sonnet-4.5` for improved quality
+
+---
+
 ### openrouter:anthropic/claude-haiku-4.5
 
 **Name:** Claude Haiku 4.5


### PR DESCRIPTION
Upgrades the default persona model for Ariadne to Claude Sonnet 4.6 for
improved reasoning quality. Adds migration to update both the column
default and existing Ariadne persona row, registers the model in
models.yaml and model-reference.md, and adds budget degradation mapping.

https://claude.ai/code/session_01TwuueJQURaEKYNzxN9hWhN