### PR TITLE
fix(frontend): widen gap between link preview title and thumbnail

### DIFF
--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -302,7 +302,7 @@ function GenericPreviewContent({
   // overflow occurs. Pre-truncating with `line-clamp-*` hid overflow from
   // `scrollHeight`, which suppressed the toggle and left blank space below.
   return (
-    <div className="flex gap-3 p-3">
+    <div className="flex gap-4 p-3">
       <div className="flex-1 min-w-0">
         {preview.title && <h4 className="text-sm font-medium text-foreground mb-0.5">{preview.title}</h4>}
         {preview.description && <p className="text-xs text-muted-foreground">{preview.description}</p>}


### PR DESCRIPTION
## Problem

On the generic link preview card (used for GitHub share links, OpenGraph site cards, PDFs), the title/description column sat too close to the right-side thumbnail. On narrow viewports (e.g. mobile), titles visibly crowded the thumbnail edge — reported via a screenshot of a GitHub "Deploy Cloudflare" share where the title ran flush against the repo preview image.

## Solution

Bumped the flex gap in `GenericPreviewContent` from `gap-3` (12px) to `gap-4` (16px). This is the single layout branch that renders title-left / thumbnail-right; GitHub-native preview types (PR/issue/commit/file/diff/comment), image-only previews, and internal message-link previews all render through separate components and are untouched.

### Key design decisions

**1. Why `gap-4` instead of responsive `gap-3 sm:gap-4`**

The card is capped at `max-w-md` (448px) everywhere, so desktop doesn't have "extra room" that would make 16px look sparse. A flat value keeps the layout rule readable and matches the spacing hierarchy: text-to-edge stays at the card padding (12px), while text-to-image — which visually needs more separation because the image is a distinct content block — is now 16px.

**2. Why not touch `p-3` padding too**

The complaint was text-vs-image crampedness, not card-edge crampedness. Bumping padding would enlarge every preview card and shift adjacent layout; the gap change is the minimal fix.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/link-preview-card.tsx` | `gap-3` → `gap-4` on the `GenericPreviewContent` flex container |

## Test plan

- [x] `bun run --cwd apps/frontend test -- link-preview-card` — all 8 `LinkPreviewCard` tests pass
- [x] Verified no test asserts the old `gap-3` class
- [ ] Manually verify on mobile: GitHub share link preview no longer crowds the title against the thumbnail
- [ ] Spot-check other generic previews (PDFs, OpenGraph site cards) still look balanced
- [ ] Confirm GitHub-native previews (PR, issue, commit, diff, comment) are unchanged

## Note on CI

The frontend typecheck currently fails on `main` due to duplicate `prosemirror-view` installs (1.41.4 via `prosemirror-tables` + 1.41.8 top-level) causing TS2322/2345 errors in `editor-behaviors.ts` and `quote-reply-extension.ts` — a pre-existing dependency-resolution issue unrelated to this change. Worth a separate follow-up.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_