### PR TITLE
fix: recover mobile composer after refresh

### DIFF
--- a/.claude/plans/mobile-composer-refresh-fix.md
+++ b/.claude/plans/mobile-composer-refresh-fix.md
@@ -1,0 +1,73 @@
+# Mobile Composer Refresh Fix
+
+## Goal
+
+Prevent the mobile stream composer from disappearing after soft restarts such as page refreshes or reloads after a deploy, while also fixing the browser-test regression currently failing on `main`.
+
+## What Was Built
+
+### Pending Message Startup Recovery
+
+Startup hydration in the pending-messages provider now treats persisted unsent-message edit state as transient UI state instead of durable app state. If IndexedDB still contains a pending message marked as `"editing"` after a refresh, the provider restores it to its pre-edit queue status (`pending` or `failed`) and clears the edit hold instead of reopening the edit surface.
+
+For restored `pending` messages, startup also nudges the background queue so those messages continue draining instead of getting stranded until the next reconnect.
+
+**Files:**
+- `apps/frontend/src/contexts/pending-messages-context.tsx` — normalize stale `"editing"` rows during hydration, persist `preEditStatus` when entering edit mode, and kick the queue after restoring pending messages
+- `apps/frontend/src/db/database.ts` — add `preEditStatus` to the persisted pending-message shape
+
+### Regression Coverage
+
+Added unit coverage for the new hydration behavior so stale edit sessions do not silently reappear in future changes.
+
+**Files:**
+- `apps/frontend/src/contexts/pending-messages-context.test.tsx` — verifies startup restores stale edits to `pending` or `failed`, and that restored pending messages trigger queue processing
+
+### CI Browser Test Repair
+
+Scoped the failing browser assertion to timeline message rows so it no longer matches both the main message body and the sidebar preview text.
+
+**Files:**
+- `tests/browser/new-channel-socket-subscription.spec.ts` — scope the send assertion to `.message-item`
+
+## Design Decisions
+
+### Persist The Pre-Edit Queue State
+
+**Chose:** Store `preEditStatus` on pending messages while they are being edited.
+**Why:** Startup recovery needs to know whether a stale edit should return to `pending` or `failed`; defaulting everything to `pending` would incorrectly requeue failed sends.
+**Alternatives considered:** Infer from the event table alone during startup. That does not work once both the event and pending record have already been flipped to `"editing"`.
+
+### Do Not Reopen Unsent Edit UI Across Reloads
+
+**Chose:** Treat unsent-message edit mode as transient and cancel it on startup.
+**Why:** The bug is caused by stale edit UI state surviving a restart and hiding the composer again on mobile. Reopening the edit surface preserves the bug class instead of removing it.
+**Alternatives considered:** Continue restoring `"editing"` and rely on DOM-driven hiding. That still remounts the hidden-composer path during reloads.
+
+### Kick The Queue After Startup Recovery
+
+**Chose:** Schedule a deferred queue notify after restoring stale edits to `pending`.
+**Why:** If hydration runs after the queue’s initial startup drain, restored pending messages would otherwise sit idle until another reconnect or manual send.
+**Alternatives considered:** Depend on the initial queue connect effect. That ordering is not reliable enough during startup.
+
+## Design Evolution
+
+- **Startup recovery widened slightly during self-review:** initial implementation restored stale `"editing"` rows to `pending`/`failed`, but self-review found that restored `pending` rows might not resume sending unless the queue was explicitly nudged. The final version schedules a queue notify after hydration.
+
+## Schema Changes
+
+- No migration required. This changes the IndexedDB cache shape only by adding `preEditStatus` to `PendingMessage`.
+
+## What's NOT Included
+
+- No new browser-level mobile reload regression test yet; coverage is currently at the provider/unit level plus the targeted browser fix for the failing CI selector.
+- No changes to the CSS `:has()` composer-hiding rule from PR #346.
+- No changes to sent-message inline-edit behavior; this patch only changes unsent pending-message recovery on startup.
+
+## Status
+
+- [x] Restore stale unsent edit state to `pending` or `failed` on startup
+- [x] Resume queue processing for restored pending messages
+- [x] Fix the current `new-channel-socket-subscription` browser-test failure
+- [x] Add unit regression coverage for the hydration path
+- [ ] Add a full browser/mobile reload regression test for stale unsent edit state

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
+import { renderHook, act, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { PendingMessagesProvider, usePendingMessages } from "./pending-messages-context"
 
@@ -10,6 +10,9 @@ const mockEventsGet = vi.fn()
 const mockEventsUpdate = vi.fn().mockResolvedValue(1)
 const mockEventsPut = vi.fn().mockResolvedValue(undefined)
 const mockEventsDelete = vi.fn().mockResolvedValue(undefined)
+let mockHydratedPendingIds: string[] = []
+let mockHydratedFailedIds: string[] = []
+let mockHydratedEditingIds: string[] = []
 
 vi.mock("@/db", () => ({
   db: {
@@ -23,6 +26,17 @@ vi.mock("@/db", () => ({
       update: (...args: unknown[]) => mockEventsUpdate(...args),
       put: (...args: unknown[]) => mockEventsPut(...args),
       delete: (...args: unknown[]) => mockEventsDelete(...args),
+      where: (field: string) => ({
+        equals: (value: string) => ({
+          primaryKeys: () => {
+            if (field !== "_status") return Promise.resolve([])
+            if (value === "pending") return Promise.resolve(mockHydratedPendingIds)
+            if (value === "failed") return Promise.resolve(mockHydratedFailedIds)
+            if (value === "editing") return Promise.resolve(mockHydratedEditingIds)
+            return Promise.resolve([])
+          },
+        }),
+      }),
     },
     // Dexie transaction — execute the callback immediately for tests
     transaction: (_mode: string, ..._tables: unknown[]) => {
@@ -39,6 +53,9 @@ function wrapper({ children }: { children: ReactNode }) {
 describe("PendingMessagesContext", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockHydratedPendingIds = []
+    mockHydratedFailedIds = []
+    mockHydratedEditingIds = []
   })
 
   describe("retryMessage", () => {
@@ -93,7 +110,7 @@ describe("PendingMessagesContext", () => {
         await result.current.markEditing("temp_edit")
       })
 
-      expect(mockUpdate).toHaveBeenCalledWith("temp_edit", { status: "editing" })
+      expect(mockUpdate).toHaveBeenCalledWith("temp_edit", { status: "editing", preEditStatus: "pending" })
       expect(mockEventsUpdate).toHaveBeenCalledWith("temp_edit", { _status: "editing" })
       expect(result.current.getStatus("temp_edit")).toBe("editing")
     })
@@ -172,6 +189,80 @@ describe("PendingMessagesContext", () => {
     })
   })
 
+  describe("startup hydration", () => {
+    it("restores persisted editing messages to pending instead of reopening edit mode", async () => {
+      mockHydratedEditingIds = ["temp_restore_pending"]
+      mockGet.mockResolvedValue({
+        clientId: "temp_restore_pending",
+        status: "editing",
+        preEditStatus: "pending",
+      })
+
+      const { result } = renderHook(() => usePendingMessages(), { wrapper })
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith("temp_restore_pending", {
+          status: undefined,
+          preEditStatus: undefined,
+        })
+      })
+
+      expect(mockEventsUpdate).toHaveBeenCalledWith("temp_restore_pending", { _status: "pending" })
+      expect(result.current.getStatus("temp_restore_pending")).toBe("pending")
+    })
+
+    it("kicks the queue when startup hydration restores a pending message", async () => {
+      vi.useFakeTimers()
+      try {
+        mockHydratedEditingIds = ["temp_restore_notify"]
+        mockGet.mockResolvedValue({
+          clientId: "temp_restore_notify",
+          status: "editing",
+          preEditStatus: "pending",
+        })
+
+        const { result } = renderHook(() => usePendingMessages(), { wrapper })
+        const notifyQueue = vi.fn()
+        act(() => {
+          result.current.registerQueueNotify(notifyQueue)
+        })
+
+        await act(async () => {
+          await vi.runAllTimersAsync()
+        })
+
+        expect(mockUpdate).toHaveBeenCalledWith("temp_restore_notify", {
+          status: undefined,
+          preEditStatus: undefined,
+        })
+        expect(notifyQueue).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it("restores persisted editing messages to failed when they were editing a failed send", async () => {
+      mockHydratedEditingIds = ["temp_restore_failed"]
+      mockGet.mockResolvedValue({
+        clientId: "temp_restore_failed",
+        status: "editing",
+        preEditStatus: "failed",
+      })
+
+      const { result } = renderHook(() => usePendingMessages(), { wrapper })
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith("temp_restore_failed", {
+          status: undefined,
+          preEditStatus: undefined,
+        })
+      })
+
+      expect(mockEventsUpdate).toHaveBeenCalledWith("temp_restore_failed", { _status: "failed" })
+      expect(result.current.getStatus("temp_restore_failed")).toBe("failed")
+    })
+  })
+
   describe("saveEditedMessage", () => {
     it("should update content and return to pending status", async () => {
       mockGet.mockResolvedValue({ clientId: "temp_save", retryCount: 0, content: "old" })
@@ -201,6 +292,7 @@ describe("PendingMessagesContext", () => {
         "temp_save",
         expect.objectContaining({
           status: undefined,
+          preEditStatus: undefined,
           retryCount: 0,
           retryAfter: 0,
         })

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -41,10 +41,12 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
   const [editingIds, setEditingIds] = useState<Map<string, PreEditStatus>>(new Map())
   const queueNotifyRef = useRef<(() => void) | null>(null)
 
-  // Hydrate pending/failed/editing state from IDB on mount so it survives page reload.
-  // The _status field on CachedEvent is the durable source of truth.
-  // For editing messages we can't recover the pre-edit status from IDB, so we
-  // default to "pending" — on cancel the message will be re-queued immediately.
+  // Hydrate pending/failed state from IDB on mount so it survives page reload.
+  // Editing is intentionally NOT restored across reloads: if the app refreshes
+  // or hot-reloads while an unsent-message edit drawer is open, reopening that
+  // transient UI on startup hides the main composer again on mobile. Instead we
+  // normalize persisted "editing" rows back to their pre-edit queue status and
+  // let the user explicitly re-enter edit mode if needed.
   useEffect(() => {
     void (async () => {
       try {
@@ -54,9 +56,38 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
         if (pending.length > 0) setPendingIds(new Set(pending as string[]))
         if (failed.length > 0) setFailedIds(new Set(failed as string[]))
         if (editing.length > 0) {
-          const map = new Map<string, PreEditStatus>()
-          for (const id of editing) map.set(id as string, "pending")
-          setEditingIds(map)
+          const restoredPendingIds = new Set<string>()
+          const restoredFailedIds = new Set<string>()
+
+          await db.transaction("rw", db.pendingMessages, db.events, async () => {
+            for (const rawId of editing) {
+              const id = rawId as string
+              const pendingMessage = await db.pendingMessages.get(id)
+              const preEditStatus = pendingMessage?.preEditStatus ?? "pending"
+
+              type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
+              await (db.pendingMessages.update as unknown as UpdateFn)(id, {
+                status: undefined,
+                preEditStatus: undefined,
+              })
+              await db.events.update(id, { _status: preEditStatus })
+
+              if (preEditStatus === "failed") {
+                restoredFailedIds.add(id)
+              } else {
+                restoredPendingIds.add(id)
+              }
+            }
+          })
+
+          setPendingIds((prev) => new Set([...prev, ...restoredPendingIds]))
+          setFailedIds((prev) => new Set([...prev, ...restoredFailedIds]))
+          setEditingIds(new Map())
+          if (restoredPendingIds.size > 0) {
+            // Defer until after descendants mount so useMessageQueue has time
+            // to register its notify callback during the same startup commit.
+            setTimeout(() => queueNotifyRef.current?.(), 0)
+          }
         }
       } catch {
         // Best-effort — works in browser, may fail in test environment mocks
@@ -148,7 +179,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
       const status: PreEditStatus = event?._status === "failed" ? "failed" : "pending"
 
       type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-      await (db.pendingMessages.update as unknown as UpdateFn)(id, { status: "editing" })
+      await (db.pendingMessages.update as unknown as UpdateFn)(id, { status: "editing", preEditStatus: status })
       await db.events.update(id, { _status: "editing" })
       return status
     })
@@ -179,6 +210,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
           content: contentMarkdown,
           contentJson,
           status: undefined, // clear editing hold
+          preEditStatus: undefined,
           retryCount: 0,
           retryAfter: 0,
         })
@@ -220,7 +252,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
         if (!existing) return false
 
         type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-        await (db.pendingMessages.update as unknown as UpdateFn)(id, { status: undefined })
+        await (db.pendingMessages.update as unknown as UpdateFn)(id, { status: undefined, preEditStatus: undefined })
         await db.events.update(id, { _status: preEditStatus })
         return true
       })

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -168,6 +168,8 @@ export interface PendingMessage {
   retryAfter?: number
   /** When "editing", the queue skips this message so it isn't sent while the user edits it */
   status?: "editing"
+  /** Original queue state before entering editing mode; used to cancel stale edits on startup. */
+  preEditStatus?: "pending" | "failed"
   /** When set, the queue creates this stream before sending the message */
   streamCreation?: PendingStreamCreation
   /** The draft ID to clean up after successful stream creation + message send */

--- a/tests/browser/new-channel-socket-subscription.spec.ts
+++ b/tests/browser/new-channel-socket-subscription.spec.ts
@@ -128,7 +128,9 @@ test.describe("New Channel Socket Subscription", () => {
       await userB.page.locator("[contenteditable='true']").click()
       await userB.page.keyboard.type(testMessage)
       await userB.page.getByRole("button", { name: "Send" }).click()
-      await expect(userB.page.getByRole("main").getByText(testMessage)).toBeVisible({ timeout: 10000 })
+      await expect(userB.page.getByRole("main").locator(".message-item").getByText(testMessage).first()).toBeVisible({
+        timeout: 10000,
+      })
 
       // ──── User A: Channel should remain accessible without refresh ────
 


### PR DESCRIPTION
## Problem

On mobile, the stream composer could disappear after soft restarts like a browser refresh or a reload after a new deploy. PR #346 removed the old ref-counted hide state, but unsent messages could still persist an `editing` status in IndexedDB and remount the hidden-composer path on startup. In parallel, `main` also picked up a browser-test failure where `new-channel-socket-subscription.spec.ts` matched both the timeline message and the sidebar preview text.

## Solution

Treat unsent edit mode as transient UI state during startup recovery. If hydration finds a pending message still marked as `editing`, restore it to its pre-edit queue state (`pending` or `failed`) and clear the edit hold instead of reopening edit mode on page load. For restored pending messages, kick the queue after hydration so they keep draining instead of waiting for a later reconnect.

I also tightened the brittle browser assertion so the failing CI spec only matches timeline message rows.

### How it works

1. `markEditing()` now persists the message's pre-edit queue status on the pending message record.
2. Startup hydration scans for stale event rows with `_status = "editing"`.
3. Each stale row is normalized back to `pending` or `failed`, the pending-message edit hold is cleared, and the React editing map stays empty.
4. If any row was restored to `pending`, a deferred queue notify runs after descendants mount so `useMessageQueue` can resume sending.

### Key design decisions

**1. Persist the pre-edit queue state**

Startup recovery needs to know whether a stale edit should return to `pending` or `failed`. Reading the event row alone is not enough once both records have already been flipped to `editing`.

**2. Do not restore unsent edit UI across reloads**

The bug is specifically caused by transient edit UI state surviving a restart. Reopening that UI during hydration preserves the same hidden-composer failure mode, so startup now cancels stale edit sessions instead.

**3. Nudge the queue after startup recovery**

Self-review found one follow-on gap in the first version of the fix: restored pending messages could remain idle if hydration completed after the queue's initial startup drain. The final patch schedules a deferred queue notify to close that ordering hole.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/mobile-composer-refresh-fix.md` | Synced plan describing the runtime fix, test repair, and remaining scope |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/contexts/pending-messages-context.tsx` | Normalize stale unsent edit state on startup, persist `preEditStatus`, and resume the queue after recovery |
| `apps/frontend/src/contexts/pending-messages-context.test.tsx` | Add startup-hydration regressions for pending/failed restoration and queue resumption |
| `apps/frontend/src/db/database.ts` | Extend `PendingMessage` with `preEditStatus` |
| `tests/browser/new-channel-socket-subscription.spec.ts` | Scope the assertion to timeline rows so it no longer collides with the sidebar preview |

## Test plan

- [x] `bunx vitest run src/contexts/pending-messages-context.test.tsx src/index.css.test.ts` (from `apps/frontend`)
- [x] `bunx tsc -p apps/frontend --noEmit`
- [x] `bunx playwright test tests/browser/new-channel-socket-subscription.spec.ts --grep "should make remote channel messages visible without a full page refresh"`
- [ ] Manual mobile verification on refresh/reload with a previously edited unsent message

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
