### PR TITLE
fix(frontend): prevent hover toolbar clipping on first stream message

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -623,13 +623,13 @@ export function StreamContent({
         <SharedMessagesProvider map={mergedSharedMessages}>
           <TextSelectionQuote streamId={streamId} />
           <div className="relative h-full">
-            <div className="absolute inset-0 overflow-hidden">
+            <div className="absolute inset-0 overflow-hidden sm:overflow-visible">
               {isSearchOpen && (
                 <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
               )}
               {isDraft && (
                 <div
-                  className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
+                  className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain pt-2"
                   style={{ paddingBottom: "var(--composer-height, 0px)" }}
                 >
                   {hasDraftPendingEvents ? (
@@ -717,6 +717,7 @@ export function StreamContent({
                   ref={plainScrollRef}
                   className={cn(
                     "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
+                    !isSearchOpen && "pt-2",
                     isSearchOpen && "pt-11"
                   )}
                   style={{ paddingBottom: "var(--composer-height, 0px)" }}
@@ -1077,9 +1078,13 @@ function VirtuosoMessageList({
   )
 }
 
+// Spacer giving the first message breathing room at the top of the list so
+// the desktop hover toolbar isn't clipped by the container edge.
+const ListHeaderSpacer = () => <div className="h-2" />
+
 // Spacer reserving room for the floating composer pill, so the most recent
 // message sits visually offset above the pill at rest and `atBottom` accounts
 // for the composer's height (Virtuoso treats Footer as content).
 const ComposerFooterSpacer = () => <div aria-hidden style={{ height: "var(--composer-height, 0px)" }} />
 
-const virtuosoComponents = { Footer: ComposerFooterSpacer }
+const virtuosoComponents = { Header: ListHeaderSpacer, Footer: ComposerFooterSpacer }


### PR DESCRIPTION
## Problem

On desktop, the hover action toolbar on the first message in a stream was partially clipped when the user hovered over it. The toolbar floats above the message row via `bottom-[calc(100%-20px)]`, but because the message sits flush against the top edge of the stream content container, the toolbar extended beyond the container boundary and was clipped by the `overflow-hidden` wrapper.

## Solution

Release the overflow clip on desktop and add a small amount of top padding to message lists so the first message has breathing room for its hover toolbar.

### Key design decisions

**1. Use `sm:overflow-visible` on the stream content wrapper**

The `absolute inset-0` container in `StreamContent` had `overflow-hidden` unconditionally. Since the hover toolbar is desktop-only (`hidden sm:block`), we now release the clip at the `sm` breakpoint with `sm:overflow-visible`. Mobile swipe-to-quote behavior is unaffected because the message-level `overflow-hidden` on each row still contains those transforms.


**2. Add top padding to scroll containers**

- Plain scroll lists: `pt-2` (8px) added when search is not open.
- Draft scroll container: `pt-2` unconditionally.
- Virtuoso virtualized lists: a `Header` spacer component (`h-2`, 8px) added to `virtuosoComponents`.

This padding is a defensive UX improvement that gives the first message (or any message at the top of the viewport) room so its toolbar does not butt up against the container edge.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Add `sm:overflow-visible` to stream wrapper; add `pt-2` padding to scroll containers; add `ListHeaderSpacer` to Virtuoso components |

## Test plan

- [x] TypeScript compilation passes
- [ ] Manual verification: hover the first message in a stream on desktop and confirm the toolbar is fully visible
