### PR TITLE
fix(timeline): never leave timeline blank while IDB is unresolved

### DIFF
--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -135,7 +135,7 @@ describe("computeTimelineLoadState", () => {
     ).toEqual({ isLoading: false, isConfirmedEmpty: false })
   })
 
-  it("reports bootstrap-settled via isConfirmedEmpty even when events are present (call site gates on item count)", () => {
+  it("does not claim confirmed-empty once events are present after bootstrap settles", () => {
     expect(
       computeTimelineLoadState({
         idbResolved: true,
@@ -143,6 +143,6 @@ describe("computeTimelineLoadState", () => {
         isBootstrapLoading: false,
         idbResolveTimedOut: false,
       })
-    ).toEqual({ isLoading: false, isConfirmedEmpty: true })
+    ).toEqual({ isLoading: false, isConfirmedEmpty: false })
   })
 })

--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  computeTimelineLoadState,
   filterEventsForDisplay,
   getCachedWindowFloor,
   getDisplayFloor,
@@ -75,5 +76,73 @@ describe("useEvents helpers", () => {
     expect(initial.floor).toBe(100n)
     expect(appendRefetch.floor).toBe(100n)
     expect(replaceRefetch.floor).toBe(200n)
+  })
+})
+
+describe("computeTimelineLoadState", () => {
+  it("stays blank while IDB is resolving within the grace window", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: false,
+        hasAnyEvents: false,
+        isBootstrapLoading: true,
+        idbResolveTimedOut: false,
+      })
+    ).toEqual({ isLoading: false, isConfirmedEmpty: false })
+  })
+
+  it("flips to skeleton once IDB resolution exceeds the grace window", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: false,
+        hasAnyEvents: false,
+        isBootstrapLoading: false,
+        idbResolveTimedOut: true,
+      })
+    ).toEqual({ isLoading: true, isConfirmedEmpty: false })
+  })
+
+  it("shows skeleton when IDB resolves empty and bootstrap is still fetching", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: true,
+        hasAnyEvents: false,
+        isBootstrapLoading: true,
+        idbResolveTimedOut: false,
+      })
+    ).toEqual({ isLoading: true, isConfirmedEmpty: false })
+  })
+
+  it("shows confirmed-empty once IDB is resolved and bootstrap has settled", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: true,
+        hasAnyEvents: false,
+        isBootstrapLoading: false,
+        idbResolveTimedOut: false,
+      })
+    ).toEqual({ isLoading: false, isConfirmedEmpty: true })
+  })
+
+  it("renders neither skeleton nor empty state when events are available", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: true,
+        hasAnyEvents: true,
+        isBootstrapLoading: true,
+        idbResolveTimedOut: false,
+      })
+    ).toEqual({ isLoading: false, isConfirmedEmpty: false })
+  })
+
+  it("reports bootstrap-settled via isConfirmedEmpty even when events are present (call site gates on item count)", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: true,
+        hasAnyEvents: true,
+        isBootstrapLoading: false,
+        idbResolveTimedOut: false,
+      })
+    ).toEqual({ isLoading: false, isConfirmedEmpty: true })
   })
 })

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -45,12 +45,8 @@ export function getMinimumSequence(events: Array<Pick<StreamEvent, "sequence">> 
 
 /**
  * Grace period before `idbResolved=false` flips the timeline to a skeleton.
- * Dexie's `useLiveQuery` typically resolves in <50ms on desktop; any blank
- * flash during that window is imperceptible. On slower devices (mobile
- * Safari under memory pressure, cold IDB opens) the resolve window can
- * stretch to hundreds of ms, and without a skeleton the user sees a DM
- * with no messages, no "No messages yet", and no loading indicator — a
- * dead-looking page they have to pull-to-refresh to unstick.
+ * Short enough that fast resolves don't flash a skeleton; long enough that a
+ * stuck resolve never leaves the timeline visibly blank with no indicator.
  */
 export const IDB_SKELETON_DELAY_MS = 200
 
@@ -78,13 +74,10 @@ export interface TimelineLoadState {
 
 /**
  * Decide whether the timeline should render a skeleton, an empty state, or
- * pass through to the virtualized scroll area. Pulled out as a pure function
- * so the state machine is easy to unit-test and reason about.
+ * pass through to the virtualized scroll area.
  *
- * The key invariant: never render a blank scroll area as a terminal state.
- * Either we have events, we're loading (skeleton), or we're confirmed empty
- * (empty state). Before this was split out, an `idbResolved=false` window
- * longer than a frame would produce a blank page with no indicator.
+ * Invariant: a blank scroll area is never a terminal state. Either we have
+ * events, we're loading (skeleton), or we're confirmed empty (empty state).
  */
 export function computeTimelineLoadState({
   idbResolved,

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -47,6 +47,11 @@ export function getMinimumSequence(events: Array<Pick<StreamEvent, "sequence">> 
  * Grace period before `idbResolved=false` flips the timeline to a skeleton.
  * Short enough that fast resolves don't flash a skeleton; long enough that a
  * stuck resolve never leaves the timeline visibly blank with no indicator.
+ *
+ * Sibling of `LOADING_DELAY_MS` (300ms) in `coordinated-loading-context.tsx`
+ * which governs the initial workspace-level load. This one is shorter because
+ * it applies after initial load, on a per-stream switch, where users expect
+ * faster feedback. When tuning either, consider both.
  */
 export const IDB_SKELETON_DELAY_MS = 200
 
@@ -93,7 +98,7 @@ export function computeTimelineLoadState({
   }
   return {
     isLoading: !hasAnyEvents && isBootstrapLoading,
-    isConfirmedEmpty: !isBootstrapLoading,
+    isConfirmedEmpty: !hasAnyEvents && !isBootstrapLoading,
   }
 }
 

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -43,6 +43,67 @@ export function getMinimumSequence(events: Array<Pick<StreamEvent, "sequence">> 
   return min
 }
 
+/**
+ * Grace period before `idbResolved=false` flips the timeline to a skeleton.
+ * Dexie's `useLiveQuery` typically resolves in <50ms on desktop; any blank
+ * flash during that window is imperceptible. On slower devices (mobile
+ * Safari under memory pressure, cold IDB opens) the resolve window can
+ * stretch to hundreds of ms, and without a skeleton the user sees a DM
+ * with no messages, no "No messages yet", and no loading indicator — a
+ * dead-looking page they have to pull-to-refresh to unstick.
+ */
+export const IDB_SKELETON_DELAY_MS = 200
+
+export interface TimelineLoadStateInput {
+  /** `true` once `useLiveQuery` has returned a result stamped with the current streamId. */
+  idbResolved: boolean
+  /** `true` when either IDB or the cached bootstrap snapshot has something to render. */
+  hasAnyEvents: boolean
+  /** `true` while the stream bootstrap query is in-flight. */
+  isBootstrapLoading: boolean
+  /**
+   * `true` once IDB has been unresolved for `IDB_SKELETON_DELAY_MS`. Callers
+   * pass `false` until the timeout fires so fast stream switches don't flash
+   * a skeleton.
+   */
+  idbResolveTimedOut: boolean
+}
+
+export interface TimelineLoadState {
+  /** Render a skeleton — we're actively waiting on data. */
+  isLoading: boolean
+  /** Render "No messages yet" — both data sources confirmed empty. */
+  isConfirmedEmpty: boolean
+}
+
+/**
+ * Decide whether the timeline should render a skeleton, an empty state, or
+ * pass through to the virtualized scroll area. Pulled out as a pure function
+ * so the state machine is easy to unit-test and reason about.
+ *
+ * The key invariant: never render a blank scroll area as a terminal state.
+ * Either we have events, we're loading (skeleton), or we're confirmed empty
+ * (empty state). Before this was split out, an `idbResolved=false` window
+ * longer than a frame would produce a blank page with no indicator.
+ */
+export function computeTimelineLoadState({
+  idbResolved,
+  hasAnyEvents,
+  isBootstrapLoading,
+  idbResolveTimedOut,
+}: TimelineLoadStateInput): TimelineLoadState {
+  if (!idbResolved) {
+    // Grace window: pretend neither loading nor empty so fast stream switches
+    // render briefly blank without a skeleton flash. Past the timeout, flip to
+    // the skeleton so slow devices don't appear frozen.
+    return { isLoading: idbResolveTimedOut, isConfirmedEmpty: false }
+  }
+  return {
+    isLoading: !hasAnyEvents && isBootstrapLoading,
+    isConfirmedEmpty: !isBootstrapLoading,
+  }
+}
+
 export function getDisplayFloor(bootstrapFloor: bigint | null, olderFloor: bigint | null): bigint | null {
   if (bootstrapFloor === null) return olderFloor
   if (olderFloor === null) return bootstrapFloor
@@ -290,18 +351,26 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     return filterEventsForDisplay(effectiveEvents, displayFloor) as unknown as StreamEvent[]
   }, [effectiveEvents, olderData, newerData, jumpState, displayFloor])
 
-  // Hard loading: neither source has anything AND bootstrap is still fetching.
-  // Gated on `idbResolved` so we don't claim "loading" during the ~10-50ms
-  // window where useLiveQuery is still resolving for the new stream — during
-  // that window we render an empty scroll area instead of a skeleton, which
-  // would only flash for a frame or two before IDB catches up anyway.
-  const isLoading = idbResolved && !hasAnyEvents && isBootstrapLoading
+  // When IDB has been unresolved long enough that a user would notice, flip
+  // the timeline to the skeleton instead of leaving it blank. Fast switches
+  // clear the timer before it fires, so the flicker-free path is preserved
+  // for the common case.
+  const [idbResolveTimedOut, setIdbResolveTimedOut] = useState(false)
+  useEffect(() => {
+    if (idbResolved) {
+      setIdbResolveTimedOut(false)
+      return
+    }
+    const timer = setTimeout(() => setIdbResolveTimedOut(true), IDB_SKELETON_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [idbResolved])
 
-  // Only render "No messages yet" once we're *certain* the stream is empty —
-  // both bootstrap and useLiveQuery must have resolved. During the 10-50ms
-  // gap after a stream switch where useLiveQuery hasn't re-resolved yet,
-  // `events` is briefly empty but we shouldn't show the empty state UI.
-  const isConfirmedEmpty = idbResolved && !isBootstrapLoading
+  const { isLoading, isConfirmedEmpty } = computeTimelineLoadState({
+    idbResolved,
+    hasAnyEvents,
+    isBootstrapLoading,
+    idbResolveTimedOut,
+  })
 
   useEffect(() => {
     if (!import.meta.env.DEV || !suppressBootstrapError || !error) return


### PR DESCRIPTION
## Summary

- Stream timeline could render a terminal blank scroll area (no skeleton, no "No messages yet") when `useLiveQuery` returned `undefined` for an extended window — observed on mobile as a DM with no messages until pull-to-refresh.
- Both `isLoading` and `isConfirmedEmpty` were gated on `idbResolved`, so any stretch where it stayed false produced a dead-looking page with no indicator.
- Add a 200ms grace window before flipping to a skeleton: fast resolves still render briefly blank (preserving the original flicker-free intent), slow/stuck resolves now show progress.
- Extracted `computeTimelineLoadState` as a pure helper with unit tests pinning the state machine.

## Root cause notes

I couldn't isolate a single deterministic logic bug that keeps `idbResolved=false` for seconds. Likely contributors:

- Dexie cold-start under iOS memory pressure (IDB open + first range scan can stretch to seconds after Safari evicts the page).
- `dexie-react-hooks` returns `undefined` across every dep change of `useLiveQuery`. Compounding dep churn (`streamId` change, bootstrap floor flipping, coordinated `useQueries` rebuilds) chains undefined windows.

The fix is defensive — it doesn't depend on the root cause. The state machine now guarantees a blank scroll area is never a terminal state.

## Test plan

- [x] Unit tests for `computeTimelineLoadState` (5 input permutations) — `apps/frontend/src/hooks/use-events.test.ts`
- [x] Full frontend test suite (`bun run test` in apps/frontend) — 1281 passing
- [x] Lint + typecheck via lint-staged on commit
- [ ] Manual verification on mobile: navigate to a DM with messages, confirm no blank flash and skeleton appears if IDB stalls

https://claude.ai/code/session_01Mqb74KEmnWuhR8ZJMxv2D9