### PR TITLE
feat(ariadne): window discuss-thread context to ~50 messages around the focal anchor

### DIFF
--- a/apps/backend/src/features/agents/context-bag/intents/discuss-thread.test.ts
+++ b/apps/backend/src/features/agents/context-bag/intents/discuss-thread.test.ts
@@ -23,8 +23,14 @@ describe("DiscussThreadIntent config", () => {
     expect(DiscussThreadIntent.supportedKinds).toContain(ContextRefKinds.THREAD)
   })
 
-  test("sets a positive inline character threshold so tiny threads inline and big ones summarize", () => {
-    expect(DiscussThreadIntent.inlineCharThreshold).toBeGreaterThan(0)
+  test("disables summarisation by setting an infinite inline-char threshold", () => {
+    // The resolver windows the source stream to ~50 messages before render,
+    // so we'd rather inline that windowed slice verbatim than summarise it.
+    // The summariser code path is intentionally kept around for future
+    // intents — but it must stay dormant for DISCUSS_THREAD. Regression
+    // guard: a finite threshold here would silently re-enable summarisation
+    // for slices with long messages, the exact failure mode we just fixed.
+    expect(DiscussThreadIntent.inlineCharThreshold).toBe(Number.POSITIVE_INFINITY)
   })
 
   test("system preamble instructs the model to treat the delta as authoritative", () => {
@@ -62,5 +68,41 @@ describe("inline-vs-summarize strategy (via renderStable)", () => {
     })
     expect(out).toContain("Messages (chronological)")
     expect(out).toContain("[msg_a]")
+  })
+
+  test("splits inline messages around the focal anchor and marks it with a chevron", () => {
+    // Render with an empty preamble so the assertion below isn't fooled by
+    // the preamble's own mention of focal-message machinery — we want to
+    // pin the *renderer's* output for this case.
+    const out = renderStable({
+      preamble: "",
+      inlineItems: [
+        msg({ messageId: "msg_a" }),
+        msg({ messageId: "msg_b", contentMarkdown: "the focal one" }),
+        msg({ messageId: "msg_c" }),
+      ],
+      refLabel: "thread:stream_x",
+      focalMessageId: "msg_b",
+    })
+    expect(out).toContain("Messages before the focused message")
+    expect(out).toContain("Focused message (the message the user opened this discussion from)")
+    expect(out).toContain("Messages after the focused message")
+    expect(out).toContain("► [msg_b]")
+    // Without a focal we'd see the un-split heading; with a focal we should not.
+    expect(out).not.toContain("Messages (chronological)")
+  })
+
+  test("falls back to the chronological list when the focal id isn't in the inline window", () => {
+    // Empty preamble — see comment in the previous test for why.
+    const out = renderStable({
+      preamble: "",
+      inlineItems: [msg({ messageId: "msg_a" }), msg({ messageId: "msg_b" })],
+      refLabel: "thread:stream_x",
+      // Caller asked for a focal that isn't present — render plain list rather
+      // than fabricate a focal section the model will get confused by.
+      focalMessageId: "msg_phantom",
+    })
+    expect(out).toContain("Messages (chronological)")
+    expect(out).not.toContain("Focused message (the message the user opened this discussion from)")
   })
 })

--- a/apps/backend/src/features/agents/context-bag/intents/discuss-thread.ts
+++ b/apps/backend/src/features/agents/context-bag/intents/discuss-thread.ts
@@ -6,17 +6,40 @@ import type { IntentConfig } from "../types"
  * thread loaded as context. Intent config drives the system-prompt preamble
  * and the inline-vs-summary threshold.
  *
+ * Summarisation is disabled here (`inlineCharThreshold: Infinity`) — the
+ * resolver windows the source stream to ~50 messages before this point, so
+ * we'd rather inline the windowed slice verbatim than summarise it. Keeping
+ * the threshold knob (instead of removing the summariser code path) leaves
+ * the door open for a later "summarise the surrounding history" mode without
+ * resurrecting plumbing we deleted.
+ *
  * The preamble explicitly tells the model that the volatile "Since last turn"
  * section overrides the main body — small prompt cost, but required to make
  * the append-only stable region safe when source messages are edited.
  */
 export const DiscussThreadIntent: IntentConfig = {
   intent: ContextIntents.DISCUSS_THREAD,
-  inlineCharThreshold: 8_000,
+  inlineCharThreshold: Number.POSITIVE_INFINITY,
   supportedKinds: [ContextRefKinds.THREAD],
   systemPreamble: [
-    "You are loaded with a private side-conversation about an existing thread.",
-    "The thread's messages are attached below as context so you can answer questions about it.",
+    "You are loaded with a private side-conversation about an existing source stream.",
+    "Below is a windowed slice of that stream's messages — roughly the 50 messages",
+    "around the user's anchor point, NOT the full history.",
+    "",
+    "When a `Focused message` section appears, the user opened this discussion from",
+    "that specific message — treat it as the most likely subject of their first",
+    "question. Messages above it are the lead-up; messages below it are what",
+    "followed. The focal message is also marked inline with a `►` chevron.",
+    "",
+    "When there is no focused message, the user opened this discussion as a",
+    "/discuss-with-ariadne slash command on the source stream itself — assume they",
+    "want to talk about the recent activity in that stream overall.",
+    "",
+    "If you need messages outside the window — earlier history, a related stream,",
+    "or a specific older message — call the `get_stream_messages` tool with the",
+    "source stream id (visible in the `## Context source` heading as",
+    "`thread:<stream_id>`). Do this BEFORE asking the user to paste content; they",
+    "expect you to fetch what you need.",
     "",
     "Internal ids for messages appear in the context as `[msg_…]` tags. They are for your",
     "grounding only — NEVER include them in your user-facing response. Refer to messages by",

--- a/apps/backend/src/features/agents/context-bag/precompute-service.test.ts
+++ b/apps/backend/src/features/agents/context-bag/precompute-service.test.ts
@@ -36,7 +36,7 @@ describe("precomputeRefSummaries", () => {
     mock.restore()
   })
 
-  it("returns status=inline and writes no summary when content fits under the intent threshold", async () => {
+  it("returns status=inline and writes no summary for a small DISCUSS_THREAD slice", async () => {
     stubWithClient()
     spyOn(ThreadResolver, "assertAccess").mockResolvedValue(undefined)
     spyOn(ThreadResolver, "fetch").mockResolvedValue({
@@ -47,6 +47,7 @@ describe("precomputeRefSummaries", () => {
       ],
       fingerprint: "fp_small",
       tailMessageId: "msg_1",
+      focalMessageId: null,
     })
     const upsert = spyOn(SummaryRepository, "upsert")
     const find = spyOn(SummaryRepository, "find")
@@ -68,71 +69,29 @@ describe("precomputeRefSummaries", () => {
     expect(ai.generateText).not.toHaveBeenCalled()
   })
 
-  it("returns status=ready and upserts a summary when content exceeds the inline threshold", async () => {
+  it("never summarises DISCUSS_THREAD even with very large windows (summariser disabled for the intent)", async () => {
+    // Windowing in the resolver caps the slice to ~50 messages, but if the
+    // user pastes huge messages the inline character count can still get
+    // arbitrarily large. Summarisation is disabled regardless — the intent
+    // sets `inlineCharThreshold` to Infinity so Ariadne always sees the raw
+    // windowed messages, never a summary. Locks in the new behavior so a
+    // future tweak to the threshold doesn't silently re-enable the summary
+    // path that was overwhelming her.
     stubWithClient()
     spyOn(ThreadResolver, "assertAccess").mockResolvedValue(undefined)
-    // 10 × 1000 chars = 10,000, well over the 8000 threshold.
     spyOn(ThreadResolver, "fetch").mockResolvedValue({
-      items: makeItems(10, 1000),
-      inputs: Array.from({ length: 10 }, (_, i) => ({
+      items: makeItems(50, 1000), // 50,000 chars — would have tripped the old 8k threshold
+      inputs: Array.from({ length: 50 }, (_, i) => ({
         messageId: `msg_${i}`,
         contentFingerprint: `f${i}`,
         editedAt: null,
         deleted: false,
       })),
       fingerprint: "fp_big",
-      tailMessageId: "msg_9",
+      tailMessageId: "msg_49",
+      focalMessageId: null,
     })
-    spyOn(SummaryRepository, "find").mockResolvedValue(null)
-    const upsert = spyOn(SummaryRepository, "upsert").mockResolvedValue({
-      id: "cs_1",
-      workspaceId: "ws_1",
-      refKind: ContextRefKinds.THREAD,
-      refKey: "thread:stream_src",
-      fingerprint: "fp_big",
-      inputs: [],
-      summaryText: "generated summary",
-      model: "openrouter:openai/gpt-5.4-nano",
-      createdAt: new Date(),
-    })
-
-    const ai = makeAi()
-    const refs: ContextRef[] = [{ kind: ContextRefKinds.THREAD, streamId: "stream_src" }]
-    const results = await precomputeRefSummaries(
-      { pool: {} as any, ai },
-      { workspaceId: "ws_1", userId: "usr_1", intent: ContextIntents.DISCUSS_THREAD, refs }
-    )
-
-    expect(results[0].status).toBe("ready")
-    expect(ai.generateText).toHaveBeenCalledTimes(1)
-    expect(upsert).toHaveBeenCalledTimes(1)
-  })
-
-  it("reuses a cached summary when the fingerprint already has a row (no AI call)", async () => {
-    stubWithClient()
-    spyOn(ThreadResolver, "assertAccess").mockResolvedValue(undefined)
-    spyOn(ThreadResolver, "fetch").mockResolvedValue({
-      items: makeItems(10, 1000),
-      inputs: Array.from({ length: 10 }, (_, i) => ({
-        messageId: `msg_${i}`,
-        contentFingerprint: `f${i}`,
-        editedAt: null,
-        deleted: false,
-      })),
-      fingerprint: "fp_cached",
-      tailMessageId: "msg_9",
-    })
-    spyOn(SummaryRepository, "find").mockResolvedValue({
-      id: "cs_cached",
-      workspaceId: "ws_1",
-      refKind: ContextRefKinds.THREAD,
-      refKey: "thread:stream_src",
-      fingerprint: "fp_cached",
-      inputs: [],
-      summaryText: "warm summary",
-      model: "openrouter:openai/gpt-5.4-nano",
-      createdAt: new Date(),
-    })
+    const find = spyOn(SummaryRepository, "find")
     const upsert = spyOn(SummaryRepository, "upsert")
 
     const ai = makeAi()
@@ -142,9 +101,10 @@ describe("precomputeRefSummaries", () => {
       { workspaceId: "ws_1", userId: "usr_1", intent: ContextIntents.DISCUSS_THREAD, refs }
     )
 
-    expect(results[0].status).toBe("ready")
+    expect(results[0].status).toBe("inline")
     expect(ai.generateText).not.toHaveBeenCalled()
     expect(upsert).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
   })
 
   it("propagates access errors from the resolver (INV-8 boundary)", async () => {
@@ -193,12 +153,14 @@ describe("precomputeRefSummaries", () => {
         inputs: [{ messageId: "msg_a", contentFingerprint: "fa", editedAt: null, deleted: false }],
         fingerprint: "fp_a",
         tailMessageId: "msg_a",
+        focalMessageId: null,
       })
       .mockResolvedValueOnce({
         items: makeItems(1, 50),
         inputs: [{ messageId: "msg_b", contentFingerprint: "fb", editedAt: null, deleted: false }],
         fingerprint: "fp_b",
         tailMessageId: "msg_b",
+        focalMessageId: null,
       })
 
     const ai = makeAi()

--- a/apps/backend/src/features/agents/context-bag/precompute-service.ts
+++ b/apps/backend/src/features/agents/context-bag/precompute-service.ts
@@ -76,7 +76,7 @@ export async function precomputeRefSummaries(
       }
       const resolver = getResolver(ref.kind)
       await resolver.assertAccess(db, ref, userId, workspaceId)
-      const part = await resolver.fetch(db, ref)
+      const part = await resolver.fetch(db, ref, { intent })
       out.push({ ref, ...part })
     }
     return out

--- a/apps/backend/src/features/agents/context-bag/render.ts
+++ b/apps/backend/src/features/agents/context-bag/render.ts
@@ -8,6 +8,13 @@ export interface StableRenderInput {
   /** When present, the stable body is the cached summary (large-thread case). */
   summaryText?: string
   refLabel: string
+  /**
+   * The id of the message the discussion is anchored on (the user clicked
+   * "Discuss with Ariadne" on it). When present and found in `inlineItems`,
+   * the renderer splits the inline list into "Messages before" / "Focused
+   * message" / "Messages after" sections and marks the focal with `►`.
+   */
+  focalMessageId?: string | null
 }
 
 /**
@@ -22,9 +29,29 @@ export function renderStable(input: StableRenderInput): string {
   if (input.summaryText) {
     parts.push("", "Summary (cached):", input.summaryText.trim())
   } else if (input.inlineItems && input.inlineItems.length > 0) {
-    parts.push("", "Messages (chronological):")
-    for (const item of input.inlineItems) {
-      parts.push(formatInlineMessage(item))
+    const focalIdx =
+      input.focalMessageId != null ? input.inlineItems.findIndex((i) => i.messageId === input.focalMessageId) : -1
+
+    if (focalIdx < 0) {
+      parts.push("", "Messages (chronological):")
+      for (const item of input.inlineItems) {
+        parts.push(formatInlineMessage(item))
+      }
+    } else {
+      const before = input.inlineItems.slice(0, focalIdx)
+      const focal = input.inlineItems[focalIdx]
+      const after = input.inlineItems.slice(focalIdx + 1)
+
+      if (before.length > 0) {
+        parts.push("", `Messages before the focused message (${before.length}, chronological):`)
+        for (const item of before) parts.push(formatInlineMessage(item))
+      }
+      parts.push("", "Focused message (the message the user opened this discussion from):")
+      parts.push(formatInlineMessage(focal, { focal: true }))
+      if (after.length > 0) {
+        parts.push("", `Messages after the focused message (${after.length}, chronological):`)
+        for (const item of after) parts.push(formatInlineMessage(item))
+      }
     }
   } else {
     parts.push("", "(no messages in source thread yet)")
@@ -33,10 +60,14 @@ export function renderStable(input: StableRenderInput): string {
   return parts.join("\n")
 }
 
-function formatInlineMessage(item: RenderableMessage): string {
+function formatInlineMessage(item: RenderableMessage, options?: { focal?: boolean }): string {
   const ts = item.createdAt
   const edited = item.editedAt ? ` (edited ${item.editedAt})` : ""
-  return `- [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}`
+  // `►` marks the focal message inline so the model has a redundant cue
+  // alongside the section header. Bullet stays a simple dash everywhere
+  // else for prompt-cache stability across non-focal renders.
+  const bullet = options?.focal ? "►" : "-"
+  return `${bullet} [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}`
 }
 
 export interface DeltaRenderInput {

--- a/apps/backend/src/features/agents/context-bag/resolve.ts
+++ b/apps/backend/src/features/agents/context-bag/resolve.ts
@@ -86,7 +86,7 @@ export async function resolveBagForStream(
         continue
       }
       const resolver = getResolver(ref.kind)
-      const part = await resolver.fetch(db, ref)
+      const part = await resolver.fetch(db, ref, { intent: bag.intent })
       resolveds.push({ ref, ...part })
     }
 
@@ -130,6 +130,7 @@ export async function resolveBagForStream(
       inlineItems: summaryText ? undefined : resolved.items,
       summaryText,
       refLabel: refKey,
+      focalMessageId: resolved.focalMessageId,
     })
     stableParts.push(stable)
 

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -471,4 +471,73 @@ describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
     // expect the full surrounding slice instead.
     expect(result.items.map((i) => i.messageId)).toEqual(["msg_a", "msg_b", "msg_focal", "msg_c", "msg_d"])
   })
+
+  it("does NOT keep focal state when origin matches the prepended thread root but isn't in the windowed slice", async () => {
+    // Regression: a user clicking "Discuss with Ariadne" on a thread's root
+    // message produces `originMessageId === root.id`. The root lives in the
+    // PARENT stream, so `findSurrounding(root.id, threadStream)` returns
+    // nothing and we fall through to the recent-tail slice. The thread root
+    // is then prepended to `items` for context — but that prepend is a
+    // rendering convenience, not "the origin is in the window." Marking the
+    // root as focal in this case would synthesize a `Focused message`
+    // section even though the discuss-window fallback path was taken.
+    spyOn(StreamRepository, "findById").mockResolvedValue(
+      makeStream({ id: "stream_thread", type: "thread", parentMessageId: "msg_root" })
+    )
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue([])
+    spyOn(MessageRepository, "list").mockResolvedValue([seq("msg_reply_1", 1), seq("msg_reply_2", 2)])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(
+      makeMessage({ id: "msg_root", streamId: "stream_root", contentMarkdown: "the originating message" })
+    )
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_thread", originMessageId: "msg_root" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    // Root is still rendered (prepend convenience) but focal is null because
+    // the origin isn't in the discuss window — we want the chronological
+    // render path here, not the focal-section split.
+    expect(result.items.map((i) => i.messageId)).toEqual(["msg_root", "msg_reply_1", "msg_reply_2"])
+    expect(result.focalMessageId).toBeNull()
+  })
+
+  it("falls back to the stream tail (not a deletion-skewed slice) when the focal message is soft-deleted", async () => {
+    // Regression: `MessageRepository.findSurrounding` looks the target's
+    // sequence up without a `deleted_at` filter but excludes the target
+    // itself from its neighbor query. So a soft-deleted focal produces
+    // `surrounding.length > 0, targetIdx < 0`. Slicing the surrounding
+    // result here would give a window skewed around the deletion point;
+    // the user's anchor is unrecoverable so we return the recent-tail
+    // (slash-command shape) instead. CodeRabbit caught this — the comment
+    // said "no-focal fallback" but the code was lying to us.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+
+    // Surrounding query found the deleted target's neighbors (so the array
+    // is non-empty) but the target row itself was filtered out by the
+    // `deleted_at IS NULL` clause on the neighbor query.
+    const neighborsAroundDeletion = [seq("msg_neighbor_a", 100), seq("msg_neighbor_b", 102)]
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue(neighborsAroundDeletion)
+    const list = spyOn(MessageRepository, "list").mockResolvedValue([
+      seq("msg_recent_1", 500),
+      seq("msg_recent_2", 501),
+    ])
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source", originMessageId: "msg_deleted" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    // Recent tail, not the deletion-skewed window.
+    expect(list).toHaveBeenCalledWith(expect.anything(), "stream_source", { limit: 50 })
+    expect(result.items.map((i) => i.messageId)).toEqual(["msg_recent_1", "msg_recent_2"])
+    expect(result.focalMessageId).toBeNull()
+  })
 })

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { ContextRefKinds, Visibilities } from "@threa/types"
+import { ContextIntents, ContextRefKinds, Visibilities } from "@threa/types"
 import { ThreadResolver } from "./thread-resolver"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, StreamMemberRepository } from "../../../streams"
@@ -326,5 +326,149 @@ describe("ThreadResolver.fetch", () => {
     })
 
     expect(result.items.map((i) => i.messageId)).toEqual(["msg_b", "msg_c"])
+  })
+})
+
+describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
+  // The discuss-thread intent narrows the source stream to ~50 messages
+  // around an anchor instead of dumping the full tail. These tests pin the
+  // shape of that window — failure mode this guards against is "Ariadne
+  // gets the entire stream and can't tell what the user actually wants to
+  // discuss", which is what motivated the change.
+  afterEach(() => mock.restore())
+
+  function seq(id: string, n: number): any {
+    return makeMessage({ id, sequence: BigInt(n) })
+  }
+
+  it("centers a 50-message window around the focal message when the stream is large enough", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+
+    // Simulate `findSurrounding` returning 50 before + focal + 50 after.
+    const before = Array.from({ length: 50 }, (_, i) => seq(`msg_b${i}`, i + 1))
+    const focal = seq("msg_focal", 51)
+    const after = Array.from({ length: 50 }, (_, i) => seq(`msg_a${i}`, i + 52))
+    const surrounding = [...before, focal, ...after]
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue(surrounding)
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source", originMessageId: "msg_focal" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    // 50-total window: 24 before + focal + 25 after (or 25/24, depending on
+    // halving — what matters is total === 50 and focal is included).
+    expect(result.items).toHaveLength(50)
+    expect(result.focalMessageId).toBe("msg_focal")
+    const ids = result.items.map((i) => i.messageId)
+    expect(ids).toContain("msg_focal")
+    expect(ids[0]).toMatch(/^msg_b/)
+    expect(ids[ids.length - 1]).toMatch(/^msg_a/)
+  })
+
+  it("rebalances toward the long side when the focal sits near the start of the stream", async () => {
+    // Focal at index 5: only 5 messages before it, plenty after. We should
+    // see all 5 before + focal + 44 after, not 5 before + focal + 24 after.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+
+    const before = Array.from({ length: 5 }, (_, i) => seq(`msg_b${i}`, i + 1))
+    const focal = seq("msg_focal", 6)
+    const after = Array.from({ length: 50 }, (_, i) => seq(`msg_a${i}`, i + 7))
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue([...before, focal, ...after])
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source", originMessageId: "msg_focal" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    expect(result.items).toHaveLength(50)
+    const ids = result.items.map((i) => i.messageId)
+    expect(ids.filter((id) => id.startsWith("msg_b"))).toHaveLength(5)
+    expect(ids.filter((id) => id.startsWith("msg_a"))).toHaveLength(44)
+    expect(ids).toContain("msg_focal")
+  })
+
+  it("falls back to the most recent 50 when there is no originMessageId (slash command)", async () => {
+    // No focal: this is the `/discuss-with-ariadne` path. We should NOT call
+    // findSurrounding, just take the tail.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+    const findSurrounding = spyOn(MessageRepository, "findSurrounding")
+    const list = spyOn(MessageRepository, "list").mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => seq(`msg_${i}`, i + 1))
+    )
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    expect(findSurrounding).not.toHaveBeenCalled()
+    expect(list).toHaveBeenCalledWith(expect.anything(), "stream_source", { limit: 50 })
+    expect(result.items).toHaveLength(50)
+    expect(result.focalMessageId).toBeNull()
+  })
+
+  it("drops the focal flag when the originMessageId can't be resolved in the source stream", async () => {
+    // Origin id is stale or points to a different stream. `findSurrounding`
+    // returns nothing; we fall back to the recent-tail slice and emit a null
+    // focal so the renderer doesn't fabricate a `Focused message` section.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue([])
+    spyOn(MessageRepository, "list").mockResolvedValue([seq("msg_x", 1)])
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source", originMessageId: "msg_unknown" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    expect(result.focalMessageId).toBeNull()
+    expect(result.items.map((i) => i.messageId)).toEqual(["msg_x"])
+  })
+
+  it("ignores fromMessageId/toMessageId in the discuss path (windowing replaces the legacy slice)", async () => {
+    // The legacy from/to anchors are still respected for non-DISCUSS_THREAD
+    // intents but the discuss flow uses the centered window instead. Mixing
+    // them would double-slice; this test pins that we take the window and
+    // drop the anchors.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+
+    const focal = seq("msg_focal", 10)
+    const surrounding = [seq("msg_a", 8), seq("msg_b", 9), focal, seq("msg_c", 11), seq("msg_d", 12)]
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue(surrounding)
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      {
+        kind: ContextRefKinds.THREAD,
+        streamId: "stream_source",
+        originMessageId: "msg_focal",
+        fromMessageId: "msg_b",
+        toMessageId: "msg_c",
+      },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    // If anchors had been honored we'd see only msg_b..msg_c (3 items). We
+    // expect the full surrounding slice instead.
+    expect(result.items.map((i) => i.messageId)).toEqual(["msg_a", "msg_b", "msg_focal", "msg_c", "msg_d"])
   })
 })

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -1,5 +1,5 @@
 import type { Querier } from "../../../../db"
-import { ContextIntents, ContextRefKinds, type ContextIntent, type ContextRef } from "@threa/types"
+import { ContextIntents, ContextRefKinds, type ContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import type { Message } from "../../../messaging"
 import { MessageRepository } from "../../../messaging"

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -1,6 +1,7 @@
 import type { Querier } from "../../../../db"
-import { ContextRefKinds, type ContextRef } from "@threa/types"
+import { ContextIntents, ContextRefKinds, type ContextIntent, type ContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
+import type { Message } from "../../../messaging"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, checkStreamAccess } from "../../../streams"
 import { resolveActorNames } from "../../actor-names"
@@ -10,6 +11,16 @@ import type { RenderableMessage, Resolver, SummaryInput } from "../types"
 type ThreadRef = Extract<ContextRef, { kind: typeof ContextRefKinds.THREAD }>
 
 const MAX_FETCH = 500
+
+/**
+ * Total messages we include when DISCUSS_THREAD windows the source stream.
+ * Tuned for "Ariadne can read the whole window without losing the plot" —
+ * larger windows quickly drown the focal message in unrelated chatter, which
+ * is exactly the failure mode this windowing is supposed to fix. If the user
+ * needs more, Ariadne can call `get_stream_messages` to pull additional
+ * history into a tool result.
+ */
+const DISCUSS_WINDOW_TOTAL = 50
 
 /**
  * Thread resolver: materializes a thread/scratchpad/channel reference into the
@@ -44,17 +55,26 @@ export const ThreadResolver: Resolver<ThreadRef> = {
     }
   },
 
-  async fetch(db, ref) {
+  async fetch(db, ref, options) {
     const stream = await StreamRepository.findById(db, ref.streamId)
     if (!stream) {
       throw new HttpError("Context source stream not found", { status: 404, code: "CONTEXT_SOURCE_NOT_FOUND" })
     }
 
-    const messages = await MessageRepository.list(db, ref.streamId, { limit: MAX_FETCH })
+    // DISCUSS_THREAD takes a narrow, focused window instead of dumping the
+    // whole tail. Other intents keep the legacy fetch-then-anchor path (and
+    // can opt into windowing later by passing their own intent here).
+    const useDiscussWindow = options?.intent === ContextIntents.DISCUSS_THREAD
+    const messages = useDiscussWindow
+      ? await fetchDiscussWindow(db, ref)
+      : await MessageRepository.list(db, ref.streamId, { limit: MAX_FETCH })
 
     // Apply optional anchoring. `fromMessageId`/`toMessageId` bound the slice
     // by sequence so the bag can pin down a specific range of the thread.
-    const anchored = await applyAnchors(db, messages, ref)
+    // The discuss-window path already returns a centered slice, so anchors
+    // are skipped there — they're a different slicing primitive that the
+    // discuss flow doesn't use (and can't combine with cleanly).
+    const anchored = useDiscussWindow ? messages : await applyAnchors(db, messages, ref)
 
     // Always prepend the thread's root message when the source is a thread —
     // the reply chain is unintelligible without the message that spawned it.
@@ -88,13 +108,82 @@ export const ThreadResolver: Resolver<ThreadRef> = {
     const fingerprint = fingerprintInputs(inputs)
     const tail = items[items.length - 1]
 
+    // The focal message is only meaningful when it actually shows up in the
+    // window — if the user pasted/typed an originMessageId that points
+    // somewhere we couldn't fetch (different stream, soft-deleted, etc.)
+    // we drop the focal rather than letting the renderer flag a phantom.
+    const focalMessageId =
+      useDiscussWindow && ref.originMessageId && items.some((i) => i.messageId === ref.originMessageId)
+        ? ref.originMessageId
+        : null
+
     return {
       items,
       inputs,
       fingerprint,
       tailMessageId: tail?.messageId ?? null,
+      focalMessageId,
     }
   },
+}
+
+/**
+ * Fetch the DISCUSS_THREAD window: ~50 messages centered on `originMessageId`,
+ * or the most recent ~50 messages when there's no focal (slash-command entry
+ * point). Rebalances when the focal is near the top or bottom of the stream
+ * so the window stays at full size whenever possible — e.g. focal at index 5
+ * with 200 messages after returns 5 before + focal + 44 after rather than
+ * leaving 19 slots empty.
+ */
+async function fetchDiscussWindow(db: Querier, ref: ThreadRef): Promise<Message[]> {
+  if (!ref.originMessageId) {
+    // No focal: return the most recent N messages (chronological order).
+    return MessageRepository.list(db, ref.streamId, { limit: DISCUSS_WINDOW_TOTAL })
+  }
+
+  // Fetch generously on both sides so we can rebalance below without a second
+  // round-trip. `findSurrounding` filters soft-deletes and returns
+  // chronological order with the target included.
+  const surrounding = await MessageRepository.findSurrounding(
+    db,
+    ref.originMessageId,
+    ref.streamId,
+    DISCUSS_WINDOW_TOTAL,
+    DISCUSS_WINDOW_TOTAL
+  )
+  if (surrounding.length === 0) {
+    // Origin doesn't resolve in this stream (wrong id, deleted, different
+    // stream). Fall back to the most-recent slice so the user still gets a
+    // useful context — matching the slash-command shape.
+    return MessageRepository.list(db, ref.streamId, { limit: DISCUSS_WINDOW_TOTAL })
+  }
+
+  const targetIdx = surrounding.findIndex((m) => m.id === ref.originMessageId)
+  if (targetIdx < 0) {
+    // Defensive: target should always be in the surrounding slice when
+    // present. Treat as no-focal fallback.
+    return surrounding.slice(-DISCUSS_WINDOW_TOTAL)
+  }
+
+  const beforeAvailable = targetIdx
+  const afterAvailable = surrounding.length - 1 - targetIdx
+  const halfBefore = Math.floor((DISCUSS_WINDOW_TOTAL - 1) / 2)
+  const halfAfter = DISCUSS_WINDOW_TOTAL - 1 - halfBefore
+
+  // Pick balanced halves first, then push leftover capacity from the short
+  // side onto the long side so the window stays at DISCUSS_WINDOW_TOTAL when
+  // possible.
+  let takeBefore = Math.min(beforeAvailable, halfBefore)
+  let takeAfter = Math.min(afterAvailable, halfAfter)
+  const remaining = DISCUSS_WINDOW_TOTAL - 1 - takeBefore - takeAfter
+  if (remaining > 0) {
+    const extraAfter = Math.min(remaining, afterAvailable - takeAfter)
+    takeAfter += extraAfter
+    const extraBefore = Math.min(remaining - extraAfter, beforeAvailable - takeBefore)
+    takeBefore += extraBefore
+  }
+
+  return surrounding.slice(targetIdx - takeBefore, targetIdx + takeAfter + 1)
 }
 
 async function applyAnchors<T extends { id: string; sequence: bigint; streamId?: string }>(

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -108,12 +108,15 @@ export const ThreadResolver: Resolver<ThreadRef> = {
     const fingerprint = fingerprintInputs(inputs)
     const tail = items[items.length - 1]
 
-    // The focal message is only meaningful when it actually shows up in the
-    // window — if the user pasted/typed an originMessageId that points
-    // somewhere we couldn't fetch (different stream, soft-deleted, etc.)
-    // we drop the focal rather than letting the renderer flag a phantom.
+    // The focal message is only meaningful when it actually shows up inside
+    // the windowed slice. We check `messages` (the discuss window) rather
+    // than `items` (which has the thread root prepended): if the user
+    // clicked on a thread root, `findSurrounding` won't locate it inside
+    // the thread stream and we'll have fallen through to the recent-tail
+    // path — even though the prepended root will land in `items`, that's
+    // not "the origin is in the window," so don't fabricate a focal section.
     const focalMessageId =
-      useDiscussWindow && ref.originMessageId && items.some((i) => i.messageId === ref.originMessageId)
+      useDiscussWindow && ref.originMessageId && messages.some((m) => m.id === ref.originMessageId)
         ? ref.originMessageId
         : null
 
@@ -160,9 +163,15 @@ async function fetchDiscussWindow(db: Querier, ref: ThreadRef): Promise<Message[
 
   const targetIdx = surrounding.findIndex((m) => m.id === ref.originMessageId)
   if (targetIdx < 0) {
-    // Defensive: target should always be in the surrounding slice when
-    // present. Treat as no-focal fallback.
-    return surrounding.slice(-DISCUSS_WINDOW_TOTAL)
+    // The target's sequence resolved (so `findSurrounding` returned its
+    // neighbors) but the target row itself is missing from the slice. The
+    // common cause is a soft-deleted focal: `findSurrounding` looks the
+    // sequence up without a `deleted_at` filter, but its neighbor query
+    // does, so a tombstoned target produces surrounding-without-target.
+    // Slicing `surrounding` here would give a window skewed around the
+    // deletion point; the slash-command tail is more honest — the user's
+    // anchor is unrecoverable, fall back to "what's recent in this stream."
+    return MessageRepository.list(db, ref.streamId, { limit: DISCUSS_WINDOW_TOTAL })
   }
 
   const beforeAvailable = targetIdx

--- a/apps/backend/src/features/agents/context-bag/types.ts
+++ b/apps/backend/src/features/agents/context-bag/types.ts
@@ -61,13 +61,30 @@ export interface ResolvedRef {
   /** SHA-256 over the canonical `inputs` manifest. */
   fingerprint: string
   tailMessageId: string | null
+  /**
+   * The id of the message the discussion is anchored on (the user clicked
+   * "Discuss with Ariadne" on it). The renderer marks this message with a
+   * focal-message chevron and splits the inline list around it. Null when
+   * the bag has no focal — e.g. `/discuss-with-ariadne` slash command on a
+   * whole stream — or when the focal id falls outside the windowed slice.
+   */
+  focalMessageId: string | null
+}
+
+/**
+ * Options threaded through to a resolver. The intent drives intent-specific
+ * fetch behavior — e.g. DISCUSS_THREAD windows the source stream around the
+ * `originMessageId` instead of dumping the whole tail.
+ */
+export interface ResolverFetchOptions {
+  intent: ContextIntent
 }
 
 export interface Resolver<TRef extends ContextRef = ContextRef> {
   readonly kind: TRef["kind"]
   canonicalKey(ref: TRef): string
   assertAccess(db: Querier, ref: TRef, userId: string, workspaceId: string): Promise<void>
-  fetch(db: Querier, ref: TRef): Promise<Omit<ResolvedRef, "ref">>
+  fetch(db: Querier, ref: TRef, options?: ResolverFetchOptions): Promise<Omit<ResolvedRef, "ref">>
 }
 
 /**


### PR DESCRIPTION
## Problem

"Discuss with Ariadne" was loading the **entire source stream** into Ariadne's context every time, which made the feature noticeably worse than it could be:

- The focal message — the one the user actually clicked on — got drowned in unrelated chatter and Ariadne struggled to tell what the user wanted to discuss.
- For any non-trivial stream the bag tripped the 8 000-char inline threshold, so Ariadne saw a **summary** of the messages instead of the messages themselves. That was the worst case: she'd answer about a recap rather than the source material.
- The slash-command path (`/discuss-with-ariadne`) had the same issue — no anchor, full-stream dump.

The user feedback was concrete: shrink the slice to ~50 messages, anchor the conversation on the focused message, and disable summarisation for now.

## Solution

Window the source stream **server-side in the resolver** for the `DISCUSS_THREAD` intent. Frontend doesn't change — the bag still carries `originMessageId` (cosmetic deep-link); the windowing happens at fetch time, not bag-creation time, so it stays fresh as new messages arrive.

### How it works

```
Button on message ──► bag.refs[0].originMessageId = msg_xyz
                           │
                           ▼
   resolver.fetch(ref, { intent: DISCUSS_THREAD })
                           │
                           ▼
   findSurrounding(originMessageId, 50, 50) ──► up to 101 msgs
                           │
                           ▼
   center-trim to 50: 24 before + focal + 25 after
   (rebalance toward long side when focal is near an edge)
                           │
                           ▼
   render: split into "Messages before / Focused / Messages after"
           prefix focal line with `►`
```

Slash-command path (no `originMessageId`) skips `findSurrounding` and just takes the most recent 50 via `MessageRepository.list`. Stale or wrong-stream `originMessageId` falls back to recent-tail with `focalMessageId: null` so the renderer doesn't fabricate a phantom focal section.

### Key design decisions

**1. Window in the resolver, not the frontend builder**

The frontend already passes `originMessageId` through the bag. Computing the window at fetch time (rather than baking `fromMessageId`/`toMessageId` into the bag at creation) means the slice tracks live source-stream activity — new messages flow into the after-side as the conversation continues. This matches how the existing diff/delta machinery expects to behave.

**2. Resolver is now intent-aware via `{ intent }` options**

Added an optional `ResolverFetchOptions` parameter so the resolver can apply intent-specific behavior. Other intents (none today) keep the legacy fetch-then-anchor path. The alternative — wiring intent-specific logic in `resolve.ts` — leaks intent semantics into the orchestration layer; making the resolver intent-aware keeps the windowing decision colocated with the data fetch.

**3. Disable summarisation, keep the code**

Set `inlineCharThreshold` to `Number.POSITIVE_INFINITY` rather than ripping out the summariser. Future intents may still want it, and a regression test pins this so a future tweak to the threshold can't silently re-enable summarisation for `DISCUSS_THREAD`.

**4. Rebalancing toward the long side**

Naïve 25+25 leaves the window short when the focal sits near the start or end of the stream. The trim algorithm pushes leftover capacity from the short side onto the long side: focal at index 5 with 200 messages after returns 5 before + focal + 44 after, not 5 before + focal + 24 after. Tested explicitly.

**5. `►` chevron + section split, not just one or the other**

The model gets a redundant cue: the `Focused message` heading **and** an inline `►` prefix on the focal line. Either alone could be missed in a long context; together they're hard to overlook.

**6. Conversations feature: not used**

Considered using `conversations` (`ConversationRepository.findByMessageIds`) as boundary candidates for the window. Decided against for v1: conversations aren't exposed to the frontend, `messageIds` grows over time via `array_append` (so the boundary isn't stable), and the active/completed lifecycle is fuzzy. Surrounding-50 is a much cleaner mental model. Easy to layer in later as a "snap window edges to conversation boundaries" enhancement once we know what we want.

**7. "Fetch more" anchor = `get_stream_messages` tool**

The user asked for "a strong anchor for Ariadne to fetch more if she feels the need for it." The `get_stream_messages` tool is already enabled on Ariadne's persona (per `20260110223232_ariadne_workspace_tools.sql`), so the preamble points her at that tool with the source stream id from the `## Context source` heading. No new tool plumbing required.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/context-bag/types.ts` | Added `focalMessageId` to `ResolvedRef`; added `ResolverFetchOptions` with `intent`; extended `Resolver.fetch` signature with optional options. |
| `apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts` | Implemented `fetchDiscussWindow` (centered 50-message slice + rebalancing, slash-command fallback, stale-origin fallback). Resolver now reads `options.intent` and routes `DISCUSS_THREAD` through the window path. From/to anchors are bypassed on the discuss path. |
| `apps/backend/src/features/agents/context-bag/render.ts` | Added optional `focalMessageId` to `StableRenderInput`. When the focal exists in `inlineItems`, the renderer splits into "Messages before / Focused message / Messages after" sections and prefixes the focal line with `►`. Falls back to the chronological list otherwise. |
| `apps/backend/src/features/agents/context-bag/intents/discuss-thread.ts` | `inlineCharThreshold` → `Number.POSITIVE_INFINITY` (summarisation disabled). Preamble rewritten to (a) explain the windowed slice, (b) describe the `Focused message` section + `►` chevron, (c) point at `get_stream_messages` for fetching outside the window. |
| `apps/backend/src/features/agents/context-bag/resolve.ts` | Pass `bag.intent` to `resolver.fetch`; pass `resolved.focalMessageId` to `renderStable`. |
| `apps/backend/src/features/agents/context-bag/precompute-service.ts` | Pass `intent` to `resolver.fetch`. |
| `apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts` | New `DISCUSS_THREAD windowing` describe block: 5 tests covering centered window, rebalancing, slash-command path, stale-origin fallback, and "from/to anchors are bypassed in the discuss path." |
| `apps/backend/src/features/agents/context-bag/intents/discuss-thread.test.ts` | Replaced "positive threshold" test with `Infinity` regression guard; added focal-section render tests (split + chevron) and a "phantom focal id falls back to chronological list" test. |
| `apps/backend/src/features/agents/context-bag/precompute-service.test.ts` | Replaced two summary-path tests with a single "never summarises DISCUSS_THREAD" regression guard. Added `focalMessageId` to all resolver-stub fixtures. |

## Test plan

- [x] `bun run typecheck` (full monorepo) — green
- [x] `bun run test:unit` (backend) — 1050 / 1050 passing
- [x] `bun run test` (frontend) — 1461 / 1461 passing
- [x] All new unit tests for windowing, rebalancing, fallbacks, render split, and summarisation-disabled
- [ ] Manual: trigger "Discuss with Ariadne" from a message context menu in a long stream → verify Ariadne references the focal message in her first turn, and that her context window only contains ~50 messages
- [ ] Manual: trigger via `/discuss-with-ariadne` slash command on a stream → verify Ariadne discusses the recent activity overall, no focal section
- [ ] Manual: trigger from a message at position 5 in a stream of 200 → verify the window is 5 before + focal + 44 after (rebalanced)
- [ ] Manual: edit a message inside the window → verify the `## Since last turn` block surfaces the edit on the next turn

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9tN3PqDmm1uRJq2ob74fF)_