### PR TITLE
fix(frontend): auto-recover from stale dynamic-import 404s after deploy

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -118,10 +118,11 @@
       // Recovery: detect when styles fail to load (stale SW cache, blocked CSS
       // @import, network hiccup, etc.). If no same-origin stylesheets have
       // loaded after the page is interactive, unregister SW, clear caches, and
-      // hard-reload to get a clean state. A counter prevents infinite loops:
-      // we allow up to 2 recovery attempts per session.
+      // hard-reload to get a clean state. The same counter key is read by
+      // src/lib/sw-recovery.ts so the router-level recovery (for failed
+      // dynamic imports) and this CSS watchdog can't loop past the shared cap.
       ;(function () {
-        var attempts = parseInt(sessionStorage.getItem("css-recovery-attempts") || "0", 10)
+        var attempts = parseInt(sessionStorage.getItem("sw-recovery-attempts") || "0", 10)
         if (attempts >= 2) return
         setTimeout(function () {
           var hasStyles = false
@@ -138,10 +139,10 @@
           }
           if (hasStyles) {
             // Styles loaded successfully — reset counter so future breaks can recover
-            sessionStorage.removeItem("css-recovery-attempts")
+            sessionStorage.removeItem("sw-recovery-attempts")
             return
           }
-          sessionStorage.setItem("css-recovery-attempts", String(attempts + 1))
+          sessionStorage.setItem("sw-recovery-attempts", String(attempts + 1))
           var tasks = []
           if (navigator.serviceWorker) {
             tasks.push(

--- a/apps/frontend/public/_redirects
+++ b/apps/frontend/public/_redirects
@@ -1,1 +1,2 @@
+/recover /recover.html 200
 /* /index.html 200

--- a/apps/frontend/public/recover.html
+++ b/apps/frontend/public/recover.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reset Threa</title>
+    <meta name="robots" content="noindex" />
+    <link rel="icon" type="image/svg+xml" href="/threa-favicon.svg" media="(prefers-color-scheme: dark)" />
+    <link rel="icon" type="image/svg+xml" href="/threa-favicon-light.svg" media="(prefers-color-scheme: light)" />
+    <link rel="icon" type="image/x-icon" href="/threa-favicon.ico" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #1a1a1a;
+        --muted: #6b7280;
+        --accent: #8b7332;
+        --border: #e5e7eb;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0c0c0d;
+          --fg: #f5f5f5;
+          --muted: #9ca3af;
+          --accent: #c8a055;
+          --border: #27272a;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        display: grid;
+        place-items: center;
+        padding: 1.5rem;
+      }
+      main {
+        width: 100%;
+        max-width: 28rem;
+        text-align: center;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      .status {
+        margin: 1.5rem 0;
+        padding: 1rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.875rem;
+        text-align: left;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .status.ok {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .status.err {
+        border-color: #dc2626;
+        color: #dc2626;
+      }
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      button,
+      a.btn {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        font-size: 0.875rem;
+        font-family: inherit;
+        border: 1px solid var(--border);
+        border-radius: 0.375rem;
+        background: transparent;
+        color: var(--fg);
+        text-decoration: none;
+        cursor: pointer;
+      }
+      button.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg);
+      }
+      [hidden] {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Reset Threa</h1>
+      <p>Unregistering the service worker and clearing cached assets. You'll be sent back to Threa once it's done.</p>
+      <div id="status" class="status" aria-live="polite">Starting…</div>
+      <div class="actions">
+        <a class="btn primary" href="/" id="home" hidden>Back to Threa</a>
+        <button id="retry" hidden>Try again</button>
+      </div>
+    </main>
+    <script>
+      // Fully self-contained: no external imports, no app dependencies. This
+      // page has to work when the SPA is broken, so it runs the same
+      // SW-unregister + caches.delete sequence as lib/sw-recovery.ts using
+      // only platform APIs. Safe to bookmark: users can type /recover in the
+      // URL bar any time they get stuck.
+      ;(function () {
+        var status = document.getElementById("status")
+        var home = document.getElementById("home")
+        var retry = document.getElementById("retry")
+        var log = []
+
+        function setStatus(line, cls) {
+          log.push(line)
+          status.textContent = log.join("\n")
+          status.className = "status" + (cls ? " " + cls : "")
+        }
+
+        function showDone() {
+          home.hidden = false
+          retry.hidden = false
+        }
+
+        retry.addEventListener("click", function () {
+          location.reload()
+        })
+        ;(async function () {
+          try {
+            if ("serviceWorker" in navigator) {
+              var regs = await navigator.serviceWorker.getRegistrations()
+              await Promise.all(
+                regs.map(function (r) {
+                  return r.unregister()
+                })
+              )
+              setStatus("Unregistered " + regs.length + " service worker(s).")
+            } else {
+              setStatus("Service workers not supported — skipped.")
+            }
+
+            if ("caches" in window) {
+              var names = await caches.keys()
+              await Promise.all(
+                names.map(function (n) {
+                  return caches.delete(n)
+                })
+              )
+              setStatus("Cleared " + names.length + " cache bucket(s).")
+            } else {
+              setStatus("Cache Storage not supported — skipped.")
+            }
+
+            // Reset the in-app auto-recovery counter so if something goes
+            // wrong again, the app gets its full quota of auto-retries.
+            try {
+              sessionStorage.removeItem("sw-recovery-attempts")
+            } catch (e) {
+              // sessionStorage can throw in privacy modes — ignore.
+            }
+
+            setStatus("Done. Returning to Threa…", "ok")
+            setTimeout(function () {
+              // replace() so Back doesn't bring the user back to /recover.
+              location.replace("/")
+            }, 800)
+          } catch (err) {
+            setStatus("Recovery failed: " + ((err && err.message) || err), "err")
+            showDone()
+          }
+        })()
+      })()
+    </script>
+  </body>
+</html>

--- a/apps/frontend/src/components/error-boundary.tsx
+++ b/apps/frontend/src/components/error-boundary.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from "react"
 import { useRouteError, isRouteErrorResponse, Link } from "react-router-dom"
-import { AlertTriangle } from "lucide-react"
+import { AlertTriangle, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from "@/components/ui/empty"
 import { ErrorDetails } from "./error-details"
+import { isChunkLoadError, runSwRecovery } from "@/lib/sw-recovery"
 
 function formatError(error: unknown): string | null {
   if (error instanceof Error) {
@@ -24,6 +26,25 @@ function formatError(error: unknown): string | null {
 
 export function ErrorBoundary() {
   const error = useRouteError()
+  const chunkLoadFailed = isChunkLoadError(error)
+
+  // Flips to true only when runSwRecovery declines to reload because the
+  // per-session attempt cap is reached. Until then we render the "Updating"
+  // spinner instead of the error UI, so we don't flash the scary card for a
+  // few hundred ms before the reload kicks in.
+  const [recoveryDeclined, setRecoveryDeclined] = useState(false)
+
+  // Stale-deploy auto-recovery: when a lazy route's dynamic import 404s, old
+  // JS is trying to fetch a chunk whose filename has been replaced by a newer
+  // build. Unregister the SW, clear caches, and hard-reload so the tab picks
+  // up the current asset manifest. Gated by a shared sessionStorage counter
+  // (see lib/sw-recovery.ts) so we can't loop past the cap.
+  useEffect(() => {
+    if (!chunkLoadFailed) return
+    void runSwRecovery().then((triggered) => {
+      if (!triggered) setRecoveryDeclined(true)
+    })
+  }, [chunkLoadFailed])
 
   let title = "Something Went Wrong"
   let description = "The labyrinth has shifted unexpectedly. We encountered an error while navigating your path."
@@ -36,13 +57,39 @@ export function ErrorBoundary() {
       title = "Access Denied"
       description = "The gates to this part of the labyrinth are sealed."
     }
+  } else if (chunkLoadFailed && recoveryDeclined) {
+    title = "Update needed"
+    description =
+      "A newer version of Threa was deployed, and we couldn't auto-update this tab. Clear the site data for app.threa.io in your browser settings, then reopen."
   }
 
   const handleReload = () => {
     window.location.reload()
   }
 
+  const handleHardReload = () => {
+    void runSwRecovery({ force: true })
+  }
+
   const errorText = formatError(error)
+
+  // Recovery is imminent — show a lightweight status instead of the scary
+  // error UI, which would flash for a few hundred ms before the reload.
+  if (chunkLoadFailed && !recoveryDeclined) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-background p-4">
+        <Empty className="border-0 max-w-md w-full">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Loader2 className="animate-spin" />
+            </EmptyMedia>
+            <EmptyTitle>Updating Threa</EmptyTitle>
+            <EmptyDescription>Fetching the latest version…</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    )
+  }
 
   return (
     <div className="flex h-screen w-full items-center justify-center bg-background p-4">
@@ -55,10 +102,13 @@ export function ErrorBoundary() {
           <EmptyDescription>{description}</EmptyDescription>
         </EmptyHeader>
         <EmptyContent>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap justify-center gap-2">
             <Button onClick={handleReload}>Try Again</Button>
             <Button variant="outline" asChild>
               <Link to="/workspaces">Back to Workspaces</Link>
+            </Button>
+            <Button variant="ghost" onClick={handleHardReload}>
+              Clear cache &amp; reload
             </Button>
           </div>
           {errorText && <ErrorDetails text={errorText} />}

--- a/apps/frontend/src/components/error-boundary.tsx
+++ b/apps/frontend/src/components/error-boundary.tsx
@@ -60,7 +60,7 @@ export function ErrorBoundary() {
   } else if (chunkLoadFailed && recoveryDeclined) {
     title = "Update needed"
     description =
-      "A newer version of Threa was deployed, and we couldn't auto-update this tab. Clear the site data for app.threa.io in your browser settings, then reopen."
+      "A newer version of Threa was deployed, and we couldn't auto-update this tab. Visit /recover to force a full reset."
   }
 
   const handleReload = () => {

--- a/apps/frontend/src/lib/sw-recovery.test.ts
+++ b/apps/frontend/src/lib/sw-recovery.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { isChunkLoadError, runSwRecovery } from "./sw-recovery"
+
+describe("isChunkLoadError", () => {
+  it("detects Chromium/Firefox dynamic-import failures", () => {
+    const err = new TypeError(
+      "Failed to fetch dynamically imported module: https://app.threa.io/assets/workspace-layout-CZWcI4f9.js"
+    )
+    expect(isChunkLoadError(err)).toBe(true)
+  })
+
+  it("detects Safari dynamic-import failures", () => {
+    const err = new TypeError("error loading dynamically imported module")
+    expect(isChunkLoadError(err)).toBe(true)
+  })
+
+  it("detects older Edge module-script failures", () => {
+    const err = new Error("Importing a module script failed")
+    expect(isChunkLoadError(err)).toBe(true)
+  })
+
+  it("accepts raw string errors (thrown non-Error values)", () => {
+    expect(isChunkLoadError("Failed to fetch dynamically imported module")).toBe(true)
+  })
+
+  it("does not match unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Network request failed"))).toBe(false)
+    expect(isChunkLoadError(new TypeError("Cannot read properties of undefined"))).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+    expect(isChunkLoadError({ message: "Failed to fetch dynamically imported module" })).toBe(false)
+  })
+})
+
+describe("runSwRecovery", () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    // jsdom's location.reload() throws "Not implemented" — replace it with a spy
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: vi.fn() },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+    sessionStorage.clear()
+  })
+
+  it("returns false without reloading once the per-session cap is reached", async () => {
+    sessionStorage.setItem("sw-recovery-attempts", "2")
+    const result = await runSwRecovery()
+    expect(result).toBe(false)
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it("increments the attempt counter on each auto-recovery call", async () => {
+    await runSwRecovery()
+    expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("1")
+    await runSwRecovery()
+    expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("2")
+  })
+
+  it("force: true bypasses the cap and does not touch the counter", async () => {
+    sessionStorage.setItem("sw-recovery-attempts", "2")
+    const result = await runSwRecovery({ force: true })
+    expect(result).toBe(true)
+    expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("2")
+    expect(window.location.reload).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/frontend/src/lib/sw-recovery.ts
+++ b/apps/frontend/src/lib/sw-recovery.ts
@@ -1,0 +1,63 @@
+/**
+ * Recovery for stale-deploy states where cached JS/SW refers to asset
+ * filenames that no longer exist on the server. Shared by:
+ *
+ * - index.html's inline "styles didn't load after 3s" watchdog, and
+ * - the router error boundary, when a lazy route's dynamic import 404s.
+ *
+ * The sessionStorage counter is shared (same key) so both paths together
+ * can only reload at most MAX_ATTEMPTS times before falling through to the
+ * normal error UI — otherwise a persistent failure could loop forever.
+ */
+
+const ATTEMPTS_KEY = "sw-recovery-attempts"
+const MAX_ATTEMPTS = 2
+
+/**
+ * Detect the various dynamic-import failure messages across browsers.
+ * After a deploy, old JS running in a user's tab tries to import() a chunk
+ * whose content-hashed filename was replaced in the new build — producing:
+ *   Chromium/Firefox: "Failed to fetch dynamically imported module"
+ *   Safari:           "error loading dynamically imported module"
+ *   Older Edge:       "Importing a module script failed"
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  let message = ""
+  if (error instanceof Error) message = error.message
+  else if (typeof error === "string") message = error
+  if (!message) return false
+  return (
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("error loading dynamically imported module") ||
+    message.includes("Importing a module script failed")
+  )
+}
+
+/**
+ * Unregister the service worker, clear all Cache Storage buckets, then
+ * hard-reload. Returns true if recovery was kicked off (a reload will
+ * follow), false if the per-session cap has been reached and the caller
+ * should fall through to a normal error UI.
+ *
+ * Pass `force: true` for user-initiated clicks — the attempt cap only
+ * exists to prevent auto-recovery loops when recovery itself is broken,
+ * not to limit the user's ability to ask for a clean reload.
+ */
+export async function runSwRecovery(options?: { force?: boolean }): Promise<boolean> {
+  if (!options?.force) {
+    const attempts = Number.parseInt(sessionStorage.getItem(ATTEMPTS_KEY) ?? "0", 10)
+    if (attempts >= MAX_ATTEMPTS) return false
+    sessionStorage.setItem(ATTEMPTS_KEY, String(attempts + 1))
+  }
+
+  const tasks: Promise<unknown>[] = []
+  if ("serviceWorker" in navigator) {
+    tasks.push(navigator.serviceWorker.getRegistrations().then((regs) => Promise.all(regs.map((r) => r.unregister()))))
+  }
+  if ("caches" in window) {
+    tasks.push(caches.keys().then((names) => Promise.all(names.map((n) => caches.delete(n)))))
+  }
+  await Promise.all(tasks).catch(() => {})
+  window.location.reload()
+  return true
+}


### PR DESCRIPTION
## Summary

Route-splitting (#354) moved each page into its own lazy chunk, which introduced a new failure mode: when the user's tab is running an in-memory `main.js` from an older deploy, its dynamic imports reference chunk filenames (e.g. `workspace-layout-CZWcI4f9.js`) that were replaced server-side by the newer deploy. The next route change throws `Failed to fetch dynamically imported module`, the router bubbles it to the error boundary, and the page stays broken — reload doesn't help because the stale SW keeps serving the old `main.js` from precache.

This PR makes the state self-healing and adds two escape hatches — one for when React is still running, and one for when it isn't.

### Three layers of recovery

1. **Auto-recovery in the route error boundary** — detects `Failed to fetch dynamically imported module` / `error loading dynamically imported module` / `Importing a module script failed` (Chromium/Firefox, Safari, older Edge), unregisters the SW, clears Cache Storage, hard-reloads. During the short reload window it shows an "Updating Threa…" spinner instead of flashing the scary error card.
2. **"Clear cache & reload" button** on the error boundary. Calls the recovery helper with `{ force: true }` (bypasses the per-session attempt cap since it's user-initiated). Useful whenever the app has _partially_ booted but gotten stuck.
3. **`/recover` static page** — dependency-free HTML, works even when React never mounts or `main.js` itself fails to load. Runs the same SW-unregister + caches.delete sequence using only platform APIs, then redirects home. Bookmarkable — type `app.threa.io/recover` in the address bar any time things are fully broken.

### Shared attempt cap

`sw-recovery-attempts` in `sessionStorage` is shared by the in-app auto-recovery and the existing CSS-watchdog in `index.html`. Together they loop at most 2 times per session before falling through to the "Update needed" error message that explicitly points users at `/recover`. `/recover` itself resets the counter so the app gets its full quota of auto-retries after a manual reset.

## Why the existing fixes don't cover this

- #312 (`recover from stale service worker cache causing unstyled pages`) — the inline watchdog only triggers when CSS fails to load, not when a dynamic `import()` throws.
- #313 (`network-first navigation in SW`) — delivers a fresh `index.html`, but once `main.js` is running in memory its chunk references are already baked in.
- #315 (`Cloudflare Pages _headers`) — keeps `index.html` uncached at the CDN, doesn't help a tab that's already running.

The gap became user-visible after #354 (route splitting) landed, which is when I hit it on Chrome Android myself.

## Files

- `apps/frontend/src/lib/sw-recovery.ts` — new. `isChunkLoadError()` + `runSwRecovery({ force? })`.
- `apps/frontend/src/lib/sw-recovery.test.ts` — new. 8 tests: browser shapes, cap, `force` bypass.
- `apps/frontend/src/components/error-boundary.tsx` — wires auto-recovery, "Clear cache & reload" button, and the `/recover` pointer in the cap-reached message.
- `apps/frontend/public/recover.html` — new. Static recovery page.
- `apps/frontend/public/_redirects` — rewrite `/recover` → `/recover.html` before the SPA catch-all.
- `apps/frontend/index.html` — shares the `sw-recovery-attempts` counter key with the new helper.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (pre-existing warnings only)
- [x] 8 new unit tests pass
- [ ] Reproduce the original Chrome-mobile stuck state (have a tab open, deploy over it, navigate) — should auto-recover.
- [ ] Click "Clear cache & reload" on the error boundary — SW unregisters, caches wipe, page reloads.
- [ ] Visit `/recover` directly in the browser — status log shows unregister/clear steps, then redirects home.
- [ ] Verify attempt cap: simulate persistent failure, confirm we only auto-reload twice before showing the "Update needed — visit /recover" message.

## Note on test suite

`src/contexts/sidebar-context.test.tsx` fails on `origin/main` with `localStorage.removeItem is not a function` — pre-existing, unrelated, left alone here so the PR stays focused. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
