### PR TITLE
fix(editor): stop paste from splitting the current paragraph

### DIFF
--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -257,6 +257,72 @@ describe("multiline block paste handling", () => {
     expect(serializeToMarkdown(editor.getJSON())).toBe("> line 1\n> line 2")
     editor.destroy()
   })
+
+  it("inserts a single-line paste inline without splitting the current paragraph", () => {
+    const editor = createTestEditor("Hello ")
+
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    insertPastedText(
+      editor,
+      "World",
+      () => "user",
+      () => null
+    )
+
+    expect(editor.state.doc.childCount).toBe(1)
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph")
+    expect(serializeToMarkdown(editor.getJSON())).toBe("Hello World")
+    editor.destroy()
+  })
+
+  it("inserts a single-line paste mid-paragraph without splitting it in two", () => {
+    const editor = createTestEditor("Hi my  friend")
+
+    setCursor(editor, " friend")
+    insertPastedText(
+      editor,
+      "little",
+      () => "user",
+      () => null
+    )
+
+    expect(editor.state.doc.childCount).toBe(1)
+    expect(editor.state.doc.firstChild?.type.name).toBe("paragraph")
+    expect(serializeToMarkdown(editor.getJSON())).toBe("Hi my little friend")
+    editor.destroy()
+  })
+
+  it("preserves active marks when pasting plain text inside a styled span", () => {
+    const editor = createTestEditor("**bold** text")
+
+    // Place the cursor in the middle of the bold word ("bol|d")
+    setCursor(editor, "d")
+    insertPastedText(
+      editor,
+      "X",
+      () => "user",
+      () => null
+    )
+
+    expect(editor.state.doc.childCount).toBe(1)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("**bolXd** text")
+    editor.destroy()
+  })
+
+  it("keeps multi-line plain-text pastes as separate paragraphs", () => {
+    const editor = createTestEditor("prefix ")
+
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    insertPastedText(
+      editor,
+      "line 1\nline 2",
+      () => "user",
+      () => null
+    )
+
+    expect(serializeToMarkdown(editor.getJSON())).toBe("prefix line 1\n\nline 2")
+    editor.destroy()
+  })
 })
 
 describe("multiline beforeinput enter handling", () => {

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -1,5 +1,5 @@
 import type { JSONContent, Editor } from "@tiptap/react"
-import { Fragment, type Node as ProseMirrorNode, type Schema } from "@tiptap/pm/model"
+import { Fragment, Slice, type Node as ProseMirrorNode, type Schema } from "@tiptap/pm/model"
 import { Selection, type Transaction, type EditorState } from "@tiptap/pm/state"
 import { parseMarkdown, type EmojiLookup, type MentionTypeLookup } from "./editor-markdown"
 
@@ -434,8 +434,43 @@ export function insertPastedText(
     return editor.chain().focus().insertContent(content).run()
   }
 
-  const parsed = parseMarkdown(normalizedText, getMentionType, getEmoji, parseOptions)
-  return editor.commands.insertContent(parsed)
+  const blocks = getParsedContent(normalizedText, getMentionType, getEmoji, parseOptions)
+  if (!blocks || blocks.length === 0) {
+    return false
+  }
+
+  // When the parsed markdown is a single paragraph (the common case for pasted
+  // plain text), unwrap to its inline content. Inserting a paragraph node mid-
+  // paragraph makes ProseMirror split the current paragraph, producing stray
+  // newlines around the paste. Inserting inline content lets tiptap route plain
+  // text through `tr.insertText`, which also preserves the cursor's active
+  // marks (bold, inline code, link, ...).
+  if (blocks.length === 1 && blocks[0].type === "paragraph") {
+    const inline = blocks[0].content
+    if (!inline || inline.length === 0) {
+      return false
+    }
+    return editor.commands.insertContent(inline)
+  }
+
+  // Multi-paragraph plain-text paste: build a slice open at both ends so the
+  // first and last pasted paragraphs merge with the paragraph surrounding the
+  // cursor, matching native paste behavior.
+  if (blocks.every((block) => block.type === "paragraph")) {
+    const { schema } = editor.state
+    const fragment = Fragment.fromArray(blocks.map((block) => schema.nodeFromJSON(block)))
+    const slice = new Slice(fragment, 1, 1)
+    return editor
+      .chain()
+      .focus()
+      .command(({ tr }) => {
+        tr.replaceSelection(slice)
+        return true
+      })
+      .run()
+  }
+
+  return editor.commands.insertContent(blocks)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Pasting plain text into a regular paragraph was running the clipboard through `parseMarkdown` and forwarding the resulting `doc` to `editor.commands.insertContent`. For a single-paragraph parse, ProseMirror's slice logic treated that paragraph as a block and split the paragraph under the cursor, surfacing the paste as a stray newline above (and below, for mid-line pastes). Shift+Cmd/Ctrl+V worked because it inserted the raw string, bypassing the parse.
- `insertPastedText` in `apps/frontend/src/components/editor/multiline-blocks.ts` now:
  - Unwraps single-paragraph parses to their inline content — tiptap routes plain text through `tr.insertText`, which preserves the cursor's active marks (bold, inline code, link, …).
  - For multi-paragraph plain-text pastes, replaces the selection with a `Slice` opened at both ends so the first and last pasted paragraphs merge with the surrounding paragraph, matching native paste.
  - Code-block and blockquote paste branches are unchanged.

Fixes the reported cases:
- `Hello [paste "World"]` → `Hello World` (was `Hello \nWorld`)
- `Hi my [paste "little"] friend` → `Hi my little friend` (was `Hi my\nlittle\nfriend`)
- Pasting inside **bold**, inline code, or a link keeps the surrounding style.

## Test plan

- [x] `bun run test` for `apps/frontend/src/components/editor` — 245/245 passing (14 files), including 4 new paste cases in `multiline-blocks.test.ts`:
  - inserts a single-line paste inline without splitting the current paragraph
  - inserts a single-line paste mid-paragraph without splitting it in two
  - preserves active marks when pasting plain text inside a styled span
  - keeps multi-line plain-text pastes as separate paragraphs
- [x] `bun run test` for `apps/frontend/src/components/composer` — 24/24 passing
- [x] `bun run typecheck` — clean
- [ ] Manual smoke test in desktop browser: paste at end-of-line, mid-line, inside bold, inside inline code, inside a link, and a multi-line paste in a regular paragraph.

https://claude.ai/code/session_01XfkqAQD45tUsZZ56vE9Yve