### PR TITLE
feat: quoted replies with markdown round-trip

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -53,6 +53,7 @@
     "@tiptap/extension-code": "^3.14.0",
     "@tiptap/extension-code-block-lowlight": "^3.14.0",
     "@tiptap/extension-document": "^3.15.3",
+    "@tiptap/extension-gapcursor": "^3.22.2",
     "@tiptap/extension-hard-break": "^3.15.3",
     "@tiptap/extension-heading": "^3.15.3",
     "@tiptap/extension-history": "^3.15.3",

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -143,7 +143,7 @@ export interface MessageComposerProps {
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
   /** Imperative handle ref for programmatic focus from parent */
-  composerRef?: React.MutableRefObject<{ focus: () => void } | null>
+  composerRef?: React.MutableRefObject<{ focus: () => void; focusAfterQuoteReply: () => void } | null>
 }
 
 export function MessageComposer({
@@ -299,6 +299,10 @@ export function MessageComposer({
       focus: () => {
         setMobileFocused(true)
         requestAnimationFrame(() => richEditorRef.current?.focus())
+      },
+      focusAfterQuoteReply: () => {
+        setMobileFocused(true)
+        requestAnimationFrame(() => richEditorRef.current?.focusAfterQuoteReply())
       },
     }
     return () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -53,6 +53,11 @@ function getPreviewText(doc: JSONContent): string {
     if (node.type === "emoji") return String(node.attrs?.emoji ?? node.attrs?.shortcode ?? "")
     if (node.type === "hardBreak") return null
 
+    if (node.type === "quoteReply") {
+      const author = typeof node.attrs?.authorName === "string" ? node.attrs.authorName : ""
+      return `Replying to ${author}`
+    }
+
     if (node.type === "codeBlock") {
       const text = (node.content ?? []).map((c) => c.text ?? "").join("")
       return text.split("\n")[0] ?? ""
@@ -137,6 +142,8 @@ export interface MessageComposerProps {
   onCollapse?: () => void
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
+  /** Imperative handle ref for programmatic focus from parent */
+  composerRef?: React.MutableRefObject<{ focus: () => void } | null>
 }
 
 export function MessageComposer({
@@ -165,6 +172,7 @@ export function MessageComposer({
   expanded = false,
   onCollapse,
   streamContext,
+  composerRef,
 }: MessageComposerProps) {
   // Controls (buttons, file input) are disabled during both external disable and sending.
   // The editor itself stays editable during sending so mobile keyboards don't close/reopen.
@@ -282,6 +290,21 @@ export function MessageComposer({
     const nextEditor = handle?.getEditor() ?? null
     setMobileToolbarEditor((currentEditor) => (currentEditor === nextEditor ? currentEditor : nextEditor))
   }, [])
+
+  // Expose focus() to parent via composerRef so external triggers (e.g. quote reply)
+  // can open the mobile editor and focus it programmatically.
+  useEffect(() => {
+    if (!composerRef) return
+    composerRef.current = {
+      focus: () => {
+        setMobileFocused(true)
+        requestAnimationFrame(() => richEditorRef.current?.focus())
+      },
+    }
+    return () => {
+      composerRef.current = null
+    }
+  }, [composerRef])
 
   const focusExpandedShell = useCallback(() => {
     expandedShellRef.current?.focus()

--- a/apps/frontend/src/components/editor/editor-action-bar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.test.tsx
@@ -7,6 +7,7 @@ import { EditorActionBar } from "./editor-action-bar"
 function renderBar(props: Partial<React.ComponentProps<typeof EditorActionBar>> = {}) {
   const editorHandle = {
     focus: vi.fn(),
+    focusAfterQuoteReply: vi.fn(),
     insertMention: vi.fn(),
     insertSlash: vi.fn(),
     insertEmoji: vi.fn(),

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -23,6 +23,7 @@ import { ChannelExtension, type ChannelOptions } from "./triggers/channel-extens
 import { CommandExtension, type CommandOptions } from "./triggers/command-extension"
 import { EmojiExtension, type EmojiExtensionOptions } from "./triggers/emoji-extension"
 import { AttachmentReferenceExtension } from "./attachment-reference-extension"
+import { QuoteReplyExtension } from "./quote-reply-extension"
 
 // Create lowlight instance with common languages
 const lowlight = createLowlight(common)
@@ -94,6 +95,9 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
 
     // Inline attachments (images, files)
     AttachmentReferenceExtension,
+
+    // Quote reply blocks
+    QuoteReplyExtension,
   ]
 
   // Add mention extension if suggestion config provided

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -4,6 +4,7 @@ import Paragraph from "@tiptap/extension-paragraph"
 import Text from "@tiptap/extension-text"
 import HardBreak from "@tiptap/extension-hard-break"
 import History from "@tiptap/extension-history"
+import Gapcursor from "@tiptap/extension-gapcursor"
 import Placeholder from "@tiptap/extension-placeholder"
 
 // Inline marks with atom-aware input rules
@@ -59,6 +60,7 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
     Text,
     HardBreak,
     History,
+    Gapcursor,
 
     // Placeholder text when empty
     Placeholder.configure({

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -41,10 +41,12 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
     }
 
     case "quoteReply": {
-      const { messageId, streamId, authorName, snippet } = node.attrs as {
+      const { messageId, streamId, authorName, authorId, actorType, snippet } = node.attrs as {
         messageId: string
         streamId: string
         authorName: string
+        authorId: string
+        actorType: string
         snippet: string
       }
       const quotedLines = snippet
@@ -52,7 +54,7 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
         .map((line: string) => "> " + line)
         .join("\n")
       const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
-      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
+      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId}/${authorId}/${actorType})`
     }
 
     case "bulletList":
@@ -342,12 +344,16 @@ export function parseMarkdown(
 
       // Check if last line is a quote-reply attribution
       const lastLine = quoteLines[quoteLines.length - 1]
-      const quoteReplyMatch = lastLine?.match(/^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
+      const quoteReplyMatch = lastLine?.match(
+        /^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)(?:\/([\w-]+)\/([\w-]+))?\)$/
+      )
 
       if (quoteReplyMatch) {
         const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
         const streamId = quoteReplyMatch[2]
         const messageId = quoteReplyMatch[3]
+        const authorId = quoteReplyMatch[4] ?? ""
+        const actorType = quoteReplyMatch[5] ?? "user"
         const snippetLines = quoteLines.slice(0, -1)
         while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1] === "") {
           snippetLines.pop()
@@ -355,7 +361,7 @@ export function parseMarkdown(
         const snippet = snippetLines.join("\n")
         content.push({
           type: "quoteReply",
-          attrs: { messageId, streamId, authorName, snippet },
+          attrs: { messageId, streamId, authorName, authorId, actorType, snippet },
         })
       } else {
         content.push({

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -40,6 +40,21 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
         .join("\n")
     }
 
+    case "quoteReply": {
+      const { messageId, streamId, authorName, snippet } = node.attrs as {
+        messageId: string
+        streamId: string
+        authorName: string
+        snippet: string
+      }
+      const quotedLines = snippet
+        .split("\n")
+        .map((line: string) => "> " + line)
+        .join("\n")
+      const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
+      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
+    }
+
     case "bulletList":
       return (
         node.content
@@ -317,22 +332,42 @@ export function parseMarkdown(
       continue
     }
 
-    // Blockquote
-    if (line.startsWith("> ")) {
+    // Blockquote (or quoteReply if last line has quote: attribution)
+    if (line.startsWith("> ") || line === ">") {
       const quoteLines: string[] = []
-      while (i < lines.length && lines[i].startsWith("> ")) {
-        quoteLines.push(lines[i].slice(2))
+      while (i < lines.length && (lines[i].startsWith("> ") || lines[i] === ">")) {
+        quoteLines.push(lines[i] === ">" ? "" : lines[i].slice(2))
         i++
       }
-      content.push({
-        type: "blockquote",
-        content: [
-          {
-            type: "paragraph",
-            content: parseInlineMarkdown(quoteLines.join("\n"), options),
-          },
-        ],
-      })
+
+      // Check if last line is a quote-reply attribution
+      const lastLine = quoteLines[quoteLines.length - 1]
+      const quoteReplyMatch = lastLine?.match(/^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
+
+      if (quoteReplyMatch) {
+        const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
+        const streamId = quoteReplyMatch[2]
+        const messageId = quoteReplyMatch[3]
+        const snippetLines = quoteLines.slice(0, -1)
+        while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1] === "") {
+          snippetLines.pop()
+        }
+        const snippet = snippetLines.join("\n")
+        content.push({
+          type: "quoteReply",
+          attrs: { messageId, streamId, authorName, snippet },
+        })
+      } else {
+        content.push({
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: parseInlineMarkdown(quoteLines.join("\n"), options),
+            },
+          ],
+        })
+      }
       continue
     }
 

--- a/apps/frontend/src/components/editor/quote-reply-extension.test.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import { GapCursor } from "@tiptap/pm/gapcursor"
+import type { ResolvedPos } from "@tiptap/pm/model"
+import type { JSONContent } from "@tiptap/react"
+import { createEditorExtensions } from "./editor-extensions"
+import { serializeToMarkdown } from "./editor-markdown"
+
+function isValidGapCursorPosition($pos: ResolvedPos): boolean {
+  const gapCursor = GapCursor as typeof GapCursor & {
+    valid?: (position: ResolvedPos) => boolean
+  }
+
+  return gapCursor.valid?.($pos) ?? false
+}
+
+function createQuoteReplyNode(): JSONContent {
+  return {
+    type: "quoteReply",
+    attrs: {
+      messageId: "msg_123",
+      streamId: "stream_123",
+      authorName: "Ariadne",
+      authorId: "user_123",
+      actorType: "user",
+      snippet: "The vibes are immaculate",
+    },
+  }
+}
+
+function createQuoteReplyEditor(content: JSONContent = { type: "doc", content: [createQuoteReplyNode()] }) {
+  const element = document.createElement("div")
+  document.body.append(element)
+
+  const editor = new Editor({
+    element,
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content,
+  })
+
+  editor.view.hasFocus = () => true
+
+  editor.on("destroy", () => {
+    element.remove()
+  })
+
+  return editor
+}
+
+function setGapCursor(editor: Editor, pos: number) {
+  const $pos = editor.state.doc.resolve(pos)
+
+  expect(isValidGapCursorPosition($pos)).toBe(true)
+  editor.view.dispatch(editor.state.tr.setSelection(new GapCursor($pos)))
+}
+
+function pressKey(editor: Editor, key: string, options: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  })
+  let handled = false
+
+  editor.view.someProp("handleKeyDown", (handleKeyDown) => {
+    if (handleKeyDown(editor.view, event)) {
+      handled = true
+      return true
+    }
+    return false
+  })
+
+  return handled
+}
+
+function insertText(editor: Editor, text: string) {
+  let handled = false
+
+  editor.view.someProp("handleTextInput", (handleTextInput) => {
+    if (
+      handleTextInput(editor.view, editor.state.selection.from, editor.state.selection.to, text, () => editor.state.tr)
+    ) {
+      handled = true
+      return true
+    }
+    return false
+  })
+
+  return handled
+}
+
+describe("quote reply gap cursor", () => {
+  const quoteMarkdown = serializeToMarkdown({ type: "doc", content: [createQuoteReplyNode()] })
+
+  it("inserts typed text into a new paragraph before a lone quote reply", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, 0)
+
+    expect(insertText(editor, "Before")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`Before\n\n${quoteMarkdown}`)
+
+    editor.destroy()
+  })
+
+  it("inserts typed text into a new paragraph after a lone quote reply", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, editor.state.doc.content.size)
+
+    expect(insertText(editor, "After")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`${quoteMarkdown}\n\nAfter`)
+
+    editor.destroy()
+  })
+
+  it("adds exactly one paragraph before a lone quote reply on Enter", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, 0)
+
+    expect(pressKey(editor, "Enter")).toBe(true)
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }, createQuoteReplyNode()],
+    })
+
+    editor.destroy()
+  })
+
+  it("adds exactly one paragraph after a lone quote reply on Enter", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, editor.state.doc.content.size)
+
+    expect(pressKey(editor, "Enter")).toBe(true)
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [createQuoteReplyNode(), { type: "paragraph" }],
+    })
+
+    editor.destroy()
+  })
+
+  it("moves from the after-quote gap cursor to the before-quote gap cursor with ArrowLeft", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, editor.state.doc.content.size)
+
+    expect(pressKey(editor, "ArrowLeft")).toBe(true)
+    expect(editor.state.selection instanceof GapCursor).toBe(true)
+    expect(editor.state.selection.from).toBe(0)
+
+    expect(insertText(editor, "Before")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`Before\n\n${quoteMarkdown}`)
+
+    editor.destroy()
+  })
+
+  it("moves from the before-quote gap cursor to the after-quote gap cursor with ArrowRight", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, 0)
+
+    expect(pressKey(editor, "ArrowRight")).toBe(true)
+    expect(editor.state.selection instanceof GapCursor).toBe(true)
+    expect(editor.state.selection.from).toBe(editor.state.doc.content.size)
+
+    expect(insertText(editor, "After")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`${quoteMarkdown}\n\nAfter`)
+
+    editor.destroy()
+  })
+
+  it("marks the before-quote gap cursor position in the DOM", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, 0)
+
+    const gapCursor = editor.view.dom.querySelector(".ProseMirror-gapcursor")
+
+    expect(gapCursor).not.toBeNull()
+    expect(gapCursor?.classList.contains("before-quote")).toBe(true)
+    expect(editor.view.dom.classList.contains("has-after-quote-gapcursor")).toBe(false)
+
+    editor.destroy()
+  })
+
+  it("marks the after-quote gap cursor position in the DOM", () => {
+    const editor = createQuoteReplyEditor()
+
+    setGapCursor(editor, editor.state.doc.content.size)
+
+    const gapCursor = editor.view.dom.querySelector(".ProseMirror-gapcursor")
+
+    expect(gapCursor).not.toBeNull()
+    expect(gapCursor?.classList.contains("after-quote")).toBe(true)
+    expect(editor.view.dom.classList.contains("has-after-quote-gapcursor")).toBe(true)
+
+    editor.destroy()
+  })
+})

--- a/apps/frontend/src/components/editor/quote-reply-extension.test.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.test.ts
@@ -90,6 +90,55 @@ function insertText(editor: Editor, text: string) {
   return handled
 }
 
+function clickQuote(editor: Editor, clientX: number) {
+  const quoteNode = editor.state.doc.firstChild
+  const quoteElement = editor.view.dom.querySelector('[data-type="quote-reply"]') as HTMLElement | null
+
+  expect(quoteNode).not.toBeNull()
+  expect(quoteElement).not.toBeNull()
+
+  Object.defineProperty(quoteElement!, "getBoundingClientRect", {
+    configurable: true,
+    value: () =>
+      ({
+        left: 0,
+        right: 100,
+        width: 100,
+        top: 0,
+        bottom: 40,
+        height: 40,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this
+        },
+      }) satisfies DOMRect,
+  })
+
+  const event = new MouseEvent("click", {
+    clientX,
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+  })
+  Object.defineProperty(event, "target", {
+    configurable: true,
+    value: quoteElement,
+  })
+
+  let handled = false
+
+  editor.view.someProp("handleClickOn", (handleClickOn) => {
+    if (handleClickOn(editor.view, 0, quoteNode!, 0, event, true)) {
+      handled = true
+      return true
+    }
+    return false
+  })
+
+  return handled
+}
+
 describe("quote reply gap cursor", () => {
   const quoteMarkdown = serializeToMarkdown({ type: "doc", content: [createQuoteReplyNode()] })
 
@@ -164,6 +213,32 @@ describe("quote reply gap cursor", () => {
     setGapCursor(editor, 0)
 
     expect(pressKey(editor, "ArrowRight")).toBe(true)
+    expect(editor.state.selection instanceof GapCursor).toBe(true)
+    expect(editor.state.selection.from).toBe(editor.state.doc.content.size)
+
+    expect(insertText(editor, "After")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`${quoteMarkdown}\n\nAfter`)
+
+    editor.destroy()
+  })
+
+  it("tapping the left half of a quote reply moves the cursor before the quote", () => {
+    const editor = createQuoteReplyEditor()
+
+    expect(clickQuote(editor, 10)).toBe(true)
+    expect(editor.state.selection instanceof GapCursor).toBe(true)
+    expect(editor.state.selection.from).toBe(0)
+
+    expect(insertText(editor, "Before")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(`Before\n\n${quoteMarkdown}`)
+
+    editor.destroy()
+  })
+
+  it("tapping the right half of a quote reply moves the cursor after the quote", () => {
+    const editor = createQuoteReplyEditor()
+
+    expect(clickQuote(editor, 90)).toBe(true)
     expect(editor.state.selection instanceof GapCursor).toBe(true)
     expect(editor.state.selection.from).toBe(editor.state.doc.content.size)
 

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,0 +1,100 @@
+import { Node, mergeAttributes } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
+import { ReactNodeViewRenderer } from "@tiptap/react"
+import { QuoteReplyView } from "./quote-reply-view"
+
+export interface QuoteReplyAttrs {
+  /** The ID of the quoted message */
+  messageId: string
+  /** The stream containing the quoted message */
+  streamId: string
+  /** Display name of the quoted message author (denormalized) */
+  authorName: string
+  /** The quoted text snippet */
+  snippet: string
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    quoteReply: {
+      /** Insert a quote reply block at the start of the document */
+      insertQuoteReply: (attrs: QuoteReplyAttrs) => ReturnType
+    }
+  }
+}
+
+export const QuoteReplyExtension = Node.create({
+  name: "quoteReply",
+  group: "block",
+  selectable: true,
+  draggable: false,
+  atom: true,
+
+  addAttributes() {
+    return {
+      messageId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-message-id"),
+        renderHTML: (attrs) => ({ "data-message-id": attrs.messageId }),
+      },
+      streamId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-stream-id"),
+        renderHTML: (attrs) => ({ "data-stream-id": attrs.streamId }),
+      },
+      authorName: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-author-name"),
+        renderHTML: (attrs) => ({ "data-author-name": attrs.authorName }),
+      },
+      snippet: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-snippet"),
+        renderHTML: (attrs) => ({ "data-snippet": attrs.snippet }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="quote-reply"]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-type": "quote-reply" })]
+  },
+
+  renderText({ node }) {
+    const attrs = node.attrs as QuoteReplyAttrs
+    return `> ${attrs.snippet}\n> — ${attrs.authorName}\n`
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(QuoteReplyView)
+  },
+
+  addCommands() {
+    return {
+      insertQuoteReply:
+        (attrs) =>
+        ({ tr, state, dispatch }) => {
+          if (!dispatch) return false
+
+          const { doc } = state
+          const quoteNode = state.schema.nodes.quoteReply.create(attrs)
+
+          // Replace any existing quoteReply at position 0, or insert at top
+          let existingQuoteEnd = 0
+          if (doc.firstChild?.type.name === "quoteReply") {
+            existingQuoteEnd = doc.firstChild.nodeSize
+          }
+
+          tr.replaceWith(0, existingQuoteEnd, quoteNode)
+          // Move cursor to after the quote reply
+          const resolvedPos = tr.doc.resolve(quoteNode.nodeSize)
+          tr.setSelection(TextSelection.near(resolvedPos))
+          dispatch(tr)
+          return true
+        },
+    }
+  },
+})

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -135,6 +135,43 @@ function moveAcrossQuoteReply(
   return false
 }
 
+function handleQuoteReplyClick(
+  editor: {
+    state: import("@tiptap/pm/state").EditorState
+    view: import("@tiptap/pm/view").EditorView
+  },
+  node: import("@tiptap/pm/model").Node,
+  nodePos: number,
+  event: MouseEvent,
+  direct: boolean
+): boolean {
+  if (!direct || node.type.name !== "quoteReply" || event.button !== 0) {
+    return false
+  }
+
+  const target = event.target
+  if (target instanceof HTMLElement && target.closest("button,a")) {
+    return false
+  }
+
+  const nodeDom = editor.view.nodeDOM(nodePos)
+  const quoteElement = getAdjacentQuoteReplyElement(nodeDom instanceof Element ? nodeDom : null)
+  if (!quoteElement) {
+    return false
+  }
+
+  const quoteRect = quoteElement.getBoundingClientRect()
+  const targetPos = event.clientX <= quoteRect.left + quoteRect.width / 2 ? nodePos : nodePos + node.nodeSize
+
+  if (!setGapCursorSelection(editor, targetPos)) {
+    return false
+  }
+
+  event.preventDefault()
+  editor.view.focus()
+  return true
+}
+
 export interface QuoteReplyAttrs {
   /** The ID of the quoted message */
   messageId: string
@@ -222,6 +259,8 @@ export const QuoteReplyExtension = Node.create({
         key: new PluginKey("quoteReplyGapCursorPosition"),
         props: {
           handleTextInput: (_view, _from, _to, text) => insertParagraphAtGapCursor(this.editor, text),
+          handleClickOn: (_view, _pos, node, nodePos, event, direct) =>
+            handleQuoteReplyClick(this.editor, node, nodePos, event, direct),
           handleKeyDown: (_view, event) => {
             if (event.key === "ArrowLeft") {
               return moveAcrossQuoteReply(this.editor, "left")

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,4 +1,5 @@
 import { Node, mergeAttributes } from "@tiptap/core"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
@@ -74,5 +75,41 @@ export const QuoteReplyExtension = Node.create({
 
   addNodeView() {
     return ReactNodeViewRenderer(QuoteReplyView)
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("quoteReplyParagraphGuard"),
+        appendTransaction: (_transactions, _oldState, newState) => {
+          const { doc, schema, tr } = newState
+          const insertions: number[] = []
+
+          doc.forEach((node, pos, index) => {
+            if (node.type.name !== "quoteReply") return
+
+            // Need a paragraph before if this is the first node or preceded by another quoteReply
+            const prev = index > 0 ? doc.child(index - 1) : null
+            if (!prev || prev.type.name === "quoteReply") {
+              insertions.push(pos)
+            }
+
+            // Need a paragraph after if this is the last node
+            if (index === doc.childCount - 1) {
+              insertions.push(pos + node.nodeSize)
+            }
+          })
+
+          if (insertions.length === 0) return null
+
+          // Insert in reverse order so positions stay valid
+          for (let i = insertions.length - 1; i >= 0; i--) {
+            tr.insert(insertions[i], schema.nodes.paragraph.create())
+          }
+
+          return tr
+        },
+      }),
+    ]
   },
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,22 +1,138 @@
 import { Node, mergeAttributes } from "@tiptap/core"
 import { GapCursor } from "@tiptap/pm/gapcursor"
-import { Plugin, PluginKey, Selection } from "@tiptap/pm/state"
+import type { ResolvedPos } from "@tiptap/pm/model"
+import { NodeSelection, Plugin, PluginKey, Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
-function insertParagraphAtGapCursor(editor: {
-  state: import("@tiptap/pm/state").EditorState
-  view: import("@tiptap/pm/view").EditorView
-}): boolean {
+function isValidGapCursorPosition($pos: ResolvedPos): boolean {
+  const gapCursor = GapCursor as typeof GapCursor & {
+    valid?: (position: ResolvedPos) => boolean
+  }
+
+  return gapCursor.valid?.($pos) ?? false
+}
+
+function insertParagraphAtGapCursor(
+  editor: {
+    state: import("@tiptap/pm/state").EditorState
+    view: import("@tiptap/pm/view").EditorView
+  },
+  text = ""
+): boolean {
   const { state } = editor
   if (!(state.selection instanceof GapCursor)) return false
 
   const pos = state.selection.$from.pos
   const paragraph = state.schema.nodes.paragraph.create()
-  const tr = state.tr.insert(pos, paragraph)
-  tr.setSelection(Selection.near(tr.doc.resolve(pos + 1)))
-  editor.view.dispatch(tr)
+  let tr = state.tr.insert(pos, paragraph)
+  const selectionPos = pos + 1
+
+  if (text.length > 0) {
+    tr = tr.insertText(text, selectionPos)
+  }
+
+  tr.setSelection(Selection.near(tr.doc.resolve(selectionPos + text.length)))
+  editor.view.dispatch(tr.scrollIntoView())
   return true
+}
+
+function syncGapCursorStyles(view: import("@tiptap/pm/view").EditorView) {
+  const root = view.dom as HTMLElement
+  const el = root.querySelector(".ProseMirror-gapcursor") as HTMLElement | null
+
+  root.classList.remove("has-after-quote-gapcursor")
+
+  if (!el) {
+    return
+  }
+
+  el.classList.remove("before-quote", "after-quote")
+  el.style.removeProperty("--quote-top")
+  el.style.removeProperty("--quote-height")
+  el.style.removeProperty("--quote-right")
+
+  const next = getAdjacentQuoteReplyElement(el.nextElementSibling)
+  const prev = getAdjacentQuoteReplyElement(el.previousElementSibling)
+
+  if (next) {
+    el.classList.add("before-quote")
+    const quoteRect = next.getBoundingClientRect()
+    const gcRect = el.getBoundingClientRect()
+    el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
+    el.style.setProperty("--quote-height", `${quoteRect.height}px`)
+    return
+  }
+
+  if (prev) {
+    el.classList.add("after-quote")
+    const quoteRect = prev.getBoundingClientRect()
+    const gcRect = el.getBoundingClientRect()
+    el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
+    el.style.setProperty("--quote-height", `${quoteRect.height}px`)
+    el.style.setProperty("--quote-right", `${root.getBoundingClientRect().right - quoteRect.right}px`)
+
+    if (!el.nextElementSibling) {
+      root.classList.add("has-after-quote-gapcursor")
+    }
+  }
+}
+
+function getAdjacentQuoteReplyElement(element: Element | null): HTMLElement | null {
+  if (!(element instanceof HTMLElement)) {
+    return null
+  }
+
+  if (element.getAttribute("data-type") === "quote-reply") {
+    return element
+  }
+
+  const nested = element.querySelector<HTMLElement>('[data-type="quote-reply"]')
+  return nested ?? null
+}
+
+function setGapCursorSelection(
+  editor: {
+    state: import("@tiptap/pm/state").EditorState
+    view: import("@tiptap/pm/view").EditorView
+  },
+  pos: number
+): boolean {
+  const $pos = editor.state.doc.resolve(pos)
+  if (!isValidGapCursorPosition($pos)) {
+    return false
+  }
+
+  editor.view.dispatch(editor.state.tr.setSelection(new GapCursor($pos)).scrollIntoView())
+  return true
+}
+
+function moveAcrossQuoteReply(
+  editor: {
+    state: import("@tiptap/pm/state").EditorState
+    view: import("@tiptap/pm/view").EditorView
+  },
+  direction: "left" | "right"
+): boolean {
+  const { selection } = editor.state
+
+  if (selection instanceof GapCursor) {
+    if (direction === "left" && selection.$from.nodeBefore?.type.name === "quoteReply") {
+      return setGapCursorSelection(editor, selection.from - selection.$from.nodeBefore.nodeSize)
+    }
+
+    if (direction === "right" && selection.$from.nodeAfter?.type.name === "quoteReply") {
+      return setGapCursorSelection(editor, selection.from + selection.$from.nodeAfter.nodeSize)
+    }
+
+    return false
+  }
+
+  if (selection instanceof NodeSelection && selection.node.type.name === "quoteReply") {
+    return setGapCursorSelection(editor, direction === "left" ? selection.from : selection.to)
+  }
+
+  return false
 }
 
 export interface QuoteReplyAttrs {
@@ -104,31 +220,29 @@ export const QuoteReplyExtension = Node.create({
     return [
       new Plugin({
         key: new PluginKey("quoteReplyGapCursorPosition"),
-        view() {
+        props: {
+          handleTextInput: (_view, _from, _to, text) => insertParagraphAtGapCursor(this.editor, text),
+          handleKeyDown: (_view, event) => {
+            if (event.key === "ArrowLeft") {
+              return moveAcrossQuoteReply(this.editor, "left")
+            }
+
+            if (event.key === "ArrowRight") {
+              return moveAcrossQuoteReply(this.editor, "right")
+            }
+
+            return false
+          },
+        },
+        view(view) {
+          syncGapCursorStyles(view)
+
           return {
-            update(view) {
-              const el = view.dom.querySelector(".ProseMirror-gapcursor") as HTMLElement | null
-              if (!el) return
-
-              el.classList.remove("before-quote", "after-quote")
-
-              const next = el.nextElementSibling
-              const prev = el.previousElementSibling
-
-              if (next?.getAttribute("data-type") === "quote-reply") {
-                el.classList.add("before-quote")
-                const quoteRect = next.getBoundingClientRect()
-                const gcRect = el.getBoundingClientRect()
-                el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
-                el.style.setProperty("--quote-height", `${quoteRect.height}px`)
-              } else if (prev?.getAttribute("data-type") === "quote-reply") {
-                el.classList.add("after-quote")
-                const quoteRect = prev.getBoundingClientRect()
-                const gcRect = el.getBoundingClientRect()
-                el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
-                el.style.setProperty("--quote-height", `${quoteRect.height}px`)
-                el.style.setProperty("--quote-right", `${view.dom.getBoundingClientRect().right - quoteRect.right}px`)
-              }
+            update(updatedView) {
+              syncGapCursorStyles(updatedView)
+            },
+            destroy() {
+              ;(view.dom as HTMLElement).classList.remove("has-after-quote-gapcursor")
             },
           }
         },

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,5 +1,6 @@
 import { Node, mergeAttributes } from "@tiptap/core"
-import { Plugin, PluginKey } from "@tiptap/pm/state"
+import { GapCursor } from "@tiptap/pm/gapcursor"
+import { Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
@@ -77,39 +78,22 @@ export const QuoteReplyExtension = Node.create({
     return ReactNodeViewRenderer(QuoteReplyView)
   },
 
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        key: new PluginKey("quoteReplyParagraphGuard"),
-        appendTransaction: (_transactions, _oldState, newState) => {
-          const { doc, schema, tr } = newState
-          const insertions: number[] = []
+  addKeyboardShortcuts() {
+    return {
+      // Prevent double-newline when pressing Enter in a gap cursor position.
+      // Without this, ProseMirror creates a paragraph (from the gap cursor)
+      // and then the default Enter handler splits it, producing two paragraphs.
+      Enter: ({ editor }) => {
+        const { state } = editor
+        if (!(state.selection instanceof GapCursor)) return false
 
-          doc.forEach((node, pos, index) => {
-            if (node.type.name !== "quoteReply") return
-
-            // Need a paragraph before if this is the first node or preceded by another quoteReply
-            const prev = index > 0 ? doc.child(index - 1) : null
-            if (!prev || prev.type.name === "quoteReply") {
-              insertions.push(pos)
-            }
-
-            // Need a paragraph after if this is the last node
-            if (index === doc.childCount - 1) {
-              insertions.push(pos + node.nodeSize)
-            }
-          })
-
-          if (insertions.length === 0) return null
-
-          // Insert in reverse order so positions stay valid
-          for (let i = insertions.length - 1; i >= 0; i--) {
-            tr.insert(insertions[i], schema.nodes.paragraph.create())
-          }
-
-          return tr
-        },
-      }),
-    ]
+        const pos = state.selection.$from.pos
+        const paragraph = state.schema.nodes.paragraph.create()
+        const tr = state.tr.insert(pos, paragraph)
+        tr.setSelection(Selection.near(tr.doc.resolve(pos + 1)))
+        editor.view.dispatch(tr)
+        return true
+      },
+    }
   },
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,5 +1,4 @@
 import { Node, mergeAttributes } from "@tiptap/core"
-import { TextSelection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
@@ -16,15 +15,6 @@ export interface QuoteReplyAttrs {
   actorType: string
   /** The quoted text snippet */
   snippet: string
-}
-
-declare module "@tiptap/core" {
-  interface Commands<ReturnType> {
-    quoteReply: {
-      /** Insert a quote reply block at the start of the document */
-      insertQuoteReply: (attrs: QuoteReplyAttrs) => ReturnType
-    }
-  }
 }
 
 export const QuoteReplyExtension = Node.create({
@@ -84,31 +74,5 @@ export const QuoteReplyExtension = Node.create({
 
   addNodeView() {
     return ReactNodeViewRenderer(QuoteReplyView)
-  },
-
-  addCommands() {
-    return {
-      insertQuoteReply:
-        (attrs) =>
-        ({ tr, state, dispatch }) => {
-          if (!dispatch) return false
-
-          const { doc } = state
-          const quoteNode = state.schema.nodes.quoteReply.create(attrs)
-
-          // Replace any existing quoteReply at position 0, or insert at top
-          let existingQuoteEnd = 0
-          if (doc.firstChild?.type.name === "quoteReply") {
-            existingQuoteEnd = doc.firstChild.nodeSize
-          }
-
-          tr.replaceWith(0, existingQuoteEnd, quoteNode)
-          // Move cursor to after the quote reply
-          const resolvedPos = tr.doc.resolve(quoteNode.nodeSize)
-          tr.setSelection(TextSelection.near(resolvedPos))
-          dispatch(tr)
-          return true
-        },
-    }
   },
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -1,6 +1,6 @@
 import { Node, mergeAttributes } from "@tiptap/core"
 import { GapCursor } from "@tiptap/pm/gapcursor"
-import { Selection } from "@tiptap/pm/state"
+import { Plugin, PluginKey, Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
@@ -98,5 +98,42 @@ export const QuoteReplyExtension = Node.create({
       Enter: () => insertParagraphAtGapCursor(this.editor),
       "Shift-Enter": () => insertParagraphAtGapCursor(this.editor),
     }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("quoteReplyGapCursorPosition"),
+        view() {
+          return {
+            update(view) {
+              const el = view.dom.querySelector(".ProseMirror-gapcursor") as HTMLElement | null
+              if (!el) return
+
+              el.classList.remove("before-quote", "after-quote")
+
+              const next = el.nextElementSibling
+              const prev = el.previousElementSibling
+
+              if (next?.getAttribute("data-type") === "quote-reply") {
+                el.classList.add("before-quote")
+                // Position vertically to overlap with the quote below
+                const quoteRect = next.getBoundingClientRect()
+                const editorRect = view.dom.getBoundingClientRect()
+                el.style.setProperty("--quote-top", `${quoteRect.top - editorRect.top}px`)
+                el.style.setProperty("--quote-height", `${quoteRect.height}px`)
+              } else if (prev?.getAttribute("data-type") === "quote-reply") {
+                el.classList.add("after-quote")
+                const quoteRect = prev.getBoundingClientRect()
+                const editorRect = view.dom.getBoundingClientRect()
+                el.style.setProperty("--quote-top", `${quoteRect.top - editorRect.top}px`)
+                el.style.setProperty("--quote-height", `${quoteRect.height}px`)
+                el.style.setProperty("--quote-right", `${editorRect.right - quoteRect.right}px`)
+              }
+            },
+          }
+        },
+      }),
+    ]
   },
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -117,18 +117,17 @@ export const QuoteReplyExtension = Node.create({
 
               if (next?.getAttribute("data-type") === "quote-reply") {
                 el.classList.add("before-quote")
-                // Position vertically to overlap with the quote below
                 const quoteRect = next.getBoundingClientRect()
-                const editorRect = view.dom.getBoundingClientRect()
-                el.style.setProperty("--quote-top", `${quoteRect.top - editorRect.top}px`)
+                const gcRect = el.getBoundingClientRect()
+                el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
                 el.style.setProperty("--quote-height", `${quoteRect.height}px`)
               } else if (prev?.getAttribute("data-type") === "quote-reply") {
                 el.classList.add("after-quote")
                 const quoteRect = prev.getBoundingClientRect()
-                const editorRect = view.dom.getBoundingClientRect()
-                el.style.setProperty("--quote-top", `${quoteRect.top - editorRect.top}px`)
+                const gcRect = el.getBoundingClientRect()
+                el.style.setProperty("--quote-top", `${quoteRect.top - gcRect.top}px`)
                 el.style.setProperty("--quote-height", `${quoteRect.height}px`)
-                el.style.setProperty("--quote-right", `${editorRect.right - quoteRect.right}px`)
+                el.style.setProperty("--quote-right", `${view.dom.getBoundingClientRect().right - quoteRect.right}px`)
               }
             },
           }

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -4,6 +4,21 @@ import { Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { QuoteReplyView } from "./quote-reply-view"
 
+function insertParagraphAtGapCursor(editor: {
+  state: import("@tiptap/pm/state").EditorState
+  view: import("@tiptap/pm/view").EditorView
+}): boolean {
+  const { state } = editor
+  if (!(state.selection instanceof GapCursor)) return false
+
+  const pos = state.selection.$from.pos
+  const paragraph = state.schema.nodes.paragraph.create()
+  const tr = state.tr.insert(pos, paragraph)
+  tr.setSelection(Selection.near(tr.doc.resolve(pos + 1)))
+  editor.view.dispatch(tr)
+  return true
+}
+
 export interface QuoteReplyAttrs {
   /** The ID of the quoted message */
   messageId: string
@@ -80,20 +95,8 @@ export const QuoteReplyExtension = Node.create({
 
   addKeyboardShortcuts() {
     return {
-      // Prevent double-newline when pressing Enter in a gap cursor position.
-      // Without this, ProseMirror creates a paragraph (from the gap cursor)
-      // and then the default Enter handler splits it, producing two paragraphs.
-      Enter: ({ editor }) => {
-        const { state } = editor
-        if (!(state.selection instanceof GapCursor)) return false
-
-        const pos = state.selection.$from.pos
-        const paragraph = state.schema.nodes.paragraph.create()
-        const tr = state.tr.insert(pos, paragraph)
-        tr.setSelection(Selection.near(tr.doc.resolve(pos + 1)))
-        editor.view.dispatch(tr)
-        return true
-      },
+      Enter: () => insertParagraphAtGapCursor(this.editor),
+      "Shift-Enter": () => insertParagraphAtGapCursor(this.editor),
     }
   },
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -10,6 +10,10 @@ export interface QuoteReplyAttrs {
   streamId: string
   /** Display name of the quoted message author (denormalized) */
   authorName: string
+  /** The ID of the quoted message author */
+  authorId: string
+  /** The actor type of the quoted message author */
+  actorType: string
   /** The quoted text snippet */
   snippet: string
 }
@@ -46,6 +50,16 @@ export const QuoteReplyExtension = Node.create({
         default: "",
         parseHTML: (element) => element.getAttribute("data-author-name"),
         renderHTML: (attrs) => ({ "data-author-name": attrs.authorName }),
+      },
+      authorId: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-author-id"),
+        renderHTML: (attrs) => ({ "data-author-id": attrs.authorId }),
+      },
+      actorType: {
+        default: "user",
+        parseHTML: (element) => element.getAttribute("data-actor-type"),
+        renderHTML: (attrs) => ({ "data-actor-type": attrs.actorType }),
       },
       snippet: {
         default: "",

--- a/apps/frontend/src/components/editor/quote-reply-view.tsx
+++ b/apps/frontend/src/components/editor/quote-reply-view.tsx
@@ -1,13 +1,21 @@
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
 import { X, Quote } from "lucide-react"
+import { useParams } from "react-router-dom"
 import { cn } from "@/lib/utils"
+import { useActors } from "@/hooks"
+import { useUserProfile } from "@/components/user-profile"
+import { PersonaAvatar } from "@/components/persona-avatar"
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import type { QuoteReplyAttrs } from "./quote-reply-extension"
+import type { AuthorType } from "@threa/types"
 
 export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
   const attrs = node.attrs as QuoteReplyAttrs
   const snippetLines = attrs.snippet.split("\n")
   const isLong = snippetLines.length > 3 || attrs.snippet.length > 200
   const displaySnippet = isLong ? snippetLines.slice(0, 3).join("\n").slice(0, 200) + "..." : attrs.snippet
+
+  const { workspaceId } = useParams<{ workspaceId: string }>()
 
   return (
     <NodeViewWrapper
@@ -20,7 +28,16 @@ export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
     >
       <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
-        <span className="text-xs font-medium text-muted-foreground">{attrs.authorName}</span>
+        {workspaceId && attrs.authorId ? (
+          <QuoteAuthor
+            workspaceId={workspaceId}
+            authorName={attrs.authorName}
+            authorId={attrs.authorId}
+            actorType={attrs.actorType as AuthorType}
+          />
+        ) : (
+          <span className="text-xs font-medium text-muted-foreground">{attrs.authorName}</span>
+        )}
         <p className="mt-0.5 whitespace-pre-wrap text-muted-foreground">{displaySnippet}</p>
       </div>
       <button
@@ -32,5 +49,66 @@ export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
         <X className="h-3.5 w-3.5" />
       </button>
     </NodeViewWrapper>
+  )
+}
+
+function QuoteAuthor({
+  workspaceId,
+  authorName,
+  authorId,
+  actorType,
+}: {
+  workspaceId: string
+  authorName: string
+  authorId: string
+  actorType: AuthorType
+}) {
+  const { getActorAvatar } = useActors(workspaceId)
+  const { openUserProfile } = useUserProfile()
+  const { fallback, slug, avatarUrl } = getActorAvatar(authorId, actorType)
+  const isPersona = actorType === "persona"
+  const isBot = actorType === "bot"
+  const isSystem = actorType === "system"
+  const isUser = actorType === "user"
+
+  const handleAuthorClick = () => {
+    if (isUser && authorId) {
+      openUserProfile(authorId)
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {isPersona ? (
+        <PersonaAvatar slug={slug} fallback={fallback} size="sm" className="h-4 w-4 text-[8px]" />
+      ) : (
+        <Avatar className="h-4 w-4 rounded-[4px] shrink-0">
+          {avatarUrl && <AvatarImage src={avatarUrl} alt={authorName} />}
+          <AvatarFallback
+            className={cn(
+              "text-[8px]",
+              isSystem && "bg-blue-500/10 text-blue-500",
+              isBot && "bg-emerald-500/10 text-emerald-600",
+              !isSystem && !isBot && "bg-muted text-foreground"
+            )}
+          >
+            {fallback}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      <button
+        type="button"
+        onClick={handleAuthorClick}
+        className={cn(
+          "text-xs font-medium",
+          isUser && authorId ? "text-muted-foreground hover:underline" : "text-muted-foreground cursor-default",
+          isPersona && "text-primary",
+          isBot && "text-emerald-600",
+          isSystem && "text-blue-500"
+        )}
+      >
+        {authorName}
+      </button>
+    </span>
   )
 }

--- a/apps/frontend/src/components/editor/quote-reply-view.tsx
+++ b/apps/frontend/src/components/editor/quote-reply-view.tsx
@@ -1,0 +1,36 @@
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
+import { X, Quote } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { QuoteReplyAttrs } from "./quote-reply-extension"
+
+export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
+  const attrs = node.attrs as QuoteReplyAttrs
+  const snippetLines = attrs.snippet.split("\n")
+  const isLong = snippetLines.length > 3 || attrs.snippet.length > 200
+  const displaySnippet = isLong ? snippetLines.slice(0, 3).join("\n").slice(0, 200) + "..." : attrs.snippet
+
+  return (
+    <NodeViewWrapper
+      className={cn(
+        "my-1 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm select-none",
+        "group/quote-reply",
+        selected && "ring-2 ring-primary/30"
+      )}
+      data-type="quote-reply"
+    >
+      <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <span className="text-xs font-medium text-muted-foreground">{attrs.authorName}</span>
+        <p className="mt-0.5 whitespace-pre-wrap text-muted-foreground">{displaySnippet}</p>
+      </div>
+      <button
+        type="button"
+        onClick={deleteNode}
+        className="shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/quote-reply:opacity-100"
+        aria-label="Remove quote"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </NodeViewWrapper>
+  )
+}

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -506,11 +506,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // dispatch caused a view update that raced with toolbar rendering,
   // briefly dropping focus in autoFocus editors (e.g. inline edit).
 
-  // Copy handler: serialize selection to markdown
+  // Copy/cut handler: serialize selection to markdown
   useEffect(() => {
     if (!editor || !containerRef.current) return
 
-    const handleCopy = (event: ClipboardEvent) => {
+    const serializeSelection = (event: ClipboardEvent) => {
       const { from, to } = editor.state.selection
       if (from === to) return // No selection, use default behavior
 
@@ -522,9 +522,23 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       event.preventDefault()
     }
 
+    const handleCopy = (event: ClipboardEvent) => {
+      serializeSelection(event)
+    }
+
+    const handleCut = (event: ClipboardEvent) => {
+      serializeSelection(event)
+      // Delete the selected content after serializing to clipboard
+      editor.commands.deleteSelection()
+    }
+
     const container = containerRef.current
     container.addEventListener("copy", handleCopy)
-    return () => container.removeEventListener("copy", handleCopy)
+    container.addEventListener("cut", handleCut)
+    return () => {
+      container.removeEventListener("copy", handleCopy)
+      container.removeEventListener("cut", handleCut)
+    }
   }, [editor])
 
   // Expose focus method

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from "react"
 import { useEditor, EditorContent } from "@tiptap/react"
+import { GapCursor } from "@tiptap/pm/gapcursor"
+import type { ResolvedPos } from "@tiptap/pm/model"
 import type { PluginKey } from "@tiptap/pm/state"
 import { useParams } from "react-router-dom"
 import { createEditorExtensions } from "./editor-extensions"
@@ -22,11 +24,20 @@ import type { MentionStreamContext } from "@/hooks/use-mentionables"
 
 export interface RichEditorHandle {
   focus(): void
+  focusAfterQuoteReply(): void
   insertMention(): void
   insertSlash(): void
   insertEmoji(): void
   /** Access the TipTap editor instance for external toolbar rendering */
   getEditor(): import("@tiptap/react").Editor | null
+}
+
+function isValidGapCursorPosition($pos: ResolvedPos): boolean {
+  const gapCursor = GapCursor as typeof GapCursor & {
+    valid?: (position: ResolvedPos) => boolean
+  }
+
+  return gapCursor.valid?.($pos) ?? false
 }
 
 interface RichEditorProps {
@@ -548,6 +559,23 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     }
   }, [editor])
 
+  const focusAfterQuoteReply = useCallback(() => {
+    if (!editor || editor.isDestroyed) {
+      return
+    }
+
+    const pos = editor.state.doc.content.size
+    const $pos = editor.state.doc.resolve(pos)
+
+    if (isValidGapCursorPosition($pos)) {
+      editor.view.focus()
+      editor.view.dispatch(editor.state.tr.setSelection(new GapCursor($pos)).scrollIntoView())
+      return
+    }
+
+    editor.commands.focus("end")
+  }, [editor])
+
   // Re-focus when scope changes (e.g., navigating between streams) on desktop.
   // TipTap's autofocus only fires on mount; without key={scopeId} remounting,
   // we need to manually re-focus when the scope changes.
@@ -620,12 +648,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     ref,
     () => ({
       focus,
+      focusAfterQuoteReply,
       insertMention: handleMentionClick,
       insertSlash: handleSlashClick,
       insertEmoji: handleEmojiClick,
       getEditor: () => editor,
     }),
-    [focus, handleMentionClick, handleSlashClick, handleEmojiClick, editor]
+    [focus, focusAfterQuoteReply, handleMentionClick, handleSlashClick, handleEmojiClick, editor]
   )
 
   return (

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react"
-import { Sparkles, MessageSquareReply, Copy, FileText, Type, Pencil, Trash2, History, Link2 } from "lucide-react"
+import { Sparkles, MessageSquareReply, Quote, Copy, FileText, Type, Pencil, Trash2, History, Link2 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
 
@@ -41,6 +41,8 @@ export interface MessageActionContext {
   onOpenFullPicker?: () => void
   /** Current reactions on this message (shortcode → userIds) for toggle logic */
   reactions?: Record<string, string[]>
+  /** Callback to insert a quote reply into the composer */
+  onQuoteReply?: () => void
 }
 
 /** A variant within a sub-menu (e.g. "Copy as Markdown" vs "Copy as Plain text"). */
@@ -92,6 +94,13 @@ export const messageActions: MessageAction[] = [
     icon: MessageSquareReply,
     when: (ctx) => !ctx.isThreadParent,
     getHref: (ctx) => ctx.replyUrl,
+  },
+  {
+    id: "quote-reply",
+    label: "Quote reply",
+    icon: Quote,
+    when: (ctx) => !!ctx.onQuoteReply,
+    action: (ctx) => ctx.onQuoteReply?.(),
   },
   {
     id: "edit-message",

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -185,7 +185,12 @@ function MessageLayout({
   const hasSwipe = swipeOffset !== undefined && swipeOffset !== 0
 
   return (
-    <div ref={containerRef} className={cn("relative overflow-hidden", containerClassName)} {...touchHandlers}>
+    <div
+      ref={containerRef}
+      data-author-name={actorName}
+      className={cn("relative overflow-hidden", containerClassName)}
+      {...touchHandlers}
+    >
       {/* Swipe-to-quote reveal icon (behind the message) */}
       {hasSwipe && (
         <div className="absolute inset-y-0 right-0 flex items-center pr-4">
@@ -348,11 +353,13 @@ function SentMessageEvent({
 
   // Mobile: swipe left to quote reply
   const handleSwipeQuote = useCallback(() => {
+    const snippet = payload.contentMarkdown.trim()
+    if (!snippet) return
     quoteReplyCtx?.triggerQuoteReply({
       messageId: payload.messageId,
       streamId,
       authorName: actorName,
-      snippet: payload.contentMarkdown,
+      snippet,
     })
   }, [quoteReplyCtx, payload.messageId, payload.contentMarkdown, streamId, actorName])
   const swipe = useSwipeAction({

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -199,7 +199,8 @@ function MessageLayout({
       )}
       <div
         className={cn(
-          "message-item group relative flex gap-[14px] py-4 px-3 sm:px-6",
+          // Opaque background so swipe-to-quote icon shows behind the message
+          "message-item group relative flex gap-[14px] py-4 px-3 sm:px-6 bg-background",
           // AI/Persona messages get full-width gradient with gold accent
           isPersona && "bg-gradient-to-r from-primary/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(var(--primary))]",
           // Bot messages get emerald accent
@@ -213,8 +214,7 @@ function MessageLayout({
             !isSystem &&
             "before:content-[''] before:absolute before:-top-4 before:-bottom-4 before:left-0 before:right-0 before:bg-primary/[0.04] before:-z-10",
           isHighlighted && "animate-highlight-flash",
-          isNew && !isHighlighted && "animate-new-message-fade",
-          "bg-background"
+          isNew && !isHighlighted && "animate-new-message-fade"
         )}
         style={hasSwipe ? { transform: `translateX(${swipeOffset}px)` } : undefined}
       >

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -27,6 +27,7 @@ import {
   focusAtEnd,
   type MessageAgentActivity,
 } from "@/hooks"
+import { Quote } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useLongPress } from "@/hooks/use-long-press"
@@ -44,6 +45,8 @@ import { EditedIndicator } from "./edited-indicator"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
 import { ReactionEmojiPicker } from "./reaction-emoji-picker"
+import { useQuoteReply } from "./quote-reply-context"
+import { useSwipeAction } from "@/hooks/use-swipe-action"
 
 interface MessagePayload {
   messageId: string
@@ -102,6 +105,10 @@ interface MessageLayoutProps {
     onTouchMove: (e: React.TouchEvent) => void
     onContextMenu: (e: React.MouseEvent) => void
   }
+  /** Horizontal swipe offset for mobile swipe-to-quote (px, negative = left) */
+  swipeOffset?: number
+  /** Whether swipe has passed the threshold */
+  swipeLocked?: boolean
 }
 
 function focusVisibleZoneEditor(zone: HTMLElement | null, attempt = 0) {
@@ -166,6 +173,8 @@ function MessageLayout({
   containerRef,
   deferSecondaryHydration,
   touchHandlers,
+  swipeOffset,
+  swipeLocked,
 }: MessageLayoutProps) {
   const isPersona = event.actorType === "persona"
   const isSystem = event.actorType === "system"
@@ -173,101 +182,110 @@ function MessageLayout({
   const isUser = event.actorType === "user"
   const { openUserProfile } = useUserProfile()
 
+  const hasSwipe = swipeOffset !== undefined && swipeOffset !== 0
+
   return (
-    <div
-      ref={containerRef}
-      {...touchHandlers}
-      className={cn(
-        "message-item group relative flex gap-[14px] py-4 px-3 sm:px-6",
-        // AI/Persona messages get full-width gradient with gold accent
-        isPersona && "bg-gradient-to-r from-primary/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(var(--primary))]",
-        // Bot messages get emerald accent
-        isBot && "bg-gradient-to-r from-emerald-500/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(152_69%_41%)]",
-        // System messages get a subtle info-toned accent
-        isSystem && "bg-gradient-to-r from-blue-500/[0.04] to-transparent shadow-[inset_3px_0_0_hsl(210_100%_55%)]",
-        // Edit mode: pseudo-element background so no layout shift — zero padding/margin changes
-        isEditing &&
-          !isPersona &&
-          !isBot &&
-          !isSystem &&
-          "before:content-[''] before:absolute before:-top-4 before:-bottom-4 before:left-0 before:right-0 before:bg-primary/[0.04] before:-z-10",
-        isHighlighted && "animate-highlight-flash",
-        isNew && !isHighlighted && "animate-new-message-fade",
-        containerClassName
-      )}
-    >
-      {isPersona ? (
-        <PersonaAvatar slug={personaSlug} fallback={actorInitials} size="md" className="message-avatar" />
-      ) : (
-        <Avatar className="message-avatar h-9 w-9 rounded-[10px] shrink-0">
-          {actorAvatarUrl && <AvatarImage src={actorAvatarUrl} alt={actorName} />}
-          <AvatarFallback
-            className={cn(
-              "text-foreground",
-              isSystem && "bg-blue-500/10 text-blue-500",
-              isBot && "bg-emerald-500/10 text-emerald-600",
-              !isSystem && !isBot && "bg-muted"
-            )}
-          >
-            {actorInitials}
-          </AvatarFallback>
-        </Avatar>
-      )}
-      <div className="message-content flex-1 min-w-0">
-        <div className="flex items-baseline gap-2 mb-1">
-          {isUser && event.actorId ? (
-            <button
-              type="button"
-              onClick={() => openUserProfile(event.actorId!)}
-              className={cn("font-semibold text-sm hover:underline text-left")}
-            >
-              {actorName}
-            </button>
-          ) : (
-            <span
-              className={cn(
-                "font-semibold text-sm",
-                isPersona && "text-primary",
-                isBot && "text-emerald-600",
-                isSystem && "text-blue-500"
-              )}
-            >
-              {actorName}
-            </span>
-          )}
-          {isBot && <span className="text-[10px] text-emerald-600/70 font-medium cursor-default">BOT</span>}
-          {payload.sentVia && isSentViaApi(payload.sentVia) && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="text-[10px] text-muted-foreground/70 font-medium cursor-default">via API</span>
-              </TooltipTrigger>
-              <TooltipContent>Sent on behalf of this user by an API key</TooltipContent>
-            </Tooltip>
-          )}
-          {statusIndicator}
-          {actions}
+    <div ref={containerRef} className={cn("relative overflow-hidden", containerClassName)} {...touchHandlers}>
+      {/* Swipe-to-quote reveal icon (behind the message) */}
+      {hasSwipe && (
+        <div className="absolute inset-y-0 right-0 flex items-center pr-4">
+          <Quote className={cn("h-5 w-5 transition-colors", swipeLocked ? "text-primary" : "text-muted-foreground")} />
         </div>
-        {children ?? (
-          <LinkPreviewProvider>
-            <AttachmentProvider workspaceId={workspaceId} attachments={payload.attachments ?? []}>
-              <MarkdownContent content={payload.contentMarkdown} className="text-sm leading-relaxed" />
-              {payload.attachments && payload.attachments.length > 0 && (
-                <AttachmentList
-                  attachments={payload.attachments}
-                  workspaceId={workspaceId}
-                  deferHydration={deferSecondaryHydration}
-                />
-              )}
-              <MessageLinkPreviews
-                messageId={payload.messageId}
-                workspaceId={workspaceId}
-                previews={payload.linkPreviews}
-                hydrateFromApi={!deferSecondaryHydration}
-              />
-            </AttachmentProvider>
-          </LinkPreviewProvider>
+      )}
+      <div
+        className={cn(
+          "message-item group relative flex gap-[14px] py-4 px-3 sm:px-6",
+          // AI/Persona messages get full-width gradient with gold accent
+          isPersona && "bg-gradient-to-r from-primary/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(var(--primary))]",
+          // Bot messages get emerald accent
+          isBot && "bg-gradient-to-r from-emerald-500/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(152_69%_41%)]",
+          // System messages get a subtle info-toned accent
+          isSystem && "bg-gradient-to-r from-blue-500/[0.04] to-transparent shadow-[inset_3px_0_0_hsl(210_100%_55%)]",
+          // Edit mode: pseudo-element background so no layout shift — zero padding/margin changes
+          isEditing &&
+            !isPersona &&
+            !isBot &&
+            !isSystem &&
+            "before:content-[''] before:absolute before:-top-4 before:-bottom-4 before:left-0 before:right-0 before:bg-primary/[0.04] before:-z-10",
+          isHighlighted && "animate-highlight-flash",
+          isNew && !isHighlighted && "animate-new-message-fade",
+          "bg-background"
         )}
-        {footer}
+        style={hasSwipe ? { transform: `translateX(${swipeOffset}px)` } : undefined}
+      >
+        {isPersona ? (
+          <PersonaAvatar slug={personaSlug} fallback={actorInitials} size="md" className="message-avatar" />
+        ) : (
+          <Avatar className="message-avatar h-9 w-9 rounded-[10px] shrink-0">
+            {actorAvatarUrl && <AvatarImage src={actorAvatarUrl} alt={actorName} />}
+            <AvatarFallback
+              className={cn(
+                "text-foreground",
+                isSystem && "bg-blue-500/10 text-blue-500",
+                isBot && "bg-emerald-500/10 text-emerald-600",
+                !isSystem && !isBot && "bg-muted"
+              )}
+            >
+              {actorInitials}
+            </AvatarFallback>
+          </Avatar>
+        )}
+        <div className="message-content flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 mb-1">
+            {isUser && event.actorId ? (
+              <button
+                type="button"
+                onClick={() => openUserProfile(event.actorId!)}
+                className={cn("font-semibold text-sm hover:underline text-left")}
+              >
+                {actorName}
+              </button>
+            ) : (
+              <span
+                className={cn(
+                  "font-semibold text-sm",
+                  isPersona && "text-primary",
+                  isBot && "text-emerald-600",
+                  isSystem && "text-blue-500"
+                )}
+              >
+                {actorName}
+              </span>
+            )}
+            {isBot && <span className="text-[10px] text-emerald-600/70 font-medium cursor-default">BOT</span>}
+            {payload.sentVia && isSentViaApi(payload.sentVia) && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-[10px] text-muted-foreground/70 font-medium cursor-default">via API</span>
+                </TooltipTrigger>
+                <TooltipContent>Sent on behalf of this user by an API key</TooltipContent>
+              </Tooltip>
+            )}
+            {statusIndicator}
+            {actions}
+          </div>
+          {children ?? (
+            <LinkPreviewProvider>
+              <AttachmentProvider workspaceId={workspaceId} attachments={payload.attachments ?? []}>
+                <MarkdownContent content={payload.contentMarkdown} className="text-sm leading-relaxed" />
+                {payload.attachments && payload.attachments.length > 0 && (
+                  <AttachmentList
+                    attachments={payload.attachments}
+                    workspaceId={workspaceId}
+                    deferHydration={deferSecondaryHydration}
+                  />
+                )}
+                <MessageLinkPreviews
+                  messageId={payload.messageId}
+                  workspaceId={workspaceId}
+                  previews={payload.linkPreviews}
+                  hydrateFromApi={!deferSecondaryHydration}
+                />
+              </AttachmentProvider>
+            </LinkPreviewProvider>
+          )}
+          {footer}
+        </div>
       </div>
     </div>
   )
@@ -308,6 +326,7 @@ function SentMessageEvent({
   const messageService = useMessageService()
   const currentUserId = useWorkspaceUserId(workspaceId)
   const { getTraceUrl } = useTrace()
+  const quoteReplyCtx = useQuoteReply()
   const replyCount = payload.replyCount ?? 0
   const threadId = payload.threadId
   const containerRef = useRef<HTMLDivElement>(null)
@@ -325,6 +344,20 @@ function SentMessageEvent({
   const longPress = useLongPress({
     onLongPress: openDrawer,
     enabled: isMobile && !isEditing,
+  })
+
+  // Mobile: swipe left to quote reply
+  const handleSwipeQuote = useCallback(() => {
+    quoteReplyCtx?.triggerQuoteReply({
+      messageId: payload.messageId,
+      streamId,
+      authorName: actorName,
+      snippet: payload.contentMarkdown,
+    })
+  }, [quoteReplyCtx, payload.messageId, payload.contentMarkdown, streamId, actorName])
+  const swipe = useSwipeAction({
+    onSwipe: handleSwipeQuote,
+    enabled: isMobile && !isEditing && !!quoteReplyCtx,
   })
 
   const startEditing = useCallback(() => {
@@ -476,6 +509,15 @@ function SentMessageEvent({
       onReact: handleAddReaction,
       onOpenFullPicker: () => setMobilePickerOpen(true),
       reactions: payload.reactions,
+      onQuoteReply: quoteReplyCtx
+        ? () =>
+            quoteReplyCtx.triggerQuoteReply({
+              messageId: payload.messageId,
+              streamId,
+              authorName: actorName,
+              snippet: payload.contentMarkdown,
+            })
+        : undefined,
     }),
     [
       payload.contentMarkdown,
@@ -497,6 +539,8 @@ function SentMessageEvent({
       streamId,
       startEditing,
       handleAddReaction,
+      quoteReplyCtx,
+      actorName,
     ]
   )
 
@@ -532,6 +576,22 @@ function SentMessageEvent({
               onSelect={handleAddReaction}
               activeShortcodes={activeReactionShortcodes}
             />
+            {actionContext.onQuoteReply && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-6 w-6 shadow-sm hover:border-primary/30 text-muted-foreground shrink-0"
+                    aria-label="Quote reply"
+                    onClick={actionContext.onQuoteReply}
+                  >
+                    <Quote className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Quote reply</TooltipContent>
+              </Tooltip>
+            )}
             <MessageContextMenu context={actionContext} />
           </div>
         }
@@ -559,7 +619,27 @@ function SentMessageEvent({
           isMobile && !isEditing && "select-none",
           longPress.isPressed && "opacity-70 transition-opacity duration-100"
         )}
-        touchHandlers={isMobile ? longPress.handlers : undefined}
+        swipeOffset={isMobile ? swipe.offset : undefined}
+        swipeLocked={isMobile ? swipe.isLocked : undefined}
+        touchHandlers={
+          isMobile
+            ? {
+                onTouchStart: (e: React.TouchEvent) => {
+                  longPress.handlers.onTouchStart(e)
+                  swipe.handlers.onTouchStart(e)
+                },
+                onTouchEnd: () => {
+                  longPress.handlers.onTouchEnd()
+                  swipe.handlers.onTouchEnd()
+                },
+                onTouchMove: (e: React.TouchEvent) => {
+                  longPress.handlers.onTouchMove(e)
+                  swipe.handlers.onTouchMove(e)
+                },
+                onContextMenu: longPress.handlers.onContextMenu,
+              }
+            : undefined
+        }
       >
         {/* Desktop: inline edit replaces message content. Mobile: drawer handles editing. */}
         {isEditing && !isMobile ? (

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -188,6 +188,8 @@ function MessageLayout({
     <div
       ref={containerRef}
       data-author-name={actorName}
+      data-author-id={event.actorId ?? ""}
+      data-actor-type={event.actorType ?? "user"}
       className={cn("relative overflow-hidden", containerClassName)}
       {...touchHandlers}
     >
@@ -359,9 +361,11 @@ function SentMessageEvent({
       messageId: payload.messageId,
       streamId,
       authorName: actorName,
+      authorId: event.actorId ?? "",
+      actorType: event.actorType ?? "user",
       snippet,
     })
-  }, [quoteReplyCtx, payload.messageId, payload.contentMarkdown, streamId, actorName])
+  }, [quoteReplyCtx, payload.messageId, payload.contentMarkdown, streamId, actorName, event.actorId, event.actorType])
   const swipe = useSwipeAction({
     onSwipe: handleSwipeQuote,
     enabled: isMobile && !isEditing && !!quoteReplyCtx,
@@ -522,6 +526,8 @@ function SentMessageEvent({
               messageId: payload.messageId,
               streamId,
               authorName: actorName,
+              authorId: event.actorId ?? "",
+              actorType: event.actorType ?? "user",
               snippet: payload.contentMarkdown,
             })
         : undefined,

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -60,7 +60,19 @@ const mockSetIsSending = vi.fn()
 const mockHandleContentChange = vi.fn()
 const mockHandleRemoveAttachment = vi.fn()
 const mockHandleFileSelect = vi.fn()
+const mockComposerFocus = vi.fn()
+const mockComposerFocusAfterQuoteReply = vi.fn()
 let mockSubmitContentOverride: JSONContent | undefined
+let registeredQuoteReplyHandler:
+  | ((data: {
+      messageId: string
+      streamId: string
+      authorName: string
+      authorId: string
+      actorType: string
+      snippet: string
+    }) => void)
+  | null = null
 
 // Composer state that tests can modify
 let mockComposerState = {
@@ -83,6 +95,29 @@ let mockComposerState = {
 
 vi.mock("@/stores/workspace-store", () => ({
   useWorkspaceStreams: () => [],
+}))
+
+vi.mock("./quote-reply-context", () => ({
+  useQuoteReply: () => ({
+    triggerQuoteReply: vi.fn(),
+    registerHandler: (
+      handler: (data: {
+        messageId: string
+        streamId: string
+        authorName: string
+        authorId: string
+        actorType: string
+        snippet: string
+      }) => void
+    ) => {
+      registeredQuoteReplyHandler = handler
+      return () => {
+        if (registeredQuoteReplyHandler === handler) {
+          registeredQuoteReplyHandler = null
+        }
+      }
+    },
+  }),
 }))
 
 vi.mock("@/hooks", () => ({
@@ -117,6 +152,7 @@ vi.mock("@/components/composer", () => ({
     isSubmitting,
     hasFailed,
     pendingAttachments,
+    composerRef,
   }: {
     content: JSONContent
     onContentChange: (v: JSONContent) => void
@@ -125,21 +161,32 @@ vi.mock("@/components/composer", () => ({
     isSubmitting: boolean
     hasFailed: boolean
     pendingAttachments: Array<{ id: string; filename: string; sizeBytes: number; status: string }>
-  }) => (
-    <div data-testid="message-composer">
-      <textarea data-testid="rich-editor" />
-      {pendingAttachments.map((a) => (
-        <div key={a.id}>
-          <span>{a.filename}</span>
-          <span>{a.sizeBytes >= 1024 ? `${(a.sizeBytes / 1024).toFixed(1)} KB` : `${a.sizeBytes} B`}</span>
-          {a.status === "error" && <span>Failed</span>}
+    composerRef?: { current: { focus: () => void; focusAfterQuoteReply: () => void } | null }
+  }) =>
+    (() => {
+      if (composerRef) {
+        composerRef.current = {
+          focus: mockComposerFocus,
+          focusAfterQuoteReply: mockComposerFocusAfterQuoteReply,
+        }
+      }
+
+      return (
+        <div data-testid="message-composer">
+          <textarea data-testid="rich-editor" />
+          {pendingAttachments.map((a) => (
+            <div key={a.id}>
+              <span>{a.filename}</span>
+              <span>{a.sizeBytes >= 1024 ? `${(a.sizeBytes / 1024).toFixed(1)} KB` : `${a.sizeBytes} B`}</span>
+              {a.status === "error" && <span>Failed</span>}
+            </div>
+          ))}
+          <button onClick={() => onSubmit(mockSubmitContentOverride)} disabled={!canSubmit || hasFailed}>
+            {isSubmitting ? "Sending..." : "Send"}
+          </button>
         </div>
-      ))}
-      <button onClick={() => onSubmit(mockSubmitContentOverride)} disabled={!canSubmit || hasFailed}>
-        {isSubmitting ? "Sending..." : "Send"}
-      </button>
-    </div>
-  ),
+      )
+    })(),
 }))
 
 describe("MessageInput", () => {
@@ -161,6 +208,9 @@ describe("MessageInput", () => {
       isLoaded: true,
     }
     mockSubmitContentOverride = undefined
+    registeredQuoteReplyHandler = null
+    mockComposerFocus.mockReset()
+    mockComposerFocusAfterQuoteReply.mockReset()
   })
 
   describe("rendering", () => {
@@ -305,6 +355,48 @@ describe("MessageInput", () => {
       await userEvent.click(sendButton)
 
       expect(mockNavigate).toHaveBeenCalledWith("/w/ws_123/s/new_stream", { replace: true })
+    })
+  })
+
+  describe("quote replies", () => {
+    it("inserts a quote block without appending a synthetic trailing paragraph", () => {
+      mockComposerState.content = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Before" }] }, { type: "paragraph" }],
+      }
+
+      render(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+
+      expect(registeredQuoteReplyHandler).not.toBeNull()
+
+      registeredQuoteReplyHandler?.({
+        messageId: "msg_123",
+        streamId: "stream_456",
+        authorName: "Ariadne",
+        authorId: "user_123",
+        actorType: "user",
+        snippet: "The vibes are immaculate",
+      })
+
+      expect(mockSetContent).toHaveBeenCalledWith({
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "Before" }] },
+          {
+            type: "quoteReply",
+            attrs: {
+              messageId: "msg_123",
+              streamId: "stream_456",
+              authorName: "Ariadne",
+              authorId: "user_123",
+              actorType: "user",
+              snippet: "The vibes are immaculate",
+            },
+          },
+        ],
+      })
+      expect(mockComposerFocusAfterQuoteReply).toHaveBeenCalledTimes(1)
+      expect(mockComposerFocus).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -225,14 +225,20 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
       const currentContent = composerRef.current.content
       const existingBlocks = currentContent.content ?? []
 
-      // Replace any existing quoteReply at the start, or prepend
-      const filteredBlocks = existingBlocks.filter((b) => b.type !== "quoteReply")
-      // Ensure there's at least one paragraph after the quote for typing
-      const blocks = filteredBlocks.length > 0 ? filteredBlocks : [{ type: "paragraph" }]
+      // Strip trailing empty paragraphs so the quote appends cleanly,
+      // then re-add one after the quote for the cursor to land in.
+      const trimmedBlocks = [...existingBlocks]
+      while (
+        trimmedBlocks.length > 0 &&
+        trimmedBlocks[trimmedBlocks.length - 1].type === "paragraph" &&
+        (trimmedBlocks[trimmedBlocks.length - 1].content?.length ?? 0) === 0
+      ) {
+        trimmedBlocks.pop()
+      }
 
       composerRef.current.setContent({
         type: "doc",
-        content: [quoteNode, ...blocks],
+        content: [...trimmedBlocks, quoteNode, { type: "paragraph" }],
       })
 
       // Focus the composer so the user can start typing immediately

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -202,6 +202,9 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
   const composerRef = useRef(composer)
   composerRef.current = composer
 
+  // Imperative handle for programmatic focus from outside (e.g. quote reply insertion)
+  const composerFocusRef = useRef<{ focus: () => void } | null>(null)
+
   // Register with QuoteReplyContext to insert quote reply nodes into the composer.
   // Stable deps: quoteReplyCtx is from context, composerRef is a ref.
   useEffect(() => {
@@ -230,6 +233,9 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
         type: "doc",
         content: [quoteNode, ...blocks],
       })
+
+      // Focus the composer so the user can start typing immediately
+      composerFocusRef.current?.focus()
     })
   }, [quoteReplyCtx])
 
@@ -424,6 +430,7 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
         }
       : undefined,
     streamContext,
+    composerRef: composerFocusRef,
   } as const
 
   return (

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -227,9 +227,8 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
 
       // Replace any existing quoteReply at the start, or prepend
       const filteredBlocks = existingBlocks.filter((b) => b.type !== "quoteReply")
-      // Ensure there's at least an empty paragraph after the quote for typing
-      const hasContent = filteredBlocks.some((b) => b.type !== "paragraph" || (b.content?.length ?? 0) > 0)
-      const blocks = hasContent ? filteredBlocks : [...filteredBlocks, { type: "paragraph" }]
+      // Ensure there's at least one paragraph after the quote for typing
+      const blocks = filteredBlocks.length > 0 ? filteredBlocks : [{ type: "paragraph" }]
 
       composerRef.current.setContent({
         type: "doc",

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -216,6 +216,8 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
           messageId: data.messageId,
           streamId: data.streamId,
           authorName: data.authorName,
+          authorId: data.authorId,
+          actorType: data.actorType,
           snippet: data.snippet,
         },
       }

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -203,7 +203,7 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
   composerRef.current = composer
 
   // Imperative handle for programmatic focus from outside (e.g. quote reply insertion)
-  const composerFocusRef = useRef<{ focus: () => void } | null>(null)
+  const composerFocusRef = useRef<{ focus: () => void; focusAfterQuoteReply: () => void } | null>(null)
 
   // Register with QuoteReplyContext to insert quote reply nodes into the composer.
   // Stable deps: quoteReplyCtx is from context, composerRef is a ref.
@@ -225,8 +225,9 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
       const currentContent = composerRef.current.content
       const existingBlocks = currentContent.content ?? []
 
-      // Strip trailing empty paragraphs so the quote appends cleanly,
-      // then re-add one after the quote for the cursor to land in.
+      // Strip trailing empty paragraphs so the quote appends cleanly.
+      // The cursor should land on the quote-side gapcursor, not in a synthetic
+      // empty paragraph rendered on the next line.
       const trimmedBlocks = [...existingBlocks]
       while (
         trimmedBlocks.length > 0 &&
@@ -238,11 +239,11 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
 
       composerRef.current.setContent({
         type: "doc",
-        content: [...trimmedBlocks, quoteNode, { type: "paragraph" }],
+        content: [...trimmedBlocks, quoteNode],
       })
 
       // Focus the composer so the user can start typing immediately
-      composerFocusRef.current?.focus()
+      composerFocusRef.current?.focusAfterQuoteReply()
     })
   }, [quoteReplyCtx])
 

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -12,6 +12,7 @@ import { isCommand } from "@/lib/commands"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useInlineEdit } from "./inline-edit-context"
+import { useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
 import { StreamTypes, type JSONContent } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import type { PendingAttachment } from "@/hooks/use-attachments"
@@ -194,6 +195,38 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
   }, [stream, idbStreams])
 
   const composer = useDraftComposer({ workspaceId, draftKey, scopeId: streamId })
+  const quoteReplyCtx = useQuoteReply()
+
+  // Register with QuoteReplyContext to insert quote reply nodes into the composer
+  useEffect(() => {
+    if (!quoteReplyCtx) return
+    return quoteReplyCtx.registerHandler((data: QuoteReplyData) => {
+      const quoteNode: JSONContent = {
+        type: "quoteReply",
+        attrs: {
+          messageId: data.messageId,
+          streamId: data.streamId,
+          authorName: data.authorName,
+          snippet: data.snippet,
+        },
+      }
+
+      const currentContent = composer.content
+      const existingBlocks = currentContent.content ?? []
+
+      // Replace any existing quoteReply at the start, or prepend
+      const filteredBlocks = existingBlocks.filter((b) => b.type !== "quoteReply")
+      // Ensure there's at least an empty paragraph after the quote for typing
+      const hasContent = filteredBlocks.some((b) => b.type !== "paragraph" || (b.content?.length ?? 0) > 0)
+      const blocks = hasContent ? filteredBlocks : [...filteredBlocks, { type: "paragraph" }]
+
+      composer.setContent({
+        type: "doc",
+        content: [quoteNode, ...blocks],
+      })
+    })
+  }, [quoteReplyCtx, composer])
+
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
   const messageSendMode = preferences?.messageSendMode ?? "enter"

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -197,7 +197,13 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
   const composer = useDraftComposer({ workspaceId, draftKey, scopeId: streamId })
   const quoteReplyCtx = useQuoteReply()
 
-  // Register with QuoteReplyContext to insert quote reply nodes into the composer
+  // Use a ref so the handler always reads fresh composer state without
+  // re-registering on every render (composer object is not memoized).
+  const composerRef = useRef(composer)
+  composerRef.current = composer
+
+  // Register with QuoteReplyContext to insert quote reply nodes into the composer.
+  // Stable deps: quoteReplyCtx is from context, composerRef is a ref.
   useEffect(() => {
     if (!quoteReplyCtx) return
     return quoteReplyCtx.registerHandler((data: QuoteReplyData) => {
@@ -211,7 +217,7 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
         },
       }
 
-      const currentContent = composer.content
+      const currentContent = composerRef.current.content
       const existingBlocks = currentContent.content ?? []
 
       // Replace any existing quoteReply at the start, or prepend
@@ -220,12 +226,12 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
       const hasContent = filteredBlocks.some((b) => b.type !== "paragraph" || (b.content?.length ?? 0) > 0)
       const blocks = hasContent ? filteredBlocks : [...filteredBlocks, { type: "paragraph" }]
 
-      composer.setContent({
+      composerRef.current.setContent({
         type: "doc",
         content: [quoteNode, ...blocks],
       })
     })
-  }, [quoteReplyCtx, composer])
+  }, [quoteReplyCtx])
 
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)

--- a/apps/frontend/src/components/timeline/quote-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/quote-reply-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useCallback, useRef } from "react"
+import { createContext, useContext, useCallback, useMemo, useRef } from "react"
 import type { ReactNode } from "react"
 
 export interface QuoteReplyData {
@@ -32,7 +32,9 @@ export function QuoteReplyProvider({ children }: { children: ReactNode }) {
     handlerRef.current?.(data)
   }, [])
 
-  return <QuoteReplyCtx.Provider value={{ triggerQuoteReply, registerHandler }}>{children}</QuoteReplyCtx.Provider>
+  const value = useMemo(() => ({ triggerQuoteReply, registerHandler }), [triggerQuoteReply, registerHandler])
+
+  return <QuoteReplyCtx.Provider value={value}>{children}</QuoteReplyCtx.Provider>
 }
 
 export function useQuoteReply(): QuoteReplyContextValue | null {

--- a/apps/frontend/src/components/timeline/quote-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/quote-reply-context.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useCallback, useRef } from "react"
+import type { ReactNode } from "react"
+
+export interface QuoteReplyData {
+  messageId: string
+  streamId: string
+  authorName: string
+  /** Markdown content to quote (preserves formatting) */
+  snippet: string
+}
+
+interface QuoteReplyContextValue {
+  /** Trigger a quote reply — called by message actions */
+  triggerQuoteReply: (data: QuoteReplyData) => void
+  /** Register the composer's insertion handler */
+  registerHandler: (handler: (data: QuoteReplyData) => void) => () => void
+}
+
+const QuoteReplyCtx = createContext<QuoteReplyContextValue | null>(null)
+
+export function QuoteReplyProvider({ children }: { children: ReactNode }) {
+  const handlerRef = useRef<((data: QuoteReplyData) => void) | null>(null)
+
+  const registerHandler = useCallback((handler: (data: QuoteReplyData) => void) => {
+    handlerRef.current = handler
+    return () => {
+      handlerRef.current = null
+    }
+  }, [])
+
+  const triggerQuoteReply = useCallback((data: QuoteReplyData) => {
+    handlerRef.current?.(data)
+  }, [])
+
+  return <QuoteReplyCtx.Provider value={{ triggerQuoteReply, registerHandler }}>{children}</QuoteReplyCtx.Provider>
+}
+
+export function useQuoteReply(): QuoteReplyContextValue | null {
+  return useContext(QuoteReplyCtx)
+}

--- a/apps/frontend/src/components/timeline/quote-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/quote-reply-context.tsx
@@ -5,6 +5,8 @@ export interface QuoteReplyData {
   messageId: string
   streamId: string
   authorName: string
+  authorId: string
+  actorType: string
   /** Markdown content to quote (preserves formatting) */
   snippet: string
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -50,6 +50,8 @@ import { JoinChannelBar } from "./join-channel-bar"
 import { ThreadParentMessage } from "../thread/thread-parent-message"
 import { EditLastMessageContext } from "./edit-last-message-context"
 import { InlineEditProvider } from "./inline-edit-context"
+import { QuoteReplyProvider } from "./quote-reply-context"
+import { TextSelectionQuote } from "./text-selection-quote"
 import { StreamSearchBar } from "./stream-search-bar"
 import { useStreamSearch } from "@/hooks/use-stream-search"
 import { useSearchHighlight } from "@/hooks/use-search-highlight"
@@ -586,157 +588,163 @@ export function StreamContent({
 
   return (
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
-      <InlineEditProvider resetKey={streamId}>
-        <div className="flex h-full flex-col">
-          <div className="relative flex-1 overflow-hidden">
-            {isSearchOpen && (
-              <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
-            )}
-            {isDraft && (
-              <div className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain">
-                {hasDraftPendingEvents ? (
-                  <EventList
-                    timelineItems={draftTimelineItems}
-                    isLoading={false}
+      <QuoteReplyProvider>
+        <InlineEditProvider resetKey={streamId}>
+          <TextSelectionQuote streamId={streamId} />
+          <div className="flex h-full flex-col">
+            <div className="relative flex-1 overflow-hidden">
+              {isSearchOpen && (
+                <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
+              )}
+              {isDraft && (
+                <div className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain">
+                  {hasDraftPendingEvents ? (
+                    <EventList
+                      timelineItems={draftTimelineItems}
+                      isLoading={false}
+                      workspaceId={workspaceId}
+                      streamId={streamId}
+                    />
+                  ) : (
+                    <Empty className="h-full border-0">
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <MessageSquare />
+                        </EmptyMedia>
+                        <EmptyTitle>Start a conversation</EmptyTitle>
+                        <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
+                      </EmptyHeader>
+                    </Empty>
+                  )}
+                </div>
+              )}
+              {!isDraft && useVirtualized && (
+                <>
+                  <VirtuosoMessageList
+                    visibleItems={visibleItems}
+                    isLoading={isLoading}
+                    isConfirmedEmpty={isConfirmedEmpty}
+                    virtuosoRef={virtuosoRef}
+                    virtuosoScrollerRef={virtuosoScrollerRef}
+                    handleScrollerRef={handleScrollerRef}
+                    firstItemIndex={firstItemIndex}
+                    initialTopMostItemIndex={initialTopMostItemIndex}
+                    shouldFollowOutput={shouldFollowOutput}
+                    handleAtBottomChange={handleAtBottomChange}
+                    handleRangeChanged={handleRangeChanged}
+                    hasOlderEvents={hasOlderEvents}
+                    hasNewerEvents={hasNewerEvents}
+                    fetchOlderEvents={fetchOlderEvents}
+                    fetchNewerEvents={fetchNewerEvents}
+                    isFetchingOlder={isFetchingOlder}
+                    isFetchingNewer={isFetchingNewer}
                     workspaceId={workspaceId}
                     streamId={streamId}
+                    highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
+                    firstUnreadEventId={dividerEventId}
+                    isDividerFading={isDividerFading}
+                    agentActivity={agentActivity}
+                    hideSessionCards={isChannel}
+                    newMessageIds={newMessageIds}
+                    isSearchOpen={isSearchOpen}
                   />
-                ) : (
-                  <Empty className="h-full border-0">
-                    <EmptyHeader>
-                      <EmptyMedia variant="icon">
-                        <MessageSquare />
-                      </EmptyMedia>
-                      <EmptyTitle>Start a conversation</EmptyTitle>
-                      <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
-                    </EmptyHeader>
-                  </Empty>
-                )}
-              </div>
-            )}
-            {!isDraft && useVirtualized && (
-              <>
-                <VirtuosoMessageList
-                  visibleItems={visibleItems}
-                  isLoading={isLoading}
-                  isConfirmedEmpty={isConfirmedEmpty}
-                  virtuosoRef={virtuosoRef}
-                  virtuosoScrollerRef={virtuosoScrollerRef}
-                  handleScrollerRef={handleScrollerRef}
-                  firstItemIndex={firstItemIndex}
-                  initialTopMostItemIndex={initialTopMostItemIndex}
-                  shouldFollowOutput={shouldFollowOutput}
-                  handleAtBottomChange={handleAtBottomChange}
-                  handleRangeChanged={handleRangeChanged}
-                  hasOlderEvents={hasOlderEvents}
-                  hasNewerEvents={hasNewerEvents}
-                  fetchOlderEvents={fetchOlderEvents}
-                  fetchNewerEvents={fetchNewerEvents}
-                  isFetchingOlder={isFetchingOlder}
-                  isFetchingNewer={isFetchingNewer}
-                  workspaceId={workspaceId}
-                  streamId={streamId}
-                  highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
-                  firstUnreadEventId={dividerEventId}
-                  isDividerFading={isDividerFading}
-                  agentActivity={agentActivity}
-                  hideSessionCards={isChannel}
-                  newMessageIds={newMessageIds}
-                  isSearchOpen={isSearchOpen}
-                />
-                {/* Overlay loading indicators — absolutely positioned so they
+                  {/* Overlay loading indicators — absolutely positioned so they
                     don't cause layout shift when prepending older messages. */}
+                  <div
+                    aria-hidden={!isFetchingOlder}
+                    className={cn(
+                      "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                      isSearchOpen ? "top-14" : "top-2",
+                      isFetchingOlder ? "opacity-100" : "opacity-0"
+                    )}
+                  >
+                    Loading older messages...
+                  </div>
+                  <div
+                    aria-hidden={!isFetchingNewer}
+                    className={cn(
+                      "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                      // Sit above the Jump to latest button (bottom-4 + button height) when visible
+                      isJumpMode || isScrolledFarFromBottom ? "bottom-16" : "bottom-2",
+                      isFetchingNewer ? "opacity-100" : "opacity-0"
+                    )}
+                  >
+                    Loading newer messages...
+                  </div>
+                </>
+              )}
+              {!isDraft && !useVirtualized && (
                 <div
-                  aria-hidden={!isFetchingOlder}
+                  ref={plainScrollRef}
                   className={cn(
-                    "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                    isSearchOpen ? "top-14" : "top-2",
-                    isFetchingOlder ? "opacity-100" : "opacity-0"
+                    "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
+                    isSearchOpen && "pt-11"
                   )}
+                  data-suppress-pull-refresh="true"
+                  onScroll={plainHandleScroll}
                 >
-                  Loading older messages...
-                </div>
-                <div
-                  aria-hidden={!isFetchingNewer}
-                  className={cn(
-                    "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                    // Sit above the Jump to latest button (bottom-4 + button height) when visible
-                    isJumpMode || isScrolledFarFromBottom ? "bottom-16" : "bottom-2",
-                    isFetchingNewer ? "opacity-100" : "opacity-0"
+                  {isThread && parentMessage && parentStreamId && (
+                    <ThreadParentMessage
+                      event={parentMessage}
+                      workspaceId={workspaceId}
+                      streamId={parentStreamId}
+                      replyCount={events.length}
+                    />
                   )}
-                >
-                  Loading newer messages...
-                </div>
-              </>
-            )}
-            {!isDraft && !useVirtualized && (
-              <div
-                ref={plainScrollRef}
-                className={cn("h-full overflow-y-auto overflow-x-hidden overscroll-y-contain", isSearchOpen && "pt-11")}
-                data-suppress-pull-refresh="true"
-                onScroll={plainHandleScroll}
-              >
-                {isThread && parentMessage && parentStreamId && (
-                  <ThreadParentMessage
-                    event={parentMessage}
+                  {isFetchingOlder && (
+                    <div className="flex justify-center py-2">
+                      <p className="text-sm text-muted-foreground">Loading older messages...</p>
+                    </div>
+                  )}
+                  <EventList
+                    timelineItems={timelineItems}
+                    isLoading={isLoading}
                     workspaceId={workspaceId}
-                    streamId={parentStreamId}
-                    replyCount={events.length}
+                    streamId={streamId}
+                    highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
+                    firstUnreadEventId={dividerEventId}
+                    isDividerFading={isDividerFading}
+                    agentActivity={agentActivity}
+                    hideSessionCards={isChannel}
+                    newMessageIds={newMessageIds}
                   />
-                )}
-                {isFetchingOlder && (
-                  <div className="flex justify-center py-2">
-                    <p className="text-sm text-muted-foreground">Loading older messages...</p>
-                  </div>
-                )}
-                <EventList
-                  timelineItems={timelineItems}
-                  isLoading={isLoading}
-                  workspaceId={workspaceId}
-                  streamId={streamId}
-                  highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
-                  firstUnreadEventId={dividerEventId}
-                  isDividerFading={isDividerFading}
-                  agentActivity={agentActivity}
-                  hideSessionCards={isChannel}
-                  newMessageIds={newMessageIds}
-                />
-                {isFetchingNewer && (
-                  <div className="flex justify-center py-2">
-                    <p className="text-sm text-muted-foreground">Loading newer messages...</p>
-                  </div>
-                )}
-              </div>
+                  {isFetchingNewer && (
+                    <div className="flex justify-center py-2">
+                      <p className="text-sm text-muted-foreground">Loading newer messages...</p>
+                    </div>
+                  )}
+                </div>
+              )}
+              {/* Jump to latest button — shown when scrolled far from bottom or in jump mode */}
+              {(isJumpMode || isScrolledFarFromBottom) && (
+                <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+                  <Button variant="secondary" size="sm" className="shadow-lg gap-1.5" onClick={handleJumpToLatest}>
+                    <ArrowDown className="h-3.5 w-3.5" />
+                    Jump to latest
+                  </Button>
+                </div>
+              )}
+            </div>
+            {membershipResolved && !isMember && isPublicChannel && (
+              <JoinChannelBar
+                workspaceId={workspaceId}
+                streamId={streamId}
+                channelName={stream?.slug ?? stream?.displayName ?? ""}
+                onJoined={handleJoined}
+              />
             )}
-            {/* Jump to latest button — shown when scrolled far from bottom or in jump mode */}
-            {(isJumpMode || isScrolledFarFromBottom) && (
-              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
-                <Button variant="secondary" size="sm" className="shadow-lg gap-1.5" onClick={handleJumpToLatest}>
-                  <ArrowDown className="h-3.5 w-3.5" />
-                  Jump to latest
-                </Button>
-              </div>
+            {(isMember || !isPublicChannel || !membershipResolved) && (
+              <MessageInput
+                workspaceId={workspaceId}
+                streamId={streamId}
+                disabled={isArchived || isSystem}
+                disabledReason={disabledReason}
+                autoFocus={autoFocus}
+              />
             )}
           </div>
-          {membershipResolved && !isMember && isPublicChannel && (
-            <JoinChannelBar
-              workspaceId={workspaceId}
-              streamId={streamId}
-              channelName={stream?.slug ?? stream?.displayName ?? ""}
-              onJoined={handleJoined}
-            />
-          )}
-          {(isMember || !isPublicChannel || !membershipResolved) && (
-            <MessageInput
-              workspaceId={workspaceId}
-              streamId={streamId}
-              disabled={isArchived || isSystem}
-              disabledReason={disabledReason}
-              autoFocus={autoFocus}
-            />
-          )}
-        </div>
-      </InlineEditProvider>
+        </InlineEditProvider>
+      </QuoteReplyProvider>
     </EditLastMessageContext.Provider>
   )
 }

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState, useCallback, useRef } from "react"
+import { createPortal } from "react-dom"
+import { Quote } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { useQuoteReply } from "./quote-reply-context"
+
+interface SelectionInfo {
+  text: string
+  messageId: string
+  streamId: string
+  authorName: string
+  rect: DOMRect
+}
+
+/**
+ * Finds the closest message element from a DOM node and extracts its metadata.
+ */
+function getMessageContext(node: Node): { messageId: string; element: HTMLElement } | null {
+  const el = node instanceof HTMLElement ? node : node.parentElement
+  if (!el) return null
+  const messageEl = el.closest<HTMLElement>("[data-message-id]")
+  if (!messageEl) return null
+  const messageId = messageEl.getAttribute("data-message-id")
+  if (!messageId) return null
+  return { messageId, element: messageEl }
+}
+
+/**
+ * Extract the author name from a message DOM element.
+ * Looks for the first text in the message header row.
+ */
+function getAuthorNameFromDom(messageEl: HTMLElement): string {
+  // The author name is in .message-content > div (first child row) > first button/span
+  const nameEl = messageEl.querySelector<HTMLElement>(
+    ".message-content > div:first-child > button, .message-content > div:first-child > span"
+  )
+  return nameEl?.textContent?.trim() ?? "Unknown"
+}
+
+interface TextSelectionQuoteProps {
+  streamId: string
+}
+
+/**
+ * Shows a floating "Quote" button when the user selects text within a message.
+ * Desktop only — mobile uses select-none on messages.
+ */
+export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
+  const isMobile = useIsMobile()
+  const quoteReplyCtx = useQuoteReply()
+  const [selection, setSelection] = useState<SelectionInfo | null>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const handleSelectionChange = useCallback(() => {
+    const sel = window.getSelection()
+    if (!sel || sel.isCollapsed || !sel.rangeCount) {
+      setSelection(null)
+      return
+    }
+
+    const text = sel.toString().trim()
+    if (!text) {
+      setSelection(null)
+      return
+    }
+
+    const range = sel.getRangeAt(0)
+
+    // Both ends of the selection must be within the same message
+    const startCtx = getMessageContext(range.startContainer)
+    const endCtx = getMessageContext(range.endContainer)
+    if (!startCtx || !endCtx || startCtx.messageId !== endCtx.messageId) {
+      setSelection(null)
+      return
+    }
+
+    // Must be within the message content area (not author name, timestamp, etc.)
+    const contentEl = startCtx.element.querySelector(".message-content .markdown-content")
+    if (!contentEl || !contentEl.contains(range.startContainer) || !contentEl.contains(range.endContainer)) {
+      setSelection(null)
+      return
+    }
+
+    const rect = range.getBoundingClientRect()
+    const authorName = getAuthorNameFromDom(startCtx.element)
+
+    setSelection({
+      text,
+      messageId: startCtx.messageId,
+      streamId,
+      authorName,
+      rect,
+    })
+  }, [streamId])
+
+  useEffect(() => {
+    if (isMobile) return
+
+    document.addEventListener("selectionchange", handleSelectionChange)
+    return () => document.removeEventListener("selectionchange", handleSelectionChange)
+  }, [isMobile, handleSelectionChange])
+
+  // Dismiss on mousedown outside the popover
+  useEffect(() => {
+    if (!selection) return
+    const handleMouseDown = (e: MouseEvent) => {
+      if (popoverRef.current?.contains(e.target as Node)) return
+      // Let the selectionchange handler handle clearing
+    }
+    document.addEventListener("mousedown", handleMouseDown)
+    return () => document.removeEventListener("mousedown", handleMouseDown)
+  }, [selection])
+
+  const handleQuote = useCallback(() => {
+    if (!selection || !quoteReplyCtx) return
+    quoteReplyCtx.triggerQuoteReply({
+      messageId: selection.messageId,
+      streamId: selection.streamId,
+      authorName: selection.authorName,
+      snippet: selection.text,
+    })
+    // Clear selection
+    window.getSelection()?.removeAllRanges()
+    setSelection(null)
+  }, [selection, quoteReplyCtx])
+
+  if (isMobile || !selection || !quoteReplyCtx) return null
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      className="fixed z-50 -translate-x-1/2 animate-in fade-in-0 zoom-in-95"
+      style={{ top: selection.rect.top - 36, left: selection.rect.left + selection.rect.width / 2 }}
+    >
+      <Button
+        variant="secondary"
+        size="sm"
+        className="h-7 gap-1.5 rounded-full shadow-md px-3 text-xs"
+        onClick={handleQuote}
+      >
+        <Quote className="h-3 w-3" />
+        Quote
+      </Button>
+    </div>,
+    document.body
+  )
+}

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { createPortal } from "react-dom"
 import { Quote } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -27,15 +27,13 @@ function getMessageContext(node: Node): { messageId: string; element: HTMLElemen
 }
 
 /**
- * Extract the author name from a message DOM element.
- * Looks for the first text in the message header row.
+ * Extract the author name from a message DOM element via data attribute.
  */
 function getAuthorNameFromDom(messageEl: HTMLElement): string {
-  // The author name is in .message-content > div (first child row) > first button/span
-  const nameEl = messageEl.querySelector<HTMLElement>(
-    ".message-content > div:first-child > button, .message-content > div:first-child > span"
-  )
-  return nameEl?.textContent?.trim() ?? "Unknown"
+  // Walk up to find the element with data-author-name (set on MessageLayout root)
+  const authorEl =
+    messageEl.closest<HTMLElement>("[data-author-name]") ?? messageEl.querySelector<HTMLElement>("[data-author-name]")
+  return authorEl?.getAttribute("data-author-name")?.trim() ?? "Unknown"
 }
 
 interface TextSelectionQuoteProps {
@@ -50,7 +48,6 @@ export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
   const isMobile = useIsMobile()
   const quoteReplyCtx = useQuoteReply()
   const [selection, setSelection] = useState<SelectionInfo | null>(null)
-  const popoverRef = useRef<HTMLDivElement>(null)
 
   const handleSelectionChange = useCallback(() => {
     const sel = window.getSelection()
@@ -101,17 +98,6 @@ export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
     return () => document.removeEventListener("selectionchange", handleSelectionChange)
   }, [isMobile, handleSelectionChange])
 
-  // Dismiss on mousedown outside the popover
-  useEffect(() => {
-    if (!selection) return
-    const handleMouseDown = (e: MouseEvent) => {
-      if (popoverRef.current?.contains(e.target as Node)) return
-      // Let the selectionchange handler handle clearing
-    }
-    document.addEventListener("mousedown", handleMouseDown)
-    return () => document.removeEventListener("mousedown", handleMouseDown)
-  }, [selection])
-
   const handleQuote = useCallback(() => {
     if (!selection || !quoteReplyCtx) return
     quoteReplyCtx.triggerQuoteReply({
@@ -129,7 +115,6 @@ export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
 
   return createPortal(
     <div
-      ref={popoverRef}
       className="fixed z-50 -translate-x-1/2 animate-in fade-in-0 zoom-in-95"
       style={{ top: selection.rect.top - 36, left: selection.rect.left + selection.rect.width / 2 }}
     >

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -10,6 +10,8 @@ interface SelectionInfo {
   messageId: string
   streamId: string
   authorName: string
+  authorId: string
+  actorType: string
   rect: DOMRect
 }
 
@@ -27,13 +29,17 @@ function getMessageContext(node: Node): { messageId: string; element: HTMLElemen
 }
 
 /**
- * Extract the author name from a message DOM element via data attribute.
+ * Extract author metadata from a message DOM element via data attributes.
  */
-function getAuthorNameFromDom(messageEl: HTMLElement): string {
+function getAuthorFromDom(messageEl: HTMLElement): { authorName: string; authorId: string; actorType: string } {
   // Walk up to find the element with data-author-name (set on MessageLayout root)
   const authorEl =
     messageEl.closest<HTMLElement>("[data-author-name]") ?? messageEl.querySelector<HTMLElement>("[data-author-name]")
-  return authorEl?.getAttribute("data-author-name")?.trim() ?? "Unknown"
+  return {
+    authorName: authorEl?.getAttribute("data-author-name")?.trim() ?? "Unknown",
+    authorId: authorEl?.getAttribute("data-author-id")?.trim() ?? "",
+    actorType: authorEl?.getAttribute("data-actor-type")?.trim() ?? "user",
+  }
 }
 
 interface TextSelectionQuoteProps {
@@ -80,13 +86,15 @@ export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
     }
 
     const rect = range.getBoundingClientRect()
-    const authorName = getAuthorNameFromDom(startCtx.element)
+    const { authorName, authorId, actorType } = getAuthorFromDom(startCtx.element)
 
     setSelection({
       text,
       messageId: startCtx.messageId,
       streamId,
       authorName,
+      authorId,
+      actorType,
       rect,
     })
   }, [streamId])
@@ -104,6 +112,8 @@ export function TextSelectionQuote({ streamId }: TextSelectionQuoteProps) {
       messageId: selection.messageId,
       streamId: selection.streamId,
       authorName: selection.authorName,
+      authorId: selection.authorId,
+      actorType: selection.actorType,
       snippet: selection.text,
     })
     // Clear selection

--- a/apps/frontend/src/components/ui/markdown-content.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.tsx
@@ -23,6 +23,10 @@ function urlTransform(url: string): string {
   if (url.startsWith("attachment:")) {
     return url
   }
+  // Allow quote: protocol for quote-reply attribution links
+  if (url.startsWith("quote:")) {
+    return url
+  }
   // For other URLs, use default behavior (returns url as-is for http/https/mailto)
   const protocols = ["http:", "https:", "mailto:", "tel:"]
   const parsed = url.includes(":") ? url.split(":")[0] + ":" : ""

--- a/apps/frontend/src/hooks/use-swipe-action.ts
+++ b/apps/frontend/src/hooks/use-swipe-action.ts
@@ -1,0 +1,124 @@
+import { useRef, useCallback, useState, useEffect } from "react"
+
+interface UseSwipeActionOptions {
+  /** Minimum horizontal distance (px) to trigger the action (default: 80) */
+  threshold?: number
+  /** Called when the user swipes past the threshold and releases */
+  onSwipe: () => void
+  /** Disable the hook */
+  enabled?: boolean
+}
+
+interface SwipeHandlers {
+  onTouchStart: (e: React.TouchEvent) => void
+  onTouchEnd: () => void
+  onTouchMove: (e: React.TouchEvent) => void
+}
+
+interface UseSwipeActionReturn {
+  handlers: SwipeHandlers
+  /** Current horizontal offset (negative = swiped left) */
+  offset: number
+  /** Whether the user has passed the threshold */
+  isLocked: boolean
+}
+
+/**
+ * Swipe-from-right gesture for mobile quote reply.
+ * The user swipes left on a message; once they cross the threshold,
+ * haptic feedback fires and the action locks in. Releasing triggers the callback.
+ */
+export function useSwipeAction({
+  threshold = 80,
+  onSwipe,
+  enabled = true,
+}: UseSwipeActionOptions): UseSwipeActionReturn {
+  const startPos = useRef<{ x: number; y: number } | null>(null)
+  const isHorizontalRef = useRef<boolean | null>(null)
+  const lockedRef = useRef(false)
+  const [offset, setOffset] = useState(0)
+  const [isLocked, setIsLocked] = useState(false)
+
+  const onSwipeRef = useRef(onSwipe)
+  onSwipeRef.current = onSwipe
+
+  const reset = useCallback(() => {
+    startPos.current = null
+    isHorizontalRef.current = null
+    lockedRef.current = false
+    setOffset(0)
+    setIsLocked(false)
+  }, [])
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled) return
+      const touch = e.touches[0]
+      startPos.current = { x: touch.clientX, y: touch.clientY }
+      isHorizontalRef.current = null
+      lockedRef.current = false
+    },
+    [enabled]
+  )
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!startPos.current || !enabled) return
+      const touch = e.touches[0]
+      if (!touch) return
+
+      const dx = touch.clientX - startPos.current.x
+      const dy = touch.clientY - startPos.current.y
+
+      // Determine direction once after a small movement
+      if (isHorizontalRef.current === null) {
+        if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+          isHorizontalRef.current = Math.abs(dx) > Math.abs(dy) && dx < 0
+          if (!isHorizontalRef.current) {
+            // Vertical scroll — bail out
+            reset()
+            return
+          }
+        } else {
+          return
+        }
+      }
+
+      if (!isHorizontalRef.current) return
+
+      // Only track leftward swipes (negative dx), capped at threshold * 1.2
+      const clampedOffset = Math.max(dx, -(threshold * 1.2))
+      setOffset(clampedOffset)
+
+      // Lock in when past threshold
+      if (Math.abs(clampedOffset) >= threshold && !lockedRef.current) {
+        lockedRef.current = true
+        setIsLocked(true)
+        try {
+          navigator.vibrate?.(10)
+        } catch {
+          // Ignore
+        }
+      } else if (Math.abs(clampedOffset) < threshold && lockedRef.current) {
+        lockedRef.current = false
+        setIsLocked(false)
+      }
+    },
+    [enabled, threshold, reset]
+  )
+
+  const onTouchEnd = useCallback(() => {
+    if (lockedRef.current) {
+      onSwipeRef.current()
+    }
+    reset()
+  }, [reset])
+
+  useEffect(() => reset, [reset])
+
+  return {
+    handlers: { onTouchStart, onTouchEnd, onTouchMove },
+    offset,
+    isLocked,
+  }
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -412,24 +412,26 @@
   width: 1px !important;
   left: 0;
   top: 0;
-  height: 1.5rem;
+  height: var(--quote-caret-height, 1.5rem);
   background: hsl(var(--foreground));
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 
 /* Before a quote: position cursor on the left, vertically centered in the quote */
 .ProseMirror .ProseMirror-gapcursor.before-quote::after {
-  top: var(--quote-top);
+  top: calc(var(--quote-top) + (var(--quote-height) - var(--quote-caret-height, 1.5rem)) / 2);
   left: 0;
-  height: var(--quote-height);
 }
 
 /* After a quote: position cursor on the right, vertically centered in the quote */
 .ProseMirror .ProseMirror-gapcursor.after-quote::after {
-  top: var(--quote-top);
+  top: calc(var(--quote-top) + (var(--quote-height) - var(--quote-caret-height, 1.5rem)) / 2);
   left: auto;
   right: var(--quote-right, 0);
-  height: var(--quote-height);
+}
+
+.ProseMirror.has-after-quote-gapcursor {
+  padding-bottom: var(--quote-caret-height, 1.5rem);
 }
 
 @keyframes ProseMirror-cursor-blink {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -392,6 +392,21 @@
   @apply my-4 border-border;
 }
 
+.ProseMirror .ProseMirror-gapcursor {
+  @apply relative;
+}
+
+.ProseMirror .ProseMirror-gapcursor::after {
+  @apply absolute top-0 block h-5 w-px border-t-0 border-l border-foreground;
+  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+
+@keyframes ProseMirror-cursor-blink {
+  to {
+    visibility: hidden;
+  }
+}
+
 /*
  * Shiki syntax highlighting - dual theme support
  *

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -393,31 +393,37 @@
 }
 
 .ProseMirror .ProseMirror-gapcursor {
-  @apply pointer-events-none relative;
+  pointer-events: none;
+  position: relative;
   height: 0 !important;
   margin: 0 !important;
   padding: 0 !important;
 }
 
 .ProseMirror .ProseMirror-gapcursor::after {
-  @apply absolute block w-px border-l border-foreground;
   content: "";
+  display: block;
+  position: absolute;
+  /* Override prosemirror-gapcursor defaults (border-top, width, top) */
+  border-top: none !important;
+  width: 1px !important;
   left: 0;
   top: 0;
   height: 1.5rem;
+  background: hsl(var(--foreground));
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 
 /* Before a quote reply: cursor on the left edge, vertically inside the quote */
 .ProseMirror .ProseMirror-gapcursor:has(+ [data-type="quote-reply"])::after {
-  top: 0.625rem; /* my-1 (0.25rem) + py-2 (0.5rem) to reach content area */
+  top: 0.625rem;
 }
 
 /* After a quote reply: cursor on the right edge, vertically inside the quote */
 .ProseMirror [data-type="quote-reply"] + .ProseMirror-gapcursor::after {
   left: auto;
   right: 0;
-  top: -2.125rem; /* Pull up into the quote's content area */
+  top: -2.125rem;
 }
 
 @keyframes ProseMirror-cursor-blink {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -304,7 +304,7 @@
  * Tiptap Editor Styles
  */
 .ProseMirror {
-  @apply outline-none;
+  @apply outline-none relative;
 }
 
 .ProseMirror p.is-editor-empty:first-child::before {
@@ -312,7 +312,7 @@
   content: attr(data-placeholder);
 }
 
-.ProseMirror > * + * {
+.ProseMirror > *:not(.ProseMirror-gapcursor) + *:not(.ProseMirror-gapcursor) {
   @apply mt-2;
 }
 
@@ -392,19 +392,22 @@
   @apply my-4 border-border;
 }
 
+/* Gapcursor base: collapse to zero space in the document flow */
 .ProseMirror .ProseMirror-gapcursor {
   pointer-events: none;
   position: relative;
   height: 0 !important;
   margin: 0 !important;
   padding: 0 !important;
+  line-height: 0 !important;
+  font-size: 0 !important;
 }
 
 .ProseMirror .ProseMirror-gapcursor::after {
   content: "";
   display: block;
   position: absolute;
-  /* Override prosemirror-gapcursor defaults (border-top, width, top) */
+  /* Override prosemirror-gapcursor defaults */
   border-top: none !important;
   width: 1px !important;
   left: 0;
@@ -414,16 +417,19 @@
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 
-/* Before a quote reply: cursor on the left edge, vertically inside the quote */
-.ProseMirror .ProseMirror-gapcursor:has(+ [data-type="quote-reply"])::after {
-  top: 0.625rem;
+/* Before a quote: position cursor on the left, vertically centered in the quote */
+.ProseMirror .ProseMirror-gapcursor.before-quote::after {
+  top: var(--quote-top);
+  left: 0;
+  height: var(--quote-height);
 }
 
-/* After a quote reply: cursor on the right edge, vertically inside the quote */
-.ProseMirror [data-type="quote-reply"] + .ProseMirror-gapcursor::after {
+/* After a quote: position cursor on the right, vertically centered in the quote */
+.ProseMirror .ProseMirror-gapcursor.after-quote::after {
+  top: var(--quote-top);
   left: auto;
-  right: 0;
-  top: -2.125rem;
+  right: var(--quote-right, 0);
+  height: var(--quote-height);
 }
 
 @keyframes ProseMirror-cursor-blink {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -393,11 +393,19 @@
 }
 
 .ProseMirror .ProseMirror-gapcursor {
-  @apply relative;
+  @apply pointer-events-none relative;
+  /* Collapse to zero height so the gap cursor doesn't create visible space between blocks */
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 .ProseMirror .ProseMirror-gapcursor::after {
-  @apply absolute top-0 block h-5 w-px border-t-0 border-l border-foreground;
+  @apply absolute left-0 block w-px border-l border-foreground;
+  content: "";
+  height: 1.2em;
+  /* Vertically center the cursor line at the boundary */
+  top: -0.6em;
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -394,8 +394,8 @@
 
 .ProseMirror .ProseMirror-gapcursor {
   @apply pointer-events-none relative;
-  /* Collapse to zero height so the gap cursor doesn't create visible space between blocks */
-  height: 0 !important;
+  /* Full line height so the cursor occupies a proper line, not a half-line sliver */
+  line-height: 1.5rem;
   margin: 0 !important;
   padding: 0 !important;
 }
@@ -403,9 +403,9 @@
 .ProseMirror .ProseMirror-gapcursor::after {
   @apply absolute left-0 block w-px border-l border-foreground;
   content: "";
-  height: 1.2em;
-  /* Vertically center the cursor line at the boundary */
-  top: -0.6em;
+  /* Match the line height of surrounding text */
+  top: 0;
+  height: 1.5rem;
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -394,19 +394,30 @@
 
 .ProseMirror .ProseMirror-gapcursor {
   @apply pointer-events-none relative;
-  /* Full line height so the cursor occupies a proper line, not a half-line sliver */
-  line-height: 1.5rem;
+  height: 0 !important;
   margin: 0 !important;
   padding: 0 !important;
 }
 
 .ProseMirror .ProseMirror-gapcursor::after {
-  @apply absolute left-0 block w-px border-l border-foreground;
+  @apply absolute block w-px border-l border-foreground;
   content: "";
-  /* Match the line height of surrounding text */
+  left: 0;
   top: 0;
   height: 1.5rem;
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+
+/* Before a quote reply: cursor on the left edge, vertically inside the quote */
+.ProseMirror .ProseMirror-gapcursor:has(+ [data-type="quote-reply"])::after {
+  top: 0.625rem; /* my-1 (0.25rem) + py-2 (0.5rem) to reach content area */
+}
+
+/* After a quote reply: cursor on the right edge, vertically inside the quote */
+.ProseMirror [data-type="quote-reply"] + .ProseMirror-gapcursor::after {
+  left: auto;
+  right: 0;
+  top: -2.125rem; /* Pull up into the quote's content area */
 }
 
 @keyframes ProseMirror-cursor-blink {

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -14,12 +14,18 @@ const CodeBlock = lazy(() => import("./code-block"))
  * Parse quote: protocol href into streamId and messageId.
  * Format: quote:streamId/messageId
  */
-function parseQuoteHref(href: string): { streamId: string; messageId: string } | null {
+function parseQuoteHref(
+  href: string
+): { streamId: string; messageId: string; authorId: string; actorType: string } | null {
   if (!href.startsWith("quote:")) return null
-  const path = href.slice("quote:".length)
-  const slashIdx = path.indexOf("/")
-  if (slashIdx === -1) return null
-  return { streamId: path.slice(0, slashIdx), messageId: path.slice(slashIdx + 1) }
+  const parts = href.slice("quote:".length).split("/")
+  if (parts.length < 2) return null
+  return {
+    streamId: parts[0],
+    messageId: parts[1],
+    authorId: parts[2] ?? "",
+    actorType: parts[3] ?? "user",
+  }
 }
 
 /**
@@ -27,9 +33,14 @@ function parseQuoteHref(href: string): { streamId: string; messageId: string } |
  * indicating this blockquote is a quote-reply.
  * Returns extracted metadata or null if not a quote-reply.
  */
-function extractQuoteReplyFromChildren(
-  children: ReactNode
-): { authorName: string; streamId: string; messageId: string; quotedContent: ReactNode[] } | null {
+function extractQuoteReplyFromChildren(children: ReactNode): {
+  authorName: string
+  streamId: string
+  messageId: string
+  authorId: string
+  actorType: string
+  quotedContent: ReactNode[]
+} | null {
   const childArray: ReactNode[] = Children.toArray(children)
 
   // The markdown renders as: <p>quoted text</p>\n<p>— <a href="quote:...">Author</a></p>
@@ -43,6 +54,8 @@ function extractQuoteReplyFromChildren(
         authorName: quoteLink.authorName,
         streamId: quoteLink.streamId,
         messageId: quoteLink.messageId,
+        authorId: quoteLink.authorId,
+        actorType: quoteLink.actorType,
         quotedContent: childArray.slice(0, i),
       }
     }
@@ -55,6 +68,8 @@ interface QuoteLinkInfo {
   authorName: string
   streamId: string
   messageId: string
+  authorId: string
+  actorType: string
 }
 
 /**
@@ -280,6 +295,8 @@ export const markdownComponents: Components = {
       return (
         <QuoteReplyBlock
           authorName={quoteReply.authorName}
+          authorId={quoteReply.authorId}
+          actorType={quoteReply.actorType}
           streamId={quoteReply.streamId}
           messageId={quoteReply.messageId}
         >

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -1,13 +1,115 @@
 import type { Components } from "react-markdown"
-import { Suspense, lazy, Component, type ReactNode, type MouseEvent } from "react"
+import { Suspense, lazy, Component, Children, isValidElement, type ReactNode, type MouseEvent } from "react"
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { ProcessedChildren } from "./mention-renderer"
 import { useAttachmentContext } from "./attachment-context"
 import { useLinkPreviewContext } from "./link-preview-context"
+import { QuoteReplyBlock } from "./quote-reply-block"
 
 const CodeBlock = lazy(() => import("./code-block"))
+
+/**
+ * Parse quote: protocol href into streamId and messageId.
+ * Format: quote:streamId/messageId
+ */
+function parseQuoteHref(href: string): { streamId: string; messageId: string } | null {
+  if (!href.startsWith("quote:")) return null
+  const path = href.slice("quote:".length)
+  const slashIdx = path.indexOf("/")
+  if (slashIdx === -1) return null
+  return { streamId: path.slice(0, slashIdx), messageId: path.slice(slashIdx + 1) }
+}
+
+/**
+ * Walk React children tree to find a link with quote: protocol,
+ * indicating this blockquote is a quote-reply.
+ * Returns extracted metadata or null if not a quote-reply.
+ */
+function extractQuoteReplyFromChildren(
+  children: ReactNode
+): { authorName: string; streamId: string; messageId: string; quotedContent: ReactNode[] } | null {
+  const childArray: ReactNode[] = Children.toArray(children)
+
+  // Look through paragraph children for the attribution pattern
+  // The markdown renders as: <p>quoted text</p>\n<p>— <a href="quote:...">Author</a></p>
+  // or all in one <p>: quoted text\n— <a href="quote:...">Author</a>
+  for (let i = childArray.length - 1; i >= 0; i--) {
+    const child = childArray[i]
+    if (!isValidElement(child)) continue
+
+    // Check if this element (likely a <p>) contains the attribution link
+    const quoteLink = findQuoteLinkInElement(child)
+    if (quoteLink) {
+      // Everything before this element is the quoted content
+      const quotedContent = childArray.slice(0, i)
+      // If the attribution is part of a larger paragraph, include content before "—"
+      if (quoteLink.precedingContent) {
+        quotedContent.push(quoteLink.precedingContent)
+      }
+      return {
+        authorName: quoteLink.authorName,
+        streamId: quoteLink.streamId,
+        messageId: quoteLink.messageId,
+        quotedContent,
+      }
+    }
+  }
+
+  return null
+}
+
+interface QuoteLinkInfo {
+  authorName: string
+  streamId: string
+  messageId: string
+  precedingContent: ReactNode | null
+}
+
+/**
+ * Recursively search a React element for a link with quote: protocol.
+ */
+function findQuoteLinkInElement(element: ReactNode): QuoteLinkInfo | null {
+  if (!isValidElement(element)) return null
+
+  // Check if this is directly a link with quote: href
+  const props = element.props as Record<string, unknown>
+  if (props.href && typeof props.href === "string") {
+    const parsed = parseQuoteHref(props.href)
+    if (parsed) {
+      // The link text is the author name
+      const authorName = extractTextFromChildren(props.children as ReactNode)
+      return { ...parsed, authorName, precedingContent: null }
+    }
+  }
+
+  // Search through children
+  if (props.children) {
+    const childArray = Children.toArray(props.children as ReactNode)
+    for (let i = childArray.length - 1; i >= 0; i--) {
+      const result = findQuoteLinkInElement(childArray[i])
+      if (result) return result
+    }
+  }
+
+  return null
+}
+
+/**
+ * Extract plain text from React children tree.
+ */
+function extractTextFromChildren(children: ReactNode): string {
+  if (typeof children === "string") return children
+  if (typeof children === "number") return String(children)
+  if (!children) return ""
+  if (Array.isArray(children)) return children.map(extractTextFromChildren).join("")
+  if (isValidElement(children)) {
+    const props = children.props as Record<string, unknown>
+    return extractTextFromChildren(props.children as ReactNode)
+  }
+  return ""
+}
 
 /**
  * Link component that handles attachment:// URLs specially
@@ -182,10 +284,26 @@ export const markdownComponents: Components = {
     </del>
   ),
 
-  // Blockquote
-  blockquote: ({ children }) => (
-    <blockquote className="border-l-2 border-primary/50 pl-4 my-2 text-muted-foreground italic">{children}</blockquote>
-  ),
+  // Blockquote — detect quote-reply attribution pattern (quote: protocol link)
+  blockquote: ({ children }) => {
+    const quoteReply = extractQuoteReplyFromChildren(children)
+    if (quoteReply) {
+      return (
+        <QuoteReplyBlock
+          authorName={quoteReply.authorName}
+          streamId={quoteReply.streamId}
+          messageId={quoteReply.messageId}
+        >
+          {quoteReply.quotedContent}
+        </QuoteReplyBlock>
+      )
+    }
+    return (
+      <blockquote className="border-l-2 border-primary/50 pl-4 my-2 text-muted-foreground italic">
+        {children}
+      </blockquote>
+    )
+  },
 
   // Lists
   ul: ({ children }) => <ul className="list-disc pl-6 my-2">{children}</ul>,

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -32,27 +32,18 @@ function extractQuoteReplyFromChildren(
 ): { authorName: string; streamId: string; messageId: string; quotedContent: ReactNode[] } | null {
   const childArray: ReactNode[] = Children.toArray(children)
 
-  // Look through paragraph children for the attribution pattern
   // The markdown renders as: <p>quoted text</p>\n<p>— <a href="quote:...">Author</a></p>
-  // or all in one <p>: quoted text\n— <a href="quote:...">Author</a>
   for (let i = childArray.length - 1; i >= 0; i--) {
     const child = childArray[i]
     if (!isValidElement(child)) continue
 
-    // Check if this element (likely a <p>) contains the attribution link
     const quoteLink = findQuoteLinkInElement(child)
     if (quoteLink) {
-      // Everything before this element is the quoted content
-      const quotedContent = childArray.slice(0, i)
-      // If the attribution is part of a larger paragraph, include content before "—"
-      if (quoteLink.precedingContent) {
-        quotedContent.push(quoteLink.precedingContent)
-      }
       return {
         authorName: quoteLink.authorName,
         streamId: quoteLink.streamId,
         messageId: quoteLink.messageId,
-        quotedContent,
+        quotedContent: childArray.slice(0, i),
       }
     }
   }
@@ -64,7 +55,6 @@ interface QuoteLinkInfo {
   authorName: string
   streamId: string
   messageId: string
-  precedingContent: ReactNode | null
 }
 
 /**
@@ -78,9 +68,8 @@ function findQuoteLinkInElement(element: ReactNode): QuoteLinkInfo | null {
   if (props.href && typeof props.href === "string") {
     const parsed = parseQuoteHref(props.href)
     if (parsed) {
-      // The link text is the author name
       const authorName = extractTextFromChildren(props.children as ReactNode)
-      return { ...parsed, authorName, precedingContent: null }
+      return { ...parsed, authorName }
     }
   }
 

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -1,9 +1,17 @@
 import type { ReactNode } from "react"
 import { Quote } from "lucide-react"
 import { Link, useParams } from "react-router-dom"
+import { useActors } from "@/hooks"
+import { useUserProfile } from "@/components/user-profile"
+import { PersonaAvatar } from "@/components/persona-avatar"
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
+import { cn } from "@/lib/utils"
+import type { AuthorType } from "@threa/types"
 
 interface QuoteReplyBlockProps {
   authorName: string
+  authorId: string
+  actorType: string
   streamId: string
   messageId: string
   children: ReactNode
@@ -12,8 +20,16 @@ interface QuoteReplyBlockProps {
 /**
  * Renders a quote-reply block in message display.
  * Clicking the block navigates to the quoted message (INV-40: navigation uses links).
+ * Clicking the author name opens the user profile modal.
  */
-export function QuoteReplyBlock({ authorName, streamId, messageId, children }: QuoteReplyBlockProps) {
+export function QuoteReplyBlock({
+  authorName,
+  authorId,
+  actorType,
+  streamId,
+  messageId,
+  children,
+}: QuoteReplyBlockProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
 
   if (!workspaceId) return null
@@ -27,9 +43,82 @@ export function QuoteReplyBlock({ authorName, streamId, messageId, children }: Q
     >
       <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
-        <span className="text-xs font-medium text-muted-foreground">{authorName}</span>
+        <QuoteAuthor
+          workspaceId={workspaceId}
+          authorName={authorName}
+          authorId={authorId}
+          actorType={actorType as AuthorType}
+        />
         <div className="mt-0.5 text-muted-foreground [&_p]:mb-0">{children}</div>
       </div>
     </Link>
+  )
+}
+
+function QuoteAuthor({
+  workspaceId,
+  authorName,
+  authorId,
+  actorType,
+}: {
+  workspaceId: string
+  authorName: string
+  authorId: string
+  actorType: AuthorType
+}) {
+  const { getActorAvatar } = useActors(workspaceId)
+  const { openUserProfile } = useUserProfile()
+  const { fallback, slug, avatarUrl } = getActorAvatar(authorId || null, actorType)
+  const isPersona = actorType === "persona"
+  const isBot = actorType === "bot"
+  const isSystem = actorType === "system"
+  const isUser = actorType === "user"
+
+  const handleAuthorClick = (e: React.MouseEvent) => {
+    if (isUser && authorId) {
+      e.preventDefault()
+      e.stopPropagation()
+      openUserProfile(authorId)
+    }
+  }
+
+  let avatar = null
+  if (authorId && isPersona) {
+    avatar = <PersonaAvatar slug={slug} fallback={fallback} size="sm" className="h-4 w-4 text-[8px]" />
+  } else if (authorId) {
+    avatar = (
+      <Avatar className="h-4 w-4 rounded-[4px] shrink-0">
+        {avatarUrl && <AvatarImage src={avatarUrl} alt={authorName} />}
+        <AvatarFallback
+          className={cn(
+            "text-[8px]",
+            isSystem && "bg-blue-500/10 text-blue-500",
+            isBot && "bg-emerald-500/10 text-emerald-600",
+            !isSystem && !isBot && "bg-muted text-foreground"
+          )}
+        >
+          {fallback}
+        </AvatarFallback>
+      </Avatar>
+    )
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {avatar}
+      <button
+        type="button"
+        onClick={handleAuthorClick}
+        className={cn(
+          "text-xs font-medium",
+          isUser && authorId ? "text-muted-foreground hover:underline" : "text-muted-foreground cursor-default",
+          isPersona && "text-primary",
+          isBot && "text-emerald-600",
+          isSystem && "text-blue-500"
+        )}
+      >
+        {authorName}
+      </button>
+    </span>
   )
 }

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import { Quote } from "lucide-react"
-import { useNavigate, useParams } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 
 interface QuoteReplyBlockProps {
   authorName: string
@@ -11,33 +11,25 @@ interface QuoteReplyBlockProps {
 
 /**
  * Renders a quote-reply block in message display.
- * Clicking the block navigates to the quoted message.
+ * Clicking the block navigates to the quoted message (INV-40: navigation uses links).
  */
 export function QuoteReplyBlock({ authorName, streamId, messageId, children }: QuoteReplyBlockProps) {
-  const navigate = useNavigate()
   const { workspaceId } = useParams<{ workspaceId: string }>()
 
-  const handleClick = () => {
-    if (!workspaceId) return
-    const url = `/w/${workspaceId}/s/${streamId}?m=${messageId}`
-    navigate(url)
-  }
+  if (!workspaceId) return null
+
+  const url = `/w/${workspaceId}/s/${streamId}?m=${messageId}`
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") handleClick()
-      }}
-      className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm cursor-pointer transition-colors hover:bg-muted/50"
+    <Link
+      to={url}
+      className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm no-underline transition-colors hover:bg-muted/50"
     >
       <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
         <span className="text-xs font-medium text-muted-foreground">{authorName}</span>
         <div className="mt-0.5 text-muted-foreground [&_p]:mb-0">{children}</div>
       </div>
-    </div>
+    </Link>
   )
 }

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react"
+import { Quote } from "lucide-react"
+import { useNavigate, useParams } from "react-router-dom"
+
+interface QuoteReplyBlockProps {
+  authorName: string
+  streamId: string
+  messageId: string
+  children: ReactNode
+}
+
+/**
+ * Renders a quote-reply block in message display.
+ * Clicking the block navigates to the quoted message.
+ */
+export function QuoteReplyBlock({ authorName, streamId, messageId, children }: QuoteReplyBlockProps) {
+  const navigate = useNavigate()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+
+  const handleClick = () => {
+    if (!workspaceId) return
+    const url = `/w/${workspaceId}/s/${streamId}?m=${messageId}`
+    navigate(url)
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") handleClick()
+      }}
+      className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm cursor-pointer transition-colors hover:bg-muted/50"
+    >
+      <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <span className="text-xs font-medium text-muted-foreground">{authorName}</span>
+        <div className="mt-0.5 text-muted-foreground [&_p]:mb-0">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@tiptap/extension-code": "^3.14.0",
         "@tiptap/extension-code-block-lowlight": "^3.14.0",
         "@tiptap/extension-document": "^3.15.3",
+        "@tiptap/extension-gapcursor": "^3.22.2",
         "@tiptap/extension-hard-break": "^3.15.3",
         "@tiptap/extension-heading": "^3.15.3",
         "@tiptap/extension-history": "^3.15.3",
@@ -1339,7 +1340,7 @@
 
     "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.14.0", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "^3.14.0", "@tiptap/pm": "^3.14.0" } }, "sha512-+ErwDF74NzX4JV0nXMSIUT9V8FDdo85r0SaBZ8lb2NLmElaA3LDklcNV7SsoKlRcwsAXtFkqQbDwXLNGQLYSPQ=="],
 
-    "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.14.0", "", { "peerDependencies": { "@tiptap/extensions": "^3.14.0" } }, "sha512-hMg2U59+c9FreYtTvzxx5GWKejdZLRITMLEu4OTfrgQok6uF4qkzGEEqmYqPiHk08TBqAg18Y5bbpyqTsuit9A=="],
+    "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.22.2", "", { "peerDependencies": { "@tiptap/extensions": "^3.22.2" } }, "sha512-rR2OLrl/k2kj7xehaZHq0Y7T+1wy2DOTabir9LsTrktTFEcklrh9qY1KC6rEBkwMKaWrmignR1l39kS6RlKFNw=="],
 
     "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@3.15.3", "", { "peerDependencies": { "@tiptap/core": "^3.15.3" } }, "sha512-8HjxmeRbBiXW+7JKemAJtZtHlmXQ9iji398CPQ0yYde68WbIvUhHXjmbJE5pxFvvQTJ/zJv1aISeEOZN2bKBaw=="],
 
@@ -3706,6 +3707,8 @@
     "@tiptap/starter-kit/@tiptap/extension-bullet-list": ["@tiptap/extension-bullet-list@3.14.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.14.0" } }, "sha512-luqPX4u52hiOAHJ95mYsNE+x+9dZxsM461Xny9d/eTXLjAcnwS7MghjrnpljvyYsSXNiwQtxUyEr4uEZZJ5gIQ=="],
 
     "@tiptap/starter-kit/@tiptap/extension-document": ["@tiptap/extension-document@3.14.0", "", { "peerDependencies": { "@tiptap/core": "^3.14.0" } }, "sha512-O3D7/GPB3XrWGy0y/b4LMHiY0eTd+dyIbSdiFtmUnbC/E9lqQLw43GiqvD9Gm6AyKhBA+Z45dKMbaOe1c6eTwQ=="],
+
+    "@tiptap/starter-kit/@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.14.0", "", { "peerDependencies": { "@tiptap/extensions": "^3.14.0" } }, "sha512-hMg2U59+c9FreYtTvzxx5GWKejdZLRITMLEu4OTfrgQok6uF4qkzGEEqmYqPiHk08TBqAg18Y5bbpyqTsuit9A=="],
 
     "@tiptap/starter-kit/@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@3.14.0", "", { "peerDependencies": { "@tiptap/core": "^3.14.0" } }, "sha512-XKxr8usQp+kFevhDK6Ccmnq1CIkLmPClhKwbt7AClGLKLBtEVAS1qUgcmKudkw8cD8Q2/69twI37LXa23sfuLA=="],
 

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -129,3 +129,116 @@ describe("@threa/prosemirror markdown attachment metadata", () => {
     })
   })
 })
+
+describe("@threa/prosemirror quote reply round-trip", () => {
+  it("serializes quoteReply to blockquote with attribution link", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "quoteReply",
+          attrs: {
+            messageId: "msg_01ABC",
+            streamId: "stream_01XYZ",
+            authorName: "Kristoffer",
+            snippet: "Hello world",
+          },
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "My reply" }],
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply")
+  })
+
+  it("parses blockquote with quote: attribution into quoteReply node", () => {
+    const markdown = "> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply"
+    const parsed = parseMarkdown(markdown)
+
+    expect(parsed.content?.[0]).toEqual({
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_01ABC",
+        streamId: "stream_01XYZ",
+        authorName: "Kristoffer",
+        snippet: "Hello world",
+      },
+    })
+    expect(parsed.content?.[1]?.type).toBe("paragraph")
+  })
+
+  it("round-trips quoteReply through markdown", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "quoteReply",
+          attrs: {
+            messageId: "msg_01KNGTTZJYCBZ8X4FEVX8YFBB3",
+            streamId: "stream_01KJMS776MNP2Q382MJ639Y2JD",
+            authorName: "Alice",
+            snippet: "Gärna! Har du automatiskt mirroring?",
+          },
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Ja, det har jag!" }],
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    const parsed = parseMarkdown(markdown)
+
+    expect(parsed.content?.[0]).toEqual({
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_01KNGTTZJYCBZ8X4FEVX8YFBB3",
+        streamId: "stream_01KJMS776MNP2Q382MJ639Y2JD",
+        authorName: "Alice",
+        snippet: "Gärna! Har du automatiskt mirroring?",
+      },
+    })
+  })
+
+  it("preserves multi-line snippets through round-trip", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "quoteReply",
+          attrs: {
+            messageId: "msg_01ABC",
+            streamId: "stream_01XYZ",
+            authorName: "Bob",
+            snippet: "Line one\nLine two\nLine three",
+          },
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> Line one\n> Line two\n> Line three\n> — [Bob](quote:stream_01XYZ/msg_01ABC)")
+
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]).toEqual({
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_01ABC",
+        streamId: "stream_01XYZ",
+        authorName: "Bob",
+        snippet: "Line one\nLine two\nLine three",
+      },
+    })
+  })
+
+  it("treats blockquote without quote: protocol as regular blockquote", () => {
+    const markdown = "> Just a regular quote"
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]?.type).toBe("blockquote")
+  })
+})

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -241,4 +241,35 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     const parsed = parseMarkdown(markdown)
     expect(parsed.content?.[0]?.type).toBe("blockquote")
   })
+
+  it("round-trips author names containing brackets and backslashes", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "quoteReply",
+          attrs: {
+            messageId: "msg_01ABC",
+            streamId: "stream_01XYZ",
+            authorName: "John [Dev] Smith\\Sr",
+            snippet: "Hello",
+          },
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("> Hello\n> — [John [Dev\\] Smith\\\\Sr](quote:stream_01XYZ/msg_01ABC)")
+
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]).toEqual({
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_01ABC",
+        streamId: "stream_01XYZ",
+        authorName: "John [Dev] Smith\\Sr",
+        snippet: "Hello",
+      },
+    })
+  })
 })

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -141,6 +141,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
             messageId: "msg_01ABC",
             streamId: "stream_01XYZ",
             authorName: "Kristoffer",
+            authorId: "usr_01KR",
+            actorType: "user",
             snippet: "Hello world",
           },
         },
@@ -152,11 +154,11 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply")
+    expect(markdown).toBe("> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user)\n\nMy reply")
   })
 
   it("parses blockquote with quote: attribution into quoteReply node", () => {
-    const markdown = "> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply"
+    const markdown = "> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user)\n\nMy reply"
     const parsed = parseMarkdown(markdown)
 
     expect(parsed.content?.[0]).toEqual({
@@ -165,13 +167,15 @@ describe("@threa/prosemirror quote reply round-trip", () => {
         messageId: "msg_01ABC",
         streamId: "stream_01XYZ",
         authorName: "Kristoffer",
+        authorId: "usr_01KR",
+        actorType: "user",
         snippet: "Hello world",
       },
     })
     expect(parsed.content?.[1]?.type).toBe("paragraph")
   })
 
-  it("parses old format (no blank separator line) for backward compatibility", () => {
+  it("parses old format (no authorId/actorType) for backward compatibility", () => {
     const markdown = "> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)"
     const parsed = parseMarkdown(markdown)
 
@@ -181,6 +185,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
         messageId: "msg_01ABC",
         streamId: "stream_01XYZ",
         authorName: "Kristoffer",
+        authorId: "",
+        actorType: "user",
         snippet: "Hello world",
       },
     })
@@ -196,6 +202,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
             messageId: "msg_01KNGTTZJYCBZ8X4FEVX8YFBB3",
             streamId: "stream_01KJMS776MNP2Q382MJ639Y2JD",
             authorName: "Alice",
+            authorId: "usr_01AL",
+            actorType: "user",
             snippet: "Gärna! Har du automatiskt mirroring?",
           },
         },
@@ -215,6 +223,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
         messageId: "msg_01KNGTTZJYCBZ8X4FEVX8YFBB3",
         streamId: "stream_01KJMS776MNP2Q382MJ639Y2JD",
         authorName: "Alice",
+        authorId: "usr_01AL",
+        actorType: "user",
         snippet: "Gärna! Har du automatiskt mirroring?",
       },
     })
@@ -230,6 +240,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
             messageId: "msg_01ABC",
             streamId: "stream_01XYZ",
             authorName: "Bob",
+            authorId: "usr_01BOB",
+            actorType: "user",
             snippet: "Line one\nLine two\nLine three",
           },
         },
@@ -237,7 +249,9 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Line one\n> Line two\n> Line three\n>\n> — [Bob](quote:stream_01XYZ/msg_01ABC)")
+    expect(markdown).toBe(
+      "> Line one\n> Line two\n> Line three\n>\n> — [Bob](quote:stream_01XYZ/msg_01ABC/usr_01BOB/user)"
+    )
 
     const parsed = parseMarkdown(markdown)
     expect(parsed.content?.[0]).toEqual({
@@ -246,6 +260,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
         messageId: "msg_01ABC",
         streamId: "stream_01XYZ",
         authorName: "Bob",
+        authorId: "usr_01BOB",
+        actorType: "user",
         snippet: "Line one\nLine two\nLine three",
       },
     })
@@ -267,6 +283,8 @@ describe("@threa/prosemirror quote reply round-trip", () => {
             messageId: "msg_01ABC",
             streamId: "stream_01XYZ",
             authorName: "John [Dev] Smith\\Sr",
+            authorId: "usr_01JOHN",
+            actorType: "user",
             snippet: "Hello",
           },
         },
@@ -274,7 +292,7 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Hello\n>\n> — [John [Dev\\] Smith\\\\Sr](quote:stream_01XYZ/msg_01ABC)")
+    expect(markdown).toBe("> Hello\n>\n> — [John [Dev\\] Smith\\\\Sr](quote:stream_01XYZ/msg_01ABC/usr_01JOHN/user)")
 
     const parsed = parseMarkdown(markdown)
     expect(parsed.content?.[0]).toEqual({
@@ -283,8 +301,33 @@ describe("@threa/prosemirror quote reply round-trip", () => {
         messageId: "msg_01ABC",
         streamId: "stream_01XYZ",
         authorName: "John [Dev] Smith\\Sr",
+        authorId: "usr_01JOHN",
+        actorType: "user",
         snippet: "Hello",
       },
     })
+  })
+
+  it("round-trips persona actorType", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "quoteReply",
+          attrs: {
+            messageId: "msg_01ABC",
+            streamId: "stream_01XYZ",
+            authorName: "Ariadne",
+            authorId: "persona_01AR",
+            actorType: "persona",
+            snippet: "Hello!",
+          },
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]).toEqual(doc.content![0])
   })
 })

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -152,11 +152,11 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply")
+    expect(markdown).toBe("> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply")
   })
 
   it("parses blockquote with quote: attribution into quoteReply node", () => {
-    const markdown = "> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply"
+    const markdown = "> Hello world\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)\n\nMy reply"
     const parsed = parseMarkdown(markdown)
 
     expect(parsed.content?.[0]).toEqual({
@@ -169,6 +169,21 @@ describe("@threa/prosemirror quote reply round-trip", () => {
       },
     })
     expect(parsed.content?.[1]?.type).toBe("paragraph")
+  })
+
+  it("parses old format (no blank separator line) for backward compatibility", () => {
+    const markdown = "> Hello world\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)"
+    const parsed = parseMarkdown(markdown)
+
+    expect(parsed.content?.[0]).toEqual({
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_01ABC",
+        streamId: "stream_01XYZ",
+        authorName: "Kristoffer",
+        snippet: "Hello world",
+      },
+    })
   })
 
   it("round-trips quoteReply through markdown", () => {
@@ -222,7 +237,7 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Line one\n> Line two\n> Line three\n> — [Bob](quote:stream_01XYZ/msg_01ABC)")
+    expect(markdown).toBe("> Line one\n> Line two\n> Line three\n>\n> — [Bob](quote:stream_01XYZ/msg_01ABC)")
 
     const parsed = parseMarkdown(markdown)
     expect(parsed.content?.[0]).toEqual({
@@ -259,7 +274,7 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     }
 
     const markdown = serializeToMarkdown(doc)
-    expect(markdown).toBe("> Hello\n> — [John [Dev\\] Smith\\\\Sr](quote:stream_01XYZ/msg_01ABC)")
+    expect(markdown).toBe("> Hello\n>\n> — [John [Dev\\] Smith\\\\Sr](quote:stream_01XYZ/msg_01ABC)")
 
     const parsed = parseMarkdown(markdown)
     expect(parsed.content?.[0]).toEqual({

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -63,7 +63,9 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
         .split("\n")
         .map((line) => "> " + line)
         .join("\n")
-      return `${quotedLines}\n> — [${authorName}](quote:${streamId}/${messageId})`
+      // Escape ] and \ in author name to prevent breaking the markdown link syntax
+      const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
+      return `${quotedLines}\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
     }
 
     case "bulletList":
@@ -349,11 +351,13 @@ export function parseMarkdown(
       }
 
       // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId)
+      // Author name may contain escaped brackets: \] and \\
       const lastLine = quoteLines[quoteLines.length - 1]
-      const quoteReplyMatch = lastLine?.match(/^—\s*\[([^\]]+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
+      const quoteReplyMatch = lastLine?.match(/^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
 
       if (quoteReplyMatch) {
-        const authorName = quoteReplyMatch[1]
+        // Unescape \] and \\ in author name
+        const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
         const streamId = quoteReplyMatch[2]
         const messageId = quoteReplyMatch[3]
         const snippet = quoteLines.slice(0, -1).join("\n")

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -65,7 +65,9 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
         .join("\n")
       // Escape ] and \ in author name to prevent breaking the markdown link syntax
       const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
-      return `${quotedLines}\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
+      // Blank `>` line forces a paragraph break so react-markdown creates separate
+      // <p> elements for the snippet and attribution (needed for display extraction).
+      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
     }
 
     case "bulletList":
@@ -343,10 +345,10 @@ export function parseMarkdown(
     }
 
     // Blockquote (or quoteReply if last line has quote: attribution)
-    if (line.startsWith("> ")) {
+    if (line.startsWith("> ") || line === ">") {
       const quoteLines: string[] = []
-      while (i < lines.length && lines[i].startsWith("> ")) {
-        quoteLines.push(lines[i].slice(2))
+      while (i < lines.length && (lines[i].startsWith("> ") || lines[i] === ">")) {
+        quoteLines.push(lines[i] === ">" ? "" : lines[i].slice(2))
         i++
       }
 
@@ -360,7 +362,12 @@ export function parseMarkdown(
         const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
         const streamId = quoteReplyMatch[2]
         const messageId = quoteReplyMatch[3]
-        const snippet = quoteLines.slice(0, -1).join("\n")
+        // Strip the attribution line and any blank separator line before it
+        const snippetLines = quoteLines.slice(0, -1)
+        while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1] === "") {
+          snippetLines.pop()
+        }
+        const snippet = snippetLines.join("\n")
         content.push({
           type: "quoteReply",
           attrs: { messageId, streamId, authorName, snippet },

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -53,10 +53,12 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
     }
 
     case "quoteReply": {
-      const { messageId, streamId, authorName, snippet } = node.attrs as {
+      const { messageId, streamId, authorName, authorId, actorType, snippet } = node.attrs as {
         messageId: string
         streamId: string
         authorName: string
+        authorId: string
+        actorType: string
         snippet: string
       }
       const quotedLines = snippet
@@ -67,7 +69,8 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
       const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
       // Blank `>` line forces a paragraph break so react-markdown creates separate
       // <p> elements for the snippet and attribution (needed for display extraction).
-      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId})`
+      // authorId and actorType are appended after messageId for avatar/profile resolution.
+      return `${quotedLines}\n>\n> — [${escapedAuthor}](quote:${streamId}/${messageId}/${authorId}/${actorType})`
     }
 
     case "bulletList":
@@ -352,16 +355,21 @@ export function parseMarkdown(
         i++
       }
 
-      // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId)
+      // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId/authorId/actorType)
       // Author name may contain escaped brackets: \] and \\
+      // authorId and actorType are optional for backward compat with old messages.
       const lastLine = quoteLines[quoteLines.length - 1]
-      const quoteReplyMatch = lastLine?.match(/^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
+      const quoteReplyMatch = lastLine?.match(
+        /^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)(?:\/([\w-]+)\/([\w-]+))?\)$/
+      )
 
       if (quoteReplyMatch) {
         // Unescape \] and \\ in author name
         const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
         const streamId = quoteReplyMatch[2]
         const messageId = quoteReplyMatch[3]
+        const authorId = quoteReplyMatch[4] ?? ""
+        const actorType = quoteReplyMatch[5] ?? "user"
         // Strip the attribution line and any blank separator line before it
         const snippetLines = quoteLines.slice(0, -1)
         while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1] === "") {
@@ -370,7 +378,7 @@ export function parseMarkdown(
         const snippet = snippetLines.join("\n")
         content.push({
           type: "quoteReply",
-          attrs: { messageId, streamId, authorName, snippet },
+          attrs: { messageId, streamId, authorName, authorId, actorType, snippet },
         })
       } else {
         content.push({

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -52,6 +52,20 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
         .join("\n")
     }
 
+    case "quoteReply": {
+      const { messageId, streamId, authorName, snippet } = node.attrs as {
+        messageId: string
+        streamId: string
+        authorName: string
+        snippet: string
+      }
+      const quotedLines = snippet
+        .split("\n")
+        .map((line) => "> " + line)
+        .join("\n")
+      return `${quotedLines}\n> — [${authorName}](quote:${streamId}/${messageId})`
+    }
+
     case "bulletList":
       return (
         node.content
@@ -326,22 +340,38 @@ export function parseMarkdown(
       continue
     }
 
-    // Blockquote
+    // Blockquote (or quoteReply if last line has quote: attribution)
     if (line.startsWith("> ")) {
       const quoteLines: string[] = []
       while (i < lines.length && lines[i].startsWith("> ")) {
         quoteLines.push(lines[i].slice(2))
         i++
       }
-      content.push({
-        type: "blockquote",
-        content: [
-          {
-            type: "paragraph",
-            content: parseInlineMarkdown(quoteLines.join("\n"), options),
-          },
-        ],
-      })
+
+      // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId)
+      const lastLine = quoteLines[quoteLines.length - 1]
+      const quoteReplyMatch = lastLine?.match(/^—\s*\[([^\]]+)\]\(quote:([\w-]+)\/([\w-]+)\)$/)
+
+      if (quoteReplyMatch) {
+        const authorName = quoteReplyMatch[1]
+        const streamId = quoteReplyMatch[2]
+        const messageId = quoteReplyMatch[3]
+        const snippet = quoteLines.slice(0, -1).join("\n")
+        content.push({
+          type: "quoteReply",
+          attrs: { messageId, streamId, authorName, snippet },
+        })
+      } else {
+        content.push({
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: parseInlineMarkdown(quoteLines.join("\n"), options),
+            },
+          ],
+        })
+      }
       continue
     }
 

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -112,6 +112,10 @@ export interface ThreaQuoteReply {
     streamId: string
     /** Display name of the quoted message author (denormalized) */
     authorName: string
+    /** The ID of the quoted message author */
+    authorId: string
+    /** The actor type of the quoted message author */
+    actorType: string
     /** The quoted text snippet */
     snippet: string
   }
@@ -431,6 +435,8 @@ const quoteReplyNodeSchema = z.object({
     messageId: z.string(),
     streamId: z.string(),
     authorName: z.string(),
+    authorId: z.string(),
+    actorType: z.string(),
     snippet: z.string(),
   }),
 })

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -56,6 +56,7 @@ export type ThreaBlockNode =
   | ThreaHeading
   | ThreaCodeBlock
   | ThreaBlockquote
+  | ThreaQuoteReply
   | ThreaBulletList
   | ThreaOrderedList
   | ThreaHorizontalRule
@@ -96,6 +97,24 @@ export interface ThreaCodeBlock {
 export interface ThreaBlockquote {
   type: "blockquote"
   content: ThreaBlockNode[]
+}
+
+/**
+ * Quote reply - quotes a specific message (or part of it) with attribution.
+ * Serializes to markdown as a blockquote with a `quote:` attribution link.
+ */
+export interface ThreaQuoteReply {
+  type: "quoteReply"
+  attrs: {
+    /** The ID of the quoted message */
+    messageId: string
+    /** The stream containing the quoted message */
+    streamId: string
+    /** Display name of the quoted message author (denormalized) */
+    authorName: string
+    /** The quoted text snippet */
+    snippet: string
+  }
 }
 
 /**
@@ -389,6 +408,7 @@ const blockNodeSchema = z.lazy(() =>
     headingNodeSchema,
     codeBlockNodeSchema,
     blockquoteNodeSchema,
+    quoteReplyNodeSchema,
     bulletListNodeSchema,
     orderedListNodeSchema,
     horizontalRuleNodeSchema,
@@ -403,6 +423,16 @@ const listItemNodeSchema = z.object({
 const blockquoteNodeSchema = z.object({
   type: z.literal("blockquote"),
   content: z.array(blockNodeSchema),
+})
+
+const quoteReplyNodeSchema = z.object({
+  type: z.literal("quoteReply"),
+  attrs: z.object({
+    messageId: z.string(),
+    streamId: z.string(),
+    authorName: z.string(),
+    snippet: z.string(),
+  }),
 })
 
 const bulletListNodeSchema = z.object({


### PR DESCRIPTION
## Follow-up polish

- Quote insertions now land on a real after-quote gapcursor instead of a synthetic empty paragraph rendered on the next line.
- `ArrowLeft` and `ArrowRight` now move directly between the before-quote and after-quote gapcursor positions, so typing on either side inserts text there instead of selecting and replacing the quote atom.
- On mobile, tapping the left or right half of an inserted quote now moves to the matching gapcursor position instead of selecting and replacing the quote block.
- Verified in `bun run dev:test` using Playwright browser repros in desktop and mobile viewports, and covered with targeted Vitest regressions for `MessageInput`, `QuoteReplyExtension`, and shared editor behaviors.

## Summary

Adds quoted replies — users can reply to a message (or a selected portion) directly in the same stream. The quote is stored as a structured `quoteReply` ProseMirror node that round-trips losslessly through markdown, enabling bots, API users, and copy/paste workflows to create and consume quoted replies with plain markdown.

### Markdown wire format

```markdown
> Gärna! Har du automatiskt mirroring?
> — [Kristoffer](quote:stream_01XYZ/msg_01ABC)

My reply here
```

The `quote:` protocol (same pattern as the existing `attachment:` protocol) makes quote-reply blockquotes unambiguous from regular blockquotes. Author names with special characters (`]`, `\`) are escaped/unescaped correctly.

## What's included

### Data model (no migration needed — JSONB schema-on-read)
- `ThreaQuoteReply` type + Zod schema in `packages/types/src/prosemirror.ts`
- Markdown serialization + parsing with `quote:` protocol attribution in `packages/prosemirror/src/markdown.ts`
- 6 round-trip tests covering multi-line snippets, special characters in author names, and regular blockquote preservation

### Editor
- `QuoteReplyExtension` — block-level atom TipTap node with `insertQuoteReply` command
- `QuoteReplyView` — React NodeView showing author chip, snippet preview, and remove button

### Message display
- `QuoteReplyBlock` — clickable card in rendered messages that navigates to the quoted message via `<Link>` (INV-40)
- Blockquote detection in markdown components upgrades `quote:` protocol blockquotes to rich rendering

### Desktop interactions
- **Hover button** — Quote icon on message hover (alongside reaction picker and context menu)
- **Context menu** — "Quote reply" action in dropdown
- **Text selection popover** — selecting text within a message shows a floating "Quote" button for partial quotes

### Mobile interactions
- **Swipe-to-quote** — swipe left on a message with haptic feedback at threshold
- **Context menu** — "Quote reply" in the long-press action drawer

### Wiring
- `QuoteReplyContext` — bridges message actions and the composer via handler registration (same pattern as `EditLastMessageContext`)
- `MessageInput` registers a stable handler (via ref) to prepend `quoteReply` nodes to editor content

## Design decisions

- **`quoteReply` as an atom node** (not a decorated blockquote) — gives structured data for rich rendering, click-to-navigate, and author attribution without conflating with user-typed blockquotes
- **Snippet stored as markdown text** — preserves formatting through the round-trip since the snippet content is the original `contentMarkdown`
- **`quote:` protocol in link href** — same pattern as `attachment:` for URL-safe custom protocols. Allowed through `react-markdown`'s `urlTransform`
- **Ref-based handler registration** — avoids effect churn from unstable composer object while keeping the handler always reading fresh state
- **`data-author-name` attribute** — avoids brittle DOM scraping for text selection quote attribution
- **Skipped partial quote on mobile** — text selection on mobile is OS-controlled and inconsistent; full-message quote via swipe + context menu covers the use case

## Test plan

- [x] Typecheck passes across full monorepo
- [x] 109 editor/markdown tests pass (including 6 new quote-reply round-trip tests)
- [x] Lint + pre-commit hooks pass
- [ ] Manual: desktop — hover quote button inserts quote into composer
- [ ] Manual: desktop — context menu "Quote reply" works
- [ ] Manual: desktop — select text in message, click floating "Quote" button for partial quote
- [ ] Manual: mobile — swipe left on message triggers quote reply with haptic
- [ ] Manual: mobile — long-press context menu "Quote reply" works
- [ ] Manual: quoted message renders as clickable card that navigates to original
- [ ] Manual: copy markdown of quoted message, paste into editor — round-trips correctly
- [ ] Manual: bot/API sends markdown with `> text\n> — [Author](quote:stream/msg)` — renders as quote reply

https://claude.ai/code/session_01FYJXEawWt5BWHtjUcRvMR1

