### PR TITLE
perf(frontend): split routes into lazy chunks and drop PWA precache cap

### DIFF
--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -1,21 +1,12 @@
 import { useEffect, useRef } from "react"
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom"
-import { LoginPage } from "@/pages/login"
-import { WorkspaceSelectPage } from "@/pages/workspace-select"
-import { WorkspaceLayout } from "@/pages/workspace-layout"
-import { StreamPage } from "@/pages/stream"
-import { DraftsPage } from "@/pages/drafts"
-import { ThreadsPage } from "@/pages/threads"
-import { ActivityPage } from "@/pages/activity"
-import { MemoryPage } from "@/pages/memory"
-import { AIUsageAdminPage } from "@/pages/ai-usage-admin"
-import { UserSetupPage } from "@/pages/user-setup"
-import { ShareTargetPage } from "@/pages/share-target"
-import { SharePickerPage } from "@/pages/share-picker"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useSidebar } from "@/contexts"
 import { useLastStream } from "@/hooks"
 
+// Route-level code splitting: each page lazy-loads its own chunk so heavy
+// dependencies (tiptap/prosemirror, recharts, limax/pinyin-pro, etc.) ride
+// with the pages that actually use them instead of bloating the main bundle.
 export const router = createBrowserRouter([
   {
     path: "/",
@@ -24,29 +15,29 @@ export const router = createBrowserRouter([
   },
   {
     path: "/login",
-    element: <LoginPage />,
+    lazy: async () => ({ Component: (await import("@/pages/login")).LoginPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/workspaces",
-    element: <WorkspaceSelectPage />,
+    lazy: async () => ({ Component: (await import("@/pages/workspace-select")).WorkspaceSelectPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/share",
-    element: <ShareTargetPage />,
+    lazy: async () => ({ Component: (await import("@/pages/share-target")).ShareTargetPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     // Setup page lives outside WorkspaceLayout — it's a lightweight form that
     // doesn't need the full workspace bootstrap (socket, sidebar, etc.)
     path: "/w/:workspaceId/setup",
-    element: <UserSetupPage />,
+    lazy: async () => ({ Component: (await import("@/pages/user-setup")).UserSetupPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/w/:workspaceId",
-    element: <WorkspaceLayout />,
+    lazy: async () => ({ Component: (await import("@/pages/workspace-layout")).WorkspaceLayout }),
     errorElement: <ErrorBoundary />,
     children: [
       {
@@ -55,19 +46,19 @@ export const router = createBrowserRouter([
       },
       {
         path: "drafts",
-        element: <DraftsPage />,
+        lazy: async () => ({ Component: (await import("@/pages/drafts")).DraftsPage }),
       },
       {
         path: "threads",
-        element: <ThreadsPage />,
+        lazy: async () => ({ Component: (await import("@/pages/threads")).ThreadsPage }),
       },
       {
         path: "activity",
-        element: <ActivityPage />,
+        lazy: async () => ({ Component: (await import("@/pages/activity")).ActivityPage }),
       },
       {
         path: "memory",
-        element: <MemoryPage />,
+        lazy: async () => ({ Component: (await import("@/pages/memory")).MemoryPage }),
       },
       {
         path: "memos/:memoId",
@@ -75,15 +66,15 @@ export const router = createBrowserRouter([
       },
       {
         path: "s/:streamId",
-        element: <StreamPage />,
+        lazy: async () => ({ Component: (await import("@/pages/stream")).StreamPage }),
       },
       {
         path: "share",
-        element: <SharePickerPage />,
+        lazy: async () => ({ Component: (await import("@/pages/share-picker")).SharePickerPage }),
       },
       {
         path: "admin/ai-usage",
-        element: <AIUsageAdminPage />,
+        lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
       },
     ],
   },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -83,7 +83,6 @@ export default defineConfig({
       manifest: false, // use existing public/manifest.json
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
-        maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
       },
       devOptions: {
         enabled: true,


### PR DESCRIPTION
## Problem

The frontend's main bundle had grown past 3 MiB, breaking the `Deploy Frontend` job at `vite build` because the PWA `injectManifest` step refuses to precache any single file over its `maximumFileSizeToCacheInBytes` limit:

```
Assets exceeding the limit:
  - assets/index-CsoM0ST9.js is 3.23 MB, and won't be precached.
```

The hotfix in #(previous PR) bumped the cap from 3 MiB → 4 MiB so deploys could proceed, but that just papered over the regression — shipping a 3.2 MB / 1 MB-gzipped entry chunk to every user on every cold load.

The root cause was statically importing every page from the top-level router. That pulled each page's entire dependency tree into `index.js` regardless of where the user was actually navigating:

| Dep | Size in main | Only used on |
|---|---|---|
| `pinyin-pro` (via `limax`) | ~522 KiB | `/w/:ws/setup` |
| `recharts` + utils | ~200+ KiB | `/w/:ws/admin/ai-usage` |
| `tiptap` + `prosemirror-*` | ~450+ KiB | stream composer / edit forms |
| shiki language files | split already | code blocks in messages |

## Solution

Convert each route to React Router v7's `lazy` route option. Rollup emits one chunk per page, and the main entry only contains the shared shell + whatever the landing route needs.

### How it works

```ts
{
  path: "/w/:workspaceId/admin/ai-usage",
  lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
}
```

On navigation, React Router awaits the lazy import before rendering; Rollup auto-emits `<link rel="modulepreload">` for dependent chunks, so the cold-path cost is a single RTT per route and parallelizes well.

### Bundle sizes, before → after

| Chunk | Before | After |
|---|---|---|
| `index-*.js` (entry) | **3,225 kB** (1,004 kB gz) | **779 kB** (241 kB gz) |
| `ai-usage-admin-*` | (bundled into main) | 417 kB (own chunk) |
| `user-setup-*` (pinyin-pro) | (bundled into main) | 331 kB (own chunk) |
| `stream-*` | (bundled into main) | 235 kB (own chunk) |
| `workspace-layout-*` | (bundled into main) | 195 kB (own chunk) |

76% reduction in entry-chunk size. No chunk now exceeds ~780 KiB, so the 4 MiB PWA precache override is no longer needed — reverted to the plugin default (2 MiB).

### Key design decisions

**1. React Router v7 `lazy` routes, not `React.lazy` + `<Suspense>`**

RR v7's route-level `lazy` has nicer ergonomics: it keeps the old route rendered during load (no Suspense flash), and failures bubble to the route's existing `errorElement: <ErrorBoundary />` so stale-deploy chunk 404s surface the normal app error UI instead of a blank page. No new `<Suspense>` boundary needed.

**2. `WorkspaceHome` and `LegacyMemoRedirect` stay eager**

Both are trivial helpers (a redirect and a sidebar-state nudge) colocated in `routes/index.tsx`. Splitting them would add chunks for kilobytes of code.

**3. `WorkspaceLayout` is lazy-loaded**

It's loaded once on entry to any `/w/:workspaceId/*` route and reused for all workspace navigation after that, so paying the chunk cost once keeps it out of the entry chunk for unauthenticated users hitting `/login` or `/workspaces`.

**4. Drop the precache override rather than pin it lower**

The plugin default (2 MiB) is the natural upper bound; the largest emitted chunk is 779 KiB with comfortable headroom. Keeping an explicit number would either drift from upstream defaults or invite the same regression to recur silently.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/routes/index.tsx` | Replaced 12 static page imports with route-level `lazy` loaders |
| `apps/frontend/vite.config.ts` | Removed `maximumFileSizeToCacheInBytes: 4 * 1024 * 1024` override |

## Test plan

- [x] `bun run --cwd apps/frontend build` succeeds; verified emitted chunk map matches the table above
- [x] `bun run --cwd apps/frontend typecheck` clean
- [x] `bun run --cwd apps/frontend test` — 1146 passing, 0 failing
- [x] Pre-commit lint + monorepo typecheck + API docs check all pass
- [ ] Manual: cold-load `/login`, `/workspaces`, a stream, `/admin/ai-usage`, `/setup` — confirm each loads correctly and nav between them is responsive
- [ ] Manual: verify DevTools Network tab shows one chunk per route on first visit, cached thereafter

## Follow-ups (not in this PR)

- Explicit `manualChunks` to promote stable vendor code (react, radix, socket.io) into a long-cache vendor chunk.
- Link-hover preloading for sidebar nav to hide chunk-fetch latency behind interaction.
- `@workos-inc/widgets` and `@radix-ui/themes` appear unimported from source (only referenced in a CSS comment) — candidates for deletion to shrink `node_modules`.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_