### PR TITLE
feat(agents): resolve quote-reply precursors into Ariadne's context

### DIFF
--- a/.claude/plans/velvet-mapping-lake.md
+++ b/.claude/plans/velvet-mapping-lake.md
@@ -1,0 +1,256 @@
+# Quote-reply context resolution for Ariadne
+
+## Context
+
+Quote replies are implemented as `quoteReply` ProseMirror atom nodes embedded in `messages.content_json` (`packages/types/src/prosemirror.ts:106`). The node carries `{messageId, streamId, authorId, authorName, actorType, snippet}` — a denormalized excerpt, not a structural DB link (per INV-1, no FKs). When the markdown serializer runs (`packages/prosemirror/src/markdown.ts:80`), the node becomes:
+
+```
+> snippet here
+>
+> — [Author](quote:streamId/messageId/authorId/actorType)
+```
+
+This is all Ariadne ever sees today. Both the in-stream history path (`companion/context.ts:167` → `formatMessagesWithTemporal`) and the researcher retrieval path (`researcher.ts:664` → `enrichMessageSearchResults`) feed her messages via `contentMarkdown` only. There is no code that parses the `quote:` URI, no fetch of the referenced message, and no expansion of context. If a user quotes 2 lines of a 40-line message, the other 38 lines are invisible to her — which defeats the point of the feature, since the whole reason to quote is to reply with reference to a prior statement that carries its own surrounding meaning.
+
+The fix is to detect `quoteReply` nodes when assembling Ariadne's prompt context, fetch the full source message(s) recursively (up to 5 precursors), and inline them as `<quoted-source>` blocks alongside the existing snippet. Applies to both paths. No DB migration — all the data already exists in `content_json.attrs.messageId`.
+
+## Approach
+
+### 1. New module: `apps/backend/src/features/agents/quote-resolver.ts`
+
+Two exported functions, colocated for testability but logically separate:
+
+**`resolveQuoteReplies(db, workspaceId, input)`** — BFS walker that returns a `Map<messageId, Message>` of all resolved precursors.
+
+```ts
+export interface ResolveQuoteRepliesInput {
+  seedMessages: Message[]              // caller already has these; not re-fetched
+  accessibleStreamIds: Set<string>     // cross-stream access filter
+  maxDepth?: number                    // default 5 (per user spec)
+  maxTotalResolved?: number            // default 100, DoS cap across all levels
+}
+
+export interface ResolveQuoteRepliesResult {
+  resolved: Map<string, Message>       // precursorId -> full Message
+  authorNames: Map<string, string>     // batch-resolved for all resolved messages
+}
+
+export async function resolveQuoteReplies(
+  db: Querier,
+  workspaceId: string,
+  input: ResolveQuoteRepliesInput
+): Promise<ResolveQuoteRepliesResult>
+```
+
+Algorithm:
+1. `visited = new Set<string>(seedMessages.map(m => m.id))` — seeded **before** level-0 walking so adjacent history messages quoting each other aren't re-fetched as duplicates.
+2. Walk each seed's `contentJson` via a small local `walkJsonNodes` helper; collect each `quoteReply.attrs.messageId` into a frontier, skipping any already in `visited`.
+3. Batch-fetch the frontier via a **new** `MessageRepository.findByIdsInStreams(db, ids, accessibleStreamIds)` (see §2). This single SQL already applies workspace scoping (via stream membership), access filtering, and `deleted_at IS NULL` — all three concerns in one query. Defense in depth: even if `quoteReply.attrs.streamId` is hostile client data, it cannot point outside the caller's accessible streams.
+4. For each returned message, mark resolved, add its ID to `visited`, walk its `contentJson` to build the next frontier. Stop when frontier is empty, depth reaches `maxDepth`, or `resolved.size` reaches `maxTotalResolved`.
+5. Log skipped quotes at debug with `{ messageId, quotedId, reason: "not_accessible" | "not_found" | "cycle" | "depth_cap" | "total_cap" }` — silent skips hide access bugs.
+6. After BFS, batch-resolve author names for every resolved message via `UserRepository.findByIds` and `PersonaRepository.findByIds`.
+
+Cycle safety: because `updateContent` mutates in place (`repository.ts:264`), edit-induced cycles (A→B, then A is edited to quote itself, or A→B→A) all resolve to the same message IDs and terminate on the `visited` check.
+
+**`renderMessageWithQuoteContext(message, resolved, authorNames, depth, maxDepth)`** — pure string builder, no DB:
+
+- Starts with `message.contentMarkdown` (the already-serialized base, including the existing `> snippet\n> — [Author](quote:...)` attribution lines — do **not** re-serialize, that would mangle it).
+- Walks `message.contentJson` to find `quoteReply` nodes at any nesting.
+- For each found `quoteReply.attrs.messageId` that has a hit in `resolved`, appends a `<quoted-source>` block after the base markdown:
+
+  ```
+  <quoted-source id="msg_456" author="Bob" streamId="stream_abc" createdAt="2024-01-01T10:00:00.000Z">
+  [serializeToMarkdown(resolved.get(msg_456).contentJson), recursively expanded]
+  </quoted-source>
+  ```
+
+- Recurses on the resolved message's `contentJson` to nest further `<quoted-source>` blocks for deeper precursors, up to `maxDepth`.
+- Unresolved quotes are skipped silently in the output (the inline snippet + attribution line still appears, so the model still knows *something* was quoted). The debug log from the resolver captures why.
+- XML attribute values go through `escapeXmlAttr` (same helper pattern as `lib/ai/message-formatter.ts:11`).
+
+### 2. `MessageRepository.findByIdsInStreams` (new)
+
+Add to `apps/backend/src/features/messaging/repository.ts` next to `findByIds`:
+
+```ts
+async findByIdsInStreams(db: Querier, ids: string[], streamIds: string[]): Promise<Map<string, Message>> {
+  if (ids.length === 0 || streamIds.length === 0) return new Map()
+  const result = await db.query<MessageRow>(sql`
+    SELECT ${sql.raw(SELECT_FIELDS)} FROM messages
+    WHERE id = ANY(${ids})
+      AND stream_id = ANY(${streamIds})
+      AND deleted_at IS NULL
+  `)
+  // ... same reaction aggregation as findByIds
+}
+```
+
+Single query, set-based (INV-56), no connection held (INV-30 — caller passes `pool` directly).
+
+### 3. Thread `accessibleStreamIds` through `AgentContext`
+
+Per the Plan agent's critique, duplicating the accessSpec computation in two places is a drift risk. Single source of truth:
+
+- Extend `AgentContext` (`companion/context.ts:34`) with `accessibleStreamIds: Set<string> | null` (null when no `invokingUserId` — bot turn).
+- Inside `buildAgentContext`, after `invokingUserId` is determined (line 76) and before `buildStreamContext`, compute:
+  ```ts
+  let accessibleStreamIds: Set<string> | null = null
+  if (invokingUserId) {
+    const accessSpec = await computeAgentAccessSpec(db, { stream, invokingUserId })
+    const ids = await SearchRepository.getAccessibleStreamsForAgent(db, accessSpec, workspaceId)
+    accessibleStreamIds = new Set(ids)
+  }
+  ```
+- `persona-agent.ts:312` stops recomputing; it reads `agentContext.accessibleStreamIds` and builds `workspaceDeps` from it. (Preserves the existing null-on-bot-turn behavior: `workspaceDeps` is still gated on `invokingUserId`.)
+- For bot turns (null), quote resolution defaults to `new Set([stream.id])` — expand only within the current stream. Documented asymmetry vs workspace tools (which skip access check entirely on bot turns); the conservative default here is "least surprise" for a feature explicitly about cross-stream references.
+
+### 4. In-stream path integration (`companion/context.ts`)
+
+After `buildStreamContext` populates `streamContext.conversationHistory` (line 104) and after the author-name maps are built (line 147), but **before** `formatMessagesWithTemporal` (line 167):
+
+```ts
+const { resolved, authorNames: quotedAuthorNames } = await resolveQuoteReplies(
+  db,
+  workspaceId,
+  {
+    seedMessages: streamContext.conversationHistory,
+    accessibleStreamIds: accessibleStreamIds ?? new Set([stream.id]),
+    maxDepth: 5,
+  }
+)
+
+// Merge quoted author names into the existing authorNames map for downstream consumers
+for (const [id, name] of quotedAuthorNames) authorNames.set(id, name)
+
+// Produce a new conversation history where each message's contentMarkdown is expanded
+const expandedHistory = streamContext.conversationHistory.map(m => ({
+  ...m,
+  contentMarkdown: renderMessageWithQuoteContext(m, resolved, authorNames, 0, 5),
+}))
+streamContext.conversationHistory = expandedHistory
+```
+
+`formatMessagesWithTemporal` is untouched — it still reads `contentMarkdown`, now containing the `<quoted-source>` expansions. This is the minimal-surface integration (INV-35).
+
+### 5. Researcher path integration (`researcher/researcher.ts` + `researcher/context-formatter.ts`)
+
+`EnrichedMessageResult` only carries `content: string`, not `contentJson`. Two surgical changes:
+
+- **Extend `EnrichedMessageResult`** with `quoteContext?: string` (pre-rendered, defaults to undefined).
+- **In `WorkspaceAgent.searchMessages`** (`researcher.ts:664`), after `enrichMessageSearchResults` returns, do a single batch fetch to get `contentJson` (the enrichment step doesn't carry it through today, and threading it through would ripple into `SearchRepository`):
+  ```ts
+  const enriched = await enrichMessageSearchResults(client, workspaceId, [...dedupedResultsById.values()])
+  if (enriched.length > 0) {
+    const seedMessageMap = await MessageRepository.findByIdsInStreams(
+      client, enriched.map(e => e.id), accessibleStreamIds
+    )
+    const { resolved, authorNames } = await resolveQuoteReplies(client, workspaceId, {
+      seedMessages: [...seedMessageMap.values()],
+      accessibleStreamIds: new Set(accessibleStreamIds),
+      maxDepth: 5,
+    })
+    // Pre-render quote context per enriched result
+    for (const e of enriched) {
+      const seed = seedMessageMap.get(e.id)
+      if (!seed) continue
+      const rendered = renderMessageWithQuoteContext(seed, resolved, mergedAuthorNames, 0, 5)
+      // Only set if there's actually expansion (avoids equality with base markdown)
+      if (rendered !== seed.contentMarkdown) {
+        e.quoteContext = extractAppendedQuotedSourceBlocks(rendered, seed.contentMarkdown)
+      }
+    }
+  }
+  ```
+  (The extract helper just returns the trailing `<quoted-source>` blocks — the portion the renderer appended beyond `contentMarkdown`. Clean separation so `e.content` stays as the snippet and `e.quoteContext` is the additive block.)
+- **In `formatMessagesSection`** (`context-formatter.ts:96`): keep the existing `msg.content.replace(/\s+/g, " ").trim()` collapse untouched for the base line (that's an unrelated concern; deferred). Append `quoteContext` after the collapsed line as a multi-line block if present:
+  ```ts
+  const quoteBlock = msg.quoteContext ? `\n${msg.quoteContext}` : ""
+  return `> **${author}** in _${msg.streamName}_ (${relativeDate}):\n> ${content}${quoteBlock}`
+  ```
+  The `<quoted-source>` XML wrapper parses fine in any context and is unambiguous to the model.
+
+### 6. Walker helper
+
+Small local function in `quote-resolver.ts`, not exported:
+
+```ts
+function walkJsonNodes(node: JSONContent, visit: (node: JSONContent) => void): void {
+  visit(node)
+  if (!node.content) return
+  for (const child of node.content) walkJsonNodes(child, visit)
+}
+```
+
+If it turns out a second consumer needs this later, it can be promoted to `packages/prosemirror/src/walk.ts`. YAGNI for now.
+
+## Critical files to modify
+
+- `apps/backend/src/features/agents/quote-resolver.ts` (new)
+- `apps/backend/src/features/agents/quote-resolver.test.ts` (new)
+- `apps/backend/src/features/agents/index.ts` — export the resolver via barrel (INV-52)
+- `apps/backend/src/features/messaging/repository.ts` — add `findByIdsInStreams`
+- `apps/backend/src/features/agents/companion/context.ts` — compute `accessibleStreamIds`, call resolver, expand history, extend `AgentContext`
+- `apps/backend/src/features/agents/persona-agent.ts` — read `accessibleStreamIds` from `agentContext` instead of recomputing (lines 312-316)
+- `apps/backend/src/features/agents/researcher/researcher.ts` — extend `searchMessages` to render quote context
+- `apps/backend/src/features/agents/researcher/context-formatter.ts` — extend `EnrichedMessageResult` with `quoteContext?: string`; append in `formatMessagesSection`
+
+## Reused utilities
+
+- `MessageRepository.findByIds` (pattern) → cloned as `findByIdsInStreams` in same file
+- `computeAgentAccessSpec` (`features/agents/researcher/access-spec.ts`) — already used by `persona-agent.ts:312`
+- `SearchRepository.getAccessibleStreamsForAgent` — same
+- `UserRepository.findByIds` + `PersonaRepository.findByIds` — for author name batch resolution inside the resolver (same pattern as `context-formatter.ts:171`)
+- `serializeToMarkdown` (`packages/prosemirror/src/markdown.ts:49`) — used by the renderer to serialize nested quoted messages
+- `escapeXmlAttr` pattern from `lib/ai/message-formatter.ts:11` — duplicate locally in resolver (three lines, not worth a shared util)
+
+## Verification
+
+### Unit tests (`quote-resolver.test.ts`)
+
+Mock `MessageRepository.findByIdsInStreams`, `UserRepository.findByIds`, `PersonaRepository.findByIds` via `spyOn` (same pattern as `message-formatter.test.ts`). Cases:
+
+- Single quote: seed A → quoteReply(B) → resolves B, renders with one `<quoted-source>` block
+- Depth chain: A→B→C→D→E→F, maxDepth=5 → resolves B..F, stops before going past F; debug log for depth cap
+- Cycle via edit: A→B→A → resolves B once, cycle detected on A
+- Self-cycle: A→A (edited) → resolves nothing (self in `visited` from seed), debug log for cycle
+- Multiple quotes in one message: A→[B,C] → both resolved, both `<quoted-source>` blocks present
+- Adjacent seeds referencing each other: seed [A, B] where A quotes B → B is in `visited` from seeds, not re-fetched (no duplicate rendering)
+- Dedup: A quotes B, C quotes B → B fetched once (verify single `findByIdsInStreams` call at level 1 contains only [B])
+- Access denied: quoted message's streamId not in `accessibleStreamIds` → `findByIdsInStreams` excludes it → not in `resolved` → inline snippet remains but no `<quoted-source>` block; debug log for not_accessible
+- Soft-deleted source: `findByIdsInStreams` filters at SQL → not resolved → debug log for not_found
+- `maxTotalResolved` cap: seed with 20 branches each of depth 5 → stops at 100 total; debug log for total_cap
+- Renderer XML escape: author name with quotes/brackets is properly escaped
+
+### Integration test (`apps/backend/src/features/agents/companion/context.test.ts` — extend or create)
+
+Mock `buildStreamContext`, `MessageRepository.findById`, `MessageRepository.findByIdsInStreams`, access-spec computation. Build a conversation history where message M (by Alice) contains a `quoteReply` to message Q (by Bob, from a different accessible stream). Assert that the `AgentContext.messages[M_index].content` contains both the original inline snippet AND a `<quoted-source id="Q" author="Bob" ...>` block with Q's full content.
+
+### Manual smoke
+
+Start a dev backend + frontend. In a workspace with at least two streams that the test user can access:
+1. Post a multi-paragraph message M1 in stream A.
+2. From stream B, quote-reply to a 1-line snippet of M1 and `@ariadne explain this in context of the full original message`.
+3. Verify Ariadne's response references content from M1 that was not in the quoted snippet (proves she saw the full source).
+4. Repeat with a message in an inaccessible stream (e.g. a DM she's not in) and confirm she falls back to snippet-only reasoning, with a debug log showing `reason: "not_accessible"`.
+
+### Commands
+
+- `bun run test apps/backend/src/features/agents/quote-resolver.test.ts`
+- `bun run test apps/backend/src/features/agents/companion/context.test.ts` (if extended)
+- `bun run test apps/backend/src/features/messaging/repository.test.ts` (if `findByIdsInStreams` gets unit coverage there)
+- `bun run test:e2e` — full regression before PR
+
+## Invariants touched / respected
+
+- **INV-1/INV-8**: No new FKs; workspace scoping enforced via stream-ID join at the query layer (`findByIdsInStreams` filters `stream_id = ANY(streamIds)` where `streamIds` is always workspace-scoped by construction).
+- **INV-30/INV-41**: Resolver takes `Querier`, does single batch queries, no connection held through iteration; callers pass `pool` directly.
+- **INV-51/INV-52**: New module in `features/agents/`, exported via barrel, imported by both `companion/` and `researcher/` via the barrel.
+- **INV-56**: Set-based batch fetches; one query per BFS level, not per-message.
+- **INV-36**: Cap `maxDepth` exposed for future tuning; no other speculative config. Debug logging is targeted at access-control correctness, not vanity.
+
+## Non-goals (explicitly deferred)
+
+- Summarization of quoted sources (the user said "we don't have that infra; just pull in the entire conversation at once").
+- Multi-line rendering in `formatMessagesSection`'s base line (the `replace(/\s+/g, " ")` collapse stays; quote context is appended as a separate block).
+- Promoting `walkJsonNodes` to a shared package (YAGNI until a second consumer exists).
+- Extending `SearchRepository` / `RawMessageSearchResult` to carry `contentJson`; the researcher path does one extra batch fetch instead.

--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -14,6 +14,9 @@ import { buildStreamContext, type StreamContext } from "../context-builder"
 import type { ConversationSummaryService } from "../conversation-summary-service"
 import { buildSystemPrompt } from "./prompt/system-prompt"
 import { formatMessagesWithTemporal } from "./prompt/message-format"
+import { resolveQuoteReplies, renderMessageWithQuoteContext, DEFAULT_MAX_QUOTE_DEPTH } from "../quote-resolver"
+import { computeAgentAccessSpec } from "../researcher/access-spec"
+import { SearchRepository } from "../../search"
 import { logger } from "../../../lib/logger"
 
 export interface ContextDeps {
@@ -39,6 +42,14 @@ export interface AgentContext {
   preferences: UserPreferences | undefined
   authorNames: Map<string, string>
   streamContext: StreamContext
+  /**
+   * Streams the invoking user can read. Used for access-scoped quote-reply
+   * resolution and downstream workspace tools. `null` when there is no
+   * invoking user (bot-initiated turn) — downstream consumers should treat
+   * that as "no workspace access" or "current stream only" per their own
+   * semantics.
+   */
+  accessibleStreamIds: Set<string> | null
 }
 
 async function resolveScratchpadCustomPrompt(
@@ -101,6 +112,16 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     }
   }
 
+  // Compute accessible streams once, here — used by both quote-reply resolution
+  // below and by the workspace-tool deps wiring in persona-agent.ts. Bot turns
+  // (no invoking user) get `null`; downstream consumers decide how to treat it.
+  let accessibleStreamIds: Set<string> | null = null
+  if (invokingUserId) {
+    const accessSpec = await computeAgentAccessSpec(db, { stream, invokingUserId })
+    const ids = await SearchRepository.getAccessibleStreamsForAgent(db, accessSpec, workspaceId)
+    accessibleStreamIds = new Set(ids)
+  }
+
   const streamContext = await buildStreamContext(db, stream, {
     preferences,
     triggerMessageId: messageId,
@@ -152,6 +173,27 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     mentionerName = mentioner?.name ?? undefined
   }
 
+  // Resolve quote-reply precursors referenced from the conversation history and
+  // expand each message's contentMarkdown inline with `<quoted-source>` blocks
+  // so the model sees the full source of anything that was quoted, not just
+  // the snippet. Bot turns fall back to "current stream only" to avoid leaking
+  // cross-stream content when there is no invoking user to gate access.
+  const quoteAccessibleStreamIds = accessibleStreamIds ?? new Set([stream.id])
+  const { resolved: resolvedQuotes, authorNames: quotedAuthorNames } = await resolveQuoteReplies(db, workspaceId, {
+    seedMessages: streamContext.conversationHistory,
+    accessibleStreamIds: quoteAccessibleStreamIds,
+  })
+  for (const [id, name] of quotedAuthorNames) {
+    if (!authorNames.has(id)) authorNames.set(id, name)
+  }
+  if (resolvedQuotes.size > 0) {
+    streamContext.conversationHistory = streamContext.conversationHistory.map((m) => {
+      const expanded = renderMessageWithQuoteContext(m, resolvedQuotes, authorNames, 0, DEFAULT_MAX_QUOTE_DEPTH)
+      if (expanded === m.contentMarkdown) return m
+      return { ...m, contentMarkdown: expanded }
+    })
+  }
+
   const scratchpadCustomPrompt = await resolveScratchpadCustomPrompt(db, stream, preferences)
 
   const systemPrompt = buildSystemPrompt(
@@ -174,5 +216,6 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     preferences,
     authorNames,
     streamContext,
+    accessibleStreamIds,
   }
 }

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -71,6 +71,16 @@ export { ConversationSummaryRepository } from "./conversation-summary-repository
 export type { AgentConversationSummary, UpsertConversationSummaryParams } from "./conversation-summary-repository"
 export { ConversationSummaryService } from "./conversation-summary-service"
 
+// Quote-reply resolution (used by both companion/ and researcher/)
+export {
+  resolveQuoteReplies,
+  renderMessageWithQuoteContext,
+  extractAppendedQuoteContext,
+  DEFAULT_MAX_QUOTE_DEPTH,
+  DEFAULT_MAX_TOTAL_RESOLVED,
+} from "./quote-resolver"
+export type { ResolveQuoteRepliesInput, ResolveQuoteRepliesResult } from "./quote-resolver"
+
 // Context builder
 export { buildStreamContext, enrichMessagesWithAttachments } from "./context-builder"
 export type {

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -22,11 +22,10 @@ import { awaitAttachmentProcessing } from "../attachments"
 import type { TraceEmitter } from "./trace-emitter"
 import type { AI } from "../../lib/ai/ai"
 import type { SearchService } from "../search"
-import { SearchRepository } from "../search"
 import type { ConversationSummaryService } from "./conversation-summary-service"
 import type { StorageProvider } from "../../lib/storage/s3-client"
 import type { ModelRegistry } from "../../lib/ai/model-registry"
-import { WorkspaceAgent, type WorkspaceAgentResult, computeAgentAccessSpec } from "./researcher"
+import { WorkspaceAgent, type WorkspaceAgentResult } from "./researcher"
 import { logger } from "../../lib/logger"
 import { buildAgentContext, buildToolSet, withCompanionSession, type WithSessionResult } from "./companion"
 import { AgentRuntime, SessionTraceObserver, OtelObserver, type NewMessageInfo } from "./runtime"
@@ -306,18 +305,16 @@ export class PersonaAgent {
           return { messageId: message.id, operation: "created" as const }
         }
 
-        // Build workspace tool deps (requires invoking member for access control)
+        // Build workspace tool deps (requires invoking member for access control).
+        // `accessibleStreamIds` was computed once by buildAgentContext; reuse it
+        // here instead of recomputing (avoids drift between quote-resolution and
+        // workspace-tool access scopes).
         let workspaceDeps: import("./tools/tool-deps").WorkspaceToolDeps | undefined
-        if (agentContext.invokingUserId) {
-          const accessSpec = await computeAgentAccessSpec(db, {
-            stream,
-            invokingUserId: agentContext.invokingUserId,
-          })
-          const accessibleStreamIds = await SearchRepository.getAccessibleStreamsForAgent(db, accessSpec, workspaceId)
+        if (agentContext.invokingUserId && agentContext.accessibleStreamIds) {
           workspaceDeps = {
             db,
             workspaceId,
-            accessibleStreamIds,
+            accessibleStreamIds: [...agentContext.accessibleStreamIds],
             invokingUserId: agentContext.invokingUserId,
             searchService,
             storage,

--- a/apps/backend/src/features/agents/quote-resolver.test.ts
+++ b/apps/backend/src/features/agents/quote-resolver.test.ts
@@ -1,0 +1,404 @@
+import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test"
+import type { JSONContent } from "@threa/types"
+import type { Querier } from "../../db"
+import { MessageRepository, type Message } from "../messaging"
+import { UserRepository } from "../workspaces"
+import { PersonaRepository } from "./persona-repository"
+import { resolveQuoteReplies, renderMessageWithQuoteContext, extractAppendedQuoteContext } from "./quote-resolver"
+
+const mockClient = {} as Querier
+
+function paragraph(text: string): JSONContent {
+  return { type: "paragraph", content: [{ type: "text", text }] }
+}
+
+function quoteReplyNode(messageId: string, streamId = "stream_src"): JSONContent {
+  return {
+    type: "quoteReply",
+    attrs: {
+      messageId,
+      streamId,
+      authorName: "Quoted Author",
+      authorId: "usr_quoted",
+      actorType: "user",
+      snippet: `snippet for ${messageId}`,
+    },
+  }
+}
+
+function doc(...nodes: JSONContent[]): JSONContent {
+  return { type: "doc", content: nodes }
+}
+
+function createMessage(overrides: Partial<Message> & { id: string }): Message {
+  const base: Message = {
+    id: overrides.id,
+    streamId: "stream_main",
+    sequence: 1n,
+    authorId: "usr_alice",
+    authorType: "user",
+    contentJson: doc(paragraph(`body of ${overrides.id}`)),
+    contentMarkdown: `body of ${overrides.id}`,
+    replyCount: 0,
+    reactions: {},
+    clientMessageId: null,
+    sentVia: null,
+    editedAt: null,
+    deletedAt: null,
+    createdAt: new Date("2024-01-01T10:00:00Z"),
+  }
+  return { ...base, ...overrides }
+}
+
+const mockFindByIdsInStreams = mock((_db: Querier, _ids: string[], _streamIds: string[]) =>
+  Promise.resolve(new Map<string, Message>())
+)
+const mockFindUsersByIds = mock(() => Promise.resolve([] as { id: string; name: string }[]))
+const mockFindPersonasByIds = mock(() => Promise.resolve([] as { id: string; name: string }[]))
+
+function primeUsers(byId: Record<string, string>): void {
+  mockFindUsersByIds.mockResolvedValue(Object.entries(byId).map(([id, name]) => ({ id, name })))
+}
+
+describe("resolveQuoteReplies", () => {
+  beforeEach(() => {
+    mockFindByIdsInStreams.mockReset()
+    mockFindUsersByIds.mockReset()
+    mockFindPersonasByIds.mockReset()
+    mockFindUsersByIds.mockResolvedValue([])
+    mockFindPersonasByIds.mockResolvedValue([])
+    spyOn(MessageRepository, "findByIdsInStreams").mockImplementation(mockFindByIdsInStreams as never)
+    spyOn(UserRepository, "findByIds").mockImplementation(mockFindUsersByIds as never)
+    spyOn(PersonaRepository, "findByIds").mockImplementation(mockFindPersonasByIds as never)
+  })
+
+  test("resolves a single direct precursor", async () => {
+    const seed = createMessage({
+      id: "msg_A",
+      contentJson: doc(quoteReplyNode("msg_B"), paragraph("reply text")),
+    })
+    const precursor = createMessage({ id: "msg_B", contentMarkdown: "original" })
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map([["msg_B", precursor]]))
+    primeUsers({ usr_alice: "Alice" })
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect(resolved.size).toBe(1)
+    expect(resolved.get("msg_B")?.id).toBe("msg_B")
+    expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
+    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B"])
+  })
+
+  test("follows a depth chain up to maxDepth=5", async () => {
+    // A quotes B, B quotes C, C quotes D, D quotes E, E quotes F, F quotes G
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    const b = createMessage({ id: "msg_B", contentJson: doc(quoteReplyNode("msg_C")) })
+    const c = createMessage({ id: "msg_C", contentJson: doc(quoteReplyNode("msg_D")) })
+    const d = createMessage({ id: "msg_D", contentJson: doc(quoteReplyNode("msg_E")) })
+    const e = createMessage({ id: "msg_E", contentJson: doc(quoteReplyNode("msg_F")) })
+    const f = createMessage({ id: "msg_F", contentJson: doc(quoteReplyNode("msg_G")) })
+
+    mockFindByIdsInStreams
+      .mockResolvedValueOnce(new Map([["msg_B", b]]))
+      .mockResolvedValueOnce(new Map([["msg_C", c]]))
+      .mockResolvedValueOnce(new Map([["msg_D", d]]))
+      .mockResolvedValueOnce(new Map([["msg_E", e]]))
+      .mockResolvedValueOnce(new Map([["msg_F", f]]))
+    primeUsers({ usr_alice: "Alice" })
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+      maxDepth: 5,
+    })
+
+    // Should resolve B through F (5 hops), stop before G
+    expect([...resolved.keys()].sort()).toEqual(["msg_B", "msg_C", "msg_D", "msg_E", "msg_F"])
+    expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(5)
+  })
+
+  test("cycle detection: A → B → A terminates", async () => {
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    // B has been edited to quote A back
+    const b = createMessage({ id: "msg_B", contentJson: doc(quoteReplyNode("msg_A")) })
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map([["msg_B", b]]))
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect([...resolved.keys()]).toEqual(["msg_B"])
+    // Only one fetch: A is the seed (visited), B's quote of A is a cycle
+    expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
+  })
+
+  test("self-cycle: message that quotes itself is skipped entirely", async () => {
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_A")) })
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect(resolved.size).toBe(0)
+    expect(mockFindByIdsInStreams).not.toHaveBeenCalled()
+  })
+
+  test("adjacent seeds referencing each other are not refetched", async () => {
+    const a = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    const b = createMessage({ id: "msg_B", contentMarkdown: "body B" })
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [a, b],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect(resolved.size).toBe(0) // B is already a seed, visited before walking
+    expect(mockFindByIdsInStreams).not.toHaveBeenCalled()
+  })
+
+  test("deduplicates when multiple messages quote the same precursor", async () => {
+    const a = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    const c = createMessage({ id: "msg_C", contentJson: doc(quoteReplyNode("msg_B")) })
+    const b = createMessage({ id: "msg_B", contentMarkdown: "body B" })
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map([["msg_B", b]]))
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [a, c],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect([...resolved.keys()]).toEqual(["msg_B"])
+    expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
+    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B"])
+  })
+
+  test("multiple distinct precursors in one message are all resolved", async () => {
+    const seed = createMessage({
+      id: "msg_A",
+      contentJson: doc(quoteReplyNode("msg_B"), quoteReplyNode("msg_C"), paragraph("tail")),
+    })
+    const b = createMessage({ id: "msg_B", contentMarkdown: "body B" })
+    const c = createMessage({ id: "msg_C", contentMarkdown: "body C" })
+    mockFindByIdsInStreams.mockResolvedValueOnce(
+      new Map([
+        ["msg_B", b],
+        ["msg_C", c],
+      ])
+    )
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect([...resolved.keys()].sort()).toEqual(["msg_B", "msg_C"])
+    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B", "msg_C"])
+  })
+
+  test("access-denied or soft-deleted precursors are filtered at the SQL layer", async () => {
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    // findByIdsInStreams filters at the SQL level; we simulate by returning an empty map
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map())
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect(resolved.size).toBe(0)
+    expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
+  })
+
+  test("passes accessibleStreamIds to the SQL-level filter", async () => {
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map())
+
+    await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main", "stream_other"]),
+    })
+
+    const streamIdsArg = mockFindByIdsInStreams.mock.calls[0][2]
+    expect(new Set(streamIdsArg)).toEqual(new Set(["stream_main", "stream_other"]))
+  })
+
+  test("maxTotalResolved caps total precursors fetched", async () => {
+    // Seed with many direct quotes to test the total cap
+    const manyQuotes = Array.from({ length: 10 }, (_, i) => quoteReplyNode(`msg_B${i}`))
+    const seed = createMessage({ id: "msg_A", contentJson: doc(...manyQuotes) })
+    // Only return the first 3 (simulating the cap)
+    mockFindByIdsInStreams.mockImplementation((_db, ids) => {
+      const result = new Map<string, Message>()
+      for (const id of ids) {
+        result.set(id, createMessage({ id, contentMarkdown: `body ${id}` }))
+      }
+      return Promise.resolve(result)
+    })
+
+    const { resolved } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+      maxTotalResolved: 3,
+    })
+
+    expect(resolved.size).toBe(3)
+    // Only the first 3 IDs should have been fetched
+    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B0", "msg_B1", "msg_B2"])
+  })
+
+  test("batch resolves author names for all precursors", async () => {
+    const seed = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")) })
+    const b = createMessage({ id: "msg_B", authorId: "usr_bob", contentMarkdown: "body B" })
+    mockFindByIdsInStreams.mockResolvedValueOnce(new Map([["msg_B", b]]))
+    primeUsers({ usr_bob: "Bob" })
+
+    const { authorNames } = await resolveQuoteReplies(mockClient, "ws_test", {
+      seedMessages: [seed],
+      accessibleStreamIds: new Set(["stream_main"]),
+    })
+
+    expect(authorNames.get("usr_bob")).toBe("Bob")
+    expect(mockFindUsersByIds).toHaveBeenCalledWith(mockClient, "ws_test", ["usr_bob"])
+  })
+})
+
+describe("renderMessageWithQuoteContext", () => {
+  test("returns base markdown when there are no quote references", () => {
+    const m = createMessage({ id: "msg_A", contentMarkdown: "plain text" })
+    const rendered = renderMessageWithQuoteContext(m, new Map(), new Map())
+    expect(rendered).toBe("plain text")
+  })
+
+  test("appends a quoted-source block for a resolved precursor", () => {
+    const seed = createMessage({
+      id: "msg_A",
+      contentJson: doc(quoteReplyNode("msg_B"), paragraph("my reply")),
+      contentMarkdown:
+        "> snippet for msg_B\n>\n> — [Quoted Author](quote:stream_src/msg_B/usr_quoted/user)\n\nmy reply",
+    })
+    const b = createMessage({
+      id: "msg_B",
+      streamId: "stream_src",
+      authorId: "usr_bob",
+      contentMarkdown: "The full original body of msg_B",
+      createdAt: new Date("2024-01-01T09:00:00Z"),
+    })
+    const rendered = renderMessageWithQuoteContext(seed, new Map([["msg_B", b]]), new Map([["usr_bob", "Bob"]]))
+
+    expect(rendered).toContain(seed.contentMarkdown)
+    expect(rendered).toContain(
+      '<quoted-source id="msg_B" author="Bob" streamId="stream_src" createdAt="2024-01-01T09:00:00.000Z">'
+    )
+    expect(rendered).toContain("The full original body of msg_B")
+    expect(rendered).toContain("</quoted-source>")
+  })
+
+  test("nests quoted-source blocks for chained precursors", () => {
+    const a = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")), contentMarkdown: "A body" })
+    const b = createMessage({
+      id: "msg_B",
+      contentJson: doc(quoteReplyNode("msg_C")),
+      contentMarkdown: "B body",
+      authorId: "usr_bob",
+    })
+    const c = createMessage({ id: "msg_C", contentMarkdown: "C body", authorId: "usr_carol" })
+
+    const rendered = renderMessageWithQuoteContext(
+      a,
+      new Map([
+        ["msg_B", b],
+        ["msg_C", c],
+      ]),
+      new Map([
+        ["usr_bob", "Bob"],
+        ["usr_carol", "Carol"],
+      ])
+    )
+
+    // B is inside A, C is inside B
+    const bIdx = rendered.indexOf('id="msg_B"')
+    const cIdx = rendered.indexOf('id="msg_C"')
+    expect(bIdx).toBeGreaterThan(-1)
+    expect(cIdx).toBeGreaterThan(-1)
+    expect(cIdx).toBeGreaterThan(bIdx)
+    expect(rendered).toContain("C body")
+  })
+
+  test("stops expanding at maxDepth", () => {
+    const a = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")), contentMarkdown: "A" })
+    const b = createMessage({ id: "msg_B", contentJson: doc(quoteReplyNode("msg_C")), contentMarkdown: "B" })
+    const c = createMessage({ id: "msg_C", contentMarkdown: "C" })
+
+    const rendered = renderMessageWithQuoteContext(
+      a,
+      new Map([
+        ["msg_B", b],
+        ["msg_C", c],
+      ]),
+      new Map(),
+      0,
+      1
+    )
+
+    expect(rendered).toContain('id="msg_B"')
+    expect(rendered).not.toContain('id="msg_C"')
+  })
+
+  test("silently skips unresolved precursor references", () => {
+    const a = createMessage({
+      id: "msg_A",
+      contentJson: doc(quoteReplyNode("msg_B"), quoteReplyNode("msg_C")),
+      contentMarkdown: "A body",
+    })
+    const b = createMessage({ id: "msg_B", contentMarkdown: "B body", authorId: "usr_bob" })
+    // msg_C is NOT in the resolved map (e.g., filtered by access)
+
+    const rendered = renderMessageWithQuoteContext(a, new Map([["msg_B", b]]), new Map([["usr_bob", "Bob"]]))
+
+    expect(rendered).toContain('id="msg_B"')
+    expect(rendered).not.toContain('id="msg_C"')
+  })
+
+  test("escapes XML special characters in author names", () => {
+    const a = createMessage({ id: "msg_A", contentJson: doc(quoteReplyNode("msg_B")), contentMarkdown: "A" })
+    const b = createMessage({ id: "msg_B", authorId: "usr_bob", contentMarkdown: "B" })
+
+    const rendered = renderMessageWithQuoteContext(
+      a,
+      new Map([["msg_B", b]]),
+      new Map([["usr_bob", 'Bob "The Builder" <bob@test>']])
+    )
+
+    expect(rendered).toContain('author="Bob &quot;The Builder&quot; &lt;bob@test&gt;"')
+  })
+
+  test("deduplicates when the same precursor is quoted twice", () => {
+    const a = createMessage({
+      id: "msg_A",
+      contentJson: doc(quoteReplyNode("msg_B"), quoteReplyNode("msg_B")),
+      contentMarkdown: "A",
+    })
+    const b = createMessage({ id: "msg_B", contentMarkdown: "B body", authorId: "usr_bob" })
+    const rendered = renderMessageWithQuoteContext(a, new Map([["msg_B", b]]), new Map([["usr_bob", "Bob"]]))
+
+    const matches = rendered.match(/id="msg_B"/g) ?? []
+    expect(matches.length).toBe(1)
+  })
+})
+
+describe("extractAppendedQuoteContext", () => {
+  test("returns empty string when nothing was appended", () => {
+    expect(extractAppendedQuoteContext("hello", "hello")).toBe("")
+  })
+
+  test("strips the base prefix and the \\n\\n separator", () => {
+    const base = "A body"
+    const rendered = 'A body\n\n<quoted-source id="msg_B">B body</quoted-source>'
+    expect(extractAppendedQuoteContext(rendered, base)).toBe('<quoted-source id="msg_B">B body</quoted-source>')
+  })
+})

--- a/apps/backend/src/features/agents/quote-resolver.ts
+++ b/apps/backend/src/features/agents/quote-resolver.ts
@@ -1,0 +1,271 @@
+import type { Querier } from "../../db"
+import type { JSONContent } from "@threa/types"
+import { MessageRepository, type Message } from "../messaging"
+import { UserRepository } from "../workspaces"
+import { PersonaRepository } from "./persona-repository"
+import { logger } from "../../lib/logger"
+
+/**
+ * Default maximum depth of quote-reply precursors to resolve.
+ * A value of 5 means: for a seed message that quotes B, we follow up to
+ * B→C→D→E→F (five hops of precursors from the seed).
+ */
+export const DEFAULT_MAX_QUOTE_DEPTH = 5
+
+/**
+ * Upper bound on the total number of precursor messages we will fetch across
+ * all depth levels. Defends against crafted messages that try to explode the
+ * fan-out (many quotes per message × many depth levels).
+ */
+export const DEFAULT_MAX_TOTAL_RESOLVED = 100
+
+export interface ResolveQuoteRepliesInput {
+  /**
+   * Messages the caller already has; we walk their `contentJson` for
+   * quoteReply nodes but never re-fetch them.
+   */
+  seedMessages: Message[]
+  /**
+   * Streams the invoking actor can read. A quoted message whose `streamId`
+   * is not in this set is silently dropped (not leaked into the prompt).
+   * For bot-initiated turns with no invoking user, callers should pass a
+   * set containing only the current stream's id.
+   */
+  accessibleStreamIds: Set<string>
+  /** Maximum precursor depth. Defaults to {@link DEFAULT_MAX_QUOTE_DEPTH}. */
+  maxDepth?: number
+  /** Hard cap on total fetched precursors. Defaults to {@link DEFAULT_MAX_TOTAL_RESOLVED}. */
+  maxTotalResolved?: number
+}
+
+export interface ResolveQuoteRepliesResult {
+  /**
+   * Map from quoted (precursor) message ID to the full resolved {@link Message}.
+   * Only contains messages that were actually fetched — callers doing rendering
+   * should treat missing entries as "do not expand" (the inline snippet will
+   * still appear via the base markdown).
+   */
+  resolved: Map<string, Message>
+  /**
+   * Author names for every author of a resolved precursor, batch-fetched in
+   * a single pair of queries at the end. Merge this into your own author map
+   * before rendering.
+   */
+  authorNames: Map<string, string>
+}
+
+/**
+ * Recursively resolve quote-reply precursors for a set of seed messages.
+ *
+ * BFS by depth level. At each level, collects all `quoteReply.attrs.messageId`
+ * references from the current frontier, filters out already-visited IDs
+ * (handles cycles, including edit-induced ones, since `MessageRepository.updateContent`
+ * mutates in place and preserves the ID), then batch-fetches the next level
+ * via `MessageRepository.findByIdsInStreams` — which applies access scoping
+ * and soft-delete filtering at the SQL level.
+ */
+export async function resolveQuoteReplies(
+  db: Querier,
+  workspaceId: string,
+  input: ResolveQuoteRepliesInput
+): Promise<ResolveQuoteRepliesResult> {
+  const maxDepth = input.maxDepth ?? DEFAULT_MAX_QUOTE_DEPTH
+  const maxTotalResolved = input.maxTotalResolved ?? DEFAULT_MAX_TOTAL_RESOLVED
+  const streamIdsArray = [...input.accessibleStreamIds]
+
+  const resolved = new Map<string, Message>()
+  // Seed visited with ALL seed IDs before walking, so adjacent history
+  // messages that quote each other are never re-fetched as "precursors".
+  const visited = new Set<string>(input.seedMessages.map((m) => m.id))
+
+  // Walk seeds to get depth-0 frontier (= depth-1 precursors, since the seed is 0 hops).
+  let frontier: string[] = []
+  for (const seed of input.seedMessages) {
+    const quotedIds = extractQuoteReplyMessageIds(seed.contentJson)
+    for (const quotedId of quotedIds) {
+      if (visited.has(quotedId)) {
+        logger.debug({ messageId: seed.id, quotedId, reason: "cycle" }, "Quote resolution skipped reference")
+        continue
+      }
+      visited.add(quotedId)
+      frontier.push(quotedId)
+    }
+  }
+
+  let depth = 0
+  while (frontier.length > 0 && depth < maxDepth && resolved.size < maxTotalResolved) {
+    // Cap the frontier if we're near the total limit
+    const remaining = maxTotalResolved - resolved.size
+    const toFetch = frontier.length > remaining ? frontier.slice(0, remaining) : frontier
+    if (toFetch.length < frontier.length) {
+      for (const skipped of frontier.slice(toFetch.length)) {
+        logger.debug({ quotedId: skipped, reason: "total_cap", maxTotalResolved }, "Quote resolution skipped reference")
+      }
+    }
+
+    const fetched = await MessageRepository.findByIdsInStreams(db, toFetch, streamIdsArray)
+
+    // Log not_accessible / not_found for anything we asked for but didn't get
+    for (const requestedId of toFetch) {
+      if (!fetched.has(requestedId)) {
+        logger.debug(
+          { quotedId: requestedId, reason: "not_accessible_or_not_found" },
+          "Quote resolution skipped reference"
+        )
+      }
+    }
+
+    const nextFrontier: string[] = []
+    for (const [id, message] of fetched) {
+      resolved.set(id, message)
+      const quotedIds = extractQuoteReplyMessageIds(message.contentJson)
+      for (const quotedId of quotedIds) {
+        if (visited.has(quotedId)) {
+          logger.debug({ messageId: id, quotedId, reason: "cycle" }, "Quote resolution skipped reference")
+          continue
+        }
+        visited.add(quotedId)
+        nextFrontier.push(quotedId)
+      }
+    }
+
+    frontier = nextFrontier
+    depth++
+  }
+
+  if (frontier.length > 0) {
+    const reason = depth >= maxDepth ? "depth_cap" : "total_cap"
+    for (const skipped of frontier) {
+      logger.debug({ quotedId: skipped, reason, maxDepth, maxTotalResolved }, "Quote resolution skipped reference")
+    }
+  }
+
+  // Batch-resolve author names for every resolved precursor
+  const authorNames = await resolveAuthorNamesForMessages(db, workspaceId, [...resolved.values()])
+
+  return { resolved, authorNames }
+}
+
+/**
+ * Build an expanded markdown string for a message, appending `<quoted-source>`
+ * blocks for each `quoteReply` node whose precursor was resolved.
+ *
+ * The output starts with `message.contentMarkdown` unchanged — including the
+ * existing inline blockquote + attribution link that the ProseMirror markdown
+ * serializer already emits for `quoteReply` nodes. We then append full-source
+ * blocks after it. This way the model sees both "which snippet was quoted"
+ * (the inline anchor) and "what the full source message was" (the appended
+ * block).
+ *
+ * Nested quotes are expanded recursively up to `maxDepth` hops from the
+ * top-level message. Unresolved references are silently omitted — the inline
+ * snippet still appears in the base markdown so the model knows *something*
+ * was quoted; the resolver logs why the expansion was skipped.
+ */
+export function renderMessageWithQuoteContext(
+  message: Message,
+  resolved: Map<string, Message>,
+  authorNames: Map<string, string>,
+  depth: number = 0,
+  maxDepth: number = DEFAULT_MAX_QUOTE_DEPTH
+): string {
+  const base = message.contentMarkdown
+  if (depth >= maxDepth) return base
+
+  const quotedIds = extractQuoteReplyMessageIds(message.contentJson)
+  if (quotedIds.length === 0) return base
+
+  const blocks: string[] = [base]
+  const seenAtThisLevel = new Set<string>()
+  for (const quotedId of quotedIds) {
+    // Dedupe: if the same message is quoted twice in one parent, only expand once
+    if (seenAtThisLevel.has(quotedId)) continue
+    seenAtThisLevel.add(quotedId)
+
+    const quotedMessage = resolved.get(quotedId)
+    if (!quotedMessage) continue
+
+    const authorName = authorNames.get(quotedMessage.authorId) ?? "Unknown"
+    const nestedContent = renderMessageWithQuoteContext(quotedMessage, resolved, authorNames, depth + 1, maxDepth)
+
+    blocks.push(
+      `<quoted-source id="${escapeXmlAttr(quotedMessage.id)}" author="${escapeXmlAttr(authorName)}" streamId="${escapeXmlAttr(quotedMessage.streamId)}" createdAt="${quotedMessage.createdAt.toISOString()}">\n${nestedContent}\n</quoted-source>`
+    )
+  }
+
+  return blocks.join("\n\n")
+}
+
+/**
+ * Extract only the appended `<quoted-source>` blocks from a rendered message,
+ * dropping the base `contentMarkdown` prefix. Used by the researcher path,
+ * which wants the base content to stay as the single-line snippet it already
+ * produces while attaching the quote context as a separate field.
+ *
+ * Returns an empty string if the renderer did not append anything (i.e. the
+ * rendered output equals the base markdown).
+ */
+export function extractAppendedQuoteContext(rendered: string, base: string): string {
+  if (rendered === base) return ""
+  if (!rendered.startsWith(base)) {
+    // Defensive: should not happen, but fall back to the full rendered output
+    return rendered
+  }
+  // Strip the base prefix and the "\n\n" separator we inserted in the renderer
+  const tail = rendered.slice(base.length)
+  return tail.startsWith("\n\n") ? tail.slice(2) : tail
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+function extractQuoteReplyMessageIds(content: JSONContent): string[] {
+  const ids: string[] = []
+  walkJsonNodes(content, (node) => {
+    if (node.type === "quoteReply") {
+      const messageId = node.attrs?.messageId
+      if (typeof messageId === "string" && messageId.length > 0) {
+        ids.push(messageId)
+      }
+    }
+  })
+  return ids
+}
+
+function walkJsonNodes(node: JSONContent, visit: (node: JSONContent) => void): void {
+  visit(node)
+  if (!node.content) return
+  for (const child of node.content) {
+    walkJsonNodes(child, visit)
+  }
+}
+
+async function resolveAuthorNamesForMessages(
+  db: Querier,
+  workspaceId: string,
+  messages: Message[]
+): Promise<Map<string, string>> {
+  if (messages.length === 0) return new Map()
+
+  const userIds = new Set<string>()
+  const personaIds = new Set<string>()
+  for (const m of messages) {
+    if (m.authorType === "user") userIds.add(m.authorId)
+    else if (m.authorType === "persona") personaIds.add(m.authorId)
+  }
+
+  const [users, personas] = await Promise.all([
+    userIds.size > 0 ? UserRepository.findByIds(db, workspaceId, [...userIds]) : Promise.resolve([]),
+    personaIds.size > 0 ? PersonaRepository.findByIds(db, [...personaIds]) : Promise.resolve([]),
+  ])
+
+  const names = new Map<string, string>()
+  for (const u of users) names.set(u.id, u.name)
+  for (const p of personas) names.set(p.id, p.name)
+  return names
+}
+
+function escapeXmlAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+}

--- a/apps/backend/src/features/agents/researcher/context-formatter.ts
+++ b/apps/backend/src/features/agents/researcher/context-formatter.ts
@@ -32,6 +32,13 @@ export interface EnrichedMessageResult {
   streamName: string
   streamType: string
   createdAt: Date
+  /**
+   * Pre-rendered `<quoted-source>` block(s) expanding any quote-reply
+   * precursors referenced from this message. Populated by the researcher when
+   * the message contains `quoteReply` nodes and their source messages are
+   * accessible. Undefined when there is no quoted-source context to add.
+   */
+  quoteContext?: string
 }
 
 /**
@@ -99,9 +106,10 @@ function formatMessagesSection(messages: EnrichedMessageResult[]): string {
       const relativeDate = formatRelativeDate(msg.createdAt)
       const author = msg.authorType === "user" ? `@${msg.authorName}` : msg.authorName
       const content = msg.content.replace(/\s+/g, " ").trim()
+      const quoteBlock = msg.quoteContext ? `\n${msg.quoteContext}` : ""
 
       return `> **${author}** in _${msg.streamName}_ (${relativeDate}):
-> ${content}`
+> ${content}${quoteBlock}`
     })
     .join("\n\n")
 

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -19,6 +19,12 @@ import {
   type EnrichedMessageResult,
   type EnrichedAttachmentResult,
 } from "./context-formatter"
+import {
+  resolveQuoteReplies,
+  renderMessageWithQuoteContext,
+  extractAppendedQuoteContext,
+  DEFAULT_MAX_QUOTE_DEPTH,
+} from "../quote-resolver"
 import { logger } from "../../../lib/logger"
 import { SEMANTIC_DISTANCE_THRESHOLD } from "../../search"
 import {
@@ -785,7 +791,38 @@ Each query must have:
         }
 
         // Enrich results with author names and stream names
-        return enrichMessageSearchResults(client, workspaceId, [...dedupedResultsById.values()])
+        const enriched = await enrichMessageSearchResults(client, workspaceId, [...dedupedResultsById.values()])
+
+        // Resolve quote-reply precursors for each retrieved message so Ariadne
+        // sees the full source of anything that was quoted, not just the
+        // snippet. Requires a batch fetch because `EnrichedMessageResult` does
+        // not carry `contentJson`.
+        if (enriched.length > 0) {
+          const seedMessageMap = await MessageRepository.findByIdsInStreams(
+            client,
+            enriched.map((e) => e.id),
+            accessibleStreamIds
+          )
+          if (seedMessageMap.size > 0) {
+            const { resolved, authorNames } = await resolveQuoteReplies(client, workspaceId, {
+              seedMessages: [...seedMessageMap.values()],
+              accessibleStreamIds: new Set(accessibleStreamIds),
+            })
+            if (resolved.size > 0) {
+              for (const e of enriched) {
+                const seed = seedMessageMap.get(e.id)
+                if (!seed) continue
+                const rendered = renderMessageWithQuoteContext(seed, resolved, authorNames, 0, DEFAULT_MAX_QUOTE_DEPTH)
+                const appended = extractAppendedQuoteContext(rendered, seed.contentMarkdown)
+                if (appended.length > 0) {
+                  e.quoteContext = appended
+                }
+              }
+            }
+          }
+        }
+
+        return enriched
       })
     } catch (error) {
       logger.warn({ error, query: query.query }, "Message search failed")

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -171,6 +171,38 @@ export const MessageRepository = {
     return map
   },
 
+  /**
+   * Fetch messages by ID, restricted to a set of accessible streams and excluding
+   * soft-deleted rows. Used by quote-reply resolution where the quoted message ID
+   * comes from untrusted client content (`content_json.attrs.messageId`) and must
+   * be filtered against the caller's access scope.
+   */
+  async findByIdsInStreams(db: Querier, ids: string[], streamIds: string[]): Promise<Map<string, Message>> {
+    if (ids.length === 0 || streamIds.length === 0) return new Map()
+
+    const result = await db.query<MessageRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)} FROM messages
+      WHERE id = ANY(${ids})
+        AND stream_id = ANY(${streamIds})
+        AND deleted_at IS NULL
+    `)
+
+    if (result.rows.length === 0) return new Map()
+
+    const foundIds = result.rows.map((r) => r.id)
+    const reactionsResult = await db.query<ReactionRow>(sql`
+      SELECT message_id, user_id, emoji FROM reactions
+      WHERE message_id = ANY(${foundIds})
+    `)
+    const reactionsByMessage = aggregateReactionsByMessage(reactionsResult.rows)
+
+    const map = new Map<string, Message>()
+    for (const row of result.rows) {
+      map.set(row.id, mapRowToMessage(row, reactionsByMessage.get(row.id) ?? {}))
+    }
+    return map
+  },
+
   async list(
     db: Querier,
     streamId: string,


### PR DESCRIPTION
When a message contains `quoteReply` nodes, Ariadne now pulls in the full
source message(s) instead of only the inline snippet — up to 5 precursor
hops, cycle-safe via visited-ID tracking (handles edit-induced cycles),
access-filtered at the SQL layer via a new `findByIdsInStreams` that also
excludes soft-deleted rows. Applies to both the in-stream conversation
history (`companion/context.ts`) and the researcher retrieval path
(`researcher/researcher.ts`). Expansions are rendered as nested
`<quoted-source>` blocks appended to the base markdown so the model sees
both the original anchor snippet and the full referenced message.

`accessibleStreamIds` is now computed once in `buildAgentContext` and
reused by both quote resolution and the workspace-tool deps wiring in
`persona-agent.ts`, removing the duplicated access-spec computation.

https://claude.ai/code/session_014jyr3dauMJPq3CExTQHNMj