### PR TITLE
fix(frontend): register service worker early to fix push subscribe timeouts

### DIFF
--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -263,6 +263,9 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       // Aborted attempts are expected when a newer subscribe() superseded us
       // — don't log or write state for them.
       if (controller.signal.aborted || !isLatest()) return
+      if (err instanceof SubscribeTimeoutError) {
+        controller.abort()
+      }
       console.error("[Push] Failed to subscribe:", err)
       setIsSubscribed(false)
       setError(toSubscriptionError(err))

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -21,12 +21,14 @@ navigator.serviceWorker?.addEventListener("message", (event) => {
   }
 })
 
-// Register the service worker with updateViaCache: 'none' so the browser always
-// byte-checks sw.js against the network instead of using the HTTP cache. This
-// prevents stale SW scripts from keeping old precache manifests alive indefinitely.
+// Register as soon as the main bundle runs — before React effects that call
+// `navigator.serviceWorker.ready` (push subscribe). Deferring to `window` "load"
+// can delay activation until all subresources finish; a slow page then races the
+// 15s push subscribe timeout. Google's SW guidance also recommends registering early.
+// updateViaCache: 'none' forces a network byte-check of sw.js instead of HTTP cache.
 if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js", { scope: "/", updateViaCache: "none" }).catch(() => {})
+  navigator.serviceWorker.register("/sw.js", { scope: "/", updateViaCache: "none" }).catch((err) => {
+    console.error("[SW] Registration failed — push and offline updates will not work:", err)
   })
 }
 


### PR DESCRIPTION
## Problem

Push subscription in production was hitting the client-side **15s** cap (`SubscribeTimeoutError`) when opening **Settings → Notifications**, and users stopped receiving push notifications.

The subscribe flow waits on `navigator.serviceWorker.ready` before calling `GET …/push/vapid-key` and `POST …/push/subscribe`. Service worker registration was deferred to **`window` `"load"`**, which can fire very late on a heavy page (or never complete successfully if registration fails silently). In those cases `ready` stays pending long enough to lose the race with the push timeout, so the backend never records a subscription.

## Solution

1. **Register `/sw.js` as soon as `main.tsx` runs** (same `updateViaCache: "none"` as before), so activation is no longer tied to full page load.
2. **Log SW registration failures** instead of an empty `.catch`, so deploy or caching issues show up clearly in DevTools.
3. On **`SubscribeTimeoutError`**, **abort** the per-attempt `AbortController` so in-flight fetches that honor `signal` are cancelled.

### Key design decisions

**1. Early registration vs. longer timeout**

Early registration matches common PWA guidance, fixes the root timing race, and avoids masking slow pages by stretching the timeout.

**2. Abort on timeout**

Minor cleanup: avoids orphaned requests after the UI has already surfaced a timeout.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/main.tsx` | Register SW immediately; log registration errors |
| `apps/frontend/src/hooks/use-push-notifications.ts` | Abort controller when subscribe times out |

## Test plan

- [x] `lint-staged` / pre-commit (eslint + monorepo typecheck) passed on commit
- [ ] After deploy: open Settings → Notifications with notifications already allowed; confirm no `SubscribeTimeoutError` and push status shows subscribed
- [ ] Optional: Network tab — `sw.js` 200, `vapid-key` + `subscribe` complete under timeout

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
