### PR TITLE
chore: add review-greptile skill

### DIFF
--- a/.agents/skills/review-greptile/SKILL.md
+++ b/.agents/skills/review-greptile/SKILL.md
@@ -88,19 +88,24 @@ Cross-reference with recent commits to determine which comments are still releva
 GREPTILE_TS=$(gh api "repos/$OWNER/$REPO/pulls/$PR/comments" \
   --jq '[.[] | select(.user.login == "greptile-apps[bot]")] | last | .created_at')
 
-# List files changed only in commits *after* Greptile's review
-gh api "repos/$OWNER/$REPO/pulls/$PR/commits" \
-  | jq -r --arg ts "$GREPTILE_TS" '[.[] | select(.commit.author.date > $ts)] | .[].sha' \
-  | while read sha; do
-      gh api "repos/$OWNER/$REPO/commits/$sha" --jq '.files[].filename'
-    done | sort -u
+# Skip staleness check if there are no inline comments
+if [ -z "$GREPTILE_TS" ]; then
+  echo "No inline comments found — skipping staleness check."
+else
+  # List files changed only in commits *after* Greptile's review
+  gh api "repos/$OWNER/$REPO/pulls/$PR/commits" \
+    | jq -r --arg ts "$GREPTILE_TS" '[.[] | select(.commit.author.date > $ts)] | .[].sha' \
+    | while read sha; do
+        gh api "repos/$OWNER/$REPO/commits/$sha" --jq '.files[].filename'
+      done | sort -u
+fi
 ```
 
 If a file mentioned in a Greptile comment was modified in a later commit, the comment may already be addressed — read the current code to verify before acting on it.
 
 ### 5. Triage
 
-For each issue found in steps 3 and 4, determine its disposition:
+For each issue found in steps 3 and 4, determine its disposition. Tag each row with its **Source** (Summary or Inline) — this determines what response actions are available in step 7:
 
 | # | Source | File:Line | Issue Summary | Disposition | Action |
 |---|--------|-----------|---------------|-------------|--------|
@@ -127,9 +132,11 @@ Commit and push all fixes together.
 
 ### 7. Respond to inline comments
 
-Reply to each inline thread with the disposition. Use the `respond-to-pr-review` skill's reply mechanics (write to temp file, post via GraphQL, include agent signature).
+Reply to each **Inline-sourced** thread with the disposition. Use the `respond-to-pr-review` skill's reply mechanics (write to temp file, post via GraphQL, include agent signature).
 
 Resolve threads for **Accept** (fix applied) and **Dispute** (with explanation). Leave **Acknowledge** threads open.
+
+**Summary-only findings** have no inline thread to reply to. For these, Dispute/Acknowledge dispositions are noted in the triage table for the user's awareness but require no thread response — the re-review in step 8 will confirm whether accepted fixes resolved them.
 
 ### 8. Wait for re-review
 


### PR DESCRIPTION
## Problem

During the infinite scroll PR (#237), we went through multiple rounds of Greptile reviews. The process was inconsistent — sometimes we missed or misread comments, re-fetched stale data, or didn't properly distinguish between the continuously-updated summary comment and the one-shot inline code comments.

## Solution

Add a `review-greptile` skill that standardizes how we interact with Greptile code reviews. It's a procedural guide with two key behaviors:

1. **Always re-read the summary comment** — it gets updated after every review cycle and contains the confidence score, outside-of-diff issues, and the "Fix with Claude" link with pre-formatted context
2. **Triage inline code comments** — these are one-shot and may already be resolved by fixes; cross-reference with recent commits before acting

### Key design decisions

**1. Separate from `respond-to-pr-review`**

The existing `respond-to-pr-review` skill handles general PR review comments from any reviewer. This skill is Greptile-specific because Greptile has unique mechanics (continuously-updated summary, "Fix with Claude" links, confidence scores, ~10 min review cycles) that need dedicated handling.

**2. Emphasis on re-reading the summary**

The biggest mistake during #237 was acting on stale summary data. The skill makes "always re-fetch the summary comment" a first-class step rather than an assumption.

## New files

| File | Purpose |
|------|---------|
| `.agents/skills/review-greptile/SKILL.md` | Greptile review triage skill with 8-step workflow |

## Test plan

- [x] Skill file created and accessible via `.claude/skills` symlink
- [x] Follows existing skill conventions (frontmatter, numbered steps, bash examples)
- [x] Registered in available skills list

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
