### PR TITLE
fix(frontend): upgrade react-virtuoso to 4.18.5 for React 19 concurrency

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -86,7 +86,7 @@
     "react-hook-form": "^7.68.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.11.0",
-    "react-virtuoso": "^4.18.4",
+    "react-virtuoso": "^4.18.5",
     "recharts": "2.15.4",
     "remark-gfm": "^4.0.1",
     "shiki": "^3.20.0",

--- a/bun.lock
+++ b/bun.lock
@@ -233,7 +233,7 @@
         "react-hook-form": "^7.68.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.11.0",
-        "react-virtuoso": "^4.18.4",
+        "react-virtuoso": "^4.18.5",
         "recharts": "2.15.4",
         "remark-gfm": "^4.0.1",
         "shiki": "^3.20.0",
@@ -2971,7 +2971,7 @@
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
-    "react-virtuoso": ["react-virtuoso@4.18.4", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-DNM4Wy2tMA/J6ejMaDdqecOug31rOwgSRg4C/Dw6Iox4dJe9qwcx32M8HdhkE5uHEVVZh7h0koYwAsCSNdxGfQ=="],
+    "react-virtuoso": ["react-virtuoso@4.18.5", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-QDyNjyNEuurZG67SOmzYyxEkQYSyGmAMixOI6M15L/Q4CF39EgG+88y6DgZRo0q7rmy0HPx3Fj90I8/tPdnRCQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 


### PR DESCRIPTION
## Problem

A noisy `TypeError: can't access property "align", e is undefined` fires from the `emoji-grid` chunk on every environment (local, staging, prod) whenever a page with a `Virtuoso` mount renders. The stack bottoms out inside minified `react-virtuoso` code, so it reads as unactionable even though it's been cluttering the console for a while.

## Root cause

`react-virtuoso@4.18.4` detects whether it can use `useSyncExternalStore` with:

```js
R = E.version.startsWith("18") ? T : w
// react-virtuoso/dist/index.mjs:2316 (installed @4.18.4)
```

React 19 doesn't start with `"18"`, so it falls back to the legacy `useState + useLayoutEffect` subscription path (`w`). That path tears under concurrent rendering — a subscriber can read a stale/initial-undefined value out of the reactive graph. When that undefined value reaches the scroll-to-index handler at `$n(t)` (`index.mjs:1073`), the very first thing it does is `e.align || (e.align = "start")`, and boom: "can't access property 'align', e is undefined".

The error surfaces from `emoji-grid-DBkDZsHI.js` because Vite auto-splits `EmojiGrid` into a chunk that carries the Virtuoso runtime, but the bug is not emoji-specific — any Virtuoso mount (stream timeline, event list, reaction emoji picker, message input) can trigger it. That's why it "happens always".

## Solution

Upgrade `react-virtuoso` from `^4.18.4` → `^4.18.5`. The 4.18.5 release ([upstream notes](https://github.com/petyosi/react-virtuoso/releases)) changes the version gate to `parseInt(React.version) >= 18`, so React 19 now correctly routes through `useSyncExternalStore` and the reactive graph no longer tears.

Verified after `bun install` that the installed bundle at `apps/frontend/node_modules/react-virtuoso/dist/index.mjs:2316` now reads:

```js
R = parseInt(E.version) >= 18 ? T : w
```

### Why just bump, no code changes

The crash is entirely internal to the library; none of our call sites (`emoji-grid.tsx`, `reaction-emoji-picker.tsx`, `stream-content.tsx`, `event-list.tsx`, `use-virtuoso-scroll.ts`) pass invalid arguments. Patching around it in our code would be a workaround for a bug the upstream maintainer already fixed.

## Modified files

| File                         | Change                                     |
| ---------------------------- | ------------------------------------------ |
| `apps/frontend/package.json` | Bump `react-virtuoso` `^4.18.4` → `^4.18.5` |
| `bun.lock`                   | Regenerated lockfile entry                 |

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 1281 frontend tests pass, 0 failing
- [x] Confirmed installed bundle has the upstream fix on line 2316
- [ ] On the deploy preview, open a stream (or the reaction picker / emoji `:` trigger) in Firefox DevTools and confirm the console no longer logs the "align, e is undefined" error

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_