### PR TITLE
fix: promote viewed DM drafts on incoming first message

### DIFF
--- a/.claude/plans/fix-broken-dm-promotion.md
+++ b/.claude/plans/fix-broken-dm-promotion.md
@@ -1,0 +1,57 @@
+# Fix Broken DM Promotion
+
+## Goal
+
+Fix the recipient-side promotion path for lazily created DMs so a user who is currently viewing a fake DM draft is moved onto the newly created real DM stream as soon as the first message arrives, without requiring a workspace refresh. The sidebar and Activity feed should resolve that DM as the real private stream immediately.
+
+## What Was Built
+
+### Recipient-side DM promotion in workspace sync
+
+`stream:created` handling for DMs now treats the event as a full local promotion for participating users instead of waiting for a follow-up workspace bootstrap refetch.
+
+**Files:**
+- `apps/frontend/src/sync/workspace-sync.ts` — resolves the DM peer from `dmUserIds`, populates the real DM stream into bootstrap and IndexedDB caches, writes the `dmPeers` entry, adds the recipient membership when needed, and subscribes the client to the new stream room immediately.
+
+### Regression coverage for the recipient path
+
+Added explicit coverage for the bug scenario where user A is sitting in a fake DM while user B sends the first message.
+
+**Files:**
+- `apps/frontend/src/sync/workspace-sync.test.ts` — verifies a DM `stream:created` event promotes the recipient immediately without a workspace refetch.
+- `tests/browser/dm-lazy-creation.spec.ts` — covers both the existing sender-side lazy-creation flow and the new recipient-side promotion/activity-label flow in the browser.
+
+## Design Decisions
+
+### Promote from the socket event instead of waiting for bootstrap
+
+**Chose:** update both TanStack workspace bootstrap state and IndexedDB from the incoming DM `stream:created` event.
+**Why:** the bug was caused by the recipient path not writing the newly created DM into the persistent client caches, which left the fake DM visible until a later refresh/bootstrap completed.
+**Alternatives considered:** keep relying on `queryClient.refetchQueries(...)` for the workspace bootstrap. This was rejected because it still leaves a race between the real-time event and the eventual refetch, which is the exact stale-state gap the bug exposed.
+
+### Resolve DM names from existing viewer-specific cache inputs
+
+**Chose:** derive the DM display name from the known peer user ID plus `workspace.users`.
+**Why:** DM `stream:created` payloads still carry the raw DB row with `displayName: null`, and the viewer-specific name already exists as a frontend concern in the workspace cache model.
+**Alternatives considered:** introduce backend-side viewer-resolved DM names on socket payloads. That would be a larger contract change than needed for this bug.
+
+## Design Evolution
+
+No earlier branch-local plan file or Claude session plan was available in this worktree, so the implementation stayed on the minimal path: fix recipient-side cache promotion only and prove it with targeted regressions.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No backend change to DM creation or upsert semantics. The existing `findOrCreateDm` flow already handles concurrent first-message creation via the DM uniqueness key.
+- No change to general sidebar organization or Smart/All view behavior outside making the promoted DM available to the existing UI state immediately.
+- No Activity feed rendering change. The fix ensures Activity has the real DM stream available in client state so existing name resolution can work.
+
+## Status
+
+- [x] Promote recipient-side fake DMs to real DMs from `stream:created`
+- [x] Persist DM peer and membership data immediately for participating users
+- [x] Cover the recipient promotion path with a unit regression
+- [x] Cover the no-refresh recipient/activity flow with a browser regression

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -620,7 +620,7 @@ function makeWorkspaceUser() {
 
 describe("registerWorkspaceSocketHandlers", () => {
   beforeEach(async () => {
-    await Promise.all([db.streams.clear(), db.streamMemberships.clear(), db.unreadState.clear()])
+    await Promise.all([db.streams.clear(), db.streamMemberships.clear(), db.dmPeers.clear(), db.unreadState.clear()])
   })
 
   it("subscribes the creator when a new stream is created at runtime", async () => {
@@ -669,6 +669,95 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     expect(subscribeStream).toHaveBeenCalledWith("stream_new")
     expect(await db.streamMemberships.get("ws_1:stream_new")).toBeDefined()
+
+    cleanup()
+  })
+
+  it("promotes newly created DMs for recipients without waiting for a workspace refetch", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({
+        users: [
+          makeWorkspaceUser(),
+          {
+            id: "member_2",
+            workspaceId: "ws_1",
+            workosUserId: "workos_2",
+            email: "invitee@example.com",
+            role: "user",
+            slug: "invitee",
+            name: "Invitee",
+            description: null,
+            avatarUrl: null,
+            timezone: "Europe/Stockholm",
+            locale: "en",
+            pronouns: null,
+            phone: null,
+            githubUsername: null,
+            setupCompleted: true,
+            joinedAt: new Date().toISOString(),
+          },
+        ],
+        streams: [],
+        streamMemberships: [],
+        dmPeers: [],
+      })
+    )
+
+    const subscribeStream = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => undefined,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream,
+    })
+
+    emit("stream:created", {
+      workspaceId: "ws_1",
+      streamId: "stream_dm_1",
+      dmUserIds: ["member_1", "member_2"],
+      stream: {
+        id: "stream_dm_1",
+        workspaceId: "ws_1",
+        type: "dm",
+        displayName: null,
+        slug: null,
+        description: null,
+        visibility: "private",
+        parentStreamId: null,
+        parentMessageId: null,
+        rootStreamId: null,
+        companionMode: "off",
+        companionPersonaId: null,
+        createdBy: "member_2",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        archivedAt: null,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(subscribeStream).toHaveBeenCalledWith("stream_dm_1")
+    expect(await db.streams.get("stream_dm_1")).toMatchObject({
+      id: "stream_dm_1",
+      type: "dm",
+      displayName: "Invitee",
+    })
+    expect(await db.streamMemberships.get("ws_1:stream_dm_1")).toMatchObject({
+      streamId: "stream_dm_1",
+      memberId: "member_1",
+    })
+    expect(await db.dmPeers.get("ws_1:stream_dm_1")).toMatchObject({
+      streamId: "stream_dm_1",
+      userId: "member_2",
+    })
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.streams).toContainEqual(expect.objectContaining({ id: "stream_dm_1", displayName: "Invitee" }))
+    expect(bootstrap?.streamMemberships).toContainEqual(expect.objectContaining({ streamId: "stream_dm_1" }))
+    expect(bootstrap?.dmPeers).toContainEqual(expect.objectContaining({ streamId: "stream_dm_1", userId: "member_2" }))
 
     cleanup()
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -142,7 +142,6 @@ function withWorkspaceUsers(bootstrap: WorkspaceBootstrap, users: User[]): Works
 function toWorkspaceUser(user: WorkspaceUserPayload): User {
   return { ...user }
 }
-
 function toWorkspaceBootstrapStream(stream: CachedStream): WorkspaceBootstrap["streams"][number] {
   return {
     id: stream.id,
@@ -346,6 +345,11 @@ export function mergeReconnectWorkspaceBootstrap({
   }
 }
 
+function resolveDmPeerUserId(dmUserIds: [string, string] | undefined, currentUserId: string | null): string | null {
+  if (!currentUserId || !dmUserIds?.includes(currentUserId)) return null
+  return dmUserIds.find((userId) => userId !== currentUserId) ?? null
+}
+
 // ============================================================================
 // Register workspace-level socket handlers
 // ============================================================================
@@ -374,7 +378,10 @@ export function registerWorkspaceSocketHandlers(
     let shouldJoinStreamRoom = false
     let shouldCacheStream = payload.stream.visibility !== Visibilities.PRIVATE
     let shouldAddMembership = false
+    let shouldAddDmPeer = false
     let currentUserId: string | null = null
+    let dmPeerUserId: string | null = null
+    let cachedStream: Stream & { lastMessagePreview?: LastMessagePreview | null } = payload.stream
 
     // Add to workspace bootstrap cache (sidebar)
     const applied = updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => {
@@ -387,27 +394,46 @@ export function registerWorkspaceSocketHandlers(
         payload.stream.type === StreamTypes.DM &&
         currentUserId !== null &&
         payload.dmUserIds?.includes(currentUserId) === true
+      dmPeerUserId = resolveDmPeerUserId(payload.dmUserIds, currentUserId)
+      const dmPeerDisplayName =
+        dmPeerUserId != null ? (getWorkspaceUsers(old).find((user) => user.id === dmPeerUserId)?.name ?? null) : null
+      cachedStream =
+        payload.stream.type === StreamTypes.DM && dmPeerDisplayName
+          ? { ...payload.stream, displayName: dmPeerDisplayName }
+          : payload.stream
       const hasMembership = old.streamMemberships.some((m: StreamMember) => m.streamId === payload.stream.id)
       shouldAddMembership = Boolean(currentUserId && !hasMembership && (isCreator || isDmParticipant))
+      shouldAddDmPeer = Boolean(
+        dmPeerUserId && !old.dmPeers.some((peer) => peer.streamId === payload.stream.id && peer.userId === dmPeerUserId)
+      )
       const isPrivate = payload.stream.visibility === Visibilities.PRIVATE
       const shouldAddStream =
         !streamExists &&
-        payload.stream.type !== StreamTypes.DM &&
-        // Private streams (scratchpads, private channels) — only add to sidebar for the creator.
-        // Other members are added via stream:member_added.
-        (!isPrivate || isCreator)
+        (payload.stream.type === StreamTypes.DM
+          ? isDmParticipant
+          : // Private streams (scratchpads, private channels) — only add to sidebar for the creator.
+            // Other members are added via stream:member_added.
+            !isPrivate || isCreator)
 
       // Ensure members are subscribed immediately for follow-up stream activity.
       shouldJoinStreamRoom = hasMembership || shouldAddMembership
-      shouldCacheStream = !isPrivate || isCreator
+      shouldCacheStream = payload.stream.type === StreamTypes.DM ? isDmParticipant : !isPrivate || isCreator
 
-      if (streamExists && !shouldAddMembership) return old
+      if (streamExists && !shouldAddMembership && !shouldAddDmPeer) return old
 
       return {
         ...old,
-        // DM payloads do not include viewer-resolved names. Avoid inserting
-        // placeholder "Direct message" entries and wait for bootstrap refetch.
-        streams: shouldAddStream ? [...old.streams, { ...payload.stream, lastMessagePreview: null }] : old.streams,
+        streams: shouldAddStream
+          ? [...old.streams, { ...cachedStream, lastMessagePreview: null }]
+          : old.streams.map((stream) =>
+              stream.id === payload.stream.id
+                ? {
+                    ...stream,
+                    ...cachedStream,
+                    displayName: cachedStream.displayName ?? stream.displayName,
+                  }
+                : stream
+            ),
         streamMemberships: shouldAddMembership
           ? [
               ...old.streamMemberships,
@@ -423,6 +449,10 @@ export function registerWorkspaceSocketHandlers(
               },
             ]
           : old.streamMemberships,
+        dmPeers:
+          shouldAddDmPeer && dmPeerUserId != null
+            ? [...old.dmPeers, { userId: dmPeerUserId, streamId: payload.stream.id }]
+            : old.dmPeers,
       }
     })
 
@@ -430,34 +460,42 @@ export function registerWorkspaceSocketHandlers(
       refs.subscribeStream(payload.stream.id)
     }
 
-    // Cache to IndexedDB — skip other users' scratchpads to avoid stale
-    // entries resurfacing on hydration if the event leaks during a deploy race.
-    if (shouldCacheStream) {
-      db.streams.put({ ...payload.stream, _cachedAt: Date.now() })
-    }
+    void db.transaction("rw", [db.streams, db.streamMemberships, db.dmPeers], async () => {
+      const now = Date.now()
 
-    // Persist membership to IDB so sidebar correctly filters public channels
-    if (shouldAddMembership && currentUserId) {
-      db.streamMemberships.put({
-        id: `${workspaceId}:${payload.stream.id}`,
-        workspaceId,
-        streamId: payload.stream.id,
-        memberId: currentUserId,
-        pinned: false,
-        pinnedAt: null,
-        notificationLevel: null,
-        lastReadEventId: null,
-        lastReadAt: null,
-        joinedAt: payload.stream.createdAt,
-        _cachedAt: Date.now(),
-      })
-    }
+      // Cache to IndexedDB — skip other users' scratchpads to avoid stale
+      // entries resurfacing on hydration if the event leaks during a deploy race.
+      if (shouldCacheStream) {
+        await db.streams.put({ ...cachedStream, _cachedAt: now })
+      }
 
-    // DM creation still requires bootstrap refetch for viewer-specific dmPeers and
-    // resolved display names in the sidebar.
-    if (payload.stream.type === StreamTypes.DM) {
-      void queryClient.refetchQueries({ queryKey: workspaceKeys.bootstrap(workspaceId), type: "active" })
-    }
+      // Persist membership to IDB so sidebar correctly filters public channels.
+      if (shouldAddMembership && currentUserId) {
+        await db.streamMemberships.put({
+          id: `${workspaceId}:${payload.stream.id}`,
+          workspaceId,
+          streamId: payload.stream.id,
+          memberId: currentUserId,
+          pinned: false,
+          pinnedAt: null,
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: payload.stream.createdAt,
+          _cachedAt: now,
+        })
+      }
+
+      if (shouldAddDmPeer && dmPeerUserId != null) {
+        await db.dmPeers.put({
+          id: `${workspaceId}:${payload.stream.id}`,
+          workspaceId,
+          userId: dmPeerUserId,
+          streamId: payload.stream.id,
+          _cachedAt: now,
+        })
+      }
+    })
   }
 
   // Handle stream updated

--- a/tests/browser/dm-lazy-creation.spec.ts
+++ b/tests/browser/dm-lazy-creation.spec.ts
@@ -39,7 +39,9 @@ test.describe("DM Lazy Creation", () => {
       await ownerPage.getByRole("button", { name: "Send" }).click()
 
       await expect(ownerPage).toHaveURL(new RegExp(`/w/${workspaceId}/s/stream_`), { timeout: 10000 })
-      await expect(ownerPage.getByRole("main").getByText(firstMessage)).toBeVisible({ timeout: 5000 })
+      await expect(ownerPage.getByRole("main").locator(".message-item").getByText(firstMessage).first()).toBeVisible({
+        timeout: 5000,
+      })
 
       const streamId = ownerPage.url().match(/\/s\/([^/?]+)/)?.[1]
       expect(streamId).toBeTruthy()
@@ -59,6 +61,72 @@ test.describe("DM Lazy Creation", () => {
       await expect(invitee.page.locator(`a[href="/w/${workspaceId}/s/${streamId}"]`).first()).toBeVisible({
         timeout: 15000,
       })
+    } finally {
+      await ownerContext.close()
+      await invitee.context.close()
+    }
+  })
+
+  test("should promote a viewed draft DM for the recipient and resolve activity without refresh", async ({
+    browser,
+  }) => {
+    test.setTimeout(90000)
+
+    const testId = Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
+    const inviteeEmail = `dm-invitee-${testId}@example.com`
+
+    const ownerContext = await browser.newContext()
+    const ownerPage = await ownerContext.newPage()
+    const invitee = await loginInNewContext(browser, inviteeEmail, inviteeEmail)
+
+    try {
+      const owner = await loginAndCreateWorkspace(ownerPage, "dm-receiver-promotion")
+      const workspaceId = ownerPage.url().match(/\/w\/([^/]+)/)?.[1]
+      expect(workspaceId).toBeTruthy()
+
+      const joinWorkspaceResponse = await invitee.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+        data: { role: "user", name: inviteeEmail },
+      })
+      expect(joinWorkspaceResponse.ok()).toBeTruthy()
+
+      const usersResponse = await ownerPage.request.get(`/api/workspaces/${workspaceId}/users`)
+      expect(usersResponse.ok()).toBeTruthy()
+      const usersBody = (await usersResponse.json()) as { users: Array<{ id: string; name: string }> }
+      const ownerUser = usersBody.users.find((user) => user.name === owner.name)
+      const inviteeUser = usersBody.users.find((user) => user.name === inviteeEmail)
+      expect(ownerUser).toBeTruthy()
+      expect(inviteeUser).toBeTruthy()
+
+      const ownerDraftStreamId = createDmDraftId(inviteeUser!.id)
+      await ownerPage.goto(`/w/${workspaceId}/s/${ownerDraftStreamId}`)
+      await expect(ownerPage.getByText("Start a conversation")).toBeVisible({ timeout: 5000 })
+
+      const inviteeDraftStreamId = createDmDraftId(ownerUser!.id)
+      await invitee.page.goto(`/w/${workspaceId}/s/${inviteeDraftStreamId}`)
+      await expect(invitee.page.getByText("Start a conversation")).toBeVisible({ timeout: 5000 })
+
+      const firstMessage = `Incoming first DM ${testId}`
+      await invitee.page.locator("[contenteditable='true']").click()
+      await invitee.page.keyboard.type(firstMessage)
+      await invitee.page.getByRole("button", { name: "Send" }).click()
+
+      await expect(invitee.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/stream_`), { timeout: 15000 })
+      const realStreamId = invitee.page.url().match(/\/s\/([^/?]+)/)?.[1]
+      expect(realStreamId).toBeTruthy()
+
+      await expect(ownerPage).toHaveURL(new RegExp(`/w/${workspaceId}/s/${realStreamId}`), { timeout: 15000 })
+      await expect(ownerPage.getByRole("main").locator(".message-item").getByText(firstMessage).first()).toBeVisible({
+        timeout: 10000,
+      })
+      await expect(ownerPage.locator(`a[href="/w/${workspaceId}/s/${ownerDraftStreamId}"]`)).toHaveCount(0, {
+        timeout: 10000,
+      })
+
+      await ownerPage.goto(`/w/${workspaceId}/activity`)
+      const activityMain = ownerPage.locator("main.py-2")
+      await expect
+        .poll(async () => ((await activityMain.textContent()) ?? "").replace(/\s+/g, "").trim(), { timeout: 20000 })
+        .toContain(`postedin${inviteeEmail}`)
     } finally {
       await ownerContext.close()
       await invitee.context.close()


### PR DESCRIPTION
## Problem

When a user was viewing a not-yet-created DM draft and the other participant sent the first DM, the backend created the real DM stream and message correctly, but the recipient client kept rendering the fake DM until a refresh. That left two visible symptoms:

- the sidebar did not promote the fake DM into the real DM immediately
- the Activity feed fell back to generic labels like `a thread` or `a conversation` until workspace bootstrap was refreshed

The backend DM creation path already handled concurrent first-message creation safely, so the gap was in the recipient-side client reconciliation.

## Solution

Promote recipient-side fake DMs directly from the DM `stream:created` socket event instead of waiting for a later workspace bootstrap refetch.

### How it works

When a DM `stream:created` event arrives for one of the two DM participants, the frontend now:

1. resolves the peer user from `dmUserIds`
2. derives the viewer-specific DM display name from the existing workspace user cache
3. writes the real DM stream into the workspace bootstrap cache and IndexedDB immediately
4. writes the `dmPeers` entry and membership row immediately
5. subscribes the client to the new DM stream room so follow-up `stream:activity` and timeline events keep flowing without a gap

That lets an open fake DM route promote in place via the existing `useStreamOrDraft` logic, and it gives the Activity page the real DM stream metadata it needs to render the correct stream label without a refresh.

### Key design decisions

**1. Promote from the socket event instead of refetching bootstrap**

The stale UI came from the recipient path not writing the new DM into the persistent client caches. Waiting for `refetchQueries` left the same race window in place, so the fix writes the stream, membership, and `dmPeers` data immediately when the socket event lands.

**2. Keep DM name resolution on the frontend**

DM `stream:created` payloads still contain the raw DB row with `displayName: null`. The patch reuses the existing viewer-specific name resolution model (`workspace users + dmPeers`) instead of expanding the socket contract.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/fix-broken-dm-promotion.md` | Captures the actual implementation and scope for review tooling |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/sync/workspace-sync.ts` | Promotes recipient-side lazy DMs from `stream:created`, including cache, membership, and `dmPeers` writes |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Adds regression coverage for recipient-side DM promotion without bootstrap refetch |
| `tests/browser/dm-lazy-creation.spec.ts` | Adds browser coverage for viewing a fake DM, receiving the first inbound DM, and seeing Activity resolve the real DM without refresh |

## Deleted files

None.

## Test plan

- [x] `bun scripts/test-silent.ts frontend src/sync/workspace-sync.test.ts`
- [x] `bun scripts/test-silent.ts frontend src/hooks/use-stream-or-draft.test.tsx`
- [x] `bun scripts/test-silent.ts browser tests/browser/dm-lazy-creation.spec.ts`
- [x] `bun run --cwd apps/frontend typecheck`
- [ ] Manual verification in a local multi-user session

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
