### PR TITLE
Add zoom and pan functionality to image gallery

### DIFF
--- a/apps/frontend/src/components/gallery/zoom-controls.tsx
+++ b/apps/frontend/src/components/gallery/zoom-controls.tsx
@@ -1,17 +1,23 @@
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ZoomIn, ZoomOut, Maximize2 } from "lucide-react"
 import { ZOOM_MIN, ZOOM_MAX } from "@/hooks/use-zoom-pan"
 import { cn } from "@/lib/utils"
 
 interface ZoomControlsProps {
-  scale: number
+  /** Subscribe to scale updates. Returns an unsubscribe fn. The component owns
+   *  its scale state locally so 60fps pinch updates don't re-render the gallery. */
+  subscribeScale: (cb: (scale: number) => void) => () => void
   onZoomIn: () => void
   onZoomOut: () => void
   onReset: () => void
   className?: string
 }
 
-export function ZoomControls({ scale, onZoomIn, onZoomOut, onReset, className }: ZoomControlsProps) {
+export function ZoomControls({ subscribeScale, onZoomIn, onZoomOut, onReset, className }: ZoomControlsProps) {
+  const [scale, setScale] = useState(1)
+  useEffect(() => subscribeScale(setScale), [subscribeScale])
+
   const canZoomIn = scale < ZOOM_MAX - 1e-3
   const canZoomOut = scale > ZOOM_MIN + 1e-3
   const percent = Math.round(scale * 100)

--- a/apps/frontend/src/components/gallery/zoom-controls.tsx
+++ b/apps/frontend/src/components/gallery/zoom-controls.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button"
+import { ZoomIn, ZoomOut, Maximize2 } from "lucide-react"
+import { ZOOM_MIN, ZOOM_MAX } from "@/hooks/use-zoom-pan"
+import { cn } from "@/lib/utils"
+
+interface ZoomControlsProps {
+  scale: number
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onReset: () => void
+  className?: string
+}
+
+export function ZoomControls({ scale, onZoomIn, onZoomOut, onReset, className }: ZoomControlsProps) {
+  const canZoomIn = scale < ZOOM_MAX - 1e-3
+  const canZoomOut = scale > ZOOM_MIN + 1e-3
+  const percent = Math.round(scale * 100)
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0.5 rounded-full bg-black/50 backdrop-blur-sm px-1 py-1 text-white",
+        className
+      )}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 rounded-full text-white hover:bg-white/20 disabled:opacity-40"
+        onClick={onZoomOut}
+        disabled={!canZoomOut}
+        aria-label="Zoom out"
+      >
+        <ZoomOut className="h-4 w-4" />
+      </Button>
+      <span className="min-w-[44px] text-center text-xs tabular-nums text-white/80 select-none">{percent}%</span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 rounded-full text-white hover:bg-white/20 disabled:opacity-40"
+        onClick={onZoomIn}
+        disabled={!canZoomIn}
+        aria-label="Zoom in"
+      >
+        <ZoomIn className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn(
+          "h-8 w-8 rounded-full text-white hover:bg-white/20 disabled:opacity-40 transition-opacity",
+          canZoomOut ? "opacity-100" : "opacity-0 pointer-events-none"
+        )}
+        onClick={onReset}
+        aria-label="Reset zoom"
+      >
+        <Maximize2 className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -1,0 +1,70 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
+import { useZoomPan } from "@/hooks/use-zoom-pan"
+
+export interface ZoomableImageHandle {
+  reset: () => void
+  zoomIn: () => void
+  zoomOut: () => void
+  getScale: () => number
+  isZoomed: () => boolean
+}
+
+interface ZoomableImageProps {
+  src: string
+  alt: string
+  onZoomChange?: (zoomed: boolean) => void
+  onScaleChange?: (scale: number) => void
+}
+
+export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>(function ZoomableImage(
+  { src, alt, onZoomChange, onScaleChange },
+  ref
+) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  const { isZoomed, scale, zoomIn, zoomOut, reset } = useZoomPan({
+    containerRef,
+    contentRef: imgRef,
+    onZoomChange,
+  })
+
+  useEffect(() => {
+    onScaleChange?.(scale)
+  }, [scale, onScaleChange])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      reset: () => reset({ transition: true }),
+      zoomIn,
+      zoomOut,
+      getScale: () => scale,
+      isZoomed: () => isZoomed,
+    }),
+    [reset, zoomIn, zoomOut, scale, isZoomed]
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute inset-0 flex items-center justify-center overflow-hidden"
+      style={{
+        // Disable browser pinch-zoom / scroll gestures inside the viewport so our
+        // custom handlers own the input. Double-tap-to-zoom is handled manually.
+        touchAction: "none",
+        cursor: isZoomed ? "grab" : "default",
+        userSelect: "none",
+      }}
+    >
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        className="max-w-full max-h-full object-contain select-none"
+        draggable={false}
+        style={{ willChange: "transform" }}
+      />
+    </div>
+  )
+})

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
+import { forwardRef, useImperativeHandle, useRef } from "react"
 import { useZoomPan } from "@/hooks/use-zoom-pan"
 
 export interface ZoomableImageHandle {
@@ -11,6 +11,9 @@ interface ZoomableImageProps {
   src: string
   alt: string
   onZoomChange?: (zoomed: boolean) => void
+  /** Fires synchronously on every scale change (including 60fps during pinch).
+   *  Subscribers should be self-contained — using this to drive parent state
+   *  defeats the ref-based fanout pattern. */
   onScaleChange?: (scale: number) => void
 }
 
@@ -21,15 +24,12 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
   const containerRef = useRef<HTMLDivElement>(null)
   const imgRef = useRef<HTMLImageElement>(null)
 
-  const { isZoomed, scale, zoomIn, zoomOut, reset } = useZoomPan({
+  const { isZoomed, zoomIn, zoomOut, reset } = useZoomPan({
     containerRef,
     contentRef: imgRef,
     onZoomChange,
+    onScaleChange,
   })
-
-  useEffect(() => {
-    onScaleChange?.(scale)
-  }, [scale, onScaleChange])
 
   useImperativeHandle(
     ref,

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -5,8 +5,6 @@ export interface ZoomableImageHandle {
   reset: () => void
   zoomIn: () => void
   zoomOut: () => void
-  getScale: () => number
-  isZoomed: () => boolean
 }
 
 interface ZoomableImageProps {
@@ -39,10 +37,8 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
       reset: () => reset({ transition: true }),
       zoomIn,
       zoomOut,
-      getScale: () => scale,
-      isZoomed: () => isZoomed,
     }),
-    [reset, zoomIn, zoomOut, scale, isZoomed]
+    [reset, zoomIn, zoomOut]
   )
 
   return (

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -19,6 +19,8 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { attachmentsApi } from "@/api"
 import { triggerDownload } from "@/lib/image-utils"
+import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
+import { ZoomControls } from "@/components/gallery/zoom-controls"
 
 export type GalleryItem =
   | { type: "image"; url: string; filename: string; attachmentId: string }
@@ -60,42 +62,86 @@ function GalleryVideo({ current }: { current: Extract<GalleryItem, { type: "vide
   )
 }
 
-function GalleryMediaContent({ current, isActive = true }: { current: GalleryItem; isActive?: boolean }) {
+interface GalleryMediaContentProps {
+  current: GalleryItem
+  isActive?: boolean
+  /** Non-null only for the currently-displayed slide. When present with an image,
+   *  the image is rendered via ZoomableImage so it can be zoomed/panned. */
+  zoomableRef?: React.Ref<ZoomableImageHandle>
+  onZoomChange?: (zoomed: boolean) => void
+  onScaleChange?: (scale: number) => void
+}
+
+function GalleryMediaContent({
+  current,
+  isActive = true,
+  zoomableRef,
+  onZoomChange,
+  onScaleChange,
+}: GalleryMediaContentProps) {
   if (current.type === "video") {
     // Non-active video slides show poster so the <video> element doesn't load
     if (!isActive) {
-      return current.thumbnailUrl ? (
-        <img
-          src={current.thumbnailUrl}
-          alt={current.filename}
-          className="max-w-full max-h-full object-contain select-none"
-          draggable={false}
-        />
-      ) : (
-        <div className="h-16 w-16 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center">
-          <Play className="h-7 w-7 text-white/60 ml-0.5" fill="currentColor" />
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          {current.thumbnailUrl ? (
+            <img
+              src={current.thumbnailUrl}
+              alt={current.filename}
+              className="max-w-full max-h-full object-contain select-none"
+              draggable={false}
+            />
+          ) : (
+            <div className="h-16 w-16 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center">
+              <Play className="h-7 w-7 text-white/60 ml-0.5" fill="currentColor" />
+            </div>
+          )}
         </div>
       )
     }
     if (!current.url)
       return (
-        <div className="flex flex-col items-center gap-3">
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
           <div className="h-16 w-16 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center">
             <Play className="h-7 w-7 text-white/60 ml-0.5" fill="currentColor" />
           </div>
           <Loader2 className="h-4 w-4 animate-spin text-white/40" />
         </div>
       )
-    return <GalleryVideo current={current} />
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <GalleryVideo current={current} />
+      </div>
+    )
   }
-  if (!current.url) return <Loader2 className="h-8 w-8 animate-spin text-white/50" />
+  if (!current.url)
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-white/50" />
+      </div>
+    )
+  // Active image slide gets the zoomable viewport. Inactive slides stay as plain
+  // <img> so we don't wire up gesture listeners for images the user isn't viewing.
+  if (zoomableRef) {
+    return (
+      <ZoomableImage
+        ref={zoomableRef}
+        src={current.url}
+        alt={current.filename}
+        onZoomChange={onZoomChange}
+        onScaleChange={onScaleChange}
+      />
+    )
+  }
   return (
-    <img
-      src={current.url}
-      alt={current.filename}
-      className="max-w-full max-h-full object-contain select-none"
-      draggable={false}
-    />
+    <div className="absolute inset-0 flex items-center justify-center">
+      <img
+        src={current.url}
+        alt={current.filename}
+        className="max-w-full max-h-full object-contain select-none"
+        draggable={false}
+      />
+    </div>
   )
 }
 
@@ -149,6 +195,15 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const containerRef = useRef<HTMLDivElement>(null)
   const stripRef = useRef<HTMLDivElement>(null)
   const dismissWrapperRef = useRef<HTMLDivElement>(null)
+
+  // Zoom/pan state for the current slide. Only reflects the active image.
+  const zoomableRef = useRef<ZoomableImageHandle>(null)
+  const [isZoomed, setIsZoomed] = useState(false)
+  const [zoomScale, setZoomScale] = useState(1)
+  // Ref mirror so touch handlers (which avoid re-rendering during gestures) can
+  // read the current zoom state without stale closures.
+  const isZoomedRef = useRef(false)
+  isZoomedRef.current = isZoomed
 
   // Touch gesture state (all refs — no setState during active gesture)
   const touchStartX = useRef(0)
@@ -243,6 +298,10 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const goTo = useCallback(
     (index: number) => {
       if (index < 0 || index >= items.length) return
+      // Reset zoom on the outgoing slide so we never navigate with a stale transform;
+      // the outgoing slide's hook will also reset when enabled flips to false, but
+      // calling here lets the zoom-out animate in sync with the strip slide.
+      zoomableRef.current?.reset()
       // On mobile, animate the strip directly before updating state so the
       // user sees a smooth slide rather than a hard cut.
       if (isMobile && stripRef.current && containerWidth > 0) {
@@ -315,6 +374,10 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // at 60fps without React rendering in the hot path.
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    // When zoomed or pinching, the zoomable viewport owns the gesture — don't
+    // start a carousel swipe in parallel (would cause the strip to drift while
+    // the user is panning inside an image).
+    if (isZoomedRef.current || e.touches.length > 1) return
     e.stopPropagation()
     // Read where the strip actually is right now (could be mid-animation)
     // so we can continue from that exact position rather than jumping.
@@ -339,6 +402,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
+      if (isZoomedRef.current || e.touches.length > 1) return
       e.stopPropagation()
       const dx = e.touches[0].clientX - touchStartX.current
       const dy = e.touches[0].clientY - touchStartY.current
@@ -378,6 +442,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   const handleTouchEnd = useCallback(
     (e: React.TouchEvent) => {
+      if (isZoomedRef.current) return
       e.stopPropagation()
       const dx = touchDeltaX.current
       const dy = touchDeltaY.current
@@ -436,10 +501,12 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     [currentIndex, hasNext, hasPrev, items, onItemChange, onClose]
   )
 
-  // Mobile: tap left/right zones to navigate (suppressed after a committed swipe)
+  // Mobile: tap left/right zones to navigate (suppressed after a committed swipe
+  // and disabled while zoomed so taps inside a zoomed image don't navigate away).
   const handleMobileTap = useCallback(
     (e: React.MouseEvent) => {
       if (!isMobile || !isMultiple) return
+      if (isZoomedRef.current) return
       if (didSwipe.current) {
         didSwipe.current = false
         return
@@ -452,9 +519,22 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     [isMobile, isMultiple, hasPrev, hasNext, goPrev, goNext]
   )
 
+  const handleZoomIn = useCallback(() => zoomableRef.current?.zoomIn(), [])
+  const handleZoomOut = useCallback(() => zoomableRef.current?.zoomOut(), [])
+  const handleZoomReset = useCallback(() => zoomableRef.current?.reset(), [])
+
   // ─── Action bar (shared between mobile/desktop) ─────────────────────────────
   const actionBar = (
     <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
+      {!isMobile && current?.type === "image" && (
+        <ZoomControls
+          scale={zoomScale}
+          onZoomIn={handleZoomIn}
+          onZoomOut={handleZoomOut}
+          onReset={handleZoomReset}
+          className="mr-1"
+        />
+      )}
       {isMultiple && (
         <span className="text-xs text-white/70 mr-1 tabular-nums">
           {currentIndex + 1} / {items.length}
@@ -558,10 +638,16 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                     {items.map((item, i) => (
                       <div
                         key={item.attachmentId}
-                        className="shrink-0 flex items-center justify-center p-8"
+                        className="shrink-0 relative"
                         style={{ width: containerWidth || "100%", height: "100%" }}
                       >
-                        <GalleryMediaContent current={item} isActive={Math.abs(i - currentIndex) <= 1} />
+                        <GalleryMediaContent
+                          current={item}
+                          isActive={Math.abs(i - currentIndex) <= 1}
+                          zoomableRef={i === currentIndex && item.type === "image" ? zoomableRef : undefined}
+                          onZoomChange={i === currentIndex && item.type === "image" ? setIsZoomed : undefined}
+                          onScaleChange={i === currentIndex && item.type === "image" ? setZoomScale : undefined}
+                        />
                       </div>
                     ))}
                   </div>
@@ -581,8 +667,13 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
               >
                 {actionBar}
 
-                <div className="absolute inset-0 flex items-center justify-center p-10">
-                  <GalleryMediaContent current={current} />
+                <div className="absolute inset-0">
+                  <GalleryMediaContent
+                    current={current}
+                    zoomableRef={current.type === "image" ? zoomableRef : undefined}
+                    onZoomChange={current.type === "image" ? setIsZoomed : undefined}
+                    onScaleChange={current.type === "image" ? setZoomScale : undefined}
+                  />
                 </div>
 
                 {isMultiple && (

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -199,11 +199,24 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // Zoom/pan state for the current slide. Only reflects the active image.
   const zoomableRef = useRef<ZoomableImageHandle>(null)
   const [isZoomed, setIsZoomed] = useState(false)
-  const [zoomScale, setZoomScale] = useState(1)
   // Ref mirror so touch handlers (which avoid re-rendering during gestures) can
   // read the current zoom state without stale closures.
   const isZoomedRef = useRef(false)
   isZoomedRef.current = isZoomed
+
+  // Pub/sub for scale so the percent display in ZoomControls can update at
+  // 60fps during pinch without re-rendering this component (PR #384 pattern:
+  // refs during gesture, React state only on commit).
+  const scaleListenersRef = useRef<Set<(scale: number) => void>>(new Set())
+  const publishScale = useCallback((scale: number) => {
+    for (const cb of scaleListenersRef.current) cb(scale)
+  }, [])
+  const subscribeScale = useCallback((cb: (scale: number) => void) => {
+    scaleListenersRef.current.add(cb)
+    return () => {
+      scaleListenersRef.current.delete(cb)
+    }
+  }, [])
 
   // Touch gesture state (all refs — no setState during active gesture)
   const touchStartX = useRef(0)
@@ -528,7 +541,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
       {!isMobile && current?.type === "image" && (
         <ZoomControls
-          scale={zoomScale}
+          subscribeScale={subscribeScale}
           onZoomIn={handleZoomIn}
           onZoomOut={handleZoomOut}
           onReset={handleZoomReset}
@@ -646,7 +659,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                           isActive={Math.abs(i - currentIndex) <= 1}
                           zoomableRef={i === currentIndex && item.type === "image" ? zoomableRef : undefined}
                           onZoomChange={i === currentIndex && item.type === "image" ? setIsZoomed : undefined}
-                          onScaleChange={i === currentIndex && item.type === "image" ? setZoomScale : undefined}
+                          onScaleChange={i === currentIndex && item.type === "image" ? publishScale : undefined}
                         />
                       </div>
                     ))}
@@ -672,7 +685,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                     current={current}
                     zoomableRef={current.type === "image" ? zoomableRef : undefined}
                     onZoomChange={current.type === "image" ? setIsZoomed : undefined}
-                    onScaleChange={current.type === "image" ? setZoomScale : undefined}
+                    onScaleChange={current.type === "image" ? publishScale : undefined}
                   />
                 </div>
 

--- a/apps/frontend/src/hooks/use-zoom-pan.test.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest"
+import { clampTranslate, fitContain, zoomToPoint } from "./use-zoom-pan"
+
+describe("fitContain", () => {
+  it("returns zeros for degenerate inputs", () => {
+    expect(fitContain(0, 100, 500, 500)).toEqual({ w: 0, h: 0 })
+    expect(fitContain(100, 100, 0, 500)).toEqual({ w: 0, h: 0 })
+  })
+
+  it("fits by width when image is wider than container aspect", () => {
+    // 200x100 image in 500x500 container → width-limited
+    expect(fitContain(200, 100, 500, 500)).toEqual({ w: 500, h: 250 })
+  })
+
+  it("fits by height when image is taller than container aspect", () => {
+    // 100x200 image in 500x500 container → height-limited
+    expect(fitContain(100, 200, 500, 500)).toEqual({ w: 250, h: 500 })
+  })
+
+  it("returns the container when aspect ratios match exactly", () => {
+    expect(fitContain(400, 200, 800, 400)).toEqual({ w: 800, h: 400 })
+  })
+})
+
+describe("zoomToPoint", () => {
+  it("is a no-op when factor is 1", () => {
+    const state = { scale: 2, tx: 10, ty: -5 }
+    expect(zoomToPoint(state, 2, 50, 50)).toEqual(state)
+  })
+
+  it("zoom from identity toward center leaves translate at zero", () => {
+    const next = zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 2, 0, 0)
+    expect(next).toEqual({ scale: 2, tx: 0, ty: 0 })
+  })
+
+  it("zoom toward an offset point shifts translate to keep that point anchored", () => {
+    // Start at identity, zoom 1→2 toward point (100, 0) from center.
+    // After zoom, the image-local point that was under (100, 0) must still be under (100, 0).
+    // Formula: tx' = px*(1-k) + tx*k = 100*(1-2) + 0*2 = -100.
+    const next = zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 2, 100, 0)
+    expect(next.scale).toBe(2)
+    expect(next.tx).toBe(-100)
+    expect(next.ty).toBe(0)
+  })
+
+  it("consecutive zoom-to-point calls compose correctly", () => {
+    // Zoom 1→2 then 2→4 toward the same point (50, 0) should equal a single 1→4 zoom toward (50, 0).
+    const step1 = zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 2, 50, 0)
+    const step2 = zoomToPoint(step1, 4, 50, 0)
+    const direct = zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 4, 50, 0)
+    expect(step2.scale).toBe(direct.scale)
+    expect(step2.tx).toBeCloseTo(direct.tx, 6)
+    expect(step2.ty).toBeCloseTo(direct.ty, 6)
+  })
+})
+
+describe("clampTranslate", () => {
+  const base = { baseW: 400, baseH: 200, containerW: 400, containerH: 200 }
+
+  it("forces translate to zero when scale is 1 (no overflow)", () => {
+    const next = clampTranslate({ scale: 1, tx: 100, ty: 50 }, base.containerW, base.containerH, base.baseW, base.baseH)
+    expect(next.tx).toBe(0)
+    expect(next.ty).toBe(0)
+  })
+
+  it("clamps translate to half the overflow at scale 2", () => {
+    // At scale 2, rendered 800x400, container 400x200 → overflow 400x200 → max ±200, ±100.
+    const next = clampTranslate(
+      { scale: 2, tx: 500, ty: 500 },
+      base.containerW,
+      base.containerH,
+      base.baseW,
+      base.baseH
+    )
+    expect(next.tx).toBe(200)
+    expect(next.ty).toBe(100)
+  })
+
+  it("clamps negative translate symmetrically", () => {
+    const next = clampTranslate(
+      { scale: 2, tx: -500, ty: -500 },
+      base.containerW,
+      base.containerH,
+      base.baseW,
+      base.baseH
+    )
+    expect(next.tx).toBe(-200)
+    expect(next.ty).toBe(-100)
+  })
+
+  it("leaves in-bounds translate unchanged", () => {
+    const next = clampTranslate({ scale: 2, tx: 50, ty: -40 }, base.containerW, base.containerH, base.baseW, base.baseH)
+    expect(next.tx).toBe(50)
+    expect(next.ty).toBe(-40)
+  })
+
+  it("preserves scale through clamping", () => {
+    const next = clampTranslate({ scale: 3.7, tx: 0, ty: 0 }, base.containerW, base.containerH, base.baseW, base.baseH)
+    expect(next.scale).toBe(3.7)
+  })
+})

--- a/apps/frontend/src/hooks/use-zoom-pan.test.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest"
-import { clampTranslate, fitContain, zoomToPoint } from "./use-zoom-pan"
+import { describe, it, expect, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { useRef } from "react"
+import { clampTranslate, fitContain, useZoomPan, zoomToPoint, ZOOM_MAX, ZOOM_STEP } from "./use-zoom-pan"
 
 describe("fitContain", () => {
   it("returns zeros for degenerate inputs", () => {
@@ -37,10 +39,7 @@ describe("zoomToPoint", () => {
     // Start at identity, zoom 1→2 toward point (100, 0) from center.
     // After zoom, the image-local point that was under (100, 0) must still be under (100, 0).
     // Formula: tx' = px*(1-k) + tx*k = 100*(1-2) + 0*2 = -100.
-    const next = zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 2, 100, 0)
-    expect(next.scale).toBe(2)
-    expect(next.tx).toBe(-100)
-    expect(next.ty).toBe(0)
+    expect(zoomToPoint({ scale: 1, tx: 0, ty: 0 }, 2, 100, 0)).toEqual({ scale: 2, tx: -100, ty: 0 })
   })
 
   it("consecutive zoom-to-point calls compose correctly", () => {
@@ -97,5 +96,106 @@ describe("clampTranslate", () => {
   it("preserves scale through clamping", () => {
     const next = clampTranslate({ scale: 3.7, tx: 0, ty: 0 }, base.containerW, base.containerH, base.baseW, base.baseH)
     expect(next.scale).toBe(3.7)
+  })
+})
+
+/**
+ * Wires up the hook with a real container div + img, mocked to a known size so
+ * the zoom math operates on stable bounds. jsdom does not lay out, so we have
+ * to spoof clientWidth/Height and naturalWidth/Height directly.
+ */
+function renderZoomPanHarness(opts?: { onZoomChange?: (z: boolean) => void; onScaleChange?: (s: number) => void }) {
+  const container = document.createElement("div")
+  const img = document.createElement("img")
+  Object.defineProperty(container, "clientWidth", { value: 400, configurable: true })
+  Object.defineProperty(container, "clientHeight", { value: 200, configurable: true })
+  Object.defineProperty(img, "naturalWidth", { value: 800, configurable: true })
+  Object.defineProperty(img, "naturalHeight", { value: 400, configurable: true })
+  Object.defineProperty(img, "complete", { value: true, configurable: true })
+  document.body.appendChild(container)
+  container.appendChild(img)
+
+  const result = renderHook(() => {
+    const containerRef = useRef<HTMLDivElement | null>(container)
+    const contentRef = useRef<HTMLImageElement | null>(img)
+    return useZoomPan({ containerRef, contentRef, ...opts })
+  })
+
+  return {
+    ...result,
+    img,
+    container,
+    cleanup: () => {
+      container.remove()
+    },
+  }
+}
+
+describe("useZoomPan (integration)", () => {
+  it("starts unzoomed and applies identity transform", () => {
+    const harness = renderZoomPanHarness()
+    expect(harness.result.current.isZoomed).toBe(false)
+    // Transform may be empty before any commit fires; either way it's effectively identity.
+    expect(harness.img.style.transform === "" || harness.img.style.transform.includes("scale(1)")).toBe(true)
+    harness.cleanup()
+  })
+
+  it("zoomIn flips isZoomed and writes a scaled transform onto the image", () => {
+    const onZoomChange = vi.fn()
+    const harness = renderZoomPanHarness({ onZoomChange })
+
+    act(() => harness.result.current.zoomIn())
+
+    expect(harness.result.current.isZoomed).toBe(true)
+    expect(onZoomChange).toHaveBeenCalledWith(true)
+    expect(harness.img.style.transform).toContain(`scale(${ZOOM_STEP})`)
+    harness.cleanup()
+  })
+
+  it("publishes scale synchronously to onScaleChange (no React state hop)", () => {
+    const onScaleChange = vi.fn()
+    const harness = renderZoomPanHarness({ onScaleChange })
+
+    act(() => harness.result.current.zoomIn())
+
+    expect(onScaleChange).toHaveBeenCalledWith(ZOOM_STEP)
+    harness.cleanup()
+  })
+
+  it("reset returns to identity and re-fires onZoomChange(false)", () => {
+    const onZoomChange = vi.fn()
+    const harness = renderZoomPanHarness({ onZoomChange })
+
+    act(() => harness.result.current.zoomIn())
+    onZoomChange.mockClear()
+    act(() => harness.result.current.reset())
+
+    expect(harness.result.current.isZoomed).toBe(false)
+    expect(onZoomChange).toHaveBeenCalledWith(false)
+    expect(harness.img.style.transform).toContain("scale(1)")
+    harness.cleanup()
+  })
+
+  it("zoomOut from identity is a no-op (clamped at ZOOM_MIN)", () => {
+    const onScaleChange = vi.fn()
+    const harness = renderZoomPanHarness({ onScaleChange })
+
+    act(() => harness.result.current.zoomOut())
+
+    expect(harness.result.current.isZoomed).toBe(false)
+    expect(onScaleChange).not.toHaveBeenCalled()
+    harness.cleanup()
+  })
+
+  it("repeated zoomIn caps at ZOOM_MAX", () => {
+    const onScaleChange = vi.fn()
+    const harness = renderZoomPanHarness({ onScaleChange })
+
+    // ZOOM_STEP=1.5, ZOOM_MAX=8 → ceil(log_1.5(8)) = 6 steps suffices.
+    for (let i = 0; i < 10; i++) act(() => harness.result.current.zoomIn())
+
+    const lastScale = onScaleChange.mock.calls.at(-1)?.[0]
+    expect(lastScale).toBe(ZOOM_MAX)
+    harness.cleanup()
   })
 })

--- a/apps/frontend/src/hooks/use-zoom-pan.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.ts
@@ -8,8 +8,6 @@ export const DOUBLE_ZOOM = 2
 interface UseZoomPanOptions {
   containerRef: RefObject<HTMLElement | null>
   contentRef: RefObject<HTMLElement | null>
-  minScale?: number
-  maxScale?: number
   onZoomChange?: (zoomed: boolean) => void
 }
 
@@ -72,13 +70,7 @@ export function fitContain(
 
 const TRANSITION_EASE = "transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
 
-export function useZoomPan({
-  containerRef,
-  contentRef,
-  minScale = ZOOM_MIN,
-  maxScale = ZOOM_MAX,
-  onZoomChange,
-}: UseZoomPanOptions) {
+export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPanOptions) {
   const stateRef = useRef<ZoomPanState>(IDENTITY)
   const containerSizeRef = useRef({ w: 0, h: 0 })
   const baseSizeRef = useRef({ w: 0, h: 0 })
@@ -113,15 +105,15 @@ export function useZoomPan({
         baseSizeRef.current.h
       )
       // At scale 1, translate collapses to 0 — prevents stuck offsets after zoom-out.
-      if (clamped.scale <= minScale + 1e-6) {
-        clamped.scale = minScale
+      if (clamped.scale <= ZOOM_MIN + 1e-6) {
+        clamped.scale = ZOOM_MIN
         clamped.tx = 0
         clamped.ty = 0
       }
       stateRef.current = clamped
       applyTransform(opts?.transition ?? false)
 
-      const zoomed = clamped.scale > minScale + 1e-6
+      const zoomed = clamped.scale > ZOOM_MIN + 1e-6
       if (zoomed !== isZoomedRef.current) {
         isZoomedRef.current = zoomed
         setIsZoomed(zoomed)
@@ -129,7 +121,7 @@ export function useZoomPan({
       }
       setScale(clamped.scale)
     },
-    [applyTransform, minScale]
+    [applyTransform]
   )
 
   const reset = useCallback(
@@ -191,11 +183,11 @@ export function useZoomPan({
       const px = (localX ?? cx) - cx
       const py = (localY ?? cy) - cy
       const current = stateRef.current
-      const target = Math.max(minScale, Math.min(maxScale, current.scale * factor))
+      const target = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, current.scale * factor))
       if (target === current.scale) return
       commit(zoomToPoint(current, target, px, py), { transition: true })
     },
-    [commit, minScale, maxScale]
+    [commit]
   )
 
   const zoomIn = useCallback(() => zoomBy(ZOOM_STEP), [zoomBy])
@@ -217,7 +209,7 @@ export function useZoomPan({
         const intensity = e.deltaMode === 0 ? 0.01 : 0.3
         const factor = Math.exp(-e.deltaY * intensity)
         const current = stateRef.current
-        const target = Math.max(minScale, Math.min(maxScale, current.scale * factor))
+        const target = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, current.scale * factor))
         if (target === current.scale) return
         const cx = container!.clientWidth / 2
         const cy = container!.clientHeight / 2
@@ -232,7 +224,7 @@ export function useZoomPan({
 
     container.addEventListener("wheel", onWheel, { passive: false })
     return () => container.removeEventListener("wheel", onWheel)
-  }, [containerRef, commit, minScale, maxScale])
+  }, [containerRef, commit])
 
   // ── Desktop: pointer-drag pan (plain drag when zoomed, or meta/ctrl+drag) ─
   useEffect(() => {
@@ -353,7 +345,7 @@ export function useZoomPan({
         const cx = cw / 2
         const cy = ch / 2
         const rawScale = startState.scale * (m.d / startDist)
-        const target = Math.max(minScale, Math.min(maxScale, rawScale))
+        const target = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, rawScale))
         // Zoom anchored at the *initial* midpoint (Figma-like: point under your fingers stays put),
         // plus pan by the midpoint delta so two-finger drag-during-pinch feels natural.
         const zoomed = zoomToPoint(startState, target, startMidLocalX - cx, startMidLocalY - cy)
@@ -391,7 +383,7 @@ export function useZoomPan({
       container.removeEventListener("touchend", onTouchEnd)
       container.removeEventListener("touchcancel", onTouchEnd)
     }
-  }, [containerRef, commit, minScale, maxScale])
+  }, [containerRef, commit])
 
   // ── Double-click / double-tap: toggle zoom ────────────────────────────────
   useEffect(() => {

--- a/apps/frontend/src/hooks/use-zoom-pan.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.ts
@@ -1,0 +1,461 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
+
+export const ZOOM_MIN = 1
+export const ZOOM_MAX = 8
+export const ZOOM_STEP = 1.5
+export const DOUBLE_ZOOM = 2
+
+interface UseZoomPanOptions {
+  containerRef: RefObject<HTMLElement | null>
+  contentRef: RefObject<HTMLElement | null>
+  minScale?: number
+  maxScale?: number
+  onZoomChange?: (zoomed: boolean) => void
+}
+
+interface ZoomPanState {
+  scale: number
+  tx: number
+  ty: number
+}
+
+const IDENTITY: ZoomPanState = { scale: 1, tx: 0, ty: 0 }
+
+// Zoom toward an element-local point (measured from the container center).
+// Holds the image-local point under the cursor invariant across the scale change.
+export function zoomToPoint(state: ZoomPanState, newScale: number, px: number, py: number): ZoomPanState {
+  const k = newScale / state.scale
+  return {
+    scale: newScale,
+    tx: px * (1 - k) + state.tx * k,
+    ty: py * (1 - k) + state.ty * k,
+  }
+}
+
+// Clamp translate so the bitmap stays within the container at the given scale.
+// baseW/baseH are the rendered dimensions at scale 1 (post-object-contain fit).
+export function clampTranslate(
+  state: ZoomPanState,
+  containerW: number,
+  containerH: number,
+  baseW: number,
+  baseH: number
+): ZoomPanState {
+  const renderedW = baseW * state.scale
+  const renderedH = baseH * state.scale
+  const maxTx = Math.max(0, (renderedW - containerW) / 2)
+  const maxTy = Math.max(0, (renderedH - containerH) / 2)
+  return {
+    scale: state.scale,
+    tx: Math.max(-maxTx, Math.min(maxTx, state.tx)),
+    ty: Math.max(-maxTy, Math.min(maxTy, state.ty)),
+  }
+}
+
+// Derive the object-contain rendered dimensions of an image inside a container.
+export function fitContain(
+  naturalW: number,
+  naturalH: number,
+  containerW: number,
+  containerH: number
+): { w: number; h: number } {
+  if (naturalW <= 0 || naturalH <= 0 || containerW <= 0 || containerH <= 0) {
+    return { w: 0, h: 0 }
+  }
+  const imgAspect = naturalW / naturalH
+  const containerAspect = containerW / containerH
+  if (imgAspect > containerAspect) {
+    return { w: containerW, h: containerW / imgAspect }
+  }
+  return { w: containerH * imgAspect, h: containerH }
+}
+
+const TRANSITION_EASE = "transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
+
+export function useZoomPan({
+  containerRef,
+  contentRef,
+  minScale = ZOOM_MIN,
+  maxScale = ZOOM_MAX,
+  onZoomChange,
+}: UseZoomPanOptions) {
+  const stateRef = useRef<ZoomPanState>(IDENTITY)
+  const containerSizeRef = useRef({ w: 0, h: 0 })
+  const baseSizeRef = useRef({ w: 0, h: 0 })
+  const naturalSizeRef = useRef({ w: 0, h: 0 })
+  const isZoomedRef = useRef(false)
+
+  const [isZoomed, setIsZoomed] = useState(false)
+  const [scale, setScale] = useState(1)
+
+  const onZoomChangeRef = useRef(onZoomChange)
+  onZoomChangeRef.current = onZoomChange
+
+  const applyTransform = useCallback(
+    (transition?: boolean) => {
+      const el = contentRef.current
+      if (!el) return
+      const { scale: s, tx, ty } = stateRef.current
+      el.style.transition = transition ? TRANSITION_EASE : "none"
+      el.style.transform = `translate(${tx}px, ${ty}px) scale(${s})`
+      el.style.transformOrigin = "center center"
+    },
+    [contentRef]
+  )
+
+  const commit = useCallback(
+    (next: ZoomPanState, opts?: { transition?: boolean }) => {
+      const clamped = clampTranslate(
+        next,
+        containerSizeRef.current.w,
+        containerSizeRef.current.h,
+        baseSizeRef.current.w,
+        baseSizeRef.current.h
+      )
+      // At scale 1, translate collapses to 0 — prevents stuck offsets after zoom-out.
+      if (clamped.scale <= minScale + 1e-6) {
+        clamped.scale = minScale
+        clamped.tx = 0
+        clamped.ty = 0
+      }
+      stateRef.current = clamped
+      applyTransform(opts?.transition ?? false)
+
+      const zoomed = clamped.scale > minScale + 1e-6
+      if (zoomed !== isZoomedRef.current) {
+        isZoomedRef.current = zoomed
+        setIsZoomed(zoomed)
+        onZoomChangeRef.current?.(zoomed)
+      }
+      setScale(clamped.scale)
+    },
+    [applyTransform, minScale]
+  )
+
+  const reset = useCallback(
+    (opts?: { transition?: boolean }) => {
+      commit(IDENTITY, { transition: opts?.transition ?? true })
+    },
+    [commit]
+  )
+
+  const recomputeBase = useCallback(() => {
+    const container = containerRef.current
+    if (!container) return
+    containerSizeRef.current = { w: container.clientWidth, h: container.clientHeight }
+    const { w: nw, h: nh } = naturalSizeRef.current
+    baseSizeRef.current = fitContain(nw, nh, containerSizeRef.current.w, containerSizeRef.current.h)
+    // Re-clamp against new bounds.
+    commit(stateRef.current)
+  }, [containerRef, commit])
+
+  // Measure natural dimensions when the content element (an <img>) becomes available
+  // or its src changes.
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el) return
+
+    const captureNatural = () => {
+      if (el instanceof HTMLImageElement) {
+        naturalSizeRef.current = { w: el.naturalWidth, h: el.naturalHeight }
+      } else {
+        naturalSizeRef.current = { w: el.offsetWidth, h: el.offsetHeight }
+      }
+      recomputeBase()
+    }
+
+    if (el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0) {
+      captureNatural()
+    } else {
+      el.addEventListener("load", captureNatural)
+      return () => el.removeEventListener("load", captureNatural)
+    }
+  }, [contentRef, recomputeBase])
+
+  // Track container resize (orientation change, window resize, panel toggle).
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const ro = new ResizeObserver(() => recomputeBase())
+    ro.observe(container)
+    return () => ro.disconnect()
+  }, [containerRef, recomputeBase])
+
+  // Imperative zoom by factor toward a container-local point (defaults to center).
+  const zoomBy = useCallback(
+    (factor: number, localX?: number, localY?: number) => {
+      const cw = containerSizeRef.current.w
+      const ch = containerSizeRef.current.h
+      const cx = cw / 2
+      const cy = ch / 2
+      const px = (localX ?? cx) - cx
+      const py = (localY ?? cy) - cy
+      const current = stateRef.current
+      const target = Math.max(minScale, Math.min(maxScale, current.scale * factor))
+      if (target === current.scale) return
+      commit(zoomToPoint(current, target, px, py), { transition: true })
+    },
+    [commit, minScale, maxScale]
+  )
+
+  const zoomIn = useCallback(() => zoomBy(ZOOM_STEP), [zoomBy])
+  const zoomOut = useCallback(() => zoomBy(1 / ZOOM_STEP), [zoomBy])
+
+  // ── Desktop: wheel (ctrl/meta = zoom, plain = pan when zoomed) ────────────
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    function onWheel(e: WheelEvent) {
+      const zoomIntent = e.ctrlKey || e.metaKey
+      if (zoomIntent) {
+        e.preventDefault()
+        const rect = container!.getBoundingClientRect()
+        const localX = e.clientX - rect.left
+        const localY = e.clientY - rect.top
+        // deltaMode 0 = pixels, 1 = lines, 2 = pages. Trackpad pinch = pixels.
+        const intensity = e.deltaMode === 0 ? 0.01 : 0.3
+        const factor = Math.exp(-e.deltaY * intensity)
+        const current = stateRef.current
+        const target = Math.max(minScale, Math.min(maxScale, current.scale * factor))
+        if (target === current.scale) return
+        const cx = container!.clientWidth / 2
+        const cy = container!.clientHeight / 2
+        commit(zoomToPoint(current, target, localX - cx, localY - cy))
+      } else if (isZoomedRef.current) {
+        e.preventDefault()
+        const current = stateRef.current
+        commit({ scale: current.scale, tx: current.tx - e.deltaX, ty: current.ty - e.deltaY })
+      }
+      // Not zoomed + no modifier: let the browser do nothing (dialog has nothing to scroll).
+    }
+
+    container.addEventListener("wheel", onWheel, { passive: false })
+    return () => container.removeEventListener("wheel", onWheel)
+  }, [containerRef, commit, minScale, maxScale])
+
+  // ── Desktop: pointer-drag pan (plain drag when zoomed, or meta/ctrl+drag) ─
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let dragging = false
+    let startX = 0
+    let startY = 0
+    let startTx = 0
+    let startTy = 0
+    let pointerId = -1
+
+    function onPointerDown(e: PointerEvent) {
+      if (e.pointerType === "touch") return // touch goes through the touch handler
+      if (e.button !== 0) return
+      const modifierHeld = e.metaKey || e.ctrlKey
+      if (!isZoomedRef.current && !modifierHeld) return
+      dragging = true
+      startX = e.clientX
+      startY = e.clientY
+      startTx = stateRef.current.tx
+      startTy = stateRef.current.ty
+      pointerId = e.pointerId
+      container!.setPointerCapture(pointerId)
+      container!.style.cursor = "grabbing"
+      e.preventDefault()
+    }
+
+    function onPointerMove(e: PointerEvent) {
+      if (!dragging || e.pointerId !== pointerId) return
+      const dx = e.clientX - startX
+      const dy = e.clientY - startY
+      commit({ scale: stateRef.current.scale, tx: startTx + dx, ty: startTy + dy })
+    }
+
+    function onPointerUp(e: PointerEvent) {
+      if (e.pointerId !== pointerId) return
+      dragging = false
+      try {
+        container!.releasePointerCapture(pointerId)
+      } catch {
+        // Pointer may already be released (e.g. after pointercancel).
+      }
+      container!.style.cursor = ""
+      pointerId = -1
+    }
+
+    container.addEventListener("pointerdown", onPointerDown)
+    container.addEventListener("pointermove", onPointerMove)
+    container.addEventListener("pointerup", onPointerUp)
+    container.addEventListener("pointercancel", onPointerUp)
+    return () => {
+      container.removeEventListener("pointerdown", onPointerDown)
+      container.removeEventListener("pointermove", onPointerMove)
+      container.removeEventListener("pointerup", onPointerUp)
+      container.removeEventListener("pointercancel", onPointerUp)
+    }
+  }, [containerRef, commit])
+
+  // ── Mobile: two-finger pinch + one-finger pan when zoomed ─────────────────
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let pinching = false
+    let startDist = 0
+    let startMidLocalX = 0
+    let startMidLocalY = 0
+    let startState: ZoomPanState = IDENTITY
+
+    let panning = false
+    let panStartX = 0
+    let panStartY = 0
+    let panStartTx = 0
+    let panStartTy = 0
+
+    function midpoint(t: TouchList, rect: DOMRect): { x: number; y: number; d: number } {
+      const x1 = t[0].clientX
+      const y1 = t[0].clientY
+      const x2 = t[1].clientX
+      const y2 = t[1].clientY
+      return {
+        x: (x1 + x2) / 2 - rect.left,
+        y: (y1 + y2) / 2 - rect.top,
+        d: Math.hypot(x2 - x1, y2 - y1),
+      }
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      const rect = container!.getBoundingClientRect()
+      if (e.touches.length === 2) {
+        const m = midpoint(e.touches, rect)
+        pinching = true
+        panning = false
+        startDist = m.d || 1
+        startMidLocalX = m.x
+        startMidLocalY = m.y
+        startState = { ...stateRef.current }
+        e.preventDefault()
+      } else if (e.touches.length === 1 && isZoomedRef.current) {
+        panning = true
+        pinching = false
+        panStartX = e.touches[0].clientX
+        panStartY = e.touches[0].clientY
+        panStartTx = stateRef.current.tx
+        panStartTy = stateRef.current.ty
+        e.stopPropagation() // keep carousel swipe handler from treating this as nav
+      }
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      const rect = container!.getBoundingClientRect()
+      if (pinching && e.touches.length === 2) {
+        const m = midpoint(e.touches, rect)
+        const cw = container!.clientWidth
+        const ch = container!.clientHeight
+        const cx = cw / 2
+        const cy = ch / 2
+        const rawScale = startState.scale * (m.d / startDist)
+        const target = Math.max(minScale, Math.min(maxScale, rawScale))
+        // Zoom anchored at the *initial* midpoint (Figma-like: point under your fingers stays put),
+        // plus pan by the midpoint delta so two-finger drag-during-pinch feels natural.
+        const zoomed = zoomToPoint(startState, target, startMidLocalX - cx, startMidLocalY - cy)
+        const panDx = m.x - startMidLocalX
+        const panDy = m.y - startMidLocalY
+        commit({ scale: zoomed.scale, tx: zoomed.tx + panDx, ty: zoomed.ty + panDy })
+        e.preventDefault()
+      } else if (panning && e.touches.length === 1) {
+        const dx = e.touches[0].clientX - panStartX
+        const dy = e.touches[0].clientY - panStartY
+        commit({ scale: stateRef.current.scale, tx: panStartTx + dx, ty: panStartTy + dy })
+        e.preventDefault()
+        e.stopPropagation()
+      }
+    }
+
+    function onTouchEnd(e: TouchEvent) {
+      if (pinching && e.touches.length < 2) {
+        pinching = false
+        // Snap back any overshoot / settle elastic bounds.
+        commit(stateRef.current, { transition: true })
+      }
+      if (panning && e.touches.length === 0) {
+        panning = false
+      }
+    }
+
+    container.addEventListener("touchstart", onTouchStart, { passive: false })
+    container.addEventListener("touchmove", onTouchMove, { passive: false })
+    container.addEventListener("touchend", onTouchEnd)
+    container.addEventListener("touchcancel", onTouchEnd)
+    return () => {
+      container.removeEventListener("touchstart", onTouchStart)
+      container.removeEventListener("touchmove", onTouchMove)
+      container.removeEventListener("touchend", onTouchEnd)
+      container.removeEventListener("touchcancel", onTouchEnd)
+    }
+  }, [containerRef, commit, minScale, maxScale])
+
+  // ── Double-click / double-tap: toggle zoom ────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    function onDblClick(e: MouseEvent) {
+      e.preventDefault()
+      if (isZoomedRef.current) {
+        reset()
+      } else {
+        const rect = container!.getBoundingClientRect()
+        const cx = container!.clientWidth / 2
+        const cy = container!.clientHeight / 2
+        const px = e.clientX - rect.left - cx
+        const py = e.clientY - rect.top - cy
+        commit(zoomToPoint(stateRef.current, DOUBLE_ZOOM, px, py), { transition: true })
+      }
+    }
+
+    // Touch double-tap (manual detection — no dblclick on iOS with touch-action: none).
+    let lastTap = 0
+    let lastTapX = 0
+    let lastTapY = 0
+    function onTouchEndTap(e: TouchEvent) {
+      if (e.changedTouches.length !== 1) return
+      const now = Date.now()
+      const t = e.changedTouches[0]
+      const dx = t.clientX - lastTapX
+      const dy = t.clientY - lastTapY
+      const isDouble = now - lastTap < 300 && Math.hypot(dx, dy) < 30
+      if (isDouble) {
+        const rect = container!.getBoundingClientRect()
+        const localX = t.clientX - rect.left
+        const localY = t.clientY - rect.top
+        if (isZoomedRef.current) {
+          reset()
+        } else {
+          const cx = container!.clientWidth / 2
+          const cy = container!.clientHeight / 2
+          commit(zoomToPoint(stateRef.current, DOUBLE_ZOOM, localX - cx, localY - cy), { transition: true })
+        }
+        lastTap = 0
+        e.preventDefault()
+      } else {
+        lastTap = now
+        lastTapX = t.clientX
+        lastTapY = t.clientY
+      }
+    }
+
+    container.addEventListener("dblclick", onDblClick)
+    container.addEventListener("touchend", onTouchEndTap)
+    return () => {
+      container.removeEventListener("dblclick", onDblClick)
+      container.removeEventListener("touchend", onTouchEndTap)
+    }
+  }, [containerRef, commit, reset])
+
+  return {
+    isZoomed,
+    scale,
+    zoomIn,
+    zoomOut,
+    reset,
+  }
+}

--- a/apps/frontend/src/hooks/use-zoom-pan.ts
+++ b/apps/frontend/src/hooks/use-zoom-pan.ts
@@ -9,6 +9,9 @@ interface UseZoomPanOptions {
   containerRef: RefObject<HTMLElement | null>
   contentRef: RefObject<HTMLElement | null>
   onZoomChange?: (zoomed: boolean) => void
+  /** Called synchronously inside `commit` whenever scale changes.
+   *  Avoids a React-state cascade through the parent during pinch (60fps). */
+  onScaleChange?: (scale: number) => void
 }
 
 interface ZoomPanState {
@@ -70,7 +73,7 @@ export function fitContain(
 
 const TRANSITION_EASE = "transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
 
-export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPanOptions) {
+export function useZoomPan({ containerRef, contentRef, onZoomChange, onScaleChange }: UseZoomPanOptions) {
   const stateRef = useRef<ZoomPanState>(IDENTITY)
   const containerSizeRef = useRef({ w: 0, h: 0 })
   const baseSizeRef = useRef({ w: 0, h: 0 })
@@ -78,10 +81,11 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
   const isZoomedRef = useRef(false)
 
   const [isZoomed, setIsZoomed] = useState(false)
-  const [scale, setScale] = useState(1)
 
   const onZoomChangeRef = useRef(onZoomChange)
   onZoomChangeRef.current = onZoomChange
+  const onScaleChangeRef = useRef(onScaleChange)
+  onScaleChangeRef.current = onScaleChange
 
   const applyTransform = useCallback(
     (transition?: boolean) => {
@@ -97,6 +101,7 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
 
   const commit = useCallback(
     (next: ZoomPanState, opts?: { transition?: boolean }) => {
+      const prevScale = stateRef.current.scale
       const clamped = clampTranslate(
         next,
         containerSizeRef.current.w,
@@ -119,7 +124,9 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
         setIsZoomed(zoomed)
         onZoomChangeRef.current?.(zoomed)
       }
-      setScale(clamped.scale)
+      // Synchronous fanout — subscribers (e.g. ZoomControls) update without
+      // pulling the gallery through a React-state cascade at 60fps.
+      if (clamped.scale !== prevScale) onScaleChangeRef.current?.(clamped.scale)
     },
     [applyTransform]
   )
@@ -199,15 +206,22 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
     if (!container) return
 
     function onWheel(e: WheelEvent) {
+      // Normalise to pixels so line-mode and page-mode mice don't make a single
+      // scroll notch jump from 1× straight to ZOOM_MAX (or pan only 1–3 px).
+      // Line height ≈ 16px, page ≈ a viewport.
+      let pxPerUnit = 1
+      if (e.deltaMode === 1) pxPerUnit = 16
+      else if (e.deltaMode === 2) pxPerUnit = container!.clientHeight
+      const dxPx = e.deltaX * pxPerUnit
+      const dyPx = e.deltaY * pxPerUnit
+
       const zoomIntent = e.ctrlKey || e.metaKey
       if (zoomIntent) {
         e.preventDefault()
         const rect = container!.getBoundingClientRect()
         const localX = e.clientX - rect.left
         const localY = e.clientY - rect.top
-        // deltaMode 0 = pixels, 1 = lines, 2 = pages. Trackpad pinch = pixels.
-        const intensity = e.deltaMode === 0 ? 0.01 : 0.3
-        const factor = Math.exp(-e.deltaY * intensity)
+        const factor = Math.exp(-dyPx * 0.01)
         const current = stateRef.current
         const target = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, current.scale * factor))
         if (target === current.scale) return
@@ -217,7 +231,7 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
       } else if (isZoomedRef.current) {
         e.preventDefault()
         const current = stateRef.current
-        commit({ scale: current.scale, tx: current.tx - e.deltaX, ty: current.ty - e.deltaY })
+        commit({ scale: current.scale, tx: current.tx - dxPx, ty: current.ty - dyPx })
       }
       // Not zoomed + no modifier: let the browser do nothing (dialog has nothing to scroll).
     }
@@ -445,7 +459,6 @@ export function useZoomPan({ containerRef, contentRef, onZoomChange }: UseZoomPa
 
   return {
     isZoomed,
-    scale,
     zoomIn,
     zoomOut,
     reset,


### PR DESCRIPTION
## Summary

Adds Figma-style zoom/pan to the media gallery: ctrl/meta+wheel zoom and trackpad pinch on desktop, two-finger pinch + one-finger pan on mobile, plain-drag or meta+drag pan when zoomed, double-click/tap toggle, desktop zoom button cluster, and a gesture lock that blocks swipe/tap navigation while zoomed (keyboard and arrow buttons still advance, auto-resetting zoom first). Videos opt out.

## Key changes

- **`apps/frontend/src/hooks/use-zoom-pan.ts`** — ref-first zoom/pan state machine. Pure helpers (`zoomToPoint`, `clampTranslate`, `fitContain`) are exported for unit testing. Native event listeners attached with `passive: false` so we can `preventDefault()` on wheel/touch. `commit()` writes the transform directly to the DOM and only flips React state on the `isZoomed` boundary; scale changes fan out via an `onScaleChange` callback fired synchronously inside `commit`, no React-state hop.
- **`apps/frontend/src/components/gallery/zoomable-image.tsx`** — wraps the `<img>`, wires the hook, exposes `reset` / `zoomIn` / `zoomOut` via an imperative handle.
- **`apps/frontend/src/components/gallery/zoom-controls.tsx`** — desktop pill: `[−] [NNN%] [+] [↔]`. Subscribes locally to scale via `subscribeScale` so 60fps pinch updates only re-render the controls, not the gallery.
- **`apps/frontend/src/components/image-gallery.tsx`** —
  - Active image renders via `<ZoomableImage>`; inactive carousel slides stay as plain `<img>` so we don't wire gesture listeners for images the user isn't viewing.
  - Owns a stable `publishScale` / `subscribeScale` pair so the scale display can update at gesture speed without dragging the gallery into 60fps reconciliation.
  - Mobile `handleTouchStart/Move/End` early-return on `isZoomedRef.current || touches.length > 1`. Mobile tap-zone nav disabled while zoomed.
  - `goTo` calls `zoomableRef.current?.reset()` before switching, so arrow keys / arrow buttons / thumbnail clicks reset zoom then advance.
  - Desktop `<ZoomControls>` mounted in the action bar for image items only.
- **`apps/frontend/src/hooks/use-zoom-pan.test.ts`** — 13 unit tests for the pure math (`fitContain`, `zoomToPoint`, `clampTranslate`) plus 6 integration tests via `renderHook` covering the imperative handle, `onZoomChange` boundary, synchronous `onScaleChange` fanout, and `ZOOM_MAX` clamping.

## Behaviour

| Surface | Input | Behaviour |
|---|---|---|
| Desktop | `wheel` + ctrl/meta | Zoom toward cursor (deltaMode-normalised) |
| Desktop | plain `wheel`, when zoomed | Pan by deltaX/Y |
| Desktop | drag, when zoomed (or meta+drag) | Pan |
| Desktop | `dblclick` | Toggle 1×↔2× toward cursor |
| Desktop | zoom buttons | ±1.5× / reset |
| Mobile | 2-finger pinch | Zoom anchored at midpoint + pan-by-midpoint |
| Mobile | 1-finger drag, when zoomed | Pan |
| Mobile | double-tap | Toggle 1×↔2× toward tap |
| Both | arrow keys / nav buttons / thumbnail click | Reset zoom, then navigate |

## Implementation notes

- **Gesture ownership** — when zoomed or pinching, native handlers `stopPropagation()` so React's carousel swipe handler never fires. Carousel handlers also defensively early-return on `isZoomedRef || touches > 1`.
- **Performance** — gesture state lives entirely in refs; only `isZoomed` boundary crossings hit React state. Scale display uses pub/sub so the gallery component does not re-render during pinch (matches PR #384's refs-during-gesture pattern).
- **Wheel deltaMode normalisation** — `deltaY`/`deltaX` are converted to a pixel-equivalent (lines→16, pages→viewport-height) before applying zoom intensity / pan offset, so traditional line-mode mice don't jump straight to `ZOOM_MAX` in a single notch.
- **Bounds** — translate clamped against the `object-contain` rendered dimensions at each scale; at scale 1 the clamp forces translate to 0 so the image always re-centres after zoom-out.
- **Responsive** — `ResizeObserver` re-clamps on container size change (rotation, panel toggle).
- **`touch-action: none`** on the zoom viewport disables browser pinch/scroll gestures so the custom handler owns input. Double-tap-to-zoom is detected manually since iOS suppresses synthesized `dblclick` under `touch-action: none`.
- **Out of scope** — videos are not zoomable; zoom state is not persisted in the URL.

## Test plan

- [ ] Open a high-DPI image on desktop → ctrl+wheel zooms toward cursor, then plain wheel pans, meta+drag pans, double-click toggles
- [ ] Trackpad pinch zoom works (deltaMode 0)
- [ ] Traditional mouse wheel zoom is calm, not snapping straight to max (deltaMode 1)
- [ ] Zoom buttons step ±1.5×; percentage label updates without layout shift
- [ ] On mobile, two-finger pinch zooms anchored at the midpoint
- [ ] One-finger drag pans when zoomed; navigates carousel when not zoomed
- [ ] Double-tap toggles 1×↔2× toward the tap point
- [ ] Arrow keys / arrow buttons / thumbnail click reset zoom then navigate
- [ ] Rotate device while zoomed → bounds re-clamp without losing zoom
- [ ] Videos still play; no zoom controls appear on video items

https://claude.ai/code/session_01Tq7ifxYfy7t3vVSRFf8hRW