### PR TITLE
fix(sync): self-heal transient stream bootstrap failures on navigation

### DIFF
--- a/apps/frontend/src/hooks/use-coordinated-stream-queries.test.ts
+++ b/apps/frontend/src/hooks/use-coordinated-stream-queries.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
-import { useCoordinatedStreamQueries } from "./use-coordinated-stream-queries"
+import { bootstrapRetry, bootstrapRetryDelay, useCoordinatedStreamQueries } from "./use-coordinated-stream-queries"
 import { QUERY_LOAD_STATE } from "@/lib/query-load-state"
+import { ApiError } from "@/api/client"
 
-const { mockBootstrap, mockJoinRoomBestEffort } = vi.hoisted(() => ({
+const { mockBootstrap, mockJoinRoomBestEffort, mockToCachedStreamBootstrap } = vi.hoisted(() => ({
   mockBootstrap: vi.fn(),
   mockJoinRoomBestEffort: vi.fn(),
+  mockToCachedStreamBootstrap: vi.fn((bootstrap: unknown) => bootstrap),
 }))
 
 vi.mock("@/contexts", () => ({
@@ -30,7 +32,7 @@ vi.mock("@/lib/socket-room", () => ({
 
 vi.mock("@/sync/stream-sync", () => ({
   applyStreamBootstrap: vi.fn(),
-  toCachedStreamBootstrap: (bootstrap: unknown) => bootstrap,
+  toCachedStreamBootstrap: mockToCachedStreamBootstrap,
 }))
 
 function createTestQueryClient() {
@@ -51,6 +53,7 @@ describe("useCoordinatedStreamQueries", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockJoinRoomBestEffort.mockResolvedValue(undefined)
+    mockToCachedStreamBootstrap.mockImplementation((bootstrap: unknown) => bootstrap)
   })
 
   it("should filter out draft IDs and not fetch them", async () => {
@@ -122,9 +125,14 @@ describe("useCoordinatedStreamQueries", () => {
 
   it("should return isError=true when any query fails", async () => {
     const queryClient = createTestQueryClient()
-    mockBootstrap
-      .mockResolvedValueOnce({ stream: { id: "stream_123" }, events: [], membership: null })
-      .mockRejectedValueOnce(new Error("Failed to load"))
+    // Use a terminal (404) error so no retry runs — this test checks error
+    // surfacing, not retry semantics.
+    mockBootstrap.mockImplementation(async (_workspaceId: string, streamId: string) => {
+      if (streamId === "stream_456") {
+        throw new ApiError(404, "STREAM_NOT_FOUND", "Stream not found")
+      }
+      return { stream: { id: streamId }, events: [], membership: null, syncMode: "replace" }
+    })
 
     const { result } = renderHook(() => useCoordinatedStreamQueries("workspace_1", ["stream_123", "stream_456"]), {
       wrapper: createWrapper(queryClient),
@@ -136,6 +144,52 @@ describe("useCoordinatedStreamQueries", () => {
 
     expect(result.current.loadState).toBe(QUERY_LOAD_STATE.READY)
     expect(result.current.errors).toHaveLength(1)
+  })
+
+  it("passes incrementWindowVersionOnReplace=true for syncMode=replace", async () => {
+    const queryClient = createTestQueryClient()
+    const bootstrap = {
+      stream: { id: "stream_123" },
+      events: [],
+      membership: null,
+      syncMode: "replace",
+    }
+    mockBootstrap.mockResolvedValue(bootstrap)
+
+    renderHook(() => useCoordinatedStreamQueries("workspace_1", ["stream_123"]), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockToCachedStreamBootstrap).toHaveBeenCalled()
+    })
+
+    expect(mockToCachedStreamBootstrap).toHaveBeenCalledWith(bootstrap, undefined, {
+      incrementWindowVersionOnReplace: true,
+    })
+  })
+
+  it("passes incrementWindowVersionOnReplace=false for syncMode=append", async () => {
+    const queryClient = createTestQueryClient()
+    const bootstrap = {
+      stream: { id: "stream_123" },
+      events: [],
+      membership: null,
+      syncMode: "append",
+    }
+    mockBootstrap.mockResolvedValue(bootstrap)
+
+    renderHook(() => useCoordinatedStreamQueries("workspace_1", ["stream_123"]), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockToCachedStreamBootstrap).toHaveBeenCalled()
+    })
+
+    expect(mockToCachedStreamBootstrap).toHaveBeenCalledWith(bootstrap, undefined, {
+      incrementWindowVersionOnReplace: false,
+    })
   })
 
   it("should return isLoading=false immediately when streamIds is empty", () => {
@@ -183,5 +237,39 @@ describe("useCoordinatedStreamQueries", () => {
     expect(mockBootstrap).toHaveBeenCalledWith("workspace_1", "stream_123")
     expect(mockBootstrap).toHaveBeenCalledWith("workspace_1", "stream_abc")
     expect(mockBootstrap).not.toHaveBeenCalledWith("workspace_1", "draft:stream_456:msg_789")
+  })
+})
+
+describe("bootstrapRetry", () => {
+  it("retries recoverable errors up to MAX_BOOTSTRAP_RETRIES", () => {
+    const networkError = new Error("network down")
+    expect(bootstrapRetry(0, networkError)).toBe(true)
+    expect(bootstrapRetry(1, networkError)).toBe(true)
+    expect(bootstrapRetry(2, networkError)).toBe(false)
+  })
+
+  it("retries 429 and 5xx API errors", () => {
+    expect(bootstrapRetry(0, new ApiError(429, "RATE_LIMITED", "Slow"))).toBe(true)
+    expect(bootstrapRetry(0, new ApiError(500, "INTERNAL", "Boom"))).toBe(true)
+    expect(bootstrapRetry(0, new ApiError(503, "UNAVAILABLE", "Unavailable"))).toBe(true)
+  })
+
+  it("does not retry terminal 403/404 errors", () => {
+    expect(bootstrapRetry(0, new ApiError(403, "FORBIDDEN", "Forbidden"))).toBe(false)
+    expect(bootstrapRetry(0, new ApiError(404, "NOT_FOUND", "Not found"))).toBe(false)
+  })
+
+  it("does not retry non-recoverable 4xx errors", () => {
+    expect(bootstrapRetry(0, new ApiError(400, "BAD_REQUEST", "Bad request"))).toBe(false)
+    expect(bootstrapRetry(0, new ApiError(401, "UNAUTHORIZED", "Unauthorized"))).toBe(false)
+  })
+})
+
+describe("bootstrapRetryDelay", () => {
+  it("uses exponential backoff capped at the max delay", () => {
+    expect(bootstrapRetryDelay(0)).toBe(500)
+    expect(bootstrapRetryDelay(1)).toBe(1000)
+    expect(bootstrapRetryDelay(2)).toBe(2000)
+    expect(bootstrapRetryDelay(10)).toBe(4000)
   })
 })

--- a/apps/frontend/src/hooks/use-coordinated-stream-queries.test.ts
+++ b/apps/frontend/src/hooks/use-coordinated-stream-queries.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
-import { bootstrapRetry, bootstrapRetryDelay, useCoordinatedStreamQueries } from "./use-coordinated-stream-queries"
+import { useCoordinatedStreamQueries } from "./use-coordinated-stream-queries"
 import { QUERY_LOAD_STATE } from "@/lib/query-load-state"
 import { ApiError } from "@/api/client"
 
@@ -53,7 +53,6 @@ describe("useCoordinatedStreamQueries", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockJoinRoomBestEffort.mockResolvedValue(undefined)
-    mockToCachedStreamBootstrap.mockImplementation((bootstrap: unknown) => bootstrap)
   })
 
   it("should filter out draft IDs and not fetch them", async () => {
@@ -125,8 +124,6 @@ describe("useCoordinatedStreamQueries", () => {
 
   it("should return isError=true when any query fails", async () => {
     const queryClient = createTestQueryClient()
-    // Use a terminal (404) error so no retry runs — this test checks error
-    // surfacing, not retry semantics.
     mockBootstrap.mockImplementation(async (_workspaceId: string, streamId: string) => {
       if (streamId === "stream_456") {
         throw new ApiError(404, "STREAM_NOT_FOUND", "Stream not found")
@@ -237,39 +234,5 @@ describe("useCoordinatedStreamQueries", () => {
     expect(mockBootstrap).toHaveBeenCalledWith("workspace_1", "stream_123")
     expect(mockBootstrap).toHaveBeenCalledWith("workspace_1", "stream_abc")
     expect(mockBootstrap).not.toHaveBeenCalledWith("workspace_1", "draft:stream_456:msg_789")
-  })
-})
-
-describe("bootstrapRetry", () => {
-  it("retries recoverable errors up to MAX_BOOTSTRAP_RETRIES", () => {
-    const networkError = new Error("network down")
-    expect(bootstrapRetry(0, networkError)).toBe(true)
-    expect(bootstrapRetry(1, networkError)).toBe(true)
-    expect(bootstrapRetry(2, networkError)).toBe(false)
-  })
-
-  it("retries 429 and 5xx API errors", () => {
-    expect(bootstrapRetry(0, new ApiError(429, "RATE_LIMITED", "Slow"))).toBe(true)
-    expect(bootstrapRetry(0, new ApiError(500, "INTERNAL", "Boom"))).toBe(true)
-    expect(bootstrapRetry(0, new ApiError(503, "UNAVAILABLE", "Unavailable"))).toBe(true)
-  })
-
-  it("does not retry terminal 403/404 errors", () => {
-    expect(bootstrapRetry(0, new ApiError(403, "FORBIDDEN", "Forbidden"))).toBe(false)
-    expect(bootstrapRetry(0, new ApiError(404, "NOT_FOUND", "Not found"))).toBe(false)
-  })
-
-  it("does not retry non-recoverable 4xx errors", () => {
-    expect(bootstrapRetry(0, new ApiError(400, "BAD_REQUEST", "Bad request"))).toBe(false)
-    expect(bootstrapRetry(0, new ApiError(401, "UNAUTHORIZED", "Unauthorized"))).toBe(false)
-  })
-})
-
-describe("bootstrapRetryDelay", () => {
-  it("uses exponential backoff capped at the max delay", () => {
-    expect(bootstrapRetryDelay(0)).toBe(500)
-    expect(bootstrapRetryDelay(1)).toBe(1000)
-    expect(bootstrapRetryDelay(2)).toBe(2000)
-    expect(bootstrapRetryDelay(10)).toBe(4000)
   })
 })

--- a/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
+++ b/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
@@ -6,6 +6,7 @@ import {
   QUERY_LOAD_STATE,
   getQueryLoadState,
   isQueryLoadStateLoading,
+  isRecoverableBootstrapError,
   isTerminalBootstrapError,
   type QueryLoadState,
 } from "@/lib/query-load-state"
@@ -20,6 +21,31 @@ function isDraftId(id: string): boolean {
 
 async function queryFnWithoutSocket() {
   throw new Error("Socket not available for stream subscription")
+}
+
+/**
+ * Retry configuration for bootstrap queries.
+ *
+ * Transient errors (5xx, 429, network failures) must self-heal — otherwise a
+ * single failed fetch on navigation leaves the stream stuck empty until the
+ * user reloads (INV-53 intent is continuous availability). Terminal 403/404
+ * stays terminal to avoid loops on deleted or forbidden streams, and other
+ * non-recoverable client errors (e.g. 400) also skip retry so we surface the
+ * error immediately rather than hammering the server.
+ */
+const MAX_BOOTSTRAP_RETRIES = 2
+const BOOTSTRAP_RETRY_BASE_DELAY_MS = 500
+const BOOTSTRAP_RETRY_MAX_DELAY_MS = 4000
+
+// Accepts Error (not unknown) so TanStack Query keeps its default `TError = Error`
+// inference — typing as unknown widens the query's error type across consumers.
+export function bootstrapRetry(failureCount: number, error: Error): boolean {
+  if (!isRecoverableBootstrapError(error)) return false
+  return failureCount < MAX_BOOTSTRAP_RETRIES
+}
+
+export function bootstrapRetryDelay(attempt: number): number {
+  return Math.min(BOOTSTRAP_RETRY_BASE_DELAY_MS * 2 ** attempt, BOOTSTRAP_RETRY_MAX_DELAY_MS)
 }
 
 function aggregateQueryLoadState(states: QueryLoadState[]): QueryLoadState {
@@ -81,16 +107,21 @@ export function useCoordinatedStreamQueries(workspaceId: string, streamIds: stri
 
               return toCachedStreamBootstrap(
                 bootstrap,
-                queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId))
+                queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId)),
+                { incrementWindowVersionOnReplace: bootstrap.syncMode === "replace" }
               )
             }
           : queryFnWithoutSocket,
-        // Don't enable queries that have already errored to prevent continuous refetch loops
+        // Don't enable queries that have already errored with a terminal 403/404.
+        // Recoverable errors are handled by `retry` below, not by disabling.
         enabled: !!workspaceId && !!socket && !erroredStreamIds.has(streamId),
         staleTime: Infinity, // Never consider data stale
         gcTime: Infinity, // Never garbage collect
-        // Prevent ALL automatic refetching
-        retry: false,
+        // Retry transient errors (5xx, 429, network) so a single hiccup on
+        // navigation doesn't leave the stream stuck empty. Terminal and other
+        // non-recoverable errors are not retried.
+        retry: bootstrapRetry,
+        retryDelay: bootstrapRetryDelay,
         refetchOnMount: false,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,

--- a/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
+++ b/apps/frontend/src/hooks/use-coordinated-stream-queries.ts
@@ -6,10 +6,10 @@ import {
   QUERY_LOAD_STATE,
   getQueryLoadState,
   isQueryLoadStateLoading,
-  isRecoverableBootstrapError,
   isTerminalBootstrapError,
   type QueryLoadState,
 } from "@/lib/query-load-state"
+import { STREAM_BOOTSTRAP_QUERY_OPTIONS } from "@/lib/stream-bootstrap-query"
 import { joinRoomBestEffort } from "@/lib/socket-room"
 import { applyStreamBootstrap, toCachedStreamBootstrap, type CachedStreamBootstrap } from "@/sync/stream-sync"
 import { streamKeys } from "./use-streams"
@@ -21,31 +21,6 @@ function isDraftId(id: string): boolean {
 
 async function queryFnWithoutSocket() {
   throw new Error("Socket not available for stream subscription")
-}
-
-/**
- * Retry configuration for bootstrap queries.
- *
- * Transient errors (5xx, 429, network failures) must self-heal — otherwise a
- * single failed fetch on navigation leaves the stream stuck empty until the
- * user reloads (INV-53 intent is continuous availability). Terminal 403/404
- * stays terminal to avoid loops on deleted or forbidden streams, and other
- * non-recoverable client errors (e.g. 400) also skip retry so we surface the
- * error immediately rather than hammering the server.
- */
-const MAX_BOOTSTRAP_RETRIES = 2
-const BOOTSTRAP_RETRY_BASE_DELAY_MS = 500
-const BOOTSTRAP_RETRY_MAX_DELAY_MS = 4000
-
-// Accepts Error (not unknown) so TanStack Query keeps its default `TError = Error`
-// inference — typing as unknown widens the query's error type across consumers.
-export function bootstrapRetry(failureCount: number, error: Error): boolean {
-  if (!isRecoverableBootstrapError(error)) return false
-  return failureCount < MAX_BOOTSTRAP_RETRIES
-}
-
-export function bootstrapRetryDelay(attempt: number): number {
-  return Math.min(BOOTSTRAP_RETRY_BASE_DELAY_MS * 2 ** attempt, BOOTSTRAP_RETRY_MAX_DELAY_MS)
 }
 
 function aggregateQueryLoadState(states: QueryLoadState[]): QueryLoadState {
@@ -112,23 +87,10 @@ export function useCoordinatedStreamQueries(workspaceId: string, streamIds: stri
               )
             }
           : queryFnWithoutSocket,
-        // Don't enable queries that have already errored with a terminal 403/404.
-        // Recoverable errors are handled by `retry` below, not by disabling.
+        // Terminal 403/404 errors disable the query to prevent loops; recoverable
+        // errors stay enabled and self-heal via STREAM_BOOTSTRAP_QUERY_OPTIONS.retry.
         enabled: !!workspaceId && !!socket && !erroredStreamIds.has(streamId),
-        staleTime: Infinity, // Never consider data stale
-        gcTime: Infinity, // Never garbage collect
-        // Retry transient errors (5xx, 429, network) so a single hiccup on
-        // navigation doesn't leave the stream stuck empty. Terminal and other
-        // non-recoverable errors are not retried.
-        retry: bootstrapRetry,
-        retryDelay: bootstrapRetryDelay,
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        // Disable structural sharing to avoid issues with the dynamic queries array.
-        // Since we create new query objects when the stream list changes, structural
-        // sharing can cause stale references. Worth the extra re-renders for correctness.
-        structuralSharing: false,
+        ...STREAM_BOOTSTRAP_QUERY_OPTIONS,
       })),
     [serverStreamIds, workspaceId, streamService, socket, erroredStreamIds, queryClient]
   )

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useSocket, useStreamService } from "@/contexts"
 import { debugBootstrap } from "@/lib/bootstrap-debug"
 import { getQueryLoadState, isTerminalBootstrapError } from "@/lib/query-load-state"
+import { bootstrapRetry, bootstrapRetryDelay } from "./use-coordinated-stream-queries"
 import { db } from "@/db"
 import { joinRoomBestEffort } from "@/lib/socket-room"
 import { applyStreamBootstrap, toCachedStreamBootstrap, type CachedStreamBootstrap } from "@/sync/stream-sync"
@@ -98,18 +99,20 @@ export function useStreamBootstrap(workspaceId: string, streamId: string, option
 
       return toCachedStreamBootstrap(
         bootstrap,
-        queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId))
+        queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId)),
+        { incrementWindowVersionOnReplace: bootstrap.syncMode === "replace" }
       )
     },
     // Keep terminal auth/not-found errors disabled to avoid loops.
-    // Non-terminal errors can recover automatically on future attempts.
+    // Non-terminal errors can recover automatically via retry below.
     enabled: (options?.enabled ?? true) && !!workspaceId && !!streamId && !!socket && !hasTerminalError,
     // Match coordinated loading options to share cache correctly and prevent
     // multiple observers from conflicting. Coordinated loading handles initial
     // fetch, and socket events handle updates.
     staleTime: Infinity,
     gcTime: Infinity,
-    retry: false,
+    retry: bootstrapRetry,
+    retryDelay: bootstrapRetryDelay,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useSocket, useStreamService } from "@/contexts"
 import { debugBootstrap } from "@/lib/bootstrap-debug"
 import { getQueryLoadState, isTerminalBootstrapError } from "@/lib/query-load-state"
-import { bootstrapRetry, bootstrapRetryDelay } from "./use-coordinated-stream-queries"
+import { STREAM_BOOTSTRAP_QUERY_OPTIONS } from "@/lib/stream-bootstrap-query"
 import { db } from "@/db"
 import { joinRoomBestEffort } from "@/lib/socket-room"
 import { applyStreamBootstrap, toCachedStreamBootstrap, type CachedStreamBootstrap } from "@/sync/stream-sync"
@@ -103,20 +103,10 @@ export function useStreamBootstrap(workspaceId: string, streamId: string, option
         { incrementWindowVersionOnReplace: bootstrap.syncMode === "replace" }
       )
     },
-    // Keep terminal auth/not-found errors disabled to avoid loops.
-    // Non-terminal errors can recover automatically via retry below.
+    // Terminal 403/404 disables the query to prevent loops; recoverable errors
+    // self-heal via STREAM_BOOTSTRAP_QUERY_OPTIONS.retry.
     enabled: (options?.enabled ?? true) && !!workspaceId && !!streamId && !!socket && !hasTerminalError,
-    // Match coordinated loading options to share cache correctly and prevent
-    // multiple observers from conflicting. Coordinated loading handles initial
-    // fetch, and socket events handle updates.
-    staleTime: Infinity,
-    gcTime: Infinity,
-    retry: bootstrapRetry,
-    retryDelay: bootstrapRetryDelay,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-    structuralSharing: false,
+    ...STREAM_BOOTSTRAP_QUERY_OPTIONS,
   })
 
   const loadState = getQueryLoadState(query.status, query.fetchStatus)

--- a/apps/frontend/src/lib/stream-bootstrap-query.test.ts
+++ b/apps/frontend/src/lib/stream-bootstrap-query.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { ApiError } from "@/api/client"
+import { bootstrapRetry, bootstrapRetryDelay } from "./stream-bootstrap-query"
+
+describe("bootstrapRetry", () => {
+  it("retries recoverable errors up to MAX_BOOTSTRAP_RETRIES", () => {
+    const networkError = new Error("network down")
+    expect(bootstrapRetry(0, networkError)).toBe(true)
+    expect(bootstrapRetry(1, networkError)).toBe(true)
+    expect(bootstrapRetry(2, networkError)).toBe(false)
+  })
+
+  it("retries 429 and 5xx API errors", () => {
+    expect(bootstrapRetry(0, new ApiError(429, "RATE_LIMITED", "Slow"))).toBe(true)
+    expect(bootstrapRetry(0, new ApiError(500, "INTERNAL", "Boom"))).toBe(true)
+    expect(bootstrapRetry(0, new ApiError(503, "UNAVAILABLE", "Unavailable"))).toBe(true)
+  })
+
+  it("does not retry terminal 403/404 errors", () => {
+    expect(bootstrapRetry(0, new ApiError(403, "FORBIDDEN", "Forbidden"))).toBe(false)
+    expect(bootstrapRetry(0, new ApiError(404, "NOT_FOUND", "Not found"))).toBe(false)
+  })
+
+  it("does not retry non-recoverable 4xx errors", () => {
+    expect(bootstrapRetry(0, new ApiError(400, "BAD_REQUEST", "Bad request"))).toBe(false)
+    expect(bootstrapRetry(0, new ApiError(401, "UNAUTHORIZED", "Unauthorized"))).toBe(false)
+  })
+})
+
+describe("bootstrapRetryDelay", () => {
+  it("uses exponential backoff capped at the max delay", () => {
+    expect(bootstrapRetryDelay(0)).toBe(500)
+    expect(bootstrapRetryDelay(1)).toBe(1000)
+    expect(bootstrapRetryDelay(2)).toBe(2000)
+    expect(bootstrapRetryDelay(10)).toBe(4000)
+  })
+})

--- a/apps/frontend/src/lib/stream-bootstrap-query.ts
+++ b/apps/frontend/src/lib/stream-bootstrap-query.ts
@@ -1,0 +1,47 @@
+import { isRecoverableBootstrapError } from "./query-load-state"
+
+/**
+ * Retry configuration for stream bootstrap queries.
+ *
+ * Transient errors (5xx, 429, network failures) must self-heal — otherwise a
+ * single failed fetch on navigation leaves the stream stuck empty until the
+ * user reloads (INV-53 intent is continuous availability). Terminal 403/404
+ * stays terminal to avoid loops on deleted or forbidden streams, and other
+ * non-recoverable client errors (e.g. 400) also skip retry so we surface the
+ * error immediately rather than hammering the server.
+ */
+const MAX_BOOTSTRAP_RETRIES = 2
+const BOOTSTRAP_RETRY_BASE_DELAY_MS = 500
+const BOOTSTRAP_RETRY_MAX_DELAY_MS = 4000
+
+export function bootstrapRetry(failureCount: number, error: Error): boolean {
+  if (!isRecoverableBootstrapError(error)) return false
+  return failureCount < MAX_BOOTSTRAP_RETRIES
+}
+
+export function bootstrapRetryDelay(attempt: number): number {
+  return Math.min(BOOTSTRAP_RETRY_BASE_DELAY_MS * 2 ** attempt, BOOTSTRAP_RETRY_MAX_DELAY_MS)
+}
+
+/**
+ * Shared React Query options for stream bootstrap queries.
+ *
+ * `useCoordinatedStreamQueries` (via `useQueries`) and `useStreamBootstrap`
+ * (via `useQuery`) share the same query key — keeping their options aligned
+ * prevents observer thrash when they co-mount (divergent options on the same
+ * key cause refetch loops).
+ *
+ * `structuralSharing: false` because `useQueries` creates new query objects
+ * when the stream list changes; structural sharing can retain stale references
+ * across rebuilds.
+ */
+export const STREAM_BOOTSTRAP_QUERY_OPTIONS = {
+  staleTime: Infinity,
+  gcTime: Infinity,
+  retry: bootstrapRetry,
+  retryDelay: bootstrapRetryDelay,
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  structuralSharing: false,
+} as const


### PR DESCRIPTION
## Problem

Reported symptom: navigate to a stream → nothing loads → wait a few seconds → page refresh fixes it. No top‑bar loading indicator, no error UI, just an empty stream.

Two latent issues in the post‑#340 bootstrap path made this possible:

**1. Per-stream bootstrap had no retry path for transient errors.**
`useCoordinatedStreamQueries` and `useStreamBootstrap` were configured with `retry: false` + every refetch flag disabled (`refetchOnMount: false`, `refetchOnWindowFocus: false`, `refetchOnReconnect: false`, `staleTime: Infinity`). Only terminal 403/404 errors were classified — any other failure (5xx, 429, transient network blip) put the query into `error` state with no automatic recovery. Recovery required either a full socket disconnect/reconnect cycle, an offline→online flap, pull‑to‑refresh, or a page reload. Worse, when workspace bootstrap had primed a stream record, `shouldSuppressBootstrapError` suppressed the error in `CoordinatedLoadingProvider`, so the user saw an empty stream rather than an error — exactly the reported symptom.

**2. `incrementWindowVersionOnReplace` was inconsistent across observers on the same query key.**
`SyncEngine.bootstrapWorkspace` correctly passes `{ incrementWindowVersionOnReplace: streamBootstrap.syncMode === "replace" }` when it writes via `setQueryData` on reconnect (`apps/frontend/src/sync/sync-engine.ts:288-294`). The two query observers that share the same key — `useCoordinatedStreamQueries` and `useStreamBootstrap` — did not. So a `syncMode=replace` response from a refetch (e.g. pull-to-refresh, where no `?after` cursor is sent) wouldn't bump `windowVersion`, and `useEvents`'s floor ratchet wouldn't reset to the fresh server window. A latent bug rather than the cause of the reported symptom, but worth fixing while in the area.

## Solution

**Self-heal transient errors.** Add `bootstrapRetry` / `bootstrapRetryDelay` helpers that retry recoverable errors (429 / 5xx / network) up to twice with exponential backoff capped at 4s, while still skipping retries for terminal 403/404 and other non-recoverable 4xx errors. Wire both observer hooks to use them.

**Align windowVersion.** Both observer hooks now pass `{ incrementWindowVersionOnReplace: bootstrap.syncMode === "replace" }` to `toCachedStreamBootstrap`, matching the SyncEngine reconnect path.

**Deduplicate shared query options.** Both hooks share the same query key — divergent options on the same key cause observer thrash. Extract the 8 identical options (`staleTime`, `gcTime`, `retry`, `retryDelay`, the three `refetchOn*` flags, `structuralSharing`) plus the retry helpers into a new `apps/frontend/src/lib/stream-bootstrap-query.ts` so they can't drift.

### Key design decisions

**1. Retry only recoverable errors, not everything.**
Reusing the existing `isRecoverableBootstrapError` classification (lib/query-load-state.ts) keeps the policy aligned with how errors are surfaced elsewhere. Terminal 403/404 stays terminal (no loops on deleted/forbidden streams). Non-recoverable 4xx (e.g. 400) also skips retry to surface programmer errors immediately rather than hammering the server.

**2. Two retries, max ~3.5s of total backoff (500 + 1000 + 2000 ms).**
Long enough to ride out a single regional blip or backend cold start, short enough that the user notices recovery rather than giving up first. Capped at 4s per attempt so we never blow past a reasonable timeout if more retries were ever added.

**3. Type `bootstrapRetry`'s `error` parameter as `Error`, not `unknown`.**
TanStack Query's `useQuery` infers `TError` from the `retry` function signature. Using `unknown` widens the inferred error type across consumers (caused 3 unrelated typecheck breakages — `stream-panel.tsx`, `use-events.ts`, `use-stream-or-draft.ts`). `Error` keeps the default `TError = Error` inference; `isRecoverableBootstrapError` accepts `unknown`, so `Error` flows through fine.

**4. Shared `STREAM_BOOTSTRAP_QUERY_OPTIONS` constant rather than a hook factory.**
Both hooks need exactly the same 8 options; a plain `as const` object that gets spread into each hook's options is the smallest expression of "these must stay aligned", and it's a static value with stable references that React Query observers see as identical config.

## New files

| File                                                | Purpose                                                                                       |
| --------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| `apps/frontend/src/lib/stream-bootstrap-query.ts`   | `bootstrapRetry`, `bootstrapRetryDelay`, and `STREAM_BOOTSTRAP_QUERY_OPTIONS` shared by both stream-bootstrap query observers |
| `apps/frontend/src/lib/stream-bootstrap-query.test.ts` | Unit tests for retry classification and exponential backoff cap                            |

## Modified files

| File                                                       | Change                                                                                                |
| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| `apps/frontend/src/hooks/use-coordinated-stream-queries.ts` | Spread `STREAM_BOOTSTRAP_QUERY_OPTIONS` into per-stream query options; pass `incrementWindowVersionOnReplace` to `toCachedStreamBootstrap` |
| `apps/frontend/src/hooks/use-streams.ts`                   | Same shared options spread + same `incrementWindowVersionOnReplace` fix in `useStreamBootstrap`     |
| `apps/frontend/src/hooks/use-coordinated-stream-queries.test.ts` | Add tests asserting `incrementWindowVersionOnReplace` propagation for `replace` and `append` syncModes; update the existing error-surfacing test to use a terminal 404 (so it doesn't wait on retries) |

## Test plan

- [x] `bun run test` — full frontend suite passes (1147 tests, 0 failures)
- [x] `bun run typecheck` — clean across the whole monorepo (ran via pre-commit hook)
- [x] Unit tests for `bootstrapRetry` cover: recoverable network, 429, 5xx, terminal 403/404, non-recoverable 4xx, and retry exhaustion
- [x] Unit tests for `bootstrapRetryDelay` cover the exponential cap
- [x] Integration tests confirm `toCachedStreamBootstrap` is called with the correct `incrementWindowVersionOnReplace` for both `replace` and `append`
- [ ] Manual smoke: reproduce the original symptom by simulating a transient 503 (e.g. `Network` panel "Block request URL" on `/bootstrap` for one navigation, then unblock) and verify the stream now self-heals within a few seconds instead of staying empty

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_