### PR TITLE
fix(push): exclude recover.html from SW precache to unbreak push

### DIFF
--- a/apps/frontend/public/_redirects
+++ b/apps/frontend/public/_redirects
@@ -1,2 +1,1 @@
-/recover /recover.html 200
 /* /index.html 200

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -83,6 +83,12 @@ export default defineConfig({
       manifest: false, // use existing public/manifest.json
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+        // recover.html is the nuclear-option SW-unregister page (public/recover.html).
+        // Precaching it would defeat its purpose — and with CF Pages Pretty URLs, the
+        // /recover ↔ /recover.html rewrite loop in _redirects causes the SW install
+        // fetch to fail with ERR_TOO_MANY_REDIRECTS, which strands the SW in
+        // "installing" forever and breaks navigator.serviceWorker.ready (and push).
+        globIgnores: ["**/recover.html"],
       },
       devOptions: {
         enabled: true,


### PR DESCRIPTION
## Problem

Push notifications were broken in production on every Chrome (desktop + mobile):

- Opening **Settings → Notifications** consistently surfaced `SubscribeTimeoutError: Timed out while subscribing to push notifications` after 15s.
- Users stopped receiving incoming push notifications entirely.
- The backend was healthy — `POST /api/workspaces/:id/push/subscribe` returned 400 instantly when called manually with an empty body, ruling out hangs in the request path or DB pool.

The actual failure was in the **service worker install handler**. DevTools surfaced an unhandled rejection inside `sw.js`:

```
sw.js:1  Uncaught (in promise) TypeError: Failed to fetch
    at Ca.fetch (sw.js:1:5730)
    at bt._handleInstall (sw.js:1:10384)
    at install @ sw.js:2
```

Network tab pinpointed it: a single failed request for `https://app.threa.io/recover` with `(failed) net::ERR_TOO_MANY_REDIRECTS`, initiated by `sw.js`.

### Why the push hook timed out

`apps/frontend/src/hooks/use-push-notifications.ts:244` waits on `await navigator.serviceWorker.ready` inside the 15s race. `serviceWorker.ready` only resolves when *some* SW reaches `activated`. With the new SW failing install and no working old SW, `ready` hung forever → 15s race fired → `SubscribeTimeoutError`. With no activated SW, FCM also had nowhere to deliver `push` events, which is why incoming notifications stopped too.

### Why `/recover` looped

Two layers fighting each other:

1. `apps/frontend/vite.config.ts:84-86` precaches everything matching `**/*.{js,css,html,ico,png,svg}`, which sweeps in `apps/frontend/public/recover.html`. Workbox's install handler then tries to `fetch()` it.
2. `apps/frontend/public/_redirects` had `/recover /recover.html 200` (a CF Pages rewrite). Combined with CF Pages' default Pretty URLs (which 301s `*.html` to its extensionless form), the fetch ping-pongs `/recover ↔ /recover.html` until the browser gives up with `ERR_TOO_MANY_REDIRECTS`.

PRs #431 (early SW registration) and #432 (preserve old subscription until new one confirmed) are reasonable hygiene changes but neither addresses this — registration was succeeding, and the flow never reaches `pushManager.subscribe()` because `serviceWorker.ready` hangs first.

## Solution

Two-line fix that removes both halves of the loop:

### How it works

```
Before:
  workbox install → fetch /recover (in manifest)
                  → CF Pages _redirects rewrites /recover → /recover.html
                  → CF Pages Pretty URLs 301s /recover.html → /recover
                  → loop → ERR_TOO_MANY_REDIRECTS → install fails → SW stuck

After:
  workbox install → recover.html not in manifest → no fetch attempted
                  → install succeeds → SW activates → push works
  /recover navigation → CF Pages Pretty URLs serves /recover.html → recovery page works
```

### Key design decisions

**1. Why exclude `recover.html` from precache instead of fixing the redirect rule alone**

`recover.html` is the manual escape hatch for users whose SW is stuck (`apps/frontend/public/recover.html:127-128`: "Safe to bookmark: users can type /recover…"). It must always serve fresh from the network — caching it via the SW would defeat its own purpose. So even setting aside the loop bug, it shouldn't be in the precache manifest.

**2. Why drop the explicit `_redirects` rule instead of rewriting it**

CF Pages' Pretty URLs already serves `/recover` from `/recover.html` with no rule needed. Any explicit rewrite (status `200`) of `/recover → /recover.html` gets re-processed by Pretty URLs on the destination, which is exactly what creates the loop. Removing the rule lets Pretty URLs handle it cleanly.

**3. Why a comment on `globIgnores`**

Without the comment, the next reader sees an arbitrary single-file ignore and might "clean up" by removing it — re-introducing the same bug. The comment captures the three-way interaction (workbox install + `_redirects` + Pretty URLs) that isn't visible from any single file.

## Modified files

| File                              | Change                                                                                              |
| --------------------------------- | --------------------------------------------------------------------------------------------------- |
| `apps/frontend/vite.config.ts`    | Add `globIgnores: ["**/recover.html"]` so the recovery page never enters the SW precache manifest. |
| `apps/frontend/public/_redirects` | Drop the redundant `/recover /recover.html 200` rewrite rule that fights CF Pages Pretty URLs.     |

## Test plan

- [x] Pre-commit hooks pass (prettier, eslint across 4 apps, dockerfile workspace check, OpenAPI freshness, monorepo typecheck across 9 workspaces)
- [ ] **Manual verification after deploy**: open `app.threa.io` in a clean Chrome profile, confirm DevTools → Application → Service Workers shows the new `sw.js` as `activated` (not `redundant` or `installing`)
- [ ] **Manual verification after deploy**: Network tab on first load shows no `(failed)` requests initiated by `sw.js`
- [ ] **Manual verification after deploy**: open Settings → Notifications, confirm status reaches "Enabled" within 15s, no `SubscribeTimeoutError` in console
- [ ] **Manual verification after deploy**: send a real push from another device, confirm it arrives
- [ ] **Manual verification after deploy**: navigate to `app.threa.io/recover` directly, confirm the recovery page renders (proves Pretty URLs is doing the right thing without the explicit rule)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012WDKDPu527HwRt54GAxXQR)_