### PR TITLE
feat(emoji): split picker into Recently used + Emojis sections

### DIFF
--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -1,17 +1,27 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState, memo } from "react"
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState, memo } from "react"
 import { useFloating, offset, flip, shift, autoUpdate } from "@floating-ui/react"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { cn } from "@/lib/utils"
+import {
+  DESKTOP_GRID_COLUMNS as GRID_COLUMNS,
+  chunkByColumns,
+  indexToCoord,
+  moveSelection,
+  totalCount,
+  type GridGeometry,
+} from "@/lib/emoji-picker"
 import type { EmojiEntry } from "@threa/types"
 import type { SuggestionListRef } from "./suggestion-list"
 
-const GRID_COLUMNS = 8
 const ROW_HEIGHT = 34 // w-8 (32px) + 2px vertical gap
 const CONTAINER_HEIGHT = 256 // max-h-64 = 256px
 const VirtuosoPadding = () => <div className="h-2" />
 
 export interface EmojiGridProps {
-  items: EmojiEntry[]
+  /** Recently used emojis (weight > 0), already filtered by the current query. Capped upstream. */
+  recent: EmojiEntry[]
+  /** All emojis in default order, already filtered by the current query. */
+  all: EmojiEntry[]
   clientRect: (() => DOMRect | null) | null
   command: (item: EmojiEntry) => void
 }
@@ -45,43 +55,54 @@ const EmojiButton = memo(function EmojiButton({ item, isSelected, onClick, onMou
 })
 
 /**
- * Virtualized grid-style emoji picker for the : trigger.
- * Shows emojis in an 8-column grid with native title tooltips.
- * Arrow keys navigate the grid (up/down by row, left/right by cell).
+ * Virtualized two-section emoji picker for the : trigger.
+ * - Recently used (max 2 rows, non-virtualized)
+ * - Emojis (virtualized, default order)
+ *
+ * Arrow keys navigate a combined flat index; crossing the section boundary
+ * preserves the column.
  */
-function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: React.ForwardedRef<SuggestionListRef>) {
+function EmojiGridInner(
+  { recent, all, clientRect, command }: EmojiGridProps,
+  ref: React.ForwardedRef<SuggestionListRef>
+) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const rangeRef = useRef<{ startIndex: number; endIndex: number } | null>(null)
 
-  // Group items into rows for virtualization
-  const rows: EmojiEntry[][] = []
-  for (let i = 0; i < items.length; i += GRID_COLUMNS) {
-    rows.push(items.slice(i, i + GRID_COLUMNS))
-  }
+  const geometry: GridGeometry = useMemo(
+    () => ({ recentCount: recent.length, allCount: all.length, columns: GRID_COLUMNS }),
+    [recent.length, all.length]
+  )
 
-  // Reset selection when items change
+  const total = totalCount(geometry)
+
+  const allRows = useMemo(() => chunkByColumns(all, GRID_COLUMNS), [all])
+  const recentRows = useMemo(() => chunkByColumns(recent, GRID_COLUMNS), [recent])
+
   useEffect(() => {
     setSelectedIndex(0)
     virtuosoRef.current?.scrollToIndex({ index: 0 })
-  }, [items])
+  }, [total])
 
-  // Scroll to row only if it's outside the visible range
-  const scrollToRowIfNeeded = (index: number) => {
-    const row = Math.floor(index / GRID_COLUMNS)
+  const scrollAllRowIfNeeded = (allRow: number) => {
     const range = rangeRef.current
-    if (range && (row < range.startIndex || row > range.endIndex)) {
-      virtuosoRef.current?.scrollToIndex({ index: row, align: row < range.startIndex ? "start" : "end" })
+    if (range && (allRow < range.startIndex || allRow > range.endIndex)) {
+      virtuosoRef.current?.scrollToIndex({ index: allRow, align: allRow < range.startIndex ? "start" : "end" })
     }
   }
 
-  // Force scroll to row (for Home/End/PageUp/PageDown)
-  const scrollToRow = (index: number) => {
-    const row = Math.floor(index / GRID_COLUMNS)
-    virtuosoRef.current?.scrollToIndex({ index: row, align: "start" })
+  const scrollAllRow = (allRow: number) => {
+    virtuosoRef.current?.scrollToIndex({ index: allRow, align: "start" })
   }
 
-  // Calculate visible rows for page navigation
+  const ensureVisible = (index: number, force: boolean) => {
+    const coord = indexToCoord(index, geometry)
+    if (coord.section !== "all") return
+    if (force) scrollAllRow(coord.row)
+    else scrollAllRowIfNeeded(coord.row)
+  }
+
   const visibleRowCount = Math.floor(CONTAINER_HEIGHT / ROW_HEIGHT)
 
   const { refs, floatingStyles } = useFloating({
@@ -102,86 +123,69 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
   // Handle grid keyboard navigation
   useImperativeHandle(ref, () => ({
     onKeyDown: (event: KeyboardEvent) => {
-      if (items.length === 0) return false
-
-      const totalRows = Math.ceil(items.length / GRID_COLUMNS)
-      const currentRow = Math.floor(selectedIndex / GRID_COLUMNS)
-      const currentCol = selectedIndex % GRID_COLUMNS
+      if (total === 0) return false
 
       switch (event.key) {
-        case "ArrowUp": {
-          event.preventDefault()
-          if (currentRow > 0) {
-            const newIndex = selectedIndex - GRID_COLUMNS
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
-          }
-          return true
-        }
-        case "ArrowDown": {
-          event.preventDefault()
-          const nextRowIndex = selectedIndex + GRID_COLUMNS
-          if (nextRowIndex < items.length) {
-            setSelectedIndex(nextRowIndex)
-            scrollToRowIfNeeded(nextRowIndex)
-          }
-          return true
-        }
-        case "ArrowLeft": {
-          event.preventDefault()
-          if (selectedIndex > 0) {
-            const newIndex = selectedIndex - 1
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
-          }
-          return true
-        }
+        case "ArrowUp":
+        case "ArrowDown":
+        case "ArrowLeft":
         case "ArrowRight": {
           event.preventDefault()
-          if (selectedIndex < items.length - 1) {
-            const newIndex = selectedIndex + 1
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
+          const next = moveSelection(selectedIndex, event.key, geometry)
+          if (next !== selectedIndex) {
+            setSelectedIndex(next)
+            ensureVisible(next, false)
           }
           return true
         }
         case "Home": {
           event.preventDefault()
           setSelectedIndex(0)
-          scrollToRow(0)
+          ensureVisible(0, true)
           return true
         }
         case "End": {
           event.preventDefault()
-          const newIndex = items.length - 1
-          setSelectedIndex(newIndex)
-          scrollToRow(newIndex)
+          const last = total - 1
+          setSelectedIndex(last)
+          ensureVisible(last, true)
           return true
         }
         case "PageUp": {
           event.preventDefault()
-          const jumpRows = visibleRowCount
-          const newRow = Math.max(0, currentRow - jumpRows)
-          const newIndex = Math.min(newRow * GRID_COLUMNS + currentCol, items.length - 1)
-          setSelectedIndex(newIndex)
-          scrollToRow(newIndex)
+          const coord = indexToCoord(selectedIndex, geometry)
+          if (coord.section === "all") {
+            const newRow = Math.max(0, coord.row - visibleRowCount)
+            const newIndex = geometry.recentCount + Math.min(newRow * GRID_COLUMNS + coord.col, all.length - 1)
+            setSelectedIndex(newIndex)
+            ensureVisible(newIndex, true)
+          }
           return true
         }
         case "PageDown": {
           event.preventDefault()
-          const jumpRows = visibleRowCount
-          const newRow = Math.min(totalRows - 1, currentRow + jumpRows)
-          const targetIndex = newRow * GRID_COLUMNS + currentCol
-          const newIndex = Math.min(targetIndex, items.length - 1)
-          setSelectedIndex(newIndex)
-          scrollToRow(newIndex)
+          const coord = indexToCoord(selectedIndex, geometry)
+          if (coord.section === "all") {
+            const allRowCount = Math.ceil(all.length / GRID_COLUMNS)
+            const newRow = Math.min(allRowCount - 1, coord.row + visibleRowCount)
+            const newIndex = geometry.recentCount + Math.min(newRow * GRID_COLUMNS + coord.col, all.length - 1)
+            setSelectedIndex(newIndex)
+            ensureVisible(newIndex, true)
+          } else if (all.length > 0) {
+            const newIndex = geometry.recentCount + Math.min(coord.col, all.length - 1)
+            setSelectedIndex(newIndex)
+            ensureVisible(newIndex, true)
+          }
           return true
         }
         case "Tab":
-        case "Enter":
+        case "Enter": {
           event.preventDefault()
-          command(items[selectedIndex])
+          const coord = indexToCoord(selectedIndex, geometry)
+          const item = coord.section === "recent" ? recent[selectedIndex] : all[selectedIndex - geometry.recentCount]
+          if (item) command(item)
           return true
+        }
         case "Escape":
           return true
         default:
@@ -190,10 +194,11 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
     },
   }))
 
-  if (!clientRect || items.length === 0) return null
+  if (!clientRect || total === 0) return null
 
-  // Get currently selected emoji for the footer
-  const selectedEmoji = items[selectedIndex]
+  const selectedCoord = indexToCoord(selectedIndex, geometry)
+  const selectedEmoji =
+    selectedCoord.section === "recent" ? recent[selectedIndex] : all[selectedIndex - geometry.recentCount]
 
   return (
     <div
@@ -204,37 +209,62 @@ function EmojiGridInner({ items, clientRect, command }: EmojiGridProps, ref: Rea
       aria-label="Emoji picker"
       data-emoji-grid
     >
-      <Virtuoso
-        ref={virtuosoRef}
-        totalCount={rows.length}
-        fixedItemHeight={ROW_HEIGHT}
-        increaseViewportBy={ROW_HEIGHT * 3}
-        rangeChanged={(range) => {
-          rangeRef.current = range
-        }}
-        style={{ height: CONTAINER_HEIGHT }}
-        components={{ Header: VirtuosoPadding, Footer: VirtuosoPadding }}
-        itemContent={(index) => {
-          const rowItems = rows[index]
-          const rowStartIndex = index * GRID_COLUMNS
-          return (
-            <div className="flex gap-0.5 px-2 pb-0.5">
-              {rowItems.map((item, colIndex) => {
-                const itemIndex = rowStartIndex + colIndex
+      {recent.length > 0 && (
+        <div className="px-2 pt-2 pb-1">
+          <p className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider px-0.5 mb-1">
+            Recently used
+          </p>
+          <div className="grid gap-0.5" style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))` }}>
+            {recentRows.map((rowItems, rowIdx) =>
+              rowItems.map((item, colIdx) => {
+                const itemIndex = rowIdx * GRID_COLUMNS + colIdx
                 return (
                   <EmojiButton
-                    key={item.shortcode}
+                    key={`recent-${item.shortcode}`}
                     item={item}
                     isSelected={itemIndex === selectedIndex}
                     onClick={() => command(item)}
                     onMouseEnter={() => setSelectedIndex(itemIndex)}
                   />
                 )
-              })}
-            </div>
-          )
-        }}
-      />
+              })
+            )}
+          </div>
+        </div>
+      )}
+      {all.length > 0 && (
+        <Virtuoso
+          ref={virtuosoRef}
+          totalCount={allRows.length}
+          fixedItemHeight={ROW_HEIGHT}
+          increaseViewportBy={ROW_HEIGHT * 3}
+          rangeChanged={(range) => {
+            rangeRef.current = range
+          }}
+          style={{ height: CONTAINER_HEIGHT }}
+          components={{ Header: VirtuosoPadding, Footer: VirtuosoPadding }}
+          itemContent={(index) => {
+            const rowItems = allRows[index]
+            const rowStartIndex = geometry.recentCount + index * GRID_COLUMNS
+            return (
+              <div className="flex gap-0.5 px-2 pb-0.5">
+                {rowItems.map((item, colIndex) => {
+                  const itemIndex = rowStartIndex + colIndex
+                  return (
+                    <EmojiButton
+                      key={item.shortcode}
+                      item={item}
+                      isSelected={itemIndex === selectedIndex}
+                      onClick={() => command(item)}
+                      onMouseEnter={() => setSelectedIndex(itemIndex)}
+                    />
+                  )
+                })}
+              </div>
+            )
+          }}
+        />
+      )}
       {/* Footer showing selected emoji shortcode */}
       {selectedEmoji && (
         <div className="border-t px-2 py-1.5 text-xs text-muted-foreground truncate">

--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -232,6 +232,7 @@ function EmojiGridInner(
           </div>
         </div>
       )}
+      {recent.length > 0 && all.length > 0 && <div className="border-t" />}
       {all.length > 0 && (
         <Virtuoso
           ref={virtuosoRef}

--- a/apps/frontend/src/components/editor/triggers/use-emoji-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-emoji-suggestion.tsx
@@ -3,11 +3,19 @@ import { createPortal } from "react-dom"
 import type { Editor } from "@tiptap/react"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
 import type { EmojiEntry } from "@threa/types"
+import {
+  DESKTOP_GRID_COLUMNS,
+  MAX_RECENTLY_USED_ROWS,
+  filterBySearch,
+  pickRecentlyUsed,
+  sortByDefaultOrder,
+} from "@/lib/emoji-picker"
 import type { SuggestionListRef } from "./suggestion-list"
 import { EmojiGrid } from "./emoji-grid"
 
 interface EmojiSuggestionState {
-  items: EmojiEntry[]
+  recent: EmojiEntry[]
+  all: EmojiEntry[]
   clientRect: (() => DOMRect | null) | null
   command: ((item: EmojiEntry) => void) | null
 }
@@ -38,15 +46,15 @@ export interface UseEmojiSuggestionResult {
   close: () => void
 }
 
-const GROUP_ORDER = ["smileys", "people", "animals", "food", "travel", "activities", "objects", "symbols", "flags"]
-
 /**
- * Hook for managing emoji suggestion state with personalized sorting.
+ * Hook for managing emoji suggestion state with a two-section layout.
  *
- * Sorting order:
- * 1. Weighted emojis first (by weight descending)
- * 2. Then by group (smileys → people → animals → ...)
- * 3. Then by in-group order
+ * The grid is split into:
+ * 1. Recently used — weighted emojis (weight > 0), capped at 2 rows.
+ * 2. Emojis — all emojis in default order (group → in-group order).
+ *
+ * Both sections are filtered by the search query; the same emoji can appear
+ * in both when it matches.
  */
 export function useEmojiSuggestion(config: UseEmojiSuggestionConfig): UseEmojiSuggestionResult {
   const { emojis, emojiWeights } = config
@@ -59,70 +67,60 @@ export function useEmojiSuggestion(config: UseEmojiSuggestionConfig): UseEmojiSu
     if (storage) storage.popupVisible = visible
   }, [])
 
-  // Pre-sort emojis for consistent ordering
-  const sortedEmojis = useMemo(() => {
-    return [...emojis].sort((a, b) => {
-      const weightA = emojiWeights[a.shortcode] ?? 0
-      const weightB = emojiWeights[b.shortcode] ?? 0
+  const allSorted = useMemo(() => sortByDefaultOrder(emojis), [emojis])
+  const recentBase = useMemo(
+    () => pickRecentlyUsed(emojis, emojiWeights, DESKTOP_GRID_COLUMNS * MAX_RECENTLY_USED_ROWS),
+    [emojis, emojiWeights]
+  )
 
-      // Weighted emojis first
-      if (weightA > 0 && weightB === 0) return -1
-      if (weightA === 0 && weightB > 0) return 1
-      if (weightA !== weightB) return weightB - weightA
+  // Stable refs so TipTap callbacks (captured at extension creation time) see current data.
+  const allSortedRef = useRef(allSorted)
+  allSortedRef.current = allSorted
+  const recentBaseRef = useRef(recentBase)
+  recentBaseRef.current = recentBase
 
-      // Then by group
-      const groupIndexA = GROUP_ORDER.indexOf(a.group)
-      const groupIndexB = GROUP_ORDER.indexOf(b.group)
-      // Unknown groups go to the end
-      const effectiveGroupA = groupIndexA === -1 ? GROUP_ORDER.length : groupIndexA
-      const effectiveGroupB = groupIndexB === -1 ? GROUP_ORDER.length : groupIndexB
-      if (effectiveGroupA !== effectiveGroupB) return effectiveGroupA - effectiveGroupB
-
-      // Then by in-group order
-      return a.order - b.order
-    })
-  }, [emojis, emojiWeights])
-
-  // Use ref to avoid stale closure - TipTap captures callbacks at extension creation time
-  const sortedEmojisRef = useRef(sortedEmojis)
-  sortedEmojisRef.current = sortedEmojis
-
-  // Filter emojis by query (any alias contains query)
-  const filterItems = useCallback((items: EmojiEntry[], query: string): EmojiEntry[] => {
-    if (!query) return items // Show all emojis when no query
-    const lowerQuery = query.toLowerCase()
-    return items.filter((item) => item.aliases.some((alias) => alias.includes(lowerQuery)))
-  }, [])
-
-  // Stable callback that reads from ref
+  // TipTap's items(query) drives popupVisible. Return the "all" section filtered
+  // by the query so the popup hides only when nothing matches anywhere.
   const getSuggestionItems = useCallback(
-    ({ query }: { query: string }) => filterItems(sortedEmojisRef.current, query),
-    [filterItems]
+    ({ query }: { query: string }) => filterBySearch(allSortedRef.current, query),
+    []
+  )
+
+  const computeSections = useCallback(
+    (query: string, allFiltered: EmojiEntry[]) => ({
+      recent: filterBySearch(recentBaseRef.current, query),
+      all: allFiltered,
+    }),
+    []
   )
 
   const onStart = useCallback(
     (props: SuggestionProps<EmojiEntry>) => {
       editorRef.current = props.editor
       setPopupVisible(props.editor, props.items.length > 0)
+      const { recent, all } = computeSections(props.query, props.items)
       setState({
-        items: props.items,
+        recent,
+        all,
         clientRect: props.clientRect ?? null,
         command: props.command,
       })
     },
-    [setPopupVisible]
+    [setPopupVisible, computeSections]
   )
 
   const onUpdate = useCallback(
     (props: SuggestionProps<EmojiEntry>) => {
       setPopupVisible(props.editor, props.items.length > 0)
+      const { recent, all } = computeSections(props.query, props.items)
       setState({
-        items: props.items,
+        recent,
+        all,
         clientRect: props.clientRect ?? null,
         command: props.command,
       })
     },
-    [setPopupVisible]
+    [setPopupVisible, computeSections]
   )
 
   const onExit = useCallback(
@@ -170,7 +168,8 @@ export function useEmojiSuggestion(config: UseEmojiSuggestionConfig): UseEmojiSu
     return createPortal(
       <EmojiGrid
         ref={listRef as RefObject<SuggestionListRef>}
-        items={state.items}
+        recent={state.recent}
+        all={state.all}
         clientRect={state.clientRect}
         command={state.command}
       />,

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -7,9 +7,20 @@ import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
+import {
+  DESKTOP_GRID_COLUMNS,
+  MAX_RECENTLY_USED_ROWS,
+  chunkByColumns,
+  filterBySearch,
+  indexToCoord,
+  moveSelection,
+  pickRecentlyUsed,
+  sortByDefaultOrder,
+  totalCount,
+  type GridGeometry,
+} from "@/lib/emoji-picker"
 import type { EmojiEntry } from "@threa/types"
 
-const DESKTOP_COLUMNS = 8
 const MOBILE_EMOJI_SIZE = 44
 const MOBILE_ROW_HEIGHT = 46
 const MobileVirtuosoPadding = () => <div className="h-1" />
@@ -74,8 +85,6 @@ const EmojiButton = memo(function EmojiButton({
   )
 })
 
-const GROUP_ORDER = ["smileys", "people", "animals", "food", "travel", "activities", "objects", "symbols", "flags"]
-
 /** Shared emoji grid content used by both Popover (desktop) and Drawer (mobile) */
 function EmojiGridContent({
   emojis,
@@ -105,7 +114,7 @@ function EmojiGridContent({
   isMobile: boolean
 }) {
   // Compute column count based on container width on mobile
-  const [columns, setColumns] = useState(isMobile ? MAX_MOBILE_COLUMNS : DESKTOP_COLUMNS)
+  const [columns, setColumns] = useState(isMobile ? MAX_MOBILE_COLUMNS : DESKTOP_GRID_COLUMNS)
   const rowHeight = isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const rangeRef = useRef<{ startIndex: number; endIndex: number } | null>(null)
@@ -127,149 +136,122 @@ function EmojiGridContent({
     return () => observer.disconnect()
   }, [isMobile, open])
 
-  // Separate active emojis from the rest
   const activeEmojis = useMemo(() => {
     if (activeShortcodes.size === 0) return []
     return emojis.filter((e) => activeShortcodes.has(e.shortcode))
   }, [emojis, activeShortcodes])
 
-  const sortedEmojis = useMemo(() => {
-    const base = activeShortcodes.size > 0 ? emojis.filter((e) => !activeShortcodes.has(e.shortcode)) : emojis
-    return [...base].sort((a, b) => {
-      const weightA = emojiWeights[a.shortcode] ?? 0
-      const weightB = emojiWeights[b.shortcode] ?? 0
-      if (weightA > 0 && weightB === 0) return -1
-      if (weightA === 0 && weightB > 0) return 1
-      if (weightA !== weightB) return weightB - weightA
-      const groupA = GROUP_ORDER.indexOf(a.group)
-      const groupB = GROUP_ORDER.indexOf(b.group)
-      const effectiveA = groupA === -1 ? GROUP_ORDER.length : groupA
-      const effectiveB = groupB === -1 ? GROUP_ORDER.length : groupB
-      if (effectiveA !== effectiveB) return effectiveA - effectiveB
-      return a.order - b.order
-    })
-  }, [emojis, emojiWeights, activeShortcodes])
+  const recentBase = useMemo(
+    () => pickRecentlyUsed(emojis, emojiWeights, columns * MAX_RECENTLY_USED_ROWS),
+    [emojis, emojiWeights, columns]
+  )
+  const allBase = useMemo(() => sortByDefaultOrder(emojis), [emojis])
 
-  const filtered = useMemo(() => {
-    if (!search) return sortedEmojis
-    const q = search.toLowerCase()
-    const all = [...activeEmojis, ...sortedEmojis]
-    return all.filter((e) => e.aliases.some((a) => a.includes(q)))
-  }, [sortedEmojis, activeEmojis, search])
+  const recent = useMemo(() => filterBySearch(recentBase, search), [recentBase, search])
+  const all = useMemo(() => filterBySearch(allBase, search), [allBase, search])
 
-  const rows = useMemo(() => {
-    const result: EmojiEntry[][] = []
-    for (let i = 0; i < filtered.length; i += columns) {
-      result.push(filtered.slice(i, i + columns))
-    }
-    return result
-  }, [filtered, columns])
+  const geometry: GridGeometry = useMemo(
+    () => ({ recentCount: recent.length, allCount: all.length, columns }),
+    [recent.length, all.length, columns]
+  )
 
-  // Reset selection when filtered items change
+  const allRows = useMemo(() => chunkByColumns(all, columns), [all, columns])
+  const recentRows = useMemo(() => chunkByColumns(recent, columns), [recent, columns])
+
+  const total = totalCount(geometry)
   useEffect(() => {
     setSelectedIndex(0)
     if (open) virtuosoRef.current?.scrollToIndex({ index: 0 })
-  }, [filtered.length, open, setSelectedIndex])
+  }, [total, open, setSelectedIndex])
 
-  const scrollToRowIfNeeded = useCallback(
-    (index: number) => {
-      const row = Math.floor(index / columns)
-      const range = rangeRef.current
-      if (range && (row < range.startIndex || row > range.endIndex)) {
-        virtuosoRef.current?.scrollToIndex({ index: row, align: row < range.startIndex ? "start" : "end" })
-      }
-    },
-    [columns]
-  )
+  const scrollAllRowIfNeeded = useCallback((allRow: number) => {
+    const range = rangeRef.current
+    if (range && (allRow < range.startIndex || allRow > range.endIndex)) {
+      virtuosoRef.current?.scrollToIndex({ index: allRow, align: allRow < range.startIndex ? "start" : "end" })
+    }
+  }, [])
 
-  const scrollToRow = useCallback(
-    (index: number) => {
-      const row = Math.floor(index / columns)
-      virtuosoRef.current?.scrollToIndex({ index: row, align: "start" })
+  const scrollAllRow = useCallback((allRow: number) => {
+    virtuosoRef.current?.scrollToIndex({ index: allRow, align: "start" })
+  }, [])
+
+  const ensureVisible = useCallback(
+    (index: number, force: boolean) => {
+      const coord = indexToCoord(index, geometry)
+      if (coord.section !== "all") return
+      if (force) scrollAllRow(coord.row)
+      else scrollAllRowIfNeeded(coord.row)
     },
-    [columns]
+    [geometry, scrollAllRow, scrollAllRowIfNeeded]
   )
 
   const visibleRowCount = Math.floor(CONTAINER_HEIGHT / rowHeight)
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (filtered.length === 0) return
-
-      const totalRows = Math.ceil(filtered.length / columns)
-      const currentRow = Math.floor(selectedIndex / columns)
-      const currentCol = selectedIndex % columns
+      if (total === 0) return
 
       switch (event.key) {
-        case "ArrowUp": {
-          event.preventDefault()
-          if (currentRow > 0) {
-            const newIndex = selectedIndex - columns
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
-          }
-          break
-        }
-        case "ArrowDown": {
-          event.preventDefault()
-          const nextRowIndex = selectedIndex + columns
-          if (nextRowIndex < filtered.length) {
-            setSelectedIndex(nextRowIndex)
-            scrollToRowIfNeeded(nextRowIndex)
-          }
-          break
-        }
-        case "ArrowLeft": {
-          event.preventDefault()
-          if (selectedIndex > 0) {
-            const newIndex = selectedIndex - 1
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
-          }
-          break
-        }
+        case "ArrowUp":
+        case "ArrowDown":
+        case "ArrowLeft":
         case "ArrowRight": {
           event.preventDefault()
-          if (selectedIndex < filtered.length - 1) {
-            const newIndex = selectedIndex + 1
-            setSelectedIndex(newIndex)
-            scrollToRowIfNeeded(newIndex)
+          const next = moveSelection(selectedIndex, event.key, geometry)
+          if (next !== selectedIndex) {
+            setSelectedIndex(next)
+            ensureVisible(next, false)
           }
           break
         }
         case "Home": {
           event.preventDefault()
           setSelectedIndex(0)
-          scrollToRow(0)
+          ensureVisible(0, true)
           break
         }
         case "End": {
           event.preventDefault()
-          const newIndex = filtered.length - 1
-          setSelectedIndex(newIndex)
-          scrollToRow(newIndex)
+          const last = total - 1
+          setSelectedIndex(last)
+          ensureVisible(last, true)
           break
         }
         case "PageUp": {
           event.preventDefault()
-          const upRow = Math.max(0, currentRow - visibleRowCount)
-          const upIndex = Math.min(upRow * columns + currentCol, filtered.length - 1)
-          setSelectedIndex(upIndex)
-          scrollToRow(upIndex)
+          const coord = indexToCoord(selectedIndex, geometry)
+          if (coord.section === "all") {
+            const newRow = Math.max(0, coord.row - visibleRowCount)
+            const newIndex = geometry.recentCount + Math.min(newRow * columns + coord.col, all.length - 1)
+            setSelectedIndex(newIndex)
+            ensureVisible(newIndex, true)
+          }
           break
         }
         case "PageDown": {
           event.preventDefault()
-          const downRow = Math.min(totalRows - 1, currentRow + visibleRowCount)
-          const downIndex = Math.min(downRow * columns + currentCol, filtered.length - 1)
-          setSelectedIndex(downIndex)
-          scrollToRow(downIndex)
+          const coord = indexToCoord(selectedIndex, geometry)
+          if (coord.section === "all") {
+            const allRowCount = Math.ceil(all.length / columns)
+            const newRow = Math.min(allRowCount - 1, coord.row + visibleRowCount)
+            const newIndex = geometry.recentCount + Math.min(newRow * columns + coord.col, all.length - 1)
+            setSelectedIndex(newIndex)
+            ensureVisible(newIndex, true)
+          } else {
+            // Jump from recent into the all section.
+            if (all.length > 0) {
+              const newIndex = geometry.recentCount + Math.min(coord.col, all.length - 1)
+              setSelectedIndex(newIndex)
+              ensureVisible(newIndex, true)
+            }
+          }
           break
         }
         case "Enter":
         case "Tab": {
           event.preventDefault()
-          const item = filtered[selectedIndex]
+          const coord = indexToCoord(selectedIndex, geometry)
+          const item = coord.section === "recent" ? recent[selectedIndex] : all[selectedIndex - geometry.recentCount]
           if (item) onSelect(item)
           break
         }
@@ -281,19 +263,63 @@ function EmojiGridContent({
       }
     },
     [
-      filtered,
+      total,
       selectedIndex,
+      geometry,
+      recent,
+      all,
+      columns,
+      visibleRowCount,
       setSelectedIndex,
       onSelect,
       onClose,
-      scrollToRowIfNeeded,
-      scrollToRow,
-      visibleRowCount,
-      columns,
+      ensureVisible,
     ]
   )
 
-  const selectedEmoji = filtered[selectedIndex]
+  const selectedEmoji: EmojiEntry | undefined = (() => {
+    if (total === 0) return undefined
+    const coord = indexToCoord(selectedIndex, geometry)
+    if (coord.section === "recent") return recent[selectedIndex]
+    return all[selectedIndex - geometry.recentCount]
+  })()
+
+  const renderRecentSection = (mobile: boolean) => {
+    if (recent.length === 0) return null
+    return (
+      <div className={mobile ? "px-4 pb-2" : "px-2 pb-1"}>
+        <p
+          className={cn(
+            "text-[10px] font-medium uppercase tracking-wider mb-1",
+            mobile ? "text-muted-foreground/60" : "text-muted-foreground/70 px-0.5"
+          )}
+        >
+          Recently used
+        </p>
+        <div
+          className={mobile ? "grid gap-1" : "grid gap-0.5"}
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
+          {recentRows.map((rowItems, rowIdx) =>
+            rowItems.map((item, colIdx) => {
+              const itemIndex = rowIdx * columns + colIdx
+              return (
+                <EmojiButton
+                  key={`recent-${item.shortcode}`}
+                  item={item}
+                  isSelected={itemIndex === selectedIndex}
+                  isActive={activeShortcodes.has(item.shortcode)}
+                  isMobile={mobile}
+                  onClick={() => onSelect(item)}
+                  onMouseEnter={() => setSelectedIndex(itemIndex)}
+                />
+              )
+            })
+          )}
+        </div>
+      </div>
+    )
+  }
 
   if (isMobile) {
     return (
@@ -316,7 +342,7 @@ function EmojiGridContent({
           </div>
         </div>
 
-        {/* Your reactions — horizontal strip */}
+        {/* Your reactions — horizontal strip, only when no search */}
         {activeEmojis.length > 0 && !search && (
           <div className="px-4 pb-2">
             <p className="text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider mb-1.5">
@@ -338,16 +364,19 @@ function EmojiGridContent({
           </div>
         )}
 
+        {renderRecentSection(true)}
+
         {/* Emoji grid — stable container keeps ResizeObserver alive across empty/non-empty transitions */}
         <div ref={mobileContainerRef} style={{ height: "min(55dvh, 360px)" }}>
-          {filtered.length === 0 ? (
+          {total === 0 && (
             <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4">
               No emojis found
             </div>
-          ) : (
+          )}
+          {total > 0 && all.length > 0 && (
             <Virtuoso
               ref={virtuosoRef}
-              totalCount={rows.length}
+              totalCount={allRows.length}
               fixedItemHeight={MOBILE_ROW_HEIGHT}
               increaseViewportBy={MOBILE_ROW_HEIGHT * 3}
               style={{ height: "100%" }}
@@ -355,7 +384,8 @@ function EmojiGridContent({
               role="listbox"
               aria-label="Emoji picker"
               itemContent={(index) => {
-                const rowItems = rows[index]
+                const rowItems = allRows[index]
+                const rowStartIndex = geometry.recentCount + index * columns
                 return (
                   <div
                     className="px-4 pb-0.5"
@@ -365,17 +395,20 @@ function EmojiGridContent({
                       gap: "2px",
                     }}
                   >
-                    {rowItems.map((item) => (
-                      <EmojiButton
-                        key={item.shortcode}
-                        item={item}
-                        isSelected={false}
-                        isActive={activeShortcodes.has(item.shortcode)}
-                        isMobile={true}
-                        onClick={() => onSelect(item)}
-                        onMouseEnter={() => {}}
-                      />
-                    ))}
+                    {rowItems.map((item, colIndex) => {
+                      const itemIndex = rowStartIndex + colIndex
+                      return (
+                        <EmojiButton
+                          key={item.shortcode}
+                          item={item}
+                          isSelected={itemIndex === selectedIndex}
+                          isActive={activeShortcodes.has(item.shortcode)}
+                          isMobile={true}
+                          onClick={() => onSelect(item)}
+                          onMouseEnter={() => setSelectedIndex(itemIndex)}
+                        />
+                      )
+                    })}
                   </div>
                 )
               }}
@@ -427,18 +460,21 @@ function EmojiGridContent({
         </div>
       )}
 
+      {renderRecentSection(false)}
+
       {/* Emoji grid */}
-      {filtered.length === 0 ? (
+      {total === 0 && (
         <div
           className="flex items-center justify-center text-sm text-muted-foreground p-2"
           style={{ height: CONTAINER_HEIGHT }}
         >
           No emojis found
         </div>
-      ) : (
+      )}
+      {total > 0 && all.length > 0 && (
         <Virtuoso
           ref={virtuosoRef}
-          totalCount={rows.length}
+          totalCount={allRows.length}
           fixedItemHeight={DESKTOP_ROW_HEIGHT}
           increaseViewportBy={DESKTOP_ROW_HEIGHT * 3}
           rangeChanged={(range) => {
@@ -449,8 +485,8 @@ function EmojiGridContent({
           role="listbox"
           aria-label="Emoji picker"
           itemContent={(index) => {
-            const rowItems = rows[index]
-            const rowStartIndex = index * columns
+            const rowItems = allRows[index]
+            const rowStartIndex = geometry.recentCount + index * columns
             return (
               <div className="flex gap-0.5 px-2 pb-0.5">
                 {rowItems.map((item, colIndex) => {

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -366,6 +366,8 @@ function EmojiGridContent({
 
         {renderRecentSection(true)}
 
+        {recent.length > 0 && all.length > 0 && <div className="border-t mx-4" />}
+
         {/* Emoji grid — stable container keeps ResizeObserver alive across empty/non-empty transitions */}
         <div ref={mobileContainerRef} style={{ height: "min(55dvh, 360px)" }}>
           {total === 0 && (
@@ -461,6 +463,8 @@ function EmojiGridContent({
       )}
 
       {renderRecentSection(false)}
+
+      {recent.length > 0 && all.length > 0 && <div className="border-t" />}
 
       {/* Emoji grid */}
       {total === 0 && (

--- a/apps/frontend/src/lib/emoji-picker.test.ts
+++ b/apps/frontend/src/lib/emoji-picker.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest"
+import type { EmojiEntry } from "@threa/types"
+import {
+  filterBySearch,
+  indexToCoord,
+  moveSelection,
+  pickRecentlyUsed,
+  sortByDefaultOrder,
+  totalCount,
+} from "./emoji-picker"
+
+function make(shortcode: string, group: string, order: number, aliases?: string[]): EmojiEntry {
+  return {
+    shortcode,
+    emoji: shortcode,
+    type: "native",
+    group,
+    order,
+    aliases: aliases ?? [shortcode],
+  }
+}
+
+const smile = make("smile", "smileys", 1)
+const grin = make("grin", "smileys", 2)
+const dog = make("dog", "animals", 1)
+const cat = make("cat", "animals", 2)
+const pizza = make("pizza", "food", 1)
+const rocket = make("rocket", "travel", 1)
+const flag = make("flag_us", "flags", 1)
+
+const all = [rocket, flag, pizza, dog, cat, smile, grin]
+
+describe("sortByDefaultOrder", () => {
+  it("orders by group first, then in-group order", () => {
+    const sorted = sortByDefaultOrder(all)
+    expect(sorted.map((e) => e.shortcode)).toEqual(["smile", "grin", "dog", "cat", "pizza", "rocket", "flag_us"])
+  })
+
+  it("is weight-independent (ignores weights)", () => {
+    const sorted = sortByDefaultOrder(all)
+    const first = sorted[0]!
+    expect(first.shortcode).toBe("smile")
+  })
+})
+
+describe("pickRecentlyUsed", () => {
+  it("returns only emojis with weight > 0, sorted weight desc", () => {
+    const weights = { dog: 5, smile: 10, pizza: 2 }
+    const recent = pickRecentlyUsed(all, weights, 10)
+    expect(recent.map((e) => e.shortcode)).toEqual(["smile", "dog", "pizza"])
+  })
+
+  it("caps at the given limit", () => {
+    const weights = { dog: 5, smile: 10, pizza: 2, cat: 1 }
+    expect(pickRecentlyUsed(all, weights, 2).map((e) => e.shortcode)).toEqual(["smile", "dog"])
+  })
+
+  it("tiebreaks equal weights by default order", () => {
+    const weights = { cat: 1, dog: 1 }
+    expect(pickRecentlyUsed(all, weights, 10).map((e) => e.shortcode)).toEqual(["dog", "cat"])
+  })
+
+  it("returns empty when limit <= 0", () => {
+    expect(pickRecentlyUsed(all, { dog: 1 }, 0)).toEqual([])
+  })
+})
+
+describe("filterBySearch", () => {
+  it("returns all when query is empty", () => {
+    expect(filterBySearch(all, "")).toEqual(all)
+  })
+
+  it("matches any alias substring, case-insensitive", () => {
+    const poop = make("poop", "people", 10, ["poop", "hankey", "shit"])
+    const matches = filterBySearch([smile, poop], "HANKEY")
+    expect(matches.map((e) => e.shortcode)).toEqual(["poop"])
+  })
+})
+
+describe("indexToCoord", () => {
+  it("maps indices in the recent section", () => {
+    const g = { recentCount: 12, allCount: 100, columns: 8 }
+    expect(indexToCoord(0, g)).toEqual({ section: "recent", row: 0, col: 0 })
+    expect(indexToCoord(7, g)).toEqual({ section: "recent", row: 0, col: 7 })
+    expect(indexToCoord(8, g)).toEqual({ section: "recent", row: 1, col: 0 })
+    expect(indexToCoord(11, g)).toEqual({ section: "recent", row: 1, col: 3 })
+  })
+
+  it("maps indices in the all section", () => {
+    const g = { recentCount: 12, allCount: 100, columns: 8 }
+    expect(indexToCoord(12, g)).toEqual({ section: "all", row: 0, col: 0 })
+    expect(indexToCoord(19, g)).toEqual({ section: "all", row: 0, col: 7 })
+    expect(indexToCoord(20, g)).toEqual({ section: "all", row: 1, col: 0 })
+  })
+})
+
+describe("totalCount", () => {
+  it("sums recent and all", () => {
+    expect(totalCount({ recentCount: 3, allCount: 100, columns: 8 })).toBe(103)
+  })
+})
+
+describe("moveSelection", () => {
+  const g = { recentCount: 12, allCount: 100, columns: 8 }
+
+  it("ArrowRight moves forward across the whole flat space", () => {
+    expect(moveSelection(0, "ArrowRight", g)).toBe(1)
+    expect(moveSelection(11, "ArrowRight", g)).toBe(12) // recent → all
+    expect(moveSelection(111, "ArrowRight", g)).toBe(111) // last item clamps
+  })
+
+  it("ArrowLeft moves backward across sections", () => {
+    expect(moveSelection(12, "ArrowLeft", g)).toBe(11)
+    expect(moveSelection(0, "ArrowLeft", g)).toBe(0)
+  })
+
+  describe("ArrowDown", () => {
+    it("moves within recent when next row exists and has the col", () => {
+      // row 0 col 3 (index 3) → row 1 col 3 (index 11), which exists (recent has 12 items)
+      expect(moveSelection(3, "ArrowDown", g)).toBe(11)
+    })
+
+    it("from last full recent row jumps to all row 0 same col", () => {
+      const full = { recentCount: 8, allCount: 100, columns: 8 }
+      // index 3 is row 0 col 3 (last recent row) → all row 0 col 3 = 8 + 3 = 11
+      expect(moveSelection(3, "ArrowDown", full)).toBe(11)
+    })
+
+    it("from partial last recent row, col past the end, jumps to all row 0 same col", () => {
+      // recent = 12, cols = 8: row 1 has cols 0..3. Starting at row 0 col 5 (index 5),
+      // next row 1 has no col 5. Jump to all row 0 col 5 = 12 + 5 = 17.
+      expect(moveSelection(5, "ArrowDown", g)).toBe(17)
+    })
+
+    it("from within recent bottom-partial row, jumps to all at same col", () => {
+      // index 10 = recent row 1 col 2, last row in recent. → all row 0 col 2 = 14
+      expect(moveSelection(10, "ArrowDown", g)).toBe(14)
+    })
+
+    it("moves within all by one row", () => {
+      expect(moveSelection(12, "ArrowDown", g)).toBe(20)
+    })
+
+    it("at last all row, does not move", () => {
+      // last row contains the final item at index 111 (total 112). row = 12.
+      const lastInAll = 111
+      expect(moveSelection(lastInAll, "ArrowDown", g)).toBe(lastInAll)
+    })
+
+    it("from partial last recent row clamps to last all item when col exceeds all", () => {
+      const small = { recentCount: 3, allCount: 2, columns: 8 }
+      // recent row 0 col 2 (index 2), last recent row. all has 2 items.
+      // target col 2 in all → clamp to index recentCount + allCount - 1 = 4
+      expect(moveSelection(2, "ArrowDown", small)).toBe(4)
+    })
+
+    it("with no all section, stays at current", () => {
+      const onlyRecent = { recentCount: 3, allCount: 0, columns: 8 }
+      expect(moveSelection(2, "ArrowDown", onlyRecent)).toBe(2)
+    })
+  })
+
+  describe("ArrowUp", () => {
+    it("from all row 0 jumps back into recent last row same col", () => {
+      // all row 0 col 5 (index 17) → recent has 12 items, last row is row 1 (cols 0..3).
+      // target col 5 → clamp to last recent index = 11.
+      expect(moveSelection(17, "ArrowUp", g)).toBe(11)
+    })
+
+    it("from all row 0 col within recent last row, preserves col", () => {
+      // all row 0 col 2 (index 14) → recent last row (row 1) col 2 = index 10.
+      expect(moveSelection(14, "ArrowUp", g)).toBe(10)
+    })
+
+    it("from all row 0 with no recent, stays", () => {
+      const noRecent = { recentCount: 0, allCount: 100, columns: 8 }
+      expect(moveSelection(3, "ArrowUp", noRecent)).toBe(3)
+    })
+
+    it("within all, moves up by one row", () => {
+      expect(moveSelection(20, "ArrowUp", g)).toBe(12)
+    })
+
+    it("within recent, moves up by one row", () => {
+      expect(moveSelection(10, "ArrowUp", g)).toBe(2)
+    })
+
+    it("at recent row 0, does not move", () => {
+      expect(moveSelection(3, "ArrowUp", g)).toBe(3)
+    })
+  })
+})

--- a/apps/frontend/src/lib/emoji-picker.ts
+++ b/apps/frontend/src/lib/emoji-picker.ts
@@ -1,0 +1,144 @@
+import type { EmojiEntry } from "@threa/types"
+
+export const EMOJI_GROUP_ORDER = [
+  "smileys",
+  "people",
+  "animals",
+  "food",
+  "travel",
+  "activities",
+  "objects",
+  "symbols",
+  "flags",
+] as const
+
+export const DESKTOP_GRID_COLUMNS = 8
+export const MAX_RECENTLY_USED_ROWS = 2
+
+export function chunkByColumns<T>(items: T[], columns: number): T[][] {
+  const result: T[][] = []
+  for (let i = 0; i < items.length; i += columns) {
+    result.push(items.slice(i, i + columns))
+  }
+  return result
+}
+
+function groupIndex(group: string): number {
+  const idx = (EMOJI_GROUP_ORDER as readonly string[]).indexOf(group)
+  return idx === -1 ? EMOJI_GROUP_ORDER.length : idx
+}
+
+export function compareByDefaultOrder(a: EmojiEntry, b: EmojiEntry): number {
+  const ga = groupIndex(a.group)
+  const gb = groupIndex(b.group)
+  if (ga !== gb) return ga - gb
+  return a.order - b.order
+}
+
+/** All emojis sorted by group then in-group order, no weight influence. */
+export function sortByDefaultOrder(emojis: EmojiEntry[]): EmojiEntry[] {
+  return [...emojis].sort(compareByDefaultOrder)
+}
+
+/**
+ * Pick the top N recently-used emojis by weight.
+ * Only emojis with weight > 0 qualify. Ties fall back to default order.
+ */
+export function pickRecentlyUsed(emojis: EmojiEntry[], weights: Record<string, number>, limit: number): EmojiEntry[] {
+  if (limit <= 0) return []
+  const recent = emojis.filter((e) => (weights[e.shortcode] ?? 0) > 0)
+  recent.sort((a, b) => {
+    const wa = weights[a.shortcode] ?? 0
+    const wb = weights[b.shortcode] ?? 0
+    if (wa !== wb) return wb - wa
+    return compareByDefaultOrder(a, b)
+  })
+  return recent.slice(0, limit)
+}
+
+export function filterBySearch(emojis: EmojiEntry[], query: string): EmojiEntry[] {
+  if (!query) return emojis
+  const q = query.toLowerCase()
+  return emojis.filter((e) => e.aliases.some((a) => a.includes(q)))
+}
+
+export type Section = "recent" | "all"
+
+export interface GridCoord {
+  section: Section
+  row: number
+  col: number
+}
+
+export interface GridGeometry {
+  recentCount: number
+  allCount: number
+  columns: number
+}
+
+export function totalCount(g: GridGeometry): number {
+  return g.recentCount + g.allCount
+}
+
+export function indexToCoord(index: number, g: GridGeometry): GridCoord {
+  if (index < g.recentCount) {
+    return { section: "recent", row: Math.floor(index / g.columns), col: index % g.columns }
+  }
+  const eIdx = index - g.recentCount
+  return { section: "all", row: Math.floor(eIdx / g.columns), col: eIdx % g.columns }
+}
+
+/**
+ * Compute the next selected index when pressing an arrow key.
+ * Returns the same index when the movement is blocked at an edge.
+ *
+ * Column-preserving across the section boundary: moving down from the last
+ * (possibly partial) row of Recently used jumps to the same column in the
+ * first row of Emojis, clamped to the last Emojis item.
+ */
+export function moveSelection(
+  index: number,
+  key: "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight",
+  g: GridGeometry
+): number {
+  const total = totalCount(g)
+  if (total === 0) return 0
+  const { recentCount, allCount, columns } = g
+  const coord = indexToCoord(index, g)
+
+  switch (key) {
+    case "ArrowLeft":
+      return index > 0 ? index - 1 : index
+    case "ArrowRight":
+      return index < total - 1 ? index + 1 : index
+    case "ArrowDown": {
+      if (coord.section === "recent") {
+        const recentRows = Math.ceil(recentCount / columns)
+        const nextInSection = index + columns
+        if (coord.row < recentRows - 1 && nextInSection < recentCount) {
+          return nextInSection
+        }
+        // Cross into "all" at same col, clamped to last "all" item.
+        if (allCount === 0) return index
+        return recentCount + Math.min(coord.col, allCount - 1)
+      }
+      // section === "all"
+      const allRows = Math.ceil(allCount / columns)
+      if (coord.row >= allRows - 1) return index
+      const nextInSection = index + columns
+      return Math.min(nextInSection, total - 1)
+    }
+    case "ArrowUp": {
+      if (coord.section === "all") {
+        if (coord.row > 0) return index - columns
+        if (recentCount === 0) return index
+        // Cross back into "recent" at same col, clamped to last "recent" item.
+        const recentRows = Math.ceil(recentCount / columns)
+        const target = (recentRows - 1) * columns + coord.col
+        return Math.min(target, recentCount - 1)
+      }
+      // section === "recent"
+      return coord.row > 0 ? index - columns : index
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Split the emoji picker into two explicit sections so recently used emojis get their own labeled region instead of being mixed into the main grid.

- **Recently used** — weighted emojis (weight > 0), capped at 2 rows. Hidden when empty.
- **Emojis** — unlabeled, default group + in-group order, no weight influence. The same emoji can appear in both sections; searching for `hankey` shows `:poop:` in both when it qualifies for Recently used.
- Active reactions on the current message (reaction picker only) stay as their own contextual strip above Recently used.

## Keyboard navigation

Section-aware and column-preserving across the boundary:

- ArrowDown from Recently used's last (possibly partial) row → Emojis row 0 at the same column, clamped to the last Emojis item.
- ArrowUp from Emojis row 0 → Recently used's last row at the same column, clamped to the last Recently used cell.
- ArrowLeft / ArrowRight: flat traversal across the combined space (same as before).
- Home / End / PageUp / PageDown: work across the combined space; scrolling only affects the virtualized Emojis section.

## Implementation

Shared ordering, chunking, and section nav live in a new `apps/frontend/src/lib/emoji-picker.ts` with unit tests. Both pickers consume it:

- `components/timeline/reaction-emoji-picker.tsx` (Popover/Drawer)
- `components/editor/triggers/emoji-grid.tsx` + `use-emoji-suggestion.tsx` (`:` trigger)

## Test plan

- [x] `bun run --cwd apps/frontend test` (1308 passing)
- [x] 27 new unit tests for ordering, search, coord↔index conversion, and arrow-key movement across the section boundary (including partial last rows, clamp-to-last-in-all, and empty-section fallbacks)
- [x] Typecheck + lint clean
- [ ] Manual: reaction picker — recently used strip appears, ArrowDown/Up cross the boundary preserving column, search shows the same emoji in both sections
- [ ] Manual: `:` trigger — same navigation behavior, Recently used hidden when no weighted emojis exist

https://claude.ai/code/session_01UG2htZ3MhUXGMCByARReq2