### PR TITLE
fix(frontend): raise PWA precache limit so main bundle fits

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
       manifest: false, // use existing public/manifest.json
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+        maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
       },
       devOptions: {
         enabled: true,


### PR DESCRIPTION
The main index bundle grew to ~3.08 MiB, pushing it past the existing
3 MiB `maximumFileSizeToCacheInBytes` cap and breaking the Deploy
Frontend workflow at `vite build`. Bumping the limit to 4 MiB restores
the precache entry while leaving comfortable headroom.