### PR TITLE
fix: focus Delete button by default in delete message dialog

### DIFF
--- a/apps/frontend/src/components/timeline/delete-message-dialog.test.tsx
+++ b/apps/frontend/src/components/timeline/delete-message-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DeleteMessageDialog } from "./delete-message-dialog"
 
@@ -22,12 +22,16 @@ describe("DeleteMessageDialog", () => {
     expect(onConfirm).toHaveBeenCalledOnce()
   })
 
-  it("should focus the Delete button by default so Enter confirms immediately", async () => {
-    render(<DeleteMessageDialog open={true} onOpenChange={vi.fn()} onConfirm={vi.fn()} isDeleting={false} />)
+  it("should confirm deletion when Enter is pressed without tabbing", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Delete" })).toHaveFocus()
-    })
+    render(<DeleteMessageDialog open={true} onOpenChange={vi.fn()} onConfirm={onConfirm} isDeleting={false} />)
+
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveFocus()
+    await user.keyboard("{Enter}")
+
+    expect(onConfirm).toHaveBeenCalledOnce()
   })
 
   it("should show loading state while deleting", () => {

--- a/apps/frontend/src/components/timeline/delete-message-dialog.test.tsx
+++ b/apps/frontend/src/components/timeline/delete-message-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DeleteMessageDialog } from "./delete-message-dialog"
 
@@ -20,6 +20,14 @@ describe("DeleteMessageDialog", () => {
     await user.click(screen.getByRole("button", { name: "Delete" }))
 
     expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it("should focus the Delete button by default so Enter confirms immediately", async () => {
+    render(<DeleteMessageDialog open={true} onOpenChange={vi.fn()} onConfirm={vi.fn()} isDeleting={false} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toHaveFocus()
+    })
   })
 
   it("should show loading state while deleting", () => {

--- a/apps/frontend/src/components/timeline/delete-message-dialog.tsx
+++ b/apps/frontend/src/components/timeline/delete-message-dialog.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import {
   ResponsiveAlertDialog,
   ResponsiveAlertDialogAction,
@@ -17,9 +18,18 @@ interface DeleteMessageDialogProps {
 }
 
 export function DeleteMessageDialog({ open, onOpenChange, onConfirm, isDeleting }: DeleteMessageDialogProps) {
+  // Message deletion is a power-user flow (triggered by clearing an edit), so we
+  // focus Delete instead of the Radix default Cancel to let Enter confirm immediately.
+  const deleteButtonRef = useRef<HTMLButtonElement>(null)
+
   return (
     <ResponsiveAlertDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveAlertDialogContent>
+      <ResponsiveAlertDialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          deleteButtonRef.current?.focus()
+        }}
+      >
         <ResponsiveAlertDialogHeader>
           <ResponsiveAlertDialogTitle>Delete message</ResponsiveAlertDialogTitle>
           <ResponsiveAlertDialogDescription>
@@ -29,6 +39,7 @@ export function DeleteMessageDialog({ open, onOpenChange, onConfirm, isDeleting 
         <ResponsiveAlertDialogFooter>
           <ResponsiveAlertDialogCancel disabled={isDeleting}>Cancel</ResponsiveAlertDialogCancel>
           <ResponsiveAlertDialogAction
+            ref={deleteButtonRef}
             onClick={onConfirm}
             disabled={isDeleting}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"


### PR DESCRIPTION
## Problem

Clearing an in-progress edit opens the delete-message confirmation dialog. Radix's `AlertDialog` focuses **Cancel** by default for safety, so a quick Enter keystroke silently dismissed the dialog and left the message intact. I expected the message to be gone after the interaction and was surprised it wasn't — other users in this power-user flow will hit the same surprise.

## Solution

Override the default focus on `DeleteMessageDialog` so the **Delete** button receives initial focus. Tab/Shift+Tab still reach Cancel as expected, and Escape still dismisses — only the *default* focus target changes.

### How it works

`ResponsiveAlertDialogContent` already passes `onOpenAutoFocus` through to the underlying Radix `AlertDialogContent`. We attach a ref to the destructive action button and intercept `onOpenAutoFocus` to `preventDefault()` Radix's Cancel-focus, then `.focus()` the Delete button ref.

### Key design decisions

**1. Per-component override, not a shared helper**

Only this dialog needs confirm-focus — every other `AlertDialog` consumer in the app (`drafts.tsx`, `general-tab.tsx`, `bot-detail.tsx`, etc.) wants the safe default. Adding a `useFocusConfirm` hook or an `autoFocusAction` prop on the wrapper would be speculative abstraction (CLAUDE.md INV-36). If a second consumer ever needs this, lifting it into a hook is a five-line refactor.

**2. `useRef` + `onOpenAutoFocus` instead of `autoFocus={true}`**

Radix manages dialog focus via the `onOpenAutoFocus` lifecycle and would override a plain `autoFocus` HTML attribute. The ref pattern is the only one that integrates with Radix's focus trap correctly.

**3. Test asserts the user-visible outcome, not the focus state**

Rather than a `toHaveFocus()` snapshot, the test focuses Delete + presses Enter and asserts `onConfirm` is called. This is what users actually experience, and it would also catch a regression where focus moved but Enter no longer triggered the action.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/timeline/delete-message-dialog.tsx` | Add `deleteButtonRef` and intercept `onOpenAutoFocus` to focus Delete instead of Cancel |
| `apps/frontend/src/components/timeline/delete-message-dialog.test.tsx` | Add test that Enter confirms deletion without tabbing |

## Test plan

- [x] `bunx vitest run src/components/timeline/delete-message-dialog.test.tsx` — 5/5 pass
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend `eslint src/` clean (pre-commit hooks)
- [ ] Manual: open a message, click Edit, clear all content → confirm dialog opens with Delete focused, Enter deletes the message
- [ ] Manual: same flow → Tab moves focus to Cancel, Shift+Tab moves it back, Escape still dismisses without deleting

---

https://claude.ai/code