### PR TITLE
fix(frontend): wrap long URLs, paths, and tokens inside message column

### DIFF
--- a/apps/frontend/src/components/ui/markdown-content.test.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.test.tsx
@@ -364,8 +364,6 @@ Some **bold** and *italic* text with \`code\`.
     it("should wrap long unbreakable strings inside the content column", () => {
       const { container } = render(<MarkdownContent content="test" />)
       const wrapper = container.querySelector(".markdown-content")
-      // break-words + min-w-0 so long URLs/paths/tokens wrap instead of
-      // pushing the flex message column wider than its parent.
       expect(wrapper).toHaveClass("break-words")
       expect(wrapper).toHaveClass("min-w-0")
     })

--- a/apps/frontend/src/components/ui/markdown-content.test.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.test.tsx
@@ -360,6 +360,33 @@ Some **bold** and *italic* text with \`code\`.
     })
   })
 
+  describe("overflow handling", () => {
+    it("should wrap long unbreakable strings inside the content column", () => {
+      const { container } = render(<MarkdownContent content="test" />)
+      const wrapper = container.querySelector(".markdown-content")
+      // break-words + min-w-0 so long URLs/paths/tokens wrap instead of
+      // pushing the flex message column wider than its parent.
+      expect(wrapper).toHaveClass("break-words")
+      expect(wrapper).toHaveClass("min-w-0")
+    })
+
+    it("should break long autolinked URLs at arbitrary points", () => {
+      const longUrl = "https://example.com/" + "averyverylongsegment".repeat(20)
+      render(<MarkdownContent content={longUrl} />)
+      const link = screen.getByRole("link")
+      // break-all allows breaking unbreakable URL text mid-token.
+      expect(link).toHaveClass("break-all")
+    })
+
+    it("should break long inline code at arbitrary points", () => {
+      const longToken = "a".repeat(200)
+      render(<MarkdownContent content={"Use `" + longToken + "` here"} />)
+      const code = screen.getByText(longToken)
+      expect(code.tagName).toBe("CODE")
+      expect(code).toHaveClass("break-all")
+    })
+  })
+
   describe("memoization", () => {
     it("should be memoized to prevent unnecessary re-renders", () => {
       const { rerender } = render(<MarkdownContent content="test" />)

--- a/apps/frontend/src/components/ui/markdown-content.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.tsx
@@ -50,7 +50,10 @@ function urlTransform(url: string): string {
  */
 export const MarkdownContent = memo(function MarkdownContent({ content, className, messageId }: MarkdownContentProps) {
   const body = (
-    <div className={cn("markdown-content", className)}>
+    // min-w-0 + break-words: prevent long URLs, paths, and tokens from
+    // overflowing the flex message-content column. overflow-wrap inherits,
+    // so links, inline code, and mention chips pick it up automatically.
+    <div className={cn("markdown-content min-w-0 break-words", className)}>
       <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents} urlTransform={urlTransform}>
         {content}
       </Markdown>

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -146,7 +146,7 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className="text-primary underline underline-offset-4 hover:text-primary/80 [&_span]:[text-decoration:inherit] cursor-pointer"
+        className="break-all text-primary underline underline-offset-4 hover:text-primary/80 [&_span]:[text-decoration:inherit] cursor-pointer"
       >
         <ProcessedChildren>{children}</ProcessedChildren>
       </button>
@@ -167,13 +167,15 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
   // the native browser menu (e.g. "Open in Firefox", "Copy link") instead of
   // the message drawer.
   return (
+    // break-all so long URLs wrap inside the message column instead of
+    // forcing horizontal overflow (URLs rarely contain whitespace).
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="text-primary underline underline-offset-4 hover:text-primary/80 [&_span]:[text-decoration:inherit]"
+      className="break-all text-primary underline underline-offset-4 hover:text-primary/80 [&_span]:[text-decoration:inherit]"
     >
       <ProcessedChildren>{children}</ProcessedChildren>
     </a>
@@ -265,8 +267,9 @@ export const markdownComponents: Components = {
       )
     }
 
-    // Inline code
-    return <code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono">{children}</code>
+    // Inline code — break-all so long identifiers, paths, or tokens inside
+    // backticks wrap inside the message column instead of overflowing.
+    return <code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono break-all">{children}</code>
   },
 
   // Code blocks wrapper - let code component handle rendering
@@ -361,7 +364,7 @@ export const markdownComponents: Components = {
       href={src}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-primary underline underline-offset-4 hover:text-primary/80"
+      className="break-all text-primary underline underline-offset-4 hover:text-primary/80"
     >
       {alt || src}
     </a>


### PR DESCRIPTION
Message content with long unbreakable strings (URLs, file paths, hashes,
identifiers in inline code) was overflowing the flex message column and
visually spilling past the timeline width. The markdown wrapper had no
overflow-wrap rule, and links/inline code had no word-break, so anything
without whitespace stayed on one line.

- Add min-w-0 + break-words to the .markdown-content wrapper so text
  content breaks on overflow and the wrapper can shrink inside its flex
  parent. overflow-wrap inherits, so paragraphs, mentions, and chips
  pick it up automatically.
- Add break-all to links (both attachment buttons and regular <a>),
  inline <code>, and the image-fallback link. URLs and identifiers
  rarely contain whitespace, so we opt into mid-token breaks for them
  specifically rather than relying only on soft-break opportunities.
- Block-level code and tables already scroll horizontally; left as-is.

https://claude.ai/code/session_01UPEkQfCS3pnXWj3LVX7Csi