### PR TITLE
feat: trace message moves with tombstones, origin badges, and per-message Move action

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,10 @@ name: Staging
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed, labeled, unlabeled]
-    branches: [main]
+    # No `branches:` filter: stacked PRs (rooted on a feature branch instead
+    # of `main`) still need staging environments. The `staging` label gate
+    # below already restricts which PRs deploy, so the base-branch filter
+    # would only cause false negatives.
 
 # Cancel in-progress runs for the same PR
 concurrency:

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -80,6 +80,53 @@ export interface ThreadCreatedPayload {
   parentMessageId: string
 }
 
+/**
+ * Per-message preview embedded inside `MessagesMovedEventPayload.messages`.
+ * Carries enough to render a clickable list inside the move drill-in
+ * drawer without an extra fetch — author + a short markdown excerpt that
+ * the frontend strips and truncates at render (INV-46: structured data,
+ * formatting on the client).
+ */
+export interface MovedMessagePreview {
+  id: string
+  authorId: string | null
+  authorType: AuthorType | null
+  /** Capped raw markdown excerpt — kept short to bound wire size for big moves. */
+  contentMarkdown: string
+  createdAt: string
+}
+
+/**
+ * Payload for a `messages_moved` stream event. One row is inserted in the
+ * source stream and one in the destination thread; the renderer collapses
+ * each row to "Actor moved N messages" and opens a drill-in drawer when
+ * clicked. The same shape serves both sides — the renderer infers role
+ * from whether `event.streamId` equals `sourceStreamId` (outbound) vs
+ * `destinationStreamId` (inbound).
+ *
+ * `event.actorId` carries the mover's user ID and `event.createdAt`
+ * carries the move timestamp, so they aren't duplicated in the payload.
+ *
+ * Source/destination stream names are embedded so the tombstone can render
+ * without an extra round-trip when the linked stream isn't already cached.
+ * They're a snapshot — a later rename won't be reflected on existing
+ * tombstones, which is acceptable since tombstones are append-only history.
+ */
+export interface MessagesMovedEventPayload {
+  sourceStreamId: string
+  sourceStreamSlug: string | null
+  sourceStreamDisplayName: string | null
+  destinationStreamId: string
+  destinationStreamSlug: string | null
+  destinationStreamDisplayName: string | null
+  /**
+   * Per-message previews for the drill-in drawer. Each entry includes
+   * enough to render a clickable summary linking to the message in the
+   * destination thread. `messages.length` is the canonical count.
+   */
+  messages: MovedMessagePreview[]
+}
+
 // Service params
 export interface CreateMessageParams {
   workspaceId: string
@@ -166,9 +213,25 @@ export interface MoveMessagesToThreadResult {
   thread: import("../streams").Stream
   events: WireStreamEvent[]
   removedEventIds: string[]
+  /** The `messages_moved` tombstone inserted into the SOURCE stream. */
+  sourceTombstoneEvent: WireStreamEvent
 }
 
 const MOVE_MESSAGES_TO_THREAD_OPERATION = "messages.move_to_thread"
+
+/**
+ * Cap each moved-message content excerpt embedded in a `messages_moved`
+ * payload. Long messages are truncated server-side so the wire size is
+ * bounded for big moves; the drill-in drawer shows a one-liner per
+ * message anyway. We append `…` only when truncation actually happened
+ * to avoid lying about completeness on already-short messages.
+ */
+const MOVED_MESSAGE_PREVIEW_CHAR_CAP = 200
+
+function capMovedPreview(content: string): string {
+  if (content.length <= MOVED_MESSAGE_PREVIEW_CHAR_CAP) return content
+  return `${content.slice(0, MOVED_MESSAGE_PREVIEW_CHAR_CAP)}…`
+}
 
 function canonicalMoveLeasePayload(params: {
   sourceStreamId: string
@@ -749,10 +812,16 @@ export class EventService {
         }
       })
 
+      const movedAt = new Date()
       const movedEvents = await StreamEventRepository.moveMessageCreatedEvents(client, {
         sourceStreamId: params.sourceStreamId,
         destinationStreamId: destinationThread.id,
         updates,
+        movedFrom: {
+          sourceStreamId: params.sourceStreamId,
+          movedAt: movedAt.toISOString(),
+          movedBy: params.actorId,
+        },
       })
       const movedAgentSessionEvents = await StreamEventRepository.moveEventsById(client, {
         sourceStreamId: params.sourceStreamId,
@@ -810,13 +879,67 @@ export class EventService {
         })
       }
 
-      const orderedEvents = [...movedEvents, ...movedAgentSessionEvents].sort((a, b) => {
-        if (a.sequence < b.sequence) return -1
-        if (a.sequence > b.sequence) return 1
-        return a.id.localeCompare(b.id)
+      // Insert "messages_moved" tombstones in BOTH streams so each side of
+      // the move keeps a visible trace. Each row collapses in the timeline
+      // to "Actor moved N messages" and opens a drill-in drawer with the
+      // per-message list. Same payload shape on both sides; the renderer
+      // infers role from `event.streamId === sourceStreamId` (outbound)
+      // vs `=== destinationStreamId` (inbound).
+      const orderedSelectedMessages = uniqueMessageIds
+        .map((id) => selectedMessages.find((message) => message.id === id))
+        .filter((message): message is Message => message !== undefined)
+      const movedMessagePreviews: MovedMessagePreview[] = orderedSelectedMessages.map((message) => ({
+        id: message.id,
+        authorId: message.authorId,
+        authorType: message.authorType,
+        contentMarkdown: capMovedPreview(message.contentMarkdown),
+        createdAt: message.createdAt.toISOString(),
+      }))
+      const tombstonePayload: MessagesMovedEventPayload = {
+        sourceStreamId: params.sourceStreamId,
+        sourceStreamSlug: sourceStream.slug,
+        sourceStreamDisplayName: sourceStream.displayName,
+        destinationStreamId: destinationThread.id,
+        destinationStreamSlug: destinationThread.slug,
+        destinationStreamDisplayName: destinationThread.displayName,
+        messages: movedMessagePreviews,
+      }
+      const sourceTombstone = await StreamEventRepository.insert(client, {
+        id: eventId(),
+        streamId: params.sourceStreamId,
+        eventType: "messages_moved",
+        payload: tombstonePayload,
+        actorId: params.actorId,
+        actorType: AuthorTypes.USER,
       })
-      const serializedEvents = orderedEvents.map((event) => serializeBigInt(event) as unknown as WireStreamEvent)
-      const removedEventIds = orderedEvents.map((event) => event.id)
+      const destinationTombstone = await StreamEventRepository.insert(client, {
+        id: eventId(),
+        streamId: destinationThread.id,
+        eventType: "messages_moved",
+        payload: tombstonePayload,
+        actorId: params.actorId,
+        actorType: AuthorTypes.USER,
+      })
+
+      // Order the wire events that will be applied to the destination
+      // stream's IDB cache. The destination tombstone slots in by sequence
+      // alongside the relocated messages (it always sorts last since its
+      // sequence was allocated after the moves).
+      const orderedDestinationEvents = [...movedEvents, ...movedAgentSessionEvents, destinationTombstone].sort(
+        (a, b) => {
+          if (a.sequence < b.sequence) return -1
+          if (a.sequence > b.sequence) return 1
+          return a.id.localeCompare(b.id)
+        }
+      )
+      const serializedDestinationEvents = orderedDestinationEvents.map(
+        (event) => serializeBigInt(event) as unknown as WireStreamEvent
+      )
+      // `removedEventIds` is what the SOURCE stream cache must drop — only
+      // the relocated rows, not the source tombstone (which we want to
+      // keep visible there).
+      const removedEventIds = [...movedEvents, ...movedAgentSessionEvents].map((event) => event.id)
+      const serializedSourceTombstone = serializeBigInt(sourceTombstone) as unknown as WireStreamEvent
 
       await OutboxRepository.insert(client, "messages:moved", {
         workspaceId: params.workspaceId,
@@ -826,8 +949,9 @@ export class EventService {
         targetMessageId: params.targetMessageId,
         movedMessageIds: uniqueMessageIds,
         thread: destinationThread,
-        events: serializedEvents,
+        events: serializedDestinationEvents,
         removedEventIds,
+        sourceTombstoneEvent: serializedSourceTombstone,
         parentReplyCount,
         parentThreadSummary,
       })
@@ -838,8 +962,9 @@ export class EventService {
         targetMessageId: params.targetMessageId,
         movedMessageIds: uniqueMessageIds,
         thread: destinationThread,
-        events: serializedEvents,
+        events: serializedDestinationEvents,
         removedEventIds,
+        sourceTombstoneEvent: serializedSourceTombstone,
       }
     })
   }

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -27,6 +27,8 @@ import {
   type JSONContent,
   type ThreadSummary,
   type StreamEvent as WireStreamEvent,
+  type MessagesMovedEventPayload,
+  type MovedMessagePreview,
 } from "@threa/types"
 
 // Event payloads
@@ -80,52 +82,8 @@ export interface ThreadCreatedPayload {
   parentMessageId: string
 }
 
-/**
- * Per-message preview embedded inside `MessagesMovedEventPayload.messages`.
- * Carries enough to render a clickable list inside the move drill-in
- * drawer without an extra fetch — author + a short markdown excerpt that
- * the frontend strips and truncates at render (INV-46: structured data,
- * formatting on the client).
- */
-export interface MovedMessagePreview {
-  id: string
-  authorId: string | null
-  authorType: AuthorType | null
-  /** Capped raw markdown excerpt — kept short to bound wire size for big moves. */
-  contentMarkdown: string
-  createdAt: string
-}
-
-/**
- * Payload for a `messages_moved` stream event. One row is inserted in the
- * source stream and one in the destination thread; the renderer collapses
- * each row to "Actor moved N messages" and opens a drill-in drawer when
- * clicked. The same shape serves both sides — the renderer infers role
- * from whether `event.streamId` equals `sourceStreamId` (outbound) vs
- * `destinationStreamId` (inbound).
- *
- * `event.actorId` carries the mover's user ID and `event.createdAt`
- * carries the move timestamp, so they aren't duplicated in the payload.
- *
- * Source/destination stream names are embedded so the tombstone can render
- * without an extra round-trip when the linked stream isn't already cached.
- * They're a snapshot — a later rename won't be reflected on existing
- * tombstones, which is acceptable since tombstones are append-only history.
- */
-export interface MessagesMovedEventPayload {
-  sourceStreamId: string
-  sourceStreamSlug: string | null
-  sourceStreamDisplayName: string | null
-  destinationStreamId: string
-  destinationStreamSlug: string | null
-  destinationStreamDisplayName: string | null
-  /**
-   * Per-message previews for the drill-in drawer. Each entry includes
-   * enough to render a clickable summary linking to the message in the
-   * destination thread. `messages.length` is the canonical count.
-   */
-  messages: MovedMessagePreview[]
-}
+// `MovedMessagePreview` and `MessagesMovedEventPayload` are wire types
+// shared with the frontend — see `packages/types/src/api.ts`.
 
 // Service params
 export interface CreateMessageParams {
@@ -213,14 +171,14 @@ export interface MoveMessagesToThreadResult {
   thread: import("../streams").Stream
   events: WireStreamEvent[]
   removedEventIds: string[]
-  /** The `messages_moved` tombstone inserted into the SOURCE stream. */
+  /** The `messages:moved` tombstone inserted into the SOURCE stream. */
   sourceTombstoneEvent: WireStreamEvent
 }
 
 const MOVE_MESSAGES_TO_THREAD_OPERATION = "messages.move_to_thread"
 
 /**
- * Cap each moved-message content excerpt embedded in a `messages_moved`
+ * Cap each moved-message content excerpt embedded in a `messages:moved`
  * payload. Long messages are truncated server-side so the wire size is
  * bounded for big moves; the drill-in drawer shows a one-liner per
  * message anyway. We append `…` only when truncation actually happened
@@ -819,6 +777,8 @@ export class EventService {
         updates,
         movedFrom: {
           sourceStreamId: params.sourceStreamId,
+          sourceStreamSlug: sourceStream.slug,
+          sourceStreamDisplayName: sourceStream.displayName,
           movedAt: movedAt.toISOString(),
           movedBy: params.actorId,
         },
@@ -879,7 +839,7 @@ export class EventService {
         })
       }
 
-      // Insert "messages_moved" tombstones in BOTH streams so each side of
+      // Insert "messages:moved" tombstones in BOTH streams so each side of
       // the move keeps a visible trace. Each row collapses in the timeline
       // to "Actor moved N messages" and opens a drill-in drawer with the
       // per-message list. Same payload shape on both sides; the renderer
@@ -907,7 +867,7 @@ export class EventService {
       const sourceTombstone = await StreamEventRepository.insert(client, {
         id: eventId(),
         streamId: params.sourceStreamId,
-        eventType: "messages_moved",
+        eventType: "messages:moved",
         payload: tombstonePayload,
         actorId: params.actorId,
         actorType: AuthorTypes.USER,
@@ -915,7 +875,7 @@ export class EventService {
       const destinationTombstone = await StreamEventRepository.insert(client, {
         id: eventId(),
         streamId: destinationThread.id,
-        eventType: "messages_moved",
+        eventType: "messages:moved",
         payload: tombstonePayload,
         actorId: params.actorId,
         actorType: AuthorTypes.USER,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -777,6 +777,14 @@ export class EventService {
         }
       })
 
+      // Pre-generate the destination tombstone's event ID so it can be
+      // stamped onto each relocated `message_created` payload via
+      // `movedFrom.moveTombstoneId`. The destination side relies on the
+      // per-message origin badge + a context-menu drill-in (rather than an
+      // inline tombstone row) — that drill-in needs to look up the
+      // tombstone in IDB by ID, so the message has to know which one.
+      const destinationTombstoneId = eventId()
+
       const movedAt = new Date()
       const movedEvents = await StreamEventRepository.moveMessageCreatedEvents(client, {
         sourceStreamId: params.sourceStreamId,
@@ -788,6 +796,7 @@ export class EventService {
           movedAt: movedAt.toISOString(),
           movedBy: params.actorId,
           movedByType: AuthorTypes.USER,
+          moveTombstoneId: destinationTombstoneId,
         },
       })
       const movedAgentSessionEvents = await StreamEventRepository.moveEventsById(client, {
@@ -852,9 +861,15 @@ export class EventService {
       // per-message list. Same payload shape on both sides; the renderer
       // infers role from `event.streamId === sourceStreamId` (outbound)
       // vs `=== destinationStreamId` (inbound).
-      const orderedSelectedMessages = uniqueMessageIds
-        .map((id) => selectedMessages.find((message) => message.id === id))
-        .filter((message): message is Message => message !== undefined)
+      // Sort by sequence so the drill-in drawer shows messages in the
+      // chronological order they were originally sent — not the order the
+      // user happened to tick checkboxes in. Sequences come from the source
+      // stream's monotonic counter, so ascending sort = oldest first.
+      const orderedSelectedMessages = [...selectedMessages].sort((a, b) => {
+        if (a.sequence < b.sequence) return -1
+        if (a.sequence > b.sequence) return 1
+        return 0
+      })
       const movedMessagePreviews: MovedMessagePreview[] = orderedSelectedMessages.map((message) => ({
         id: message.id,
         authorId: message.authorId,
@@ -885,7 +900,7 @@ export class EventService {
         createdAt: movedAt,
       })
       const destinationTombstone = await StreamEventRepository.insert(client, {
-        id: eventId(),
+        id: destinationTombstoneId,
         streamId: destinationThread.id,
         eventType: "messages:moved",
         payload: tombstonePayload,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -188,7 +188,14 @@ const MOVED_MESSAGE_PREVIEW_CHAR_CAP = 200
 
 function capMovedPreview(content: string): string {
   if (content.length <= MOVED_MESSAGE_PREVIEW_CHAR_CAP) return content
-  return `${content.slice(0, MOVED_MESSAGE_PREVIEW_CHAR_CAP)}…`
+  // Iterate by code points so emoji and other non-BMP characters don't get
+  // split into a lone surrogate at the truncation boundary. `Array.from`
+  // on a string yields one entry per code point, which is what we want
+  // for "200 user-perceived characters" (close enough — grapheme clusters
+  // would be ideal but cost more for very little user benefit here).
+  const codePoints = Array.from(content)
+  if (codePoints.length <= MOVED_MESSAGE_PREVIEW_CHAR_CAP) return content
+  return `${codePoints.slice(0, MOVED_MESSAGE_PREVIEW_CHAR_CAP).join("")}…`
 }
 
 function canonicalMoveLeasePayload(params: {
@@ -776,11 +783,11 @@ export class EventService {
         destinationStreamId: destinationThread.id,
         updates,
         movedFrom: {
-          sourceStreamId: params.sourceStreamId,
           sourceStreamSlug: sourceStream.slug,
           sourceStreamDisplayName: sourceStream.displayName,
           movedAt: movedAt.toISOString(),
           movedBy: params.actorId,
+          movedByType: AuthorTypes.USER,
         },
       })
       const movedAgentSessionEvents = await StreamEventRepository.moveEventsById(client, {
@@ -864,6 +871,10 @@ export class EventService {
         destinationStreamDisplayName: destinationThread.displayName,
         messages: movedMessagePreviews,
       }
+      // Pin both tombstones AND the per-message `movedFrom.movedAt` to the
+      // same `movedAt` value so the badge tooltip and the tombstone summary
+      // line render identical timestamps for the same move (otherwise app
+      // clock vs DB NOW() can drift visibly under slow transactions).
       const sourceTombstone = await StreamEventRepository.insert(client, {
         id: eventId(),
         streamId: params.sourceStreamId,
@@ -871,6 +882,7 @@ export class EventService {
         payload: tombstonePayload,
         actorId: params.actorId,
         actorType: AuthorTypes.USER,
+        createdAt: movedAt,
       })
       const destinationTombstone = await StreamEventRepository.insert(client, {
         id: eventId(),
@@ -879,6 +891,7 @@ export class EventService {
         payload: tombstonePayload,
         actorId: params.actorId,
         actorType: AuthorTypes.USER,
+        createdAt: movedAt,
       })
 
       // Order the wire events that will be applied to the destination

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -334,6 +334,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         thread: moveResult.thread,
         events: moveResult.events,
         removedEventIds: moveResult.removedEventIds,
+        sourceTombstoneEvent: moveResult.sourceTombstoneEvent,
       })
     },
 

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -1,3 +1,20 @@
+// Metadata schemas come FIRST so that consumers reaching this barrel via a
+// cycle (e.g. public-api/schemas.ts → messaging → event-service →
+// public-api/...) find `messageMetadataSchema` already bound. With the
+// heavy modules above, evaluating `event-service` could transitively load
+// public-api/schemas.ts before `metadata-schema.ts` had a chance to run,
+// producing a TDZ ("Cannot access 'messageMetadataSchema' before
+// initialization") at integration-test boot.
+export {
+  messageMetadataSchema,
+  messageMetadataFilterSchema,
+  MESSAGE_METADATA_MAX_KEYS,
+  MESSAGE_METADATA_MAX_KEY_LENGTH,
+  MESSAGE_METADATA_MAX_VALUE_LENGTH,
+  MESSAGE_METADATA_MAX_SERIALIZED_BYTES,
+  MESSAGE_METADATA_RESERVED_PREFIX,
+} from "./metadata-schema"
+
 // Repository
 export { MessageRepository } from "./repository"
 export type { Message, InsertMessageParams } from "./repository"
@@ -34,17 +51,6 @@ export {
   moveMessagesToThreadSchema,
   validateMoveMessagesToThreadSchema,
 } from "./handlers"
-
-// Metadata
-export {
-  messageMetadataSchema,
-  messageMetadataFilterSchema,
-  MESSAGE_METADATA_MAX_KEYS,
-  MESSAGE_METADATA_MAX_KEY_LENGTH,
-  MESSAGE_METADATA_MAX_VALUE_LENGTH,
-  MESSAGE_METADATA_MAX_SERIALIZED_BYTES,
-  MESSAGE_METADATA_RESERVED_PREFIX,
-} from "./metadata-schema"
 
 // Sharing sub-feature
 export {

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -329,11 +329,13 @@ export const StreamEventRepository = {
       updates: MoveEventSequenceUpdate[]
       /**
        * Stamps `movedFrom: { sourceStreamId, sourceStreamSlug,
-       * sourceStreamDisplayName, movedAt, movedBy, movedByType }` onto each
-       * relocated `message_created` payload so the destination timeline
-       * can render a per-message origin badge without a join. Uses jsonb
-       * concat (`||`) so re-moves overwrite the previous provenance — we
-       * surface the most recent origin, not a chain.
+       * sourceStreamDisplayName, movedAt, movedBy, movedByType,
+       * moveTombstoneId }` onto each relocated `message_created` payload
+       * so the destination timeline can render a per-message origin badge
+       * without a join, and so the badge's context-menu can open the
+       * drill-in drawer keyed off the destination tombstone's event id.
+       * Uses jsonb concat (`||`) so re-moves overwrite the previous
+       * provenance — we surface the most recent origin, not a chain.
        *
        * `sourceStreamId` is reused from the top-level param (they're
        * always equal, this helper rejects mixed sources implicitly) so
@@ -345,6 +347,7 @@ export const StreamEventRepository = {
         movedAt: string
         movedBy: string
         movedByType: string
+        moveTombstoneId: string
       }
     }
   ): Promise<StreamEvent[]> {
@@ -364,7 +367,8 @@ export const StreamEventRepository = {
                'sourceStreamDisplayName', $6::text,
                'movedAt', $7::text,
                'movedBy', $8::text,
-               'movedByType', $9::text
+               'movedByType', $9::text,
+               'moveTombstoneId', $10::text
              )
            )
        FROM (
@@ -384,6 +388,7 @@ export const StreamEventRepository = {
         params.movedFrom.movedAt,
         params.movedFrom.movedBy,
         params.movedFrom.movedByType,
+        params.movedFrom.moveTombstoneId,
       ]
     )
     return result.rows.map(mapRowToEvent)

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -37,6 +37,13 @@ export interface InsertEventParams {
   payload: unknown
   actorId?: string
   actorType?: AuthorType
+  /**
+   * Override the row's `created_at`. Defaults to DB `NOW()` when omitted.
+   * Used by the move flow to give a single timestamp to source + destination
+   * tombstones and to per-message `movedFrom` provenance, so all three
+   * surfaces render the same "X moved messages 2m ago" time.
+   */
+  createdAt?: Date
 }
 
 export interface MoveEventSequenceUpdate {
@@ -107,9 +114,10 @@ export const StreamEventRepository = {
 
   async insert(db: Querier, params: InsertEventParams): Promise<StreamEvent> {
     const sequence = await this.getNextSequence(db, params.streamId)
+    const createdAt = params.createdAt ?? new Date()
 
     const result = await db.query<StreamEventRow>(sql`
-      INSERT INTO stream_events (id, stream_id, sequence, event_type, payload, actor_id, actor_type)
+      INSERT INTO stream_events (id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at)
       VALUES (
         ${params.id},
         ${params.streamId},
@@ -117,7 +125,8 @@ export const StreamEventRepository = {
         ${params.eventType},
         ${JSON.stringify(params.payload)},
         ${params.actorId ?? null},
-        ${params.actorType ?? null}
+        ${params.actorType ?? null},
+        ${createdAt}
       )
       RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
     `)
@@ -320,18 +329,22 @@ export const StreamEventRepository = {
       updates: MoveEventSequenceUpdate[]
       /**
        * Stamps `movedFrom: { sourceStreamId, sourceStreamSlug,
-       * sourceStreamDisplayName, movedAt, movedBy }` onto each relocated
-       * `message_created` payload so the destination timeline can render a
-       * per-message origin badge without a join. Uses jsonb concat (`||`)
-       * so re-moves overwrite the previous provenance — we surface the
-       * most recent origin, not a chain.
+       * sourceStreamDisplayName, movedAt, movedBy, movedByType }` onto each
+       * relocated `message_created` payload so the destination timeline
+       * can render a per-message origin badge without a join. Uses jsonb
+       * concat (`||`) so re-moves overwrite the previous provenance — we
+       * surface the most recent origin, not a chain.
+       *
+       * `sourceStreamId` is reused from the top-level param (they're
+       * always equal, this helper rejects mixed sources implicitly) so
+       * there's only one source-of-truth on the wire.
        */
       movedFrom: {
-        sourceStreamId: string
         sourceStreamSlug: string | null
         sourceStreamDisplayName: string | null
         movedAt: string
         movedBy: string
+        movedByType: string
       }
     }
   ): Promise<StreamEvent[]> {
@@ -346,11 +359,12 @@ export const StreamEventRepository = {
            sequence = updates.new_sequence,
            payload = e.payload || jsonb_build_object(
              'movedFrom', jsonb_build_object(
-               'sourceStreamId', $5::text,
-               'sourceStreamSlug', $6::text,
-               'sourceStreamDisplayName', $7::text,
-               'movedAt', $8::text,
-               'movedBy', $9::text
+               'sourceStreamId', $4::text,
+               'sourceStreamSlug', $5::text,
+               'sourceStreamDisplayName', $6::text,
+               'movedAt', $7::text,
+               'movedBy', $8::text,
+               'movedByType', $9::text
              )
            )
        FROM (
@@ -365,11 +379,11 @@ export const StreamEventRepository = {
         messageIds,
         sequences,
         params.sourceStreamId,
-        params.movedFrom.sourceStreamId,
         params.movedFrom.sourceStreamSlug,
         params.movedFrom.sourceStreamDisplayName,
         params.movedFrom.movedAt,
         params.movedFrom.movedBy,
+        params.movedFrom.movedByType,
       ]
     )
     return result.rows.map(mapRowToEvent)

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -314,12 +314,56 @@ export const StreamEventRepository = {
 
   async moveMessageCreatedEvents(
     db: Querier,
-    params: { sourceStreamId: string; destinationStreamId: string; updates: MoveEventSequenceUpdate[] }
+    params: {
+      sourceStreamId: string
+      destinationStreamId: string
+      updates: MoveEventSequenceUpdate[]
+      /**
+       * When provided, stamps `movedFrom: { sourceStreamId, movedAt, movedBy }`
+       * onto each relocated `message_created` payload so the destination
+       * timeline can render a per-message origin badge without a join. Uses
+       * jsonb concat (`||`) so re-moves overwrite the previous provenance —
+       * we surface the most recent origin, not a chain.
+       */
+      movedFrom?: { sourceStreamId: string; movedAt: string; movedBy: string }
+    }
   ): Promise<StreamEvent[]> {
     if (params.updates.length === 0) return []
 
     const messageIds = params.updates.map((update) => update.messageId)
     const sequences = params.updates.map((update) => update.sequence.toString())
+
+    if (params.movedFrom) {
+      const result = await db.query<StreamEventRow>(
+        `UPDATE stream_events e
+         SET stream_id = $1,
+             sequence = updates.new_sequence,
+             payload = e.payload || jsonb_build_object(
+               'movedFrom', jsonb_build_object(
+                 'sourceStreamId', $5::text,
+                 'movedAt', $6::text,
+                 'movedBy', $7::text
+               )
+             )
+         FROM (
+           SELECT * FROM unnest($2::text[], $3::bigint[]) AS u(message_id, new_sequence)
+         ) updates
+         WHERE e.stream_id = $4
+           AND e.event_type = 'message_created'
+           AND e.payload->>'messageId' = updates.message_id
+         RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
+        [
+          params.destinationStreamId,
+          messageIds,
+          sequences,
+          params.sourceStreamId,
+          params.movedFrom.sourceStreamId,
+          params.movedFrom.movedAt,
+          params.movedFrom.movedBy,
+        ]
+      )
+      return result.rows.map(mapRowToEvent)
+    }
 
     const result = await db.query<StreamEventRow>(
       `UPDATE stream_events e

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -319,13 +319,20 @@ export const StreamEventRepository = {
       destinationStreamId: string
       updates: MoveEventSequenceUpdate[]
       /**
-       * When provided, stamps `movedFrom: { sourceStreamId, movedAt, movedBy }`
-       * onto each relocated `message_created` payload so the destination
-       * timeline can render a per-message origin badge without a join. Uses
-       * jsonb concat (`||`) so re-moves overwrite the previous provenance —
-       * we surface the most recent origin, not a chain.
+       * Stamps `movedFrom: { sourceStreamId, sourceStreamSlug,
+       * sourceStreamDisplayName, movedAt, movedBy }` onto each relocated
+       * `message_created` payload so the destination timeline can render a
+       * per-message origin badge without a join. Uses jsonb concat (`||`)
+       * so re-moves overwrite the previous provenance — we surface the
+       * most recent origin, not a chain.
        */
-      movedFrom?: { sourceStreamId: string; movedAt: string; movedBy: string }
+      movedFrom: {
+        sourceStreamId: string
+        sourceStreamSlug: string | null
+        sourceStreamDisplayName: string | null
+        movedAt: string
+        movedBy: string
+      }
     }
   ): Promise<StreamEvent[]> {
     if (params.updates.length === 0) return []
@@ -333,41 +340,19 @@ export const StreamEventRepository = {
     const messageIds = params.updates.map((update) => update.messageId)
     const sequences = params.updates.map((update) => update.sequence.toString())
 
-    if (params.movedFrom) {
-      const result = await db.query<StreamEventRow>(
-        `UPDATE stream_events e
-         SET stream_id = $1,
-             sequence = updates.new_sequence,
-             payload = e.payload || jsonb_build_object(
-               'movedFrom', jsonb_build_object(
-                 'sourceStreamId', $5::text,
-                 'movedAt', $6::text,
-                 'movedBy', $7::text
-               )
-             )
-         FROM (
-           SELECT * FROM unnest($2::text[], $3::bigint[]) AS u(message_id, new_sequence)
-         ) updates
-         WHERE e.stream_id = $4
-           AND e.event_type = 'message_created'
-           AND e.payload->>'messageId' = updates.message_id
-         RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
-        [
-          params.destinationStreamId,
-          messageIds,
-          sequences,
-          params.sourceStreamId,
-          params.movedFrom.sourceStreamId,
-          params.movedFrom.movedAt,
-          params.movedFrom.movedBy,
-        ]
-      )
-      return result.rows.map(mapRowToEvent)
-    }
-
     const result = await db.query<StreamEventRow>(
       `UPDATE stream_events e
-       SET stream_id = $1, sequence = updates.new_sequence
+       SET stream_id = $1,
+           sequence = updates.new_sequence,
+           payload = e.payload || jsonb_build_object(
+             'movedFrom', jsonb_build_object(
+               'sourceStreamId', $5::text,
+               'sourceStreamSlug', $6::text,
+               'sourceStreamDisplayName', $7::text,
+               'movedAt', $8::text,
+               'movedBy', $9::text
+             )
+           )
        FROM (
          SELECT * FROM unnest($2::text[], $3::bigint[]) AS u(message_id, new_sequence)
        ) updates
@@ -375,7 +360,17 @@ export const StreamEventRepository = {
          AND e.event_type = 'message_created'
          AND e.payload->>'messageId' = updates.message_id
        RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
-      [params.destinationStreamId, messageIds, sequences, params.sourceStreamId]
+      [
+        params.destinationStreamId,
+        messageIds,
+        sequences,
+        params.sourceStreamId,
+        params.movedFrom.sourceStreamId,
+        params.movedFrom.sourceStreamSlug,
+        params.movedFrom.sourceStreamDisplayName,
+        params.movedFrom.movedAt,
+        params.movedFrom.movedBy,
+      ]
     )
     return result.rows.map(mapRowToEvent)
   },

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -142,7 +142,7 @@ export interface MessagesMovedOutboxPayload extends StreamScopedPayload {
   events: WireStreamEvent[]
   removedEventIds: string[]
   /**
-   * The `messages_moved` tombstone inserted into the SOURCE stream. Source
+   * The `messages:moved` tombstone inserted into the SOURCE stream. Source
    * clients append this to their IDB cache after applying `removedEventIds`
    * so the timeline keeps a "moved 3 messages → thread" trace where the
    * messages used to be. Not part of `events` because that array is the

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -142,6 +142,14 @@ export interface MessagesMovedOutboxPayload extends StreamScopedPayload {
   events: WireStreamEvent[]
   removedEventIds: string[]
   /**
+   * The `messages_moved` tombstone inserted into the SOURCE stream. Source
+   * clients append this to their IDB cache after applying `removedEventIds`
+   * so the timeline keeps a "moved 3 messages → thread" trace where the
+   * messages used to be. Not part of `events` because that array is the
+   * destination-side write set.
+   */
+  sourceTombstoneEvent: WireStreamEvent
+  /**
    * Authoritative `replyCount` for the drop-target message (the thread
    * parent), recomputed AFTER the move's `incrementReplyCountBy`. Frontend
    * sets this directly on the parent message in the source stream. Including

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -195,6 +195,9 @@ describe("message move integration", () => {
     }
     expect(sourceTombstonePayload.sourceStreamId).toBe(sourceStreamId)
     expect(sourceTombstonePayload.destinationStreamId).toBe(result.thread.id)
+    // Order is by source-stream sequence (chronological), not the order the
+    // user happened to click checkboxes in. The validate request above
+    // passed `[movedB, movedA]` deliberately to verify this.
     expect(sourceTombstonePayload.messages.map((message) => message.id)).toEqual([movedA.id, movedB.id])
 
     const destinationTombstoneRows = await StreamEventRepository.list(pool, result.thread.id, {
@@ -230,6 +233,7 @@ describe("message move integration", () => {
           movedAt: string
           movedBy: string
           movedByType: string
+          moveTombstoneId: string
         }
       }
       expect(payload.movedFrom?.sourceStreamId).toBe(sourceStreamId)
@@ -238,6 +242,9 @@ describe("message move integration", () => {
       expect(payload.movedFrom?.movedBy).toBe(actor.id)
       expect(payload.movedFrom?.movedByType).toBe("user")
       expect(typeof payload.movedFrom?.movedAt).toBe("string")
+      // `moveTombstoneId` points at the destination-side tombstone so the
+      // per-message context-menu drill-in can fetch it from IDB.
+      expect(payload.movedFrom?.moveTombstoneId).toBe(destinationTombstone?.id)
     }
   })
 

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -179,7 +179,7 @@ describe("message move integration", () => {
     // messages" + a drill-in drawer; this assertion locks in the wire shape
     // (per-message previews + stream metadata) the drawer depends on.
     const sourceTombstones = await StreamEventRepository.list(pool, sourceStreamId, {
-      types: ["messages_moved"],
+      types: ["messages:moved"],
     })
     expect(sourceTombstones).toHaveLength(1)
     const sourceTombstone = sourceTombstones[0]
@@ -195,7 +195,7 @@ describe("message move integration", () => {
     expect(sourceTombstonePayload.messages.map((message) => message.id)).toEqual([movedA.id, movedB.id])
 
     const destinationTombstones = await StreamEventRepository.list(pool, result.thread.id, {
-      types: ["messages_moved"],
+      types: ["messages:moved"],
     })
     expect(destinationTombstones).toHaveLength(1)
     expect(destinationTombstones[0].payload).toEqual(sourceTombstonePayload)

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -173,6 +173,53 @@ describe("message move integration", () => {
       "agent_session:started",
       "agent_session:completed",
     ])
+
+    // Tombstone is inserted into BOTH streams so each side keeps a clickable
+    // trace of the move. The renderer collapses each row to "Actor moved N
+    // messages" + a drill-in drawer; this assertion locks in the wire shape
+    // (per-message previews + stream metadata) the drawer depends on.
+    const sourceTombstones = await StreamEventRepository.list(pool, sourceStreamId, {
+      types: ["messages_moved"],
+    })
+    expect(sourceTombstones).toHaveLength(1)
+    const sourceTombstone = sourceTombstones[0]
+    expect(sourceTombstone.actorId).toBe(actor.id)
+    expect(sourceTombstone.actorType).toBe("user")
+    const sourceTombstonePayload = sourceTombstone.payload as {
+      sourceStreamId: string
+      destinationStreamId: string
+      messages: Array<{ id: string; authorId: string | null; contentMarkdown: string }>
+    }
+    expect(sourceTombstonePayload.sourceStreamId).toBe(sourceStreamId)
+    expect(sourceTombstonePayload.destinationStreamId).toBe(result.thread.id)
+    expect(sourceTombstonePayload.messages.map((message) => message.id)).toEqual([movedA.id, movedB.id])
+
+    const destinationTombstones = await StreamEventRepository.list(pool, result.thread.id, {
+      types: ["messages_moved"],
+    })
+    expect(destinationTombstones).toHaveLength(1)
+    expect(destinationTombstones[0].payload).toEqual(sourceTombstonePayload)
+
+    // The outbox payload carries the source tombstone separately so source
+    // clients can append it after applying `removedEventIds` (the tombstone
+    // is NOT in `events`, which is the destination-side write set).
+    expect(result.sourceTombstoneEvent.id).toBe(sourceTombstone.id)
+    expect(result.sourceTombstoneEvent.streamId).toBe(sourceStreamId)
+    expect(result.events.find((event) => event.id === destinationTombstones[0].id)).toBeDefined()
+    expect(result.removedEventIds).not.toContain(sourceTombstone.id)
+
+    // Relocated `message_created` payloads carry `movedFrom` provenance so
+    // the destination timeline can show a per-message origin badge without
+    // joining a separate provenance table.
+    const relocatedMessageCreated = await StreamEventRepository.list(pool, result.thread.id, {
+      types: ["message_created"],
+    })
+    for (const event of relocatedMessageCreated) {
+      const payload = event.payload as { movedFrom?: { sourceStreamId: string; movedAt: string; movedBy: string } }
+      expect(payload.movedFrom?.sourceStreamId).toBe(sourceStreamId)
+      expect(payload.movedFrom?.movedBy).toBe(actor.id)
+      expect(typeof payload.movedFrom?.movedAt).toBe("string")
+    }
   })
 
   test("rejects moving a message onto a following message", async () => {

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -178,11 +178,14 @@ describe("message move integration", () => {
     // trace of the move. The renderer collapses each row to "Actor moved N
     // messages" + a drill-in drawer; this assertion locks in the wire shape
     // (per-message previews + stream metadata) the drawer depends on.
-    const sourceTombstones = await StreamEventRepository.list(pool, sourceStreamId, {
+    // Find by id rather than asserting count (INV-23) — future test setup
+    // could add a second move call without breaking these assertions.
+    const sourceTombstoneRows = await StreamEventRepository.list(pool, sourceStreamId, {
       types: ["messages:moved"],
     })
-    expect(sourceTombstones).toHaveLength(1)
-    const sourceTombstone = sourceTombstones[0]
+    const sourceTombstone = sourceTombstoneRows.find((event) => event.id === result.sourceTombstoneEvent.id)
+    expect(sourceTombstone).toBeDefined()
+    if (!sourceTombstone) throw new Error("unreachable")
     expect(sourceTombstone.actorId).toBe(actor.id)
     expect(sourceTombstone.actorType).toBe("user")
     const sourceTombstonePayload = sourceTombstone.payload as {
@@ -194,30 +197,46 @@ describe("message move integration", () => {
     expect(sourceTombstonePayload.destinationStreamId).toBe(result.thread.id)
     expect(sourceTombstonePayload.messages.map((message) => message.id)).toEqual([movedA.id, movedB.id])
 
-    const destinationTombstones = await StreamEventRepository.list(pool, result.thread.id, {
+    const destinationTombstoneRows = await StreamEventRepository.list(pool, result.thread.id, {
       types: ["messages:moved"],
     })
-    expect(destinationTombstones).toHaveLength(1)
-    expect(destinationTombstones[0].payload).toEqual(sourceTombstonePayload)
+    const destinationTombstone = destinationTombstoneRows.find(
+      (event) => (event.payload as { destinationStreamId: string }).destinationStreamId === result.thread.id
+    )
+    expect(destinationTombstone).toBeDefined()
+    expect(destinationTombstone?.payload).toEqual(sourceTombstonePayload)
 
     // The outbox payload carries the source tombstone separately so source
     // clients can append it after applying `removedEventIds` (the tombstone
     // is NOT in `events`, which is the destination-side write set).
-    expect(result.sourceTombstoneEvent.id).toBe(sourceTombstone.id)
     expect(result.sourceTombstoneEvent.streamId).toBe(sourceStreamId)
-    expect(result.events.find((event) => event.id === destinationTombstones[0].id)).toBeDefined()
+    expect(result.events.find((event) => event.id === destinationTombstone?.id)).toBeDefined()
     expect(result.removedEventIds).not.toContain(sourceTombstone.id)
 
     // Relocated `message_created` payloads carry `movedFrom` provenance so
     // the destination timeline can show a per-message origin badge without
-    // joining a separate provenance table.
+    // joining a separate provenance table. Locks in the full provenance
+    // shape — including the snapshotted source slug/displayName the
+    // tooltip depends on, and the explicit movedByType.
     const relocatedMessageCreated = await StreamEventRepository.list(pool, result.thread.id, {
       types: ["message_created"],
     })
     for (const event of relocatedMessageCreated) {
-      const payload = event.payload as { movedFrom?: { sourceStreamId: string; movedAt: string; movedBy: string } }
+      const payload = event.payload as {
+        movedFrom?: {
+          sourceStreamId: string
+          sourceStreamSlug: string | null
+          sourceStreamDisplayName: string | null
+          movedAt: string
+          movedBy: string
+          movedByType: string
+        }
+      }
       expect(payload.movedFrom?.sourceStreamId).toBe(sourceStreamId)
+      expect(payload.movedFrom?.sourceStreamSlug).toBe(null)
+      expect(payload.movedFrom?.sourceStreamDisplayName).toBe(null)
       expect(payload.movedFrom?.movedBy).toBe(actor.id)
+      expect(payload.movedFrom?.movedByType).toBe("user")
       expect(typeof payload.movedFrom?.movedAt).toBe("string")
     }
   })

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams, useParams } from "react-router-dom"
 import { useMemo, useCallback, useEffect, useState, useRef } from "react"
 import { createPortal } from "react-dom"
-import { MessageSquare, ChevronLeft, MoreHorizontal, CheckSquare } from "lucide-react"
+import { MessageSquare, ChevronLeft, MoreHorizontal, CornerDownRight } from "lucide-react"
 import {
   SidePanel,
   SidePanelHeader,
@@ -190,9 +190,9 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
 
   const panelMenuActions: SidebarActionItem[] = [
     {
-      id: "select-messages",
-      label: "Select messages",
-      icon: CheckSquare,
+      id: "move-messages",
+      label: "Move messages…",
+      icon: CornerDownRight,
       onSelect: handleSelectMessages,
     },
   ]
@@ -418,8 +418,8 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-40">
                 <DropdownMenuItem onClick={handleSelectMessages} disabled={!!stream.archivedAt}>
-                  <CheckSquare className="mr-2 h-4 w-4" />
-                  Select messages
+                  <CornerDownRight className="mr-2 h-4 w-4" />
+                  Move messages…
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -3,6 +3,7 @@ import type { MessageAgentActivity } from "@/hooks"
 import type { BatchTimelineState } from "./event-list"
 import { MessageEvent } from "./message-event"
 import { MembershipEvent } from "./membership-event"
+import { MessagesMovedEvent } from "./messages-moved-event"
 import { SystemEvent } from "./system-event"
 
 interface EventItemProps {
@@ -102,6 +103,13 @@ export function EventItem({
       return (
         <div data-event-id={event.id}>
           <SystemEvent event={event} />
+        </div>
+      )
+
+    case "messages_moved":
+      return (
+        <div data-event-id={event.id}>
+          <MessagesMovedEvent event={event} workspaceId={workspaceId} streamId={streamId} />
         </div>
       )
 

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -106,12 +106,21 @@ export function EventItem({
         </div>
       )
 
-    case "messages:moved":
+    case "messages:moved": {
+      // Destination-side rows render no inline tombstone — the destination
+      // already shows the moved messages themselves, plus a per-message
+      // origin badge + "Show move details" context-menu entry. Short-
+      // circuiting here (rather than inside `MessagesMovedEvent`) avoids
+      // mounting the component at all on destination rows, so the
+      // tombstone's `useActors` subscription only runs where it's used.
+      const movedPayload = event.payload as { destinationStreamId?: string }
+      if (movedPayload.destinationStreamId === streamId) return null
       return (
         <div data-event-id={event.id}>
-          <MessagesMovedEvent event={event} workspaceId={workspaceId} streamId={streamId} />
+          <MessagesMovedEvent event={event} workspaceId={workspaceId} />
         </div>
       )
+    }
 
     case "reaction_added":
     case "reaction_removed":

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -106,7 +106,7 @@ export function EventItem({
         </div>
       )
 
-    case "messages_moved":
+    case "messages:moved":
       return (
         <div data-event-id={event.id}>
           <MessagesMovedEvent event={event} workspaceId={workspaceId} streamId={streamId} />

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -13,6 +13,7 @@ import {
   BookmarkX,
   Bell,
   Share2,
+  CornerDownRight,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -86,6 +87,14 @@ export interface MessageActionContext {
   isSaved?: boolean
   /** Callback to start a private "Discuss with Ariadne" scratchpad seeded with this thread */
   onDiscussWithAriadne?: () => void | Promise<void>
+  /**
+   * Callback to enter batch-select mode with this message preselected, so
+   * the user can extend the selection or drop straight onto a target. The
+   * stream-level "Move messages…" entry uses the same flow with no
+   * preselection. Only present when the move action is reachable from this
+   * surface (e.g. not on archived streams).
+   */
+  onMoveToThread?: () => void
 }
 
 /** A top-level action in the message context menu. */
@@ -261,6 +270,16 @@ export const messageActions: MessageAction[] = [
     icon: Bell,
     when: (ctx) => !!ctx.onRequestReminder,
     action: (ctx) => ctx.onRequestReminder?.(),
+  },
+  {
+    // Per-message entry into the move-to-thread flow. Mirrors the stream
+    // header entry but seeds the selection with this single message so the
+    // common "I just want this one in a thread" path is one tap shorter.
+    id: "move-to-thread",
+    label: "Move to thread…",
+    icon: CornerDownRight,
+    when: (ctx) => !!ctx.onMoveToThread,
+    action: (ctx) => ctx.onMoveToThread?.(),
   },
   {
     id: "edit-message",

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -95,6 +95,13 @@ export interface MessageActionContext {
    * surface (e.g. not on archived streams).
    */
   onMoveToThread?: () => void
+  /**
+   * Open the move drill-in drawer for a message that arrived in this
+   * stream via a move. Set only when `payload.movedFrom` is present —
+   * this is the destination-side discovery path, since destination
+   * streams don't render an inline `messages:moved` tombstone.
+   */
+  onShowMoveDetails?: () => void
 }
 
 /** A top-level action in the message context menu. */
@@ -280,6 +287,16 @@ export const messageActions: MessageAction[] = [
     icon: CornerDownRight,
     when: (ctx) => !!ctx.onMoveToThread,
     action: (ctx) => ctx.onMoveToThread?.(),
+  },
+  {
+    // Destination-side discovery for messages that arrived via a move.
+    // The destination doesn't render an inline tombstone — this entry
+    // opens the same drill-in drawer the source-side tombstone does.
+    id: "show-move-details",
+    label: "Show move details",
+    icon: CornerDownRight,
+    when: (ctx) => !!ctx.onShowMoveDetails,
+    action: (ctx) => ctx.onShowMoveDetails?.(),
   },
   {
     id: "edit-message",

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -22,6 +22,7 @@ import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useEditLastMessage } from "./edit-last-message-context"
 import {
   useActors,
+  useMovedTombstone,
   useWorkspaceUserId,
   useMessageReactions,
   stripColons,
@@ -50,6 +51,7 @@ import { UnsentMessageEditForm } from "./unsent-message-edit-form"
 import { UnsentMessageActionDrawer } from "./unsent-message-action-drawer"
 import { EditedIndicator } from "./edited-indicator"
 import { MovedFromIndicator } from "./moved-from-indicator"
+import { MovedMessagesDrawer } from "./moved-messages-drawer"
 import { SavedIndicator } from "@/components/saved/saved-indicator"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
@@ -768,6 +770,11 @@ function SentMessageEvent({
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [moveDetailsOpen, setMoveDetailsOpen] = useState(false)
+  // Hydrate the destination tombstone on demand for the per-message
+  // "Show move details" action. Reactive — populates as soon as the row
+  // lands in IDB (live socket apply or bootstrap).
+  const movedTombstoneEvent = useMovedTombstone(payload.movedFrom?.moveTombstoneId)
 
   // Mobile: long-press opens action drawer instead of dropdown
   const isMobile = useIsMobile()
@@ -1037,6 +1044,12 @@ function SentMessageEvent({
         !batch?.enabled && !isThreadParentProp && !currentStream?.archivedAt
           ? () => dispatchStartBatchSelect(streamId, payload.messageId)
           : undefined,
+      // Destination-side discovery for moved messages. The drawer only
+      // renders once the tombstone hydrates from IDB, so gate the menu
+      // entry on the full lookup rather than just the id — keeps the
+      // user from clicking into a no-op while bootstrap is still in
+      // flight.
+      onShowMoveDetails: movedTombstoneEvent ? () => setTimeout(() => setMoveDetailsOpen(true), 0) : undefined,
     }),
     [
       payload.contentMarkdown,
@@ -1072,6 +1085,7 @@ function SentMessageEvent({
       handleDiscussWithAriadne,
       batch?.enabled,
       currentStream?.archivedAt,
+      movedTombstoneEvent,
     ]
   )
 
@@ -1253,6 +1267,15 @@ function SentMessageEvent({
             contentMarkdown: payload.contentMarkdown,
             editedAt: payload.editedAt,
           }}
+        />
+      )}
+      {moveDetailsOpen && movedTombstoneEvent && (
+        <MovedMessagesDrawer
+          open={moveDetailsOpen}
+          onOpenChange={setMoveDetailsOpen}
+          event={movedTombstoneEvent}
+          workspaceId={workspaceId}
+          currentStreamId={streamId}
         />
       )}
       {isMobile && (

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1127,7 +1127,13 @@ function SentMessageEvent({
             {payload.editedAt && (
               <EditedIndicator editedAt={payload.editedAt} onShowHistory={() => setHistoryOpen(true)} />
             )}
-            {payload.movedFrom && <MovedFromIndicator workspaceId={workspaceId} movedFrom={payload.movedFrom} />}
+            {payload.movedFrom && (
+              <MovedFromIndicator
+                workspaceId={workspaceId}
+                movedFrom={payload.movedFrom}
+                onClick={movedTombstoneEvent ? () => setMoveDetailsOpen(true) : undefined}
+              />
+            )}
             <SavedIndicator saved={savedForMessage ?? null} />
           </>
         }
@@ -1275,7 +1281,6 @@ function SentMessageEvent({
           onOpenChange={setMoveDetailsOpen}
           event={movedTombstoneEvent}
           workspaceId={workspaceId}
-          currentStreamId={streamId}
         />
       )}
       {isMobile && (

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -6,6 +6,7 @@ import {
   type JSONContent,
   type LinkPreviewSummary,
   type ThreadSummary,
+  type MovedFromProvenance,
 } from "@threa/types"
 import { toast } from "sonner"
 import { enqueueOperation } from "@/sync/operation-queue"
@@ -83,11 +84,7 @@ interface MessagePayload {
    * scrollers-by can see this message wasn't authored in this stream. We
    * keep only the most recent move — re-moves overwrite earlier provenance.
    */
-  movedFrom?: {
-    sourceStreamId: string
-    movedAt: string
-    movedBy: string
-  }
+  movedFrom?: MovedFromProvenance
 }
 
 interface MessageEventProps {

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -48,6 +48,7 @@ import { MessageEditForm } from "./message-edit-form"
 import { UnsentMessageEditForm } from "./unsent-message-edit-form"
 import { UnsentMessageActionDrawer } from "./unsent-message-action-drawer"
 import { EditedIndicator } from "./edited-indicator"
+import { MovedFromIndicator } from "./moved-from-indicator"
 import { SavedIndicator } from "@/components/saved/saved-indicator"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
@@ -57,6 +58,7 @@ import { useSwipeAction } from "@/hooks/use-swipe-action"
 import type { BatchTimelineState } from "./event-list"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
 
 interface MessagePayload {
   messageId: string
@@ -75,6 +77,17 @@ interface MessagePayload {
   editedAt?: string
   sentVia?: string
   reactions?: Record<string, string[]>
+  /**
+   * Stamped onto the relocated `message_created` payload by the move flow.
+   * Surfaces a small "moved from #X" indicator alongside the timestamp so
+   * scrollers-by can see this message wasn't authored in this stream. We
+   * keep only the most recent move — re-moves overwrite earlier provenance.
+   */
+  movedFrom?: {
+    sourceStreamId: string
+    movedAt: string
+    movedBy: string
+  }
 }
 
 interface MessageEventProps {
@@ -1019,6 +1032,14 @@ function SentMessageEvent({
             }
           : undefined,
       shareToParentLabel: showParentEntry && parentStream ? buildShareToStreamLabel(parentStream) : undefined,
+      // Per-message entry into the batch-move flow. Hidden during batch
+      // mode itself (the row's own checkbox handles that), on the thread
+      // parent (moving the parent into its own thread is nonsensical),
+      // and on archived streams to match the stream-header menu's gating.
+      onMoveToThread:
+        !batch?.enabled && !isThreadParentProp && !currentStream?.archivedAt
+          ? () => dispatchStartBatchSelect(streamId, payload.messageId)
+          : undefined,
     }),
     [
       payload.contentMarkdown,
@@ -1052,6 +1073,8 @@ function SentMessageEvent({
       location,
       isMobile,
       handleDiscussWithAriadne,
+      batch?.enabled,
+      currentStream?.archivedAt,
     ]
   )
 
@@ -1093,6 +1116,7 @@ function SentMessageEvent({
             {payload.editedAt && (
               <EditedIndicator editedAt={payload.editedAt} onShowHistory={() => setHistoryOpen(true)} />
             )}
+            {payload.movedFrom && <MovedFromIndicator workspaceId={workspaceId} movedFrom={payload.movedFrom} />}
             <SavedIndicator saved={savedForMessage ?? null} />
           </>
         }

--- a/apps/frontend/src/components/timeline/messages-moved-event.tsx
+++ b/apps/frontend/src/components/timeline/messages-moved-event.tsx
@@ -1,18 +1,8 @@
 import { useState } from "react"
-import { Link } from "react-router-dom"
-import { CornerDownRight, X } from "lucide-react"
-import type { StreamEvent, MessagesMovedEventPayload, MovedMessagePreview } from "@threa/types"
-import {
-  ResponsiveDialog,
-  ResponsiveDialogContent,
-  ResponsiveDialogClose,
-  ResponsiveDialogTitle,
-  ResponsiveDialogDescription,
-} from "@/components/ui/responsive-dialog"
-import { ActorAvatar } from "@/components/actor-avatar"
-import { RelativeTime } from "@/components/relative-time"
-import { useActors, type ActorLookup } from "@/hooks"
-import { stripMarkdownToInline } from "@/lib/markdown/strip"
+import { CornerDownRight } from "lucide-react"
+import type { StreamEvent, MessagesMovedEventPayload } from "@threa/types"
+import { useActors } from "@/hooks"
+import { MovedMessagesDrawer } from "./moved-messages-drawer"
 
 interface MessagesMovedEventProps {
   event: StreamEvent
@@ -20,29 +10,30 @@ interface MessagesMovedEventProps {
   streamId: string
 }
 
-function formatStreamName(displayName: string | null, slug: string | null): string | null {
-  if (displayName) return displayName
-  if (slug) return `#${slug}`
-  return null
-}
-
 /**
- * Minimal in-timeline trace of a move operation. Renders as a single line
- * — "Actor moved N messages" — that opens a drawer with full per-message
- * detail. The icon is the same `CornerDownRight` used by the move action
- * everywhere so the visual identity is consistent.
+ * Source-side `messages:moved` tombstone. Renders as a single line —
+ * "Actor moved N messages" — that opens the move drill-in drawer.
+ *
+ * The destination-side row is intentionally NOT rendered: at the
+ * destination the user already sees the moved messages themselves, plus
+ * a per-message origin badge (`MovedFromIndicator`) and a "Show move
+ * details" entry on each moved message's context menu — duplicating the
+ * tombstone inline there would be visual noise on top of the messages
+ * the user is already looking at. The `stream_events` row is still
+ * cached in IDB so the per-message context-menu drill-in can find it
+ * via `movedFrom.moveTombstoneId`.
  */
 export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMovedEventProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
-  const payload = event.payload as MessagesMovedEventPayload
-  // Single `useActors` subscription for both the tombstone summary and
-  // every drawer row. `MovedMessagesDrawer` is rendered unconditionally
-  // (only its `open` prop toggles visibility), so calling `useActors`
-  // inside it would create a parallel IDB subscription on every
-  // tombstone in the timeline.
+  // Always called so hook order is stable, even though we may early-return
+  // for destination rows below. Cost is one IDB subscription per source-
+  // side tombstone in the timeline (typically rare).
   const actors = useActors(workspaceId)
-  const moverName = actors.getActorName(event.actorId, event.actorType)
 
+  const payload = event.payload as MessagesMovedEventPayload
+  if (streamId === payload.destinationStreamId) return null
+
+  const moverName = actors.getActorName(event.actorId, event.actorType)
   const count = payload.messages.length
   const noun = count === 1 ? "message" : "messages"
 
@@ -61,147 +52,15 @@ export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMov
           </span>
         </button>
       </div>
-      <MovedMessagesDrawer
-        open={drawerOpen}
-        onOpenChange={setDrawerOpen}
-        event={event}
-        payload={payload}
-        workspaceId={workspaceId}
-        currentStreamId={streamId}
-        moverName={moverName}
-        actors={actors}
-      />
+      {drawerOpen && (
+        <MovedMessagesDrawer
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+          event={event}
+          workspaceId={workspaceId}
+          currentStreamId={streamId}
+        />
+      )}
     </>
-  )
-}
-
-interface MovedMessagesDrawerProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  event: StreamEvent
-  payload: MessagesMovedEventPayload
-  workspaceId: string
-  currentStreamId: string
-  moverName: string
-  actors: ActorLookup
-}
-
-function MovedMessagesDrawer({
-  open,
-  onOpenChange,
-  event,
-  payload,
-  workspaceId,
-  currentStreamId,
-  moverName,
-  actors,
-}: MovedMessagesDrawerProps) {
-  const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
-  const destinationLabel =
-    formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"
-  const isOutbound = currentStreamId === payload.sourceStreamId
-  const count = payload.messages.length
-  const noun = count === 1 ? "message" : "messages"
-
-  return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent
-        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col p-0 gap-0 [&>button:last-child]:hidden"
-        drawerClassName="flex flex-col p-0"
-        hideCloseButton
-      >
-        <div className="px-4 sm:px-6 py-4 border-b shrink-0 flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <ResponsiveDialogTitle className="text-base font-semibold flex items-center gap-2">
-              <CornerDownRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-              {moverName} moved {count} {noun}
-            </ResponsiveDialogTitle>
-            <ResponsiveDialogDescription className="mt-1 text-xs text-muted-foreground inline-flex items-center gap-1.5 flex-wrap">
-              <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
-              <span aria-hidden="true">•</span>
-              <Link
-                to={`/w/${workspaceId}/s/${payload.sourceStreamId}`}
-                className="font-medium text-foreground hover:underline underline-offset-2"
-              >
-                {sourceLabel}
-              </Link>
-              <span aria-hidden="true">→</span>
-              <Link
-                to={`/w/${workspaceId}/s/${payload.destinationStreamId}`}
-                className="font-medium text-foreground hover:underline underline-offset-2"
-              >
-                {destinationLabel}
-              </Link>
-              {isOutbound && <span className="text-muted-foreground">(outbound)</span>}
-              {!isOutbound && <span className="text-muted-foreground">(inbound)</span>}
-            </ResponsiveDialogDescription>
-          </div>
-          <ResponsiveDialogClose className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0">
-            <X className="w-5 h-5" />
-            <span className="sr-only">Close</span>
-          </ResponsiveDialogClose>
-        </div>
-        <div className="flex-1 min-h-0 overflow-y-auto px-2 sm:px-3 py-2">
-          <ul className="flex flex-col gap-1">
-            {payload.messages.map((message) => (
-              <MovedMessageRow
-                key={message.id}
-                message={message}
-                workspaceId={workspaceId}
-                destinationStreamId={payload.destinationStreamId}
-                actors={actors}
-                onNavigate={() => onOpenChange(false)}
-              />
-            ))}
-          </ul>
-        </div>
-      </ResponsiveDialogContent>
-    </ResponsiveDialog>
-  )
-}
-
-interface MovedMessageRowProps {
-  message: MovedMessagePreview
-  workspaceId: string
-  destinationStreamId: string
-  actors: ActorLookup
-  onNavigate: () => void
-}
-
-function MovedMessageRow({ message, workspaceId, destinationStreamId, actors, onNavigate }: MovedMessageRowProps) {
-  const authorName = actors.getActorName(message.authorId, message.authorType)
-  // Preview field is markdown by design — INV-60 carve-out for preview
-  // surfaces. Strip + truncate at render so display stays plain text.
-  const stripped = stripMarkdownToInline(message.contentMarkdown).trim()
-  const previewText = stripped.length > 0 ? stripped : "(empty message)"
-
-  return (
-    <li>
-      <Link
-        to={`/w/${workspaceId}/s/${destinationStreamId}?m=${message.id}`}
-        onClick={onNavigate}
-        className="block px-3 py-2 rounded-md hover:bg-muted/60 transition-colors group"
-      >
-        <div className="flex items-start gap-3 min-w-0">
-          <ActorAvatar
-            actorId={message.authorId}
-            actorType={message.authorType}
-            workspaceId={workspaceId}
-            size="sm"
-            alt={authorName}
-            className="shrink-0 mt-0.5"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-baseline gap-2 min-w-0">
-              <span className="font-medium text-sm truncate">{authorName}</span>
-              <RelativeTime date={message.createdAt} className="text-xs text-muted-foreground shrink-0" />
-            </div>
-            <p className="text-sm text-muted-foreground line-clamp-2 group-hover:text-foreground transition-colors">
-              {previewText}
-            </p>
-          </div>
-        </div>
-      </Link>
-    </li>
   )
 }

--- a/apps/frontend/src/components/timeline/messages-moved-event.tsx
+++ b/apps/frontend/src/components/timeline/messages-moved-event.tsx
@@ -1,0 +1,214 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { CornerDownRight, X } from "lucide-react"
+import type { StreamEvent, AuthorType } from "@threa/types"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogClose,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from "@/components/ui/responsive-dialog"
+import { ActorAvatar } from "@/components/actor-avatar"
+import { RelativeTime } from "@/components/relative-time"
+import { useActors } from "@/hooks"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
+
+interface MovedMessagePreview {
+  id: string
+  authorId: string | null
+  authorType: AuthorType | null
+  contentMarkdown: string
+  createdAt: string
+}
+
+interface MessagesMovedEventPayload {
+  sourceStreamId: string
+  sourceStreamSlug: string | null
+  sourceStreamDisplayName: string | null
+  destinationStreamId: string
+  destinationStreamSlug: string | null
+  destinationStreamDisplayName: string | null
+  messages: MovedMessagePreview[]
+}
+
+interface MessagesMovedEventProps {
+  event: StreamEvent
+  workspaceId: string
+  streamId: string
+}
+
+function formatStreamName(displayName: string | null, slug: string | null): string | null {
+  if (displayName) return displayName
+  if (slug) return `#${slug}`
+  return null
+}
+
+/**
+ * Minimal in-timeline trace of a move operation. Renders as a single line
+ * — "Actor moved N messages" — that opens a drawer with full per-message
+ * detail. The icon is the same `CornerDownRight` used by the move action
+ * everywhere so the visual identity is consistent.
+ */
+export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMovedEventProps) {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const payload = event.payload as MessagesMovedEventPayload
+  const { getActorName } = useActors(workspaceId)
+  const moverName = getActorName(event.actorId, event.actorType)
+
+  const count = payload.messages.length
+  const noun = count === 1 ? "message" : "messages"
+
+  return (
+    <>
+      <div className="py-2 px-3 sm:px-6 text-center">
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center justify-center gap-1.5 hover:underline underline-offset-2"
+          aria-label={`Show ${count} moved ${noun}`}
+        >
+          <CornerDownRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            <span className="font-medium">{moverName}</span> moved {count} {noun}
+          </span>
+        </button>
+      </div>
+      <MovedMessagesDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        event={event}
+        payload={payload}
+        workspaceId={workspaceId}
+        currentStreamId={streamId}
+        moverName={moverName}
+      />
+    </>
+  )
+}
+
+interface MovedMessagesDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  event: StreamEvent
+  payload: MessagesMovedEventPayload
+  workspaceId: string
+  currentStreamId: string
+  moverName: string
+}
+
+function MovedMessagesDrawer({
+  open,
+  onOpenChange,
+  event,
+  payload,
+  workspaceId,
+  currentStreamId,
+  moverName,
+}: MovedMessagesDrawerProps) {
+  const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
+  const destinationLabel =
+    formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"
+  const isOutbound = currentStreamId === payload.sourceStreamId
+  const count = payload.messages.length
+  const noun = count === 1 ? "message" : "messages"
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent
+        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col p-0 gap-0 [&>button:last-child]:hidden"
+        drawerClassName="flex flex-col p-0"
+        hideCloseButton
+      >
+        <div className="px-4 sm:px-6 py-4 border-b shrink-0 flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <ResponsiveDialogTitle className="text-base font-semibold flex items-center gap-2">
+              <CornerDownRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              {moverName} moved {count} {noun}
+            </ResponsiveDialogTitle>
+            <ResponsiveDialogDescription className="mt-1 text-xs text-muted-foreground inline-flex items-center gap-1.5 flex-wrap">
+              <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
+              <span aria-hidden="true">•</span>
+              <Link
+                to={`/w/${workspaceId}/s/${payload.sourceStreamId}`}
+                className="font-medium text-foreground hover:underline underline-offset-2"
+              >
+                {sourceLabel}
+              </Link>
+              <span aria-hidden="true">→</span>
+              <Link
+                to={`/w/${workspaceId}/s/${payload.destinationStreamId}`}
+                className="font-medium text-foreground hover:underline underline-offset-2"
+              >
+                {destinationLabel}
+              </Link>
+              {isOutbound && <span className="text-muted-foreground">(outbound)</span>}
+              {!isOutbound && <span className="text-muted-foreground">(inbound)</span>}
+            </ResponsiveDialogDescription>
+          </div>
+          <ResponsiveDialogClose className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0">
+            <X className="w-5 h-5" />
+            <span className="sr-only">Close</span>
+          </ResponsiveDialogClose>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto px-2 sm:px-3 py-2">
+          <ul className="flex flex-col gap-1">
+            {payload.messages.map((message) => (
+              <MovedMessageRow
+                key={message.id}
+                message={message}
+                workspaceId={workspaceId}
+                destinationStreamId={payload.destinationStreamId}
+                onNavigate={() => onOpenChange(false)}
+              />
+            ))}
+          </ul>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}
+
+interface MovedMessageRowProps {
+  message: MovedMessagePreview
+  workspaceId: string
+  destinationStreamId: string
+  onNavigate: () => void
+}
+
+function MovedMessageRow({ message, workspaceId, destinationStreamId, onNavigate }: MovedMessageRowProps) {
+  const { getActorName } = useActors(workspaceId)
+  const authorName = getActorName(message.authorId, message.authorType)
+  const stripped = stripMarkdownToInline(message.contentMarkdown).trim()
+  const previewText = stripped.length > 0 ? stripped : "(empty message)"
+
+  return (
+    <li>
+      <Link
+        to={`/w/${workspaceId}/s/${destinationStreamId}?m=${message.id}`}
+        onClick={onNavigate}
+        className="block px-3 py-2 rounded-md hover:bg-muted/60 transition-colors group"
+      >
+        <div className="flex items-start gap-3 min-w-0">
+          <ActorAvatar
+            actorId={message.authorId}
+            actorType={message.authorType}
+            workspaceId={workspaceId}
+            size="sm"
+            alt={authorName}
+            className="shrink-0 mt-0.5"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2 min-w-0">
+              <span className="font-medium text-sm truncate">{authorName}</span>
+              <RelativeTime date={message.createdAt} className="text-xs text-muted-foreground shrink-0" />
+            </div>
+            <p className="text-sm text-muted-foreground line-clamp-2 group-hover:text-foreground transition-colors">
+              {previewText}
+            </p>
+          </div>
+        </div>
+      </Link>
+    </li>
+  )
+}

--- a/apps/frontend/src/components/timeline/messages-moved-event.tsx
+++ b/apps/frontend/src/components/timeline/messages-moved-event.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { CornerDownRight, X } from "lucide-react"
-import type { StreamEvent, AuthorType } from "@threa/types"
+import type { StreamEvent, MessagesMovedEventPayload, MovedMessagePreview } from "@threa/types"
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -11,26 +11,8 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
-import { useActors } from "@/hooks"
+import { useActors, type ActorLookup } from "@/hooks"
 import { stripMarkdownToInline } from "@/lib/markdown/strip"
-
-interface MovedMessagePreview {
-  id: string
-  authorId: string | null
-  authorType: AuthorType | null
-  contentMarkdown: string
-  createdAt: string
-}
-
-interface MessagesMovedEventPayload {
-  sourceStreamId: string
-  sourceStreamSlug: string | null
-  sourceStreamDisplayName: string | null
-  destinationStreamId: string
-  destinationStreamSlug: string | null
-  destinationStreamDisplayName: string | null
-  messages: MovedMessagePreview[]
-}
 
 interface MessagesMovedEventProps {
   event: StreamEvent
@@ -106,6 +88,12 @@ function MovedMessagesDrawer({
   currentStreamId,
   moverName,
 }: MovedMessagesDrawerProps) {
+  // One `useActors` call for the whole drawer — without this hoist each
+  // `MovedMessageRow` would subscribe its own copy of the workspace
+  // users/personas/bots live queries, so a 50-message move would create
+  // 150 redundant IDB subscriptions for identical data. Mirrors the
+  // membership-event.tsx pattern (single call at the parent).
+  const actors = useActors(workspaceId)
   const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
   const destinationLabel =
     formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"
@@ -159,6 +147,7 @@ function MovedMessagesDrawer({
                 message={message}
                 workspaceId={workspaceId}
                 destinationStreamId={payload.destinationStreamId}
+                actors={actors}
                 onNavigate={() => onOpenChange(false)}
               />
             ))}
@@ -173,12 +162,14 @@ interface MovedMessageRowProps {
   message: MovedMessagePreview
   workspaceId: string
   destinationStreamId: string
+  actors: ActorLookup
   onNavigate: () => void
 }
 
-function MovedMessageRow({ message, workspaceId, destinationStreamId, onNavigate }: MovedMessageRowProps) {
-  const { getActorName } = useActors(workspaceId)
-  const authorName = getActorName(message.authorId, message.authorType)
+function MovedMessageRow({ message, workspaceId, destinationStreamId, actors, onNavigate }: MovedMessageRowProps) {
+  const authorName = actors.getActorName(message.authorId, message.authorType)
+  // Preview field is markdown by design — INV-60 carve-out for preview
+  // surfaces. Strip + truncate at render so display stays plain text.
   const stripped = stripMarkdownToInline(message.contentMarkdown).trim()
   const previewText = stripped.length > 0 ? stripped : "(empty message)"
 

--- a/apps/frontend/src/components/timeline/messages-moved-event.tsx
+++ b/apps/frontend/src/components/timeline/messages-moved-event.tsx
@@ -35,8 +35,13 @@ function formatStreamName(displayName: string | null, slug: string | null): stri
 export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMovedEventProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const payload = event.payload as MessagesMovedEventPayload
-  const { getActorName } = useActors(workspaceId)
-  const moverName = getActorName(event.actorId, event.actorType)
+  // Single `useActors` subscription for both the tombstone summary and
+  // every drawer row. `MovedMessagesDrawer` is rendered unconditionally
+  // (only its `open` prop toggles visibility), so calling `useActors`
+  // inside it would create a parallel IDB subscription on every
+  // tombstone in the timeline.
+  const actors = useActors(workspaceId)
+  const moverName = actors.getActorName(event.actorId, event.actorType)
 
   const count = payload.messages.length
   const noun = count === 1 ? "message" : "messages"
@@ -64,6 +69,7 @@ export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMov
         workspaceId={workspaceId}
         currentStreamId={streamId}
         moverName={moverName}
+        actors={actors}
       />
     </>
   )
@@ -77,6 +83,7 @@ interface MovedMessagesDrawerProps {
   workspaceId: string
   currentStreamId: string
   moverName: string
+  actors: ActorLookup
 }
 
 function MovedMessagesDrawer({
@@ -87,13 +94,8 @@ function MovedMessagesDrawer({
   workspaceId,
   currentStreamId,
   moverName,
+  actors,
 }: MovedMessagesDrawerProps) {
-  // One `useActors` call for the whole drawer — without this hoist each
-  // `MovedMessageRow` would subscribe its own copy of the workspace
-  // users/personas/bots live queries, so a 50-message move would create
-  // 150 redundant IDB subscriptions for identical data. Mirrors the
-  // membership-event.tsx pattern (single call at the parent).
-  const actors = useActors(workspaceId)
   const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
   const destinationLabel =
     formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"

--- a/apps/frontend/src/components/timeline/messages-moved-event.tsx
+++ b/apps/frontend/src/components/timeline/messages-moved-event.tsx
@@ -7,33 +7,24 @@ import { MovedMessagesDrawer } from "./moved-messages-drawer"
 interface MessagesMovedEventProps {
   event: StreamEvent
   workspaceId: string
-  streamId: string
 }
 
 /**
  * Source-side `messages:moved` tombstone. Renders as a single line —
  * "Actor moved N messages" — that opens the move drill-in drawer.
  *
- * The destination-side row is intentionally NOT rendered: at the
- * destination the user already sees the moved messages themselves, plus
- * a per-message origin badge (`MovedFromIndicator`) and a "Show move
- * details" entry on each moved message's context menu — duplicating the
- * tombstone inline there would be visual noise on top of the messages
- * the user is already looking at. The `stream_events` row is still
- * cached in IDB so the per-message context-menu drill-in can find it
- * via `movedFrom.moveTombstoneId`.
+ * Destination-side rows are filtered out one level up in
+ * `event-item.tsx`, so this component is only mounted on the source
+ * stream. At the destination the user reaches the same drawer via the
+ * per-message origin badge or the "Show move details" context-menu
+ * entry on each moved message.
  */
-export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMovedEventProps) {
+export function MessagesMovedEvent({ event, workspaceId }: MessagesMovedEventProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
-  // Always called so hook order is stable, even though we may early-return
-  // for destination rows below. Cost is one IDB subscription per source-
-  // side tombstone in the timeline (typically rare).
   const actors = useActors(workspaceId)
-
   const payload = event.payload as MessagesMovedEventPayload
-  if (streamId === payload.destinationStreamId) return null
-
   const moverName = actors.getActorName(event.actorId, event.actorType)
+
   const count = payload.messages.length
   const noun = count === 1 ? "message" : "messages"
 
@@ -53,13 +44,7 @@ export function MessagesMovedEvent({ event, workspaceId, streamId }: MessagesMov
         </button>
       </div>
       {drawerOpen && (
-        <MovedMessagesDrawer
-          open={drawerOpen}
-          onOpenChange={setDrawerOpen}
-          event={event}
-          workspaceId={workspaceId}
-          currentStreamId={streamId}
-        />
+        <MovedMessagesDrawer open={drawerOpen} onOpenChange={setDrawerOpen} event={event} workspaceId={workspaceId} />
       )}
     </>
   )

--- a/apps/frontend/src/components/timeline/moved-from-indicator.tsx
+++ b/apps/frontend/src/components/timeline/moved-from-indicator.tsx
@@ -1,0 +1,40 @@
+import { CornerDownRight } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { RelativeTime } from "@/components/relative-time"
+import { useActors } from "@/hooks"
+
+interface MovedFromIndicatorProps {
+  workspaceId: string
+  movedFrom: {
+    sourceStreamId: string
+    movedAt: string
+    movedBy: string
+  }
+}
+
+/**
+ * Subtle "moved here" badge shown next to a message's timestamp when the
+ * message was relocated into this stream by a move-to-thread operation.
+ * The icon doubles as the visual identity of the move action everywhere
+ * (context menus + tombstones use the same `CornerDownRight`).
+ */
+export function MovedFromIndicator({ workspaceId, movedFrom }: MovedFromIndicatorProps) {
+  const { getActorName } = useActors(workspaceId)
+  const moverName = getActorName(movedFrom.movedBy, "user")
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex items-center text-muted-foreground hover:text-foreground cursor-default"
+          aria-label="Moved from another stream"
+        >
+          <CornerDownRight className="h-3 w-3" aria-hidden="true" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        Moved here by {moverName} <RelativeTime date={movedFrom.movedAt} />
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/frontend/src/components/timeline/moved-from-indicator.tsx
+++ b/apps/frontend/src/components/timeline/moved-from-indicator.tsx
@@ -3,10 +3,18 @@ import type { MovedFromProvenance } from "@threa/types"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { RelativeTime } from "@/components/relative-time"
 import { useActors } from "@/hooks"
+import { cn } from "@/lib/utils"
 
 interface MovedFromIndicatorProps {
   workspaceId: string
   movedFrom: MovedFromProvenance
+  /**
+   * When provided, the badge becomes a click target that fires this
+   * callback (e.g. opens the move drill-in drawer). Tooltip-on-hover
+   * behavior is preserved either way. Omit for tooltip-only display
+   * (e.g. when the destination tombstone hasn't hydrated yet).
+   */
+  onClick?: () => void
 }
 
 function formatSourceName(displayName: string | null, slug: string | null): string | null {
@@ -20,34 +28,70 @@ function formatSourceName(displayName: string | null, slug: string | null): stri
  * message was relocated into this stream by a move-to-thread operation.
  * The icon doubles as the visual identity of the move action everywhere
  * (context menus + tombstones use the same `CornerDownRight`).
+ *
+ * On desktop the badge is clickable when an `onClick` is wired — saves
+ * users a right-click → context-menu hop to the same drawer the menu
+ * entry opens. Mobile users without hover discoverability still reach
+ * the drawer via the message context menu's "Show move details" entry.
  */
-export function MovedFromIndicator({ workspaceId, movedFrom }: MovedFromIndicatorProps) {
+export function MovedFromIndicator({ workspaceId, movedFrom, onClick }: MovedFromIndicatorProps) {
   const { getActorName } = useActors(workspaceId)
   const moverName = getActorName(movedFrom.movedBy, movedFrom.movedByType)
   const sourceName = formatSourceName(movedFrom.sourceStreamDisplayName, movedFrom.sourceStreamSlug)
+  const ariaLabel = sourceName ? `Moved from ${sourceName}` : "Moved from another stream"
+
+  const tooltipContent = (
+    <TooltipContent side="top" className="text-xs">
+      {sourceName ? (
+        <>
+          Moved here by {moverName} from <span className="font-medium">{sourceName}</span>{" "}
+          <RelativeTime date={movedFrom.movedAt} />
+        </>
+      ) : (
+        <>
+          Moved here by {moverName} <RelativeTime date={movedFrom.movedAt} />
+        </>
+      )}
+    </TooltipContent>
+  )
+
+  if (onClick) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(event) => {
+              // Don't bubble into row-level handlers (e.g. batch-select
+              // toggles when the row is clickable in selection mode).
+              event.stopPropagation()
+              onClick()
+            }}
+            aria-label={ariaLabel}
+            className={cn(
+              "inline-flex items-center text-muted-foreground hover:text-foreground cursor-pointer",
+              "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            )}
+          >
+            <CornerDownRight className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        {tooltipContent}
+      </Tooltip>
+    )
+  }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span
           className="inline-flex items-center text-muted-foreground hover:text-foreground cursor-default"
-          aria-label={sourceName ? `Moved from ${sourceName}` : "Moved from another stream"}
+          aria-label={ariaLabel}
         >
           <CornerDownRight className="h-3 w-3" aria-hidden="true" />
         </span>
       </TooltipTrigger>
-      <TooltipContent side="top" className="text-xs">
-        {sourceName ? (
-          <>
-            Moved here by {moverName} from <span className="font-medium">{sourceName}</span>{" "}
-            <RelativeTime date={movedFrom.movedAt} />
-          </>
-        ) : (
-          <>
-            Moved here by {moverName} <RelativeTime date={movedFrom.movedAt} />
-          </>
-        )}
-      </TooltipContent>
+      {tooltipContent}
     </Tooltip>
   )
 }

--- a/apps/frontend/src/components/timeline/moved-from-indicator.tsx
+++ b/apps/frontend/src/components/timeline/moved-from-indicator.tsx
@@ -1,15 +1,18 @@
 import { CornerDownRight } from "lucide-react"
+import type { MovedFromProvenance } from "@threa/types"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { RelativeTime } from "@/components/relative-time"
 import { useActors } from "@/hooks"
 
 interface MovedFromIndicatorProps {
   workspaceId: string
-  movedFrom: {
-    sourceStreamId: string
-    movedAt: string
-    movedBy: string
-  }
+  movedFrom: MovedFromProvenance
+}
+
+function formatSourceName(displayName: string | null, slug: string | null): string | null {
+  if (displayName) return displayName
+  if (slug) return `#${slug}`
+  return null
 }
 
 /**
@@ -21,19 +24,29 @@ interface MovedFromIndicatorProps {
 export function MovedFromIndicator({ workspaceId, movedFrom }: MovedFromIndicatorProps) {
   const { getActorName } = useActors(workspaceId)
   const moverName = getActorName(movedFrom.movedBy, "user")
+  const sourceName = formatSourceName(movedFrom.sourceStreamDisplayName, movedFrom.sourceStreamSlug)
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span
           className="inline-flex items-center text-muted-foreground hover:text-foreground cursor-default"
-          aria-label="Moved from another stream"
+          aria-label={sourceName ? `Moved from ${sourceName}` : "Moved from another stream"}
         >
           <CornerDownRight className="h-3 w-3" aria-hidden="true" />
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" className="text-xs">
-        Moved here by {moverName} <RelativeTime date={movedFrom.movedAt} />
+        {sourceName ? (
+          <>
+            Moved here by {moverName} from <span className="font-medium">{sourceName}</span>{" "}
+            <RelativeTime date={movedFrom.movedAt} />
+          </>
+        ) : (
+          <>
+            Moved here by {moverName} <RelativeTime date={movedFrom.movedAt} />
+          </>
+        )}
       </TooltipContent>
     </Tooltip>
   )

--- a/apps/frontend/src/components/timeline/moved-from-indicator.tsx
+++ b/apps/frontend/src/components/timeline/moved-from-indicator.tsx
@@ -23,7 +23,7 @@ function formatSourceName(displayName: string | null, slug: string | null): stri
  */
 export function MovedFromIndicator({ workspaceId, movedFrom }: MovedFromIndicatorProps) {
   const { getActorName } = useActors(workspaceId)
-  const moverName = getActorName(movedFrom.movedBy, "user")
+  const moverName = getActorName(movedFrom.movedBy, movedFrom.movedByType)
   const sourceName = formatSourceName(movedFrom.sourceStreamDisplayName, movedFrom.sourceStreamSlug)
 
   return (

--- a/apps/frontend/src/components/timeline/moved-messages-drawer.tsx
+++ b/apps/frontend/src/components/timeline/moved-messages-drawer.tsx
@@ -1,0 +1,164 @@
+import { Link } from "react-router-dom"
+import { CornerDownRight, X } from "lucide-react"
+import type { StreamEvent, MessagesMovedEventPayload, MovedMessagePreview } from "@threa/types"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogClose,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from "@/components/ui/responsive-dialog"
+import { ActorAvatar } from "@/components/actor-avatar"
+import { RelativeTime } from "@/components/relative-time"
+import { useActors, type ActorLookup } from "@/hooks"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
+
+interface MovedMessagesDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The `messages:moved` tombstone backing this drawer. */
+  event: StreamEvent
+  workspaceId: string
+  /** The stream the user is currently viewing — drives outbound vs inbound label. */
+  currentStreamId: string
+}
+
+function formatStreamName(displayName: string | null, slug: string | null): string | null {
+  if (displayName) return displayName
+  if (slug) return `#${slug}`
+  return null
+}
+
+/**
+ * Drill-in drawer for a `messages:moved` event. Used from two surfaces:
+ *
+ * - **Source-stream tombstone** — clicking the inline "Actor moved N
+ *   messages" row opens this drawer with the source-side tombstone.
+ * - **Destination per-message context menu** — the destination doesn't
+ *   render an inline tombstone, so each moved message exposes a
+ *   "Show move details" menu entry that opens this drawer with the
+ *   destination tombstone (looked up by `movedFrom.moveTombstoneId`).
+ *
+ * Both callers mount conditionally (`{open && <Drawer .../>}`) so the
+ * internal `useActors` subscription only runs when the drawer is
+ * actually visible.
+ */
+export function MovedMessagesDrawer({
+  open,
+  onOpenChange,
+  event,
+  workspaceId,
+  currentStreamId,
+}: MovedMessagesDrawerProps) {
+  const actors = useActors(workspaceId)
+  const payload = event.payload as MessagesMovedEventPayload
+  const moverName = actors.getActorName(event.actorId, event.actorType)
+  const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
+  const destinationLabel =
+    formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"
+  const isOutbound = currentStreamId === payload.sourceStreamId
+  const count = payload.messages.length
+  const noun = count === 1 ? "message" : "messages"
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent
+        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col p-0 gap-0 [&>button:last-child]:hidden"
+        drawerClassName="flex flex-col p-0"
+        hideCloseButton
+      >
+        <div className="px-4 sm:px-6 py-4 border-b shrink-0 flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <ResponsiveDialogTitle className="text-base font-semibold flex items-center gap-2">
+              <CornerDownRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              {moverName} moved {count} {noun}
+            </ResponsiveDialogTitle>
+            <ResponsiveDialogDescription className="mt-1 text-xs text-muted-foreground inline-flex items-center gap-1.5 flex-wrap">
+              <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
+              <span aria-hidden="true">•</span>
+              <Link
+                to={`/w/${workspaceId}/s/${payload.sourceStreamId}`}
+                className="font-medium text-foreground hover:underline underline-offset-2"
+              >
+                {sourceLabel}
+              </Link>
+              <span aria-hidden="true">→</span>
+              <Link
+                to={`/w/${workspaceId}/s/${payload.destinationStreamId}`}
+                className="font-medium text-foreground hover:underline underline-offset-2"
+              >
+                {destinationLabel}
+              </Link>
+              {isOutbound && <span className="text-muted-foreground">(outbound)</span>}
+              {!isOutbound && <span className="text-muted-foreground">(inbound)</span>}
+            </ResponsiveDialogDescription>
+          </div>
+          <ResponsiveDialogClose className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0">
+            <X className="w-5 h-5" />
+            <span className="sr-only">Close</span>
+          </ResponsiveDialogClose>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto px-2 sm:px-3 py-2">
+          <ul className="flex flex-col gap-1">
+            {payload.messages.map((message) => (
+              <MovedMessageRow
+                key={message.id}
+                message={message}
+                workspaceId={workspaceId}
+                destinationStreamId={payload.destinationStreamId}
+                actors={actors}
+                onNavigate={() => onOpenChange(false)}
+              />
+            ))}
+          </ul>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}
+
+interface MovedMessageRowProps {
+  message: MovedMessagePreview
+  workspaceId: string
+  destinationStreamId: string
+  actors: ActorLookup
+  onNavigate: () => void
+}
+
+function MovedMessageRow({ message, workspaceId, destinationStreamId, actors, onNavigate }: MovedMessageRowProps) {
+  const authorName = actors.getActorName(message.authorId, message.authorType)
+  // Preview field is markdown by design — INV-60 carve-out for preview
+  // surfaces. Strip + truncate at render so display stays plain text.
+  const stripped = stripMarkdownToInline(message.contentMarkdown).trim()
+  const previewText = stripped.length > 0 ? stripped : "(empty message)"
+
+  return (
+    <li>
+      <Link
+        to={`/w/${workspaceId}/s/${destinationStreamId}?m=${message.id}`}
+        onClick={onNavigate}
+        className="block px-3 py-2 rounded-md hover:bg-muted/60 transition-colors group"
+      >
+        <div className="flex items-start gap-3 min-w-0">
+          <ActorAvatar
+            actorId={message.authorId}
+            actorType={message.authorType}
+            workspaceId={workspaceId}
+            size="sm"
+            alt={authorName}
+            className="shrink-0 mt-0.5"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2 min-w-0">
+              <span className="font-medium text-sm truncate">{authorName}</span>
+              <RelativeTime date={message.createdAt} className="text-xs text-muted-foreground shrink-0" />
+            </div>
+            <p className="text-sm text-muted-foreground line-clamp-2 group-hover:text-foreground transition-colors">
+              {previewText}
+            </p>
+          </div>
+        </div>
+      </Link>
+    </li>
+  )
+}

--- a/apps/frontend/src/components/timeline/moved-messages-drawer.tsx
+++ b/apps/frontend/src/components/timeline/moved-messages-drawer.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import { CornerDownRight, X } from "lucide-react"
+import { X } from "lucide-react"
 import type { StreamEvent, MessagesMovedEventPayload, MovedMessagePreview } from "@threa/types"
 import {
   ResponsiveDialog,
@@ -19,14 +19,12 @@ interface MovedMessagesDrawerProps {
   /** The `messages:moved` tombstone backing this drawer. */
   event: StreamEvent
   workspaceId: string
-  /** The stream the user is currently viewing — drives outbound vs inbound label. */
-  currentStreamId: string
 }
 
-function formatStreamName(displayName: string | null, slug: string | null): string | null {
+function formatStreamName(displayName: string | null, slug: string | null, fallback: string): string {
   if (displayName) return displayName
   if (slug) return `#${slug}`
-  return null
+  return fallback
 }
 
 /**
@@ -34,29 +32,28 @@ function formatStreamName(displayName: string | null, slug: string | null): stri
  *
  * - **Source-stream tombstone** — clicking the inline "Actor moved N
  *   messages" row opens this drawer with the source-side tombstone.
- * - **Destination per-message context menu** — the destination doesn't
- *   render an inline tombstone, so each moved message exposes a
- *   "Show move details" menu entry that opens this drawer with the
+ * - **Destination per-message indicator + context menu** — the
+ *   destination doesn't render an inline tombstone, so each moved
+ *   message exposes both a hover-clickable origin badge and a
+ *   "Show move details" menu entry that open this drawer with the
  *   destination tombstone (looked up by `movedFrom.moveTombstoneId`).
  *
  * Both callers mount conditionally (`{open && <Drawer .../>}`) so the
  * internal `useActors` subscription only runs when the drawer is
  * actually visible.
  */
-export function MovedMessagesDrawer({
-  open,
-  onOpenChange,
-  event,
-  workspaceId,
-  currentStreamId,
-}: MovedMessagesDrawerProps) {
+export function MovedMessagesDrawer({ open, onOpenChange, event, workspaceId }: MovedMessagesDrawerProps) {
   const actors = useActors(workspaceId)
   const payload = event.payload as MessagesMovedEventPayload
   const moverName = actors.getActorName(event.actorId, event.actorType)
-  const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug) ?? "another stream"
-  const destinationLabel =
-    formatStreamName(payload.destinationStreamDisplayName, payload.destinationStreamSlug) ?? "a thread"
-  const isOutbound = currentStreamId === payload.sourceStreamId
+  // Source can be any stream type; destination is always a thread (the
+  // move flow only creates child threads). Fallbacks reflect that.
+  const sourceLabel = formatStreamName(payload.sourceStreamDisplayName, payload.sourceStreamSlug, "Untitled stream")
+  const destinationLabel = formatStreamName(
+    payload.destinationStreamDisplayName,
+    payload.destinationStreamSlug,
+    "Untitled thread"
+  )
   const count = payload.messages.length
   const noun = count === 1 ? "message" : "messages"
 
@@ -70,8 +67,17 @@ export function MovedMessagesDrawer({
         <div className="px-4 sm:px-6 py-4 border-b shrink-0 flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <ResponsiveDialogTitle className="text-base font-semibold flex items-center gap-2">
-              <CornerDownRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-              {moverName} moved {count} {noun}
+              <ActorAvatar
+                actorId={event.actorId}
+                actorType={event.actorType}
+                workspaceId={workspaceId}
+                size="sm"
+                alt={moverName}
+                className="shrink-0"
+              />
+              <span className="truncate">
+                {moverName} moved {count} {noun}
+              </span>
             </ResponsiveDialogTitle>
             <ResponsiveDialogDescription className="mt-1 text-xs text-muted-foreground inline-flex items-center gap-1.5 flex-wrap">
               <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
@@ -89,8 +95,6 @@ export function MovedMessagesDrawer({
               >
                 {destinationLabel}
               </Link>
-              {isOutbound && <span className="text-muted-foreground">(outbound)</span>}
-              {!isOutbound && <span className="text-muted-foreground">(inbound)</span>}
             </ResponsiveDialogDescription>
           </div>
           <ResponsiveDialogClose className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0">
@@ -130,7 +134,7 @@ function MovedMessageRow({ message, workspaceId, destinationStreamId, actors, on
   // Preview field is markdown by design — INV-60 carve-out for preview
   // surfaces. Strip + truncate at render so display stays plain text.
   const stripped = stripMarkdownToInline(message.contentMarkdown).trim()
-  const previewText = stripped.length > 0 ? stripped : "(empty message)"
+  const hasContent = stripped.length > 0
 
   return (
     <li>
@@ -153,9 +157,13 @@ function MovedMessageRow({ message, workspaceId, destinationStreamId, actors, on
               <span className="font-medium text-sm truncate">{authorName}</span>
               <RelativeTime date={message.createdAt} className="text-xs text-muted-foreground shrink-0" />
             </div>
-            <p className="text-sm text-muted-foreground line-clamp-2 group-hover:text-foreground transition-colors">
-              {previewText}
-            </p>
+            {hasContent ? (
+              <p className="text-sm text-muted-foreground line-clamp-2 group-hover:text-foreground transition-colors">
+                {stripped}
+              </p>
+            ) : (
+              <p className="text-sm italic text-muted-foreground/70">no text content</p>
+            )}
           </div>
         </div>
       </Link>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -347,16 +347,19 @@ export function StreamContent({
     [messageEventMeta, selectedMessageIds, selectedSequenceFloor]
   )
 
-  const startBatchSelect = useCallback(() => {
-    setBatchMode(true)
-    setSelectedMessageIds(new Set())
-    setHoveredBatchTargetId(null)
-    setDragGhost(null)
-    // Selection and search share the same flush-top strip; keep one open at a
-    // time so they can't stack. Search bar's own listeners handle the reverse.
-    setIsSearchOpen(false)
-    clearSearch()
-  }, [clearSearch])
+  const startBatchSelect = useCallback(
+    (preselectedMessageId?: string) => {
+      setBatchMode(true)
+      setSelectedMessageIds(preselectedMessageId ? new Set([preselectedMessageId]) : new Set())
+      setHoveredBatchTargetId(null)
+      setDragGhost(null)
+      // Selection and search share the same flush-top strip; keep one open at a
+      // time so they can't stack. Search bar's own listeners handle the reverse.
+      setIsSearchOpen(false)
+      clearSearch()
+    },
+    [clearSearch]
+  )
 
   const toggleBatchMessage = useCallback((messageId: string) => {
     setSelectedMessageIds((prev) => {
@@ -391,7 +394,7 @@ export function StreamContent({
   useEffect(() => {
     return addStartBatchSelectListener((detail) => {
       if (detail.streamId !== streamId) return
-      startBatchSelect()
+      startBatchSelect(detail.preselectedMessageId)
     })
   }, [startBatchSelect, streamId])
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -78,7 +78,7 @@ export {
 
 export { useSearch } from "./use-search"
 
-export { useActors } from "./use-actors"
+export { useActors, type ActorLookup } from "./use-actors"
 
 export { useWorkspaceEmoji } from "./use-workspace-emoji"
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -79,6 +79,7 @@ export {
 export { useSearch } from "./use-search"
 
 export { useActors, type ActorLookup } from "./use-actors"
+export { useMovedTombstone } from "./use-moved-tombstone"
 
 export { useWorkspaceEmoji } from "./use-workspace-emoji"
 

--- a/apps/frontend/src/hooks/use-actors.ts
+++ b/apps/frontend/src/hooks/use-actors.ts
@@ -10,7 +10,7 @@ interface ActorAvatarInfo {
   avatarUrl?: string
 }
 
-interface ActorLookup {
+export interface ActorLookup {
   getActorName: (actorId: string | null, actorType: AuthorType | null) => string
   getActorInitials: (actorId: string | null, actorType: AuthorType | null) => string
   /** Returns avatar info including fallback text and persona slug (for SVG icon support) */

--- a/apps/frontend/src/hooks/use-moved-tombstone.ts
+++ b/apps/frontend/src/hooks/use-moved-tombstone.ts
@@ -1,0 +1,23 @@
+import { useLiveQuery } from "dexie-react-hooks"
+import type { StreamEvent } from "@threa/types"
+import { db, type CachedEvent } from "@/db"
+
+/**
+ * Look up a `messages:moved` tombstone event from the local IDB cache by
+ * its `event.id`. Returns the cached row (shaped as the wire `StreamEvent`
+ * — the cache adds workspaceId + cache-housekeeping fields the drawer
+ * doesn't read), or `undefined` when the id is missing or the row hasn't
+ * been cached yet (before bootstrap hydrates the destination stream).
+ *
+ * Used by the destination-side per-message context-menu action ("Show
+ * move details") to populate the move drill-in drawer. The destination
+ * doesn't render an inline tombstone, so the drawer needs to fetch the
+ * tombstone on demand.
+ */
+export function useMovedTombstone(moveTombstoneId: string | undefined): StreamEvent | undefined {
+  return useLiveQuery<StreamEvent | undefined>(async () => {
+    if (!moveTombstoneId) return undefined
+    const cached: CachedEvent | undefined = await db.events.get(moveTombstoneId)
+    return cached as StreamEvent | undefined
+  }, [moveTombstoneId])
+}

--- a/apps/frontend/src/lib/batch-selection-events.ts
+++ b/apps/frontend/src/lib/batch-selection-events.ts
@@ -2,10 +2,22 @@ const START_BATCH_SELECT_EVENT = "threa:start-batch-select"
 
 interface BatchSelectEventDetail {
   streamId: string
+  /**
+   * When the move flow is launched from a per-message context menu, the
+   * single message acts as the initial selection so the user can either
+   * confirm immediately or extend the selection. Absent for the
+   * stream-level "Move messages…" entry, which starts with nothing
+   * selected.
+   */
+  preselectedMessageId?: string
 }
 
-export function dispatchStartBatchSelect(streamId: string): void {
-  document.dispatchEvent(new CustomEvent<BatchSelectEventDetail>(START_BATCH_SELECT_EVENT, { detail: { streamId } }))
+export function dispatchStartBatchSelect(streamId: string, preselectedMessageId?: string): void {
+  document.dispatchEvent(
+    new CustomEvent<BatchSelectEventDetail>(START_BATCH_SELECT_EVENT, {
+      detail: { streamId, preselectedMessageId },
+    })
+  )
 }
 
 export function addStartBatchSelectListener(listener: (detail: BatchSelectEventDetail) => void): () => void {

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
-import { MoreHorizontal, Pencil, Archive, MessageCircle, X, ArchiveX, Search, CheckSquare } from "lucide-react"
+import { MoreHorizontal, Pencil, Archive, MessageCircle, X, ArchiveX, Search, CornerDownRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -160,9 +160,9 @@ export function StreamPage() {
   const streamMenuActions: SidebarActionItem[] = []
   if (!isArchived) {
     streamMenuActions.push({
-      id: "select-messages",
-      label: "Select messages",
-      icon: CheckSquare,
+      id: "move-messages",
+      label: "Move messages…",
+      icon: CornerDownRight,
       onSelect: handleSelectMessages,
     })
   }
@@ -322,15 +322,15 @@ export function StreamPage() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-40">
-                  {/* Hide "Select messages" entirely on archived streams to
+                  {/* Hide "Move messages…" entirely on archived streams to
                     match the mobile drawer (which builds via
                     `streamMenuActions` and skips the entry when isArchived).
                     A disabled menu item would just confuse — there's no path
                     to enable it without unarchiving first. */}
                   {!isArchived && (
                     <DropdownMenuItem onClick={handleSelectMessages}>
-                      <CheckSquare className="mr-2 h-4 w-4" />
-                      Select messages
+                      <CornerDownRight className="mr-2 h-4 w-4" />
+                      Move messages…
                     </DropdownMenuItem>
                   )}
                   {isScratchpad && (

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -244,6 +244,9 @@ interface MessagesMovedPayload {
   thread: Stream
   events: StreamEvent[]
   removedEventIds: string[]
+  /** Tombstone event inserted into the source stream — appended to the
+   *  source-side IDB cache so the timeline keeps a "moved → thread" trace. */
+  sourceTombstoneEvent: StreamEvent
   /** Authoritative replyCount for the drop-target after the move (see backend payload doc). */
   parentReplyCount: number
   /** Recomputed thread summary for the drop-target — same shape as `message:updated` ships. */
@@ -512,6 +515,17 @@ export function registerStreamSocketHandlers(
     await db.transaction("rw", [db.events, db.streams], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
+        // Append the source tombstone after the deletes so the timeline
+        // shows a "moved 3 messages → thread" trace where the messages
+        // used to be. The event was assigned a fresh sequence in the
+        // source stream so it sorts naturally at the bottom of the
+        // post-move state.
+        await db.events.put({
+          ...payload.sourceTombstoneEvent,
+          workspaceId,
+          _sequenceNum: sequenceToNum(payload.sourceTombstoneEvent.sequence),
+          _cachedAt: now,
+        })
         // SET replyCount + threadSummary directly from the payload (not
         // additive) so the patch is idempotent against the sibling
         // `message:updated` event — they carry the same authoritative

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -320,6 +320,14 @@ export interface MovedFromProvenance {
    * is ever reused.
    */
   movedByType: AuthorType
+  /**
+   * `event.id` of the destination-side `messages:moved` tombstone. The
+   * destination doesn't render the tombstone inline — it shows a small
+   * origin badge per message instead — so a per-message context-menu
+   * action ("Show move details") looks the tombstone up by id from IDB
+   * to populate the drill-in drawer.
+   */
+  moveTombstoneId: string
 }
 
 export interface ValidateMoveMessagesToThreadInput {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -247,6 +247,74 @@ export interface MoveMessagesToThreadResponse {
   sourceTombstoneEvent: StreamEvent
 }
 
+/**
+ * Per-message preview embedded in a `messages:moved` stream event payload.
+ *
+ * Carries enough to render a clickable summary in the move drill-in
+ * drawer without an extra fetch. `contentMarkdown` is a capped raw
+ * markdown excerpt — preview surfaces are exempt from INV-58 (canonical
+ * content lives in `contentJson` on the actual message row); per INV-60
+ * they ship as markdown and the frontend strips at render via
+ * `stripMarkdownToInline`.
+ */
+export interface MovedMessagePreview {
+  id: string
+  authorId: string | null
+  authorType: AuthorType | null
+  contentMarkdown: string
+  createdAt: string
+}
+
+/**
+ * Payload for a `messages:moved` stream event. One row is inserted in the
+ * source stream and one in the destination thread on every move; the
+ * renderer collapses each row to "Actor moved N messages" and opens a
+ * drill-in drawer when clicked. The same shape serves both sides — the
+ * renderer infers role from whether `event.streamId === sourceStreamId`
+ * (outbound) vs `=== destinationStreamId` (inbound).
+ *
+ * `event.actorId` carries the mover's user ID and `event.createdAt`
+ * carries the move timestamp, so they aren't duplicated in the payload.
+ *
+ * Source/destination stream names are embedded so the tombstone can
+ * render without an extra round-trip when the linked stream isn't
+ * already cached. They're a snapshot — a later rename won't be reflected
+ * on existing tombstones, which is acceptable since tombstones are
+ * append-only history.
+ */
+export interface MessagesMovedEventPayload {
+  sourceStreamId: string
+  sourceStreamSlug: string | null
+  sourceStreamDisplayName: string | null
+  destinationStreamId: string
+  destinationStreamSlug: string | null
+  destinationStreamDisplayName: string | null
+  /**
+   * Per-message previews for the drill-in drawer.
+   * `messages.length` is the canonical count.
+   */
+  messages: MovedMessagePreview[]
+}
+
+/**
+ * Provenance stamped onto a relocated `message_created` event payload by
+ * the move flow. Surfaces a per-message origin badge in the destination
+ * timeline without a join. Re-moves overwrite earlier provenance — we
+ * surface the most recent origin, not a chain.
+ *
+ * Source-stream metadata (slug + display name) is snapshotted alongside
+ * the IDs so the badge can render the origin name without a separate
+ * lookup. Like the tombstone payload, this snapshot is intentional —
+ * later renames don't reflect on existing badges.
+ */
+export interface MovedFromProvenance {
+  sourceStreamId: string
+  sourceStreamSlug: string | null
+  sourceStreamDisplayName: string | null
+  movedAt: string
+  movedBy: string
+}
+
 export interface ValidateMoveMessagesToThreadInput {
   sourceStreamId: string
   targetMessageId: string

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -313,6 +313,13 @@ export interface MovedFromProvenance {
   sourceStreamDisplayName: string | null
   movedAt: string
   movedBy: string
+  /**
+   * Author type of `movedBy`. Today the move handler is gated to user
+   * actors, so this is always `"user"` — but persisting the type alongside
+   * the id avoids silently mislabelling bot/agent movers if the move flow
+   * is ever reused.
+   */
+  movedByType: AuthorType
 }
 
 export interface ValidateMoveMessagesToThreadInput {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -242,6 +242,9 @@ export interface MoveMessagesToThreadResponse {
   thread: Stream
   events: StreamEvent[]
   removedEventIds: string[]
+  /** Tombstone event inserted into the source stream that the source-side
+   *  client appends to its cache so the move leaves a visible trace. */
+  sourceTombstoneEvent: StreamEvent
 }
 
 export interface ValidateMoveMessagesToThreadInput {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -66,6 +66,7 @@ export const EVENT_TYPES = [
   "agent_session:completed",
   "agent_session:failed",
   "agent_session:deleted",
+  "messages_moved",
 ] as const
 export type EventType = (typeof EVENT_TYPES)[number]
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -66,7 +66,7 @@ export const EVENT_TYPES = [
   "agent_session:completed",
   "agent_session:failed",
   "agent_session:deleted",
-  "messages_moved",
+  "messages:moved",
 ] as const
 export type EventType = (typeof EVENT_TYPES)[number]
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -267,6 +267,9 @@ export type {
   MoveMessagesToThreadResponse,
   ValidateMoveMessagesToThreadInput,
   ValidateMoveMessagesToThreadResponse,
+  MovedMessagePreview,
+  MessagesMovedEventPayload,
+  MovedFromProvenance,
   // Workspaces
   CreateWorkspaceInput,
   WorkspaceBootstrap,


### PR DESCRIPTION
> Stacked on top of #420 — diff against `add-batch-move-messages-to-thread`. Merge target should be flipped to `main` once #420 lands.

## Problem

PR #420's move flow is "extremely clean — leaving no real trace of the message ever having been in the stream." That breaks two things:

1. **Source readers lose continuity.** A scroller-by who remembers writing in a stream gets no clue that the messages still exist somewhere — moves look identical to deletions.
2. **Destination readers lose context.** Messages just appear in a thread with no signal that they were authored elsewhere.

We also went too far when promoting "Select messages" to the stream context menu — moving a single message intuitively belongs in the per-message context menu too.

## Solution

Three layers of trace, all sharing one visual identity (the `CornerDownRight` icon):

### 1. Tombstone events on both sides

A new `messages_moved` stream event is inserted in **both** the source and destination on every move. In the timeline it collapses to a single line:

> ↳ **Kristoffer Remback** moved 3 messages

Clicking it opens a drawer (using `ResponsiveDialog` so mobile gets a bottom sheet) with the move metadata — who moved what, when, source → destination chips — and a clickable list of every moved message (author + content preview + timestamp). Clicking any message navigates to its new location in the destination thread. Full transparency, minimal in-line overhead, grouped per move.

### 2. Per-message origin badge

The move flow now stamps `movedFrom: { sourceStreamId, movedAt, movedBy }` onto each relocated `message_created` payload via jsonb concat in the same UPDATE that moves the row. `MessageEvent` renders a subtle `CornerDownRight` chip next to the timestamp; tooltip reads "Moved here by Kristoffer 2m ago." No new table — provenance lives on the event payload, which event-sourcing already treats as immutable history.

### 3. Per-message context-menu entry restored

"Move to thread…" is back on the per-message context menu. It dispatches the same batch-select event the stream menu uses, but with the message **preselected** so the common "I just want this one in a thread" path is one drag away. The stream-level entry is renamed "Move messages…" and now uses the same icon as the message-level entry, the origin badge, and the tombstone — one visual identity for the move action everywhere.

## How it works

- **Tombstone payload** carries `messages: Array<{ id, authorId, authorType, contentMarkdown, createdAt }>` (capped to 200 chars per excerpt) so the drawer renders without an extra fetch. Per INV-46, raw markdown ships on the wire and the frontend strips at render via `stripMarkdownToInline`.
- **Outbox payload** gains `sourceTombstoneEvent` as a separate field from `events` (the destination write set), so `stream-sync.ts` can append the tombstone to the source's IDB cache after applying `removedEventIds` without polluting the destination flow.
- **`moveMessageCreatedEvents`** now accepts an optional `movedFrom` and bakes it into the same UPDATE — single round trip, returned events have the patched payload.
- **Preselection** rides through `dispatchStartBatchSelect(streamId, preselectedMessageId?)`. The listener in `stream-content.tsx` seeds `selectedMessageIds` with the preselected ID when present.

## Bonus: staging deploy fix

`staging.yml` had `branches: [main]` on its `pull_request` trigger, which silently filters out PRs stacked on feature branches (like this one). The `staging` label gate already restricts deploys, so the base-branch filter only caused false negatives. Removed.

## Test plan

- [x] `bun run typecheck` clean across all 9 workspaces
- [x] Frontend tests pass: `event-item`, `message-context-menu`, `message-event`, `stream-sync` (47 tests, 0 failing)
- [x] Integration test extended (`message-move.test.ts`) to assert:
  - Tombstones inserted in both source and destination streams
  - `messages_moved` payload carries source/destination IDs + per-message previews
  - `result.sourceTombstoneEvent` arrives on the move response separate from `events`
  - `result.removedEventIds` does NOT include the source tombstone (we want it visible)
  - Relocated `message_created` events carry `movedFrom: { sourceStreamId, movedAt, movedBy }`
- [ ] Backend integration suite blocked locally by the same pre-existing `messageMetadataSchema` import-cycle error called out in #420

## Files

| File | Change |
| --- | --- |
| `packages/types/src/constants.ts` | Adds `messages_moved` to `EVENT_TYPES` |
| `packages/types/src/api.ts` | Adds `sourceTombstoneEvent` to `MoveMessagesToThreadResponse` |
| `apps/backend/src/features/messaging/event-service.ts` | `MovedMessagePreview` + `MessagesMovedEventPayload` types; inserts both tombstones; passes `movedFrom` into `moveMessageCreatedEvents`; ships source tombstone via outbox |
| `apps/backend/src/features/messaging/handlers.ts` | Returns `sourceTombstoneEvent` on the move response |
| `apps/backend/src/features/streams/event-repository.ts` | `moveMessageCreatedEvents` accepts optional `movedFrom` and bakes it into the UPDATE |
| `apps/backend/src/lib/outbox/repository.ts` | `MessagesMovedOutboxPayload.sourceTombstoneEvent` |
| `apps/backend/tests/integration/message-move.test.ts` | Asserts tombstones, `movedFrom`, and outbox shape |
| `apps/frontend/src/components/timeline/messages-moved-event.tsx` | New: minimal tombstone + `ResponsiveDialog` drill-in drawer with clickable message list |
| `apps/frontend/src/components/timeline/moved-from-indicator.tsx` | New: per-message origin badge |
| `apps/frontend/src/components/timeline/event-item.tsx` | Routes `messages_moved` to the new component |
| `apps/frontend/src/components/timeline/message-event.tsx` | Renders the badge; adds `onMoveToThread` to action context |
| `apps/frontend/src/components/timeline/message-actions.ts` | Adds "Move to thread…" entry |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `startBatchSelect` accepts a preselected message ID |
| `apps/frontend/src/lib/batch-selection-events.ts` | `dispatchStartBatchSelect` accepts an optional `preselectedMessageId` |
| `apps/frontend/src/pages/stream.tsx` + `apps/frontend/src/components/thread/stream-panel.tsx` | Renames "Select messages" → "Move messages…", swaps `CheckSquare` → `CornerDownRight` |
| `apps/frontend/src/sync/stream-sync.ts` | Appends `sourceTombstoneEvent` to source-side IDB after `removedEventIds` are dropped |
| `.github/workflows/staging.yml` | Drops `branches: [main]` filter so stacked PRs can deploy

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0159wNhY2NKKjVD1ufN6xoFW)_