### PR TITLE
fix(ariadne): align discuss-thread chip + send button + AI trace with the windowed bag

### DIFF
--- a/apps/backend/src/features/agents/context-bag/fetch-stream-bag.ts
+++ b/apps/backend/src/features/agents/context-bag/fetch-stream-bag.ts
@@ -1,11 +1,12 @@
 import type { Querier } from "../../../db"
-import { ContextRefKinds, type ContextIntent } from "@threa/types"
+import { ContextIntents, ContextRefKinds, type ContextIntent } from "@threa/types"
 import { HttpError } from "../../../lib/errors"
 import { StreamRepository, checkStreamAccess } from "../../streams"
 import { MessageRepository } from "../../messaging"
 import { logger } from "../../../lib/logger"
 import { ContextBagRepository } from "./repository"
 import { getResolver } from "./registry"
+import { DISCUSS_WINDOW_TOTAL } from "./resolvers/thread-resolver"
 
 export interface ContextRefSource {
   streamId: string
@@ -124,10 +125,20 @@ export async function fetchStreamBag(
   ])
   const streamById = new Map(sourceStreams.map((s) => [s.id, s]))
 
+  // For DISCUSS_THREAD, the resolver only sends ~DISCUSS_WINDOW_TOTAL messages
+  // to the model regardless of how big the source stream is. Surfacing the
+  // raw stream total in the context pill ("487 messages in #intro") is
+  // misleading because the AI never sees more than the window — clamp the
+  // displayed count to what's actually shared so the chip matches reality.
+  const isWindowedIntent = bag.intent === ContextIntents.DISCUSS_THREAD
+
   const enriched: EnrichedContextRef[] = []
   for (const ref of visibleRefs) {
     const sourceStream = streamById.get(ref.streamId)
     if (!sourceStream) continue
+
+    const totalCount = itemCounts.get(ref.streamId) ?? 0
+    const itemCount = isWindowedIntent ? Math.min(totalCount, DISCUSS_WINDOW_TOTAL) : totalCount
 
     enriched.push({
       kind: ContextRefKinds.THREAD,
@@ -140,7 +151,7 @@ export async function fetchStreamBag(
         displayName: sourceStream.displayName ?? null,
         slug: sourceStream.slug ?? null,
         type: sourceStream.type,
-        itemCount: itemCounts.get(ref.streamId) ?? 0,
+        itemCount,
       },
     })
   }

--- a/apps/backend/src/features/agents/context-bag/handlers.test.ts
+++ b/apps/backend/src/features/agents/context-bag/handlers.test.ts
@@ -200,6 +200,45 @@ describe("createContextBagHandlers.getStreamBag", () => {
     })
   })
 
+  it("clamps itemCount to the discuss-window size for DISCUSS_THREAD bags", async () => {
+    // Regression: the resolver only sends ~50 messages to the AI for the
+    // discuss-thread intent, but the chip used to show the raw stream total
+    // (e.g. "487 messages in #intro") which lied about what the model
+    // actually sees. Pin the clamp here so the chip matches reality.
+    stubWithClient()
+    stubAccessOk()
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      {
+        id: "stream_src",
+        workspaceId: "ws_1",
+        type: "channel",
+        slug: "intro",
+        displayName: "Intro",
+      } as any,
+    ])
+    spyOn(ContextBagRepository, "findByStream").mockResolvedValue({
+      id: "sca_1",
+      workspaceId: "ws_1",
+      streamId: "stream_scratch",
+      intent: ContextIntents.DISCUSS_THREAD,
+      refs: [{ kind: ContextRefKinds.THREAD, streamId: "stream_src" }],
+      lastRendered: null,
+      createdBy: "usr_1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    spyOn(ThreadResolver, "assertAccess").mockResolvedValue(undefined)
+    spyOn(MessageRepository, "countByStreams").mockResolvedValue(new Map([["stream_src", 487]]))
+
+    const handlers = createContextBagHandlers({ pool: {} as any, ai: {} as any })
+    const req = mockReq(undefined, { streamId: "stream_scratch" })
+    const res = mockRes() as any
+    await handlers.getStreamBag(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect((res.body as any).refs[0].source.itemCount).toBe(50)
+  })
+
   it("returns an empty bag when the stream has no attachment", async () => {
     stubWithClient()
     stubAccessOk()

--- a/apps/backend/src/features/agents/context-bag/render.test.ts
+++ b/apps/backend/src/features/agents/context-bag/render.test.ts
@@ -61,6 +61,29 @@ describe("renderStable", () => {
     expect(rendered).toContain("A short summary [msg_a]")
     expect(rendered).not.toContain("Messages (chronological)")
   })
+
+  test("renders attachment metadata under each message that has attachments", () => {
+    // Without this the Discuss-with-Ariadne trace shows text-only messages
+    // even when the focal message had a PDF attached, which makes the model
+    // (and the human reading the trace) think nothing was shared.
+    const rendered = renderStable({
+      preamble: "p",
+      inlineItems: [
+        item({
+          messageId: "msg_a",
+          contentMarkdown: "see attached",
+          attachments: [{ id: "att_1", filename: "spec.pdf", mimeType: "application/pdf", sizeBytes: 12345 }],
+        }),
+        item({ messageId: "msg_b", contentMarkdown: "no attachments here" }),
+      ],
+      refLabel: "thread:stream_x",
+    })
+    expect(rendered).toContain("[att_1] spec.pdf")
+    expect(rendered).toContain("application/pdf")
+    expect(rendered).toContain("12345 bytes")
+    // Messages without attachments should NOT get an empty attachments line.
+    expect(rendered).not.toMatch(/no attachments here\n\s+Attachments:/)
+  })
 })
 
 describe("renderDelta", () => {

--- a/apps/backend/src/features/agents/context-bag/render.ts
+++ b/apps/backend/src/features/agents/context-bag/render.ts
@@ -67,7 +67,18 @@ function formatInlineMessage(item: RenderableMessage, options?: { focal?: boolea
   // alongside the section header. Bullet stays a simple dash everywhere
   // else for prompt-cache stability across non-focal renders.
   const bullet = options?.focal ? "►" : "-"
-  return `${bullet} [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}`
+  // Attachments render as a sibling line under the message body so the model
+  // (and the trace UI) can see what was attached. We only carry filename +
+  // mime + size — full text is loaded on demand through the existing
+  // attachment tools, keeping the stable region small.
+  const attachments =
+    item.attachments && item.attachments.length > 0 ? `\n  ${formatAttachments(item.attachments)}` : ""
+  return `${bullet} [${item.messageId}] ${item.authorName} at ${ts}${edited}:\n  ${item.contentMarkdown.replaceAll("\n", "\n  ")}${attachments}`
+}
+
+function formatAttachments(attachments: NonNullable<RenderableMessage["attachments"]>): string {
+  const parts = attachments.map((a) => `[${a.id}] ${a.filename} (${a.mimeType}, ${a.sizeBytes} bytes)`)
+  return `Attachments: ${parts.join("; ")}`
 }
 
 export interface DeltaRenderInput {

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -1,10 +1,18 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { ContextIntents, ContextRefKinds, Visibilities } from "@threa/types"
 import { ThreadResolver } from "./thread-resolver"
+import { AttachmentRepository } from "../../../attachments"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, StreamMemberRepository } from "../../../streams"
 import { UserRepository } from "../../../workspaces"
 import { PersonaRepository } from "../../persona-repository"
+
+// All ThreadResolver.fetch paths now batch-fetch attachments for the windowed
+// message ids. Default to an empty map so individual tests don't have to
+// re-stub it; tests that care about attachment rendering override locally.
+beforeEach(() => {
+  spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+})
 
 function makeStream(overrides: Record<string, any> = {}): any {
   return {
@@ -503,6 +511,45 @@ describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
     // render path here, not the focal-section split.
     expect(result.items.map((i) => i.messageId)).toEqual(["msg_root", "msg_reply_1", "msg_reply_2"])
     expect(result.focalMessageId).toBeNull()
+  })
+
+  it("attaches attachment metadata onto the renderable items so the trace surfaces what was attached", async () => {
+    // Without this the focal message in a "Discuss with Ariadne" window
+    // renders as text-only — the trace lies about the attached PDF and the
+    // model has no idea anything was attached.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+    spyOn(MessageRepository, "list").mockResolvedValue([seq("msg_a", 1), seq("msg_b", 2)])
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_a",
+          [
+            {
+              id: "att_1",
+              filename: "spec.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 12345,
+            } as any,
+          ],
+        ],
+      ])
+    )
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    const itemA = result.items.find((i) => i.messageId === "msg_a")!
+    const itemB = result.items.find((i) => i.messageId === "msg_b")!
+    expect(itemA.attachments).toEqual([
+      { id: "att_1", filename: "spec.pdf", mimeType: "application/pdf", sizeBytes: 12345 },
+    ])
+    expect(itemB.attachments).toBeUndefined()
   })
 
   it("falls back to the stream tail (not a deletion-skewed slice) when the focal message is soft-deleted", async () => {

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { ContextIntents, ContextRefKinds, Visibilities } from "@threa/types"
 import { ThreadResolver } from "./thread-resolver"
-import { AttachmentRepository } from "../../../attachments"
+import { AttachmentRepository, type Attachment } from "../../../attachments"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, StreamMemberRepository } from "../../../streams"
 import { UserRepository } from "../../../workspaces"
@@ -53,6 +53,25 @@ function makeMessage(overrides: Record<string, any> = {}): any {
     metadata: {},
     editedAt: null,
     deletedAt: null,
+    createdAt: new Date("2026-04-22T09:00:00Z"),
+    ...overrides,
+  }
+}
+
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    id: "att_1",
+    workspaceId: "ws_1",
+    streamId: "stream_source",
+    messageId: "msg_a",
+    uploadedBy: "usr_author",
+    filename: "spec.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 12345,
+    storageProvider: "s3",
+    storagePath: "ws_1/att_1",
+    processingStatus: "completed",
+    safetyStatus: "clean",
     createdAt: new Date("2026-04-22T09:00:00Z"),
     ...overrides,
   }
@@ -523,19 +542,7 @@ describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
     spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
     spyOn(MessageRepository, "list").mockResolvedValue([seq("msg_a", 1), seq("msg_b", 2)])
     spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(
-      new Map([
-        [
-          "msg_a",
-          [
-            {
-              id: "att_1",
-              filename: "spec.pdf",
-              mimeType: "application/pdf",
-              sizeBytes: 12345,
-            } as any,
-          ],
-        ],
-      ])
+      new Map([["msg_a", [makeAttachment({ id: "att_1", filename: "spec.pdf", sizeBytes: 12345 })]]])
     )
 
     const result = await ThreadResolver.fetch(
@@ -566,9 +573,9 @@ describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
         [
           "msg_a",
           [
-            { id: "att_3", filename: "c.pdf", mimeType: "application/pdf", sizeBytes: 3 } as any,
-            { id: "att_1", filename: "a.pdf", mimeType: "application/pdf", sizeBytes: 1 } as any,
-            { id: "att_2", filename: "b.pdf", mimeType: "application/pdf", sizeBytes: 2 } as any,
+            makeAttachment({ id: "att_3", filename: "c.pdf", sizeBytes: 3 }),
+            makeAttachment({ id: "att_1", filename: "a.pdf", sizeBytes: 1 }),
+            makeAttachment({ id: "att_2", filename: "b.pdf", sizeBytes: 2 }),
           ],
         ],
       ])

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts
@@ -552,6 +552,38 @@ describe("ThreadResolver.fetch — DISCUSS_THREAD windowing", () => {
     expect(itemB.attachments).toBeUndefined()
   })
 
+  it("sorts attachments by id so the rendered context-bag stays byte-stable across resolves", async () => {
+    // `findByMessageIds` doesn't ORDER BY, so PG row order can drift between
+    // calls. The stable region MUST hash identically across turns to preserve
+    // prompt-cache reuse — pin the deterministic sort here.
+    spyOn(StreamRepository, "findById").mockResolvedValue(makeStream())
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_author", name: "Author" }] as any)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([])
+    spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+    spyOn(MessageRepository, "list").mockResolvedValue([seq("msg_a", 1)])
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_a",
+          [
+            { id: "att_3", filename: "c.pdf", mimeType: "application/pdf", sizeBytes: 3 } as any,
+            { id: "att_1", filename: "a.pdf", mimeType: "application/pdf", sizeBytes: 1 } as any,
+            { id: "att_2", filename: "b.pdf", mimeType: "application/pdf", sizeBytes: 2 } as any,
+          ],
+        ],
+      ])
+    )
+
+    const result = await ThreadResolver.fetch(
+      {} as any,
+      { kind: ContextRefKinds.THREAD, streamId: "stream_source" },
+      { intent: ContextIntents.DISCUSS_THREAD }
+    )
+
+    const itemA = result.items.find((i) => i.messageId === "msg_a")!
+    expect(itemA.attachments?.map((a) => a.id)).toEqual(["att_1", "att_2", "att_3"])
+  })
+
   it("falls back to the stream tail (not a deletion-skewed slice) when the focal message is soft-deleted", async () => {
     // Regression: `MessageRepository.findSurrounding` looks the target's
     // sequence up without a `deleted_at` filter but excludes the target

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -1,12 +1,13 @@
 import type { Querier } from "../../../../db"
 import { ContextIntents, ContextRefKinds, type ContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
+import { AttachmentRepository } from "../../../attachments"
 import type { Message } from "../../../messaging"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, checkStreamAccess } from "../../../streams"
 import { resolveActorNames } from "../../actor-names"
 import { fingerprintContent, fingerprintManifest as fingerprintInputs } from "../fingerprint"
-import type { RenderableMessage, Resolver, SummaryInput } from "../types"
+import type { RenderableAttachment, RenderableMessage, Resolver, SummaryInput } from "../types"
 
 type ThreadRef = Extract<ContextRef, { kind: typeof ContextRefKinds.THREAD }>
 
@@ -19,8 +20,13 @@ const MAX_FETCH = 500
  * is exactly the failure mode this windowing is supposed to fix. If the user
  * needs more, Ariadne can call `get_stream_messages` to pull additional
  * history into a tool result.
+ *
+ * Exported so callers that surface a "messages in source" count to the user
+ * (e.g. the context-pill label in `fetchStreamBag`) can clamp to the actual
+ * window size — otherwise the chip claims the AI sees thousands of messages
+ * when it's only ever sent ~50.
  */
-const DISCUSS_WINDOW_TOTAL = 50
+export const DISCUSS_WINDOW_TOTAL = 50
 
 /**
  * Thread resolver: materializes a thread/scratchpad/channel reference into the
@@ -86,17 +92,39 @@ export const ThreadResolver: Resolver<ThreadRef> = {
     const withRoot = root && !anchored.some((m) => m.id === root.id) ? [root, ...anchored] : anchored
 
     const authorIds = new Set(withRoot.map((m) => m.authorId))
-    const authorNames = await resolveActorNames(db, stream.workspaceId, authorIds)
+    const messageIds = withRoot.map((m) => m.id)
+    const [authorNames, attachmentsByMessage] = await Promise.all([
+      resolveActorNames(db, stream.workspaceId, authorIds),
+      // Without this the focal message in a "Discuss with Ariadne" window
+      // loses its attachments — the trace shows only the text and the model
+      // has no idea anything was attached. The renderer formats the metadata
+      // inline below; full extraction content stays behind the existing
+      // attachment tools so we don't duplicate the heavy enrichment path.
+      AttachmentRepository.findByMessageIds(db, messageIds),
+    ])
 
-    const items: RenderableMessage[] = withRoot.map((m) => ({
-      messageId: m.id,
-      authorId: m.authorId,
-      authorName: authorNames.get(m.authorId) ?? "Unknown",
-      contentMarkdown: m.contentMarkdown,
-      createdAt: m.createdAt.toISOString(),
-      editedAt: m.editedAt?.toISOString() ?? null,
-      sequence: m.sequence,
-    }))
+    const items: RenderableMessage[] = withRoot.map((m) => {
+      const messageAttachments = attachmentsByMessage.get(m.id)
+      const attachments: RenderableAttachment[] | undefined =
+        messageAttachments && messageAttachments.length > 0
+          ? messageAttachments.map((a) => ({
+              id: a.id,
+              filename: a.filename,
+              mimeType: a.mimeType,
+              sizeBytes: a.sizeBytes,
+            }))
+          : undefined
+      return {
+        messageId: m.id,
+        authorId: m.authorId,
+        authorName: authorNames.get(m.authorId) ?? "Unknown",
+        contentMarkdown: m.contentMarkdown,
+        createdAt: m.createdAt.toISOString(),
+        editedAt: m.editedAt?.toISOString() ?? null,
+        sequence: m.sequence,
+        ...(attachments && { attachments }),
+      }
+    })
 
     const inputs: SummaryInput[] = items.map((item) => ({
       messageId: item.messageId,

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -105,14 +105,20 @@ export const ThreadResolver: Resolver<ThreadRef> = {
 
     const items: RenderableMessage[] = withRoot.map((m) => {
       const messageAttachments = attachmentsByMessage.get(m.id)
+      // Sort by id (ULID, time-ordered) so the rendered attachments line is
+      // byte-identical across resolves — `findByMessageIds` doesn't ORDER BY,
+      // so PG row order would otherwise drift and break prompt-cache reuse
+      // on the stable region.
       const attachments: AttachmentSummary[] | undefined =
         messageAttachments && messageAttachments.length > 0
-          ? messageAttachments.map((a) => ({
-              id: a.id,
-              filename: a.filename,
-              mimeType: a.mimeType,
-              sizeBytes: a.sizeBytes,
-            }))
+          ? [...messageAttachments]
+              .sort((a, b) => a.id.localeCompare(b.id))
+              .map((a) => ({
+                id: a.id,
+                filename: a.filename,
+                mimeType: a.mimeType,
+                sizeBytes: a.sizeBytes,
+              }))
           : undefined
       return {
         messageId: m.id,

--- a/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
+++ b/apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts
@@ -2,12 +2,12 @@ import type { Querier } from "../../../../db"
 import { ContextIntents, ContextRefKinds, type ContextRef } from "@threa/types"
 import { HttpError } from "../../../../lib/errors"
 import { AttachmentRepository } from "../../../attachments"
-import type { Message } from "../../../messaging"
+import type { AttachmentSummary, Message } from "../../../messaging"
 import { MessageRepository } from "../../../messaging"
 import { StreamRepository, checkStreamAccess } from "../../../streams"
 import { resolveActorNames } from "../../actor-names"
 import { fingerprintContent, fingerprintManifest as fingerprintInputs } from "../fingerprint"
-import type { RenderableAttachment, RenderableMessage, Resolver, SummaryInput } from "../types"
+import type { RenderableMessage, Resolver, SummaryInput } from "../types"
 
 type ThreadRef = Extract<ContextRef, { kind: typeof ContextRefKinds.THREAD }>
 
@@ -105,7 +105,7 @@ export const ThreadResolver: Resolver<ThreadRef> = {
 
     const items: RenderableMessage[] = withRoot.map((m) => {
       const messageAttachments = attachmentsByMessage.get(m.id)
-      const attachments: RenderableAttachment[] | undefined =
+      const attachments: AttachmentSummary[] | undefined =
         messageAttachments && messageAttachments.length > 0
           ? messageAttachments.map((a) => ({
               id: a.id,
@@ -126,6 +126,12 @@ export const ThreadResolver: Resolver<ThreadRef> = {
       }
     })
 
+    // Attachments are intentionally NOT folded into the fingerprint: they're
+    // immutable after message creation (the link is set at insert time and
+    // never mutated), so adding them would expand the manifest without ever
+    // changing the value. If that invariant ever breaks (e.g. retroactive
+    // attach/detach), the rendered stable region would drift while the
+    // fingerprint stays put — the cache would silently serve a stale summary.
     const inputs: SummaryInput[] = items.map((item) => ({
       messageId: item.messageId,
       contentFingerprint: fingerprintContent(item.contentMarkdown),

--- a/apps/backend/src/features/agents/context-bag/types.ts
+++ b/apps/backend/src/features/agents/context-bag/types.ts
@@ -38,6 +38,23 @@ export interface LastRenderedSnapshot {
 }
 
 /**
+ * Attachment metadata surfaced in the rendered context block. We only carry
+ * the fields the model needs to know an attachment exists and what it is —
+ * full extractions/page text are loaded on demand through Ariadne's existing
+ * attachment tools (`load_attachment`, `load_pdf_section`, etc.) so we don't
+ * duplicate the heavy enrichment that runs for the live conversation history.
+ *
+ * Without this the focal message in a "Discuss with Ariadne" window renders
+ * as text-only, which makes the trace lie about what the user attached.
+ */
+export interface RenderableAttachment {
+  id: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+}
+
+/**
  * Minimal renderable unit for the thread resolver. Kept narrow so the resolver
  * doesn't leak the full Message shape into the render step.
  */
@@ -49,6 +66,8 @@ export interface RenderableMessage {
   createdAt: string
   editedAt: string | null
   sequence: bigint
+  /** Attachments on this source message, if any. Empty/omitted when the message has none. */
+  attachments?: RenderableAttachment[]
 }
 
 /**

--- a/apps/backend/src/features/agents/context-bag/types.ts
+++ b/apps/backend/src/features/agents/context-bag/types.ts
@@ -1,6 +1,7 @@
 import type { ContextBag, ContextIntent, ContextRef, ContextRefKind } from "@threa/types"
 import type { Querier } from "../../../db"
 import type { AI, CostContext } from "../../../lib/ai/ai"
+import type { AttachmentSummary } from "../../messaging"
 
 /**
  * Persisted bag row (before resolution). `lastRendered` is the snapshot
@@ -38,25 +39,14 @@ export interface LastRenderedSnapshot {
 }
 
 /**
- * Attachment metadata surfaced in the rendered context block. We only carry
- * the fields the model needs to know an attachment exists and what it is —
- * full extractions/page text are loaded on demand through Ariadne's existing
- * attachment tools (`load_attachment`, `load_pdf_section`, etc.) so we don't
- * duplicate the heavy enrichment that runs for the live conversation history.
- *
- * Without this the focal message in a "Discuss with Ariadne" window renders
- * as text-only, which makes the trace lie about what the user attached.
- */
-export interface RenderableAttachment {
-  id: string
-  filename: string
-  mimeType: string
-  sizeBytes: number
-}
-
-/**
  * Minimal renderable unit for the thread resolver. Kept narrow so the resolver
  * doesn't leak the full Message shape into the render step.
+ *
+ * Attachments use the same `AttachmentSummary` shape that message_created
+ * events carry on the wire — no need for a parallel context-bag-only type.
+ * Without `attachments` here the focal message in a "Discuss with Ariadne"
+ * window renders as text-only, which makes the trace lie about what the
+ * user attached.
  */
 export interface RenderableMessage {
   messageId: string
@@ -66,8 +56,8 @@ export interface RenderableMessage {
   createdAt: string
   editedAt: string | null
   sequence: bigint
-  /** Attachments on this source message, if any. Empty/omitted when the message has none. */
-  attachments?: RenderableAttachment[]
+  /** Attachments on this source message, if any. Omitted when the message has none. */
+  attachments?: AttachmentSummary[]
 }
 
 /**

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -510,6 +510,32 @@ describe("useDraftComposer", () => {
       const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
       expect(result.current.canSend).toBe(true)
     })
+
+    it("should be true with only a ready context-ref (no body text, no attachments)", () => {
+      // Regression: clicking "Discuss with Ariadne" attaches a thread chip
+      // but doesn't fill the composer body. The send button shouldn't force
+      // the user to type a placeholder message — the chip itself is a
+      // sufficient payload to dispatch the discussion turn.
+      mockDraftStateByKey[`stream:${scopeId}`] = {
+        isLoaded: true,
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        contextRefs: [
+          {
+            refKind: "thread",
+            streamId: "stream_src",
+            fromMessageId: null,
+            toMessageId: null,
+            status: "ready",
+            fingerprint: "fp_1",
+            errorMessage: null,
+          },
+        ],
+      }
+
+      const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.canSend).toBe(true)
+    })
   })
 
   describe("isSending state", () => {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -231,10 +231,16 @@ export function useDraftComposer({
   // delay on the first turn), and `error` means the server couldn't resolve
   // the ref (we'd produce a turn without context). `ready` and `inline`
   // are safe.
+  //
+  // A context ref alone is enough to send: "Discuss with Ariadne" can be
+  // dispatched with just the attached thread chip — no body text, no upload
+  // required. Treating refs as a third payload type lets the user fire off
+  // "what's going on here?" without typing.
   const contextRefsReady = savedContextRefs.every(
     (ref: DraftContextRef) => ref.status === "ready" || ref.status === "inline"
   )
-  const canSend = (hasContent || uploadedIds.length > 0) && !isSending && !isUploading && contextRefsReady
+  const hasPayload = hasContent || uploadedIds.length > 0 || savedContextRefs.length > 0
+  const canSend = hasPayload && !isSending && !isUploading && contextRefsReady
 
   return {
     // Content


### PR DESCRIPTION
## Problem

Three connected gaps in the "Discuss with Ariadne" flow that we shipped recently — each one is a small lie about what the model is actually doing:

1. **Context pill lies about scope.** The chip on the composer says "487 messages in #intro" even though the resolver only sends ~50 messages to the model after the discuss-thread windowing change.
2. **Send button rejects a valid payload.** Clicking "Discuss with Ariadne" attaches a thread chip, but the composer refuses to send unless the user also types text or attaches a file. The chip itself is a sufficient payload — the user shouldn't have to type a placeholder.
3. **AI trace omits the focal attachment.** When you start a discussion from a message that has a PDF attached, neither the rendered system prompt nor the trace UI mentions the attachment. The model has no idea the file is there, and the trace lies about what was shared.

## Solution

### 1. Clamp `itemCount` to the window in `fetchStreamBag`

When `bag.intent === DISCUSS_THREAD`, clamp `source.itemCount` to `Math.min(totalCount, DISCUSS_WINDOW_TOTAL)`. The chip now matches what the resolver actually feeds the model.

`DISCUSS_WINDOW_TOTAL = 50` is exported from `thread-resolver.ts` so the chip and the resolver pull from the same constant — moving it to `intents/discuss-thread.ts` was considered but adds churn for marginal benefit; the export comment makes the cross-use explicit.

### 2. Treat context refs as a third payload type in `useDraftComposer`

Send is enabled when **any** of body content, uploaded attachments, or context refs are present (with the same readiness gate as before). One inline comment explains the semantic shift; the `contextRefsReady` precompute gate is unchanged.

### 3. Surface attachment metadata on `RenderableMessage`

- `RenderableMessage.attachments?: AttachmentSummary[]` — reuses the existing `AttachmentSummary` shape that `message_created` events already carry on the wire, no parallel context-bag-only type.
- `ThreadResolver.fetch` batch-fetches via `AttachmentRepository.findByMessageIds(...)`, parallel with `resolveActorNames`. One SQL query per resolve regardless of window size.
- `formatInlineMessage` renders `Attachments: [att_…] filename (mime, sizeBytes bytes)` under each message that has any. The model gets enough metadata to reason about what's attached; full extraction text stays behind the existing attachment tools (`load_attachment`, `load_pdf_section`) so the stable region stays small and prompt-cache-friendly.

### Key design decisions

**Attachments are NOT folded into the fingerprint manifest.** They're immutable after message creation — the link is set at insert time and never mutated — so adding them to the fingerprint would expand the manifest without ever changing the value. There's an explicit comment at the fingerprint computation site so a future contributor who breaks that invariant gets the warning right next to the code that would silently serve a stale summary.

**Reuse over new types.** First pass introduced a new `RenderableAttachment` type with the same four fields as `AttachmentSummary`. Self-review caught the duplication and replaced it with the existing wire-event type — one fewer place for the shape to drift.

**Render minimal metadata, not extracted content.** Including extraction text would bloat the stable region for every turn; Ariadne already has tools to load attachment content on demand. Showing filename + mime + size is the smallest signal that closes both the trace-completeness gap and the model-awareness gap.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/agents/context-bag/fetch-stream-bag.ts` | Clamp `itemCount` to `DISCUSS_WINDOW_TOTAL` for `DISCUSS_THREAD` bags |
| `apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.ts` | Export `DISCUSS_WINDOW_TOTAL`; batch-fetch attachments parallel with author names; pin fingerprint immutability assumption with a comment |
| `apps/backend/src/features/agents/context-bag/render.ts` | `formatInlineMessage` renders an attachments line per message that has any |
| `apps/backend/src/features/agents/context-bag/types.ts` | Add `attachments?: AttachmentSummary[]` to `RenderableMessage` (reuses messaging type) |
| `apps/frontend/src/hooks/use-draft-composer.ts` | `canSend` accepts context refs as a third payload type |

### Tests

| File | Coverage |
| --- | --- |
| `apps/backend/src/features/agents/context-bag/handlers.test.ts` | Regression: `getStreamBag` clamps `itemCount` to 50 when total is 487 |
| `apps/backend/src/features/agents/context-bag/render.test.ts` | Attachments render with id/filename/mime/size; messages without attachments don't get an empty line |
| `apps/backend/src/features/agents/context-bag/resolvers/thread-resolver.test.ts` | Per-test default stub for `findByMessageIds`; new test pins attachment passthrough |
| `apps/frontend/src/hooks/use-draft-composer.test.ts` | `canSend === true` with only a ready context-ref (no body, no attachments) |

## Test plan

- [x] `bun test apps/backend/src/` — 1065 pass, 1 pre-existing flake (GitHub tools, unrelated)
- [x] `bunx vitest run apps/frontend/src/hooks/use-draft-composer.test.ts` — 34 pass
- [x] `bun run typecheck` (all workspaces) — clean
- [x] `bun run lint` (all workspaces) — clean
- [x] `bun run check:dockerfiles` — clean
- [x] OpenAPI spec up to date
- [ ] Manual: open Discuss-with-Ariadne on a message with a PDF attached → trace's `context_received` shows the attachment line; chip says "≤50 messages in #foo"; send works with the chip alone

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2dBzbAVijq6DP6ne1AAMj)_