### PR TITLE
fix(ci): force clean install on Claude Code web session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; bun install; }; exit 0",
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { cp -n .env.claude-code-web .env; docker compose up -d --wait 2>/dev/null; rm -rf node_modules; bun install; }; exit 0",
             "timeout": 180
           }
         ]


### PR DESCRIPTION
Past web sessions booted from snapshots that sometimes had stale
`node_modules/.bun` symlinks pointing at old package copies (e.g.
`prosemirror-view@1.41.4` alongside `1.41.8`). `bun install` against
the already-satisfied lockfile would not repair those orphaned dirs,
leaving `tsc --noEmit` tripping on duplicate `EditorView` types and
forcing us to ship commits with `--no-verify`.

Drop `node_modules` before running `bun install` in the SessionStart
hook so the install always reconciles with `bun.lock`. The global
`~/.bun/install/cache` keeps this fast (~1s on a warm cache).