### PR TITLE
feat: align settings dialogs with sidebar layout

### DIFF
--- a/.claude/plans/improve-workspace-settings.md
+++ b/.claude/plans/improve-workspace-settings.md
@@ -1,0 +1,88 @@
+# Settings Sidebar Consistency
+
+## Goal
+
+Extend the newer desktop sidebar settings layout beyond user settings so the other settings dialogs in the app use the same navigation pattern. The change keeps the existing mobile selector behavior and focuses on layout consistency rather than changing the underlying settings content.
+
+## What Was Built
+
+### Shared responsive settings navigation
+
+Extracted the desktop sidebar navigation treatment into a small shared component that reuses the existing mobile `ResponsiveTabs` selector while rendering descriptive sidebar buttons on desktop.
+
+**Files:**
+- `apps/frontend/src/components/ui/responsive-settings-nav.tsx` - Shared responsive settings nav with desktop sidebar buttons and mobile tab selector reuse.
+
+### User settings aligned to the shared shell
+
+The existing user settings sidebar implementation now uses the shared navigation component instead of carrying an inline copy of the same desktop sidebar markup. The dialog also now includes an accessible description to satisfy the Radix dialog contract.
+
+**Files:**
+- `apps/frontend/src/components/settings/settings-dialog.tsx` - Swaps the inline sidebar nav for `ResponsiveSettingsNav` and adds a hidden dialog description.
+
+### Workspace settings sidebar conversion
+
+The workspace settings dialog now uses the same larger fixed-height desktop shell and left-hand sidebar navigation pattern as user settings. Tab metadata now includes short descriptions so the desktop nav communicates each section clearly.
+
+**Files:**
+- `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx` - Converts the old top-row tab layout to the sidebar shell and adds sidebar tab descriptions.
+
+### Stream settings sidebar conversion
+
+The stream settings dialog now uses the same shared desktop shell and responsive navigation pattern, while preserving its stream-type-specific tab filtering. DMs still only expose the members section; channels and scratchpads still expose the full tab set.
+
+**Files:**
+- `apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx` - Converts the dialog shell to the sidebar layout and keeps stream-type-aware tab availability intact.
+
+### Regression coverage
+
+Added targeted tests for the two converted dialogs so the URL-driven workspace tab state and stream-type-specific tab filtering remain protected after the layout change.
+
+**Files:**
+- `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx` - Verifies sidebar navigation updates the `ws-settings` query param and renders the correct pane.
+- `apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx` - Verifies only the allowed sidebar items render for DM streams.
+
+## Design Decisions
+
+### Extract only the shared navigation, not a full dialog framework
+
+**Chose:** Create a small `ResponsiveSettingsNav` helper and keep the dialog shells local to each settings dialog.
+**Why:** The layouts are now visually aligned, but their state sources differ (`useSettings`, `useSearchParams`, and `useStreamSettings`). Extracting only the navigation keeps the patch small and avoids forcing a broader abstraction.
+**Alternatives considered:** Building a larger generic settings dialog shell. Rejected because it would introduce more structural churn than this branch needs.
+
+### Keep mobile behavior unchanged
+
+**Chose:** Reuse `ResponsiveTabs` so mobile continues to use the existing select-based navigation.
+**Why:** The request was specifically about matching the newer sidebar pattern, which only applies on desktop. The mobile interaction already fit the dialogs.
+**Alternatives considered:** Redesigning mobile settings navigation too. Rejected as out of scope.
+
+### Widen converted dialogs to match user settings
+
+**Chose:** Give workspace and stream settings the same wider fixed-height desktop shell used by user settings.
+**Why:** The sidebar layout needs more horizontal space than the older compact topbar shell, and keeping the shell sizes aligned makes the settings surfaces feel consistent.
+**Alternatives considered:** Keeping the old narrow dialog width and only swapping the navigator. Rejected because it would make the content pane cramped next to the sidebar.
+
+## Design Evolution
+
+- **One-off sidebar conversion to shared nav extraction:** The direct ask was to make the remaining settings menus match the newer user settings layout. The final patch extracted the sidebar navigation instead of copying the same markup into multiple dialogs.
+- **Layout-only change to accessibility cleanup too:** The initial implementation surfaced Radix dialog warnings in tests. The final version adds hidden dialog descriptions while touching the shells so the dialogs remain accessible.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- Any changes to the actual settings fields within user, workspace, or stream settings panes.
+- Any new settings tabs or changes to tab availability rules beyond preserving existing behavior.
+- A broader reusable settings-shell abstraction beyond the shared responsive navigation component.
+- Mobile-specific design changes beyond continuing to reuse the existing responsive selector pattern.
+
+## Status
+
+- [x] Extract shared responsive settings sidebar navigation.
+- [x] Move user settings to the shared nav component.
+- [x] Convert workspace settings to the sidebar shell.
+- [x] Convert stream settings to the sidebar shell.
+- [x] Add focused regression tests for converted dialogs.
+- [x] Run targeted frontend tests and frontend typecheck.

--- a/apps/frontend/src/components/settings/settings-dialog.test.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { SettingsDialog } from "./settings-dialog"
+
+const mocks = vi.hoisted(() => ({
+  useSettings: vi.fn(),
+}))
+
+vi.mock("@/contexts", () => ({
+  useSettings: () => mocks.useSettings(),
+}))
+
+vi.mock("./profile-settings", () => ({
+  ProfileSettings: () => <div>Profile panel</div>,
+}))
+
+vi.mock("./ai-settings", () => ({
+  AISettings: () => <div>AI panel</div>,
+}))
+
+vi.mock("./appearance-settings", () => ({
+  AppearanceSettings: () => <div>Appearance panel</div>,
+}))
+
+vi.mock("./datetime-settings", () => ({
+  DateTimeSettings: () => <div>Date & Time panel</div>,
+}))
+
+vi.mock("./notifications-settings", () => ({
+  NotificationsSettings: () => <div>Notifications panel</div>,
+}))
+
+vi.mock("./keyboard-settings", () => ({
+  KeyboardSettings: () => <div>Keyboard panel</div>,
+}))
+
+vi.mock("./accessibility-settings", () => ({
+  AccessibilitySettings: () => <div>Accessibility panel</div>,
+}))
+
+describe("SettingsDialog", () => {
+  it("keeps the navigation and active panel in scrollable regions", async () => {
+    mocks.useSettings.mockReturnValue({
+      isOpen: true,
+      activeTab: "profile",
+      closeSettings: vi.fn(),
+      setActiveTab: vi.fn(),
+    })
+
+    render(<SettingsDialog />)
+
+    expect(await screen.findByText("Identity and account details")).toBeInTheDocument()
+    expect(screen.getByText("Profile panel")).toBeVisible()
+
+    const tabs = document.body.querySelector('[data-slot="settings-tabs"]')
+    const panels = document.body.querySelector('[data-slot="settings-panels"]')
+    const nav = document.body.querySelector('[data-slot="settings-nav"]')
+    const content = document.body.querySelector('[data-slot="settings-content"]')
+
+    expect(tabs).toHaveClass("flex", "flex-1", "min-h-0", "flex-col")
+    expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
+    expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
+    expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
+  })
+})

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from "react"
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
+  ResponsiveDialogDescription,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveTabs } from "@/components/ui/responsive-tabs"
+import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { useSettings } from "@/contexts"
 import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
@@ -47,6 +48,9 @@ export function SettingsDialog() {
       >
         <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            Manage your profile, AI preferences, notifications, and accessibility settings.
+          </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
         <Tabs
@@ -55,38 +59,12 @@ export function SettingsDialog() {
           className="flex-1 min-h-0"
         >
           <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
-            <ResponsiveTabs
+            <ResponsiveSettingsNav
               tabs={SETTINGS_TABS}
-              labels={
-                Object.fromEntries(SETTINGS_TABS.map((tab) => [tab, TAB_CONFIG[tab].label])) as Record<
-                  SettingsTab,
-                  string
-                >
-              }
+              items={TAB_CONFIG}
               value={activeTab}
               onValueChange={(value) => setActiveTab(value as SettingsTab)}
-            >
-              <div className="hidden sm:flex h-full flex-col border-r bg-muted/20 p-3">
-                {SETTINGS_TABS.map((tab) => {
-                  const isActive = tab === activeTab
-                  return (
-                    <button
-                      key={tab}
-                      type="button"
-                      onClick={() => setActiveTab(tab)}
-                      className={`rounded-xl px-3 py-2.5 text-left transition-colors ${
-                        isActive
-                          ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:bg-background/70"
-                      }`}
-                    >
-                      <div className="text-sm font-medium">{TAB_CONFIG[tab].label}</div>
-                      <div className="mt-0.5 text-xs">{TAB_CONFIG[tab].description}</div>
-                    </button>
-                  )
-                })}
-              </div>
-            </ResponsiveTabs>
+            />
 
             <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6">
               <TabsContent value="profile" className="mt-0">

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -6,7 +6,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
+import { ResponsiveSettingsNav, SETTINGS_DIALOG_LAYOUT_CLASSNAMES } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { useSettings } from "@/contexts"
 import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
@@ -54,11 +54,12 @@ export function SettingsDialog() {
         </ResponsiveDialogHeader>
 
         <Tabs
+          data-slot="settings-tabs"
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as SettingsTab)}
-          className="flex-1 min-h-0"
+          className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.tabs}
         >
-          <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+          <div data-slot="settings-panels" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.panels}>
             <ResponsiveSettingsNav
               tabs={SETTINGS_TABS}
               items={TAB_CONFIG}
@@ -66,7 +67,7 @@ export function SettingsDialog() {
               onValueChange={(value) => setActiveTab(value as SettingsTab)}
             />
 
-            <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6">
+            <div data-slot="settings-content" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.content}>
               <TabsContent value="profile" className="mt-0">
                 <ProfileSettings />
               </TabsContent>

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -1,23 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
-import { StreamTypes } from "@threa/types"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes, type Stream, type StreamBootstrap } from "@threa/types"
+import { streamKeys } from "@/hooks"
 import { StreamSettingsDialog } from "./stream-settings-dialog"
 
 const mocks = vi.hoisted(() => ({
-  useQuery: vi.fn(),
-  queryClient: {
-    getQueryData: vi.fn(),
-  },
   useStreamSettings: vi.fn(),
   useWorkspaceStreams: vi.fn(),
   useWorkspaceStreamMemberships: vi.fn(),
   closeStreamSettings: vi.fn(),
   setTab: vi.fn(),
-}))
-
-vi.mock("@tanstack/react-query", () => ({
-  useQuery: (...args: unknown[]) => mocks.useQuery(...args),
-  useQueryClient: () => mocks.queryClient,
 }))
 
 vi.mock("./use-stream-settings", () => ({
@@ -42,11 +35,39 @@ vi.mock("./members-tab", () => ({
   MembersTab: () => <div>Members panel</div>,
 }))
 
+function makeStream(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_dm",
+    workspaceId: "ws_1",
+    type: StreamTypes.DM,
+    displayName: "Direct chat",
+    slug: null,
+    description: null,
+    visibility: "private",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: "2026-04-07T00:00:00.000Z",
+    updatedAt: "2026-04-07T00:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
 describe("StreamSettingsDialog", () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
     vi.clearAllMocks()
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
 
-    mocks.useQuery.mockReturnValue({ data: null })
     mocks.useStreamSettings.mockReturnValue({
       isOpen: true,
       activeTab: "general",
@@ -54,13 +75,20 @@ describe("StreamSettingsDialog", () => {
       closeStreamSettings: mocks.closeStreamSettings,
       setTab: mocks.setTab,
     })
-    mocks.useWorkspaceStreams.mockReturnValue([
-      {
-        id: "stream_dm",
-        type: StreamTypes.DM,
-        displayName: "Direct chat",
-      },
-    ])
+
+    const stream = makeStream()
+    const bootstrap: StreamBootstrap = {
+      stream,
+      events: [],
+      members: [],
+      membership: null,
+      latestSequence: "0",
+      hasOlderEvents: false,
+    }
+
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_dm"), bootstrap)
+
+    mocks.useWorkspaceStreams.mockReturnValue([])
     mocks.useWorkspaceStreamMemberships.mockReturnValue([
       {
         streamId: "stream_dm",
@@ -71,7 +99,11 @@ describe("StreamSettingsDialog", () => {
   })
 
   it("shows only the available sidebar items for the resolved stream type", async () => {
-    render(<StreamSettingsDialog workspaceId="ws_1" />)
+    render(
+      <QueryClientProvider client={queryClient}>
+        <StreamSettingsDialog workspaceId="ws_1" />
+      </QueryClientProvider>
+    )
 
     expect(await screen.findByText("Direct chat Settings")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Members/i })).toBeInTheDocument()

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { StreamTypes } from "@threa/types"
+import { StreamSettingsDialog } from "./stream-settings-dialog"
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  queryClient: {
+    getQueryData: vi.fn(),
+  },
+  useStreamSettings: vi.fn(),
+  useWorkspaceStreams: vi.fn(),
+  useWorkspaceStreamMemberships: vi.fn(),
+  closeStreamSettings: vi.fn(),
+  setTab: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (...args: unknown[]) => mocks.useQuery(...args),
+  useQueryClient: () => mocks.queryClient,
+}))
+
+vi.mock("./use-stream-settings", () => ({
+  STREAM_SETTINGS_TABS: ["general", "companion", "members"],
+  useStreamSettings: () => mocks.useStreamSettings(),
+}))
+
+vi.mock("@/stores/workspace-store", () => ({
+  useWorkspaceStreams: (...args: unknown[]) => mocks.useWorkspaceStreams(...args),
+  useWorkspaceStreamMemberships: (...args: unknown[]) => mocks.useWorkspaceStreamMemberships(...args),
+}))
+
+vi.mock("./general-tab", () => ({
+  GeneralTab: () => <div>General panel</div>,
+}))
+
+vi.mock("./companion-tab", () => ({
+  CompanionTab: () => <div>Companion panel</div>,
+}))
+
+vi.mock("./members-tab", () => ({
+  MembersTab: () => <div>Members panel</div>,
+}))
+
+describe("StreamSettingsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useQuery.mockReturnValue({ data: null })
+    mocks.useStreamSettings.mockReturnValue({
+      isOpen: true,
+      activeTab: "general",
+      streamId: "stream_dm",
+      closeStreamSettings: mocks.closeStreamSettings,
+      setTab: mocks.setTab,
+    })
+    mocks.useWorkspaceStreams.mockReturnValue([
+      {
+        id: "stream_dm",
+        type: StreamTypes.DM,
+        displayName: "Direct chat",
+      },
+    ])
+    mocks.useWorkspaceStreamMemberships.mockReturnValue([
+      {
+        streamId: "stream_dm",
+        memberId: "user_1",
+        notificationLevel: "activity",
+      },
+    ])
+  })
+
+  it("shows only the available sidebar items for the resolved stream type", async () => {
+    render(<StreamSettingsDialog workspaceId="ws_1" />)
+
+    expect(await screen.findByText("Direct chat Settings")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Members/i })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /General/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Companion/i })).not.toBeInTheDocument()
+    expect(screen.getByText("People and bot access")).toBeInTheDocument()
+    expect(screen.getByText("Members panel")).toBeVisible()
+  })
+})

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -111,5 +111,15 @@ describe("StreamSettingsDialog", () => {
     expect(screen.queryByRole("button", { name: /Companion/i })).not.toBeInTheDocument()
     expect(screen.getByText("People and bot access")).toBeInTheDocument()
     expect(screen.getByText("Members panel")).toBeVisible()
+
+    const tabs = document.body.querySelector('[data-slot="settings-tabs"]')
+    const panels = document.body.querySelector('[data-slot="settings-panels"]')
+    const nav = document.body.querySelector('[data-slot="settings-nav"]')
+    const content = document.body.querySelector('[data-slot="settings-content"]')
+
+    expect(tabs).toHaveClass("flex", "flex-1", "min-h-0", "flex-col")
+    expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
+    expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
+    expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
   })
 })

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -7,7 +7,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
+import { ResponsiveSettingsNav, SETTINGS_DIALOG_LAYOUT_CLASSNAMES } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { useStreamSettings, STREAM_SETTINGS_TABS, type StreamSettingsTab } from "./use-stream-settings"
 import { GeneralTab } from "./general-tab"
@@ -93,8 +93,13 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
         </ResponsiveDialogHeader>
 
         {resolvedStream && streamId && currentUserId ? (
-          <Tabs value={effectiveTab} onValueChange={setTab} className="flex-1 min-h-0">
-            <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+          <Tabs
+            data-slot="settings-tabs"
+            value={effectiveTab}
+            onValueChange={setTab}
+            className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.tabs}
+          >
+            <div data-slot="settings-panels" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.panels}>
               <ResponsiveSettingsNav
                 tabs={availableTabs}
                 items={TAB_CONFIG}
@@ -102,7 +107,7 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
                 onValueChange={setTab}
               />
 
-              <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6 scrollbar-thin">
+              <div data-slot="settings-content" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.content}>
                 <TabsContent value="general" className="mt-0">
                   <GeneralTab
                     workspaceId={workspaceId}

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -3,10 +3,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
+  ResponsiveDialogDescription,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveTabs } from "@/components/ui/responsive-tabs"
+import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { useStreamSettings, STREAM_SETTINGS_TABS, type StreamSettingsTab } from "./use-stream-settings"
 import { GeneralTab } from "./general-tab"
@@ -16,10 +17,10 @@ import { streamKeys } from "@/hooks"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
 import { StreamTypes, type Stream, type StreamBootstrap, type NotificationLevel } from "@threa/types"
 
-const TAB_LABELS: Record<StreamSettingsTab, string> = {
-  general: "General",
-  companion: "Companion",
-  members: "Members",
+const TAB_CONFIG: Record<StreamSettingsTab, { label: string; description: string }> = {
+  general: { label: "General", description: "Notifications and stream details" },
+  companion: { label: "Companion", description: "AI instructions and behavior" },
+  members: { label: "Members", description: "People and bot access" },
 }
 
 interface StreamSettingsDialogProps {
@@ -80,39 +81,43 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && closeStreamSettings()}>
       <ResponsiveDialogContent
-        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col overflow-hidden"
-        drawerClassName="flex flex-col"
+        desktopClassName="w-[min(96vw,980px)] max-w-none h-[min(720px,calc(100vh-2rem))] sm:flex flex-col overflow-hidden p-0 gap-0"
+        drawerClassName="flex flex-col gap-0"
         hideCloseButton
       >
-        <ResponsiveDialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6">
+        <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>{streamName} Settings</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            Manage notifications, members, and companion settings for this stream.
+          </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
         {resolvedStream && streamId && currentUserId ? (
-          <Tabs value={effectiveTab} onValueChange={setTab} className="flex-1 flex flex-col min-h-0 px-4 sm:px-6">
-            <ResponsiveTabs
-              tabs={availableTabs}
-              labels={TAB_LABELS}
-              value={effectiveTab}
-              onValueChange={setTab}
-              columns={availableTabs.length}
-            />
+          <Tabs value={effectiveTab} onValueChange={setTab} className="flex-1 min-h-0">
+            <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+              <ResponsiveSettingsNav
+                tabs={availableTabs}
+                items={TAB_CONFIG}
+                value={effectiveTab}
+                onValueChange={setTab}
+              />
 
-            <div className="flex-1 overflow-y-auto mt-4 pr-2 pb-4 sm:pb-6 scrollbar-thin">
-              <TabsContent value="general" className="mt-0">
-                <GeneralTab
-                  workspaceId={workspaceId}
-                  stream={resolvedStream}
-                  currentUserId={currentUserId}
-                  notificationLevel={currentNotificationLevel}
-                />
-              </TabsContent>
-              <TabsContent value="companion" className="mt-0">
-                <CompanionTab stream={resolvedStream} />
-              </TabsContent>
-              <TabsContent value="members" className="mt-0">
-                <MembersTab workspaceId={workspaceId} streamId={streamId} currentUserId={currentUserId} />
-              </TabsContent>
+              <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6 scrollbar-thin">
+                <TabsContent value="general" className="mt-0">
+                  <GeneralTab
+                    workspaceId={workspaceId}
+                    stream={resolvedStream}
+                    currentUserId={currentUserId}
+                    notificationLevel={currentNotificationLevel}
+                  />
+                </TabsContent>
+                <TabsContent value="companion" className="mt-0">
+                  <CompanionTab stream={resolvedStream} />
+                </TabsContent>
+                <TabsContent value="members" className="mt-0">
+                  <MembersTab workspaceId={workspaceId} streamId={streamId} currentUserId={currentUserId} />
+                </TabsContent>
+              </div>
             </div>
           </Tabs>
         ) : (

--- a/apps/frontend/src/components/ui/responsive-settings-nav.tsx
+++ b/apps/frontend/src/components/ui/responsive-settings-nav.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils"
+import { ResponsiveTabs } from "./responsive-tabs"
+
+interface SettingsNavItem {
+  label: string
+  description?: string
+}
+
+interface ResponsiveSettingsNavProps<T extends string> {
+  tabs: readonly T[]
+  items: Record<T, SettingsNavItem>
+  value: T
+  onValueChange: (value: T) => void
+}
+
+export function ResponsiveSettingsNav<T extends string>({
+  tabs,
+  items,
+  value,
+  onValueChange,
+}: ResponsiveSettingsNavProps<T>) {
+  const labels = Object.fromEntries(tabs.map((tab) => [tab, items[tab].label])) as Record<T, string>
+
+  return (
+    <ResponsiveTabs tabs={tabs} labels={labels} value={value} onValueChange={onValueChange}>
+      <div className="hidden sm:flex h-full flex-col border-r bg-muted/20 p-3">
+        {tabs.map((tab) => {
+          const item = items[tab]
+          const isActive = tab === value
+
+          return (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => onValueChange(tab)}
+              className={cn(
+                "rounded-xl px-3 py-2.5 text-left transition-colors",
+                isActive ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:bg-background/70"
+              )}
+            >
+              <div className="text-sm font-medium">{item.label}</div>
+              {item.description ? <div className="mt-0.5 text-xs">{item.description}</div> : null}
+            </button>
+          )
+        })}
+      </div>
+    </ResponsiveTabs>
+  )
+}

--- a/apps/frontend/src/components/ui/responsive-settings-nav.tsx
+++ b/apps/frontend/src/components/ui/responsive-settings-nav.tsx
@@ -13,6 +13,12 @@ interface ResponsiveSettingsNavProps<T extends string> {
   onValueChange: (value: T) => void
 }
 
+export const SETTINGS_DIALOG_LAYOUT_CLASSNAMES = {
+  tabs: "flex min-h-0 flex-1 flex-col",
+  panels: "flex min-h-0 flex-1 flex-col overflow-hidden sm:grid sm:grid-cols-[220px,minmax(0,1fr)]",
+  content: "flex-1 min-h-0 overflow-y-auto px-4 pb-4 pt-4 scrollbar-thin sm:px-6 sm:py-6",
+} as const
+
 export function ResponsiveSettingsNav<T extends string>({
   tabs,
   items,
@@ -23,7 +29,10 @@ export function ResponsiveSettingsNav<T extends string>({
 
   return (
     <ResponsiveTabs tabs={tabs} labels={labels} value={value} onValueChange={onValueChange}>
-      <div className="hidden sm:flex h-full flex-col border-r bg-muted/20 p-3">
+      <div
+        data-slot="settings-nav"
+        className="hidden h-full min-h-0 flex-col overflow-y-auto border-r bg-muted/20 p-3 scrollbar-thin sm:flex"
+      >
         {tabs.map((tab) => {
           const item = items[tab]
           const isActive = tab === value

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
@@ -49,6 +49,16 @@ describe("WorkspaceSettingsDialog", () => {
     expect(await screen.findByText("Workspace identity and region")).toBeInTheDocument()
     expect(screen.getByText("General panel")).toBeVisible()
 
+    const tabs = document.body.querySelector('[data-slot="settings-tabs"]')
+    const panels = document.body.querySelector('[data-slot="settings-panels"]')
+    const nav = document.body.querySelector('[data-slot="settings-nav"]')
+    const content = document.body.querySelector('[data-slot="settings-content"]')
+
+    expect(tabs).toHaveClass("flex", "flex-1", "min-h-0", "flex-col")
+    expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
+    expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
+    expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
+
     await user.click(screen.getByRole("button", { name: /Bots/i }))
 
     await waitFor(() => {

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { WorkspaceSettingsDialog } from "./workspace-settings-dialog"
+
+vi.mock("./general-tab", () => ({
+  GeneralTab: () => <div>General panel</div>,
+}))
+
+vi.mock("./users-tab", () => ({
+  UsersTab: () => <div>Users panel</div>,
+}))
+
+vi.mock("./bots-tab", () => ({
+  BotsTab: () => <div>Bots panel</div>,
+}))
+
+vi.mock("./api-keys-tab", () => ({
+  ApiKeysTab: () => <div>API keys panel</div>,
+}))
+
+function SearchEcho() {
+  const location = useLocation()
+  return <div data-testid="search">{location.search}</div>
+}
+
+function WorkspaceSettingsRoute() {
+  return (
+    <>
+      <WorkspaceSettingsDialog workspaceId="ws_1" />
+      <SearchEcho />
+    </>
+  )
+}
+
+describe("WorkspaceSettingsDialog", () => {
+  it("uses the sidebar navigation and keeps URL tab state in sync", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter initialEntries={["/w/ws_1?ws-settings=general"]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<WorkspaceSettingsRoute />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText("Workspace identity and region")).toBeInTheDocument()
+    expect(screen.getByText("General panel")).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: /Bots/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search")).toHaveTextContent("?ws-settings=bots")
+    })
+    expect(screen.getByText("Bots panel")).toBeVisible()
+    expect(screen.getByText("Members and pending invites")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
@@ -3,10 +3,11 @@ import { useSearchParams } from "react-router-dom"
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
+  ResponsiveDialogDescription,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveTabs } from "@/components/ui/responsive-tabs"
+import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { GeneralTab } from "./general-tab"
 import { UsersTab } from "./users-tab"
@@ -16,11 +17,11 @@ import { BotsTab } from "./bots-tab"
 const ALL_TABS = ["general", "users", "bots", "api-keys"] as const
 type WorkspaceSettingsTab = (typeof ALL_TABS)[number]
 
-const TAB_LABELS: Record<WorkspaceSettingsTab, string> = {
-  general: "General",
-  users: "Users",
-  bots: "Bots",
-  "api-keys": "API Keys",
+const TAB_CONFIG: Record<WorkspaceSettingsTab, { label: string; description: string }> = {
+  general: { label: "General", description: "Workspace identity and region" },
+  users: { label: "Users", description: "Members and pending invites" },
+  bots: { label: "Bots", description: "Workspace automation accounts" },
+  "api-keys": { label: "API Keys", description: "Create and revoke access keys" },
 }
 
 interface WorkspaceSettingsDialogProps {
@@ -60,30 +61,35 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && close()}>
       <ResponsiveDialogContent
-        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col overflow-hidden"
-        drawerClassName="flex flex-col"
+        desktopClassName="w-[min(96vw,980px)] max-w-none h-[min(720px,calc(100vh-2rem))] sm:flex flex-col overflow-hidden p-0 gap-0"
+        drawerClassName="flex flex-col gap-0"
         hideCloseButton
       >
-        <ResponsiveDialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6">
+        <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>Workspace Settings</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            Manage workspace details, members, bots, and API keys.
+          </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
-        <Tabs value={activeTab} onValueChange={setTab} className="flex-1 flex flex-col min-h-0 px-4 sm:px-6">
-          <ResponsiveTabs tabs={ALL_TABS} labels={TAB_LABELS} value={activeTab} onValueChange={setTab} />
+        <Tabs value={activeTab} onValueChange={setTab} className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+            <ResponsiveSettingsNav tabs={ALL_TABS} items={TAB_CONFIG} value={activeTab} onValueChange={setTab} />
 
-          <div className="flex-1 overflow-y-auto mt-4 pb-4 sm:pb-6">
-            <TabsContent value="general" className="mt-0">
-              <GeneralTab workspaceId={workspaceId} />
-            </TabsContent>
-            <TabsContent value="users" className="mt-0">
-              <UsersTab workspaceId={workspaceId} />
-            </TabsContent>
-            <TabsContent value="bots" className="mt-0">
-              <BotsTab workspaceId={workspaceId} />
-            </TabsContent>
-            <TabsContent value="api-keys" className="mt-0">
-              <ApiKeysTab workspaceId={workspaceId} />
-            </TabsContent>
+            <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6">
+              <TabsContent value="general" className="mt-0">
+                <GeneralTab workspaceId={workspaceId} />
+              </TabsContent>
+              <TabsContent value="users" className="mt-0">
+                <UsersTab workspaceId={workspaceId} />
+              </TabsContent>
+              <TabsContent value="bots" className="mt-0">
+                <BotsTab workspaceId={workspaceId} />
+              </TabsContent>
+              <TabsContent value="api-keys" className="mt-0">
+                <ApiKeysTab workspaceId={workspaceId} />
+              </TabsContent>
+            </div>
           </div>
         </Tabs>
       </ResponsiveDialogContent>

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
@@ -7,7 +7,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { ResponsiveSettingsNav } from "@/components/ui/responsive-settings-nav"
+import { ResponsiveSettingsNav, SETTINGS_DIALOG_LAYOUT_CLASSNAMES } from "@/components/ui/responsive-settings-nav"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { GeneralTab } from "./general-tab"
 import { UsersTab } from "./users-tab"
@@ -72,11 +72,16 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
-        <Tabs value={activeTab} onValueChange={setTab} className="flex-1 min-h-0">
-          <div className="flex-1 min-h-0 sm:grid sm:grid-cols-[220px,minmax(0,1fr)]">
+        <Tabs
+          data-slot="settings-tabs"
+          value={activeTab}
+          onValueChange={setTab}
+          className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.tabs}
+        >
+          <div data-slot="settings-panels" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.panels}>
             <ResponsiveSettingsNav tabs={ALL_TABS} items={TAB_CONFIG} value={activeTab} onValueChange={setTab} />
 
-            <div className="min-h-0 overflow-y-auto px-4 pb-4 pt-4 sm:px-6 sm:py-6">
+            <div data-slot="settings-content" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.content}>
               <TabsContent value="general" className="mt-0">
                 <GeneralTab workspaceId={workspaceId} />
               </TabsContent>

--- a/tests/browser/message-send-mode.spec.ts
+++ b/tests/browser/message-send-mode.spec.ts
@@ -29,21 +29,29 @@ test.describe("Message Send Mode", () => {
    */
   async function setSendMode(page: import("@playwright/test").Page, mode: "enter" | "cmdEnter") {
     await openSettings(page)
-    // The Send Messages section might be on Appearance or Keyboard tab
-    // Try to click Keyboard tab if visible
-    const keyboardTab = page.getByRole("tab", { name: /keyboard/i })
-    if (await keyboardTab.isVisible()) {
-      await keyboardTab.click()
+    const dialog = page.getByRole("dialog")
+
+    // Settings now use sidebar buttons on desktop but older flows used tabs.
+    const keyboardSidebarButton = dialog.getByRole("button", { name: /keyboard/i })
+    if (await keyboardSidebarButton.isVisible().catch(() => false)) {
+      await keyboardSidebarButton.click()
+    } else {
+      const keyboardTab = dialog.getByRole("tab", { name: /keyboard/i })
+      if (await keyboardTab.isVisible().catch(() => false)) {
+        await keyboardTab.click()
+      }
     }
+
+    await expect(dialog.getByRole("radio", { name: "Enter to send", exact: true })).toBeVisible({ timeout: 5000 })
 
     // Use exact name match for radio buttons
     if (mode === "enter") {
-      await page.getByRole("radio", { name: "Enter to send", exact: true }).click()
+      await dialog.getByRole("radio", { name: "Enter to send", exact: true }).click()
     } else {
-      await page.getByRole("radio", { name: /Ctrl.*Enter to send/ }).click()
+      await dialog.getByRole("radio", { name: "⌘/Ctrl + Enter to send", exact: true }).click()
     }
     await page.keyboard.press("Escape")
-    await expect(page.getByRole("dialog")).not.toBeVisible()
+    await expect(dialog).not.toBeVisible()
   }
 
   test.beforeEach(async ({ page }) => {

--- a/tests/browser/new-channel-socket-subscription.spec.ts
+++ b/tests/browser/new-channel-socket-subscription.spec.ts
@@ -176,7 +176,9 @@ test.describe("New Channel Socket Subscription", () => {
     await userB.page.locator("[contenteditable='true']").click()
     await userB.page.keyboard.type(previewMessage)
     await userB.page.getByRole("button", { name: "Send" }).click()
-    await expect(userB.page.getByRole("main").getByText(previewMessage)).toBeVisible({ timeout: 10000 })
+    await expect(
+      userB.page.getByRole("main").locator(".message-item").filter({ hasText: previewMessage }).first()
+    ).toBeVisible({ timeout: 10000 })
 
     // ──── User A: Channel should be reachable from sidebar without refresh ────
 
@@ -197,7 +199,9 @@ test.describe("New Channel Socket Subscription", () => {
     await userA.page.locator("[contenteditable='true']").click()
     await userA.page.keyboard.type(followUpMessage)
     await userA.page.getByRole("button", { name: "Send" }).click()
-    await expect(userA.page.getByRole("main").getByText(followUpMessage)).toBeVisible({ timeout: 10000 })
+    await expect(
+      userA.page.getByRole("main").locator(".message-item").filter({ hasText: followUpMessage }).first()
+    ).toBeVisible({ timeout: 10000 })
 
     await userA.context.close()
     await userB.context.close()


### PR DESCRIPTION
# Settings Sidebar Consistency

## Problem

User settings already moved from a cramped top-row tab strip to a sidebar layout when custom AI prompts were added, but workspace and stream settings were still using the older topbar treatment. That left the settings surfaces inconsistent and made the non-user dialogs feel tighter and harder to scan as they grow.

## Solution

Bring the remaining settings dialogs onto the same desktop shell pattern: shared responsive navigation, a left-hand sidebar on desktop, and the existing mobile selector behavior on smaller screens.

### How it works

- Extract `ResponsiveSettingsNav` so the desktop sidebar treatment is implemented once while still reusing `ResponsiveTabs` for mobile.
- Reuse that shared nav in user settings, workspace settings, and stream settings.
- Widen workspace and stream settings to match the newer fixed-height user settings shell.
- Keep stream-specific tab availability intact so DMs still only expose the members section.
- Add hidden dialog descriptions so the updated dialogs satisfy the Radix dialog accessibility contract.

### Key design decisions

**1. Extract only the navigation, not a full shared dialog framework**

The three dialogs share the navigation pattern, but they do not share state ownership. User settings are context-driven, workspace settings are URL-param-driven, and stream settings derive tab availability from stream type. A small shared nav component keeps the duplication out without forcing a larger abstraction.

**2. Keep mobile behavior unchanged**

The request was about matching the newer desktop sidebar pattern. Mobile already used the responsive selector path, so the change keeps that flow and only replaces the desktop treatment.

**3. Match the desktop shell sizing across settings dialogs**

The sidebar layout needs more room than the older compact topbar shell. Bringing workspace and stream settings onto the same wider shell as user settings keeps the content panes readable and makes the settings surfaces feel intentionally related.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/improve-workspace-settings.md` | Branch plan describing the settings sidebar consistency work for reviewers and Greptile. |
| `apps/frontend/src/components/ui/responsive-settings-nav.tsx` | Shared responsive settings navigation for desktop sidebar + mobile selector behavior. |
| `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx` | Regression coverage for workspace settings sidebar navigation and URL tab syncing. |
| `apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx` | Regression coverage for stream settings sidebar availability by stream type. |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/settings/settings-dialog.tsx` | Swapped the inline user settings sidebar markup to the shared nav and added dialog description text. |
| `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx` | Converted the old top-row tabs to the shared sidebar shell and added tab descriptions. |
| `apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx` | Converted the old top-row tabs to the shared sidebar shell while preserving stream-type-aware tab filtering. |

## Test plan

- [x] `bunx vitest run src/components/workspace-settings/workspace-settings-dialog.test.tsx src/components/stream-settings/stream-settings-dialog.test.tsx src/components/settings/ai-settings.test.tsx`
- [x] `bun run typecheck` in `apps/frontend`
- [ ] Manual desktop/mobile visual verification in the app

## Self-review

- No blocking issues found in the patch.
- Residual risk is primarily visual/layout behavior across breakpoints because verification here was test- and typecheck-based rather than a live browser pass.

---

Generated by Codex
