### PR TITLE
fix(push): surface subscribe errors and let users recover from stuck state

### DIFF
--- a/apps/backend/src/features/push/handlers.ts
+++ b/apps/backend/src/features/push/handlers.ts
@@ -116,5 +116,21 @@ export function createPushHandlers({ pushService }: Dependencies) {
         enabled: pushService.isEnabled(),
       })
     },
+
+    /**
+     * Send a real push notification to all of the caller's devices in this
+     * workspace. Used by the in-app "Send test" diagnostic so the user can
+     * verify the full delivery loop, not just the local SW notification path.
+     */
+    async sendTest(req: Request, res: Response) {
+      if (!pushService.isEnabled()) {
+        throw new HttpError("Push notifications are not enabled", { status: 503, code: "PUSH_DISABLED" })
+      }
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { attempted, failed } = await pushService.deliverTestPush(workspaceId, userId)
+      res.json({ attempted, failed, delivered: attempted - failed })
+    },
   }
 }

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -115,6 +115,70 @@ export class PushService {
     return PushSubscriptionRepository.deleteByEndpointForUser(this.pool, endpoint, workosUserId)
   }
 
+  /**
+   * Sends a server-driven test push to all of the user's subscriptions in the
+   * workspace. Bypasses the focus-suppression and notification-preference logic
+   * because this is an explicit user diagnostic — we want to know whether the
+   * full delivery loop (DB → web-push → device) is working.
+   *
+   * Returns delivery stats so the caller can show "delivered to N devices" or
+   * "all N devices failed". Stale endpoints (404/410) are evicted so the next
+   * test reflects current registration state.
+   */
+  async deliverTestPush(workspaceId: string, userId: string): Promise<{ attempted: number; failed: number }> {
+    if (!this.canSend) {
+      throw new Error("Push notifications are not enabled on this server")
+    }
+
+    const subscriptions = await PushSubscriptionRepository.findByUserId(this.pool, workspaceId, userId)
+    if (subscriptions.length === 0) {
+      return { attempted: 0, failed: 0 }
+    }
+
+    const pushPayload = JSON.stringify({
+      data: {
+        kind: "test" as const,
+        workspaceId,
+        sentAt: Date.now(),
+      },
+    })
+
+    let failed = 0
+    const staleIds: string[] = []
+    await Promise.allSettled(
+      subscriptions.map(async (sub) => {
+        try {
+          await webpush.sendNotification(
+            { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+            pushPayload
+          )
+        } catch (err: unknown) {
+          failed++
+          const statusCode = (err as { statusCode?: number }).statusCode
+          if (statusCode === 404 || statusCode === 410) {
+            logger.info(
+              { subscriptionId: sub.id, statusCode },
+              "Marking stale subscription for removal during test push"
+            )
+            staleIds.push(sub.id)
+          } else {
+            logger.warn({ err, subscriptionId: sub.id }, "Test push failed")
+          }
+        }
+      })
+    )
+
+    if (staleIds.length > 0) {
+      try {
+        await PushSubscriptionRepository.deleteByIds(this.pool, workspaceId, staleIds)
+      } catch (deleteErr) {
+        logger.warn({ err: deleteErr, count: staleIds.length }, "Failed to delete stale subscriptions after test push")
+      }
+    }
+
+    return { attempted: subscriptions.length, failed }
+  }
+
   async upsertSession(params: {
     workspaceId: string
     userId: string

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -11,6 +11,7 @@ import {
   type StreamType,
 } from "@threa/types"
 import { logger } from "../../lib/logger"
+import { HttpError } from "../../lib/errors"
 import type { ActivityCreatedOutboxPayload, SavedReminderFiredOutboxPayload } from "../../lib/outbox"
 
 /** Maximum push subscriptions per user per workspace to bound parallel delivery calls */
@@ -127,7 +128,10 @@ export class PushService {
    */
   async deliverTestPush(workspaceId: string, userId: string): Promise<{ attempted: number; failed: number }> {
     if (!this.canSend) {
-      throw new Error("Push notifications are not enabled on this server")
+      // Mirror handlers.ts contract (INV-32) so non-handler callers (workers,
+      // internal APIs) get the same status/code semantics instead of a generic
+      // 500 from a plain Error bubbling through the error middleware.
+      throw new HttpError("Push notifications are not enabled", { status: 503, code: "PUSH_DISABLED" })
     }
 
     const subscriptions = await PushSubscriptionRepository.findByUserId(this.pool, workspaceId, userId)

--- a/apps/backend/src/middleware/rate-limit.ts
+++ b/apps/backend/src/middleware/rate-limit.ts
@@ -9,6 +9,7 @@ export interface RateLimiterSet {
   upload: RequestHandler
   messageCreate: RequestHandler
   commandDispatch: RequestHandler
+  pushTest: RequestHandler
   publicApiWorkspace: RequestHandler
   publicApiKey: RequestHandler
 }
@@ -63,6 +64,16 @@ export function createRateLimiters(config: RateLimiterConfig): RateLimiterSet {
       name: "command-dispatch",
       windowMs: 60_000,
       max: 30,
+      key: userScopeKey,
+    }),
+
+    // The test push triggers up to MAX_SUBSCRIPTIONS_PER_USER outbound webpush
+    // calls per request, so cap aggressively — a user shouldn't need to test
+    // more than a few times a minute, and this prevents hammering FCM/Mozilla.
+    pushTest: createRateLimit({
+      name: "push-test",
+      windowMs: 60_000,
+      max: 6,
       key: userScopeKey,
     }),
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -327,7 +327,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/push/vapid-key", ...authed, push.getVapidKey)
   app.post("/api/workspaces/:workspaceId/push/subscribe", ...authed, push.subscribe)
   app.post("/api/workspaces/:workspaceId/push/unsubscribe", ...authed, push.unsubscribe)
-  app.post("/api/workspaces/:workspaceId/push/test", ...authed, push.sendTest)
+  app.post("/api/workspaces/:workspaceId/push/test", ...authed, rateLimits.pushTest, push.sendTest)
   // Non-workspace-scoped: cleans up all push subscriptions for a browser endpoint (used on logout)
   app.post("/api/push/cleanup-endpoint", auth, push.cleanupEndpoint)
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -327,6 +327,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/push/vapid-key", ...authed, push.getVapidKey)
   app.post("/api/workspaces/:workspaceId/push/subscribe", ...authed, push.subscribe)
   app.post("/api/workspaces/:workspaceId/push/unsubscribe", ...authed, push.unsubscribe)
+  app.post("/api/workspaces/:workspaceId/push/test", ...authed, push.sendTest)
   // Non-workspace-scoped: cleans up all push subscriptions for a browser endpoint (used on logout)
   app.post("/api/push/cleanup-endpoint", auth, push.cleanupEndpoint)
 

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -985,4 +985,105 @@ describe("Push Notifications", () => {
       expect(remaining).toHaveLength(0)
     })
   })
+
+  describe("PushService.deliverTestPush", () => {
+    function createService() {
+      return new PushService({
+        pool,
+        vapidConfig: {
+          publicKey: "BM1RQ2UEVpAlbEgYOQ3bDrGAOrJGBmmh4_4UkmtGRzhi-5WPFmPuJbA6zv4kCp0iycvTaH6eveCXedCE0xSnZbk",
+          privateKey: "eHUfakWGHrS4ft0HiSGyhTOBCQJ9VAKWl4XK53qsjMg",
+          subject: "mailto:test@threa.app",
+        },
+        lookups: {
+          getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
+          getStreamType: async () => StreamTypes.CHANNEL,
+        },
+      })
+    }
+
+    test("returns zero attempted when user has no subscriptions", async () => {
+      const service = createService()
+      const result = await service.deliverTestPush(testWorkspaceId, testUserId)
+      expect(result).toEqual({ attempted: 0, failed: 0 })
+      expect(sendSpy).not.toHaveBeenCalled()
+    })
+
+    test("sends a test payload to every subscription regardless of session state", async () => {
+      const service = createService()
+
+      // Two subs, neither device has any session — normal delivery would skip these
+      // (session_expired path), but a test push should bypass that gating.
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/test-1",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d1",
+      })
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/test-2",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d2",
+      })
+
+      const result = await service.deliverTestPush(testWorkspaceId, testUserId)
+
+      expect(result).toEqual({ attempted: 2, failed: 0 })
+      expect(sendSpy).toHaveBeenCalledTimes(2)
+      const payload = JSON.parse(sendSpy.mock.calls[0]![1] as string)
+      expect(payload.data.kind).toBe("test")
+      expect(payload.data.workspaceId).toBe(testWorkspaceId)
+    })
+
+    test("counts failures and evicts subscriptions returning 410 Gone", async () => {
+      const service = createService()
+
+      const liveSub = await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/live",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d-live",
+      })
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/stale",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d-stale",
+      })
+
+      sendSpy.mockImplementation(async (sub: any) => {
+        if (sub.endpoint.endsWith("/stale")) {
+          throw Object.assign(new Error("Gone"), { statusCode: 410 })
+        }
+        return {} as any
+      })
+
+      const result = await service.deliverTestPush(testWorkspaceId, testUserId)
+
+      expect(result).toEqual({ attempted: 2, failed: 1 })
+      const remaining = await PushSubscriptionRepository.findByUserId(pool, testWorkspaceId, testUserId)
+      expect(remaining.map((s) => s.id)).toEqual([liveSub.id])
+    })
+
+    test("throws when push is not enabled on the server", async () => {
+      const service = new PushService({
+        pool,
+        vapidConfig: null,
+        lookups: {
+          getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
+          getStreamType: async () => StreamTypes.CHANNEL,
+        },
+      })
+      await expect(service.deliverTestPush(testWorkspaceId, testUserId)).rejects.toThrow(/not enabled/i)
+    })
+  })
 })

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { api, ApiError } from "./client"
+
+const originalFetch = globalThis.fetch
+
+function mockResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("apiFetch error parsing", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("hydrates ApiError from the canonical { error, code } shape emitted by the backend's errorHandler", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse(503, { error: "Push notifications are not enabled", code: "PUSH_DISABLED" })
+    )
+
+    const err = await api.get("/anything").catch((e) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(503)
+    expect((err as ApiError).code).toBe("PUSH_DISABLED")
+    expect((err as ApiError).message).toBe("Push notifications are not enabled")
+  })
+
+  it("falls back to a generic message when the body is missing fields", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}))
+    const err = (await api.get("/anything").catch((e) => e)) as ApiError
+    expect(err.code).toBe("UNKNOWN_ERROR")
+    expect(err.message).toBe("Request failed with status 500")
+  })
+
+  it("captures details when the handler ships them alongside error/code", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse(400, {
+        error: "Validation failed",
+        code: "VALIDATION_ERROR",
+        details: { fieldErrors: { endpoint: ["Required"] } },
+      })
+    )
+
+    const err = (await api.get("/anything").catch((e) => e)) as ApiError
+    expect(err.message).toBe("Validation failed")
+    expect(err.code).toBe("VALIDATION_ERROR")
+    expect(err.details).toEqual({ fieldErrors: { endpoint: ["Required"] } })
+  })
+})

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -24,18 +24,23 @@ describe("apiFetch error parsing", () => {
       mockResponse(503, { error: "Push notifications are not enabled", code: "PUSH_DISABLED" })
     )
 
-    const err = await api.get("/anything").catch((e) => e)
+    const err = (await api.get("/anything").catch((e) => e)) as ApiError
     expect(err).toBeInstanceOf(ApiError)
-    expect((err as ApiError).status).toBe(503)
-    expect((err as ApiError).code).toBe("PUSH_DISABLED")
-    expect((err as ApiError).message).toBe("Push notifications are not enabled")
+    expect(err).toMatchObject({
+      status: 503,
+      code: "PUSH_DISABLED",
+      message: "Push notifications are not enabled",
+    })
   })
 
   it("falls back to a generic message when the body is missing fields", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}))
     const err = (await api.get("/anything").catch((e) => e)) as ApiError
-    expect(err.code).toBe("UNKNOWN_ERROR")
-    expect(err.message).toBe("Request failed with status 500")
+    expect(err).toMatchObject({
+      status: 500,
+      code: "UNKNOWN_ERROR",
+      message: "Request failed with status 500",
+    })
   })
 
   it("captures details when the handler ships them alongside error/code", async () => {
@@ -48,8 +53,11 @@ describe("apiFetch error parsing", () => {
     )
 
     const err = (await api.get("/anything").catch((e) => e)) as ApiError
-    expect(err.message).toBe("Validation failed")
-    expect(err.code).toBe("VALIDATION_ERROR")
-    expect(err.details).toEqual({ fieldErrors: { endpoint: ["Required"] } })
+    expect(err).toMatchObject({
+      status: 400,
+      code: "VALIDATION_ERROR",
+      message: "Validation failed",
+      details: { fieldErrors: { endpoint: ["Required"] } },
+    })
   })
 })

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -15,13 +15,14 @@ export class ApiError extends Error {
   }
 }
 
-// Response type for error responses
+// Response type for error responses.
+// Canonical shape emitted by the backend's `errorHandler` middleware
+// (packages/backend-common/src/middleware/error-handler.ts) and matched by
+// inline handler responses: `{ error: "<message>", code?: "<CODE>" }`.
 interface ErrorResponse {
-  error?: {
-    code: string
-    message: string
-    details?: Record<string, unknown>
-  }
+  error?: string
+  code?: string
+  details?: Record<string, unknown>
 }
 
 /**
@@ -58,9 +59,9 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
   if (!response.ok) {
     throw new ApiError(
       response.status,
-      body.error?.code || "UNKNOWN_ERROR",
-      body.error?.message || `Request failed with status ${response.status}`,
-      body.error?.details
+      body.code || "UNKNOWN_ERROR",
+      body.error || `Request failed with status ${response.status}`,
+      body.details
     )
   }
 

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -55,8 +55,17 @@ function TestNotificationButton({ workspaceId }: { workspaceId: string }) {
 }
 
 function PushNotificationSection({ workspaceId }: { workspaceId: string }) {
-  const { permission, isSubscribed, optedOut, pushDisabledOnServer, requestPermission, unsubscribe } =
-    usePushNotifications(workspaceId)
+  const {
+    permission,
+    isSubscribed,
+    status,
+    error,
+    optedOut,
+    pushDisabledOnServer,
+    requestPermission,
+    unsubscribe,
+    retry,
+  } = usePushNotifications(workspaceId)
 
   return (
     <section className="space-y-3">
@@ -102,10 +111,36 @@ function PushNotificationSection({ workspaceId }: { workspaceId: string }) {
         </div>
       )}
       {permission === "granted" && !isSubscribed && !optedOut && pushDisabledOnServer && (
-        <p className="text-sm text-muted-foreground">Push notifications are not available on this server.</p>
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">Push notifications are not available on this server.</p>
+          <Button onClick={retry} variant="outline" size="sm">
+            Check again
+          </Button>
+        </div>
       )}
-      {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && (
+      {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "subscribing" && (
         <p className="text-sm text-muted-foreground">Subscribing to push notifications...</p>
+      )}
+      {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "error" && (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-sm text-destructive">Couldn't enable push notifications.</p>
+            {error && (
+              <p className="text-xs text-muted-foreground">
+                {error.message}
+                {error.code ? ` (${error.code})` : ""}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={retry} variant="outline" size="sm">
+              Retry
+            </Button>
+            <Button onClick={unsubscribe} variant="ghost" size="sm">
+              Stop trying for this device
+            </Button>
+          </div>
+        </div>
       )}
     </section>
   )

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useParams } from "react-router-dom"
 import { Bell, BellOff, CheckCircle2, Loader2, ServerCrash, TriangleAlert } from "lucide-react"
 import { Label } from "@/components/ui/label"
@@ -36,10 +36,33 @@ type TestStatus =
   | { kind: "ok"; delivered: number; attempted: number; failed: number }
   | { kind: "error"; message: string }
 
-function TestPushButton({ workspaceId, disabled }: { workspaceId: string; disabled?: boolean }) {
+function TestPushButton({ workspaceId }: { workspaceId: string }) {
   const [state, setState] = useState<TestStatus>({ kind: "idle" })
+  // Track the auto-reset timer so a second click clears any pending reset
+  // from the previous click — without this, a stale timer can fire mid-flight
+  // and clobber a "sending"/"ok" state with "idle".
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current)
+    },
+    []
+  )
+
+  function scheduleReset() {
+    if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current)
+    resetTimerRef.current = setTimeout(() => {
+      resetTimerRef.current = null
+      setState({ kind: "idle" })
+    }, 5000)
+  }
 
   async function sendTest() {
+    if (resetTimerRef.current !== null) {
+      clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = null
+    }
     setState({ kind: "sending" })
     try {
       // Backend-driven test: actually exercises the full delivery loop
@@ -57,7 +80,7 @@ function TestPushButton({ workspaceId, disabled }: { workspaceId: string; disabl
       const message = ApiError.isApiError(err) ? err.message : "Failed to send test"
       setState({ kind: "error", message })
     } finally {
-      setTimeout(() => setState({ kind: "idle" }), 5000)
+      scheduleReset()
     }
   }
 
@@ -80,7 +103,7 @@ function TestPushButton({ workspaceId, disabled }: { workspaceId: string; disabl
   }
 
   return (
-    <Button onClick={sendTest} variant="outline" size="sm" disabled={disabled || state.kind === "sending"}>
+    <Button onClick={sendTest} variant="outline" size="sm" disabled={state.kind === "sending"}>
       {state.kind === "sending" && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}
       {label}
     </Button>

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -220,16 +220,16 @@ function PushNotificationSection({ workspaceId }: { workspaceId: string }) {
           </Alert>
         )}
 
-        {permission === "granted" &&
-          !isSubscribed &&
-          !optedOut &&
-          !pushDisabledOnServer &&
-          status === "subscribing" && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span>Subscribing this device…</span>
-            </div>
-          )}
+        {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status !== "error" && (
+          // Covers both "subscribing" (active flow) and "idle" (fresh mount before
+          // the auto-subscribe effect has set status). Without the "idle" case the
+          // card body was empty whenever a fresh permission grant raced ahead of
+          // the first subscribe() call.
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Subscribing this device…</span>
+          </div>
+        )}
 
         {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "error" && (
           <Alert variant="destructive">
@@ -272,9 +272,10 @@ function resolveStatusInfo(args: {
   if (isSubscribed) return { label: "Enabled", variant: "default" }
   if (optedOut) return { label: "Off", variant: "outline" }
   if (pushDisabledOnServer) return { label: "Unavailable", variant: "outline" }
-  if (status === "subscribing") return { label: "Subscribing…", variant: "secondary" }
   if (status === "error") return { label: "Error", variant: "destructive" }
-  return { label: "Off", variant: "outline" }
+  // permission=granted, no other flag set → either "subscribing" or "idle"
+  // before the first subscribe() call. Either way we're trying, not Off.
+  return { label: "Subscribing…", variant: "secondary" }
 }
 
 export function NotificationsSettings() {

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react"
 import { useParams } from "react-router-dom"
+import { Bell, BellOff, CheckCircle2, Loader2, ServerCrash, TriangleAlert } from "lucide-react"
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ApiError, api } from "@/api/client"
 import { usePreferences } from "@/contexts"
 import { usePushNotifications } from "@/hooks/use-push-notifications"
 import { PREF_NOTIFICATION_LEVEL_OPTIONS, type PrefNotificationLevel } from "@threa/types"
@@ -20,37 +24,79 @@ const NOTIFICATION_DESCRIPTIONS: Record<PrefNotificationLevel, string> = {
   none: "Don't send any notifications",
 }
 
-const TEST_BUTTON_LABELS = { idle: "Test", sent: "Sent!", failed: "Failed" } as const
+interface TestPushResponse {
+  attempted: number
+  delivered: number
+  failed: number
+}
 
-function TestNotificationButton({ workspaceId }: { workspaceId: string }) {
-  const [label, setLabel] = useState<keyof typeof TEST_BUTTON_LABELS>("idle")
+type TestStatus =
+  | { kind: "idle" }
+  | { kind: "sending" }
+  | { kind: "ok"; delivered: number; attempted: number; failed: number }
+  | { kind: "error"; message: string }
+
+function TestPushButton({ workspaceId, disabled }: { workspaceId: string; disabled?: boolean }) {
+  const [state, setState] = useState<TestStatus>({ kind: "idle" })
 
   async function sendTest() {
+    setState({ kind: "sending" })
     try {
-      const registration = await navigator.serviceWorker?.ready
-      if (!registration) throw new Error("Service worker not available")
-
-      await registration.showNotification("Test notification", {
-        body: "If you can see this, push notifications are working!",
-        icon: "/threa-logo-192.png",
-        badge: "/threa-logo-192.png",
-        tag: "threa-test",
-        data: { workspaceId },
+      // Backend-driven test: actually exercises the full delivery loop
+      // (DB → web-push → device), not just the local SW path. The phone
+      // should receive the notification within a few seconds.
+      const result = await api.post<TestPushResponse>(`/api/workspaces/${workspaceId}/push/test`)
+      setState({
+        kind: "ok",
+        delivered: result.delivered,
+        attempted: result.attempted,
+        failed: result.failed,
       })
-
-      setLabel("sent")
     } catch (err) {
-      console.error("[Push] Test notification failed:", err)
-      setLabel("failed")
+      console.error("[Push] Test push failed:", err)
+      const message = ApiError.isApiError(err) ? err.message : "Failed to send test"
+      setState({ kind: "error", message })
     } finally {
-      setTimeout(() => setLabel("idle"), 3000)
+      setTimeout(() => setState({ kind: "idle" }), 5000)
     }
   }
 
+  let label: string
+  switch (state.kind) {
+    case "idle":
+      label = "Send test"
+      break
+    case "sending":
+      label = "Sending…"
+      break
+    case "ok":
+      if (state.attempted === 0) label = "No devices to test"
+      else if (state.failed === 0) label = `Sent to ${state.delivered} device${state.delivered === 1 ? "" : "s"}`
+      else label = `${state.delivered}/${state.attempted} delivered`
+      break
+    case "error":
+      label = state.message
+      break
+  }
+
   return (
-    <Button onClick={sendTest} variant="outline" size="sm">
-      {TEST_BUTTON_LABELS[label]}
+    <Button onClick={sendTest} variant="outline" size="sm" disabled={disabled || state.kind === "sending"}>
+      {state.kind === "sending" && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}
+      {label}
     </Button>
+  )
+}
+
+interface StatusInfo {
+  label: string
+  variant: "default" | "secondary" | "destructive" | "outline"
+}
+
+function PushStatusBadge({ info }: { info: StatusInfo }) {
+  return (
+    <Badge variant={info.variant} className="font-normal">
+      {info.label}
+    </Badge>
   )
 }
 
@@ -67,83 +113,145 @@ function PushNotificationSection({ workspaceId }: { workspaceId: string }) {
     retry,
   } = usePushNotifications(workspaceId)
 
+  const statusInfo = resolveStatusInfo({ permission, isSubscribed, status, optedOut, pushDisabledOnServer })
+
   return (
-    <section className="space-y-3">
-      <div>
-        <h3 className="text-sm font-medium">Push Notifications</h3>
-        <p className="text-sm text-muted-foreground">Get notified even when you're away from the app</p>
+    <section className="space-y-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
+          {isSubscribed ? <Bell className="h-4 w-4" /> : <BellOff className="h-4 w-4" />}
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium">Push notifications</h3>
+            <PushStatusBadge info={statusInfo} />
+          </div>
+          <p className="text-sm text-muted-foreground">Get notified on this device even when Threa isn't open.</p>
+        </div>
       </div>
-      {permission === "unsupported" && (
-        <p className="text-sm text-muted-foreground">Push notifications are not supported in this browser.</p>
-      )}
-      {permission === "denied" && (
-        <p className="text-sm text-muted-foreground">
-          Push notifications are blocked. Enable them in your browser settings to receive notifications.
-        </p>
-      )}
-      {permission === "default" && (
-        <div className="space-y-3">
+
+      <div className="rounded-lg border bg-card p-4">
+        {permission === "unsupported" && (
+          <p className="text-sm text-muted-foreground">Push notifications aren't supported in this browser.</p>
+        )}
+
+        {permission === "denied" && (
           <p className="text-sm text-muted-foreground">
-            Enable push notifications to get notified when you receive messages and mentions.
+            Notifications are blocked at the browser level. Open your browser's site settings and allow notifications
+            for Threa, then reload this page.
           </p>
-          <Button onClick={requestPermission} variant="outline" size="sm">
-            Enable push notifications
-          </Button>
-        </div>
-      )}
-      {permission === "granted" && isSubscribed && (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">Push notifications are enabled for this device.</p>
-          <div className="flex gap-2">
-            <Button onClick={unsubscribe} variant="outline" size="sm">
-              Disable push notifications
+        )}
+
+        {permission === "default" && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Allow notifications so messages and mentions can reach you when the app is closed.
+            </p>
+            <Button onClick={requestPermission} variant="default" size="sm">
+              <Bell className="mr-2 h-3.5 w-3.5" />
+              Enable push notifications
             </Button>
-            <TestNotificationButton workspaceId={workspaceId} />
           </div>
-        </div>
-      )}
-      {permission === "granted" && !isSubscribed && optedOut && (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">Push notifications are disabled for this device.</p>
-          <Button onClick={requestPermission} variant="outline" size="sm">
-            Enable push notifications
-          </Button>
-        </div>
-      )}
-      {permission === "granted" && !isSubscribed && !optedOut && pushDisabledOnServer && (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">Push notifications are not available on this server.</p>
-          <Button onClick={retry} variant="outline" size="sm">
-            Check again
-          </Button>
-        </div>
-      )}
-      {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "subscribing" && (
-        <p className="text-sm text-muted-foreground">Subscribing to push notifications...</p>
-      )}
-      {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "error" && (
-        <div className="space-y-3">
-          <div className="space-y-1">
-            <p className="text-sm text-destructive">Couldn't enable push notifications.</p>
-            {error && (
-              <p className="text-xs text-muted-foreground">
-                {error.message}
-                {error.code ? ` (${error.code})` : ""}
+        )}
+
+        {permission === "granted" && isSubscribed && (
+          <div className="space-y-3">
+            <div className="flex items-start gap-2 text-sm">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <p className="text-muted-foreground">
+                This device is subscribed. Use <span className="font-medium text-foreground">Send test</span> to verify
+                that your phone or other devices actually receive a push.
               </p>
-            )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <TestPushButton workspaceId={workspaceId} />
+              <Button onClick={unsubscribe} variant="outline" size="sm">
+                Disable for this device
+              </Button>
+            </div>
           </div>
-          <div className="flex gap-2">
-            <Button onClick={retry} variant="outline" size="sm">
-              Retry
-            </Button>
-            <Button onClick={unsubscribe} variant="ghost" size="sm">
-              Stop trying for this device
+        )}
+
+        {permission === "granted" && !isSubscribed && optedOut && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              You've turned off push for this device. Re-enable to start getting notifications again.
+            </p>
+            <Button onClick={requestPermission} variant="outline" size="sm">
+              <Bell className="mr-2 h-3.5 w-3.5" />
+              Re-enable
             </Button>
           </div>
-        </div>
-      )}
+        )}
+
+        {permission === "granted" && !isSubscribed && !optedOut && pushDisabledOnServer && (
+          <Alert>
+            <ServerCrash className="h-4 w-4" />
+            <AlertTitle>Not available on this server</AlertTitle>
+            <AlertDescription className="mt-1 space-y-3">
+              <p>The Threa server isn't configured to send push notifications.</p>
+              <Button onClick={retry} variant="outline" size="sm">
+                Check again
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {permission === "granted" &&
+          !isSubscribed &&
+          !optedOut &&
+          !pushDisabledOnServer &&
+          status === "subscribing" && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Subscribing this device…</span>
+            </div>
+          )}
+
+        {permission === "granted" && !isSubscribed && !optedOut && !pushDisabledOnServer && status === "error" && (
+          <Alert variant="destructive">
+            <TriangleAlert className="h-4 w-4" />
+            <AlertTitle>Couldn't enable push notifications</AlertTitle>
+            <AlertDescription className="mt-1 space-y-3">
+              {error && (
+                <p className="text-xs">
+                  {error.message}
+                  {error.code ? ` (${error.code})` : ""}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={retry} variant="outline" size="sm">
+                  Retry
+                </Button>
+                <Button onClick={unsubscribe} variant="ghost" size="sm">
+                  Stop trying for this device
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
     </section>
   )
+}
+
+function resolveStatusInfo(args: {
+  permission: ReturnType<typeof usePushNotifications>["permission"]
+  isSubscribed: boolean
+  status: ReturnType<typeof usePushNotifications>["status"]
+  optedOut: boolean
+  pushDisabledOnServer: boolean
+}): StatusInfo {
+  const { permission, isSubscribed, status, optedOut, pushDisabledOnServer } = args
+  if (permission === "unsupported") return { label: "Unsupported", variant: "outline" }
+  if (permission === "denied") return { label: "Blocked", variant: "destructive" }
+  if (permission === "default") return { label: "Off", variant: "outline" }
+  if (isSubscribed) return { label: "Enabled", variant: "default" }
+  if (optedOut) return { label: "Off", variant: "outline" }
+  if (pushDisabledOnServer) return { label: "Unavailable", variant: "outline" }
+  if (status === "subscribing") return { label: "Subscribing…", variant: "secondary" }
+  if (status === "error") return { label: "Error", variant: "destructive" }
+  return { label: "Off", variant: "outline" }
 }
 
 export function NotificationsSettings() {
@@ -156,7 +264,7 @@ export function NotificationsSettings() {
     <div className="space-y-6">
       <section className="space-y-3">
         <div>
-          <h3 className="text-sm font-medium">Notification Level</h3>
+          <h3 className="text-sm font-medium">Notification level</h3>
           <p className="text-sm text-muted-foreground">Choose when you want to be notified</p>
         </div>
         <RadioGroup

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -84,29 +84,45 @@ function TestPushButton({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  let label: string
-  switch (state.kind) {
-    case "idle":
-      label = "Send test"
-      break
-    case "sending":
-      label = "Sending…"
-      break
-    case "ok":
-      if (state.attempted === 0) label = "No devices to test"
-      else if (state.failed === 0) label = `Sent to ${state.delivered} device${state.delivered === 1 ? "" : "s"}`
-      else label = `${state.delivered}/${state.attempted} delivered`
-      break
-    case "error":
-      label = state.message
-      break
+  // Keep the button label fixed so a long backend message (e.g. "Push
+  // notifications are not enabled on this server") never blows out the layout
+  // — surface the message in an adjacent line instead.
+  let buttonLabel: string
+  if (state.kind === "sending") buttonLabel = "Sending…"
+  else if (state.kind === "error") buttonLabel = "Retry test"
+  else buttonLabel = "Send test"
+
+  let resultLine: { tone: "muted" | "destructive"; text: string } | null = null
+  if (state.kind === "ok") {
+    if (state.attempted === 0) {
+      resultLine = { tone: "muted", text: "No devices subscribed yet." }
+    } else if (state.failed === 0) {
+      resultLine = {
+        tone: "muted",
+        text: `Sent to ${state.delivered} device${state.delivered === 1 ? "" : "s"}.`,
+      }
+    } else {
+      resultLine = {
+        tone: "destructive",
+        text: `Delivered to ${state.delivered} of ${state.attempted} devices — ${state.failed} failed.`,
+      }
+    }
+  } else if (state.kind === "error") {
+    resultLine = { tone: "destructive", text: state.message }
   }
 
   return (
-    <Button onClick={sendTest} variant="outline" size="sm" disabled={state.kind === "sending"}>
-      {state.kind === "sending" && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}
-      {label}
-    </Button>
+    <div className="flex flex-col gap-1">
+      <Button onClick={sendTest} variant="outline" size="sm" disabled={state.kind === "sending"} className="self-start">
+        {state.kind === "sending" && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}
+        {buttonLabel}
+      </Button>
+      {resultLine && (
+        <p className={resultLine.tone === "destructive" ? "text-xs text-destructive" : "text-xs text-muted-foreground"}>
+          {resultLine.text}
+        </p>
+      )}
+    </div>
   )
 }
 

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -191,45 +191,55 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     setOptedOut(workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId)) === "1" : false)
   }, [workspaceId])
 
-  // Subscribe to push notifications
-  const subscribe = useCallback(
-    async (registration: ServiceWorkerRegistration) => {
-      if (!workspaceId) return
+  // Subscribe to push notifications. Owns the full flow including waiting for
+  // the service worker to be ready, so a hung SW activation is covered by the
+  // same 15s timeout as the subscribe handshake itself.
+  const subscribe = useCallback(async () => {
+    if (!workspaceId) return
 
-      setStatus("subscribing")
-      setError(null)
+    setStatus("subscribing")
+    setError(null)
 
-      // Hard timeout — without this, a hung fetch (e.g. suspended SW or stuck network)
-      // would leave the UI in "subscribing" forever.
-      let timeoutId: ReturnType<typeof setTimeout> | undefined
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => reject(new SubscribeTimeoutError()), SUBSCRIBE_TIMEOUT_MS)
-      })
+    // Hard timeout — covers both the serviceWorker.ready wait and the
+    // subscribe handshake. Without this, a never-resolving SW activation
+    // (mobile Firefox on a fresh domain, blocked SW install, etc.) leaves
+    // the UI in "subscribing" forever.
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new SubscribeTimeoutError()), SUBSCRIBE_TIMEOUT_MS)
+    })
 
-      try {
-        const result = await Promise.race([runSubscribeFlow(workspaceId, registration, vapidCacheRef), timeoutPromise])
+    try {
+      const result = await Promise.race([
+        (async () => {
+          if (!("serviceWorker" in navigator)) {
+            throw new Error("Service workers are not available in this browser")
+          }
+          const registration = await navigator.serviceWorker.ready
+          return runSubscribeFlow(workspaceId, registration, vapidCacheRef)
+        })(),
+        timeoutPromise,
+      ])
 
-        if (result.kind === "disabled-on-server") {
-          setIsSubscribed(false)
-          setPushDisabledOnServer(true)
-          setStatus("idle")
-          return
-        }
-
-        setPushDisabledOnServer(false)
-        setIsSubscribed(true)
-        setStatus("subscribed")
-      } catch (err) {
-        console.error("[Push] Failed to subscribe:", err)
+      if (result.kind === "disabled-on-server") {
         setIsSubscribed(false)
-        setError(toSubscriptionError(err))
-        setStatus("error")
-      } finally {
-        if (timeoutId !== undefined) clearTimeout(timeoutId)
+        setPushDisabledOnServer(true)
+        setStatus("idle")
+        return
       }
-    },
-    [workspaceId]
-  )
+
+      setPushDisabledOnServer(false)
+      setIsSubscribed(true)
+      setStatus("subscribed")
+    } catch (err) {
+      console.error("[Push] Failed to subscribe:", err)
+      setIsSubscribed(false)
+      setError(toSubscriptionError(err))
+      setStatus("error")
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+    }
+  }, [workspaceId])
 
   // Reset subscription state when permission is revoked or workspaceId changes
   useEffect(() => {
@@ -245,24 +255,14 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   useEffect(() => {
     if (permission !== "granted" || !workspaceId || optedOut) return
 
-    const doSubscribe = () => {
-      navigator.serviceWorker?.ready
-        .then(async (registration) => {
-          // Always call subscribe — it upserts on the backend, so it handles both
-          // new subscriptions and re-registering after pushsubscriptionchange events.
-          await subscribe(registration)
-        })
-        .catch((err) => {
-          console.error("[Push] Failed to check subscription:", err)
-          setError(toSubscriptionError(err))
-          setStatus("error")
-        })
-    }
-
-    doSubscribe()
+    // subscribe() owns the SW-ready wait and timeout, so callers don't need
+    // to gate on it themselves — they just kick off the flow.
+    void subscribe()
 
     // Re-register when the SW notifies us of a subscription change (avoids full page reload)
-    const handleSubscriptionChange = () => doSubscribe()
+    const handleSubscriptionChange = () => {
+      void subscribe()
+    }
     window.addEventListener("pushsubscriptionchanged", handleSubscriptionChange)
     return () => window.removeEventListener("pushsubscriptionchanged", handleSubscriptionChange)
   }, [permission, workspaceId, subscribe, optedOut])
@@ -318,8 +318,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       setPermission(result)
 
       if (result === "granted") {
-        const registration = await navigator.serviceWorker.ready
-        await subscribe(registration)
+        await subscribe()
       }
     } catch (err) {
       console.error("[Push] Failed to request permission:", err)
@@ -333,21 +332,9 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   // picked up without a full reload.
   const retry = useCallback(async () => {
     if (!workspaceId) return
-    try {
-      vapidCacheRef.current = null
-      setPushDisabledOnServer(false)
-      const registration = await navigator.serviceWorker?.ready
-      if (!registration) {
-        setError({ message: "Service worker is not available", code: "NO_SERVICE_WORKER" })
-        setStatus("error")
-        return
-      }
-      await subscribe(registration)
-    } catch (err) {
-      console.error("[Push] Retry failed:", err)
-      setError(toSubscriptionError(err))
-      setStatus("error")
-    }
+    vapidCacheRef.current = null
+    setPushDisabledOnServer(false)
+    await subscribe()
   }, [subscribe, workspaceId])
 
   return {

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -292,8 +292,11 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       setOptedOut(true)
       localStorage.setItem(pushOptOutKey(workspaceId), "1")
     } catch (err) {
+      // Failure surfaces only to the console — the "subscribed" UI doesn't
+      // render the error field, so setting it would just leak stale state
+      // into the next mount. If users hit this, a follow-up should add a
+      // toast (sonner is already wired in).
       console.error("[Push] Failed to unsubscribe:", err)
-      setError(toSubscriptionError(err))
     }
   }, [workspaceId])
 

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -1,8 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { DEVICE_KEY_LENGTH } from "@threa/types"
-import { api } from "@/api/client"
+import { ApiError, api } from "@/api/client"
 
 type PushPermission = NotificationPermission | "unsupported"
+
+/**
+ * Lifecycle of the workspace's push subscription:
+ * - `idle`        → not currently working; either pre-permission, opted-out, or disabled-on-server
+ * - `subscribing` → actively negotiating with browser + backend
+ * - `subscribed`  → browser registration confirmed and backend record stored
+ * - `error`       → last attempt failed; `error` field carries diagnostics; `retry()` to try again
+ */
+type SubscriptionStatus = "idle" | "subscribing" | "subscribed" | "error"
+
+interface PushSubscriptionError {
+  message: string
+  code?: string
+  status?: number
+}
 
 interface VapidConfig {
   vapidPublicKey: string | null
@@ -12,12 +27,42 @@ interface VapidConfig {
 interface UsePushNotificationsResult {
   permission: PushPermission
   isSubscribed: boolean
+  status: SubscriptionStatus
+  error: PushSubscriptionError | null
   /** True when the user has explicitly opted out of push for this workspace. */
   optedOut: boolean
   /** True when push is disabled on the backend (no VAPID keys configured). */
   pushDisabledOnServer: boolean
   requestPermission: () => Promise<void>
   unsubscribe: () => Promise<void>
+  /** Retry the subscription flow after a transient failure. */
+  retry: () => Promise<void>
+}
+
+/** Hard cap on the subscribe round-trip so a hung fetch never strands the UI in "subscribing". */
+const SUBSCRIBE_TIMEOUT_MS = 15_000
+
+class SubscribeTimeoutError extends Error {
+  constructor() {
+    super("Timed out while subscribing to push notifications")
+    this.name = "SubscribeTimeoutError"
+  }
+}
+
+function toSubscriptionError(err: unknown): PushSubscriptionError {
+  if (ApiError.isApiError(err)) {
+    return { message: err.message, code: err.code, status: err.status }
+  }
+  if (err instanceof SubscribeTimeoutError) {
+    return { message: err.message, code: "TIMEOUT" }
+  }
+  if (err instanceof DOMException) {
+    return { message: err.message || err.name, code: err.name }
+  }
+  if (err instanceof Error) {
+    return { message: err.message }
+  }
+  return { message: "Unknown error while subscribing to push notifications" }
 }
 
 /**
@@ -62,6 +107,71 @@ function pushOptOutKey(workspaceId: string): string {
   return `threa:push-opted-out:${workspaceId}`
 }
 
+type SubscribeOutcome = { kind: "subscribed" } | { kind: "disabled-on-server" }
+
+/**
+ * Runs the full subscribe handshake: fetch VAPID config, reconcile the browser
+ * subscription, and register it with the backend. Pure flow — all state
+ * transitions live in the caller.
+ */
+async function runSubscribeFlow(
+  workspaceId: string,
+  registration: ServiceWorkerRegistration,
+  vapidCacheRef: React.MutableRefObject<{ workspaceId: string; config: VapidConfig } | null>
+): Promise<SubscribeOutcome> {
+  // Cache VAPID config per workspace to avoid redundant fetches (key doesn't change)
+  let vapidPublicKey: string | null
+  let enabled: boolean
+  if (vapidCacheRef.current?.workspaceId === workspaceId) {
+    ;({ vapidPublicKey, enabled } = vapidCacheRef.current.config)
+  } else {
+    const config = await api.get<VapidConfig>(`/api/workspaces/${workspaceId}/push/vapid-key`)
+    vapidCacheRef.current = { workspaceId, config }
+    ;({ vapidPublicKey, enabled } = config)
+  }
+
+  if (!enabled || !vapidPublicKey) {
+    return { kind: "disabled-on-server" }
+  }
+
+  // Reuse existing browser subscription if its VAPID key matches the server's.
+  // If VAPID keys were rotated, unsubscribe the stale one and create a fresh subscription.
+  const expectedKey = urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer
+  let existing = await registration.pushManager.getSubscription()
+  if (existing) {
+    const existingKey = existing.options.applicationServerKey
+    if (!existingKey || !arrayBuffersEqual(existingKey, expectedKey)) {
+      await existing.unsubscribe()
+      existing = null
+    }
+  }
+  const subscription =
+    existing ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: expectedKey,
+    }))
+
+  const json = subscription.toJSON()
+  if (!json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error("Browser returned a push subscription without encryption keys")
+  }
+
+  const deviceKey = await getDeviceKey()
+
+  // Backend upsert (ON CONFLICT DO UPDATE) — idempotent for re-registrations
+  // toJSON().keys returns base64url encoding, matching web-push library's contract
+  await api.post(`/api/workspaces/${workspaceId}/push/subscribe`, {
+    endpoint: subscription.endpoint,
+    p256dh: json.keys.p256dh,
+    auth: json.keys.auth,
+    deviceKey,
+    userAgent: navigator.userAgent,
+  })
+
+  return { kind: "subscribed" }
+}
+
 export function usePushNotifications(workspaceId: string | undefined): UsePushNotificationsResult {
   const [permission, setPermission] = useState<PushPermission>(() => {
     if (typeof window === "undefined" || !("Notification" in window)) return "unsupported"
@@ -72,6 +182,8 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId)) === "1" : false
   )
   const [pushDisabledOnServer, setPushDisabledOnServer] = useState(false)
+  const [status, setStatus] = useState<SubscriptionStatus>("idle")
+  const [error, setError] = useState<PushSubscriptionError | null>(null)
   const vapidCacheRef = useRef<{ workspaceId: string; config: VapidConfig } | null>(null)
 
   // Re-sync opt-out state when workspaceId changes (initializer only runs on mount)
@@ -84,61 +196,36 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     async (registration: ServiceWorkerRegistration) => {
       if (!workspaceId) return
 
-      try {
-        // Cache VAPID config per workspace to avoid redundant fetches (key doesn't change)
-        let vapidPublicKey: string | null
-        let enabled: boolean
-        if (vapidCacheRef.current?.workspaceId === workspaceId) {
-          ;({ vapidPublicKey, enabled } = vapidCacheRef.current.config)
-        } else {
-          const config = await api.get<VapidConfig>(`/api/workspaces/${workspaceId}/push/vapid-key`)
-          vapidCacheRef.current = { workspaceId, config }
-          ;({ vapidPublicKey, enabled } = config)
-        }
+      setStatus("subscribing")
+      setError(null)
 
-        if (!enabled || !vapidPublicKey) {
+      // Hard timeout — without this, a hung fetch (e.g. suspended SW or stuck network)
+      // would leave the UI in "subscribing" forever.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new SubscribeTimeoutError()), SUBSCRIBE_TIMEOUT_MS)
+      })
+
+      try {
+        const result = await Promise.race([runSubscribeFlow(workspaceId, registration, vapidCacheRef), timeoutPromise])
+
+        if (result.kind === "disabled-on-server") {
           setIsSubscribed(false)
           setPushDisabledOnServer(true)
+          setStatus("idle")
           return
         }
+
         setPushDisabledOnServer(false)
-
-        // Reuse existing browser subscription if its VAPID key matches the server's.
-        // If VAPID keys were rotated, unsubscribe the stale one and create a fresh subscription.
-        const expectedKey = urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer
-        let existing = await registration.pushManager.getSubscription()
-        if (existing) {
-          const existingKey = existing.options.applicationServerKey
-          if (!existingKey || !arrayBuffersEqual(existingKey, expectedKey)) {
-            await existing.unsubscribe()
-            existing = null
-          }
-        }
-        const subscription =
-          existing ??
-          (await registration.pushManager.subscribe({
-            userVisibleOnly: true,
-            applicationServerKey: expectedKey,
-          }))
-
-        const json = subscription.toJSON()
-        if (!json.keys?.p256dh || !json.keys?.auth) return
-
-        const deviceKey = await getDeviceKey()
-
-        // Backend upsert (ON CONFLICT DO UPDATE) — idempotent for re-registrations
-        // toJSON().keys returns base64url encoding, matching web-push library's contract
-        await api.post(`/api/workspaces/${workspaceId}/push/subscribe`, {
-          endpoint: subscription.endpoint,
-          p256dh: json.keys.p256dh,
-          auth: json.keys.auth,
-          deviceKey,
-          userAgent: navigator.userAgent,
-        })
-
         setIsSubscribed(true)
+        setStatus("subscribed")
       } catch (err) {
         console.error("[Push] Failed to subscribe:", err)
+        setIsSubscribed(false)
+        setError(toSubscriptionError(err))
+        setStatus("error")
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId)
       }
     },
     [workspaceId]
@@ -148,6 +235,8 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   useEffect(() => {
     if (permission !== "granted" || !workspaceId) {
       setIsSubscribed(false)
+      setStatus("idle")
+      setError(null)
     }
   }, [permission, workspaceId])
 
@@ -165,6 +254,8 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
         })
         .catch((err) => {
           console.error("[Push] Failed to check subscription:", err)
+          setError(toSubscriptionError(err))
+          setStatus("error")
         })
     }
 
@@ -194,12 +285,15 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       }
 
       setIsSubscribed(false)
+      setStatus("idle")
+      setError(null)
 
       // Persist opt-out so auto-subscribe doesn't re-register on next mount
       setOptedOut(true)
       localStorage.setItem(pushOptOutKey(workspaceId), "1")
     } catch (err) {
       console.error("[Push] Failed to unsubscribe:", err)
+      setError(toSubscriptionError(err))
     }
   }, [workspaceId])
 
@@ -226,8 +320,42 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       }
     } catch (err) {
       console.error("[Push] Failed to request permission:", err)
+      setError(toSubscriptionError(err))
+      setStatus("error")
     }
   }, [subscribe, workspaceId])
 
-  return { permission, isSubscribed, optedOut, pushDisabledOnServer, requestPermission, unsubscribe }
+  // Manually retry the subscription flow after a failure. Clears the cached VAPID
+  // config so a server config change (e.g. push enabled after env vars added) is
+  // picked up without a full reload.
+  const retry = useCallback(async () => {
+    if (!workspaceId) return
+    try {
+      vapidCacheRef.current = null
+      setPushDisabledOnServer(false)
+      const registration = await navigator.serviceWorker?.ready
+      if (!registration) {
+        setError({ message: "Service worker is not available", code: "NO_SERVICE_WORKER" })
+        setStatus("error")
+        return
+      }
+      await subscribe(registration)
+    } catch (err) {
+      console.error("[Push] Retry failed:", err)
+      setError(toSubscriptionError(err))
+      setStatus("error")
+    }
+  }, [subscribe, workspaceId])
+
+  return {
+    permission,
+    isSubscribed,
+    status,
+    error,
+    optedOut,
+    pushDisabledOnServer,
+    requestPermission,
+    unsubscribe,
+    retry,
+  }
 }

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -113,11 +113,16 @@ type SubscribeOutcome = { kind: "subscribed" } | { kind: "disabled-on-server" }
  * Runs the full subscribe handshake: fetch VAPID config, reconcile the browser
  * subscription, and register it with the backend. Pure flow — all state
  * transitions live in the caller.
+ *
+ * Accepts an `AbortSignal` so a stale attempt (newer subscribe() superseded it)
+ * can cancel its in-flight HTTP work instead of running to completion in the
+ * background and racing the newer attempt's terminal state.
  */
 async function runSubscribeFlow(
   workspaceId: string,
   registration: ServiceWorkerRegistration,
-  vapidCacheRef: React.MutableRefObject<{ workspaceId: string; config: VapidConfig } | null>
+  vapidCacheRef: React.RefObject<{ workspaceId: string; config: VapidConfig } | null>,
+  signal: AbortSignal
 ): Promise<SubscribeOutcome> {
   // Cache VAPID config per workspace to avoid redundant fetches (key doesn't change)
   let vapidPublicKey: string | null
@@ -125,7 +130,7 @@ async function runSubscribeFlow(
   if (vapidCacheRef.current?.workspaceId === workspaceId) {
     ;({ vapidPublicKey, enabled } = vapidCacheRef.current.config)
   } else {
-    const config = await api.get<VapidConfig>(`/api/workspaces/${workspaceId}/push/vapid-key`)
+    const config = await api.get<VapidConfig>(`/api/workspaces/${workspaceId}/push/vapid-key`, { signal })
     vapidCacheRef.current = { workspaceId, config }
     ;({ vapidPublicKey, enabled } = config)
   }
@@ -161,13 +166,17 @@ async function runSubscribeFlow(
 
   // Backend upsert (ON CONFLICT DO UPDATE) — idempotent for re-registrations
   // toJSON().keys returns base64url encoding, matching web-push library's contract
-  await api.post(`/api/workspaces/${workspaceId}/push/subscribe`, {
-    endpoint: subscription.endpoint,
-    p256dh: json.keys.p256dh,
-    auth: json.keys.auth,
-    deviceKey,
-    userAgent: navigator.userAgent,
-  })
+  await api.post(
+    `/api/workspaces/${workspaceId}/push/subscribe`,
+    {
+      endpoint: subscription.endpoint,
+      p256dh: json.keys.p256dh,
+      auth: json.keys.auth,
+      deviceKey,
+      userAgent: navigator.userAgent,
+    },
+    { signal }
+  )
 
   return { kind: "subscribed" }
 }
@@ -185,17 +194,34 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   const [status, setStatus] = useState<SubscriptionStatus>("idle")
   const [error, setError] = useState<PushSubscriptionError | null>(null)
   const vapidCacheRef = useRef<{ workspaceId: string; config: VapidConfig } | null>(null)
+  // Per-attempt generation counter: every subscribe() bumps this and gates its
+  // terminal state writes on it. Combined with the per-attempt AbortController,
+  // a stale attempt (e.g. an early auto-subscribe whose timeout fires after the
+  // user already retried successfully) can't clobber the latest result.
+  const subscribeGenRef = useRef(0)
+  const currentAbortRef = useRef<AbortController | null>(null)
 
   // Re-sync opt-out state when workspaceId changes (initializer only runs on mount)
   useEffect(() => {
     setOptedOut(workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId)) === "1" : false)
   }, [workspaceId])
 
+  // Cancel any in-flight subscribe on unmount
+  useEffect(() => () => currentAbortRef.current?.abort(), [])
+
   // Subscribe to push notifications. Owns the full flow including waiting for
   // the service worker to be ready, so a hung SW activation is covered by the
   // same 15s timeout as the subscribe handshake itself.
   const subscribe = useCallback(async () => {
     if (!workspaceId) return
+
+    // Bump generation and abort any prior attempt's HTTP work so it stops
+    // racing toward a terminal state we no longer want.
+    const gen = ++subscribeGenRef.current
+    const isLatest = () => subscribeGenRef.current === gen
+    currentAbortRef.current?.abort()
+    const controller = new AbortController()
+    currentAbortRef.current = controller
 
     setStatus("subscribing")
     setError(null)
@@ -216,10 +242,12 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
             throw new Error("Service workers are not available in this browser")
           }
           const registration = await navigator.serviceWorker.ready
-          return runSubscribeFlow(workspaceId, registration, vapidCacheRef)
+          return runSubscribeFlow(workspaceId, registration, vapidCacheRef, controller.signal)
         })(),
         timeoutPromise,
       ])
+
+      if (!isLatest()) return
 
       if (result.kind === "disabled-on-server") {
         setIsSubscribed(false)
@@ -232,12 +260,16 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       setIsSubscribed(true)
       setStatus("subscribed")
     } catch (err) {
+      // Aborted attempts are expected when a newer subscribe() superseded us
+      // — don't log or write state for them.
+      if (controller.signal.aborted || !isLatest()) return
       console.error("[Push] Failed to subscribe:", err)
       setIsSubscribed(false)
       setError(toSubscriptionError(err))
       setStatus("error")
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId)
+      if (currentAbortRef.current === controller) currentAbortRef.current = null
     }
   }, [workspaceId])
 

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -296,6 +296,8 @@ interface PushData {
   messages?: Array<{ authorName?: string; contentPreview?: string }>
   /** Backend-driven action: "clear" dismisses notifications for the stream; "session_expired" prompts re-login. */
   action?: "clear" | "session_expired"
+  /** Payload kind: "test" is sent by the in-app diagnostic to verify end-to-end delivery. */
+  kind?: "test"
 }
 
 self.addEventListener("push", (event) => {
@@ -322,6 +324,23 @@ self.addEventListener("push", (event) => {
       ]).then(([streamNotifs, mentionNotifs]) => {
         for (const n of [...streamNotifs, ...mentionNotifs]) n.close()
       })
+    )
+    return
+  }
+
+  // Test push from the in-app diagnostic. Always display, even with the app
+  // focused — the user explicitly asked to verify the delivery loop, so
+  // suppressing it would defeat the purpose.
+  if (data.kind === "test") {
+    event.waitUntil(
+      self.registration.showNotification("Threa test notification", {
+        body: "Push delivery is working — you should see this on every subscribed device.",
+        icon: "/threa-logo-192.png",
+        badge: "/threa-logo-192.png",
+        tag: "threa-test",
+        renotify: true,
+        data: { ...data, kind: "test" },
+      } as ExtendedNotificationOptions)
     )
     return
   }


### PR DESCRIPTION
The push subscription flow swallowed every failure in a silent catch,
so any network blip, timed-out fetch, or browser-side error would leave
the Notification settings UI permanently displaying "Subscribing to
push notifications...". The hook also offered no way to retry without
a full page reload.

This change replaces the implicit boolean state with an explicit
status machine (idle | subscribing | subscribed | error), exposes a
typed `error` field with the API code/message, and adds a `retry()`
callback. A 15s timeout guards against a hung fetch never resolving.

The settings UI now distinguishes "subscribing" from "errored" and
gives the user a Retry button plus a "Stop trying for this device"
escape hatch that opts them out so the auto-subscribe loop quiets
down.

https://claude.ai/code/session_01SiXF9oEEn1ncVfPGmLYn2t