### PR TITLE
fix(ci): stamp-aware SessionStart hook so resumes don't pay a 150s reinstall

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { [ -f .env.remote-dev ] || { echo \"Missing .env.remote-dev\" >&2; exit 1; }; cp -n .env.remote-dev .env; docker compose up -d --wait; rm -rf node_modules apps/*/node_modules packages/*/node_modules; bun install; }; exit 0",
+            "command": "bash scripts/claude-code-web-session-start.sh",
             "timeout": 300
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,8 +8,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { [ -f .env.remote-dev ] || { echo \"Missing .env.remote-dev\" >&2; exit 1; }; cp -n .env.remote-dev .env; docker compose up -d --wait; rm -rf node_modules; bun install; }; exit 0",
-            "timeout": 180
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && { [ -f .env.remote-dev ] || { echo \"Missing .env.remote-dev\" >&2; exit 1; }; cp -n .env.remote-dev .env; docker compose up -d --wait; rm -rf node_modules apps/*/node_modules packages/*/node_modules; bun install; }; exit 0",
+            "timeout": 300
           }
         ]
       }

--- a/scripts/claude-code-web-session-start.sh
+++ b/scripts/claude-code-web-session-start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Claude Code Web SessionStart hook.
+# Wired up from .claude/settings.json; runs on every session start/resume.
+#
+# Goal: keep node_modules healthy across snapshot restores without paying the
+# ~150s full reinstall on every resume. We stamp node_modules with the
+# bun.lock hash after a successful install, and fast-path when the stamp
+# still matches the current lockfile.
+
+set -u
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+[ -f .env.remote-dev ] || { echo "Missing .env.remote-dev" >&2; exit 1; }
+cp -n .env.remote-dev .env
+docker compose up -d --wait
+
+LOCK_HASH=$(sha256sum bun.lock | awk '{print $1}')
+STAMP=node_modules/.install-stamp
+
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$LOCK_HASH" ]; then
+  exit 0
+fi
+
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
+bun install || exit 1
+echo "$LOCK_HASH" > "$STAMP"

--- a/scripts/claude-code-web-session-start.sh
+++ b/scripts/claude-code-web-session-start.sh
@@ -15,10 +15,10 @@ set -u
 cp -n .env.remote-dev .env
 docker compose up -d --wait
 
-LOCK_HASH=$(sha256sum bun.lock | awk '{print $1}')
+LOCK_HASH=$(sha256sum bun.lock 2>/dev/null | awk '{print $1}')
 STAMP=node_modules/.install-stamp
 
-if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$LOCK_HASH" ]; then
+if [ -n "$LOCK_HASH" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$LOCK_HASH" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Problem

The Claude Code web SessionStart hook was doing a full `rm -rf node_modules && bun install` on every session start — ~150s of wall time per resume, even when `bun.lock` was unchanged. Worse, the `rm -rf` only hit the **root** `node_modules/`, leaving `apps/*/node_modules` and `packages/*/node_modules` intact with symlinks dangling into the just-deleted `.bun/` central store. `bun install` didn't always re-reconcile every workspace symlink after that, which manifested as "node_modules rot": different modules going missing on different runs (tinyglobby in root, openai in backend, react-day-picker/date-fns in frontend — exactly the packages that live in separate workspace `node_modules/` dirs), only healable with `bun install --force`.

Two follow-up issues from the prior hook (#371):

1. **Incomplete clean** → rot between commits (pre-commit failing on missing packages).
2. **Unconditional reinstall** → every session resume cost ~150s even when nothing changed.

## Solution

Extract the hook to `scripts/claude-code-web-session-start.sh` and make it stamp-aware:

1. On every SessionStart, compute `sha256(bun.lock)`.
2. If `node_modules/.install-stamp` matches the hash, exit in ~150ms — the prior install is still good.
3. Otherwise, nuke **all** node_modules dirs (root + every `apps/*` and `packages/*`), run `bun install`, and rewrite the stamp only on success.

The stamp lives inside `node_modules/` so it cannot outlive the install state. Writing it is gated on `bun install` succeeding (`|| exit 1` before the `echo > stamp`), so a failed install leaves no stamp and the next resume retries from scratch.

### Key design decisions

**1. Stamp inside `node_modules/`, keyed on the full `bun.lock` hash**

Keying on `sha256(bun.lock)` catches any dependency change (workspace deps, transitive versions, peer resolutions). Keeping the stamp under `node_modules/` means it's gitignored automatically and can never outlive a `rm -rf node_modules`. A stamp outside `node_modules` (e.g. `/tmp` or a dotfile at repo root) could be restored by a snapshot while the install state wasn't, which would fast-path a broken tree.

**2. Clean every workspace `node_modules/`, not just the root**

Bun's isolated install mode puts a central store at `node_modules/.bun/` and symlinks from each workspace's `node_modules/`. Removing only the root leaves dangling symlinks that `bun install` doesn't always repair — which is exactly the rot the prior fix (#371) was trying to prevent but didn't fully catch. We now remove all 10 dirs (root + 7 apps + 3 packages).

**3. No fsck-style health probe (intentional scope limit)**

If `bun install` returns 0 but leaves a subtly-broken tree, we'd stamp and fast-path future resumes. A health probe (e.g. probing a few canonical package paths) would catch this but adds complexity. Known residual risk; the escape hatch is deleting `node_modules/.install-stamp` to force a reinstall.

**4. Timeout bumped 180s → 300s**

Observed cold installs take 145–170s; 180s was too thin a margin. 300s gives 2x headroom without penalty — the fast path exits in <200ms regardless.

## New files

| File                                       | Purpose                                                                                 |
| ------------------------------------------ | --------------------------------------------------------------------------------------- |
| `scripts/claude-code-web-session-start.sh` | SessionStart hook logic: gate on `CLAUDE_CODE_REMOTE`, stamp-check, nuke+reinstall path |

## Modified files

| File                    | Change                                                                                            |
| ----------------------- | ------------------------------------------------------------------------------------------------- |
| `.claude/settings.json` | SessionStart hook now calls the script; timeout bumped 180s → 300s                                |

## Test plan

- [x] `bash -n scripts/claude-code-web-session-start.sh` — syntax clean
- [x] Fast-path verified locally with a matching stamp: 126–145ms, exit 0
- [x] Slow-path `rm -rf` glob verified to expand to all 10 expected node_modules dirs (root + 7 apps + 3 packages)
- [x] Guard for empty `LOCK_HASH` (missing/unreadable `bun.lock`) — forces slow path instead of false fast-path match on empty string
- [x] Pre-commit hook (lint + full workspace typecheck + api-docs check) green on all three commits
- [ ] Next web session resume on an unchanged `bun.lock` should skip the install (look for absence of the `3295 packages installed` line in the SessionStart output)
- [ ] Next resume after a lockfile change should still do a full clean install

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGBs6bffP99WxEzETMnrKi)_