### PR TITLE
fix: prevent hover toolbar clipping on first stream message

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1080,6 +1080,8 @@ function VirtuosoMessageList({
 // Spacer reserving room for the floating composer pill, so the most recent
 // message sits visually offset above the pill at rest and `atBottom` accounts
 // for the composer's height (Virtuoso treats Footer as content).
+const StreamHeaderSpacer = () => <div className="h-3 sm:h-6" aria-hidden />
+
 const ComposerFooterSpacer = () => <div aria-hidden style={{ height: "var(--composer-height, 0px)" }} />
 
-const virtuosoComponents = { Footer: ComposerFooterSpacer }
+const virtuosoComponents = { Header: StreamHeaderSpacer, Footer: ComposerFooterSpacer }


### PR DESCRIPTION
## Problem

The first message in a stream's hover toolbar (action bar) was being clipped/hidden because the Virtuoso message list had no top padding. The `Footer` spacer ensures the last message has room above the composer pill, but there was no equivalent `Header` spacer for the first message.

## Solution

Added a `StreamHeaderSpacer` component that provides responsive top padding (`h-3` on small screens, `h-6` on larger screens) so the first message's hover toolbar has room to render without being clipped.

### How it works

The spacer is registered as the `Header` component in the Virtuoso config, mirroring the existing `Footer` pattern. Virtuoso renders the `Header` at the top of the scrollable area, pushing the first message down by the spacer height.

## New files

_None_

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Added `StreamHeaderSpacer` component and registered it as Virtuoso `Header` |

## Deleted files

_None_

## Test plan

- [ ] Manually verify that the first message's hover toolbar is fully visible when scrolling to the top of a stream

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
