### PR TITLE
fix: prevent message flicker on send in stream view

### DIFF
--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useCallback } from "react"
-import { useQueryClient } from "@tanstack/react-query"
 import { useSocketConnected, useMessageService, usePendingMessages } from "@/contexts"
 import { db } from "@/db"
-import { streamKeys } from "./use-streams"
 import { parseMarkdown } from "@threa/prosemirror"
-import type { StreamEvent } from "@threa/types"
 
 const MAX_RETRY_COUNT = 3
 
@@ -25,7 +22,6 @@ export function useMessageQueue(): void {
   const isConnected = useSocketConnected()
   const messageService = useMessageService()
   const { markPending, markFailed, markSent, registerQueueNotify } = usePendingMessages()
-  const queryClient = useQueryClient()
 
   const isProcessing = useRef(false)
   const hasPendingWork = useRef(false)
@@ -77,15 +73,11 @@ export function useMessageQueue(): void {
           await db.pendingMessages.delete(next.clientId)
           await db.events.delete(next.clientId)
 
-          queryClient.setQueryData(streamKeys.bootstrap(next.workspaceId, next.streamId), (old: unknown) => {
-            if (!old || typeof old !== "object") return old
-            const bootstrap = old as { events: StreamEvent[] }
-            return {
-              ...bootstrap,
-              events: bootstrap.events.filter((e) => e.id !== next.clientId),
-            }
-          })
-
+          // Don't remove the optimistic event from the React Query cache here.
+          // The socket handler (handleMessageCreated) atomically swaps the
+          // optimistic event for the real server event in a single setQueryData
+          // call, preventing the message from flickering out of view between
+          // the HTTP response and the socket broadcast.
           markSent(next.clientId)
         } catch {
           // Increment retry count only after a confirmed failure, so transient
@@ -110,7 +102,7 @@ export function useMessageQueue(): void {
         void processQueue()
       }
     }
-  }, [messageService, queryClient, markPending, markFailed, markSent])
+  }, [messageService, markPending, markFailed, markSent])
 
   // Register notify callback so other hooks can kick the queue via context
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Remove the eager optimistic event removal from the message queue's success handler (`use-message-queue.ts`), which was causing a one-render-cycle gap where the sent message disappeared before the socket broadcast arrived with the real event
- The socket handler (`handleMessageCreated`) already performs an atomic swap — finding the matching optimistic event and replacing it with the real server event in a single `setQueryData` call — so the queue's removal was redundant and racy

## How it worked before (bug)
1. User sends message → optimistic event added to cache (instant UI)
2. Queue sends HTTP request → server creates message, broadcasts via socket
3. **Queue success handler removes optimistic event from cache** → message disappears
4. Socket event arrives → real event added → message reappears (flicker)

## How it works now (fix)
1. User sends message → optimistic event added to cache (instant UI)
2. Queue sends HTTP request → `markSent()` transitions message from "Sending..." to normal appearance
3. Socket event arrives → atomically swaps optimistic for real event (no gap, no flicker)

## Follow-up needed
- Messages currently display from React Query cache, not IndexedDB — this means optimistic events can be lost on bootstrap refetch (e.g. socket reconnect). Making IndexedDB the single source of truth for displayed messages would fix the separate "messages sometimes disappear" issue.

## Test plan
- [x] TypeScript type check passes
- [x] All 8 `use-message-queue.test.ts` tests pass
- [x] Lint and pre-commit hooks pass
- [ ] Manual: send a message in a stream — it should appear instantly with "Sending..." then transition to sent without any flicker or jump
- [ ] Manual: send multiple messages quickly — all should remain visible in order
- [ ] Manual: send a message while offline, reconnect — message should be delivered without disappearing

https://claude.ai/code/session_01HzuZfhxS8NyJyNqXDJ9Kht
