### PR TITLE
fix: render tool_call args as a contained code block

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -277,7 +277,7 @@ function TraceBody({
     content = <div className="p-6 text-center text-destructive">Failed to load trace. Please try again.</div>
   }
 
-  return <div className="flex-1 min-h-0 overflow-y-auto">{content}</div>
+  return <div className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden">{content}</div>
 }
 
 function TraceFooter({

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -154,6 +154,35 @@ describe("TraceStep", () => {
     )
   })
 
+  it("renders tool_call args as a pretty-printed code block to prevent overflow", () => {
+    // Regression for the case where wide JSON args (e.g. GitHub tool calls
+    // with long repo paths) were rendered as a single inline span, which
+    // forced the trace dialog to scroll horizontally. The fix renders args
+    // in a <pre> with overflow-x-auto so the scroll is contained.
+    render(
+      <MemoryRouter>
+        <TraceStep
+          step={createStep({
+            stepType: "tool_call",
+            content: JSON.stringify({
+              tool: "github_list_pull_requests",
+              args: { repo: "kristofferremback/threa", path: null, author: null, page: 1 },
+            }),
+          })}
+          workspaceId="ws_1"
+          streamId="stream_1"
+        />
+      </MemoryRouter>
+    )
+
+    const code = screen.getByText(/"repo": "kristofferremback\/threa"/)
+    const pre = code.closest("pre")
+    expect(pre).not.toBeNull()
+    expect(pre?.className).toMatch(/overflow-x-auto/)
+    // Pretty-printed (multiline) rather than a single long line.
+    expect(code.textContent).toContain("\n")
+  })
+
   it("renders workspace_search content that arrives as a raw object without crashing", () => {
     // Regression for the crash where a step row's content was persisted as a
     // JSONB object (bypassing the pre-stringify convention), node-postgres

--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -453,12 +453,14 @@ function renderStepContent(
           )
         }
         return (
-          <span>
+          <div className="space-y-1.5">
             <strong>{tool}</strong>
             {"args" in structured && (
-              <span className="text-muted-foreground ml-1 text-xs font-mono">{JSON.stringify(structured.args)}</span>
+              <pre className="rounded bg-muted/50 px-3 py-2 text-xs font-mono overflow-x-auto whitespace-pre">
+                <code>{JSON.stringify(structured.args, null, 2)}</code>
+              </pre>
             )}
-          </span>
+          </div>
         )
       }
       return <span>{content}</span>


### PR DESCRIPTION
## Summary

Tool call JSON args in the Agent Session Trace dialog were rendered as an inline `<span>`, so wide payloads (notably GitHub tool calls with long repo paths like `kristofferremback/threa`) overflowed and forced the dialog into horizontal scroll.

- Render args as a pretty-printed `<pre><code>` block with `overflow-x-auto`, so any horizontal scrolling is contained inside the snippet — and the JSON is actually readable.
- Add a defensive `min-w-0 overflow-x-hidden` on the trace body so no future widget can push the dialog into horizontal scroll.

## Test plan

- [x] `bun run test trace-step` — 7/7 pass (including new regression test for tool_call args rendering)
- [x] `bun run test trace-dialog` — 3/3 pass
- [x] `bun run typecheck` — clean
- [x] Lint + prettier (via pre-commit hook) — clean
- [ ] Manual: open an Ariadne session that uses GitHub MCP tools and confirm the trace dialog no longer scrolls horizontally; args render as a tidy multiline code block.

https://claude.ai/code/session_01Ko42Jxpjib8MPLjhTnfTT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko42Jxpjib8MPLjhTnfTT4)_