### PR TITLE
fix(sync): refresh on page resume with zombie-socket detection

### DIFF
--- a/.claude/plans/gleaming-inventing-deer.md
+++ b/.claude/plans/gleaming-inventing-deer.md
@@ -1,0 +1,161 @@
+# Plan: stale messages on app resume from background
+
+## Context
+
+PR #350 fixed transient HTTP errors during stream bootstrap on navigation. A separate failure mode exists for mobile/desktop tab resume:
+
+A user backgrounded the app on their phone, sent messages from another device into a stream they were viewing, then returned to the app and saw stale data. No bootstrap fired on resume because none of the existing resume signals matched the scenario:
+
+- `socket.io` reconnect didn't fire — the WebSocket was likely a zombie (mobile OS killed the underlying transport but the client thinks it's alive). socket.io's native pingTimeout takes 20–25s to detect this.
+- `navigator.onLine` didn't flap — the phone never lost network, only the app was suspended.
+- Nothing else in the codebase reacts to `visibilitychange`.
+
+The intended outcome: when the page becomes visible after being hidden long enough to suggest real backgrounding, the app should proactively (a) verify the socket is actually alive, (b) force a reconnect if it's a zombie, and (c) refetch any state that may have drifted while we couldn't receive socket events.
+
+## Design
+
+Two coordinated additions:
+
+1. **Visibility-resume trigger** — react to `visibilitychange` going hidden→visible after ≥10s hidden, and call into the SyncEngine.
+2. **Active socket health probe** — on resume, send a lightweight ack-bearing event with a 3s timeout. If the ack doesn't come back, the socket is a zombie; force `socket.disconnect()` + `socket.connect()` to short-circuit socket.io's 20–25s native detection. If the ack succeeds, just call the existing `refreshAfterConnectivityResume()` since events may have been missed during background.
+
+Reuses existing infrastructure throughout — no new singleflight, no new sync orchestration. The 10s threshold avoids spurious refetches from quick app-switcher previews and notification-shade glances.
+
+## Files to add
+
+### `apps/backend/src/socket.ts`
+
+Add a `'health:ping'` handler near the existing `heartbeat` handler (~line 366). One line:
+
+```ts
+socket.on("health:ping", (callback?: (result: { ok: true }) => void) => {
+  callback?.({ ok: true })
+})
+```
+
+Naming: `health:ping` (not bare `ping`) keeps grep hits separate from socket.io's transport-level ping that shows up in logs. No throttling, no auth check beyond connection-level — purely a liveness probe.
+
+### `apps/frontend/src/lib/socket-health.ts` (new)
+
+```ts
+export async function pingSocket(socket: Socket, timeoutMs?: number): Promise<boolean>
+```
+
+Emits `'health:ping'` with an ack callback, returns `true` on ack within `timeoutMs` (default 3000), `false` on timeout or socket disconnect during the probe. No throw — boolean return so call sites stay flat.
+
+### `apps/frontend/src/lib/socket-health.test.ts` (new)
+
+Cases:
+- Returns `true` when the ack fires before timeout.
+- Returns `false` when the ack does not fire before timeout.
+- Returns `false` when the socket disconnects mid-probe.
+- Cleans up the disconnect listener on settle (no leaked handlers).
+
+Use a stub `Socket` (vi.fn-driven `emit`/`on`/`off`) — no live socket.io needed.
+
+### `apps/frontend/src/hooks/use-page-resume.ts` (new)
+
+```ts
+export function usePageResume(onResume: () => void, hiddenThresholdMs?: number): void
+```
+
+- Listens to `visibilitychange` on `document`.
+- On `hidden`: records `hiddenSinceRef.current = Date.now()`.
+- On `visible`: if `hiddenSinceRef.current` is set and `Date.now() - hiddenSinceRef.current >= HIDDEN_THRESHOLD_MS` (default 10_000), invokes `onResume()`. Clears the timestamp either way.
+- Stores `onResume` in a ref so consumers don't need to memoize.
+- Cleans up listeners on unmount.
+
+Pattern: same shape as the transition-tracking ref in `apps/frontend/src/contexts/socket-context.tsx:163-185`, but pulled into a dedicated hook because the semantics (hidden-for-≥N-ms then visible again) are distinct from the socket heartbeat's "any visibility/focus transition fires immediately."
+
+### `apps/frontend/src/hooks/use-page-resume.test.ts` (new)
+
+Use the established Vitest pattern from `apps/frontend/src/hooks/use-auto-mark-as-read.test.ts:54-130`:
+
+```ts
+Object.defineProperty(document, "visibilityState", { configurable: true, get: () => visibilityState })
+visibilityState = "hidden"; document.dispatchEvent(new Event("visibilitychange"))
+```
+
+Cases:
+- Short hide (< threshold) does not fire `onResume`.
+- Long hide (>= threshold) fires `onResume` exactly once.
+- Multiple hide/visible cycles each evaluate independently.
+- Becomes-visible without prior hide does not fire.
+- Updates to the `onResume` callback are honored (ref refresh).
+
+### `apps/frontend/src/sync/sync-engine.test.ts` (new)
+
+This file doesn't exist yet — `SyncEngine`'s coverage so far has been via `workspace-sync.test.ts` integration tests. Create it focused on the new method to keep the surface tight.
+
+Cases for `handlePageResume`:
+- Early-returns when `isDestroyed`, when no `socket`, when `!hasEverConnected`, when `socket.connected === false`.
+- On successful ping, calls `refreshAfterConnectivityResume()` (assert via spy on `runBootstrap` or by asserting bootstrap fires).
+- On failed ping, calls `socket.disconnect()` and then `socket.connect()`, and does NOT call `refreshAfterConnectivityResume()` (the natural `onConnect(isReconnect=true)` cycle will handle it).
+- Two rapid `handlePageResume` calls do not double-bootstrap (the existing `runBootstrap` singleflight covers this).
+
+## Files to modify
+
+### `apps/frontend/src/sync/sync-engine.ts`
+
+Add a public method:
+
+```ts
+async handlePageResume(): Promise<void>
+```
+
+Logic:
+
+```
+if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
+if (!this.socket.connected) return    // socket.io is already reconnecting — don't pile on
+const healthy = await pingSocket(this.socket, 3000)
+if (!healthy) {
+  this.socket.disconnect()
+  this.socket.connect()               // socket.io-client v4: manual disconnect disables auto-reconnect, so we connect explicitly
+  return                              // onConnect(isReconnect=true) will fire via the SocketProvider/WorkspaceSyncHandler chain
+}
+await this.refreshAfterConnectivityResume()
+```
+
+### `apps/frontend/src/pages/workspace-layout.tsx`
+
+In `WorkspaceSyncHandler` (lines 116–220), add one hook call alongside the existing online-resume effect:
+
+```ts
+usePageResume(useCallback(() => {
+  void syncEngine.handlePageResume()
+}, [syncEngine]))
+```
+
+No changes to existing effects — the new trigger is additive.
+
+## Reused existing infrastructure
+
+- `SyncEngine.refreshAfterConnectivityResume()` (`apps/frontend/src/sync/sync-engine.ts:135-138`) — already singleflighted via `runBootstrap`'s `activeBootstrap` + `queuedReconnectBootstrap` (lines 343-374). Overlapping resume + socket-reconnect calls collapse into one queued reconnect bootstrap.
+- `SocketProvider`'s `connect` handler (`apps/frontend/src/contexts/socket-context.tsx:68-79`) sets `reconnectCount++` on every reconnect, which drives `WorkspaceSyncHandler`'s socket effect (workspace-layout.tsx:177-184) → `syncEngine.onConnect(isReconnect=true)`. The force-reconnect branch piggybacks on this exact path.
+- Vitest visibility-mocking pattern from `apps/frontend/src/hooks/use-auto-mark-as-read.test.ts:54-130`.
+- `joinRoomBestEffort`'s settle/cleanup pattern in `apps/frontend/src/lib/socket-room.ts` is a good template for `pingSocket`'s settle-once + cleanup discipline.
+
+## Out of scope
+
+- iOS Safari `pageshow` with `event.persisted=true` (BFCache restore) — different lifecycle. The reported bug is `visibilitychange`, which fires reliably for app-switch resume.
+- Server-side presence/idle bumping on `health:ping` — keep the handler stateless. If presence semantics need it later, that's a separate change.
+- Configurable thresholds — module-level constant for now; expose if a second consumer needs a different value.
+
+## Verification
+
+1. **Unit tests** — `bun --cwd apps/frontend run test:watch --run src/lib/socket-health.test.ts src/hooks/use-page-resume.test.ts src/sync/sync-engine.test.ts` should pass.
+2. **Full frontend suite** — `bun --cwd apps/frontend run test` should pass without regressions to the existing 1147 tests.
+3. **Typecheck** — `bun --cwd apps/frontend run typecheck` (and the monorepo-wide pre-commit check) clean.
+4. **Backend** — at minimum manual: `bun --cwd apps/backend run test` should pass (the new handler is a one-liner and existing socket tests don't cover handlers, so this doesn't gain a new test unless the team prefers adding one — flag at PR review time).
+5. **Manual smoke (mobile)** — open the app on phone, send a message from a second device, switch to another app for >10s, return to the app: stream should refresh within ~1 second (probe + delta fetch) instead of remaining stale.
+6. **Manual smoke (zombie socket)** — Chrome DevTools → Application → Service Workers → "Offline" toggle is unreliable here (doesn't suspend the JS context). Better repro: with the dev server, toggle the laptop's Wi-Fi off, wait a few seconds, toggle back on with the tab still focused, then trigger a visibility change (Cmd+Tab away and back). Verify the loading indicator appears briefly and stale events are replaced by fresh ones.
+
+## Sequencing
+
+1. Backend `health:ping` handler.
+2. `socket-health.ts` + tests.
+3. `use-page-resume.ts` + tests.
+4. `SyncEngine.handlePageResume` + new `sync-engine.test.ts`.
+5. Wire into `WorkspaceSyncHandler`.
+6. Run the full test suite, typecheck, then commit and push to the new branch (rebase first onto `origin/main` since #350 is merged).

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -381,6 +381,13 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
       })
     })
 
+    // Liveness probe for client-initiated zombie-socket detection on resume.
+    // Distinct from socket.io's transport-level ping so we can ack synchronously
+    // without coupling to the native pingTimeout cycle.
+    socket.on("health:ping", (callback?: (result: { ok: true }) => void) => {
+      callback?.({ ok: true })
+    })
+
     socket.on("disconnect", () => {
       userSocketRegistry.unregister(workosUserId, socket)
 

--- a/apps/frontend/src/hooks/use-page-resume.test.ts
+++ b/apps/frontend/src/hooks/use-page-resume.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { usePageResume } from "./use-page-resume"
+
+let visibilityState: DocumentVisibilityState = "visible"
+const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState")
+
+function setVisibility(state: DocumentVisibilityState) {
+  visibilityState = state
+  document.dispatchEvent(new Event("visibilitychange"))
+}
+
+describe("usePageResume", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    visibilityState = "visible"
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    })
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    if (originalVisibilityState) {
+      Object.defineProperty(document, "visibilityState", originalVisibilityState)
+    } else {
+      Reflect.deleteProperty(document, "visibilityState")
+    }
+  })
+
+  it("does not fire when hide is shorter than the threshold", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(5_000)
+      setVisibility("visible")
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("fires exactly once when hide meets the threshold", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(10_500)
+      setVisibility("visible")
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("evaluates each hide/visible cycle independently", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(12_000)
+      setVisibility("visible")
+    })
+    expect(onResume).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(2_000)
+      setVisibility("visible")
+    })
+    expect(onResume).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(15_000)
+      setVisibility("visible")
+    })
+    expect(onResume).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not fire when becoming visible without a prior hide", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("visible")
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("honors updates to the onResume callback without re-subscribing", () => {
+    const onResumeA = vi.fn()
+    const onResumeB = vi.fn()
+
+    const { rerender } = renderHook(({ cb }: { cb: () => void }) => usePageResume(cb, 10_000), {
+      initialProps: { cb: onResumeA },
+    })
+
+    rerender({ cb: onResumeB })
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(12_000)
+      setVisibility("visible")
+    })
+
+    expect(onResumeA).not.toHaveBeenCalled()
+    expect(onResumeB).toHaveBeenCalledTimes(1)
+  })
+
+  it("removes the listener on unmount", () => {
+    const onResume = vi.fn()
+    const { unmount } = renderHook(() => usePageResume(onResume, 10_000))
+
+    unmount()
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(12_000)
+      setVisibility("visible")
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-page-resume.ts
+++ b/apps/frontend/src/hooks/use-page-resume.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react"
+
+const DEFAULT_HIDDEN_THRESHOLD_MS = 10_000
+
+/**
+ * Fires `onResume` when the page transitions from hidden → visible after
+ * being hidden for at least `hiddenThresholdMs` (default 10s).
+ *
+ * The threshold filters out quick app-switcher previews and notification-shade
+ * glances, so the callback only runs when the page was genuinely backgrounded
+ * long enough that socket events may have been missed.
+ *
+ * `onResume` is stored in a ref so consumers don't need to memoize.
+ */
+export function usePageResume(onResume: () => void, hiddenThresholdMs: number = DEFAULT_HIDDEN_THRESHOLD_MS): void {
+  const onResumeRef = useRef(onResume)
+  onResumeRef.current = onResume
+
+  useEffect(() => {
+    let hiddenSince: number | null = null
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenSince = Date.now()
+        return
+      }
+
+      if (document.visibilityState === "visible") {
+        if (hiddenSince !== null && Date.now() - hiddenSince >= hiddenThresholdMs) {
+          onResumeRef.current()
+        }
+        hiddenSince = null
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [hiddenThresholdMs])
+}

--- a/apps/frontend/src/lib/socket-health.test.ts
+++ b/apps/frontend/src/lib/socket-health.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest"
+import type { Socket } from "socket.io-client"
+import { pingSocket } from "./socket-health"
+
+type EventHandler = (...args: unknown[]) => void
+
+class MockSocket {
+  ackDelayMs: number | null = 0
+  emitCalls = 0
+  private listeners = new Map<string, Set<EventHandler>>()
+
+  on(event: string, handler: EventHandler) {
+    const handlers = this.listeners.get(event)
+    if (handlers) {
+      handlers.add(handler)
+    } else {
+      this.listeners.set(event, new Set([handler]))
+    }
+    return this
+  }
+
+  off(event: string, handler: EventHandler) {
+    this.listeners.get(event)?.delete(handler)
+    return this
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    if (event !== "health:ping") return this
+    this.emitCalls += 1
+    const callback = args[0] as ((result?: { ok: true }) => void) | undefined
+    if (!callback) return this
+    if (this.ackDelayMs === null) return this
+    setTimeout(() => callback({ ok: true }), this.ackDelayMs)
+    return this
+  }
+
+  trigger(event: string, ...args: unknown[]) {
+    const handlers = this.listeners.get(event)
+    if (!handlers) return
+    for (const handler of handlers) {
+      handler(...args)
+    }
+  }
+
+  listenerCount(event: string): number {
+    return this.listeners.get(event)?.size ?? 0
+  }
+}
+
+function asSocket(mock: MockSocket): Socket {
+  return mock as unknown as Socket
+}
+
+describe("pingSocket", () => {
+  it("resolves to true when ack fires before timeout", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = 5
+
+    await expect(pingSocket(asSocket(socket), 100)).resolves.toBe(true)
+    expect(socket.emitCalls).toBe(1)
+  })
+
+  it("resolves to false when ack does not fire before timeout", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = null
+
+    await expect(pingSocket(asSocket(socket), 20)).resolves.toBe(false)
+  })
+
+  it("resolves to false when socket disconnects mid-probe", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = null
+
+    const pingPromise = pingSocket(asSocket(socket), 200)
+    setTimeout(() => socket.trigger("disconnect", "transport close"), 5)
+
+    await expect(pingPromise).resolves.toBe(false)
+  })
+
+  it("cleans up the disconnect listener on successful ack", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = 5
+
+    await pingSocket(asSocket(socket), 100)
+
+    expect(socket.listenerCount("disconnect")).toBe(0)
+  })
+
+  it("cleans up the disconnect listener on timeout", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = null
+
+    await pingSocket(asSocket(socket), 20)
+
+    expect(socket.listenerCount("disconnect")).toBe(0)
+  })
+
+  it("cleans up the disconnect listener when triggered by disconnect", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = null
+
+    const pingPromise = pingSocket(asSocket(socket), 200)
+    setTimeout(() => socket.trigger("disconnect", "transport close"), 5)
+    await pingPromise
+
+    expect(socket.listenerCount("disconnect")).toBe(0)
+  })
+
+  it("ignores a late ack arriving after timeout", async () => {
+    const socket = new MockSocket()
+    socket.ackDelayMs = 40
+
+    const result = await pingSocket(asSocket(socket), 10)
+    expect(result).toBe(false)
+
+    // Wait for the late ack to fire; the promise already resolved, so nothing should break.
+    await new Promise((resolve) => setTimeout(resolve, 60))
+    expect(socket.listenerCount("disconnect")).toBe(0)
+  })
+})

--- a/apps/frontend/src/lib/socket-health.ts
+++ b/apps/frontend/src/lib/socket-health.ts
@@ -1,0 +1,47 @@
+import type { Socket } from "socket.io-client"
+
+const DEFAULT_PING_TIMEOUT_MS = 3000
+
+/**
+ * Client-initiated liveness probe. Emits `health:ping` with an ack callback.
+ * Returns `true` if the server acks within `timeoutMs`, `false` on timeout
+ * or if the socket disconnects mid-probe.
+ *
+ * Used on page-resume to detect zombie sockets that socket.io's native
+ * pingTimeout (~20-25s) hasn't caught yet.
+ */
+export function pingSocket(socket: Socket, timeoutMs: number = DEFAULT_PING_TIMEOUT_MS): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      socket.off("disconnect", handleDisconnect)
+    }
+
+    const settle = (result: boolean) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+
+    const handleDisconnect = () => {
+      settle(false)
+    }
+
+    socket.on("disconnect", handleDisconnect)
+
+    timeoutId = setTimeout(() => {
+      settle(false)
+    }, timeoutMs)
+
+    socket.emit("health:ping", () => {
+      settle(true)
+    })
+  })
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -208,12 +208,10 @@ function WorkspaceSyncHandler({
   // Visibility-resume trigger: on phone/tab resume after long background,
   // probe the socket and refresh state. navigator.onLine doesn't flap in that
   // scenario and socket.io's native pingTimeout can take 20–25s to notice a
-  // zombie transport.
-  usePageResume(
-    useCallback(() => {
-      void syncEngine.handlePageResume()
-    }, [syncEngine])
-  )
+  // zombie transport. The hook stores the callback in a ref, so no memoization needed.
+  usePageResume(() => {
+    void syncEngine.handlePageResume()
+  })
 
   // No destroy effect — StrictMode's effect cleanup cycle would destroy the
   // engine before the socket connect effect re-runs. The engine is destroyed

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -47,6 +47,7 @@ import {
   useMessageQueue,
   useUnreadTabIndicator,
 } from "@/hooks"
+import { usePageResume } from "@/hooks/use-page-resume"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext } from "@/sync/sync-engine"
@@ -203,6 +204,16 @@ function WorkspaceSyncHandler({
       void syncEngine.refreshAfterConnectivityResume()
     }
   }, [isOnline, socket, syncEngine])
+
+  // Visibility-resume trigger: on phone/tab resume after long background,
+  // probe the socket and refresh state. navigator.onLine doesn't flap in that
+  // scenario and socket.io's native pingTimeout can take 20–25s to notice a
+  // zombie transport.
+  usePageResume(
+    useCallback(() => {
+      void syncEngine.handlePageResume()
+    }, [syncEngine])
+  )
 
   // No destroy effect — StrictMode's effect cleanup cycle would destroy the
   // engine before the socket connect effect re-runs. The engine is destroyed

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import type { Socket } from "socket.io-client"
+import { QueryClient } from "@tanstack/react-query"
+import { SyncEngine } from "./sync-engine"
+import { SyncStatusStore } from "./sync-status"
+import { db } from "@/db"
+import { DEFAULT_USER_PREFERENCES, type WorkspaceBootstrap, type StreamBootstrap } from "@threa/types"
+
+type EventHandler = (...args: unknown[]) => void
+
+class MockSocket {
+  connected = true
+  /** null = never ack; true = ack immediately with ok; false = reserved */
+  ackBehavior: "immediate" | "never" | "delayed" = "immediate"
+  ackDelayMs = 0
+  disconnectCalls = 0
+  connectCalls = 0
+  emittedEvents: Array<{ event: string; args: unknown[] }> = []
+  private listeners = new Map<string, Set<EventHandler>>()
+
+  on(event: string, handler: EventHandler) {
+    const handlers = this.listeners.get(event)
+    if (handlers) handlers.add(handler)
+    else this.listeners.set(event, new Set([handler]))
+    return this
+  }
+
+  off(event: string, handler: EventHandler) {
+    this.listeners.get(event)?.delete(handler)
+    return this
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    this.emittedEvents.push({ event, args })
+
+    if (event === "health:ping") {
+      const callback = args[0] as (() => void) | undefined
+      if (!callback) return this
+      if (this.ackBehavior === "never") return this
+      if (this.ackBehavior === "immediate") {
+        callback()
+      } else {
+        setTimeout(callback, this.ackDelayMs)
+      }
+      return this
+    }
+
+    // join ack: reply ok so onConnect's workspace join succeeds in tests
+    if (event === "join") {
+      const callback = args[1] as ((result?: { ok: boolean }) => void) | undefined
+      callback?.({ ok: true })
+      return this
+    }
+
+    return this
+  }
+
+  trigger(event: string, ...args: unknown[]) {
+    const handlers = this.listeners.get(event)
+    if (!handlers) return
+    for (const handler of handlers) handler(...args)
+  }
+
+  disconnect() {
+    this.disconnectCalls += 1
+    this.connected = false
+    return this
+  }
+
+  connect() {
+    this.connectCalls += 1
+    return this
+  }
+}
+
+function asSocket(mock: MockSocket): Socket {
+  return mock as unknown as Socket
+}
+
+function makeWorkspaceBootstrap(): WorkspaceBootstrap {
+  const now = new Date().toISOString()
+  return {
+    workspace: {
+      id: "ws_1",
+      name: "Test",
+      slug: "test",
+      createdBy: "user_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+    users: [],
+    streams: [],
+    streamMemberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    mutedStreamIds: [],
+    userPreferences: {
+      ...DEFAULT_USER_PREFERENCES,
+      workspaceId: "ws_1",
+      userId: "user_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+  } satisfies WorkspaceBootstrap
+}
+
+function makeDeps() {
+  const workspaceBootstrap = vi.fn(async () => makeWorkspaceBootstrap())
+  const streamBootstrap = vi.fn(async () => ({}) as StreamBootstrap)
+  return {
+    workspaceId: "ws_1",
+    syncStatus: new SyncStatusStore(),
+    queryClient: new QueryClient(),
+    workspaceService: { bootstrap: workspaceBootstrap },
+    streamService: { bootstrap: streamBootstrap },
+  }
+}
+
+async function primeConnectedEngine(engine: SyncEngine, socket: MockSocket): Promise<void> {
+  await engine.onConnect(asSocket(socket))
+}
+
+describe("SyncEngine.handlePageResume", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.workspaces.clear(),
+      db.workspaceUsers.clear(),
+      db.streams.clear(),
+      db.streamMemberships.clear(),
+      db.dmPeers.clear(),
+      db.personas.clear(),
+      db.bots.clear(),
+      db.unreadState.clear(),
+      db.userPreferences.clear(),
+      db.workspaceMetadata.clear(),
+    ])
+  })
+
+  it("is a no-op when the engine has never connected", async () => {
+    const engine = new SyncEngine(makeDeps())
+    const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume")
+
+    await engine.handlePageResume()
+
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it("is a no-op when the engine is destroyed", async () => {
+    const engine = new SyncEngine(makeDeps())
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    engine.destroy()
+
+    const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume")
+    await engine.handlePageResume()
+
+    expect(refreshSpy).not.toHaveBeenCalled()
+    expect(socket.disconnectCalls).toBe(0)
+    expect(socket.connectCalls).toBe(0)
+  })
+
+  it("is a no-op when the transport is already disconnected", async () => {
+    const engine = new SyncEngine(makeDeps())
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    socket.connected = false
+
+    const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume")
+    const pingsBefore = socket.emittedEvents.filter((e) => e.event === "health:ping").length
+
+    await engine.handlePageResume()
+
+    expect(refreshSpy).not.toHaveBeenCalled()
+    expect(socket.disconnectCalls).toBe(0)
+    expect(socket.connectCalls).toBe(0)
+    expect(socket.emittedEvents.filter((e) => e.event === "health:ping").length).toBe(pingsBefore)
+  })
+
+  it("refreshes after a successful ping", async () => {
+    const engine = new SyncEngine(makeDeps())
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+    await primeConnectedEngine(engine, socket)
+
+    const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume").mockResolvedValue()
+
+    await engine.handlePageResume()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(socket.disconnectCalls).toBe(0)
+    expect(socket.connectCalls).toBe(0)
+  })
+
+  it("force-reconnects after a failed ping and skips refresh", async () => {
+    const engine = new SyncEngine(makeDeps())
+    const socket = new MockSocket()
+    socket.ackBehavior = "never"
+    await primeConnectedEngine(engine, socket)
+
+    const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume").mockResolvedValue()
+
+    // Use a short timeout inside pingSocket via module constant default (3000) — but
+    // the test uses real timers and we don't want to wait 3s. Trigger a disconnect
+    // event instead so pingSocket settles immediately with `false`.
+    const resumePromise = engine.handlePageResume()
+    // Let the ping emit happen in the microtask queue
+    await Promise.resolve()
+    socket.trigger("disconnect", "transport close")
+
+    await resumePromise
+
+    expect(refreshSpy).not.toHaveBeenCalled()
+    expect(socket.disconnectCalls).toBe(1)
+    expect(socket.connectCalls).toBe(1)
+  })
+
+  it("does not double-bootstrap on rapid successive resume calls", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+    await primeConnectedEngine(engine, socket)
+
+    // Clear the bootstrap count from onConnect
+    deps.workspaceService.bootstrap.mockClear()
+
+    await Promise.all([engine.handlePageResume(), engine.handlePageResume()])
+
+    // activeBootstrap singleflight + queuedReconnectBootstrap guarantees
+    // at most 2 bootstrap fetches for overlapping calls (active + 1 queued).
+    // Two rapid resume calls should NOT fan out to 3+ fetches.
+    expect(deps.workspaceService.bootstrap.mock.calls.length).toBeLessThanOrEqual(2)
+  })
+})

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -3,6 +3,7 @@ import type { Socket } from "socket.io-client"
 import type { QueryClient } from "@tanstack/react-query"
 import { db } from "@/db"
 import { joinRoomFireAndForget, joinRoomBestEffort } from "@/lib/socket-room"
+import { pingSocket } from "@/lib/socket-health"
 import { ApiError } from "@/api/client"
 import {
   applyReconnectBootstrapBatch,
@@ -135,6 +136,33 @@ export class SyncEngine {
   async refreshAfterConnectivityResume(): Promise<void> {
     if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
     await this.runBootstrap(true)
+  }
+
+  /**
+   * Called when the page resumes from a long hidden period (e.g. phone
+   * unlocked after app-switch). Probes the socket for liveness; if the
+   * probe fails, forces a reconnect to short-circuit socket.io's 20–25s
+   * native zombie detection. If the probe succeeds, refreshes state since
+   * events may have been missed while the page was backgrounded.
+   */
+  async handlePageResume(): Promise<void> {
+    if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
+    // If the transport is already down, socket.io is handling the reconnect;
+    // don't layer another probe on top of it.
+    if (!this.socket.connected) return
+
+    const healthy = await pingSocket(this.socket, 3000)
+    if (this.isDestroyed) return
+
+    if (!healthy) {
+      // Manual disconnect disables socket.io's auto-reconnect, so connect explicitly.
+      // onConnect(isReconnect=true) will drive the fresh bootstrap cycle.
+      this.socket.disconnect()
+      this.socket.connect()
+      return
+    }
+
+    await this.refreshAfterConnectivityResume()
   }
 
   /**

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -151,7 +151,7 @@ export class SyncEngine {
     // don't layer another probe on top of it.
     if (!this.socket.connected) return
 
-    const healthy = await pingSocket(this.socket, 3000)
+    const healthy = await pingSocket(this.socket)
     if (this.isDestroyed) return
 
     if (!healthy) {


### PR DESCRIPTION
## Problem

After PR #350, stream bootstrap self-heals on navigation. But there's a separate resume-from-background failure mode that still produces stale messages:

User backgrounds the app on their phone (or switches to another tab on desktop for a while), sends messages from another device into a stream they're viewing, then returns to the app — stale events, no refresh. None of the existing resume signals fire in this scenario:

- **`socket.io` reconnect doesn't fire** — the WebSocket is a zombie (mobile OS killed the transport but the client still thinks it's alive). socket.io's native `pingTimeout` takes 20–25s to detect this.
- **`navigator.onLine` doesn't flap** — the phone never lost network, only the app was suspended.
- **Nothing else in the codebase reacts to `visibilitychange`** for sync purposes.

## Solution

Two coordinated additions behind a shared 10s backgrounded threshold:

1. **Visibility-resume trigger** — on `visibilitychange` hidden→visible after ≥10s hidden, call into the SyncEngine. The threshold filters out quick app-switcher previews and notification-shade glances.
2. **Active socket health probe** — on resume, emit a `health:ping` with a 3s ack timeout. On success, just refresh via the existing `refreshAfterConnectivityResume` path (events may have been missed while backgrounded). On failure, the socket is a zombie — force `disconnect() + connect()` to short-circuit socket.io's 20–25s native detection; the natural `onConnect(isReconnect=true)` cycle then drives a fresh bootstrap.

### How it works

```
visibilitychange (hidden→visible, ≥10s hidden)
                    │
                    ▼
         SyncEngine.handlePageResume()
                    │
          ┌─── pingSocket(3s) ───┐
          │                      │
      healthy                  zombie
          │                      │
          ▼                      ▼
 refreshAfterConnectivity   socket.disconnect()
   Resume() (existing         + socket.connect()
   singleflight)            → onConnect(isReconnect=true)
                            → full bootstrap
```

### Key design decisions

**1. Separate `usePageResume` hook instead of extending `usePageActivity`**

`usePageActivity` fires on every visibility/focus transition immediately (for socket-heartbeat purposes). `usePageResume` has distinct semantics: it only cares about hidden-for-≥N-ms → visible transitions. Folding these into the same hook would require merging two unrelated predicates. Kept separate; added ref-stored callback so consumers don't need to memoize.

**2. Client-initiated `health:ping` instead of relying on socket.io's native ping**

socket.io's transport-level ping runs on a server-driven interval with `pingTimeout` ~20s default. That's too slow when the user is staring at a stale UI. An ack-based application event gives us a bounded 3s probe that's immediately actionable.

**3. Force `disconnect() + connect()` instead of waiting for socket.io to detect the zombie**

Manual `disconnect()` on socket.io v4 disables auto-reconnect, so we explicitly `connect()` after. This piggybacks on the existing `SocketProvider` → `reconnectCount` → `WorkspaceSyncHandler` → `syncEngine.onConnect(isReconnect=true)` chain — no new orchestration.

**4. Reuse `refreshAfterConnectivityResume`'s existing singleflight**

`runBootstrap` already singleflights via `activeBootstrap` + `queuedReconnectBootstrap`. Overlapping resume + socket-reconnect triggers collapse into one queued reconnect bootstrap — no new coordination needed.

**5. Early-return when `!socket.connected`**

If the transport is already down, socket.io is handling the reconnect; don't layer a probe on top of it.

## New files

| File                                              | Purpose                                                                              |
| ------------------------------------------------- | ------------------------------------------------------------------------------------ |
| `apps/frontend/src/lib/socket-health.ts`          | `pingSocket(socket, timeoutMs)` — ack-based liveness probe with settle-once cleanup  |
| `apps/frontend/src/lib/socket-health.test.ts`     | Covers ack success, timeout, disconnect mid-probe, listener cleanup on all paths     |
| `apps/frontend/src/hooks/use-page-resume.ts`      | `usePageResume(onResume, hiddenThresholdMs?)` — ref-stored callback, 10s default     |
| `apps/frontend/src/hooks/use-page-resume.test.ts` | Covers threshold gating, multiple cycles, callback updates, unmount cleanup          |
| `apps/frontend/src/sync/sync-engine.test.ts`      | Focused tests for `handlePageResume` — guards, healthy path, zombie path, dedup      |
| `.claude/plans/gleaming-inventing-deer.md`        | Implementation plan (committed for Greptile plan-adherence checks)                   |

## Modified files

| File                                          | Change                                                                                                   |
| --------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| `apps/backend/src/socket.ts`                  | New `health:ping` handler — synchronous ack, no side effects, distinct from socket.io's transport ping   |
| `apps/frontend/src/sync/sync-engine.ts`       | New `handlePageResume()` method — probe then branch on healthy-refresh vs zombie-reconnect               |
| `apps/frontend/src/pages/workspace-layout.tsx`| Wire `usePageResume` into `WorkspaceSyncHandler` alongside the existing online-resume effect             |

## Test plan

- [x] 7 unit tests for `pingSocket` (ack success/timeout/disconnect + listener cleanup on all paths)
- [x] 6 unit tests for `usePageResume` (threshold gating, multiple cycles, callback updates, unmount)
- [x] 6 unit tests for `SyncEngine.handlePageResume` (all early-return guards + healthy/zombie paths + dedup)
- [x] Full frontend test suite: 1162 passing
- [x] Backend unit test suite: 803 passing
- [x] Monorepo typecheck + lint + dockerfile check + openapi check: all clean
- [ ] **Manual smoke (mobile)** — phone, send message from second device, switch apps >10s, return: verify stream refreshes within ~1s
- [ ] **Manual smoke (zombie socket)** — toggle laptop Wi-Fi off, wait, toggle back on, Cmd+Tab away and back: verify loading indicator appears briefly and stale events replaced

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_