### PR TITLE
fix(ci): fix notify.yml YAML parse error — zero-indented message lines

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -40,10 +40,9 @@ jobs:
             *)         ICON="⚠️"; STATUS="$CONCLUSION" ;;
           esac
 
-          MESSAGE="$ICON **$WORKFLOW_NAME $STATUS** on \`main\`
-
-\`$SHORT_SHA\` — $FIRST_LINE
-by @$ACTOR · [View run]($RUN_URL)"
+          # Build message with printf to avoid multiline YAML indentation issues
+          MESSAGE=$(printf '%s **%s %s** on `main`\n\n`%s` — %s\nby @%s · [View run](%s)' \
+            "$ICON" "$WORKFLOW_NAME" "$STATUS" "$SHORT_SHA" "$FIRST_LINE" "$ACTOR" "$RUN_URL")
 
           PAYLOAD=$(jq -n --arg content "$MESSAGE" '{"content": $content}')
 


### PR DESCRIPTION
## Problem

`notify.yml` has been failing with "workflow file issue" on every run since it was introduced. No notifications were ever sent.

Root cause: the `MESSAGE=` variable assignment spanned multiple lines, and two of those lines (`\`$SHORT_SHA\`` and `by @$ACTOR`) had **zero indentation** — they broke out of the `run: |` block scalar's indentation level. GitHub's YAML parser rejected the file entirely.

## Fix

Replace the multiline string literal with a single `printf` call so the entire assignment stays within the block scalar's indentation.

**Before:**
\`\`\`bash
MESSAGE="$ICON **$WORKFLOW_NAME $STATUS** on \`main\`

\`$SHORT_SHA\` — $FIRST_LINE   ← column 0, breaks YAML
by @$ACTOR · [View run]($RUN_URL)"  ← column 0, breaks YAML
\`\`\`

**After:**
\`\`\`bash
MESSAGE=$(printf '%s **%s %s** on `main`\n\n`%s` — %s\nby @%s · [View run](%s)' \
  "$ICON" "$WORKFLOW_NAME" "$STATUS" "$SHORT_SHA" "$FIRST_LINE" "$ACTOR" "$RUN_URL")
\`\`\`

## Test plan

- [ ] Merge and confirm the next CI run / deploy triggers a successful notify.yml run and a message appears in the Threa channel

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_