### PR TITLE
fix(deploy): copy backoffice workspace package.json into Railway build

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,6 +10,8 @@ COPY apps/backend/package.json apps/backend/
 COPY apps/frontend/package.json apps/frontend/
 COPY apps/workspace-router/package.json apps/workspace-router/
 COPY apps/control-plane/package.json apps/control-plane/
+COPY apps/backoffice/package.json apps/backoffice/
+COPY apps/backoffice-router/package.json apps/backoffice-router/
 # Remove prepare script (husky) so post-install scripts still run (sharp needs native binaries)
 RUN sed -i '/"prepare"/d' package.json && bun install --frozen-lockfile --production
 

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -10,6 +10,8 @@ COPY apps/backend/package.json apps/backend/
 COPY apps/frontend/package.json apps/frontend/
 COPY apps/workspace-router/package.json apps/workspace-router/
 COPY apps/control-plane/package.json apps/control-plane/
+COPY apps/backoffice/package.json apps/backoffice/
+COPY apps/backoffice-router/package.json apps/backoffice-router/
 RUN sed -i '/"prepare"/d' package.json && bun install --frozen-lockfile --production
 
 # Copy source


### PR DESCRIPTION
## Problem

After merging #329, the next push to main triggered Railway rebuilds for backend + control-plane that both failed at the install step:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

```
Dockerfile.control-plane:13
-------------------
11 |     COPY apps/workspace-router/package.json apps/workspace-router/
12 |     COPY apps/control-plane/package.json apps/control-plane/
13 | >>> RUN sed -i '/"prepare"/d' package.json && bun install --frozen-lockfile --production
```

Both Railway services were down.

## Root cause

`#329` added `apps/backoffice/` and `apps/backoffice-router/` as new workspaces. The root `package.json` already uses `"workspaces": ["apps/*", "packages/*"]` so they're picked up automatically, and `bun.lock` carries entries for both.

But `Dockerfile.backend` and `Dockerfile.control-plane` enumerate every workspace `package.json` explicitly via `COPY` (not via a glob), and the new ones were never added. When the container builds:

1. `COPY package.json bun.lock ./` — root carries the workspaces glob
2. Subset of workspace `package.json` files are copied (no backoffice / backoffice-router)
3. `bun install --frozen-lockfile` — bun reads the lockfile, sees workspace entries that don't exist on disk in the build context, tries to update the lockfile to drop them, hits `--frozen-lockfile`, fails

This is the same shape as PR #329's COPY list missing the new workspaces — a mechanical oversight when adding new apps to a monorepo with explicit Dockerfile copies.

## Fix

Add the two missing `COPY` lines to both Dockerfiles, in the same spot as the other `apps/*` workspace copies:

```
COPY apps/workspace-router/package.json apps/workspace-router/
COPY apps/control-plane/package.json apps/control-plane/
COPY apps/backoffice/package.json apps/backoffice/                ← new
COPY apps/backoffice-router/package.json apps/backoffice-router/  ← new
RUN sed -i '/"prepare"/d' package.json && bun install --frozen-lockfile --production
```

Backend and control-plane don't actually USE the backoffice workspaces at runtime — they don't `require` them, they don't compile against them. The `COPY` is purely so bun's workspace resolution sees a consistent on-disk state matching the lockfile. (Source `COPY` lines further down the Dockerfile that pull in the actual TypeScript code remain unchanged — backoffice source isn't copied because it isn't needed at runtime.)

## Test plan

- [ ] Once merged, watch the next Railway rebuild for backend and control-plane succeed
- [ ] Both services come back up and pass their `/health` checks
- [ ] No regression in the existing image content — runtime `apps/<service>/` source copies are untouched

## Alternative considered

Switch the explicit `COPY` lines to a glob like `COPY apps/*/package.json apps/`. Cleaner long-term but Docker's `COPY` glob handling for nested paths is fiddly (it flattens into one directory rather than preserving structure), and changing this would also touch the working pattern that the other Dockerfiles rely on. Punting that cleanup; the targeted fix is enough to unblock prod.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_