### PR TITLE
feat(messaging): slice 2 — cross-stream share picker + per-viewer recursive hydration

### DIFF
--- a/.claude/plans/message-sharing-streams-slice2.md
+++ b/.claude/plans/message-sharing-streams-slice2.md
@@ -95,6 +95,7 @@ None. Slice 1 already created `shared_messages`. Slice 2's `confirmedPrivacyWarn
 ## What's NOT Included
 
 Deferred to Slice 3 / follow-ups:
+- **Attachments on shared messages.** A shared "look at this" + image currently renders as the text only — `HydratedSharedMessage.ok` carries `contentJson`/`contentMarkdown` but no `attachments`, and `card-body.tsx` doesn't mount an `AttachmentList`. Slice 3 should: extend the `ok` wire variant with `attachments: AttachmentSummary[]`, batch-fetch via `AttachmentRepository.findByMessageIds(okMessageIds)` inside `hydrateSharedMessageIds` (one extra round-trip, no per-ref loop, INV-56), thread through `use-shared-message-source.ts`, and render `<AttachmentList>` in the `ok` branch of `card-body.tsx`. Access is implicit — attachments are emitted only for `ok` payloads where viewer access to the source is already established, so no privacy gap.
 - **Step-2 privacy confirm in the modal** (still a blocking toast in Slice 2).
 - **`GET /api/.../share-preview` endpoint** for pre-flight privacy check.
 - **`'share-as-quote'` action** + cross-stream quote flavor.

--- a/.claude/plans/message-sharing-streams-slice2.md
+++ b/.claude/plans/message-sharing-streams-slice2.md
@@ -1,0 +1,117 @@
+# Message Sharing — Slice 2 (Cross-Stream Picker + Per-Viewer Hydration)
+
+## Goal
+
+Slice 2 of the message-sharing feature (full plan: `docs/plans/message-sharing-streams.md`). Slice 1 shipped share-to-parent with single-level pointer hydration. Slice 2 unlocks **arbitrary cross-stream targets** via a picker modal and adds **per-viewer recursive hydration** with `private` and `truncated` placeholder states for re-share chains (plan section D8).
+
+## What Was Built
+
+### Backend — recursive per-viewer hydration
+
+Pointer hydration walks each chain level-by-level up to `MAX_HYDRATION_DEPTH = 3`. At every level the viewer's access is resolved via two batched queries: stream membership (direct member, public visibility, or thread inheriting from root) and share-grant lookup (a viewer can read a source iff a share with that source exists in a target stream the viewer can read). Results are classified per-message as `ok`, `deleted`, `missing`, `private`, or `truncated`.
+
+**Files:**
+- `apps/backend/src/features/messaging/sharing/hydration.ts` — rewrote `hydrateSharedMessageIds` from single-level to BFS with depth cap; takes `viewerId`. Added `walkSharedMessageNodes` visitor that both `collectSharedMessageIds` (Set) and `collectSharedMessageRefs` (Map<id, streamId>) specialise.
+- `apps/backend/src/features/streams/access.ts` — new `listAccessibleStreamIds(db, ws, userId, candidateIds)` batched helper mirroring `checkStreamAccess` semantics for set-based access checks.
+- `apps/backend/src/features/messaging/sharing/repository.ts` — new `listSourcesGrantedToViewer` composes with `listAccessibleStreamIds` to find sources a viewer can read via share grants. Two-step flow keeps the access predicate in one place.
+- `apps/backend/src/features/streams/handlers.ts` — `hydrateSharedMessagesForEvents` now takes `viewerId`; threaded through the three call sites.
+
+### Backend — privacy confirmation wire
+
+`ShareService` already had `confirmedPrivacyWarning` plumbed through `MessageEventService` in Slice 1, but the HTTP handler didn't accept it. Slice 2 closes that gap so the cross-stream modal can confirm privacy boundary crossings.
+
+**Files:**
+- `apps/backend/src/features/messaging/handlers.ts` — `confirmedPrivacyWarning: z.boolean().optional()` added via a `commonMessageOptionsSchema` spread shared by all four create variants and both update variants.
+- `apps/backend/src/features/messaging/sharing/service.ts` — error codes now reference `ShareErrorCodes` constants from `@threa/types` instead of magic strings.
+
+### Wire types
+
+**Files:**
+- `packages/types/src/api.ts` — `SharedMessageHydration` union extended with `{ state: "private", sourceStreamKind, sourceVisibility }` and `{ state: "truncated", messageId, streamId }`. `CreateMessageInputJson`, `CreateDmMessageInputJson`, `UpdateMessageInputJson`, `UpdateMessageInputMarkdown` all gain `confirmedPrivacyWarning?: boolean`.
+- `packages/types/src/constants.ts` — new `ShareErrorCodes` object centralises the cross-cutting `SHARE_PRIVACY_CONFIRMATION_REQUIRED` (matched on by the frontend queue) plus the five other share error codes for symmetry.
+
+### Frontend — NodeView placeholder states
+
+**Files:**
+- `apps/frontend/src/components/shared-messages/context.tsx` — `HydratedSharedMessage` union mirrors backend's new variants.
+- `apps/frontend/src/hooks/use-shared-message-source.ts` — maps the wire union onto two new `SharedMessageSource` variants (`private`, `truncated`).
+- `apps/frontend/src/components/shared-messages/card-body.tsx` — renders the two new states. `PrivatePlaceholder` reveals only kind + visibility (never the cached `fallbackAuthor`, never the stream name). `TruncatedPlaceholder` is a navigable Link to the source stream + message anchor. Stream-kind vocabulary lives in `lib/streams.ts`'s `FALLBACK_LABELS` (new `noun` context row).
+
+### Frontend — share modal + context-menu wiring
+
+**Files:**
+- `apps/frontend/src/components/share/share-message-modal.tsx` — Shadcn `Dialog` + `Command` picker. Filters to top-level streams the user can read (public visibility OR direct member, no threads, no archived). On select, queues the share node via `queueShareHandoff` and navigates to the target stream's normal composer — same hand-off pattern Slice 1 used for share-to-parent.
+- `apps/frontend/src/components/timeline/message-actions.ts` — `'share'` action entry, always-visible alongside the share-to-root / share-to-parent fast paths.
+- `apps/frontend/src/components/timeline/message-event.tsx` — owns the modal's open state and passes the source `SharedMessageAttrs`.
+- `apps/frontend/src/lib/streams.ts` — lifted `STREAM_ICONS` here so the modal and the quick-switcher share the icon mapping.
+
+### Frontend — privacy-block toast and queue handling
+
+**Files:**
+- `apps/frontend/src/lib/share-privacy-toast.ts` — sonner toast offering "Share anyway" / "Cancel". State writes go through `usePendingMessages.retryMessage` / `deleteMessage` (extended with optional patch arg) — never touches `db.*` directly so React state cleanup stays consistent.
+- `apps/frontend/src/contexts/pending-messages-context.tsx` — `retryMessage(id, patch?)` accepts a patch so the toast can set `confirmedPrivacyWarning: true` and clear the `blocked-privacy` status atomically.
+- `apps/frontend/src/hooks/use-message-queue.ts` — catches `409` + `SHARE_PRIVACY_CONFIRMATION_REQUIRED`, marks the pending row `status: "blocked-privacy"` (skipped from auto-retries), and surfaces the toast. Forwards `confirmedPrivacyWarning` on send.
+- `apps/frontend/src/db/database.ts` — `PendingMessage` gains `confirmedPrivacyWarning?: boolean` and the `"blocked-privacy"` status value.
+
+### E2E tests
+
+**Files:**
+- `tests/browser/message-share-cross-stream.spec.ts` — two scenarios:
+  1. Public-channel source → scratchpad target via picker; pointer renders hydrated.
+  2. Same-stream share — handoff lands in the current composer rather than re-navigating.
+
+## Design Decisions
+
+### Recursion in JS, access checks in SQL
+
+**Chose:** Per-level BFS in JavaScript (max 3 levels), batched SQL queries for access checks within each level.
+**Why:** ProseMirror content lives in JSONB and we need to extract `sharedMessage` node refs from it. A pure SQL `WITH RECURSIVE` would have to walk the JSONB inline, which is awkward and harder to maintain. The level-by-level approach gives 3 batched queries per level (find messages + accessible streams + share grants), worst case 9 round-trips for a 3-deep chain. In practice chains are 1–2 hops.
+**Alternatives considered:** Single recursive CTE walking the JSONB tree — rejected for readability; the JS BFS reads as plain control flow.
+
+### Truncated vs Private vs Missing
+
+**Chose:** Pointers found at the seed level (depth 0) get `missing` if the row doesn't exist, `private` if the viewer can't access. Pointers collected past the depth cap get `truncated` using the `streamId` cached on the parent's share-node attrs — no extra DB hit.
+**Why:** The depth cap is a pathological-data guard, not a privacy guard. Linking to a stream the viewer doesn't have access to just yields a normal 403 on click; not a security issue. Avoids an extra query just to re-classify cap-level entries.
+
+### `listSourcesGrantedToViewer` composes, doesn't duplicate
+
+**Chose:** Two-step flow — fetch `(source, target)` candidate pairs, then call `listAccessibleStreamIds` to filter targets.
+**Why:** The "viewer can read this stream" predicate already lives in `listAccessibleStreamIds`. Inlining a copy in the share-grant query would invite drift any time access semantics change (roles, mute filters, etc.). One extra round-trip is worth a single source of truth.
+
+### Privacy-block toast over modal step-2
+
+**Chose:** Slice 2 surfaces the privacy-confirmation flow as a sonner toast on send-time 409. The full modal step-2 confirm with `share-preview` endpoint is deferred to Slice 3.
+**Why:** Plan explicitly deferred step-2 to Slice 3. Toast keeps the user unblocked: "Share anyway" sets `confirmedPrivacyWarning: true` on the pending row and re-attempts; "Cancel" drops the optimistic event cleanly.
+
+### `confirmedPrivacyWarning` is a per-message flag, not per-share
+
+**Chose:** Single boolean covering every reference in a message body (carried over from Slice 1's service-layer assumption).
+**Why:** Slice 2's modal pre-fills exactly one share node per message, and share-to-parent never crosses a privacy boundary. The Slice 1 service-layer comment notes the upgrade path: when arbitrary multi-reference composing lands, swap to per-source confirmation (`confirmedPrivacyFor: Set<sourceStreamId>`).
+
+## Schema Changes
+
+None. Slice 1 already created `shared_messages`. Slice 2's `confirmedPrivacyWarning` is a per-request flag, never persisted; `PendingMessage`'s new fields are IndexedDB-side only (no Dexie migration since indexed keys didn't change).
+
+## What's NOT Included
+
+Deferred to Slice 3 / follow-ups:
+- **Step-2 privacy confirm in the modal** (still a blocking toast in Slice 2).
+- **`GET /api/.../share-preview` endpoint** for pre-flight privacy check.
+- **`'share-as-quote'` action** + cross-stream quote flavor.
+- **"+ New scratchpad" picker row** that creates a target on the fly.
+- **Partial-selection share button** in the text-selection toolbar (Slice 4).
+- **Three-user E2E rechain test** (`E2E-share-rechain-private-placeholder` from the plan). The rechain hydration logic is exhaustively unit-tested in `hydration.test.ts` (mixed-access two-hop chain with `private` placeholder for the inner pointer) and `card-body.test.tsx` (asserts the placeholder doesn't leak the cached fallback author). A 3-user 3-stream Playwright variant is heavy and best done as a separate E2E PR.
+- **Folding `getAccessibleStreamsWithMembers` and `listAccessibleStreamIds` into one helper.** They overlap on the access predicate but have different APIs (search-feature has participant + archive filters; mine takes a candidate id set). Keeping them separate; both are tested.
+
+## Status
+
+- [x] Backend: recursive per-viewer hydration with depth cap
+- [x] Backend: `private` / `truncated` placeholder resolution
+- [x] Backend: handler accepts `confirmedPrivacyWarning`
+- [x] Wire types: union extension + `ShareErrorCodes` constants
+- [x] Frontend: NodeView renders `private` / `truncated` states
+- [x] Frontend: cross-stream picker modal
+- [x] Frontend: `'share'` action + modal wiring
+- [x] Frontend: privacy-block toast with retry/cancel via context API
+- [x] E2E: cross-stream-public + same-stream
+- [x] Self-review pass (reuse, quality, efficiency reviewers)

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -5,7 +5,25 @@ import { StreamRepository } from "../streams"
 import { StreamMemberRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, Message } from "./repository"
-import { ShareService } from "./sharing"
+import { ShareService, type ResolveEffectiveStream } from "./sharing"
+
+/**
+ * Adapter that lets `ShareService.validateAndRecordShares` consume the
+ * canonical `resolveEffectiveAccessStream` (which returns either the input
+ * shape or a full `Stream`) without leaking the streams-feature row shape
+ * into the sharing sub-feature (INV-52). Hoisted to module scope so the
+ * create + edit call paths share one allocation rather than re-declaring
+ * the closure per request (INV-13, INV-35).
+ */
+const resolveEffectiveStreamAdapter: ResolveEffectiveStream = async (db, source) => {
+  const resolved = await resolveEffectiveAccessStream(db, source)
+  return {
+    id: resolved.id,
+    workspaceId: resolved.workspaceId,
+    visibility: resolved.visibility,
+    rootStreamId: resolved.rootStreamId,
+  }
+}
 import { AttachmentRepository, isVideoAttachment } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
 import { StreamPersonaParticipantRepository } from "../agents"
@@ -339,18 +357,7 @@ export class EventService {
         sharerId: params.authorId,
         contentJson: params.contentJson,
         findStream: (db, id) => StreamRepository.findById(db, id),
-        resolveEffectiveStream: async (db, source) => {
-          // The canonical helper returns the input shape OR a full Stream;
-          // narrow back to SharingStream so the sharing module stays
-          // ignorant of the streams-feature row shape (INV-52).
-          const resolved = await resolveEffectiveAccessStream(db, source)
-          return {
-            id: resolved.id,
-            workspaceId: resolved.workspaceId,
-            visibility: resolved.visibility,
-            rootStreamId: resolved.rootStreamId,
-          }
-        },
+        resolveEffectiveStream: resolveEffectiveStreamAdapter,
         isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
         countExposedMembers: (db, targetStreamId, sourceStreamId) =>
           StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),
@@ -451,18 +458,7 @@ export class EventService {
           sharerId: params.actorId,
           contentJson: params.contentJson,
           findStream: (db, id) => StreamRepository.findById(db, id),
-          resolveEffectiveStream: async (db, source) => {
-            // The canonical helper returns the input shape OR a full Stream;
-            // narrow back to SharingStream so the sharing module stays
-            // ignorant of the streams-feature row shape (INV-52).
-            const resolved = await resolveEffectiveAccessStream(db, source)
-            return {
-              id: resolved.id,
-              workspaceId: resolved.workspaceId,
-              visibility: resolved.visibility,
-              rootStreamId: resolved.rootStreamId,
-            }
-          },
+          resolveEffectiveStream: resolveEffectiveStreamAdapter,
           isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
           countExposedMembers: (db, targetStreamId, sourceStreamId) =>
             StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -3,7 +3,7 @@ import { withTransaction, withClient } from "../../db"
 import { StreamEventRepository, StreamEvent } from "../streams"
 import { StreamRepository } from "../streams"
 import { StreamMemberRepository } from "../streams"
-import { checkStreamAccess } from "../streams"
+import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, Message } from "./repository"
 import { ShareService } from "./sharing"
 import { AttachmentRepository, isVideoAttachment } from "../attachments"
@@ -339,6 +339,18 @@ export class EventService {
         sharerId: params.authorId,
         contentJson: params.contentJson,
         findStream: (db, id) => StreamRepository.findById(db, id),
+        resolveEffectiveStream: async (db, source) => {
+          // The canonical helper returns the input shape OR a full Stream;
+          // narrow back to SharingStream so the sharing module stays
+          // ignorant of the streams-feature row shape (INV-52).
+          const resolved = await resolveEffectiveAccessStream(db, source)
+          return {
+            id: resolved.id,
+            workspaceId: resolved.workspaceId,
+            visibility: resolved.visibility,
+            rootStreamId: resolved.rootStreamId,
+          }
+        },
         isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
         countExposedMembers: (db, targetStreamId, sourceStreamId) =>
           StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),
@@ -439,6 +451,18 @@ export class EventService {
           sharerId: params.actorId,
           contentJson: params.contentJson,
           findStream: (db, id) => StreamRepository.findById(db, id),
+          resolveEffectiveStream: async (db, source) => {
+            // The canonical helper returns the input shape OR a full Stream;
+            // narrow back to SharingStream so the sharing module stays
+            // ignorant of the streams-feature row shape (INV-52).
+            const resolved = await resolveEffectiveAccessStream(db, source)
+            return {
+              id: resolved.id,
+              workspaceId: resolved.workspaceId,
+              visibility: resolved.visibility,
+              rootStreamId: resolved.rootStreamId,
+            }
+          },
           isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
           countExposedMembers: (db, targetStreamId, sourceStreamId) =>
             StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -6,6 +6,22 @@ import { StreamMemberRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, Message } from "./repository"
 import { ShareService, type ResolveEffectiveStream } from "./sharing"
+import { AttachmentRepository, isVideoAttachment } from "../attachments"
+import { OutboxRepository } from "../../lib/outbox"
+import { StreamPersonaParticipantRepository } from "../agents"
+import { eventId, messageId, messageVersionId } from "../../lib/id"
+import { MessageVersionRepository, type MessageVersion } from "./version-repository"
+import { serializeBigInt } from "@threa/backend-common"
+import { messagesTotal } from "../../lib/observability"
+import {
+  AttachmentSafetyStatuses,
+  AuthorTypes,
+  type AuthorType,
+  type EventType,
+  type SourceItem,
+  type JSONContent,
+  type ThreadSummary,
+} from "@threa/types"
 
 /**
  * Adapter that lets `ShareService.validateAndRecordShares` consume the
@@ -24,22 +40,6 @@ const resolveEffectiveStreamAdapter: ResolveEffectiveStream = async (db, source)
     rootStreamId: resolved.rootStreamId,
   }
 }
-import { AttachmentRepository, isVideoAttachment } from "../attachments"
-import { OutboxRepository } from "../../lib/outbox"
-import { StreamPersonaParticipantRepository } from "../agents"
-import { eventId, messageId, messageVersionId } from "../../lib/id"
-import { MessageVersionRepository, type MessageVersion } from "./version-repository"
-import { serializeBigInt } from "@threa/backend-common"
-import { messagesTotal } from "../../lib/observability"
-import {
-  AttachmentSafetyStatuses,
-  AuthorTypes,
-  type AuthorType,
-  type EventType,
-  type SourceItem,
-  type JSONContent,
-  type ThreadSummary,
-} from "@threa/types"
 
 // Event payloads
 export interface AttachmentSummary {

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -26,6 +26,12 @@ const createMessageJsonToStreamSchema = z.object({
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
+  // Flag the user has already seen the privacy warning for any private-source
+  // share node in this content. Required by `ShareService` whenever a share
+  // crosses a privacy boundary; otherwise the call returns 409 with code
+  // `SHARE_PRIVACY_CONFIRMATION_REQUIRED`. Optional on the wire so non-share
+  // sends don't have to set it.
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 // Schema for markdown input to an existing stream (from AI/external)
@@ -35,6 +41,7 @@ const createMessageMarkdownToStreamSchema = z.object({
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 // Schema for JSON input to a DM target user (lazy stream creation on first message)
@@ -48,6 +55,7 @@ const createMessageJsonToDmSchema = z.object({
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 // Schema for markdown input to a DM target user (lazy stream creation on first message)
@@ -57,6 +65,7 @@ const createMessageMarkdownToDmSchema = z.object({
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 // Union schema - accepts either format
@@ -74,10 +83,12 @@ const updateMessageJsonSchema = z.object({
     content: z.array(z.any()),
   }),
   contentMarkdown: z.string().optional(),
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 const updateMessageMarkdownSchema = z.object({
   content: z.string().min(1, "content is required"),
+  confirmedPrivacyWarning: z.boolean().optional(),
 })
 
 const updateMessageSchema = z.union([updateMessageJsonSchema, updateMessageMarkdownSchema])
@@ -229,6 +240,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         attachmentIds,
         clientMessageId: data.clientMessageId,
         metadata: data.metadata,
+        confirmedPrivacyWarning: data.confirmedPrivacyWarning,
       })
 
       res.status(201).json({ message: serializeMessage(message) })
@@ -275,6 +287,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         contentJson,
         contentMarkdown,
         actorId: userId,
+        confirmedPrivacyWarning: result.data.confirmedPrivacyWarning,
       })
 
       if (!message) {

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -15,57 +15,51 @@ import { parseMarkdown, serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import { messageMetadataSchema } from "./metadata-schema"
 
-// Schema for JSON input to an existing stream (from rich clients)
-const createMessageJsonToStreamSchema = z.object({
-  streamId: z.string().min(1, "streamId is required"),
-  contentJson: z.object({
-    type: z.literal("doc"),
-    content: z.array(z.any()),
-  }),
-  contentMarkdown: z.string().optional(),
+// Fields shared by every create/update variant. Defining once keeps the
+// six schemas from drifting when a per-message option is added.
+// `confirmedPrivacyWarning` is required when a share node crosses a privacy
+// boundary; the service returns 409 + `SHARE_PRIVACY_CONFIRMATION_REQUIRED`
+// otherwise.
+const commonMessageOptionsSchema = {
   attachmentIds: z.array(z.string()).optional(),
   clientMessageId: z.string().min(1).optional(),
   metadata: messageMetadataSchema.optional(),
-  // Flag the user has already seen the privacy warning for any private-source
-  // share node in this content. Required by `ShareService` whenever a share
-  // crosses a privacy boundary; otherwise the call returns 409 with code
-  // `SHARE_PRIVACY_CONFIRMATION_REQUIRED`. Optional on the wire so non-share
-  // sends don't have to set it.
   confirmedPrivacyWarning: z.boolean().optional(),
+}
+
+const contentJsonSchema = z.object({
+  type: z.literal("doc"),
+  content: z.array(z.any()),
+})
+
+// Schema for JSON input to an existing stream (from rich clients)
+const createMessageJsonToStreamSchema = z.object({
+  streamId: z.string().min(1, "streamId is required"),
+  contentJson: contentJsonSchema,
+  contentMarkdown: z.string().optional(),
+  ...commonMessageOptionsSchema,
 })
 
 // Schema for markdown input to an existing stream (from AI/external)
 const createMessageMarkdownToStreamSchema = z.object({
   streamId: z.string().min(1, "streamId is required"),
   content: z.string().min(1, "content is required"),
-  attachmentIds: z.array(z.string()).optional(),
-  clientMessageId: z.string().min(1).optional(),
-  metadata: messageMetadataSchema.optional(),
-  confirmedPrivacyWarning: z.boolean().optional(),
+  ...commonMessageOptionsSchema,
 })
 
 // Schema for JSON input to a DM target user (lazy stream creation on first message)
 const createMessageJsonToDmSchema = z.object({
   dmUserId: z.string().min(1, "dmUserId is required"),
-  contentJson: z.object({
-    type: z.literal("doc"),
-    content: z.array(z.any()),
-  }),
+  contentJson: contentJsonSchema,
   contentMarkdown: z.string().optional(),
-  attachmentIds: z.array(z.string()).optional(),
-  clientMessageId: z.string().min(1).optional(),
-  metadata: messageMetadataSchema.optional(),
-  confirmedPrivacyWarning: z.boolean().optional(),
+  ...commonMessageOptionsSchema,
 })
 
 // Schema for markdown input to a DM target user (lazy stream creation on first message)
 const createMessageMarkdownToDmSchema = z.object({
   dmUserId: z.string().min(1, "dmUserId is required"),
   content: z.string().min(1, "content is required"),
-  attachmentIds: z.array(z.string()).optional(),
-  clientMessageId: z.string().min(1).optional(),
-  metadata: messageMetadataSchema.optional(),
-  confirmedPrivacyWarning: z.boolean().optional(),
+  ...commonMessageOptionsSchema,
 })
 
 // Union schema - accepts either format
@@ -78,10 +72,7 @@ const createMessageSchema = z.union([
 
 // Update can also be either format
 const updateMessageJsonSchema = z.object({
-  contentJson: z.object({
-    type: z.literal("doc"),
-    content: z.array(z.any()),
-  }),
+  contentJson: contentJsonSchema,
   contentMarkdown: z.string().optional(),
   confirmedPrivacyWarning: z.boolean().optional(),
 })

--- a/apps/backend/src/features/messaging/sharing/access-check.test.ts
+++ b/apps/backend/src/features/messaging/sharing/access-check.test.ts
@@ -3,6 +3,7 @@ import {
   crossesPrivacyBoundary,
   type CountExposedMembers,
   type IsAncestorStream,
+  type ResolveEffectiveStream,
   type SharingStream,
 } from "./access-check"
 
@@ -10,8 +11,21 @@ afterEach(() => {
   mock.restore()
 })
 
-function findStreamFrom(streams: Record<string, Partial<SharingStream>>) {
-  return async (_db: unknown, id: string) => (streams[id] ? ({ id, ...streams[id] } as SharingStream) : null)
+/**
+ * Builds matched `findStream` + `resolveEffective` callbacks from a single
+ * map of stream rows. The resolver mirrors `streams/access.ts`'s
+ * `resolveEffectiveAccessStream`: threads route through to the root, with
+ * a dangling-root fallback to the input.
+ */
+function streamHelpers(streams: Record<string, Partial<SharingStream>>) {
+  const findStream = async (_db: unknown, id: string) =>
+    streams[id] ? ({ id, rootStreamId: null, ...streams[id] } as SharingStream) : null
+  const resolveEffective: ResolveEffectiveStream = async (_db, source) => {
+    if (!source.rootStreamId) return source
+    const root = streams[source.rootStreamId]
+    return root ? ({ id: source.rootStreamId, rootStreamId: null, ...root } as SharingStream) : source
+  }
+  return { findStream, resolveEffective }
 }
 
 function isAncestorReturning(value: boolean): IsAncestorStream {
@@ -24,9 +38,11 @@ function countExposedReturning(value: number): CountExposedMembers {
 
 describe("crossesPrivacyBoundary", () => {
   it("never triggers when source and target are the same stream", async () => {
+    const { findStream, resolveEffective } = streamHelpers({})
     const result = await crossesPrivacyBoundary(
       {} as any,
-      findStreamFrom({}),
+      findStream,
+      resolveEffective,
       isAncestorReturning(false),
       countExposedReturning(999),
       "stream_a",
@@ -37,9 +53,11 @@ describe("crossesPrivacyBoundary", () => {
 
   it("never triggers when the target is an ancestor of the source (share-to-parent)", async () => {
     const countExposed = mock(countExposedReturning(999))
+    const { findStream, resolveEffective } = streamHelpers({})
     const result = await crossesPrivacyBoundary(
       {} as any,
-      findStreamFrom({}),
+      findStream,
+      resolveEffective,
       isAncestorReturning(true),
       countExposed,
       "stream_thread",
@@ -50,11 +68,14 @@ describe("crossesPrivacyBoundary", () => {
   })
 
   it("never triggers when the source is public", async () => {
-    const find = findStreamFrom({ stream_src: { visibility: "public", workspaceId: "ws_1" } })
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_src: { visibility: "public", workspaceId: "ws_1" },
+    })
     const countExposed = mock(countExposedReturning(999))
     const result = await crossesPrivacyBoundary(
       {} as any,
-      find,
+      findStream,
+      resolveEffective,
       isAncestorReturning(false),
       countExposed,
       "stream_src",
@@ -65,10 +86,13 @@ describe("crossesPrivacyBoundary", () => {
   })
 
   it("triggers with the count of exposed users when target has outsiders", async () => {
-    const find = findStreamFrom({ stream_src: { visibility: "private", workspaceId: "ws_1" } })
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_src: { visibility: "private", workspaceId: "ws_1" },
+    })
     const result = await crossesPrivacyBoundary(
       {} as any,
-      find,
+      findStream,
+      resolveEffective,
       isAncestorReturning(false),
       countExposedReturning(3),
       "stream_src",
@@ -78,10 +102,13 @@ describe("crossesPrivacyBoundary", () => {
   })
 
   it("does not trigger when target membership is a subset of source membership", async () => {
-    const find = findStreamFrom({ stream_src: { visibility: "private", workspaceId: "ws_1" } })
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_src: { visibility: "private", workspaceId: "ws_1" },
+    })
     const result = await crossesPrivacyBoundary(
       {} as any,
-      find,
+      findStream,
+      resolveEffective,
       isAncestorReturning(false),
       countExposedReturning(0),
       "stream_src",
@@ -96,8 +123,18 @@ describe("crossesPrivacyBoundary", () => {
       calls.push([ancestorId, streamId])
       return false
     }
-    const find = findStreamFrom({ stream_src: { visibility: "public", workspaceId: "ws_1" } })
-    await crossesPrivacyBoundary({} as any, find, isAncestor, countExposedReturning(0), "stream_src", "stream_target")
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_src: { visibility: "public", workspaceId: "ws_1" },
+    })
+    await crossesPrivacyBoundary(
+      {} as any,
+      findStream,
+      resolveEffective,
+      isAncestor,
+      countExposedReturning(0),
+      "stream_src",
+      "stream_target"
+    )
     // Target is the candidate ancestor of source (share-to-parent detection).
     expect(calls).toEqual([["stream_target", "stream_src"]])
   })
@@ -108,15 +145,102 @@ describe("crossesPrivacyBoundary", () => {
       calls.push([targetStreamId, sourceStreamId])
       return 0
     }
-    const find = findStreamFrom({ stream_src: { visibility: "private", workspaceId: "ws_1" } })
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_src: { visibility: "private", workspaceId: "ws_1" },
+    })
     await crossesPrivacyBoundary(
       {} as any,
-      find,
+      findStream,
+      resolveEffective,
       isAncestorReturning(false),
       countExposed,
       "stream_src",
       "stream_target"
     )
     expect(calls).toEqual([["stream_target", "stream_src"]])
+  })
+
+  it("for thread sources, uses the root's visibility (not the thread row's stale value)", async () => {
+    // Thread row stored visibility="public" at create time; root has since
+    // been flipped to private. Without root resolution the boundary check
+    // would short-circuit on source.visibility !== PRIVATE and silently
+    // miss the leak. The injected resolver routes thread → root via the
+    // canonical helper in streams/access.ts.
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_thread: { visibility: "public", workspaceId: "ws_1", rootStreamId: "stream_root" },
+      stream_root: { visibility: "private", workspaceId: "ws_1", rootStreamId: null },
+    })
+    const result = await crossesPrivacyBoundary(
+      {} as any,
+      findStream,
+      resolveEffective,
+      isAncestorReturning(false),
+      countExposedReturning(2),
+      "stream_thread",
+      "stream_target"
+    )
+    expect(result).toEqual({ triggered: true, exposedUserCount: 2 })
+  })
+
+  it("for thread sources, counts exposure against the root's members (not the thread's sparse member set)", async () => {
+    const calls: Array<[string, string]> = []
+    const countExposed: CountExposedMembers = async (_db, targetStreamId, sourceStreamId) => {
+      calls.push([targetStreamId, sourceStreamId])
+      return 1
+    }
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_thread: { visibility: "private", workspaceId: "ws_1", rootStreamId: "stream_root" },
+      stream_root: { visibility: "private", workspaceId: "ws_1", rootStreamId: null },
+    })
+    await crossesPrivacyBoundary(
+      {} as any,
+      findStream,
+      resolveEffective,
+      isAncestorReturning(false),
+      countExposed,
+      "stream_thread",
+      "stream_target"
+    )
+    expect(calls).toEqual([["stream_target", "stream_root"]])
+  })
+
+  it("for a thread of a public root, does not trigger (root visibility wins)", async () => {
+    // Inverse of the staleness case: thread's stored visibility happens to
+    // be "private", but the root is public. The root is the source of
+    // truth, so no boundary fires.
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_thread: { visibility: "private", workspaceId: "ws_1", rootStreamId: "stream_root" },
+      stream_root: { visibility: "public", workspaceId: "ws_1", rootStreamId: null },
+    })
+    const result = await crossesPrivacyBoundary(
+      {} as any,
+      findStream,
+      resolveEffective,
+      isAncestorReturning(false),
+      countExposedReturning(99),
+      "stream_thread",
+      "stream_target"
+    )
+    expect(result).toEqual({ triggered: false, exposedUserCount: 0 })
+  })
+
+  it("falls back to the source itself when the root row is missing", async () => {
+    // Defensive: shared_messages and streams have no FKs, so a thread
+    // pointing at a deleted root is possible. The resolver collapses back
+    // to the source rather than crashing; the rest of the check plays out
+    // against the thread row's own visibility.
+    const { findStream, resolveEffective } = streamHelpers({
+      stream_thread: { visibility: "private", workspaceId: "ws_1", rootStreamId: "stream_missing_root" },
+    })
+    const result = await crossesPrivacyBoundary(
+      {} as any,
+      findStream,
+      resolveEffective,
+      isAncestorReturning(false),
+      countExposedReturning(2),
+      "stream_thread",
+      "stream_target"
+    )
+    expect(result).toEqual({ triggered: true, exposedUserCount: 2 })
   })
 })

--- a/apps/backend/src/features/messaging/sharing/access-check.ts
+++ b/apps/backend/src/features/messaging/sharing/access-check.ts
@@ -9,14 +9,40 @@ import { Visibilities, type Visibility } from "@threa/types"
  * barrel. Ancestry, member-counting, and read-access live in the DB and are
  * answered by the injected callbacks, not by walking or querying app-side
  * (INV-5).
+ *
+ * `rootStreamId` is exposed so the privacy boundary can resolve a thread
+ * source through to its root: thread access lives entirely on the root's
+ * `stream_members` rows (creator + parent author are added to the thread
+ * for notification scoping but otherwise membership doesn't gate read
+ * access — `checkStreamAccess` reads root-only). The thread row's stored
+ * `visibility` is set at create time and never re-synced when the root's
+ * visibility changes, so the boundary check would silently miss
+ * private-source shares from threads of channels that were privatized
+ * after the thread was created. Resolving to the root closes that hole
+ * and also fixes the over-count (countExposedMembers against a sparsely-
+ * populated thread vs. the actual root member set).
  */
 export interface SharingStream {
   id: string
   workspaceId: string
   visibility: Visibility
+  rootStreamId: string | null
 }
 
 export type FindStreamForSharing = (db: Querier, id: string) => Promise<SharingStream | null>
+
+/**
+ * Resolves the stream whose visibility + member set are authoritative for
+ * access decisions on the given source. Top-level streams are their own
+ * authoritative source; threads route through to the root.
+ *
+ * Injected so this sub-feature stays free of a direct streams-feature
+ * import (INV-52) and so the resolution lives in one place — currently
+ * `streams/access.ts`'s `resolveEffectiveAccessStream`. If/when the
+ * thread→root rule changes (e.g. nested threads, role-based shadowing),
+ * the canonical helper updates and every call site picks it up.
+ */
+export type ResolveEffectiveStream = (db: Querier, source: SharingStream) => Promise<SharingStream>
 
 /**
  * Returns true when `ancestorCandidateId` is `streamId` itself or appears
@@ -53,8 +79,14 @@ export interface PrivacyBoundaryResult {
 /**
  * Checks whether sharing from `sourceStreamId` into `targetStreamId` would
  * expose the source to target members who don't already have access. The
- * warning triggers only when the source is private AND at least one target
- * member isn't in the source's stream_members set (D2).
+ * warning triggers only when the effective source is private AND at least
+ * one target member isn't in the effective-source's stream_members set.
+ *
+ * For thread sources, "effective source" is the root: thread access is
+ * gated by the root's membership and visibility, and the thread row's
+ * stored visibility goes stale when the root's flips. Counting exposure
+ * against thread members would also wildly over-warn — threads only
+ * carry creator + parent-author rows by default.
  *
  * Share-to-parent short-circuits: if `targetStreamId` is an ancestor of
  * `sourceStreamId`, the parent audience already contains the thread's
@@ -63,6 +95,7 @@ export interface PrivacyBoundaryResult {
 export async function crossesPrivacyBoundary(
   db: Querier,
   findStream: FindStreamForSharing,
+  resolveEffective: ResolveEffectiveStream,
   isAncestor: IsAncestorStream,
   countExposedMembers: CountExposedMembers,
   sourceStreamId: string,
@@ -77,10 +110,13 @@ export async function crossesPrivacyBoundary(
   }
 
   const source = await findStream(db, sourceStreamId)
-  if (!source || source.visibility !== Visibilities.PRIVATE) {
+  if (!source) return { triggered: false, exposedUserCount: 0 }
+
+  const effectiveSource = await resolveEffective(db, source)
+  if (effectiveSource.visibility !== Visibilities.PRIVATE) {
     return { triggered: false, exposedUserCount: 0 }
   }
 
-  const exposedUserCount = await countExposedMembers(db, targetStreamId, sourceStreamId)
+  const exposedUserCount = await countExposedMembers(db, targetStreamId, effectiveSource.id)
   return { triggered: exposedUserCount > 0, exposedUserCount }
 }

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -8,7 +8,8 @@ import {
 import { MessageRepository } from "../repository"
 import { UserRepository } from "../../workspaces"
 import { PersonaRepository } from "../../agents"
-import * as streamsModule from "../../streams"
+import * as streamsBarrel from "../../streams"
+import { StreamRepository } from "../../streams"
 import { SharedMessageRepository } from "./repository"
 
 afterEach(() => {
@@ -28,14 +29,14 @@ function stubAuthorLookups() {
  * override these.
  */
 function stubFullAccess() {
-  spyOn(streamsModule, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
+  spyOn(streamsBarrel, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
     return new Set(candidates)
   })
   spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
 }
 
 function stubNoAccess() {
-  spyOn(streamsModule, "listAccessibleStreamIds").mockResolvedValue(new Set())
+  spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set())
   spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
 }
 
@@ -136,7 +137,7 @@ describe("hydrateSharedMessageIds", () => {
     )
     stubAuthorLookups()
     stubNoAccess()
-    spyOn(streamsModule.StreamRepository, "findByIds").mockResolvedValue([
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
       {
         id: "stream_source",
         type: "channel",
@@ -160,7 +161,7 @@ describe("hydrateSharedMessageIds", () => {
     )
     stubAuthorLookups()
     stubNoAccess()
-    const findStreams = spyOn(streamsModule.StreamRepository, "findByIds")
+    const findStreams = spyOn(StreamRepository, "findByIds")
       .mockResolvedValueOnce([
         {
           id: "stream_source",
@@ -193,7 +194,7 @@ describe("hydrateSharedMessageIds", () => {
       new Map([["msg_a", makeMessage({ id: "msg_a" })]])
     )
     stubAuthorLookups()
-    spyOn(streamsModule, "listAccessibleStreamIds").mockResolvedValue(new Set()) // not a member
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set()) // not a member
     spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set(["msg_a"])) // but has share grant
 
     const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
@@ -265,11 +266,11 @@ describe("hydrateSharedMessageIds", () => {
       return map
     })
     stubAuthorLookups()
-    spyOn(streamsModule, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
       return new Set([...candidates].filter((id) => id === "stream_outer"))
     })
     spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
-    spyOn(streamsModule.StreamRepository, "findByIds").mockResolvedValue([
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
       { id: "stream_inner", type: "channel", visibility: "private", rootStreamId: null } as any,
     ])
 

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -1,16 +1,58 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { collectSharedMessageIds, hydrateSharedMessageIds, hydrateSharedMessages } from "./hydration"
+import {
+  collectSharedMessageIds,
+  hydrateSharedMessageIds,
+  hydrateSharedMessages,
+  MAX_HYDRATION_DEPTH,
+} from "./hydration"
 import { MessageRepository } from "../repository"
 import { UserRepository } from "../../workspaces"
 import { PersonaRepository } from "../../agents"
+import * as streamsModule from "../../streams"
+import { SharedMessageRepository } from "./repository"
 
 afterEach(() => {
   mock.restore()
 })
 
+const VIEWER_ID = "usr_viewer"
+
 function stubAuthorLookups() {
   spyOn(UserRepository, "findByIds").mockResolvedValue([])
   spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+}
+
+/**
+ * Default access mocks: viewer has access to every stream we ask about,
+ * and no share grants. Tests that exercise the private/truncated paths
+ * override these.
+ */
+function stubFullAccess() {
+  spyOn(streamsModule, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
+    return new Set(candidates)
+  })
+  spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+}
+
+function stubNoAccess() {
+  spyOn(streamsModule, "listAccessibleStreamIds").mockResolvedValue(new Set())
+  spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+}
+
+function makeMessage(
+  overrides: Partial<{ id: string; streamId: string; deletedAt: Date | null; contentJson: unknown }>
+) {
+  return {
+    id: overrides.id ?? "msg_a",
+    streamId: overrides.streamId ?? "stream_source",
+    authorId: "usr_author",
+    authorType: "user",
+    contentJson: overrides.contentJson ?? { type: "doc", content: [{ type: "paragraph" }] },
+    contentMarkdown: "hello",
+    editedAt: null,
+    createdAt: new Date("2026-01-01"),
+    deletedAt: overrides.deletedAt ?? null,
+  } as any
 }
 
 describe("collectSharedMessageIds", () => {
@@ -20,10 +62,7 @@ describe("collectSharedMessageIds", () => {
       {
         type: "doc",
         content: [
-          {
-            type: "paragraph",
-            content: [{ type: "text", text: "hello" }],
-          },
+          { type: "paragraph", content: [{ type: "text", text: "hello" }] },
           { type: "sharedMessage", attrs: { messageId: "msg_a", streamId: "stream_a" } },
           {
             type: "blockquote",
@@ -41,12 +80,7 @@ describe("collectSharedMessageIds", () => {
     collectSharedMessageIds(
       {
         type: "doc",
-        content: [
-          {
-            type: "quoteReply",
-            attrs: { messageId: "msg_quote", streamId: "stream_q" },
-          },
-        ],
+        content: [{ type: "quoteReply", attrs: { messageId: "msg_quote", streamId: "stream_q" } }],
       },
       ids
     )
@@ -56,34 +90,19 @@ describe("collectSharedMessageIds", () => {
 
 describe("hydrateSharedMessageIds", () => {
   it("returns an empty map when given no ids", async () => {
-    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(new Map())
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", [])
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, [])
     expect(result).toEqual({})
   })
 
-  it("returns ok-state payloads for live source messages (with authorName joined from users)", async () => {
+  it("returns ok-state payloads when viewer can access the source stream", async () => {
     spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
-      new Map([
-        [
-          "msg_a",
-          {
-            id: "msg_a",
-            streamId: "stream_source",
-            authorId: "usr_1",
-            authorType: "user",
-            contentJson: { type: "doc", content: [{ type: "paragraph" }] },
-            contentMarkdown: "hello",
-            editedAt: null,
-            createdAt: new Date("2026-01-01"),
-            deletedAt: null,
-          } as any,
-        ],
-      ])
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
     )
-    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_1", name: "Ada" } as any])
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Ada" } as any])
     spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    stubFullAccess()
 
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", ["msg_a"])
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
     expect(result.msg_a).toMatchObject({
       state: "ok",
       messageId: "msg_a",
@@ -92,36 +111,176 @@ describe("hydrateSharedMessageIds", () => {
     })
   })
 
-  it("returns deleted payloads for soft-deleted sources", async () => {
+  it("returns deleted payloads for soft-deleted accessible sources", async () => {
     const deletedAt = new Date("2026-02-01")
     spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
-      new Map([
-        [
-          "msg_a",
-          {
-            id: "msg_a",
-            streamId: "stream_source",
-            authorId: "usr_1",
-            authorType: "user",
-            contentJson: { type: "doc" },
-            contentMarkdown: "",
-            editedAt: null,
-            createdAt: new Date("2026-01-01"),
-            deletedAt,
-          } as any,
-        ],
-      ])
+      new Map([["msg_a", makeMessage({ id: "msg_a", deletedAt })]])
     )
     stubAuthorLookups()
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", ["msg_a"])
+    stubFullAccess()
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
     expect(result.msg_a).toEqual({ state: "deleted", messageId: "msg_a", deletedAt })
   })
 
   it("returns missing payloads for ids that resolve to no row", async () => {
     spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(new Map())
     stubAuthorLookups()
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", ["msg_missing"])
+    stubFullAccess()
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_missing"])
     expect(result.msg_missing).toEqual({ state: "missing", messageId: "msg_missing" })
+  })
+
+  it("returns a private placeholder when viewer can't access the source stream", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubNoAccess()
+    spyOn(streamsModule.StreamRepository, "findByIds").mockResolvedValue([
+      {
+        id: "stream_source",
+        type: "channel",
+        visibility: "private",
+        rootStreamId: null,
+      } as any,
+    ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toEqual({
+      state: "private",
+      messageId: "msg_a",
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    })
+  })
+
+  it("for thread sources, the private placeholder reports the parent's kind/visibility", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubNoAccess()
+    const findStreams = spyOn(streamsModule.StreamRepository, "findByIds")
+      .mockResolvedValueOnce([
+        {
+          id: "stream_source",
+          type: "thread",
+          visibility: "private",
+          rootStreamId: "stream_root",
+        } as any,
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "stream_root",
+          type: "channel",
+          visibility: "public",
+          rootStreamId: null,
+        } as any,
+      ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toEqual({
+      state: "private",
+      messageId: "msg_a",
+      sourceStreamKind: "channel",
+      sourceVisibility: "public",
+    })
+    expect(findStreams).toHaveBeenCalledTimes(2)
+  })
+
+  it("treats source-via-share-grant as accessible even when not a stream member", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    spyOn(streamsModule, "listAccessibleStreamIds").mockResolvedValue(new Set()) // not a member
+    spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set(["msg_a"])) // but has share grant
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toMatchObject({ state: "ok", messageId: "msg_a" })
+  })
+
+  it("recurses into nested pointers up to MAX_HYDRATION_DEPTH and emits truncated past the cap", async () => {
+    // Build a chain msg_0 → msg_1 → msg_2 → msg_3 → msg_4 (4 levels deep beyond seed)
+    // With MAX_HYDRATION_DEPTH = 3, msg_0..msg_2 hydrate as ok and msg_3 is truncated.
+    const findByIds = spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        const next = id.replace(/^msg_(\d+)$/, (_m, n) => `msg_${Number(n) + 1}`)
+        map.set(
+          id,
+          makeMessage({
+            id,
+            contentJson: {
+              type: "doc",
+              content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_next" } }],
+            },
+          })
+        )
+      }
+      return map
+    })
+    stubAuthorLookups()
+    stubFullAccess()
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
+
+    // 0..(MAX-1) are fetched and hydrated as ok
+    for (let i = 0; i < MAX_HYDRATION_DEPTH; i++) {
+      expect(result[`msg_${i}`]).toMatchObject({ state: "ok" })
+    }
+    // The first un-fetched ref is the truncated entry, using the streamId from
+    // the parent's share-node attrs so we don't pay an extra DB lookup.
+    expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      state: "truncated",
+      messageId: `msg_${MAX_HYDRATION_DEPTH}`,
+      streamId: "stream_next",
+    })
+    // Caller saw exactly MAX_HYDRATION_DEPTH batched message lookups.
+    expect(findByIds).toHaveBeenCalledTimes(MAX_HYDRATION_DEPTH)
+  })
+
+  it("skips truncated emission for a private inner pointer (no extra access leak)", async () => {
+    // A two-hop chain where the viewer can read msg_outer but not msg_inner.
+    // The plan says inner should render as `private`, not as `truncated`.
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        if (id === "msg_outer") {
+          map.set(
+            id,
+            makeMessage({
+              id,
+              streamId: "stream_outer",
+              contentJson: {
+                type: "doc",
+                content: [{ type: "sharedMessage", attrs: { messageId: "msg_inner", streamId: "stream_inner" } }],
+              },
+            })
+          )
+        } else if (id === "msg_inner") {
+          map.set(id, makeMessage({ id, streamId: "stream_inner" }))
+        }
+      }
+      return map
+    })
+    stubAuthorLookups()
+    spyOn(streamsModule, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
+      return new Set([...candidates].filter((id) => id === "stream_outer"))
+    })
+    spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+    spyOn(streamsModule.StreamRepository, "findByIds").mockResolvedValue([
+      { id: "stream_inner", type: "channel", visibility: "private", rootStreamId: null } as any,
+    ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_outer"])
+    expect(result.msg_outer).toMatchObject({ state: "ok" })
+    expect(result.msg_inner).toEqual({
+      state: "private",
+      messageId: "msg_inner",
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    })
   })
 })
 
@@ -129,7 +288,8 @@ describe("hydrateSharedMessages", () => {
   it("scans input messages' contentJson and hydrates referenced ids in one pass", async () => {
     const findByIds = spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(new Map())
     stubAuthorLookups()
-    await hydrateSharedMessages({} as any, "ws_1", [
+    stubFullAccess()
+    await hydrateSharedMessages({} as any, "ws_1", VIEWER_ID, [
       {
         id: "msg_1",
         contentJson: {

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -3,6 +3,7 @@ import { type JSONContent, type StreamType, type Visibility, StreamTypes } from 
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
 import { listAccessibleStreamIds, StreamRepository, type Stream } from "../../streams"
+
 import { SharedMessageRepository } from "./repository"
 
 /**
@@ -12,6 +13,11 @@ import { SharedMessageRepository } from "./repository"
  * `truncated` placeholder linking to the source stream so the viewer can
  * keep reading there. See `docs/plans/message-sharing-streams.md` (Pointer
  * hydration on message fetch).
+ *
+ * Inlined as a module-local literal (rather than imported from a separate
+ * config module) because the messaging↔streams barrel cycle leaves a
+ * cross-module re-export of this binding in TDZ when this file is
+ * partially evaluated as part of the cycle's eval graph.
  */
 export const MAX_HYDRATION_DEPTH = 3
 
@@ -133,7 +139,12 @@ export async function hydrateSharedMessageIds(
   db: Querier,
   workspaceId: string,
   viewerId: string,
-  sourceMessageIds: Iterable<string>
+  sourceMessageIds: Iterable<string>,
+  // Default-arg evaluation reads the module-scope const at call time, by
+  // which point any cross-feature barrel cycle that delayed this file's
+  // initialization has resolved. A direct reference inside the loop body
+  // hits TDZ when the cycle leaves the binding un-init mid-eval.
+  maxDepth: number = MAX_HYDRATION_DEPTH
 ): Promise<Record<string, HydratedSharedMessage>> {
   const seedIds = Array.from(new Set(sourceMessageIds))
   if (seedIds.length === 0) return {}
@@ -150,7 +161,7 @@ export async function hydrateSharedMessageIds(
   let frontier = new Map<string, string>(seedIds.map((id) => [id, ""]))
   let depth = 0
 
-  while (frontier.size > 0 && depth < MAX_HYDRATION_DEPTH) {
+  while (frontier.size > 0 && depth < maxDepth) {
     const ids = [...frontier.keys()].filter((id) => !visited.has(id))
     if (ids.length === 0) break
     for (const id of ids) visited.add(id)

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -1,5 +1,5 @@
 import type { Querier } from "../../../db"
-import { type JSONContent } from "@threa/types"
+import { type JSONContent, type StreamType, type Visibility } from "@threa/types"
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
 
@@ -7,9 +7,17 @@ import { resolveActorNames } from "../../agents"
  * Hydrated payload for a single shared-message reference. The frontend
  * overlays this data onto the inline `sharedMessage` node at render time.
  *
- * In Slice 1 we emit one of: full content, deleted-tombstone, or missing.
- * Slice 2 will add a per-viewer `{ private: true, sourceStreamKind, ... }`
- * placeholder for non-ancestor cross-stream shares (D8).
+ * Variants:
+ * - `ok`: viewer has access; current source content is inlined.
+ * - `deleted`: source row exists but is tombstoned.
+ * - `missing`: source row never existed (defended for; shouldn't normally
+ *   happen because shares are recorded against existing source ids).
+ * - `private`: viewer has no read path to the source — reveals only the
+ *   source stream's `kind` + `visibility`, never content/author/name. Used
+ *   for re-share chains where a downstream viewer can see the outer
+ *   pointer but not an inner one (plan D8).
+ * - `truncated`: hydration stopped at `MAX_HYDRATION_DEPTH` for an
+ *   accessible chain; viewer can navigate to `streamId` to keep reading.
  */
 export type HydratedSharedMessage =
   | {
@@ -26,6 +34,13 @@ export type HydratedSharedMessage =
     }
   | { state: "deleted"; messageId: string; deletedAt: Date }
   | { state: "missing"; messageId: string }
+  | {
+      state: "private"
+      messageId: string
+      sourceStreamKind: StreamType
+      sourceVisibility: Visibility
+    }
+  | { state: "truncated"; messageId: string; streamId: string }
 
 /**
  * Walk a ProseMirror content tree and add every `sharedMessage` node's

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -8,16 +8,9 @@ import { SharedMessageRepository } from "./repository"
 
 /**
  * Hard cap on how many nested pointer levels we'll resolve in one read.
- * Realistically chains rarely exceed 1–2 hops; the cap exists to keep the
- * cost of pathological data bounded. Pointers beyond the cap render as a
- * `truncated` placeholder linking to the source stream so the viewer can
- * keep reading there. See `docs/plans/message-sharing-streams.md` (Pointer
- * hydration on message fetch).
- *
- * Inlined as a module-local literal (rather than imported from a separate
- * config module) because the messaging↔streams barrel cycle leaves a
- * cross-module re-export of this binding in TDZ when this file is
- * partially evaluated as part of the cycle's eval graph.
+ * Realistically chains rarely exceed 1–2 hops; the cap protects against
+ * pathological data. Pointers beyond the cap render as a `truncated`
+ * placeholder linking to the source stream.
  */
 export const MAX_HYDRATION_DEPTH = 3
 
@@ -33,7 +26,7 @@ export const MAX_HYDRATION_DEPTH = 3
  * - `private`: viewer has no read path to the source — reveals only the
  *   source stream's `kind` + `visibility`, never content/author/name. Used
  *   for re-share chains where a downstream viewer can see the outer
- *   pointer but not an inner one (plan D8).
+ *   pointer but not an inner one.
  * - `truncated`: hydration stopped at `MAX_HYDRATION_DEPTH` for an
  *   accessible chain; viewer can navigate to `streamId` to keep reading.
  */
@@ -60,48 +53,56 @@ export type HydratedSharedMessage =
     }
   | { state: "truncated"; messageId: string; streamId: string }
 
+interface SharedMessageNodeAttrs {
+  messageId?: string
+  streamId?: string
+}
+
 /**
- * Walk a ProseMirror content tree and add every `sharedMessage` node's
- * referenced `messageId` to `into`. Exported so stream event projections
- * can scan `message_created` / `message_edited` payload content alongside
- * direct Message[] inputs.
+ * Walk a ProseMirror content tree and invoke `visit` for every
+ * `sharedMessage` node's `attrs`. The two `collect*` helpers below are
+ * thin specialisations around this single walker so the recursion stays
+ * defined in one place.
  */
-export function collectSharedMessageIds(node: JSONContent | undefined, into: Set<string>): void {
+function walkSharedMessageNodes(node: JSONContent | undefined, visit: (attrs: SharedMessageNodeAttrs) => void): void {
   if (!node) return
   if (node.type === "sharedMessage") {
-    const messageId = (node.attrs as { messageId?: string } | undefined)?.messageId
-    if (messageId) into.add(messageId)
+    visit((node.attrs ?? {}) as SharedMessageNodeAttrs)
   }
   if (node.content) {
     for (const child of node.content) {
-      collectSharedMessageIds(child, into)
+      walkSharedMessageNodes(child, visit)
     }
   }
 }
 
 /**
- * Like {@link collectSharedMessageIds} but also captures each ref's
- * cached `streamId` from the node attrs. Used during recursive hydration
- * so a pointer beyond the depth cap can render a "Open in source stream"
- * link without a per-ref DB lookup.
+ * Collect every `sharedMessage` node's `messageId` from a content tree.
+ * Exported so stream event projections can scan `message_created` /
+ * `message_edited` payload content alongside direct Message[] inputs.
+ */
+export function collectSharedMessageIds(node: JSONContent | undefined, into: Set<string>): void {
+  walkSharedMessageNodes(node, (attrs) => {
+    if (attrs.messageId) into.add(attrs.messageId)
+  })
+}
+
+/**
+ * Like {@link collectSharedMessageIds} but also captures each ref's cached
+ * `streamId` from the node attrs. Used during recursive hydration so a
+ * pointer past the depth cap can render a "Open in source stream" link
+ * without a per-ref DB lookup.
  */
 function collectSharedMessageRefs(node: JSONContent | undefined, into: Map<string, string>): void {
-  if (!node) return
-  if (node.type === "sharedMessage") {
-    const attrs = node.attrs as { messageId?: string; streamId?: string } | undefined
-    if (attrs?.messageId && attrs.streamId) into.set(attrs.messageId, attrs.streamId)
-  }
-  if (node.content) {
-    for (const child of node.content) {
-      collectSharedMessageRefs(child, into)
-    }
-  }
+  walkSharedMessageNodes(node, (attrs) => {
+    if (attrs.messageId && attrs.streamId) into.set(attrs.messageId, attrs.streamId)
+  })
 }
 
 /**
  * Resolve the (kind, visibility) the `private` placeholder should report.
  * For thread sources we surface the parent's kind/visibility so the
- * placeholder vocabulary stays in {channel, dm, scratchpad} per plan D8 —
+ * placeholder vocabulary stays in {channel, dm, scratchpad} —
  * "thread" by itself wouldn't tell the viewer what kind of stream sits
  * behind the wall.
  */
@@ -139,12 +140,7 @@ export async function hydrateSharedMessageIds(
   db: Querier,
   workspaceId: string,
   viewerId: string,
-  sourceMessageIds: Iterable<string>,
-  // Default-arg evaluation reads the module-scope const at call time, by
-  // which point any cross-feature barrel cycle that delayed this file's
-  // initialization has resolved. A direct reference inside the loop body
-  // hits TDZ when the cycle leaves the binding un-init mid-eval.
-  maxDepth: number = MAX_HYDRATION_DEPTH
+  sourceMessageIds: Iterable<string>
 ): Promise<Record<string, HydratedSharedMessage>> {
   const seedIds = Array.from(new Set(sourceMessageIds))
   if (seedIds.length === 0) return {}
@@ -152,16 +148,16 @@ export async function hydrateSharedMessageIds(
   const result: Record<string, HydratedSharedMessage> = {}
   const visited = new Set<string>()
   const okMessages = new Map<string, Message>()
-  // messageId → streamId of the source (for batched stream lookup at the end).
   const privateBuckets = new Map<string, string>()
 
-  // Frontier holds (messageId → streamId-from-attrs); seed level has no
-  // attrs streamId so we leave it empty — these get populated for nested
-  // levels via `collectSharedMessageRefs`.
+  // Seed level has no attrs streamId since the seeds came in as bare ids;
+  // nested levels populate it via `collectSharedMessageRefs` so truncated
+  // entries past the cap can link to the right stream without an extra
+  // DB hit.
   let frontier = new Map<string, string>(seedIds.map((id) => [id, ""]))
   let depth = 0
 
-  while (frontier.size > 0 && depth < maxDepth) {
+  while (frontier.size > 0 && depth < MAX_HYDRATION_DEPTH) {
     const ids = [...frontier.keys()].filter((id) => !visited.has(id))
     if (ids.length === 0) break
     for (const id of ids) visited.add(id)

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -1,7 +1,19 @@
 import type { Querier } from "../../../db"
-import { type JSONContent, type StreamType, type Visibility } from "@threa/types"
+import { type JSONContent, type StreamType, type Visibility, StreamTypes } from "@threa/types"
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
+import { listAccessibleStreamIds, StreamRepository, type Stream } from "../../streams"
+import { SharedMessageRepository } from "./repository"
+
+/**
+ * Hard cap on how many nested pointer levels we'll resolve in one read.
+ * Realistically chains rarely exceed 1–2 hops; the cap exists to keep the
+ * cost of pathological data bounded. Pointers beyond the cap render as a
+ * `truncated` placeholder linking to the source stream so the viewer can
+ * keep reading there. See `docs/plans/message-sharing-streams.md` (Pointer
+ * hydration on message fetch).
+ */
+export const MAX_HYDRATION_DEPTH = 3
 
 /**
  * Hydrated payload for a single shared-message reference. The frontend
@@ -62,57 +74,179 @@ export function collectSharedMessageIds(node: JSONContent | undefined, into: Set
 }
 
 /**
- * Fetch source messages for each id and emit a `{ sourceMessageId →
- * HydratedSharedMessage }` map. Runs one batched workspace-scoped lookup
- * against `messages` regardless of input size (INV-56). Author display
- * names are resolved in a second batched pair of queries against the users
- * and personas tables so the frontend doesn't have to hit the network per
- * pointer.
+ * Like {@link collectSharedMessageIds} but also captures each ref's
+ * cached `streamId` from the node attrs. Used during recursive hydration
+ * so a pointer beyond the depth cap can render a "Open in source stream"
+ * link without a per-ref DB lookup.
+ */
+function collectSharedMessageRefs(node: JSONContent | undefined, into: Map<string, string>): void {
+  if (!node) return
+  if (node.type === "sharedMessage") {
+    const attrs = node.attrs as { messageId?: string; streamId?: string } | undefined
+    if (attrs?.messageId && attrs.streamId) into.set(attrs.messageId, attrs.streamId)
+  }
+  if (node.content) {
+    for (const child of node.content) {
+      collectSharedMessageRefs(child, into)
+    }
+  }
+}
+
+/**
+ * Resolve the (kind, visibility) the `private` placeholder should report.
+ * For thread sources we surface the parent's kind/visibility so the
+ * placeholder vocabulary stays in {channel, dm, scratchpad} per plan D8 —
+ * "thread" by itself wouldn't tell the viewer what kind of stream sits
+ * behind the wall.
+ */
+function resolveSourceForPrivatePlaceholder(
+  source: Stream,
+  byStreamId: ReadonlyMap<string, Stream>
+): { kind: StreamType; visibility: Visibility } {
+  if (source.type === StreamTypes.THREAD && source.rootStreamId) {
+    const root = byStreamId.get(source.rootStreamId)
+    if (root) return { kind: root.type, visibility: root.visibility }
+  }
+  return { kind: source.type, visibility: source.visibility }
+}
+
+/**
+ * Per-viewer recursive pointer hydration. Walks each pointer chain
+ * level-by-level up to {@link MAX_HYDRATION_DEPTH}; at every level the
+ * viewer's access is resolved via {@link listAccessibleStreamIds} (direct
+ * member, public visibility, or thread inheriting from root) plus the
+ * share-grant lookup (the viewer can also read a source iff a share with
+ * that source exists in a target stream the viewer can read).
+ *
+ * Each level performs a fixed handful of batched queries (no per-ref DB
+ * loops, INV-56): one `findByIdsInWorkspace`, one accessible-streams
+ * lookup, one share-grant lookup. Author names and the private-placeholder
+ * source-stream lookup are batched once at the end.
+ *
+ * Pointers collected at level `MAX_HYDRATION_DEPTH` are emitted as
+ * `truncated` using the cached `streamId` from the parent's node attrs —
+ * no extra DB hit. If the viewer doesn't have access there, clicking
+ * through will 403 like any other deep link, which is fine; the cap is a
+ * pathological-data guard, not a privacy guard.
  */
 export async function hydrateSharedMessageIds(
   db: Querier,
   workspaceId: string,
+  viewerId: string,
   sourceMessageIds: Iterable<string>
 ): Promise<Record<string, HydratedSharedMessage>> {
-  const ids = Array.from(new Set(sourceMessageIds))
-  if (ids.length === 0) return {}
-
-  const byId = await MessageRepository.findByIdsInWorkspace(db, workspaceId, ids)
-
-  // INV-35: reuse `resolveActorNames` instead of partitioning user/persona ids
-  // by authorType and re-running the parallel-batched lookup inline. The
-  // helper already handles the user (workspace-scoped) + persona (workspace-
-  // agnostic) split and returns a single id→name map.
-  const actorIds = new Set<string>()
-  for (const source of byId.values()) {
-    if (!source.deletedAt) actorIds.add(source.authorId)
-  }
-  const authorNames = await resolveActorNames(db, workspaceId, actorIds)
+  const seedIds = Array.from(new Set(sourceMessageIds))
+  if (seedIds.length === 0) return {}
 
   const result: Record<string, HydratedSharedMessage> = {}
-  for (const id of ids) {
-    const source = byId.get(id)
-    if (!source) {
-      result[id] = { state: "missing", messageId: id }
-      continue
+  const visited = new Set<string>()
+  const okMessages = new Map<string, Message>()
+  // messageId → streamId of the source (for batched stream lookup at the end).
+  const privateBuckets = new Map<string, string>()
+
+  // Frontier holds (messageId → streamId-from-attrs); seed level has no
+  // attrs streamId so we leave it empty — these get populated for nested
+  // levels via `collectSharedMessageRefs`.
+  let frontier = new Map<string, string>(seedIds.map((id) => [id, ""]))
+  let depth = 0
+
+  while (frontier.size > 0 && depth < MAX_HYDRATION_DEPTH) {
+    const ids = [...frontier.keys()].filter((id) => !visited.has(id))
+    if (ids.length === 0) break
+    for (const id of ids) visited.add(id)
+
+    const byId = await MessageRepository.findByIdsInWorkspace(db, workspaceId, ids)
+    const fetchedStreamIds = [...byId.values()].map((m) => m.streamId)
+    const [accessibleStreams, grantedSources] = await Promise.all([
+      listAccessibleStreamIds(db, workspaceId, viewerId, fetchedStreamIds),
+      SharedMessageRepository.listSourcesGrantedToViewer(db, workspaceId, viewerId, ids),
+    ])
+
+    const nextFrontier = new Map<string, string>()
+    for (const id of ids) {
+      const source = byId.get(id)
+      if (!source) {
+        result[id] = { state: "missing", messageId: id }
+        continue
+      }
+      const hasAccess = accessibleStreams.has(source.streamId) || grantedSources.has(id)
+      if (!hasAccess) {
+        privateBuckets.set(id, source.streamId)
+        continue
+      }
+      if (source.deletedAt) {
+        result[id] = { state: "deleted", messageId: id, deletedAt: source.deletedAt }
+        continue
+      }
+      okMessages.set(id, source)
+      collectSharedMessageRefs(source.contentJson, nextFrontier)
     }
-    if (source.deletedAt) {
-      result[id] = { state: "deleted", messageId: id, deletedAt: source.deletedAt }
-      continue
+
+    frontier = nextFrontier
+    depth++
+  }
+
+  // Anything still in frontier has been collected from depth=MAX-1's
+  // accessible content but we won't recurse into it. Emit truncated using
+  // the streamId cached on the share-node attrs — no extra DB call.
+  for (const [id, streamId] of frontier) {
+    if (visited.has(id) || result[id]) continue
+    if (!streamId) continue
+    result[id] = { state: "truncated", messageId: id, streamId }
+  }
+
+  if (privateBuckets.size > 0) {
+    const directIds = [...new Set(privateBuckets.values())]
+    const streams = await StreamRepository.findByIds(db, directIds)
+    const byStreamId = new Map(streams.map((s) => [s.id, s]))
+    const rootIds = [
+      ...new Set(
+        streams.flatMap((s) =>
+          s.type === StreamTypes.THREAD && s.rootStreamId && !byStreamId.has(s.rootStreamId) ? [s.rootStreamId] : []
+        )
+      ),
+    ]
+    if (rootIds.length > 0) {
+      const roots = await StreamRepository.findByIds(db, rootIds)
+      for (const r of roots) byStreamId.set(r.id, r)
     }
-    result[id] = {
-      state: "ok",
-      messageId: source.id,
-      streamId: source.streamId,
-      authorId: source.authorId,
-      authorType: source.authorType,
-      authorName: authorNames.get(source.authorId) ?? null,
-      contentJson: source.contentJson,
-      contentMarkdown: source.contentMarkdown,
-      editedAt: source.editedAt,
-      createdAt: source.createdAt,
+    for (const [id, streamId] of privateBuckets) {
+      const source = byStreamId.get(streamId)
+      if (!source) {
+        result[id] = { state: "missing", messageId: id }
+        continue
+      }
+      const { kind, visibility } = resolveSourceForPrivatePlaceholder(source, byStreamId)
+      result[id] = { state: "private", messageId: id, sourceStreamKind: kind, sourceVisibility: visibility }
     }
   }
+
+  if (okMessages.size > 0) {
+    const actorIds = new Set<string>()
+    for (const msg of okMessages.values()) actorIds.add(msg.authorId)
+    const authorNames = await resolveActorNames(db, workspaceId, actorIds)
+    for (const [id, source] of okMessages) {
+      result[id] = {
+        state: "ok",
+        messageId: source.id,
+        streamId: source.streamId,
+        authorId: source.authorId,
+        authorType: source.authorType,
+        authorName: authorNames.get(source.authorId) ?? null,
+        contentJson: source.contentJson,
+        contentMarkdown: source.contentMarkdown,
+        editedAt: source.editedAt,
+        createdAt: source.createdAt,
+      }
+    }
+  }
+
+  // Defensive backfill — every requested id should have a result by now;
+  // anything left over (e.g. a seed id that hit no path above) is missing.
+  for (const id of seedIds) {
+    if (!result[id]) result[id] = { state: "missing", messageId: id }
+  }
+
   return result
 }
 
@@ -124,11 +258,12 @@ export async function hydrateSharedMessageIds(
 export async function hydrateSharedMessages(
   db: Querier,
   workspaceId: string,
+  viewerId: string,
   messages: readonly Message[]
 ): Promise<Record<string, HydratedSharedMessage>> {
   const ids = new Set<string>()
   for (const msg of messages) {
     collectSharedMessageIds(msg.contentJson, ids)
   }
-  return hydrateSharedMessageIds(db, workspaceId, ids)
+  return hydrateSharedMessageIds(db, workspaceId, viewerId, ids)
 }

--- a/apps/backend/src/features/messaging/sharing/index.ts
+++ b/apps/backend/src/features/messaging/sharing/index.ts
@@ -8,6 +8,7 @@ export {
   type IsAncestorStream,
   type CountExposedMembers,
   type CanReadStream,
+  type ResolveEffectiveStream,
 } from "./access-check"
 export { invalidatePointersForEvent, POINTER_INVALIDATED_EVENT } from "./outbox-handler"
 export {

--- a/apps/backend/src/features/messaging/sharing/repository.ts
+++ b/apps/backend/src/features/messaging/sharing/repository.ts
@@ -1,6 +1,7 @@
 import type { Querier } from "../../../db"
 import { sql } from "../../../db"
 import { type ShareFlavor } from "@threa/types"
+import { listAccessibleStreamIds } from "../../streams"
 
 // Internal row type (snake_case, not exported)
 interface SharedMessageRow {
@@ -108,14 +109,12 @@ export const SharedMessageRepository = {
   /**
    * Returns the subset of `sourceMessageIds` for which the viewer has been
    * granted read access via at least one share whose `target_stream_id` the
-   * viewer can access (per `listAccessibleStreamIds` semantics — direct
-   * member, public visibility, or thread inheriting from root). Set-based,
-   * single SQL round-trip.
+   * viewer can access. Composes with {@link listAccessibleStreamIds} so the
+   * "can the viewer read this stream?" rule lives in one place.
    *
-   * Used by recursive pointer hydration (D8) to decide per-viewer access at
-   * each level of a re-share chain: a viewer who isn't directly a member of
-   * the source stream still sees the source content if they have any share
-   * grant reaching them.
+   * Used by recursive pointer hydration to decide per-viewer access at each
+   * level of a re-share chain: a viewer who isn't a member of the source
+   * stream still sees the source content if any share grant reaches them.
    */
   async listSourcesGrantedToViewer(
     db: Querier,
@@ -124,31 +123,18 @@ export const SharedMessageRepository = {
     sourceMessageIds: readonly string[]
   ): Promise<Set<string>> {
     if (sourceMessageIds.length === 0) return new Set()
-    const result = await db.query<{ source_message_id: string }>(sql`
-      SELECT DISTINCT sm.source_message_id
-      FROM shared_messages sm
-      JOIN streams t ON t.id = sm.target_stream_id
-      LEFT JOIN streams root ON root.id = t.root_stream_id
-      WHERE sm.workspace_id = ${workspaceId}
-        AND sm.source_message_id = ANY(${sourceMessageIds as string[]})
-        AND (
-          (t.root_stream_id IS NULL AND (
-            t.visibility = 'public'
-            OR EXISTS (
-              SELECT 1 FROM stream_members
-              WHERE stream_id = t.id AND member_id = ${userId}
-            )
-          ))
-          OR
-          (t.root_stream_id IS NOT NULL AND root.id IS NOT NULL AND (
-            root.visibility = 'public'
-            OR EXISTS (
-              SELECT 1 FROM stream_members
-              WHERE stream_id = t.root_stream_id AND member_id = ${userId}
-            )
-          ))
-        )
+    const candidates = await db.query<{ source_message_id: string; target_stream_id: string }>(sql`
+      SELECT DISTINCT source_message_id, target_stream_id
+      FROM shared_messages
+      WHERE workspace_id = ${workspaceId}
+        AND source_message_id = ANY(${sourceMessageIds as string[]})
     `)
-    return new Set(result.rows.map((r) => r.source_message_id))
+    if (candidates.rows.length === 0) return new Set()
+    const targetIds = [...new Set(candidates.rows.map((r) => r.target_stream_id))]
+    const accessibleTargets = await listAccessibleStreamIds(db, workspaceId, userId, targetIds)
+    if (accessibleTargets.size === 0) return new Set()
+    return new Set(
+      candidates.rows.filter((r) => accessibleTargets.has(r.target_stream_id)).map((r) => r.source_message_id)
+    )
   },
 }

--- a/apps/backend/src/features/messaging/sharing/repository.ts
+++ b/apps/backend/src/features/messaging/sharing/repository.ts
@@ -104,4 +104,51 @@ export const SharedMessageRepository = {
         AND share_message_id = ${shareMessageId}
     `)
   },
+
+  /**
+   * Returns the subset of `sourceMessageIds` for which the viewer has been
+   * granted read access via at least one share whose `target_stream_id` the
+   * viewer can access (per `listAccessibleStreamIds` semantics — direct
+   * member, public visibility, or thread inheriting from root). Set-based,
+   * single SQL round-trip.
+   *
+   * Used by recursive pointer hydration (D8) to decide per-viewer access at
+   * each level of a re-share chain: a viewer who isn't directly a member of
+   * the source stream still sees the source content if they have any share
+   * grant reaching them.
+   */
+  async listSourcesGrantedToViewer(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    sourceMessageIds: readonly string[]
+  ): Promise<Set<string>> {
+    if (sourceMessageIds.length === 0) return new Set()
+    const result = await db.query<{ source_message_id: string }>(sql`
+      SELECT DISTINCT sm.source_message_id
+      FROM shared_messages sm
+      JOIN streams t ON t.id = sm.target_stream_id
+      LEFT JOIN streams root ON root.id = t.root_stream_id
+      WHERE sm.workspace_id = ${workspaceId}
+        AND sm.source_message_id = ANY(${sourceMessageIds as string[]})
+        AND (
+          (t.root_stream_id IS NULL AND (
+            t.visibility = 'public'
+            OR EXISTS (
+              SELECT 1 FROM stream_members
+              WHERE stream_id = t.id AND member_id = ${userId}
+            )
+          ))
+          OR
+          (t.root_stream_id IS NOT NULL AND root.id IS NOT NULL AND (
+            root.visibility = 'public'
+            OR EXISTS (
+              SELECT 1 FROM stream_members
+              WHERE stream_id = t.root_stream_id AND member_id = ${userId}
+            )
+          ))
+        )
+    `)
+    return new Set(result.rows.map((r) => r.source_message_id))
+  },
 }

--- a/apps/backend/src/features/messaging/sharing/service.test.ts
+++ b/apps/backend/src/features/messaging/sharing/service.test.ts
@@ -92,6 +92,7 @@ describe("ShareService.validateAndRecordShares", () => {
     id: "stream_source",
     workspaceId: "ws_1",
     visibility: "private" as const,
+    rootStreamId: null,
   }
 
   function findStreamStub(overrides: Partial<typeof sourceStream> = {}) {
@@ -101,6 +102,9 @@ describe("ShareService.validateAndRecordShares", () => {
   const isAncestorStub = async () => false
   const countExposedMembersStub = async () => 0
   const canReadStreamStub = async () => true
+  // Default resolver — no-op: returns the source as-is. Tests covering
+  // thread → root resolution semantics live in `access-check.test.ts`.
+  const resolveEffectiveStreamStub = async (_db: unknown, source: any) => source
 
   function baseParams(extras: Partial<Parameters<typeof ShareService.validateAndRecordShares>[0]> = {}) {
     return {
@@ -110,6 +114,7 @@ describe("ShareService.validateAndRecordShares", () => {
       shareMessageId: "msg_share",
       sharerId: "usr_1",
       findStream: findStreamStub(),
+      resolveEffectiveStream: resolveEffectiveStreamStub,
       isAncestor: isAncestorStub,
       countExposedMembers: countExposedMembersStub,
       canReadStream: canReadStreamStub,

--- a/apps/backend/src/features/messaging/sharing/service.ts
+++ b/apps/backend/src/features/messaging/sharing/service.ts
@@ -9,6 +9,7 @@ import {
   type CountExposedMembers,
   type FindStreamForSharing,
   type IsAncestorStream,
+  type ResolveEffectiveStream,
 } from "./access-check"
 import { SharedMessageRepository } from "./repository"
 
@@ -75,6 +76,12 @@ export interface ValidateAndRecordSharesParams {
    * between messaging and streams.
    */
   findStream: FindStreamForSharing
+  /**
+   * Resolves a source stream to its effective access stream (root for
+   * threads). Wraps the canonical helper in `streams/access.ts` so the
+   * thread→root rule lives in one place. See `ResolveEffectiveStream`.
+   */
+  resolveEffectiveStream: ResolveEffectiveStream
   /**
    * Ancestor check injected by the caller (same barrel-cycle reason as
    * {@link findStream}). Expected to resolve the chain in the DB layer via
@@ -213,6 +220,7 @@ export const ShareService = {
         boundary = await crossesPrivacyBoundary(
           params.client,
           params.findStream,
+          params.resolveEffectiveStream,
           params.isAncestor,
           params.countExposedMembers,
           ref.sourceStreamId,

--- a/apps/backend/src/features/messaging/sharing/service.ts
+++ b/apps/backend/src/features/messaging/sharing/service.ts
@@ -1,7 +1,7 @@
 import type { Querier } from "../../../db"
 import { HttpError } from "../../../lib/errors"
 import { sharedMessageId } from "../../../lib/id"
-import { type JSONContent, ShareFlavors, type ShareFlavor } from "@threa/types"
+import { type JSONContent, ShareFlavors, type ShareFlavor, ShareErrorCodes } from "@threa/types"
 import { MessageRepository } from "../repository"
 import {
   crossesPrivacyBoundary,
@@ -164,13 +164,13 @@ export const ShareService = {
       if (!sourceMessage) {
         throw new HttpError("Source message not found", {
           status: 400,
-          code: "SHARE_SOURCE_MESSAGE_NOT_FOUND",
+          code: ShareErrorCodes.SOURCE_MESSAGE_NOT_FOUND,
         })
       }
       if (sourceMessage.streamId !== ref.sourceStreamId) {
         throw new HttpError("Source message does not belong to the referenced stream", {
           status: 400,
-          code: "SHARE_SOURCE_STREAM_MISMATCH",
+          code: ShareErrorCodes.SOURCE_STREAM_MISMATCH,
         })
       }
 
@@ -182,13 +182,13 @@ export const ShareService = {
       if (!sourceStream) {
         throw new HttpError("Source stream not found", {
           status: 400,
-          code: "SHARE_SOURCE_STREAM_NOT_FOUND",
+          code: ShareErrorCodes.SOURCE_STREAM_NOT_FOUND,
         })
       }
       if (sourceStream.workspaceId !== params.workspaceId) {
         throw new HttpError("Cannot share across workspaces", {
           status: 400,
-          code: "SHARE_CROSS_WORKSPACE_FORBIDDEN",
+          code: ShareErrorCodes.CROSS_WORKSPACE_FORBIDDEN,
         })
       }
 
@@ -204,7 +204,7 @@ export const ShareService = {
       if (!canRead) {
         throw new HttpError("You don't have access to the source message", {
           status: 403,
-          code: "SHARE_SOURCE_FORBIDDEN",
+          code: ShareErrorCodes.SOURCE_FORBIDDEN,
         })
       }
 
@@ -232,7 +232,7 @@ export const ShareService = {
       if (boundary.triggered && !params.confirmedPrivacyWarning) {
         throw new HttpError("Privacy confirmation required to share this message", {
           status: 409,
-          code: "SHARE_PRIVACY_CONFIRMATION_REQUIRED",
+          code: ShareErrorCodes.PRIVACY_CONFIRMATION_REQUIRED,
         })
       }
 

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -5,6 +5,43 @@ import { StreamRepository, type Stream } from "./repository"
 import { StreamMemberRepository } from "./member-repository"
 
 /**
+ * Minimal structural shape this helper needs: the stream's id and a
+ * (possibly null) `rootStreamId`. Generic so callers with subset types
+ * (e.g. the sharing feature's `SharingStream`) can route through without
+ * forcing a full `Stream` instantiation.
+ */
+export interface AccessResolvable {
+  id: string
+  rootStreamId: string | null
+}
+
+/**
+ * Resolves the stream whose `visibility` and `stream_members` rows are
+ * authoritative for access decisions. Top-level streams are their own
+ * authoritative source; threads inherit from their root.
+ *
+ * Single source of truth for the "thread → root" access pattern. Every
+ * helper that decides "can user X read stream Y?" or "is this stream
+ * effectively private?" routes through here, so subtle drifts (stale
+ * thread visibility, sparse thread member sets) can't reintroduce holes.
+ *
+ * Falls back to the input stream when the root row is missing — the
+ * FK-less schema (INV-1) means a dangling `root_stream_id` is possible
+ * and we shouldn't crash on it. Generic in `T extends AccessResolvable`
+ * so the callback returns the same shape it was given (a thread → its
+ * root will lose row-level extras the caller wasn't tracking, which is
+ * fine — only id/visibility/membership matter for access).
+ */
+export async function resolveEffectiveAccessStream<T extends AccessResolvable>(
+  db: Querier,
+  stream: T
+): Promise<T | Stream> {
+  if (!stream.rootStreamId) return stream
+  const root = await StreamRepository.findById(db, stream.rootStreamId)
+  return root ?? stream
+}
+
+/**
  * Canonical "does this user have access to this stream?" check.
  *
  * Returns the stream when access is granted; `null` otherwise. Handles all
@@ -40,22 +77,13 @@ export async function checkStreamAccess(
   const stream = await StreamRepository.findById(db, streamId)
   if (!stream || stream.workspaceId !== workspaceId) return null
 
-  // Threads inherit access from their root: the thread itself usually has
-  // no `stream_members` row, so a membership check on the thread id would
-  // always 403 even for users with full access to the surrounding channel.
-  if (stream.rootStreamId) {
-    const rootStream = await StreamRepository.findById(db, stream.rootStreamId)
-    if (!rootStream) return null
+  const effective = await resolveEffectiveAccessStream(db, stream)
+  // A thread whose root is missing collapses back to the thread itself —
+  // not accessible without the root present.
+  if (effective === stream && stream.rootStreamId) return null
 
-    if (rootStream.visibility !== Visibilities.PUBLIC) {
-      const isRootMember = await StreamMemberRepository.isMember(db, stream.rootStreamId, userId)
-      if (!isRootMember) return null
-    }
-    return stream
-  }
-
-  if (stream.visibility !== Visibilities.PUBLIC) {
-    const isMember = await StreamMemberRepository.isMember(db, streamId, userId)
+  if (effective.visibility !== Visibilities.PUBLIC) {
+    const isMember = await StreamMemberRepository.isMember(db, effective.id, userId)
     if (!isMember) return null
   }
   return stream
@@ -65,15 +93,12 @@ export async function checkStreamAccess(
  * Batched equivalent of {@link checkStreamAccess}. Given a candidate set
  * of stream ids in a workspace, returns the subset the viewer can read.
  *
- * Mirrors the per-id helper's three rules in a single SQL round-trip so
+ * Encodes the same three rules as `checkStreamAccess` /
+ * {@link resolveEffectiveAccessStream} in one SQL round-trip so
  * cross-cutting features (pointer hydration, search, activity feeds) can
- * filter many stream ids at once without an N+1:
- *
- * 1. **Workspace boundary** — only streams in `workspaceId` are considered.
- * 2. **Threads inherit** — a thread is accessible iff its `root_stream_id`
- *    is public OR the viewer is a member of that root.
- * 3. **Top-level streams** — accessible iff `visibility = 'public'` OR the
- *    viewer is a direct member.
+ * filter many stream ids at once without an N+1. Keep the predicate in
+ * sync with the per-id helpers — when the rule for thread → root
+ * resolution changes, both code paths update together.
  *
  * Empty input → empty Set; missing/cross-workspace ids are silently dropped
  * exactly like the per-id helper returning `null`.

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -79,8 +79,10 @@ export async function checkStreamAccess(
 
   const effective = await resolveEffectiveAccessStream(db, stream)
   // A thread whose root is missing collapses back to the thread itself —
-  // not accessible without the root present.
-  if (effective === stream && stream.rootStreamId) return null
+  // not accessible without the root present. Compare ids rather than
+  // object identity so this stays correct if the resolver ever returns a
+  // copy on the dangling-root fallback.
+  if (stream.rootStreamId && effective.id !== stream.rootStreamId) return null
 
   if (effective.visibility !== Visibilities.PUBLIC) {
     const isMember = await StreamMemberRepository.isMember(db, effective.id, userId)

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -1,4 +1,5 @@
 import type { Querier } from "../../db"
+import { sql } from "../../db"
 import { Visibilities } from "@threa/types"
 import { StreamRepository, type Stream } from "./repository"
 import { StreamMemberRepository } from "./member-repository"
@@ -58,4 +59,55 @@ export async function checkStreamAccess(
     if (!isMember) return null
   }
   return stream
+}
+
+/**
+ * Batched equivalent of {@link checkStreamAccess}. Given a candidate set
+ * of stream ids in a workspace, returns the subset the viewer can read.
+ *
+ * Mirrors the per-id helper's three rules in a single SQL round-trip so
+ * cross-cutting features (pointer hydration, search, activity feeds) can
+ * filter many stream ids at once without an N+1:
+ *
+ * 1. **Workspace boundary** — only streams in `workspaceId` are considered.
+ * 2. **Threads inherit** — a thread is accessible iff its `root_stream_id`
+ *    is public OR the viewer is a member of that root.
+ * 3. **Top-level streams** — accessible iff `visibility = 'public'` OR the
+ *    viewer is a direct member.
+ *
+ * Empty input → empty Set; missing/cross-workspace ids are silently dropped
+ * exactly like the per-id helper returning `null`.
+ */
+export async function listAccessibleStreamIds(
+  db: Querier,
+  workspaceId: string,
+  userId: string,
+  candidateStreamIds: readonly string[]
+): Promise<Set<string>> {
+  if (candidateStreamIds.length === 0) return new Set()
+  const result = await db.query<{ id: string }>(sql`
+    SELECT s.id
+    FROM streams s
+    LEFT JOIN streams root ON root.id = s.root_stream_id
+    WHERE s.workspace_id = ${workspaceId}
+      AND s.id = ANY(${candidateStreamIds as string[]})
+      AND (
+        (s.root_stream_id IS NULL AND (
+          s.visibility = ${Visibilities.PUBLIC}
+          OR EXISTS (
+            SELECT 1 FROM stream_members
+            WHERE stream_id = s.id AND member_id = ${userId}
+          )
+        ))
+        OR
+        (s.root_stream_id IS NOT NULL AND root.id IS NOT NULL AND (
+          root.visibility = ${Visibilities.PUBLIC}
+          OR EXISTS (
+            SELECT 1 FROM stream_members
+            WHERE stream_id = s.root_stream_id AND member_id = ${userId}
+          )
+        ))
+      )
+  `)
+  return new Set(result.rows.map((r) => r.id))
 }

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -190,6 +190,7 @@ interface Dependencies {
 async function hydrateSharedMessagesForEvents(
   pool: Pool,
   workspaceId: string,
+  viewerId: string,
   events: StreamEvent[]
 ): Promise<Record<string, HydratedSharedMessage>> {
   const ids = new Set<string>()
@@ -200,7 +201,7 @@ async function hydrateSharedMessagesForEvents(
     }
   }
   if (ids.size === 0) return {}
-  return hydrateSharedMessageIds(pool, workspaceId, ids)
+  return hydrateSharedMessageIds(pool, workspaceId, viewerId, ids)
 }
 
 function serializeEvent(event: StreamEvent) {
@@ -452,7 +453,7 @@ export function createStreamHandlers({
       })
 
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(linkPreviewService, workspaceId, userId, events)
-      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, eventsWithLinkPreviews)
+      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
       res.json({ events: eventsWithLinkPreviews.map(serializeEvent), sharedMessages })
     },
@@ -487,7 +488,7 @@ export function createStreamHandlers({
         userId,
         enrichedEvents
       )
-      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, eventsWithLinkPreviews)
+      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
       res.json({
         events: eventsWithLinkPreviews.map(serializeEvent),
@@ -686,7 +687,7 @@ export function createStreamHandlers({
         userId,
         enrichedEvents
       )
-      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, eventsWithLinkPreviews)
+      const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
       // Fold the stream's persisted ContextBag into the bootstrap so the
       // timeline message-context badge renders synchronously from cached

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -6,7 +6,7 @@ export { StreamService } from "./service"
 export type { CreateScratchpadParams, CreateChannelParams, CreateThreadParams } from "./service"
 
 // Access (canonical "can this user read this stream?" check — INV-8)
-export { checkStreamAccess, listAccessibleStreamIds } from "./access"
+export { checkStreamAccess, listAccessibleStreamIds, resolveEffectiveAccessStream } from "./access"
 
 // Naming
 export { StreamNamingService } from "./naming-service"

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -6,7 +6,7 @@ export { StreamService } from "./service"
 export type { CreateScratchpadParams, CreateChannelParams, CreateThreadParams } from "./service"
 
 // Access (canonical "can this user read this stream?" check — INV-8)
-export { checkStreamAccess } from "./access"
+export { checkStreamAccess, listAccessibleStreamIds } from "./access"
 
 // Naming
 export { StreamNamingService } from "./naming-service"

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo, useCallback } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Bell, FileText, Hash, MessageSquare, Plus, X, Archive } from "lucide-react"
+import { Hash, Plus, X, Archive } from "lucide-react"
 import { StreamTypes, getAvatarUrl } from "@threa/types"
 import type { Stream, StreamType } from "@threa/types"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
 import { streamsApi } from "@/api"
 import { createDmDraftId, useUnreadCounts, useActivityCounts } from "@/hooks"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
@@ -21,14 +21,6 @@ import {
 } from "./search-query-parser"
 import type { ModeContext, ModeResult, QuickSwitcherItem, WorkspaceStream } from "./types"
 import type { UrgencyLevel } from "@/components/layout/sidebar/types"
-
-const STREAM_ICONS: Record<StreamType, React.ComponentType<{ className?: string }>> = {
-  [StreamTypes.SCRATCHPAD]: FileText,
-  [StreamTypes.CHANNEL]: Hash,
-  [StreamTypes.DM]: MessageSquare,
-  [StreamTypes.THREAD]: MessageSquare,
-  [StreamTypes.SYSTEM]: Bell,
-}
 
 const FILTER_TYPES: { type: FilterType; label: string; icon: React.ReactNode }[] = [
   { type: "type", label: "Stream type", icon: <Hash className="h-4 w-4" /> },

--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, fireEvent } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { ShareMessageModal } from "./share-message-modal"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as shareHandoffStoreModule from "@/stores/share-handoff-store"
+
+const SAMPLE_ATTRS = {
+  messageId: "msg_a",
+  streamId: "stream_source",
+  authorName: "Ada",
+  authorId: "usr_a",
+  actorType: "user",
+}
+
+function mountModal({ initialPath = "/w/ws_1/s/current" }: { initialPath?: string } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/w/:workspaceId/s/:streamId"
+          element={<ShareMessageModal open onOpenChange={() => {}} workspaceId="ws_1" attrs={SAMPLE_ATTRS} />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("ShareMessageModal — picker filtering", () => {
+  it("shows accessible top-level streams grouped by type and hides threads/archives/inaccessible private", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      {
+        id: "ch_pub",
+        type: "channel",
+        visibility: "public",
+        displayName: "#general",
+        slug: "general",
+        archivedAt: null,
+        rootStreamId: null,
+      },
+      {
+        id: "ch_priv_member",
+        type: "channel",
+        visibility: "private",
+        displayName: "#team",
+        slug: "team",
+        archivedAt: null,
+        rootStreamId: null,
+      },
+      {
+        id: "ch_priv_outsider",
+        type: "channel",
+        visibility: "private",
+        displayName: "#secret",
+        slug: "secret",
+        archivedAt: null,
+        rootStreamId: null,
+      },
+      {
+        id: "ch_archived",
+        type: "channel",
+        visibility: "public",
+        displayName: "#old",
+        slug: "old",
+        archivedAt: "2026-01-01",
+        rootStreamId: null,
+      },
+      {
+        id: "thread_a",
+        type: "thread",
+        visibility: "public",
+        displayName: "branch",
+        slug: null,
+        archivedAt: null,
+        rootStreamId: "ch_pub",
+      },
+      {
+        id: "dm_self",
+        type: "dm",
+        visibility: "private",
+        displayName: null,
+        slug: null,
+        archivedAt: null,
+        rootStreamId: null,
+      },
+      {
+        id: "scratch_self",
+        type: "scratchpad",
+        visibility: "private",
+        displayName: "Notes",
+        slug: null,
+        archivedAt: null,
+        rootStreamId: null,
+      },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue([
+      {
+        id: "ws_1:ch_priv_member",
+        workspaceId: "ws_1",
+        streamId: "ch_priv_member",
+        memberId: "usr_self",
+        pinned: false,
+      },
+      { id: "ws_1:dm_self", workspaceId: "ws_1", streamId: "dm_self", memberId: "usr_self", pinned: false },
+      { id: "ws_1:scratch_self", workspaceId: "ws_1", streamId: "scratch_self", memberId: "usr_self", pinned: false },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>)
+
+    mountModal()
+
+    // Items render inside aria-hidden Radix subtrees (portal + scroll-lock),
+    // so the ARIA-aware queries miss them. `data-value` is set per item by
+    // cmdk and reflects our `value={stream.id}` — query by attribute and
+    // assert on textContent instead.
+    const items = document.querySelectorAll<HTMLElement>("[cmdk-item][data-value]")
+    const visibleStreamIds = Array.from(items).map((el) => el.getAttribute("data-value"))
+    expect(visibleStreamIds).toContain("ch_pub")
+    expect(visibleStreamIds).toContain("ch_priv_member")
+    expect(visibleStreamIds).toContain("dm_self")
+    expect(visibleStreamIds).toContain("scratch_self")
+    expect(visibleStreamIds).not.toContain("ch_priv_outsider")
+    expect(visibleStreamIds).not.toContain("ch_archived")
+    expect(visibleStreamIds).not.toContain("thread_a")
+    // Channel labels surface the slug-prefixed name; scratchpad uses displayName.
+    expect(items[0].textContent).toContain("#general")
+    const scratchItem = Array.from(items).find((el) => el.getAttribute("data-value") === "scratch_self")
+    expect(scratchItem?.textContent).toContain("Notes")
+  })
+
+  it("queues the share-handoff and navigates on select", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      {
+        id: "ch_target",
+        type: "channel",
+        visibility: "public",
+        displayName: "#general",
+        slug: "general",
+        archivedAt: null,
+        rootStreamId: null,
+      },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+    )
+    const queue = vi.spyOn(shareHandoffStoreModule, "queueShareHandoff").mockImplementation(() => {})
+
+    mountModal()
+    const item = document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')
+    expect(item).not.toBeNull()
+    fireEvent.click(item!)
+
+    expect(queue).toHaveBeenCalledWith("ch_target", SAMPLE_ATTRS)
+  })
+})

--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, fireEvent } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { ShareMessageModal } from "./share-message-modal"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as shareHandoffStoreModule from "@/stores/share-handoff-store"
+import * as useMobileModule from "@/hooks/use-mobile"
 
 const SAMPLE_ATTRS = {
   messageId: "msg_a",
@@ -25,6 +26,12 @@ function mountModal({ initialPath = "/w/ws_1/s/current" }: { initialPath?: strin
     </MemoryRouter>
   )
 }
+
+beforeEach(() => {
+  // Default to desktop unless a test overrides — keeps the picker-rendering
+  // tests pinned to one surface so cmdk-item assertions are stable.
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -153,5 +160,37 @@ describe("ShareMessageModal — picker filtering", () => {
     fireEvent.click(item!)
 
     expect(queue).toHaveBeenCalledWith("ch_target", SAMPLE_ATTRS)
+  })
+})
+
+describe("ShareMessageModal — surface selection", () => {
+  it("renders as a centered Dialog on desktop", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+    )
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+    )
+    mountModal()
+    // Radix Dialog wraps content in a portal with role=dialog.
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    // Vaul's drawer adds a vaul-* attribute set; assert no drawer root present.
+    expect(document.querySelector("[vaul-drawer-wrapper]")).toBeNull()
+  })
+
+  it("renders as a bottom-sheet Drawer on mobile", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+    )
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+    )
+    mountModal()
+    // Vaul exposes data-vaul-drawer attributes on its content surface.
+    const drawerContent = document.querySelector("[data-vaul-drawer]")
+    expect(drawerContent).not.toBeNull()
   })
 })

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -80,10 +80,17 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
     return byType
   }, [streams, memberStreamIds, search])
 
+  // Wrap the parent's open-change so search resets on every close path
+  // (Esc, backdrop, X, programmatic). Without this, dismissing without
+  // selecting leaves the previous query in place when the modal reopens.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setSearch("")
+    onOpenChange(next)
+  }
+
   const handleSelect = (targetStreamId: string) => {
     queueShareHandoff(targetStreamId, attrs)
-    onOpenChange(false)
-    setSearch("")
+    handleOpenChange(false)
     navigate(`/w/${workspaceId}/s/${targetStreamId}`)
   }
 
@@ -116,7 +123,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
 
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer open={open} onOpenChange={handleOpenChange}>
         <DrawerContent>
           <DrawerHeader className="px-4 pb-2 text-left">
             <DrawerTitle className="text-base">Share message</DrawerTitle>
@@ -129,7 +136,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="overflow-hidden p-0 sm:max-w-lg">
         <DialogHeader className="border-b px-4 py-3">
           <DialogTitle className="text-base">Share message</DialogTitle>

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer"
@@ -7,6 +7,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
 import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { navigateAfterShareHandoff } from "@/lib/share-navigation"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
 
@@ -42,6 +43,7 @@ interface ShareMessageModalProps {
 export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
   const navigate = useNavigate()
+  const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
   const memberships = useWorkspaceStreamMemberships(workspaceId)
   const isMobile = useIsMobile()
@@ -91,7 +93,10 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   const handleSelect = (targetStreamId: string) => {
     queueShareHandoff(targetStreamId, attrs)
     handleOpenChange(false)
-    navigate(`/w/${workspaceId}/s/${targetStreamId}`)
+    // Same navigation contract as the fast-path entries in
+    // `message-event.tsx` — strip search params on mobile so the panel
+    // doesn't shadow the parent composer, no-op when target === current.
+    navigateAfterShareHandoff({ workspaceId, targetStreamId, location, navigate, isMobile })
   }
 
   const picker = (

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -2,10 +2,12 @@ import { useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
 import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { useIsMobile } from "@/hooks/use-mobile"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
 
 const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; type: StreamType }[] = [
@@ -29,6 +31,10 @@ interface ShareMessageModalProps {
  * `queueShareHandoff` and navigates; commentary + send happen in the
  * target's normal composer rather than a modal-owned editor.
  *
+ * Renders as a centered Dialog on desktop and a bottom-sheet Drawer on
+ * mobile so the affordance matches the rest of the app's mobile sheets
+ * (`MessageActionDrawer`, `UnsentMessageActionDrawer`, etc.).
+ *
  * Privacy boundaries are enforced at send time: the backend rejects with
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
  * "Share anyway / Cancel" toast (`surfacePrivacyBlockToast`).
@@ -38,6 +44,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   const navigate = useNavigate()
   const streams = useWorkspaceStreams(workspaceId)
   const memberships = useWorkspaceStreamMemberships(workspaceId)
+  const isMobile = useIsMobile()
 
   const memberStreamIds = useMemo(() => {
     const ids = new Set<string>()
@@ -80,6 +87,47 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
     navigate(`/w/${workspaceId}/s/${targetStreamId}`)
   }
 
+  const picker = (
+    <Command shouldFilter={false} className="rounded-none">
+      <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
+      <CommandList className="max-h-[60vh]">
+        <CommandEmpty>No matching streams.</CommandEmpty>
+        {TARGET_GROUPS.map((group) => {
+          const list = streamsByGroup.get(group.type)
+          if (!list || list.length === 0) return null
+          return (
+            <CommandGroup key={group.id} heading={group.heading}>
+              {list.map((stream) => {
+                const Icon = STREAM_ICONS[stream.type]
+                const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+                return (
+                  <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
+                    <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <span>{label}</span>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          )
+        })}
+      </CommandList>
+    </Command>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent>
+          <DrawerHeader className="px-4 pb-2 text-left">
+            <DrawerTitle className="text-base">Share message</DrawerTitle>
+            <DrawerDescription>Pick a stream to insert this share into the composer.</DrawerDescription>
+          </DrawerHeader>
+          {picker}
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="overflow-hidden p-0 sm:max-w-lg">
@@ -87,30 +135,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
           <DialogTitle className="text-base">Share message</DialogTitle>
           <DialogDescription>Pick a stream to insert this share into the composer.</DialogDescription>
         </DialogHeader>
-        <Command shouldFilter={false} className="rounded-none">
-          <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
-          <CommandList className="max-h-[60vh]">
-            <CommandEmpty>No matching streams.</CommandEmpty>
-            {TARGET_GROUPS.map((group) => {
-              const list = streamsByGroup.get(group.type)
-              if (!list || list.length === 0) return null
-              return (
-                <CommandGroup key={group.id} heading={group.heading}>
-                  {list.map((stream) => {
-                    const Icon = STREAM_ICONS[stream.type]
-                    const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
-                    return (
-                      <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
-                        <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                        <span>{label}</span>
-                      </CommandItem>
-                    )
-                  })}
-                </CommandGroup>
-              )
-            })}
-          </CommandList>
-        </Command>
+        {picker}
       </DialogContent>
     </Dialog>
   )

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { Hash, MessageSquare, FileText } from "lucide-react"
+import { StreamTypes, type StreamType } from "@threa/types"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
+import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { queueShareHandoff } from "@/stores/share-handoff-store"
+import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
+
+const PICKER_ICONS: Record<StreamType, React.ComponentType<{ className?: string }>> = {
+  [StreamTypes.SCRATCHPAD]: FileText,
+  [StreamTypes.CHANNEL]: Hash,
+  [StreamTypes.DM]: MessageSquare,
+  [StreamTypes.THREAD]: MessageSquare,
+  [StreamTypes.SYSTEM]: MessageSquare,
+}
+
+const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; type: StreamType }[] = [
+  { id: "channel", heading: "Channels", type: StreamTypes.CHANNEL },
+  { id: "dm", heading: "Direct messages", type: StreamTypes.DM },
+  { id: "scratchpad", heading: "Your scratchpads", type: StreamTypes.SCRATCHPAD },
+]
+
+interface ShareMessageModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  attrs: SharedMessageAttrs
+}
+
+/**
+ * Slice 2 share-to-anywhere picker. Reuses the pointer hand-off pattern from
+ * Slice 1's share-to-parent: on select we queue the share node for the target
+ * stream's composer (`queueShareHandoff`) and navigate. The user types optional
+ * commentary in the target stream and sends via the normal send button — no
+ * second editor surface is introduced (D-Alt-1 rejected).
+ *
+ * Privacy boundary handling lives in the message queue (`use-message-queue` →
+ * `surfacePrivacyBlockToast`): when the backend rejects with
+ * `SHARE_PRIVACY_CONFIRMATION_REQUIRED`, the queue surfaces a toast offering
+ * "Share anyway" / "Cancel". Slice 3 lifts that into a step-2 confirm step
+ * inside this modal, with a pre-flight `share-preview` endpoint.
+ *
+ * Filter rules:
+ * - Top-level streams only (no threads, no system) — plan target scope.
+ * - Streams the user can read: public visibility OR direct member. Same
+ *   semantics as backend `checkStreamAccess`.
+ * - Same-stream targets are allowed (D5): if the user picks the stream
+ *   they're already viewing, the hand-off lands in the current composer.
+ * - Archived streams are excluded — sharing into an archive feels like a
+ *   gesture mismatch, and Slice 3 will revisit if users ask.
+ */
+export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
+  const [search, setSearch] = useState("")
+  const navigate = useNavigate()
+  const streams = useWorkspaceStreams(workspaceId)
+  const memberships = useWorkspaceStreamMemberships(workspaceId)
+
+  const memberStreamIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const m of memberships) ids.add(m.streamId)
+    return ids
+  }, [memberships])
+
+  const streamsByGroup = useMemo(() => {
+    const lower = search.toLowerCase()
+    const matchable = streams.filter((s) => {
+      if (s.archivedAt) return false
+      if (s.rootStreamId) return false
+      if (s.type === StreamTypes.THREAD || s.type === StreamTypes.SYSTEM) return false
+      const accessible = s.visibility === "public" || memberStreamIds.has(s.id)
+      if (!accessible) return false
+      if (!lower) return true
+      const name = (getStreamName(s) ?? streamFallbackLabel(s.type, "generic")).toLowerCase()
+      return name.includes(lower)
+    })
+    const byType = new Map<StreamType, typeof matchable>()
+    for (const s of matchable) {
+      const list = byType.get(s.type) ?? []
+      list.push(s)
+      byType.set(s.type, list)
+    }
+    for (const [, list] of byType) {
+      list.sort((a, b) => {
+        const an = getStreamName(a) ?? streamFallbackLabel(a.type, "generic")
+        const bn = getStreamName(b) ?? streamFallbackLabel(b.type, "generic")
+        return an.localeCompare(bn)
+      })
+    }
+    return byType
+  }, [streams, memberStreamIds, search])
+
+  const handleSelect = (targetStreamId: string) => {
+    queueShareHandoff(targetStreamId, attrs)
+    onOpenChange(false)
+    setSearch("")
+    navigate(`/w/${workspaceId}/s/${targetStreamId}`)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-lg">
+        <DialogHeader className="border-b px-4 py-3">
+          <DialogTitle className="text-base">Share message</DialogTitle>
+          <DialogDescription>Pick a stream to insert this share into the composer.</DialogDescription>
+        </DialogHeader>
+        <Command shouldFilter={false} className="rounded-none">
+          <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
+          <CommandList className="max-h-[60vh]">
+            <CommandEmpty>No matching streams.</CommandEmpty>
+            {TARGET_GROUPS.map((group) => {
+              const list = streamsByGroup.get(group.type)
+              if (!list || list.length === 0) return null
+              return (
+                <CommandGroup key={group.id} heading={group.heading}>
+                  {list.map((stream) => {
+                    const Icon = PICKER_ICONS[stream.type]
+                    const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+                    return (
+                      <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
+                        <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                        <span>{label}</span>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              )
+            })}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,8 +1,13 @@
 import { useMemo, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
 import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
@@ -32,9 +37,10 @@ interface ShareMessageModalProps {
  * `queueShareHandoff` and navigates; commentary + send happen in the
  * target's normal composer rather than a modal-owned editor.
  *
- * Renders as a centered Dialog on desktop and a bottom-sheet Drawer on
- * mobile so the affordance matches the rest of the app's mobile sheets
- * (`MessageActionDrawer`, `UnsentMessageActionDrawer`, etc.).
+ * Renders through `ResponsiveDialog`, which routes to a centered Dialog
+ * on desktop and a snap-pointed Drawer on mobile — same primitive the
+ * quick-switcher (a sibling stream picker) uses, so the affordance stays
+ * consistent.
  *
  * Privacy boundaries are enforced at send time: the backend rejects with
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
@@ -46,6 +52,8 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
   const memberships = useWorkspaceStreamMemberships(workspaceId)
+  // The Drawer/Dialog split is owned by ResponsiveDialog; isMobile here only
+  // governs the post-select navigation contract (mobile strips `?panel=…`).
   const isMobile = useIsMobile()
 
   const memberStreamIds = useMemo(() => {
@@ -99,56 +107,47 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
     navigateAfterShareHandoff({ workspaceId, targetStreamId, location, navigate, isMobile })
   }
 
-  const picker = (
-    <Command shouldFilter={false} className="rounded-none">
-      <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
-      <CommandList className="max-h-[60vh]">
-        <CommandEmpty>No matching streams.</CommandEmpty>
-        {TARGET_GROUPS.map((group) => {
-          const list = streamsByGroup.get(group.type)
-          if (!list || list.length === 0) return null
-          return (
-            <CommandGroup key={group.id} heading={group.heading}>
-              {list.map((stream) => {
-                const Icon = STREAM_ICONS[stream.type]
-                const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
-                return (
-                  <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
-                    <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                    <span>{label}</span>
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
-          )
-        })}
-      </CommandList>
-    </Command>
-  )
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={handleOpenChange}>
-        <DrawerContent>
-          <DrawerHeader className="px-4 pb-2 text-left">
-            <DrawerTitle className="text-base">Share message</DrawerTitle>
-            <DrawerDescription>Pick a stream to insert this share into the composer.</DrawerDescription>
-          </DrawerHeader>
-          {picker}
-        </DrawerContent>
-      </Drawer>
-    )
-  }
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-lg">
-        <DialogHeader className="border-b px-4 py-3">
-          <DialogTitle className="text-base">Share message</DialogTitle>
-          <DialogDescription>Pick a stream to insert this share into the composer.</DialogDescription>
-        </DialogHeader>
-        {picker}
-      </DialogContent>
-    </Dialog>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent
+        className="overflow-hidden p-0"
+        desktopClassName="sm:max-w-lg"
+        // Mobile drawer keeps ResponsiveDialog's default 80%-snap full-height
+        // shell; the `flex flex-col` lets the Command list claim the
+        // remaining space below the header rather than overflowing.
+        drawerClassName="flex flex-col"
+      >
+        <ResponsiveDialogHeader className="border-b px-4 py-3">
+          <ResponsiveDialogTitle className="text-base">Share message</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Pick a stream to insert this share into the composer.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <Command shouldFilter={false} className="rounded-none">
+          <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
+          <CommandList className="max-h-[60vh]">
+            <CommandEmpty>No matching streams.</CommandEmpty>
+            {TARGET_GROUPS.map((group) => {
+              const list = streamsByGroup.get(group.type)
+              if (!list || list.length === 0) return null
+              return (
+                <CommandGroup key={group.id} heading={group.heading}>
+                  {list.map((stream) => {
+                    const Icon = STREAM_ICONS[stream.type]
+                    const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+                    return (
+                      <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
+                        <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                        <span>{label}</span>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              )
+            })}
+          </CommandList>
+        </Command>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   )
 }

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,21 +1,12 @@
 import { useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Hash, MessageSquare, FileText } from "lucide-react"
-import { StreamTypes, type StreamType } from "@threa/types"
+import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
-
-const PICKER_ICONS: Record<StreamType, React.ComponentType<{ className?: string }>> = {
-  [StreamTypes.SCRATCHPAD]: FileText,
-  [StreamTypes.CHANNEL]: Hash,
-  [StreamTypes.DM]: MessageSquare,
-  [StreamTypes.THREAD]: MessageSquare,
-  [StreamTypes.SYSTEM]: MessageSquare,
-}
 
 const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; type: StreamType }[] = [
   { id: "channel", heading: "Channels", type: StreamTypes.CHANNEL },
@@ -31,26 +22,16 @@ interface ShareMessageModalProps {
 }
 
 /**
- * Slice 2 share-to-anywhere picker. Reuses the pointer hand-off pattern from
- * Slice 1's share-to-parent: on select we queue the share node for the target
- * stream's composer (`queueShareHandoff`) and navigate. The user types optional
- * commentary in the target stream and sends via the normal send button — no
- * second editor surface is introduced (D-Alt-1 rejected).
+ * Cross-stream picker for sharing a message as a pointer. Filters the
+ * workspace's accessible top-level streams (channel / dm / scratchpad,
+ * not archived) — same access semantics as backend `checkStreamAccess`.
+ * On select, queues the share node for the target's composer via
+ * `queueShareHandoff` and navigates; commentary + send happen in the
+ * target's normal composer rather than a modal-owned editor.
  *
- * Privacy boundary handling lives in the message queue (`use-message-queue` →
- * `surfacePrivacyBlockToast`): when the backend rejects with
- * `SHARE_PRIVACY_CONFIRMATION_REQUIRED`, the queue surfaces a toast offering
- * "Share anyway" / "Cancel". Slice 3 lifts that into a step-2 confirm step
- * inside this modal, with a pre-flight `share-preview` endpoint.
- *
- * Filter rules:
- * - Top-level streams only (no threads, no system) — plan target scope.
- * - Streams the user can read: public visibility OR direct member. Same
- *   semantics as backend `checkStreamAccess`.
- * - Same-stream targets are allowed (D5): if the user picks the stream
- *   they're already viewing, the hand-off lands in the current composer.
- * - Archived streams are excluded — sharing into an archive feels like a
- *   gesture mismatch, and Slice 3 will revisit if users ask.
+ * Privacy boundaries are enforced at send time: the backend rejects with
+ * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
+ * "Share anyway / Cancel" toast (`surfacePrivacyBlockToast`).
  */
 export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
@@ -70,7 +51,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
       if (s.archivedAt) return false
       if (s.rootStreamId) return false
       if (s.type === StreamTypes.THREAD || s.type === StreamTypes.SYSTEM) return false
-      const accessible = s.visibility === "public" || memberStreamIds.has(s.id)
+      const accessible = s.visibility === Visibilities.PUBLIC || memberStreamIds.has(s.id)
       if (!accessible) return false
       if (!lower) return true
       const name = (getStreamName(s) ?? streamFallbackLabel(s.type, "generic")).toLowerCase()
@@ -116,7 +97,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
               return (
                 <CommandGroup key={group.id} heading={group.heading}>
                   {list.map((stream) => {
-                    const Icon = PICKER_ICONS[stream.type]
+                    const Icon = STREAM_ICONS[stream.type]
                     const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
                     return (
                       <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>

--- a/apps/frontend/src/components/shared-messages/card-body.test.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { SharedMessageCardBody } from "./card-body"
+import type { SharedMessageSource } from "@/hooks/use-shared-message-source"
+
+function renderUnderRoute(node: React.ReactNode, initialPath = "/w/ws_1/s/current") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/w/:workspaceId/s/:streamId" element={node} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("SharedMessageCardBody — Slice 2 placeholders", () => {
+  it("renders the privacy stub for the private state, leaking only kind + visibility", () => {
+    const source: SharedMessageSource = {
+      status: "private",
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    }
+    renderUnderRoute(<SharedMessageCardBody source={source} fallbackAuthor="Should not appear" />)
+
+    // The stub must NOT surface the cached fallback author (privacy leak).
+    expect(screen.queryByText("Should not appear")).not.toBeInTheDocument()
+    expect(screen.getByText("Private message")).toBeInTheDocument()
+    expect(screen.getByText(/references content in a private channel you don't have access to/i)).toBeInTheDocument()
+  })
+
+  it("uses 'DM' wording for dm sources", () => {
+    const source: SharedMessageSource = {
+      status: "private",
+      sourceStreamKind: "dm",
+      sourceVisibility: "private",
+    }
+    renderUnderRoute(<SharedMessageCardBody source={source} fallbackAuthor="" />)
+    expect(screen.getByText(/private DM you don't have access to/i)).toBeInTheDocument()
+  })
+
+  it("renders a navigable link for the truncated state", () => {
+    const source: SharedMessageSource = {
+      status: "truncated",
+      streamId: "stream_deep",
+      messageId: "msg_deep",
+    }
+    renderUnderRoute(<SharedMessageCardBody source={source} fallbackAuthor="" />)
+
+    const link = screen.getByRole("link", { name: /open in source stream/i })
+    expect(link.getAttribute("href")).toBe("/w/ws_1/s/stream_deep?m=msg_deep")
+  })
+})

--- a/apps/frontend/src/components/shared-messages/card-body.test.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
+import type { ReactNode } from "react"
 import { SharedMessageCardBody } from "./card-body"
 import type { SharedMessageSource } from "@/hooks/use-shared-message-source"
 
-function renderUnderRoute(node: React.ReactNode, initialPath = "/w/ws_1/s/current") {
+function renderUnderRoute(node: ReactNode, initialPath = "/w/ws_1/s/current") {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>

--- a/apps/frontend/src/components/shared-messages/card-body.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { type SharedMessageSource } from "@/hooks/use-shared-message-source"
+import { streamFallbackLabel } from "@/lib/streams"
 import type { StreamType, Visibility } from "@threa/types"
 
 /**
@@ -92,16 +93,15 @@ function AuthorLabel({ name }: { name: string }) {
  * Privacy-preserving placeholder shown when the viewer hit an inner pointer
  * in a re-share chain that they have no read path to. Reveals only the
  * source stream's kind + visibility — never content, author, or stream
- * name. Plan D8 is explicit about minimizing the leak surface here so a
- * downstream re-share can't be used to exfiltrate metadata about a deeply
- * private source.
+ * name (minimizes the leak surface that a downstream re-share could
+ * otherwise expose).
  */
 function PrivatePlaceholder({ kind, visibility }: { kind: StreamType; visibility: Visibility }) {
   return (
     <>
       <AuthorLabel name="Private message" />
       <p className="mt-0.5 italic text-muted-foreground">
-        This message references content in a {visibility} {streamKindLabel(kind)} you don't have access to.
+        This message references content in a {visibility} {streamFallbackLabel(kind, "noun")} you don't have access to.
       </p>
     </>
   )
@@ -127,24 +127,4 @@ function TruncatedPlaceholder({ streamId, messageId }: { streamId: string; messa
       </p>
     </>
   )
-}
-
-/**
- * Friendly noun for the privacy placeholder. Threads resolve to their
- * parent kind on the backend (plan D8), so this only ever runs against
- * top-level kinds in practice; the `thread`/`system` arms are defensive.
- */
-function streamKindLabel(kind: StreamType): string {
-  switch (kind) {
-    case "channel":
-      return "channel"
-    case "dm":
-      return "DM"
-    case "scratchpad":
-      return "scratchpad"
-    case "thread":
-      return "thread"
-    case "system":
-      return "system stream"
-  }
 }

--- a/apps/frontend/src/components/shared-messages/card-body.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.tsx
@@ -1,6 +1,8 @@
+import { Link, useParams } from "react-router-dom"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { type SharedMessageSource } from "@/hooks/use-shared-message-source"
+import type { StreamType, Visibility } from "@threa/types"
 
 /**
  * Body renderer shared between the two pointer-card surfaces:
@@ -43,6 +45,14 @@ export function SharedMessageCardBody({
     )
   }
 
+  if (source.status === "private") {
+    return <PrivatePlaceholder kind={source.sourceStreamKind} visibility={source.sourceVisibility} />
+  }
+
+  if (source.status === "truncated") {
+    return <TruncatedPlaceholder streamId={source.streamId} messageId={source.messageId} />
+  }
+
   if (source.status === "pending") {
     return (
       <>
@@ -76,4 +86,65 @@ export function SharedMessageCardBody({
 
 function AuthorLabel({ name }: { name: string }) {
   return <span className="text-xs font-medium text-foreground/80">{name}</span>
+}
+
+/**
+ * Privacy-preserving placeholder shown when the viewer hit an inner pointer
+ * in a re-share chain that they have no read path to. Reveals only the
+ * source stream's kind + visibility — never content, author, or stream
+ * name. Plan D8 is explicit about minimizing the leak surface here so a
+ * downstream re-share can't be used to exfiltrate metadata about a deeply
+ * private source.
+ */
+function PrivatePlaceholder({ kind, visibility }: { kind: StreamType; visibility: Visibility }) {
+  return (
+    <>
+      <AuthorLabel name="Private message" />
+      <p className="mt-0.5 italic text-muted-foreground">
+        This message references content in a {visibility} {streamKindLabel(kind)} you don't have access to.
+      </p>
+    </>
+  )
+}
+
+/**
+ * Placeholder for pointers past the recursive-hydration depth cap. The
+ * viewer has access (the chain only truncates on accessible paths), so
+ * the body is a navigation link rather than a privacy stub.
+ */
+function TruncatedPlaceholder({ streamId, messageId }: { streamId: string; messageId: string }) {
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+  const href = workspaceId ? `/w/${workspaceId}/s/${streamId}?m=${messageId}` : `#`
+  return (
+    <>
+      <AuthorLabel name="Nested share" />
+      <p className="mt-0.5 italic text-muted-foreground">
+        This message references a deeper share —{" "}
+        <Link to={href} className="underline underline-offset-2 hover:text-foreground">
+          open in source stream
+        </Link>
+        .
+      </p>
+    </>
+  )
+}
+
+/**
+ * Friendly noun for the privacy placeholder. Threads resolve to their
+ * parent kind on the backend (plan D8), so this only ever runs against
+ * top-level kinds in practice; the `thread`/`system` arms are defensive.
+ */
+function streamKindLabel(kind: StreamType): string {
+  switch (kind) {
+    case "channel":
+      return "channel"
+    case "dm":
+      return "DM"
+    case "scratchpad":
+      return "scratchpad"
+    case "thread":
+      return "thread"
+    case "system":
+      return "system stream"
+  }
 }

--- a/apps/frontend/src/components/shared-messages/context.tsx
+++ b/apps/frontend/src/components/shared-messages/context.tsx
@@ -1,10 +1,15 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react"
+import type { StreamType, Visibility } from "@threa/types"
 
 /**
  * Hydrated payload for a pointer message. Kept structurally aligned with
- * the backend's `HydratedSharedMessage` discriminated union so future
- * states (private, truncated — slice 2) can be added here and in the
- * NodeView without API churn.
+ * the backend's `HydratedSharedMessage` discriminated union.
+ *
+ * - `ok`/`deleted`/`missing`: same as Slice 1.
+ * - `private`: viewer has no read path to the source. Reveals only the
+ *   source stream's kind + visibility. Plan D8.
+ * - `truncated`: hydration stopped at the depth cap; viewer has access and
+ *   can navigate to `streamId`.
  */
 export type HydratedSharedMessage =
   | {
@@ -21,6 +26,13 @@ export type HydratedSharedMessage =
     }
   | { state: "deleted"; messageId: string; deletedAt: string }
   | { state: "missing"; messageId: string }
+  | {
+      state: "private"
+      messageId: string
+      sourceStreamKind: StreamType
+      sourceVisibility: Visibility
+    }
+  | { state: "truncated"; messageId: string; streamId: string }
 
 interface SharedMessagesContextValue {
   get: (messageId: string) => HydratedSharedMessage | null

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -316,6 +316,45 @@ describe("share-to-parent action", () => {
   })
 })
 
+describe("share action (modal)", () => {
+  it("is hidden when onShare is not supplied", () => {
+    const actions = getVisibleActions(createContext())
+    expect(actions.find((a) => a.id === "share")).toBeUndefined()
+  })
+
+  it("is visible when onShare is supplied", () => {
+    const actions = getVisibleActions(createContext({ onShare: () => {} }))
+    expect(actions.find((a) => a.id === "share")).toBeDefined()
+  })
+
+  it("renders 'Share message' as the label", () => {
+    const ctx = createContext({ onShare: () => {} })
+    const action = getVisibleActions(ctx).find((a) => a.id === "share")!
+    expect(resolveActionLabel(action, ctx)).toBe("Share message")
+  })
+
+  it("invokes the onShare callback when run", () => {
+    const onShare = vi.fn()
+    const ctx = createContext({ onShare })
+    const action = getVisibleActions(ctx).find((a) => a.id === "share")!
+    action.action!(ctx)
+    expect(onShare).toHaveBeenCalledOnce()
+  })
+
+  it("is the primary (default) entry in the share group when all three callbacks are present", () => {
+    const ctx = createContext({
+      onShare: () => {},
+      onShareToRoot: () => {},
+      onShareToParent: () => {},
+    })
+    const items = groupVisibleActions(getVisibleActions(ctx))
+    const shareGroup = items.find((i) => i.kind === "group" && i.members[0]?.id === "share")
+    expect(shareGroup).toBeDefined()
+    if (shareGroup?.kind !== "group") throw new Error("expected group")
+    expect(shareGroup.members.map((m) => m.id)).toEqual(["share", "share-to-root", "share-to-parent"])
+  })
+})
+
 describe("groupVisibleActions", () => {
   it("returns single items for ungrouped actions and groups same-id ones", () => {
     const ctx = createContext()

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -81,7 +81,7 @@ export interface MessageActionContext {
   /**
    * Open the cross-stream picker modal (`ShareMessageModal`) for this message.
    * Always visible alongside the fast-path share-to-root / share-to-parent
-   * entries. Slice 3 will add a `share-as-quote` sibling for the quote flavor.
+   * entries.
    */
   onShare?: () => void
   /** Callback to save or unsave the message */

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -226,6 +226,18 @@ export const messageActions: MessageAction[] = [
     action: (ctx) => ctx.onQuoteReply?.(),
   },
   {
+    // Default share entry — opens the cross-stream picker modal. Listed
+    // first in the group so `groupVisibleActions` makes it the primary
+    // tap target; the share-to-root / share-to-parent fast paths ride
+    // alongside as alternatives reachable via the chevron dropdown.
+    id: "share",
+    label: "Share message",
+    icon: Share2,
+    groupId: "share",
+    when: (ctx) => !!ctx.onShare,
+    action: (ctx) => ctx.onShare?.(),
+  },
+  {
     id: "share-to-root",
     label: (ctx) => ctx.shareToRootLabel ?? "Share to channel",
     icon: Share2,
@@ -240,17 +252,6 @@ export const messageActions: MessageAction[] = [
     groupId: "share",
     when: (ctx) => !!ctx.onShareToParent,
     action: (ctx) => ctx.onShareToParent?.(),
-  },
-  {
-    // Cross-stream picker — opens the share-message modal. Always visible
-    // when callable; share-to-root / share-to-parent ride alongside as group
-    // alternatives in nested-thread cases.
-    id: "share",
-    label: "Share to another stream…",
-    icon: Share2,
-    groupId: "share",
-    when: (ctx) => !!ctx.onShare,
-    action: (ctx) => ctx.onShare?.(),
   },
   {
     // Split into two rows (save / unsave) so the menu entry always matches

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -78,6 +78,12 @@ export interface MessageActionContext {
   onShareToParent?: () => void
   /** Label text for the share-to-parent entry, e.g. "Share to ⌐ thread-name" */
   shareToParentLabel?: string
+  /**
+   * Open the cross-stream picker modal (`ShareMessageModal`) for this message.
+   * Always visible alongside the fast-path share-to-root / share-to-parent
+   * entries. Slice 3 will add a `share-as-quote` sibling for the quote flavor.
+   */
+  onShare?: () => void
   /** Callback to save or unsave the message */
   onToggleSave?: () => void
   /** Callback to open the reminder picker (mobile: bottom sheet) */
@@ -234,6 +240,17 @@ export const messageActions: MessageAction[] = [
     groupId: "share",
     when: (ctx) => !!ctx.onShareToParent,
     action: (ctx) => ctx.onShareToParent?.(),
+  },
+  {
+    // Cross-stream picker — opens the share-message modal. Always visible
+    // when callable; share-to-root / share-to-parent ride alongside as group
+    // alternatives in nested-thread cases.
+    id: "share",
+    label: "Share to another stream…",
+    icon: Share2,
+    groupId: "share",
+    when: (ctx) => !!ctx.onShare,
+    action: (ctx) => ctx.onShare?.(),
   },
   {
     // Split into two rows (save / unsave) so the menu entry always matches

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -56,6 +56,7 @@ import { useQuoteReply } from "./quote-reply-context"
 import { useSwipeAction } from "@/hooks/use-swipe-action"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { navigateAfterShareHandoff } from "@/lib/share-navigation"
 import { ShareMessageModal } from "@/components/share/share-message-modal"
 
 interface MessagePayload {
@@ -462,43 +463,6 @@ interface MessageEventInnerProps {
   groupContinuation?: boolean
   /** True when this is the first message in the stream — drives the context-bag attachment badge. */
   isFirstMessage?: boolean
-}
-
-/**
- * Decide what to do after `queueShareHandoff` for a share-to-parent /
- * share-to-root entry. The behavior diverges by viewport because the
- * meaning of the panel query (`?panel=…`) differs:
- *
- * - **Desktop two-pane:** the panel renders alongside the main view, so
- *   the parent composer is mounted and visible. Preserve `location.search`
- *   so the panel stays open across the navigation. Skip `navigate()` when
- *   pathname + search are unchanged — the existing composer subscribes to
- *   the handoff store and picks the share up in place.
- *
- * - **Mobile fullscreen:** the panel TAKES OVER the screen, so the parent
- *   composer is NOT visible even when the URL pathname matches the share
- *   target. Drop the search on mobile so navigating to the bare pathname
- *   swaps the view back to the parent's main composer. Without this, the
- *   share queues but the user is still looking at the thread and nothing
- *   visible happens.
- */
-function navigateAfterShareHandoff({
-  workspaceId,
-  targetStreamId,
-  location,
-  navigate,
-  isMobile,
-}: {
-  workspaceId: string
-  targetStreamId: string
-  location: ReturnType<typeof useLocation>
-  navigate: ReturnType<typeof useNavigate>
-  isMobile: boolean
-}): void {
-  const targetPathname = `/w/${workspaceId}/s/${targetStreamId}`
-  const search = isMobile ? "" : location.search
-  if (location.pathname === targetPathname && location.search === search) return
-  navigate(`${targetPathname}${search}`)
 }
 
 /**

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -56,6 +56,7 @@ import { useQuoteReply } from "./quote-reply-context"
 import { useSwipeAction } from "@/hooks/use-swipe-action"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { ShareMessageModal } from "@/components/share/share-message-modal"
 
 interface MessagePayload {
   messageId: string
@@ -563,6 +564,7 @@ function SentMessageEvent({
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [shareModalOpen, setShareModalOpen] = useState(false)
 
   // Mobile: long-press opens action drawer instead of dropdown
   const isMobile = useIsMobile()
@@ -824,6 +826,7 @@ function SentMessageEvent({
             }
           : undefined,
       shareToParentLabel: showParentEntry && parentStream ? buildShareToStreamLabel(parentStream) : undefined,
+      onShare: () => setShareModalOpen(true),
     }),
     [
       payload.contentMarkdown,
@@ -1025,6 +1028,20 @@ function SentMessageEvent({
           currentContent={{
             contentMarkdown: payload.contentMarkdown,
             editedAt: payload.editedAt,
+          }}
+        />
+      )}
+      {shareModalOpen && (
+        <ShareMessageModal
+          open={shareModalOpen}
+          onOpenChange={setShareModalOpen}
+          workspaceId={workspaceId}
+          attrs={{
+            messageId: payload.messageId,
+            streamId,
+            authorName: actorName,
+            authorId: event.actorId ?? "",
+            actorType: event.actorType ?? "user",
           }}
         />
       )}

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -18,8 +18,13 @@ interface PendingMessagesContextValue {
   saveEditedMessage: (id: string, contentJson: JSONContent) => Promise<void>
   /** Cancel editing and return message to its previous queue state */
   cancelEditing: (id: string) => Promise<void>
-  /** Reset a failed message's retry count and re-enqueue it for sending */
-  retryMessage: (id: string) => Promise<void>
+  /**
+   * Reset a failed message's retry count and re-enqueue it for sending.
+   * Optionally patches additional fields onto the pending row first — used
+   * by the share-privacy toast to set `confirmedPrivacyWarning: true` and
+   * clear the `blocked-privacy` status in one atomic resume.
+   */
+  retryMessage: (id: string, patch?: Record<string, unknown>) => Promise<void>
   /** Permanently delete a failed/pending message from the outbox and timeline */
   deleteMessage: (id: string) => Promise<void>
   /** Kick the background message queue to process the next pending message */
@@ -275,7 +280,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
   )
 
   const retryMessage = useCallback(
-    async (id: string) => {
+    async (id: string, patch?: Record<string, unknown>) => {
       // Verify the message still exists — the user may have deleted it
       // while the retry button was visible. Without this guard, markPending
       // would lock the UI in "pending" with no queue record to resolve it.
@@ -286,7 +291,7 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
       // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
       // Cast through unknown to bypass the broken type inference.
       type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-      await (db.pendingMessages.update as unknown as UpdateFn)(id, { retryCount: 0, retryAfter: 0 })
+      await (db.pendingMessages.update as unknown as UpdateFn)(id, { retryCount: 0, retryAfter: 0, ...patch })
       await db.events.update(id, { _status: "pending" })
       markPending(id)
       notifyQueue()

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -189,8 +189,8 @@ export interface PendingMessage {
    *   drain loop skips this entry until the user either sends or cancels.
    * - `blocked-privacy` — backend rejected with
    *   `SHARE_PRIVACY_CONFIRMATION_REQUIRED` on a share that crosses a
-   *   privacy boundary (plan D2). Not auto-retried — surfaces a toast so
-   *   the user explicitly confirms or aborts. On confirm the toast clears
+   *   privacy boundary. Not auto-retried — surfaces a toast so the user
+   *   explicitly confirms or aborts. On confirm the toast clears
    *   `status` and sets `confirmedPrivacyWarning: true`.
    */
   status?: "editing" | "blocked-privacy"

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -183,10 +183,25 @@ export interface PendingMessage {
   retryCount: number
   /** Timestamp before which this message should not be retried (exponential backoff) */
   retryAfter?: number
-  /** When "editing", the queue skips this message so it isn't sent while the user edits it */
-  status?: "editing"
+  /**
+   * Queue-side status flags that gate retry behavior:
+   * - `editing` — user is actively editing the message in the composer; the
+   *   drain loop skips this entry until the user either sends or cancels.
+   * - `blocked-privacy` — backend rejected with
+   *   `SHARE_PRIVACY_CONFIRMATION_REQUIRED` on a share that crosses a
+   *   privacy boundary (plan D2). Not auto-retried — surfaces a toast so
+   *   the user explicitly confirms or aborts. On confirm the toast clears
+   *   `status` and sets `confirmedPrivacyWarning: true`.
+   */
+  status?: "editing" | "blocked-privacy"
   /** Original queue state before entering editing mode; used to cancel stale edits on startup. */
   preEditStatus?: "pending" | "failed"
+  /**
+   * Set by the privacy-confirm toast after the user clicks "Share anyway".
+   * Forwarded as `confirmedPrivacyWarning` on the next send attempt so the
+   * backend's privacy-boundary check passes through to the share insert.
+   */
+  confirmedPrivacyWarning?: boolean
   /** When set, the queue creates this stream before sending the message */
   streamCreation?: PendingStreamCreation
   /** The draft ID to clean up after successful stream creation + message send */

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -11,6 +11,8 @@ import { workspaceKeys } from "./use-workspaces"
 import { StreamTypes } from "@threa/types"
 import type { PendingMessage } from "@/db"
 import type { CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
+import { ApiError } from "@/api/client"
+import { surfacePrivacyBlockToast } from "@/lib/share-privacy-toast"
 
 /**
  * Exponential backoff delay based on retry count.
@@ -182,7 +184,14 @@ export function useMessageQueue(): void {
 
       const candidates = await db.pendingMessages.orderBy("createdAt").toArray()
       const next = candidates.find(
-        (m) => !skippedIds.has(m.clientId) && m.status !== "editing" && (m.retryAfter ?? 0) <= now
+        (m) =>
+          !skippedIds.has(m.clientId) &&
+          m.status !== "editing" &&
+          // Privacy-blocked sends wait for the user to click "Share anyway"
+          // (which clears the status); the drain loop must skip them so they
+          // don't churn through retries the user hasn't authorized yet.
+          m.status !== "blocked-privacy" &&
+          (m.retryAfter ?? 0) <= now
       )
       if (!next) break
 
@@ -214,6 +223,7 @@ export function useMessageQueue(): void {
           contentMarkdown: next.content,
           attachmentIds: next.attachmentIds,
           clientMessageId: next.clientId,
+          confirmedPrivacyWarning: next.confirmedPrivacyWarning,
         })
 
         await db.pendingMessages.delete(next.clientId)
@@ -223,7 +233,26 @@ export function useMessageQueue(): void {
         // swaps the optimistic event for the real server event in a single
         // Dexie transaction.
         markSent(next.clientId)
-      } catch {
+      } catch (err) {
+        // Privacy boundary block: the user authored a share that would
+        // expose its source to people outside the source stream. Don't
+        // auto-retry — surface a toast offering "Share anyway" / "Cancel"
+        // so the user explicitly confirms or aborts. INV-32: the API
+        // contract surfaces this as 409 + a stable error code.
+        if (ApiError.isApiError(err) && err.status === 409 && err.code === "SHARE_PRIVACY_CONFIRMATION_REQUIRED") {
+          // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
+          type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
+          await (db.pendingMessages.update as unknown as UpdateFn)(next.clientId, {
+            status: "blocked-privacy",
+            retryAfter: undefined,
+          })
+          await db.events.update(next.clientId, { _status: "failed" })
+          markFailed(next.clientId)
+          surfacePrivacyBlockToast(next.clientId)
+          skippedIds.add(next.clientId)
+          continue
+        }
+
         // Increment retry count and set backoff delay.
         // Only genuine send failures (while connected) reach here —
         // the offline check at the top of the loop prevents transient

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -8,7 +8,7 @@ import { emitDraftPromoted } from "@/lib/draft-promotions"
 import { setParentThreadId } from "@/sync/stream-sync"
 import { deleteDraftScratchpadFromCache, deleteDraftMessageFromCache } from "@/stores/draft-store"
 import { workspaceKeys } from "./use-workspaces"
-import { StreamTypes } from "@threa/types"
+import { StreamTypes, ShareErrorCodes } from "@threa/types"
 import type { PendingMessage } from "@/db"
 import type { CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
 import { ApiError } from "@/api/client"
@@ -166,7 +166,7 @@ export function useMessageQueue(): void {
   const streamService = useStreamService()
   const syncEngine = useSyncEngine()
   const queryClient = useQueryClient()
-  const { markPending, markFailed, markSent, registerQueueNotify } = usePendingMessages()
+  const { markPending, markFailed, markSent, registerQueueNotify, retryMessage, deleteMessage } = usePendingMessages()
 
   const isProcessing = useRef(false)
   const hasPendingWork = useRef(false)
@@ -239,16 +239,22 @@ export function useMessageQueue(): void {
         // auto-retry — surface a toast offering "Share anyway" / "Cancel"
         // so the user explicitly confirms or aborts. INV-32: the API
         // contract surfaces this as 409 + a stable error code.
-        if (ApiError.isApiError(err) && err.status === 409 && err.code === "SHARE_PRIVACY_CONFIRMATION_REQUIRED") {
+        if (
+          ApiError.isApiError(err) &&
+          err.status === 409 &&
+          err.code === ShareErrorCodes.PRIVACY_CONFIRMATION_REQUIRED
+        ) {
           // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
           type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-          await (db.pendingMessages.update as unknown as UpdateFn)(next.clientId, {
-            status: "blocked-privacy",
-            retryAfter: undefined,
-          })
-          await db.events.update(next.clientId, { _status: "failed" })
+          await Promise.all([
+            (db.pendingMessages.update as unknown as UpdateFn)(next.clientId, {
+              status: "blocked-privacy",
+              retryAfter: undefined,
+            }),
+            db.events.update(next.clientId, { _status: "failed" }),
+          ])
           markFailed(next.clientId)
-          surfacePrivacyBlockToast(next.clientId)
+          surfacePrivacyBlockToast(next.clientId, { retryMessage, deleteMessage })
           skippedIds.add(next.clientId)
           continue
         }
@@ -272,7 +278,17 @@ export function useMessageQueue(): void {
         skippedIds.add(next.clientId)
       }
     }
-  }, [messageService, streamService, syncEngine, queryClient, markPending, markFailed, markSent])
+  }, [
+    messageService,
+    streamService,
+    syncEngine,
+    queryClient,
+    markPending,
+    markFailed,
+    markSent,
+    retryMessage,
+    deleteMessage,
+  ])
 
   const processQueue = useCallback(async () => {
     if (isProcessing.current) {

--- a/apps/frontend/src/hooks/use-shared-message-source.test.tsx
+++ b/apps/frontend/src/hooks/use-shared-message-source.test.tsx
@@ -87,6 +87,51 @@ describe("useSharedMessageSource", () => {
     expect(result.current).toEqual({ status: "missing" })
   })
 
+  it("maps private hydration state to a privacy placeholder source", () => {
+    const { result } = renderHook(() => useSharedMessageSource("msg_p", "stream_src"), {
+      wrapper: ({ children }) => (
+        <SharedMessagesProvider
+          map={{
+            msg_p: {
+              state: "private",
+              messageId: "msg_p",
+              sourceStreamKind: "channel",
+              sourceVisibility: "private",
+            },
+          }}
+        >
+          {children}
+        </SharedMessagesProvider>
+      ),
+    })
+
+    expect(result.current).toEqual({
+      status: "private",
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    })
+  })
+
+  it("maps truncated hydration state to a navigable placeholder source", () => {
+    const { result } = renderHook(() => useSharedMessageSource("msg_t", "stream_src"), {
+      wrapper: ({ children }) => (
+        <SharedMessagesProvider
+          map={{
+            msg_t: { state: "truncated", messageId: "msg_t", streamId: "stream_deep" },
+          }}
+        >
+          {children}
+        </SharedMessagesProvider>
+      ),
+    })
+
+    expect(result.current).toEqual({
+      status: "truncated",
+      streamId: "stream_deep",
+      messageId: "msg_t",
+    })
+  })
+
   it("falls back to the local IDB event cache when hydration is absent", async () => {
     await db.events.put({
       id: "evt_cached",

--- a/apps/frontend/src/hooks/use-shared-message-source.ts
+++ b/apps/frontend/src/hooks/use-shared-message-source.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db } from "@/db"
 import { useSharedMessageHydration } from "@/components/shared-messages/context"
+import type { StreamType, Visibility } from "@threa/types"
 
 /**
  * Resolved preview for a shared-message pointer. `authorName` is optional at
@@ -32,11 +33,38 @@ export interface SharedMessagePending {
   showSkeleton: boolean
 }
 
+/**
+ * Viewer has no read path to the source message. The card renders a
+ * privacy-preserving placeholder showing only the source stream's `kind`
+ * and `visibility` — never the content, author, or stream name. Used for
+ * re-share chains where a downstream viewer can see the outer pointer
+ * but the inner one references a stream they don't have access to.
+ */
+export interface SharedMessagePrivate {
+  status: "private"
+  sourceStreamKind: StreamType
+  sourceVisibility: Visibility
+}
+
+/**
+ * Hydration stopped at the recursive depth cap for an accessible chain.
+ * The viewer can navigate to the source stream to keep reading. The
+ * `streamId` carries from the share-node's cached attrs so we always have
+ * a navigable target without an extra fetch.
+ */
+export interface SharedMessageTruncated {
+  status: "truncated"
+  streamId: string
+  messageId: string
+}
+
 export type SharedMessageSource =
   | SharedMessageResolved
   | SharedMessageDeleted
   | SharedMessageMissing
   | SharedMessagePending
+  | SharedMessagePrivate
+  | SharedMessageTruncated
 
 const SKELETON_DELAY_MS = 300
 
@@ -79,6 +107,20 @@ export function useSharedMessageSource(messageId: string, sourceStreamId: string
     if (hydrated) {
       if (hydrated.state === "deleted") return { status: "deleted" }
       if (hydrated.state === "missing") return { status: "missing" }
+      if (hydrated.state === "private") {
+        return {
+          status: "private",
+          sourceStreamKind: hydrated.sourceStreamKind,
+          sourceVisibility: hydrated.sourceVisibility,
+        }
+      }
+      if (hydrated.state === "truncated") {
+        return {
+          status: "truncated",
+          streamId: hydrated.streamId,
+          messageId: hydrated.messageId,
+        }
+      }
       if (hydrated.state === "ok") {
         return {
           status: "resolved",

--- a/apps/frontend/src/lib/share-navigation.ts
+++ b/apps/frontend/src/lib/share-navigation.ts
@@ -1,0 +1,42 @@
+import type { useLocation, useNavigate } from "react-router-dom"
+
+/**
+ * Decide what to do after `queueShareHandoff` for any share affordance —
+ * fast-path entries in the message context menu and the cross-stream
+ * picker modal both call here so the navigation behavior stays
+ * consistent across surfaces.
+ *
+ * Behavior diverges by viewport because the meaning of the panel query
+ * (`?panel=…`) differs:
+ *
+ * - **Desktop two-pane:** the panel renders alongside the main view, so
+ *   the parent composer is mounted and visible. Preserve `location.search`
+ *   so the panel stays open across the navigation. Skip `navigate()` when
+ *   pathname + search are unchanged — the existing composer subscribes to
+ *   the handoff store and picks the share up in place.
+ *
+ * - **Mobile fullscreen:** the panel TAKES OVER the screen, so the parent
+ *   composer is NOT visible even when the URL pathname matches the share
+ *   target. Drop the search on mobile so navigating to the bare pathname
+ *   swaps the view back to the parent's main composer. Without this, the
+ *   share queues but the user is still looking at the thread and nothing
+ *   visible happens.
+ */
+export function navigateAfterShareHandoff({
+  workspaceId,
+  targetStreamId,
+  location,
+  navigate,
+  isMobile,
+}: {
+  workspaceId: string
+  targetStreamId: string
+  location: ReturnType<typeof useLocation>
+  navigate: ReturnType<typeof useNavigate>
+  isMobile: boolean
+}): void {
+  const targetPathname = `/w/${workspaceId}/s/${targetStreamId}`
+  const search = isMobile ? "" : location.search
+  if (location.pathname === targetPathname && location.search === search) return
+  navigate(`${targetPathname}${search}`)
+}

--- a/apps/frontend/src/lib/share-privacy-toast.ts
+++ b/apps/frontend/src/lib/share-privacy-toast.ts
@@ -1,0 +1,53 @@
+import { toast } from "sonner"
+import { db } from "@/db"
+
+/**
+ * Surfaced when the message queue receives 409 +
+ * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` for a pending share. The send is
+ * not auto-retried because the user has not acknowledged that the share
+ * exposes its source to people outside the source stream (plan D2).
+ *
+ * The toast offers two paths:
+ *
+ * - **Share anyway** — sets `confirmedPrivacyWarning: true` on the pending
+ *   row and clears the `blocked-privacy` status so the next drain cycle
+ *   re-attempts with the confirmation flag forwarded to the API.
+ * - **Cancel** — deletes both the pending row and its optimistic event so
+ *   the share disappears from the timeline. The user can re-author from
+ *   scratch (or pick a less-private target) without leaving a half-failed
+ *   message in the queue.
+ *
+ * This is the Slice 2 placeholder UX. Slice 3 lifts the prompt into the
+ * picker modal as an explicit step-2 confirm, surfacing the warning before
+ * the user types commentary, and replaces this toast.
+ */
+export function surfacePrivacyBlockToast(clientMessageId: string): void {
+  const id = `share-privacy-${clientMessageId}`
+  toast.warning("This share would expose the source to people outside the source stream.", {
+    id,
+    duration: Infinity,
+    action: {
+      label: "Share anyway",
+      onClick: async () => {
+        // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
+        type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
+        await (db.pendingMessages.update as unknown as UpdateFn)(clientMessageId, {
+          status: undefined,
+          confirmedPrivacyWarning: true,
+          retryAfter: undefined,
+          retryCount: 0,
+        })
+        await db.events.update(clientMessageId, { _status: "pending" })
+        toast.dismiss(id)
+      },
+    },
+    cancel: {
+      label: "Cancel",
+      onClick: async () => {
+        await db.pendingMessages.delete(clientMessageId)
+        await db.events.delete(clientMessageId)
+        toast.dismiss(id)
+      },
+    },
+  })
+}

--- a/apps/frontend/src/lib/share-privacy-toast.ts
+++ b/apps/frontend/src/lib/share-privacy-toast.ts
@@ -1,27 +1,27 @@
 import { toast } from "sonner"
-import { db } from "@/db"
 
 /**
  * Surfaced when the message queue receives 409 +
- * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` for a pending share. The send is
- * not auto-retried because the user has not acknowledged that the share
- * exposes its source to people outside the source stream (plan D2).
+ * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` for a pending share — the user has
+ * not acknowledged that the share exposes its source to people outside
+ * the source stream. Two paths:
  *
- * The toast offers two paths:
- *
- * - **Share anyway** — sets `confirmedPrivacyWarning: true` on the pending
- *   row and clears the `blocked-privacy` status so the next drain cycle
+ * - **Share anyway** — re-enqueue with `confirmedPrivacyWarning: true` and
+ *   clear the `blocked-privacy` status so the queue's next drain
  *   re-attempts with the confirmation flag forwarded to the API.
- * - **Cancel** — deletes both the pending row and its optimistic event so
- *   the share disappears from the timeline. The user can re-author from
- *   scratch (or pick a less-private target) without leaving a half-failed
- *   message in the queue.
+ * - **Cancel** — drop the pending row and its optimistic event so the
+ *   half-failed share disappears cleanly.
  *
- * This is the Slice 2 placeholder UX. Slice 3 lifts the prompt into the
- * picker modal as an explicit step-2 confirm, surfacing the warning before
- * the user types commentary, and replaces this toast.
+ * State writes go through `usePendingMessages` (`retryMessage` /
+ * `deleteMessage`) rather than touching `db.*` directly so we don't
+ * bypass the React state cleanup the context performs.
  */
-export function surfacePrivacyBlockToast(clientMessageId: string): void {
+export interface SharePrivacyToastDeps {
+  retryMessage: (id: string, patch?: Record<string, unknown>) => Promise<void>
+  deleteMessage: (id: string) => Promise<void>
+}
+
+export function surfacePrivacyBlockToast(clientMessageId: string, deps: SharePrivacyToastDeps): void {
   const id = `share-privacy-${clientMessageId}`
   toast.warning("This share would expose the source to people outside the source stream.", {
     id,
@@ -29,23 +29,14 @@ export function surfacePrivacyBlockToast(clientMessageId: string): void {
     action: {
       label: "Share anyway",
       onClick: async () => {
-        // Dexie's deep KeyPaths inference hits a circular type on JSONContent.
-        type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
-        await (db.pendingMessages.update as unknown as UpdateFn)(clientMessageId, {
-          status: undefined,
-          confirmedPrivacyWarning: true,
-          retryAfter: undefined,
-          retryCount: 0,
-        })
-        await db.events.update(clientMessageId, { _status: "pending" })
+        await deps.retryMessage(clientMessageId, { confirmedPrivacyWarning: true, status: undefined })
         toast.dismiss(id)
       },
     },
     cancel: {
       label: "Cancel",
       onClick: async () => {
-        await db.pendingMessages.delete(clientMessageId)
-        await db.events.delete(clientMessageId)
+        await deps.deleteMessage(clientMessageId)
         toast.dismiss(id)
       },
     },

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -1,5 +1,20 @@
 import { StreamTypes } from "@threa/types"
 import type { StreamType } from "@threa/types"
+import { Bell, FileText, Hash, MessageSquare } from "lucide-react"
+import type { ComponentType } from "react"
+
+/**
+ * Canonical icon for each stream type. Shared by the quick-switcher list
+ * and the share-message picker so the visual vocabulary doesn't drift
+ * between two surfaces that ultimately list the same streams.
+ */
+export const STREAM_ICONS: Record<StreamType, ComponentType<{ className?: string }>> = {
+  [StreamTypes.SCRATCHPAD]: FileText,
+  [StreamTypes.CHANNEL]: Hash,
+  [StreamTypes.DM]: MessageSquare,
+  [StreamTypes.THREAD]: MessageSquare,
+  [StreamTypes.SYSTEM]: Bell,
+}
 
 /**
  * Returns the resolved display name for a stream, or null if the stream
@@ -41,14 +56,20 @@ export function resolveDmDisplayName(
   return workspaceUsers.find((u) => u.id === peerUserId)?.name ?? null
 }
 
-type FallbackContext = "sidebar" | "activity" | "breadcrumb" | "generic"
+type FallbackContext = "sidebar" | "activity" | "breadcrumb" | "generic" | "noun"
 
 const FALLBACK_LABELS: Record<string, Record<FallbackContext, string>> = {
-  scratchpad: { sidebar: "New scratchpad", activity: "a scratchpad", breadcrumb: "Untitled", generic: "Untitled" },
-  thread: { sidebar: "New thread", activity: "a thread", breadcrumb: "Thread", generic: "Thread" },
-  channel: { sidebar: "Untitled", activity: "a channel", breadcrumb: "...", generic: "Untitled" },
-  dm: { sidebar: "Direct message", activity: "a conversation", breadcrumb: "DM", generic: "DM" },
-  system: { sidebar: "System", activity: "system", breadcrumb: "System", generic: "System" },
+  scratchpad: {
+    sidebar: "New scratchpad",
+    activity: "a scratchpad",
+    breadcrumb: "Untitled",
+    generic: "Untitled",
+    noun: "scratchpad",
+  },
+  thread: { sidebar: "New thread", activity: "a thread", breadcrumb: "Thread", generic: "Thread", noun: "thread" },
+  channel: { sidebar: "Untitled", activity: "a channel", breadcrumb: "...", generic: "Untitled", noun: "channel" },
+  dm: { sidebar: "Direct message", activity: "a conversation", breadcrumb: "DM", generic: "DM", noun: "DM" },
+  system: { sidebar: "System", activity: "system", breadcrumb: "System", generic: "System", noun: "system stream" },
 }
 
 /** Context-appropriate fallback text for streams that truly have no name yet. */

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -174,6 +174,14 @@ export interface CreateMessageInputJson {
   clientMessageId?: string
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
+  /**
+   * Set to `true` after the user has acknowledged that a share node in
+   * `contentJson` would expose its source to people outside the source
+   * stream. Required by the backend for shares that cross a privacy
+   * boundary; sends without it return 409 + code
+   * `SHARE_PRIVACY_CONFIRMATION_REQUIRED`.
+   */
+  confirmedPrivacyWarning?: boolean
 }
 
 export interface CreateDmMessageInputJson {
@@ -187,6 +195,8 @@ export interface CreateDmMessageInputJson {
   clientMessageId?: string
   /** External references as a flat string->string map. Keys under `threa.*` are reserved. */
   metadata?: Record<string, string>
+  /** Same semantics as `CreateMessageInputJson.confirmedPrivacyWarning`. */
+  confirmedPrivacyWarning?: boolean
 }
 
 /**
@@ -227,6 +237,8 @@ export type CreateDmMessageInput = CreateDmMessageInputJson | CreateDmMessageInp
 export interface UpdateMessageInputJson {
   contentJson: JSONContent
   contentMarkdown?: string
+  /** See `CreateMessageInputJson.confirmedPrivacyWarning`. */
+  confirmedPrivacyWarning?: boolean
 }
 
 /**
@@ -234,6 +246,8 @@ export interface UpdateMessageInputJson {
  */
 export interface UpdateMessageInputMarkdown {
   content: string
+  /** See `CreateMessageInputJson.confirmedPrivacyWarning`. */
+  confirmedPrivacyWarning?: boolean
 }
 
 /**

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -115,10 +115,17 @@ export interface StreamBootstrap {
 }
 
 /**
- * Wire-format variants for an individual pointer's hydrated content. `ok`
- * includes the source's current content; `deleted` and `missing` surface
- * tombstone states. Slice 2 will add `private` / `truncated` variants for
- * the recursive chain case.
+ * Wire-format variants for an individual pointer's hydrated content.
+ *
+ * - `ok`: viewer has access; current source content is inlined.
+ * - `deleted`: source row exists but is tombstoned.
+ * - `missing`: source row never existed (or was hard-deleted in a way that
+ *   leaves no tombstone — defended for, shouldn't normally occur).
+ * - `private`: viewer has no read access to the source and no share-grant
+ *   reaches them. Reveals only the source stream's `kind` + `visibility`,
+ *   never the content/author/stream-name. See plan D8.
+ * - `truncated`: hydration stopped at `MAX_HYDRATION_DEPTH` for an
+ *   accessible chain; viewer can follow `streamId` to read in source.
  */
 export type SharedMessageHydration =
   | {
@@ -134,6 +141,13 @@ export type SharedMessageHydration =
     }
   | { state: "deleted"; messageId: string; deletedAt: string }
   | { state: "missing"; messageId: string }
+  | {
+      state: "private"
+      messageId: string
+      sourceStreamKind: StreamType
+      sourceVisibility: Visibility
+    }
+  | { state: "truncated"; messageId: string; streamId: string }
 
 export interface EventsAroundResponse {
   events: StreamEvent[]

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -538,5 +538,20 @@ export const ShareFlavors = {
   QUOTE: "quote",
 } as const satisfies Record<string, ShareFlavor>
 
+/**
+ * Wire-format error codes for the sharing feature. Centralised here because
+ * the privacy-confirmation code is matched on by the frontend message queue
+ * to surface the "Share anyway" / "Cancel" toast — keeping it as a magic
+ * string in two places would let typos drift the contract silently.
+ */
+export const ShareErrorCodes = {
+  PRIVACY_CONFIRMATION_REQUIRED: "SHARE_PRIVACY_CONFIRMATION_REQUIRED",
+  SOURCE_MESSAGE_NOT_FOUND: "SHARE_SOURCE_MESSAGE_NOT_FOUND",
+  SOURCE_STREAM_MISMATCH: "SHARE_SOURCE_STREAM_MISMATCH",
+  SOURCE_STREAM_NOT_FOUND: "SHARE_SOURCE_STREAM_NOT_FOUND",
+  CROSS_WORKSPACE_FORBIDDEN: "SHARE_CROSS_WORKSPACE_FORBIDDEN",
+  SOURCE_FORBIDDEN: "SHARE_SOURCE_FORBIDDEN",
+} as const
+
 // Inter-service authentication header (control-plane ↔ regional backend ↔ workspace-router)
 export const INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -154,6 +154,7 @@ export {
   SHARE_FLAVORS,
   type ShareFlavor,
   ShareFlavors,
+  ShareErrorCodes,
   // Inter-service authentication
   INTERNAL_API_KEY_HEADER,
 } from "./constants"

--- a/tests/browser/message-share-cross-stream.spec.ts
+++ b/tests/browser/message-share-cross-stream.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Page } from "@playwright/test"
+import { createChannel, expectApiOk, generateTestId, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * E2E coverage for Slice 2 of message sharing — the cross-stream picker
+ * modal. Covers the two single-user scenarios that exercise the new modal
+ * flow end-to-end:
+ *
+ * 1. **Cross-stream into a scratchpad (public source).** Share a message
+ *    from a public channel into the user's own scratchpad. No privacy
+ *    boundary fires. Asserts the picker filters correctly and the pointer
+ *    lands hydrated in the target stream.
+ * 2. **Same-stream share.** Share a message into the stream it lives in.
+ *    Plan D5 says this is allowed; the hand-off lands in the current
+ *    composer and the user can send a duplicate pointer back.
+ *
+ * The recursive private-placeholder rechain scenario from the plan
+ * (E2E-share-rechain-private-placeholder) is covered exhaustively at
+ * unit-test level in `hydration.test.ts` and `card-body.test.tsx`. A
+ * three-user three-stream Playwright variant is deferred to a follow-up;
+ * this slice's E2Es focus on the modal + handoff path that's new in Slice
+ * 2.
+ */
+
+async function sendChannelMessageViaApi(page: Page, text: string): Promise<string> {
+  const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+  expect(match).toBeTruthy()
+  const [, workspaceId, streamId] = match!
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: {
+      streamId,
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] },
+      contentMarkdown: text,
+    },
+  })
+  await expectApiOk(response, `Create stream message: ${text}`)
+  const body = (await response.json()) as { message?: { id: string } }
+  return body.message?.id ?? ""
+}
+
+async function openMessageContextMenu(page: Page, text: string): Promise<void> {
+  const row = page.getByText(text, { exact: false }).first().locator("xpath=ancestor::*[@data-message-id][1]")
+  await row.hover()
+  await row.getByRole("button", { name: /message actions/i }).click()
+}
+
+async function createScratchpad(page: Page, name: string): Promise<string> {
+  await page.getByRole("button", { name: "+ New Scratchpad" }).click()
+  // The new-scratchpad action navigates immediately to the draft route.
+  // Wait for the URL to settle on /s/<id> so subsequent helpers can read it.
+  await expect(page).toHaveURL(/\/w\/[^/]+\/s\/[^/?]+/, { timeout: 5000 })
+  // Optional rename via the page header — best-effort; skipped if not exposed.
+  const header = page.getByRole("heading", { level: 1 }).first()
+  await header.waitFor({ state: "visible", timeout: 5000 })
+  return name
+}
+
+test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
+  let testId: string
+
+  test.beforeEach(async ({ page }) => {
+    const result = await loginAndCreateWorkspace(page, "share-x-stream")
+    testId = result.testId
+  })
+
+  test("shares a public-channel message into the user's scratchpad via the picker", async ({ page }) => {
+    const channelName = `pub-${testId}`
+    await createChannel(page, channelName, { switchToAll: false })
+    const sourceText = `source-msg-${testId}`
+    await sendChannelMessageViaApi(page, sourceText)
+
+    const sourceUrl = page.url()
+    // Pre-create the scratchpad target so it shows up in the picker.
+    const scratchpadName = `Saved ${testId}`
+    await createScratchpad(page, scratchpadName)
+    // Hop back to the source channel.
+    await page.goto(sourceUrl)
+    await expect(page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible()
+
+    await openMessageContextMenu(page, sourceText)
+    // The new "Share to another stream…" entry. Group share-to-* may collapse
+    // it inside a chevron dropdown, so account for both surfaces by matching
+    // any visible menuitem with the share verb.
+    await page.getByRole("menuitem", { name: /share to another stream/i }).click()
+
+    // Picker dialog opens. The scratchpad we just created is selectable.
+    const dialog = page.getByRole("dialog", { name: /share message/i })
+    await expect(dialog).toBeVisible()
+    const target = dialog.locator(`[cmdk-item][data-value]`).first()
+    await expect(target).toBeVisible()
+    // Click whichever scratchpad-row is exposed; in the no-named-scratchpad
+    // case the list shows just our newly-created untitled one.
+    const scratchItem = dialog
+      .locator("[cmdk-item][data-value]")
+      .filter({ hasText: /scratchpad|saved|notes|untitled/i })
+      .first()
+    if ((await scratchItem.count()) > 0) {
+      await scratchItem.click()
+    } else {
+      // Fallback: the only non-channel option is the scratchpad anyway.
+      await target.click()
+    }
+
+    // Modal closes and we navigate to the target. Composer pre-fills with
+    // the share node — send via the normal Enter shortcut.
+    await expect(dialog).not.toBeVisible()
+    const composer = page.locator("[contenteditable='true']").first()
+    await expect(composer).toBeVisible()
+    await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 5000 })
+    await composer.focus()
+    await page.keyboard.press("Enter")
+
+    // Sent — pointer card lands hydrated in the target stream.
+    await expect(page.locator("[data-type='shared-message']").filter({ hasText: new RegExp(sourceText) })).toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  test("supports same-stream share — handoff lands in the current composer", async ({ page }) => {
+    const channelName = `self-${testId}`
+    await createChannel(page, channelName, { switchToAll: false })
+    const sourceText = `self-share-msg-${testId}`
+    await sendChannelMessageViaApi(page, sourceText)
+
+    await openMessageContextMenu(page, sourceText)
+    await page.getByRole("menuitem", { name: /share to another stream/i }).click()
+
+    const dialog = page.getByRole("dialog", { name: /share message/i })
+    await expect(dialog).toBeVisible()
+    // Pick the same channel we're already in.
+    const sameItem = dialog
+      .locator("[cmdk-item][data-value]")
+      .filter({ hasText: new RegExp(channelName, "i") })
+      .first()
+    await expect(sameItem).toBeVisible()
+    await sameItem.click()
+
+    // Modal closes, current composer receives the share node — no
+    // navigation flicker since target === current.
+    await expect(dialog).not.toBeVisible()
+    const composer = page.locator("[contenteditable='true']").first()
+    await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 5000 })
+    await composer.focus()
+    await page.keyboard.press("Enter")
+
+    // The channel now contains the original message AND a hydrated share
+    // pointer to it. Two `[data-type='shared-message']` would only render in
+    // the timeline if the send went through — the composer's transient one
+    // disappears post-send.
+    await expect(page.locator("[data-type='shared-message']").filter({ hasText: new RegExp(sourceText) })).toBeVisible({
+      timeout: 5000,
+    })
+  })
+})

--- a/tests/browser/message-share-cross-stream.spec.ts
+++ b/tests/browser/message-share-cross-stream.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect, type Page } from "@playwright/test"
-import { createChannel, expectApiOk, generateTestId, loginAndCreateWorkspace } from "./helpers"
+import { createChannel, expectApiOk, generateTestId, loginAndCreateWorkspace, loginInNewContext } from "./helpers"
 
 /**
  * E2E coverage for Slice 2 of message sharing — the cross-stream picker
- * modal. Covers the two single-user scenarios that exercise the new modal
- * flow end-to-end:
+ * modal. Covers the single-user happy paths plus the two-user privacy-
+ * boundary flows that gate accidental information leaks:
  *
  * 1. **Cross-stream into a scratchpad (public source).** Share a message
  *    from a public channel into the user's own scratchpad. No privacy
@@ -13,13 +13,19 @@ import { createChannel, expectApiOk, generateTestId, loginAndCreateWorkspace } f
  * 2. **Same-stream share.** Share a message into the stream it lives in.
  *    Plan D5 says this is allowed; the hand-off lands in the current
  *    composer and the user can send a duplicate pointer back.
+ * 3. **Private → public, blocked then confirmed.** Two-user scenario where
+ *    sharing from a private channel into a public one User B has joined
+ *    triggers `crossesPrivacyBoundary`. The first send must fail with the
+ *    `blocked-privacy` status, surface the toast, and only after the user
+ *    explicitly clicks "Share anyway" should the pointer reach the public
+ *    timeline. **The whole point of this test is to prove a share never
+ *    leaves the device without a deliberate user click.**
+ * 4. **Private → public, blocked then cancelled.** Same setup, but Cancel
+ *    on the toast must drop the pending row and never deliver the share.
  *
  * The recursive private-placeholder rechain scenario from the plan
  * (E2E-share-rechain-private-placeholder) is covered exhaustively at
- * unit-test level in `hydration.test.ts` and `card-body.test.tsx`. A
- * three-user three-stream Playwright variant is deferred to a follow-up;
- * this slice's E2Es focus on the modal + handoff path that's new in Slice
- * 2.
+ * unit-test level in `hydration.test.ts` and `card-body.test.tsx`.
  */
 
 async function sendChannelMessageViaApi(page: Page, text: string): Promise<string> {
@@ -36,6 +42,40 @@ async function sendChannelMessageViaApi(page: Page, text: string): Promise<strin
   await expectApiOk(response, `Create stream message: ${text}`)
   const body = (await response.json()) as { message?: { id: string } }
   return body.message?.id ?? ""
+}
+
+/**
+ * Create a channel directly via the streams API rather than the modal — the
+ * privacy tests need a private channel and the in-app modal only exposes a
+ * "public channel" affordance to keep workspace creation simple.
+ */
+async function createChannelViaApi(
+  page: Page,
+  workspaceId: string,
+  slug: string,
+  visibility: "public" | "private"
+): Promise<string> {
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+    data: { type: "channel", slug, visibility },
+  })
+  await expectApiOk(response, `Create ${visibility} channel ${slug}`)
+  const body = (await response.json()) as { stream: { id: string } }
+  return body.stream.id
+}
+
+/**
+ * Resolve the workspace user id for a given email by reading the workspace
+ * bootstrap. Used to admin-add User B to the public channel so the
+ * `stream_members` row exists — `crossesPrivacyBoundary`'s exposure count is
+ * over `stream_members`, not "every workspace member with read access".
+ */
+async function getWorkspaceUserIdByEmail(page: Page, workspaceId: string, email: string): Promise<string> {
+  const response = await page.request.get(`/api/workspaces/${workspaceId}/bootstrap`)
+  await expectApiOk(response, "Get workspace bootstrap")
+  const body = (await response.json()) as { data: { users: Array<{ id: string; email: string }> } }
+  const user = body.data.users.find((candidate) => candidate.email === email)
+  if (!user) throw new Error(`Workspace user not found for email ${email}`)
+  return user.id
 }
 
 async function openMessageContextMenu(page: Page, text: string): Promise<void> {
@@ -148,5 +188,192 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
     await expect(page.locator("[data-type='shared-message']").filter({ hasText: new RegExp(sourceText) })).toBeVisible({
       timeout: 5000,
     })
+  })
+
+  test("blocks a private→public share until the user explicitly confirms 'Share anyway'", async ({ browser, page }) => {
+    // ---- Setup: two users, one workspace, two channels --------------------
+    // User A owns the workspace and is the only member of the private source.
+    // User B joins the workspace and is added to the public target so the
+    // backend's exposure count is > 0 (User B is in `pub`'s stream_members
+    // but NOT in `priv`'s — exactly the case the privacy boundary is meant
+    // to catch).
+    const { testId, workspaceId } = await loginAndCreateWorkspace(page, "share-priv-confirm").then((r) => ({
+      testId: r.testId,
+      workspaceId: page.url().match(/\/w\/([^/]+)/)?.[1] ?? "",
+    }))
+    expect(workspaceId).not.toBe("")
+
+    const pubSlug = `pub-${testId}`
+    const privSlug = `priv-${testId}`
+    const pubStreamId = await createChannelViaApi(page, workspaceId, pubSlug, "public")
+    const privStreamId = await createChannelViaApi(page, workspaceId, privSlug, "private")
+
+    const memberEmail = `share-priv-other-${testId}@example.com`
+    const otherUser = await loginInNewContext(browser, memberEmail, `Share Priv Other ${testId}`)
+    try {
+      await expectApiOk(
+        await otherUser.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, { data: { role: "user" } }),
+        "User B join workspace"
+      )
+      const memberId = await getWorkspaceUserIdByEmail(page, workspaceId, memberEmail)
+      // Admin-add User B to the public channel so the stream_members row
+      // exists. A drive-by `joinChannel` from User B's session would also
+      // work for public channels, but going through the owner keeps the test
+      // independent of User B's UI state.
+      await expectApiOk(
+        await page.request.post(`/api/workspaces/${workspaceId}/streams/${pubStreamId}/members`, {
+          data: { memberId },
+        }),
+        "Add User B to public channel"
+      )
+
+      // ---- Act: User A sends a private message, opens picker, selects pub.
+      await page.goto(`/w/${workspaceId}/s/${privStreamId}`)
+      await expect(page.getByRole("heading", { name: `#${privSlug}`, level: 1 })).toBeVisible({ timeout: 10000 })
+
+      const sourceText = `secret-${testId}`
+      await sendChannelMessageViaApi(page, sourceText)
+      await expect(page.getByText(sourceText, { exact: false }).first()).toBeVisible({ timeout: 5000 })
+
+      await openMessageContextMenu(page, sourceText)
+      await page.getByRole("menuitem", { name: /^share message$/i }).click()
+
+      const dialog = page.getByRole("dialog", { name: /share message/i })
+      await expect(dialog).toBeVisible()
+      const pubItem = dialog
+        .locator("[cmdk-item][data-value]")
+        .filter({ hasText: new RegExp(pubSlug, "i") })
+        .first()
+      await expect(pubItem).toBeVisible()
+      await pubItem.click()
+
+      // Modal closes, navigation lands on `pub`, composer receives the share.
+      await expect(dialog).not.toBeVisible()
+      await expect(page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${pubStreamId}`), { timeout: 10000 })
+      const composer = page.locator("[contenteditable='true']").first()
+      await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 5000 })
+      await composer.focus()
+      await page.keyboard.press("Enter")
+
+      // ---- Assert: NOT delivered. Toast appears asking for confirmation.
+      // The toast is the only thing standing between an accidental click and
+      // the source content reaching User B — its presence is the contract.
+      const toast = page.getByText(/expose the source to people outside the source stream/i)
+      await expect(toast).toBeVisible({ timeout: 10000 })
+
+      // The pointer must NOT appear in the public timeline before confirmation.
+      // We check inside `[role='main']` so the composer's transient share node
+      // (still mounted because the send was rejected) doesn't false-positive.
+      const publishedPointer = page
+        .getByRole("main")
+        .locator("[data-type='shared-message']")
+        .filter({ hasText: new RegExp(sourceText) })
+      await expect(publishedPointer).toHaveCount(0)
+
+      // ---- Confirm: click "Share anyway" → re-enqueue with the flag set.
+      await page.getByRole("button", { name: /share anyway/i }).click()
+
+      // Now — and only now — the pointer should land in the public channel.
+      // For User A (a member of the source) it hydrates with the original text.
+      await expect(publishedPointer).toBeVisible({ timeout: 10000 })
+
+      // The toast should be dismissed once the retry is in flight.
+      await expect(toast).not.toBeVisible({ timeout: 5000 })
+    } finally {
+      await otherUser.context.close()
+    }
+  })
+
+  test("blocks a private→public share and discards it cleanly when the user clicks 'Cancel'", async ({
+    browser,
+    page,
+  }) => {
+    // Mirrors the confirm test up to the toast — then asserts the cancel path
+    // tears down the optimistic state without ever hitting the server.
+    const { testId, workspaceId } = await loginAndCreateWorkspace(page, "share-priv-cancel").then((r) => ({
+      testId: r.testId,
+      workspaceId: page.url().match(/\/w\/([^/]+)/)?.[1] ?? "",
+    }))
+    expect(workspaceId).not.toBe("")
+
+    const pubSlug = `pub-${testId}`
+    const privSlug = `priv-${testId}`
+    const pubStreamId = await createChannelViaApi(page, workspaceId, pubSlug, "public")
+    const privStreamId = await createChannelViaApi(page, workspaceId, privSlug, "private")
+
+    const memberEmail = `share-priv-cancel-other-${testId}@example.com`
+    const otherUser = await loginInNewContext(browser, memberEmail, `Share Priv Cancel ${testId}`)
+    try {
+      await expectApiOk(
+        await otherUser.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, { data: { role: "user" } }),
+        "User B join workspace"
+      )
+      const memberId = await getWorkspaceUserIdByEmail(page, workspaceId, memberEmail)
+      await expectApiOk(
+        await page.request.post(`/api/workspaces/${workspaceId}/streams/${pubStreamId}/members`, {
+          data: { memberId },
+        }),
+        "Add User B to public channel"
+      )
+
+      await page.goto(`/w/${workspaceId}/s/${privStreamId}`)
+      await expect(page.getByRole("heading", { name: `#${privSlug}`, level: 1 })).toBeVisible({ timeout: 10000 })
+
+      const sourceText = `do-not-leak-${testId}`
+      await sendChannelMessageViaApi(page, sourceText)
+      await expect(page.getByText(sourceText, { exact: false }).first()).toBeVisible({ timeout: 5000 })
+
+      await openMessageContextMenu(page, sourceText)
+      await page.getByRole("menuitem", { name: /^share message$/i }).click()
+
+      const dialog = page.getByRole("dialog", { name: /share message/i })
+      await expect(dialog).toBeVisible()
+      const pubItem = dialog
+        .locator("[cmdk-item][data-value]")
+        .filter({ hasText: new RegExp(pubSlug, "i") })
+        .first()
+      await expect(pubItem).toBeVisible()
+      await pubItem.click()
+      await expect(dialog).not.toBeVisible()
+      await expect(page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${pubStreamId}`), { timeout: 10000 })
+
+      const composer = page.locator("[contenteditable='true']").first()
+      await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 5000 })
+      await composer.focus()
+      await page.keyboard.press("Enter")
+
+      const toast = page.getByText(/expose the source to people outside the source stream/i)
+      await expect(toast).toBeVisible({ timeout: 10000 })
+
+      await page.getByRole("button", { name: /^cancel$/i }).click()
+
+      // Toast dismisses; pointer never appears in the public timeline. We
+      // wait long enough for any (hypothetical) deferred retry to drain so
+      // the absence assertion is meaningful, not just a race.
+      await expect(toast).not.toBeVisible({ timeout: 5000 })
+      await page.waitForTimeout(2000)
+      const publishedPointer = page
+        .getByRole("main")
+        .locator("[data-type='shared-message']")
+        .filter({ hasText: new RegExp(sourceText) })
+      await expect(publishedPointer).toHaveCount(0)
+
+      // Independent verification from User B's perspective: User B is in `pub`
+      // and would see any leaked share. Bootstrap the public channel as User B
+      // and assert no share-pointer messages exist for the source text. This
+      // closes the loop between "frontend optimistic state cleared" and
+      // "backend never accepted the write".
+      await otherUser.page.goto(`/w/${workspaceId}/s/${pubStreamId}`)
+      await expect(otherUser.page.getByRole("heading", { name: `#${pubSlug}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+      const otherPointer = otherUser.page
+        .getByRole("main")
+        .locator("[data-type='shared-message']")
+        .filter({ hasText: new RegExp(sourceText) })
+      await expect(otherPointer).toHaveCount(0)
+    } finally {
+      await otherUser.context.close()
+    }
   })
 })

--- a/tests/browser/message-share-cross-stream.spec.ts
+++ b/tests/browser/message-share-cross-stream.spec.ts
@@ -78,10 +78,8 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
     await expect(page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible()
 
     await openMessageContextMenu(page, sourceText)
-    // The new "Share to another stream…" entry. Group share-to-* may collapse
-    // it inside a chevron dropdown, so account for both surfaces by matching
-    // any visible menuitem with the share verb.
-    await page.getByRole("menuitem", { name: /share to another stream/i }).click()
+    // The default "Share message" entry — opens the picker modal.
+    await page.getByRole("menuitem", { name: /^share message$/i }).click()
 
     // Picker dialog opens. The scratchpad we just created is selectable.
     const dialog = page.getByRole("dialog", { name: /share message/i })
@@ -123,7 +121,7 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
     await sendChannelMessageViaApi(page, sourceText)
 
     await openMessageContextMenu(page, sourceText)
-    await page.getByRole("menuitem", { name: /share to another stream/i }).click()
+    await page.getByRole("menuitem", { name: /^share message$/i }).click()
 
     const dialog = page.getByRole("dialog", { name: /share message/i })
     await expect(dialog).toBeVisible()

--- a/tests/browser/message-share-to-parent.spec.ts
+++ b/tests/browser/message-share-to-parent.spec.ts
@@ -94,6 +94,10 @@ async function setUpSharedPointer(
   expect(threadMessageId, "thread reply should expose data-message-id").not.toBe("")
 
   await openMessageContextMenu(page, opts.threadText)
+  // The default `share` entry (modal) sits as the primary in the share group;
+  // share-to-root and share-to-parent ride alongside as alternatives behind
+  // the chevron sub-menu (aria-label "Other share").
+  await page.getByLabel("Other share").click()
   const shareEntry = page.getByRole("menuitem", { name: new RegExp(`share to #?${opts.channelName}`, "i") })
   await expect(shareEntry).toBeVisible()
   await shareEntry.click()


### PR DESCRIPTION
## Problem

Slice 1 of message sharing (#409) shipped share-to-parent only — a thread message could be shared up to its parent stream, with single-level pointer hydration. Anything more (cross-stream pickers, private re-share chains) was deferred. This PR ships **Slice 2** of the plan in `docs/plans/message-sharing-streams.md`: the cross-stream picker, recursive per-viewer hydration with `private` and `truncated` placeholder states, and the wire to send + confirm shares that cross a privacy boundary.

## Solution

### Picker → handoff → composer

Reuses the same hand-off pattern Slice 1 used for share-to-parent. The new `ShareMessageModal` filters the workspace's accessible top-level streams (channel / DM / scratchpad, no threads, no archived), and on select queues a `ThreaSharedMessage` node for the target stream's composer via `queueShareHandoff`. Commentary and send happen in the target's normal composer — there is no second editor surface.

### Per-viewer recursive hydration

`hydrateSharedMessageIds` now walks each pointer chain level-by-level up to `MAX_HYDRATION_DEPTH = 3`. At every level the viewer's access is resolved via two batched queries:

- **Stream membership** (`listAccessibleStreamIds`) — workspace boundary, public visibility, direct member, or thread inheriting from root. Same three rules as `checkStreamAccess`, in one set-based SQL round-trip.
- **Share-grant lookup** (`SharedMessageRepository.listSourcesGrantedToViewer`) — a viewer can read a source iff a share with that source exists in a target stream the viewer can read. Composes with `listAccessibleStreamIds` so the access predicate stays in one place.

Per-message classification:

- `ok` — viewer has access; current source content inlined.
- `deleted` — accessible source, tombstoned.
- `missing` — source row never existed.
- `private` — viewer has no read path. Reveals only the source stream's `kind` + `visibility`. Threads resolve to their parent's kind so the placeholder vocabulary stays in {channel, dm, scratchpad}.
- `truncated` — pointer collected past the depth cap. Renders a "open in source stream" link using the cached attrs streamId — no extra DB hit.

### Privacy-block toast

`ShareService` already had `confirmedPrivacyWarning` plumbed in Slice 1 but the HTTP handler didn't accept it. This PR closes that gap. When the user shares across a privacy boundary, the backend rejects with `409 + SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the message queue surfaces a sonner toast with **Share anyway** / **Cancel**. State writes go through `usePendingMessages` (`retryMessage` extended with an optional patch arg) — never touches `db.*` directly so React state cleanup stays consistent.

### Key design decisions

**1. Recursion in JS, access checks in SQL**

The BFS over levels lives in JavaScript so the JSONB walk for share-node refs reads as plain control flow. Each level is 3 batched queries (messages, accessible streams, share grants). Worst case at depth 3 = 9 round-trips; in practice chains are 1–2 hops.

**2. `truncated` doesn't access-check at the cap**

Pointers found past the depth cap render as `truncated` regardless of whether the viewer would have access. Linking to a stream the viewer can't read just yields a normal 403 on click — not a security issue, and the cap is a pathological-data guard rather than a privacy one. Saves one extra batched query per request.

**3. `listSourcesGrantedToViewer` composes, doesn't duplicate**

The grant query started life with the access predicate inlined. Refactored to fetch `(source, target)` candidate pairs and then call `listAccessibleStreamIds` to filter targets. One extra round-trip, but the access rule has a single source of truth — adding new access dimensions (roles, mute filters) only happens in one place.

**4. Toast over modal step-2 for Slice 2**

Plan defers the proper modal step-2 confirm + `share-preview` endpoint to Slice 3. Slice 2 ships the toast so the user is unblocked: "Share anyway" sets `confirmedPrivacyWarning: true` on the pending row and re-attempts; "Cancel" drops the optimistic event cleanly.

**5. `confirmedPrivacyWarning` is per-message, not per-share**

Single boolean covering every reference in a message body. Slice 2's modal pre-fills exactly one share node per message; multi-share composing is out-of-scope, so the upgrade path (per-source confirmation) isn't needed yet — but the Slice 1 service-layer comment notes it.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/share/share-message-modal.tsx` | The picker dialog. |
| `apps/frontend/src/components/share/share-message-modal.test.tsx` | Filter rules + on-select handoff. |
| `apps/frontend/src/components/shared-messages/card-body.test.tsx` | Private/truncated placeholder rendering, asserts `fallbackAuthor` doesn't leak. |
| `apps/frontend/src/lib/share-privacy-toast.ts` | Toast surface for the queue's 409 handler. |
| `tests/browser/message-share-cross-stream.spec.ts` | E2E: cross-stream-public + same-stream + privacy-block confirm/cancel. |
| `.claude/plans/message-sharing-streams-slice2.md` | Slice-specific plan for Greptile/PR review context. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/messaging/sharing/hydration.ts` | Single-level → recursive BFS with depth cap; takes `viewerId`; classifies into 5 states. Unified `walkSharedMessageNodes` visitor. |
| `apps/backend/src/features/streams/access.ts` | New `listAccessibleStreamIds` batched helper. |
| `apps/backend/src/features/messaging/sharing/repository.ts` | New `listSourcesGrantedToViewer` composes with `listAccessibleStreamIds`. |
| `apps/backend/src/features/messaging/handlers.ts` | Accept `confirmedPrivacyWarning` via shared `commonMessageOptionsSchema`. |
| `apps/backend/src/features/messaging/sharing/service.ts` | Error codes via `ShareErrorCodes` constants. |
| `apps/backend/src/features/streams/handlers.ts` | `hydrateSharedMessagesForEvents(pool, ws, viewerId, events)`. |
| `apps/frontend/src/components/shared-messages/context.tsx` | Wire-type union extension. |
| `apps/frontend/src/components/shared-messages/card-body.tsx` | Render `private` / `truncated` states; uses `streamFallbackLabel(kind, "noun")`. |
| `apps/frontend/src/hooks/use-shared-message-source.ts` | Map wire union → source variants. |
| `apps/frontend/src/components/timeline/message-actions.ts` | `'share'` action entry. |
| `apps/frontend/src/components/timeline/message-event.tsx` | Owns modal open state. |
| `apps/frontend/src/lib/streams.ts` | Lifted `STREAM_ICONS`; added `noun` row to `FALLBACK_LABELS`. |
| `apps/frontend/src/components/quick-switcher/use-stream-items.tsx` | Reuses lifted `STREAM_ICONS`. |
| `apps/frontend/src/contexts/pending-messages-context.tsx` | `retryMessage(id, patch?)` accepts a patch. |
| `apps/frontend/src/hooks/use-message-queue.ts` | 409 handling + forwards `confirmedPrivacyWarning`. |
| `apps/frontend/src/db/database.ts` | `PendingMessage` gains `confirmedPrivacyWarning?` and `"blocked-privacy"` status. |
| `packages/types/src/api.ts` | Hydration union + input types extended. |
| `packages/types/src/constants.ts` | `ShareErrorCodes` constant. |

## What's NOT included (deferred)

- **Attachments on shared messages — Slice 3.** A shared "look at this" + image currently renders as the text only; `HydratedSharedMessage.ok` carries `contentJson`/`contentMarkdown` but no `attachments`, and `card-body.tsx` doesn't mount an `AttachmentList`. Slice 3 should extend the `ok` wire variant with `attachments: AttachmentSummary[]`, batch-fetch via `AttachmentRepository.findByMessageIds(okMessageIds)` inside `hydrateSharedMessageIds` (one extra round-trip, no per-ref loop, INV-56), thread through `use-shared-message-source.ts`, and render `<AttachmentList>` in the `ok` branch of `card-body.tsx`. Access is implicit — attachments are emitted only for `ok` payloads where viewer access to the source is already established, so no privacy gap.
- **Modal step-2 privacy confirm** + `GET /api/.../share-preview` endpoint — Slice 3.
- **`'share-as-quote'` action** + cross-stream quote flavor — Slice 3.
- **"+ New scratchpad" picker row** — Slice 3.
- **Partial-selection share** in the text-selection toolbar — Slice 4.
- **Three-user E2E rechain test** — covered exhaustively at unit level (`hydration.test.ts`: mixed-access two-hop chain with `private` placeholder for the inner pointer; `card-body.test.tsx`: asserts the placeholder doesn't leak the cached `fallbackAuthor`). A 3-user 3-stream Playwright variant is a separate E2E PR.
- **Folding `getAccessibleStreamsWithMembers` (search) and `listAccessibleStreamIds` (streams) into one helper** — they overlap on the access predicate but have different APIs (search has participant + archive filters; mine takes a candidate id set). Both are tested.

## Test plan

- [x] Backend: `1040 successful tests` via `bun run --cwd apps/backend test:unit`. New hydration cases cover ok / deleted / missing / private / private-thread-resolution / via-grant / recursive truncation / mixed-access chain.
- [x] Frontend: `1434 successful tests` via `bun run --cwd apps/frontend test`. New tests cover the picker filter rules, on-select handoff, hook → source mapping for new states, and placeholder rendering.
- [x] Typecheck + lint clean across the monorepo.
- [ ] CI E2E: `tests/browser/message-share-cross-stream.spec.ts` runs cross-stream-public, same-stream, and the two privacy-block scenarios (Share anyway confirm, Cancel discard with cross-user verification).
- [ ] Manual smoke: open a thread message → "Share message" → pick a scratchpad → composer pre-fills with the share node → send. Verify the pointer renders hydrated in the target stream.
- [ ] Manual smoke: share a private channel's message into a DM with someone outside the source — toast surfaces "Share anyway / Cancel"; "Share anyway" lets the send through.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRG5ZrJRUbsG4bpuxCMDKU)_