### PR TITLE
feat: move built-in agent config to code-backed defaults

### DIFF
--- a/.claude/plans/agent-config-as-override.md
+++ b/.claude/plans/agent-config-as-override.md
@@ -1,0 +1,97 @@
+# Agent Config As Override
+
+## Goal
+
+Move built-in agent defaults from Postgres seed/update rows into code-backed configuration, while keeping Postgres as a sparse workspace override layer. Ariadne remains the default built-in companion via the stable `persona_system_ariadne` ID, and workspace-managed personas continue to use full `personas` rows.
+
+## What Was Built
+
+### Built-In Agent Registry
+
+Ariadne now has a code-defined base config with identity, prompt, model, temperature, max tokens, tools, and visibility. A locked-down empty agent is also registered as internal-only so it can be used later without appearing in workspace bootstrap.
+
+**Files:**
+- `apps/backend/src/features/agents/built-in-agents.ts` — built-in registry, Ariadne/empty agent defaults, patch schemas, and patch merge validation.
+- `apps/backend/src/features/agents/companion/config.ts` — companion defaults now reference the Ariadne built-in config to avoid model drift.
+- `apps/backend/src/features/agents/index.ts` — exports built-in config helpers and override repository.
+
+### Sparse Postgres Overrides
+
+Added an override table for workspace-specific built-in agent patches. Runtime validates patches with Zod and fails loudly for invalid override documents.
+
+**Files:**
+- `apps/backend/src/db/migrations/20260425164228_agent_config_overrides.sql` — creates `agent_config_overrides` and archives the historical Ariadne row.
+- `apps/backend/src/features/agents/agent-config-override-repository.ts` — fetches active per-workspace override patches.
+
+### Persona Resolution Boundary
+
+`PersonaRepository` now synthesizes built-ins from code, applies workspace patches where a workspace is available, and falls back to `personas` for workspace-managed personas. Built-in Ariadne remains addressable by `persona_system_ariadne`; `getSystemDefault` returns Ariadne explicitly rather than relying on oldest active system row.
+
+**Files:**
+- `apps/backend/src/features/agents/persona-repository.ts` — resolves code-backed built-ins, patched built-ins, and DB personas through one API.
+- `apps/backend/src/features/agents/companion-outbox-handler.ts` — resolves companion/default personas with workspace scope.
+- `apps/backend/src/features/agents/persona-agent.ts` — runtime uses resolved persona config and forwards model options.
+- `apps/backend/src/features/agents/companion/context.ts`, `apps/backend/src/features/agents/quote-resolver.ts`, `apps/backend/src/features/agents/researcher/context-formatter.ts`, `apps/backend/src/features/agents/tools/search-workspace-tool.ts`, `apps/backend/src/features/memos/explorer-service.ts`, `apps/backend/src/lib/ai/message-formatter.ts`, `apps/backend/src/features/activity/service.ts`, `apps/backend/src/features/public-api/handlers.ts`, `apps/backend/src/socket.ts`, `apps/backend/src/features/agents/session-handlers.ts` — pass workspace context into persona lookups so patched built-in display/config can resolve consistently.
+
+### Runtime Model Options
+
+The agent loop now forwards persona-level `temperature` and `maxTokens` into tool-capable generation, so these configurable fields affect the main companion loop.
+
+**Files:**
+- `apps/backend/src/lib/ai/ai.ts` — adds tool-generation `temperature` and `maxTokens` options.
+- `apps/backend/src/features/agents/runtime/agent-runtime.ts` — forwards runtime config to the AI wrapper.
+- `apps/backend/src/features/agents/runtime/agent-runtime.test.ts` — verifies forwarding behavior.
+
+### Tests And Import Hygiene
+
+Added direct coverage for base config resolution, workspace patch application, invalid patch failure, default disabling, workspace persona preservation, and internal empty-agent non-exposure. Also reordered messaging barrel exports so public API schemas can keep using feature barrels without reintroducing an initialization cycle.
+
+**Files:**
+- `apps/backend/src/features/agents/persona-repository.test.ts` — built-in/override resolution coverage.
+- `apps/backend/src/lib/ai/config-resolver.test.ts` and `apps/backend/src/lib/ai/message-formatter.test.ts` — updated expected defaults/signatures.
+- `apps/backend/src/features/messaging/index.ts` and `apps/backend/src/features/public-api/schemas.ts` — preserve INV-52 barrel imports while avoiding schema initialization issues.
+
+## Design Decisions
+
+### Code Owns Built-In Defaults
+
+**Chose:** Ariadne and the empty agent are defined in `built-in-agents.ts`.
+**Why:** Built-in behavior is product-managed and should change through code review rather than DB seed/update migrations.
+**Alternatives considered:** Keep Ariadne as a full `personas` row with nullable override columns. This was rejected because it keeps defaults in data and requires schema changes for every configurable field.
+
+### JSON Patch Overrides
+
+**Chose:** Store sparse JSONB patches per `(workspace_id, agent_id)`.
+**Why:** It keeps the base config in code while allowing any built-in configurable field to be overridden per workspace.
+**Alternatives considered:** Typed nullable override columns. More explicit, but less flexible and migration-heavy.
+
+### Preserve `personas` For Workspace Agents
+
+**Chose:** Workspace-managed personas remain full DB rows.
+**Why:** The user agent config surface is separate and should continue working as-is.
+**Alternatives considered:** Move every persona through patch resolution now. This would unnecessarily broaden the change.
+
+### Internal Empty Agent
+
+**Chose:** Register the empty agent as `visibility: "internal"`.
+**Why:** It prepares the runtime shape for multiple built-ins without exposing an unfinished product option.
+
+## Schema Changes
+
+- `apps/backend/src/db/migrations/20260425164228_agent_config_overrides.sql` creates `agent_config_overrides`.
+- The same migration archives `persona_system_ariadne` so default behavior no longer comes from the historical seeded row.
+
+## What's NOT Included
+
+- No UI or public admin API for editing `agent_config_overrides`.
+- No migration of workspace-managed personas into override patches.
+- No exposure of the internal empty agent in workspace bootstrap or persona selection.
+- No change to `scratchpadCustomPrompt`; user prompt preferences remain layered as before.
+
+## Status
+
+- [x] Built-in Ariadne config lives in code.
+- [x] Sparse workspace override storage exists.
+- [x] Runtime and bootstrap persona resolution apply overrides.
+- [x] Workspace-managed personas remain DB-backed.
+- [x] Tests cover built-in resolution and override behavior.

--- a/apps/backend/src/db/migrations/20260425164228_agent_config_overrides.sql
+++ b/apps/backend/src/db/migrations/20260425164228_agent_config_overrides.sql
@@ -1,0 +1,25 @@
+-- Store sparse workspace overrides for code-backed built-in agent configuration.
+-- Built-in defaults live in application code; rows here only patch values that
+-- differ for a workspace.
+
+CREATE TABLE IF NOT EXISTS agent_config_overrides (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    patch JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (workspace_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_config_overrides_workspace_active
+    ON agent_config_overrides (workspace_id, agent_id)
+    WHERE status = 'active';
+
+-- Ariadne is now resolved from the code-backed built-in registry. Keep the
+-- historical row non-active so old databases no longer source defaults from it.
+UPDATE personas
+SET status = 'archived',
+    updated_at = NOW()
+WHERE id = 'persona_system_ariadne';

--- a/apps/backend/src/db/migrations/20260425213434_agent_config_overrides_updated_at_and_index.sql
+++ b/apps/backend/src/db/migrations/20260425213434_agent_config_overrides_updated_at_and_index.sql
@@ -1,0 +1,20 @@
+-- Follow-up for `agent_config_overrides`:
+-- - Drop a redundant partial index (the table already has UNIQUE (workspace_id, agent_id))
+-- - Keep `updated_at` fresh on UPDATE (mirrors other tables that maintain this column in-app)
+
+DROP INDEX IF EXISTS idx_agent_config_overrides_workspace_active;
+
+CREATE OR REPLACE FUNCTION set_agent_config_overrides_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_agent_config_overrides_set_updated_at ON agent_config_overrides;
+
+CREATE TRIGGER trg_agent_config_overrides_set_updated_at
+BEFORE UPDATE ON agent_config_overrides
+FOR EACH ROW
+EXECUTE FUNCTION set_agent_config_overrides_updated_at();

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -438,7 +438,7 @@ export class ActivityService {
         return bot?.name ?? null
       }
       case AuthorTypes.PERSONA: {
-        const persona = await PersonaRepository.findById(client, actorId)
+        const persona = await PersonaRepository.findById(client, actorId, workspaceId)
         return persona?.name ?? null
       }
       case AuthorTypes.SYSTEM:

--- a/apps/backend/src/features/agents/agent-config-override-repository.ts
+++ b/apps/backend/src/features/agents/agent-config-override-repository.ts
@@ -1,0 +1,41 @@
+import { sql, type Querier } from "../../db"
+
+interface AgentConfigOverrideRow {
+  agent_id: string
+  patch: unknown
+}
+
+export interface AgentConfigOverride {
+  agentId: string
+  patch: unknown
+}
+
+export const AgentConfigOverrideRepository = {
+  async findActiveByWorkspaceAndAgent(
+    db: Querier,
+    workspaceId: string,
+    agentId: string
+  ): Promise<AgentConfigOverride | null> {
+    const result = await db.query<AgentConfigOverrideRow>(sql`
+      SELECT agent_id, patch
+      FROM agent_config_overrides
+      WHERE workspace_id = ${workspaceId}
+        AND agent_id = ${agentId}
+        AND status = 'active'
+    `)
+
+    const row = result.rows[0]
+    return row ? { agentId: row.agent_id, patch: row.patch } : null
+  },
+
+  async listActiveByWorkspace(db: Querier, workspaceId: string): Promise<AgentConfigOverride[]> {
+    const result = await db.query<AgentConfigOverrideRow>(sql`
+      SELECT agent_id, patch
+      FROM agent_config_overrides
+      WHERE workspace_id = ${workspaceId}
+        AND status = 'active'
+    `)
+
+    return result.rows.map((row) => ({ agentId: row.agent_id, patch: row.patch }))
+  },
+}

--- a/apps/backend/src/features/agents/agent-config-override-repository.ts
+++ b/apps/backend/src/features/agents/agent-config-override-repository.ts
@@ -5,12 +5,22 @@ interface AgentConfigOverrideRow {
   patch: unknown
 }
 
+/**
+ * A row from `agent_config_overrides` (JSONB is opaque in the DB; validate/apply via
+ * `applyBuiltInAgentPatch` in `built-in-agents.ts`).
+ */
 export interface AgentConfigOverride {
   agentId: string
   patch: unknown
 }
 
+/**
+ * Read helpers for `agent_config_overrides`. All methods filter to `status = 'active'`.
+ */
 export const AgentConfigOverrideRepository = {
+  /**
+   * Fetch the active override for a single built-in `persona_system_*` id in a workspace, if any.
+   */
   async findActiveByWorkspaceAndAgent(
     db: Querier,
     workspaceId: string,
@@ -28,6 +38,9 @@ export const AgentConfigOverrideRepository = {
     return row ? { agentId: row.agent_id, patch: row.patch } : null
   },
 
+  /**
+   * List all active overrides for a workspace (used to batch-apply built-in patches).
+   */
   async listActiveByWorkspace(db: Querier, workspaceId: string): Promise<AgentConfigOverride[]> {
     const result = await db.query<AgentConfigOverrideRow>(sql`
       SELECT agent_id, patch

--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -1,5 +1,7 @@
 import { z } from "zod"
-import { AgentToolNames } from "@threa/types"
+import { AGENT_TOOL_NAMES, AgentToolNames } from "@threa/types"
+
+const agentToolNameSchema = z.enum(AGENT_TOOL_NAMES)
 
 export const ARIADNE_AGENT_ID = "persona_system_ariadne"
 export const EMPTY_AGENT_ID = "persona_system_empty"
@@ -18,7 +20,7 @@ export const builtInAgentConfigSchema = z.object({
   model: z.string().min(1),
   temperature: z.number().nullable(),
   maxTokens: z.number().int().positive().nullable(),
-  enabledTools: z.array(z.string()),
+  enabledTools: z.array(agentToolNameSchema),
   managedBy: z.literal("system"),
   status: agentStatusSchema,
   visibility: agentVisibilitySchema,
@@ -101,14 +103,27 @@ Keep responses short and direct. Default to a few sentences unless the user asks
 
 const BUILT_IN_AGENT_CONFIGS: Record<string, BuiltInAgentConfig> = BUILT_IN_AGENTS
 
+/**
+ * Return the static built-in agent config for a known `persona_system_*` id, or `null` if unknown.
+ */
 export function getBuiltInAgentConfig(agentId: string): BuiltInAgentConfig | null {
   return BUILT_IN_AGENT_CONFIGS[agentId] ?? null
 }
 
+/**
+ * List built-in agents that are product-visible (excludes `internal` agents such as the empty shell).
+ */
 export function listVisibleBuiltInAgentConfigs(): BuiltInAgentConfig[] {
-  return Object.values(BUILT_IN_AGENTS).filter((agent) => agent.visibility === "visible")
+  return Object.values(BUILT_IN_AGENT_CONFIGS).filter((agent) => agent.visibility === "visible")
 }
 
+/**
+ * Apply and validate a workspace override patch for a code-backed built-in.
+ *
+ * This is the only supported path to merge `agent_config_overrides.patch` into built-in defaults: it
+ * validates the patch, merges with `base`, then re-parses the full config so invalid end states
+ * fail loudly.
+ */
 export function applyBuiltInAgentPatch(
   base: BuiltInAgentConfig,
   rawPatch: unknown,

--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -1,0 +1,126 @@
+import { z } from "zod"
+import { AgentToolNames } from "@threa/types"
+
+export const ARIADNE_AGENT_ID = "persona_system_ariadne"
+export const EMPTY_AGENT_ID = "persona_system_empty"
+
+const agentVisibilitySchema = z.enum(["visible", "internal"])
+const agentStatusSchema = z.enum(["active", "disabled", "archived"])
+
+export const builtInAgentConfigSchema = z.object({
+  id: z.string(),
+  workspaceId: z.null(),
+  slug: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  avatarEmoji: z.string().nullable(),
+  systemPrompt: z.string().min(1),
+  model: z.string().min(1),
+  temperature: z.number().nullable(),
+  maxTokens: z.number().int().positive().nullable(),
+  enabledTools: z.array(z.string()),
+  managedBy: z.literal("system"),
+  status: agentStatusSchema,
+  visibility: agentVisibilitySchema,
+})
+
+export const builtInAgentConfigPatchSchema = builtInAgentConfigSchema
+  .pick({
+    name: true,
+    description: true,
+    avatarEmoji: true,
+    systemPrompt: true,
+    model: true,
+    temperature: true,
+    maxTokens: true,
+    enabledTools: true,
+    status: true,
+  })
+  .partial()
+  .strict()
+
+export type BuiltInAgentConfig = z.infer<typeof builtInAgentConfigSchema>
+export type BuiltInAgentConfigPatch = z.infer<typeof builtInAgentConfigPatchSchema>
+
+export const BUILT_IN_AGENTS = {
+  [ARIADNE_AGENT_ID]: {
+    id: ARIADNE_AGENT_ID,
+    workspaceId: null,
+    slug: "ariadne",
+    name: "Ariadne",
+    description:
+      "Your AI thinking companion. Ariadne helps you explore ideas, make decisions, and remember what matters.",
+    avatarEmoji: ":thread:",
+    systemPrompt: `You are Ariadne, an AI thinking companion in Threa. You help users explore ideas, think through problems, and make decisions. You have access to their previous conversations and knowledge base through the GAM (General Agentic Memory) system.
+
+Keep responses short and direct. Default to a few sentences unless the user asks for depth. Be warm but not wordy — say what matters and stop. Ask clarifying questions rather than guessing at length.`,
+    model: "openrouter:anthropic/claude-sonnet-4.6",
+    temperature: 0.7,
+    maxTokens: null,
+    enabledTools: [
+      AgentToolNames.SEND_MESSAGE,
+      AgentToolNames.WEB_SEARCH,
+      AgentToolNames.READ_URL,
+      AgentToolNames.GITHUB_LIST_REPOS,
+      AgentToolNames.GITHUB_LIST_BRANCHES,
+      AgentToolNames.GITHUB_LIST_COMMITS,
+      AgentToolNames.GITHUB_GET_COMMIT,
+      AgentToolNames.GITHUB_LIST_PULL_REQUESTS,
+      AgentToolNames.GITHUB_GET_PULL_REQUEST,
+      AgentToolNames.GITHUB_LIST_PR_FILES,
+      AgentToolNames.GITHUB_GET_FILE_CONTENTS,
+      AgentToolNames.GITHUB_SEARCH_CODE,
+      AgentToolNames.GITHUB_LIST_WORKFLOW_RUNS,
+      AgentToolNames.GITHUB_GET_WORKFLOW_RUN,
+      AgentToolNames.GITHUB_LIST_RELEASES,
+      AgentToolNames.GITHUB_GET_RELEASE,
+      AgentToolNames.GITHUB_SEARCH_ISSUES,
+      AgentToolNames.GITHUB_GET_ISSUE,
+    ],
+    managedBy: "system",
+    status: "active",
+    visibility: "visible",
+  },
+  [EMPTY_AGENT_ID]: {
+    id: EMPTY_AGENT_ID,
+    workspaceId: null,
+    slug: "empty",
+    name: "Empty Agent",
+    description: "Locked-down internal agent shell.",
+    avatarEmoji: null,
+    systemPrompt: "You are a minimal Threa agent. Follow system instructions and do not use tools.",
+    model: "openrouter:anthropic/claude-haiku-4.5",
+    temperature: 0,
+    maxTokens: null,
+    enabledTools: [],
+    managedBy: "system",
+    status: "active",
+    visibility: "internal",
+  },
+} as const satisfies Record<string, BuiltInAgentConfig>
+
+const BUILT_IN_AGENT_CONFIGS: Record<string, BuiltInAgentConfig> = BUILT_IN_AGENTS
+
+export function getBuiltInAgentConfig(agentId: string): BuiltInAgentConfig | null {
+  return BUILT_IN_AGENT_CONFIGS[agentId] ?? null
+}
+
+export function listVisibleBuiltInAgentConfigs(): BuiltInAgentConfig[] {
+  return Object.values(BUILT_IN_AGENTS).filter((agent) => agent.visibility === "visible")
+}
+
+export function applyBuiltInAgentPatch(
+  base: BuiltInAgentConfig,
+  rawPatch: unknown,
+  context: { workspaceId: string; agentId: string }
+): BuiltInAgentConfig {
+  const patchResult = builtInAgentConfigPatchSchema.safeParse(rawPatch)
+  if (!patchResult.success) {
+    throw new Error(
+      `Invalid agent config override for ${context.agentId} in workspace ${context.workspaceId}: ${patchResult.error.message}`
+    )
+  }
+
+  const merged = { ...base, ...patchResult.data }
+  return builtInAgentConfigSchema.parse(merged)
+}

--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -153,11 +153,15 @@ export class CompanionHandler implements OutboxHandler {
           }
 
           let persona = companionSource.companionPersonaId
-            ? await PersonaRepository.findById(this.db, companionSource.companionPersonaId!, stream.workspaceId)
+            ? await PersonaRepository.findById(
+                this.db,
+                companionSource.companionPersonaId!,
+                companionSource.workspaceId
+              )
             : null
 
           if (!persona || persona.status !== "active") {
-            persona = await PersonaRepository.getSystemDefault(this.db, stream.workspaceId)
+            persona = await PersonaRepository.getSystemDefault(this.db, companionSource.workspaceId)
           }
 
           if (!persona) {

--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -153,11 +153,11 @@ export class CompanionHandler implements OutboxHandler {
           }
 
           let persona = companionSource.companionPersonaId
-            ? await PersonaRepository.findById(this.db, companionSource.companionPersonaId!)
+            ? await PersonaRepository.findById(this.db, companionSource.companionPersonaId!, stream.workspaceId)
             : null
 
           if (!persona || persona.status !== "active") {
-            persona = await PersonaRepository.getSystemDefault(this.db)
+            persona = await PersonaRepository.getSystemDefault(this.db, stream.workspaceId)
           }
 
           if (!persona) {

--- a/apps/backend/src/features/agents/companion/config.ts
+++ b/apps/backend/src/features/agents/companion/config.ts
@@ -4,7 +4,11 @@ import { BUILT_IN_AGENTS, ARIADNE_AGENT_ID } from "../built-in-agents"
 export const COMPANION_MODEL_ID = BUILT_IN_AGENTS[ARIADNE_AGENT_ID].model
 
 // Temperature for response generation
-export const COMPANION_TEMPERATURE = BUILT_IN_AGENTS[ARIADNE_AGENT_ID].temperature ?? 0.7
+const ariadneTemperature = BUILT_IN_AGENTS[ARIADNE_AGENT_ID].temperature
+if (ariadneTemperature == null) {
+  throw new Error("Built-in Ariadne configuration is missing temperature (expected a number).")
+}
+export const COMPANION_TEMPERATURE = ariadneTemperature
 
 // Model for rolling long-context summaries of dropped history
 export const COMPANION_SUMMARY_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"

--- a/apps/backend/src/features/agents/companion/config.ts
+++ b/apps/backend/src/features/agents/companion/config.ts
@@ -1,14 +1,10 @@
-/**
- * Companion Agent Configuration
- *
- * Production config for the companion agent (INV-44).
- */
+import { BUILT_IN_AGENTS, ARIADNE_AGENT_ID } from "../built-in-agents"
 
 // Default model for companion responses
-export const COMPANION_MODEL_ID = "openrouter:anthropic/claude-sonnet-4.5"
+export const COMPANION_MODEL_ID = BUILT_IN_AGENTS[ARIADNE_AGENT_ID].model
 
 // Temperature for response generation
-export const COMPANION_TEMPERATURE = 0.7
+export const COMPANION_TEMPERATURE = BUILT_IN_AGENTS[ARIADNE_AGENT_ID].temperature ?? 0.7
 
 // Model for rolling long-context summaries of dropped history
 export const COMPANION_SUMMARY_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -108,6 +108,19 @@ export type { OrphanSessionCleanup } from "./orphan-session-cleanup"
 // Repositories
 export { PersonaRepository } from "./persona-repository"
 export type { Persona } from "./persona-repository"
+export {
+  ARIADNE_AGENT_ID,
+  EMPTY_AGENT_ID,
+  BUILT_IN_AGENTS,
+  getBuiltInAgentConfig,
+  listVisibleBuiltInAgentConfigs,
+  applyBuiltInAgentPatch,
+  builtInAgentConfigPatchSchema,
+  builtInAgentConfigSchema,
+} from "./built-in-agents"
+export type { BuiltInAgentConfig, BuiltInAgentConfigPatch } from "./built-in-agents"
+export { AgentConfigOverrideRepository } from "./agent-config-override-repository"
+export type { AgentConfigOverride } from "./agent-config-override-repository"
 
 export { AgentSessionRepository, SessionStatuses } from "./session-repository"
 export type {

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -147,7 +147,7 @@ export class PersonaAgent {
 
     // Step 1: Load and validate persona + stream
     const precheck = await withClient(pool, async (client) => {
-      const persona = await PersonaRepository.findById(client, personaId)
+      const persona = await PersonaRepository.findById(client, personaId, workspaceId)
       if (!persona || persona.status !== "active") {
         return { skip: true as const, reason: "persona not found or inactive" }
       }
@@ -416,6 +416,8 @@ export class PersonaAgent {
           ),
           messages: agentContext.messages,
           tools,
+          maxTokens: persona.maxTokens,
+          temperature: persona.temperature,
           sendMessage: doSendMessage,
           allowNoMessageOutput: isSupersedeRerun,
           validateFinalResponse: isSupersedeRerun
@@ -505,7 +507,7 @@ export class PersonaAgent {
 
               const [members, personas] = await Promise.all([
                 userIds.length > 0 ? UserRepository.findByIds(db, workspaceId, userIds) : Promise.resolve([]),
-                personaIds.length > 0 ? PersonaRepository.findByIds(db, personaIds) : Promise.resolve([]),
+                personaIds.length > 0 ? PersonaRepository.findByIds(db, personaIds, workspaceId) : Promise.resolve([]),
               ])
 
               const names = new Map<string, string>()

--- a/apps/backend/src/features/agents/persona-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-repository.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test"
+import { AgentToolNames } from "@threa/types"
+import { ARIADNE_AGENT_ID, EMPTY_AGENT_ID } from "./built-in-agents"
+import { PersonaRepository } from "./persona-repository"
+
+function createDb(rowsByQuery: unknown[][]) {
+  return {
+    query: async () => ({ rows: rowsByQuery.shift() ?? [] }),
+  } as any
+}
+
+const workspacePersonaRow = {
+  id: "persona_workspace_helper",
+  workspace_id: "workspace_1",
+  slug: "helper",
+  name: "Helper",
+  description: "Workspace helper",
+  avatar_emoji: ":sparkles:",
+  system_prompt: "Help this workspace.",
+  model: "openrouter:anthropic/claude-haiku-4.5",
+  temperature: "0.2",
+  max_tokens: 1000,
+  enabled_tools: [AgentToolNames.READ_URL],
+  managed_by: "workspace",
+  status: "active",
+  created_at: new Date("2026-01-01T00:00:00Z"),
+  updated_at: new Date("2026-01-01T00:00:00Z"),
+}
+
+describe("PersonaRepository built-in agent config", () => {
+  test("resolves Ariadne from code without requiring a personas row", async () => {
+    const persona = await PersonaRepository.findById(createDb([]), ARIADNE_AGENT_ID)
+
+    expect(persona).toMatchObject({
+      id: ARIADNE_AGENT_ID,
+      slug: "ariadne",
+      name: "Ariadne",
+      model: "openrouter:anthropic/claude-sonnet-4.6",
+      managedBy: "system",
+      status: "active",
+    })
+    expect(persona?.systemPrompt).toContain("You are Ariadne")
+    expect(persona?.enabledTools).toContain(AgentToolNames.GITHUB_GET_PULL_REQUEST)
+  })
+
+  test("applies workspace override patches to built-ins", async () => {
+    const db = createDb([
+      [
+        {
+          agent_id: ARIADNE_AGENT_ID,
+          patch: {
+            model: "openrouter:anthropic/claude-haiku-4.5",
+            enabledTools: [AgentToolNames.READ_URL],
+          },
+        },
+      ],
+    ])
+
+    const persona = await PersonaRepository.findById(db, ARIADNE_AGENT_ID, "workspace_1")
+
+    expect(persona?.model).toBe("openrouter:anthropic/claude-haiku-4.5")
+    expect(persona?.enabledTools).toEqual([AgentToolNames.READ_URL])
+  })
+
+  test("rejects invalid workspace override patches", async () => {
+    const db = createDb([
+      [
+        {
+          agent_id: ARIADNE_AGENT_ID,
+          patch: { model: "" },
+        },
+      ],
+    ])
+
+    await expect(PersonaRepository.findById(db, ARIADNE_AGENT_ID, "workspace_1")).rejects.toThrow(
+      "Invalid agent config override"
+    )
+  })
+
+  test("does not return Ariadne as default when a workspace disables it", async () => {
+    const db = createDb([
+      [
+        {
+          agent_id: ARIADNE_AGENT_ID,
+          patch: { status: "disabled" },
+        },
+      ],
+    ])
+
+    const persona = await PersonaRepository.getSystemDefault(db, "workspace_1")
+
+    expect(persona).toBeNull()
+  })
+
+  test("lists visible built-ins and workspace personas but not internal built-ins", async () => {
+    const personas = await PersonaRepository.listForWorkspace(createDb([[], [workspacePersonaRow]]), "workspace_1")
+
+    expect(personas.map((persona) => persona.id)).toEqual([ARIADNE_AGENT_ID, "persona_workspace_helper"])
+    expect(personas.some((persona) => persona.id === EMPTY_AGENT_ID)).toBe(false)
+    expect(personas[1]).toMatchObject({
+      workspaceId: "workspace_1",
+      managedBy: "workspace",
+      systemPrompt: "Help this workspace.",
+    })
+  })
+})

--- a/apps/backend/src/features/agents/persona-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-repository.test.ts
@@ -104,10 +104,9 @@ describe("PersonaRepository built-in agent config", () => {
     await PersonaRepository.findById(db, "persona_workspace_helper", "workspace_1")
 
     const query = db.queries[0] as { text: string; values: unknown[] }
-    const nested = query.values[1] as { text: string; values: unknown[] }
-    expect(nested.text).toContain("workspace_id = $1")
-    expect(nested.text).toContain("workspace_id IS NULL")
-    expect(nested.values).toEqual(["workspace_1"])
+    expect(query.text).toContain("workspace_id = $2")
+    expect(query.text).toContain("workspace_id IS NULL")
+    expect(query.values).toEqual(["persona_workspace_helper", "workspace_1"])
   })
 
   test("does not return Ariadne as default when a workspace disables it", async () => {

--- a/apps/backend/src/features/agents/persona-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-repository.test.ts
@@ -4,8 +4,13 @@ import { ARIADNE_AGENT_ID, EMPTY_AGENT_ID } from "./built-in-agents"
 import { PersonaRepository } from "./persona-repository"
 
 function createDb(rowsByQuery: unknown[][]) {
+  const queries: unknown[] = []
   return {
-    query: async () => ({ rows: rowsByQuery.shift() ?? [] }),
+    queries,
+    query: async (query: unknown) => {
+      queries.push(query)
+      return { rows: rowsByQuery.shift() ?? [] }
+    },
   } as any
 }
 
@@ -41,6 +46,7 @@ describe("PersonaRepository built-in agent config", () => {
     })
     expect(persona?.systemPrompt).toContain("You are Ariadne")
     expect(persona?.enabledTools).toContain(AgentToolNames.GITHUB_GET_PULL_REQUEST)
+    expect(persona?.createdAt.toISOString()).toBe("2026-04-25T00:00:00.000Z")
   })
 
   test("applies workspace override patches to built-ins", async () => {
@@ -90,6 +96,28 @@ describe("PersonaRepository built-in agent config", () => {
     const persona = await PersonaRepository.getSystemDefault(db, "workspace_1")
 
     expect(persona).toBeNull()
+  })
+
+  test("batch-resolves built-in overrides in findByIds", async () => {
+    const db = createDb([
+      [
+        {
+          agent_id: ARIADNE_AGENT_ID,
+          patch: { model: "openrouter:anthropic/claude-haiku-4.5" },
+        },
+      ],
+      [workspacePersonaRow],
+    ])
+
+    const personas = await PersonaRepository.findByIds(
+      db,
+      [ARIADNE_AGENT_ID, "persona_workspace_helper"],
+      "workspace_1"
+    )
+
+    expect(personas.map((persona) => persona.id)).toEqual([ARIADNE_AGENT_ID, "persona_workspace_helper"])
+    expect(personas[0].model).toBe("openrouter:anthropic/claude-haiku-4.5")
+    expect(db.queries).toHaveLength(2)
   })
 
   test("lists visible built-ins and workspace personas but not internal built-ins", async () => {

--- a/apps/backend/src/features/agents/persona-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-repository.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { AgentToolNames } from "@threa/types"
 import { ARIADNE_AGENT_ID, EMPTY_AGENT_ID } from "./built-in-agents"
-import { PersonaRepository } from "./persona-repository"
+import { BUILT_IN_AGENT_CONFIG_TIMESTAMP, PersonaRepository } from "./persona-repository"
 
 function createDb(rowsByQuery: unknown[][]) {
   const queries: unknown[] = []
@@ -46,7 +46,7 @@ describe("PersonaRepository built-in agent config", () => {
     })
     expect(persona?.systemPrompt).toContain("You are Ariadne")
     expect(persona?.enabledTools).toContain(AgentToolNames.GITHUB_GET_PULL_REQUEST)
-    expect(persona?.createdAt.toISOString()).toBe("2026-04-25T00:00:00.000Z")
+    expect(persona?.createdAt.toISOString()).toBe(BUILT_IN_AGENT_CONFIG_TIMESTAMP.toISOString())
   })
 
   test("applies workspace override patches to built-ins", async () => {
@@ -81,6 +81,33 @@ describe("PersonaRepository built-in agent config", () => {
     await expect(PersonaRepository.findById(db, ARIADNE_AGENT_ID, "workspace_1")).rejects.toThrow(
       "Invalid agent config override"
     )
+  })
+
+  test("rejects workspace override patches with unknown tool names", async () => {
+    const db = createDb([
+      [
+        {
+          agent_id: ARIADNE_AGENT_ID,
+          patch: { enabledTools: ["not_a_real_tool"] },
+        },
+      ],
+    ])
+
+    await expect(PersonaRepository.findById(db, ARIADNE_AGENT_ID, "workspace_1")).rejects.toThrow(
+      "Invalid agent config override"
+    )
+  })
+
+  test("scopes DB persona reads to the caller workspace (and global system rows) when workspaceId is provided", async () => {
+    const db = createDb([[]])
+
+    await PersonaRepository.findById(db, "persona_workspace_helper", "workspace_1")
+
+    const query = db.queries[0] as { text: string; values: unknown[] }
+    const nested = query.values[1] as { text: string; values: unknown[] }
+    expect(nested.text).toContain("workspace_id = $1")
+    expect(nested.text).toContain("workspace_id IS NULL")
+    expect(nested.values).toEqual(["workspace_1"])
   })
 
   test("does not return Ariadne as default when a workspace disables it", async () => {

--- a/apps/backend/src/features/agents/persona-repository.ts
+++ b/apps/backend/src/features/agents/persona-repository.ts
@@ -67,7 +67,15 @@ function mapRowToPersona(row: PersonaRow): Persona {
   }
 }
 
-const BUILT_IN_AGENT_CONFIG_TIMESTAMP = new Date("2026-04-25T00:00:00.000Z")
+export const BUILT_IN_AGENT_CONFIG_TIMESTAMP = new Date("2026-04-25T00:00:00.000Z")
+
+function dbPersonaWorkspaceFilter(workspaceId: string | null | undefined) {
+  if (workspaceId === null || workspaceId === undefined) return sql``
+
+  // INV-8: when a caller scopes to a workspace, only return that workspace's rows or global system
+  // rows (`workspace_id IS NULL`), never another workspace's persona by id.
+  return sql`AND (workspace_id = ${workspaceId} OR workspace_id IS NULL)`
+}
 
 function mapBuiltInToPersona(agent: BuiltInAgentConfig): Persona {
   return {
@@ -130,6 +138,7 @@ export const PersonaRepository = {
         SELECT ${sql.raw(SELECT_FIELDS)}
         FROM personas
         WHERE id = ${id}
+          ${dbPersonaWorkspaceFilter(workspaceId)}
       `
     )
     return result.rows[0] ? mapRowToPersona(result.rows[0]) : null
@@ -159,6 +168,7 @@ export const PersonaRepository = {
         SELECT ${sql.raw(SELECT_FIELDS)}
         FROM personas
         WHERE id = ANY(${dbIds})
+          ${dbPersonaWorkspaceFilter(workspaceId)}
       `
     )
     return [...builtIns, ...result.rows.map(mapRowToPersona)]

--- a/apps/backend/src/features/agents/persona-repository.ts
+++ b/apps/backend/src/features/agents/persona-repository.ts
@@ -1,5 +1,13 @@
 import type { Querier } from "../../db"
 import { sql } from "../../db"
+import { AgentConfigOverrideRepository } from "./agent-config-override-repository"
+import {
+  ARIADNE_AGENT_ID,
+  applyBuiltInAgentPatch,
+  getBuiltInAgentConfig,
+  listVisibleBuiltInAgentConfigs,
+  type BuiltInAgentConfig,
+} from "./built-in-agents"
 
 // Internal row type (snake_case)
 interface PersonaRow {
@@ -49,7 +57,7 @@ function mapRowToPersona(row: PersonaRow): Persona {
     avatarEmoji: row.avatar_emoji,
     systemPrompt: row.system_prompt,
     model: row.model,
-    temperature: row.temperature ? Number(row.temperature) : null,
+    temperature: row.temperature === null ? null : Number(row.temperature),
     maxTokens: row.max_tokens,
     enabledTools: row.enabled_tools,
     managedBy: row.managed_by as "system" | "workspace",
@@ -59,6 +67,41 @@ function mapRowToPersona(row: PersonaRow): Persona {
   }
 }
 
+function mapBuiltInToPersona(agent: BuiltInAgentConfig): Persona {
+  return {
+    id: agent.id,
+    workspaceId: agent.workspaceId,
+    slug: agent.slug,
+    name: agent.name,
+    description: agent.description,
+    avatarEmoji: agent.avatarEmoji,
+    systemPrompt: agent.systemPrompt,
+    model: agent.model,
+    temperature: agent.temperature,
+    maxTokens: agent.maxTokens,
+    enabledTools: agent.enabledTools,
+    managedBy: agent.managedBy,
+    status: agent.status,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }
+}
+
+async function resolveBuiltInPersona(
+  db: Querier,
+  agentId: string,
+  workspaceId?: string | null
+): Promise<Persona | null> {
+  const base = getBuiltInAgentConfig(agentId)
+  if (!base) return null
+
+  if (!workspaceId) return mapBuiltInToPersona(base)
+
+  const override = await AgentConfigOverrideRepository.findActiveByWorkspaceAndAgent(db, workspaceId, agentId)
+  const resolved = override ? applyBuiltInAgentPatch(base, override.patch, { workspaceId, agentId }) : base
+  return mapBuiltInToPersona(resolved)
+}
+
 const SELECT_FIELDS = `
   id, workspace_id, slug, name, description, avatar_emoji,
   system_prompt, model, temperature, max_tokens, enabled_tools,
@@ -66,7 +109,10 @@ const SELECT_FIELDS = `
 `
 
 export const PersonaRepository = {
-  async findById(db: Querier, id: string): Promise<Persona | null> {
+  async findById(db: Querier, id: string, workspaceId?: string | null): Promise<Persona | null> {
+    const builtIn = await resolveBuiltInPersona(db, id, workspaceId)
+    if (builtIn) return builtIn
+
     const result = await db.query<PersonaRow>(
       sql`
         SELECT ${sql.raw(SELECT_FIELDS)}
@@ -77,22 +123,35 @@ export const PersonaRepository = {
     return result.rows[0] ? mapRowToPersona(result.rows[0]) : null
   },
 
-  async findByIds(db: Querier, ids: string[]): Promise<Persona[]> {
+  async findByIds(db: Querier, ids: string[], workspaceId?: string | null): Promise<Persona[]> {
     if (ids.length === 0) return []
+
+    const builtIns = (await Promise.all(ids.map((id) => resolveBuiltInPersona(db, id, workspaceId)))).filter(
+      (persona): persona is Persona => persona !== null
+    )
+    const dbIds = ids.filter((id) => !getBuiltInAgentConfig(id))
+
+    if (dbIds.length === 0) return builtIns
 
     const result = await db.query<PersonaRow>(
       sql`
         SELECT ${sql.raw(SELECT_FIELDS)}
         FROM personas
-        WHERE id = ANY(${ids})
+        WHERE id = ANY(${dbIds})
       `
     )
-    return result.rows.map(mapRowToPersona)
+    return [...builtIns, ...result.rows.map(mapRowToPersona)]
   },
 
   async findBySlug(db: Querier, slug: string, workspaceId?: string | null): Promise<Persona | null> {
+    const builtInBySlug = listVisibleBuiltInAgentConfigs().find((agent) => agent.slug === slug)
+
     // System personas have null workspace_id
     if (workspaceId === null || workspaceId === undefined) {
+      if (builtInBySlug) {
+        return resolveBuiltInPersona(db, builtInBySlug.id)
+      }
+
       const result = await db.query<PersonaRow>(
         sql`
           SELECT ${sql.raw(SELECT_FIELDS)}
@@ -104,47 +163,64 @@ export const PersonaRepository = {
     }
 
     // Look for workspace-specific first, fall back to system
-    const result = await db.query<PersonaRow>(
+    const workspaceResult = await db.query<PersonaRow>(
       sql`
         SELECT ${sql.raw(SELECT_FIELDS)}
         FROM personas
-        WHERE slug = ${slug} AND (workspace_id = ${workspaceId} OR workspace_id IS NULL)
-        ORDER BY workspace_id NULLS LAST
+        WHERE slug = ${slug} AND workspace_id = ${workspaceId}
+          AND status = 'active'
         LIMIT 1
       `
     )
-    return result.rows[0] ? mapRowToPersona(result.rows[0]) : null
+    if (workspaceResult.rows[0]) return mapRowToPersona(workspaceResult.rows[0])
+
+    if (builtInBySlug) {
+      return resolveBuiltInPersona(db, builtInBySlug.id, workspaceId)
+    }
+
+    const systemResult = await db.query<PersonaRow>(
+      sql`
+        SELECT ${sql.raw(SELECT_FIELDS)}
+        FROM personas
+        WHERE slug = ${slug} AND workspace_id IS NULL
+          AND status = 'active'
+        LIMIT 1
+      `
+    )
+    return systemResult.rows[0] ? mapRowToPersona(systemResult.rows[0]) : null
   },
 
   /**
    * Get the default system persona (Ariadne).
    */
-  async getSystemDefault(db: Querier): Promise<Persona | null> {
-    const result = await db.query<PersonaRow>(
-      sql`
-        SELECT ${sql.raw(SELECT_FIELDS)}
-        FROM personas
-        WHERE managed_by = 'system' AND status = 'active'
-        ORDER BY created_at ASC
-        LIMIT 1
-      `
-    )
-    return result.rows[0] ? mapRowToPersona(result.rows[0]) : null
+  async getSystemDefault(db: Querier, workspaceId?: string | null): Promise<Persona | null> {
+    const persona = await resolveBuiltInPersona(db, ARIADNE_AGENT_ID, workspaceId)
+    return persona?.status === "active" ? persona : null
   },
 
   /**
    * List all personas available to a workspace (system + workspace-specific).
    */
   async listForWorkspace(db: Querier, workspaceId: string): Promise<Persona[]> {
+    const overrides = await AgentConfigOverrideRepository.listActiveByWorkspace(db, workspaceId)
+    const overridesByAgentId = new Map(overrides.map((override) => [override.agentId, override.patch]))
+    const builtIns = listVisibleBuiltInAgentConfigs()
+      .map((agent) => {
+        const patch = overridesByAgentId.get(agent.id)
+        return patch ? applyBuiltInAgentPatch(agent, patch, { workspaceId, agentId: agent.id }) : agent
+      })
+      .filter((agent) => agent.status === "active")
+      .map(mapBuiltInToPersona)
+
     const result = await db.query<PersonaRow>(
       sql`
         SELECT ${sql.raw(SELECT_FIELDS)}
         FROM personas
-        WHERE (workspace_id = ${workspaceId} OR workspace_id IS NULL)
+        WHERE workspace_id = ${workspaceId}
           AND status = 'active'
         ORDER BY managed_by ASC, name ASC
       `
     )
-    return result.rows.map(mapRowToPersona)
+    return [...builtIns, ...result.rows.map(mapRowToPersona)]
   },
 }

--- a/apps/backend/src/features/agents/persona-repository.ts
+++ b/apps/backend/src/features/agents/persona-repository.ts
@@ -69,13 +69,11 @@ function mapRowToPersona(row: PersonaRow): Persona {
 
 export const BUILT_IN_AGENT_CONFIG_TIMESTAMP = new Date("2026-04-25T00:00:00.000Z")
 
-function dbPersonaWorkspaceFilter(workspaceId: string | null | undefined) {
-  if (workspaceId === null || workspaceId === undefined) return sql``
-
-  // INV-8: when a caller scopes to a workspace, only return that workspace's rows or global system
-  // rows (`workspace_id IS NULL`), never another workspace's persona by id.
-  return sql`AND (workspace_id = ${workspaceId} OR workspace_id IS NULL)`
-}
+// Do not return a nested `sql`...`` fragment from a helper and embed it in another
+// `sql` template: squid 0.5 flattens placeholders incorrectly (sub-fragment object in
+// `values`), which yields invalid SQL ("syntax error at or near $2"). Inline the
+// optional workspace filter in each query (INV-8: scoped reads see only the caller
+// workspace or global system rows).
 
 function mapBuiltInToPersona(agent: BuiltInAgentConfig): Persona {
   return {
@@ -134,12 +132,18 @@ export const PersonaRepository = {
     if (builtIn) return builtIn
 
     const result = await db.query<PersonaRow>(
-      sql`
-        SELECT ${sql.raw(SELECT_FIELDS)}
-        FROM personas
-        WHERE id = ${id}
-          ${dbPersonaWorkspaceFilter(workspaceId)}
-      `
+      workspaceId == null
+        ? sql`
+            SELECT ${sql.raw(SELECT_FIELDS)}
+            FROM personas
+            WHERE id = ${id}
+          `
+        : sql`
+            SELECT ${sql.raw(SELECT_FIELDS)}
+            FROM personas
+            WHERE id = ${id}
+              AND (workspace_id = ${workspaceId} OR workspace_id IS NULL)
+          `
     )
     return result.rows[0] ? mapRowToPersona(result.rows[0]) : null
   },
@@ -164,12 +168,18 @@ export const PersonaRepository = {
     if (dbIds.length === 0) return builtIns
 
     const result = await db.query<PersonaRow>(
-      sql`
-        SELECT ${sql.raw(SELECT_FIELDS)}
-        FROM personas
-        WHERE id = ANY(${dbIds})
-          ${dbPersonaWorkspaceFilter(workspaceId)}
-      `
+      workspaceId == null
+        ? sql`
+            SELECT ${sql.raw(SELECT_FIELDS)}
+            FROM personas
+            WHERE id = ANY(${dbIds})
+          `
+        : sql`
+            SELECT ${sql.raw(SELECT_FIELDS)}
+            FROM personas
+            WHERE id = ANY(${dbIds})
+              AND (workspace_id = ${workspaceId} OR workspace_id IS NULL)
+          `
     )
     return [...builtIns, ...result.rows.map(mapRowToPersona)]
   },

--- a/apps/backend/src/features/agents/persona-repository.ts
+++ b/apps/backend/src/features/agents/persona-repository.ts
@@ -67,6 +67,8 @@ function mapRowToPersona(row: PersonaRow): Persona {
   }
 }
 
+const BUILT_IN_AGENT_CONFIG_TIMESTAMP = new Date("2026-04-25T00:00:00.000Z")
+
 function mapBuiltInToPersona(agent: BuiltInAgentConfig): Persona {
   return {
     id: agent.id,
@@ -82,8 +84,8 @@ function mapBuiltInToPersona(agent: BuiltInAgentConfig): Persona {
     enabledTools: agent.enabledTools,
     managedBy: agent.managedBy,
     status: agent.status,
-    createdAt: new Date(0),
-    updatedAt: new Date(0),
+    createdAt: BUILT_IN_AGENT_CONFIG_TIMESTAMP,
+    updatedAt: BUILT_IN_AGENT_CONFIG_TIMESTAMP,
   }
 }
 
@@ -99,6 +101,16 @@ async function resolveBuiltInPersona(
 
   const override = await AgentConfigOverrideRepository.findActiveByWorkspaceAndAgent(db, workspaceId, agentId)
   const resolved = override ? applyBuiltInAgentPatch(base, override.patch, { workspaceId, agentId }) : base
+  return mapBuiltInToPersona(resolved)
+}
+
+function resolveBuiltInPersonaWithOverrides(
+  base: BuiltInAgentConfig,
+  overridesByAgentId: Map<string, unknown>,
+  workspaceId: string
+): Persona {
+  const patch = overridesByAgentId.get(base.id)
+  const resolved = patch ? applyBuiltInAgentPatch(base, patch, { workspaceId, agentId: base.id }) : base
   return mapBuiltInToPersona(resolved)
 }
 
@@ -126,10 +138,19 @@ export const PersonaRepository = {
   async findByIds(db: Querier, ids: string[], workspaceId?: string | null): Promise<Persona[]> {
     if (ids.length === 0) return []
 
-    const builtIns = (await Promise.all(ids.map((id) => resolveBuiltInPersona(db, id, workspaceId)))).filter(
-      (persona): persona is Persona => persona !== null
-    )
+    const builtInConfigs = ids.map(getBuiltInAgentConfig).filter((agent): agent is BuiltInAgentConfig => agent !== null)
     const dbIds = ids.filter((id) => !getBuiltInAgentConfig(id))
+    let builtIns: Persona[]
+
+    if (workspaceId && builtInConfigs.length > 0) {
+      const overrides = await AgentConfigOverrideRepository.listActiveByWorkspace(db, workspaceId)
+      const overridesByAgentId = new Map(overrides.map((override) => [override.agentId, override.patch]))
+      builtIns = builtInConfigs.map((agent) =>
+        resolveBuiltInPersonaWithOverrides(agent, overridesByAgentId, workspaceId)
+      )
+    } else {
+      builtIns = builtInConfigs.map(mapBuiltInToPersona)
+    }
 
     if (dbIds.length === 0) return builtIns
 
@@ -205,12 +226,8 @@ export const PersonaRepository = {
     const overrides = await AgentConfigOverrideRepository.listActiveByWorkspace(db, workspaceId)
     const overridesByAgentId = new Map(overrides.map((override) => [override.agentId, override.patch]))
     const builtIns = listVisibleBuiltInAgentConfigs()
-      .map((agent) => {
-        const patch = overridesByAgentId.get(agent.id)
-        return patch ? applyBuiltInAgentPatch(agent, patch, { workspaceId, agentId: agent.id }) : agent
-      })
-      .filter((agent) => agent.status === "active")
-      .map(mapBuiltInToPersona)
+      .map((agent) => resolveBuiltInPersonaWithOverrides(agent, overridesByAgentId, workspaceId))
+      .filter((persona) => persona.status === "active")
 
     const result = await db.query<PersonaRow>(
       sql`

--- a/apps/backend/src/features/agents/quote-resolver.ts
+++ b/apps/backend/src/features/agents/quote-resolver.ts
@@ -258,7 +258,7 @@ async function resolveAuthorNamesForMessages(
 
   const [users, personas] = await Promise.all([
     userIds.size > 0 ? UserRepository.findByIds(db, workspaceId, [...userIds]) : Promise.resolve([]),
-    personaIds.size > 0 ? PersonaRepository.findByIds(db, [...personaIds]) : Promise.resolve([]),
+    personaIds.size > 0 ? PersonaRepository.findByIds(db, [...personaIds], workspaceId) : Promise.resolve([]),
   ])
 
   const names = new Map<string, string>()

--- a/apps/backend/src/features/agents/researcher/context-formatter.ts
+++ b/apps/backend/src/features/agents/researcher/context-formatter.ts
@@ -178,7 +178,7 @@ export async function enrichMessageSearchResults(
   // Batch fetch users, personas, streams
   const [members, personas, streams] = await Promise.all([
     userIds.size > 0 ? UserRepository.findByIds(db, workspaceId, [...userIds]) : Promise.resolve([]),
-    personaIds.size > 0 ? PersonaRepository.findByIds(db, [...personaIds]) : Promise.resolve([]),
+    personaIds.size > 0 ? PersonaRepository.findByIds(db, [...personaIds], workspaceId) : Promise.resolve([]),
     StreamRepository.findByIds(db, [...streamIds]),
   ])
 

--- a/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
@@ -135,23 +135,42 @@ describe("AgentRuntime message counting", () => {
     expect(events.some((event) => event.type === "response:kept")).toBe(true)
   })
 
-  it("forwards modelString and costContext to generateTextWithTools so usage is recorded", async () => {
-    const captured: Array<{ modelString?: string; context?: Record<string, unknown> }> = []
-    const generateTextWithTools = mock(async (opts: { modelString?: string; context?: Record<string, unknown> }) => {
-      captured.push({ modelString: opts.modelString, context: opts.context })
-      return {
-        text: "All done.",
-        toolCalls: [],
-        response: {
-          messages: [{ role: "assistant", content: "All done." } as any],
-        },
+  it("forwards model config and cost context to generateTextWithTools", async () => {
+    const captured: Array<{
+      modelString?: string
+      context?: Record<string, unknown>
+      maxTokens?: number
+      temperature?: number
+    }> = []
+    const generateTextWithTools = mock(
+      async (opts: {
+        modelString?: string
+        context?: Record<string, unknown>
+        maxTokens?: number
+        temperature?: number
+      }) => {
+        captured.push({
+          modelString: opts.modelString,
+          context: opts.context,
+          maxTokens: opts.maxTokens,
+          temperature: opts.temperature,
+        })
+        return {
+          text: "All done.",
+          toolCalls: [],
+          response: {
+            messages: [{ role: "assistant", content: "All done." } as any],
+          },
+        }
       }
-    })
+    )
 
     const runtime = new AgentRuntime({
       ai: { generateTextWithTools } as any,
       model: {} as any,
       modelString: "openrouter:anthropic/claude-haiku-4.5",
+      maxTokens: 500,
+      temperature: 0.2,
       costContext: {
         workspaceId: "ws_abc",
         userId: "user_xyz",
@@ -170,6 +189,8 @@ describe("AgentRuntime message counting", () => {
     expect(captured).toHaveLength(1)
     expect(captured[0]).toEqual({
       modelString: "openrouter:anthropic/claude-haiku-4.5",
+      maxTokens: 500,
+      temperature: 0.2,
       context: {
         workspaceId: "ws_abc",
         userId: "user_xyz",

--- a/apps/backend/src/features/agents/runtime/agent-runtime.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.ts
@@ -43,6 +43,8 @@ export interface AgentRuntimeConfig {
   systemPrompt: string
   messages: ModelMessage[]
   tools: AgentTool[]
+  maxTokens?: number | null
+  temperature?: number | null
   maxIterations?: number
   observers?: AgentObserver[]
   telemetry?: { functionId: string; metadata?: Record<string, string | number | boolean> }
@@ -235,6 +237,8 @@ export class AgentRuntime {
           system: fullSystemPrompt,
           messages: truncatedMessages,
           tools: this.toolDefs,
+          maxTokens: this.config.maxTokens ?? undefined,
+          temperature: this.config.temperature ?? undefined,
           telemetry: this.config.telemetry,
           context: this.config.costContext,
         })

--- a/apps/backend/src/features/agents/session-handlers.ts
+++ b/apps/backend/src/features/agents/session-handlers.ts
@@ -33,7 +33,7 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
         const [stream, membership, persona, steps] = await Promise.all([
           StreamRepository.findById(db, session.streamId),
           StreamMemberRepository.findByStreamAndMember(db, session.streamId, userId),
-          PersonaRepository.findById(db, session.personaId),
+          PersonaRepository.findById(db, session.personaId, workspaceId),
           AgentSessionRepository.findStepsBySession(db, sessionId),
         ])
 

--- a/apps/backend/src/features/agents/tools/search-workspace-tool.ts
+++ b/apps/backend/src/features/agents/tools/search-workspace-tool.ts
@@ -441,7 +441,7 @@ You can reference streams by their ID (stream_xxx), slug (general), or prefixed 
         const personaIds = [...new Set(messages.filter((m) => m.authorType === "persona").map((m) => m.authorId))]
         const [members, personas] = await Promise.all([
           userIds.length > 0 ? UserRepository.findByIds(db, workspaceId, userIds) : Promise.resolve([]),
-          personaIds.length > 0 ? PersonaRepository.findByIds(db, personaIds) : Promise.resolve([]),
+          personaIds.length > 0 ? PersonaRepository.findByIds(db, personaIds, workspaceId) : Promise.resolve([]),
         ])
 
         const memberMap = new Map(members.map((m) => [m.id, m.name]))

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -238,7 +238,7 @@ export class MemoExplorerService {
 
     const [members, personas, streams] = await Promise.all([
       userIds.size > 0 ? UserRepository.findByIds(this.pool, workspaceId, [...userIds]) : Promise.resolve([]),
-      personaIds.size > 0 ? PersonaRepository.findByIds(this.pool, [...personaIds]) : Promise.resolve([]),
+      personaIds.size > 0 ? PersonaRepository.findByIds(this.pool, [...personaIds], workspaceId) : Promise.resolve([]),
       StreamRepository.findByIds(this.pool, [...streamIds]),
     ])
 

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -1,3 +1,14 @@
+// Metadata (export before heavier modules so barrels can import schemas without TDZ cycles)
+export {
+  messageMetadataSchema,
+  messageMetadataFilterSchema,
+  MESSAGE_METADATA_MAX_KEYS,
+  MESSAGE_METADATA_MAX_KEY_LENGTH,
+  MESSAGE_METADATA_MAX_VALUE_LENGTH,
+  MESSAGE_METADATA_MAX_SERIALIZED_BYTES,
+  MESSAGE_METADATA_RESERVED_PREFIX,
+} from "./metadata-schema"
+
 // Repository
 export { MessageRepository } from "./repository"
 export type { Message, InsertMessageParams } from "./repository"
@@ -25,17 +36,6 @@ export type {
 // Handlers
 export { createMessageHandlers } from "./handlers"
 export { createMessageSchema, updateMessageSchema, addReactionSchema } from "./handlers"
-
-// Metadata
-export {
-  messageMetadataSchema,
-  messageMetadataFilterSchema,
-  MESSAGE_METADATA_MAX_KEYS,
-  MESSAGE_METADATA_MAX_KEY_LENGTH,
-  MESSAGE_METADATA_MAX_VALUE_LENGTH,
-  MESSAGE_METADATA_MAX_SERIALIZED_BYTES,
-  MESSAGE_METADATA_RESERVED_PREFIX,
-} from "./metadata-schema"
 
 // Sharing sub-feature
 export {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -284,7 +284,7 @@ async function resolveAuthorDisplayNames(
   }
   if (byType.persona.size > 0) {
     fetches.push(
-      PersonaRepository.findByIds(pool, [...byType.persona]).then((personas) => {
+      PersonaRepository.findByIds(pool, [...byType.persona], workspaceId).then((personas) => {
         for (const p of personas) nameMap.set(p.id, p.name)
       })
     )

--- a/apps/backend/src/lib/ai/ai.ts
+++ b/apps/backend/src/lib/ai/ai.ts
@@ -195,6 +195,8 @@ export interface GenerateTextWithToolsOptions {
   system?: string
   messages: ModelMessage[]
   tools?: Record<string, Tool<any, any>>
+  maxTokens?: number
+  temperature?: number
   telemetry?: TelemetryConfig
   /** When provided with `modelString`, usage will be recorded to the database */
   context?: CostContext
@@ -785,6 +787,8 @@ export function createAI(config: AIConfig): AI {
         system: options.system,
         messages: options.messages,
         tools: options.tools,
+        maxOutputTokens: options.maxTokens,
+        temperature: options.temperature,
         abortSignal: options.abortSignal,
         // @ts-expect-error AI SDK telemetry types are stricter than needed; our TelemetryConfig output is compatible at runtime
         experimental_telemetry: options.telemetry

--- a/apps/backend/src/lib/ai/config-resolver.test.ts
+++ b/apps/backend/src/lib/ai/config-resolver.test.ts
@@ -24,7 +24,7 @@ describe("StaticConfigResolver", () => {
     expect(memoMemorizerConfig.temperature).toBe(0.3)
 
     const companionConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_AGENT)
-    expect(companionConfig.modelId).toBe("openrouter:anthropic/claude-sonnet-4.5")
+    expect(companionConfig.modelId).toBe("openrouter:anthropic/claude-sonnet-4.6")
     expect(companionConfig.temperature).toBe(0.7)
 
     const researcherConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_RESEARCHER)

--- a/apps/backend/src/lib/ai/message-formatter.test.ts
+++ b/apps/backend/src/lib/ai/message-formatter.test.ts
@@ -130,7 +130,7 @@ describe("MessageFormatter", () => {
 
     // Verify batch efficiency: only 1 call per author type despite 3 messages
     expect(mockFindUsersByIds).toHaveBeenCalledWith(mockClient, "ws_test", ["usr_123"])
-    expect(mockFindPersonasByIds).toHaveBeenCalledWith(mockClient, ["persona_456"])
+    expect(mockFindPersonasByIds).toHaveBeenCalledWith(mockClient, ["persona_456"], "ws_test")
 
     expect(result).toBe(
       "<messages>\n" +

--- a/apps/backend/src/lib/ai/message-formatter.ts
+++ b/apps/backend/src/lib/ai/message-formatter.ts
@@ -59,7 +59,7 @@ export class MessageFormatter {
 
     const [users, personas] = await Promise.all([
       UserRepository.findByIds(client, workspaceId, [...userIds]),
-      PersonaRepository.findByIds(client, [...personaIds]),
+      PersonaRepository.findByIds(client, [...personaIds], workspaceId),
     ])
 
     const nameById = new Map<string, string>()

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -437,7 +437,7 @@ async function emitRunningSessionBootstrap(
 
   const [steps, persona] = await Promise.all([
     AgentSessionRepository.findStepsBySession(pool, session.id),
-    PersonaRepository.findById(pool, session.personaId),
+    PersonaRepository.findById(pool, session.personaId, wsId),
   ])
 
   const stepCount = steps.length

--- a/apps/backend/tests/e2e/companion.test.ts
+++ b/apps/backend/tests/e2e/companion.test.ts
@@ -10,8 +10,9 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, setDefaultTimeout } from "bun:test"
 
-// Companion jobs run asynchronously, need longer timeout
-setDefaultTimeout(30000)
+// Companion jobs are queued; full e2e runs many files and can delay persona.agent.
+// Must exceed waitForCompanionResponse (60s) plus setup or Bun kills the test first.
+setDefaultTimeout(120_000)
 import { io, Socket } from "socket.io-client"
 import {
   TestClient,
@@ -87,7 +88,7 @@ function waitForEvent<T = unknown>(socket: Socket, eventName: string, timeoutMs:
 function waitForCompanionResponse(
   socket: Socket,
   streamId: string,
-  timeoutMs: number = 20000
+  timeoutMs: number = 60_000
 ): Promise<{ event: any }> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -123,10 +124,13 @@ describe("Companion Agent", () => {
     workspaceId = workspace.id
   })
 
-  beforeEach(async () => {
-    socket = createSocket(client)
-    await connectSocket(socket)
-  })
+  beforeEach(
+    async () => {
+      socket = createSocket(client)
+      await connectSocket(socket)
+    },
+    { timeout: 30_000 }
+  )
 
   afterEach(() => {
     if (socket) {

--- a/apps/backend/tests/e2e/conversations.test.ts
+++ b/apps/backend/tests/e2e/conversations.test.ts
@@ -13,8 +13,8 @@
 
 import { describe, test, expect, setDefaultTimeout } from "bun:test"
 
-// Boundary extraction uses LLM which can be slow in CI - use 30s like companion tests
-setDefaultTimeout(30000)
+// waitForConversations defaults to 45s; per-test timeout must stay above that
+setDefaultTimeout(90_000)
 
 import {
   TestClient,
@@ -39,8 +39,8 @@ async function waitForConversations(
   streamId: string,
   options?: { timeoutMs?: number; minCount?: number }
 ): Promise<void> {
-  // Boundary extraction uses LLM which can be slow in CI - use 15s like companion tests
-  const timeout = options?.timeoutMs ?? 15000
+  // E2E runs many parallel files; the boundary queue can lag behind 15s under load
+  const timeout = options?.timeoutMs ?? 45_000
   const minCount = options?.minCount ?? 1
   const start = Date.now()
 

--- a/apps/backend/tests/setup.ts
+++ b/apps/backend/tests/setup.ts
@@ -20,13 +20,16 @@ export function getBaseUrl(): string {
   return testServer.url
 }
 
-// Global setup - runs once before all test files
-beforeAll(async () => {
-  testServer = await startTestServer()
-  // Set environment variable so client.ts can pick it up
-  process.env.TEST_BASE_URL = testServer.url
-  console.log(`Test server started at ${testServer.url}`)
-})
+// Global setup - runs once before all test files (migrations + MinIO can exceed 5s default hook time)
+beforeAll(
+  async () => {
+    testServer = await startTestServer()
+    // Set environment variable so client.ts can pick it up
+    process.env.TEST_BASE_URL = testServer.url
+    console.log(`Test server started at ${testServer.url}`)
+  },
+  { timeout: 120_000 }
+)
 
 // Global teardown - runs once after all test files
 // Fast shutdown mode enables immediate shutdown, so no long timeout needed

--- a/apps/backend/tests/test-server.ts
+++ b/apps/backend/tests/test-server.ts
@@ -175,14 +175,20 @@ export async function startTestServer(): Promise<TestServer> {
   process.env.QUEUE_MAX_ACTIVE_TOKENS = "15"
   process.env.QUEUE_POLL_INTERVAL_MS = "100"
   process.env.DATABASE_POOL_MAX = "50"
+  // Starvation guard: a long e2e run fills the DB-backed queue; light/heavy work
+  // (memo.batch-process, etc.) can otherwise delay persona.agent and boundary.extract.
+  process.env.QUEUE_INTERACTIVE_TOKENS = "12"
+  process.env.QUEUE_LIGHT_TOKENS = "10"
+  process.env.QUEUE_HEAVY_TOKENS = "5"
 
-  // S3/MinIO configuration for file upload tests
-  // Use a test-specific bucket name to avoid conflicts with local development
-  process.env.S3_BUCKET = process.env.S3_BUCKET || "threa-test-uploads"
-  process.env.S3_REGION = process.env.S3_REGION || "us-east-1"
-  process.env.S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID || "minioadmin"
-  process.env.S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY || "minioadmin"
-  process.env.S3_ENDPOINT = process.env.S3_ENDPOINT || "http://localhost:9099"
+  // S3/MinIO for e2e: always use local MinIO, never workspace `.env` AWS values.
+  // Bun loads `.env` before tests; inheriting S3_* would send HeadBucket/CreateBucket
+  // to real S3 and fail with 403 (or hit the wrong account).
+  process.env.S3_BUCKET = "threa-test-uploads"
+  process.env.S3_REGION = "us-east-1"
+  process.env.S3_ACCESS_KEY_ID = "minioadmin"
+  process.env.S3_SECRET_ACCESS_KEY = "minioadmin"
+  process.env.S3_ENDPOINT = "http://localhost:9099"
 
   // Ensure MinIO bucket exists
   await ensureMinioBucketExists()

--- a/apps/backend/tests/test-server.ts
+++ b/apps/backend/tests/test-server.ts
@@ -181,14 +181,22 @@ export async function startTestServer(): Promise<TestServer> {
   process.env.QUEUE_LIGHT_TOKENS = "10"
   process.env.QUEUE_HEAVY_TOKENS = "5"
 
-  // S3/MinIO for e2e: always use local MinIO, never workspace `.env` AWS values.
-  // Bun loads `.env` before tests; inheriting S3_* would send HeadBucket/CreateBucket
-  // to real S3 and fail with 403 (or hit the wrong account).
-  process.env.S3_BUCKET = "threa-test-uploads"
-  process.env.S3_REGION = "us-east-1"
-  process.env.S3_ACCESS_KEY_ID = "minioadmin"
-  process.env.S3_SECRET_ACCESS_KEY = "minioadmin"
-  process.env.S3_ENDPOINT = "http://localhost:9099"
+  // S3/MinIO for e2e
+  // - CI (`.github/workflows/ci.yml`) exports MinIO on :9000 — must not override.
+  // - Local dev: Bun loads `.env` with real AWS; force our compose MinIO (:9099) or HeadBucket 403s.
+  if (process.env.CI) {
+    process.env.S3_BUCKET = process.env.S3_BUCKET || "threa-test-uploads"
+    process.env.S3_REGION = process.env.S3_REGION || "us-east-1"
+    process.env.S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID || "minioadmin"
+    process.env.S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY || "minioadmin"
+    process.env.S3_ENDPOINT = process.env.S3_ENDPOINT || "http://localhost:9000"
+  } else {
+    process.env.S3_BUCKET = "threa-test-uploads"
+    process.env.S3_REGION = "us-east-1"
+    process.env.S3_ACCESS_KEY_ID = "minioadmin"
+    process.env.S3_SECRET_ACCESS_KEY = "minioadmin"
+    process.env.S3_ENDPOINT = "http://localhost:9099"
+  }
 
   // Ensure MinIO bucket exists
   await ensureMinioBucketExists()


### PR DESCRIPTION
## Problem

Ariadne's built-in agent configuration was managed as full Postgres data through the `personas` seed row and follow-up migrations. That made product-owned defaults drift from code-owned companion config, and made default behavior changes look like tenant data changes instead of reviewed application configuration.

## Solution

Move built-in agent defaults into backend code and keep Postgres as a sparse workspace override layer. Ariadne is now resolved from a code-backed registry with optional `agent_config_overrides` patches, while workspace-managed personas continue to use full `personas` rows.

### How it works

- `built-in-agents.ts` defines Ariadne and an internal-only empty agent, plus Zod schemas for base configs and patches.
- `agent_config_overrides` stores one active sparse JSONB patch per workspace and built-in agent.
- `PersonaRepository` synthesizes visible built-ins, applies workspace patches when workspace context is available, and falls back to DB rows for workspace personas.
- Runtime persona lookups now pass workspace context through display, activity, search, quote, socket, and agent session paths.
- Tool-capable generation now receives persona-level `temperature` and `maxTokens`.

### Key design decisions

**1. Code owns built-in defaults**

Ariadne's default prompt, model, and tools now live in code so built-in behavior is reviewed and versioned with the application.

**2. Postgres stores sparse JSON patches**

Overrides are JSONB patches instead of typed nullable columns so any built-in configurable field can be overridden without adding a new column for each field.

**3. Workspace personas stay DB-backed**

The user/workspace agent config surface remains unchanged; this PR only changes built-in agent defaults and overrides.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/agent-config-as-override.md` | Review plan for this branch |
| `apps/backend/src/db/migrations/20260425164228_agent_config_overrides.sql` | Creates sparse built-in agent override storage and archives the historical Ariadne row |
| `apps/backend/src/features/agents/built-in-agents.ts` | Code-backed Ariadne and internal empty agent defaults plus patch schemas |
| `apps/backend/src/features/agents/agent-config-override-repository.ts` | Repository for active workspace agent override patches |
| `apps/backend/src/features/agents/persona-repository.test.ts` | Coverage for built-in resolution and overrides |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/agents/persona-repository.ts` | Resolves built-ins from code, applies overrides, and preserves workspace persona rows |
| `apps/backend/src/features/agents/persona-agent.ts` | Uses resolved persona config and forwards model options |
| `apps/backend/src/features/agents/companion/config.ts` | Aligns companion defaults with Ariadne built-in config |
| `apps/backend/src/lib/ai/ai.ts` / `apps/backend/src/features/agents/runtime/agent-runtime.ts` | Adds `temperature` and `maxTokens` support for tool generation |
| Persona display/lookup call sites | Pass workspace context into persona lookups for patched built-ins |
| Tests | Update expected defaults and workspace-scoped lookup signatures |

## Test plan

- [x] Self-review of diff; fixed disabled-default behavior and barrel import issue
- [x] `bun test apps/backend/src/features/agents/persona-repository.test.ts && bun run typecheck 2>&1`
- [x] `bun test apps/backend/src/lib/ai/message-formatter.test.ts apps/backend/src/features/agents/persona-repository.test.ts apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts && bun run --cwd apps/backend lint`
- [x] Commit hooks: lint, typecheck, Dockerfile workspace checks, OpenAPI check
- [x] Earlier focused tests: `bun test apps/backend/src/features/agents/persona-repository.test.ts apps/backend/src/features/agents/runtime/agent-runtime.test.ts apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts`
- [x] Earlier `bun run test`: backend unit phase passed (`925 successful tests`)
- [ ] Backend E2E could not complete locally because shared setup failed uniformly with AWS S3 403 `UnknownError`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

Made with [Cursor](https://cursor.com)