### PR TITLE
fix: exclude test postgres containers in setup-worktree and assign backoffice-router unique inspector port

### DIFF
--- a/apps/backoffice-router/package.json
+++ b/apps/backoffice-router/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --inspector-port 9230",
     "deploy": "wrangler deploy",
     "test": "bun test src/",
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.test.json"

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -394,7 +394,7 @@ async function main() {
   })
 
   const backofficeRouterDir = path.join(process.cwd(), "apps/backoffice-router")
-  const backofficeRouter = Bun.spawn(["bunx", "wrangler", "dev", "--port", "3005"], {
+  const backofficeRouter = Bun.spawn(["bunx", "wrangler", "dev", "--port", "3005", "--inspector-port", "9230"], {
     cwd: backofficeRouterDir,
     stdout: "inherit",
     stderr: "inherit",

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -100,7 +100,10 @@ async function findPostgresContainer(): Promise<string | null> {
   const result = await $`docker ps --format '{{.Names}}' --filter 'name=threa-postgres'`.quiet().nothrow()
   const containers = result.stdout.toString().trim().split("\n").filter(Boolean)
 
-  return containers[0] || null
+  // Exclude test containers (e.g. threa-postgres-test-1) which also match the filter
+  const mainContainers = containers.filter((name) => !name.includes("test"))
+
+  return mainContainers[0] || null
 }
 
 async function createDatabaseIfNotExists(dbName: string): Promise<boolean> {


### PR DESCRIPTION
## Problem

1. **`setup-worktree.ts` picked the wrong Postgres container**: `findPostgresContainer()` used `docker ps --filter 'name=threa-postgres'`, which matches *any* container with that substring — including `threa-postgres-test-1`. It then blindly returned `containers[0]`, so when the test container happened to sort first, the script would clone the DB into the test container instead of the main dev one.

2. **Two Wrangler processes fought over port 9229**: In `scripts/dev.ts`, both `workspace-router` and `backoffice-router` were spawned without an explicit `--inspector-port`, so both defaulted to `9229`. Whichever started second would crash with "Address already in use". (`dev-test.ts` already avoided this, but `dev.ts` did not.)

## Solution

1. **Filter out test containers** in `findPostgresContainer()`: after listing matching containers, exclude any whose name includes `"test"`, then return the first remaining entry.

2. **Assign `backoffice-router` a unique inspector port** (`9230`), both in:
   - `apps/backoffice-router/package.json` — so `bun run dev` inside the package works standalone.
   - `scripts/dev.ts` — so the orchestrated dev stack works.

### Key design decisions

**1. Which router gets the non-default port?**

`workspace-router` keeps the default `9229` (no change). `backoffice-router` (the more recently added wrangler app) gets `9230`. This matches the convention already used in `dev-test.ts`, where each router's inspector port is derived as `devPort + 1000`.

## Modified files

| File | Change |
|------|--------|
| `scripts/setup-worktree.ts` | `findPostgresContainer()` now filters out containers with `"test"` in their name. |
| `apps/backoffice-router/package.json` | Added `--inspector-port 9230` to the `dev` script. |
| `scripts/dev.ts` | Added `--inspector-port 9230` to the `backoffice-router` spawn arguments. |

## Test plan

- [x] `bun run lint` passes
- [x] `bun run check:dockerfiles` passes
- [x] Type-check passes across all workspaces

---

🤖 _PR by Claude Code_
