### PR TITLE
test: reduce flaky CI failures

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      TOTAL_SHARDS: 2
+      TOTAL_SHARDS: 3
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [1, 2]
+        shard_index: [1, 2, 3]
 
     services:
       postgres:

--- a/apps/backend/tests/integration/outbox-repository.test.ts
+++ b/apps/backend/tests/integration/outbox-repository.test.ts
@@ -7,6 +7,18 @@ import { setupTestDatabase } from "./setup"
 describe("OutboxRepository", () => {
   let pool: Pool
 
+  async function listTrackedOutboxIds(
+    client: Parameters<typeof withTestTransaction>[1] extends (client: infer T) => Promise<unknown> ? T : never,
+    ids: bigint[]
+  ) {
+    const result = await client.query<{ id: string }>(
+      "SELECT id FROM outbox WHERE id = ANY($1::bigint[]) ORDER BY id",
+      [ids.map((id) => id.toString())]
+    )
+
+    return result.rows.map((row) => BigInt(row.id))
+  }
+
   beforeAll(async () => {
     pool = await setupTestDatabase()
   })
@@ -139,6 +151,7 @@ describe("OutboxRepository", () => {
         const first = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_1"))
         const second = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_2"))
         const third = await OutboxRepository.insert(client, "message:created", testEventPayload("stream_3"))
+        const inserted = [first.id, second.id, third.id]
 
         const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
         await client.query("UPDATE outbox SET created_at = $1 WHERE id IN ($2, $3, $4)", [
@@ -154,17 +167,15 @@ describe("OutboxRepository", () => {
           limit: 100,
         })
 
-        const remaining = await OutboxRepository.fetchAfterId(client, 0n, 10)
+        const remainingInsertedIds = await listTrackedOutboxIds(client, inserted)
         const want = {
           deleted: 2,
           remainingEventIds: [third.id],
-          remainingEventTypes: ["message:created"],
         }
 
         expect({
           deleted,
-          remainingEventIds: remaining.map((event) => event.id),
-          remainingEventTypes: remaining.map((event) => event.eventType),
+          remainingEventIds: remainingInsertedIds,
         }).toEqual(want)
       })
     })
@@ -193,13 +204,13 @@ describe("OutboxRepository", () => {
           limit: 2,
         })
 
-        const remaining = await OutboxRepository.fetchAfterId(client, 0n, 10)
+        const remainingInsertedIds = await listTrackedOutboxIds(client, inserted)
         expect({
           deleted,
-          remainingCount: remaining.length,
+          remainingInsertedIds,
         }).toEqual({
           deleted: 2,
-          remainingCount: 3,
+          remainingInsertedIds: inserted.slice(2),
         })
       })
     })

--- a/tests/browser/new-channel-socket-subscription.spec.ts
+++ b/tests/browser/new-channel-socket-subscription.spec.ts
@@ -177,7 +177,7 @@ test.describe("New Channel Socket Subscription", () => {
   })
 
   test("should keep newly active channels navigable in smart view without refresh", async ({ browser }) => {
-    test.setTimeout(60000)
+    test.setTimeout(90000)
     const testId = Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
 
     const userAEmail = `preview-creator-${testId}@example.com`

--- a/tests/browser/new-channel-socket-subscription.spec.ts
+++ b/tests/browser/new-channel-socket-subscription.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "@playwright/test"
-import { createChannel, expectApiOk, loginInNewContext } from "./helpers"
+import { test, expect, type Locator, type Page, type Response } from "@playwright/test"
+import { createChannel, expectApiOk, loginInNewContext, waitForWorkspaceProvisioned } from "./helpers"
 
 /**
  * Tests that newly created channels receive real-time socket events.
@@ -10,8 +10,57 @@ import { createChannel, expectApiOk, loginInNewContext } from "./helpers"
  */
 
 test.describe("New Channel Socket Subscription", () => {
+  async function waitForSidebarPreview(link: Locator, expectedText: string): Promise<void> {
+    await expect(link).toBeVisible({ timeout: 10000 })
+    await expect
+      .poll(async () => ((await link.textContent()) ?? "").toLowerCase(), {
+        timeout: 30000,
+        message: `sidebar preview should include "${expectedText}"`,
+      })
+      .toContain(expectedText.toLowerCase())
+  }
+
+  async function waitForStreamMessage(page: Page, message: string): Promise<void> {
+    const messageItem = page.getByRole("main").locator(".message-item").filter({ hasText: message }).first()
+    await expect
+      .poll(async () => await messageItem.isVisible().catch(() => false), {
+        timeout: 30000,
+        message: `stream should render message "${message}"`,
+      })
+      .toBe(true)
+  }
+
+  async function waitForStreamBootstrapAfterAction(
+    page: Page,
+    workspaceId: string,
+    streamId: string,
+    action: () => Promise<void>
+  ): Promise<void> {
+    const bootstrapPath = `/api/workspaces/${workspaceId}/streams/${streamId}/bootstrap`
+    const bootstrapStatuses: number[] = []
+    const handleResponse = (response: Response) => {
+      if (response.url().includes(bootstrapPath)) {
+        bootstrapStatuses.push(response.status())
+      }
+    }
+
+    page.on("response", handleResponse)
+    try {
+      await action()
+      await expect
+        .poll(() => bootstrapStatuses.at(-1) ?? 0, {
+          timeout: 45000,
+          message: `stream bootstrap should refresh for ${streamId}`,
+        })
+        .toBeGreaterThanOrEqual(200)
+      expect(bootstrapStatuses.at(-1)).toBeLessThan(300)
+    } finally {
+      page.off("response", handleResponse)
+    }
+  }
+
   test("should make remote channel messages visible without a full page refresh", async ({ browser }) => {
-    test.setTimeout(60000)
+    test.setTimeout(90000)
     const testId = Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
 
     const userAEmail = `creator-${testId}@example.com`
@@ -23,95 +72,108 @@ test.describe("New Channel Socket Subscription", () => {
     // ──── User A: Create workspace and channel ────
 
     const userA = await loginInNewContext(browser, userAEmail, userAName)
-    const createWorkspaceRes = await userA.page.request.post("/api/workspaces", {
-      data: { name: `Socket Sub Test ${testId}` },
-    })
-    await expectApiOk(createWorkspaceRes, "Create workspace for socket subscription test")
-    const workspaceBody = (await createWorkspaceRes.json()) as { workspace: { id: string } }
-    const workspaceId = workspaceBody.workspace.id
+    let userB: Awaited<ReturnType<typeof loginInNewContext>> | undefined
 
-    await userA.page.goto(`/w/${workspaceId}`)
-    await expect(userA.page.getByRole("button", { name: "+ New Channel" })).toBeVisible({ timeout: 10000 })
+    try {
+      const createWorkspaceRes = await userA.page.request.post("/api/workspaces", {
+        data: { name: `Socket Sub Test ${testId}` },
+      })
+      await expectApiOk(createWorkspaceRes, "Create workspace for socket subscription test")
+      const workspaceBody = (await createWorkspaceRes.json()) as { workspace: { id: string } }
+      const workspaceId = workspaceBody.workspace.id
 
-    // Create a channel
-    await createChannel(userA.page, channelName, { switchToAll: false })
+      await waitForWorkspaceProvisioned(userA.page, workspaceId)
+      await userA.page.goto(`/w/${workspaceId}`)
+      await expect(userA.page.getByRole("button", { name: "+ New Channel" })).toBeVisible({ timeout: 10000 })
 
-    // Grab the stream ID from the URL
-    const streamMatch = userA.page.url().match(/\/s\/([^/?]+)/)
-    expect(streamMatch).toBeTruthy()
-    const streamId = streamMatch![1]
+      // Create a channel
+      await createChannel(userA.page, channelName, { switchToAll: false })
 
-    // Send a message so there's something in the channel
-    await userA.page.locator("[contenteditable='true']").click()
-    await userA.page.keyboard.type("Anyone here?")
-    await userA.page.getByRole("button", { name: "Send" }).click()
-    await expect(userA.page.getByRole("main").getByText("Anyone here?")).toBeVisible({ timeout: 5000 })
+      // Grab the stream ID from the URL
+      const streamMatch = userA.page.url().match(/\/s\/([^/?]+)/)
+      expect(streamMatch).toBeTruthy()
+      const streamId = streamMatch![1]
 
-    // Navigate away to a scratchpad via quick switcher (User A is no longer viewing the channel)
-    await userA.page.keyboard.press("Meta+k")
-    await expect(userA.page.getByRole("dialog")).toBeVisible()
-    await userA.page.keyboard.type("> New Scratchpad")
-    await userA.page.keyboard.press("Enter")
-    await expect(userA.page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({
-      timeout: 5000,
-    })
+      // Send a message so there's something in the channel
+      await userA.page.locator("[contenteditable='true']").click()
+      await userA.page.keyboard.type("Anyone here?")
+      await userA.page.getByRole("button", { name: "Send" }).click()
+      await expect(userA.page.getByRole("main").getByText("Anyone here?")).toBeVisible({ timeout: 5000 })
 
-    // Verify the channel link is visible in sidebar (Recent or expanded Everything Else)
-    const initialChannelLink = userA.page.getByRole("link", { name: `#${channelName}` })
-    const everythingElseToggle = userA.page.getByRole("button", { name: /everything else/i })
-    if (!(await initialChannelLink.isVisible()) && (await everythingElseToggle.isVisible())) {
-      await everythingElseToggle.click()
+      // Navigate away to a scratchpad via quick switcher (User A is no longer viewing the channel)
+      await userA.page.keyboard.press("Meta+k")
+      await expect(userA.page.getByRole("dialog")).toBeVisible()
+      await userA.page.keyboard.type("> New Scratchpad")
+      await userA.page.keyboard.press("Enter")
+      await expect(userA.page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({
+        timeout: 5000,
+      })
+
+      // Verify the channel link is visible in sidebar (Recent or expanded Everything Else)
+      const initialChannelLink = userA.page.getByRole("link", { name: `#${channelName}` })
+      const everythingElseToggle = userA.page.getByRole("button", { name: /everything else/i })
+      if (!(await initialChannelLink.isVisible()) && (await everythingElseToggle.isVisible())) {
+        await everythingElseToggle.click()
+      }
+      await expect(initialChannelLink).toBeVisible({ timeout: 10000 })
+
+      // ──── User B: Join workspace and channel, send a message ────
+
+      userB = await loginInNewContext(browser, userBEmail, userBName)
+
+      // Join workspace via dev endpoint
+      const joinWorkspaceRes = await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+        data: { role: "user" },
+      })
+      expect(joinWorkspaceRes.ok()).toBeTruthy()
+
+      await waitForWorkspaceProvisioned(userB.page, workspaceId)
+
+      // Navigate to workspace so workspace member middleware picks up
+      await userB.page.goto(`/w/${workspaceId}`)
+      await userB.page.waitForURL(/\/w\//, { timeout: 10000 })
+
+      // Join the channel via dev endpoint
+      const joinStreamRes = await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/streams/${streamId}/join`)
+      expect(joinStreamRes.ok()).toBeTruthy()
+
+      // Navigate to the channel and send via UI to avoid API/session race edge-cases
+      await userB.page.goto(`/w/${workspaceId}/s/${streamId}`)
+      await expect(userB.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+      const joinButtonB = userB.page.getByRole("button", { name: "Join Channel" })
+      if (await joinButtonB.isVisible().catch(() => false)) {
+        await joinButtonB.click()
+        await expect(joinButtonB).not.toBeVisible({ timeout: 5000 })
+      }
+
+      const testMessage = `Reply from User B ${Date.now()}`
+      await userB.page.locator("[contenteditable='true']").click()
+      await userB.page.keyboard.type(testMessage)
+      await userB.page.getByRole("button", { name: "Send" }).click()
+      await expect(userB.page.getByRole("main").getByText(testMessage)).toBeVisible({ timeout: 10000 })
+
+      // ──── User A: Channel should remain accessible without refresh ────
+
+      const channelLink = userA.page.getByRole("link", { name: `#${channelName}` })
+      await waitForSidebarPreview(channelLink, testMessage)
+
+      // Click the channel to verify the new message is available
+      await waitForStreamBootstrapAfterAction(userA.page, workspaceId, streamId, async () => {
+        await channelLink.click()
+      })
+      await expect(userA.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${streamId}`), { timeout: 10000 })
+      await expect(userA.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+      await waitForStreamMessage(userA.page, testMessage)
+    } finally {
+      await userA.context.close()
+      if (userB) {
+        await userB.context.close()
+      }
     }
-    await expect(initialChannelLink).toBeVisible({ timeout: 10000 })
-
-    // ──── User B: Join workspace and channel, send a message ────
-
-    const userB = await loginInNewContext(browser, userBEmail, userBName)
-
-    // Join workspace via dev endpoint
-    const joinWorkspaceRes = await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
-      data: { role: "user" },
-    })
-    expect(joinWorkspaceRes.ok()).toBeTruthy()
-
-    // Navigate to workspace so workspace member middleware picks up
-    await userB.page.goto(`/w/${workspaceId}`)
-    await userB.page.waitForURL(/\/w\//, { timeout: 10000 })
-
-    // Join the channel via dev endpoint
-    const joinStreamRes = await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/streams/${streamId}/join`)
-    expect(joinStreamRes.ok()).toBeTruthy()
-
-    // Navigate to the channel and send via UI to avoid API/session race edge-cases
-    await userB.page.goto(`/w/${workspaceId}/s/${streamId}`)
-    await expect(userB.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({ timeout: 10000 })
-    const joinButtonB = userB.page.getByRole("button", { name: "Join Channel" })
-    if (await joinButtonB.isVisible().catch(() => false)) {
-      await joinButtonB.click()
-      await expect(joinButtonB).not.toBeVisible({ timeout: 5000 })
-    }
-
-    const testMessage = `Reply from User B ${Date.now()}`
-    await userB.page.locator("[contenteditable='true']").click()
-    await userB.page.keyboard.type(testMessage)
-    await userB.page.getByRole("button", { name: "Send" }).click()
-    await expect(userB.page.getByRole("main").getByText(testMessage)).toBeVisible({ timeout: 10000 })
-
-    // ──── User A: Channel should remain accessible without refresh ────
-
-    const channelLink = userA.page.getByRole("link", { name: `#${channelName}` })
-
-    await expect(channelLink).toBeVisible({ timeout: 10000 })
-
-    // Click the channel to verify the new message is available
-    await channelLink.click()
-    await expect(userA.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${streamId}`), { timeout: 10000 })
-    await expect(userA.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({ timeout: 10000 })
-    await expect(userA.page.getByRole("main").getByText(testMessage).first()).toBeVisible({ timeout: 15000 })
-
-    // Cleanup
-    await userA.context.close()
-    await userB.context.close()
   })
 
   test("should keep newly active channels navigable in smart view without refresh", async ({ browser }) => {
@@ -127,83 +189,95 @@ test.describe("New Channel Socket Subscription", () => {
     // ──── User A: Create workspace and channel ────
 
     const userA = await loginInNewContext(browser, userAEmail, userAName)
-    const createWorkspaceRes = await userA.page.request.post("/api/workspaces", {
-      data: { name: `Preview Sub Test ${testId}` },
-    })
-    await expectApiOk(createWorkspaceRes, "Create workspace for preview subscription test")
-    const workspaceBody = (await createWorkspaceRes.json()) as { workspace: { id: string } }
-    const workspaceId = workspaceBody.workspace.id
+    let userB: Awaited<ReturnType<typeof loginInNewContext>> | undefined
 
-    await userA.page.goto(`/w/${workspaceId}`)
-    await expect(userA.page.getByRole("button", { name: "+ New Channel" })).toBeVisible({ timeout: 10000 })
+    try {
+      const createWorkspaceRes = await userA.page.request.post("/api/workspaces", {
+        data: { name: `Preview Sub Test ${testId}` },
+      })
+      await expectApiOk(createWorkspaceRes, "Create workspace for preview subscription test")
+      const workspaceBody = (await createWorkspaceRes.json()) as { workspace: { id: string } }
+      const workspaceId = workspaceBody.workspace.id
 
-    // Create channel
-    await createChannel(userA.page, channelName, { switchToAll: false })
+      await waitForWorkspaceProvisioned(userA.page, workspaceId)
+      await userA.page.goto(`/w/${workspaceId}`)
+      await expect(userA.page.getByRole("button", { name: "+ New Channel" })).toBeVisible({ timeout: 10000 })
 
-    const streamMatch = userA.page.url().match(/\/s\/([^/?]+)/)
-    const streamId = streamMatch![1]
+      // Create channel
+      await createChannel(userA.page, channelName, { switchToAll: false })
 
-    // Navigate away via quick switcher
-    await userA.page.keyboard.press("Meta+k")
-    await expect(userA.page.getByRole("dialog")).toBeVisible()
-    await userA.page.keyboard.type("> New Scratchpad")
-    await userA.page.keyboard.press("Enter")
-    await expect(userA.page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({
-      timeout: 5000,
-    })
+      const streamMatch = userA.page.url().match(/\/s\/([^/?]+)/)
+      const streamId = streamMatch![1]
 
-    // ──── User B: Join and send a message ────
+      // Navigate away via quick switcher
+      await userA.page.keyboard.press("Meta+k")
+      await expect(userA.page.getByRole("dialog")).toBeVisible()
+      await userA.page.keyboard.type("> New Scratchpad")
+      await userA.page.keyboard.press("Enter")
+      await expect(userA.page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({
+        timeout: 5000,
+      })
 
-    const userB = await loginInNewContext(browser, userBEmail, userBName)
+      // ──── User B: Join and send a message ────
 
-    await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
-      data: { role: "user" },
-    })
-    await userB.page.goto(`/w/${workspaceId}`)
-    await userB.page.waitForURL(/\/w\//, { timeout: 10000 })
+      userB = await loginInNewContext(browser, userBEmail, userBName)
 
-    await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/streams/${streamId}/join`)
+      await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+        data: { role: "user" },
+      })
+      await waitForWorkspaceProvisioned(userB.page, workspaceId)
+      await userB.page.goto(`/w/${workspaceId}`)
+      await userB.page.waitForURL(/\/w\//, { timeout: 10000 })
 
-    await userB.page.goto(`/w/${workspaceId}/s/${streamId}`)
-    await expect(userB.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({ timeout: 10000 })
-    const joinButtonB = userB.page.getByRole("button", { name: "Join Channel" })
-    if (await joinButtonB.isVisible().catch(() => false)) {
-      await joinButtonB.click()
-      await expect(joinButtonB).not.toBeVisible({ timeout: 5000 })
+      await userB.page.request.post(`/api/dev/workspaces/${workspaceId}/streams/${streamId}/join`)
+
+      await userB.page.goto(`/w/${workspaceId}/s/${streamId}`)
+      await expect(userB.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+      const joinButtonB = userB.page.getByRole("button", { name: "Join Channel" })
+      if (await joinButtonB.isVisible().catch(() => false)) {
+        await joinButtonB.click()
+        await expect(joinButtonB).not.toBeVisible({ timeout: 5000 })
+      }
+
+      const previewMessage = `Preview check ${Date.now()}`
+      await userB.page.locator("[contenteditable='true']").click()
+      await userB.page.keyboard.type(previewMessage)
+      await userB.page.getByRole("button", { name: "Send" }).click()
+      await expect(
+        userB.page.getByRole("main").locator(".message-item").filter({ hasText: previewMessage }).first()
+      ).toBeVisible({ timeout: 10000 })
+
+      // ──── User A: Channel should be reachable from sidebar without refresh ────
+
+      const channelLink = userA.page.getByRole("link", { name: `#${channelName}` })
+
+      const everythingElseToggle = userA.page.getByRole("button", { name: /everything else/i })
+      if (await everythingElseToggle.isVisible()) {
+        await everythingElseToggle.click()
+      }
+
+      await waitForSidebarPreview(channelLink, previewMessage)
+      await channelLink.click()
+      await expect(userA.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${streamId}`), { timeout: 10000 })
+      await expect(userA.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+
+      // Verify channel is fully navigable/interactive without refresh by sending from User A.
+      const followUpMessage = `User A follow-up ${Date.now()}`
+      await userA.page.locator("[contenteditable='true']").click()
+      await userA.page.keyboard.type(followUpMessage)
+      await userA.page.getByRole("button", { name: "Send" }).click()
+      await expect(
+        userA.page.getByRole("main").locator(".message-item").filter({ hasText: followUpMessage }).first()
+      ).toBeVisible({ timeout: 10000 })
+    } finally {
+      await userA.context.close()
+      if (userB) {
+        await userB.context.close()
+      }
     }
-
-    const previewMessage = `Preview check ${Date.now()}`
-    await userB.page.locator("[contenteditable='true']").click()
-    await userB.page.keyboard.type(previewMessage)
-    await userB.page.getByRole("button", { name: "Send" }).click()
-    await expect(
-      userB.page.getByRole("main").locator(".message-item").filter({ hasText: previewMessage }).first()
-    ).toBeVisible({ timeout: 10000 })
-
-    // ──── User A: Channel should be reachable from sidebar without refresh ────
-
-    const channelLink = userA.page.getByRole("link", { name: `#${channelName}` })
-
-    const everythingElseToggle = userA.page.getByRole("button", { name: /everything else/i })
-    if (await everythingElseToggle.isVisible()) {
-      await everythingElseToggle.click()
-    }
-
-    await expect(channelLink).toBeVisible({ timeout: 10000 })
-    await channelLink.click()
-    await expect(userA.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${streamId}`), { timeout: 10000 })
-    await expect(userA.page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible({ timeout: 10000 })
-
-    // Verify channel is fully navigable/interactive without refresh by sending from User A.
-    const followUpMessage = `User A follow-up ${Date.now()}`
-    await userA.page.locator("[contenteditable='true']").click()
-    await userA.page.keyboard.type(followUpMessage)
-    await userA.page.getByRole("button", { name: "Send" }).click()
-    await expect(
-      userA.page.getByRole("main").locator(".message-item").filter({ hasText: followUpMessage }).first()
-    ).toBeVisible({ timeout: 10000 })
-
-    await userA.context.close()
-    await userB.context.close()
   })
 })


### PR DESCRIPTION
## Summary
- narrow the outbox retention integration assertions to the rows each test inserts so concurrent outbox traffic cannot skew the expected counts
- harden the new-channel socket subscription browser spec by waiting for the sidebar preview, the follow-up stream bootstrap response, and guaranteed context cleanup on failures
- reduce browser suite load by sharding CI across 3 jobs instead of 2

## Verification
- bun test ./apps/backend/tests/integration/outbox-repository.test.ts
- 10 consecutive runs of bun test ./apps/backend/tests/integration/outbox-repository.test.ts
- bunx playwright test tests/browser/new-channel-socket-subscription.spec.ts --project=chromium --workers=1 --repeat-each=5
- bun run typecheck
- bun run lint