### PR TITLE
Fix workspace logo/title drift when opening sidebar

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
@@ -19,13 +19,12 @@ interface SidebarHeaderProps {
 
 export function SidebarHeader({ workspaceName, viewMode, onViewModeChange, hideViewToggle }: SidebarHeaderProps) {
   const { openSwitcher } = useQuickSwitcher()
-  const { state, collapseOnMobile } = useSidebar()
+  const { collapseOnMobile } = useSidebar()
   const { preferences } = usePreferences()
   const customBindings = preferences?.keyboardShortcuts ?? {}
   const streamBinding = getEffectiveKeyBinding("openQuickSwitcher", customBindings)
   const commandBinding = getEffectiveKeyBinding("openCommands", customBindings)
   const searchBinding = getEffectiveKeyBinding("openSearch", customBindings)
-  const isOpen = state === "pinned" || state === "preview"
 
   const handleOpenSwitcher = (mode: "stream" | "command" | "search") => () => {
     collapseOnMobile()
@@ -38,15 +37,9 @@ export function SidebarHeader({ workspaceName, viewMode, onViewModeChange, hideV
            in the identical viewport position whether the sidebar is open or not. */}
       <div className="flex h-12 items-center gap-1 px-4">
         <SidebarToggle location="sidebar" />
-        {/* Logo + workspace name drift 4px left as the sidebar opens, paired
-             with the page-header toggle sliding off to the left — together
-             they read as a coordinated "everything shifts left" swap. */}
         <Link
           to="/workspaces"
-          className={cn(
-            "flex min-w-0 items-center gap-2 truncate transition-[transform,opacity] duration-200 ease-out hover:opacity-80",
-            isOpen ? "translate-x-0" : "translate-x-1"
-          )}
+          className="flex min-w-0 items-center gap-2 truncate transition-opacity hover:opacity-80"
           onClick={collapseOnMobile}
         >
           <ThreaLogo size="sm" />


### PR DESCRIPTION
The sidebar header link applied a conditional translate-x-1 when
collapsed and translate-x-0 when open, with a 200ms transform
transition. The intent was a coordinated "swap" with the page-header
toggle sliding off to the left, but on mobile the page-header toggle
is hidden behind the sheet so there's nothing to coordinate with —
the logo and workspace name just visibly jitter 4px to the left when
the drawer opens.

Drop the transform; keep the hover opacity transition.