### PR TITLE
ci(deploy): redeploy main staging frontend + workspace-router on merge

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -195,3 +195,71 @@ jobs:
           command: deploy --config wrangler.staging.toml
           workingDirectory: apps/backoffice-router
           packageManager: bun
+
+  deploy-frontend-staging:
+    name: Deploy Frontend (Staging)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    concurrency:
+      group: deploy-frontend-staging
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build frontend
+        run: bun run --cwd apps/frontend build
+
+      # Pushes to the `main` branch of the `threa-staging` Pages project, which
+      # the workspace-router-staging worker resolves for `staging.threa.io`. The
+      # PR-staging workflow uses the same project but with `--branch pr-N` for
+      # ephemeral previews; this job is the missing piece that keeps
+      # staging.threa.io fresh as PRs land.
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name threa-staging --branch main
+          workingDirectory: apps/frontend
+          packageManager: bun
+
+  deploy-workspace-router-staging:
+    name: Deploy Workspace Router (Staging)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    concurrency:
+      group: deploy-workspace-router-staging
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler.staging.toml
+          workingDirectory: apps/workspace-router
+          packageManager: bun

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,6 +15,8 @@ How production deploys work for each component of the Threa stack.
 | Backoffice                  | Cloudflare Pages   | Auto-deploy on push to `main` (via `deploy-cloudflare.yml`)       | `admin.threa.io`                               |
 | Backoffice-router (staging) | Cloudflare Workers | Auto-deploy on push to `main` (via `deploy-cloudflare.yml`)       | `admin-staging.threa.io/*`                     |
 | Backoffice (staging)        | Cloudflare Pages   | Auto-deploy on push to `main` (via `deploy-cloudflare.yml`)       | `admin-staging.threa.io`                       |
+| Frontend (staging)          | Cloudflare Pages   | Auto-deploy on push to `main` (via `deploy-cloudflare.yml`)       | `staging.threa.io`                             |
+| Workspace-router (staging)  | Cloudflare Workers | Auto-deploy on push to `main` (via `deploy-cloudflare.yml`)       | `staging.threa.io/api/*`, `pr-N-staging.*`     |
 
 ## Railway Services (Auto-Deploy)
 
@@ -116,16 +118,25 @@ Both services share the same PostgreSQL instance but use different databases:
 
 ## Cloudflare (Workers + Pages)
 
-All Cloudflare surfaces auto-deploy on push to `main` via `.github/workflows/deploy-cloudflare.yml`. The workflow fires on `workflow_run` after CI passes and runs six parallel deploy jobs:
+All Cloudflare surfaces auto-deploy on push to `main` via `.github/workflows/deploy-cloudflare.yml`. The workflow fires on `workflow_run` after CI passes and runs eight parallel deploy jobs:
 
-| Job                                | Resource                                | What it does                                                               |
-| ---------------------------------- | --------------------------------------- | -------------------------------------------------------------------------- |
-| `deploy-frontend`                  | `threa-frontend` (CF Pages)             | builds `apps/frontend` and pushes `dist/` to the Pages project             |
-| `deploy-workspace-router`          | `workspace-router` (CF Worker)          | `wrangler deploy --config wrangler.production.toml`                        |
-| `deploy-backoffice`                | `threa-backoffice` (CF Pages)           | builds `apps/backoffice` and pushes to the Pages project                   |
-| `deploy-backoffice-router`         | `backoffice-router` (CF Worker)         | `wrangler deploy --config wrangler.production.toml`                        |
-| `deploy-backoffice-staging`        | `threa-backoffice-staging` (CF Pages)   | builds `apps/backoffice` and pushes the same bundle to the staging project |
-| `deploy-backoffice-router-staging` | `backoffice-router-staging` (CF Worker) | `wrangler deploy --config wrangler.staging.toml`                           |
+| Job                                | Resource                                | What it does                                                                   |
+| ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
+| `deploy-frontend`                  | `threa-frontend` (CF Pages)             | builds `apps/frontend` and pushes `dist/` to the prod Pages project            |
+| `deploy-workspace-router`          | `workspace-router` (CF Worker)          | `wrangler deploy --config wrangler.production.toml`                            |
+| `deploy-backoffice`                | `threa-backoffice` (CF Pages)           | builds `apps/backoffice` and pushes to the Pages project                       |
+| `deploy-backoffice-router`         | `backoffice-router` (CF Worker)         | `wrangler deploy --config wrangler.production.toml`                            |
+| `deploy-backoffice-staging`        | `threa-backoffice-staging` (CF Pages)   | builds `apps/backoffice` and pushes the same bundle to the staging project     |
+| `deploy-backoffice-router-staging` | `backoffice-router-staging` (CF Worker) | `wrangler deploy --config wrangler.staging.toml`                               |
+| `deploy-frontend-staging`          | `threa-staging` (CF Pages)              | builds `apps/frontend` and pushes to the staging Pages project (`main` branch) |
+| `deploy-workspace-router-staging`  | `workspace-router-staging` (CF Worker)  | `wrangler deploy --config wrangler.staging.toml`                               |
+
+The PR-staging workflow (`staging.yml`) deploys the same `threa-staging` Pages
+project but with `--branch pr-N` to give each PR an isolated preview at
+`pr-N-staging.threa.io`. The new `deploy-frontend-staging` job above keeps the
+`main` branch of `threa-staging` (served at `staging.threa.io`) in sync as PRs
+land — without it, the always-on staging environment fossilizes on whatever
+build was last manually pushed.
 
 ### Workspace-router (`apps/workspace-router/`)
 


### PR DESCRIPTION
## Problem

`docs/deployment.md` claims the frontend "auto-deploys on push to `main`", but `deploy-cloudflare.yml` only deploys to **`threa-frontend`** (the prod Pages project). The **`threa-staging`** Pages project's `main` branch — which `workspace-router-staging` serves at `staging.threa.io` — never gets refreshed on merge. Same gap for `workspace-router-staging` itself: there's a `wrangler.staging.toml`, but no workflow that runs `wrangler deploy` against it on merge.

Net effect: PR-staging envs at `pr-N-staging.threa.io` always work (they're rebuilt on every PR sync via `staging.yml`), but the always-on `staging.threa.io` slowly fossilises on top of stale frontend bundles + stale router code. That's the immediate blocker the user hit while trying to test invitations on staging.

## Solution

Two new jobs in `deploy-cloudflare.yml`, mirroring the existing prod jobs but targeting the staging resources. They run on the same `workflow_run` trigger as everything else (after CI passes on `main`):

- **`deploy-frontend-staging`** — builds `apps/frontend` and runs `wrangler pages deploy dist --project-name threa-staging --branch main`. The `--branch main` flag is the key piece — it deploys to the production-equivalent branch of the staging Pages project, distinct from the `--branch pr-N` ephemeral previews that `staging.yml` already pushes.
- **`deploy-workspace-router-staging`** — runs `wrangler deploy --config wrangler.staging.toml` for the `workspace-router-staging` worker.

Updated `docs/deployment.md` to list both new jobs alongside the existing six (now eight total) and to note how main-staging and PR-staging share the `threa-staging` Pages project under different branches.

### Out of scope

- **Backend / control-plane staging on Railway.** Those auto-deploy via `watchPatterns` and are configured in the Railway dashboard rather than in this workflow. If a staging-env Railway service exists tracking `main`, it'll already pick up changes. If not, that's a Railway-dashboard fix orthogonal to this PR. (Worth verifying before assuming staging is fully unblocked.)

## Modified files

| File | Change |
| ---- | ------ |
| `.github/workflows/deploy-cloudflare.yml` | Added `deploy-frontend-staging` and `deploy-workspace-router-staging` jobs. |
| `docs/deployment.md` | Listed the two new jobs in the overview + Cloudflare table. |

## Test plan

- [x] YAML parses cleanly (`bun -e` job-id extraction returns all 8 jobs).
- [x] Lint + typecheck pass (deploy-cloudflare.yml isn't TS but the other lint hooks ran).
- [ ] Merge → CI passes → 8 deploy jobs run in parallel → confirm `staging.threa.io` serves the new frontend bundle. Verifies the `--branch main` flag is correct (vs the per-PR `--branch pr-N` deploys that already work).
- [ ] After confirming the frontend updates, test the invite flow on staging end-to-end.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRG5ZrJRUbsG4bpuxCMDKU)_