### PR TITLE
feat(messaging): slice 3 — attachments on shared messages

### DIFF
--- a/apps/backend/src/features/attachments/index.ts
+++ b/apps/backend/src/features/attachments/index.ts
@@ -2,6 +2,9 @@
 export { AttachmentRepository } from "./repository"
 export type { Attachment, InsertAttachmentParams, AttachmentWithExtraction } from "./repository"
 
+// Wire-shape mappers
+export { toAttachmentSummary } from "./summary"
+
 export { AttachmentExtractionRepository } from "./extraction-repository"
 export type {
   AttachmentExtraction,

--- a/apps/backend/src/features/attachments/summary.ts
+++ b/apps/backend/src/features/attachments/summary.ts
@@ -1,0 +1,20 @@
+import type { AttachmentSummary } from "@threa/types"
+import type { Attachment } from "./repository"
+import { isVideoAttachment } from "./video"
+
+/**
+ * Map a stored `Attachment` row to the lightweight `AttachmentSummary` wire
+ * shape used in `message_created` event payloads and shared-message
+ * hydration. The `processingStatus` carve-out for videos is the only
+ * conditional bit — keeping it in one place avoids drift between the
+ * timeline and shared-message paths (INV-37).
+ */
+export function toAttachmentSummary(a: Attachment): AttachmentSummary {
+  return {
+    id: a.id,
+    filename: a.filename,
+    mimeType: a.mimeType,
+    sizeBytes: a.sizeBytes,
+    ...(isVideoAttachment(a.mimeType, a.filename) && { processingStatus: a.processingStatus }),
+  }
+}

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -6,7 +6,7 @@ import { StreamMemberRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, Message } from "./repository"
 import { ShareService, type ResolveEffectiveStream } from "./sharing"
-import { AttachmentRepository, isVideoAttachment } from "../attachments"
+import { AttachmentRepository, toAttachmentSummary } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
 import { StreamPersonaParticipantRepository } from "../agents"
 import { eventId, messageId, messageVersionId } from "../../lib/id"
@@ -16,6 +16,7 @@ import { messagesTotal } from "../../lib/observability"
 import {
   AttachmentSafetyStatuses,
   AuthorTypes,
+  type AttachmentSummary,
   type AuthorType,
   type EventType,
   type SourceItem,
@@ -42,14 +43,6 @@ const resolveEffectiveStreamAdapter: ResolveEffectiveStream = async (db, source)
 }
 
 // Event payloads
-export interface AttachmentSummary {
-  id: string
-  filename: string
-  mimeType: string
-  sizeBytes: number
-  processingStatus?: string
-}
-
 export interface MessageCreatedPayload {
   messageId: string
   contentJson: JSONContent
@@ -257,13 +250,7 @@ export class EventService {
           throw new Error("Invalid attachment IDs: must be clean, unattached, and belong to this workspace")
         }
 
-        attachmentSummaries = attachments.map((a) => ({
-          id: a.id,
-          filename: a.filename,
-          mimeType: a.mimeType,
-          sizeBytes: a.sizeBytes,
-          ...(isVideoAttachment(a.mimeType, a.filename) && { processingStatus: a.processingStatus }),
-        }))
+        attachmentSummaries = attachments.map(toAttachmentSummary)
       }
 
       // Non-empty metadata only — keep payloads and projections clean of `{}`.

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -20,7 +20,6 @@ export type { MessageVersion } from "./version-repository"
 // Event Service
 export { EventService } from "./event-service"
 export type {
-  AttachmentSummary,
   MessageCreatedPayload,
   MessageEditedPayload,
   MessageDeletedPayload,

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import {
   collectSharedMessageIds,
   hydrateSharedMessageIds,
@@ -10,10 +10,19 @@ import { UserRepository } from "../../workspaces"
 import { PersonaRepository } from "../../agents"
 import * as streamsBarrel from "../../streams"
 import { StreamRepository } from "../../streams"
+import { AttachmentRepository } from "../../attachments"
 import { SharedMessageRepository } from "./repository"
 
 afterEach(() => {
   mock.restore()
+})
+
+// Every ok-state hydration triggers `AttachmentRepository.findByMessageIds`
+// to enrich the payload. Default the stub to "no attachments" so the
+// existing battery of tests doesn't have to opt in; the dedicated
+// attachment tests below override it.
+beforeEach(() => {
+  spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
 })
 
 const VIEWER_ID = "usr_viewer"
@@ -282,6 +291,83 @@ describe("hydrateSharedMessageIds", () => {
       sourceStreamKind: "channel",
       sourceVisibility: "private",
     })
+  })
+
+  it("inlines attachments on ok-state payloads", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubFullAccess()
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_a",
+          [
+            {
+              id: "att_pic",
+              filename: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 1234,
+              processingStatus: "completed",
+            } as any,
+          ],
+        ],
+      ])
+    )
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toMatchObject({
+      state: "ok",
+      attachments: [{ id: "att_pic", filename: "screenshot.png", mimeType: "image/png", sizeBytes: 1234 }],
+    })
+    // Non-video attachments must NOT carry processingStatus on the wire —
+    // the field is exclusively for video transcoding state, mirroring
+    // event-service.ts's emit logic so the wire payload stays consistent.
+    expect(
+      (result.msg_a as { attachments: Array<{ processingStatus?: string }> }).attachments[0].processingStatus
+    ).toBeUndefined()
+  })
+
+  it("emits an empty attachments array when the source has none", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubFullAccess()
+    // Default beforeEach stub returns an empty map, but be explicit here.
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toMatchObject({ state: "ok", attachments: [] })
+  })
+
+  it("batches attachment lookups across every ok-state message in one round-trip (INV-56)", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([
+        ["msg_a", makeMessage({ id: "msg_a" })],
+        ["msg_b", makeMessage({ id: "msg_b" })],
+      ])
+    )
+    stubAuthorLookups()
+    stubFullAccess()
+    const findAttachments = spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a", "msg_b"])
+    expect(findAttachments).toHaveBeenCalledTimes(1)
+    const calledWith = (findAttachments as any).mock.calls[0][1].sort()
+    expect(calledWith).toEqual(["msg_a", "msg_b"])
+  })
+
+  it("does not fetch attachments when no ok-state messages survive", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(new Map())
+    stubAuthorLookups()
+    stubFullAccess()
+    const findAttachments = spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_missing"])
+    expect(result.msg_missing).toEqual({ state: "missing", messageId: "msg_missing" })
+    expect(findAttachments).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -1,8 +1,9 @@
 import type { Querier } from "../../../db"
-import { type JSONContent, type StreamType, type Visibility, StreamTypes } from "@threa/types"
+import { type AttachmentSummary, type JSONContent, type StreamType, type Visibility, StreamTypes } from "@threa/types"
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
 import { listAccessibleStreamIds, StreamRepository, type Stream } from "../../streams"
+import { AttachmentRepository, isVideoAttachment } from "../../attachments"
 
 import { SharedMessageRepository } from "./repository"
 
@@ -42,6 +43,13 @@ export type HydratedSharedMessage =
       contentMarkdown: string
       editedAt: Date | null
       createdAt: Date
+      /**
+       * Attachments on the source message. Always present (possibly empty)
+       * so the wire shape is uniform; rides only on `ok` payloads where
+       * viewer access to the source is already established by the access
+       * resolver above, so no privacy gap.
+       */
+      attachments: AttachmentSummary[]
     }
   | { state: "deleted"; messageId: string; deletedAt: Date }
   | { state: "missing"; messageId: string }
@@ -231,8 +239,23 @@ export async function hydrateSharedMessageIds(
   if (okMessages.size > 0) {
     const actorIds = new Set<string>()
     for (const msg of okMessages.values()) actorIds.add(msg.authorId)
-    const authorNames = await resolveActorNames(db, workspaceId, actorIds)
+    // One round-trip for author names and one for attachments across every
+    // ok-state message, regardless of chain depth (INV-56). Mirrors
+    // `event-service.ts`'s `attachmentSummaries` shape so the wire payload
+    // for a shared message matches what `message_created` would have
+    // emitted on the source stream.
+    const [authorNames, attachmentsByMessageId] = await Promise.all([
+      resolveActorNames(db, workspaceId, actorIds),
+      AttachmentRepository.findByMessageIds(db, [...okMessages.keys()]),
+    ])
     for (const [id, source] of okMessages) {
+      const attachments: AttachmentSummary[] = (attachmentsByMessageId.get(source.id) ?? []).map((a) => ({
+        id: a.id,
+        filename: a.filename,
+        mimeType: a.mimeType,
+        sizeBytes: a.sizeBytes,
+        ...(isVideoAttachment(a.mimeType, a.filename) && { processingStatus: a.processingStatus }),
+      }))
       result[id] = {
         state: "ok",
         messageId: source.id,
@@ -244,6 +267,7 @@ export async function hydrateSharedMessageIds(
         contentMarkdown: source.contentMarkdown,
         editedAt: source.editedAt,
         createdAt: source.createdAt,
+        attachments,
       }
     }
   }

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -3,7 +3,7 @@ import { type AttachmentSummary, type JSONContent, type StreamType, type Visibil
 import { MessageRepository, type Message } from "../repository"
 import { resolveActorNames } from "../../agents"
 import { listAccessibleStreamIds, StreamRepository, type Stream } from "../../streams"
-import { AttachmentRepository, isVideoAttachment } from "../../attachments"
+import { AttachmentRepository, toAttachmentSummary } from "../../attachments"
 
 import { SharedMessageRepository } from "./repository"
 
@@ -249,13 +249,7 @@ export async function hydrateSharedMessageIds(
       AttachmentRepository.findByMessageIds(db, [...okMessages.keys()]),
     ])
     for (const [id, source] of okMessages) {
-      const attachments: AttachmentSummary[] = (attachmentsByMessageId.get(source.id) ?? []).map((a) => ({
-        id: a.id,
-        filename: a.filename,
-        mimeType: a.mimeType,
-        sizeBytes: a.sizeBytes,
-        ...(isVideoAttachment(a.mimeType, a.filename) && { processingStatus: a.processingStatus }),
-      }))
+      const attachments = (attachmentsByMessageId.get(source.id) ?? []).map(toAttachmentSummary)
       result[id] = {
         state: "ok",
         messageId: source.id,

--- a/apps/frontend/src/components/shared-messages/card-body.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from "react-router-dom"
 import { Skeleton } from "@/components/ui/skeleton"
-import { MarkdownContent } from "@/components/ui/markdown-content"
+import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
+import { AttachmentList } from "@/components/timeline/attachment-list"
 import { type SharedMessageSource } from "@/hooks/use-shared-message-source"
 import { streamFallbackLabel } from "@/lib/streams"
 import type { StreamType, Visibility } from "@threa/types"
@@ -28,6 +29,13 @@ export function SharedMessageCardBody({
   source: SharedMessageSource
   fallbackAuthor: string
 }) {
+  // The ok-branch needs `workspaceId` to render `<AttachmentList>` (it
+  // resolves presigned URLs via the workspace-scoped attachment API).
+  // Both call sites — `SharedMessageView` (TipTap NodeView) and
+  // `SharedMessagePointerBlock` (markdown renderer) — mount under the
+  // `/w/:workspaceId` route, so this is always defined at runtime.
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+
   if (source.status === "deleted") {
     return (
       <>
@@ -71,16 +79,33 @@ export function SharedMessageCardBody({
     )
   }
 
-  return (
-    <>
-      <AuthorLabel name={source.authorName || fallbackAuthor || "—"} />
+  const attachments = source.attachments ?? []
+  // Only mount `<AttachmentProvider>` when there's something to render —
+  // it depends on `MediaGalleryContext`, which the shared-message card's
+  // call sites (TipTap NodeView, markdown-block) wrap in but isolated
+  // tests don't necessarily provide. Cards without attachments stay a
+  // pure markdown render, matching the Slice 1/2 behavior.
+  const hasAttachments = workspaceId !== undefined && attachments.length > 0
+  const body = (
+    <div className="mt-0.5">
       {/* The card is the live inline rendering of the source message, not a
           single-line preview, so it gets full markdown (emoji, mentions,
           formatting) rather than the strip-to-inline used by sidebar
           surfaces. INV-60 doesn't apply here. */}
-      <div className="mt-0.5">
-        <MarkdownContent content={source.contentMarkdown} className="text-sm leading-relaxed" />
-      </div>
+      <MarkdownContent content={source.contentMarkdown} className="text-sm leading-relaxed" />
+    </div>
+  )
+  return (
+    <>
+      <AuthorLabel name={source.authorName || fallbackAuthor || "—"} />
+      {hasAttachments ? (
+        <AttachmentProvider workspaceId={workspaceId} attachments={attachments}>
+          {body}
+          <AttachmentList attachments={attachments} workspaceId={workspaceId} />
+        </AttachmentProvider>
+      ) : (
+        body
+      )}
     </>
   )
 }

--- a/apps/frontend/src/components/shared-messages/context.test.tsx
+++ b/apps/frontend/src/components/shared-messages/context.test.tsx
@@ -26,6 +26,7 @@ describe("SharedMessagesProvider", () => {
       contentMarkdown: "hi",
       editedAt: null,
       createdAt: "2026-04-23T10:00:00Z",
+      attachments: [],
     }
     const { result } = renderHook(() => useSharedMessageHydration("msg_1"), {
       wrapper: ({ children }) => <SharedMessagesProvider map={{ msg_1: ok }}>{children}</SharedMessagesProvider>,

--- a/apps/frontend/src/components/shared-messages/context.tsx
+++ b/apps/frontend/src/components/shared-messages/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react"
-import type { StreamType, Visibility } from "@threa/types"
+import type { AttachmentSummary, StreamType, Visibility } from "@threa/types"
 
 /**
  * Hydrated payload for a pointer message. Kept structurally aligned with
@@ -23,6 +23,7 @@ export type HydratedSharedMessage =
       contentMarkdown: string
       editedAt: string | null
       createdAt: string
+      attachments: AttachmentSummary[]
     }
   | { state: "deleted"; messageId: string; deletedAt: string }
   | { state: "missing"; messageId: string }

--- a/apps/frontend/src/hooks/use-shared-message-source.test.tsx
+++ b/apps/frontend/src/hooks/use-shared-message-source.test.tsx
@@ -48,6 +48,7 @@ describe("useSharedMessageSource", () => {
               contentMarkdown: "hello from hydration",
               editedAt: null,
               createdAt: "2026-04-23T10:00:00Z",
+              attachments: [],
             },
           }}
         >
@@ -63,6 +64,7 @@ describe("useSharedMessageSource", () => {
       actorType: "user",
       authorName: "Ada",
       editedAt: null,
+      attachments: [],
     })
   })
 

--- a/apps/frontend/src/hooks/use-shared-message-source.ts
+++ b/apps/frontend/src/hooks/use-shared-message-source.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db } from "@/db"
 import { useSharedMessageHydration } from "@/components/shared-messages/context"
-import type { StreamType, Visibility } from "@threa/types"
+import type { AttachmentSummary, StreamType, Visibility } from "@threa/types"
 
 /**
  * Resolved preview for a shared-message pointer. `authorName` is optional at
@@ -16,6 +16,15 @@ export interface SharedMessageResolved {
   actorType: string
   authorName?: string
   editedAt: string | null
+  /**
+   * Attachments on the source message. Always present from the server-side
+   * hydration map; absent only on the IndexedDB-cache fallback (cached
+   * events store attachment metadata under the same key but the cache
+   * fallback below intentionally doesn't reach for it — the timeline
+   * renders attachments via its own `payload.attachments` path, so the
+   * shared-message card only needs them when hydrated from the server).
+   */
+  attachments?: AttachmentSummary[]
 }
 
 export interface SharedMessageDeleted {
@@ -129,6 +138,7 @@ export function useSharedMessageSource(messageId: string, sourceStreamId: string
           actorType: hydrated.authorType,
           authorName: hydrated.authorName,
           editedAt: hydrated.editedAt,
+          attachments: hydrated.attachments,
         }
       }
     }

--- a/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
@@ -58,6 +58,7 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
         contentMarkdown: "hi from the source",
         editedAt: null,
         createdAt: "2026-04-23T10:00:00Z",
+        attachments: [],
       },
     })
 
@@ -107,6 +108,7 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
         contentMarkdown: "**Hey** with [a link](https://example.com)",
         editedAt: null,
         createdAt: "2026-04-23T10:00:00Z",
+        attachments: [],
       },
     })
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -8,6 +8,7 @@ import type { StreamType, Visibility, CompanionMode, SavedStatus, AuthorType } f
 import type { ContextBag, ContextIntent } from "./context-bag"
 import type { JSONContent } from "./prosemirror"
 import type {
+  AttachmentSummary,
   Stream,
   StreamWithPreview,
   StreamEvent,
@@ -138,6 +139,7 @@ export type SharedMessageHydration =
       contentMarkdown: string
       editedAt: string | null
       createdAt: string
+      attachments: AttachmentSummary[]
     }
   | { state: "deleted"; messageId: string; deletedAt: string }
   | { state: "missing"; messageId: string }


### PR DESCRIPTION
## Summary

A "look at this" + image share previously rendered as text only. The hydration backend's `ok` variant only carried `contentJson` / `contentMarkdown`, and the shared-message card-body never reached for `<AttachmentList>`. This slice extends the wire shape end-to-end so a shared image, video, or file appears inside the card the same way it appears in the source stream.

Privacy is implicit — attachments only ride on `ok` payloads, where the access resolver above the mapping has already established viewer access to the source. `private` / `deleted` / `truncated` placeholders never surface attachments.

## What changed

**Backend — `hydration.ts`:**
- `HydratedSharedMessage.ok` carries `attachments: AttachmentSummary[]`.
- `hydrateSharedMessageIds` batches `AttachmentRepository.findByMessageIds` alongside the author-name lookup in a single `Promise.all` across every ok-state message in the chain — one extra round-trip regardless of recursion depth (INV-56). The lookup runs **outside** the BFS while-loop against the accumulated `okMessages` map, so messages that fail the per-level access check never reach the attachment fetch.
- The mapping uses the shared `toAttachmentSummary` helper, mirroring the `message_created` event payload exactly.

**Backend — `attachments/summary.ts` (new, refactor commit):**
- `toAttachmentSummary(a: Attachment): AttachmentSummary` — single source of truth for `Attachment` row → wire-shape mapping, including the video-only `processingStatus` carve-out.
- `event-service.ts` drops its local `interface AttachmentSummary` (which had a looser `processingStatus?: string`) in favor of the canonical `@threa/types` one and routes through the shared mapper. Resolves the INV-37 duplication that slice 3's second copy would otherwise have introduced.

**Wire types — `packages/types/src/api.ts`:**
- `SharedMessageHydration.ok` adds `attachments: AttachmentSummary[]`.

**Frontend:**
- `context.tsx` and `use-shared-message-source.ts` thread the new field through their respective type mirrors.
- `SharedMessageCardBody` renders `<AttachmentList>` inside `<AttachmentProvider>` for the ok branch. The provider mounts only when there are attachments to render so isolated card-body unit tests (no `MediaGalleryProvider` in scope) still cover the no-attachment ok case.

## Tests

- 4 new `hydrateSharedMessageIds` cases:
  - ok-state inlines attachment summaries
  - empty array when source has none (uniform wire shape)
  - one batched lookup across multiple ok messages (INV-56)
  - skipped entirely when no ok-state messages survive
- Existing fixtures updated for the new required `attachments` field (5 frontend test files).
- A module-scope `beforeEach` stub for `AttachmentRepository.findByMessageIds` (returning an empty Map) keeps the existing ok-state tests passing without per-test boilerplate. Uses scoped `spyOn` against the namespace import per INV-48.
- Backend hydration suite 16/16, full frontend suite 1466/1466.

## Test plan

- [ ] Pull a private channel + DM with an image attachment, share the channel message into the DM, confirm the image renders inside the DM card.
- [ ] Share a message into a re-share chain (A → B → C), confirm `ok`-state pointers along the chain show attachments and the truncated/private pointers don't.
- [ ] Share a video attachment, confirm `processingStatus` rides on the wire and the video player gates correctly on the `completed` / `skipped` states.
- [ ] Share a deleted message, confirm no attachments leak (deleted placeholder).
- [ ] Backend tests: `bun test src/features/messaging/sharing/hydration.test.ts` and `src/features/messaging/event-service.test.ts`.

https://claude.ai/code/session_01FRG5ZrJRUbsG4bpuxCMDKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRG5ZrJRUbsG4bpuxCMDKU)_