### PR TITLE
feat(frontend): float the message input over the scroll area

### DIFF
--- a/.claude/plans/the-ui-has-currently-witty-stonebraker.md
+++ b/.claude/plans/the-ui-has-currently-witty-stonebraker.md
@@ -1,0 +1,109 @@
+# Floating Message Input
+
+## Context
+
+The UI feels cramped — the message input currently sits in a bordered box glued to the bottom of the scroll area, and every message vanishes at the box's top edge. We want the input to feel like a floating pill instead: messages scroll *under* the pill and briefly appear *below* it (in the gap between pill and viewport bottom) before leaving the scroll area, while the default resting position of the most recent message stays visually offset above the pill exactly as it is today. Same behaviour on mobile and desktop, in the main stream view and the thread panel, for real streams and for every kind of draft (scratchpad, channel, DM, thread). All composer controls (toolbar, Aa, emoji, @, attach, send, expand-to-fullscreen, mobile formatting drawer) must keep behaving exactly as today.
+
+## Approach
+
+Turn the composer wrapper into an absolutely-positioned floating pill inside the existing `data-editor-zone` container, reserve space for it inside the scroll content (Virtuoso Footer for virtualized lists, `padding-bottom` for plain-scroll fallbacks), and publish the measured composer height as a CSS custom property so the spacer keeps pace with height changes (mobile-expanded 75dvh, attachments row, formatting drawer, error message). The composer component itself does not change — it already renders as a rounded pill.
+
+## Files to modify
+
+### `apps/frontend/src/components/timeline/message-input.tsx` (~line 459)
+
+- Remove the `border-t` wrapper around the composer pill. Replace with an absolute-positioned wrapper that sits at the bottom of the scroll area with a small gap.
+  - New root: `<div ref={selfRef} data-message-composer-root className={cn("pointer-events-none absolute inset-x-0 bottom-0 z-20", expanded && "hidden")}>`
+  - Inner centered container keeps `pt-3 px-3 pb-3 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0 pointer-events-auto` (pb-1 → pb-3/4 gives the "messages briefly appear below" space).
+- Add a `ResizeObserver` on `selfRef` that writes `--composer-height` (in px) onto the closest `[data-editor-zone]` ancestor. Clean up on unmount.
+- While `expanded`, set `--composer-height` to `0px` (or skip observing) so the Virtuoso Footer collapses behind the fullscreen overlay.
+- No changes to `MessageComposer` itself (INV-38, INV-36): all toolbars and controls continue to work untouched.
+
+### `apps/frontend/src/components/timeline/stream-content.tsx`
+
+- Restructure `stream-content.tsx:606-754`: the outer `<div className="flex h-full flex-col">` becomes `<div className="relative h-full">`. The scroll wrapper stays `relative h-full overflow-hidden` (fills the parent). `MessageInput` becomes an absolute-positioned sibling — no longer taking flex space.
+- `JoinChannelBar` (lines 737-744): keep as a sibling, but position it absolutely just above the composer pill (e.g. `absolute inset-x-0 bottom-[var(--composer-height,0px)] z-10`), so it never reclaims layout space from the scroll area.
+- **Jump-to-latest button (lines 728-735)**: change `bottom-4` → `bottom-[calc(var(--composer-height,0px)+0.5rem)]` so it floats above the pill.
+- **Loading "Loading newer messages" pill (lines 675-685)**: same offset — currently uses `bottom-16` / `bottom-2`. Rebase on `--composer-height`.
+- **Virtualized path (line 1004)**: add `components={{ Footer: VirtuosoFooterSpacer }}` where `VirtuosoFooterSpacer = () => <div style={{ height: "var(--composer-height, 0px)" }} aria-hidden />`. Confirm `atBottomThreshold={30}` and `followOutput` still behave — Footer is treated as content by Virtuoso, so "at bottom" means "Footer in view", which is exactly what we want (last message offset above the pill at rest).
+- **Plain-scroll fallback (line 689)**: add `style={{ paddingBottom: "var(--composer-height, 0px)" }}` (or Tailwind arbitrary `pb-[var(--composer-height,0px)]`).
+- **Draft scratchpad scroll (line 612)**: same `padding-bottom: var(--composer-height)` treatment.
+
+### `apps/frontend/src/components/thread/stream-panel.tsx` (lines 327-420, draft branch)
+
+- Replace the flex-column with `relative flex-1` + absolutely-positioned composer (mirror the main stream change). The `SidePanelContent` already has `data-editor-zone="panel"` — that's where `--composer-height` gets written by the draft composer's own observer.
+- Drop `border-t` from line 393 wrapper. Make the scroll div (line 361) add `padding-bottom: var(--composer-height, 0px)`.
+- The draft branch builds its own `<MessageComposer>` inline instead of using `<MessageInput>`. Extract the small ResizeObserver logic into a shared hook: **new file** `apps/frontend/src/hooks/use-composer-height-publish.ts` that takes a `ref` and publishes `--composer-height` onto the nearest `[data-editor-zone]`. Reuse from both `message-input.tsx` and the draft branch in `stream-panel.tsx`.
+- Keep the draft expanded overlay (lines 332-360) as-is — it already uses `absolute inset-0 z-30`, which sits above the floating pill (z-20).
+
+## Shared hook
+
+**New:** `apps/frontend/src/hooks/use-composer-height-publish.ts`
+
+```ts
+export function useComposerHeightPublish(
+  ref: React.RefObject<HTMLElement | null>,
+  { active = true }: { active?: boolean } = {}
+) {
+  useEffect(() => {
+    const el = ref.current
+    if (!el || !active) return
+    const zone = el.closest<HTMLElement>("[data-editor-zone]")
+    if (!zone) return
+    const write = (h: number) => zone.style.setProperty("--composer-height", `${h}px`)
+    write(el.getBoundingClientRect().height)
+    const ro = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect.height ?? el.getBoundingClientRect().height
+      write(h)
+    })
+    ro.observe(el)
+    return () => {
+      ro.disconnect()
+      zone.style.removeProperty("--composer-height")
+    }
+  }, [ref, active])
+}
+```
+
+- Scoping via `[data-editor-zone]` means main-stream composer writes to `<main>` and panel draft composer writes to `SidePanelContent`. Each scroll area consumes its own scope's variable — no cross-pollination between main view and thread panel even when both are open.
+- `active=false` while expanded disposes the observer and clears the variable (Footer collapses to 0).
+
+## Expanded overlay interaction
+
+- Floating pill: `z-20`.
+- Expanded fullscreen overlay (portaled into `data-editor-zone`): `z-30`, `bg-background`, `absolute inset-0` — already covers the pill. No change needed.
+- When expanded, clear `--composer-height` so the Virtuoso Footer spacer collapses (scroll area returns to full height, hidden behind the overlay anyway).
+
+## Pointer events
+
+- Absolute wrapper gets `pointer-events-none`; the inner pill container gets `pointer-events-auto`. The gap around the pill remains click-through, so hover/right-click on messages visible below the pill still works.
+
+## Mobile-expanded composer
+
+- Composer's own `max-h-[75dvh] min-h-[75dvh]` transition grows the pill upward. With absolute positioning from `bottom-0`, the pill grows up from the bottom naturally. The ResizeObserver picks up the new height and the Virtuoso Footer spacer tracks it — messages reflow so the most recent one still sits just above the pill.
+
+## `JoinChannelBar`
+
+- Positioned `absolute inset-x-0 bottom-[var(--composer-height,0px)] z-10` so it docks above the pill. It won't cause layout shift, but we should verify its contents remain visible when the pill is tall on mobile — if it overlaps the pill in pathological cases, add a subtle opaque background.
+
+## Verification
+
+1. `bun install` already ran via SessionStart.
+2. `bun run --cwd apps/frontend dev` (or equivalent) — open the main stream view.
+3. Manual checks:
+   - Default view: last message sits offset above the pill (same spacing as today).
+   - Scroll up: messages pass under the pill and are briefly visible in the gap below it.
+   - Jump-to-latest button renders above the pill, not clipped.
+   - Attachments row + formatting drawer on mobile still grow the pill correctly; messages reflow.
+   - Thread panel: open a draft thread, verify same floating behaviour; open a real thread, verify `StreamContent` floats the same way.
+   - Drafts: new scratchpad, channel draft, DM draft, thread draft — each composes fine; auto-save unchanged.
+   - Expand-to-fullscreen: overlay covers the pill and the scroll area; collapse restores the pill and the scroll offset.
+   - Mobile virtual keyboard (dvh): pill stays above the keyboard; messages reflow.
+4. `bun run test` for unit/integration.
+5. `bun run test:e2e` — particularly any suite touching composer, scroll, or thread panel.
+
+## Risks
+
+- **Virtuoso Footer + `followOutput: "auto"`**: confirm auto-scroll still lands "at bottom" with the Footer present. Footer is part of content, so `followOutput` scrolls so Footer is in view — which visually means last message sits just above the pill. This is the desired behaviour, not a regression.
+- **Dynamic `--composer-height` during scroll**: if the pill height changes mid-scroll (e.g. attachment added), Virtuoso re-measures the Footer; brief layout jump possible. Acceptable — matches today's behaviour when the bordered box grows.
+- **CSS variable absence**: fallback `var(--composer-height, 0px)` ensures no layout breakage before the observer fires on first paint.

--- a/apps/frontend/src/components/composer/floating-composer-shell.tsx
+++ b/apps/frontend/src/components/composer/floating-composer-shell.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode, type Ref } from "react"
+
+/**
+ * Wrapper for the floating composer pill. Provides the shared shell —
+ * absolute-positioned container with `pointer-events-none`, plus the inner
+ * `pointer-events-auto` centered pill with the canonical padding. Used from
+ * both the main stream `MessageInput` and the draft branch of `StreamPanel`
+ * so visual tweaks (shadow, radius, padding, safe-area) stay in one place.
+ *
+ * When `hidden` is true the wrapper collapses to `display: none` — callers use
+ * this while the expand-to-fullscreen overlay is mounted.
+ */
+interface FloatingComposerShellProps {
+  hidden?: boolean
+  children: ReactNode
+  ref?: Ref<HTMLDivElement>
+  "data-message-composer-root"?: boolean
+}
+
+export function FloatingComposerShell({ hidden = false, children, ref, ...rest }: FloatingComposerShellProps) {
+  return (
+    <div ref={ref} {...rest} className={hidden ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}>
+      <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/composer/index.ts
+++ b/apps/frontend/src/components/composer/index.ts
@@ -1,1 +1,2 @@
 export { MessageComposer, type MessageComposerProps } from "./message-composer"
+export { FloatingComposerShell } from "./floating-composer-shell"

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/components/timeline"
 import { StreamErrorBoundary } from "@/components/stream-error-boundary"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
-import { MessageComposer } from "@/components/composer"
+import { FloatingComposerShell, MessageComposer } from "@/components/composer"
 import { ThreadParentMessage } from "./thread-parent-message"
 import { ThreadHeader } from "./thread-header"
 import { ResponsiveBreadcrumbs } from "./responsive-breadcrumbs"
@@ -399,36 +399,31 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 </Empty>
               )}
             </div>
-            <div
-              ref={draftComposerRef}
-              className={draftExpanded ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}
-            >
-              <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
-                {!draftExpanded && (
-                  <MessageComposer
-                    content={composer.content}
-                    onContentChange={composer.handleContentChange}
-                    pendingAttachments={composer.pendingAttachments}
-                    onRemoveAttachment={composer.handleRemoveAttachment}
-                    fileInputRef={composer.fileInputRef}
-                    onFileSelect={composer.handleFileSelect}
-                    onFileUpload={composer.uploadFile}
-                    imageCount={composer.imageCount}
-                    onSubmit={handleSubmit}
-                    canSubmit={composer.canSend}
-                    isSubmitting={composer.isSending}
-                    hasFailed={composer.hasFailed}
-                    submitLabel="Reply"
-                    submittingLabel="Creating..."
-                    placeholder="Write your reply..."
-                    autoFocus={!isMobile}
-                    scopeId={panelId}
-                    onExpandClick={handleDraftExpand}
-                    streamContext={draftStreamContext}
-                  />
-                )}
-              </div>
-            </div>
+            <FloatingComposerShell ref={draftComposerRef} hidden={draftExpanded}>
+              {!draftExpanded && (
+                <MessageComposer
+                  content={composer.content}
+                  onContentChange={composer.handleContentChange}
+                  pendingAttachments={composer.pendingAttachments}
+                  onRemoveAttachment={composer.handleRemoveAttachment}
+                  fileInputRef={composer.fileInputRef}
+                  onFileSelect={composer.handleFileSelect}
+                  onFileUpload={composer.uploadFile}
+                  imageCount={composer.imageCount}
+                  onSubmit={handleSubmit}
+                  canSubmit={composer.canSend}
+                  isSubmitting={composer.isSending}
+                  hasFailed={composer.hasFailed}
+                  submitLabel="Reply"
+                  submittingLabel="Creating..."
+                  placeholder="Write your reply..."
+                  autoFocus={!isMobile}
+                  scopeId={panelId}
+                  onExpandClick={handleDraftExpand}
+                  streamContext={draftStreamContext}
+                />
+              )}
+            </FloatingComposerShell>
           </>
         ) : (
           // Regular stream UI

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -16,6 +16,7 @@ import {
   getDraftMessageKey,
   useThreadAncestors,
   useQueueDraftMessage,
+  useComposerHeightPublish,
 } from "@/hooks"
 import { useCoordinatedLoading, usePanel, isDraftPanel, parseDraftPanel, useSidebar } from "@/contexts"
 import { useUser } from "@/auth"
@@ -148,6 +149,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const setDraftPortalTarget = useCallback((el: HTMLElement | null) => {
     draftPortalTargetRef.current = el
   }, [])
+
+  // Measured height of the draft composer pill; consumed by the scroll area
+  // below it (padding-bottom) so messages sit offset above the floating pill.
+  const draftComposerRef = useRef<HTMLDivElement>(null)
+  useComposerHeightPublish(draftComposerRef, { active: !draftExpanded })
 
   // Reset expand state when panel changes
   useEffect(() => {
@@ -358,7 +364,10 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 </div>,
                 draftPortalTargetRef.current
               )}
-            <div className={draftExpanded ? "flex-1 overflow-y-auto hidden" : "flex-1 overflow-y-auto"}>
+            <div
+              className={draftExpanded ? "flex-1 overflow-y-auto hidden" : "flex-1 overflow-y-auto"}
+              style={{ paddingBottom: "var(--composer-height, 0px)" }}
+            >
               {parentMessage && (
                 <ThreadParentMessage
                   event={parentMessage}
@@ -390,8 +399,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 </Empty>
               )}
             </div>
-            <div className={draftExpanded ? "border-t hidden" : "border-t"}>
-              <div className="pt-3 px-3 pb-1 sm:pt-6 sm:px-6 sm:pb-1 mx-auto max-w-[800px] w-full min-w-0">
+            <div
+              ref={draftComposerRef}
+              className={draftExpanded ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}
+            >
+              <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
                 {!draftExpanded && (
                   <MessageComposer
                     content={composer.content}

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -142,6 +142,7 @@ vi.mock("@/hooks", () => ({
     clearAttachments: mockClearAttachments,
     isLoaded: mockComposerState.isLoaded,
   }),
+  useComposerHeightPublish: () => {},
 }))
 
 // Mock MessageComposer

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { ReactNode } from "react"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MessageInput, materializePendingAttachmentReferences } from "./message-input"
@@ -147,6 +148,8 @@ vi.mock("@/hooks", () => ({
 
 // Mock MessageComposer
 vi.mock("@/components/composer", () => ({
+  FloatingComposerShell: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) =>
+    hidden ? null : <div>{children}</div>,
   MessageComposer: ({
     onSubmit,
     canSubmit,

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react"
 import { createPortal } from "react-dom"
 import { useNavigate } from "react-router-dom"
-import { useDraftComposer, getDraftMessageKey, useStreamOrDraft } from "@/hooks"
+import { useDraftComposer, getDraftMessageKey, useStreamOrDraft, useComposerHeightPublish } from "@/hooks"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { usePreferences } from "@/contexts"
@@ -281,6 +281,12 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
   }, [])
   const handleCollapse = useCallback(() => setExpanded(false), [])
 
+  // Publish the floating composer's measured height so the scroll area can
+  // reserve matching space (Virtuoso Footer, plain-scroll padding-bottom).
+  // Disabled while the expanded overlay is open so the scroll area can use its
+  // full height behind the overlay.
+  useComposerHeightPublish(selfRef, { active: !expanded })
+
   // Escape to close — only when focus is inside this expanded editor
   useEffect(() => {
     if (!expanded) return
@@ -456,8 +462,12 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
           under document.body), so the composer is hidden purely from DOM presence.
           This replaces a previous ref-counted React state mechanism that was prone to
           leaks across hydration races and virtualization cycles. */}
-      <div ref={selfRef} data-message-composer-root className={expanded ? "border-t hidden" : "border-t"}>
-        <div className="pt-3 px-3 pb-1 sm:pt-6 sm:px-6 sm:pb-1 mx-auto max-w-[800px] w-full min-w-0">
+      <div
+        ref={selfRef}
+        data-message-composer-root
+        className={expanded ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}
+      >
+        <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
           {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
           {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
         </div>

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -6,7 +6,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { usePreferences } from "@/contexts"
 import { useConnectionState } from "@/components/layout/connection-status"
-import { MessageComposer } from "@/components/composer"
+import { FloatingComposerShell, MessageComposer } from "@/components/composer"
 import { commandsApi } from "@/api"
 import { hasCommandNode } from "@/lib/commands"
 import { serializeToMarkdown } from "@threa/prosemirror"
@@ -462,16 +462,10 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
           under document.body), so the composer is hidden purely from DOM presence.
           This replaces a previous ref-counted React state mechanism that was prone to
           leaks across hydration races and virtualization cycles. */}
-      <div
-        ref={selfRef}
-        data-message-composer-root
-        className={expanded ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}
-      >
-        <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
-          {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
-          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
-        </div>
-      </div>
+      <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
+        {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
+        {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+      </FloatingComposerShell>
     </>
   )
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -603,13 +603,16 @@ export function StreamContent({
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
       <QuoteReplyProvider>
         <TextSelectionQuote streamId={streamId} />
-        <div className="flex h-full flex-col">
-          <div className="relative flex-1 overflow-hidden">
+        <div className="relative h-full">
+          <div className="absolute inset-0 overflow-hidden">
             {isSearchOpen && (
               <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
             )}
             {isDraft && (
-              <div className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain">
+              <div
+                className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
+                style={{ paddingBottom: "var(--composer-height, 0px)" }}
+              >
                 {hasDraftPendingEvents ? (
                   <EventList
                     timelineItems={draftTimelineItems}
@@ -676,10 +679,15 @@ export function StreamContent({
                   aria-hidden={!isFetchingNewer}
                   className={cn(
                     "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                    // Sit above the Jump to latest button (bottom-4 + button height) when visible
-                    isJumpMode || isScrolledFarFromBottom ? "bottom-16" : "bottom-2",
                     isFetchingNewer ? "opacity-100" : "opacity-0"
                   )}
+                  style={{
+                    // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
+                    bottom:
+                      isJumpMode || isScrolledFarFromBottom
+                        ? "calc(var(--composer-height, 0px) + 3.5rem)"
+                        : "calc(var(--composer-height, 0px) + 0.5rem)",
+                  }}
                 >
                   Loading newer messages...
                 </div>
@@ -689,6 +697,7 @@ export function StreamContent({
               <div
                 ref={plainScrollRef}
                 className={cn("h-full overflow-y-auto overflow-x-hidden overscroll-y-contain", isSearchOpen && "pt-11")}
+                style={{ paddingBottom: "var(--composer-height, 0px)" }}
                 data-suppress-pull-refresh="true"
                 onScroll={plainHandleScroll}
               >
@@ -724,23 +733,34 @@ export function StreamContent({
                 )}
               </div>
             )}
-            {/* Jump to latest button — shown when scrolled far from bottom or in jump mode */}
-            {(isJumpMode || isScrolledFarFromBottom) && (
-              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
-                <Button variant="secondary" size="sm" className="shadow-lg gap-1.5" onClick={handleJumpToLatest}>
-                  <ArrowDown className="h-3.5 w-3.5" />
-                  Jump to latest
-                </Button>
-              </div>
-            )}
           </div>
+          {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
+              Positioned above the floating composer pill. */}
+          {(isJumpMode || isScrolledFarFromBottom) && (
+            <div
+              className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
+              style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
+            >
+              <Button
+                variant="secondary"
+                size="sm"
+                className="pointer-events-auto shadow-lg gap-1.5"
+                onClick={handleJumpToLatest}
+              >
+                <ArrowDown className="h-3.5 w-3.5" />
+                Jump to latest
+              </Button>
+            </div>
+          )}
           {membershipResolved && !isMember && isPublicChannel && (
-            <JoinChannelBar
-              workspaceId={workspaceId}
-              streamId={streamId}
-              channelName={stream?.slug ?? stream?.displayName ?? ""}
-              onJoined={handleJoined}
-            />
+            <div className="absolute inset-x-0 z-10" style={{ bottom: "var(--composer-height, 0px)" }}>
+              <JoinChannelBar
+                workspaceId={workspaceId}
+                streamId={streamId}
+                channelName={stream?.slug ?? stream?.displayName ?? ""}
+                onJoined={handleJoined}
+              />
+            </div>
           )}
           {(isMember || !isPublicChannel || !membershipResolved) && (
             <MessageInput
@@ -1020,6 +1040,14 @@ function VirtuosoMessageList({
       endReached={handleEndReached}
       atBottomThreshold={30}
       increaseViewportBy={{ top: 600, bottom: 600 }}
+      components={virtuosoComponents}
     />
   )
 }
+
+// Spacer reserving room for the floating composer pill, so the most recent
+// message sits visually offset above the pill at rest and `atBottom` accounts
+// for the composer's height (Virtuoso treats Footer as content).
+const ComposerFooterSpacer = () => <div aria-hidden style={{ height: "var(--composer-height, 0px)" }} />
+
+const virtuosoComponents = { Footer: ComposerFooterSpacer }

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -135,4 +135,6 @@ export { useAppUpdate } from "./use-app-update"
 
 export { useQueueDraftMessage } from "./use-queue-draft-message"
 
+export { useComposerHeightPublish } from "./use-composer-height-publish"
+
 export { useUnreadTabIndicator } from "./use-unread-tab-indicator"

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react"
+
+/**
+ * Measures the element referenced by `ref` and publishes its height (in px) as
+ * `--composer-height` on the nearest `[data-editor-zone]` ancestor. Scrollable
+ * siblings inside the same editor zone can consume the variable (Virtuoso
+ * Footer spacer, plain-scroll `padding-bottom`) to reserve space for the
+ * floating composer pill.
+ *
+ * Pass `active: false` (e.g. while the expand-to-fullscreen overlay is open)
+ * to disconnect the observer and clear the variable so consumers collapse back
+ * to zero.
+ */
+export function useComposerHeightPublish(
+  ref: React.RefObject<HTMLElement | null>,
+  { active = true }: { active?: boolean } = {}
+): void {
+  useEffect(() => {
+    const el = ref.current
+    if (!el || !active) return
+
+    const zone = el.closest<HTMLElement>("[data-editor-zone]")
+    if (!zone) return
+
+    const write = (h: number) => {
+      zone.style.setProperty("--composer-height", `${Math.ceil(h)}px`)
+    }
+
+    write(el.getBoundingClientRect().height)
+
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      const h = entry?.borderBoxSize?.[0]?.blockSize ?? entry?.contentRect.height ?? el.getBoundingClientRect().height
+      write(h)
+    })
+    ro.observe(el)
+
+    return () => {
+      ro.disconnect()
+      zone.style.removeProperty("--composer-height")
+    }
+  }, [ref, active])
+}


### PR DESCRIPTION
## Problem

The UI felt cramped — the message composer sat in a bordered box glued to the bottom of the scroll area. Messages were clipped at the top of that box instead of passing smoothly under the input. The hard `border-t` boundary added to an overall "too many boxes everywhere" feel that the user flagged in the design review screenshot.

## Solution

Turn the composer wrapper into an absolutely-positioned floating pill inside the existing `[data-editor-zone]` container, and reserve matching space inside the scroll content so the resting position of the last message is unchanged. Messages now scroll *under* the floating pill and briefly reappear in the gap below it before leaving the viewport.

### How it works

```
<main data-editor-zone="main" class="relative">
  <div class="absolute inset-0 overflow-hidden">   ← scroll area fills the zone
    <Virtuoso components={{ Footer: Spacer }} /> ← Footer height = --composer-height
  </div>
  <MessageInput class="absolute bottom-0 inset-x-0 z-20" /> ← floating pill
</main>
```

A `ResizeObserver` on the floating composer publishes its measured height as `--composer-height` on the nearest `[data-editor-zone]` ancestor. Scrollable siblings in the same zone consume the variable:

- **Virtuoso list** — `components.Footer` renders a spacer of `height: var(--composer-height)`. Virtuoso treats the Footer as content, so `atBottom`/`followOutput` resolve to "last message above the pill" — identical to today's flex-sibling layout.
- **Plain-scroll fallback & draft scratchpad scroll** — `padding-bottom: var(--composer-height)`.
- **Thread panel draft** — same pattern inside `SidePanelContent`.

### Key design decisions

**1. CSS custom property instead of React context or prop drilling**

`--composer-height` lives on the nearest `[data-editor-zone]` ancestor, which naturally scopes each composer to its own scroll area (main `<main>` vs. thread panel `SidePanelContent`). No cross-pollination even when both are open. Consumers (Virtuoso Footer, padding-bottom) read the variable declaratively. A context would have required threading setters through `MessageInput`, the draft branch of `StreamPanel`, and the many scroll consumers — not worth it for a one-way value.

**2. Virtuoso `Footer` for the virtualized path, `padding-bottom` for plain scroll**

Virtuoso's `components.Footer` is part of content measurement — `atBottomThreshold`, `followOutput: "auto"`, and "jump to latest" all keep working correctly because "last message + Footer" is treated as the content bottom. Plain scroll containers don't need content-aware measurement, so a plain `padding-bottom` is enough.

**3. `pointer-events-none` wrapper + `pointer-events-auto` pill**

The wrapper spans the full width at the bottom of the scroll area, but only the inner pill is interactive. The gap around the pill stays click-through so hover/right-click on messages partially visible under the pill still works.

**4. Publisher hook disables itself while expanded**

When the composer enters fullscreen (portaled `absolute inset-0 z-30` overlay), the observer is disconnected and `--composer-height` is cleared. The Footer spacer collapses to `0px` and the scroll area uses its full height behind the overlay — no reserved-space artifacts peeking out.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-composer-height-publish.ts` | ResizeObserver-based hook that publishes `--composer-height` to the nearest `[data-editor-zone]` ancestor. |
| `.claude/plans/the-ui-has-currently-witty-stonebraker.md` | Implementation plan captured during planning. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-input.tsx` | Wrapper becomes `absolute bottom-0 inset-x-0 z-20` with `pointer-events-none`; inner pill wrapper gets `pointer-events-auto`. `border-t` removed. Calls `useComposerHeightPublish(selfRef, { active: !expanded })`. |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Outer `flex h-full flex-col` → `relative h-full`; scroll wrapper `flex-1` → `absolute inset-0`. `Virtuoso` gets `components={{ Footer: ComposerFooterSpacer }}`. Plain-scroll fallback and draft scratchpad scroll pad bottom by `var(--composer-height)`. Jump-to-latest button, "Loading newer messages" pill, and `JoinChannelBar` rebased on `var(--composer-height)`. |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Draft thread branch mirrors the floating-pill pattern inside `SidePanelContent`. Scroll div gets `padding-bottom: var(--composer-height)`. |
| `apps/frontend/src/hooks/index.ts` | Re-export `useComposerHeightPublish`. |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | Add `useComposerHeightPublish: () => {}` to the `@/hooks` mock. |

## Test plan

- [x] `bun run --cwd apps/frontend test` — 888 pass, 0 failing
- [x] `bun run typecheck` across the monorepo — clean
- [x] `bun run lint` — no new errors
- [ ] Manual: scroll up in a stream, confirm messages pass under the pill and briefly appear in the gap below it before leaving
- [ ] Manual: at rest, most recent message sits offset above the pill (same visible spacing as before)
- [ ] Manual: Jump-to-latest button renders above the pill, not clipped
- [ ] Manual: thread panel (draft + real) behaves the same as the main stream
- [ ] Manual: draft kinds — scratchpad, channel, DM, thread — all compose and auto-save
- [ ] Manual: expand-to-fullscreen overlay still covers pill and scroll area; collapse restores the floating pill
- [ ] Manual: mobile virtual keyboard (dvh) — pill stays above the keyboard; formatting drawer still works
- [ ] Manual: public-channel non-member path — `JoinChannelBar` docks at bottom when composer is absent

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_