### PR TITLE
chore: add Codex-cloud non-DB test command

### DIFF
--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -43,6 +43,14 @@ bun run lint
 bun run typecheck
 ```
 
+For Codex Cloud test runs that avoid Docker-backed DB usage, browser tests, and intent/agent suites, use:
+
+```bash
+bun run test:codex:cloud
+```
+
+This command runs only backend unit tests from `apps/backend/src`, excluding `features/agents/**` and any `*intent*.test.ts` files.
+
 ## Notes for cloud sandboxes
 
 - The scripts are intentionally idempotent enough for disposable environments.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "docker:build": "bun run docker:build:backend && bun run docker:build:control-plane",
     "generate:api-docs": "bun apps/backend/scripts/generate-api-docs.ts",
     "generate:api-docs:check": "bun apps/backend/scripts/generate-api-docs.ts --check",
-    "infra:validate": "cd infra/aws && terraform validate"
+    "infra:validate": "cd infra/aws && terraform validate",
+    "test:codex:cloud": "bash scripts/test-codex-cloud.sh"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/scripts/test-codex-cloud.sh
+++ b/scripts/test-codex-cloud.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Codex Cloud quick test pass: unit tests only, excluding DB/browser/intent-heavy suites.
+# Runs backend unit tests from src/ and excludes agent/intent paths.
+
+cd "$(dirname "$0")/.."
+
+mapfile -t backend_unit_files < <(
+  rg --files apps/backend/src \
+    -g '*.test.ts' \
+    -g '!**/features/agents/**' \
+    -g '!**/*intent*.test.ts' \
+    | sed 's#^apps/backend/##' \
+    | sort
+)
+
+if [[ ${#backend_unit_files[@]} -eq 0 ]]; then
+  echo "No eligible non-DB backend unit tests found."
+  exit 1
+fi
+
+bun scripts/test-silent.ts backend-unit "${backend_unit_files[@]}"


### PR DESCRIPTION
### Motivation
- Codex cloud sessions cannot reliably run Docker-backed database suites, browser E2E tests, or intent/agent-heavy tests, so a clear, safe test command is needed for that environment.
- Provide an explicit, repeatable command that runs only fast backend unit tests which do not require a DB or browser.

### Description
- Add `scripts/test-codex-cloud.sh`, a shell script that collects `apps/backend/src/**/*.test.ts` files while excluding `features/agents/**` and `*intent*.test.ts`, then invokes the silent runner with `bun scripts/test-silent.ts backend-unit` and the filtered file list.
- Expose the script via a root npm script alias `test:codex:cloud` in `package.json` so it can be run with `bun run test:codex:cloud`.
- Document the new command and its intent in `docs/codex-cloud.md` with usage instructions and the exclusion policy for DB/browser/intent suites.

### Testing
- Ran the new command with `bun run test:codex:cloud` in the Codex cloud environment, which reported `308 successful tests` and `0 failing tests`.
- The `scripts/test-silent.ts` harness was used to execute the filtered `backend-unit` test set and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec61579010832dacd380a7653d9e40)