### PR TITLE
fix(ai-usage): record usage for companion/persona agent calls

### DIFF
--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -21,7 +21,7 @@ import { AttachmentRepository } from "../attachments"
 import { awaitAttachmentProcessing } from "../attachments"
 import type { TraceEmitter } from "./trace-emitter"
 import type { SessionAbortRegistry } from "./session-abort-registry"
-import type { AI } from "../../lib/ai/ai"
+import type { AI, CostContext } from "../../lib/ai/ai"
 import type { SearchService } from "../search"
 import type { ConversationSummaryService } from "./conversation-summary-service"
 import type { StorageProvider } from "../../lib/storage/s3-client"
@@ -368,6 +368,15 @@ export class PersonaAgent {
         const runtime = new AgentRuntime({
           ai,
           model,
+          modelString: persona.model,
+          // Origin is "user" for mention-triggered runs where we can attribute
+          // cost to the invoking user; otherwise fall back to "system".
+          costContext: {
+            workspaceId,
+            userId: agentContext.invokingUserId,
+            sessionId: session.id,
+            origin: agentContext.invokingUserId ? "user" : "system",
+          },
           systemPrompt: isSupersedeRerun
             ? buildSupersedeRerunSystemPrompt(agentContext.systemPrompt, rerunContext)
             : agentContext.systemPrompt,
@@ -380,6 +389,12 @@ export class PersonaAgent {
                 ai,
                 sessionId: session.id,
                 rerunContext,
+                costContext: {
+                  workspaceId,
+                  userId: agentContext.invokingUserId,
+                  sessionId: session.id,
+                  origin: agentContext.invokingUserId ? "user" : "system",
+                },
               })
             : undefined,
           telemetry: {
@@ -805,8 +820,9 @@ function buildSupersedeResponseValidator(params: {
   ai: AI
   sessionId: string
   rerunContext?: AgentSessionRerunContext
+  costContext: CostContext
 }): (content: string) => Promise<string | null> {
-  const { ai, sessionId, rerunContext } = params
+  const { ai, sessionId, rerunContext, costContext } = params
   const editedBefore = rerunContext?.editedMessageBefore ?? null
   const editedAfter = rerunContext?.editedMessageAfter ?? null
 
@@ -827,6 +843,7 @@ function buildSupersedeResponseValidator(params: {
             rerun_cause: rerunContext?.cause ?? "unknown",
           },
         },
+        context: costContext,
         maxTokens: SUPERSEDE_RESPONSE_VALIDATOR_MAX_TOKENS,
         temperature: SUPERSEDE_RESPONSE_VALIDATOR_TEMPERATURE,
         messages: [

--- a/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
@@ -135,6 +135,50 @@ describe("AgentRuntime message counting", () => {
     expect(events.some((event) => event.type === "response:kept")).toBe(true)
   })
 
+  it("forwards modelString and costContext to generateTextWithTools so usage is recorded", async () => {
+    const captured: Array<{ modelString?: string; context?: Record<string, unknown> }> = []
+    const generateTextWithTools = mock(async (opts: { modelString?: string; context?: Record<string, unknown> }) => {
+      captured.push({ modelString: opts.modelString, context: opts.context })
+      return {
+        text: "All done.",
+        toolCalls: [],
+        response: {
+          messages: [{ role: "assistant", content: "All done." } as any],
+        },
+      }
+    })
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      modelString: "openrouter:anthropic/claude-haiku-4.5",
+      costContext: {
+        workspaceId: "ws_abc",
+        userId: "user_xyz",
+        sessionId: "session_123",
+        origin: "user",
+      },
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "Say hi." }],
+      tools: [],
+      sendMessage: async () => ({ messageId: "msg_1", operation: "created" }),
+    })
+
+    const result = await runtime.run()
+
+    expect(result.messagesSent).toBe(1)
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toEqual({
+      modelString: "openrouter:anthropic/claude-haiku-4.5",
+      context: {
+        workspaceId: "ws_abc",
+        userId: "user_xyz",
+        sessionId: "session_123",
+        origin: "user",
+      },
+    })
+  })
+
   it("stops early when rerun keeps returning empty final decisions", async () => {
     const generateTextWithTools = mock(async () => ({
       text: " ",

--- a/apps/backend/src/features/agents/runtime/agent-runtime.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.ts
@@ -1,7 +1,7 @@
 import type { LanguageModel, ModelMessage, Tool, ToolResultPart } from "ai"
 import type { SourceItem, TraceSource } from "@threa/types"
 import { AgentToolNames } from "@threa/types"
-import type { AI } from "../../../lib/ai/ai"
+import type { AI, CostContext } from "../../../lib/ai/ai"
 import { logger } from "../../../lib/logger"
 import { protectToolOutputText } from "../tool-trust-boundary"
 import { MAX_MESSAGE_CHARS, truncateMessages } from "../companion/truncation"
@@ -34,12 +34,20 @@ export interface NewMessageAwareness {
 export interface AgentRuntimeConfig {
   ai: AI
   model: LanguageModel
+  /**
+   * Original provider:model string for `model`. Required alongside `costContext`
+   * for AI usage tracking — the resolved LanguageModel does not expose the
+   * prefix the cost recorder needs.
+   */
+  modelString?: string
   systemPrompt: string
   messages: ModelMessage[]
   tools: AgentTool[]
   maxIterations?: number
   observers?: AgentObserver[]
   telemetry?: { functionId: string; metadata?: Record<string, string | number | boolean> }
+  /** Cost context forwarded to every AI call the runtime makes (enables usage recording). */
+  costContext?: CostContext
 
   /** Terminal action — sends a message to the conversation */
   sendMessage: (input: {
@@ -223,10 +231,12 @@ export class AgentRuntime {
       const result = await this.wrapWithObserverContext(() =>
         ai.generateTextWithTools({
           model,
+          modelString: this.config.modelString,
           system: fullSystemPrompt,
           messages: truncatedMessages,
           tools: this.toolDefs,
           telemetry: this.config.telemetry,
+          context: this.config.costContext,
         })
       )
       const durationMs = Date.now() - startTime

--- a/apps/backend/src/lib/ai/ai.ts
+++ b/apps/backend/src/lib/ai/ai.ts
@@ -185,10 +185,19 @@ export interface GenerateTextOptions {
  */
 export interface GenerateTextWithToolsOptions {
   model: LanguageModel
+  /**
+   * The original provider:model string for the resolved `model`.
+   * Required alongside `context` so usage can be recorded with a parseable
+   * model identifier (the resolved LanguageModel does not expose the
+   * original provider prefix needed by the cost recorder).
+   */
+  modelString?: string
   system?: string
   messages: ModelMessage[]
   tools?: Record<string, Tool<any, any>>
   telemetry?: TelemetryConfig
+  /** When provided with `modelString`, usage will be recorded to the database */
+  context?: CostContext
   /** Abort signal for graceful cancellation / per-call timeouts */
   abortSignal?: AbortSignal
 }
@@ -782,6 +791,26 @@ export function createAI(config: AIConfig): AI {
           ? { isEnabled: true, functionId: options.telemetry.functionId, metadata: options.telemetry.metadata }
           : undefined,
       })
+
+      // Usage recording requires the original model string because the resolved
+      // LanguageModel instance does not carry the provider:model prefix the cost
+      // recorder expects. Callers that want tracked usage must pass `modelString`
+      // alongside `context` (agent loops do this via AgentRuntime).
+      if (options.modelString) {
+        const usage = extractUsageWithCost(response)
+        logger.debug(
+          { usage, model: options.modelString, functionId: options.telemetry?.functionId },
+          "AI generateTextWithTools completed with usage"
+        )
+
+        await maybeRecordUsage({
+          context: options.context,
+          functionId: options.telemetry?.functionId ?? "generateTextWithTools",
+          modelString: options.modelString,
+          usage,
+          metadata: options.telemetry?.metadata as Record<string, unknown> | undefined,
+        })
+      }
 
       return {
         text: response.text,


### PR DESCRIPTION
## Problem

The AI usage dashboard showed **zero per-user and zero per-component rows** for user-facing agents. Only system-level entries (embeddings, memo classification, workspace-agent research) appeared in `byOrigin: "system"`. The companion / persona agent loop — arguably the most cost-relevant component in the workspace — was silently invisible.

Root cause: the `createAI` wrapper has five entry points and four of them (`generateText`, `generateObject`, `embed`, `embedMany`) call `maybeRecordUsage(...)` after the AI call. The fifth — `generateTextWithTools`, which is the *only* method the companion agent loop uses — did not. Usage was dropped on the floor before it ever reached `ai_usage_records`, so the dashboard had nothing to show for `origin: "user"`, `user_id`, or `function_id = "agent-loop"`.

Secondary: the supersede response validator (`buildSupersedeResponseValidator` in `persona-agent.ts`) called `ai.generateObject()` without a `context`, so its usage was dropped too.

## Solution

Thread `modelString` + `CostContext` (`workspaceId`, `userId`, `sessionId`, `origin`) through `AgentRuntimeConfig` down to `generateTextWithTools`, and record usage there the same way the other four wrapper methods do. Build the context in `PersonaAgent.run()` from the invoking user so each loop iteration is attributed correctly.

### How it works

```
PersonaAgent.run()
  └── costContext = { workspaceId, userId: invokingUserId, sessionId, origin: invokingUserId ? "user" : "system" }
      └── new AgentRuntime({ modelString: persona.model, costContext, ... })
          └── loop iteration → ai.generateTextWithTools({ model, modelString, context, ... })
              └── maybeRecordUsage() → AICostService.recordUsage()
                  └── INSERT INTO ai_usage_records (workspace_id, user_id, session_id, function_id, origin, ...)
```

Each loop iteration is one model roundtrip → one recorded row. The dashboard's `byUser`, `byOrigin`, and `byFunction` queries then pick them up automatically (no frontend change needed).

### Key design decisions

**1. Pass `modelString` alongside the pre-resolved `LanguageModel`**

The agent loop resolves the model once (`ai.getLanguageModel(persona.model)`) and reuses the instance across iterations as an optimization. The resolved `LanguageModel` instance does not carry the `provider:` prefix that `parseModelId` / the cost recorder needs. Options considered:

- Re-resolve each iteration — throws away the optimization.
- Dig the model string out of the `LanguageModel` object — fragile, depends on AI SDK internals.
- **Chosen:** make `modelString` an explicit optional field on `GenerateTextWithToolsOptions`. Usage recording is gated on it being present; everything else works without it. Minimal invasive change.

**2. Origin falls back to `"system"` when there's no invoking user**

`agentContext.invokingUserId` is only set for mention-triggered runs where `triggerMessage.authorType === "user"`. For system-triggered runs (scheduled reruns, etc.) there is no attributable user, so origin is `"system"` and `user_id` is null. The dashboard's `byUser` view already handles null `user_id` rows.

**3. Did not add budget enforcement or `buildTelemetry` to `generateTextWithTools`**

Both were pre-existing omissions in that method and are orthogonal to the reported bug. `persona-agent.ts` already manually adds `model_id` / `model_provider` / `model_name` into `telemetry.metadata` so Langfuse model matching still works. Scope discipline per CLAUDE.md — minimal patch.

**4. Also fixed the supersede response validator**

Same class of bug — `ai.generateObject()` called without `context`, so usage from rerun validation was silently dropped. Adding the context was a two-line change in the same file and fits the same fix.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/lib/ai/ai.ts` | Added optional `modelString` and `context: CostContext` to `GenerateTextWithToolsOptions`; call `extractUsageWithCost` + `maybeRecordUsage` after the AI call when `modelString` is present. |
| `apps/backend/src/features/agents/runtime/agent-runtime.ts` | Added optional `modelString` and `costContext` to `AgentRuntimeConfig`; forward them on every `generateTextWithTools` call inside `loop()`. |
| `apps/backend/src/features/agents/persona-agent.ts` | Build `CostContext` (`workspaceId`, `userId: invokingUserId`, `sessionId: session.id`, `origin`) and pass it plus `modelString: persona.model` into `AgentRuntime`. Thread the same context into `buildSupersedeResponseValidator` so its `generateObject` call also records usage. |
| `apps/backend/src/features/agents/runtime/agent-runtime.test.ts` | New test `"forwards modelString and costContext to generateTextWithTools so usage is recorded"` — asserts the runtime passes both fields through verbatim. Guards against regression. |

## Test plan

- [x] `bun test apps/backend/src/features/agents/runtime/agent-runtime.test.ts apps/backend/src/lib/ai/ai.test.ts` — 26/26 pass (including new runtime test)
- [x] `bun test apps/backend/src/features/agents` — 121/121 pass
- [x] `bun test apps/backend/src/features/ai-usage apps/backend/src/lib/ai` — 73/73 pass
- [x] `bun run typecheck` — clean across all packages
- [x] Pre-commit lint + openapi-spec check — clean
- [ ] Mention a companion persona in a stream in staging, confirm a row appears in `ai_usage_records` with `origin = 'user'`, `user_id` = the mentioning user, `session_id` set, `function_id = 'agent-loop'`, and non-zero `cost_usd`.
- [ ] Open the AI Usage admin dashboard and confirm the new row appears under both the "By user" and "By origin (user)" breakdowns.
- [ ] Trigger a supersede rerun (edit a message that a persona already answered) and confirm an additional `function_id = 'agent-rerun-response-validation'` row is recorded alongside the `agent-loop` rows.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
