### PR TITLE
fix: make Codex Cloud bootstrap Docker-free

### DIFF
--- a/.claude/plans/codex-cloud-bootstrap.md
+++ b/.claude/plans/codex-cloud-bootstrap.md
@@ -1,0 +1,78 @@
+# Codex Cloud Bootstrap
+
+## Goal
+
+Add a Codex Cloud setup path for this repo so a cloud task can land in a predictable remote-dev environment, install workspace dependencies, and run repo checks without depending on local Docker orchestration inside the Codex container.
+
+## What Was Built
+
+### Codex Cloud Scripts
+
+Added a dedicated setup script, maintenance script, and doctor script for Codex Cloud. The scripts copy the shared remote-dev env template into `.env`, require Bun, install or resync dependencies, and validate the Codex Cloud prerequisites that should exist in the container.
+
+**Files:**
+- `scripts/codex-cloud-setup.sh` — bootstraps the Codex Cloud workspace by copying the shared env template and running `bun install`
+- `scripts/codex-cloud-maintenance.sh` — refreshes `.env` from the shared template and reruns `bun install` when a cached environment resumes
+- `scripts/codex-cloud-doctor.sh` — checks for `bun`, `.env`, and `node_modules`, then points Docker-backed flows to CI
+
+### Shared Remote-Dev Environment
+
+Unified the Claude web and Codex Cloud remote-dev flows onto a single checked-in env template so both paths point at the same baseline configuration and the repo only has one source of truth for remote sandbox defaults.
+
+**Files:**
+- `.env.remote-dev` — shared remote-dev sandbox defaults for both Codex Cloud and Claude web
+- `.gitignore` — allows the shared template to remain checked in
+- `.claude/settings.json` — updates the Claude SessionStart hook to use `.env.remote-dev`
+- `docs/claude-code-web.md` — documents the shared template for the Claude web flow
+
+### Codex Cloud Docs and Scripts Exposure
+
+Documented the Codex Cloud workflow and exposed the setup and doctor entry points through package scripts.
+
+**Files:**
+- `docs/codex-cloud.md` — Codex Cloud workflow, expectations, and CI guidance for Docker-backed flows
+- `package.json` — adds `codex:setup` and `codex:doctor`
+
+## Design Decisions
+
+### Shared Env Template Across Remote Flows
+
+**Chose:** rename the Claude-only env template into `.env.remote-dev` and reuse it for Codex Cloud.
+**Why:** the branch started with separate Codex and Claude env files that carried the same values, which would drift over time.
+**Alternatives considered:** keep separate `.env.claude-code-web` and `.env.codex-cloud` files. This was rejected because the duplication created unnecessary config sprawl.
+
+### Fail Loudly on Missing Required Inputs
+
+**Chose:** make setup and maintenance fail immediately if the shared env template or Bun is missing, and make the doctor print actionable failure output for missing Codex Cloud prerequisites.
+**Why:** the repo guidance favors loud, actionable failures over silent fallback behavior.
+**Alternatives considered:** warn and continue when the template or Bun is missing. This was rejected because it would leave the task in a partially configured state that looks successful.
+
+### Docker-Free Codex Cloud Workflow
+
+**Chose:** remove Docker startup and compose orchestration from the Codex Cloud scripts.
+**Why:** Codex Cloud runs inside a managed container, and the final workflow should not depend on Docker-in-Docker for local Postgres or MinIO.
+**Alternatives considered:** best-effort Docker startup and `docker compose up` inside the Codex setup path. This was rejected because Docker availability is inconsistent in Codex Cloud and Docker-backed tests already have CI coverage.
+
+## Design Evolution
+
+- **Remote env strategy:** started with a Codex-specific `.env.codex-cloud` file, then converged on a single `.env.remote-dev` template shared with the Claude web path.
+- **Docker strategy:** started with best-effort Docker bootstrap for Postgres and MinIO, then pivoted to a Docker-free Codex Cloud workflow after validating the platform constraints and deciding to leave Docker-backed tests to CI.
+- **Doctor behavior:** started as a warning-only script, then was tightened to fail on missing Codex Cloud prerequisites while treating Docker-backed services as intentionally out of scope.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No attempt to provision Postgres or MinIO inside Codex Cloud
+- No Codex-specific test runner for splitting DB-backed tests from non-DB-backed tests
+- No changes to the main local Docker Compose workflow used outside Codex Cloud
+
+## Status
+
+- [x] Add Codex Cloud setup, maintenance, and doctor scripts
+- [x] Expose setup and doctor through package scripts
+- [x] Unify the remote-dev env template across Claude web and Codex Cloud
+- [x] Document the Codex Cloud workflow and its Docker-free constraints
+- [ ] Add a dedicated Codex-specific test command or remote database strategy

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -19,14 +19,13 @@ bash scripts/codex-cloud-maintenance.sh
 The setup script will:
 
 1. copy `.env.remote-dev` into `.env`
-2. start Docker with the sandbox proxy env when the sandbox exposes `dockerd`
-3. start the local compose services and wait for them to become healthy
-4. reinstall workspace dependencies with Bun
+2. skip local Docker startup in Codex Cloud
+3. reinstall workspace dependencies with Bun
 
 The maintenance script will:
 
 1. refresh `.env` from `.env.remote-dev`
-2. ensure local compose services are running after cache resume or branch checkout
+2. keep Docker-backed services out of scope for Codex Cloud
 3. resync dependencies with Bun without doing the full fresh-container bootstrap
 
 Then verify the environment:
@@ -35,17 +34,18 @@ Then verify the environment:
 bash scripts/codex-cloud-doctor.sh
 ```
 
-The doctor exits non-zero when a required check fails and prints the failing command output so the broken dependency is visible.
+The doctor exits non-zero when the Codex Cloud prerequisites fail and reminds you that Docker-backed flows stay in CI for now.
 
-When the checks look good, start development as usual:
+When the checks look good, run the commands relevant to your task:
 
 ```bash
-bun run dev
+bun run lint
+bun run typecheck
 ```
 
 ## Notes for cloud sandboxes
 
 - The scripts are intentionally idempotent enough for disposable environments.
-- Docker startup is best-effort because some hosted sandboxes do not expose a daemon.
+- Codex Cloud does not try to start Docker for local Postgres/MinIO. Use CI for Docker-backed tests and flows.
 - This repo is Bun-first, so the Codex scripts require `bun` instead of falling back to other package managers.
 - `.env.remote-dev` is the single shared env template used by both the Codex and Claude remote-dev flows.

--- a/scripts/codex-cloud-doctor.sh
+++ b/scripts/codex-cloud-doctor.sh
@@ -24,13 +24,14 @@ check() {
   fi
 }
 
+info() {
+  echo "[info] $1"
+}
+
 check "bun installed" command -v bun
-check "docker installed" command -v docker
-check "docker daemon reachable" docker info
 check ".env present" test -f .env
 check "dependencies installed" test -d node_modules
-check "postgres container running" bash -c "docker compose ps --status running --services postgres | grep -qx postgres"
-check "minio container running" bash -c "docker compose ps --status running --services minio | grep -qx minio"
+info "Docker-backed services are not bootstrapped in Codex Cloud; run those tests in CI."
 
 echo
 
@@ -39,4 +40,4 @@ if [ "$failures" -gt 0 ]; then
   exit 1
 fi
 
-echo "Suggested next step: bun run dev"
+echo "Suggested next step: run the checks relevant to your task; use CI for Docker-backed flows."

--- a/scripts/codex-cloud-maintenance.sh
+++ b/scripts/codex-cloud-maintenance.sh
@@ -14,14 +14,6 @@ require_bun() {
   fi
 }
 
-compose_up() {
-  if docker compose up --help | grep -q -- '--wait'; then
-    docker compose up -d --wait
-  else
-    docker compose up -d
-  fi
-}
-
 # Refresh the dev env on resumed cached containers.
 if [ ! -f "$ENV_TEMPLATE" ]; then
   echo "Missing $ENV_TEMPLATE. Restore the shared remote-dev env template, then rerun maintenance." >&2
@@ -31,16 +23,7 @@ fi
 cp "$ENV_TEMPLATE" .env
 echo "==> Refreshed .env from $ENV_TEMPLATE"
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required to start the local Postgres and MinIO services." >&2
-  exit 1
-fi
-
-# Ensure local services are up after branch checkout or cache resume.
-if [ -f docker-compose.yml ]; then
-  echo "==> Ensuring docker compose services are running"
-  compose_up
-fi
+echo "==> Skipping Docker startup in Codex Cloud; Docker-backed tests should run in CI"
 
 require_bun
 

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -14,34 +14,6 @@ require_bun() {
   fi
 }
 
-start_docker_daemon() {
-  if docker info >/dev/null 2>&1; then
-    return 0
-  fi
-
-  echo "==> Starting Docker daemon"
-  HTTP_PROXY="${https_proxy:-}" HTTPS_PROXY="${https_proxy:-}" NO_PROXY="${no_proxy:-}" \
-    nohup dockerd --host unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
-
-  for _ in $(seq 1 45); do
-    if docker info >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "Docker daemon failed to become ready; see /tmp/dockerd.log" >&2
-  return 1
-}
-
-compose_up() {
-  if docker compose up --help | grep -q -- '--wait'; then
-    docker compose up -d --wait
-  else
-    docker compose up -d
-  fi
-}
-
 if [ ! -f "$ENV_TEMPLATE" ]; then
   echo "Missing $ENV_TEMPLATE. Restore the shared remote-dev env template, then rerun setup." >&2
   exit 1
@@ -50,19 +22,7 @@ fi
 cp "$ENV_TEMPLATE" .env
 echo "==> Copied $ENV_TEMPLATE -> .env"
 
-if command -v dockerd >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
-  start_docker_daemon
-fi
-
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required to start the local Postgres and MinIO services." >&2
-  exit 1
-fi
-
-if [ -f docker-compose.yml ]; then
-  echo "==> Starting docker compose services"
-  compose_up
-fi
+echo "==> Skipping Docker startup in Codex Cloud; Docker-backed tests should run in CI"
 
 require_bun
 


### PR DESCRIPTION
## Problem

PR #406 landed the initial Codex Cloud bootstrap path on `main`, but the final follow-up behavior still needed to catch up with how Codex Cloud actually runs. The branch still treated Docker-backed local services as part of setup even though Codex Cloud tasks run inside a managed container, and the PR needed a committed branch plan for review tooling.

## Solution

Make the Codex Cloud workflow explicitly Docker-free and keep Docker-backed Postgres/MinIO flows in CI, then add a synced branch plan that documents the final implementation and the design pivot.

### How it works

1. `scripts/codex-cloud-setup.sh` now copies `.env.remote-dev`, requires Bun, installs dependencies, and explicitly skips Docker startup in Codex Cloud.
2. `scripts/codex-cloud-maintenance.sh` refreshes `.env` from the same template, reruns `bun install`, and keeps Docker-backed services out of scope.
3. `scripts/codex-cloud-doctor.sh` validates only the Codex Cloud prerequisites that should exist in the managed container and points Docker-backed checks to CI.
4. `.claude/plans/codex-cloud-bootstrap.md` records the final behavior and the evolution from the earlier Docker-oriented approach.

### Key design decisions

**1. Do not bootstrap Docker in Codex Cloud**

Codex Cloud is treated as a managed container environment, so the setup path no longer attempts to provision local Postgres or MinIO there.

**2. Keep Docker-backed checks in CI**

The doctor script and docs now make the split explicit: Codex Cloud handles repo bootstrap and non-Docker checks, while Docker-backed tests continue to rely on CI.

**3. Commit a branch plan for review tooling**

The branch includes a synced plan file so automated reviewers can evaluate the follow-up PR against the final intended behavior rather than the original pre-merge branch history.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/codex-cloud-bootstrap.md` | Documents the final Codex Cloud follow-up implementation and design evolution |

## Modified files

| File | Change |
| --- | --- |
| `docs/codex-cloud.md` | Updates the Codex Cloud docs to describe the Docker-free workflow and CI split |
| `scripts/codex-cloud-doctor.sh` | Narrows doctor checks to Codex Cloud prerequisites and points Docker-backed flows to CI |
| `scripts/codex-cloud-maintenance.sh` | Removes Docker orchestration from maintenance |
| `scripts/codex-cloud-setup.sh` | Removes Docker orchestration from setup |

## Test plan

- [x] `bash -n scripts/codex-cloud-setup.sh scripts/codex-cloud-maintenance.sh scripts/codex-cloud-doctor.sh`
- [x] Docker-free shell smoke test with only `bun` on `PATH` to verify setup, maintenance, and doctor behavior
- [ ] Docker-backed tests remain covered in CI rather than inside Codex Cloud

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
