### PR TITLE
fix: collapse memo view min-content so long URLs can't force overflow

### DIFF
--- a/apps/frontend/src/pages/memory.test.tsx
+++ b/apps/frontend/src/pages/memory.test.tsx
@@ -30,6 +30,40 @@ function renderPage(initialEntry = "/w/ws_1/memory?memo=memo_1") {
   )
 }
 
+// Long, unbreakable strings that would otherwise push Radix ScrollArea's
+// display:table wrapper past the viewport. These shouldn't cause horizontal
+// overflow because the memory page relies on [overflow-wrap:anywhere] to
+// collapse min-content for long URLs and hashes.
+const LONG_UNBREAKABLE_TITLE =
+  "https://example.com/a/very/long/unbreakable/path/that/absolutely/will/not/fit/in/a/narrow/sidebar/viewport/without/wrapping/characters"
+const LONG_UNBREAKABLE_ABSTRACT =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+function buildMemo(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "memo_1",
+    workspaceId: "ws_1",
+    memoType: "message",
+    sourceMessageId: "msg_1",
+    sourceConversationId: null,
+    title: "Launch decision",
+    abstract: "Approved launch plan",
+    keyPoints: [],
+    sourceMessageIds: ["msg_1"],
+    participantIds: ["user_1"],
+    knowledgeType: "decision",
+    tags: [],
+    parentMemoId: null,
+    status: "active",
+    version: 1,
+    revisionReason: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
 describe("MemoryPage", () => {
   beforeEach(() => {
     mockUseWorkspaceStreams.mockReset()
@@ -120,5 +154,178 @@ describe("MemoryPage", () => {
 
     expect(refetchSearch).toHaveBeenCalledTimes(1)
     expect(refetchDetail).toHaveBeenCalledTimes(1)
+  })
+
+  // Regression guard for memory view overflow: long unbreakable strings (URLs,
+  // hashes) must not be able to push the Radix ScrollArea's display:table
+  // wrapper past the viewport width. This is achieved via inherited
+  // [overflow-wrap:anywhere] which collapses min-content calculations, plus
+  // min-w-0 on every flex path that holds user content.
+  describe("overflow safety", () => {
+    it("renders memo list cards inside an overflow-wrap:anywhere container so long titles can't blow out the sidebar", () => {
+      mockUseMemoSearch.mockReturnValue({
+        data: {
+          results: [
+            {
+              memo: buildMemo({
+                id: "memo_long",
+                title: LONG_UNBREAKABLE_TITLE,
+                abstract: LONG_UNBREAKABLE_ABSTRACT,
+              }),
+              distance: 0,
+              sourceStream: null,
+              rootStream: null,
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      mockUseMemoDetail.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      renderPage("/w/ws_1/memory")
+
+      const title = screen.getByText(LONG_UNBREAKABLE_TITLE)
+      const card = title.closest("a")
+      expect(card).not.toBeNull()
+      expect(card?.className).toContain("[overflow-wrap:anywhere]")
+      expect(card?.className).toContain("overflow-hidden")
+
+      // The title itself must be shrinkable in its flex parent so line-clamp
+      // can actually clip rather than forcing the card wider.
+      expect(title.className).toContain("min-w-0")
+      expect(title.className).toContain("line-clamp-2")
+    })
+
+    it("renders memo detail with overflow-wrap:anywhere so long content wraps inside the viewport", () => {
+      mockUseMemoSearch.mockReturnValue({
+        data: {
+          results: [
+            {
+              memo: buildMemo({ id: "memo_1", title: "Pick me" }),
+              distance: 0,
+              sourceStream: null,
+              rootStream: null,
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      mockUseMemoDetail.mockReturnValue({
+        data: {
+          memo: {
+            memo: buildMemo({
+              id: "memo_1",
+              title: LONG_UNBREAKABLE_TITLE,
+              abstract: LONG_UNBREAKABLE_ABSTRACT,
+              keyPoints: [LONG_UNBREAKABLE_ABSTRACT],
+              tags: [LONG_UNBREAKABLE_ABSTRACT],
+            }),
+            distance: 0,
+            sourceStream: { id: "stream_1", name: LONG_UNBREAKABLE_TITLE, type: "channel" },
+            rootStream: null,
+            sourceMessages: [
+              {
+                id: "msg_1",
+                streamId: "stream_1",
+                streamName: LONG_UNBREAKABLE_TITLE,
+                authorId: "user_1",
+                authorType: "user" as const,
+                authorName: "Alice",
+                content: `Look at this URL: ${LONG_UNBREAKABLE_TITLE}`,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      renderPage("/w/ws_1/memory?memo=memo_1")
+
+      // The detail root should have overflow-wrap:anywhere so all nested text
+      // (title, abstract, key points, source messages, markdown) inherits it.
+      const detailTitle = screen.getAllByText(LONG_UNBREAKABLE_TITLE)[0]
+      // Walk up to the memo detail root wrapper
+      let current: HTMLElement | null = detailTitle
+      let foundOverflowWrap = false
+      while (current) {
+        if (current.className?.includes?.("[overflow-wrap:anywhere]")) {
+          foundOverflowWrap = true
+          break
+        }
+        current = current.parentElement
+      }
+      expect(foundOverflowWrap).toBe(true)
+    })
+
+    it("keeps source message headers from overflowing when stream names and author names are long", () => {
+      mockUseMemoSearch.mockReturnValue({
+        data: {
+          results: [
+            {
+              memo: buildMemo({ id: "memo_1", title: "Pick me" }),
+              distance: 0,
+              sourceStream: null,
+              rootStream: null,
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      mockUseMemoDetail.mockReturnValue({
+        data: {
+          memo: {
+            memo: buildMemo({ id: "memo_1" }),
+            distance: 0,
+            sourceStream: null,
+            rootStream: null,
+            sourceMessages: [
+              {
+                id: "msg_1",
+                streamId: "stream_1",
+                streamName: LONG_UNBREAKABLE_TITLE,
+                authorId: "user_1",
+                authorType: "user" as const,
+                authorName: LONG_UNBREAKABLE_ABSTRACT,
+                content: "Short content",
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      renderPage("/w/ws_1/memory?memo=memo_1")
+
+      // Author name must be truncatable in the flex header (not shrink-0)
+      const authorSpan = screen.getByText(LONG_UNBREAKABLE_ABSTRACT)
+      expect(authorSpan.className).toContain("min-w-0")
+      expect(authorSpan.className).toContain("truncate")
+      expect(authorSpan.className).not.toContain("shrink-0")
+
+      // Stream name link must be truncatable
+      const streamLink = screen.getAllByText(LONG_UNBREAKABLE_TITLE)[0]
+      expect(streamLink.className).toContain("min-w-0")
+      expect(streamLink.className).toContain("truncate")
+    })
   })
 })

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -140,15 +140,20 @@ function MemoResultItem({ result, isActive, href }: { result: MemoExplorerResult
     <Link
       to={href}
       className={cn(
-        "group block overflow-hidden rounded-lg border-l-[3px] border border-l-transparent bg-card transition-all",
+        // [overflow-wrap:anywhere] is inherited by descendants and collapses the
+        // intrinsic min-content of long unbreakable strings (URLs, hashes) so the
+        // Radix ScrollArea's display:table wrapper can't be forced wider than the
+        // viewport. `break-words` alone is insufficient — per spec it doesn't
+        // affect min-content calculation.
+        "group block overflow-hidden rounded-lg border-l-[3px] border border-l-transparent bg-card transition-all [overflow-wrap:anywhere]",
         isActive
           ? cn("border-primary/30 shadow-sm", config.accent)
           : "border-border/50 hover:border-border hover:shadow-sm"
       )}
     >
-      <div className="px-3.5 py-3">
-        <div className="flex items-start justify-between gap-2 min-w-0">
-          <h3 className="min-w-0 text-[13px] font-semibold leading-snug text-foreground line-clamp-2">
+      <div className="min-w-0 px-3.5 py-3">
+        <div className="flex min-w-0 items-start justify-between gap-2">
+          <h3 className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-foreground line-clamp-2">
             {result.memo.title}
           </h3>
           <RelativeTime
@@ -159,15 +164,18 @@ function MemoResultItem({ result, isActive, href }: { result: MemoExplorerResult
 
         <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground line-clamp-2">{result.memo.abstract}</p>
 
-        <div className="mt-2.5 flex items-center gap-2">
+        <div className="mt-2.5 flex min-w-0 items-center gap-2">
           <KnowledgeTypeBadge type={result.memo.knowledgeType} size="xs" />
 
           {result.memo.tags.length > 0 && (
-            <div className="flex items-center gap-1 overflow-hidden">
+            <div className="flex min-w-0 items-center gap-1 overflow-hidden">
               {result.memo.tags.slice(0, 2).map((tag) => (
-                <span key={tag} className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground/70">
-                  <Hash className="h-2.5 w-2.5" />
-                  {tag}
+                <span
+                  key={tag}
+                  className="inline-flex min-w-0 items-center gap-0.5 text-[10px] text-muted-foreground/70"
+                >
+                  <Hash className="h-2.5 w-2.5 shrink-0" />
+                  <span className="truncate">{tag}</span>
                 </span>
               ))}
             </div>
@@ -175,9 +183,9 @@ function MemoResultItem({ result, isActive, href }: { result: MemoExplorerResult
         </div>
 
         {(sourceLabel || rootLabel) && (
-          <div className="mt-2 flex items-center gap-1 text-[10px] text-muted-foreground/60">
+          <div className="mt-2 flex min-w-0 items-center gap-1 text-[10px] text-muted-foreground/60">
             <MessageSquareQuote className="h-2.5 w-2.5 shrink-0" />
-            <span className="truncate">
+            <span className="min-w-0 truncate">
               {sourceLabel}
               {sourceLabel && rootLabel && result.rootStream?.id !== result.sourceStream?.id && (
                 <span className="text-muted-foreground/40"> in {rootLabel}</span>
@@ -241,9 +249,12 @@ function MemoDetailContent({
   }
 
   return (
-    <div className="min-w-0 space-y-8">
+    // [overflow-wrap:anywhere] is inherited by descendants so long unbreakable
+    // strings collapse in min-content calculations. Without this, the Radix
+    // ScrollArea / Drawer viewport can be forced wider than the screen on mobile.
+    <div className="min-w-0 space-y-8 [overflow-wrap:anywhere]">
       {/* Title section */}
-      <div>
+      <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2 mb-3">
           <KnowledgeTypeBadge type={data.memo.knowledgeType} size="sm" />
           <Badge variant="secondary" className="text-[10px] font-medium">
@@ -262,10 +273,10 @@ function MemoDetailContent({
             {data.memo.tags.map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center gap-0.5 rounded-md bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground"
+                className="inline-flex max-w-full items-center gap-0.5 rounded-md bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground"
               >
-                <Hash className="h-2.5 w-2.5" />
-                {tag}
+                <Hash className="h-2.5 w-2.5 shrink-0" />
+                <span className="min-w-0 truncate">{tag}</span>
               </span>
             ))}
           </div>
@@ -279,7 +290,7 @@ function MemoDetailContent({
             {data.memo.keyPoints.map((keyPoint) => (
               <li
                 key={keyPoint}
-                className="relative pl-4 text-sm leading-relaxed before:absolute before:left-0 before:top-[0.6em] before:h-1.5 before:w-1.5 before:rounded-full before:bg-primary/40"
+                className="relative min-w-0 pl-4 text-sm leading-relaxed before:absolute before:left-0 before:top-[0.6em] before:h-1.5 before:w-1.5 before:rounded-full before:bg-primary/40"
               >
                 {keyPoint}
               </li>
@@ -290,26 +301,26 @@ function MemoDetailContent({
 
       {/* Provenance */}
       <DetailSection title="Provenance">
-        <div className="flex flex-wrap gap-2">
+        <div className="flex min-w-0 flex-wrap gap-2">
           {data.sourceStream && (
             <Link
               to={buildSourceLink(workspaceId, data.sourceStream.id)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
             >
-              <MessageSquareQuote className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="font-medium">{formatStreamRef(data.sourceStream)}</span>
-              <ExternalLink className="h-3 w-3 text-muted-foreground/40" />
+              <MessageSquareQuote className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.sourceStream)}</span>
+              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
             </Link>
           )}
 
           {data.rootStream && data.rootStream.id !== data.sourceStream?.id && (
             <Link
               to={buildSourceLink(workspaceId, data.rootStream.id)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
             >
-              <span className="text-xs text-muted-foreground/60">in</span>
-              <span className="font-medium">{formatStreamRef(data.rootStream)}</span>
-              <ExternalLink className="h-3 w-3 text-muted-foreground/40" />
+              <span className="shrink-0 text-xs text-muted-foreground/60">in</span>
+              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.rootStream)}</span>
+              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
             </Link>
           )}
 
@@ -326,24 +337,24 @@ function MemoDetailContent({
         ) : (
           <div className="space-y-3">
             {data.sourceMessages.map((message) => (
-              <div key={message.id} className="overflow-hidden rounded-lg border border-border/50 bg-card">
-                <div className="flex items-center gap-2 border-b border-border/30 px-4 py-2 min-w-0">
-                  <span className="shrink-0 text-xs font-semibold">{message.authorName}</span>
-                  <span className="text-[10px] text-muted-foreground/40">in</span>
+              <div key={message.id} className="min-w-0 overflow-hidden rounded-lg border border-border/50 bg-card">
+                <div className="flex min-w-0 items-center gap-2 border-b border-border/30 px-4 py-2">
+                  <span className="min-w-0 truncate text-xs font-semibold">{message.authorName}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground/40">in</span>
                   <Link
                     to={buildSourceLink(workspaceId, message.streamId, message.id)}
-                    className="truncate text-xs text-primary/80 hover:text-primary hover:underline"
+                    className="min-w-0 truncate text-xs text-primary/80 hover:text-primary hover:underline"
                   >
                     {message.streamName}
                   </Link>
-                  <span className="ml-auto">
+                  <span className="ml-auto shrink-0">
                     <RelativeTime
                       date={message.createdAt}
                       className="text-[10px] tabular-nums text-muted-foreground/40"
                     />
                   </span>
                 </div>
-                <div className="overflow-hidden px-4 py-3 text-sm leading-relaxed">
+                <div className="min-w-0 overflow-hidden px-4 py-3 text-sm leading-relaxed">
                   <MarkdownContent content={message.content} className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0" />
                 </div>
               </div>
@@ -695,7 +706,7 @@ export function MemoryPage() {
         <LoadingBar visible={isRefreshing} />
         {/* Results list — full width on mobile, fixed sidebar on desktop */}
         <ScrollArea className="min-w-0 flex-1 lg:w-[22rem] lg:flex-none lg:border-r border-border/50">
-          <div className="space-y-1.5 p-2">
+          <div className="min-w-0 space-y-1.5 p-2 [overflow-wrap:anywhere]">
             {searchResponse.isLoading && (
               <>
                 <Skeleton className="h-24 rounded-lg" />
@@ -735,8 +746,8 @@ export function MemoryPage() {
 
         {/* Desktop detail pane */}
         {!isMobile && (
-          <ScrollArea className="flex-1">
-            <main className="mx-auto max-w-3xl p-5 sm:p-8">
+          <ScrollArea className="min-w-0 flex-1">
+            <main className="mx-auto min-w-0 max-w-3xl p-5 sm:p-8">
               <MemoDetailContent data={selectedMemoData} workspaceId={workspaceId} isLoading={selectedMemo.isLoading} />
             </main>
           </ScrollArea>
@@ -752,8 +763,14 @@ export function MemoryPage() {
           }}
         >
           <DrawerContent className="max-h-[85dvh]">
-            <ScrollArea className="min-w-0 overflow-auto p-4 pb-8">
-              <MemoDetailContent data={selectedMemoData} workspaceId={workspaceId} isLoading={selectedMemo.isLoading} />
+            <ScrollArea className="min-w-0">
+              <div className="min-w-0 p-4 pb-8">
+                <MemoDetailContent
+                  data={selectedMemoData}
+                  workspaceId={workspaceId}
+                  isLoading={selectedMemo.isLoading}
+                />
+              </div>
             </ScrollArea>
           </DrawerContent>
         </Drawer>


### PR DESCRIPTION
## Summary

Third time's the charm on memory-view overflow. The previous `min-w-0` fix (#327) wasn't enough — cards still overflowed on mobile *and* desktop, and source messages sometimes overflowed in the detail drawer.

**Root cause:** Radix `ScrollArea` wraps children in a `display: table; min-width: 100%` element. When a child's intrinsic **min-content** exceeds the viewport (long URL, hash, unbreakable string), the table grows wider than the screen. Critically, per the CSS spec, `overflow-wrap: break-word` (what Tailwind's `break-words` emits) **does not** affect min-content calculations — only `overflow-wrap: anywhere` does. So `break-words` + `min-w-0` alone can't stop min-content from pushing the table wider than the viewport.

**Secondary bug in source-message headers:** the author-name `<span>` was `shrink-0` (so a long name pushed the whole header wide), and the stream-name `<Link>` had `truncate` without `min-w-0` (classic flex truncate gotcha — flex items default to `min-width: auto`, so `truncate` alone does nothing inside a flex parent).

## Changes

**Memo list cards** (`MemoResultItem`):
- `[overflow-wrap:anywhere]` at the card root — inherited by all descendants, collapses min-content for long URLs so the Radix table can't be forced wider than the sidebar
- `min-w-0` on the source-label flex parent + inner truncate span
- Tag chips now wrap content in a truncate span instead of laying bare text

**Memo detail view** (`MemoDetailContent`):
- `[overflow-wrap:anywhere]` at the detail root — title, abstract, key points, source-message markdown all inherit it
- Provenance `<Link>`s get `min-w-0 max-w-full`, inner text gets `min-w-0 truncate`, icons get `shrink-0`
- Key-point `<li>`s get `min-w-0`
- **Source-message headers:** author-name span changed from `shrink-0` to `min-w-0 truncate`, stream-name link gets `min-w-0 truncate`, time span gets `shrink-0` so it doesn't collapse

**Layout containers:**
- Sidebar scroll wrapper: `min-w-0 [overflow-wrap:anywhere]`
- Desktop detail pane `<ScrollArea>`: add missing `min-w-0` so `flex-1` can actually shrink
- Mobile drawer: removed spurious `overflow-auto` (twMerge was overriding Radix's default `overflow-hidden` on the Root) and moved padding to a proper inner wrapper

## Test plan

- [x] 3 new regression tests render memos with long unbreakable URLs/hashes and assert the overflow-safe classes survive on cards, detail view, and source-message headers
- [x] `bun run --cwd apps/frontend test` — 1060/1060 pass
- [x] `bun run typecheck` — clean across monorepo
- [x] Lint clean
- [ ] Manual check on mobile Safari with a memo whose title/abstract/source message contains a very long URL
- [ ] Manual check on desktop with the sidebar at 22rem and a memo with a long title

https://claude.ai/code/session_01DoVyU483qyu6YqFH9yDPb1