### PR TITLE
feat(conversations): show conversation panel button in DMs

### DIFF
--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -228,7 +228,7 @@ export function StreamPage() {
               <Search className="h-4 w-4" />
             </Button>
           )}
-          {isChannel && (
+          {(isChannel || isDm) && (
             <Button
               variant="ghost"
               size="icon"
@@ -274,8 +274,8 @@ export function StreamPage() {
     </div>
   )
 
-  // Conversation side panel - only shown for channels
-  const conversationPanel = isChannel && (
+  // Conversation side panel - shown for channels and DMs
+  const conversationPanel = (isChannel || isDm) && (
     <>
       {/* Backdrop */}
       <div


### PR DESCRIPTION
The boundary extraction worker already creates conversations for DM
streams, but the frontend only surfaced the side panel for channels.
Reuse the same toggle/panel for DMs so a 1:1 thread of messages can be
inspected as conversations.