### PR TITLE
fix(ci): deduplicate staging deployment notifications

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -72,6 +72,18 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           STAGING_URL="https://pr-${PR_NUMBER}-staging.threa.io"
+
+          # Skip if we've already posted a notification for this staging URL
+          SEARCH=$(curl -s -X POST \
+            "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/messages/search" \
+            -H "Authorization: Bearer $THREA_BOT_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg q "$STAGING_URL" '{"query": $q, "streams": ["stream_01KP36GA56WZREGN6VTKREWRM9"], "semantic": false, "limit": 1}')") || true
+          if [[ "$(echo "$SEARCH" | jq -r 'if .data then (.data | length > 0) else false end' 2>/dev/null)" == "true" ]]; then
+            echo "Already notified for $STAGING_URL — skipping"
+            exit 0
+          fi
+
           MESSAGE=$(printf '🚀 **Staging deployed** — [%s](%s)\n\n%s' \
             "$PR_TITLE" "$PR_URL" "$STAGING_URL")
           PAYLOAD=$(jq -n --arg content "$MESSAGE" '{"content": $content}')


### PR DESCRIPTION
## Problem

Every push to a staging-labeled PR retriggers the staging deploy workflow, which would post a new "🚀 Staging deployed" notification to the Threa channel each time. On an active PR with multiple iterations, this floods the channel with duplicate messages all pointing to the same staging URL.

## Solution

Before posting a staging notification, search the channel for an existing message containing the PR's staging URL (`https://pr-N-staging.threa.io`). If a match is found, skip posting. If not found, post as normal.

### How it works

1. Compute `STAGING_URL` for the PR
2. Call `POST /api/v1/workspaces/.../messages/search` with `semantic: false` and `limit: 1`, querying the exact staging URL string
3. If `.data.length > 0` → skip; otherwise post the notification

This guarantees exactly one notification per staging environment regardless of how many times the PR is updated.

### Key design decisions

**1. Keyword search, not semantic**

`semantic: false` is used intentionally — we're matching an exact URL string, not a concept. Semantic search could match unrelated messages about the same PR or domain.

**2. Search failure is non-fatal**

The `|| true` on the `curl` search call means a transient API error won't block the notification. The `jq` check safely falls back to `false` on malformed output. Worst case: a duplicate notification is sent — which is acceptable compared to silently dropping the first notification.

**3. `continue-on-error: true` on the step**

The notify step is already best-effort. If the dedup check or the post itself fails, the downstream "Comment PR with staging URL" step must still run.

## Modified files

| File | Change |
|------|--------|
| `.github/workflows/staging.yml` | Add deduplication check before posting staging notification |

## Test plan

- [x] Workflow logic reviewed — search is called before post, exit 0 short-circuits correctly
- [ ] Manually verify: deploy staging, push a second commit, confirm only one Threa message per PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
