### PR TITLE
Add trailing paragraph for quote replies and clarify PR URL capture order

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -134,6 +134,17 @@ gh api repos/{owner}/{repo}/pulls --method POST \
 
 Always provide the PR URL to the user when done.
 
+Use this URL capture order:
+
+1. If `gh pr create` succeeds, capture and return the URL printed by `gh`.
+2. If using the GitHub REST API, parse `html_url` from the response body and return it.
+3. If using the `make_pr` MCP tool, return the URL from tool output when available.
+4. If URL cannot be determined (e.g., missing remote/token/tool does not return URL), explicitly say so and include:
+   - the exact reason (for example, "no `origin` remote configured in this checkout")
+   - the PR title used
+   - the branch name used
+   - the next command/API call required to fetch the URL once connectivity/remote is available
+
 ## PR Title Conventions
 
 Use conventional commit format with Linear ticket ID when available:

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -441,7 +441,7 @@ describe("MessageInput", () => {
   })
 
   describe("quote replies", () => {
-    it("inserts a quote block without appending a synthetic trailing paragraph", () => {
+    it("inserts a quote block with one trailing paragraph so typing starts on the next line", () => {
       mockComposerState.content = {
         type: "doc",
         content: [{ type: "paragraph", content: [{ type: "text", text: "Before" }] }, { type: "paragraph" }],
@@ -475,6 +475,7 @@ describe("MessageInput", () => {
               snippet: "The vibes are immaculate",
             },
           },
+          { type: "paragraph" },
         ],
       })
       expect(mockComposerFocusAfterQuoteReply).toHaveBeenCalledTimes(1)

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -265,9 +265,8 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
       const currentContent = composerRef.current.content
       const existingBlocks = currentContent.content ?? []
 
-      // Strip trailing empty paragraphs so the quote appends cleanly.
-      // The cursor should land on the quote-side gapcursor, not in a synthetic
-      // empty paragraph rendered on the next line.
+      // Strip trailing empty paragraphs so the quote appends cleanly and we
+      // re-add exactly one trailing paragraph for post-quote typing.
       const trimmedBlocks = [...existingBlocks]
       while (
         trimmedBlocks.length > 0 &&
@@ -279,7 +278,7 @@ export function MessageInput({ workspaceId, streamId, disabled, disabledReason, 
 
       composerRef.current.setContent({
         type: "doc",
-        content: [...trimmedBlocks, quoteNode],
+        content: [...trimmedBlocks, quoteNode, { type: "paragraph" }],
       })
 
       // Focus the composer so the user can start typing immediately


### PR DESCRIPTION
### Motivation

- Ensure that inserting a quote reply leaves the editor with a single empty paragraph after the quote so the user can start typing on the next line.
- Make the PR-creation skill more robust by documenting the exact order to capture and return the PR URL from different creation methods.

### Description

- Update `MessageInput` to append exactly one trailing `{ type: "paragraph" }` after inserting a `quoteReply` node instead of leaving the cursor in a synthetic/ambiguous position. 
- Adjust the trimming logic to remove existing empty paragraphs before appending the quote and the single trailing paragraph. 
- Update the unit test name and expectations in `message-input.test.tsx` to assert that the `setContent` call includes the quote node followed by one trailing paragraph. 
- Extend `.agents/skills/create-pr/SKILL.md` to specify the URL capture order for `gh pr create`, the GitHub REST API response (`html_url`), the `make_pr` MCP tool, and fallback behavior when a URL cannot be determined.

### Testing

- Ran the `MessageInput` unit tests in `apps/frontend/src/components/timeline/message-input.test.tsx` with the repository test runner (`jest`), and the updated test passed. 
- Verified the modified test asserts `mockSetContent` was called with the expected document shape including the trailing paragraph, and the assertion passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4b1ce484832da449366b9fe5ca9d)