### PR TITLE
fix: first message hover action bar clipping on desktop

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -623,7 +623,7 @@ export function StreamContent({
         <SharedMessagesProvider map={mergedSharedMessages}>
           <TextSelectionQuote streamId={streamId} />
           <div className="relative h-full">
-            <div className="absolute inset-0 overflow-hidden">
+            <div className="absolute inset-0 overflow-hidden sm:overflow-visible">
               {isSearchOpen && (
                 <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
               )}


### PR DESCRIPTION
## Problem

On desktop, the hover action bar on the first message in a stream is partially clipped. The action bar floats above the row via `bottom-[calc(100%-20px)]`, but the outer scroll container has `overflow-hidden` which cuts it off.

## Solution

Add `sm:overflow-visible` to the outer scroll container so the action bar can escape the clipping boundary on desktop. Mobile retains `overflow-hidden` to contain the swipe-to-quote gesture.

### Key design decisions

**1. Release overflow on desktop, keep it on mobile**

The `overflow-hidden` exists to contain the mobile swipe-to-quote translate. On desktop, swipe is disabled and the hover toolbar needs to float above the row. Using `sm:overflow-visible` gives desktop the breathing room while keeping mobile containment intact.

This mirrors the same pattern already used at the message row level in `message-event.tsx:384` (`overflow-hidden sm:overflow-visible`).

**2. Single-line fix at the container level**

The previous attempt added `pt-2` to individual scroll containers, but padding doesn't extend the clipping boundary of `overflow-hidden`. The real fix is releasing the overflow constraint where it matters.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Added `sm:overflow-visible` to the outer scroll container (line 626) |

## Test plan

- [ ] Hover over the first message in a stream on desktop — action bar should be fully visible
- [ ] Hover over continuation messages — no regression
- [ ] Open search bar — first message action bar still visible
- [ ] Draft scratchpad — first message action bar visible
- [ ] Mobile — swipe-to-quote still contained, no visual bleed

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_