### PR TITLE
feat(frontend): clamp link previews to a uniform height with persisted expand

### DIFF
--- a/apps/frontend/src/components/timeline/link-preview-body.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-body.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, afterEach, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { LinkPreviewBody, LINK_PREVIEW_BODY_HEIGHT_PX } from "./link-preview-body"
+
+/**
+ * jsdom reports `scrollHeight` as 0 for every element, so we stub it with a
+ * configurable getter. This lets a test pretend the content overflows (or
+ * doesn't) independently of layout.
+ */
+function stubScrollHeight(value: number) {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight")
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return value
+    },
+  })
+  return () => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", original)
+    } else {
+      // @ts-expect-error - restore jsdom default
+      delete HTMLElement.prototype.scrollHeight
+    }
+  }
+}
+
+describe("LinkPreviewBody", () => {
+  let restoreScrollHeight: (() => void) | null = null
+
+  afterEach(() => {
+    restoreScrollHeight?.()
+    restoreScrollHeight = null
+    vi.restoreAllMocks()
+  })
+
+  it("does not render a Show more toggle for content that fits the clamp", () => {
+    restoreScrollHeight = stubScrollHeight(LINK_PREVIEW_BODY_HEIGHT_PX - 20)
+
+    render(
+      <LinkPreviewBody messageId={undefined} previewId="preview_short">
+        <p>Short preview</p>
+      </LinkPreviewBody>
+    )
+
+    expect(screen.getByText("Short preview")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument()
+  })
+
+  it("shows a Show more toggle when content overflows the clamp", () => {
+    restoreScrollHeight = stubScrollHeight(LINK_PREVIEW_BODY_HEIGHT_PX + 200)
+
+    render(
+      <LinkPreviewBody messageId={undefined} previewId="preview_tall">
+        <p>Tall preview content</p>
+      </LinkPreviewBody>
+    )
+
+    expect(screen.getByRole("button", { name: /show more/i })).toBeInTheDocument()
+  })
+
+  it("toggles the affordance from Show more to Show less on click", async () => {
+    restoreScrollHeight = stubScrollHeight(LINK_PREVIEW_BODY_HEIGHT_PX + 200)
+    const user = userEvent.setup()
+
+    render(
+      <LinkPreviewBody messageId="msg_1" previewId="preview_tall">
+        <p>Tall preview content</p>
+      </LinkPreviewBody>
+    )
+
+    await user.click(screen.getByRole("button", { name: /show more/i }))
+
+    expect(await screen.findByRole("button", { name: /show less/i })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/timeline/link-preview-body.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-body.tsx
@@ -4,16 +4,16 @@ import { cn } from "@/lib/utils"
 import { useLinkPreviewCollapse } from "@/hooks/use-link-preview-collapse"
 
 /**
- * Shared fixed body height for every card-style link preview. GitHub diffs,
- * long file snippets, and chatty PR/issue/comment bodies are clipped to this
- * height by default so a message with multiple previews lines up neatly;
- * users can expand individual cards with the "Show more" affordance.
+ * Shared cap on every card-style link preview's body height. Tall content
+ * (GitHub diffs, long READMEs, chatty PR/issue/comment bodies) clips to this
+ * ceiling so it can't dominate a message; short content keeps its natural
+ * height so cards never render awkward trailing whitespace.
  *
  * Expressed in pixels because overflow detection compares `scrollHeight`
  * against this value. Keep in sync with `BODY_HEIGHT_CLASS`.
  */
 export const LINK_PREVIEW_BODY_HEIGHT_PX = 128
-const BODY_HEIGHT_CLASS = "h-32"
+const BODY_HEIGHT_CLASS = "max-h-32"
 
 interface LinkPreviewBodyProps {
   children: ReactNode

--- a/apps/frontend/src/components/timeline/link-preview-body.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-body.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react"
+import { ChevronsDown, ChevronsUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useLinkPreviewCollapse } from "@/hooks/use-link-preview-collapse"
+
+/**
+ * Shared fixed body height for every card-style link preview. GitHub diffs,
+ * long file snippets, and chatty PR/issue/comment bodies are clipped to this
+ * height by default so a message with multiple previews lines up neatly;
+ * users can expand individual cards with the "Show more" affordance.
+ *
+ * Expressed in pixels because overflow detection compares `scrollHeight`
+ * against this value. Keep in sync with `BODY_HEIGHT_CLASS`.
+ */
+export const LINK_PREVIEW_BODY_HEIGHT_PX = 128
+const BODY_HEIGHT_CLASS = "h-32"
+
+interface LinkPreviewBodyProps {
+  children: ReactNode
+  /**
+   * Scopes the expand/collapse persistence key. When absent (tests or
+   * transient contexts), toggling is disabled and state stays in IDB-free
+   * memory — the clamp still applies so layout is consistent.
+   */
+  messageId: string | undefined
+  previewId: string
+}
+
+/**
+ * Clamps arbitrary preview content to a shared fixed height and reveals a
+ * "Show more" / "Show less" toggle when the natural content overflows. The
+ * expansion choice is persisted via `useLinkPreviewCollapse` so reloads
+ * restore the user's selection, mirroring the collapsible markdown block
+ * pattern used elsewhere in the timeline.
+ */
+export function LinkPreviewBody({ children, messageId, previewId }: LinkPreviewBodyProps) {
+  const { expanded, toggle } = useLinkPreviewCollapse(messageId, previewId)
+  const innerRef = useRef<HTMLDivElement>(null)
+  const [naturalHeight, setNaturalHeight] = useState(0)
+
+  // Measure the content's natural height off of the inner element (not the
+  // clamped wrapper) so the value is stable across expand/collapse toggles.
+  useLayoutEffect(() => {
+    const el = innerRef.current
+    if (!el) return
+    setNaturalHeight(el.scrollHeight)
+  }, [children])
+
+  useEffect(() => {
+    const el = innerRef.current
+    if (!el || typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(() => {
+      setNaturalHeight(el.scrollHeight)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  // Small tolerance so sub-pixel layout differences don't flicker the
+  // "Show more" button on and off across re-renders.
+  const overflows = naturalHeight > LINK_PREVIEW_BODY_HEIGHT_PX + 1
+  const showToggle = overflows || expanded
+
+  const handleToggle = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+      toggle()
+    },
+    [toggle]
+  )
+
+  return (
+    <>
+      <div className={cn("relative overflow-hidden", !expanded && BODY_HEIGHT_CLASS)}>
+        <div ref={innerRef}>{children}</div>
+        {!expanded && overflows && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-card to-transparent"
+          />
+        )}
+      </div>
+      {showToggle && (
+        <button
+          type="button"
+          onClick={handleToggle}
+          className={cn(
+            "flex w-full items-center justify-center gap-1 border-t bg-muted/20 px-3 py-1",
+            "text-[11px] font-medium text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
+          )}
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <>
+              <ChevronsUp className="h-3 w-3" aria-hidden="true" />
+              Show less
+            </>
+          ) : (
+            <>
+              <ChevronsDown className="h-3 w-3" aria-hidden="true" />
+              Show more
+            </>
+          )}
+        </button>
+      )}
+    </>
+  )
+}

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { cn } from "@/lib/utils"
+import { LinkPreviewBody } from "./link-preview-body"
 import type {
   GitHubFilePreviewData,
   GitHubPrPreviewData,
@@ -32,6 +33,11 @@ import type {
 
 interface LinkPreviewCardProps {
   preview: LinkPreviewSummary
+  /**
+   * Scopes the per-preview "Show more" persistence key. Optional so tests and
+   * transient previews without a host message still render.
+   */
+  messageId?: string
   isHighlighted?: boolean
   isCollapsed?: boolean
   onDismiss?: (previewId: string) => void
@@ -59,6 +65,7 @@ function getDomain(url: string): string {
 
 export function LinkPreviewCard({
   preview,
+  messageId,
   isHighlighted,
   isCollapsed: isCollapsedProp,
   onDismiss,
@@ -194,16 +201,22 @@ export function LinkPreviewCard({
         </div>
       </div>
 
-      {/* Expandable content */}
+      {/* Expandable content — always clamped to a shared body height so a
+          message with mixed preview types (e.g. a PR + a diff) lines up.
+          Tall cards reveal a "Show more" affordance that persists per
+          (messageId, previewId) in IDB, mirroring the collapsible markdown
+          block pattern. */}
       {!isCollapsedProp && (
-        <a
-          href={preview.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block hover:bg-muted/20 transition-colors"
-        >
-          <GitHubContent preview={preview} imageError={imageError} onImageError={() => setImageError(true)} />
-        </a>
+        <LinkPreviewBody messageId={messageId} previewId={preview.id}>
+          <a
+            href={preview.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block hover:bg-muted/20 transition-colors"
+          >
+            <GitHubContent preview={preview} imageError={imageError} onImageError={() => setImageError(true)} />
+          </a>
+        </LinkPreviewBody>
       )}
     </div>
   )

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -297,11 +297,15 @@ function GenericPreviewContent({
   imageError: boolean
   onImageError: () => void
 }) {
+  // Text intentionally flows at natural height — `LinkPreviewBody` clips the
+  // whole card to a shared ceiling and reveals a "Show more" toggle when
+  // overflow occurs. Pre-truncating with `line-clamp-*` hid overflow from
+  // `scrollHeight`, which suppressed the toggle and left blank space below.
   return (
     <div className="flex gap-3 p-3">
       <div className="flex-1 min-w-0">
-        {preview.title && <h4 className="text-sm font-medium text-foreground line-clamp-2 mb-0.5">{preview.title}</h4>}
-        {preview.description && <p className="text-xs text-muted-foreground line-clamp-2">{preview.description}</p>}
+        {preview.title && <h4 className="text-sm font-medium text-foreground mb-0.5">{preview.title}</h4>}
+        {preview.description && <p className="text-xs text-muted-foreground">{preview.description}</p>}
       </div>
       {preview.imageUrl && !imageError && (
         <img
@@ -329,7 +333,7 @@ function GitHubPrContent({ data }: { data: GitHubPrPreviewData }) {
       <div className="flex items-start gap-2">
         <ActorAvatar actor={data.author} className="mt-0.5" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground line-clamp-2">
+          <h4 className="text-sm font-medium text-foreground">
             {data.title}
             <span className="ml-1.5 font-normal text-muted-foreground">#{data.number}</span>
           </h4>
@@ -384,7 +388,7 @@ function GitHubIssueContent({ data }: { data: GitHubIssuePreviewData }) {
       <div className="flex items-start gap-2">
         <ActorAvatar actor={data.author} className="mt-0.5" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground line-clamp-2">
+          <h4 className="text-sm font-medium text-foreground">
             {data.title}
             <span className="ml-1.5 font-normal text-muted-foreground">#{data.number}</span>
           </h4>
@@ -450,7 +454,7 @@ function GitHubCommitContent({ data }: { data: GitHubCommitPreviewData }) {
       <div className="flex items-start gap-2">
         <ActorAvatar actor={data.author} className="mt-0.5" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground line-clamp-2">{firstLine}</h4>
+          <h4 className="text-sm font-medium text-foreground">{firstLine}</h4>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
             <code className="rounded bg-muted px-1 py-px font-mono text-[11px]">{data.shortSha}</code>
             <span>
@@ -519,7 +523,7 @@ function GitHubDiffContent({ data }: { data: GitHubDiffPreviewData }) {
     <div className="p-3">
       <div className="min-w-0">
         <h4 className="text-sm font-medium text-foreground line-clamp-1">{data.path}</h4>
-        <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+        <p className="mt-0.5 text-xs text-muted-foreground">
           PR #{data.pullRequest.number} · {data.pullRequest.title} · {capitalizeChangeType(data.changeType)}
           {data.language ? ` · ${data.language}` : ""}
           {formatDiffAnchor(data)}
@@ -594,7 +598,7 @@ function GitHubCommentContent({ data }: { data: GitHubCommentPreviewData }) {
             <div className="mt-1.5 overflow-hidden rounded-md border bg-muted/20 px-2.5 py-1.5">
               <MarkdownContent
                 content={data.body}
-                className="text-xs leading-relaxed text-foreground line-clamp-4 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                className="text-xs leading-relaxed text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
               />
             </div>
           )}

--- a/apps/frontend/src/components/timeline/link-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.tsx
@@ -107,6 +107,7 @@ export function LinkPreviewList({
               <MessageLinkPreviewCard
                 preview={preview}
                 workspaceId={workspaceId}
+                messageId={messageId}
                 onDismiss={handleDismiss}
                 hydrate={hydrateFromApi}
               />
@@ -126,6 +127,7 @@ export function LinkPreviewList({
           <PreviewRenderBoundary key={preview.id}>
             <LinkPreviewCard
               preview={preview}
+              messageId={messageId}
               isHighlighted={isHighlighted}
               isCollapsed={isCollapsed}
               onDismiss={handleDismiss}

--- a/apps/frontend/src/components/timeline/message-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/message-link-preview-card.tsx
@@ -5,11 +5,17 @@ import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { linkPreviewsApi } from "@/api"
+import { LinkPreviewBody } from "./link-preview-body"
 import type { LinkPreviewSummary, MessageLinkPreviewData } from "@threa/types"
 
 interface MessageLinkPreviewCardProps {
   preview: LinkPreviewSummary
   workspaceId: string
+  /**
+   * Scopes the per-preview "Show more" persistence key. Optional so tests and
+   * transient previews without a host message still render.
+   */
+  messageId?: string
   onDismiss?: (previewId: string) => void
   hydrate?: boolean
 }
@@ -17,6 +23,7 @@ interface MessageLinkPreviewCardProps {
 export function MessageLinkPreviewCard({
   preview,
   workspaceId,
+  messageId,
   onDismiss,
   hydrate = true,
 }: MessageLinkPreviewCardProps) {
@@ -81,36 +88,36 @@ export function MessageLinkPreviewCard({
   }
 
   const internalPath = getInternalMessagePath(preview.url)
-  const content = (
-    <>
+  const body = (
+    <div className="flex gap-2.5 px-3 py-2">
+      <AuthorAvatar avatarUrl={data.authorAvatarUrl} authorName={data.authorName} />
+      <div className="flex-1 min-w-0">
+        {data.authorName && <span className="text-xs font-medium text-foreground">{data.authorName}</span>}
+        {data.contentPreview && (
+          <div className="mt-0.5">
+            <MarkdownContent content={data.contentPreview} className="text-xs text-muted-foreground" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="group/preview relative overflow-hidden rounded-lg border bg-card transition-all max-w-md hover:border-primary/50 hover:shadow-sm">
       <div className="flex items-center gap-2 px-3 py-1.5 border-b bg-muted/30">
         <MessageSquare className="h-4 w-4 text-primary shrink-0" />
         {data.streamName && <span className="text-xs text-muted-foreground truncate">#{data.streamName}</span>}
         <DismissButton previewId={preview.id} onDismiss={onDismiss} />
       </div>
-      <div className="flex gap-2.5 px-3 py-2">
-        <AuthorAvatar avatarUrl={data.authorAvatarUrl} authorName={data.authorName} />
-        <div className="flex-1 min-w-0">
-          {data.authorName && <span className="text-xs font-medium text-foreground">{data.authorName}</span>}
-          {data.contentPreview && (
-            <div className="line-clamp-3 mt-0.5">
-              <MarkdownContent content={data.contentPreview} className="text-xs text-muted-foreground" />
-            </div>
-          )}
-        </div>
-      </div>
-    </>
-  )
-
-  return (
-    <div className="group/preview relative overflow-hidden rounded-lg border bg-card transition-all max-w-md hover:border-primary/50 hover:shadow-sm">
-      {internalPath ? (
-        <Link to={internalPath} className="block">
-          {content}
-        </Link>
-      ) : (
-        content
-      )}
+      <LinkPreviewBody messageId={messageId} previewId={preview.id}>
+        {internalPath ? (
+          <Link to={internalPath} className="block hover:bg-muted/20 transition-colors">
+            {body}
+          </Link>
+        ) : (
+          body
+        )}
+      </LinkPreviewBody>
     </div>
   )
 }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -264,6 +264,22 @@ export interface CachedMarkdownBlockCollapse {
   updatedAt: number
 }
 
+/**
+ * Persisted per-user "Show more" state for a single link preview card.
+ * By default every card clamps its body to a fixed height so mixed-content
+ * messages line up; when a preview's natural content overflows the clamp,
+ * users can expand it. That expanded/collapsed choice is persisted here so
+ * it survives reloads without bleeding across messages.
+ * Key format: `${messageId}:${previewId}`.
+ */
+export interface CachedLinkPreviewCollapse {
+  id: string
+  messageId: string
+  previewId: string
+  expanded: boolean
+  updatedAt: number
+}
+
 export interface CachedWorkspaceMetadata {
   id: string // workspaceId
   workspaceId: string
@@ -292,6 +308,7 @@ class ThreaDatabase extends Dexie {
   workspaceMetadata!: EntityTable<CachedWorkspaceMetadata, "id">
   pendingOperations!: EntityTable<PendingOperation, "id">
   markdownBlockCollapse!: EntityTable<CachedMarkdownBlockCollapse, "id">
+  linkPreviewCollapse!: EntityTable<CachedLinkPreviewCollapse, "id">
 
   constructor() {
     super("threa")
@@ -484,6 +501,13 @@ class ThreaDatabase extends Dexie {
         }
       })
 
+    // v23: Add linkPreviewCollapse table for persisted per-preview expand state.
+    // Every card clamps its body to a fixed height by default; users expand
+    // tall ones (e.g. GitHub diffs, long READMEs) and that choice persists.
+    this.version(23).stores({
+      linkPreviewCollapse: "id, messageId, updatedAt",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -509,6 +533,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.workspaceMetadata.clear(),
       db.pendingOperations.clear(),
       db.markdownBlockCollapse.clear(),
+      db.linkPreviewCollapse.clear(),
       // Note: we keep pendingMessages to retry sending after re-login
     ])
   } finally {

--- a/apps/frontend/src/hooks/use-link-preview-collapse.test.ts
+++ b/apps/frontend/src/hooks/use-link-preview-collapse.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useLinkPreviewCollapse } from "./use-link-preview-collapse"
+import { db } from "@/db"
+
+describe("useLinkPreviewCollapse", () => {
+  beforeEach(async () => {
+    await db.linkPreviewCollapse.clear()
+  })
+
+  it("defaults to collapsed when no row is persisted", () => {
+    const { result } = renderHook(() => useLinkPreviewCollapse("msg_1", "preview_1"))
+
+    expect(result.current.expanded).toBe(false)
+    expect(result.current.canToggle).toBe(true)
+  })
+
+  it("persists expansion per `(messageId, previewId)` and survives remount", async () => {
+    const { result, unmount } = renderHook(() => useLinkPreviewCollapse("msg_1", "preview_1"))
+
+    act(() => {
+      result.current.toggle()
+    })
+
+    await waitFor(() => {
+      expect(result.current.expanded).toBe(true)
+    })
+
+    const stored = await db.linkPreviewCollapse.get("msg_1:preview_1")
+    expect(stored?.expanded).toBe(true)
+    expect(stored?.messageId).toBe("msg_1")
+    expect(stored?.previewId).toBe("preview_1")
+
+    unmount()
+
+    const { result: remounted } = renderHook(() => useLinkPreviewCollapse("msg_1", "preview_1"))
+    await waitFor(() => {
+      expect(remounted.current.expanded).toBe(true)
+    })
+  })
+
+  it("scopes state per preview so sibling previews are independent", async () => {
+    const { result: a } = renderHook(() => useLinkPreviewCollapse("msg_1", "preview_a"))
+    const { result: b } = renderHook(() => useLinkPreviewCollapse("msg_1", "preview_b"))
+
+    act(() => {
+      a.current.toggle()
+    })
+
+    await waitFor(() => {
+      expect(a.current.expanded).toBe(true)
+    })
+    expect(b.current.expanded).toBe(false)
+  })
+
+  it("disables toggling and persistence when messageId is absent", () => {
+    const { result } = renderHook(() => useLinkPreviewCollapse(undefined, "preview_1"))
+
+    expect(result.current.canToggle).toBe(false)
+
+    act(() => {
+      result.current.toggle()
+    })
+
+    expect(result.current.expanded).toBe(false)
+  })
+})

--- a/apps/frontend/src/hooks/use-link-preview-collapse.ts
+++ b/apps/frontend/src/hooks/use-link-preview-collapse.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "@/db"
+
+export interface LinkPreviewCollapseState {
+  expanded: boolean
+  /** True once a valid scope is available so toggles can be persisted. */
+  canToggle: boolean
+  toggle: () => void
+}
+
+/**
+ * Persists the "Show more" state of a link preview card per `(messageId,
+ * previewId)` in IDB so user choices survive reloads without leaking across
+ * messages. Mirrors the pattern used by `useBlockCollapse` for collapsible
+ * markdown blocks.
+ *
+ * A missing `messageId` (e.g. tests or transient render contexts) disables
+ * persistence — toggles become no-ops and `canToggle` reports false.
+ */
+export function useLinkPreviewCollapse(messageId: string | undefined, previewId: string): LinkPreviewCollapseState {
+  const id = messageId ? `${messageId}:${previewId}` : null
+
+  const persistedOverride = useLiveQuery(async () => {
+    if (!id) return undefined
+    const row = await db.linkPreviewCollapse.get(id)
+    return row?.expanded
+  }, [id])
+
+  const expanded = persistedOverride ?? false
+
+  const toggle = useCallback(() => {
+    if (!id || !messageId) return
+    void db.linkPreviewCollapse.put({
+      id,
+      messageId,
+      previewId,
+      expanded: !expanded,
+      updatedAt: Date.now(),
+    })
+  }, [id, messageId, previewId, expanded])
+
+  return {
+    expanded,
+    canToggle: Boolean(id),
+    toggle,
+  }
+}


### PR DESCRIPTION
Every card-style link preview (generic, GitHub PR/issue/commit/file/diff/
comment, and accessible message links) now clamps its body to a shared fixed
height so a message with mixed preview types lines up visually. Tall
content — notably GitHub diffs and long READMEs — reveals a "Show more"
toggle whose state persists per (messageId, previewId) in IDB, mirroring
the collapsible markdown block pattern.