### PR TITLE
Fix unread divider too close to message content

### DIFF
--- a/apps/frontend/src/components/timeline/unread-divider.tsx
+++ b/apps/frontend/src/components/timeline/unread-divider.tsx
@@ -5,7 +5,7 @@ interface UnreadDividerProps {
 export function UnreadDivider({ isFading }: UnreadDividerProps) {
   return (
     <div
-      className={`absolute left-0 right-0 top-0 -translate-y-1/2 z-10 flex items-center gap-3 pointer-events-none transition-opacity duration-500 ${
+      className={`absolute left-0 right-0 -top-2 -translate-y-1/2 z-10 flex items-center gap-3 pointer-events-none transition-opacity duration-500 ${
         isFading ? "opacity-0" : "opacity-100"
       }`}
     >


### PR DESCRIPTION
Move the absolutely-positioned unread indicator strip up by 8px
(-top-2) to add visual breathing room above the first unread
message. No layout shift since the divider is position: absolute.

https://claude.ai/code/session_013Kf7a1DdLKh2sJ8pKdDyw5