### PR TITLE
feat: user-defined keyboard shortcuts with editor conflict resolution

### DIFF
--- a/.claude/plans/jiggly-plotting-acorn.md
+++ b/.claude/plans/jiggly-plotting-acorn.md
@@ -1,0 +1,143 @@
+# User-Defined Keyboard Shortcuts
+
+## Context
+
+Keyboard shortcuts are currently hardcoded — the app-level shortcuts (quick switcher, search, etc.) support custom bindings in the preferences system but the UI says "coming soon", and editor formatting shortcuts (`Mod-b` for bold, etc.) are entirely hardcoded in the TipTap extension. Users should be able to rebind all shortcuts from the settings modal, with bindings persisting globally across devices via the existing preferences sync system. Critically, when a user binds an app shortcut to a key that was previously an editor shortcut (e.g., `mod+b` for sidebar toggle), the editor must yield that key to avoid double-firing.
+
+## Plan
+
+### Phase 1: Expand the shortcut registry
+
+**File: `apps/frontend/src/lib/keyboard-shortcuts.ts`**
+
+1. Add 5 editor formatting actions to `SHORTCUT_ACTIONS` with `category: "editing"` (no `global` flag — they only apply when the editor has focus):
+
+| id | label | defaultKey |
+|---|---|---|
+| `formatBold` | Bold | `mod+b` |
+| `formatItalic` | Italic | `mod+i` |
+| `formatStrike` | Strikethrough | `mod+shift+s` |
+| `formatCode` | Inline Code | `mod+e` |
+| `formatCodeBlock` | Code Block | `mod+shift+c` |
+
+2. Add utility functions:
+   - `keyEventToBinding(event: KeyboardEvent): string | null` — converts a KeyboardEvent to normalized binding string (`"mod+shift+f"`), returns null for lone modifier presses. Used by the key capture UI.
+   - `toProseMirrorKey(appBinding: string): string` — converts `"mod+shift+c"` to `"Mod-Shift-c"` for ProseMirror keymap compatibility.
+
+3. Update `getEffectiveKeyBinding()` to handle a `"none"` sentinel value — returns `undefined` when the user has explicitly disabled a shortcut.
+
+### Phase 2: Make editor shortcuts dynamic
+
+The core challenge: TipTap's `addKeyboardShortcuts()` returns a static object at extension creation time. User bindings change at runtime. Solution: move formatting shortcuts to a ProseMirror plugin with a `handleKeyDown` that reads from a ref on every keystroke.
+
+**File: `apps/frontend/src/components/editor/editor-behaviors.ts`**
+
+1. Add `keyBindingsRef: { current: Record<string, string> }` to `EditorBehaviorsOptions` (follows existing `sendModeRef`/`onSubmitRef` pattern).
+
+2. Remove the 5 formatting shortcuts (`Mod-b`, `Mod-i`, `Mod-Shift-s`, `Mod-e`, `Mod-Shift-c`) from `addKeyboardShortcuts()`. Keep all non-formatting shortcuts (Tab, Enter, Arrow keys, Mod-a, Mod-Enter) there since they are not user-configurable.
+
+3. Add a new ProseMirror plugin in `addProseMirrorPlugins()` with a `handleKeyDown` that:
+   - Reads `keyBindingsRef.current` to get effective bindings for each formatting action
+   - Uses `matchesKeyBinding()` to check the event against each binding
+   - Executes the corresponding editor command (`toggleBold`, `toggleItalic`, etc.) when matched
+   - Returns `true` to consume the event, preventing it from bubbling
+
+**File: `apps/frontend/src/components/editor/atom-aware-marks.ts`**
+
+4. Override `addKeyboardShortcuts()` on each atom-aware mark extension (`AtomAwareBold`, `AtomAwareItalic`, `AtomAwareStrike`, `AtomAwareCode`) to return `{}`. This prevents the base TipTap Bold/Italic/etc. extensions from handling `Mod-b`/`Mod-i` independently — EditorBehaviors owns all formatting shortcuts now.
+
+**File: `apps/frontend/src/components/editor/rich-editor.tsx`**
+
+5. Create a `keyBindingsRef` and populate it reactively from preferences:
+   - Use `usePreferences()` to get `customBindings`
+   - Compute effective bindings for each `format*` action using `getEffectiveKeyBinding()`
+   - **Filter out any editor binding that conflicts with an app-level global shortcut** (app shortcuts always win) — this is the conflict resolution: if `toggleSidebar` is bound to `mod+b`, `formatBold`'s `mod+b` is excluded so the editor never tries to handle it
+   - Pass `keyBindingsRef` to `EditorBehaviors.configure()` (NOT as a useMemo dependency — ref avoids editor re-creation)
+
+**File: `apps/frontend/src/components/editor/document-editor-modal.tsx`**
+
+6. Same wiring as rich-editor.tsx: pass `keyBindingsRef` to `EditorBehaviors.configure()`.
+
+### Phase 3: Dynamic toolbar shortcut hints
+
+**File: `apps/frontend/src/components/editor/editor-toolbar.tsx`**
+
+1. Accept an optional `shortcutOverrides` prop (or use `usePreferences` directly) to get effective bindings.
+2. Replace hardcoded `shortcut="⌘B"` strings with `formatKeyBinding(getEffectiveKeyBinding("formatBold", customBindings))`. When a binding is `undefined` (disabled or conflicted away), omit the shortcut hint.
+
+**File: `apps/frontend/src/components/editor/document-editor-modal.tsx`**
+
+3. Same: replace 5 hardcoded shortcut strings with dynamic lookups.
+
+### Phase 4: Preferences context enhancement
+
+**File: `apps/frontend/src/contexts/preferences-context.tsx`**
+
+1. Add `resetKeyboardShortcut(actionId: string)` — removes the key from the `keyboardShortcuts` map and persists the full replacement object (not a merge).
+
+2. Fix the optimistic update in `onMutate`: when `input.keyboardShortcuts` is provided, **replace** the entire `keyboardShortcuts` object rather than spreading/merging, since callers (`updateKeyboardShortcut`, `resetKeyboardShortcut`) already provide the complete desired state.
+
+### Phase 5: Rebinding UI
+
+**File: `apps/frontend/src/components/settings/keyboard-settings.tsx`**
+
+Replace the "Customization coming soon" card with interactive rebinding for every shortcut row.
+
+1. **`ShortcutRow` component** — each row shows:
+   - Left: action label + description
+   - Right: clickable binding badge + reset button (visible only when custom binding differs from default)
+
+2. **Key capture flow** — when the binding badge is clicked:
+   - Badge enters "listening" state (visual change, text says "Press keys...")
+   - A document-level `keydown` listener (with `capture: true`) intercepts the next key combination
+   - `keyEventToBinding(event)` converts the event to a normalized string
+   - Lone modifier presses are ignored
+   - Escape cancels capture mode
+   - On valid capture: check for conflicts via `detectConflicts()`. If conflict exists, show inline warning ("Already used by [action]. Override?"). On confirm, save the new binding and clear the conflicting action's binding. On cancel, revert.
+
+3. **"Reset All Shortcuts" button** at the top that clears the entire `keyboardShortcuts` object.
+
+4. Remove the "Customization coming soon" card.
+
+### Phase 6: Testing
+
+**Unit tests** (`keyboard-shortcuts.test.ts`):
+- `keyEventToBinding()`: verify modifier combos, lone modifier rejection, special keys
+- `toProseMirrorKey()`: verify format conversion
+- `getEffectiveKeyBinding()` with `"none"` sentinel
+- `detectConflicts()` with editor shortcuts included
+
+**Editor integration tests**:
+- Verify custom formatting binding triggers the correct command
+- Verify disabled binding (`"none"`) does not trigger
+- Verify app-level shortcut claiming an editor key causes the editor to yield
+
+**Settings UI tests** (`keyboard-settings.test.tsx`):
+- Key capture mode enters/exits correctly
+- Conflict detection shown in UI
+- Reset individual / reset all
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `apps/frontend/src/lib/keyboard-shortcuts.ts` | Shortcut registry, utilities |
+| `apps/frontend/src/components/editor/editor-behaviors.ts` | TipTap extension with formatting shortcuts |
+| `apps/frontend/src/components/editor/atom-aware-marks.ts` | Must suppress built-in mark shortcuts |
+| `apps/frontend/src/components/editor/rich-editor.tsx` | Wires preferences → editor via ref |
+| `apps/frontend/src/components/editor/document-editor-modal.tsx` | Same wiring for document editor |
+| `apps/frontend/src/components/editor/editor-toolbar.tsx` | Dynamic shortcut hint display |
+| `apps/frontend/src/contexts/preferences-context.tsx` | Reset support, optimistic update fix |
+| `apps/frontend/src/components/settings/keyboard-settings.tsx` | Rebinding UI |
+| `apps/frontend/src/hooks/use-keyboard-shortcuts.ts` | No structural changes needed |
+| `packages/types/src/preferences.ts` | No changes needed (types already support this) |
+| `apps/backend/src/features/user-preferences/handlers.ts` | No changes needed (validation already accepts arbitrary shortcuts) |
+
+## Verification
+
+1. `bun run typecheck` — no type errors
+2. `bun run test` — all existing + new unit tests pass
+3. Manual: open settings → keyboard tab → click a shortcut binding → press new key combo → verify it saves and syncs
+4. Manual: rebind `mod+b` to sidebar toggle → open editor → press `Cmd+B` → verify sidebar toggles and text does NOT bold
+5. Manual: verify toolbar tooltip shows updated shortcut hint
+6. Manual: reset a shortcut → verify it reverts to default

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -132,6 +132,8 @@ export class UserPreferencesService {
     updates: UpdateUserPreferencesInput
   ): Promise<UserPreferences> {
     return withTransaction(this.pool, async (client) => {
+      const currentOverrides =
+        updates.keyboardShortcuts !== undefined ? await UserPreferencesRepository.findOverrides(client, userId) : null
       const pairs = flattenUpdates(updates)
 
       // Separate into overrides to set vs keys to delete (match default)
@@ -143,6 +145,18 @@ export class UserPreferencesService {
           toDelete.push(key)
         } else {
           toSet.push({ key, value })
+        }
+      }
+
+      if (currentOverrides) {
+        const nextShortcutKeys = new Set(
+          Object.keys(updates.keyboardShortcuts ?? {}).map((actionId) => `keyboardShortcuts.${actionId}`)
+        )
+
+        for (const { key } of currentOverrides) {
+          if (!key.startsWith("keyboardShortcuts.")) continue
+          if (nextShortcutKeys.has(key)) continue
+          toDelete.push(key)
         }
       }
 

--- a/apps/backend/tests/integration/user-preferences.test.ts
+++ b/apps/backend/tests/integration/user-preferences.test.ts
@@ -177,6 +177,48 @@ describe("User Preferences - Sparse Override Pattern", () => {
         value: "mod+p",
       })
     })
+
+    test("should delete omitted keyboard shortcut overrides when updating the map", async () => {
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        keyboardShortcuts: {
+          openQuickSwitcher: "mod+p",
+          openSearch: "mod+shift+f",
+        },
+      })
+
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        keyboardShortcuts: {
+          openSearch: "mod+shift+s",
+        },
+      })
+
+      const overrides = await UserPreferencesRepository.findOverrides(pool, testUserId)
+
+      expect(overrides).toEqual([{ key: "keyboardShortcuts.openSearch", value: "mod+shift+s" }])
+
+      const prefs = await service.getPreferences(testWorkspaceId, testUserId)
+      expect(prefs.keyboardShortcuts).toEqual({
+        openSearch: "mod+shift+s",
+      })
+    })
+
+    test("should clear all keyboard shortcut overrides when resetting to an empty map", async () => {
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        keyboardShortcuts: {
+          openQuickSwitcher: "mod+p",
+        },
+      })
+
+      await service.updatePreferences(testWorkspaceId, testUserId, {
+        keyboardShortcuts: {},
+      })
+
+      const overrides = await UserPreferencesRepository.findOverrides(pool, testUserId)
+      expect(overrides).toHaveLength(0)
+
+      const prefs = await service.getPreferences(testWorkspaceId, testUserId)
+      expect(prefs.keyboardShortcuts).toEqual({})
+    })
   })
 
   describe("outbox events", () => {

--- a/apps/frontend/src/components/editor/atom-aware-marks.ts
+++ b/apps/frontend/src/components/editor/atom-aware-marks.ts
@@ -21,6 +21,9 @@ import { atomAwareMarkInputRule } from "./atom-aware-input-rules"
  * Typing **text** or __text__ converts to bold, even with mentions inside.
  */
 export const AtomAwareBold = Bold.extend({
+  addKeyboardShortcuts() {
+    return {} // Formatting shortcuts handled by EditorBehaviors
+  },
   addInputRules() {
     return [
       atomAwareMarkInputRule({
@@ -42,6 +45,9 @@ export const AtomAwareBold = Bold.extend({
  * Typing *text* or _text_ converts to italic, even with mentions inside.
  */
 export const AtomAwareItalic = Italic.extend({
+  addKeyboardShortcuts() {
+    return {} // Formatting shortcuts handled by EditorBehaviors
+  },
   addInputRules() {
     return [
       atomAwareMarkInputRule({
@@ -63,6 +69,9 @@ export const AtomAwareItalic = Italic.extend({
  * Typing ~~text~~ converts to strikethrough, even with mentions inside.
  */
 export const AtomAwareStrike = Strike.extend({
+  addKeyboardShortcuts() {
+    return {} // Formatting shortcuts handled by EditorBehaviors
+  },
   addInputRules() {
     return [
       atomAwareMarkInputRule({
@@ -82,6 +91,9 @@ export const AtomAwareStrike = Strike.extend({
 export const AtomAwareCode = Code.extend({
   exitable: false,
 
+  addKeyboardShortcuts() {
+    return {} // Formatting shortcuts handled by EditorBehaviors
+  },
   addInputRules() {
     return [
       atomAwareMarkInputRule({

--- a/apps/frontend/src/components/editor/document-editor-modal.test.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.test.tsx
@@ -21,6 +21,14 @@ vi.mock("@/hooks/use-workspace-emoji", () => ({
   }),
 }))
 
+// Mock preferences context
+vi.mock("@/contexts", () => ({
+  usePreferences: () => ({
+    preferences: { keyboardShortcuts: {} },
+    isLoading: false,
+  }),
+}))
+
 // Mock trigger hooks used by the editor
 vi.mock("./triggers", () => ({
   useMentionSuggestion: () => ({

--- a/apps/frontend/src/components/editor/document-editor-modal.test.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DocumentEditorModal } from "./document-editor-modal"
 
+const mockPreferences = {
+  keyboardShortcuts: {} as Record<string, string>,
+}
+
 // Mock react-router-dom
 vi.mock("react-router-dom", () => ({
   useParams: () => ({ workspaceId: "ws_123" }),
@@ -24,7 +28,7 @@ vi.mock("@/hooks/use-workspace-emoji", () => ({
 // Mock preferences context
 vi.mock("@/contexts", () => ({
   usePreferences: () => ({
-    preferences: { keyboardShortcuts: {} },
+    preferences: mockPreferences,
     isLoading: false,
   }),
 }))
@@ -55,6 +59,7 @@ describe("DocumentEditorModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPreferences.keyboardShortcuts = {}
   })
 
   describe("rendering", () => {
@@ -105,6 +110,18 @@ describe("DocumentEditorModal", () => {
       render(<DocumentEditorModal {...defaultProps} />)
 
       expect(screen.getByText(/to send/)).toBeInTheDocument()
+    })
+
+    it("should omit formatting hints that are disabled by a conflicting global shortcut", async () => {
+      const user = userEvent.setup()
+      mockPreferences.keyboardShortcuts = { toggleSidebar: "mod+b" }
+
+      render(<DocumentEditorModal {...defaultProps} />)
+
+      await user.hover(screen.getByRole("button", { name: "Bold" }))
+
+      expect((await screen.findAllByText("Bold")).length).toBeGreaterThan(0)
+      expect(screen.queryByText(/^Ctrl\+B$|^⌘B$/)).not.toBeInTheDocument()
     })
   })
 

--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -34,6 +34,8 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { LinkEditor } from "./link-editor"
 import { handleBeforeInputNewline, insertPastedText, toggleMultilineBlock } from "./multiline-blocks"
 import { cn } from "@/lib/utils"
+import { usePreferences } from "@/contexts"
+import { getEffectiveKeyBinding, getEffectiveEditorBindings, formatKeyBinding } from "@/lib/keyboard-shortcuts"
 
 interface DocumentEditorModalProps {
   open: boolean
@@ -88,6 +90,19 @@ export function DocumentEditorModal({
   const handleSubmitRef = useRef(() => {})
   const editorRef = useRef<ReturnType<typeof useEditor>>(null)
 
+  // Effective editor formatting bindings (updated reactively via ref)
+  const { preferences } = usePreferences()
+  const docCustomBindings = preferences?.keyboardShortcuts ?? {}
+  const keyBindingsRef = useRef<Record<string, string>>({})
+  keyBindingsRef.current = useMemo(() => getEffectiveEditorBindings(docCustomBindings), [docCustomBindings])
+  const docShortcutHint = useCallback(
+    (actionId: string): string | undefined => {
+      const binding = getEffectiveKeyBinding(actionId, docCustomBindings)
+      return binding ? formatKeyBinding(binding) : undefined
+    },
+    [docCustomBindings]
+  )
+
   // Create extensions (no cmdEnter handling - explicit Send button only)
   const extensions = useMemo(
     () => [
@@ -101,6 +116,7 @@ export function DocumentEditorModal({
       EditorBehaviors.configure({
         sendModeRef: { current: "cmdEnter" }, // Use cmdEnter mode in modal
         onSubmitRef: handleSubmitRef,
+        keyBindingsRef: keyBindingsRef,
       }),
     ],
     [mentionConfig, channelConfig, emojiConfig, toEmoji]
@@ -267,28 +283,28 @@ export function DocumentEditorModal({
               onAction={() => editor?.chain().focus().toggleBold().run()}
               icon={Bold}
               label="Bold"
-              shortcut="⌘B"
+              shortcut={docShortcutHint("formatBold")}
               isActive={editor?.isActive("bold")}
             />
             <ToolbarButton
               onAction={() => editor?.chain().focus().toggleItalic().run()}
               icon={Italic}
               label="Italic"
-              shortcut="⌘I"
+              shortcut={docShortcutHint("formatItalic")}
               isActive={editor?.isActive("italic")}
             />
             <ToolbarButton
               onAction={() => editor?.chain().focus().toggleStrike().run()}
               icon={Strikethrough}
               label="Strikethrough"
-              shortcut="⌘⇧S"
+              shortcut={docShortcutHint("formatStrike")}
               isActive={editor?.isActive("strike")}
             />
             <ToolbarButton
               onAction={() => editor?.chain().focus().toggleCode().run()}
               icon={Code}
               label="Inline code"
-              shortcut="⌘E"
+              shortcut={docShortcutHint("formatCode")}
               isActive={editor?.isActive("code")}
             />
             <ToolbarButton
@@ -323,7 +339,7 @@ export function DocumentEditorModal({
               onAction={() => editor && toggleMultilineBlock(editor, "codeBlock")}
               icon={Braces}
               label="Code block"
-              shortcut="⌘⇧C"
+              shortcut={docShortcutHint("formatCodeBlock")}
               isActive={editor?.isActive("codeBlock")}
             />
           </div>

--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -35,7 +35,7 @@ import { LinkEditor } from "./link-editor"
 import { handleBeforeInputNewline, insertPastedText, toggleMultilineBlock } from "./multiline-blocks"
 import { cn } from "@/lib/utils"
 import { usePreferences } from "@/contexts"
-import { getEffectiveKeyBinding, getEffectiveEditorBindings, formatKeyBinding } from "@/lib/keyboard-shortcuts"
+import { getEffectiveEditorBindings, formatKeyBinding } from "@/lib/keyboard-shortcuts"
 
 interface DocumentEditorModalProps {
   open: boolean
@@ -93,14 +93,15 @@ export function DocumentEditorModal({
   // Effective editor formatting bindings (updated reactively via ref)
   const { preferences } = usePreferences()
   const docCustomBindings = preferences?.keyboardShortcuts ?? {}
+  const effectiveDocBindings = useMemo(() => getEffectiveEditorBindings(docCustomBindings), [docCustomBindings])
   const keyBindingsRef = useRef<Record<string, string>>({})
-  keyBindingsRef.current = useMemo(() => getEffectiveEditorBindings(docCustomBindings), [docCustomBindings])
+  keyBindingsRef.current = effectiveDocBindings
   const docShortcutHint = useCallback(
     (actionId: string): string | undefined => {
-      const binding = getEffectiveKeyBinding(actionId, docCustomBindings)
+      const binding = effectiveDocBindings[actionId]
       return binding ? formatKeyBinding(binding) : undefined
     },
-    [docCustomBindings]
+    [effectiveDocBindings]
   )
 
   // Create extensions (no cmdEnter handling - explicit Send button only)

--- a/apps/frontend/src/components/editor/editor-behaviors-custom-shortcuts.test.ts
+++ b/apps/frontend/src/components/editor/editor-behaviors-custom-shortcuts.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest"
+import { Editor } from "@tiptap/core"
+import { createEditorExtensions } from "./editor-extensions"
+import { EditorBehaviors } from "./editor-behaviors"
+import { getEffectiveEditorBindings, resolveShortcutBindingUpdate } from "@/lib/keyboard-shortcuts"
+
+function createEditorWithBindings(bindings: Record<string, string>) {
+  const element = document.createElement("div")
+  document.body.append(element)
+
+  const keyBindingsRef = { current: bindings }
+
+  const editor = new Editor({
+    element,
+    extensions: [
+      ...createEditorExtensions({ placeholder: "Type..." }),
+      EditorBehaviors.configure({
+        sendModeRef: { current: "enter" },
+        onSubmitRef: { current: () => {} },
+        keyBindingsRef,
+      }),
+    ],
+    content: "<p>hello</p>",
+  })
+
+  editor.view.hasFocus = () => true
+  editor.on("destroy", () => element.remove())
+
+  return { editor, keyBindingsRef }
+}
+
+function pressKey(editor: Editor, key: string, options: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  })
+
+  let handled = false
+  editor.view.someProp("handleKeyDown", (fn) => {
+    if (fn(editor.view, event)) {
+      handled = true
+      return true
+    }
+    return false
+  })
+  return handled
+}
+
+describe("editor custom formatting shortcuts", () => {
+  it("triggers bold when pressing the custom binding mod+f", () => {
+    const { editor } = createEditorWithBindings({ formatBold: "mod+f" })
+
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size })
+    const handled = pressKey(editor, "f", { metaKey: true })
+
+    expect(handled).toBe(true)
+    expect(editor.isActive("bold")).toBe(true)
+    editor.destroy()
+  })
+
+  it("triggers bold when pressing mod+å (non-ASCII key)", () => {
+    const { editor } = createEditorWithBindings({ formatBold: "mod+å" })
+
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size })
+    const handled = pressKey(editor, "å", { metaKey: true })
+
+    expect(handled).toBe(true)
+    expect(editor.isActive("bold")).toBe(true)
+    editor.destroy()
+  })
+
+  it("resolveShortcutBindingUpdate + getEffectiveEditorBindings: remapping formatBold to mod+f disables searchInStream and keeps formatBold active in editor", () => {
+    const nextBindings = resolveShortcutBindingUpdate({}, "formatBold", "mod+f")
+    expect(nextBindings).toEqual({ searchInStream: "none", formatBold: "mod+f" })
+
+    const editorBindings = getEffectiveEditorBindings(nextBindings)
+    expect(editorBindings.formatBold).toBe("mod+f")
+  })
+
+  it("end-to-end: user remaps formatBold to mod+f, editor triggers bold", () => {
+    const nextBindings = resolveShortcutBindingUpdate({}, "formatBold", "mod+f")
+    const editorBindings = getEffectiveEditorBindings(nextBindings)
+
+    const { editor } = createEditorWithBindings(editorBindings)
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size })
+
+    const handled = pressKey(editor, "f", { metaKey: true })
+    expect(handled).toBe(true)
+    expect(editor.isActive("bold")).toBe(true)
+    editor.destroy()
+  })
+
+  it("picks up bindings that are mutated into keyBindingsRef AFTER editor construction (reactive)", () => {
+    const { editor, keyBindingsRef } = createEditorWithBindings({})
+
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size })
+
+    // Before: empty bindings → nothing handles mod+f
+    let handled = pressKey(editor, "f", { metaKey: true })
+    expect(handled).toBe(false)
+    expect(editor.isActive("bold")).toBe(false)
+
+    // Mutate ref AFTER construction (simulates preferences loading async)
+    keyBindingsRef.current = { formatBold: "mod+f" }
+
+    handled = pressKey(editor, "f", { metaKey: true })
+    expect(handled).toBe(true)
+    expect(editor.isActive("bold")).toBe(true)
+    editor.destroy()
+  })
+
+  it("does NOT trigger bold with default mod+b when custom binding replaces it", () => {
+    const { editor } = createEditorWithBindings({ formatBold: "mod+f" })
+
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size })
+    const handled = pressKey(editor, "b", { metaKey: true })
+
+    expect(handled).toBe(false)
+    expect(editor.isActive("bold")).toBe(false)
+    editor.destroy()
+  })
+})

--- a/apps/frontend/src/components/editor/editor-behaviors.ts
+++ b/apps/frontend/src/components/editor/editor-behaviors.ts
@@ -5,12 +5,15 @@ import type { EditorState } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
 import type { MessageSendMode } from "@threa/types"
 import { handleEnterTextBehavior, toggleMultilineBlock } from "./multiline-blocks"
+import { matchesKeyBinding } from "@/lib/keyboard-shortcuts"
 
 export interface EditorBehaviorsOptions {
   /** Ref to current send mode - using ref avoids stale closure in keyboard shortcuts */
   sendModeRef: { current: MessageSendMode }
   /** Ref to submit callback - using ref avoids stale closure in keyboard shortcuts */
   onSubmitRef: { current: () => void }
+  /** Ref to effective editor formatting bindings (app-format: "mod+b"), with app-level conflicts already excluded */
+  keyBindingsRef: { current: Record<string, string> }
 }
 
 export function indentSelection(editor: Editor): boolean {
@@ -684,11 +687,46 @@ export const EditorBehaviors = Extension.create<EditorBehaviorsOptions>({
     return {
       sendModeRef: { current: "enter" as MessageSendMode },
       onSubmitRef: { current: () => {} },
+      keyBindingsRef: { current: {} as Record<string, string> },
     }
   },
 
   addProseMirrorPlugins() {
+    const editor = this.editor
+    const keyBindingsRef = this.options.keyBindingsRef
+
+    const formattingPlugin = new Plugin({
+      props: {
+        handleKeyDown(_view: EditorView, event: KeyboardEvent) {
+          const bindings = keyBindingsRef.current
+          for (const [actionId, binding] of Object.entries(bindings)) {
+            if (!matchesKeyBinding(event, binding)) continue
+
+            switch (actionId) {
+              case "formatBold":
+                editor.chain().focus().toggleBold().run()
+                return true
+              case "formatItalic":
+                editor.chain().focus().toggleItalic().run()
+                return true
+              case "formatStrike":
+                editor.chain().focus().toggleStrike().run()
+                return true
+              case "formatCode":
+                editor.chain().focus().toggleCode().run()
+                return true
+              case "formatCodeBlock":
+                toggleMultilineBlock(editor, "codeBlock")
+                return true
+            }
+          }
+          return false
+        },
+      },
+    })
+
     return [
+      formattingPlugin,
       new Plugin({
         view(view) {
           const defaultView = view.dom.ownerDocument.defaultView
@@ -793,12 +831,6 @@ export const EditorBehaviors = Extension.create<EditorBehaviorsOptions>({
 
   addKeyboardShortcuts() {
     return {
-      // Formatting shortcuts
-      "Mod-b": () => this.editor.chain().focus().toggleBold().run(),
-      "Mod-i": () => this.editor.chain().focus().toggleItalic().run(),
-      "Mod-Shift-s": () => this.editor.chain().focus().toggleStrike().run(),
-      "Mod-e": () => this.editor.chain().focus().toggleCode().run(),
-      "Mod-Shift-c": () => toggleMultilineBlock(this.editor, "codeBlock"),
       ArrowLeft: () => {
         if (isSuggestionActive(this.editor)) {
           return false

--- a/apps/frontend/src/components/editor/editor-behaviors.ts
+++ b/apps/frontend/src/components/editor/editor-behaviors.ts
@@ -16,6 +16,18 @@ export interface EditorBehaviorsOptions {
   keyBindingsRef: { current: Record<string, string> }
 }
 
+// Tiptap's `.configure()` runs options through `mergeDeep`, which recursively
+// clones plain `{ current: ... }` objects. That would detach the caller's
+// React ref from the ref the extension reads inside its ProseMirror plugin,
+// so later mutations to `ref.current` would never propagate. Wrapping the
+// default in a prototype-less object makes `isPlainObject` return false for
+// the target, causing `mergeDeep` to use the caller's ref by reference.
+function createOptionRef<T>(initial: T): { current: T } {
+  const ref = Object.create(null) as { current: T }
+  ref.current = initial
+  return ref
+}
+
 export function indentSelection(editor: Editor): boolean {
   if (editor.isActive("codeBlock")) {
     return handleCodeBlockTab(editor, false)
@@ -685,9 +697,9 @@ export const EditorBehaviors = Extension.create<EditorBehaviorsOptions>({
 
   addOptions() {
     return {
-      sendModeRef: { current: "enter" as MessageSendMode },
-      onSubmitRef: { current: () => {} },
-      keyBindingsRef: { current: {} as Record<string, string> },
+      sendModeRef: createOptionRef<MessageSendMode>("enter"),
+      onSubmitRef: createOptionRef<() => void>(() => {}),
+      keyBindingsRef: createOptionRef<Record<string, string>>({}),
     }
   },
 

--- a/apps/frontend/src/components/editor/editor-toolbar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.test.tsx
@@ -6,6 +6,10 @@ import type { Editor } from "@tiptap/react"
 import { EditorToolbar } from "./editor-toolbar"
 import { indentSelection, dedentSelection, handleLinkToolbarAction, isSuggestionActive } from "./editor-behaviors"
 
+const mockPreferences = {
+  keyboardShortcuts: {} as Record<string, string>,
+}
+
 vi.mock("./editor-behaviors", () => ({
   indentSelection: vi.fn(),
   dedentSelection: vi.fn(),
@@ -15,7 +19,7 @@ vi.mock("./editor-behaviors", () => ({
 
 vi.mock("@/contexts", () => ({
   usePreferences: () => ({
-    preferences: { keyboardShortcuts: {} },
+    preferences: mockPreferences,
     isLoading: false,
   }),
 }))
@@ -72,6 +76,7 @@ function ToolbarHarness({ editor }: { editor: Editor }) {
 describe("EditorToolbar", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPreferences.keyboardShortcuts = {}
   })
 
   it("keeps inline formatting buttons in the tab order", async () => {
@@ -121,6 +126,19 @@ describe("EditorToolbar", () => {
     expect(editor.__chainState.focus).toHaveBeenCalled()
     expect(editor.__chainState.toggleBold).toHaveBeenCalled()
     expect(editor.__run).toHaveBeenCalled()
+  })
+
+  it("omits dead shortcut hints when a global shortcut claims the editor binding", async () => {
+    const user = userEvent.setup()
+    mockPreferences.keyboardShortcuts = { toggleSidebar: "mod+b" }
+    const editor = createEditorStub()
+
+    render(<EditorToolbar editor={editor} isVisible />)
+
+    await user.hover(screen.getByRole("button", { name: "Bold" }))
+
+    expect((await screen.findAllByText("Bold")).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/^Ctrl\+B$|^⌘B$/)).not.toBeInTheDocument()
   })
 
   it("routes the link button through the shared link toolbar action", async () => {

--- a/apps/frontend/src/components/editor/editor-toolbar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.test.tsx
@@ -13,6 +13,13 @@ vi.mock("./editor-behaviors", () => ({
   isSuggestionActive: vi.fn(() => false),
 }))
 
+vi.mock("@/contexts", () => ({
+  usePreferences: () => ({
+    preferences: { keyboardShortcuts: {} },
+    isLoading: false,
+  }),
+}))
+
 function createEditorStub() {
   const chain = {
     focus: vi.fn(() => chain),

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useEffect, useState, useCallback, useReducer, useRef } from "react"
+import { useLayoutEffect, useEffect, useState, useCallback, useReducer, useRef, useMemo } from "react"
 import type { Editor } from "@tiptap/react"
 import { useFloating, offset, flip, shift, autoUpdate } from "@floating-ui/react"
 import {
@@ -25,7 +25,7 @@ import { indentSelection, dedentSelection, handleLinkToolbarAction, isSuggestion
 import { toggleMultilineBlock } from "./multiline-blocks"
 import { cn } from "@/lib/utils"
 import { usePreferences } from "@/contexts"
-import { getEffectiveKeyBinding, formatKeyBinding } from "@/lib/keyboard-shortcuts"
+import { getEffectiveEditorBindings, formatKeyBinding } from "@/lib/keyboard-shortcuts"
 
 interface EditorToolbarProps {
   editor: Editor | null
@@ -79,12 +79,13 @@ export function EditorToolbar({
   // Dynamic shortcut hints from user preferences
   const { preferences } = usePreferences()
   const kb = preferences?.keyboardShortcuts ?? {}
+  const effectiveEditorBindings = useMemo(() => getEffectiveEditorBindings(kb), [kb])
   const shortcutHint = useCallback(
     (actionId: string): string | undefined => {
-      const binding = getEffectiveKeyBinding(actionId, kb)
+      const binding = effectiveEditorBindings[actionId]
       return binding ? formatKeyBinding(binding) : undefined
     },
-    [kb]
+    [effectiveEditorBindings]
   )
 
   // Virtual reference: position the toolbar above the current text selection

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -24,6 +24,8 @@ import { LinkEditor } from "./link-editor"
 import { indentSelection, dedentSelection, handleLinkToolbarAction, isSuggestionActive } from "./editor-behaviors"
 import { toggleMultilineBlock } from "./multiline-blocks"
 import { cn } from "@/lib/utils"
+import { usePreferences } from "@/contexts"
+import { getEffectiveKeyBinding, formatKeyBinding } from "@/lib/keyboard-shortcuts"
 
 interface EditorToolbarProps {
   editor: Editor | null
@@ -73,6 +75,17 @@ export function EditorToolbar({
   const floatingRootRef = useRef<HTMLDivElement | null>(null)
   const lastSelectionRectRef = useRef<DOMRect>(new DOMRect())
   const [linkEditorSnapshot, setLinkEditorSnapshot] = useState<LinkEditorSnapshot | null>(null)
+
+  // Dynamic shortcut hints from user preferences
+  const { preferences } = usePreferences()
+  const kb = preferences?.keyboardShortcuts ?? {}
+  const shortcutHint = useCallback(
+    (actionId: string): string | undefined => {
+      const binding = getEffectiveKeyBinding(actionId, kb)
+      return binding ? formatKeyBinding(binding) : undefined
+    },
+    [kb]
+  )
 
   // Virtual reference: position the toolbar above the current text selection
   useLayoutEffect(() => {
@@ -182,7 +195,7 @@ export function EditorToolbar({
         onAction={() => editor.chain().focus().toggleBold().run()}
         icon={Bold}
         label="Bold"
-        shortcut="⌘B"
+        shortcut={shortcutHint("formatBold")}
         isActive={editor.isActive("bold")}
         roomy={isMobileInlineToolbar}
         showTooltip={!isMobileInlineToolbar}
@@ -192,7 +205,7 @@ export function EditorToolbar({
         onAction={() => editor.chain().focus().toggleItalic().run()}
         icon={Italic}
         label="Italic"
-        shortcut="⌘I"
+        shortcut={shortcutHint("formatItalic")}
         isActive={editor.isActive("italic")}
         roomy={isMobileInlineToolbar}
         showTooltip={!isMobileInlineToolbar}
@@ -202,7 +215,7 @@ export function EditorToolbar({
         onAction={() => editor.chain().focus().toggleStrike().run()}
         icon={Strikethrough}
         label="Strikethrough"
-        shortcut="⌘⇧S"
+        shortcut={shortcutHint("formatStrike")}
         isActive={editor.isActive("strike")}
         roomy={isMobileInlineToolbar}
         showTooltip={!isMobileInlineToolbar}
@@ -212,7 +225,7 @@ export function EditorToolbar({
         onAction={() => editor.chain().focus().toggleCode().run()}
         icon={Code}
         label="Inline code"
-        shortcut="⌘E"
+        shortcut={shortcutHint("formatCode")}
         isActive={editor.isActive("code")}
         roomy={isMobileInlineToolbar}
         showTooltip={!isMobileInlineToolbar}
@@ -260,7 +273,7 @@ export function EditorToolbar({
         onAction={() => toggleMultilineBlock(editor, "codeBlock")}
         icon={Braces}
         label="Code block"
-        shortcut="⌘⇧C"
+        shortcut={shortcutHint("formatCodeBlock")}
         isActive={editor.isActive("codeBlock")}
         roomy={isMobileInlineToolbar}
         showTooltip={!isMobileInlineToolbar}

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -17,6 +17,8 @@ import { handleBeforeInputNewline, insertPastedText } from "./multiline-blocks"
 import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { cn } from "@/lib/utils"
+import { usePreferences } from "@/contexts"
+import { getEffectiveEditorBindings } from "@/lib/keyboard-shortcuts"
 import type { UploadResult } from "@/hooks/use-attachments"
 import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
 import type { MessageSendMode, JSONContent } from "@threa/types"
@@ -205,6 +207,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const onEscapeBlurRef = useRef(onEscapeBlur)
   onEscapeBlurRef.current = onEscapeBlur
 
+  // Effective editor formatting bindings (updated reactively, read by ref to avoid editor re-creation)
+  const { preferences } = usePreferences()
+  const customBindings = preferences?.keyboardShortcuts ?? {}
+  const keyBindingsRef = useRef<Record<string, string>>({})
+  keyBindingsRef.current = useMemo(() => getEffectiveEditorBindings(customBindings), [customBindings])
+
   // Ref to access editor instance from callbacks defined before useEditor returns
   const editorRef = useRef<ReturnType<typeof useEditor>>(null)
 
@@ -226,6 +234,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       EditorBehaviors.configure({
         sendModeRef: messageSendModeRef,
         onSubmitRef: onSubmitRef,
+        keyBindingsRef: keyBindingsRef,
       }),
     ],
     [

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -210,8 +210,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // Effective editor formatting bindings (updated reactively, read by ref to avoid editor re-creation)
   const { preferences } = usePreferences()
   const customBindings = preferences?.keyboardShortcuts ?? {}
+  const effectiveEditorBindings = useMemo(() => getEffectiveEditorBindings(customBindings), [customBindings])
   const keyBindingsRef = useRef<Record<string, string>>({})
-  keyBindingsRef.current = useMemo(() => getEffectiveEditorBindings(customBindings), [customBindings])
+  keyBindingsRef.current = effectiveEditorBindings
 
   // Ref to access editor instance from callbacks defined before useEditor returns
   const editorRef = useRef<ReturnType<typeof useEditor>>(null)

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -1,6 +1,6 @@
 import type React from "react"
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { QuickSwitcher } from "./quick-switcher"
@@ -379,24 +379,6 @@ describe("QuickSwitcher Integration Tests", () => {
         renderWithProviders(<QuickSwitcher {...defaultProps} onOpenChange={onOpenChange} />)
 
         await user.keyboard("{Escape}")
-
-        expect(onOpenChange).toHaveBeenCalledWith(false)
-      })
-
-      it("should close dialog with Ctrl+[", async () => {
-        const user = userEvent.setup()
-        const onOpenChange = vi.fn()
-        renderWithProviders(<QuickSwitcher {...defaultProps} onOpenChange={onOpenChange} />)
-
-        // Focus the input first
-        const input = screen.getByLabelText("Quick switcher input")
-        await user.click(input)
-
-        // Simulate Ctrl+[ using fireEvent since userEvent doesn't properly handle this combo
-        // The component checks e.ctrlKey && e.key === "[" on the DialogContent's onKeyDown
-        // Use fireEvent to properly trigger React's synthetic event handlers
-        const dialog = screen.getByRole("dialog")
-        fireEvent.keyDown(dialog, { key: "[", ctrlKey: true })
 
         expect(onOpenChange).toHaveBeenCalledWith(false)
       })

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -267,24 +267,13 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
 
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Ctrl+[ as vim-style Escape alternative (handled here since onEscapeKeyDown doesn't catch it)
-      if (e.ctrlKey && e.key === "[") {
-        e.preventDefault()
-        if (inputRequest) {
-          clearInputRequest()
-        } else {
-          handleClose()
-        }
-        return
-      }
-
       if (e.key === "Enter" && inputRequest) {
         e.preventDefault()
         inputRequest.onSubmit(inputValue)
         return
       }
     },
-    [inputRequest, inputValue, clearInputRequest, handleClose]
+    [inputRequest, inputValue]
   )
 
   const ModeIcon = inputRequest?.icon ?? MODE_ICONS[mode]
@@ -333,21 +322,6 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
         onKeyDown={(e) => {
           // If TipTap already handled this event (e.g., popover keyboard nav), don't interfere
           if (e.defaultPrevented) return
-
-          // Ctrl+[ as vim-style Escape alternative
-          if (e.ctrlKey && e.key === "[") {
-            e.preventDefault()
-            if (isSuggestionPopoverActiveRef.current) {
-              richInputRef.current?.closePopovers()
-            } else if (currentResult.isFilterSelectActive && currentResult.closeFilterSelect) {
-              currentResult.closeFilterSelect()
-            } else if (inputRequest) {
-              clearInputRequest()
-            } else {
-              handleClose()
-            }
-            return
-          }
 
           const isMod = e.metaKey || e.ctrlKey
           // Use ref for synchronous access (state updates are batched)

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -38,15 +38,34 @@ describe("KeyboardSettings", () => {
     await user.click(badge)
     fireEvent.keyDown(document, { key: "b", ctrlKey: true })
 
-    expect(screen.getByText(/Conflicts with Bold/i)).toBeInTheDocument()
+    expect(screen.getByText(/Already used by Bold/i)).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Override" }))
+    await user.click(screen.getByRole("button", { name: "Override existing shortcut" }))
 
     expect(updatePreference).toHaveBeenCalledTimes(1)
     expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {
       formatBold: "none",
       toggleSidebar: "mod+b",
     })
+  })
+
+  it("explains that conflicting shortcuts can be overridden", async () => {
+    const user = userEvent.setup()
+    render(<KeyboardSettings />)
+
+    const row = screen.getByText("Toggle Sidebar").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    await user.click(badge)
+
+    expect(screen.getByText(/you can override them here/i)).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: "b", ctrlKey: true })
+
+    expect(screen.getByText(/override to move/i)).toBeInTheDocument()
+    expect(screen.getByText(/clear it there/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Override existing shortcut" })).toBeInTheDocument()
   })
 
   it("ignores unsafe bare keys during capture", async () => {
@@ -86,9 +105,9 @@ describe("KeyboardSettings", () => {
     await user.click(badge)
     await user.click(screen.getByRole("button", { name: "Use Escape" }))
 
-    expect(screen.getByText(/Conflicts with Close/i)).toBeInTheDocument()
+    expect(screen.getByText(/Already used by Close/i)).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Override" }))
+    await user.click(screen.getByRole("button", { name: "Override existing shortcut" }))
 
     expect(updatePreference).toHaveBeenCalledTimes(1)
     expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -63,4 +63,22 @@ describe("KeyboardSettings", () => {
     expect(updatePreference).not.toHaveBeenCalled()
     expect(screen.queryByText(/Conflicts with/i)).not.toBeInTheDocument()
   })
+
+  it("reports capture state changes and cancels capture on Escape", async () => {
+    const user = userEvent.setup()
+    const onCaptureStateChange = vi.fn()
+    render(<KeyboardSettings onCaptureStateChange={onCaptureStateChange} />)
+
+    const row = screen.getByText("Toggle Sidebar").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    await user.click(badge)
+    fireEvent.keyDown(document, { key: "Escape" })
+    fireEvent.keyDown(document, { key: "b", ctrlKey: true })
+
+    expect(onCaptureStateChange).toHaveBeenCalledWith(true)
+    expect(onCaptureStateChange).toHaveBeenCalledWith(false)
+    expect(updatePreference).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { formatKeyBindingText } from "@/lib/keyboard-shortcuts"
 import { KeyboardSettings } from "./keyboard-settings"
 
 const mockPreferences = {
@@ -89,6 +90,16 @@ describe("KeyboardSettings", () => {
     await user.hover(resetButton)
 
     expect((await screen.findAllByText("Reset to default")).length).toBeGreaterThan(0)
+  })
+
+  it("shows the text version of a shortcut on hover", () => {
+    render(<KeyboardSettings />)
+
+    const row = screen.getByText("Quick Switcher").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    expect(badge).toHaveAttribute("title", formatKeyBindingText("mod+k"))
   })
 
   it("lets the user bind Escape explicitly", async () => {

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { KeyboardSettings } from "./keyboard-settings"
+
+const mockPreferences = {
+  keyboardShortcuts: {} as Record<string, string>,
+  messageSendMode: "enter" as const,
+}
+
+const updatePreference = vi.fn()
+const resetKeyboardShortcut = vi.fn()
+const resetAllKeyboardShortcuts = vi.fn()
+
+vi.mock("@/contexts", () => ({
+  usePreferences: () => ({
+    preferences: mockPreferences,
+    updatePreference,
+    resetKeyboardShortcut,
+    resetAllKeyboardShortcuts,
+  }),
+}))
+
+describe("KeyboardSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPreferences.keyboardShortcuts = {}
+  })
+
+  it("saves conflict overrides as a single keyboardShortcuts update", async () => {
+    const user = userEvent.setup()
+    render(<KeyboardSettings />)
+
+    const row = screen.getByText("Toggle Sidebar").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    await user.click(badge)
+    fireEvent.keyDown(document, { key: "b", ctrlKey: true })
+
+    expect(screen.getByText(/Conflicts with Bold/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Override" }))
+
+    expect(updatePreference).toHaveBeenCalledTimes(1)
+    expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {
+      formatBold: "none",
+      toggleSidebar: "mod+b",
+    })
+  })
+
+  it("ignores unsafe bare keys during capture", async () => {
+    const user = userEvent.setup()
+    render(<KeyboardSettings />)
+
+    const row = screen.getByText("Toggle Sidebar").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    await user.click(badge)
+    fireEvent.keyDown(document, { key: "b" })
+
+    expect(updatePreference).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Conflicts with/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -63,7 +63,7 @@ describe("KeyboardSettings", () => {
     await user.click(badge)
 
     expect(screen.getByText("Press shortcut keys")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Bind Escape" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
   })
 
   it("ignores unsafe bare keys during capture", async () => {
@@ -102,7 +102,7 @@ describe("KeyboardSettings", () => {
     expect(badge).toHaveAttribute("title", formatKeyBindingText("mod+k"))
   })
 
-  it("lets the user bind Escape explicitly", async () => {
+  it("does not expose a way to bind Escape — it is reserved for close/cancel flows", async () => {
     const user = userEvent.setup()
     render(<KeyboardSettings />)
 
@@ -111,18 +111,8 @@ describe("KeyboardSettings", () => {
 
     const badge = within(row! as HTMLElement).getByRole("button")
     await user.click(badge)
-    await user.click(screen.getByRole("button", { name: "Bind Escape" }))
 
-    expect(screen.getByText("Move shortcut?")).toBeInTheDocument()
-    expect(screen.getByText(/is currently used by Close/i)).toBeInTheDocument()
-
-    await user.click(screen.getByRole("button", { name: "Move to Toggle Sidebar" }))
-
-    expect(updatePreference).toHaveBeenCalledTimes(1)
-    expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {
-      closeModal: "none",
-      toggleSidebar: "escape",
-    })
+    expect(screen.queryByRole("button", { name: "Bind Escape" })).toBeNull()
   })
 
   it("reports capture state changes and cancels capture on Escape", async () => {

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -64,6 +64,39 @@ describe("KeyboardSettings", () => {
     expect(screen.queryByText(/Conflicts with/i)).not.toBeInTheDocument()
   })
 
+  it("shows a tooltip for the reset icon button", async () => {
+    const user = userEvent.setup()
+    mockPreferences.keyboardShortcuts = { toggleSidebar: "mod+b" }
+    render(<KeyboardSettings />)
+
+    const resetButton = screen.getByRole("button", { name: "Reset to default" })
+    await user.hover(resetButton)
+
+    expect((await screen.findAllByText("Reset to default")).length).toBeGreaterThan(0)
+  })
+
+  it("lets the user bind Escape explicitly", async () => {
+    const user = userEvent.setup()
+    render(<KeyboardSettings />)
+
+    const row = screen.getByText("Toggle Sidebar").closest("[data-shortcut-row]")
+    expect(row).not.toBeNull()
+
+    const badge = within(row! as HTMLElement).getByRole("button")
+    await user.click(badge)
+    await user.click(screen.getByRole("button", { name: "Use Escape" }))
+
+    expect(screen.getByText(/Conflicts with Close/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Override" }))
+
+    expect(updatePreference).toHaveBeenCalledTimes(1)
+    expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {
+      closeModal: "none",
+      toggleSidebar: "escape",
+    })
+  })
+
   it("reports capture state changes and cancels capture on Escape", async () => {
     const user = userEvent.setup()
     const onCaptureStateChange = vi.fn()

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -38,9 +38,11 @@ describe("KeyboardSettings", () => {
     await user.click(badge)
     fireEvent.keyDown(document, { key: "b", ctrlKey: true })
 
-    expect(screen.getByText(/Already used by Bold/i)).toBeInTheDocument()
+    expect(screen.getByText("Move shortcut?")).toBeInTheDocument()
+    expect(screen.getByText(/is currently used by Bold/i)).toBeInTheDocument()
+    expect(screen.getByText("New owner")).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Override existing shortcut" }))
+    await user.click(screen.getByRole("button", { name: "Move to Toggle Sidebar" }))
 
     expect(updatePreference).toHaveBeenCalledTimes(1)
     expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {
@@ -49,7 +51,7 @@ describe("KeyboardSettings", () => {
     })
   })
 
-  it("explains that conflicting shortcuts can be overridden", async () => {
+  it("shows the capture popover before a shortcut is chosen", async () => {
     const user = userEvent.setup()
     render(<KeyboardSettings />)
 
@@ -59,13 +61,8 @@ describe("KeyboardSettings", () => {
     const badge = within(row! as HTMLElement).getByRole("button")
     await user.click(badge)
 
-    expect(screen.getByText(/you can override them here/i)).toBeInTheDocument()
-
-    fireEvent.keyDown(document, { key: "b", ctrlKey: true })
-
-    expect(screen.getByText(/override to move/i)).toBeInTheDocument()
-    expect(screen.getByText(/clear it there/i)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Override existing shortcut" })).toBeInTheDocument()
+    expect(screen.getByText("Press shortcut keys")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Bind Escape" })).toBeInTheDocument()
   })
 
   it("ignores unsafe bare keys during capture", async () => {
@@ -103,11 +100,12 @@ describe("KeyboardSettings", () => {
 
     const badge = within(row! as HTMLElement).getByRole("button")
     await user.click(badge)
-    await user.click(screen.getByRole("button", { name: "Use Escape" }))
+    await user.click(screen.getByRole("button", { name: "Bind Escape" }))
 
-    expect(screen.getByText(/Already used by Close/i)).toBeInTheDocument()
+    expect(screen.getByText("Move shortcut?")).toBeInTheDocument()
+    expect(screen.getByText(/is currently used by Close/i)).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Override existing shortcut" }))
+    await user.click(screen.getByRole("button", { name: "Move to Toggle Sidebar" }))
 
     expect(updatePreference).toHaveBeenCalledTimes(1)
     expect(updatePreference).toHaveBeenCalledWith("keyboardShortcuts", {

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -13,6 +13,7 @@ import {
   getShortcutsByCategory,
   getEffectiveKeyBinding,
   formatKeyBinding,
+  formatKeyBindingText,
   detectConflicts,
   keyEventToBinding,
   resolveShortcutBindingUpdate,
@@ -169,6 +170,7 @@ function ShortcutRow({
                 ref={badgeRef}
                 type="button"
                 onClick={() => (isCapturing ? onCancelCapture() : onStartCapture(action.id))}
+                title={!isCapturing && binding ? formatKeyBindingText(binding) : undefined}
                 className={
                   isCapturing
                     ? "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-primary bg-primary/10 text-primary animate-pulse cursor-pointer focus:outline-none"
@@ -186,7 +188,11 @@ function ShortcutRow({
                     <div className="space-y-1">
                       <p className="font-medium text-sm">Move shortcut?</p>
                       <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                        <Badge variant="outline" className="mr-1 font-mono">
+                        <Badge
+                          variant="outline"
+                          className="mr-1 font-mono"
+                          title={formatKeyBindingText(conflictInfo.binding)}
+                        >
                           {formatKeyBinding(conflictInfo.binding)}
                         </Badge>
                         is currently used by {conflictOwnersLabel}.
@@ -367,7 +373,7 @@ export function KeyboardSettings({ onCaptureStateChange }: KeyboardSettingsProps
             <ul className="space-y-2 text-sm">
               {Array.from(conflicts.entries()).map(([key, actionIds]) => (
                 <li key={key}>
-                  <Badge variant="outline" className="font-mono mr-2">
+                  <Badge variant="outline" className="font-mono mr-2" title={formatKeyBindingText(key)}>
                     {formatKeyBinding(key)}
                   </Badge>
                   <span className="text-muted-foreground">

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -175,14 +175,15 @@ function ShortcutRow({
       {isCapturing && conflictInfo && (
         <div className="flex items-center gap-2 ml-1 text-xs">
           <span className="text-destructive">
-            Conflicts with{" "}
+            Already used by{" "}
             {conflictInfo.conflictIds
               .map((id) => SHORTCUT_ACTIONS.find((a) => a.id === id)?.label)
               .filter(Boolean)
               .join(", ")}
+            . Override to move {formatKeyBinding(conflictInfo.binding)} here and clear it there.
           </span>
           <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleConfirmConflict}>
-            Override
+            Override existing shortcut
           </Button>
           <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
             Cancel
@@ -192,7 +193,10 @@ function ShortcutRow({
 
       {isCapturing && !conflictInfo && (
         <div className="flex items-center gap-2 ml-1 text-xs">
-          <span className="text-muted-foreground">Press shortcut keys, or use the button below to bind Escape.</span>
+          <span className="text-muted-foreground">
+            Press shortcut keys. If they&apos;re already in use, you can override them here. Use the button below to
+            bind Escape.
+          </span>
           <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleUseEscape}>
             Use Escape
           </Button>

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -66,6 +67,12 @@ function ShortcutRow({
   const badgeRef = useRef<HTMLButtonElement>(null)
   const binding = getEffectiveKeyBinding(action.id, customBindings)
   const isCustom = action.id in customBindings && customBindings[action.id] !== action.defaultKey
+  const conflictLabels =
+    conflictInfo?.conflictIds
+      .map((id) => SHORTCUT_ACTIONS.find((shortcutAction) => shortcutAction.id === id)?.label)
+      .filter((label): label is string => Boolean(label)) ?? []
+  const conflictOwnersLabel = conflictLabels.join(", ")
+  const keepLabel = conflictLabels.length === 1 ? `Keep ${conflictOwnersLabel}` : "Keep current owners"
 
   const handleCapturedBinding = useCallback(
     (captured: string) => {
@@ -156,55 +163,88 @@ function ShortcutRow({
               </Tooltip>
             </TooltipProvider>
           )}
-          <button
-            ref={badgeRef}
-            type="button"
-            onClick={() => (isCapturing ? onCancelCapture() : onStartCapture(action.id))}
-            className={
-              isCapturing
-                ? "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-primary bg-primary/10 text-primary animate-pulse cursor-pointer focus:outline-none"
-                : "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80 cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-            }
-          >
-            {getBadgeLabel(isCapturing, conflictInfo, binding)}
-          </button>
+          <Popover open={isCapturing} onOpenChange={(open) => !open && onCancelCapture()}>
+            <PopoverAnchor asChild>
+              <button
+                ref={badgeRef}
+                type="button"
+                onClick={() => (isCapturing ? onCancelCapture() : onStartCapture(action.id))}
+                className={
+                  isCapturing
+                    ? "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-primary bg-primary/10 text-primary animate-pulse cursor-pointer focus:outline-none"
+                    : "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80 cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                }
+              >
+                {getBadgeLabel(isCapturing, conflictInfo, binding)}
+              </button>
+            </PopoverAnchor>
+
+            {isCapturing && (
+              <PopoverContent align="end" className="w-80 p-3" onOpenAutoFocus={(event) => event.preventDefault()}>
+                {conflictInfo ? (
+                  <div className="space-y-3">
+                    <div className="space-y-1">
+                      <p className="font-medium text-sm">Move shortcut?</p>
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <Badge variant="outline" className="mr-1 font-mono">
+                          {formatKeyBinding(conflictInfo.binding)}
+                        </Badge>
+                        is currently used by {conflictOwnersLabel}.
+                      </div>
+                    </div>
+
+                    <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">
+                          {conflictLabels.length === 1 ? "Current owner" : "Current owners"}
+                        </span>
+                        <span className="font-medium text-right">{conflictOwnersLabel}</span>
+                      </div>
+                      <div className="mt-2 flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">New owner</span>
+                        <span className="font-medium text-right">{action.label}</span>
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end gap-2">
+                      <Button variant="ghost" size="sm" onClick={onCancelCapture}>
+                        {keepLabel}
+                      </Button>
+                      <Button size="sm" onClick={handleConfirmConflict}>
+                        Move to {action.label}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <div className="space-y-1">
+                      <p className="font-medium text-sm">Press shortcut keys</p>
+                      <p className="text-xs text-muted-foreground">
+                        Click <span className="font-mono text-foreground">Esc</span> if you want to assign Escape.
+                      </p>
+                    </div>
+
+                    <div className="flex items-center justify-between gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8 min-w-10 px-3 font-mono"
+                        onClick={handleUseEscape}
+                        aria-label="Bind Escape"
+                      >
+                        Esc
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={onCancelCapture}>
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </PopoverContent>
+            )}
+          </Popover>
         </div>
       </div>
-
-      {/* Conflict resolution inline */}
-      {isCapturing && conflictInfo && (
-        <div className="flex items-center gap-2 ml-1 text-xs">
-          <span className="text-destructive">
-            Already used by{" "}
-            {conflictInfo.conflictIds
-              .map((id) => SHORTCUT_ACTIONS.find((a) => a.id === id)?.label)
-              .filter(Boolean)
-              .join(", ")}
-            . Override to move {formatKeyBinding(conflictInfo.binding)} here and clear it there.
-          </span>
-          <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleConfirmConflict}>
-            Override existing shortcut
-          </Button>
-          <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
-            Cancel
-          </Button>
-        </div>
-      )}
-
-      {isCapturing && !conflictInfo && (
-        <div className="flex items-center gap-2 ml-1 text-xs">
-          <span className="text-muted-foreground">
-            Press shortcut keys. If they&apos;re already in use, you can override them here. Use the button below to
-            bind Escape.
-          </span>
-          <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleUseEscape}>
-            Use Escape
-          </Button>
-          <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
-            Cancel
-          </Button>
-        </div>
-      )}
     </div>
   )
 }
@@ -281,25 +321,6 @@ export function KeyboardSettings({ onCaptureStateChange }: KeyboardSettingsProps
   useEffect(() => {
     return () => onCaptureStateChange?.(false)
   }, [onCaptureStateChange])
-
-  // Click outside to cancel capture
-  useEffect(() => {
-    if (!capturingId) return
-    function handleClick(e: MouseEvent) {
-      const target = e.target as HTMLElement
-      // Don't cancel if clicking inside a shortcut row
-      if (target.closest("[data-shortcut-row]")) return
-      setCapturingId(null)
-    }
-    // Use timeout to avoid immediately cancelling from the click that started capture
-    const id = setTimeout(() => {
-      document.addEventListener("click", handleClick)
-    }, 0)
-    return () => {
-      clearTimeout(id)
-      document.removeEventListener("click", handleClick)
-    }
-  }, [capturingId])
 
   const handleSaveBinding = useCallback(
     (actionId: string, binding: string) => {

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -13,6 +13,7 @@ import {
   formatKeyBinding,
   detectConflicts,
   keyEventToBinding,
+  resolveShortcutBindingUpdate,
   type ShortcutAction,
 } from "@/lib/keyboard-shortcuts"
 import { MESSAGE_SEND_MODE_OPTIONS, type MessageSendMode } from "@threa/types"
@@ -221,8 +222,7 @@ function ShortcutCategory({
 }
 
 export function KeyboardSettings() {
-  const { preferences, updatePreference, updateKeyboardShortcut, resetKeyboardShortcut, resetAllKeyboardShortcuts } =
-    usePreferences()
+  const { preferences, updatePreference, resetKeyboardShortcut, resetAllKeyboardShortcuts } = usePreferences()
 
   const customBindings = preferences?.keyboardShortcuts ?? {}
   const shortcuts = useMemo(() => getShortcutsByCategory(), [])
@@ -254,20 +254,11 @@ export function KeyboardSettings() {
 
   const handleSaveBinding = useCallback(
     (actionId: string, binding: string) => {
-      // If the new binding conflicts with other actions, clear those conflicting bindings
-      const testBindings = { ...customBindings, [actionId]: binding }
-      const newConflicts = detectConflicts(testBindings)
-      const conflicting = newConflicts.get(binding)?.filter((id) => id !== actionId) ?? []
-
-      // Clear conflicting bindings by setting them to "none"
-      for (const conflictId of conflicting) {
-        updateKeyboardShortcut(conflictId, "none")
-      }
-
-      updateKeyboardShortcut(actionId, binding)
+      const nextBindings = resolveShortcutBindingUpdate(customBindings, actionId, binding)
+      void updatePreference("keyboardShortcuts", nextBindings)
       setCapturingId(null)
     },
-    [customBindings, updateKeyboardShortcut]
+    [customBindings, updatePreference]
   )
 
   const handleResetBinding = useCallback(

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -77,6 +77,7 @@ function ShortcutRow({
     function handleKeyDown(e: KeyboardEvent) {
       e.preventDefault()
       e.stopPropagation()
+      e.stopImmediatePropagation()
 
       // Escape cancels capture
       if (e.key === "Escape") {
@@ -100,8 +101,8 @@ function ShortcutRow({
       }
     }
 
-    document.addEventListener("keydown", handleKeyDown, { capture: true })
-    return () => document.removeEventListener("keydown", handleKeyDown, { capture: true })
+    window.addEventListener("keydown", handleKeyDown, { capture: true })
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true })
   }, [isCapturing, action.id, customBindings, onCancelCapture, onSaveBinding])
 
   // Focus badge when entering capture mode
@@ -221,7 +222,11 @@ function ShortcutCategory({
   )
 }
 
-export function KeyboardSettings() {
+interface KeyboardSettingsProps {
+  onCaptureStateChange?: (isCapturing: boolean) => void
+}
+
+export function KeyboardSettings({ onCaptureStateChange }: KeyboardSettingsProps = {}) {
   const { preferences, updatePreference, resetKeyboardShortcut, resetAllKeyboardShortcuts } = usePreferences()
 
   const customBindings = preferences?.keyboardShortcuts ?? {}
@@ -232,6 +237,14 @@ export function KeyboardSettings() {
   const messageSendMode = preferences?.messageSendMode ?? "enter"
 
   const [capturingId, setCapturingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    onCaptureStateChange?.(capturingId !== null)
+  }, [capturingId, onCaptureStateChange])
+
+  useEffect(() => {
+    return () => onCaptureStateChange?.(false)
+  }, [onCaptureStateChange])
 
   // Click outside to cancel capture
   useEffect(() => {

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -132,10 +132,6 @@ function ShortcutRow({
     onSaveBinding(action.id, pendingBinding)
   }, [action.id, pendingBinding, conflictInfo, onSaveBinding])
 
-  const handleUseEscape = useCallback(() => {
-    handleCapturedBinding("escape")
-  }, [handleCapturedBinding])
-
   return (
     <div className="space-y-2" data-shortcut-row>
       <div className="flex items-center justify-between gap-2">
@@ -223,23 +219,8 @@ function ShortcutRow({
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <div className="space-y-1">
-                      <p className="font-medium text-sm">Press shortcut keys</p>
-                      <p className="text-xs text-muted-foreground">
-                        Click <span className="font-mono text-foreground">Esc</span> if you want to assign Escape.
-                      </p>
-                    </div>
-
-                    <div className="flex items-center justify-between gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-8 min-w-10 px-3 font-mono"
-                        onClick={handleUseEscape}
-                        aria-label="Bind Escape"
-                      >
-                        Esc
-                      </Button>
+                    <p className="font-medium text-sm">Press shortcut keys</p>
+                    <div className="flex items-center justify-end">
                       <Button variant="ghost" size="sm" onClick={onCancelCapture}>
                         Cancel
                       </Button>

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -1,8 +1,10 @@
-import { useMemo } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
+import { RotateCcw } from "lucide-react"
 import { usePreferences } from "@/contexts"
 import {
   SHORTCUT_ACTIONS,
@@ -10,6 +12,8 @@ import {
   getEffectiveKeyBinding,
   formatKeyBinding,
   detectConflicts,
+  keyEventToBinding,
+  type ShortcutAction,
 } from "@/lib/keyboard-shortcuts"
 import { MESSAGE_SEND_MODE_OPTIONS, type MessageSendMode } from "@threa/types"
 
@@ -24,15 +28,271 @@ const SEND_MODE_CONFIG: Record<MessageSendMode, { label: string; description: st
   },
 }
 
+function getBadgeLabel(
+  isCapturing: boolean,
+  conflictInfo: { binding: string } | null,
+  binding: string | undefined
+): string {
+  if (isCapturing) {
+    return conflictInfo ? formatKeyBinding(conflictInfo.binding) : "Press keys..."
+  }
+  return binding ? formatKeyBinding(binding) : "—"
+}
+
+interface ShortcutRowProps {
+  action: ShortcutAction
+  customBindings: Record<string, string>
+  capturingId: string | null
+  onStartCapture: (id: string) => void
+  onCancelCapture: () => void
+  onSaveBinding: (actionId: string, binding: string) => void
+  onResetBinding: (actionId: string) => void
+}
+
+function ShortcutRow({
+  action,
+  customBindings,
+  capturingId,
+  onStartCapture,
+  onCancelCapture,
+  onSaveBinding,
+  onResetBinding,
+}: ShortcutRowProps) {
+  const isCapturing = capturingId === action.id
+  const [pendingBinding, setPendingBinding] = useState<string | null>(null)
+  const [conflictInfo, setConflictInfo] = useState<{ binding: string; conflictIds: string[] } | null>(null)
+  const badgeRef = useRef<HTMLButtonElement>(null)
+  const binding = getEffectiveKeyBinding(action.id, customBindings)
+  const isCustom = action.id in customBindings && customBindings[action.id] !== action.defaultKey
+
+  // Handle keydown during capture mode
+  useEffect(() => {
+    if (!isCapturing) {
+      setPendingBinding(null)
+      setConflictInfo(null)
+      return
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      e.preventDefault()
+      e.stopPropagation()
+
+      // Escape cancels capture
+      if (e.key === "Escape") {
+        onCancelCapture()
+        return
+      }
+
+      const captured = keyEventToBinding(e)
+      if (!captured) return
+
+      // Check for conflicts
+      const testBindings = { ...customBindings, [action.id]: captured }
+      const conflicts = detectConflicts(testBindings)
+      const conflicting = conflicts.get(captured)?.filter((id) => id !== action.id) ?? []
+
+      if (conflicting.length > 0) {
+        setPendingBinding(captured)
+        setConflictInfo({ binding: captured, conflictIds: conflicting })
+      } else {
+        onSaveBinding(action.id, captured)
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true })
+    return () => document.removeEventListener("keydown", handleKeyDown, { capture: true })
+  }, [isCapturing, action.id, customBindings, onCancelCapture, onSaveBinding])
+
+  // Focus badge when entering capture mode
+  useEffect(() => {
+    if (isCapturing) {
+      badgeRef.current?.focus()
+    }
+  }, [isCapturing])
+
+  const handleConfirmConflict = useCallback(() => {
+    if (!pendingBinding || !conflictInfo) return
+    onSaveBinding(action.id, pendingBinding)
+  }, [action.id, pendingBinding, conflictInfo, onSaveBinding])
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-medium text-sm">{action.label}</p>
+          <p className="text-xs text-muted-foreground">{action.description}</p>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          {isCustom && !isCapturing && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0"
+              onClick={() => onResetBinding(action.id)}
+              title="Reset to default"
+            >
+              <RotateCcw className="h-3 w-3" />
+            </Button>
+          )}
+          <button
+            ref={badgeRef}
+            type="button"
+            onClick={() => (isCapturing ? onCancelCapture() : onStartCapture(action.id))}
+            className={
+              isCapturing
+                ? "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-primary bg-primary/10 text-primary animate-pulse cursor-pointer focus:outline-none"
+                : "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-mono font-semibold border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80 cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            }
+          >
+            {getBadgeLabel(isCapturing, conflictInfo, binding)}
+          </button>
+        </div>
+      </div>
+
+      {/* Conflict resolution inline */}
+      {isCapturing && conflictInfo && (
+        <div className="flex items-center gap-2 ml-1 text-xs">
+          <span className="text-destructive">
+            Conflicts with{" "}
+            {conflictInfo.conflictIds
+              .map((id) => SHORTCUT_ACTIONS.find((a) => a.id === id)?.label)
+              .filter(Boolean)
+              .join(", ")}
+          </span>
+          <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleConfirmConflict}>
+            Override
+          </Button>
+          <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
+            Cancel
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ShortcutCategory({
+  title,
+  description,
+  actions,
+  customBindings,
+  capturingId,
+  onStartCapture,
+  onCancelCapture,
+  onSaveBinding,
+  onResetBinding,
+}: {
+  title: string
+  description: string
+  actions: ShortcutAction[]
+  customBindings: Record<string, string>
+  capturingId: string | null
+  onStartCapture: (id: string) => void
+  onCancelCapture: () => void
+  onSaveBinding: (actionId: string, binding: string) => void
+  onResetBinding: (actionId: string) => void
+}) {
+  if (actions.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {actions.map((action) => (
+            <ShortcutRow
+              key={action.id}
+              action={action}
+              customBindings={customBindings}
+              capturingId={capturingId}
+              onStartCapture={onStartCapture}
+              onCancelCapture={onCancelCapture}
+              onSaveBinding={onSaveBinding}
+              onResetBinding={onResetBinding}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function KeyboardSettings() {
-  const { preferences, updatePreference } = usePreferences()
+  const { preferences, updatePreference, updateKeyboardShortcut, resetKeyboardShortcut, resetAllKeyboardShortcuts } =
+    usePreferences()
 
   const customBindings = preferences?.keyboardShortcuts ?? {}
   const shortcuts = useMemo(() => getShortcutsByCategory(), [])
   const conflicts = useMemo(() => detectConflicts(customBindings), [customBindings])
-
   const hasConflicts = conflicts.size > 0
+  const hasCustomBindings = Object.keys(customBindings).length > 0
   const messageSendMode = preferences?.messageSendMode ?? "enter"
+
+  const [capturingId, setCapturingId] = useState<string | null>(null)
+
+  // Click outside to cancel capture
+  useEffect(() => {
+    if (!capturingId) return
+    function handleClick(e: MouseEvent) {
+      const target = e.target as HTMLElement
+      // Don't cancel if clicking inside a shortcut row
+      if (target.closest("[data-shortcut-row]")) return
+      setCapturingId(null)
+    }
+    // Use timeout to avoid immediately cancelling from the click that started capture
+    const id = setTimeout(() => {
+      document.addEventListener("click", handleClick)
+    }, 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener("click", handleClick)
+    }
+  }, [capturingId])
+
+  const handleSaveBinding = useCallback(
+    (actionId: string, binding: string) => {
+      // If the new binding conflicts with other actions, clear those conflicting bindings
+      const testBindings = { ...customBindings, [actionId]: binding }
+      const newConflicts = detectConflicts(testBindings)
+      const conflicting = newConflicts.get(binding)?.filter((id) => id !== actionId) ?? []
+
+      // Clear conflicting bindings by setting them to "none"
+      for (const conflictId of conflicting) {
+        updateKeyboardShortcut(conflictId, "none")
+      }
+
+      updateKeyboardShortcut(actionId, binding)
+      setCapturingId(null)
+    },
+    [customBindings, updateKeyboardShortcut]
+  )
+
+  const handleResetBinding = useCallback(
+    (actionId: string) => {
+      resetKeyboardShortcut(actionId)
+    },
+    [resetKeyboardShortcut]
+  )
+
+  const handleCancelCapture = useCallback(() => {
+    setCapturingId(null)
+  }, [])
+
+  const handleStartCapture = useCallback((id: string) => {
+    setCapturingId(id)
+  }, [])
+
+  const sharedProps = {
+    customBindings,
+    capturingId,
+    onStartCapture: handleStartCapture,
+    onCancelCapture: handleCancelCapture,
+    onSaveBinding: handleSaveBinding,
+    onResetBinding: handleResetBinding,
+  }
 
   return (
     <div className="space-y-6">
@@ -88,97 +348,35 @@ export function KeyboardSettings() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Navigation</CardTitle>
-          <CardDescription>Keyboard shortcuts for navigating Threa</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {shortcuts.navigation.map((action) => {
-              const binding = getEffectiveKeyBinding(action.id, customBindings)
-              return (
-                <div key={action.id} className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium">{action.label}</p>
-                    <p className="text-sm text-muted-foreground">{action.description}</p>
-                  </div>
-                  <Badge variant="secondary" className="font-mono">
-                    {binding ? formatKeyBinding(binding) : "—"}
-                  </Badge>
-                </div>
-              )
-            })}
-          </div>
-        </CardContent>
-      </Card>
+      <ShortcutCategory
+        title="Navigation"
+        description="Keyboard shortcuts for navigating Threa"
+        actions={shortcuts.navigation}
+        {...sharedProps}
+      />
 
-      {shortcuts.view.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>View</CardTitle>
-            <CardDescription>Keyboard shortcuts for view controls</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {shortcuts.view.map((action) => {
-                const binding = getEffectiveKeyBinding(action.id, customBindings)
-                return (
-                  <div key={action.id} className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium">{action.label}</p>
-                      <p className="text-sm text-muted-foreground">{action.description}</p>
-                    </div>
-                    <Badge variant="secondary" className="font-mono">
-                      {binding ? formatKeyBinding(binding) : "—"}
-                    </Badge>
-                  </div>
-                )
-              })}
-            </div>
-          </CardContent>
-        </Card>
+      <ShortcutCategory
+        title="View"
+        description="Keyboard shortcuts for view controls"
+        actions={shortcuts.view}
+        {...sharedProps}
+      />
+
+      <ShortcutCategory
+        title="Editing"
+        description="Keyboard shortcuts for formatting in the editor"
+        actions={shortcuts.editing}
+        {...sharedProps}
+      />
+
+      {hasCustomBindings && (
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={resetAllKeyboardShortcuts}>
+            <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+            Reset all shortcuts
+          </Button>
+        </div>
       )}
-
-      {shortcuts.editing.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Editing</CardTitle>
-            <CardDescription>Keyboard shortcuts for editing</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {shortcuts.editing.map((action) => {
-                const binding = getEffectiveKeyBinding(action.id, customBindings)
-                return (
-                  <div key={action.id} className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium">{action.label}</p>
-                      <p className="text-sm text-muted-foreground">{action.description}</p>
-                    </div>
-                    <Badge variant="secondary" className="font-mono">
-                      {binding ? formatKeyBinding(binding) : "—"}
-                    </Badge>
-                  </div>
-                )
-              })}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Customization</CardTitle>
-          <CardDescription>Shortcut customization coming soon</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            The ability to rebind keyboard shortcuts will be available in a future update. For now, you can view the
-            available shortcuts above.
-          </p>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -116,7 +116,7 @@ function ShortcutRow({
   }, [action.id, pendingBinding, conflictInfo, onSaveBinding])
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" data-shortcut-row>
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0">
           <p className="font-medium text-sm">{action.label}</p>

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { RotateCcw } from "lucide-react"
 import { usePreferences } from "@/contexts"
 import {
@@ -66,6 +67,22 @@ function ShortcutRow({
   const binding = getEffectiveKeyBinding(action.id, customBindings)
   const isCustom = action.id in customBindings && customBindings[action.id] !== action.defaultKey
 
+  const handleCapturedBinding = useCallback(
+    (captured: string) => {
+      const testBindings = { ...customBindings, [action.id]: captured }
+      const conflicts = detectConflicts(testBindings)
+      const conflicting = conflicts.get(captured)?.filter((id) => id !== action.id) ?? []
+
+      if (conflicting.length > 0) {
+        setPendingBinding(captured)
+        setConflictInfo({ binding: captured, conflictIds: conflicting })
+      } else {
+        onSaveBinding(action.id, captured)
+      }
+    },
+    [action.id, customBindings, onSaveBinding]
+  )
+
   // Handle keydown during capture mode
   useEffect(() => {
     if (!isCapturing) {
@@ -88,22 +105,12 @@ function ShortcutRow({
       const captured = keyEventToBinding(e)
       if (!captured) return
 
-      // Check for conflicts
-      const testBindings = { ...customBindings, [action.id]: captured }
-      const conflicts = detectConflicts(testBindings)
-      const conflicting = conflicts.get(captured)?.filter((id) => id !== action.id) ?? []
-
-      if (conflicting.length > 0) {
-        setPendingBinding(captured)
-        setConflictInfo({ binding: captured, conflictIds: conflicting })
-      } else {
-        onSaveBinding(action.id, captured)
-      }
+      handleCapturedBinding(captured)
     }
 
     window.addEventListener("keydown", handleKeyDown, { capture: true })
     return () => window.removeEventListener("keydown", handleKeyDown, { capture: true })
-  }, [isCapturing, action.id, customBindings, onCancelCapture, onSaveBinding])
+  }, [isCapturing, onCancelCapture, handleCapturedBinding])
 
   // Focus badge when entering capture mode
   useEffect(() => {
@@ -117,6 +124,10 @@ function ShortcutRow({
     onSaveBinding(action.id, pendingBinding)
   }, [action.id, pendingBinding, conflictInfo, onSaveBinding])
 
+  const handleUseEscape = useCallback(() => {
+    handleCapturedBinding("escape")
+  }, [handleCapturedBinding])
+
   return (
     <div className="space-y-2" data-shortcut-row>
       <div className="flex items-center justify-between gap-2">
@@ -126,15 +137,24 @@ function ShortcutRow({
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           {isCustom && !isCapturing && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 w-6 p-0"
-              onClick={() => onResetBinding(action.id)}
-              title="Reset to default"
-            >
-              <RotateCcw className="h-3 w-3" />
-            </Button>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    onClick={() => onResetBinding(action.id)}
+                    aria-label="Reset to default"
+                  >
+                    <RotateCcw className="h-3 w-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  Reset to default
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <button
             ref={badgeRef}
@@ -163,6 +183,18 @@ function ShortcutRow({
           </span>
           <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleConfirmConflict}>
             Override
+          </Button>
+          <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      {isCapturing && !conflictInfo && (
+        <div className="flex items-center gap-2 ml-1 text-xs">
+          <span className="text-muted-foreground">Press shortcut keys, or use the button below to bind Escape.</span>
+          <Button variant="outline" size="sm" className="h-5 px-2 text-xs" onClick={handleUseEscape}>
+            Use Escape
           </Button>
           <Button variant="ghost" size="sm" className="h-5 px-2 text-xs" onClick={onCancelCapture}>
             Cancel

--- a/apps/frontend/src/components/settings/settings-dialog.test.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.test.tsx
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from "vitest"
+import { useEffect } from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { SettingsDialog } from "./settings-dialog"
 
 const mocks = vi.hoisted(() => ({
   useSettings: vi.fn(),
+  keyboardCaptureActive: false,
 }))
 
 vi.mock("@/contexts", () => ({
@@ -31,7 +34,18 @@ vi.mock("./notifications-settings", () => ({
 }))
 
 vi.mock("./keyboard-settings", () => ({
-  KeyboardSettings: () => <div>Keyboard panel</div>,
+  KeyboardSettings: ({ onCaptureStateChange }: { onCaptureStateChange?: (isCapturing: boolean) => void }) => {
+    useEffect(() => {
+      if (!mocks.keyboardCaptureActive) {
+        return
+      }
+
+      onCaptureStateChange?.(true)
+      return () => onCaptureStateChange?.(false)
+    }, [onCaptureStateChange])
+
+    return <div>Keyboard panel</div>
+  },
 }))
 
 vi.mock("./accessibility-settings", () => ({
@@ -39,6 +53,10 @@ vi.mock("./accessibility-settings", () => ({
 }))
 
 describe("SettingsDialog", () => {
+  beforeEach(() => {
+    mocks.keyboardCaptureActive = false
+  })
+
   it("keeps the navigation and active panel in scrollable regions", async () => {
     mocks.useSettings.mockReturnValue({
       isOpen: true,
@@ -61,5 +79,23 @@ describe("SettingsDialog", () => {
     expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
     expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
     expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
+  })
+
+  it("does not close on Escape while shortcut capture is active", async () => {
+    const user = userEvent.setup()
+    const closeSettings = vi.fn()
+    mocks.keyboardCaptureActive = true
+    mocks.useSettings.mockReturnValue({
+      isOpen: true,
+      activeTab: "keyboard",
+      closeSettings,
+      setActiveTab: vi.fn(),
+    })
+
+    render(<SettingsDialog />)
+
+    await user.keyboard("{Escape}")
+
+    expect(closeSettings).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -31,6 +31,7 @@ const TAB_CONFIG: Record<SettingsTab, { label: string; description: string }> = 
 export function SettingsDialog() {
   const { isOpen, activeTab, closeSettings, setActiveTab } = useSettings()
   const [mounted, setMounted] = useState(false)
+  const [isShortcutCaptureActive, setIsShortcutCaptureActive] = useState(false)
 
   // Delay dialog render until after hydration to avoid scroll lock measurement issues
   useEffect(() => {
@@ -45,6 +46,11 @@ export function SettingsDialog() {
         desktopClassName="w-[min(96vw,980px)] max-w-none h-[min(720px,calc(100vh-2rem))] sm:flex flex-col overflow-hidden p-0 gap-0"
         drawerClassName="flex flex-col gap-0"
         hideCloseButton
+        onEscapeKeyDown={(event) => {
+          if (isShortcutCaptureActive) {
+            event.preventDefault()
+          }
+        }}
       >
         <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
@@ -84,7 +90,7 @@ export function SettingsDialog() {
                 <NotificationsSettings />
               </TabsContent>
               <TabsContent value="keyboard" className="mt-0">
-                <KeyboardSettings />
+                <KeyboardSettings onCaptureStateChange={setIsShortcutCaptureActive} />
               </TabsContent>
               <TabsContent value="accessibility" className="mt-0">
                 <AccessibilitySettings />

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -17,6 +17,7 @@ import {
   useAgentActivity,
   useAbortResearch,
   useEditLastMessageTrigger,
+  useKeyboardShortcuts,
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
@@ -187,37 +188,48 @@ export function StreamContent({
   // --- In-stream search ---
   const streamSearch = useStreamSearch({ workspaceId, streamId })
   const clearSearch = streamSearch.clear
-
-  // Cmd+F / Ctrl+F opens in-stream search or re-focuses if already open.
-  // Also listens for the custom event from the header search button.
-  // Escape closes search when focus is outside the input.
-  // Skip in thread views to avoid double search bar.
-  useEffect(() => {
-    if (isThread) return
-    const openOrFocus = () => {
-      if (isSearchOpen) {
-        streamSearch.focus()
-      } else {
-        setIsSearchOpen(true)
-      }
+  const openOrFocusSearch = useCallback(() => {
+    if (isSearchOpen) {
+      streamSearch.focus()
+    } else {
+      setIsSearchOpen(true)
     }
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
-        e.preventDefault()
-        openOrFocus()
-      }
-      if (e.key === "Escape" && isSearchOpen) {
+  }, [isSearchOpen, streamSearch])
+
+  useKeyboardShortcuts(
+    {
+      searchInStream: openOrFocusSearch,
+    },
+    !isThread && !isDraft
+  )
+
+  // Header search button dispatches a custom event so it can share the same open/focus path.
+  useEffect(() => {
+    if (isThread || isDraft) return
+
+    document.addEventListener("threa:open-stream-search", openOrFocusSearch)
+    return () => {
+      document.removeEventListener("threa:open-stream-search", openOrFocusSearch)
+    }
+  }, [isDraft, isThread, openOrFocusSearch])
+
+  // Escape closes search when focus is outside the search input.
+  useEffect(() => {
+    if (!isSearchOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const isInput = target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable
+
+      if (event.key === "Escape" && !isInput) {
         setIsSearchOpen(false)
         clearSearch()
       }
     }
+
     document.addEventListener("keydown", handleKeyDown)
-    document.addEventListener("threa:open-stream-search", openOrFocus)
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown)
-      document.removeEventListener("threa:open-stream-search", openOrFocus)
-    }
-  }, [isThread, isSearchOpen, streamSearch, clearSearch])
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [isSearchOpen, clearSearch])
 
   const handleSearchClose = useCallback(() => {
     setIsSearchOpen(false)

--- a/apps/frontend/src/components/ui/popover.tsx
+++ b/apps/frontend/src/components/ui/popover.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils"
 
 const Popover = PopoverPrimitive.Root
 
+const PopoverAnchor = PopoverPrimitive.Anchor
+
 const PopoverTrigger = PopoverPrimitive.Trigger
 
 const PopoverContent = React.forwardRef<
@@ -26,4 +28,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverAnchor, PopoverTrigger, PopoverContent }

--- a/apps/frontend/src/components/ui/sidebar.tsx
+++ b/apps/frontend/src/components/ui/sidebar.tsx
@@ -17,7 +17,6 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
-const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -74,19 +73,6 @@ const SidebarProvider = React.forwardRef<
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
-
-  // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault()
-        toggleSidebar()
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleSidebar])
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/apps/frontend/src/contexts/preferences-context.tsx
+++ b/apps/frontend/src/contexts/preferences-context.tsx
@@ -41,6 +41,8 @@ interface PreferencesContextValue {
   ) => Promise<void>
   updateAccessibility: (updates: Partial<AccessibilityPreferences>) => Promise<void>
   updateKeyboardShortcut: (actionId: string, keyBinding: string) => Promise<void>
+  resetKeyboardShortcut: (actionId: string) => Promise<void>
+  resetAllKeyboardShortcuts: () => Promise<void>
 }
 
 const PreferencesContext = createContext<PreferencesContextValue | null>(null)
@@ -102,10 +104,10 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
             input.accessibility !== undefined
               ? { ...previousBootstrap.userPreferences.accessibility, ...input.accessibility }
               : previousBootstrap.userPreferences.accessibility,
-          // Handle keyboard shortcut updates
+          // Keyboard shortcuts: callers provide the complete desired state, so replace entirely
           keyboardShortcuts:
             input.keyboardShortcuts !== undefined
-              ? { ...previousBootstrap.userPreferences.keyboardShortcuts, ...input.keyboardShortcuts }
+              ? input.keyboardShortcuts
               : previousBootstrap.userPreferences.keyboardShortcuts,
           updatedAt: new Date().toISOString(),
         }
@@ -168,13 +170,25 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
 
   const updateKeyboardShortcut = useCallback(
     async (actionId: string, keyBinding: string) => {
-      const currentShortcuts = preferences?.keyboardShortcuts ?? {}
-      await mutation.mutateAsync({
-        keyboardShortcuts: { ...currentShortcuts, [actionId]: keyBinding },
-      })
+      const currentShortcuts = { ...(preferences?.keyboardShortcuts ?? {}) }
+      currentShortcuts[actionId] = keyBinding
+      await mutation.mutateAsync({ keyboardShortcuts: currentShortcuts })
     },
     [mutation, preferences?.keyboardShortcuts]
   )
+
+  const resetKeyboardShortcut = useCallback(
+    async (actionId: string) => {
+      const currentShortcuts = { ...(preferences?.keyboardShortcuts ?? {}) }
+      delete currentShortcuts[actionId]
+      await mutation.mutateAsync({ keyboardShortcuts: currentShortcuts })
+    },
+    [mutation, preferences?.keyboardShortcuts]
+  )
+
+  const resetAllKeyboardShortcuts = useCallback(async () => {
+    await mutation.mutateAsync({ keyboardShortcuts: {} })
+  }, [mutation])
 
   const value = useMemo<PreferencesContextValue>(
     () => ({
@@ -184,8 +198,19 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
       updatePreference,
       updateAccessibility,
       updateKeyboardShortcut,
+      resetKeyboardShortcut,
+      resetAllKeyboardShortcuts,
     }),
-    [preferences, resolvedTheme, mutation.isPending, updatePreference, updateAccessibility, updateKeyboardShortcut]
+    [
+      preferences,
+      resolvedTheme,
+      mutation.isPending,
+      updatePreference,
+      updateAccessibility,
+      updateKeyboardShortcut,
+      resetKeyboardShortcut,
+      resetAllKeyboardShortcuts,
+    ]
   )
 
   return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>

--- a/apps/frontend/src/hooks/use-keyboard-shortcuts.test.tsx
+++ b/apps/frontend/src/hooks/use-keyboard-shortcuts.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { useKeyboardShortcuts } from "./use-keyboard-shortcuts"
+
+const mockPreferences = {
+  keyboardShortcuts: {} as Record<string, string>,
+}
+
+vi.mock("@/contexts", () => ({
+  usePreferences: () => ({
+    preferences: mockPreferences,
+  }),
+}))
+
+function TestShortcutHandler({
+  onSearchInStream,
+  enabled = true,
+}: {
+  onSearchInStream: () => void
+  enabled?: boolean
+}) {
+  useKeyboardShortcuts(
+    {
+      searchInStream: onSearchInStream,
+    },
+    enabled
+  )
+
+  return <input aria-label="Editor" />
+}
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => {
+    mockPreferences.keyboardShortcuts = {}
+  })
+
+  it("triggers searchInStream on the default mod+f binding", () => {
+    const onSearchInStream = vi.fn()
+
+    render(<TestShortcutHandler onSearchInStream={onSearchInStream} />)
+
+    fireEvent.keyDown(document, { key: "f", ctrlKey: true })
+
+    expect(onSearchInStream).toHaveBeenCalledOnce()
+  })
+
+  it("respects custom searchInStream bindings", () => {
+    const onSearchInStream = vi.fn()
+    mockPreferences.keyboardShortcuts = { searchInStream: "mod+shift+f" }
+
+    render(<TestShortcutHandler onSearchInStream={onSearchInStream} />)
+
+    fireEvent.keyDown(document, { key: "f", ctrlKey: true })
+    fireEvent.keyDown(document, { key: "f", ctrlKey: true, shiftKey: true })
+
+    expect(onSearchInStream).toHaveBeenCalledOnce()
+  })
+
+  it("allows global searchInStream shortcuts while focus is in an input", () => {
+    const onSearchInStream = vi.fn()
+
+    render(<TestShortcutHandler onSearchInStream={onSearchInStream} />)
+
+    const input = screen.getByRole("textbox", { name: "Editor" })
+    input.focus()
+    fireEvent.keyDown(input, { key: "f", ctrlKey: true })
+
+    expect(onSearchInStream).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,11 @@
 import { useEffect, useCallback, useRef } from "react"
 import { usePreferences } from "@/contexts"
-import { SHORTCUT_ACTIONS, matchesKeyBinding, getEffectiveKeyBinding } from "@/lib/keyboard-shortcuts"
+import {
+  SHORTCUT_ACTIONS,
+  matchesKeyBinding,
+  getEffectiveKeyBinding,
+  isSafeShortcutBinding,
+} from "@/lib/keyboard-shortcuts"
 
 type ShortcutHandlers = Partial<Record<string, () => void>>
 
@@ -38,7 +43,7 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, enabled = true)
         if (!handler) continue
 
         const binding = getEffectiveKeyBinding(action.id, customBindings)
-        if (!binding) continue
+        if (!binding || !isSafeShortcutBinding(binding)) continue
 
         // Skip non-global shortcuts when focus is in an input
         if (isInput && !action.global) continue

--- a/apps/frontend/src/lib/keyboard-shortcuts.test.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.test.ts
@@ -148,9 +148,9 @@ describe("keyEventToBinding", () => {
     expect(keyEventToBinding(event)).toBe("alt+k")
   })
 
-  it("returns bare key for safe unmodified keys", () => {
+  it("refuses to capture Escape — it is reserved for close/cancel flows", () => {
     const event = new KeyboardEvent("keydown", { key: "Escape" })
-    expect(keyEventToBinding(event)).toBe("escape")
+    expect(keyEventToBinding(event)).toBeNull()
   })
 
   it("returns null for lone modifier presses", () => {
@@ -172,10 +172,9 @@ describe("keyEventToBinding", () => {
 })
 
 describe("isSafeShortcutBinding", () => {
-  it("allows modified shortcuts and safe bare keys", () => {
+  it("allows modified shortcuts and function keys", () => {
     expect(isSafeShortcutBinding("mod+b")).toBe(true)
     expect(isSafeShortcutBinding("alt+k")).toBe(true)
-    expect(isSafeShortcutBinding("escape")).toBe(true)
     expect(isSafeShortcutBinding("f6")).toBe(true)
   })
 
@@ -183,6 +182,12 @@ describe("isSafeShortcutBinding", () => {
     expect(isSafeShortcutBinding("b")).toBe(false)
     expect(isSafeShortcutBinding("shift+b")).toBe(false)
     expect(isSafeShortcutBinding("shift++")).toBe(false)
+  })
+
+  it("rejects Escape in any form — reserved for close/cancel flows", () => {
+    expect(isSafeShortcutBinding("escape")).toBe(false)
+    expect(isSafeShortcutBinding("mod+escape")).toBe(false)
+    expect(isSafeShortcutBinding("shift+escape")).toBe(false)
   })
 })
 

--- a/apps/frontend/src/lib/keyboard-shortcuts.test.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.test.ts
@@ -55,6 +55,21 @@ describe("toggleSidebar shortcut", () => {
   })
 })
 
+describe("searchInStream shortcut", () => {
+  it("is registered as a navigation action with mod+f default", () => {
+    const action = getShortcutAction("searchInStream")
+    expect(action).toBeDefined()
+    expect(action?.defaultKey).toBe("mod+f")
+    expect(action?.category).toBe("navigation")
+    expect(action?.global).toBe(true)
+  })
+
+  it("does not conflict with any other default binding", () => {
+    const conflicts = detectConflicts()
+    expect(conflicts.get("mod+f")).toBeUndefined()
+  })
+})
+
 describe("editor formatting shortcuts", () => {
   it("registers all 5 editor formatting actions in the editing category", () => {
     for (const id of EDITOR_SHORTCUT_IDS) {

--- a/apps/frontend/src/lib/keyboard-shortcuts.test.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.test.ts
@@ -11,6 +11,7 @@ import {
   isSafeShortcutBinding,
   resolveShortcutBindingUpdate,
   formatKeyBinding,
+  formatKeyBindingText,
 } from "./keyboard-shortcuts"
 
 describe("toggleSidebar shortcut", () => {
@@ -178,6 +179,11 @@ describe("parse and format bindings", () => {
 
   it("formats bindings whose key contains +", () => {
     expect(formatKeyBinding("mod+shift++")).toMatch(/^\u2318\u21e7\+$|^Ctrl\+Shift\+\+$/)
+  })
+
+  it("formats bindings as plain text", () => {
+    expect(formatKeyBindingText("mod+shift++")).toMatch(/^cmd\+shift\+\+$|^ctrl\+shift\+\+$/)
+    expect(formatKeyBindingText("escape")).toBe("escape")
   })
 })
 

--- a/apps/frontend/src/lib/keyboard-shortcuts.test.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest"
-import { SHORTCUT_ACTIONS, getShortcutAction, matchesKeyBinding, detectConflicts } from "./keyboard-shortcuts"
+import {
+  SHORTCUT_ACTIONS,
+  getShortcutAction,
+  matchesKeyBinding,
+  detectConflicts,
+  getEffectiveKeyBinding,
+  keyEventToBinding,
+  getEffectiveEditorBindings,
+  EDITOR_SHORTCUT_IDS,
+} from "./keyboard-shortcuts"
 
 describe("toggleSidebar shortcut", () => {
   it("is registered as a view-category action with mod+§ default", () => {
@@ -39,5 +48,127 @@ describe("toggleSidebar shortcut", () => {
   it("is included in SHORTCUT_ACTIONS exactly once", () => {
     const matches = SHORTCUT_ACTIONS.filter((a) => a.id === "toggleSidebar")
     expect(matches).toHaveLength(1)
+  })
+})
+
+describe("editor formatting shortcuts", () => {
+  it("registers all 5 editor formatting actions in the editing category", () => {
+    for (const id of EDITOR_SHORTCUT_IDS) {
+      const action = getShortcutAction(id)
+      expect(action).toBeDefined()
+      expect(action?.category).toBe("editing")
+      expect(action?.global).toBeUndefined()
+    }
+  })
+
+  it("has correct default keys", () => {
+    expect(getShortcutAction("formatBold")?.defaultKey).toBe("mod+b")
+    expect(getShortcutAction("formatItalic")?.defaultKey).toBe("mod+i")
+    expect(getShortcutAction("formatStrike")?.defaultKey).toBe("mod+shift+s")
+    expect(getShortcutAction("formatCode")?.defaultKey).toBe("mod+e")
+    expect(getShortcutAction("formatCodeBlock")?.defaultKey).toBe("mod+shift+c")
+  })
+
+  it("no default editor shortcuts conflict with each other", () => {
+    const conflicts = detectConflicts()
+    for (const id of EDITOR_SHORTCUT_IDS) {
+      const action = getShortcutAction(id)!
+      const conflicting = conflicts.get(action.defaultKey)
+      expect(conflicting).toBeUndefined()
+    }
+  })
+})
+
+describe("getEffectiveKeyBinding", () => {
+  it("returns default key when no custom bindings", () => {
+    expect(getEffectiveKeyBinding("formatBold")).toBe("mod+b")
+  })
+
+  it("returns custom binding when set", () => {
+    expect(getEffectiveKeyBinding("formatBold", { formatBold: "mod+shift+b" })).toBe("mod+shift+b")
+  })
+
+  it("returns undefined when set to 'none' (disabled)", () => {
+    expect(getEffectiveKeyBinding("formatBold", { formatBold: "none" })).toBeUndefined()
+  })
+
+  it("returns undefined for unknown action IDs", () => {
+    expect(getEffectiveKeyBinding("nonexistent")).toBeUndefined()
+  })
+})
+
+describe("detectConflicts", () => {
+  it("detects conflict when two actions share the same binding", () => {
+    const conflicts = detectConflicts({ toggleSidebar: "mod+b" })
+    const conflicting = conflicts.get("mod+b")
+    expect(conflicting).toBeDefined()
+    expect(conflicting).toContain("toggleSidebar")
+    expect(conflicting).toContain("formatBold")
+  })
+
+  it("excludes disabled shortcuts from conflict detection", () => {
+    const conflicts = detectConflicts({ formatBold: "none", toggleSidebar: "mod+b" })
+    // formatBold is disabled, so mod+b is only used by toggleSidebar — no conflict
+    expect(conflicts.get("mod+b")).toBeUndefined()
+  })
+})
+
+describe("keyEventToBinding", () => {
+  it("converts Ctrl+B to mod+b", () => {
+    const event = new KeyboardEvent("keydown", { key: "b", ctrlKey: true })
+    expect(keyEventToBinding(event)).toBe("mod+b")
+  })
+
+  it("converts Cmd+Shift+F to mod+shift+f", () => {
+    const event = new KeyboardEvent("keydown", { key: "f", metaKey: true, shiftKey: true })
+    expect(keyEventToBinding(event)).toBe("mod+shift+f")
+  })
+
+  it("converts Alt+K to alt+k", () => {
+    const event = new KeyboardEvent("keydown", { key: "k", altKey: true })
+    expect(keyEventToBinding(event)).toBe("alt+k")
+  })
+
+  it("returns bare key for unmodified key", () => {
+    const event = new KeyboardEvent("keydown", { key: "Escape" })
+    expect(keyEventToBinding(event)).toBe("escape")
+  })
+
+  it("returns null for lone modifier presses", () => {
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Control" }))).toBeNull()
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Shift" }))).toBeNull()
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Alt" }))).toBeNull()
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Meta" }))).toBeNull()
+  })
+})
+
+describe("getEffectiveEditorBindings", () => {
+  it("returns all default editor bindings when no custom bindings", () => {
+    const bindings = getEffectiveEditorBindings()
+    expect(bindings).toEqual({
+      formatBold: "mod+b",
+      formatItalic: "mod+i",
+      formatStrike: "mod+shift+s",
+      formatCode: "mod+e",
+      formatCodeBlock: "mod+shift+c",
+    })
+  })
+
+  it("excludes editor bindings that conflict with global app shortcuts", () => {
+    // User binds toggleSidebar to mod+b — formatBold should be excluded
+    const bindings = getEffectiveEditorBindings({ toggleSidebar: "mod+b" })
+    expect(bindings.formatBold).toBeUndefined()
+    // Other editor shortcuts unaffected
+    expect(bindings.formatItalic).toBe("mod+i")
+  })
+
+  it("respects custom editor bindings", () => {
+    const bindings = getEffectiveEditorBindings({ formatBold: "mod+shift+b" })
+    expect(bindings.formatBold).toBe("mod+shift+b")
+  })
+
+  it("excludes disabled editor shortcuts", () => {
+    const bindings = getEffectiveEditorBindings({ formatBold: "none" })
+    expect(bindings.formatBold).toBeUndefined()
   })
 })

--- a/apps/frontend/src/lib/keyboard-shortcuts.test.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.test.ts
@@ -8,6 +8,9 @@ import {
   keyEventToBinding,
   getEffectiveEditorBindings,
   EDITOR_SHORTCUT_IDS,
+  isSafeShortcutBinding,
+  resolveShortcutBindingUpdate,
+  formatKeyBinding,
 } from "./keyboard-shortcuts"
 
 describe("toggleSidebar shortcut", () => {
@@ -129,7 +132,7 @@ describe("keyEventToBinding", () => {
     expect(keyEventToBinding(event)).toBe("alt+k")
   })
 
-  it("returns bare key for unmodified key", () => {
+  it("returns bare key for safe unmodified keys", () => {
     const event = new KeyboardEvent("keydown", { key: "Escape" })
     expect(keyEventToBinding(event)).toBe("escape")
   })
@@ -139,6 +142,42 @@ describe("keyEventToBinding", () => {
     expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Shift" }))).toBeNull()
     expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Alt" }))).toBeNull()
     expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "Meta" }))).toBeNull()
+  })
+
+  it("rejects unsafe bare printable keys", () => {
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "b" }))).toBeNull()
+    expect(keyEventToBinding(new KeyboardEvent("keydown", { key: "B", shiftKey: true }))).toBeNull()
+  })
+
+  it("captures keys whose names contain + when the shortcut is otherwise safe", () => {
+    const event = new KeyboardEvent("keydown", { key: "+", metaKey: true, shiftKey: true })
+    expect(keyEventToBinding(event)).toBe("mod+shift++")
+  })
+})
+
+describe("isSafeShortcutBinding", () => {
+  it("allows modified shortcuts and safe bare keys", () => {
+    expect(isSafeShortcutBinding("mod+b")).toBe(true)
+    expect(isSafeShortcutBinding("alt+k")).toBe(true)
+    expect(isSafeShortcutBinding("escape")).toBe(true)
+    expect(isSafeShortcutBinding("f6")).toBe(true)
+  })
+
+  it("rejects unsafe bare printable bindings", () => {
+    expect(isSafeShortcutBinding("b")).toBe(false)
+    expect(isSafeShortcutBinding("shift+b")).toBe(false)
+    expect(isSafeShortcutBinding("shift++")).toBe(false)
+  })
+})
+
+describe("parse and format bindings", () => {
+  it("matches bindings whose key contains +", () => {
+    const event = new KeyboardEvent("keydown", { key: "+", metaKey: true, shiftKey: true })
+    expect(matchesKeyBinding(event, "mod+shift++")).toBe(true)
+  })
+
+  it("formats bindings whose key contains +", () => {
+    expect(formatKeyBinding("mod+shift++")).toMatch(/^\u2318\u21e7\+$|^Ctrl\+Shift\+\+$/)
   })
 })
 
@@ -170,5 +209,19 @@ describe("getEffectiveEditorBindings", () => {
   it("excludes disabled editor shortcuts", () => {
     const bindings = getEffectiveEditorBindings({ formatBold: "none" })
     expect(bindings.formatBold).toBeUndefined()
+  })
+
+  it("excludes unsafe editor bindings that would hijack typing", () => {
+    const bindings = getEffectiveEditorBindings({ formatBold: "b" })
+    expect(bindings.formatBold).toBeUndefined()
+  })
+})
+
+describe("resolveShortcutBindingUpdate", () => {
+  it("builds a single update that clears conflicting bindings", () => {
+    expect(resolveShortcutBindingUpdate({}, "toggleSidebar", "mod+b")).toEqual({
+      formatBold: "none",
+      toggleSidebar: "mod+b",
+    })
   })
 })

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -187,13 +187,41 @@ export function parseKeyBinding(key: string): {
   alt: boolean
 } {
   const parts = key.toLowerCase().split("+")
-  const actualKey = parts[parts.length - 1]
+  let mod = false
+  let shift = false
+  let alt = false
+  let keyStartIndex = 0
+
+  while (keyStartIndex < parts.length) {
+    const part = parts[keyStartIndex]
+    if (part === "mod") {
+      mod = true
+      keyStartIndex += 1
+      continue
+    }
+
+    if (part === "shift") {
+      shift = true
+      keyStartIndex += 1
+      continue
+    }
+
+    if (part === "alt") {
+      alt = true
+      keyStartIndex += 1
+      continue
+    }
+
+    break
+  }
+
+  const actualKey = parts.slice(keyStartIndex).join("+")
 
   return {
     key: actualKey,
-    mod: parts.includes("mod"),
-    shift: parts.includes("shift"),
-    alt: parts.includes("alt"),
+    mod,
+    shift,
+    alt,
   }
 }
 
@@ -224,34 +252,59 @@ export function matchesKeyBinding(event: KeyboardEvent, binding: string): boolea
  */
 export function formatKeyBinding(binding: string): string {
   const mac = isMac()
-  const parts = binding.split("+")
+  const parsed = parseKeyBinding(binding)
+  if (!parsed.key) {
+    return binding
+  }
 
-  const formatted = parts.map((part) => {
-    switch (part.toLowerCase()) {
-      case "mod":
-        return mac ? "⌘" : "Ctrl"
-      case "shift":
-        return mac ? "⇧" : "Shift"
-      case "alt":
-        return mac ? "⌥" : "Alt"
-      case "escape":
-        return mac ? "⎋" : "Esc"
-      case ",":
-        return ","
-      default:
-        return part.toUpperCase()
-    }
-  })
+  const formatted: string[] = []
+  if (parsed.mod) formatted.push(mac ? "⌘" : "Ctrl")
+  if (parsed.shift) formatted.push(mac ? "⇧" : "Shift")
+  if (parsed.alt) formatted.push(mac ? "⌥" : "Alt")
+
+  switch (parsed.key.toLowerCase()) {
+    case "escape":
+      formatted.push(mac ? "⎋" : "Esc")
+      break
+    case ",":
+      formatted.push(",")
+      break
+    case "+":
+      formatted.push("+")
+      break
+    default:
+      formatted.push(parsed.key.toUpperCase())
+      break
+  }
 
   return mac ? formatted.join("") : formatted.join("+")
 }
 
 /** Keys that are only modifiers and should not be captured as standalone bindings. */
 const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"])
+const SAFE_UNMODIFIED_KEYS = new Set(["escape"])
+
+function isFunctionKey(key: string): boolean {
+  return /^f([1-9]|1[0-2])$/i.test(key)
+}
+
+export function isSafeShortcutBinding(binding: string): boolean {
+  const parsed = parseKeyBinding(binding)
+  if (!parsed.key) {
+    return false
+  }
+
+  if (parsed.mod || parsed.alt) {
+    return true
+  }
+
+  const normalizedKey = parsed.key.toLowerCase()
+  return SAFE_UNMODIFIED_KEYS.has(normalizedKey) || isFunctionKey(normalizedKey)
+}
 
 /**
  * Convert a KeyboardEvent to a normalized binding string (e.g. "mod+shift+f").
- * Returns null for lone modifier presses.
+ * Returns null for lone modifier presses or unsafe bare keys that would hijack normal typing.
  */
 export function keyEventToBinding(event: KeyboardEvent): string | null {
   if (MODIFIER_KEYS.has(event.key)) return null
@@ -262,7 +315,8 @@ export function keyEventToBinding(event: KeyboardEvent): string | null {
   if (event.altKey) parts.push("alt")
   parts.push(event.key.toLowerCase())
 
-  return parts.join("+")
+  const binding = parts.join("+")
+  return isSafeShortcutBinding(binding) ? binding : null
 }
 
 /**
@@ -293,9 +347,27 @@ export function getEffectiveEditorBindings(customBindings: Record<string, string
   const result: Record<string, string> = {}
   for (const id of EDITOR_SHORTCUT_IDS) {
     const binding = getEffectiveKeyBinding(id, customBindings)
-    if (binding && !globalBindings.has(binding)) {
+    if (binding && isSafeShortcutBinding(binding) && !globalBindings.has(binding)) {
       result[id] = binding
     }
   }
   return result
+}
+
+export function resolveShortcutBindingUpdate(
+  customBindings: Record<string, string> = {},
+  actionId: string,
+  binding: string
+): Record<string, string> {
+  const nextBindings = { ...customBindings }
+  const testBindings = { ...customBindings, [actionId]: binding }
+  const conflicts = detectConflicts(testBindings)
+  const conflicting = conflicts.get(binding)?.filter((id) => id !== actionId) ?? []
+
+  for (const conflictId of conflicting) {
+    nextBindings[conflictId] = "none"
+  }
+
+  nextBindings[actionId] = binding
+  return nextBindings
 }

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -29,6 +29,14 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
     global: true,
   },
   {
+    id: "searchInStream",
+    label: "Search in Stream",
+    description: "Search messages in the current stream",
+    defaultKey: "mod+f",
+    category: "navigation",
+    global: true,
+  },
+  {
     id: "openSearch",
     label: "Search",
     description: "Open search",

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -280,6 +280,40 @@ export function formatKeyBinding(binding: string): string {
   return mac ? formatted.join("") : formatted.join("+")
 }
 
+/**
+ * Format a key binding as plain text for hover text and accessibility.
+ * Converts "mod+k" to "cmd+k" on Mac or "ctrl+k" elsewhere.
+ */
+export function formatKeyBindingText(binding: string): string {
+  const mac = isMac()
+  const parsed = parseKeyBinding(binding)
+  if (!parsed.key) {
+    return binding
+  }
+
+  const formatted: string[] = []
+  if (parsed.mod) formatted.push(mac ? "cmd" : "ctrl")
+  if (parsed.shift) formatted.push("shift")
+  if (parsed.alt) formatted.push(mac ? "opt" : "alt")
+
+  switch (parsed.key.toLowerCase()) {
+    case "escape":
+      formatted.push("escape")
+      break
+    case ",":
+      formatted.push(",")
+      break
+    case "+":
+      formatted.push("+")
+      break
+    default:
+      formatted.push(parsed.key.toLowerCase())
+      break
+  }
+
+  return formatted.join("+")
+}
+
 /** Keys that are only modifiers and should not be captured as standalone bindings. */
 const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"])
 const SAFE_UNMODIFIED_KEYS = new Set(["escape"])

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -68,6 +68,42 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
     category: "view",
     global: true,
   },
+  // Editor formatting shortcuts (not global — only active when editor is focused)
+  {
+    id: "formatBold",
+    label: "Bold",
+    description: "Toggle bold formatting",
+    defaultKey: "mod+b",
+    category: "editing",
+  },
+  {
+    id: "formatItalic",
+    label: "Italic",
+    description: "Toggle italic formatting",
+    defaultKey: "mod+i",
+    category: "editing",
+  },
+  {
+    id: "formatStrike",
+    label: "Strikethrough",
+    description: "Toggle strikethrough formatting",
+    defaultKey: "mod+shift+s",
+    category: "editing",
+  },
+  {
+    id: "formatCode",
+    label: "Inline Code",
+    description: "Toggle inline code formatting",
+    defaultKey: "mod+e",
+    category: "editing",
+  },
+  {
+    id: "formatCodeBlock",
+    label: "Code Block",
+    description: "Toggle code block",
+    defaultKey: "mod+shift+c",
+    category: "editing",
+  },
 ]
 
 /**
@@ -96,14 +132,15 @@ export function getShortcutsByCategory(): Record<ShortcutAction["category"], Sho
 
 /**
  * Get the effective key binding for an action, considering user customizations.
+ * Returns undefined if the shortcut is explicitly disabled ("none") or unregistered.
  */
 export function getEffectiveKeyBinding(
   actionId: string,
   customBindings: Record<string, string> = {}
 ): string | undefined {
-  if (customBindings[actionId]) {
-    return customBindings[actionId]
-  }
+  const custom = customBindings[actionId]
+  if (custom === "none") return undefined
+  if (custom) return custom
   return getShortcutAction(actionId)?.defaultKey
 }
 
@@ -115,7 +152,8 @@ export function detectConflicts(customBindings: Record<string, string> = {}): Ma
   const keyToActions = new Map<string, string[]>()
 
   for (const action of SHORTCUT_ACTIONS) {
-    const key = customBindings[action.id] || action.defaultKey
+    const key = getEffectiveKeyBinding(action.id, customBindings)
+    if (!key) continue
     const existing = keyToActions.get(key) || []
     keyToActions.set(key, [...existing, action.id])
   }
@@ -206,4 +244,58 @@ export function formatKeyBinding(binding: string): string {
   })
 
   return mac ? formatted.join("") : formatted.join("+")
+}
+
+/** Keys that are only modifiers and should not be captured as standalone bindings. */
+const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"])
+
+/**
+ * Convert a KeyboardEvent to a normalized binding string (e.g. "mod+shift+f").
+ * Returns null for lone modifier presses.
+ */
+export function keyEventToBinding(event: KeyboardEvent): string | null {
+  if (MODIFIER_KEYS.has(event.key)) return null
+
+  const parts: string[] = []
+  if (event.metaKey || event.ctrlKey) parts.push("mod")
+  if (event.shiftKey) parts.push("shift")
+  if (event.altKey) parts.push("alt")
+  parts.push(event.key.toLowerCase())
+
+  return parts.join("+")
+}
+
+/**
+ * IDs of all editor formatting shortcut actions.
+ */
+export const EDITOR_SHORTCUT_IDS = [
+  "formatBold",
+  "formatItalic",
+  "formatStrike",
+  "formatCode",
+  "formatCodeBlock",
+] as const
+
+/**
+ * Compute effective editor formatting bindings, excluding any that conflict
+ * with a global app-level shortcut (app shortcuts always win).
+ */
+export function getEffectiveEditorBindings(customBindings: Record<string, string> = {}): Record<string, string> {
+  // Collect all global app-level binding values
+  const globalBindings = new Set<string>()
+  for (const action of SHORTCUT_ACTIONS) {
+    if (!action.global) continue
+    const binding = getEffectiveKeyBinding(action.id, customBindings)
+    if (binding) globalBindings.add(binding)
+  }
+
+  // Build editor bindings, excluding any claimed by a global shortcut
+  const result: Record<string, string> = {}
+  for (const id of EDITOR_SHORTCUT_IDS) {
+    const binding = getEffectiveKeyBinding(id, customBindings)
+    if (binding && !globalBindings.has(binding)) {
+      result[id] = binding
+    }
+  }
+  return result
 }

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -61,14 +61,6 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
     global: true,
   },
   {
-    id: "closeModal",
-    label: "Close",
-    description: "Close current modal or popover",
-    defaultKey: "escape",
-    category: "navigation",
-    global: true,
-  },
-  {
     id: "toggleSidebar",
     label: "Toggle Sidebar",
     description: "Show or hide the sidebar",
@@ -324,7 +316,12 @@ export function formatKeyBindingText(binding: string): string {
 
 /** Keys that are only modifiers and should not be captured as standalone bindings. */
 const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"])
-const SAFE_UNMODIFIED_KEYS = new Set(["escape"])
+/**
+ * Keys reserved by the app and never bindable as custom shortcuts.
+ * Escape is hardcoded to cancel/close flows across the app (Radix Dialog, capture UI,
+ * local popovers), so we refuse to capture it as a binding for any action.
+ */
+const RESERVED_KEYS = new Set(["escape"])
 
 function isFunctionKey(key: string): boolean {
   return /^f([1-9]|1[0-2])$/i.test(key)
@@ -336,12 +333,15 @@ export function isSafeShortcutBinding(binding: string): boolean {
     return false
   }
 
+  if (RESERVED_KEYS.has(parsed.key.toLowerCase())) {
+    return false
+  }
+
   if (parsed.mod || parsed.alt) {
     return true
   }
 
-  const normalizedKey = parsed.key.toLowerCase()
-  return SAFE_UNMODIFIED_KEYS.has(normalizedKey) || isFunctionKey(normalizedKey)
+  return isFunctionKey(parsed.key.toLowerCase())
 }
 
 /**

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -62,32 +62,18 @@ import { ApiError } from "@/api/client"
 import { SyncStatusStore, SyncStatusContext } from "@/sync/sync-status"
 
 interface WorkspaceKeyboardHandlerProps {
-  switcherOpen: boolean
   onOpenSwitcher: (mode: QuickSwitcherMode) => void
-  onCloseSwitcher: () => void
   children: ReactNode
 }
 
-function WorkspaceKeyboardHandler({
-  switcherOpen,
-  onOpenSwitcher,
-  onCloseSwitcher,
-  children,
-}: WorkspaceKeyboardHandlerProps) {
-  const { isOpen: settingsOpen, openSettings, closeSettings } = useSettings()
+function WorkspaceKeyboardHandler({ onOpenSwitcher, children }: WorkspaceKeyboardHandlerProps) {
+  const { openSettings } = useSettings()
 
   useKeyboardShortcuts({
     openQuickSwitcher: () => onOpenSwitcher("stream"),
     openSearch: () => onOpenSwitcher("search"),
     openCommands: () => onOpenSwitcher("command"),
     openSettings: () => openSettings(),
-    closeModal: () => {
-      if (settingsOpen) {
-        closeSettings()
-      } else if (switcherOpen) {
-        onCloseSwitcher()
-      }
-    },
   })
 
   return <>{children}</>
@@ -307,10 +293,6 @@ export function WorkspaceLayout() {
     setSwitcherOpen(true)
   }, [])
 
-  const closeSwitcher = useCallback(() => {
-    setSwitcherOpen(false)
-  }, [])
-
   // Single SyncStatusStore instance per workspace — tracks sync state for all resources.
   const syncStatusStore = useMemo(() => new SyncStatusStore(), [workspaceId])
 
@@ -340,11 +322,7 @@ export function WorkspaceLayout() {
                   <WorkspaceEmojiProvider workspaceId={workspaceId}>
                     <PreferencesProvider workspaceId={workspaceId}>
                       <SettingsProvider>
-                        <WorkspaceKeyboardHandler
-                          switcherOpen={switcherOpen}
-                          onOpenSwitcher={openSwitcher}
-                          onCloseSwitcher={closeSwitcher}
-                        >
+                        <WorkspaceKeyboardHandler onOpenSwitcher={openSwitcher}>
                           <QuickSwitcherProvider openSwitcher={openSwitcher}>
                             <PanelProvider>
                               <TraceProvider>


### PR DESCRIPTION
## Summary

- **Customizable keyboard shortcuts**: Users can now rebind all keyboard shortcuts (navigation, view, and editor formatting) from Settings → Keyboard. Bindings persist globally across devices via the existing preferences sync system.
- **Editor conflict resolution**: When a user binds an app-level shortcut to a key previously used by the editor (e.g., `Cmd+B` for sidebar toggle), the editor yields that key — no double-firing. App shortcuts always win over editor formatting shortcuts.
- **Interactive rebinding UI**: Click any shortcut badge to enter capture mode, press a new key combination, and save. Conflicts are detected inline with an "Override" option that clears the conflicting binding. Individual and "Reset all" buttons available.
- **Dynamic toolbar hints**: Editor toolbar tooltips now reflect the user's current bindings instead of showing hardcoded shortcuts.

## Technical approach

- Moved editor formatting shortcuts (`Mod-b`, `Mod-i`, `Mod-Shift-s`, `Mod-e`, `Mod-Shift-c`) from TipTap's static `addKeyboardShortcuts()` to a ProseMirror plugin with `handleKeyDown` that reads bindings from a ref on every keystroke — enables runtime rebinding without editor re-creation.
- Suppressed built-in mark shortcuts in `AtomAwareBold/Italic/Strike/Code` extensions so `EditorBehaviors` owns all formatting shortcuts.
- Added `keyEventToBinding()`, `getEffectiveEditorBindings()`, and `"none"` sentinel support to the shortcut registry.
- Fixed optimistic update in preferences context: `keyboardShortcuts` is now replaced entirely (not merged) since callers provide complete state.

## Files changed

| File | Change |
|---|---|
| `lib/keyboard-shortcuts.ts` | 5 editor formatting actions, `keyEventToBinding`, `getEffectiveEditorBindings`, `"none"` sentinel |
| `editor/editor-behaviors.ts` | Dynamic formatting plugin via ProseMirror `handleKeyDown` |
| `editor/atom-aware-marks.ts` | Suppress base mark extension shortcuts |
| `editor/rich-editor.tsx` | Wire `keyBindingsRef` from preferences |
| `editor/document-editor-modal.tsx` | Same wiring + dynamic shortcut hints |
| `editor/editor-toolbar.tsx` | Dynamic shortcut hints from preferences |
| `contexts/preferences-context.tsx` | `resetKeyboardShortcut`, `resetAllKeyboardShortcuts`, optimistic update fix |
| `settings/keyboard-settings.tsx` | Full rebinding UI replacing "coming soon" card |
| `lib/keyboard-shortcuts.test.ts` | 18 new tests (registry, conflicts, `keyEventToBinding`, `getEffectiveEditorBindings`) |

## Test plan

- [x] `bun run typecheck` passes across all packages
- [x] All 1109 frontend tests pass (including 18 new shortcut tests)
- [x] Lint passes
- [ ] Manual: Settings → Keyboard → click shortcut badge → press new key combo → verify save and cross-device sync
- [ ] Manual: Rebind `Cmd+B` to sidebar toggle → open editor → press `Cmd+B` → sidebar toggles, text does NOT bold
- [ ] Manual: Verify toolbar tooltip shows updated shortcut hint
- [ ] Manual: Reset individual shortcut → verify revert to default
- [ ] Manual: Reset all shortcuts → verify all revert

https://claude.ai/code/session_01WEEQFEFCLLMyD7mPe4AMz3