### PR TITLE
feat: separate activity tabs — All shows others only, Me shows own

### DIFF
--- a/apps/backend/src/features/activity/handlers.ts
+++ b/apps/backend/src/features/activity/handlers.ts
@@ -16,12 +16,14 @@ export function createActivityHandlers({ activityService }: Dependencies) {
       const cursor = typeof req.query.cursor === "string" ? req.query.cursor : undefined
       const unreadOnly = req.query.unreadOnly === "true"
       const mineOnly = req.query.mineOnly === "true"
+      const othersOnly = req.query.othersOnly === "true"
 
       const activities = await activityService.listFeed(userId, workspaceId, {
         limit,
         cursor,
         unreadOnly,
         mineOnly,
+        othersOnly,
       })
 
       res.json({ activities })

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -195,13 +195,14 @@ export const ActivityRepository = {
     db: Querier,
     userId: string,
     workspaceId: string,
-    opts?: { limit?: number; cursor?: string; unreadOnly?: boolean; mineOnly?: boolean }
+    opts?: { limit?: number; cursor?: string; unreadOnly?: boolean; mineOnly?: boolean; othersOnly?: boolean }
   ): Promise<Activity[]> {
     const limit = opts?.limit ?? 50
     const hasCursor = opts?.cursor !== undefined
     const cursor = opts?.cursor ?? ""
     const unreadOnly = opts?.unreadOnly ?? false
     const mineOnly = opts?.mineOnly ?? false
+    const othersOnly = opts?.othersOnly ?? false
 
     const result = await db.query<ActivityRow>(sql`
       SELECT ${sql.raw(USER_ACTIVITY_COLUMNS)}
@@ -210,6 +211,7 @@ export const ActivityRepository = {
         AND workspace_id = ${workspaceId}
         AND (${!unreadOnly} OR read_at IS NULL)
         AND (${!mineOnly} OR is_self = TRUE)
+        AND (${!othersOnly} OR is_self = FALSE)
         AND (${!hasCursor} OR created_at < (
           SELECT created_at FROM user_activity
           WHERE id = ${cursor} AND user_id = ${userId} AND workspace_id = ${workspaceId}

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -451,7 +451,7 @@ export class ActivityService {
   async listFeed(
     userId: string,
     workspaceId: string,
-    opts?: { limit?: number; cursor?: string; unreadOnly?: boolean; mineOnly?: boolean }
+    opts?: { limit?: number; cursor?: string; unreadOnly?: boolean; mineOnly?: boolean; othersOnly?: boolean }
   ) {
     return ActivityRepository.listByUser(this.pool, userId, workspaceId, opts)
   }

--- a/apps/frontend/src/api/activity.ts
+++ b/apps/frontend/src/api/activity.ts
@@ -6,6 +6,7 @@ export interface ListActivityParams {
   cursor?: string
   unreadOnly?: boolean
   mineOnly?: boolean
+  othersOnly?: boolean
 }
 
 export const activityApi = {
@@ -15,6 +16,7 @@ export const activityApi = {
     if (params?.cursor) query.set("cursor", params.cursor)
     if (params?.unreadOnly) query.set("unreadOnly", "true")
     if (params?.mineOnly) query.set("mineOnly", "true")
+    if (params?.othersOnly) query.set("othersOnly", "true")
 
     const qs = query.toString()
     const path = `/api/workspaces/${workspaceId}/activity${qs ? `?${qs}` : ""}`

--- a/apps/frontend/src/hooks/use-activity.ts
+++ b/apps/frontend/src/hooks/use-activity.ts
@@ -7,18 +7,22 @@ import type { Activity, WorkspaceBootstrap } from "@threa/types"
 export const activityKeys = {
   all: ["activity"] as const,
   list: (workspaceId: string) => ["activity", workspaceId] as const,
-  listFiltered: (workspaceId: string, filters: { unreadOnly: boolean; mineOnly: boolean }) =>
+  listFiltered: (workspaceId: string, filters: { unreadOnly: boolean; mineOnly: boolean; othersOnly: boolean }) =>
     ["activity", workspaceId, filters] as const,
 }
 
-export function useActivityFeed(workspaceId: string, opts?: { unreadOnly?: boolean; mineOnly?: boolean }) {
+export function useActivityFeed(
+  workspaceId: string,
+  opts?: { unreadOnly?: boolean; mineOnly?: boolean; othersOnly?: boolean }
+) {
   const activityService = useActivityService()
   const unreadOnly = opts?.unreadOnly ?? false
   const mineOnly = opts?.mineOnly ?? false
+  const othersOnly = opts?.othersOnly ?? false
 
   return useQuery({
-    queryKey: activityKeys.listFiltered(workspaceId, { unreadOnly, mineOnly }),
-    queryFn: () => activityService.list(workspaceId, { limit: 50, unreadOnly, mineOnly }),
+    queryKey: activityKeys.listFiltered(workspaceId, { unreadOnly, mineOnly, othersOnly }),
+    queryFn: () => activityService.list(workspaceId, { limit: 50, unreadOnly, mineOnly, othersOnly }),
     // Subscribe-then-bootstrap pattern:
     // staleTime: Infinity prevents auto-refetch; socket events invalidate when needed.
     // refetchOnMount: true triggers refetch when data is stale (after invalidation).

--- a/apps/frontend/src/pages/activity.tsx
+++ b/apps/frontend/src/pages/activity.tsx
@@ -51,6 +51,7 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
   const { data: activities, isLoading } = useActivityFeed(workspaceId, {
     unreadOnly: filter === "unread",
     mineOnly: filter === "me",
+    othersOnly: filter === "all",
   })
   const markRead = useMarkActivityRead(workspaceId)
   const markAllRead = useMarkAllActivityRead(workspaceId)


### PR DESCRIPTION
## Problem

The **All** tab in the activity feed included the user's own actions (messages sent, reactions added). These are `isSelf` rows — they exist so users can track their own history in the **Me** tab, but surfacing them in **All** made that tab noisy. The three tabs had no clear semantic division: **All** was truly "everything", but that's not useful when you just want to see what others are doing that involves you.

## Solution

Give each tab a clear, distinct scope:

| Tab | Shows |
|-----|-------|
| **All** | Activity from others — reactions to your posts, mentions, thread replies, etc. |
| **Me** | Your own actions — messages you sent, reactions you added (`isSelf = TRUE`) |
| **Unread** | Unread items (unchanged — self rows are pre-read at insert, so they never appeared here anyway) |

This is done by adding an `othersOnly` query parameter that filters `WHERE is_self = FALSE`, mirroring the existing `mineOnly` path.

### How it works

```
activity.tsx (filter === "all")
  → othersOnly: true
  → useActivityFeed({ othersOnly: true })
  → activityApi.list({ othersOnly: true })
  → GET /activity?othersOnly=true
  → handlers.ts parses othersOnly
  → service.listFeed({ othersOnly: true })
  → repository.listByUser — AND (is_self = FALSE)
```

### Key design decisions

**1. New `othersOnly` flag instead of changing the default**

An explicit flag keeps the API backward-compatible and makes intent clear at every layer. The alternative — always excluding self rows unless `mineOnly` is set — would silently change behavior for any future caller passing no flags.

**2. No new index for `othersOnly`**

There is already a partial index `idx_user_activity_mine` covering `is_self = TRUE` for the Mine tab. Non-self rows are the majority of activity, so the existing composite index on `(user_id, workspace_id, created_at DESC)` covers the `othersOnly` path well without a new index.

**3. `othersOnly` + `mineOnly` together returns zero rows**

If both are passed, `is_self = TRUE AND is_self = FALSE` produces an empty result set. The frontend never sets both simultaneously, so this is an acceptable edge case rather than something worth guarding against.

## Modified files

| File | Change |
|------|--------|
| `apps/backend/src/features/activity/handlers.ts` | Parse `othersOnly` query param, pass to service |
| `apps/backend/src/features/activity/service.ts` | Thread `othersOnly` through to repository |
| `apps/backend/src/features/activity/repository.ts` | Add `othersOnly` to opts type + SQL condition |
| `apps/frontend/src/api/activity.ts` | Add `othersOnly` to `ListActivityParams`, serialize to query string |
| `apps/frontend/src/hooks/use-activity.ts` | Accept `othersOnly` in hook opts, include in query key |
| `apps/frontend/src/pages/activity.tsx` | Pass `othersOnly: filter === "all"` to the feed hook |

## Test plan

- [x] TypeScript passes across all packages (`bun run typecheck`)
- [x] Lint passes with no new errors
- [ ] Open activity feed → **All** tab shows only others' activity (no own messages/reactions)
- [ ] Open **Me** tab shows only own messages and reactions (unchanged behavior)
- [ ] Open **Unread** tab — no change in behavior
- [ ] Switching tabs loads distinct cached results (query keys differ by filter object)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_