### PR TITLE
feat: add scratchpad AI custom prompt settings

### DIFF
--- a/.claude/plans/user-assistant-options.md
+++ b/.claude/plans/user-assistant-options.md
@@ -1,0 +1,103 @@
+# Scratchpad Custom AI Instructions
+
+## Goal
+
+Add a scratchpad-only custom instruction setting so users can shape how Ariadne behaves in their personal notes, while keeping shared contexts unchanged. The implementation also refreshes the desktop settings shell so the growing settings surface remains usable.
+
+## What Was Built
+
+### Scratchpad Prompt Preference
+
+Added a new `scratchpadCustomPrompt` user preference and wired it through validation, sparse preference storage, and bootstrap typing so the value can be saved like other settings.
+
+**Files:**
+- `packages/types/src/preferences.ts` - Adds the new preference field, default value, and `ai` settings tab.
+- `apps/backend/src/features/user-preferences/handlers.ts` - Validates incoming prompt updates.
+- `apps/backend/src/features/user-preferences/service.ts` - Persists the prompt through the sparse override pipeline.
+- `apps/backend/tests/integration/user-preferences.test.ts` - Verifies the prompt is stored as an override.
+
+### Scratchpad-Scoped Prompt Injection
+
+The companion context now resolves the saved prompt only for scratchpads and scratchpad-root threads, then injects it immediately after Ariadne's base system prompt.
+
+**Files:**
+- `apps/backend/src/features/agents/companion/context.ts` - Resolves whether the current stream inherits scratchpad custom instructions.
+- `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` - Injects the scratchpad custom instructions section into the final system prompt.
+- `apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts` - Verifies injection order and omission when unset.
+
+### AI Settings UI
+
+Added a new desktop settings tab for AI behavior. The scratchpad prompt editor uses the same rich editor surface as the message composer, but with mentions, channels, commands, and emoji parsing disabled so the field behaves like instructions instead of chat input.
+
+**Files:**
+- `apps/frontend/src/components/settings/ai-settings.tsx` - New scratchpad instructions editor with explicit save and reset controls.
+- `apps/frontend/src/components/settings/index.ts` - Exports the new settings section.
+- `apps/frontend/src/components/settings/ai-settings.test.tsx` - Verifies save, clear, and reset behavior.
+
+### Settings Dialog Redesign
+
+Reworked the desktop settings dialog from a cramped pill tab row to a sidebar layout with a larger fixed-height shell and internal scrolling. Mobile keeps the existing responsive tab selector behavior.
+
+**Files:**
+- `apps/frontend/src/components/settings/settings-dialog.tsx` - Introduces the sidebar layout, larger dialog sizing, and AI tab wiring.
+
+### Reusable Editor Gating
+
+Extended the rich editor and markdown parser so structured chat features can be selectively disabled. This lets the AI settings field reuse the message composer without unwanted mention or slash-command behavior.
+
+**Files:**
+- `apps/frontend/src/components/editor/rich-editor.tsx` - Adds feature flags for mentions, channels, commands, and emoji.
+- `apps/frontend/src/components/editor/editor-markdown.ts` - Supports parsing markdown with structured token parsing disabled.
+- `apps/frontend/src/components/editor/multiline-blocks.ts` - Passes parser options through paste handling.
+- `apps/frontend/src/components/editor/editor-action-bar.tsx` - Lets callers hide mention and emoji actions.
+- `apps/frontend/src/components/editor/editor-markdown.test.ts` - Verifies disabled token parsing preserves plain text.
+
+## Design Decisions
+
+### Scratchpad-Only Scope
+
+**Chose:** Apply the custom prompt only in scratchpads and scratchpad-root threads.
+**Why:** The user explicitly wanted to start with personal contexts only until the shared-context model is clearer.
+**Alternatives considered:** Applying the prompt across every Ariadne invocation, which risks leaking personal instruction styles into shared spaces.
+
+### Inject After the Base System Prompt
+
+**Chose:** Insert the saved instructions immediately after Ariadne's base persona prompt.
+**Why:** This matches the requested ordering and keeps persona identity primary while still giving the user durable influence over scratchpad behavior.
+**Alternatives considered:** Appending the custom prompt later in the context, which would weaken its priority and make the behavior harder to reason about.
+
+### Reuse the Rich Composer Surface
+
+**Chose:** Reuse the existing rich editor rather than introducing a plain textarea.
+**Why:** The user wanted the same writing surface across the app, and reusing the editor keeps formatting, keyboard behavior, and editing feel consistent.
+**Alternatives considered:** Shipping a textarea first, which would be cheaper but visually and behaviorally inconsistent.
+
+### Generalize Editor Parsing Controls
+
+**Chose:** Add explicit feature flags to the shared rich editor and markdown parser.
+**Why:** The AI settings editor needs the same surface without chat-specific tokenization, and a shared toggle is cleaner than forking the editor.
+**Alternatives considered:** Building a one-off settings-only editor or post-processing the parsed document to strip structured nodes.
+
+## Design Evolution
+
+- **Editor choice changed:** Plain settings textarea -> shared rich editor. The user called out the mismatch in writing surfaces, so the implementation switched to the fancy message input and disabled chat-only affordances inside that context.
+- **Settings navigation changed:** Expanding pill tabs -> desktop sidebar shell. The original request expanded the settings surface enough that the existing top-row tab treatment was no longer appropriate.
+
+## Schema Changes
+
+No database schema changes or migrations were required. The prompt is stored in the existing sparse user-preferences override model.
+
+## What's NOT Included
+
+- Shared-context custom prompts for channels, DMs, or other public/private collaborative spaces.
+- Per-stream or per-thread custom prompt overrides.
+- Special autocomplete or AI-specific templating inside the custom prompt editor.
+- New backend access rules beyond the existing scratchpad and scratchpad-root thread scoping.
+
+## Status
+
+- [x] Added a persisted scratchpad custom prompt preference.
+- [x] Injected the custom prompt into scratchpad and scratchpad-root thread system prompts.
+- [x] Added a new AI settings tab with a shared rich editor surface.
+- [x] Redesigned the desktop settings dialog to use a sidebar and fixed-height layout.
+- [x] Added targeted frontend and backend tests for the new behavior.

--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -1,14 +1,14 @@
 import type { Pool } from "pg"
 import type { ModelMessage } from "ai"
 import type { UserPreferences } from "@threa/types"
-import { AgentTriggers, AuthorTypes } from "@threa/types"
+import { AgentTriggers, AuthorTypes, StreamTypes } from "@threa/types"
 import type { UserPreferencesService } from "../../user-preferences"
 import { MessageRepository, type Message } from "../../messaging"
 import { UserRepository } from "../../workspaces"
 import { PersonaRepository } from "../persona-repository"
 import type { Persona } from "../persona-repository"
 import { AttachmentRepository } from "../../attachments"
-import type { Stream } from "../../streams"
+import { StreamRepository, type Stream } from "../../streams"
 import { awaitAttachmentProcessing } from "../../attachments"
 import { buildStreamContext, type StreamContext } from "../context-builder"
 import type { ConversationSummaryService } from "../conversation-summary-service"
@@ -39,6 +39,28 @@ export interface AgentContext {
   preferences: UserPreferences | undefined
   authorNames: Map<string, string>
   streamContext: StreamContext
+}
+
+async function resolveScratchpadCustomPrompt(
+  db: Pool,
+  stream: Stream,
+  preferences: UserPreferences | undefined
+): Promise<string | null> {
+  const customPrompt = preferences?.scratchpadCustomPrompt?.trim()
+  if (!customPrompt) {
+    return null
+  }
+
+  if (stream.type === StreamTypes.SCRATCHPAD) {
+    return customPrompt
+  }
+
+  if (stream.type !== StreamTypes.THREAD || !stream.rootStreamId) {
+    return null
+  }
+
+  const rootStream = await StreamRepository.findById(db, stream.rootStreamId)
+  return rootStream?.type === StreamTypes.SCRATCHPAD ? customPrompt : null
 }
 
 /**
@@ -130,9 +152,12 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     mentionerName = mentioner?.name ?? undefined
   }
 
+  const scratchpadCustomPrompt = await resolveScratchpadCustomPrompt(db, stream, preferences)
+
   const systemPrompt = buildSystemPrompt(
     persona,
     streamContext,
+    scratchpadCustomPrompt,
     trigger,
     mentionerName,
     rollingConversationSummary,

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { StreamTypes } from "@threa/types"
+import type { Persona } from "../../persona-repository"
+import type { StreamContext } from "../../context-builder"
+import { buildSystemPrompt } from "./system-prompt"
+
+const persona: Persona = {
+  id: "persona_ariadne",
+  workspaceId: null,
+  slug: "ariadne",
+  name: "Ariadne",
+  description: null,
+  avatarEmoji: null,
+  systemPrompt: "Base system prompt",
+  model: "openai/gpt-5.4",
+  temperature: 0.2,
+  maxTokens: 1000,
+  enabledTools: null,
+  managedBy: "system",
+  status: "active",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+
+const scratchpadContext: StreamContext = {
+  streamType: StreamTypes.SCRATCHPAD,
+  streamInfo: {
+    name: "Ideas",
+    description: null,
+    slug: null,
+  },
+  conversationHistory: [],
+}
+
+describe("buildSystemPrompt", () => {
+  test("injects scratchpad custom instructions immediately after the base system prompt", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, "Be concise and prioritize concrete next steps.")
+
+    expect(prompt).toContain("Base system prompt\n\n## Scratchpad Custom Instructions")
+    expect(prompt).toContain("Be concise and prioritize concrete next steps.")
+    expect(prompt.indexOf("## Scratchpad Custom Instructions")).toBeLessThan(prompt.indexOf("## Context"))
+  })
+
+  test("omits the custom instruction section when no scratchpad prompt exists", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null)
+
+    expect(prompt).not.toContain("## Scratchpad Custom Instructions")
+  })
+})

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -12,6 +12,7 @@ import { buildPromptSectionForStreamType } from "./stream-context-sections"
 export function buildSystemPrompt(
   persona: Persona,
   context: StreamContext,
+  scratchpadCustomPrompt?: string | null,
   trigger?: typeof AgentTriggers.MENTION,
   mentionerName?: string,
   rollingConversationSummary?: string | null,
@@ -22,6 +23,17 @@ export function buildSystemPrompt(
   }
 
   let prompt = persona.systemPrompt
+
+  if (scratchpadCustomPrompt?.trim()) {
+    prompt += `
+
+## Scratchpad Custom Instructions
+
+The user configured the following standing instructions for their personal scratchpads.
+Apply them in scratchpads and scratchpad-root threads unless they conflict with higher-priority system rules.
+
+${scratchpadCustomPrompt.trim()}`
+  }
 
   // Add mention invocation context if applicable
   if (trigger === AgentTriggers.MENTION) {

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -24,6 +24,7 @@ const updatePreferencesSchema = z.object({
   sidebarCollapsed: z.boolean().optional(),
   messageSendMode: z.enum(MESSAGE_SEND_MODE_OPTIONS).optional(),
   linkPreviewDefault: z.enum(LINK_PREVIEW_DEFAULT_OPTIONS).optional(),
+  scratchpadCustomPrompt: z.string().max(8000).nullable().optional(),
   keyboardShortcuts: z.record(z.string(), z.string()).optional(),
   accessibility: z
     .object({

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -82,6 +82,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "notificationLevel",
     "sidebarCollapsed",
     "messageSendMode",
+    "scratchpadCustomPrompt",
   ] as const
 
   for (const key of simpleKeys) {

--- a/apps/backend/tests/integration/user-preferences.test.ts
+++ b/apps/backend/tests/integration/user-preferences.test.ts
@@ -149,6 +149,16 @@ describe("User Preferences - Sparse Override Pattern", () => {
       expect(prefs.accessibility.reducedMotion).toBe(false)
       expect(prefs.accessibility.highContrast).toBe(false)
     })
+
+    test("should store scratchpad custom prompt overrides", async () => {
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        scratchpadCustomPrompt: "Be terse in scratchpads.",
+      })
+
+      const overrides = await UserPreferencesRepository.findOverrides(pool, testUserId)
+
+      expect(overrides).toEqual([{ key: "scratchpadCustomPrompt", value: "Be terse in scratchpads." }])
+    })
   })
 
   describe("keyboard shortcuts", () => {

--- a/apps/frontend/src/components/editor/editor-action-bar.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.tsx
@@ -29,6 +29,8 @@ export interface EditorActionBarProps {
   // Optional buttons
   showExpand?: boolean
   showAttach?: boolean
+  showMention?: boolean
+  showEmoji?: boolean
   showSlashCommand?: boolean
   onAttachClick?: () => void
   // Desktop expand (opens fullscreen modal)
@@ -47,6 +49,8 @@ export function EditorActionBar({
   onMobileExpandedChange,
   showExpand = true,
   showAttach = true,
+  showMention = true,
+  showEmoji = true,
   showSlashCommand = false,
   onAttachClick,
   showDesktopExpand = false,
@@ -130,46 +134,50 @@ export function EditorActionBar({
       </Tooltip>
 
       {/* Insert emoji */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Insert emoji"
-            className="h-7 w-7 shrink-0"
-            onPointerDown={handlePointerAction(() => editorHandle?.insertEmoji())}
-            onClick={handleKeyboardClick(() => editorHandle?.insertEmoji())}
-            disabled={disabled}
-          >
-            <span className="text-sm leading-none">😊</span>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          Emoji
-        </TooltipContent>
-      </Tooltip>
+      {showEmoji && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Insert emoji"
+              className="h-7 w-7 shrink-0"
+              onPointerDown={handlePointerAction(() => editorHandle?.insertEmoji())}
+              onClick={handleKeyboardClick(() => editorHandle?.insertEmoji())}
+              disabled={disabled}
+            >
+              <span className="text-sm leading-none">😊</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Emoji
+          </TooltipContent>
+        </Tooltip>
+      )}
 
       {/* Insert mention */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Insert mention"
-            className="h-7 w-7 shrink-0"
-            onPointerDown={handlePointerAction(() => editorHandle?.insertMention())}
-            onClick={handleKeyboardClick(() => editorHandle?.insertMention())}
-            disabled={disabled}
-          >
-            <AtSign className="h-4 w-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          Mention
-        </TooltipContent>
-      </Tooltip>
+      {showMention && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Insert mention"
+              className="h-7 w-7 shrink-0"
+              onPointerDown={handlePointerAction(() => editorHandle?.insertMention())}
+              onClick={handleKeyboardClick(() => editorHandle?.insertMention())}
+              disabled={disabled}
+            >
+              <AtSign className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Mention
+          </TooltipContent>
+        </Tooltip>
+      )}
 
       {/* Insert slash command */}
       {showSlashCommand && (

--- a/apps/frontend/src/components/editor/editor-markdown.test.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.test.ts
@@ -882,6 +882,19 @@ const x = 1
         expect(content?.[2]).toEqual({ type: "text", text: " for details" })
       })
 
+      it("keeps mentions, channels, slash commands, and emoji as plain text when token parsing is disabled", () => {
+        const source = "See #general and @alice\n\n/todo\n\n:wave:"
+        const result = parseMarkdown(source, undefined, undefined, {
+          enableMentions: false,
+          enableChannels: false,
+          enableSlashCommands: false,
+          enableEmoji: false,
+        })
+
+        expect(serializeToMarkdown(result)).toBe(source)
+        expect(result.content?.flatMap((block) => block.content ?? []).every((node) => node.type === "text")).toBe(true)
+      })
+
       it("should parse multiple mentions", () => {
         const result = parseMarkdown("@alice and @bob")
         const content = result.content?.[0]?.content

--- a/apps/frontend/src/components/editor/editor-markdown.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.ts
@@ -264,6 +264,10 @@ export type EmojiLookup = (shortcode: string) => string | null
 interface ParseOptions {
   getMentionType?: MentionTypeLookup
   getEmoji?: EmojiLookup
+  enableMentions?: boolean
+  enableChannels?: boolean
+  enableSlashCommands?: boolean
+  enableEmoji?: boolean
 }
 
 /**
@@ -273,9 +277,10 @@ interface ParseOptions {
 export function parseMarkdown(
   markdown: string,
   getMentionType?: MentionTypeLookup,
-  getEmoji?: EmojiLookup
+  getEmoji?: EmojiLookup,
+  parseOptions: Omit<ParseOptions, "getMentionType" | "getEmoji"> = {}
 ): JSONContent {
-  const options: ParseOptions = { getMentionType, getEmoji }
+  const options: ParseOptions = { getMentionType, getEmoji, ...parseOptions }
   if (!markdown.trim()) {
     return { type: "doc", content: [{ type: "paragraph" }] }
   }
@@ -403,6 +408,10 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
 
   const result: JSONContent[] = []
   const { getMentionType, getEmoji } = options
+  const allowMentions = options.enableMentions ?? true
+  const allowChannels = options.enableChannels ?? true
+  const allowSlashCommands = options.enableSlashCommands ?? true
+  const allowEmoji = options.enableEmoji ?? true
 
   // Default lookup for mention types (without context, can't determine "me")
   const lookupMentionType: MentionTypeLookup =
@@ -413,7 +422,7 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
     })
 
   // Check for slash command at start of text
-  const commandMatch = text.match(/^(\s*)(\/)([\w-]+)/)
+  const commandMatch = allowSlashCommands ? text.match(/^(\s*)(\/)([\w-]+)/) : null
   let processText = text
   if (commandMatch) {
     // Preserve leading whitespace
@@ -539,22 +548,30 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
     } else if (match[18]) {
       // Mention: @slug
       const slug = match[19]
-      result.push({
-        type: "mention",
-        attrs: { id: slug, slug, name: slug, mentionType: lookupMentionType(slug) },
-      })
+      if (allowMentions) {
+        result.push({
+          type: "mention",
+          attrs: { id: slug, slug, name: slug, mentionType: lookupMentionType(slug) },
+        })
+      } else {
+        result.push({ type: "text", text: match[0] })
+      }
     } else if (match[20]) {
       // Channel: #slug
       const slug = match[21]
-      result.push({
-        type: "channelLink",
-        attrs: { id: slug, slug, name: slug },
-      })
+      if (allowChannels) {
+        result.push({
+          type: "channelLink",
+          attrs: { id: slug, slug, name: slug },
+        })
+      } else {
+        result.push({ type: "text", text: match[0] })
+      }
     } else if (match[22]) {
       // Emoji: :shortcode:
       const shortcode = match[23]
-      const emoji = getEmoji?.(shortcode)
-      if (emoji) {
+      const emoji = allowEmoji ? getEmoji?.(shortcode) : null
+      if (allowEmoji && emoji) {
         result.push({
           type: "emoji",
           attrs: { shortcode, emoji },

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -396,16 +396,28 @@ export function toggleMultilineBlock(editor: Editor, nodeName: "codeBlock" | "bl
 function getParsedContent(
   text: string,
   getMentionType?: MentionTypeLookup,
-  getEmoji?: EmojiLookup
+  getEmoji?: EmojiLookup,
+  parseOptions?: {
+    enableMentions?: boolean
+    enableChannels?: boolean
+    enableSlashCommands?: boolean
+    enableEmoji?: boolean
+  }
 ): JSONContent[] | undefined {
-  return parseMarkdown(text, getMentionType, getEmoji).content
+  return parseMarkdown(text, getMentionType, getEmoji, parseOptions).content
 }
 
 export function insertPastedText(
   editor: Editor,
   text: string,
   getMentionType?: MentionTypeLookup,
-  getEmoji?: EmojiLookup
+  getEmoji?: EmojiLookup,
+  parseOptions?: {
+    enableMentions?: boolean
+    enableChannels?: boolean
+    enableSlashCommands?: boolean
+    enableEmoji?: boolean
+  }
 ): boolean {
   const normalizedText = text.replace(/\r\n?/g, "\n")
 
@@ -414,7 +426,7 @@ export function insertPastedText(
   }
 
   if (editor.isActive("blockquote") && normalizedText.includes("\n")) {
-    const content = getParsedContent(normalizedText, getMentionType, getEmoji)
+    const content = getParsedContent(normalizedText, getMentionType, getEmoji, parseOptions)
     if (!content || content.length === 0) {
       return false
     }
@@ -422,7 +434,7 @@ export function insertPastedText(
     return editor.chain().focus().insertContent(content).run()
   }
 
-  const parsed = parseMarkdown(normalizedText, getMentionType, getEmoji)
+  const parsed = parseMarkdown(normalizedText, getMentionType, getEmoji, parseOptions)
   return editor.commands.insertContent(parsed)
 }
 

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -66,6 +66,14 @@ interface RichEditorProps {
   onEscapeBlur?: () => void
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
+  /** Whether @mentions should be parsed and autocompleted. */
+  enableMentions?: boolean
+  /** Whether #channel references should be parsed and autocompleted. */
+  enableChannels?: boolean
+  /** Whether slash commands should be parsed and autocompleted. */
+  enableCommands?: boolean
+  /** Whether emoji shortcodes should be parsed and autocompleted. */
+  enableEmoji?: boolean
 }
 
 function isEditorCompletelyEmpty(editor: import("@tiptap/react").Editor | null | undefined): boolean {
@@ -105,6 +113,10 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     blurOnEscape = false,
     onEscapeBlur,
     streamContext,
+    enableMentions = true,
+    enableChannels = true,
+    enableCommands = true,
+    enableEmoji = true,
   },
   ref
 ) {
@@ -146,6 +158,15 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   getMentionTypeRef.current = getMentionType
   const toEmojiRef = useRef(toEmoji)
   toEmojiRef.current = toEmoji
+  const markdownParseOptions = useMemo(
+    () => ({
+      enableMentions,
+      enableChannels,
+      enableSlashCommands: enableCommands,
+      enableEmoji,
+    }),
+    [enableMentions, enableChannels, enableCommands, enableEmoji]
+  )
 
   // Ref to avoid stale closure for file upload callback
   const onFileUploadRef = useRef(onFileUpload)
@@ -185,18 +206,29 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     () => [
       ...createEditorExtensions({
         placeholder,
-        mentionSuggestion: mentionConfig,
-        channelSuggestion: channelConfig,
-        commandSuggestion: commandConfig,
-        emojiSuggestion: emojiConfig,
-        toEmoji,
+        mentionSuggestion: enableMentions ? mentionConfig : undefined,
+        channelSuggestion: enableChannels ? channelConfig : undefined,
+        commandSuggestion: enableCommands ? commandConfig : undefined,
+        emojiSuggestion: enableEmoji ? emojiConfig : undefined,
+        toEmoji: enableEmoji ? toEmoji : undefined,
       }),
       EditorBehaviors.configure({
         sendModeRef: messageSendModeRef,
         onSubmitRef: onSubmitRef,
       }),
     ],
-    [placeholder, mentionConfig, channelConfig, commandConfig, emojiConfig, toEmoji]
+    [
+      placeholder,
+      mentionConfig,
+      channelConfig,
+      commandConfig,
+      emojiConfig,
+      toEmoji,
+      enableMentions,
+      enableChannels,
+      enableCommands,
+      enableEmoji,
+    ]
   )
 
   // Debounced toolbar visibility — show only when focused with selection, or
@@ -340,7 +372,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           return false
         }
 
-        const handled = insertPastedText(editorRef.current, text, getMentionTypeRef.current, toEmojiRef.current)
+        const handled = insertPastedText(
+          editorRef.current,
+          text,
+          enableMentions ? getMentionTypeRef.current : undefined,
+          enableEmoji ? toEmojiRef.current : undefined,
+          markdownParseOptions
+        )
         if (handled) {
           event.preventDefault()
         }
@@ -476,10 +514,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     // Re-parse if:
     // 1. More mentionables loaded than last time, OR
     // 2. We now have current user info but didn't before
+    const shouldReparseForStructuredTokens = enableMentions || enableChannels || enableCommands || enableEmoji
+
     const shouldReparse =
-      pendingMentionReparse.current ||
-      current.count > lastParsedState.current.count ||
-      (current.hasCurrentUser && !lastParsedState.current.hasCurrentUser)
+      shouldReparseForStructuredTokens &&
+      (pendingMentionReparse.current ||
+        current.count > lastParsedState.current.count ||
+        (current.hasCurrentUser && !lastParsedState.current.hasCurrentUser))
 
     if (shouldReparse) {
       lastParsedState.current = current
@@ -495,11 +536,29 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       const markdown = serializeToMarkdown(editor.getJSON())
       if (markdown) {
         isInternalUpdate.current = true
-        editor.commands.setContent(parseMarkdown(markdown, getMentionType, toEmoji))
+        editor.commands.setContent(
+          parseMarkdown(
+            markdown,
+            enableMentions ? getMentionType : undefined,
+            enableEmoji ? toEmoji : undefined,
+            markdownParseOptions
+          )
+        )
         isInternalUpdate.current = false
       }
     }
-  }, [editor, mentionables, getMentionType, toEmoji, isFocused])
+  }, [
+    editor,
+    mentionables,
+    getMentionType,
+    toEmoji,
+    isFocused,
+    enableMentions,
+    enableChannels,
+    enableCommands,
+    enableEmoji,
+    markdownParseOptions,
+  ])
 
   // TipTap's autofocus option handles initial focus.
   // No additional focus-on-mount effect needed — the redundant focus()
@@ -627,10 +686,10 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       />
       {belowToolbarContent}
       <EditorContent editor={editor} />
-      {renderMentionList()}
-      {renderChannelList()}
-      {renderCommandList()}
-      {renderEmojiGrid()}
+      {enableMentions ? renderMentionList() : null}
+      {enableChannels ? renderChannelList() : null}
+      {enableCommands ? renderCommandList() : null}
+      {enableEmoji ? renderEmojiGrid() : null}
     </div>
   )
 })

--- a/apps/frontend/src/components/settings/ai-settings.test.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.test.tsx
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { forwardRef, useImperativeHandle } from "react"
+import { AISettings } from "./ai-settings"
+import type { JSONContent } from "@threa/types"
+
+const updatePreferenceMock = vi.fn().mockResolvedValue(undefined)
+
+let mockPreferences: { scratchpadCustomPrompt: string | null } = {
+  scratchpadCustomPrompt: "Current instructions",
+}
+
+function extractText(node: JSONContent | undefined): string {
+  if (!node) return ""
+  if (node.type === "text") return node.text ?? ""
+  return (node.content ?? []).map((child) => extractText(child)).join("")
+}
+
+function createDoc(text: string): JSONContent {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
+  }
+}
+
+vi.mock("@/contexts", () => ({
+  usePreferences: () => ({
+    preferences: mockPreferences,
+    updatePreference: updatePreferenceMock,
+    isLoading: false,
+  }),
+}))
+
+vi.mock("@/components/editor", () => {
+  const RichEditor = forwardRef<
+    {
+      focus: () => void
+      insertMention: () => void
+      insertSlash: () => void
+      insertEmoji: () => void
+      getEditor: () => null
+    },
+    {
+      value: JSONContent
+      onChange: (value: JSONContent) => void
+      onSubmit: () => void
+      ariaLabel: string
+    }
+  >(function MockRichEditor({ value, onChange, onSubmit, ariaLabel }, ref) {
+    useImperativeHandle(ref, () => ({
+      focus: () => undefined,
+      insertMention: () => undefined,
+      insertSlash: () => undefined,
+      insertEmoji: () => undefined,
+      getEditor: () => null,
+    }))
+
+    return (
+      <textarea
+        aria-label={ariaLabel}
+        value={extractText(value)}
+        onChange={(event) => onChange(createDoc(event.target.value))}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && event.metaKey) {
+            event.preventDefault()
+            onSubmit()
+          }
+        }}
+      />
+    )
+  })
+
+  const EditorActionBar = ({ onFormatOpenChange, formatOpen, trailingContent }: Record<string, any>) => (
+    <div>
+      <button type="button" onClick={() => onFormatOpenChange(!formatOpen)}>
+        Formatting
+      </button>
+      {trailingContent}
+    </div>
+  )
+
+  return { RichEditor, EditorActionBar }
+})
+
+describe("AISettings", () => {
+  beforeEach(() => {
+    mockPreferences = { scratchpadCustomPrompt: "Current instructions" }
+    updatePreferenceMock.mockClear()
+  })
+
+  it("saves updated scratchpad instructions", async () => {
+    const user = userEvent.setup()
+    render(<AISettings />)
+
+    const editor = screen.getByLabelText("Scratchpad custom prompt editor")
+    await user.clear(editor)
+    await user.type(editor, "Be concise and practical.")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("scratchpadCustomPrompt", "Be concise and practical.")
+  })
+
+  it("clears the saved prompt when saving an empty editor", async () => {
+    const user = userEvent.setup()
+    render(<AISettings />)
+
+    const editor = screen.getByLabelText("Scratchpad custom prompt editor")
+    await user.clear(editor)
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("scratchpadCustomPrompt", null)
+  })
+
+  it("resets unsaved edits back to the saved prompt", async () => {
+    const user = userEvent.setup()
+    render(<AISettings />)
+
+    const editor = screen.getByLabelText("Scratchpad custom prompt editor") as HTMLTextAreaElement
+    await user.clear(editor)
+    await user.type(editor, "Temporary draft")
+    await user.click(screen.getByRole("button", { name: "Reset" }))
+
+    expect(editor.value).toBe("Current instructions")
+  })
+})

--- a/apps/frontend/src/components/settings/ai-settings.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { serializeToMarkdown, parseMarkdown } from "@/components/editor/editor-markdown"
+import { EditorActionBar, RichEditor, type RichEditorHandle } from "@/components/editor"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { usePreferences } from "@/contexts"
+import { useIsMobile } from "@/hooks/use-mobile"
+import type { JSONContent } from "@threa/types"
+
+const MODIFIER_LABEL =
+  typeof navigator !== "undefined" && navigator.platform?.toLowerCase().includes("mac") ? "Cmd" : "Ctrl"
+
+function parsePrompt(markdown: string): JSONContent {
+  return parseMarkdown(markdown, undefined, undefined, {
+    enableMentions: false,
+    enableChannels: false,
+    enableSlashCommands: false,
+    enableEmoji: false,
+  })
+}
+
+export function AISettings() {
+  const { preferences, updatePreference, isLoading } = usePreferences()
+  const isMobile = useIsMobile()
+  const editorRef = useRef<RichEditorHandle>(null)
+  const savedPrompt = preferences?.scratchpadCustomPrompt ?? ""
+  const normalizedSavedPrompt = savedPrompt.trim()
+  const [contentJson, setContentJson] = useState<JSONContent>(() => parsePrompt(savedPrompt))
+  const [formatOpen, setFormatOpen] = useState(false)
+
+  useEffect(() => {
+    setContentJson(parsePrompt(savedPrompt))
+    setFormatOpen(false)
+  }, [savedPrompt])
+
+  const currentMarkdown = useMemo(() => serializeToMarkdown(contentJson).trim(), [contentJson])
+  const isDirty = currentMarkdown !== normalizedSavedPrompt
+
+  const handleSave = async () => {
+    if (!isDirty || isLoading) {
+      return
+    }
+
+    await updatePreference("scratchpadCustomPrompt", currentMarkdown.length > 0 ? currentMarkdown : null)
+  }
+
+  const handleReset = () => {
+    setContentJson(parsePrompt(savedPrompt))
+    setFormatOpen(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Scratchpad Instructions</CardTitle>
+          <CardDescription>
+            Add standing guidance that Ariadne should follow in your personal scratchpads. This is injected after the
+            base system prompt for scratchpads and scratchpad-root threads only.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="input-glow-wrapper">
+            <div
+              className="rounded-[16px] border border-input bg-card p-3"
+              onClick={(event) => {
+                if (
+                  (event.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']")
+                ) {
+                  return
+                }
+                editorRef.current?.focus()
+              }}
+            >
+              <RichEditor
+                ref={editorRef}
+                value={contentJson}
+                onChange={setContentJson}
+                onSubmit={handleSave}
+                placeholder="Tell Ariadne how to think and help in your scratchpads..."
+                messageSendMode="cmdEnter"
+                staticToolbarOpen={formatOpen}
+                disableSelectionToolbar={isMobile}
+                ariaLabel="Scratchpad custom prompt editor"
+                className="min-h-0 [&_.tiptap]:min-h-[180px] [&_.tiptap]:max-h-[320px]"
+                enableMentions={false}
+                enableChannels={false}
+                enableCommands={false}
+                enableEmoji={false}
+              />
+
+              <div className="mt-2 border-t pt-2" onMouseDown={(event) => event.preventDefault()}>
+                <EditorActionBar
+                  editorHandle={editorRef.current}
+                  disabled={isLoading}
+                  formatOpen={formatOpen}
+                  onFormatOpenChange={setFormatOpen}
+                  showAttach={false}
+                  showMention={false}
+                  showEmoji={false}
+                  trailingContent={
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleReset}
+                        disabled={!isDirty || isLoading}
+                      >
+                        Reset
+                      </Button>
+                      <Button type="button" size="sm" onClick={handleSave} disabled={!isDirty || isLoading}>
+                        Save
+                      </Button>
+                    </div>
+                  }
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+            <span>Delete everything and save to remove the custom prompt.</span>
+            <span>{MODIFIER_LABEL}+Enter to save</span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/settings/index.ts
+++ b/apps/frontend/src/components/settings/index.ts
@@ -1,4 +1,5 @@
 export { SettingsDialog } from "./settings-dialog"
+export { AISettings } from "./ai-settings"
 export { AppearanceSettings } from "./appearance-settings"
 export { DateTimeSettings } from "./datetime-settings"
 export { NotificationsSettings } from "./notifications-settings"

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -9,6 +9,7 @@ import { ResponsiveTabs } from "@/components/ui/responsive-tabs"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { useSettings } from "@/contexts"
 import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
+import { AISettings } from "./ai-settings"
 import { ProfileSettings } from "./profile-settings"
 import { AppearanceSettings } from "./appearance-settings"
 import { DateTimeSettings } from "./datetime-settings"
@@ -16,13 +17,14 @@ import { NotificationsSettings } from "./notifications-settings"
 import { KeyboardSettings } from "./keyboard-settings"
 import { AccessibilitySettings } from "./accessibility-settings"
 
-const TAB_LABELS: Record<SettingsTab, string> = {
-  profile: "Profile",
-  appearance: "Appearance",
-  datetime: "Date & Time",
-  notifications: "Notifications",
-  keyboard: "Keyboard",
-  accessibility: "Accessibility",
+const TAB_CONFIG: Record<SettingsTab, { label: string; description: string }> = {
+  profile: { label: "Profile", description: "Identity and account details" },
+  ai: { label: "AI", description: "Scratchpad behavior and guidance" },
+  appearance: { label: "Appearance", description: "Theme and message density" },
+  datetime: { label: "Date & Time", description: "Timezone and formatting" },
+  notifications: { label: "Notifications", description: "Alerts and push behavior" },
+  keyboard: { label: "Keyboard", description: "Shortcuts and send behavior" },
+  accessibility: { label: "Accessibility", description: "Motion, contrast, and fonts" },
 }
 
 export function SettingsDialog() {
@@ -39,45 +41,76 @@ export function SettingsDialog() {
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && closeSettings()}>
       <ResponsiveDialogContent
-        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col overflow-hidden"
-        drawerClassName="flex flex-col"
+        desktopClassName="w-[min(96vw,980px)] max-w-none h-[min(720px,calc(100vh-2rem))] sm:flex flex-col overflow-hidden p-0 gap-0"
+        drawerClassName="flex flex-col gap-0"
         hideCloseButton
       >
-        <ResponsiveDialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6">
+        <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
 
         <Tabs
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as SettingsTab)}
-          className="flex-1 flex flex-col min-h-0 px-4 sm:px-6"
+          className="flex-1 min-h-0"
         >
-          <ResponsiveTabs
-            tabs={SETTINGS_TABS}
-            labels={TAB_LABELS}
-            value={activeTab}
-            onValueChange={(value) => setActiveTab(value as SettingsTab)}
-          />
+          <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+            <ResponsiveTabs
+              tabs={SETTINGS_TABS}
+              labels={
+                Object.fromEntries(SETTINGS_TABS.map((tab) => [tab, TAB_CONFIG[tab].label])) as Record<
+                  SettingsTab,
+                  string
+                >
+              }
+              value={activeTab}
+              onValueChange={(value) => setActiveTab(value as SettingsTab)}
+            >
+              <div className="hidden sm:flex h-full flex-col border-r bg-muted/20 p-3">
+                {SETTINGS_TABS.map((tab) => {
+                  const isActive = tab === activeTab
+                  return (
+                    <button
+                      key={tab}
+                      type="button"
+                      onClick={() => setActiveTab(tab)}
+                      className={`rounded-xl px-3 py-2.5 text-left transition-colors ${
+                        isActive
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:bg-background/70"
+                      }`}
+                    >
+                      <div className="text-sm font-medium">{TAB_CONFIG[tab].label}</div>
+                      <div className="mt-0.5 text-xs">{TAB_CONFIG[tab].description}</div>
+                    </button>
+                  )
+                })}
+              </div>
+            </ResponsiveTabs>
 
-          <div className="flex-1 overflow-y-auto mt-4 pb-4 sm:pb-6">
-            <TabsContent value="profile" className="mt-0">
-              <ProfileSettings />
-            </TabsContent>
-            <TabsContent value="appearance" className="mt-0">
-              <AppearanceSettings />
-            </TabsContent>
-            <TabsContent value="datetime" className="mt-0">
-              <DateTimeSettings />
-            </TabsContent>
-            <TabsContent value="notifications" className="mt-0">
-              <NotificationsSettings />
-            </TabsContent>
-            <TabsContent value="keyboard" className="mt-0">
-              <KeyboardSettings />
-            </TabsContent>
-            <TabsContent value="accessibility" className="mt-0">
-              <AccessibilitySettings />
-            </TabsContent>
+            <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6">
+              <TabsContent value="profile" className="mt-0">
+                <ProfileSettings />
+              </TabsContent>
+              <TabsContent value="ai" className="mt-0">
+                <AISettings />
+              </TabsContent>
+              <TabsContent value="appearance" className="mt-0">
+                <AppearanceSettings />
+              </TabsContent>
+              <TabsContent value="datetime" className="mt-0">
+                <DateTimeSettings />
+              </TabsContent>
+              <TabsContent value="notifications" className="mt-0">
+                <NotificationsSettings />
+              </TabsContent>
+              <TabsContent value="keyboard" className="mt-0">
+                <KeyboardSettings />
+              </TabsContent>
+              <TabsContent value="accessibility" className="mt-0">
+                <AccessibilitySettings />
+              </TabsContent>
+            </div>
           </div>
         </Tabs>
       </ResponsiveDialogContent>

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -74,6 +74,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       notificationLevel: "all",
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
+      scratchpadCustomPrompt: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -75,6 +75,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       notificationLevel: "all",
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
+      scratchpadCustomPrompt: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -92,6 +92,7 @@ export const MessageSendModes = {
 // Settings tab options (for URL-driven settings dialog)
 export const SETTINGS_TAB_OPTIONS = [
   "profile",
+  "ai",
   "appearance",
   "datetime",
   "notifications",
@@ -151,6 +152,7 @@ export interface UserPreferences {
   sidebarCollapsed: boolean
   messageSendMode: MessageSendMode
   linkPreviewDefault: LinkPreviewDefault
+  scratchpadCustomPrompt: string | null
   keyboardShortcuts: KeyboardShortcuts
   accessibility: AccessibilityPreferences
   createdAt: string
@@ -171,6 +173,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   sidebarCollapsed: false,
   messageSendMode: "enter",
   linkPreviewDefault: "open",
+  scratchpadCustomPrompt: null,
   keyboardShortcuts: {},
   accessibility: DEFAULT_ACCESSIBILITY,
 }
@@ -193,6 +196,7 @@ export interface UpdateUserPreferencesInput {
   sidebarCollapsed?: boolean
   messageSendMode?: MessageSendMode
   linkPreviewDefault?: LinkPreviewDefault
+  scratchpadCustomPrompt?: string | null
   keyboardShortcuts?: KeyboardShortcuts
   accessibility?: Partial<AccessibilityPreferences>
 }


### PR DESCRIPTION
## Problem

Ariadne currently behaves almost the same regardless of where she is invoked. That is acceptable in shared contexts, but scratchpads are the personal entry point for the product and need a stronger way for users to shape the assistant's behavior. The settings dialog was also running out of room with the current pill-based tab row, and a plain textarea for AI instructions would have been inconsistent with the rest of the writing experience.

## Solution

Added a scratchpad-only `scratchpadCustomPrompt` preference and applied it to Ariadne's system prompt for scratchpads and scratchpad-root threads. The setting is exposed in a new `AI` settings tab that uses the shared rich message editor surface, with chat-specific token parsing disabled so it behaves like an instruction field. The desktop settings dialog was redesigned to use a sidebar, larger fixed-height shell, and internal scrolling.

### How it works

1. `scratchpadCustomPrompt` is stored through the existing sparse user-preferences override flow.
2. Companion context resolves the saved prompt only when the active stream is a scratchpad or a thread rooted in a scratchpad.
3. The prompt builder injects a `Scratchpad Custom Instructions` section immediately after Ariadne's base system prompt.
4. The new `AI` settings tab renders a `RichEditor` with mentions, channels, slash commands, and emoji parsing disabled, plus explicit `Save` and `Reset` actions.
5. The desktop settings shell now uses a left sidebar instead of a growing pill row; mobile keeps the responsive select-based navigation.

### Key design decisions

**1. Limit the feature to scratchpads for now**

This keeps personal guidance out of shared contexts until the shared-context model is defined more clearly.

**2. Inject immediately after the base system prompt**

That preserves Ariadne's persona as the highest local instruction layer while still giving the user durable influence over scratchpad behavior.

**3. Reuse the shared rich editor instead of introducing a textarea**

The goal was to keep writing interactions consistent across the app. Reusing the editor also avoids inventing a second formatting/input model for one settings field.

**4. Add reusable editor feature flags rather than forking the composer**

The AI settings field needs the same editing surface without chat semantics. Gating structured token parsing and suggestion UIs keeps the implementation local and reusable.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/user-assistant-options.md` | Branch plan describing the shipped behavior and design decisions. |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts` | Covers scratchpad custom prompt injection behavior. |
| `apps/frontend/src/components/settings/ai-settings.tsx` | Adds the new AI settings panel and scratchpad instructions editor. |
| `apps/frontend/src/components/settings/ai-settings.test.tsx` | Covers save, clear, and reset behavior for the AI settings editor. |

## Modified files

| File | Change |
| --- | --- |
| `packages/types/src/preferences.ts` | Added the `ai` settings tab and `scratchpadCustomPrompt` preference typing/defaults. |
| `apps/backend/src/features/agents/companion/context.ts` | Scoped custom prompt resolution to scratchpads and scratchpad-root threads. |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` | Injects the custom instructions block into the final system prompt. |
| `apps/backend/src/features/user-preferences/handlers.ts` | Accepts validated scratchpad prompt updates. |
| `apps/backend/src/features/user-preferences/service.ts` | Persists the new preference through sparse overrides. |
| `apps/backend/tests/integration/user-preferences.test.ts` | Verifies sparse storage for the new preference. |
| `apps/frontend/src/components/settings/settings-dialog.tsx` | Reworked desktop settings layout to use a sidebar and fixed-height shell. |
| `apps/frontend/src/components/settings/index.ts` | Exports the new AI settings section. |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Added feature flags to disable chat-specific parsing/suggestions when reusing the editor. |
| `apps/frontend/src/components/editor/editor-markdown.ts` | Added parser controls for mentions, channels, slash commands, and emoji. |
| `apps/frontend/src/components/editor/multiline-blocks.ts` | Threads parser options through paste handling. |
| `apps/frontend/src/components/editor/editor-action-bar.tsx` | Allows callers to hide mention and emoji actions. |
| `apps/frontend/src/components/editor/editor-markdown.test.ts` | Verifies plain-text behavior when structured token parsing is disabled. |
| `apps/frontend/src/hooks/use-streams.test.tsx` | Updates preference fixtures for the new field. |
| `apps/frontend/src/hooks/use-unread-counts.test.tsx` | Updates preference fixtures for the new field. |

## Test plan

- [x] `bunx vitest run src/components/settings/ai-settings.test.tsx src/components/editor/editor-markdown.test.ts`
- [x] `bun test src/features/agents/companion/prompt/system-prompt.test.ts tests/integration/user-preferences.test.ts`
- [x] `bun run typecheck` in `apps/frontend`
- [x] `bun run typecheck` in `apps/backend`
- [x] `bun run test:e2e`
- [x] `bun run test` (unit/integration plus e2e wrapper; first pass hit a flaky timeout in `tests/e2e/activity.test.ts`, replay passed and a direct `bun run test:e2e` rerun passed)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
