### PR TITLE
fix(frontend): route pull-to-refresh through SyncEngine, not query invalidation

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,9 +1,8 @@
 import { type ReactNode, useCallback } from "react"
-import { useQueryClient } from "@tanstack/react-query"
-import { useParams } from "react-router-dom"
 import { RefreshCw } from "lucide-react"
 import { useSidebar, useCoordinatedLoading } from "@/contexts"
-import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, workspaceKeys, streamKeys } from "@/hooks"
+import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh } from "@/hooks"
+import { useSyncEngine } from "@/sync/sync-engine"
 import { TopbarLoadingIndicator } from "./topbar-loading-indicator"
 import { ConnectionStatus } from "./connection-status"
 import { cn } from "@/lib/utils"
@@ -101,16 +100,14 @@ export function AppShell({ sidebar, children }: AppShellProps) {
 
   const isKeyboardOpen = useVisualViewport(isMobile)
 
-  const queryClient = useQueryClient()
-  const { workspaceId } = useParams<{ workspaceId: string }>()
+  const syncEngine = useSyncEngine()
 
+  // Workspace + stream bootstrap caches are primed by SyncEngine (not a React
+  // Query observer), so invalidateQueries never triggers a refetch. Route the
+  // refresh through the engine's reconnect-style bootstrap instead.
   const handleSoftRefresh = useCallback(async () => {
-    if (!workspaceId) return
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) }),
-      queryClient.invalidateQueries({ queryKey: [...streamKeys.all, "bootstrap", workspaceId] }),
-    ])
-  }, [queryClient, workspaceId])
+    await syncEngine.refreshAfterConnectivityResume()
+  }, [syncEngine])
 
   // Light pull = soft refresh (re-fetch data), heavy pull = hard refresh (page reload)
   const {


### PR DESCRIPTION
## Problem

Pull-to-refresh on mobile no longer reliably refreshes data. The handler in `app-shell.tsx` called `queryClient.invalidateQueries` on the workspace and stream bootstrap keys, expecting React Query to refetch them — but nothing observes those queries in production.

- `useWorkspaceBootstrap` (`hooks/use-workspaces.ts:78`) is exported but never mounted. The only production callers of the workspace bootstrap cache are cache-only observers (e.g. `workspace-settings/users-tab.tsx`, `preferences-context.tsx`) that read via `queryClient.getQueryData` with `enabled: false`.
- The actual fetcher is `SyncEngine.bootstrapWorkspace()` (`sync/sync-engine.ts:234`), which writes directly via `queryClient.setQueryData` from a plain class — no observer, no refetch on invalidation.
- Stream bootstrap queries share the same `STREAM_BOOTSTRAP_QUERY_OPTIONS` (`lib/stream-bootstrap-query.ts`) with `refetchOnMount/Focus/Reconnect: false`, so even if they were marked stale by invalidation, observers that mount later would not refetch.

Net result: invalidation toggled the stale bit on cache entries that nothing would ever refetch, and pull-to-refresh was effectively a no-op against the authoritative bootstrap data. The 300ms spinner delay in `usePullToRefresh` hid this — the UI still showed a "refreshing" state, so the bug looked intermittent rather than absolute.

## Solution

Route `handleSoftRefresh` through `syncEngine.refreshAfterConnectivityResume()` (`sync/sync-engine.ts:136`) instead of invalidating React Query keys. That method already encapsulates the "fetch fresh state now" flow the engine uses for socket reconnects and `handlePageResume`:

- Fresh workspace bootstrap fetch.
- Delta fetches for visible streams (`currentStreamId` + `visibleStreamIds`), with `syncMode=replace` bumping `windowVersion` so `useEvents`'s floor ratchet resets (INV-53).
- Writes to IDB via `applyReconnectBootstrapBatch` / `applyWorkspaceBootstrap` so Dexie live queries pick up the new data.
- Writes to the React Query cache via `setQueryData` so cache-only observers re-render.

### Key design decisions

**1. Reuse `refreshAfterConnectivityResume` instead of introducing a new engine method**

The reconnect bootstrap already does exactly what pull-to-refresh needs: refresh workspace state plus delta-fetch visible streams. It also dedupes in-flight bootstraps via `activeBootstrap` / `queuedReconnectBootstrap`, so a user mashing the pull gesture doesn't stack duplicate requests. Adding a parallel "refresh" method would split that state machine in two (INV-35, INV-37).

**2. Drop the `workspaceId` param from `handleSoftRefresh`**

The engine already owns its workspace. AppShell is only mounted inside `SyncEngineContext.Provider` (`workspace-layout.tsx:232–345`), so `useSyncEngine()` is safe and the `useParams` lookup is redundant.

**3. Keep the pre-connect guard inside the engine, not the caller**

`refreshAfterConnectivityResume` already bails if `isDestroyed || !socket || !hasEverConnected`. Pulling before the first connect is a safe no-op — the 300ms spinner still fires so the user gets feedback, and no duplicate guard is needed in the shell.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/layout/app-shell.tsx` | `handleSoftRefresh` now calls `syncEngine.refreshAfterConnectivityResume()` instead of `queryClient.invalidateQueries`. Dropped now-unused imports (`useQueryClient`, `useParams`, `workspaceKeys`, `streamKeys`). |

## Test plan

- [x] `bun run typecheck` (frontend) clean.
- [ ] Manual: on mobile, pull-to-refresh from the sidebar while viewing a stream and confirm the active stream's events and sidebar stream previews update.
- [ ] Manual: pull-to-refresh on the workspace root (no stream open) and confirm the sidebar list refreshes (new streams, updated unread counts).
- [ ] Manual: pull-to-refresh while offline — spinner cycles, engine guard no-ops, no thrown errors.
- [ ] Manual: pull-to-refresh repeatedly in quick succession — confirm dedup via `activeBootstrap` (no duplicate network requests in devtools).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_