### PR TITLE
feat(mobile): partial quote reply via expandable drawer preview

### DIFF
--- a/.claude/plans/glistening-imagining-snail.md
+++ b/.claude/plans/glistening-imagining-snail.md
@@ -1,0 +1,110 @@
+# Mobile Partial Quote Reply via Expandable Preview
+
+## Context
+
+On desktop, users can highlight text in messages and a floating "Quote" button appears to create partial quotes. On mobile, text selection is disabled (`select-none`) because long-press opens the message context menu (Vaul bottom-sheet drawer). Currently, mobile can only quote the full message via the "Quote reply" action or swipe-to-quote.
+
+The goal is to let mobile users select specific text to quote by making the message preview in the context menu drawer expandable into a full message view with text selection.
+
+## Approach: Two-mode Drawer
+
+Add an `expanded` state to `MessageActionDrawer`. Tapping the preview toggles the drawer into a "selection mode" where the full message is shown with text selection enabled.
+
+### Normal mode (current behavior)
+- Message preview (author + 2-line clamp)
+- Quick reactions row
+- Action list (quote reply, edit, delete, etc.)
+
+### Expanded/selection mode (new)
+- Header: back arrow + "Select text to quote"
+- Full message content, scrollable, with text selection enabled
+- Floating "Quote" button at bottom when text is selected
+
+## Key Technical Solution: `data-vaul-no-drag`
+
+The critical challenge is that Vaul captures touch events for drag-to-dismiss, which conflicts with text selection. Vaul supports a `data-vaul-no-drag` attribute on child elements — this tells the drawer to ignore drag events originating from that element. We apply this to the expanded message content area, allowing native text selection and scrolling to work within the drawer while the handle still allows dismissal.
+
+## Files to Modify
+
+### 1. `apps/frontend/src/components/timeline/message-action-drawer.tsx`
+Main changes:
+
+- Add `expanded` boolean state, reset to `false` in `onOpenChange`
+- **Normal mode**: Make the preview section tappable (add `onClick={() => setExpanded(true)}` and visual affordance — small "Tap to select quote" hint text or expand icon in preview corner). Only show this affordance when `context.onQuoteReplyWithSnippet` exists (i.e., quote reply is available)
+- **Expanded mode**: Replace entire drawer body with:
+  - Header row: back button (ChevronLeft icon) + "Select text to quote" title
+  - Scrollable content area with `data-vaul-no-drag` attribute and `select-text` CSS class
+  - Full message rendered via `<MarkdownContent content={context.contentMarkdown} />`
+  - Fixed footer with "Quote" button, enabled only when text is selected
+- Track text selection via `selectionchange` event listener (similar pattern to `text-selection-quote.tsx` but scoped to the expanded content ref)
+- On "Quote" tap: call `context.onQuoteReplyWithSnippet(selectedText)`, then `onOpenChange(false)`
+- On "Back" tap: `setExpanded(false)`, clear selection
+
+### 2. `apps/frontend/src/components/timeline/message-actions.ts`
+- Add to `MessageActionContext`:
+  ```ts
+  onQuoteReplyWithSnippet?: (snippet: string) => void
+  ```
+
+### 3. `apps/frontend/src/components/timeline/message-event.tsx`
+- Wire up `onQuoteReplyWithSnippet` in the `actionContext` useMemo (alongside existing `onQuoteReply`):
+  ```ts
+  onQuoteReplyWithSnippet: quoteReplyCtx
+    ? (snippet: string) =>
+        quoteReplyCtx.triggerQuoteReply({
+          messageId: payload.messageId,
+          streamId,
+          authorName: actorName,
+          authorId: event.actorId ?? "",
+          actorType: event.actorType ?? "user",
+          snippet,
+        })
+    : undefined,
+  ```
+- Add `quoteReplyCtx` to the existing dependency array (already there)
+
+## Existing Code to Reuse
+
+- `QuoteReplyContext.triggerQuoteReply()` — exact same data flow as desktop partial quote
+- `MarkdownContent` component — same renderer used in the current preview (just without `line-clamp-2`)
+- `selectionchange` listener pattern from `text-selection-quote.tsx` (lines 58-100) — adapt for scoped use within the drawer content ref
+- `QuoteReplyData` interface — unchanged, the only difference is the `snippet` field content
+
+## Design Decisions
+
+- **Keep both quote options**: The existing "Quote reply" action in the action list stays as-is (full-message quote). The expandable preview is a separate path for partial quotes. Users get both.
+- **Text hint affordance**: Small muted text "Tap to select quote" below the preview bubble signals it's tappable. Only shown when `context.onQuoteReplyWithSnippet` exists.
+
+## Edge Cases
+
+- **Short messages (1-2 lines)**: Expanding still works fine — user sees the same content but with selection enabled. The hint text signals the purpose.
+- **Drawer close resets state**: `onOpenChange` callback resets `expanded` to false so re-opening starts in normal mode.
+- **User selects all text**: Functionally a full quote — acceptable behavior.
+- **Empty selection after expanding**: User can tap "Back" to return to normal mode and use other actions.
+
+## UX Flow
+
+1. User long-presses a message → drawer opens (normal mode)
+2. User sees preview with a subtle "Tap to select quote" hint
+3. User taps preview → drawer transitions to selection mode (full message, scrollable)
+4. User long-presses text in the message → native selection handles appear
+5. User drags selection handles to highlight desired text
+6. "Quote" button becomes active at the bottom
+7. User taps "Quote" → partial quote inserted in composer, drawer closes
+
+## Verification
+
+1. Test on mobile viewport (< 640px) that:
+   - Long-press opens drawer with tappable preview
+   - Tapping preview expands to full message
+   - Text selection works (no conflict with Vaul drag-to-dismiss)
+   - Scrolling works for long messages in expanded view
+   - "Quote" button appears when text is selected
+   - Tapping "Quote" inserts partial snippet in composer
+   - "Back" returns to normal drawer mode
+   - Closing and re-opening drawer resets to normal mode
+2. Test that existing flows still work:
+   - "Quote reply" action still quotes full message
+   - Swipe-to-quote still works
+   - Desktop text selection quote unchanged
+3. Run `bun run test` for unit/integration tests

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
-import { SmilePlus } from "lucide-react"
+import { ChevronLeft, Quote, SmilePlus } from "lucide-react"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { Separator } from "@/components/ui/separator"
+import { Button } from "@/components/ui/button"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useMessageReactions, stripColons } from "@/hooks/use-message-reactions"
@@ -25,6 +26,63 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
   const actions = getVisibleActions(context)
   const { emojis, emojiWeights } = useWorkspaceEmoji(context.workspaceId ?? "")
   const { toggleReaction } = useMessageReactions(context.workspaceId ?? "", context.messageId ?? "")
+  const [expanded, setExpanded] = useState(false)
+  const [selectedText, setSelectedText] = useState("")
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // Reset expanded state when drawer closes
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) setExpanded(false)
+      onOpenChange(open)
+    },
+    [onOpenChange]
+  )
+
+  // Track text selection within the expanded content area
+  useEffect(() => {
+    if (!expanded) {
+      setSelectedText("")
+      return
+    }
+
+    const handleSelectionChange = () => {
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed || !sel.rangeCount) {
+        setSelectedText("")
+        return
+      }
+
+      const text = sel.toString().trim()
+      if (!text) {
+        setSelectedText("")
+        return
+      }
+
+      // Verify selection is within our content area
+      const range = sel.getRangeAt(0)
+      if (contentRef.current?.contains(range.startContainer) && contentRef.current?.contains(range.endContainer)) {
+        setSelectedText(text)
+      } else {
+        setSelectedText("")
+      }
+    }
+
+    document.addEventListener("selectionchange", handleSelectionChange)
+    return () => document.removeEventListener("selectionchange", handleSelectionChange)
+  }, [expanded])
+
+  const handleQuoteSelected = useCallback(() => {
+    if (!selectedText || !context.onQuoteReplyWithSnippet) return
+    context.onQuoteReplyWithSnippet(selectedText)
+    window.getSelection()?.removeAllRanges()
+    handleOpenChange(false)
+  }, [selectedText, context, handleOpenChange])
+
+  const handleBack = useCallback(() => {
+    window.getSelection()?.removeAllRanges()
+    setExpanded(false)
+  }, [])
 
   const quickEmojis = useMemo(() => {
     if (!emojis.length) return []
@@ -65,144 +123,224 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
   // Quick-react toggles: removes if user already reacted, adds otherwise
   const handleQuickReact = useCallback(
     (shortcode: string) => {
-      onOpenChange(false)
+      handleOpenChange(false)
       toggleReaction(shortcode, context.reactions ?? {}, context.currentUserId ?? null)
     },
-    [onOpenChange, toggleReaction, context.reactions, context.currentUserId]
+    [handleOpenChange, toggleReaction, context.reactions, context.currentUserId]
   )
 
   const handleAction = useCallback(
     (action: MessageAction) => {
-      onOpenChange(false)
+      handleOpenChange(false)
       action.action?.(context)
     },
-    [context, onOpenChange]
+    [context, handleOpenChange]
   )
 
   const handleSubAction = useCallback(
     (sub: { action: (ctx: MessageActionContext) => void | Promise<void> }) => {
-      onOpenChange(false)
+      handleOpenChange(false)
       sub.action(context)
     },
-    [context, onOpenChange]
+    [context, handleOpenChange]
   )
 
   if (!open && actions.length === 0) return null
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="max-h-[85dvh]">
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerContent className={cn("max-h-[85dvh]", expanded && "max-h-[95dvh]")}>
         {/* Accessible title (visually hidden) */}
-        <DrawerTitle className="sr-only">Message actions</DrawerTitle>
+        <DrawerTitle className="sr-only">{expanded ? "Select text to quote" : "Message actions"}</DrawerTitle>
 
-        {/* Message preview */}
-        <div className="px-4 pt-1 pb-3">
-          <div className="rounded-xl bg-muted/60 px-3.5 py-2.5">
-            <p className="text-[13px] font-medium text-muted-foreground mb-0.5">{authorName}</p>
-            <div className="text-sm text-foreground/80 line-clamp-2 leading-snug">
-              <MarkdownContent content={context.contentMarkdown} />
-            </div>
-          </div>
-        </div>
-
-        {/* Quick reactions row + full picker button */}
-        {quickEmojis.length > 0 && context.onReact && (
-          <div className="flex justify-center gap-2 px-4 pb-3">
-            {quickEmojis.map((entry) => {
-              const isActive = activeShortcodes.has(entry.shortcode)
-              return (
-                <button
-                  key={entry.shortcode}
-                  type="button"
-                  className={cn(
-                    "flex items-center justify-center w-10 h-10 rounded-full transition-colors text-xl",
-                    isActive ? "bg-primary/10 ring-1 ring-primary/30" : "hover:bg-muted active:bg-muted/80"
-                  )}
-                  title={`:${entry.shortcode}:`}
-                  onClick={() => handleQuickReact(entry.shortcode)}
-                >
-                  {entry.emoji}
-                </button>
-              )
-            })}
-            <button
-              type="button"
-              className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-muted active:bg-muted/80 transition-colors text-muted-foreground"
-              aria-label="More reactions"
-              onClick={() => {
-                onOpenChange(false)
-                // Deferred so the drawer finishes closing before the picker opens
-                setTimeout(() => context.onOpenFullPicker?.(), 150)
-              }}
-            >
-              <SmilePlus className="h-5 w-5" />
-            </button>
-          </div>
-        )}
-
-        {/* Action list */}
-        <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
-          {actions.map((action) => {
-            // Flatten sub-actions into separate rows (no nested menus on mobile)
-            if (action.subActions && action.subActions.length > 0) {
-              return (
-                <div key={action.id}>
-                  {action.separatorBefore && <Divider />}
-                  {action.subActions.map((sub) => {
-                    const SubIcon = sub.icon
-                    return (
-                      <button
-                        key={sub.id}
-                        type="button"
-                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm active:bg-muted/80 transition-colors"
-                        onClick={() => handleSubAction(sub)}
-                      >
-                        <SubIcon className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
-                        <span>{sub.label}</span>
-                      </button>
-                    )
-                  })}
-                </div>
-              )
-            }
-
-            const Icon = action.icon
-            const isDestructive = action.variant === "destructive"
-            const href = action.getHref?.(context)
-
-            const rowClassName = cn(
-              "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
-              isDestructive ? "text-destructive active:bg-destructive/10" : "active:bg-muted/80"
-            )
-            const iconEl = (
-              <Icon
+        {expanded ? (
+          <ExpandedQuoteView
+            contentMarkdown={context.contentMarkdown}
+            authorName={authorName}
+            selectedText={selectedText}
+            contentRef={contentRef}
+            onBack={handleBack}
+            onQuote={handleQuoteSelected}
+          />
+        ) : (
+          <>
+            {/* Message preview */}
+            <div className="px-4 pt-1 pb-3">
+              <div
                 className={cn(
-                  "h-[18px] w-[18px] shrink-0",
-                  isDestructive ? "text-destructive" : "text-muted-foreground"
+                  "rounded-xl bg-muted/60 px-3.5 py-2.5",
+                  context.onQuoteReplyWithSnippet && "active:bg-muted/80 transition-colors"
                 )}
-              />
-            )
-
-            return (
-              <div key={action.id}>
-                {action.separatorBefore && <Divider />}
-                {href ? (
-                  <Link to={href} className={rowClassName} onClick={() => onOpenChange(false)}>
-                    {iconEl}
-                    <span>{action.label}</span>
-                  </Link>
-                ) : (
-                  <button type="button" className={rowClassName} onClick={() => handleAction(action)}>
-                    {iconEl}
-                    <span>{action.label}</span>
-                  </button>
-                )}
+                role={context.onQuoteReplyWithSnippet ? "button" : undefined}
+                onClick={context.onQuoteReplyWithSnippet ? () => setExpanded(true) : undefined}
+              >
+                <p className="text-[13px] font-medium text-muted-foreground mb-0.5">{authorName}</p>
+                <div className="text-sm text-foreground/80 line-clamp-2 leading-snug">
+                  <MarkdownContent content={context.contentMarkdown} />
+                </div>
               </div>
-            )
-          })}
-        </div>
+              {context.onQuoteReplyWithSnippet && (
+                <p className="text-[11px] text-muted-foreground/60 mt-1 px-1">Tap to select quote</p>
+              )}
+            </div>
+
+            {/* Quick reactions row + full picker button */}
+            {quickEmojis.length > 0 && context.onReact && (
+              <div className="flex justify-center gap-2 px-4 pb-3">
+                {quickEmojis.map((entry) => {
+                  const isActive = activeShortcodes.has(entry.shortcode)
+                  return (
+                    <button
+                      key={entry.shortcode}
+                      type="button"
+                      className={cn(
+                        "flex items-center justify-center w-10 h-10 rounded-full transition-colors text-xl",
+                        isActive ? "bg-primary/10 ring-1 ring-primary/30" : "hover:bg-muted active:bg-muted/80"
+                      )}
+                      title={`:${entry.shortcode}:`}
+                      onClick={() => handleQuickReact(entry.shortcode)}
+                    >
+                      {entry.emoji}
+                    </button>
+                  )
+                })}
+                <button
+                  type="button"
+                  className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-muted active:bg-muted/80 transition-colors text-muted-foreground"
+                  aria-label="More reactions"
+                  onClick={() => {
+                    handleOpenChange(false)
+                    // Deferred so the drawer finishes closing before the picker opens
+                    setTimeout(() => context.onOpenFullPicker?.(), 150)
+                  }}
+                >
+                  <SmilePlus className="h-5 w-5" />
+                </button>
+              </div>
+            )}
+
+            {/* Action list */}
+            <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
+              {actions.map((action) => {
+                // Flatten sub-actions into separate rows (no nested menus on mobile)
+                if (action.subActions && action.subActions.length > 0) {
+                  return (
+                    <div key={action.id}>
+                      {action.separatorBefore && <Divider />}
+                      {action.subActions.map((sub) => {
+                        const SubIcon = sub.icon
+                        return (
+                          <button
+                            key={sub.id}
+                            type="button"
+                            className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm active:bg-muted/80 transition-colors"
+                            onClick={() => handleSubAction(sub)}
+                          >
+                            <SubIcon className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
+                            <span>{sub.label}</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )
+                }
+
+                const Icon = action.icon
+                const isDestructive = action.variant === "destructive"
+                const href = action.getHref?.(context)
+
+                const rowClassName = cn(
+                  "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
+                  isDestructive ? "text-destructive active:bg-destructive/10" : "active:bg-muted/80"
+                )
+                const iconEl = (
+                  <Icon
+                    className={cn(
+                      "h-[18px] w-[18px] shrink-0",
+                      isDestructive ? "text-destructive" : "text-muted-foreground"
+                    )}
+                  />
+                )
+
+                return (
+                  <div key={action.id}>
+                    {action.separatorBefore && <Divider />}
+                    {href ? (
+                      <Link to={href} className={rowClassName} onClick={() => handleOpenChange(false)}>
+                        {iconEl}
+                        <span>{action.label}</span>
+                      </Link>
+                    ) : (
+                      <button type="button" className={rowClassName} onClick={() => handleAction(action)}>
+                        {iconEl}
+                        <span>{action.label}</span>
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </>
+        )}
       </DrawerContent>
     </Drawer>
+  )
+}
+
+interface ExpandedQuoteViewProps {
+  contentMarkdown: string
+  authorName: string
+  selectedText: string
+  contentRef: React.RefObject<HTMLDivElement | null>
+  onBack: () => void
+  onQuote: () => void
+}
+
+function ExpandedQuoteView({
+  contentMarkdown,
+  authorName,
+  selectedText,
+  contentRef,
+  onBack,
+  onQuote,
+}: ExpandedQuoteViewProps) {
+  return (
+    <div className="flex flex-col min-h-0">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-2 py-2 border-b">
+        <button
+          type="button"
+          className="flex items-center justify-center h-8 w-8 rounded-full active:bg-muted/80 transition-colors"
+          aria-label="Back to actions"
+          onClick={onBack}
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+        <span className="text-sm font-medium">Select text to quote</span>
+      </div>
+
+      {/* Author name */}
+      <div className="px-4 pt-3 pb-1">
+        <p className="text-[13px] font-medium text-muted-foreground">{authorName}</p>
+      </div>
+
+      {/* Scrollable message content with text selection enabled */}
+      <div
+        ref={contentRef}
+        data-vaul-no-drag
+        className="flex-1 overflow-y-auto px-4 pb-3 select-text text-sm text-foreground/80 leading-snug"
+      >
+        <MarkdownContent content={contentMarkdown} />
+      </div>
+
+      {/* Quote button footer */}
+      <div className="px-4 py-3 border-t pb-[max(12px,env(safe-area-inset-bottom))]">
+        <Button className="w-full gap-2" disabled={!selectedText} onClick={onQuote}>
+          <Quote className="h-4 w-4" />
+          {selectedText ? "Quote selected text" : "Select text to quote"}
+        </Button>
+      </div>
+    </div>
   )
 }
 

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -324,6 +324,24 @@ function ExpandedQuoteView({
   const isBot = actorType === "bot"
   const isSystem = actorType === "system"
 
+  // Match timeline message-event.tsx accent styling exactly: persona=gold,
+  // bot=emerald, system=blue, user=no accent. Inset shadow forms the left
+  // "thread" stripe; gradient adds a faint actor-typed wash.
+  const accentClass = cn(
+    isPersona && "bg-gradient-to-r from-primary/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(var(--primary))]",
+    isBot && "bg-gradient-to-r from-emerald-500/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(152_69%_41%)]",
+    isSystem && "bg-gradient-to-r from-blue-500/[0.04] to-transparent shadow-[inset_3px_0_0_hsl(210_100%_55%)]"
+  )
+
+  // Decorative watermark color follows the same actor-typed logic, neutral for users
+  const watermarkClass = cn(
+    "absolute top-[-12px] right-3 text-[140px] leading-none font-serif select-none pointer-events-none",
+    isPersona && "text-primary/[0.05]",
+    isBot && "text-emerald-500/[0.05]",
+    isSystem && "text-blue-500/[0.05]",
+    !isPersona && !isBot && !isSystem && "text-muted-foreground/[0.08]"
+  )
+
   return (
     <div className="flex flex-col min-h-0 h-full">
       {/* Header — soft app-bar with gradient divider */}
@@ -336,28 +354,33 @@ function ExpandedQuoteView({
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="text-[15px] font-semibold tracking-tight">Quote a passage</h2>
+        <h2 className="text-[15px] font-semibold tracking-tight text-muted-foreground">Full message</h2>
         <div className="absolute left-0 right-0 bottom-0 h-px bg-gradient-to-r from-transparent via-border/70 to-transparent" />
       </div>
 
-      {/* Scrollable byline + content */}
+      {/* Scrollable byline + content as a single actor-typed block */}
       <div data-vaul-no-drag className="flex-1 min-h-0 overflow-y-auto">
-        {/* Byline — avatar anchored, matches timeline message style */}
-        <div className="flex items-center gap-3 px-4 pt-4 pb-3">
-          <Avatar className="h-9 w-9 rounded-[10px] shrink-0">
-            <AvatarFallback
-              className={cn(
-                "rounded-[10px] text-[13px] font-semibold",
-                isSystem && "bg-blue-500/10 text-blue-500",
-                isBot && "bg-emerald-500/10 text-emerald-600",
-                isPersona && "bg-primary/10 text-primary",
-                !isSystem && !isBot && !isPersona && "bg-muted text-foreground"
-              )}
-            >
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-          <div className="min-w-0">
+        <div className={cn("relative", accentClass)}>
+          {/* Decorative quote watermark */}
+          <div aria-hidden="true" className={watermarkClass}>
+            &ldquo;
+          </div>
+
+          {/* Byline — avatar anchored, matches timeline message style */}
+          <div className="relative flex items-center gap-3 px-4 pt-4 pb-3">
+            <Avatar className="h-9 w-9 rounded-[10px] shrink-0">
+              <AvatarFallback
+                className={cn(
+                  "rounded-[10px] text-[13px] font-semibold",
+                  isSystem && "bg-blue-500/10 text-blue-500",
+                  isBot && "bg-emerald-500/10 text-emerald-600",
+                  isPersona && "bg-primary/10 text-primary",
+                  !isSystem && !isBot && !isPersona && "bg-muted text-foreground"
+                )}
+              >
+                {initials}
+              </AvatarFallback>
+            </Avatar>
             <p
               className={cn(
                 "text-sm font-semibold truncate",
@@ -369,53 +392,35 @@ function ExpandedQuoteView({
               {authorName}
             </p>
           </div>
-        </div>
 
-        {/* Message content with left gold accent stripe + decorative quote watermark */}
-        <div className="relative px-4 pb-6">
-          {/* Left accent stripe — gold thread fading downward */}
-          <div
-            aria-hidden="true"
-            className="absolute left-4 top-0 bottom-6 w-[3px] rounded-full bg-gradient-to-b from-primary/60 via-primary/25 to-primary/[0.04]"
-          />
-
-          {/* Decorative quote watermark */}
-          <div
-            aria-hidden="true"
-            className="absolute top-[-12px] right-3 text-[140px] leading-none font-serif text-primary/[0.05] select-none pointer-events-none"
-          >
-            &ldquo;
-          </div>
-
-          {/* Actual message content — selectable, message-grade typography */}
-          <div ref={contentRef} className="relative pl-5 select-text">
+          {/* Selectable message content */}
+          <div ref={contentRef} className="relative px-4 pb-6 select-text">
             <MarkdownContent content={contentMarkdown} className="text-sm leading-relaxed text-foreground" />
           </div>
         </div>
       </div>
 
-      {/* Footer: idle hint card vs active quote button */}
-      <div className="border-t px-4 pt-3 pb-[max(12px,env(safe-area-inset-bottom))]">
+      {/* Footer toolbar — compact, two-state */}
+      <div className="relative px-4 pt-2.5 pb-[max(10px,env(safe-area-inset-bottom))]">
+        <div
+          aria-hidden="true"
+          className="absolute left-0 right-0 top-0 h-px bg-gradient-to-r from-transparent via-border/70 to-transparent"
+        />
         {selectedText ? (
-          <div key="active" className="space-y-2 animate-in fade-in slide-in-from-bottom-2 duration-200">
-            <p className="text-[11px] font-medium text-muted-foreground/80 text-center tabular-nums tracking-wide uppercase">
-              {charCount} {charCount === 1 ? "character" : "characters"} selected
+          <div className="flex items-center justify-between gap-3 animate-in fade-in slide-in-from-bottom-1 duration-150">
+            <p className="text-[12px] text-muted-foreground tabular-nums">
+              <span className="font-semibold text-foreground/85">{charCount}</span>{" "}
+              {charCount === 1 ? "character" : "characters"} selected
             </p>
-            <Button className="w-full h-11 gap-2 thread-glow shadow-sm font-semibold" onClick={onQuote}>
-              <Quote className="h-4 w-4" />
-              Quote selection
+            <Button size="sm" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onQuote}>
+              <Quote className="h-3.5 w-3.5" />
+              Quote
             </Button>
           </div>
         ) : (
-          <div
-            key="idle"
-            className="flex items-center gap-3 rounded-xl border border-dashed border-border/70 bg-muted/30 px-3.5 py-3 text-muted-foreground"
-          >
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-background shrink-0 ring-1 ring-border/60">
-              <Quote className="h-3.5 w-3.5 text-muted-foreground/70" />
-            </div>
-            <p className="text-[12px] leading-snug">Long-press the message to highlight a passage you want to quote.</p>
-          </div>
+          <p className="text-[12px] text-muted-foreground/70 text-center py-1">
+            Long-press the message to highlight a passage
+          </p>
         )}
       </div>
     </div>

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -149,7 +149,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
 
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
-      <DrawerContent className={cn("max-h-[85dvh]", expanded && "max-h-[95dvh]")}>
+      <DrawerContent className={cn(expanded ? "h-[95dvh]" : "max-h-[85dvh]")}>
         {/* Accessible title (visually hidden) */}
         <DrawerTitle className="sr-only">{expanded ? "Select text to quote" : "Message actions"}</DrawerTitle>
 
@@ -305,7 +305,7 @@ function ExpandedQuoteView({
   onQuote,
 }: ExpandedQuoteViewProps) {
   return (
-    <div className="flex flex-col min-h-0">
+    <div className="flex flex-col min-h-0 h-full">
       {/* Header */}
       <div className="flex items-center gap-2 px-2 py-2 border-b">
         <button

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -4,9 +4,11 @@ import { ChevronLeft, Quote, SmilePlus } from "lucide-react"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useMessageReactions, stripColons } from "@/hooks/use-message-reactions"
+import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
 import { type MessageActionContext, type MessageAction, getVisibleActions } from "./message-actions"
 
@@ -157,6 +159,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
           <ExpandedQuoteView
             contentMarkdown={context.contentMarkdown}
             authorName={authorName}
+            actorType={context.actorType}
             selectedText={selectedText}
             contentRef={contentRef}
             onBack={handleBack}
@@ -168,19 +171,28 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
             <div className="px-4 pt-1 pb-3">
               <div
                 className={cn(
-                  "rounded-xl bg-muted/60 px-3.5 py-2.5",
-                  context.onQuoteReplyWithSnippet && "active:bg-muted/80 transition-colors"
+                  "group/preview relative rounded-xl bg-muted/60 px-3.5 py-2.5",
+                  context.onQuoteReplyWithSnippet && "active:bg-muted/80 transition-colors cursor-pointer"
                 )}
                 role={context.onQuoteReplyWithSnippet ? "button" : undefined}
                 onClick={context.onQuoteReplyWithSnippet ? () => setExpanded(true) : undefined}
               >
                 <p className="text-[13px] font-medium text-muted-foreground mb-0.5">{authorName}</p>
-                <div className="text-sm text-foreground/80 line-clamp-2 leading-snug">
+                <div className="text-sm text-foreground/80 line-clamp-2 leading-snug pr-6">
                   <MarkdownContent content={context.contentMarkdown} />
                 </div>
+                {context.onQuoteReplyWithSnippet && (
+                  <Quote
+                    aria-hidden="true"
+                    className="absolute top-2.5 right-2.5 h-3.5 w-3.5 text-muted-foreground/40 group-active/preview:text-primary transition-colors"
+                  />
+                )}
               </div>
               {context.onQuoteReplyWithSnippet && (
-                <p className="text-[11px] text-muted-foreground/60 mt-1 px-1">Tap to select quote</p>
+                <p className="text-[11px] text-muted-foreground/60 mt-1.5 px-1 flex items-center gap-1">
+                  <span className="inline-block h-1 w-1 rounded-full bg-primary/60" />
+                  Tap to highlight a passage
+                </p>
               )}
             </div>
 
@@ -290,6 +302,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
 interface ExpandedQuoteViewProps {
   contentMarkdown: string
   authorName: string
+  actorType: string | null
   selectedText: string
   contentRef: React.RefObject<HTMLDivElement | null>
   onBack: () => void
@@ -299,46 +312,111 @@ interface ExpandedQuoteViewProps {
 function ExpandedQuoteView({
   contentMarkdown,
   authorName,
+  actorType,
   selectedText,
   contentRef,
   onBack,
   onQuote,
 }: ExpandedQuoteViewProps) {
+  const initials = getInitials(authorName)
+  const charCount = selectedText.length
+  const isPersona = actorType === "persona"
+  const isBot = actorType === "bot"
+  const isSystem = actorType === "system"
+
   return (
     <div className="flex flex-col min-h-0 h-full">
-      {/* Header */}
-      <div className="flex items-center gap-2 px-2 py-2 border-b">
+      {/* Header — soft app-bar with gradient divider */}
+      <div className="relative flex items-center gap-1 px-2 pt-2 pb-3">
         <button
           type="button"
-          className="flex items-center justify-center h-8 w-8 rounded-full active:bg-muted/80 transition-colors"
+          className="flex items-center justify-center h-9 w-9 rounded-full text-muted-foreground active:bg-muted/80 transition-colors"
           aria-label="Back to actions"
           onClick={onBack}
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <span className="text-sm font-medium">Select text to quote</span>
+        <h2 className="text-[15px] font-semibold tracking-tight">Quote a passage</h2>
+        <div className="absolute left-0 right-0 bottom-0 h-px bg-gradient-to-r from-transparent via-border/70 to-transparent" />
       </div>
 
-      {/* Author name */}
-      <div className="px-4 pt-3 pb-1">
-        <p className="text-[13px] font-medium text-muted-foreground">{authorName}</p>
+      {/* Scrollable byline + content */}
+      <div data-vaul-no-drag className="flex-1 min-h-0 overflow-y-auto">
+        {/* Byline — avatar anchored, matches timeline message style */}
+        <div className="flex items-center gap-3 px-4 pt-4 pb-3">
+          <Avatar className="h-9 w-9 rounded-[10px] shrink-0">
+            <AvatarFallback
+              className={cn(
+                "rounded-[10px] text-[13px] font-semibold",
+                isSystem && "bg-blue-500/10 text-blue-500",
+                isBot && "bg-emerald-500/10 text-emerald-600",
+                isPersona && "bg-primary/10 text-primary",
+                !isSystem && !isBot && !isPersona && "bg-muted text-foreground"
+              )}
+            >
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p
+              className={cn(
+                "text-sm font-semibold truncate",
+                isPersona && "text-primary",
+                isBot && "text-emerald-600",
+                isSystem && "text-blue-500"
+              )}
+            >
+              {authorName}
+            </p>
+          </div>
+        </div>
+
+        {/* Message content with left gold accent stripe + decorative quote watermark */}
+        <div className="relative px-4 pb-6">
+          {/* Left accent stripe — gold thread fading downward */}
+          <div
+            aria-hidden="true"
+            className="absolute left-4 top-0 bottom-6 w-[3px] rounded-full bg-gradient-to-b from-primary/60 via-primary/25 to-primary/[0.04]"
+          />
+
+          {/* Decorative quote watermark */}
+          <div
+            aria-hidden="true"
+            className="absolute top-[-12px] right-3 text-[140px] leading-none font-serif text-primary/[0.05] select-none pointer-events-none"
+          >
+            &ldquo;
+          </div>
+
+          {/* Actual message content — selectable, message-grade typography */}
+          <div ref={contentRef} className="relative pl-5 select-text">
+            <MarkdownContent content={contentMarkdown} className="text-sm leading-relaxed text-foreground" />
+          </div>
+        </div>
       </div>
 
-      {/* Scrollable message content with text selection enabled */}
-      <div
-        ref={contentRef}
-        data-vaul-no-drag
-        className="flex-1 overflow-y-auto px-4 pb-3 select-text text-sm text-foreground/80 leading-snug"
-      >
-        <MarkdownContent content={contentMarkdown} />
-      </div>
-
-      {/* Quote button footer */}
-      <div className="px-4 py-3 border-t pb-[max(12px,env(safe-area-inset-bottom))]">
-        <Button className="w-full gap-2" disabled={!selectedText} onClick={onQuote}>
-          <Quote className="h-4 w-4" />
-          {selectedText ? "Quote selected text" : "Select text to quote"}
-        </Button>
+      {/* Footer: idle hint card vs active quote button */}
+      <div className="border-t px-4 pt-3 pb-[max(12px,env(safe-area-inset-bottom))]">
+        {selectedText ? (
+          <div key="active" className="space-y-2 animate-in fade-in slide-in-from-bottom-2 duration-200">
+            <p className="text-[11px] font-medium text-muted-foreground/80 text-center tabular-nums tracking-wide uppercase">
+              {charCount} {charCount === 1 ? "character" : "characters"} selected
+            </p>
+            <Button className="w-full h-11 gap-2 thread-glow shadow-sm font-semibold" onClick={onQuote}>
+              <Quote className="h-4 w-4" />
+              Quote selection
+            </Button>
+          </div>
+        ) : (
+          <div
+            key="idle"
+            className="flex items-center gap-3 rounded-xl border border-dashed border-border/70 bg-muted/30 px-3.5 py-3 text-muted-foreground"
+          >
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-background shrink-0 ring-1 ring-border/60">
+              <Quote className="h-3.5 w-3.5 text-muted-foreground/70" />
+            </div>
+            <p className="text-[12px] leading-snug">Long-press the message to highlight a passage you want to quote.</p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -43,6 +43,8 @@ export interface MessageActionContext {
   reactions?: Record<string, string[]>
   /** Callback to insert a quote reply into the composer */
   onQuoteReply?: () => void
+  /** Callback to insert a partial quote reply with a user-selected snippet */
+  onQuoteReplyWithSnippet?: (snippet: string) => void
 }
 
 /** A variant within a sub-menu (e.g. "Copy as Markdown" vs "Copy as Plain text"). */

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -531,6 +531,17 @@ function SentMessageEvent({
               snippet: payload.contentMarkdown,
             })
         : undefined,
+      onQuoteReplyWithSnippet: quoteReplyCtx
+        ? (snippet: string) =>
+            quoteReplyCtx.triggerQuoteReply({
+              messageId: payload.messageId,
+              streamId,
+              authorName: actorName,
+              authorId: event.actorId ?? "",
+              actorType: event.actorType ?? "user",
+              snippet,
+            })
+        : undefined,
     }),
     [
       payload.contentMarkdown,


### PR DESCRIPTION
## Problem

On desktop, users can highlight text in a message and a floating "Quote" button appears to create partial quotes. On mobile, text selection is disabled (`select-none`) because long-press is already reserved for opening the message action drawer, so mobile users can only quote the full message — either via the "Quote reply" action in the drawer or by swipe-to-quote.

This is a long-standing gap: mobile users who want to reply to a specific phrase or sentence in a long message have no way to do so without quoting the entire thing.

## Solution

Make the message preview at the top of the mobile action drawer expandable. Tapping it transitions the drawer into a "selection mode" that shows the full message with native text selection enabled. The user highlights the text they want and taps "Quote selected text" to insert a partial quote into the composer.

### How it works

```
long-press message
      ↓
drawer opens (normal mode)
      ↓  [user taps preview]
drawer expands to 95dvh, content swaps to ExpandedQuoteView
      ↓  [user long-presses text, drags selection handles]
selectionchange listener captures selectedText
      ↓  [user taps "Quote selected text"]
context.onQuoteReplyWithSnippet(selectedText) → QuoteReplyContext.triggerQuoteReply()
      ↓
partial quote inserted into composer, drawer closes
```

### Key design decisions

**1. `data-vaul-no-drag` for the touch conflict**

The critical challenge was that Vaul's drawer captures touch events for drag-to-dismiss, which directly conflicts with the long-press + drag gesture mobile browsers use for native text selection. Vaul supports a `data-vaul-no-drag` attribute on child elements — setting it on the scrollable content area tells Vaul to ignore drag events originating there, freeing up touch for selection and scrolling. The drawer handle still allows drag-to-dismiss.

This is the cleanest mechanism available; the alternative (toggling `dismissible={false}`) would disable drag-to-dismiss entirely.

**2. Two-mode drawer instead of a separate fullscreen dialog**

An alternative was adding a "Partial quote" action that opens a separate fullscreen modal. The expandable preview was chosen because it stays within the same drawer flow, avoids mounting another dialog, and the preview-as-entry-point is more discoverable since users already see it.

**3. Fixed `h-[95dvh]` when expanded (not `max-h`)**

Vaul's `DrawerContent` uses `h-auto` by default. With only a max-h cap, the `flex-1 overflow-y-auto` content area had no definite height to grow within, so long messages wouldn't scroll reliably. Switching to a fixed `h-[95dvh]` when expanded gives flex-1 a parent height to fill.

**4. Keep both full and partial quote paths**

The existing "Quote reply" action in the drawer action list still quotes the full message — it's faster for users who want a full quote. The expandable preview adds a partial-quote path alongside it rather than replacing it.

**5. Reuse the existing quote-reply data flow**

A new `onQuoteReplyWithSnippet(snippet: string)` callback was added to `MessageActionContext`, wired in `message-event.tsx` to the existing `quoteReplyCtx.triggerQuoteReply()`. The `QuoteReplyData` interface is unchanged — the only difference between a full and partial quote is the content of the `snippet` field. This mirrors how the desktop `text-selection-quote.tsx` flow works.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/timeline/message-action-drawer.tsx` | Add `expanded` state, tappable preview with "Tap to select quote" hint, new `ExpandedQuoteView` subcomponent with back button, scrollable content (`data-vaul-no-drag` + `select-text`), and Quote button footer. Reset `expanded` on drawer close. |
| `apps/frontend/src/components/timeline/message-actions.ts` | Add `onQuoteReplyWithSnippet?: (snippet: string) => void` to `MessageActionContext`. |
| `apps/frontend/src/components/timeline/message-event.tsx` | Wire up `onQuoteReplyWithSnippet` alongside existing `onQuoteReply`, routing the user-provided snippet through `quoteReplyCtx.triggerQuoteReply()`. |
| `.claude/plans/glistening-imagining-snail.md` | Design plan for this change. |

## Test plan

- [x] Type check passes (`tsc --noEmit` clean across the monorepo)
- [x] Lint passes
- [x] Existing `message-actions.test.ts` passes (25/25)
- [ ] Manual verification on a mobile device/viewport:
  - [ ] Long-press a message → drawer opens with "Tap to select quote" hint below preview
  - [ ] Tap preview → drawer grows, shows full message content, "Quote selected text" disabled
  - [ ] Long-press text in expanded view → native selection handles appear
  - [ ] Drag handles to highlight text → "Quote selected text" enables
  - [ ] Tap it → partial quote inserted in composer, drawer closes
  - [ ] Long messages scroll inside the expanded view without triggering drawer drag
  - [ ] Back button returns to normal drawer mode, clears selection
  - [ ] Closing and re-opening drawer starts in normal mode
- [ ] Existing flows still work:
  - [ ] "Quote reply" action in the action list still quotes full message
  - [ ] Swipe-to-quote still quotes full message
  - [ ] Desktop text selection quote unchanged

---

https://claude.ai/code/session_012R6oZrQX886UgKiJipASkd