### PR TITLE
fix(frontend): make soft pull refresh fetch latest stream data pre-connect

### DIFF
--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -153,6 +153,15 @@ describe("SyncEngine.handlePageResume", () => {
     expect(refreshSpy).not.toHaveBeenCalled()
   })
 
+  it("soft refreshes visible data even before the first socket connect", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+
+    await engine.refreshAfterConnectivityResume()
+
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+  })
+
   it("is a no-op when the engine is destroyed", async () => {
     const engine = new SyncEngine(makeDeps())
     const socket = new MockSocket()

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -134,7 +134,7 @@ export class SyncEngine {
    * transport survives but the client missed stream updates).
    */
   async refreshAfterConnectivityResume(): Promise<void> {
-    if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
+    if (this.isDestroyed) return
     await this.runBootstrap(true)
   }
 
@@ -232,7 +232,6 @@ export class SyncEngine {
   // =========================================================================
 
   private async bootstrapWorkspace(_isReconnect: boolean): Promise<void> {
-    if (!this.socket) return
     const { workspaceId, syncStatus, queryClient, workspaceService, streamService } = this.deps
 
     syncStatus.set(`workspace:${workspaceId}`, "syncing")
@@ -244,8 +243,12 @@ export class SyncEngine {
     }
 
     try {
-      // Subscribe-then-fetch (INV-53)
-      await joinRoomBestEffort(this.socket, `ws:${workspaceId}`, "SyncEngine")
+      // Subscribe-then-fetch (INV-53). Soft refresh can run while the socket
+      // client is still reconnecting; in that case we still fetch fresh
+      // bootstrap data and skip the room-join step.
+      if (this.socket) {
+        await joinRoomBestEffort(this.socket, `ws:${workspaceId}`, "SyncEngine")
+      }
 
       const fetchStartedAt = Date.now()
       let bootstrap: WorkspaceBootstrap


### PR DESCRIPTION
### Motivation
- Pull-to-refresh (soft refresh) could release without updating stream content when the socket had not yet connected, causing the UI to show stale messages.
- The refresh flow must fetch fresh workspace/stream bootstraps even if the socket join step cannot run immediately to avoid race windows on mobile or reconnect.

### Description
- Relaxed the guard in `SyncEngine.refreshAfterConnectivityResume()` so it no longer returns early when the socket is not yet established, allowing a reconnect-style bootstrap to run; the method still short-circuits when the engine is destroyed (`apps/frontend/src/sync/sync-engine.ts`).
- Make the workspace room join conditional: call `joinRoomBestEffort()` only when a `socket` instance exists, but still proceed to fetch workspace/stream bootstrap data when the socket is unavailable (`apps/frontend/src/sync/sync-engine.ts`).
- Added a regression test `soft refreshes visible data even before the first socket connect` that asserts `refreshAfterConnectivityResume()` performs a bootstrap before the first socket connect (`apps/frontend/src/sync/sync-engine.test.ts`).

### Testing
- Ran the targeted frontend unit tests with `bunx vitest src/sync/sync-engine.test.ts` inside `apps/frontend` and all tests passed (7 passed).
- Running the repository-root `bun run vitest` for the single-file invocation initially failed due to module resolution in that invocation mode; the targeted frontend test run was used to validate the change and succeeded.
- Pre-commit hooks in this environment failed due to an unrelated `ajv/dist/core` module lookup during docs generation, so the change was validated by the focused test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed023654e4832d90cb97c1eb127f71)