### PR TITLE
Remove @tanstack/react-virtual in favor of react-virtuoso

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -43,7 +43,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/themes": "^3.3.0",
     "@tanstack/react-query": "^5.90.12",
-    "@tanstack/react-virtual": "^3.13.23",
     "@threa/prosemirror": "workspace:*",
     "@threa/types": "workspace:*",
     "@tiptap/core": "^3.14.0",

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -8,6 +8,7 @@ import type { SuggestionListRef } from "./suggestion-list"
 const GRID_COLUMNS = 8
 const ROW_HEIGHT = 34 // w-8 (32px) + 2px vertical gap
 const CONTAINER_HEIGHT = 256 // max-h-64 = 256px
+const VirtuosoPadding = () => <div className="h-2" />
 
 export interface EmojiGridProps {
   items: EmojiEntry[]
@@ -212,7 +213,7 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
           rangeRef.current = range
         }}
         style={{ height: CONTAINER_HEIGHT }}
-        components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
+        components={{ Header: VirtuosoPadding, Footer: VirtuosoPadding }}
         itemContent={(index) => {
           const rowItems = rows[index]
           const rowStartIndex = index * GRID_COLUMNS

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -6,7 +6,7 @@ import type { EmojiEntry } from "@threa/types"
 import type { SuggestionListRef } from "./suggestion-list"
 
 const GRID_COLUMNS = 8
-const ROW_HEIGHT = 32 // 8 (w-8) = 32px
+const ROW_HEIGHT = 34 // w-8 (32px) + 2px vertical gap
 const CONTAINER_HEIGHT = 256 // max-h-64 = 256px
 
 export interface EmojiGridProps {
@@ -217,7 +217,7 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
           const rowItems = rows[index]
           const rowStartIndex = index * GRID_COLUMNS
           return (
-            <div className="flex gap-0.5">
+            <div className="flex gap-0.5 pb-0.5">
               {rowItems.map((item, colIndex) => {
                 const itemIndex = rowStartIndex + colIndex
                 return (

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -212,7 +212,8 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
           rangeRef.current = range
         }}
         style={{ height: CONTAINER_HEIGHT }}
-        className="p-2"
+        className="px-2"
+        components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
         itemContent={(index) => {
           const rowItems = rows[index]
           const rowStartIndex = index * GRID_COLUMNS

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState, memo } from "react"
 import { useFloating, offset, flip, shift, autoUpdate } from "@floating-ui/react"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { cn } from "@/lib/utils"
 import type { EmojiEntry } from "@threa/types"
 import type { SuggestionListRef } from "./suggestion-list"
@@ -50,7 +50,8 @@ const EmojiButton = memo(function EmojiButton({ item, isSelected, onClick, onMou
  */
 function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: React.ForwardedRef<SuggestionListRef>) {
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const virtuosoRef = useRef<VirtuosoHandle>(null)
+  const rangeRef = useRef<{ startIndex: number; endIndex: number } | null>(null)
 
   // Group items into rows for virtualization
   const rows: EmojiEntry[][] = []
@@ -58,32 +59,25 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
     rows.push(items.slice(i, i + GRID_COLUMNS))
   }
 
-  const virtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => ROW_HEIGHT,
-    overscan: 3,
-  })
-
   // Reset selection when items change
   useEffect(() => {
     setSelectedIndex(0)
-    virtualizer.scrollToIndex(0)
-  }, [items, virtualizer])
+    virtuosoRef.current?.scrollToIndex({ index: 0 })
+  }, [items])
 
   // Scroll to row only if it's outside the visible range
   const scrollToRowIfNeeded = (index: number) => {
     const row = Math.floor(index / GRID_COLUMNS)
-    const range = virtualizer.range
+    const range = rangeRef.current
     if (range && (row < range.startIndex || row > range.endIndex)) {
-      virtualizer.scrollToIndex(row, { align: "auto" })
+      virtuosoRef.current?.scrollToIndex({ index: row, align: row < range.startIndex ? "start" : "end" })
     }
   }
 
   // Force scroll to row (for Home/End/PageUp/PageDown)
   const scrollToRow = (index: number) => {
     const row = Math.floor(index / GRID_COLUMNS)
-    virtualizer.scrollToIndex(row, { align: "start" })
+    virtuosoRef.current?.scrollToIndex({ index: row, align: "start" })
   }
 
   // Calculate visible rows for page navigation
@@ -209,48 +203,37 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
       aria-label="Emoji picker"
       data-emoji-grid
     >
-      <div ref={scrollContainerRef} className="overflow-y-auto p-2" style={{ height: CONTAINER_HEIGHT }}>
-        <div
-          style={{
-            height: virtualizer.getTotalSize(),
-            width: "100%",
-            position: "relative",
-          }}
-        >
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const rowItems = rows[virtualRow.index]
-            const rowStartIndex = virtualRow.index * GRID_COLUMNS
-
-            return (
-              <div
-                key={virtualRow.key}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  height: ROW_HEIGHT,
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-                className="flex gap-0.5"
-              >
-                {rowItems.map((item, colIndex) => {
-                  const itemIndex = rowStartIndex + colIndex
-                  return (
-                    <EmojiButton
-                      key={item.shortcode}
-                      item={item}
-                      isSelected={itemIndex === selectedIndex}
-                      onClick={() => command(item)}
-                      onMouseEnter={() => setSelectedIndex(itemIndex)}
-                    />
-                  )
-                })}
-              </div>
-            )
-          })}
-        </div>
-      </div>
+      <Virtuoso
+        ref={virtuosoRef}
+        totalCount={rows.length}
+        fixedItemHeight={ROW_HEIGHT}
+        increaseViewportBy={ROW_HEIGHT * 3}
+        rangeChanged={(range) => {
+          rangeRef.current = range
+        }}
+        style={{ height: CONTAINER_HEIGHT }}
+        className="p-2"
+        itemContent={(index) => {
+          const rowItems = rows[index]
+          const rowStartIndex = index * GRID_COLUMNS
+          return (
+            <div className="flex gap-0.5">
+              {rowItems.map((item, colIndex) => {
+                const itemIndex = rowStartIndex + colIndex
+                return (
+                  <EmojiButton
+                    key={item.shortcode}
+                    item={item}
+                    isSelected={itemIndex === selectedIndex}
+                    onClick={() => command(item)}
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}
+                  />
+                )
+              })}
+            </div>
+          )
+        }}
+      />
       {/* Footer showing selected emoji shortcode */}
       {selectedEmoji && (
         <div className="border-t px-2 py-1.5 text-xs text-muted-foreground truncate">

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -212,13 +212,12 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
           rangeRef.current = range
         }}
         style={{ height: CONTAINER_HEIGHT }}
-        className="px-2"
         components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
         itemContent={(index) => {
           const rowItems = rows[index]
           const rowStartIndex = index * GRID_COLUMNS
           return (
-            <div className="flex gap-0.5 pb-0.5">
+            <div className="flex gap-0.5 px-2 pb-0.5">
               {rowItems.map((item, colIndex) => {
                 const itemIndex = rowStartIndex + colIndex
                 return (

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -349,7 +349,6 @@ function EmojiGridContent({
               fixedItemHeight={MOBILE_ROW_HEIGHT}
               increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
               style={{ height: "100%" }}
-              className="px-4"
               components={{ Header: () => <div className="h-1" />, Footer: () => <div className="h-1" /> }}
               role="listbox"
               aria-label="Emoji picker"
@@ -357,7 +356,7 @@ function EmojiGridContent({
                 const rowItems = rows[index]
                 return (
                   <div
-                    className="pb-0.5"
+                    className="px-4 pb-0.5"
                     style={{
                       display: "grid",
                       gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -350,6 +350,7 @@ function EmojiGridContent({
               increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
               style={{ height: "100%" }}
               className="px-4"
+              components={{ Header: () => <div className="h-1" />, Footer: () => <div className="h-1" /> }}
               role="listbox"
               aria-label="Emoji picker"
               itemContent={(index) => {
@@ -443,7 +444,8 @@ function EmojiGridContent({
             rangeRef.current = range
           }}
           style={{ height: CONTAINER_HEIGHT }}
-          className="p-2"
+          className="px-2"
+          components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
           role="listbox"
           aria-label="Emoji picker"
           itemContent={(index) => {

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef, useEffect, memo } from "react"
 import { Search, SmilePlus } from "lucide-react"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer"
@@ -86,7 +86,6 @@ function EmojiGridContent({
   onSelect,
   onClose,
   searchInputRef,
-  scrollContainerRef,
   open,
   isMobile,
 }: {
@@ -100,18 +99,21 @@ function EmojiGridContent({
   onSelect: (item: EmojiEntry) => void
   onClose: () => void
   searchInputRef: React.RefObject<HTMLInputElement | null>
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>
   open: boolean
   isMobile: boolean
 }) {
   // Compute column count based on container width on mobile
   const [columns, setColumns] = useState(isMobile ? MAX_MOBILE_COLUMNS : DESKTOP_COLUMNS)
   const rowHeight = isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT
+  const virtuosoRef = useRef<VirtuosoHandle>(null)
+  const rangeRef = useRef<{ startIndex: number; endIndex: number } | null>(null)
+  const scrollerElRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    if (!isMobile || !scrollContainerRef.current) return
+    if (!isMobile || !scrollerElRef.current) return
+    const el = scrollerElRef.current
     const measure = () => {
-      const width = scrollContainerRef.current?.clientWidth ?? 0
+      const width = el?.clientWidth ?? 0
       if (width > 0) {
         const cols = Math.min(MAX_MOBILE_COLUMNS, Math.max(5, Math.floor(width / MOBILE_EMOJI_SIZE)))
         setColumns(cols)
@@ -119,7 +121,7 @@ function EmojiGridContent({
     }
     requestAnimationFrame(measure)
     const observer = new ResizeObserver(measure)
-    observer.observe(scrollContainerRef.current)
+    observer.observe(el)
     return () => observer.disconnect()
   }, [isMobile, open])
 
@@ -161,45 +163,29 @@ function EmojiGridContent({
     return result
   }, [filtered, columns])
 
-  const virtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => rowHeight,
-    overscan: 3,
-  })
-
-  // Force re-measure when the container mounts (portals delay ref attachment)
-  useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => {
-        virtualizer.measure()
-      })
-    }
-  }, [open, virtualizer])
-
   // Reset selection when filtered items change
   useEffect(() => {
     setSelectedIndex(0)
-    if (open) virtualizer.scrollToIndex(0)
-  }, [filtered.length, open, virtualizer, setSelectedIndex])
+    if (open) virtuosoRef.current?.scrollToIndex({ index: 0 })
+  }, [filtered.length, open, setSelectedIndex])
 
   const scrollToRowIfNeeded = useCallback(
     (index: number) => {
       const row = Math.floor(index / columns)
-      const range = virtualizer.range
+      const range = rangeRef.current
       if (range && (row < range.startIndex || row > range.endIndex)) {
-        virtualizer.scrollToIndex(row, { align: "auto" })
+        virtuosoRef.current?.scrollToIndex({ index: row, align: row < range.startIndex ? "start" : "end" })
       }
     },
-    [virtualizer, columns]
+    [columns]
   )
 
   const scrollToRow = useCallback(
     (index: number) => {
       const row = Math.floor(index / columns)
-      virtualizer.scrollToIndex(row, { align: "start" })
+      virtuosoRef.current?.scrollToIndex({ index: row, align: "start" })
     },
-    [virtualizer, columns]
+    [columns]
   )
 
   const visibleRowCount = Math.floor(CONTAINER_HEIGHT / rowHeight)
@@ -351,57 +337,52 @@ function EmojiGridContent({
         )}
 
         {/* Emoji grid — full-bleed CSS grid */}
-        <div
-          ref={scrollContainerRef}
-          className="overflow-y-auto flex-1 px-4"
-          style={{ height: "min(55dvh, 360px)" }}
-          role="listbox"
-          aria-label="Emoji picker"
-        >
-          {filtered.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">No emojis found</div>
-          ) : (
-            <div
-              style={{
-                height: virtualizer.getTotalSize(),
-                width: "100%",
-                position: "relative",
-              }}
-            >
-              {virtualizer.getVirtualItems().map((virtualRow) => {
-                const rowItems = rows[virtualRow.index]
-                return (
-                  <div
-                    key={virtualRow.key}
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: "100%",
-                      height: MOBILE_ROW_HEIGHT,
-                      transform: `translateY(${virtualRow.start}px)`,
-                      display: "grid",
-                      gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                      gap: "2px",
-                    }}
-                  >
-                    {rowItems.map((item) => (
-                      <EmojiButton
-                        key={item.shortcode}
-                        item={item}
-                        isSelected={false}
-                        isActive={activeShortcodes.has(item.shortcode)}
-                        isMobile={true}
-                        onClick={() => onSelect(item)}
-                        onMouseEnter={() => {}}
-                      />
-                    ))}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
+        {filtered.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm text-muted-foreground px-4"
+            style={{ height: "min(55dvh, 360px)" }}
+          >
+            No emojis found
+          </div>
+        ) : (
+          <Virtuoso
+            ref={virtuosoRef}
+            scrollerRef={(el) => {
+              scrollerElRef.current = el as HTMLElement
+            }}
+            totalCount={rows.length}
+            fixedItemHeight={MOBILE_ROW_HEIGHT}
+            increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
+            style={{ height: "min(55dvh, 360px)" }}
+            className="px-4"
+            role="listbox"
+            aria-label="Emoji picker"
+            itemContent={(index) => {
+              const rowItems = rows[index]
+              return (
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                    gap: "2px",
+                  }}
+                >
+                  {rowItems.map((item) => (
+                    <EmojiButton
+                      key={item.shortcode}
+                      item={item}
+                      isSelected={false}
+                      isActive={activeShortcodes.has(item.shortcode)}
+                      isMobile={true}
+                      onClick={() => onSelect(item)}
+                      onMouseEnter={() => {}}
+                    />
+                  ))}
+                </div>
+              )
+            }}
+          />
+        )}
       </>
     )
   }
@@ -448,59 +429,50 @@ function EmojiGridContent({
       )}
 
       {/* Emoji grid */}
-      <div
-        ref={scrollContainerRef}
-        className="overflow-y-auto p-2"
-        style={{ height: CONTAINER_HEIGHT }}
-        role="listbox"
-        aria-label="Emoji picker"
-      >
-        {filtered.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">No emojis found</div>
-        ) : (
-          <div
-            style={{
-              height: virtualizer.getTotalSize(),
-              width: "100%",
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((virtualRow) => {
-              const rowItems = rows[virtualRow.index]
-              const rowStartIndex = virtualRow.index * columns
-              return (
-                <div
-                  key={virtualRow.key}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: DESKTOP_ROW_HEIGHT,
-                    transform: `translateY(${virtualRow.start}px)`,
-                  }}
-                  className="flex gap-0.5"
-                >
-                  {rowItems.map((item, colIndex) => {
-                    const itemIndex = rowStartIndex + colIndex
-                    return (
-                      <EmojiButton
-                        key={item.shortcode}
-                        item={item}
-                        isSelected={itemIndex === selectedIndex}
-                        isActive={activeShortcodes.has(item.shortcode)}
-                        isMobile={false}
-                        onClick={() => onSelect(item)}
-                        onMouseEnter={() => setSelectedIndex(itemIndex)}
-                      />
-                    )
-                  })}
-                </div>
-              )
-            })}
-          </div>
-        )}
-      </div>
+      {filtered.length === 0 ? (
+        <div
+          className="flex items-center justify-center text-sm text-muted-foreground p-2"
+          style={{ height: CONTAINER_HEIGHT }}
+        >
+          No emojis found
+        </div>
+      ) : (
+        <Virtuoso
+          ref={virtuosoRef}
+          totalCount={rows.length}
+          fixedItemHeight={DESKTOP_ROW_HEIGHT}
+          increaseViewportBy={DESKTOP_ROW_HEIGHT * 3}
+          rangeChanged={(range) => {
+            rangeRef.current = range
+          }}
+          style={{ height: CONTAINER_HEIGHT }}
+          className="p-2"
+          role="listbox"
+          aria-label="Emoji picker"
+          itemContent={(index) => {
+            const rowItems = rows[index]
+            const rowStartIndex = index * columns
+            return (
+              <div className="flex gap-0.5">
+                {rowItems.map((item, colIndex) => {
+                  const itemIndex = rowStartIndex + colIndex
+                  return (
+                    <EmojiButton
+                      key={item.shortcode}
+                      item={item}
+                      isSelected={itemIndex === selectedIndex}
+                      isActive={activeShortcodes.has(item.shortcode)}
+                      isMobile={false}
+                      onClick={() => onSelect(item)}
+                      onMouseEnter={() => setSelectedIndex(itemIndex)}
+                    />
+                  )
+                })}
+              </div>
+            )
+          }}
+        />
+      )}
 
       {/* Footer — desktop only */}
       {selectedEmoji && (
@@ -530,7 +502,6 @@ export function ReactionEmojiPicker({
   const setOpen = isControlled ? (v: boolean) => controlledOnOpenChange?.(v) : setUncontrolledOpen
   const [search, setSearch] = useState("")
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const { emojis, emojiWeights } = useWorkspaceEmoji(workspaceId)
   const isNarrow = useIsMobile()
@@ -594,7 +565,6 @@ export function ReactionEmojiPicker({
       onSelect={handleSelect}
       onClose={handleClose}
       searchInputRef={searchInputRef}
-      scrollContainerRef={scrollContainerRef}
       open={open}
       isMobile={useDrawer}
     />

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -337,7 +337,7 @@ function EmojiGridContent({
         )}
 
         {/* Emoji grid — stable container keeps ResizeObserver alive across empty/non-empty transitions */}
-        <div ref={mobileContainerRef} className="flex-1" style={{ height: "min(55dvh, 360px)" }}>
+        <div ref={mobileContainerRef} style={{ height: "min(55dvh, 360px)" }}>
           {filtered.length === 0 ? (
             <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4">
               No emojis found

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -443,7 +443,6 @@ function EmojiGridContent({
             rangeRef.current = range
           }}
           style={{ height: CONTAINER_HEIGHT }}
-          className="px-2"
           components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
           role="listbox"
           aria-label="Emoji picker"
@@ -451,7 +450,7 @@ function EmojiGridContent({
             const rowItems = rows[index]
             const rowStartIndex = index * columns
             return (
-              <div className="flex gap-0.5 pb-0.5">
+              <div className="flex gap-0.5 px-2 pb-0.5">
                 {rowItems.map((item, colIndex) => {
                   const itemIndex = rowStartIndex + colIndex
                   return (

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -12,6 +12,8 @@ import type { EmojiEntry } from "@threa/types"
 const DESKTOP_COLUMNS = 8
 const MOBILE_EMOJI_SIZE = 44
 const MOBILE_ROW_HEIGHT = 46
+const MobileVirtuosoPadding = () => <div className="h-1" />
+const DesktopVirtuosoPadding = () => <div className="h-2" />
 const DESKTOP_ROW_HEIGHT = 34
 const CONTAINER_HEIGHT = 256
 const MAX_MOBILE_COLUMNS = 8
@@ -349,7 +351,7 @@ function EmojiGridContent({
               fixedItemHeight={MOBILE_ROW_HEIGHT}
               increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
               style={{ height: "100%" }}
-              components={{ Header: () => <div className="h-1" />, Footer: () => <div className="h-1" /> }}
+              components={{ Header: MobileVirtuosoPadding, Footer: MobileVirtuosoPadding }}
               role="listbox"
               aria-label="Emoji picker"
               itemContent={(index) => {
@@ -443,7 +445,7 @@ function EmojiGridContent({
             rangeRef.current = range
           }}
           style={{ height: CONTAINER_HEIGHT }}
-          components={{ Header: () => <div className="h-2" />, Footer: () => <div className="h-2" /> }}
+          components={{ Header: DesktopVirtuosoPadding, Footer: DesktopVirtuosoPadding }}
           role="listbox"
           aria-label="Emoji picker"
           itemContent={(index) => {

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -11,8 +11,8 @@ import type { EmojiEntry } from "@threa/types"
 
 const DESKTOP_COLUMNS = 8
 const MOBILE_EMOJI_SIZE = 44
-const MOBILE_ROW_HEIGHT = 44
-const DESKTOP_ROW_HEIGHT = 32
+const MOBILE_ROW_HEIGHT = 46
+const DESKTOP_ROW_HEIGHT = 34
 const CONTAINER_HEIGHT = 256
 const MAX_MOBILE_COLUMNS = 8
 
@@ -107,13 +107,13 @@ function EmojiGridContent({
   const rowHeight = isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const rangeRef = useRef<{ startIndex: number; endIndex: number } | null>(null)
-  const scrollerElRef = useRef<HTMLElement | null>(null)
+  const mobileContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!isMobile || !scrollerElRef.current) return
-    const el = scrollerElRef.current
+    if (!isMobile || !mobileContainerRef.current) return
+    const el = mobileContainerRef.current
     const measure = () => {
-      const width = el?.clientWidth ?? 0
+      const width = el.clientWidth ?? 0
       if (width > 0) {
         const cols = Math.min(MAX_MOBILE_COLUMNS, Math.max(5, Math.floor(width / MOBILE_EMOJI_SIZE)))
         setColumns(cols)
@@ -336,53 +336,50 @@ function EmojiGridContent({
           </div>
         )}
 
-        {/* Emoji grid — full-bleed CSS grid */}
-        {filtered.length === 0 ? (
-          <div
-            className="flex items-center justify-center text-sm text-muted-foreground px-4"
-            style={{ height: "min(55dvh, 360px)" }}
-          >
-            No emojis found
-          </div>
-        ) : (
-          <Virtuoso
-            ref={virtuosoRef}
-            scrollerRef={(el) => {
-              scrollerElRef.current = el as HTMLElement
-            }}
-            totalCount={rows.length}
-            fixedItemHeight={MOBILE_ROW_HEIGHT}
-            increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
-            style={{ height: "min(55dvh, 360px)" }}
-            className="px-4"
-            role="listbox"
-            aria-label="Emoji picker"
-            itemContent={(index) => {
-              const rowItems = rows[index]
-              return (
-                <div
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                    gap: "2px",
-                  }}
-                >
-                  {rowItems.map((item) => (
-                    <EmojiButton
-                      key={item.shortcode}
-                      item={item}
-                      isSelected={false}
-                      isActive={activeShortcodes.has(item.shortcode)}
-                      isMobile={true}
-                      onClick={() => onSelect(item)}
-                      onMouseEnter={() => {}}
-                    />
-                  ))}
-                </div>
-              )
-            }}
-          />
-        )}
+        {/* Emoji grid — stable container keeps ResizeObserver alive across empty/non-empty transitions */}
+        <div ref={mobileContainerRef} className="flex-1" style={{ height: "min(55dvh, 360px)" }}>
+          {filtered.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4">
+              No emojis found
+            </div>
+          ) : (
+            <Virtuoso
+              ref={virtuosoRef}
+              totalCount={rows.length}
+              fixedItemHeight={MOBILE_ROW_HEIGHT}
+              increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
+              style={{ height: "100%" }}
+              className="px-4"
+              role="listbox"
+              aria-label="Emoji picker"
+              itemContent={(index) => {
+                const rowItems = rows[index]
+                return (
+                  <div
+                    className="pb-0.5"
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                      gap: "2px",
+                    }}
+                  >
+                    {rowItems.map((item) => (
+                      <EmojiButton
+                        key={item.shortcode}
+                        item={item}
+                        isSelected={false}
+                        isActive={activeShortcodes.has(item.shortcode)}
+                        isMobile={true}
+                        onClick={() => onSelect(item)}
+                        onMouseEnter={() => {}}
+                      />
+                    ))}
+                  </div>
+                )
+              }}
+            />
+          )}
+        </div>
       </>
     )
   }
@@ -453,7 +450,7 @@ function EmojiGridContent({
             const rowItems = rows[index]
             const rowStartIndex = index * columns
             return (
-              <div className="flex gap-0.5">
+              <div className="flex gap-0.5 pb-0.5">
                 {rowItems.map((item, colIndex) => {
                   const itemIndex = rowStartIndex + colIndex
                   return (

--- a/bun.lock
+++ b/bun.lock
@@ -148,7 +148,6 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/themes": "^3.3.0",
         "@tanstack/react-query": "^5.90.12",
-        "@tanstack/react-virtual": "^3.13.23",
         "@threa/prosemirror": "workspace:*",
         "@threa/types": "workspace:*",
         "@tiptap/core": "^3.14.0",
@@ -1292,10 +1291,6 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.90.12", "", {}, "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.12", "", { "dependencies": { "@tanstack/query-core": "5.90.12" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg=="],
-
-    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
-
-    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.23", "", {}, "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 


### PR DESCRIPTION
## Summary

- Migrate the two emoji grid virtualizers (`emoji-grid.tsx` and `reaction-emoji-picker.tsx`) from `@tanstack/react-virtual` to `react-virtuoso`, which is already used for the stream message list
- Remove `@tanstack/react-virtual` (and transitive `@tanstack/virtual-core`) from the dependency tree, eliminating a redundant virtualizer library from the bundle

## What changed

**`emoji-grid.tsx`** — Replaced `useVirtualizer` hook + manual absolute positioning with `<Virtuoso>` using `fixedItemHeight` and `itemContent` render prop. Keyboard navigation (arrow keys, Home/End, PageUp/PageDown) preserved via `rangeChanged` callback + ref-based `scrollToIndex`.

**`reaction-emoji-picker.tsx`** — Same migration for both mobile and desktop layouts. Mobile ResizeObserver for dynamic column count now uses Virtuoso's `scrollerRef` callback instead of a separate `scrollContainerRef`. Removed the `measure()` workaround effect since Virtuoso handles portal remounting automatically.

**`package.json`** — Removed `@tanstack/react-virtual` dependency.

## Test plan

- [ ] Open the `:` emoji trigger in the message editor — verify grid renders, scrolls, and keyboard navigation works (arrow keys, Enter to select, Home/End, PageUp/PageDown)
- [ ] Open the reaction emoji picker on desktop — verify search, grid rendering, keyboard nav, and footer shortcode display
- [ ] Open the reaction emoji picker on mobile — verify touch scrolling, dynamic column layout, and active reaction highlighting
- [ ] Verify no `@tanstack/react-virtual` or `@tanstack/virtual-core` in the production bundle

https://claude.ai/code/session_01TwiApFHvG95KZHLb6XiDXg