### PR TITLE
fix(messaging): keep shared_messages and pointer hydration consistent across moves

### DIFF
--- a/apps/backend/src/features/messaging/repository.test.ts
+++ b/apps/backend/src/features/messaging/repository.test.ts
@@ -1,6 +1,19 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { MessageRepository } from "./repository"
 
+function fakeDb() {
+  const queries: Array<{ text: string; values: unknown[] }> = []
+  const db = {
+    async query(textOrConfig: any, values?: unknown[]) {
+      const text = typeof textOrConfig === "string" ? textOrConfig : textOrConfig.text
+      const vals = typeof textOrConfig === "string" ? (values ?? []) : (textOrConfig.values ?? [])
+      queries.push({ text, values: vals })
+      return { rows: [], rowCount: 0 }
+    },
+  }
+  return { db: db as any, queries }
+}
+
 function makeMessage(overrides: Record<string, any> = {}): any {
   return {
     id: "msg_root",
@@ -65,5 +78,51 @@ describe("MessageRepository.findThreadRoot", () => {
     const result = await MessageRepository.findThreadRoot({} as any, { parentMessageId: "msg_deleted" })
 
     expect(result).toBeNull()
+  })
+})
+
+describe("MessageRepository.updateStreamScopedReferences", () => {
+  it("re-stamps shared_messages on both sides — source-of-share and share-message-target", async () => {
+    // Pin the columns the batch move-to-thread flow must keep in sync. A
+    // moved message can be a SOURCE (shared elsewhere) or the SHARE MESSAGE
+    // itself (its body contains a sharedMessage node). Both columns are
+    // denormalized on shared_messages; without this re-stamp,
+    // pointer:invalidated fans out to the old room and any future joins on
+    // shared_messages.source_stream_id resolve to the wrong stream.
+    const { db, queries } = fakeDb()
+
+    await MessageRepository.updateStreamScopedReferences(db, {
+      workspaceId: "ws_1",
+      sourceStreamId: "stream_src",
+      destinationStreamId: "stream_dst",
+      messageIds: ["msg_a", "msg_b"],
+    })
+
+    const sharedMessageQueries = queries.filter((q) => /UPDATE shared_messages/i.test(q.text))
+    expect(sharedMessageQueries).toHaveLength(2)
+
+    const sourceSideQuery = sharedMessageQueries.find((q) => /source_stream_id\s*=/.test(q.text.split("WHERE")[1] ?? ""))
+    const targetSideQuery = sharedMessageQueries.find((q) => /target_stream_id\s*=/.test(q.text.split("WHERE")[1] ?? ""))
+
+    expect(sourceSideQuery).toBeDefined()
+    expect(sourceSideQuery!.text).toMatch(/source_message_id\s*=\s*ANY/i)
+    expect(sourceSideQuery!.values).toEqual(["stream_dst", "ws_1", "stream_src", ["msg_a", "msg_b"]])
+
+    expect(targetSideQuery).toBeDefined()
+    expect(targetSideQuery!.text).toMatch(/share_message_id\s*=\s*ANY/i)
+    expect(targetSideQuery!.values).toEqual(["stream_dst", "ws_1", "stream_src", ["msg_a", "msg_b"]])
+  })
+
+  it("is a no-op when messageIds is empty (no rows to re-stamp)", async () => {
+    const { db, queries } = fakeDb()
+
+    await MessageRepository.updateStreamScopedReferences(db, {
+      workspaceId: "ws_1",
+      sourceStreamId: "stream_src",
+      destinationStreamId: "stream_dst",
+      messageIds: [],
+    })
+
+    expect(queries).toEqual([])
   })
 })

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -481,6 +481,29 @@ export const MessageRepository = {
         AND target_message_id = ANY(${params.messageIds})
     `)
 
+    // shared_messages denormalizes both the source's stream and the share
+    // message's stream. A move can hit either side: the moved message can be
+    // a SOURCE (someone else's message embeds it) or the SHARE MESSAGE itself
+    // (its body contains a `sharedMessage` node). Re-stamp both columns so the
+    // pointer-invalidation broadcaster (`outbox-handler.ts`) targets the room
+    // where the share actually lives, and so any future joins on
+    // `source_stream_id` for navigation/UI resolve to the current stream.
+    await db.query(sql`
+      UPDATE shared_messages
+      SET source_stream_id = ${params.destinationStreamId}
+      WHERE workspace_id = ${params.workspaceId}
+        AND source_stream_id = ${params.sourceStreamId}
+        AND source_message_id = ANY(${params.messageIds})
+    `)
+
+    await db.query(sql`
+      UPDATE shared_messages
+      SET target_stream_id = ${params.destinationStreamId}
+      WHERE workspace_id = ${params.workspaceId}
+        AND target_stream_id = ${params.sourceStreamId}
+        AND share_message_id = ANY(${params.messageIds})
+    `)
+
     await db.query(sql`
       UPDATE agent_sessions
       SET stream_id = ${params.destinationStreamId}

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -321,6 +321,52 @@ describe("hydrateSharedMessageIds", () => {
     })
   })
 
+  it("emits private (not truncated) when a past-cap source has been moved into an inaccessible stream", async () => {
+    // Past-cap source M lives in stream_private after a move; the cached
+    // streamId on the share-node attrs is "stream_cached", but the viewer
+    // can only read the streams reachable along the BFS chain. Surfacing
+    // the live `stream_private` without an access check would leak the
+    // existence of the new private stream the viewer has no rights to.
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        const next = id.replace(/^msg_(\d+)$/, (_m, n) => `msg_${Number(n) + 1}`)
+        const past = id === `msg_${MAX_HYDRATION_DEPTH}`
+        map.set(
+          id,
+          makeMessage({
+            id,
+            streamId: past ? "stream_private" : "stream_chain",
+            contentJson: past
+              ? { type: "doc", content: [] }
+              : {
+                  type: "doc",
+                  content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_cached" } }],
+                },
+          })
+        )
+      }
+      return map
+    })
+    stubAuthorLookups()
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockImplementation(async (_db, _ws, _uid, candidates) => {
+      // Viewer can read the BFS chain's stream but NOT the post-move private one.
+      return new Set([...candidates].filter((id) => id !== "stream_private"))
+    })
+    spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      { id: "stream_private", type: "channel", visibility: "private", rootStreamId: null } as any,
+    ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
+    expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      state: "private",
+      messageId: `msg_${MAX_HYDRATION_DEPTH}`,
+      sourceStreamKind: "channel",
+      sourceVisibility: "private",
+    })
+  })
+
   it("skips truncated emission for a private inner pointer (no extra access leak)", async () => {
     // A two-hop chain where the viewer can read msg_outer but not msg_inner.
     // The plan says inner should render as `private`, not as `truncated`.

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -213,6 +213,12 @@ describe("hydrateSharedMessageIds", () => {
   it("recurses into nested pointers up to MAX_HYDRATION_DEPTH and emits truncated past the cap", async () => {
     // Build a chain msg_0 → msg_1 → msg_2 → msg_3 → msg_4 (4 levels deep beyond seed)
     // With MAX_HYDRATION_DEPTH = 3, msg_0..msg_2 hydrate as ok and msg_3 is truncated.
+    //
+    // The cached `streamId` on every share node attr is "stream_cached", but
+    // the live row for the past-cap source lives in "stream_live" (simulating
+    // a post-move state where the cached attr went stale). The truncated
+    // payload must report the live streamId, not the cached one — otherwise
+    // the "open in source stream" link drops the user on the wrong stream.
     const findByIds = spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
       const map = new Map<string, any>()
       for (const id of ids) {
@@ -221,9 +227,10 @@ describe("hydrateSharedMessageIds", () => {
           id,
           makeMessage({
             id,
+            streamId: id === `msg_${MAX_HYDRATION_DEPTH}` ? "stream_live" : "stream_source",
             contentJson: {
               type: "doc",
-              content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_next" } }],
+              content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_cached" } }],
             },
           })
         )
@@ -239,15 +246,79 @@ describe("hydrateSharedMessageIds", () => {
     for (let i = 0; i < MAX_HYDRATION_DEPTH; i++) {
       expect(result[`msg_${i}`]).toMatchObject({ state: "ok" })
     }
-    // The first un-fetched ref is the truncated entry, using the streamId from
-    // the parent's share-node attrs so we don't pay an extra DB lookup.
+    // The truncated entry reports the LIVE streamId from the row, not the
+    // stale cached attr — the fix for "shared_messages cached streamId goes
+    // stale after batch move-to-thread".
     expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
       state: "truncated",
       messageId: `msg_${MAX_HYDRATION_DEPTH}`,
-      streamId: "stream_next",
+      streamId: "stream_live",
     })
-    // Caller saw exactly MAX_HYDRATION_DEPTH batched message lookups.
-    expect(findByIds).toHaveBeenCalledTimes(MAX_HYDRATION_DEPTH)
+    // MAX_HYDRATION_DEPTH BFS lookups + 1 batched lookup for past-cap entries.
+    expect(findByIds).toHaveBeenCalledTimes(MAX_HYDRATION_DEPTH + 1)
+  })
+
+  it("emits deleted (not truncated) when a past-cap source has been tombstoned", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        const next = id.replace(/^msg_(\d+)$/, (_m, n) => `msg_${Number(n) + 1}`)
+        const past = id === `msg_${MAX_HYDRATION_DEPTH}`
+        map.set(
+          id,
+          makeMessage({
+            id,
+            deletedAt: past ? new Date("2026-04-01") : null,
+            contentJson: past
+              ? { type: "doc", content: [] }
+              : {
+                  type: "doc",
+                  content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_cached" } }],
+                },
+          })
+        )
+      }
+      return map
+    })
+    stubAuthorLookups()
+    stubFullAccess()
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
+    expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      state: "deleted",
+      messageId: `msg_${MAX_HYDRATION_DEPTH}`,
+      deletedAt: new Date("2026-04-01"),
+    })
+  })
+
+  it("emits missing when a past-cap source row is gone entirely", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockImplementation(async (_db, _ws, ids) => {
+      const map = new Map<string, any>()
+      for (const id of ids) {
+        // Simulate the past-cap source being deleted from the row set.
+        if (id === `msg_${MAX_HYDRATION_DEPTH}`) continue
+        const next = id.replace(/^msg_(\d+)$/, (_m, n) => `msg_${Number(n) + 1}`)
+        map.set(
+          id,
+          makeMessage({
+            id,
+            contentJson: {
+              type: "doc",
+              content: [{ type: "sharedMessage", attrs: { messageId: next, streamId: "stream_cached" } }],
+            },
+          })
+        )
+      }
+      return map
+    })
+    stubAuthorLookups()
+    stubFullAccess()
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_0"])
+    expect(result[`msg_${MAX_HYDRATION_DEPTH}`]).toEqual({
+      state: "missing",
+      messageId: `msg_${MAX_HYDRATION_DEPTH}`,
+    })
   })
 
   it("skips truncated emission for a private inner pointer (no extra access leak)", async () => {

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -204,16 +204,31 @@ export async function hydrateSharedMessageIds(
   // Anything still in frontier has been collected from depth=MAX-1's
   // accessible content but we won't recurse into it. The cached `streamId`
   // from the share-node attrs goes stale when the source message gets moved
-  // (batch move-to-thread doesn't rewrite cached attrs), so resolve current
-  // streamIds in one batched lookup. Surfaces deleted/missing past the cap
-  // too, instead of handing out a truncated link to a tombstone.
+  // (batch move-to-thread doesn't rewrite cached attrs), so resolve the
+  // current streamId from the live row.
+  //
+  // Mirror the BFS access check so this branch can't surface a streamId the
+  // viewer can't read (post-move, the source might live in a private thread
+  // the viewer was never a member of) or a `deleted` tombstone for an
+  // inaccessible source. Inaccessible entries route into the existing
+  // privateBuckets path so the wire shape stays uniform.
   const truncatedIds = [...frontier.keys()].filter((id) => !visited.has(id) && !result[id])
   if (truncatedIds.length > 0) {
     const truncatedMessages = await MessageRepository.findByIdsInWorkspace(db, workspaceId, truncatedIds)
+    const fetchedStreamIds = [...truncatedMessages.values()].map((m) => m.streamId)
+    const [accessibleStreams, grantedSources] = await Promise.all([
+      listAccessibleStreamIds(db, workspaceId, viewerId, fetchedStreamIds),
+      SharedMessageRepository.listSourcesGrantedToViewer(db, workspaceId, viewerId, truncatedIds),
+    ])
     for (const id of truncatedIds) {
       const msg = truncatedMessages.get(id)
       if (!msg) {
         result[id] = { state: "missing", messageId: id }
+        continue
+      }
+      const hasAccess = accessibleStreams.has(msg.streamId) || grantedSources.has(id)
+      if (!hasAccess) {
+        privateBuckets.set(id, msg.streamId)
         continue
       }
       if (msg.deletedAt) {

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -202,12 +202,26 @@ export async function hydrateSharedMessageIds(
   }
 
   // Anything still in frontier has been collected from depth=MAX-1's
-  // accessible content but we won't recurse into it. Emit truncated using
-  // the streamId cached on the share-node attrs — no extra DB call.
-  for (const [id, streamId] of frontier) {
-    if (visited.has(id) || result[id]) continue
-    if (!streamId) continue
-    result[id] = { state: "truncated", messageId: id, streamId }
+  // accessible content but we won't recurse into it. The cached `streamId`
+  // from the share-node attrs goes stale when the source message gets moved
+  // (batch move-to-thread doesn't rewrite cached attrs), so resolve current
+  // streamIds in one batched lookup. Surfaces deleted/missing past the cap
+  // too, instead of handing out a truncated link to a tombstone.
+  const truncatedIds = [...frontier.keys()].filter((id) => !visited.has(id) && !result[id])
+  if (truncatedIds.length > 0) {
+    const truncatedMessages = await MessageRepository.findByIdsInWorkspace(db, workspaceId, truncatedIds)
+    for (const id of truncatedIds) {
+      const msg = truncatedMessages.get(id)
+      if (!msg) {
+        result[id] = { state: "missing", messageId: id }
+        continue
+      }
+      if (msg.deletedAt) {
+        result[id] = { state: "deleted", messageId: id, deletedAt: msg.deletedAt }
+        continue
+      }
+      result[id] = { state: "truncated", messageId: id, streamId: msg.streamId }
+    }
   }
 
   if (privateBuckets.size > 0) {

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.test.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.test.ts
@@ -48,9 +48,9 @@ describe("invalidatePointersForEvent", () => {
 
   it("emits pointer:invalidated once per distinct target stream when pointers exist", async () => {
     spyOn(SharedMessageRepository, "listBySourceMessageIds").mockResolvedValue([
-      { targetStreamId: "stream_t1" },
-      { targetStreamId: "stream_t2" },
-      { targetStreamId: "stream_t1" }, // duplicate → deduped
+      { sourceMessageId: "msg_a", targetStreamId: "stream_t1" },
+      { sourceMessageId: "msg_a", targetStreamId: "stream_t2" },
+      { sourceMessageId: "msg_a", targetStreamId: "stream_t1" }, // duplicate → deduped
     ] as any)
     const { io, emits } = fakeIo()
     await invalidatePointersForEvent(
@@ -85,5 +85,54 @@ describe("invalidatePointersForEvent", () => {
       io
     )
     expect(list).toHaveBeenCalledWith({}, "ws_1", ["msg_edited"])
+  })
+
+  it("fans out a per-source pointer:invalidated for each share when a messages:moved event lands", async () => {
+    spyOn(SharedMessageRepository, "listBySourceMessageIds").mockResolvedValue([
+      { sourceMessageId: "msg_a", targetStreamId: "stream_t1" },
+      { sourceMessageId: "msg_b", targetStreamId: "stream_t1" },
+      { sourceMessageId: "msg_a", targetStreamId: "stream_t2" },
+    ] as any)
+    const { io, emits } = fakeIo()
+    await invalidatePointersForEvent(
+      {
+        eventType: "messages:moved",
+        payload: {
+          workspaceId: "ws_1",
+          streamId: "stream_src",
+          movedMessageIds: ["msg_a", "msg_b", "msg_c"],
+        },
+      } as any,
+      {} as any,
+      io
+    )
+    // One emit per (target, source) pair: (t1,a), (t1,b), (t2,a). msg_c has
+    // no shares so it doesn't surface.
+    expect(emits).toHaveLength(3)
+    const pairs = emits.map((e) => `${e.room}|${(e.payload as { sourceMessageId: string }).sourceMessageId}`).sort()
+    expect(pairs).toEqual([
+      "ws:ws_1:stream:stream_t1|msg_a",
+      "ws:ws_1:stream:stream_t1|msg_b",
+      "ws:ws_1:stream:stream_t2|msg_a",
+    ])
+    expect(emits.every((e) => e.event === POINTER_INVALIDATED_EVENT)).toBe(true)
+  })
+
+  it("passes every moved message id to the share lookup when a messages:moved event lands", async () => {
+    const list = spyOn(SharedMessageRepository, "listBySourceMessageIds").mockResolvedValue([])
+    const { io } = fakeIo()
+    await invalidatePointersForEvent(
+      {
+        eventType: "messages:moved",
+        payload: {
+          workspaceId: "ws_1",
+          streamId: "stream_src",
+          movedMessageIds: ["msg_a", "msg_b"],
+        },
+      } as any,
+      {} as any,
+      io
+    )
+    expect(list).toHaveBeenCalledWith({}, "ws_1", ["msg_a", "msg_b"])
   })
 })

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.ts
@@ -13,26 +13,37 @@ import { SharedMessageRepository } from "./repository"
 export const POINTER_INVALIDATED_EVENT = "pointer:invalidated"
 
 /**
- * Extract the source messageId from an outbox event that signals the source
- * has changed. Returns null when the event is for a different type or when
- * the payload shape is unexpected.
+ * Extract every source messageId from an outbox event that signals a source
+ * change pointer consumers care about. Returns an empty array when the event
+ * type is unrelated or the payload shape is unexpected.
  *
- * Only `message:edited` (content change) and `message:deleted` (tombstone)
- * affect what a hydrated pointer renders. `message:updated` is reserved for
- * thread-reply-count bumps (`event-service.ts:163`) and never carries a
- * content delta, so including it here would fan out a `pointer:invalidated`
- * to every target stream of every shared parent message on every reply —
- * a pure cache-bust with nothing to re-fetch.
+ * - `message:edited` / `message:deleted` carry one messageId.
+ * - `messages:moved` carries N: a moved message's `streamId` changes, which
+ *   changes what hydrated pointers' "open in source stream" link should
+ *   target. Content/author/createdAt are unchanged, so the invalidation is
+ *   purely a cache-bust hint to re-fetch the hydration payload.
+ *
+ * `message:updated` is reserved for thread-reply-count bumps
+ * (`event-service.ts:163`) and never carries a content/streamId delta, so
+ * including it here would fan out `pointer:invalidated` to every target
+ * stream of every shared parent on every reply — a pure cache-bust with
+ * nothing to re-fetch.
  */
-function extractMessageIdForInvalidation(event: OutboxEvent): string | null {
+function extractMessageIdsForInvalidation(event: OutboxEvent): string[] {
   if (event.eventType === "message:edited") {
     const inner = (event.payload as { event?: { payload?: { messageId?: string } } }).event
-    return inner?.payload?.messageId ?? null
+    const id = inner?.payload?.messageId
+    return id ? [id] : []
   }
   if (event.eventType === "message:deleted") {
-    return (event.payload as { messageId?: string }).messageId ?? null
+    const id = (event.payload as { messageId?: string }).messageId
+    return id ? [id] : []
   }
-  return null
+  if (event.eventType === "messages:moved") {
+    const ids = (event.payload as { movedMessageIds?: string[] }).movedMessageIds
+    return ids ?? []
+  }
+  return []
 }
 
 /**
@@ -46,19 +57,34 @@ function extractMessageIdForInvalidation(event: OutboxEvent): string | null {
  * message's own broadcast.
  */
 export async function invalidatePointersForEvent(event: OutboxEvent, db: Pool, io: Server): Promise<void> {
-  const sourceMessageId = extractMessageIdForInvalidation(event)
-  if (!sourceMessageId) return
+  const sourceMessageIds = extractMessageIdsForInvalidation(event)
+  if (sourceMessageIds.length === 0) return
 
   const { workspaceId } = event.payload as { workspaceId: string }
-  const shares = await SharedMessageRepository.listBySourceMessageIds(db, workspaceId, [sourceMessageId])
+  const shares = await SharedMessageRepository.listBySourceMessageIds(db, workspaceId, sourceMessageIds)
   if (shares.length === 0) return
 
-  const targetStreamIds = new Set(shares.map((s) => s.targetStreamId))
-  for (const targetStreamId of targetStreamIds) {
-    io.to(`ws:${workspaceId}:stream:${targetStreamId}`).emit(POINTER_INVALIDATED_EVENT, {
-      workspaceId,
-      targetStreamId,
-      sourceMessageId,
-    })
+  // Group affected target streams by the source whose pointer they host so
+  // each invalidation event names the specific source the client should
+  // refetch. One emit per (targetStream, source) pair — clients subscribe
+  // by stream, not by source, so collapsing across sources here would force
+  // every pointer in the room to refetch on every per-source change.
+  const sourcesByTarget = new Map<string, Set<string>>()
+  for (const share of shares) {
+    let sources = sourcesByTarget.get(share.targetStreamId)
+    if (!sources) {
+      sources = new Set()
+      sourcesByTarget.set(share.targetStreamId, sources)
+    }
+    sources.add(share.sourceMessageId)
+  }
+  for (const [targetStreamId, sources] of sourcesByTarget) {
+    for (const sourceMessageId of sources) {
+      io.to(`ws:${workspaceId}:stream:${targetStreamId}`).emit(POINTER_INVALIDATED_EVENT, {
+        workspaceId,
+        targetStreamId,
+        sourceMessageId,
+      })
+    }
   }
 }

--- a/apps/backend/src/features/messaging/sharing/outbox-handler.ts
+++ b/apps/backend/src/features/messaging/sharing/outbox-handler.ts
@@ -1,6 +1,6 @@
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
-import type { OutboxEvent } from "../../../lib/outbox"
+import { isOutboxEventType, type OutboxEvent } from "../../../lib/outbox"
 import { SharedMessageRepository } from "./repository"
 
 /**
@@ -30,18 +30,18 @@ export const POINTER_INVALIDATED_EVENT = "pointer:invalidated"
  * nothing to re-fetch.
  */
 function extractMessageIdsForInvalidation(event: OutboxEvent): string[] {
-  if (event.eventType === "message:edited") {
-    const inner = (event.payload as { event?: { payload?: { messageId?: string } } }).event
-    const id = inner?.payload?.messageId
-    return id ? [id] : []
+  if (isOutboxEventType(event, "message:edited")) {
+    // event.payload.event is a StreamEvent whose inner `payload` is typed
+    // as `unknown` (event-shape varies by event type). Narrow only that
+    // field; the outer envelope is fully typed via isOutboxEventType.
+    const inner = event.payload.event?.payload as { messageId?: string } | undefined
+    return inner?.messageId ? [inner.messageId] : []
   }
-  if (event.eventType === "message:deleted") {
-    const id = (event.payload as { messageId?: string }).messageId
-    return id ? [id] : []
+  if (isOutboxEventType(event, "message:deleted")) {
+    return event.payload.messageId ? [event.payload.messageId] : []
   }
-  if (event.eventType === "messages:moved") {
-    const ids = (event.payload as { movedMessageIds?: string[] }).movedMessageIds
-    return ids ?? []
+  if (isOutboxEventType(event, "messages:moved")) {
+    return event.payload.movedMessageIds
   }
   return []
 }


### PR DESCRIPTION
## Problem

Three logical conflicts surface when batch move-to-thread (#420) lands on top of the share-message slices (#409, #421, #435). They're independent on the wire but they all leak the same root cause: a few denormalized columns and one cached attr value record where a message lives, and a move doesn't update them.

> Stacks on top of #420 (`add-batch-move-messages-to-thread`) — fix 1 modifies code that doesn't exist on main yet. Once #420 merges this rebases onto main directly.

## Solution

### 1. `shared_messages` is missing from `updateStreamScopedReferences`

`MessageRepository.updateStreamScopedReferences` re-stamps `stream_id` on every other table that denormalizes it after a move (`attachments`, `saved_messages`, `user_activity`, `researcher_cache`, `memo_pending_items`, `link_previews.target_stream_id`, `agent_sessions.stream_id`) but didn't touch `shared_messages`. That row has **two** denormalized columns:

- `source_stream_id` — stale when a moved message is the source of one or more shares.
- `target_stream_id` — stale when a moved message is the share message itself (its body contains a `sharedMessage` node).

Concrete failure: after moving a share message into a thread, edits to its source still emit `pointer:invalidated` to the **old** target stream's room (because the broadcaster reads `target_stream_id`), so viewers in the new thread don't get a refresh signal until the next bootstrap.

Fix mirrors the existing `link_previews` block — two `UPDATE shared_messages` statements, one per side.

### 2. Cached `streamId` on `sharedMessage` node attrs goes stale

The pointer node carries `{ messageId, streamId }` baked at share time. `hydrateSharedMessageIds` was using that cached `streamId` for the **truncated** branch past `MAX_HYDRATION_DEPTH = 3`. After a source move, the cache is wrong and the deep-link points to the wrong stream.

Fix: resolve current streamIds for past-cap entries in one batched lookup post-loop. Past-cap entries also now surface `deleted` and `missing` correctly instead of handing out a truncated link to a tombstone or a deleted row.

Cost: one extra `findByIdsInWorkspace` only when the chain hits the cap. Hot path (chains ≤ 3) is unchanged.

### 3. No `pointer:invalidated` fan-out from `messages:moved`

`invalidatePointersForEvent` only handled `message:edited` and `message:deleted`. A move changes `source.streamId` (which hydration returns to clients), so pointer consumers in target streams should re-fetch on `messages:moved` too — even though content/author/createdAt are unchanged, the "open in source stream" link should follow the move.

Fix: extend the extractor to a multi-id form and look up shares for every moved id. Emit one event per `(targetStreamId, sourceMessageId)` pair so each pointer in a room knows which source to refetch — collapsing across sources would force every pointer to refetch on every per-source change.

### Key design decisions

**Stacked on #420, not on main.** Fix 1 modifies `updateStreamScopedReferences`, which is part of the move flow and lives only on the batch-move branch. Targeting main would require carrying the move code in this PR too.

**No move-time content rewrite for the cached `streamId` attr.** The straightforward alternative for fix 2 is to walk every share-message body that references a moved source and rewrite the cached `streamId` attr in place. That would touch every target message's contentJson + emit `message:edited` for each — heavy work for a cache that hydration can refresh at read time anyway. Resolving at hydration is one batched query, off the hot path, and self-correcting after any future move.

**Per-source pointer-invalidate emit.** Clients subscribe to streams, not to sources. Collapsing the fan-out to one emit per target stream (regardless of source) would force every pointer in that room to refetch on every per-source change. The plural form keeps the existing single-source contract — clients can route the cache-bust to the specific pointer that needs it.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/messaging/repository.ts` | `updateStreamScopedReferences` re-stamps both columns on `shared_messages` |
| `apps/backend/src/features/messaging/sharing/hydration.ts` | Past-cap entries resolve current streamId via a batched lookup; emit `deleted`/`missing` for moved sources past the cap |
| `apps/backend/src/features/messaging/sharing/outbox-handler.ts` | Extractor returns `string[]`; handle `messages:moved`; emit one event per `(target, source)` pair |

## Tests

| File | Coverage |
| --- | --- |
| `apps/backend/src/features/messaging/repository.test.ts` | Pins both `UPDATE shared_messages` statements with their WHERE clauses; pins the empty-messageIds no-op |
| `apps/backend/src/features/messaging/sharing/hydration.test.ts` | Truncated entry uses the live row's streamId, not the cached attr; deleted/missing past-cap states surface correctly |
| `apps/backend/src/features/messaging/sharing/outbox-handler.test.ts` | `messages:moved` fans out per `(target, source)` pair; share lookup receives every moved id; existing tests updated to include `sourceMessageId` on mock rows |

## Test plan

- [x] `bun test apps/backend/src/features/messaging/` — 74 pass, 0 fail
- [x] `bun run --cwd apps/backend typecheck` — clean
- [x] `bun run --cwd apps/backend lint` — clean
- [ ] Backend integration / E2E — would require a DB; the unit tests pin the SQL shape and the broadcast contract directly.
- [ ] Manual: share a message, then move it into a thread → verify the source-side `shared_messages.source_stream_id` row reflects the destination, and editing the moved source still pushes `pointer:invalidated` to viewers of the share.

## Notes on what's intentionally NOT fixed

- **Privacy boundary re-evaluation on move.** `moveMessagesToThread` always creates the destination thread under the same root, inheriting visibility, so the audience for any moved message is unchanged. `crossesPrivacyBoundary` results from share time stay correct. If the thread-inheritance rule ever changes, that needs to be revisited.
- **`SOURCE_STREAM_MISMATCH` during a concurrent move.** A client racing a move into a fresh share gets a clean 400 from `validateAndRecordShares`. That's a correctness check, not a bug — the client retries with the current attrs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NbwyBgCwjUXzJkHwKkvMaH)_