### PR TITLE
fix(push): preserve existing subscription until new one is confirmed

### DIFF
--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -140,13 +140,16 @@ async function runSubscribeFlow(
   }
 
   // Reuse existing browser subscription if its VAPID key matches the server's.
-  // If VAPID keys were rotated, unsubscribe the stale one and create a fresh subscription.
+  // If VAPID keys were rotated, create the fresh subscription FIRST, then
+  // clean up the stale one — so a hung or failed subscribe() doesn't destroy
+  // the only working subscription and strand the user with no push delivery.
   const expectedKey = urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer
   let existing = await registration.pushManager.getSubscription()
+  let staleSubscription: PushSubscription | null = null
   if (existing) {
     const existingKey = existing.options.applicationServerKey
     if (!existingKey || !arrayBuffersEqual(existingKey, expectedKey)) {
-      await existing.unsubscribe()
+      staleSubscription = existing
       existing = null
     }
   }
@@ -156,6 +159,13 @@ async function runSubscribeFlow(
       userVisibleOnly: true,
       applicationServerKey: expectedKey,
     }))
+
+  // Clean up the stale subscription only after the new one is confirmed.
+  // Guard against browsers that return the same subscription despite a
+  // different applicationServerKey (dedup by endpoint).
+  if (staleSubscription && subscription.endpoint !== staleSubscription.endpoint) {
+    staleSubscription.unsubscribe().catch(() => {})
+  }
 
   const json = subscription.toJSON()
   if (!json.keys?.p256dh || !json.keys?.auth) {


### PR DESCRIPTION
## Problem

Push notification subscription times out (15s) and existing push delivery stops working. This happens when the browser has a push subscription with VAPID key K1 but the server now uses K2 (key rotation, or browser reinstalled from backup).

The root cause is in `runSubscribeFlow`: when the VAPID key mismatches, the code **unsubscribes the old browser subscription BEFORE creating a new one**. If `pushManager.subscribe()` then hangs (push service unreachable from the device, network blip, FCM/APNs throttling), the old subscription is already destroyed and the user is stranded with no working subscription — no push delivery, and the subscribe flow times out.

The timeout error surfaced 3 consecutive times in the console because each retry attempt calls `pushManager.subscribe()` which queues behind the still-pending first call, timing out again after 15s.

## Solution

**Don't destroy the old subscription until the new one is confirmed.** Instead of:

```
existing.unsubscribe()          // destroy old (dangerous: subscribe may fail)
pushManager.subscribe(key2)     // create new (may hang)
```

The flow now:

```
mark old as staleSubscription   // remember to clean up later
pushManager.subscribe(key2)     // create new FIRST (may hang, old intact)
if success: unsubscribe(stale)  // cleanup old only on success
```

### Guard against browser dedup

Some browsers may return the same subscription despite a different `applicationServerKey` (dedup by endpoint). The cleanup guard checks `subscription.endpoint !== staleSubscription.endpoint` to avoid unsubscribing the subscription we just confirmed. Failed `unsubscribe()` calls are caught so cleanup errors cannot break the flow.

### Edge cases

- **No existing subscription**: `staleSubscription` stays null, `subscribe()` called directly. No cleanup needed.
- **Matching VAPID keys**: `existing` is reused, no `subscribe()` call, no cleanup.
- **`pushManager.subscribe()` hangs**: old subscription preserved, user still receives push via the old key. Timeout error shown in UI with Retry button.
- **`pushManager.subscribe()` throws**: old subscription preserved, error propagated to UI.
- **Concurrent `subscribe()` calls**: protected by the existing generation token + `AbortController` pattern. Cleanup is fire-and-forget with `.catch(() => {})`.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/hooks/use-push-notifications.ts` | Reorder subscription lifecycle: create new subscription first, clean up stale one after confirmation |

## Test plan

- [x] Typecheck passes (all 9 workspaces)
- [x] Lint passes (frontend)
- [x] Pre-commit hooks pass (prettier, lint, typecheck, dockerfile check, API docs)
- [ ] Manual verification: deploy to staging, rotate VAPID keys, verify existing subscriptions survive and new subscriptions work

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
