### PR TITLE
fix: prevent assistant-prefill rerun requests

### DIFF
--- a/.claude/plans/fix-assistant-prefill-bug.md
+++ b/.claude/plans/fix-assistant-prefill-bug.md
@@ -1,0 +1,59 @@
+# Fix Assistant Prefill Bug
+
+## Goal
+
+Prevent companion supersede reruns from failing against Anthropic models that reject assistant-prefill requests. Edited-message reruns must still reconsider the prior response, but the outgoing provider request must end with a user turn instead of the previous assistant reply.
+
+## What Was Built
+
+### Runtime request normalization
+
+The agent runtime now normalizes the conversation immediately before each model call. If the in-memory conversation ends with an `assistant` or `system` message, it appends a synthetic trailing `user` prompt so the provider sees a valid request shape.
+
+**Files:**
+- `apps/backend/src/features/agents/runtime/agent-runtime.ts` - Adds conversation preparation before each `generateTextWithTools` call.
+
+### Reconsideration prompt role changes
+
+Internal reconsideration and revision prompts now enter the runtime conversation as `user` messages instead of `system` messages. This keeps later turns compatible with providers that require the conversation to end with a user message.
+
+**Files:**
+- `apps/backend/src/features/agents/runtime/agent-runtime.ts` - Replaces runtime-injected `system` follow-ups with `user` follow-ups.
+
+### Regression coverage
+
+Added a regression test for the supersede-rerun case where history starts as `user -> assistant` and the rerun must bridge that with a trailing user prompt before asking the model to decide between `keep_response` and `send_message`.
+
+**Files:**
+- `apps/backend/src/features/agents/runtime/agent-runtime.test.ts` - Covers the edited-message rerun path and preserves existing message-counting assertions.
+
+## Design Decisions
+
+### Fix it in the agent runtime
+
+**Chose:** Normalize the message sequence in `AgentRuntime` instead of adding provider-specific logic higher up the stack.
+**Why:** The invalid request is created by runtime loop behavior during reconsideration, so the fix belongs at the point where messages are assembled for each model call.
+**Alternatives considered:** Patching only the persona-agent rerun entrypoint would miss later runtime-generated reconsideration turns.
+
+### Use user-role continuation prompts
+
+**Chose:** Convert runtime-injected reconsideration prompts to `user` messages.
+**Why:** The provider constraint is about the final conversational turn. Making these prompts user-role preserves their directive effect while keeping each subsequent model request valid.
+**Alternatives considered:** Leaving them as `system` and only appending a bridge at the start would still allow later iterations to end with `system`.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No provider-wide adapter changes outside the agent runtime.
+- No changes to persona-agent context building or message formatting.
+- No new end-to-end test coverage for the full edited-message flow.
+
+## Status
+
+- [x] Normalize runtime conversations before model calls
+- [x] Update reconsideration prompts to use user-role follow-ups
+- [x] Add regression coverage for supersede reruns
+- [x] Run targeted agent tests and backend typecheck

--- a/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
@@ -4,6 +4,56 @@ import type { AgentEvent } from "./agent-events"
 import { AgentRuntime } from "./agent-runtime"
 
 describe("AgentRuntime message counting", () => {
+  it("bridges supersede reruns with a trailing user prompt when history ends with assistant", async () => {
+    const generateTextWithTools = mock(async ({ messages }: { messages: Array<{ role: string; content: string }> }) => {
+      expect(messages).toHaveLength(3)
+      expect(messages.at(-2)).toEqual({
+        role: "assistant",
+        content: "Hey! :wave: Great to see you. I'm Ariadne, your thinking companion here in Threa.",
+      })
+      expect(messages.at(-1)?.role).toBe("user")
+      expect(messages.at(-1)?.content).toContain("keep_response or send_message")
+
+      return {
+        text: "",
+        toolCalls: [
+          {
+            toolCallId: "tool_1",
+            toolName: "keep_response",
+            input: {
+              reason: "The greeting edit does not change what the previous response should say.",
+            },
+          },
+        ],
+        response: {
+          messages: [{ role: "assistant", content: "No update needed." } as any],
+        },
+      }
+    })
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [
+        { role: "user", content: "(14:54) Hi there :wave: My friend!" },
+        {
+          role: "assistant",
+          content: "Hey! :wave: Great to see you. I'm Ariadne, your thinking companion here in Threa.",
+        },
+      ],
+      tools: [],
+      allowNoMessageOutput: true,
+      sendMessage: async () => ({ messageId: "msg_unused", operation: "created" }),
+    })
+
+    const result = await runtime.run()
+
+    expect(generateTextWithTools).toHaveBeenCalledTimes(1)
+    expect(result.messagesSent).toBe(0)
+    expect(result.noMessageReason).toBe("The greeting edit does not change what the previous response should say.")
+  })
+
   it("counts edited responses as sent output", async () => {
     const events: AgentEvent[] = []
 

--- a/apps/backend/src/features/agents/runtime/agent-runtime.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.ts
@@ -208,7 +208,8 @@ export class AgentRuntime {
       }
 
       const fullSystemPrompt = retrievedContext ? `${systemPrompt}\n\n${retrievedContext}` : systemPrompt
-      const truncatedMessages = truncateMessages(conversation, MAX_MESSAGE_CHARS)
+      const preparedConversation = this.prepareConversationForModel(conversation)
+      const truncatedMessages = truncateMessages(preparedConversation, MAX_MESSAGE_CHARS)
 
       const startTime = Date.now()
       const result = await this.wrapWithObserverContext(() =>
@@ -250,13 +251,12 @@ export class AgentRuntime {
 
             if (!hasTextReconsidered && lastAssistantText) {
               hasTextReconsidered = true
-              conversation.push({
-                role: "system",
-                content:
-                  `[New context arrived while you were responding]\n\n` +
+              this.pushRuntimePrompt(
+                conversation,
+                `[New context arrived while you were responding]\n\n` +
                   `Your draft response was:\n"${lastAssistantText}"\n\n` +
-                  `Please incorporate the new messages and respond.`,
-              })
+                  `Please incorporate the new messages and respond.`
+              )
               continue
             }
           }
@@ -280,14 +280,13 @@ export class AgentRuntime {
               break
             }
 
-            conversation.push({
-              role: "system",
-              content:
-                `[Final response needs revision]\n\n` +
+            this.pushRuntimePrompt(
+              conversation,
+              `[Final response needs revision]\n\n` +
                 `${validationError}\n\n` +
                 `Your proposed response was:\n"${lastAssistantText}"\n\n` +
-                `Please provide a revised final response now.`,
-            })
+                `Please provide a revised final response now.`
+            )
             continue
           }
 
@@ -304,15 +303,14 @@ export class AgentRuntime {
             break
           }
 
-          conversation.push({
-            role: "system",
-            content:
-              `[Final decision required]\n\n` +
+          this.pushRuntimePrompt(
+            conversation,
+            `[Final decision required]\n\n` +
               `You must choose one final action now.\n` +
               `- If previous responses remain correct, call keep_response with a specific reason tied to the edited message.\n` +
               `- If changes are needed, call send_message with the revised response.\n` +
-              `Do not return an empty response.`,
-          })
+              `Do not return an empty response.`
+          )
           continue
         }
         break
@@ -344,14 +342,13 @@ export class AgentRuntime {
           if (newMessages.length === 0) {
             const invalidPending = await this.findInvalidPendingMessage(execResult.pendingMessages)
             if (invalidPending) {
-              conversation.push({
-                role: "system",
-                content:
-                  `[Final response needs revision]\n\n` +
+              this.pushRuntimePrompt(
+                conversation,
+                `[Final response needs revision]\n\n` +
                   `${invalidPending.reason}\n\n` +
                   `Your proposed response was:\n"${invalidPending.content}"\n\n` +
-                  `Please provide a revised final response and call send_message again.`,
-              })
+                  `Please provide a revised final response and call send_message again.`
+              )
               continue
             }
 
@@ -374,14 +371,13 @@ export class AgentRuntime {
               newMessages,
             })
 
-            conversation.push({
-              role: "system",
-              content:
-                `[New context arrived while you were responding]\n\n` +
+            this.pushRuntimePrompt(
+              conversation,
+              `[New context arrived while you were responding]\n\n` +
                 `Your draft response${execResult.pendingMessages.length > 1 ? "s were" : " was"}:\n"${pendingContents}"\n\n` +
                 `Please respond to all messages, incorporating the new context. ` +
-                `You may send the same response${execResult.pendingMessages.length > 1 ? "s" : ""} if still appropriate, or revise based on the new information.`,
-            })
+                `You may send the same response${execResult.pendingMessages.length > 1 ? "s" : ""} if still appropriate, or revise based on the new information.`
+            )
           }
         } else if (execResult.keepResponseReason) {
           if (newMessages.length === 0) {
@@ -403,14 +399,13 @@ export class AgentRuntime {
             newMessages,
           })
 
-          conversation.push({
-            role: "system",
-            content:
-              `[New context arrived after you decided to keep the existing response]\n\n` +
+          this.pushRuntimePrompt(
+            conversation,
+            `[New context arrived after you decided to keep the existing response]\n\n` +
               `Your keep-response reason was:\n"${execResult.keepResponseReason}"\n\n` +
               `Please reconsider. If the previous response is still correct, call keep_response again with an updated reason. ` +
-              `If changes are needed, call send_message with the updated response.`,
-          })
+              `If changes are needed, call send_message with the updated response.`
+          )
         } else if (newMessages.length > 0) {
           const maxSeq = await this.injectNewMessages(newMessages, lastProcessedSequence, nm, conversation)
           lastProcessedSequence = maxSeq
@@ -420,14 +415,13 @@ export class AgentRuntime {
         if (execResult.pendingMessages.length > 0) {
           const invalidPending = await this.findInvalidPendingMessage(execResult.pendingMessages)
           if (invalidPending) {
-            conversation.push({
-              role: "system",
-              content:
-                `[Final response needs revision]\n\n` +
+            this.pushRuntimePrompt(
+              conversation,
+              `[Final response needs revision]\n\n` +
                 `${invalidPending.reason}\n\n` +
                 `Your proposed response was:\n"${invalidPending.content}"\n\n` +
-                `Please provide a revised final response and call send_message again.`,
-            })
+                `Please provide a revised final response and call send_message again.`
+            )
             continue
           }
 
@@ -680,6 +674,23 @@ export class AgentRuntime {
     }
 
     return null
+  }
+
+  private prepareConversationForModel(conversation: ModelMessage[]): ModelMessage[] {
+    const lastMessage = conversation.at(-1)
+    if (!lastMessage || (lastMessage.role !== "assistant" && lastMessage.role !== "system")) {
+      return conversation
+    }
+
+    const continuationPrompt = this.config.allowNoMessageOutput
+      ? "Review the conversation above and follow the system instructions. Compare the latest assistant response against the updated context, then call keep_response or send_message."
+      : "Continue from the conversation above and follow the system instructions."
+
+    return [...conversation, { role: "user", content: continuationPrompt }]
+  }
+
+  private pushRuntimePrompt(conversation: ModelMessage[], content: string): void {
+    conversation.push({ role: "user", content })
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Edited-message reruns could send Anthropic a conversation that ended with the previous assistant response instead of a user turn. Azure rejects that request shape for Claude models with "This model does not support assistant message prefill. The conversation must end with a user message.", so Ariadne failed instead of reconsidering the prior reply.

## Solution

Normalize the agent runtime conversation immediately before each provider call, and make runtime reconsideration prompts user-role follow-ups instead of system-role follow-ups. That keeps supersede reruns compatible with providers that require a trailing user message without changing the higher-level rerun flow.

### How it works

- `AgentRuntime` now appends a synthetic trailing user prompt when the in-memory conversation ends with `assistant` or `system`.
- Internal reconsideration, validation, and keep-response follow-ups are injected as `user` messages so later iterations stay valid too.
- Added a regression test that covers the supersede-rerun shape that originally failed.

### Key design decisions

**1. Fix the issue in the runtime loop**

The invalid request is assembled inside `AgentRuntime`, so the fix lives where each `generateTextWithTools` call is prepared. That covers both the initial rerun request and any later reconsideration turns.

**2. Use user-role continuation prompts**

The Anthropic constraint is about the final conversational turn, not just the first rerun entrypoint. Converting runtime follow-ups to `user` messages avoids repeating the same failure mode on subsequent iterations.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/fix-assistant-prefill-bug.md` | Reviewer-facing plan describing the runtime fix, tradeoffs, and scope. |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/agents/runtime/agent-runtime.ts` | Normalizes outgoing conversations and injects runtime follow-up prompts as `user` turns. |
| `apps/backend/src/features/agents/runtime/agent-runtime.test.ts` | Adds regression coverage for supersede reruns that previously ended with an assistant message. |

## Deleted files

None.

## Test plan

- [x] `bun test apps/backend/src/features/agents/runtime/agent-runtime.test.ts`
- [x] `bun test apps/backend/src/features/agents/companion/session.test.ts apps/backend/src/features/agents/message-mutation-outbox-handler.test.ts`
- [x] `bun run tsc --noEmit -p apps/backend/tsconfig.json`
- [x] Pre-commit checks: repo lint, workspace typechecks, and OpenAPI up-to-date check
- [ ] Manual verification of the edited-message rerun flow against Anthropic via OpenRouter/Azure

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
