### PR TITLE
fix: add HydrateFallback for lazy routes and guard scrollToIndex in emoji grids

### DIFF
--- a/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
+++ b/apps/frontend/src/components/editor/triggers/emoji-grid.tsx
@@ -82,7 +82,9 @@ function EmojiGridInner(
 
   useEffect(() => {
     setSelectedIndex(0)
-    virtuosoRef.current?.scrollToIndex({ index: 0 })
+    if (total > 0) {
+      virtuosoRef.current?.scrollToIndex({ index: 0 })
+    }
   }, [total])
 
   const scrollAllRowIfNeeded = (allRow: number) => {

--- a/apps/frontend/src/components/fallback-loader.tsx
+++ b/apps/frontend/src/components/fallback-loader.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react"
+import { Loader2 } from "lucide-react"
+
+const DELAY_MS = 300
+
+export function FallbackLoader() {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShow(true), DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!show) return null
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
+++ b/apps/frontend/src/components/timeline/reaction-emoji-picker.tsx
@@ -165,7 +165,9 @@ function EmojiGridContent({
   const total = totalCount(geometry)
   useEffect(() => {
     setSelectedIndex(0)
-    if (open) virtuosoRef.current?.scrollToIndex({ index: 0 })
+    if (open && total > 0) {
+      virtuosoRef.current?.scrollToIndex({ index: 0 })
+    }
   }, [total, open, setSelectedIndex])
 
   const scrollAllRowIfNeeded = useCallback((allRow: number) => {

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react"
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { FallbackLoader } from "@/components/fallback-loader"
 import { useSidebar } from "@/contexts"
 import { useLastStream } from "@/hooks"
 
@@ -15,16 +16,19 @@ export const router = createBrowserRouter([
   },
   {
     path: "/login",
+    HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/login")).LoginPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/workspaces",
+    HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/workspace-select")).WorkspaceSelectPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/share",
+    HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/share-target")).ShareTargetPage }),
     errorElement: <ErrorBoundary />,
   },
@@ -32,11 +36,13 @@ export const router = createBrowserRouter([
     // Setup page lives outside WorkspaceLayout — it's a lightweight form that
     // doesn't need the full workspace bootstrap (socket, sidebar, etc.)
     path: "/w/:workspaceId/setup",
+    HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/user-setup")).UserSetupPage }),
     errorElement: <ErrorBoundary />,
   },
   {
     path: "/w/:workspaceId",
+    HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/workspace-layout")).WorkspaceLayout }),
     errorElement: <ErrorBoundary />,
     children: [
@@ -46,22 +52,27 @@ export const router = createBrowserRouter([
       },
       {
         path: "drafts",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/drafts")).DraftsPage }),
       },
       {
         path: "saved/:tab?",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/saved")).SavedPage }),
       },
       {
         path: "threads",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/threads")).ThreadsPage }),
       },
       {
         path: "activity/:filter?",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/activity")).ActivityPage }),
       },
       {
         path: "memory",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/memory")).MemoryPage }),
       },
       {
@@ -70,14 +81,17 @@ export const router = createBrowserRouter([
       },
       {
         path: "s/:streamId",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/stream")).StreamPage }),
       },
       {
         path: "share",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/share-picker")).SharePickerPage }),
       },
       {
         path: "admin/ai-usage",
+        HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
       },
     ],


### PR DESCRIPTION
## Problem

Two browser runtime errors on app startup:

1. **Hydration error** — `No HydrateFallback element provided to render during initial hydration` fires because React Router v7's `RouterProvider` requires a `HydrateFallback` when route modules use `lazy` loading. The initial client-side render happens before lazy chunks load, and without a fallback the router logs this error.

2. **Emoji picker crash** — `Cannot read properties of undefined (reading 'align')` originates from react-virtuoso's internal `$n` function. When the emoji grid's `total` count changes rapidly (e.g., during search filtering), the `scrollToIndex` imperative call can reach the Virtuoso before its internal UI state machine is ready, or while the component is unmounting.

## Solution

### HydrateFallback

Added `HydrateFallback: FallbackLoader` to all 10 lazy route definitions in `routes/index.tsx`. The `FallbackLoader` component uses a **deferred render pattern** (300ms delay via `setTimeout` + cleanup) to avoid flashing a spinner on fast route transitions — following the same pattern used by `StreamLoadingIndicator`.

### Emoji grid scroll guard

Added a `total > 0` guard to the `scrollToIndex` calls inside the `useEffect` in both `emoji-grid.tsx` and `reaction-emoji-picker.tsx`. When `total === 0`, the Virtuoso component is not rendered (or is unmounting), so `scrollToIndex` should not be called.

## Key design decisions

**1. HydrateFallback on route objects (not per-module)** — Rather than adding a `HydrateFallback` export to each of the 10 lazy page modules, the fallback is set directly on each route object. This keeps the change centralized in the route config and avoids touching unrelated page files.

**2. Deferred spinner (300ms)** — To avoid layout flash on fast loads, the spinner only appears if the lazy module takes longer than 300ms to load. If the module loads within 300ms, the user sees no interstitial.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/fallback-loader.tsx` | Deferred spinner for HydrateFallback |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/routes/index.tsx` | Added `HydrateFallback: FallbackLoader` to all lazy routes |
| `apps/frontend/src/components/editor/triggers/emoji-grid.tsx` | Guard `scrollToIndex` with `total > 0` |
| `apps/frontend/src/components/timeline/reaction-emoji-picker.tsx` | Guard `scrollToIndex` with `total > 0` |

## Test plan

- [x] TypeScript typecheck passes across all 9 workspaces
- [x] ESLint passes across all apps
- [x] Pre-commit hooks pass (prettier, lint-staged)
- [ ] Manual verification: open app, confirm no console errors on startup
- [ ] Manual verification: open emoji picker, type/search rapidly, confirm no crash

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_