### PR TITLE
fix(frontend): only fold the outermost markdown block

### DIFF
--- a/apps/frontend/src/lib/markdown/blockquote-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/blockquote-block.test.tsx
@@ -178,4 +178,26 @@ describe("BlockquoteBlock collapse behavior", () => {
     const rows = await db.markdownBlockCollapse.where("messageId").equals(messageId).toArray()
     expect(rows.every((row) => row.kind === "blockquote")).toBe(true)
   })
+
+  it("only the outermost blockquote folds when blockquotes are nested", () => {
+    // Threshold high enough that neither block defaults to collapsed —
+    // we want to verify the inner block renders without fold chrome at all,
+    // not just that it happens to be expanded.
+    currentPrefs = { blockquoteCollapseThreshold: 100 }
+    render(
+      <MarkdownBlockProvider messageId="msg_nested">
+        <BlockquoteBlock>
+          <p>Outer quote line.</p>
+          <BlockquoteBlock>
+            <p>Inner quote line.</p>
+          </BlockquoteBlock>
+        </BlockquoteBlock>
+      </MarkdownBlockProvider>
+    )
+
+    // Exactly one fold toggle exists — the outer one's "Collapse block quote".
+    expect(screen.getAllByRole("button", { name: /collapse block quote/i })).toHaveLength(1)
+    expect(screen.getByText("Outer quote line.")).toBeInTheDocument()
+    expect(screen.getByText("Inner quote line.")).toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/lib/markdown/blockquote-block.tsx
+++ b/apps/frontend/src/lib/markdown/blockquote-block.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
+import { InsideCollapsibleBlockProvider } from "./markdown-block-context"
 import { extractBlockText, estimateBlockLines, takeQuotePreview, QUOTE_PREVIEW_LINE_COUNT } from "./extract-block-text"
 
 interface BlockquoteBlockProps {
@@ -42,37 +43,39 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
   const bodyTogglesExpand = collapsed && hasTruncatedPreview
 
   return (
-    <blockquote className="my-2 rounded-r-md border-l-2 border-primary/50 bg-muted/20">
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={!collapsed}
-        aria-label={toggleLabel}
-        title={toggleLabel}
-        className="flex w-full cursor-pointer items-center gap-1 px-3 py-1 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground"
-      >
-        {collapsed ? (
-          <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
-        ) : (
-          <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
-        )}
-        <span className="shrink-0">Quote</span>
-        {collapsed && (
-          <span className="text-muted-foreground/80 font-normal shrink-0">
-            — {lineCount} line{lineCount === 1 ? "" : "s"}, click to expand
-          </span>
-        )}
-      </button>
-      {collapsed ? (
-        <div
-          className={cn("px-4 pb-2 text-sm text-muted-foreground italic", bodyTogglesExpand && "cursor-pointer")}
-          onClick={bodyTogglesExpand ? toggle : undefined}
+    <InsideCollapsibleBlockProvider>
+      <blockquote className="my-2 rounded-r-md border-l-2 border-primary/50 bg-muted/20">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-label={toggleLabel}
+          title={toggleLabel}
+          className="flex w-full cursor-pointer items-center gap-1 px-3 py-1 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground"
         >
-          {hasTruncatedPreview ? <p className="mb-0 truncate">{previewText}</p> : children}
-        </div>
-      ) : (
-        <div className="px-4 pb-2 text-muted-foreground italic">{children}</div>
-      )}
-    </blockquote>
+          {collapsed ? (
+            <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
+          )}
+          <span className="shrink-0">Quote</span>
+          {collapsed && (
+            <span className="text-muted-foreground/80 font-normal shrink-0">
+              — {lineCount} line{lineCount === 1 ? "" : "s"}, click to expand
+            </span>
+          )}
+        </button>
+        {collapsed ? (
+          <div
+            className={cn("px-4 pb-2 text-sm text-muted-foreground italic", bodyTogglesExpand && "cursor-pointer")}
+            onClick={bodyTogglesExpand ? toggle : undefined}
+          >
+            {hasTruncatedPreview ? <p className="mb-0 truncate">{previewText}</p> : children}
+          </div>
+        ) : (
+          <div className="px-4 pb-2 text-muted-foreground italic">{children}</div>
+        )}
+      </blockquote>
+    </InsideCollapsibleBlockProvider>
   )
 }

--- a/apps/frontend/src/lib/markdown/markdown-block-context.tsx
+++ b/apps/frontend/src/lib/markdown/markdown-block-context.tsx
@@ -28,6 +28,26 @@ export function useMarkdownBlockContext(): MarkdownBlockContextValue | null {
 }
 
 /**
+ * Marks descendants as rendered inside a foldable block so nested foldable
+ * blocks (blockquote-in-blockquote, code-in-blockquote, quote-reply-in-quote)
+ * skip their own collapse chrome. Only the outermost block folds; inner blocks
+ * render plain. See `useBlockCollapse`.
+ */
+const InsideCollapsibleBlockContext = createContext<boolean>(false)
+
+interface InsideCollapsibleBlockProviderProps {
+  children: ReactNode
+}
+
+export function InsideCollapsibleBlockProvider({ children }: InsideCollapsibleBlockProviderProps) {
+  return <InsideCollapsibleBlockContext.Provider value={true}>{children}</InsideCollapsibleBlockContext.Provider>
+}
+
+export function useIsInsideCollapsibleBlock(): boolean {
+  return useContext(InsideCollapsibleBlockContext)
+}
+
+/**
  * DJB2 hash of `namespace\0content`. Namespacing keeps the hash spaces of
  * different block kinds (and of different code-block languages) disjoint so
  * identical content doesn't alias across them. Not cryptographic.

--- a/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD } from "@threa/types"
+import { db } from "@/db"
+import { QuoteReplyBlock } from "./quote-reply-block"
+import { BlockquoteBlock } from "./blockquote-block"
+import { MarkdownBlockProvider } from "./markdown-block-context"
+import * as preferencesModule from "@/contexts/preferences-context"
+import * as hooksModule from "@/hooks"
+import * as userProfileModule from "@/components/user-profile"
+
+let currentPrefs: { blockquoteCollapseThreshold?: number } | null = {
+  blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
+}
+
+function buildPreferencesContext() {
+  if (!currentPrefs) return null
+  return {
+    preferences: currentPrefs,
+    resolvedTheme: "light",
+    isLoading: false,
+    updatePreference: vi.fn(),
+    updateAccessibility: vi.fn(),
+    updateKeyboardShortcut: vi.fn(),
+    resetKeyboardShortcut: vi.fn(),
+    resetAllKeyboardShortcuts: vi.fn(),
+  } as unknown as ReturnType<typeof preferencesModule.usePreferences>
+}
+
+function renderInWorkspace(ui: React.ReactElement, workspaceId = "ws_test") {
+  return render(
+    <MemoryRouter initialEntries={[`/w/${workspaceId}`]}>
+      <Routes>
+        <Route path="/w/:workspaceId" element={ui} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("QuoteReplyBlock nesting behavior", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(() => buildPreferencesContext())
+    vi.spyOn(hooksModule, "useActors").mockReturnValue({
+      getActorName: () => "Alex",
+      getActorInitials: () => "AL",
+      getActorAvatar: () => ({ fallback: "AL" }),
+      getUser: () => undefined,
+      getPersona: () => undefined,
+      getBot: () => undefined,
+    } as unknown as ReturnType<typeof hooksModule.useActors>)
+    vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({
+      openUserProfile: vi.fn(),
+    } as unknown as ReturnType<typeof userProfileModule.useUserProfile>)
+    currentPrefs = { blockquoteCollapseThreshold: 100 }
+    await db.markdownBlockCollapse.clear()
+  })
+
+  afterEach(async () => {
+    await db.markdownBlockCollapse.clear()
+  })
+
+  it("only the outer quote-reply folds when a blockquote is nested inside it", () => {
+    renderInWorkspace(
+      <MarkdownBlockProvider messageId="msg_nested_qr">
+        <QuoteReplyBlock
+          authorName="Alex"
+          authorId="user_alex"
+          actorType="user"
+          streamId="stream_src"
+          messageId="msg_src"
+        >
+          <BlockquoteBlock>
+            <p>Inner quote line.</p>
+          </BlockquoteBlock>
+        </QuoteReplyBlock>
+      </MarkdownBlockProvider>
+    )
+
+    // Quote-reply renders its own toggle (the outermost foldable block).
+    expect(screen.getAllByRole("button", { name: /collapse quote reply/i })).toHaveLength(1)
+    // The nested blockquote does NOT render a fold toggle of its own.
+    expect(screen.queryByRole("button", { name: /collapse block quote/i })).not.toBeInTheDocument()
+    expect(screen.getByText("Inner quote line.")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
+import { InsideCollapsibleBlockProvider } from "./markdown-block-context"
 import { extractBlockText, estimateBlockLines } from "./extract-block-text"
 
 interface QuoteReplyBlockProps {
@@ -61,49 +62,51 @@ export function QuoteReplyBlock({
   const collapseLabel = collapsed ? `Expand ${lineCount} line${lineCount === 1 ? "" : "s"}` : "Collapse quote reply"
 
   return (
-    <div className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm">
-      <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <QuoteAuthor
-            workspaceId={workspaceId}
-            authorName={authorName}
-            authorId={authorId}
-            actorType={actorType as AuthorType}
-          />
-          {canToggle && (
-            <button
-              type="button"
-              onClick={toggle}
-              aria-expanded={!collapsed}
-              aria-label={collapseLabel}
-              title={collapseLabel}
-              className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-primary/10 hover:text-foreground"
-            >
-              {collapsed ? (
-                <ChevronRight className="h-3 w-3" aria-hidden="true" />
-              ) : (
-                <ChevronDown className="h-3 w-3" aria-hidden="true" />
-              )}
-            </button>
-          )}
+    <InsideCollapsibleBlockProvider>
+      <div className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm">
+        <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <QuoteAuthor
+              workspaceId={workspaceId}
+              authorName={authorName}
+              authorId={authorId}
+              actorType={actorType as AuthorType}
+            />
+            {canToggle && (
+              <button
+                type="button"
+                onClick={toggle}
+                aria-expanded={!collapsed}
+                aria-label={collapseLabel}
+                title={collapseLabel}
+                className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-primary/10 hover:text-foreground"
+              >
+                {collapsed ? (
+                  <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                ) : (
+                  <ChevronDown className="h-3 w-3" aria-hidden="true" />
+                )}
+              </button>
+            )}
+          </div>
+          <Link
+            to={url}
+            className="mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
+          >
+            {collapsed ? (
+              <div className="truncate text-xs italic text-muted-foreground/80">
+                {lineCount > 0
+                  ? `${lineCount} line${lineCount === 1 ? "" : "s"} — click chevron to expand`
+                  : "Quoted message"}
+              </div>
+            ) : (
+              <div className="[&_p]:mb-0">{children}</div>
+            )}
+          </Link>
         </div>
-        <Link
-          to={url}
-          className="mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
-        >
-          {collapsed ? (
-            <div className="truncate text-xs italic text-muted-foreground/80">
-              {lineCount > 0
-                ? `${lineCount} line${lineCount === 1 ? "" : "s"} — click chevron to expand`
-                : "Quoted message"}
-            </div>
-          ) : (
-            <div className="[&_p]:mb-0">{children}</div>
-          )}
-        </Link>
       </div>
-    </div>
+    </InsideCollapsibleBlockProvider>
   )
 }
 

--- a/apps/frontend/src/lib/markdown/use-block-collapse.ts
+++ b/apps/frontend/src/lib/markdown/use-block-collapse.ts
@@ -4,6 +4,7 @@ import { db } from "@/db"
 import {
   composeBlockCollapseKey,
   hashMarkdownBlock,
+  useIsInsideCollapsibleBlock,
   useMarkdownBlockContext,
   type MarkdownBlockKind,
 } from "./markdown-block-context"
@@ -40,11 +41,12 @@ export function useBlockCollapse({
   defaultCollapsed,
 }: UseBlockCollapseOptions): BlockCollapseState {
   const messageContext = useMarkdownBlockContext()
+  const nested = useIsInsideCollapsibleBlock()
 
   const collapseKey = useMemo(() => {
-    if (!messageContext) return null
+    if (!messageContext || nested) return null
     return composeBlockCollapseKey(messageContext.messageId, kind, hashMarkdownBlock(content, hashNamespace))
-  }, [messageContext, kind, hashNamespace, content])
+  }, [messageContext, nested, kind, hashNamespace, content])
 
   const persistedOverride = useLiveQuery(async () => {
     if (!collapseKey) return undefined
@@ -52,7 +54,9 @@ export function useBlockCollapse({
     return row?.collapsed
   }, [collapseKey])
 
-  const collapsed = persistedOverride ?? defaultCollapsed
+  // Nested blocks render plain (always expanded, no toggle) so only the
+  // outermost foldable block folds.
+  const collapsed = nested ? false : (persistedOverride ?? defaultCollapsed)
 
   const toggle = useCallback(() => {
     if (!collapseKey || !messageContext) return


### PR DESCRIPTION
## Summary

Nested foldable markdown blocks each rendered their own collapse toggle — a quote inside a quote, or a code block inside a quote, all became independently foldable. Now only the outermost block folds; inner ones render plain.

## How

- Add `InsideCollapsibleBlockProvider` / `useIsInsideCollapsibleBlock` to `markdown-block-context.tsx`.
- `useBlockCollapse` short-circuits to `canToggle=false, collapsed=false` when nested, so inner blocks fall into their existing plain-render branch.
- `BlockquoteBlock` and `QuoteReplyBlock` wrap their rendered output in the provider so descendants (including nested code blocks) see the flag.
- `CodeBlock` needs no changes — its existing `canToggle &&` chevron gate handles the nested case automatically.

## Test plan

- [x] New test: `BlockquoteBlock` containing another `BlockquoteBlock` renders exactly one fold toggle.
- [x] Existing `blockquote-block`, `code-block`, and `markdown-block-context` tests still pass.
- [x] Frontend typecheck passes.
- [ ] Manual: render a message with a nested quote (`> > text`) and a code block inside a quote — only the outer quote should show a chevron.

https://claude.ai/code/session_01N6i52MgtELZ3zbzJML77Vm

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6i52MgtELZ3zbzJML77Vm)_