### PR TITLE
ci: make browser tests non-blocking with shard retry and Threa notifications

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -202,6 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: browser-tests
     if: always()
+    continue-on-error: true
     steps:
       - name: Download shard result markers
         uses: actions/download-artifact@v4
@@ -253,6 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: browser-tests
     if: always()
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -220,13 +220,11 @@ jobs:
           flaky_count=0
           failed_count=0
 
-          for i in 1 2 3; do
-            result_file="shard-results/shard-result-${i}/shard-result.txt"
-            if [ -f "$result_file" ]; then
-              result=$(cat "$result_file")
-            else
-              result="unknown"
-            fi
+          # Derive shards from downloaded artifact directories so this stays
+          # correct if TOTAL_SHARDS changes without touching evaluate-results.
+          for result_file in shard-results/shard-result-*/shard-result.txt; do
+            shard_num=$(basename "$(dirname "$result_file")" | sed 's/shard-result-//')
+            result=$(cat "$result_file")
 
             case "$result" in
               passed) icon="✅"; passed_count=$((passed_count + 1)) ;;
@@ -234,12 +232,12 @@ jobs:
               *)      icon="❌"; failed_count=$((failed_count + 1)) ;;
             esac
 
-            echo "| $i | $icon $result |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| $shard_num | $icon $result |" >> "$GITHUB_STEP_SUMMARY"
           done
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ $failed_count -eq 3 ]]; then
+          if [[ $passed_count -eq 0 && $flaky_count -eq 0 && $failed_count -gt 0 ]]; then
             echo "⛔ All shards failed — likely an infra issue, not test failures." >> "$GITHUB_STEP_SUMMARY"
           elif [[ $failed_count -gt 0 && $flaky_count -gt 0 ]]; then
             echo "⚠️ Some confirmed failures. Some tests are flaky (passed on retry)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   browser-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
+    continue-on-error: true
     env:
       TOTAL_SHARDS: 3
     strategy:
@@ -130,23 +131,130 @@ jobs:
           fi
 
       - name: Run browser tests
+        id: initial-run
+        continue-on-error: true
         run: bun run test:browser -- --reporter=line,blob --shard=${{ matrix.shard_index }}/${{ env.TOTAL_SHARDS }}
         env:
           CI: true
           PLAYWRIGHT_TEST_DB_NAME: ${{ env.PLAYWRIGHT_TEST_DB_NAME }}
 
-      - name: Upload Playwright report
+      - name: Archive initial blob report before retry
+        if: steps.initial-run.outcome == 'failure'
+        run: |
+          if [ -d blob-report ]; then
+            mv blob-report blob-report-initial
+          fi
+
+      - name: Retry failed tests in isolation
+        id: retry-run
+        if: steps.initial-run.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          if [ ! -f test-results/.last-run.json ]; then
+            echo "::warning::No .last-run.json found — skipping retry (likely an infra failure)"
+            exit 1
+          fi
+          bun run test:browser -- --reporter=line,blob --last-failed --retries=0
+        env:
+          CI: true
+          PLAYWRIGHT_TEST_DB_NAME: ${{ env.PLAYWRIGHT_TEST_DB_NAME }}
+
+      - name: Write shard result marker
+        if: always()
+        run: |
+          if [[ "${{ steps.initial-run.outcome }}" == "success" ]]; then
+            result="passed"
+          elif [[ "${{ steps.retry-run.outcome }}" == "success" ]]; then
+            result="flaky"
+          else
+            result="failed"
+          fi
+          echo "$result" > shard-result.txt
+          echo "Shard ${{ matrix.shard_index }} result: $result"
+
+      - name: Upload initial blob report (when retry ran)
+        uses: actions/upload-artifact@v4
+        if: steps.initial-run.outcome == 'failure' && !cancelled()
+        with:
+          name: playwright-blob-report-shard-${{ matrix.shard_index }}-initial
+          path: blob-report-initial/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Playwright blob report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-blob-report-shard-${{ matrix.shard_index }}
           path: blob-report/
+          if-no-files-found: ignore
           retention-days: 30
+
+      - name: Upload shard result marker
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: shard-result-${{ matrix.shard_index }}
+          path: shard-result.txt
+          retention-days: 7
+
+  evaluate-results:
+    runs-on: ubuntu-latest
+    needs: browser-tests
+    if: always()
+    steps:
+      - name: Download shard result markers
+        uses: actions/download-artifact@v4
+        with:
+          path: shard-results
+          pattern: shard-result-*
+
+      - name: Summarize results
+        run: |
+          echo "## Browser Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Shard | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          passed_count=0
+          flaky_count=0
+          failed_count=0
+
+          for i in 1 2 3; do
+            result_file="shard-results/shard-result-${i}/shard-result.txt"
+            if [ -f "$result_file" ]; then
+              result=$(cat "$result_file")
+            else
+              result="unknown"
+            fi
+
+            case "$result" in
+              passed) icon="✅"; passed_count=$((passed_count + 1)) ;;
+              flaky)  icon="🌀"; flaky_count=$((flaky_count + 1)) ;;
+              *)      icon="❌"; failed_count=$((failed_count + 1)) ;;
+            esac
+
+            echo "| $i | $icon $result |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ $failed_count -eq 3 ]]; then
+            echo "⛔ All shards failed — likely an infra issue, not test failures." >> "$GITHUB_STEP_SUMMARY"
+          elif [[ $failed_count -gt 0 && $flaky_count -gt 0 ]]; then
+            echo "⚠️ Some confirmed failures. Some tests are flaky (passed on retry)." >> "$GITHUB_STEP_SUMMARY"
+          elif [[ $failed_count -gt 0 ]]; then
+            echo "⚠️ Some tests have confirmed failures (failed in isolation). Check the merged Playwright report." >> "$GITHUB_STEP_SUMMARY"
+          elif [[ $flaky_count -gt 0 ]]; then
+            echo "🌀 All failures were flaky — tests passed when retried in isolation." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ All shards passed." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   merge-playwright-reports:
     runs-on: ubuntu-latest
     needs: browser-tests
-    if: ${{ !cancelled() && always() }}
+    if: always()
     steps:
       - uses: actions/checkout@v4
 
@@ -161,7 +269,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: downloaded-blob-reports
-          pattern: playwright-blob-report-shard-*
+          pattern: playwright-blob-report-*
 
       - name: Merge Playwright blob reports
         run: |

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,54 @@
+name: Notify Threa
+
+on:
+  workflow_run:
+    workflows: [CI, Deploy Cloudflare]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Threa notification
+        env:
+          THREA_BOT_API_KEY: ${{ secrets.THREA_BOT_API_KEY }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_MSG: ${{ github.event.workflow_run.head_commit.message }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+        run: |
+          # Exit early for conclusions we don't care about
+          case "$WORKFLOW_NAME/$CONCLUSION" in
+            "Deploy Cloudflare/success"|"Deploy Cloudflare/failure"|"Deploy Cloudflare/timed_out") ;;
+            "CI/failure"|"CI/timed_out") ;;
+            *)
+              echo "No notification needed ($WORKFLOW_NAME / $CONCLUSION)"
+              exit 0
+              ;;
+          esac
+
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          FIRST_LINE="${COMMIT_MSG%%$'\n'*}"
+
+          case "$CONCLUSION" in
+            success)   ICON="✅"; STATUS="succeeded" ;;
+            failure)   ICON="❌"; STATUS="failed" ;;
+            timed_out) ICON="⏱"; STATUS="timed out" ;;
+            *)         ICON="⚠️"; STATUS="$CONCLUSION" ;;
+          esac
+
+          MESSAGE="$ICON **$WORKFLOW_NAME $STATUS** on \`main\`
+
+\`$SHORT_SHA\` — $FIRST_LINE
+by @$ACTOR · [View run]($RUN_URL)"
+
+          PAYLOAD=$(jq -n --arg content "$MESSAGE" '{"content": $content}')
+
+          curl -f --show-error -X POST \
+            "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/streams/stream_01KP36GA56WZREGN6VTKREWRM9/messages" \
+            -H "Authorization: Bearer $THREA_BOT_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Problem

Browser E2E tests have been intermittently blocking merges to `main` due to flaky test failures. Because `browser-tests` is a required status check, any shard failure prevents PRs from merging — even if only one of three shards failed and the failures are transient.

Additionally, there was no visibility into pipeline outcomes in the team channel: deploys completing (successfully or not) and CI failures on `main` went unnoticed unless someone checked GitHub manually.

## Solution

**Browser tests:** Make the workflow fully informational — shard failures never fail the workflow. Each shard retries its failing tests in isolation after the initial run, distinguishing flaky tests (passed on retry) from confirmed failures (still failing in isolation). A summary job collects all shard outcomes and writes a result table to the GitHub step summary.

**Notifications:** New `notify.yml` workflow POSTs to a Threa channel on every deploy completion and every CI failure on `main` via the public bot API.

### How it works (browser tests)

```
browser-tests (3 shards, continue-on-error: true)
  ├── Initial run with --reporter=line,blob --shard=N/3
  ├── On failure: archive blob-report/, retry --last-failed --retries=0
  ├── Write shard-result.txt (passed / flaky / failed)
  └── Upload: initial blob, retry blob, shard-result marker

evaluate-results (parallel with merge)     merge-playwright-reports (parallel with evaluate)
  ├── Download shard-result-* artifacts      ├── Download all playwright-blob-report-* artifacts
  └── Write GITHUB_STEP_SUMMARY table        └── Merge into HTML report
```

The retry runs with `--retries=0` so a test that passes on the first attempt in isolation is definitively flaky, not just lucky on a rerun.

### Key design decisions

**1. Retry in the same shard job, not a separate job**

The tests need real infrastructure (Postgres + MinIO), which is wired up as service containers on the shard job. Spinning up a separate retry job would duplicate the full infra setup and cost. Retrying within the same job reuses the running services.

**2. `--retries=0` on the retry pass**

`playwright.config.ts` already sets `retries: 2` in CI, giving each test three attempts in the initial run. The workflow-level retry is a fourth attempt in isolation — the goal is to see if the test passes cleanly with no other tests running alongside it. Adding Playwright-level retries there would blur flaky vs. broken.

**3. Blob reports preserved for both passes**

When retry runs, the initial `blob-report/` is moved to `blob-report-initial/` before the retry writes its own `blob-report/`. The merge job downloads both sets (`playwright-blob-report-*`), so the HTML report shows the full picture: initial failures, retry outcomes, and flaky test history.

**4. All-shards-failed guard in evaluate-results**

If all three shards fail (vs. some), it almost certainly indicates an infra problem rather than test failures. The summary calls this out separately so it's easy to distinguish "our tests are broken" from "CI infra had a bad day".

**5. No blocking — purely informational**

`continue-on-error: true` on the matrix job means the workflow-level result is always `success`. Branch protection checks pointing at this workflow will never block merges. The evaluate-results job is the canonical place to check test health.

## Modified files

| File | Change |
|------|--------|
| `.github/workflows/browser-tests.yml` | Added retry logic per shard, `evaluate-results` summary job, `continue-on-error: true` throughout; timeout 15→25 min; updated blob download pattern to include initial blobs |

## New files

| File | Purpose |
|------|---------|
| `.github/workflows/notify.yml` | Posts to Threa channel on deploy completion and CI failure on `main` via `THREA_BOT_API_KEY` secret |

## Test plan

- [ ] Push to a branch and confirm browser tests run, retry kicks in on a failure, and `evaluate-results` writes the correct summary
- [ ] Verify merged Playwright report includes both initial and retry blobs when retry ran
- [ ] Confirm `notify.yml` fires on next CI failure or deploy — check the Threa channel for the notification
- [ ] Confirm successful deploys also appear in the channel

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
