### PR TITLE
fix: harden GitHub integration against open redirect and state replay

### DIFF
--- a/apps/backend/src/features/link-previews/github-preview.test.ts
+++ b/apps/backend/src/features/link-previews/github-preview.test.ts
@@ -292,6 +292,100 @@ describe("fetchGitHubPreview", () => {
     ])
   })
 
+  test("caps blob path resolution at the configured ref-depth instead of grinding through every segment", async () => {
+    const requests: Array<{ route: string; params: Record<string, unknown> | undefined }> = []
+
+    const preview = await fetchGitHubPreview(
+      "ws_123",
+      // 9 segments after `blob/` — none of the candidate splits resolve, so the
+      // loop must bail out at the cap rather than issuing one request per segment.
+      "https://github.com/octocat/hello-world/blob/a/b/c/d/e/f/g/h/i.ts",
+      {
+        async getGithubPreviewClient() {
+          return {
+            async request(route: string, params?: Record<string, unknown>) {
+              requests.push({ route, params })
+
+              if (route === "GET /repos/{owner}/{repo}") {
+                return {
+                  owner: { login: "octocat" },
+                  name: "hello-world",
+                  full_name: "octocat/hello-world",
+                  private: false,
+                }
+              }
+
+              if (route === "GET /repos/{owner}/{repo}/contents/{path}") {
+                throw new Error("not found")
+              }
+
+              throw new Error(`Unexpected route: ${route}`)
+            },
+          }
+        },
+      } as unknown as WorkspaceIntegrationService
+    )
+
+    expect(preview).toBeNull()
+    const contentsCalls = requests.filter((r) => r.route === "GET /repos/{owner}/{repo}/contents/{path}")
+    // Cap is 5 attempts; without the cap this URL would issue 8.
+    expect(contentsCalls).toHaveLength(5)
+    expect(contentsCalls.map((r) => r.params?.ref)).toEqual(["a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/d/e"])
+  })
+
+  test("normalizes issue label colors and rejects non-hex values", async () => {
+    const preview = await fetchGitHubPreview("ws_123", "https://github.com/octocat/hello-world/issues/7", {
+      async getGithubPreviewClient() {
+        return {
+          async request(route: string) {
+            if (route === "GET /repos/{owner}/{repo}") {
+              return {
+                owner: { login: "octocat" },
+                name: "hello-world",
+                full_name: "octocat/hello-world",
+                private: false,
+              }
+            }
+            if (route === "GET /repos/{owner}/{repo}/issues/{issue_number}") {
+              return {
+                number: 7,
+                title: "Something broke",
+                state: "open",
+                user: { login: "kris", avatar_url: "https://avatars.example/kris.png" },
+                labels: [
+                  { name: "ok-hex", color: "ff8800" },
+                  { name: "ok-hash-prefix", color: "#ABCDEF" },
+                  { name: "bad-css", color: "red; background: url(x)" },
+                  { name: "bad-too-short", color: "fff" },
+                  { name: "bad-non-string", color: 123 },
+                ],
+                assignees: [],
+                comments: 0,
+                created_at: "2026-04-07T10:00:00.000Z",
+                updated_at: "2026-04-07T11:00:00.000Z",
+              }
+            }
+            throw new Error(`Unexpected route: ${route}`)
+          },
+        }
+      },
+    } as unknown as WorkspaceIntegrationService)
+
+    expect(preview).not.toBeNull()
+    expect(preview?.previewData).toMatchObject({
+      type: "github_issue",
+      data: {
+        labels: [
+          { name: "ok-hex", color: "ff8800" },
+          { name: "ok-hash-prefix", color: "abcdef" },
+          { name: "bad-css", color: "999999" },
+          { name: "bad-too-short", color: "999999" },
+          { name: "bad-non-string", color: "999999" },
+        ],
+      },
+    })
+  })
+
   test("builds a README-backed file preview for tree URLs", async () => {
     const preview = await fetchGitHubPreview("ws_123", "https://github.com/octocat/hello-world/tree/main", {
       async getGithubPreviewClient() {

--- a/apps/backend/src/features/link-previews/github-preview.ts
+++ b/apps/backend/src/features/link-previews/github-preview.ts
@@ -12,6 +12,15 @@ const GITHUB_FAVICON_URL = "https://github.com/favicon.ico"
 const DEFAULT_FILE_LINE_COUNT = 30
 const COMMENT_PREVIEW_MAX_LENGTH = 320
 const README_MARKDOWN_MAX_CHARS = 3000
+// Maximum number of (ref, path) split candidates to try when resolving a GitHub
+// blob URL. The cost of resolveBlobPath is bounded by the number of slashes in
+// the *branch name*, not the file path — nested file paths still resolve in a
+// single GitHub call. A cap of 5 covers branches up to 4 slashes deep
+// (e.g. `feature/team/sprint-42/foo`) and prevents an adversarial URL with
+// many segments from burning installation API quota.
+const MAX_BLOB_PATH_SPLIT_ATTEMPTS = 5
+const LABEL_COLOR_HEX_PATTERN = /^[0-9a-f]{6}$/i
+const DEFAULT_LABEL_COLOR = "999999"
 
 interface LoadedGitHubRepository {
   preview: GitHubPreviewRepository
@@ -226,7 +235,7 @@ async function fetchIssuePreview(
               ? [
                   {
                     name: label.name,
-                    color: typeof label.color === "string" ? label.color : "999999",
+                    color: normalizeLabelColor(label.color),
                     description: typeof label.description === "string" ? label.description : null,
                   },
                 ]
@@ -517,7 +526,8 @@ async function resolveBlobPath(
   blobPath: string
 ): Promise<{ ref: string; path: string; contentResponse: any } | null> {
   const segments = blobPath.split("/").filter(Boolean)
-  for (let splitIndex = 1; splitIndex < segments.length; splitIndex++) {
+  const maxSplits = Math.min(segments.length - 1, MAX_BLOB_PATH_SPLIT_ATTEMPTS)
+  for (let splitIndex = 1; splitIndex <= maxSplits; splitIndex++) {
     const ref = segments.slice(0, splitIndex).join("/")
     const path = segments.slice(splitIndex).join("/")
     try {
@@ -536,6 +546,12 @@ async function resolveBlobPath(
   }
 
   return null
+}
+
+function normalizeLabelColor(value: unknown): string {
+  if (typeof value !== "string") return DEFAULT_LABEL_COLOR
+  const trimmed = value.startsWith("#") ? value.slice(1) : value
+  return LABEL_COLOR_HEX_PATTERN.test(trimmed) ? trimmed.toLowerCase() : DEFAULT_LABEL_COLOR
 }
 
 function summarizePullReviews(reviews: any[], pull: any) {

--- a/apps/backend/src/features/workspace-integrations/crypto.test.ts
+++ b/apps/backend/src/features/workspace-integrations/crypto.test.ts
@@ -78,9 +78,17 @@ describe("workspace integration crypto helpers", () => {
     const now = Date.UTC(2026, 3, 7, 12, 0, 0)
     const state = createGithubInstallState(secret, "ws_123", now)
 
-    expect(() => verifyGithubInstallState(secret, state, now + 60 * 60 * 1000 + 1)).toThrow(
+    expect(() => verifyGithubInstallState(secret, state, now + 10 * 60 * 1000 + 1)).toThrow(
       "GitHub install state has expired"
     )
+  })
+
+  test("accepts GitHub installation state just under the 10-minute window", () => {
+    const secret = "workspace-integration-secret"
+    const now = Date.UTC(2026, 3, 7, 12, 0, 0)
+    const state = createGithubInstallState(secret, "ws_123", now)
+
+    expect(verifyGithubInstallState(secret, state, now + 10 * 60 * 1000 - 1)).toEqual({ workspaceId: "ws_123" })
   })
 })
 

--- a/apps/backend/src/features/workspace-integrations/crypto.ts
+++ b/apps/backend/src/features/workspace-integrations/crypto.ts
@@ -5,7 +5,10 @@ export { extractWorkspaceIdFromGithubInstallState } from "@threa/backend-common"
 const ENCRYPTION_VERSION = 2
 const GCM_ALGORITHM = "aes-256-gcm"
 const IV_LENGTH_BYTES = 12
-const MAX_STATE_AGE_MS = 60 * 60 * 1000
+// Tight enough to bound replay if a state value leaks (referer, browser history, log
+// line) but still long enough to cover the realistic GitHub install completion flow,
+// including a quick org admin approval step.
+const MAX_STATE_AGE_MS = 10 * 60 * 1000
 
 export interface EncryptedJsonPayload extends Record<string, unknown> {
   v: number

--- a/apps/backend/src/features/workspace-integrations/handlers.test.ts
+++ b/apps/backend/src/features/workspace-integrations/handlers.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test"
 import { buildGithubCallbackRedirectUrl } from "./handlers"
 
 describe("buildGithubCallbackRedirectUrl", () => {
-  test("returns an absolute frontend URL when forwarded headers are present", () => {
+  const allowedOrigins = ["http://localhost:3000", "https://app.threa.io"]
+
+  test("returns an absolute frontend URL when the forwarded origin is allowlisted", () => {
     const url = buildGithubCallbackRedirectUrl(
       {
         headers: {
@@ -11,7 +13,8 @@ describe("buildGithubCallbackRedirectUrl", () => {
         },
         protocol: "http",
       } as any,
-      "ws_123"
+      "ws_123",
+      allowedOrigins
     )
 
     expect(url).toBe("http://localhost:3000/w/ws_123?ws-settings=integrations&provider=github")
@@ -27,7 +30,8 @@ describe("buildGithubCallbackRedirectUrl", () => {
         },
         protocol: "http",
       } as any,
-      "ws_123"
+      "ws_123",
+      allowedOrigins
     )
 
     expect(url).toBe("http://localhost:3000/w/ws_123?ws-settings=integrations&provider=github")
@@ -39,7 +43,40 @@ describe("buildGithubCallbackRedirectUrl", () => {
         headers: {},
         protocol: "https",
       } as any,
-      "ws_123"
+      "ws_123",
+      allowedOrigins
+    )
+
+    expect(url).toBe("/w/ws_123?ws-settings=integrations&provider=github")
+  })
+
+  test("falls back to a relative path when the forwarded origin is not in the allowlist", () => {
+    const url = buildGithubCallbackRedirectUrl(
+      {
+        headers: {
+          "x-forwarded-host": "evil.example",
+          "x-forwarded-proto": "https",
+        },
+        protocol: "https",
+      } as any,
+      "ws_123",
+      allowedOrigins
+    )
+
+    expect(url).toBe("/w/ws_123?ws-settings=integrations&provider=github")
+  })
+
+  test("falls back to a relative path when the forwarded host is malformed", () => {
+    const url = buildGithubCallbackRedirectUrl(
+      {
+        headers: {
+          "x-forwarded-host": "not a valid host",
+          "x-forwarded-proto": "https",
+        },
+        protocol: "https",
+      } as any,
+      "ws_123",
+      allowedOrigins
     )
 
     expect(url).toBe("/w/ws_123?ws-settings=integrations&provider=github")

--- a/apps/backend/src/features/workspace-integrations/handlers.ts
+++ b/apps/backend/src/features/workspace-integrations/handlers.ts
@@ -9,11 +9,21 @@ const githubCallbackSchema = z.object({
 
 interface Dependencies {
   workspaceIntegrationService: WorkspaceIntegrationService
+  /**
+   * Allowlist of frontend origins (e.g. CORS allowed origins) the GitHub install
+   * callback is permitted to redirect to. Forwarded host headers that resolve to
+   * an origin outside this list fall back to a relative redirect, which prevents
+   * an attacker-controlled `x-forwarded-host` from turning the callback into an
+   * open redirect if the backend is ever reached without going through the
+   * trusted Cloudflare → control-plane proxy chain.
+   */
+  allowedFrontendOrigins: string[]
 }
 
 export function buildGithubCallbackRedirectUrl(
   req: Pick<Request, "headers" | "protocol">,
-  workspaceId: string
+  workspaceId: string,
+  allowedFrontendOrigins: string[]
 ): string {
   const path = `/w/${workspaceId}?ws-settings=integrations&provider=github`
   const forwardedHost = getFirstHeaderValue(req.headers["x-forwarded-host"])
@@ -24,10 +34,16 @@ export function buildGithubCallbackRedirectUrl(
   const forwardedProto = getFirstHeaderValue(req.headers["x-forwarded-proto"]) ?? req.protocol
   const forwardedPort = getFirstHeaderValue(req.headers["x-forwarded-port"])
   const origin = buildForwardedOrigin(forwardedProto, forwardedHost, forwardedPort)
+  if (!origin || !allowedFrontendOrigins.includes(origin)) {
+    return path
+  }
   return `${origin}${path}`
 }
 
-export function createWorkspaceIntegrationHandlers({ workspaceIntegrationService }: Dependencies) {
+export function createWorkspaceIntegrationHandlers({
+  workspaceIntegrationService,
+  allowedFrontendOrigins,
+}: Dependencies) {
   return {
     async getGithub(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
@@ -66,7 +82,7 @@ export function createWorkspaceIntegrationHandlers({ workspaceIntegrationService
         workosUserId,
       })
 
-      res.redirect(buildGithubCallbackRedirectUrl(req, workspaceId))
+      res.redirect(buildGithubCallbackRedirectUrl(req, workspaceId, allowedFrontendOrigins))
     },
   }
 }
@@ -83,12 +99,16 @@ function getFirstHeaderValue(value: string | string[] | undefined): string | nul
   return first ?? null
 }
 
-function buildForwardedOrigin(proto: string, host: string, port: string | null): string {
-  const url = new URL(`${proto}://${host}`)
-  if (port) {
-    url.port = isDefaultPort(proto, port) ? "" : port
+function buildForwardedOrigin(proto: string, host: string, port: string | null): string | null {
+  try {
+    const url = new URL(`${proto}://${host}`)
+    if (port) {
+      url.port = isDefaultPort(proto, port) ? "" : port
+    }
+    return url.origin
+  } catch {
+    return null
   }
-  return url.origin
 }
 
 function isDefaultPort(proto: string, port: string): boolean {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -79,6 +79,7 @@ interface Dependencies {
   commandRegistry: CommandRegistry
   avatarService: AvatarService
   rateLimiterConfig: RateLimiterConfig
+  corsAllowedOrigins: string[]
   allowDevAuthRoutes: boolean
   internalApiKey: string | null
   apiKeyService: ApiKeyService
@@ -110,6 +111,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     commandRegistry,
     avatarService,
     rateLimiterConfig,
+    corsAllowedOrigins,
     allowDevAuthRoutes,
     internalApiKey,
     apiKeyService,
@@ -158,7 +160,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const activity = createActivityHandlers({ activityService })
   const agentSession = createAgentSessionHandlers({ pool })
   const linkPreview = createLinkPreviewHandlers({ linkPreviewService })
-  const workspaceIntegration = createWorkspaceIntegrationHandlers({ workspaceIntegrationService })
+  const workspaceIntegration = createWorkspaceIntegrationHandlers({
+    workspaceIntegrationService,
+    allowedFrontendOrigins: corsAllowedOrigins,
+  })
 
   // Ops endpoints - registered before rate limiter so probes aren't throttled
   app.get("/readyz", opsAccess, debug.readiness)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -399,6 +399,7 @@ export async function startServer(): Promise<ServerInstance> {
     commandRegistry,
     avatarService,
     rateLimiterConfig: config.rateLimits,
+    corsAllowedOrigins: config.corsAllowedOrigins,
     allowDevAuthRoutes: config.useStubAuth && !isProduction,
     internalApiKey: config.internalApiKey,
     apiKeyService,


### PR DESCRIPTION
## Problem

Three independent security weaknesses in the GitHub integration introduced alongside the initial feature:

1. **Open redirect in the GitHub install callback**: `buildGithubCallbackRedirectUrl` built an absolute URL from the `x-forwarded-host` request header with no validation. An attacker who could reach the backend directly (bypassing the Cloudflare → control-plane proxy chain) could craft a request with an arbitrary `x-forwarded-host` value and turn the OAuth callback into an open redirect.

2. **State token replay window too wide**: `MAX_STATE_AGE_MS` was set to 60 minutes. A leaked state token (via referer header, browser history, or log line) could be replayed for up to an hour.

3. **Blob URL path resolution unbounded**: `resolveBlobPath` iterated through every slash segment of the URL when probing for the correct (ref, path) split. An adversarially crafted URL with many segments could burn GitHub API quota proportionally.

4. **Label color injection in issue previews**: Issue label `color` values from the GitHub API were passed through with only a `typeof` string check. A value like `"red; background: url(x)"` would have been forwarded to the frontend as-is.

## Solution

Each weakness is fixed at its narrowest point, with tests covering the new behavior.

### How it works

**Open redirect fix**: `buildForwardedOrigin` now returns `null` on malformed input (instead of throwing). The resolved origin is validated against the injected `allowedFrontendOrigins` allowlist (sourced from `config.corsAllowedOrigins`, the same list already used for CORS). Unrecognized or missing origins fall back to a safe relative path. The allowlist is injected at construction time through `createWorkspaceIntegrationHandlers` and wired through `registerRoutes`.

**State window**: `MAX_STATE_AGE_MS` reduced from 60 min → 10 min. Still covers the realistic install flow (including an org admin needing to approve).

**Blob resolution cap**: `resolveBlobPath` now tries at most `MAX_BLOB_PATH_SPLIT_ATTEMPTS = 5` candidates. This covers branch names with up to 4 slashes (e.g. `feature/team/sprint-42/foo`) and hard-bounds API usage regardless of URL length.

**Label color normalization**: New `normalizeLabelColor` helper accepts only `/^[0-9a-f]{6}$/i` hex strings, strips leading `#`, lowercases, and falls back to `"999999"`.

### Key design decisions

**1. Reuse `corsAllowedOrigins` as the redirect allowlist**

The CORS allowed-origins list is already the canonical source of truth for "which frontend origins are permitted to talk to this backend." Reusing it avoids a parallel config value that could drift. `corsAllowedOrigins` is threaded through `registerRoutes → createWorkspaceIntegrationHandlers` as an explicit dependency.

**2. Relative-path fallback instead of hard error**

Falling back to the relative path (`/w/{workspaceId}?...`) on an unrecognized origin means legitimate requests that arrive without forwarded headers (direct local dev, unusual proxy configs) still work — they just don't get the absolute URL. An outright 400 would break those cases unnecessarily.

**3. Cap at 5 blob splits, not a tighter limit**

5 covers `feature/a/b/c/d` (a 4-segment branch name), which is already unusual. Tighter limits would break real-world deeply-nested branch structures; looser limits defeat the purpose.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/workspace-integrations/handlers.ts` | Allowlist guard on redirect; `buildForwardedOrigin` returns `null` on bad input; `allowedFrontendOrigins` dep injected |
| `apps/backend/src/features/workspace-integrations/handlers.test.ts` | Tests for allowlist rejection and malformed host fallback |
| `apps/backend/src/features/workspace-integrations/crypto.ts` | `MAX_STATE_AGE_MS` 60 min → 10 min with explanatory comment |
| `apps/backend/src/features/workspace-integrations/crypto.test.ts` | Updated expiry test + positive test at boundary |
| `apps/backend/src/features/link-previews/github-preview.ts` | Blob split cap constant + `normalizeLabelColor` helper |
| `apps/backend/src/features/link-previews/github-preview.test.ts` | Tests for split cap and label color normalization |
| `apps/backend/src/routes.ts` | Thread `corsAllowedOrigins` through `registerRoutes` |
| `apps/backend/src/server.ts` | Pass `config.corsAllowedOrigins` to `registerRoutes` |

## Test plan

- [x] `bun run test` passes (unit + integration)
- [x] Open redirect: forwarded host not in allowlist → relative path
- [x] Open redirect: malformed forwarded host → relative path
- [x] Open redirect: allowlisted origin → absolute URL
- [x] State window: expiry at 10 min + 1 ms throws; 10 min - 1 ms succeeds
- [x] Blob split: 9-segment URL issues exactly 5 `contents` calls
- [x] Label color: `#ABCDEF`, bare hex, CSS injection, too-short, non-string all handled correctly

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
