### PR TITLE
fix(staging): connect PR preview backends to Postgres over internal network

### DIFF
--- a/scripts/staging-pr.ts
+++ b/scripts/staging-pr.ts
@@ -90,6 +90,14 @@ const prHostname = `pr-${prNumber}-staging.threa.io`
 // Database helpers (uses psql via STAGING_DATABASE_URL)
 // ---------------------------------------------------------------------------
 
+// STAGING_DATABASE_URL is the public proxy URL (required so GH Actions runners
+// can reach Postgres for psql/pg_dump). Railway services in the same project
+// must talk to Postgres over the internal network to avoid egress charges.
+function toInternalDbUrl(publicUrl: string, dbName: string): string {
+  const u = new URL(publicUrl)
+  return `postgresql://${u.username}:${u.password}@postgres.railway.internal:5432/${dbName}`
+}
+
 async function runPsql(db: string, sql: string): Promise<string> {
   // Replace the database name in the URL
   const url = STAGING_DATABASE_URL.replace(/\/([^/?]+)(\?.*)?$/, `/${db}$2`)
@@ -333,7 +341,7 @@ async function createRailwayService(): Promise<string> {
     baseEnvVars = (baseEnvVars as unknown as { variables: Record<string, string> }).variables ?? {}
   }
 
-  const prDbUrl = STAGING_DATABASE_URL.replace(/\/([^/?]+)(\?.*)?$/, `/${prDbName}$2`)
+  const prDbUrl = toInternalDbUrl(STAGING_DATABASE_URL, prDbName)
   const envVars: Record<string, string> = {
     ...baseEnvVars,
     // PR-specific overrides


### PR DESCRIPTION
## Summary

PR preview backends in the staging Railway project were connecting to Postgres over the public proxy (`nozomi.proxy.rlwy.net:<port>`) instead of the internal network (`postgres.railway.internal:5432`). All three services live in the same Railway project, so this routed every query through the public internet for no reason.

**Egress impact (last period):**
- Staging: ~105 GB (≈$5.27)
- Prod: ~0.9 GB

The main staging `backend` service is fine — only the per-PR preview services (`pr-<N>-backend`) are affected.

## Root cause

`scripts/staging-pr.ts` builds `DATABASE_URL` for each PR's Railway service by swapping the DB name into `STAGING_DATABASE_URL` (a GH Actions secret). That secret has to be the public proxy URL because GH runners can't reach `*.railway.internal` for the workflow's `psql`/`pg_dump` calls. The public URL was then being written verbatim as `DATABASE_URL` on the PR Railway service, so the service used the public network to talk to Postgres in the same project.

## Fix

Single-file, infra-only change in `scripts/staging-pr.ts`:

- Add a `toInternalDbUrl(publicUrl, dbName)` helper that reuses the public URL's credentials but rewrites host/port to `postgres.railway.internal:5432`.
- Use it when setting `DATABASE_URL` on the PR Railway service.
- Leave GH-runner-side `psql`/`pg_dump`/`cloneDatabase`/`runPsql` calls unchanged — they still need the public URL.

No workflow secret changes, no service renames, no new secrets.

## Test plan

- [x] `bun run typecheck` passes
- [ ] After merge, trigger Staging workflow on a PR with the `staging` label
- [ ] In Railway dashboard, confirm the PR service's `DATABASE_URL` variable uses `postgres.railway.internal`
- [ ] Monitor staging project egress for the next day — PR service egress should drop to near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)