### PR TITLE
fix: ground companion temporal reasoning

### DIFF
--- a/.claude/plans/improve-agent-harness.md
+++ b/.claude/plans/improve-agent-harness.md
@@ -1,0 +1,92 @@
+# Improve Companion Temporal Grounding
+
+## Goal
+
+Make the companion agent reliably understand invocation-time "now" for temporal questions, especially relative date queries, current-events questions, and long-lived conversations where the stream started months before the latest user message.
+
+## What Was Built
+
+### Companion temporal context
+
+The companion prompt now treats the generated Current Time section as the authoritative invocation-time definition of now. The instruction explicitly separates invocation time from the model training cutoff and stream creation time, and tells the model to resolve relative dates silently unless the user asks about time directly.
+
+**Files:**
+- `apps/backend/src/lib/temporal.ts` — strengthens Current Time prompt grounding.
+- `apps/backend/src/lib/temporal.test.ts` — asserts the new grounding language is present.
+- `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` — adds recency guidance for web-search-backed answers.
+
+### Invocation-time plumbing
+
+The companion runtime can now accept a deterministic invocation time for evals/tests, while production continues to default to `new Date()`. The same invocation time flows into temporal context, participant timezone offsets, and web-search tool construction.
+
+**Files:**
+- `apps/backend/src/features/agents/persona-agent.ts` — accepts optional `currentTime` and passes temporal context into tools.
+- `apps/backend/src/features/agents/companion/context.ts` — passes invocation time into stream context construction.
+- `apps/backend/src/features/agents/context-builder.ts` — uses the supplied invocation time for participant UTC offsets.
+- `apps/backend/src/features/agents/companion/tool-set.ts` — passes temporal context into `web_search`.
+
+### Web search recency grounding
+
+The `web_search` tool now includes invocation-time guidance in its description and returns `searchedAt` metadata in tool output. This helps the model search with the relevant current year/date for latest, recent, current, and news queries.
+
+**Files:**
+- `apps/backend/src/features/agents/tools/web-search-tool.ts` — adds recency hint and `searchedAt`/`timezone` output metadata.
+- `apps/backend/src/features/agents/tools/web-search-tool.test.ts` — verifies temporal metadata and description hints.
+
+### Companion temporal evals
+
+The companion eval suite can now set invocation time, user timezone, and historical message timestamps. Three temporal cases cover direct relative-date resolution, long-lived stream recency, and current-news web search.
+
+**Files:**
+- `apps/backend/evals/suites/companion/cases.ts` — adds temporal case inputs and expected query checks.
+- `apps/backend/evals/suites/companion/evaluators.ts` — adds a web-search query evaluator.
+- `apps/backend/evals/suites/companion/suite.ts` — threads eval invocation time into production `PersonaAgent.run()` and resets timezone per case.
+
+### Messaging barrel initialization
+
+The messaging barrel exports metadata schemas before handler exports so public API schema imports can use the feature barrel without hitting initialization order issues.
+
+**Files:**
+- `apps/backend/src/features/messaging/index.ts` — reorders metadata exports ahead of handler exports.
+
+## Design Decisions
+
+### Keep time grounding low-noise
+
+**Chose:** Strengthen the existing Current Time section instead of introducing a new agent behavior mode.
+**Why:** The agent should reason with time as background context, not talk about time unless asked.
+**Alternatives considered:** Adding a separate temporal reasoning prompt block or tool. That would make time overly salient for ordinary responses.
+
+### Use invocation time, not stream time
+
+**Chose:** Define now at each agent invocation and allow evals to override it deterministically.
+**Why:** Long-lived conversations must interpret "recent" against the latest user turn, not when the stream was created.
+**Alternatives considered:** Deriving now from the trigger message timestamp only. That is less explicit for production and less convenient for evals.
+
+### Ground current-events search at the tool boundary
+
+**Chose:** Pass invocation time into `web_search` and expose it in both tool description and output metadata.
+**Why:** Current-events correctness depends on search behavior as much as final response wording.
+**Alternatives considered:** Prompt-only web-search guidance. That would not give tool output a timestamp for later reasoning.
+
+## Design Evolution
+
+- **Self-review fix:** The first eval plumbing only updated timezone when a case specified it. That could leak non-default timezones across eval cases sharing the same user. The final version resets the eval user timezone to the case timezone or UTC for every case.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No new database columns or persisted temporal state.
+- No new time-resolution tool.
+- No frontend changes.
+- No attempt to make the companion narrate its temporal reasoning in normal answers.
+
+## Status
+
+- [x] Companion prompt treats now as invocation time.
+- [x] Web search receives invocation-time grounding.
+- [x] Eval suite covers relative dates, current news, and long-lived streams.
+- [x] Targeted tests, backend typecheck, lint, and temporal companion evals passed.

--- a/.claude/plans/improve-agent-harness.md
+++ b/.claude/plans/improve-agent-harness.md
@@ -11,71 +11,76 @@ Make the companion agent reliably understand invocation-time "now" for temporal 
 The companion prompt now treats the generated Current Time section as the authoritative invocation-time definition of now. The instruction explicitly separates invocation time from the model training cutoff and stream creation time, and tells the model to resolve relative dates silently unless the user asks about time directly.
 
 **Files:**
+
 - `apps/backend/src/lib/temporal.ts` — strengthens Current Time prompt grounding.
 - `apps/backend/src/lib/temporal.test.ts` — asserts the new grounding language is present.
-- `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` — adds recency guidance for web-search-backed answers.
+- `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` — adds recency guidance for web-search-backed answers (wording branches on whether temporal context is present).
 
 ### Invocation-time plumbing
 
-The companion runtime can now accept a deterministic invocation time for evals/tests, while production continues to default to `new Date()`. The same invocation time flows into temporal context, participant timezone offsets, and web-search tool construction.
+The companion runtime can accept a deterministic invocation time for evals/tests, while production continues to default to `new Date()`. The same invocation time flows into temporal context, participant timezone offsets, and web-search tool construction. When user preferences are absent but `currentTime` is set, stream context still gets temporal fields using UTC and default date/time formats so tooling and prompts stay consistent.
 
 **Files:**
+
 - `apps/backend/src/features/agents/persona-agent.ts` — accepts optional `currentTime` and passes temporal context into tools.
 - `apps/backend/src/features/agents/companion/context.ts` — passes invocation time into stream context construction.
-- `apps/backend/src/features/agents/context-builder.ts` — uses the supplied invocation time for participant UTC offsets.
+- `apps/backend/src/features/agents/context-builder.ts` — uses the supplied invocation time for offsets and temporal context.
 - `apps/backend/src/features/agents/companion/tool-set.ts` — passes temporal context into `web_search`.
+- `apps/backend/tests/integration/context-builder.test.ts` — covers temporal from `currentTime` only.
 
 ### Web search recency grounding
 
-The `web_search` tool now includes invocation-time guidance in its description and returns `searchedAt` metadata in tool output. This helps the model search with the relevant current year/date for latest, recent, current, and news queries.
+The `web_search` tool includes invocation-time guidance in its description and returns `searchedAt` metadata in tool output. This helps the model search with the relevant current year/date for latest, recent, current, and news queries.
 
 **Files:**
-- `apps/backend/src/features/agents/tools/web-search-tool.ts` — adds recency hint and `searchedAt`/`timezone` output metadata.
+
+- `apps/backend/src/features/agents/tools/web-search-tool.ts` — recency hint and `searchedAt`/`timezone` output metadata.
 - `apps/backend/src/features/agents/tools/web-search-tool.test.ts` — verifies temporal metadata and description hints.
 
 ### Companion temporal evals
 
-The companion eval suite can now set invocation time, user timezone, and historical message timestamps. Three temporal cases cover direct relative-date resolution, long-lived stream recency, and current-news web search.
+The companion eval suite sets invocation time, user timezone, and historical message timestamps where needed. Temporal cases cover relative-date resolution, long-lived stream recency, and current-news web search. Eval personas copy **resolved** Ariadne configuration (built-in defaults in `built-in-agents.ts` plus optional workspace agent overrides via `PersonaRepository`) into a throwaway DB row so the eval can pin a different model without touching the canonical built-in definition.
 
 **Files:**
-- `apps/backend/evals/suites/companion/cases.ts` — adds temporal case inputs and expected query checks.
-- `apps/backend/evals/suites/companion/evaluators.ts` — adds a web-search query evaluator.
-- `apps/backend/evals/suites/companion/suite.ts` — threads eval invocation time into production `PersonaAgent.run()` and resets timezone per case.
 
-### Messaging barrel initialization
-
-The messaging barrel exports metadata schemas before handler exports so public API schema imports can use the feature barrel without hitting initialization order issues.
-
-**Files:**
-- `apps/backend/src/features/messaging/index.ts` — reorders metadata exports ahead of handler exports.
+- `apps/backend/evals/suites/companion/cases.ts` — temporal case inputs and expected query checks.
+- `apps/backend/evals/suites/companion/evaluators.ts` — web-search query evaluator.
+- `apps/backend/evals/suites/companion/suite.ts` — threads invocation time into `PersonaAgent.run()`, seeds message ordering under pinned time, resolves template persona with `ARIADNE_AGENT_ID` + eval workspace.
 
 ## Design Decisions
 
 ### Keep time grounding low-noise
 
-**Chose:** Strengthen the existing Current Time section instead of introducing a new agent behavior mode.
-**Why:** The agent should reason with time as background context, not talk about time unless asked.
+**Chose:** Strengthen the existing Current Time section instead of introducing a new agent behavior mode.  
+**Why:** The agent should reason with time as background context, not talk about time unless asked.  
 **Alternatives considered:** Adding a separate temporal reasoning prompt block or tool. That would make time overly salient for ordinary responses.
 
 ### Use invocation time, not stream time
 
-**Chose:** Define now at each agent invocation and allow evals to override it deterministically.
-**Why:** Long-lived conversations must interpret "recent" against the latest user turn, not when the stream was created.
+**Chose:** Define now at each agent invocation and allow evals to override it deterministically.  
+**Why:** Long-lived conversations must interpret "recent" against the latest user turn, not when the stream was created.  
 **Alternatives considered:** Deriving now from the trigger message timestamp only. That is less explicit for production and less convenient for evals.
 
 ### Ground current-events search at the tool boundary
 
-**Chose:** Pass invocation time into `web_search` and expose it in both tool description and output metadata.
-**Why:** Current-events correctness depends on search behavior as much as final response wording.
+**Chose:** Pass invocation time into `web_search` and expose it in both tool description and output metadata.  
+**Why:** Current-events correctness depends on search behavior as much as final response wording.  
 **Alternatives considered:** Prompt-only web-search guidance. That would not give tool output a timestamp for later reasoning.
+
+### Align eval persona template with production resolution
+
+**Chose:** Load Ariadne via `PersonaRepository.findById(..., ARIADNE_AGENT_ID, workspaceId)` so evals inherit the same built-in config and workspace overrides as production.  
+**Why:** System default Ariadne is defined in code (`built-in-agents.ts`); migrations no longer need to carry prompt/model truth for the harness.  
+**Alternatives considered:** Reading a `personas` seed row only — that would drift from the built-in source of truth.
 
 ## Design Evolution
 
-- **Self-review fix:** The first eval plumbing only updated timezone when a case specified it. That could leak non-default timezones across eval cases sharing the same user. The final version resets the eval user timezone to the case timezone or UTC for every case.
+- **Self-review fix:** Eval plumbing resets the eval user timezone per case so timezones do not leak across cases.
+- **Review follow-ups:** Web-search recency wording when temporal block is absent; `currentTime` without prefs; stable `created_at` ordering for seeded eval history under pinned invocation time; broader regression phrases on temporal-long-lived case.
 
 ## Schema Changes
 
-None.
+None. No new migrations on this branch.
 
 ## What's NOT Included
 
@@ -89,4 +94,5 @@ None.
 - [x] Companion prompt treats now as invocation time.
 - [x] Web search receives invocation-time grounding.
 - [x] Eval suite covers relative dates, current news, and long-lived streams.
-- [x] Targeted tests, backend typecheck, lint, and temporal companion evals passed.
+- [x] Eval suite resolves Ariadne from built-in + workspace overrides, not migration-seeded prompt text.
+- [x] Targeted tests and backend checks pass.

--- a/apps/backend/evals/suites/companion/cases.ts
+++ b/apps/backend/evals/suites/companion/cases.ts
@@ -18,14 +18,18 @@ export interface CompanionInput {
   streamType: StreamType
   /** Invocation trigger */
   trigger: AgentTrigger
+  /** Invocation time override for deterministic temporal evals */
+  currentTime?: string
+  /** Invoking user's timezone override */
+  timezone?: string
   /** Conversation history (if any) */
-  conversationHistory?: Array<{ role: "user" | "assistant"; content: string }>
+  conversationHistory?: Array<{ role: "user" | "assistant"; content: string; createdAt?: string }>
   /** Additional workspace context from other streams for cross-stream memory tests */
   workspaceContext?: Array<{
     streamType?: StreamType
     name?: string
     description?: string
-    conversationHistory: Array<{ role: "user" | "assistant"; content: string }>
+    conversationHistory: Array<{ role: "user" | "assistant"; content: string; createdAt?: string }>
   }>
   /** Additional context about the stream */
   streamContext?: {
@@ -57,6 +61,8 @@ export interface CompanionExpected {
     shouldAskQuestion?: boolean
     /** Should use web search */
     shouldUseWebSearch?: boolean
+    /** Web search query should include these terms */
+    webSearchQueryShouldContain?: string[]
   }
   /** Reason for this expected behavior */
   reason: string
@@ -212,6 +218,88 @@ const scratchpadCases: EvalCase<CompanionInput, CompanionExpected>[] = [
         shouldAskQuestion: true,
       },
       reason: "Vague request should prompt for clarification rather than guessing",
+    }
+  ),
+]
+
+// =============================================================================
+// Temporal Grounding Cases
+// =============================================================================
+
+const temporalGroundingCases: EvalCase<CompanionInput, CompanionExpected>[] = [
+  createCase(
+    "temporal-now-001",
+    "Temporal: Tomorrow should resolve from invocation time",
+    {
+      message: "What is tomorrow's date? Answer with the YYYY-MM-DD date only.",
+      streamType: "scratchpad",
+      trigger: "companion",
+      currentTime: "2026-11-15T10:00:00.000Z",
+      timezone: "UTC",
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        brief: true,
+        shouldContain: ["2026-11-16"],
+        shouldNotContain: ["2025", "2024", "knowledge cutoff"],
+      },
+      reason:
+        "Relative dates must resolve from the invocation time, not model training cutoff or wall-clock assumptions",
+    }
+  ),
+
+  createCase(
+    "temporal-long-lived-001",
+    "Temporal: Recent should use November invocation time in an old stream",
+    {
+      message: "Which of these decisions is more recent, and what did we decide?",
+      streamType: "scratchpad",
+      trigger: "companion",
+      currentTime: "2026-11-15T10:00:00.000Z",
+      timezone: "UTC",
+      conversationHistory: [
+        {
+          role: "user",
+          content: "Decision log: In April we chose Redis for the short-lived cache.",
+          createdAt: "2026-04-20T09:00:00.000Z",
+        },
+        {
+          role: "user",
+          content: "Decision log: This week we replaced that with Postgres advisory locks for coordination.",
+          createdAt: "2026-11-12T14:00:00.000Z",
+        },
+      ],
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldContain: ["Postgres", "advisory"],
+        shouldNotContain: ["Redis is more recent"],
+      },
+      reason:
+        "Long-lived streams must interpret recent relative to the current November invocation, while preserving historical message dates",
+    }
+  ),
+
+  createCase(
+    "temporal-news-001",
+    "Temporal: Latest AI news should search with the current year",
+    {
+      message: "What's the most recent news in AI?",
+      streamType: "scratchpad",
+      trigger: "companion",
+      currentTime: "2026-11-15T10:00:00.000Z",
+      timezone: "UTC",
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldUseWebSearch: true,
+        webSearchQueryShouldContain: ["2026"],
+        shouldNotContain: ["knowledge cutoff", "last update"],
+      },
+      reason: "Open-ended recent-news questions should be grounded with web search against the invocation year",
     }
   ),
 ]
@@ -633,6 +721,7 @@ const consistencyCases: EvalCase<CompanionInput, CompanionExpected>[] = [
 
 export const companionCases: EvalCase<CompanionInput, CompanionExpected>[] = [
   ...scratchpadCases,
+  ...temporalGroundingCases,
   ...channelCases,
   ...threadCases,
   ...dmCases,
@@ -642,4 +731,13 @@ export const companionCases: EvalCase<CompanionInput, CompanionExpected>[] = [
 ]
 
 // Export case subsets for targeted testing
-export { scratchpadCases, channelCases, threadCases, dmCases, workspaceMemoryCases, edgeCases, consistencyCases }
+export {
+  scratchpadCases,
+  temporalGroundingCases,
+  channelCases,
+  threadCases,
+  dmCases,
+  workspaceMemoryCases,
+  edgeCases,
+  consistencyCases,
+}

--- a/apps/backend/evals/suites/companion/cases.ts
+++ b/apps/backend/evals/suites/companion/cases.ts
@@ -275,7 +275,11 @@ const temporalGroundingCases: EvalCase<CompanionInput, CompanionExpected>[] = [
       shouldRespond: true,
       responseCharacteristics: {
         shouldContain: ["Postgres", "advisory"],
-        shouldNotContain: ["Redis is more recent"],
+        shouldNotContain: [
+          "Redis is more recent",
+          "redis was the more recent choice",
+          "the redis decision is more recent",
+        ],
       },
       reason:
         "Long-lived streams must interpret recent relative to the current November invocation, while preserving historical message dates",

--- a/apps/backend/evals/suites/companion/evaluators.ts
+++ b/apps/backend/evals/suites/companion/evaluators.ts
@@ -250,6 +250,41 @@ export const webSearchUsageEvaluator: Evaluator<CompanionOutput, CompanionExpect
   },
 }
 
+/**
+ * Evaluates whether web search queries include expected temporal grounding terms.
+ */
+export const webSearchQueryEvaluator: Evaluator<CompanionOutput, CompanionExpected> = {
+  name: "web-search-query",
+  evaluate: (output: CompanionOutput, expected: CompanionExpected): EvaluatorResult => {
+    const expectedTerms = expected.responseCharacteristics?.webSearchQueryShouldContain
+    if (!expectedTerms || expectedTerms.length === 0) {
+      return { name: "web-search-query", score: 1, passed: true, details: "No web search query requirements" }
+    }
+
+    const searchQueries =
+      output.toolCalls
+        ?.filter((tc) => tc.name === "web_search")
+        .map((tc) => tc.args.query)
+        .filter((query): query is string => typeof query === "string") ?? []
+
+    if (searchQueries.length === 0) {
+      return { name: "web-search-query", score: 0, passed: false, details: "No web search query found" }
+    }
+
+    const combinedQueries = searchQueries.join(" ").toLowerCase()
+    const found = expectedTerms.filter((term) => combinedQueries.includes(term.toLowerCase()))
+    const missing = expectedTerms.filter((term) => !combinedQueries.includes(term.toLowerCase()))
+    const score = found.length / expectedTerms.length
+
+    return {
+      name: "web-search-query",
+      score,
+      passed: missing.length === 0,
+      details: missing.length > 0 ? `Search query missing: ${missing.map((s) => `"${s}"`).join(", ")}` : undefined,
+    }
+  },
+}
+
 // =============================================================================
 // Run-Level Evaluators
 // =============================================================================

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -42,6 +42,7 @@ import {
   averageQualityEvaluator,
 } from "./evaluators"
 import {
+  ARIADNE_AGENT_ID,
   COMPANION_MODEL_ID,
   COMPANION_TEMPERATURE,
   COMPANION_SUMMARY_MODEL_ID,
@@ -70,9 +71,6 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { AuthorTypes, AgentTriggers, StreamTypes } from "@threa/types"
 import { ulid } from "ulid"
 import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
-
-/** The production Ariadne system persona ID */
-const ARIADNE_PERSONA_ID = "persona_system_ariadne"
 
 /**
  * Get model configuration from context.
@@ -105,7 +103,9 @@ function mapStreamTypeToDbStreamType(
 
 /**
  * Set up test data for a companion eval case.
- * Creates persona, stream, and trigger message in the database.
+ * Creates a workspace-scoped eval persona row, stream, and trigger message.
+ * Prompt text and tools come from the built-in Ariadne config (see `built-in-agents.ts`),
+ * merged with any workspace agent overrides — same resolution as production.
  */
 async function setupTestData(
   input: CompanionInput,
@@ -118,17 +118,16 @@ async function setupTestData(
   const pool = ctx.pool
   const modelConfig = getModelConfig(ctx)
 
-  // Read the production Ariadne persona to get its system prompt
-  // This ensures evals use the EXACT production prompt (INV-44)
-  const productionPersona = await PersonaRepository.findById(pool, ARIADNE_PERSONA_ID)
-  if (!productionPersona) {
-    throw new Error(`Production persona ${ARIADNE_PERSONA_ID} not found - ensure migrations have run`)
+  // Resolve Ariadne as production does: built-in defaults in code plus optional workspace overrides.
+  const templatePersona = await PersonaRepository.findById(pool, ARIADNE_AGENT_ID, ctx.workspaceId)
+  if (!templatePersona) {
+    throw new Error(`Could not resolve built-in companion persona ${ARIADNE_AGENT_ID} (see built-in-agents.ts)`)
   }
-  if (!productionPersona.systemPrompt) {
-    throw new Error(`Production persona ${ARIADNE_PERSONA_ID} has no system prompt`)
+  if (!templatePersona.systemPrompt) {
+    throw new Error(`Built-in companion persona ${ARIADNE_AGENT_ID} has no system prompt`)
   }
 
-  // Create a test persona with production's system prompt but eval's model
+  // Create a test persona row with the resolved prompt and tools but the eval permutation model.
   const testPersonaId = generatePersonaId()
   await pool.query(
     `
@@ -142,11 +141,11 @@ async function setupTestData(
       testPersonaId,
       `eval-ariadne-${ulid().toLowerCase().slice(0, 8)}`,
       "Ariadne (Eval)",
-      productionPersona.description,
-      productionPersona.avatarEmoji,
-      productionPersona.systemPrompt,
+      templatePersona.description,
+      templatePersona.avatarEmoji,
+      templatePersona.systemPrompt,
       modelConfig.model,
-      productionPersona.enabledTools ?? ["send_message"],
+      templatePersona.enabledTools ?? ["send_message"],
     ]
   )
 

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -187,9 +187,15 @@ async function setupTestData(
 
   const seedConversationHistory = async (
     targetStreamId: string,
-    history: Array<{ role: "user" | "assistant"; content: string; createdAt?: string }>
+    history: Array<{ role: "user" | "assistant"; content: string; createdAt?: string }>,
+    pinTimeIso?: string
   ): Promise<void> => {
-    for (const msg of history) {
+    const pinMs = pinTimeIso ? new Date(pinTimeIso).getTime() : undefined
+    if (pinTimeIso && pinMs !== undefined && Number.isNaN(pinMs)) {
+      throw new Error(`Invalid eval pin time for seeded history: ${pinTimeIso}`)
+    }
+    for (let i = 0; i < history.length; i++) {
+      const msg = history[i]
       const authorId = msg.role === "user" ? ctx.userId : testPersonaId
       const authorType = msg.role === "user" ? AuthorTypes.USER : AuthorTypes.PERSONA
       const message = await eventService.createMessage({
@@ -200,15 +206,17 @@ async function setupTestData(
         contentJson: parseMarkdown(msg.content),
         contentMarkdown: msg.content,
       })
-      if (msg.createdAt) {
-        await setMessageCreatedAt(message.id, msg.createdAt)
+      const syntheticCreatedAt =
+        msg.createdAt ?? (pinMs !== undefined ? new Date(pinMs - (history.length - i) * 1000).toISOString() : undefined)
+      if (syntheticCreatedAt) {
+        await setMessageCreatedAt(message.id, syntheticCreatedAt)
       }
     }
   }
 
   // Create conversation history if provided
   if (input.conversationHistory && input.conversationHistory.length > 0) {
-    await seedConversationHistory(testStreamId, input.conversationHistory)
+    await seedConversationHistory(testStreamId, input.conversationHistory, input.currentTime)
   }
 
   // Seed additional workspace context in separate streams for cross-stream retrieval tests
@@ -228,7 +236,7 @@ async function setupTestData(
       })
 
       await StreamMemberRepository.insert(pool, contextStreamId, ctx.userId)
-      await seedConversationHistory(contextStreamId, contextStream.conversationHistory)
+      await seedConversationHistory(contextStreamId, contextStream.conversationHistory, input.currentTime)
     }
   }
 

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -34,6 +34,7 @@ import {
   brevityEvaluator,
   asksQuestionEvaluator,
   webSearchUsageEvaluator,
+  webSearchQueryEvaluator,
   createResponseQualityEvaluator,
   createToneEvaluator,
   accuracyEvaluator,
@@ -173,14 +174,25 @@ async function setupTestData(
   // Create event service for message creation
   const eventService = new EventService(pool)
 
+  const userPreferencesService = new UserPreferencesService(pool)
+  await userPreferencesService.updatePreferences(ctx.workspaceId, ctx.userId, { timezone: input.timezone ?? "UTC" })
+
+  const setMessageCreatedAt = async (messageId: string, createdAt: string): Promise<void> => {
+    const date = new Date(createdAt)
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(`Invalid eval message createdAt: ${createdAt}`)
+    }
+    await pool.query(`UPDATE messages SET created_at = $1 WHERE id = $2`, [date, messageId])
+  }
+
   const seedConversationHistory = async (
     targetStreamId: string,
-    history: Array<{ role: "user" | "assistant"; content: string }>
+    history: Array<{ role: "user" | "assistant"; content: string; createdAt?: string }>
   ): Promise<void> => {
     for (const msg of history) {
       const authorId = msg.role === "user" ? ctx.userId : testPersonaId
       const authorType = msg.role === "user" ? AuthorTypes.USER : AuthorTypes.PERSONA
-      await eventService.createMessage({
+      const message = await eventService.createMessage({
         workspaceId: ctx.workspaceId,
         streamId: targetStreamId,
         authorId,
@@ -188,6 +200,9 @@ async function setupTestData(
         contentJson: parseMarkdown(msg.content),
         contentMarkdown: msg.content,
       })
+      if (msg.createdAt) {
+        await setMessageCreatedAt(message.id, msg.createdAt)
+      }
     }
   }
 
@@ -226,6 +241,9 @@ async function setupTestData(
     contentJson: parseMarkdown(input.message),
     contentMarkdown: input.message,
   })
+  if (input.currentTime) {
+    await setMessageCreatedAt(triggerMessage.id, input.currentTime)
+  }
 
   return {
     personaId: testPersonaId,
@@ -385,6 +403,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       personaId,
       serverId: `eval-server-${ulid()}`,
       trigger: input.trigger === "mention" ? AgentTriggers.MENTION : undefined,
+      currentTime: input.currentTime ? new Date(input.currentTime) : undefined,
     }
 
     // Run the agent!
@@ -445,6 +464,7 @@ export const companionSuite: EvalSuite<CompanionInput, CompanionOutput, Companio
     brevityEvaluator,
     asksQuestionEvaluator,
     webSearchUsageEvaluator,
+    webSearchQueryEvaluator,
     createResponseQualityEvaluator(),
     createToneEvaluator(),
   ],

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -36,6 +36,7 @@ import {
   hallucinationRateEvaluator,
 } from "./evaluators"
 import {
+  ARIADNE_AGENT_ID,
   COMPANION_MODEL_ID,
   COMPANION_TEMPERATURE,
   COMPANION_SUMMARY_MODEL_ID,
@@ -72,9 +73,6 @@ import {
   attachmentId as generateAttachmentId,
   extractionId as generateExtractionId,
 } from "../../../src/lib/id"
-
-/** The production Ariadne system persona ID */
-const ARIADNE_PERSONA_ID = "persona_system_ariadne"
 
 /** Default vision model for eval (must support image input) */
 const VISION_MODEL_ID = "openrouter:anthropic/claude-sonnet-4.5"
@@ -135,7 +133,8 @@ function createMockStorage(images: Map<string, Buffer>): StorageProvider {
 
 /**
  * Set up test data for a multimodal vision eval case.
- * Creates persona, stream, trigger message with image attachment, and populates mock storage.
+ * Creates eval persona row, stream, trigger message with image attachment, and populates mock storage.
+ * Template config comes from built-in Ariadne (`built-in-agents.ts`) plus workspace overrides.
  */
 async function setupTestData(
   input: MultimodalVisionInput,
@@ -149,19 +148,15 @@ async function setupTestData(
   const pool = ctx.pool
   const modelConfig = getModelConfig(ctx)
 
-  // Read the production Ariadne persona to get its system prompt (INV-44)
-  const productionPersona = await PersonaRepository.findById(pool, ARIADNE_PERSONA_ID)
-  if (!productionPersona) {
-    throw new Error(`Production persona ${ARIADNE_PERSONA_ID} not found - ensure migrations have run`)
+  const templatePersona = await PersonaRepository.findById(pool, ARIADNE_AGENT_ID, ctx.workspaceId)
+  if (!templatePersona) {
+    throw new Error(`Could not resolve built-in companion persona ${ARIADNE_AGENT_ID} (see built-in-agents.ts)`)
   }
-  if (!productionPersona.systemPrompt) {
-    throw new Error(`Production persona ${ARIADNE_PERSONA_ID} has no system prompt`)
+  if (!templatePersona.systemPrompt) {
+    throw new Error(`Built-in companion persona ${ARIADNE_AGENT_ID} has no system prompt`)
   }
 
-  // Create a test persona that uses production Ariadne's config (system prompt, tools, etc.)
-  // but with the eval's model. This is intentional: vision evals need vision-capable models,
-  // which may differ from production. We copy production config to ensure the eval tests
-  // realistic behavior, while model variation lets us test across different vision models.
+  // Copy resolved config into a throwaway row with the eval permutation model (vision-capable).
   const testPersonaId = generatePersonaId()
   await pool.query(
     `
@@ -175,11 +170,11 @@ async function setupTestData(
       testPersonaId,
       `eval-vision-${ulid().toLowerCase().slice(0, 8)}`,
       "Ariadne (Vision Eval)",
-      productionPersona.description,
-      productionPersona.avatarEmoji,
-      productionPersona.systemPrompt,
+      templatePersona.description,
+      templatePersona.avatarEmoji,
+      templatePersona.systemPrompt,
       modelConfig.model,
-      productionPersona.enabledTools ?? ["send_message"],
+      templatePersona.enabledTools ?? ["send_message"],
     ]
   )
 

--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -33,6 +33,8 @@ export interface ContextParams {
   messageId: string
   persona: Persona
   trigger?: typeof AgentTriggers.MENTION
+  /** Invocation time override for deterministic evals/tests. Production uses Date.now(). */
+  currentTime?: Date
 }
 
 export interface AgentContext {
@@ -82,7 +84,7 @@ async function resolveScratchpadCustomPrompt(
  */
 export async function buildAgentContext(deps: ContextDeps, params: ContextParams): Promise<AgentContext> {
   const { db, userPreferencesService, conversationSummaryService } = deps
-  const { workspaceId, streamId, stream, messageId, persona, trigger } = params
+  const { workspaceId, streamId, stream, messageId, persona, trigger, currentTime } = params
 
   const triggerMessage = await MessageRepository.findById(db, messageId)
   const invokingUserId = triggerMessage?.authorType === AuthorTypes.USER ? triggerMessage.authorId : undefined
@@ -125,6 +127,7 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
 
   const streamContext = await buildStreamContext(db, stream, {
     preferences,
+    currentTime,
     triggerMessageId: messageId,
     includeAttachments: true,
   })

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -46,4 +46,35 @@ describe("buildSystemPrompt", () => {
 
     expect(prompt).not.toContain("## Scratchpad Custom Instructions")
   })
+
+  test("web search recency guidance references tool metadata when temporal context is absent", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null)
+
+    expect(prompt).toContain("## Web Search")
+    expect(prompt).toContain("ground recency in web_search tool metadata")
+    expect(prompt).not.toContain(
+      "ground your search and answer against the Current Time section; do not mix stale search results"
+    )
+  })
+
+  test("web search recency guidance references Current Time when temporal context is present", () => {
+    const prompt = buildSystemPrompt(
+      persona,
+      {
+        ...scratchpadContext,
+        temporal: {
+          currentTime: "2026-11-15T10:00:00.000Z",
+          timezone: "UTC",
+          utcOffset: "UTC+0",
+          dateFormat: "YYYY-MM-DD",
+          timeFormat: "24h",
+        },
+      },
+      null
+    )
+
+    expect(prompt).toContain(
+      "ground your search and answer against the Current Time section; do not mix stale search results"
+    )
+  })
 })

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -111,6 +111,9 @@ Safety rules:
 
   // Add web search tool instructions if enabled
   if (isToolEnabled(persona.enabledTools, AgentToolNames.WEB_SEARCH)) {
+    const recencyGroundingBullet = context.temporal
+      ? `- For latest/recent/current/news questions, ground your search and answer against the Current Time section; do not mix stale search results or training-cutoff facts into a "recent" answer`
+      : `- For latest/recent/current/news questions, ground recency in web_search tool metadata and fresh results; do not mix stale results or training-cutoff facts into a "recent" answer`
     prompt += `
 
 ## Web Search
@@ -120,7 +123,7 @@ You have a \`web_search\` tool to search the web for current information.
 When using web search:
 - Search when you need up-to-date information not in your training data
 - Search for facts, current events, or specific details you're uncertain about
-- For latest/recent/current/news questions, ground your search and answer against the Current Time section; do not mix stale search results or training-cutoff facts into a "recent" answer
+${recencyGroundingBullet}
 - Cite sources in your responses using markdown links: [Title](URL)
 - Use the snippets to answer accurately`
   }

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -120,6 +120,7 @@ You have a \`web_search\` tool to search the web for current information.
 When using web search:
 - Search when you need up-to-date information not in your training data
 - Search for facts, current events, or specific details you're uncertain about
+- For latest/recent/current/news questions, ground your search and answer against the Current Time section; do not mix stale search results or training-cutoff facts into a "recent" answer
 - Cite sources in your responses using markdown links: [Title](URL)
 - Use the snippets to answer accurately`
   }

--- a/apps/backend/src/features/agents/companion/tool-set.ts
+++ b/apps/backend/src/features/agents/companion/tool-set.ts
@@ -39,6 +39,9 @@ import {
 export interface ToolSetConfig {
   enabledTools: string[] | null
   tavilyApiKey?: string
+  /** Invocation time used to ground current/latest/recent web searches. */
+  currentTime?: string
+  timezone?: string
   runWorkspaceAgent?: (query: string, opts: RunWorkspaceAgentOptions) => Promise<WorkspaceAgentResult>
   workspace?: WorkspaceToolDeps
   github?: GitHubToolDeps
@@ -51,7 +54,8 @@ export interface ToolSetConfig {
  * Returns AgentTool[] — send_message is NOT included (the runtime handles it).
  */
 export function buildToolSet(config: ToolSetConfig): AgentTool[] {
-  const { enabledTools, tavilyApiKey, runWorkspaceAgent, workspace, github, supportsVision } = config
+  const { enabledTools, tavilyApiKey, currentTime, timezone, runWorkspaceAgent, workspace, github, supportsVision } =
+    config
 
   if (!github && enabledTools !== null) {
     const requestedGithubTools = enabledTools.filter((t) => t.startsWith("github_"))
@@ -69,7 +73,7 @@ export function buildToolSet(config: ToolSetConfig): AgentTool[] {
 
     // Web tools
     tavilyApiKey && isToolEnabled(enabledTools, AgentToolNames.WEB_SEARCH)
-      ? createWebSearchTool({ tavilyApiKey })
+      ? createWebSearchTool({ tavilyApiKey, currentTime, timezone })
       : null,
     isToolEnabled(enabledTools, AgentToolNames.READ_URL) ? createReadUrlTool() : null,
 

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -10,7 +10,14 @@ import type {
   TableData,
   DiagramData,
 } from "@threa/types"
-import { StreamTypes, AuthorTypes, ExtractionSourceTypes, PdfSizeTiers, InjectionStrategies } from "@threa/types"
+import {
+  StreamTypes,
+  AuthorTypes,
+  ExtractionSourceTypes,
+  PdfSizeTiers,
+  InjectionStrategies,
+  DEFAULT_USER_PREFERENCES,
+} from "@threa/types"
 import { StreamRepository, StreamMemberRepository, type Stream } from "../streams"
 import { MessageRepository, type Message } from "../messaging"
 import { UserRepository } from "../workspaces"
@@ -157,8 +164,9 @@ export interface BuildStreamContextOptions {
  * Build stream context for the companion agent.
  * Returns stream-type-specific context for enriching the system prompt.
  *
- * When preferences are provided, includes temporal context
- * with the invoking user's timezone and time preferences.
+ * When preferences are provided, includes temporal context with the invoking user's
+ * timezone and time preferences. When only `currentTime` is provided (e.g. deterministic
+ * evals without a user prefs row), temporal context uses UTC and default date/time formats.
  *
  * When includeAttachments is true, messages are enriched with attachment context.
  * Detail level varies based on message recency relative to triggerMessageId.
@@ -168,10 +176,18 @@ export async function buildStreamContext(
   stream: Stream,
   options?: BuildStreamContextOptions
 ): Promise<StreamContext> {
-  // Build temporal context if we have user preferences
   let temporal: TemporalContext | undefined
   if (options?.preferences) {
     temporal = buildTemporalContext(options.preferences, options.currentTime)
+  } else if (options?.currentTime) {
+    temporal = buildTemporalContext(
+      {
+        timezone: DEFAULT_USER_PREFERENCES.timezone,
+        dateFormat: DEFAULT_USER_PREFERENCES.dateFormat,
+        timeFormat: DEFAULT_USER_PREFERENCES.timeFormat,
+      },
+      options.currentTime
+    )
   }
 
   let context: StreamContext
@@ -208,10 +224,12 @@ export async function buildStreamContext(
   return context
 }
 
+type TemporalPreferenceFields = Pick<UserPreferences, "timezone" | "dateFormat" | "timeFormat">
+
 /**
- * Build temporal context from user preferences.
+ * Build temporal context from timezone and display preferences.
  */
-function buildTemporalContext(preferences: UserPreferences, currentTime?: Date): TemporalContext {
+function buildTemporalContext(preferences: TemporalPreferenceFields, currentTime?: Date): TemporalContext {
   const now = currentTime ?? new Date()
 
   return {

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -181,7 +181,7 @@ export async function buildStreamContext(
       break
 
     case StreamTypes.CHANNEL:
-      context = await buildChannelContext(db, stream, temporal)
+      context = await buildChannelContext(db, stream, temporal, options?.currentTime)
       break
 
     case StreamTypes.THREAD:
@@ -189,7 +189,7 @@ export async function buildStreamContext(
       break
 
     case StreamTypes.DM:
-      context = await buildDmContext(db, stream, temporal)
+      context = await buildDmContext(db, stream, temporal, options?.currentTime)
       break
 
     default:
@@ -244,7 +244,12 @@ async function buildScratchpadContext(db: Querier, stream: Stream, temporal?: Te
 /**
  * Channel context: collaborative. Includes members, slug, and conversation.
  */
-async function buildChannelContext(db: Querier, stream: Stream, temporal?: TemporalContext): Promise<StreamContext> {
+async function buildChannelContext(
+  db: Querier,
+  stream: Stream,
+  temporal?: TemporalContext,
+  currentTime?: Date
+): Promise<StreamContext> {
   const [messages, members] = await Promise.all([
     MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
     StreamMemberRepository.list(db, { streamId: stream.id }),
@@ -255,7 +260,8 @@ async function buildChannelContext(db: Querier, stream: Stream, temporal?: Tempo
     db,
     stream.workspaceId,
     userIds,
-    temporal !== undefined
+    temporal !== undefined,
+    currentTime
   )
 
   return {
@@ -275,7 +281,12 @@ async function buildChannelContext(db: Querier, stream: Stream, temporal?: Tempo
 /**
  * DM context: two-party. Like channels but focused.
  */
-async function buildDmContext(db: Querier, stream: Stream, temporal?: TemporalContext): Promise<StreamContext> {
+async function buildDmContext(
+  db: Querier,
+  stream: Stream,
+  temporal?: TemporalContext,
+  currentTime?: Date
+): Promise<StreamContext> {
   const [messages, members] = await Promise.all([
     MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
     StreamMemberRepository.list(db, { streamId: stream.id }),
@@ -286,7 +297,8 @@ async function buildDmContext(db: Querier, stream: Stream, temporal?: TemporalCo
     db,
     stream.workspaceId,
     userIds,
-    temporal !== undefined
+    temporal !== undefined,
+    currentTime
   )
 
   return {
@@ -392,7 +404,8 @@ async function resolveParticipantsWithTimezones(
   db: Querier,
   workspaceId: string,
   userIds: string[],
-  includeTimezones: boolean
+  includeTimezones: boolean,
+  currentTime?: Date
 ): Promise<{ participants: Participant[]; participantTimezones?: ParticipantTemporal[] }> {
   if (userIds.length === 0) {
     return { participants: [], participantTimezones: includeTimezones ? [] : undefined }
@@ -409,7 +422,7 @@ async function resolveParticipantsWithTimezones(
   // Build timezone info from the same member data if needed
   let participantTimezones: ParticipantTemporal[] | undefined
   if (includeTimezones) {
-    const now = new Date()
+    const now = currentTime ?? new Date()
     participantTimezones = members.map((member) => {
       const timezone = member.timezone ?? "UTC"
       return {

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -101,6 +101,8 @@ export interface PersonaAgentInput {
   trigger?: typeof AgentTriggers.MENTION
   supersedesSessionId?: string
   rerunContext?: AgentSessionRerunContext
+  /** Invocation time override for deterministic evals/tests. Production leaves this unset. */
+  currentTime?: Date
 }
 
 export interface PersonaAgentResult {
@@ -143,7 +145,17 @@ export class PersonaAgent {
       deleteMessage,
       createThread,
     } = this.deps
-    const { workspaceId, streamId, messageId, personaId, serverId, trigger, supersedesSessionId, rerunContext } = input
+    const {
+      workspaceId,
+      streamId,
+      messageId,
+      personaId,
+      serverId,
+      trigger,
+      supersedesSessionId,
+      rerunContext,
+      currentTime,
+    } = input
 
     // Step 1: Load and validate persona + stream
     const precheck = await withClient(pool, async (client) => {
@@ -226,7 +238,7 @@ export class PersonaAgent {
         // Build all context the agent needs
         const agentContext = await buildAgentContext(
           { db: pool, userPreferencesService, conversationSummaryService },
-          { workspaceId, streamId, stream, messageId, persona, trigger }
+          { workspaceId, streamId, stream, messageId, persona, trigger, currentTime }
         )
 
         // Resolve an attached ContextBag (if any) so `stable + delta` flow into
@@ -375,6 +387,8 @@ export class PersonaAgent {
         const tools = buildToolSet({
           enabledTools: persona.enabledTools,
           tavilyApiKey,
+          currentTime: agentContext.streamContext.temporal?.currentTime,
+          timezone: agentContext.streamContext.temporal?.timezone,
           runWorkspaceAgent,
           workspace: workspaceDeps,
           github: githubDeps,

--- a/apps/backend/src/features/agents/tools/web-search-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/web-search-tool.test.ts
@@ -67,6 +67,28 @@ describe("web-search-tool", () => {
     expect(body.include_answer).toBe(true)
   })
 
+  it("should expose invocation time in the tool description and output", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ query: "AI news 2026", results: [], response_time: 0.1 }),
+      } as Response)
+    ) as unknown as typeof fetch
+
+    const tool = createWebSearchTool({
+      tavilyApiKey: "test-api-key",
+      currentTime: "2026-11-15T10:00:00.000Z",
+      timezone: "Europe/Stockholm",
+    })
+    const { output } = await tool.config.execute({ query: "AI news 2026" }, toolOpts)
+    const parsed = JSON.parse(output)
+
+    expect(tool.config.description).toContain("Current invocation time is 2026-11-15T10:00:00.000Z")
+    expect(tool.config.description).toContain("include the current date/year")
+    expect(parsed.searchedAt).toBe("2026-11-15T10:00:00.000Z")
+    expect(parsed.timezone).toBe("Europe/Stockholm")
+  })
+
   it("should return error on API failure", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve({

--- a/apps/backend/src/features/agents/tools/web-search-tool.ts
+++ b/apps/backend/src/features/agents/tools/web-search-tool.ts
@@ -18,6 +18,8 @@ export interface WebSearchResultItem {
 
 export interface WebSearchResult {
   query: string
+  searchedAt?: string
+  timezone?: string
   results: WebSearchResultItem[]
   answer?: string
 }
@@ -37,6 +39,9 @@ interface TavilySearchResponse {
 export interface CreateWebSearchToolParams {
   tavilyApiKey: string
   maxResults?: number
+  /** Invocation time from the agent context, used to ground recency-sensitive searches. */
+  currentTime?: string
+  timezone?: string
 }
 
 const FETCH_TIMEOUT_MS = 30000
@@ -57,12 +62,14 @@ function redactQuery(query: string): string {
 }
 
 export function createWebSearchTool(params: CreateWebSearchToolParams) {
-  const { tavilyApiKey, maxResults = 5 } = params
+  const { tavilyApiKey, maxResults = 5, currentTime, timezone } = params
+  const recencyHint = currentTime
+    ? ` Current invocation time is ${currentTime}${timezone ? ` (${timezone})` : ""}; for latest, recent, current, or news queries, include the current date/year in your query and judge results against that invocation time.`
+    : ""
 
   return defineAgentTool({
     name: "web_search",
-    description:
-      "Search the web for current information. Returns relevant results with titles, URLs, and content snippets. Use this when you need up-to-date information or facts not in your training data.",
+    description: `Search the web for current information. Returns relevant results with titles, URLs, and content snippets. Use this when you need up-to-date information or facts not in your training data.${recencyHint}`,
     inputSchema: WebSearchSchema,
 
     execute: async (input): Promise<AgentToolResult> => {
@@ -97,6 +104,10 @@ export function createWebSearchTool(params: CreateWebSearchToolParams) {
 
         const result: WebSearchResult = {
           query: data.query,
+          ...(currentTime && {
+            searchedAt: new Date(currentTime).toISOString(),
+            timezone,
+          }),
           results: data.results.map((r) => ({
             title: r.title,
             url: r.url,

--- a/apps/backend/src/lib/temporal.test.ts
+++ b/apps/backend/src/lib/temporal.test.ts
@@ -162,6 +162,10 @@ describe("temporal utilities", () => {
     it("should build simple time section without participants", () => {
       const section = buildTemporalPromptSection(baseContext)
       expect(section).toContain("Current time: 2026-01-06 14:30")
+      expect(section).toContain("invocation-time definition of now")
+      expect(section).toContain("not your training cutoff date")
+      expect(section).toContain("not the stream creation date")
+      expect(section).toContain("Resolve relative times silently")
       expect(section).toContain("use 24-hour format")
     })
 

--- a/apps/backend/src/lib/temporal.ts
+++ b/apps/backend/src/lib/temporal.ts
@@ -168,6 +168,8 @@ export function buildTemporalPromptSection(temporal: TemporalContext, participan
   const formatExample = temporal.timeFormat === "12h" ? "2:30 PM" : "14:30"
   const formatInstruction = `When referencing times, use ${temporal.timeFormat === "12h" ? "12-hour" : "24-hour"} format (e.g., ${formatExample}).`
   const timestampInstruction = `User messages are prefixed with their send time, e.g., (${formatExample}). Do not include timestamps in your responses.`
+  const groundingInstruction =
+    "Treat the current time above as the invocation-time definition of now for relative terms like today, tomorrow, yesterday, this week, recently, latest, and current. It is not your training cutoff date and not the stream creation date. Resolve relative times silently while reasoning; mention the current time only when the user asks for it."
 
   if (hasMixedTimezones && participants) {
     // Different offsets: state offsets once in system prompt
@@ -182,12 +184,12 @@ export function buildTemporalPromptSection(temporal: TemporalContext, participan
       }
     }
 
-    section += `\n${formatInstruction}\n${timestampInstruction}`
+    section += `\n${groundingInstruction}\n${formatInstruction}\n${timestampInstruction}`
     return section
   }
 
   // Same offset: simple format
-  return `\n\n## Current Time\n\nCurrent time: ${currentTimeFormatted}\n\n${formatInstruction}\n${timestampInstruction}`
+  return `\n\n## Current Time\n\nCurrent time: ${currentTimeFormatted}\n\n${groundingInstruction}\n${formatInstruction}\n${timestampInstruction}`
 }
 
 /**

--- a/apps/backend/tests/integration/context-builder.test.ts
+++ b/apps/backend/tests/integration/context-builder.test.ts
@@ -87,6 +87,41 @@ describe("Context Builder", () => {
         expect(context.participants).toBeUndefined()
       })
     })
+
+    test("should include temporal when only currentTime is provided (no user preferences)", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const workosUserId = userId()
+        const wsId = workspaceId()
+        const scratchpadId = streamId()
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Context Test Workspace 2",
+          slug: `ctx-ws-${wsId}`,
+          createdBy: workosUserId,
+        })
+        const ownerUserId = (await addTestMember(client, wsId, workosUserId)).id
+
+        const scratchpad = await StreamRepository.insert(client, {
+          id: scratchpadId,
+          workspaceId: wsId,
+          type: StreamTypes.SCRATCHPAD,
+          displayName: "Pinned time scratchpad",
+          description: null,
+          visibility: Visibilities.PRIVATE,
+          createdBy: ownerUserId,
+        })
+
+        const pinned = new Date("2026-11-15T10:00:00.000Z")
+        const context = await buildStreamContext(client, scratchpad, { currentTime: pinned })
+
+        expect(context.temporal).toMatchObject({
+          currentTime: pinned.toISOString(),
+          timezone: "UTC",
+          dateFormat: "YYYY-MM-DD",
+          timeFormat: "24h",
+        })
+      })
+    })
   })
 
   describe("Channel Context", () => {


### PR DESCRIPTION
## Problem

The companion agent could confuse invocation-time "now" with model cutoff timing or older stream context. That made current-events and relative-time answers less trustworthy, especially in long-lived conversations where "recent" should follow the latest invocation rather than the stream's initial date.

## Solution

Ground companion temporal reasoning on invocation time, thread that context into web search, and add companion eval coverage for relative dates, current news, and long-lived streams.

### How it works

- The existing Current Time prompt section now explicitly defines now as invocation time, separate from model cutoff and stream creation time.
- `PersonaAgent.run()` can accept a deterministic `currentTime` for evals/tests while production keeps using runtime `new Date()`.
- The same temporal context flows into stream context, participant timezone offsets, and the `web_search` tool.
- Web search includes invocation-time hints and returns `searchedAt` metadata so current/recent/news queries can be judged against the right date.

### Key design decisions

**1. Keep temporal grounding low-noise**

The agent gets stronger temporal instructions but is told to resolve relative dates silently and mention current time only when asked. This keeps time as background reasoning rather than a new response style.

**2. Ground current-events behavior at the tool boundary**

The web-search tool gets invocation-time context in its description and output, because current-events correctness depends on search query behavior as well as final response wording.

**3. Make evals deterministic**

Companion eval inputs now support `currentTime`, `timezone`, and historical message timestamps. The eval setup resets timezone per case to avoid cross-case leakage.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/improve-agent-harness.md` | Review plan describing the temporal grounding implementation and scope. |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/lib/temporal.ts` | Strengthens Current Time prompt grounding. |
| `apps/backend/src/features/agents/persona-agent.ts` | Threads optional invocation time into context and tools. |
| `apps/backend/src/features/agents/context-builder.ts` | Uses invocation time for participant timezone offsets. |
| `apps/backend/src/features/agents/companion/*` | Passes temporal context through companion context/tool setup and web-search prompt guidance. |
| `apps/backend/src/features/agents/tools/web-search-tool.ts` | Adds invocation-time search hints and `searchedAt` metadata. |
| `apps/backend/evals/suites/companion/*` | Adds deterministic temporal eval inputs, cases, and query evaluator. |
| `apps/backend/src/features/messaging/index.ts` | Reorders metadata exports to avoid an initialization-order failure while preserving barrel imports. |

## Self-review

- Fixed one issue found during review: eval timezone overrides could have leaked across cases using the same eval user. The final setup resets timezone to the case timezone or UTC for every case.
- Verified the messaging barrel reorder keeps INV-52 barrel imports intact while resolving the import-time `ReferenceError` exposed by tests.

## Test plan

- [x] `bun test apps/backend/src/lib/temporal.test.ts apps/backend/src/features/agents/tools/web-search-tool.test.ts apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts`
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run --cwd apps/backend lint`
- [x] `bun run eval -- -s companion -c scratchpad-companion-temporal-now-001`
- [x] `bun run eval -- -s companion -c scratchpad-companion-temporal-long-lived-001`
- [x] `bun run eval -- -s companion -c scratchpad-companion-temporal-news-001`
- [x] Commit hooks ran full repo lint/typecheck and API docs check.

Made with [Cursor](https://cursor.com)