### PR TITLE
fix: make memo detail scrollable on mobile drawer and narrow desktop

### DIFF
--- a/apps/frontend/src/pages/memory.test.tsx
+++ b/apps/frontend/src/pages/memory.test.tsx
@@ -6,6 +6,7 @@ import { MemoryPage } from "./memory"
 const mockUseMemoSearch = vi.fn()
 const mockUseMemoDetail = vi.fn()
 const mockUseWorkspaceStreams = vi.fn()
+const mockUseIsMobile = vi.fn()
 
 vi.mock("@/hooks", () => ({
   useMemoSearch: (...args: unknown[]) => mockUseMemoSearch(...args),
@@ -14,6 +15,10 @@ vi.mock("@/hooks", () => ({
 
 vi.mock("@/stores/workspace-store", () => ({
   useWorkspaceStreams: (...args: unknown[]) => mockUseWorkspaceStreams(...args),
+}))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockUseIsMobile(),
 }))
 
 vi.mock("@/components/relative-time", () => ({
@@ -69,8 +74,11 @@ describe("MemoryPage", () => {
     mockUseWorkspaceStreams.mockReset()
     mockUseMemoSearch.mockReset()
     mockUseMemoDetail.mockReset()
+    mockUseIsMobile.mockReset()
 
     mockUseWorkspaceStreams.mockReturnValue([])
+    // Default to desktop layout; individual tests opt into mobile.
+    mockUseIsMobile.mockReturnValue(false)
   })
 
   it("manually refreshes the memo list and selected memo", async () => {
@@ -326,6 +334,63 @@ describe("MemoryPage", () => {
       const streamLink = screen.getAllByText(LONG_UNBREAKABLE_TITLE)[0]
       expect(streamLink.className).toContain("min-w-0")
       expect(streamLink.className).toContain("truncate")
+    })
+  })
+
+  // Regression guard for mobile memo drawer scroll. The drawer uses Vaul
+  // inside a flex-col DrawerContent with max-h-[85dvh], so the content body
+  // must use `flex-1 min-h-0 overflow-y-auto` to actually claim space and
+  // scroll — otherwise tall memos get clipped and the user can't see
+  // Context/Provenance/Source sections. Also needs `data-vaul-no-drag` so
+  // Vaul doesn't intercept touch scrolls as drawer-close gestures.
+  describe("mobile drawer scroll", () => {
+    it("renders the mobile detail drawer with a scrollable flex-1 body", () => {
+      mockUseIsMobile.mockReturnValue(true)
+
+      mockUseMemoSearch.mockReturnValue({
+        data: {
+          results: [
+            {
+              memo: buildMemo({ id: "memo_1", title: "Launch decision" }),
+              distance: 0,
+              sourceStream: null,
+              rootStream: null,
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      mockUseMemoDetail.mockReturnValue({
+        data: {
+          memo: {
+            memo: buildMemo({ id: "memo_1", title: "Launch decision" }),
+            distance: 0,
+            sourceStream: null,
+            rootStream: null,
+            sourceMessages: [],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      renderPage("/w/ws_1/memory?memo=memo_1")
+
+      // The drawer renders MemoDetailContent — walk up to find the scroll
+      // container and assert it has the canonical drawer-scroll classes.
+      const detailTitle = screen.getByRole("heading", { name: "Launch decision" })
+      let scrollContainer: HTMLElement | null = detailTitle.parentElement
+      while (scrollContainer && !scrollContainer.hasAttribute("data-vaul-no-drag")) {
+        scrollContainer = scrollContainer.parentElement
+      }
+      expect(scrollContainer).not.toBeNull()
+      expect(scrollContainer?.className).toContain("flex-1")
+      expect(scrollContainer?.className).toContain("min-h-0")
+      expect(scrollContainer?.className).toContain("overflow-y-auto")
     })
   })
 })

--- a/apps/frontend/src/pages/memory.test.tsx
+++ b/apps/frontend/src/pages/memory.test.tsx
@@ -337,6 +337,63 @@ describe("MemoryPage", () => {
     })
   })
 
+  // Regression guard for desktop detail pane scroll. Between the mobile
+  // breakpoint (640px) and lg (1024px) the content wrapper is a flex-col
+  // with two flex-1 siblings (list + detail), and Radix ScrollArea's
+  // `h-full` viewport height chain is brittle in that layout. The desktop
+  // detail pane uses a plain div with `flex-1 min-h-0 overflow-y-auto` for
+  // unambiguous native scrolling.
+  describe("desktop detail pane scroll", () => {
+    it("renders the desktop detail pane as a scrollable flex-1 div", () => {
+      mockUseIsMobile.mockReturnValue(false)
+
+      mockUseMemoSearch.mockReturnValue({
+        data: {
+          results: [
+            {
+              memo: buildMemo({ id: "memo_1", title: "Launch decision" }),
+              distance: 0,
+              sourceStream: null,
+              rootStream: null,
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      mockUseMemoDetail.mockReturnValue({
+        data: {
+          memo: {
+            memo: buildMemo({ id: "memo_1", title: "Launch decision" }),
+            distance: 0,
+            sourceStream: null,
+            rootStream: null,
+            sourceMessages: [],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      })
+
+      renderPage("/w/ws_1/memory?memo=memo_1")
+
+      // Walk up from the h2 title to find the scroll container. The detail
+      // pane wraps the title in a <main> which is the direct child of the
+      // scroll div.
+      const detailTitle = screen.getByRole("heading", { level: 2, name: "Launch decision" })
+      const mainEl = detailTitle.closest("main")
+      expect(mainEl).not.toBeNull()
+      const scrollContainer = mainEl?.parentElement
+      expect(scrollContainer).not.toBeNull()
+      expect(scrollContainer?.className).toContain("flex-1")
+      expect(scrollContainer?.className).toContain("min-h-0")
+      expect(scrollContainer?.className).toContain("overflow-y-auto")
+    })
+  })
+
   // Regression guard for mobile memo drawer scroll. The drawer uses Vaul
   // inside a flex-col DrawerContent with max-h-[85dvh], so the content body
   // must use `flex-1 min-h-0 overflow-y-auto` to actually claim space and

--- a/apps/frontend/src/pages/memory.test.tsx
+++ b/apps/frontend/src/pages/memory.test.tsx
@@ -380,9 +380,10 @@ describe("MemoryPage", () => {
 
       renderPage("/w/ws_1/memory?memo=memo_1")
 
-      // The drawer renders MemoDetailContent — walk up to find the scroll
-      // container and assert it has the canonical drawer-scroll classes.
-      const detailTitle = screen.getByRole("heading", { name: "Launch decision" })
+      // The drawer renders MemoDetailContent with the title as an <h2>; the
+      // sidebar list renders each result's title as an <h3>. Scope to level=2
+      // so we're unambiguously inside the drawer body.
+      const detailTitle = screen.getByRole("heading", { level: 2, name: "Launch decision" })
       let scrollContainer: HTMLElement | null = detailTitle.parentElement
       while (scrollContainer && !scrollContainer.hasAttribute("data-vaul-no-drag")) {
         scrollContainer = scrollContainer.parentElement

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -763,15 +763,20 @@ export function MemoryPage() {
           }}
         >
           <DrawerContent className="max-h-[85dvh]">
-            <ScrollArea className="min-w-0">
-              <div className="min-w-0 p-4 pb-8">
-                <MemoDetailContent
-                  data={selectedMemoData}
-                  workspaceId={workspaceId}
-                  isLoading={selectedMemo.isLoading}
-                />
-              </div>
-            </ScrollArea>
+            {/*
+              Scrollable content inside a Vaul drawer needs an explicit flex
+              scroll container: DrawerContent is a flex-col with max-h, so the
+              child must `flex-1 min-h-0 overflow-y-auto` to claim remaining
+              height and actually scroll. `data-vaul-no-drag` stops Vaul from
+              intercepting touch-drags as close gestures once the user is
+              inside the scrollable body. Radix ScrollArea doesn't fit here
+              because its Root has fixed overflow:hidden and no intrinsic
+              flex sizing — a plain div is the codebase convention (see
+              message-action-drawer.tsx).
+            */}
+            <div data-vaul-no-drag className="min-w-0 flex-1 min-h-0 overflow-y-auto p-4 pb-8">
+              <MemoDetailContent data={selectedMemoData} workspaceId={workspaceId} isLoading={selectedMemo.isLoading} />
+            </div>
           </DrawerContent>
         </Drawer>
       )}

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -744,13 +744,21 @@ export function MemoryPage() {
           </div>
         </ScrollArea>
 
-        {/* Desktop detail pane */}
+        {/* Desktop detail pane. Uses `flex-1 min-h-0 overflow-y-auto` on a
+            plain div rather than Radix ScrollArea: between the mobile
+            breakpoint (640px) and `lg:flex-row` (1024px) the parent is a
+            flex-col with TWO flex-1 siblings (list + detail), and Radix
+            ScrollArea's `h-full` Viewport height chain is brittle when
+            sharing vertical space — the Root relies on `overflow-hidden`
+            implying min-height:0 on flex items, which some flex-col +
+            sibling-ScrollArea combinations don't resolve reliably. Native
+            `overflow-y-auto` + explicit `min-h-0` is unambiguous. */}
         {!isMobile && (
-          <ScrollArea className="min-w-0 flex-1">
+          <div className="min-w-0 flex-1 min-h-0 overflow-y-auto">
             <main className="mx-auto min-w-0 max-w-3xl p-5 sm:p-8">
               <MemoDetailContent data={selectedMemoData} workspaceId={workspaceId} isLoading={selectedMemo.isLoading} />
             </main>
-          </ScrollArea>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Problem

The memo detail view can't be scrolled when the content overflows the visible pane:

1. **Mobile** — opening a memo shows the pull-up drawer, but the content inside can't be scrolled. Tall memos are clipped at `85dvh` with no way to reach Key Points, Provenance, or Source messages:

   > There is a new problem with the memory view where, at least on mobile, where I can't anymore scroll the full up tab which means message is truncated in another way than before. I can't scroll the pull up tab in this window so I can't see the context.

2. **Desktop, narrow window** — the same bug hides on wide monitors because the memo content comfortably fits in the detail pane. When the user shrinks the browser window narrow enough (or short enough) that content overflows, the detail pane refuses to scroll too.

   > This is an issue on mobile as well. Sorry. On desktop as well.

### Root cause

Both sites share the same flavor of bug: a Radix `<ScrollArea>` without a definite height on its Root element, so its `h-full` internal Viewport can't compute a scrollable region.

**Mobile drawer (#330 regression):** `overflow-auto` was removed from the drawer's `<ScrollArea>` and padding moved into an inner wrapper. Radix ScrollArea's Viewport only scrolls when its Root has a definite height — and the Root had neither `flex-1` nor any `h-*` class inside the flex-col `DrawerContent`. Content ballooned past `85dvh` with no scroll affordance.

**Desktop detail pane:** Between the mobile breakpoint (640px) and `lg` (1024px), the content wrapper is a `flex-col` with **two** `flex-1` ScrollArea siblings stacked vertically (list + detail). Radix ScrollArea's Root relies on `overflow-hidden` implying `min-height: 0` on flex items (per spec) so it can shrink to its flex share — but in practice that chain is brittle when two Radix ScrollAreas share vertical space, and the Viewport's `h-full` fails to resolve to a scrollable box. On wide monitors the memo content fits without triggering the bug, which is why it went unnoticed.

## Solution

Apply the same minimal fix to both sites: replace the broken `<ScrollArea>` with a plain `<div>` using native overflow scrolling and explicit flex-shrink plumbing.

**Mobile drawer (`memory.tsx:765`):**

```tsx
<DrawerContent className="max-h-[85dvh]">
  <div data-vaul-no-drag className="min-w-0 flex-1 min-h-0 overflow-y-auto p-4 pb-8">
    <MemoDetailContent ... />
  </div>
</DrawerContent>
```

**Desktop detail pane (`memory.tsx:756`):**

```tsx
{!isMobile && (
  <div className="min-w-0 flex-1 min-h-0 overflow-y-auto">
    <main className="mx-auto min-w-0 max-w-3xl p-5 sm:p-8">
      <MemoDetailContent ... />
    </main>
  </div>
)}
```

### Key design decisions

**1. Plain `<div>` instead of Radix `<ScrollArea>` at both sites**

Radix ScrollArea's Root is hardcoded to `overflow: hidden` and relies on an internal Viewport (`h-full w-full`) for scrolling — which needs height plumbing that works reliably in simple flex contexts but is fragile in nested flex-col layouts with ScrollArea siblings. A plain div with `overflow-y-auto` uses native browser scrolling and has no indirection to debug. Mobile doesn't show custom scrollbars anyway, and the desktop native scrollbar is perfectly fine for a memo detail pane. This matches the codebase convention for scrollable drawer/pane bodies (`message-action-drawer.tsx:362`).

**2. `flex-1 min-h-0 overflow-y-auto` on the scroll container**

`flex-1` claims the remaining main-axis space. `min-h-0` explicitly allows shrinking below intrinsic content height (belt-and-suspenders: even if `overflow-y-auto` should imply this, making it explicit removes any ambiguity across browser flex implementations). `overflow-y-auto` does the actual scrolling.

**3. `data-vaul-no-drag` on the drawer scroll body**

Prevents Vaul from interpreting vertical touch-drags inside the body as a drawer-close gesture. The drawer handle at the top of `DrawerContent` remains drag-to-close, so users keep both affordances: scroll the body, or grab the handle to dismiss.

**4. Keep `min-w-0` on both scroll containers**

Preserves the horizontal overflow fix from #330. `MemoDetailContent` has `[overflow-wrap:anywhere]` which collapses min-content for long URLs, but that only works when the scroll container can shrink below its content width — hence `min-w-0`.

**5. Leave the list ScrollArea alone**

The results list (`memory.tsx:708`) also uses Radix ScrollArea, but it wasn't reported as broken and there's no direct evidence of a failure mode there. Per CLAUDE.md minimal-patch rules, I don't touch working code. If it turns out to have the same issue, it can be converted in a follow-up.

## Modified files

| File                                                        | Change                                                                                                          |
| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| `apps/frontend/src/pages/memory.tsx`                        | Replace mobile drawer and desktop detail pane `ScrollArea`s with `flex-1 min-h-0 overflow-y-auto` divs. Drawer also gets `data-vaul-no-drag`. Explanatory comments at both sites. |
| `apps/frontend/src/pages/memory.test.tsx`                   | Mock `useIsMobile`; add two regression tests asserting (a) the desktop pane wraps `<main>` in a `flex-1 min-h-0 overflow-y-auto` div, and (b) the mobile drawer scroll container has `data-vaul-no-drag` + `flex-1 min-h-0 overflow-y-auto`. Heading queries scoped to `level: 2` to disambiguate from the sidebar list's `<h3>`. |

## Test plan

- [x] `bun run vitest run src/pages/memory.test.tsx` — 6/6 passing, including both new regression guards
- [x] Typecheck + lint + prettier pass via pre-commit hook
- [ ] Manual verification on mobile Safari: open a tall memo, confirm the drawer body scrolls, confirm drag-to-close still works from the handle
- [ ] Manual verification on mobile Chrome: same as above
- [ ] Manual verification on desktop at a narrow+short window (e.g., 800×500): open a tall memo, confirm the detail pane scrolls
- [ ] Manual verification on wide desktop: confirm nothing regressed (detail pane still scrolls, list still scrolls)

## Follow-ups (not addressed here)

- The mobile drawer is missing a `DrawerTitle` — Radix Dialog emits an a11y warning about this. It's preexisting (only now surfaced because this PR's test is the first to render the mobile drawer in tests) and out of scope for a focused scroll fix. Worth a small follow-up to add a `sr-only` title for screen reader users.
- The list `ScrollArea` (`memory.tsx:708`) uses the same Radix pattern and might be susceptible to the same narrow-desktop failure mode; if users report it, apply the same plain-div conversion.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
