### PR TITLE
Route staging deploy notifications to dedicated channel

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -97,7 +97,7 @@ jobs:
             }')
 
           curl -f --show-error -X POST \
-            "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/streams/stream_01KP36GA56WZREGN6VTKREWRM9/messages" \
+            "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/streams/stream_01KP81PS9AR7Z1WAQ47V3SA2TT/messages" \
             -H "Authorization: Bearer $THREA_BOT_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"


### PR DESCRIPTION
Point the staging PR deploy notification to stream_01KP81PS9AR7Z1WAQ47V3SA2TT
so staging noise no longer mixes with prod CI/deploy notifications in
stream_01KP36GA56WZREGN6VTKREWRM9. The teardown step uses the workspace-scoped
/messages/find-by-metadata and /messages/{id} endpoints, so it will find and
update the deploy message in its new channel without code changes.

notify.yml (prod CI + Deploy Cloudflare) is intentionally left on the original
channel.