### PR TITLE
fix(frontend): unify stream-event read paths and enforce ASC ordering

### DIFF
--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -183,4 +183,22 @@ describe("loadStreamEvents", () => {
     // (seqs 51..200 — 200 reals capped to latest 150 = seqs 51..200).
     expect(ids[0]).toBe("temp_low")
   })
+
+  it("excludes pending events below the floor when one is provided", async () => {
+    // Floor-bounded reads must not pull in unsent events with
+    // `_sequenceNum < fromSequenceNum`, or the window contract breaks.
+    const streamId = "stream_floored"
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "100"),
+      makeRealEvent(streamId, "101"),
+      // Pending event below the floor — must be filtered out.
+      makeOptimisticEvent(streamId, "temp_below", "50"),
+      // Pending event above the floor — must be kept.
+      makeOptimisticEvent(streamId, "temp_above", "999999"),
+    ])
+
+    const events = await loadStreamEvents(streamId, 100)
+
+    expect(events.map((e) => e.id)).toEqual(["evt_stream_floored_100", "evt_stream_floored_101", "temp_above"])
+  })
 })

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { db, sequenceToNum, type CachedEvent } from "@/db"
+import { loadStreamEvents } from "./stream-store"
+
+const WORKSPACE_ID = "ws_1"
+
+function makeRealEvent(streamId: string, sequence: string): CachedEvent {
+  const sequenceNum = sequenceToNum(sequence)
+  return {
+    id: `evt_${streamId}_${sequence}`,
+    workspaceId: WORKSPACE_ID,
+    streamId,
+    sequence,
+    _sequenceNum: sequenceNum,
+    eventType: "message_created",
+    payload: { messageId: `evt_${streamId}_${sequence}`, contentMarkdown: sequence },
+    actorId: "user_1",
+    actorType: "user",
+    createdAt: new Date(2026, 0, 1, 0, 0, sequenceNum).toISOString(),
+    _cachedAt: Date.now(),
+  }
+}
+
+function makeOptimisticEvent(streamId: string, clientId: string, placeholderSeq: string): CachedEvent {
+  const sequenceNum = sequenceToNum(placeholderSeq)
+  return {
+    id: clientId,
+    workspaceId: WORKSPACE_ID,
+    streamId,
+    sequence: placeholderSeq,
+    _sequenceNum: sequenceNum,
+    eventType: "message_created",
+    payload: { messageId: clientId, contentMarkdown: clientId },
+    actorId: "user_1",
+    actorType: "user",
+    createdAt: new Date().toISOString(),
+    _clientId: clientId,
+    _status: "pending",
+    _cachedAt: Date.now(),
+  }
+}
+
+describe("loadStreamEvents", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("returns events ASC by _sequenceNum with no floor", async () => {
+    const streamId = "stream_1"
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "3"),
+      makeRealEvent(streamId, "1"),
+      makeRealEvent(streamId, "5"),
+      makeRealEvent(streamId, "2"),
+      makeRealEvent(streamId, "4"),
+    ])
+
+    const events = await loadStreamEvents(streamId, null)
+
+    expect(events.map((e) => e.sequence)).toEqual(["1", "2", "3", "4", "5"])
+  })
+
+  it("returns events ASC by _sequenceNum when a floor is provided", async () => {
+    const streamId = "stream_1"
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "3"),
+      makeRealEvent(streamId, "1"),
+      makeRealEvent(streamId, "5"),
+      makeRealEvent(streamId, "2"),
+      makeRealEvent(streamId, "4"),
+    ])
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((e) => e.sequence)).toEqual(["1", "2", "3", "4", "5"])
+  })
+
+  it("places optimistic events with Date.now() placeholder seqs after real events in a new channel", async () => {
+    // Mirrors the bug scenario: empty channel after refresh, user fires off
+    // 5 messages in rapid succession. All 5 are optimistic with placeholder
+    // sequences in send order.
+    const streamId = "stream_new"
+    const t0 = 1714428000000
+    await db.events.bulkPut([
+      makeOptimisticEvent(streamId, "temp_1", String(t0 + 1)),
+      makeOptimisticEvent(streamId, "temp_2", String(t0 + 2)),
+      makeOptimisticEvent(streamId, "temp_3", String(t0 + 3)),
+      makeOptimisticEvent(streamId, "temp_4", String(t0 + 4)),
+      makeOptimisticEvent(streamId, "temp_5", String(t0 + 5)),
+    ])
+
+    const events = await loadStreamEvents(streamId, null)
+
+    expect(events.map((e) => e.id)).toEqual(["temp_1", "temp_2", "temp_3", "temp_4", "temp_5"])
+  })
+
+  it("preserves order across the optimistic→real swap (newly-created channel)", async () => {
+    // Bug repro: send 5 messages in a fresh channel. As each acks, the
+    // optimistic event is replaced with a real one (server-assigned low seq).
+    // The visible array must stay ASC by send order at every step — the just-
+    // acked message must not "move up to the top".
+    const streamId = "stream_new"
+    const t0 = 1714428000000
+
+    // All 5 sent (still pending)
+    await db.events.bulkPut([
+      makeOptimisticEvent(streamId, "temp_1", String(t0 + 1)),
+      makeOptimisticEvent(streamId, "temp_2", String(t0 + 2)),
+      makeOptimisticEvent(streamId, "temp_3", String(t0 + 3)),
+      makeOptimisticEvent(streamId, "temp_4", String(t0 + 4)),
+      makeOptimisticEvent(streamId, "temp_5", String(t0 + 5)),
+    ])
+
+    let events = await loadStreamEvents(streamId, null)
+    expect(events.map((e) => e.id)).toEqual(["temp_1", "temp_2", "temp_3", "temp_4", "temp_5"])
+
+    // Ack message 1: real evt_…_1 takes its place with server seq=1
+    await db.transaction("rw", db.events, async () => {
+      await db.events.put(makeRealEvent(streamId, "1"))
+      await db.events.delete("temp_1")
+    })
+    events = await loadStreamEvents(streamId, null)
+    expect(events.map((e) => e.sequence)).toEqual(["1", String(t0 + 2), String(t0 + 3), String(t0 + 4), String(t0 + 5)])
+
+    // Ack messages 2, 3, 4, 5 in order
+    for (const seq of ["2", "3", "4", "5"]) {
+      await db.transaction("rw", db.events, async () => {
+        await db.events.put(makeRealEvent(streamId, seq))
+        await db.events.delete(`temp_${seq}`)
+      })
+    }
+
+    events = await loadStreamEvents(streamId, null)
+    expect(events.map((e) => e.sequence)).toEqual(["1", "2", "3", "4", "5"])
+  })
+
+  it("preserves order with a mixed pending+real window (channel with history)", async () => {
+    // Channel already has messages 1–3 from a prior session (bootstrap floor=1).
+    // User sends a new message — optimistic with placeholder seq lands at end.
+    const streamId = "stream_with_history"
+    const t0 = 1714428000000
+
+    await db.events.bulkPut([
+      makeRealEvent(streamId, "1"),
+      makeRealEvent(streamId, "2"),
+      makeRealEvent(streamId, "3"),
+      makeOptimisticEvent(streamId, "temp_x", String(t0 + 1)),
+    ])
+
+    const events = await loadStreamEvents(streamId, 1)
+    expect(events.map((e) => e.id)).toEqual([
+      "evt_stream_with_history_1",
+      "evt_stream_with_history_2",
+      "evt_stream_with_history_3",
+      "temp_x",
+    ])
+  })
+
+  it("merges pending events that fell outside the count-capped window in ASC order", async () => {
+    // Defensive: if a pending event's _sequenceNum is somehow lower than the
+    // window of latest events, the merge step must still place it correctly
+    // by _sequenceNum rather than appending at the end.
+    const streamId = "stream_fallback"
+
+    // Stuff the stream with > DEFAULT_IDB_EVENT_LIMIT (150) real events so the
+    // window cap matters. Insert one pending event with a deliberately low
+    // _sequenceNum (simulating a hypothetical alternative scheme).
+    const reals: CachedEvent[] = []
+    for (let i = 1; i <= 200; i++) {
+      reals.push(makeRealEvent(streamId, String(i)))
+    }
+    const lowPending = makeOptimisticEvent(streamId, "temp_low", "10")
+    await db.events.bulkPut([...reals, lowPending])
+
+    const events = await loadStreamEvents(streamId, null)
+
+    // Pending event must appear before the events with seq=11..200, between
+    // seq=10 and seq=51 (the floor of the latest 150 real events).
+    const ids = events.map((e) => e.id)
+    const lowIdx = ids.indexOf("temp_low")
+    expect(lowIdx).toBeGreaterThanOrEqual(0)
+    // It sorts by _sequenceNum=10, which falls before all reals in the window
+    // (seqs 51..200 — 200 reals capped to latest 150 = seqs 51..200).
+    expect(ids[0]).toBe("temp_low")
+  })
+})

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -5,13 +5,52 @@ import { db, type CachedEvent, type CachedStream } from "@/db"
 /**
  * Cap the number of events loaded from IDB per stream when no sequence floor
  * is known (initial load before bootstrap resolves). Once the caller provides
- * a floor, the IDB query switches to a range scan with no count limit —
- * the floor itself bounds memory usage.
+ * a floor, the floor itself bounds memory usage and the cap doesn't apply.
  */
 const DEFAULT_IDB_EVENT_LIMIT = 150
 
 /** No-op — the in-memory event cache has been removed. Kept for clearAllCachedData compat. */
 export function resetStreamStoreCache(): void {}
+
+/**
+ * Read events for a stream from IndexedDB, sorted ASC by `_sequenceNum`.
+ *
+ * Single read path regardless of whether a floor is provided:
+ *   - With a floor: range scan from the floor to maxKey, no count cap.
+ *   - Without a floor: same range, but capped to the latest N events as a
+ *     memory bound on initial pre-bootstrap load.
+ *
+ * Pending and failed optimistic events with placeholder sequences are merged
+ * in and the full list re-sorted, so they always land in their natural slot
+ * by `_sequenceNum` rather than being appended at the end of the array.
+ */
+export async function loadStreamEvents(streamId: string, fromSequenceNum: number | null): Promise<CachedEvent[]> {
+  // Iterate the index in DESC so the count cap (when applied) keeps the
+  // newest events; flip to ASC at the end for rendering.
+  const lowerBound: [string, number] | [string, typeof Dexie.minKey] =
+    fromSequenceNum != null ? [streamId, fromSequenceNum] : [streamId, Dexie.minKey]
+  const collection = db.events
+    .where("[streamId+_sequenceNum]")
+    .between(lowerBound, [streamId, Dexie.maxKey], true, true)
+    .reverse()
+  const reversed =
+    fromSequenceNum != null ? await collection.toArray() : await collection.limit(DEFAULT_IDB_EVENT_LIMIT).toArray()
+
+  // Merge in pending/failed optimistic events that fell outside the window
+  // (defensive — the current placeholder scheme uses `Date.now()` so they
+  // sort to the very top and are already in-window). Re-sort the full list
+  // so order is determined solely by `_sequenceNum`, not insertion path.
+  const loadedIds = new Set(reversed.map((e) => e.id))
+  const unsent = await db.events
+    .where("streamId")
+    .equals(streamId)
+    .filter((e) => (e._status === "pending" || e._status === "failed") && !loadedIds.has(e.id))
+    .toArray()
+
+  const merged = unsent.length > 0 ? [...reversed, ...unsent] : reversed
+  merged.sort((a, b) => a._sequenceNum - b._sequenceNum)
+  return merged
+}
 
 /**
  * Reactively read all events for a stream from IndexedDB.
@@ -31,41 +70,10 @@ export function useStreamEvents(
 ): CachedEvent[] | undefined {
   const result = useLiveQuery(async () => {
     if (!streamId) return []
-
-    let events: CachedEvent[]
-    if (fromSequenceNum != null) {
-      // Floor-based range scan: return all events from the floor onward.
-      // The floor is controlled by the caller (bootstrap + pagination) so
-      // memory is bounded by how far the user has actually scrolled back.
-      events = await db.events
-        .where("[streamId+_sequenceNum]")
-        .between([streamId, fromSequenceNum], [streamId, Dexie.maxKey], true, true)
-        .toArray()
-    } else {
-      // No floor known yet (pre-bootstrap) — use a count-based cap so the
-      // initial load is bounded on low-memory devices.
-      events = await db.events
-        .where("[streamId+_sequenceNum]")
-        .between([streamId, Dexie.minKey], [streamId, Dexie.maxKey])
-        .reverse()
-        .limit(DEFAULT_IDB_EVENT_LIMIT)
-        .toArray()
-      events.reverse()
-    }
-
-    // Include any pending/failed optimistic events that may have
-    // placeholder sequences outside the loaded window.
-    const loadedIds = new Set(events.map((e) => e.id))
-    const unsent = await db.events
-      .where("streamId")
-      .equals(streamId)
-      .filter((e) => (e._status === "pending" || e._status === "failed") && !loadedIds.has(e.id))
-      .toArray()
-    for (const e of unsent)
-      events.push(e)
-      // Stamp the result with the streamId it was fetched for so the caller
-      // can distinguish a fresh empty result from a stale empty result left
-      // over from the previous stream.
+    const events = await loadStreamEvents(streamId, fromSequenceNum ?? null)
+    // Stamp the result with the streamId it was fetched for so the caller
+    // can distinguish a fresh empty result from a stale empty result left
+    // over from the previous stream.
     ;(events as CachedEvent[] & { __streamId?: string }).__streamId = streamId
     return events
   }, [streamId, fromSequenceNum])

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -44,7 +44,12 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
   const unsent = await db.events
     .where("streamId")
     .equals(streamId)
-    .filter((e) => (e._status === "pending" || e._status === "failed") && !loadedIds.has(e.id))
+    .filter(
+      (e) =>
+        (e._status === "pending" || e._status === "failed") &&
+        !loadedIds.has(e.id) &&
+        (fromSequenceNum == null || e._sequenceNum >= fromSequenceNum)
+    )
     .toArray()
 
   const merged = unsent.length > 0 ? [...reversed, ...unsent] : reversed


### PR DESCRIPTION
The two branches in `useStreamEvents` (floor-based range scan vs.
count-capped latest-N) had diverged enough that pending events were
appended at the end of the array via `events.push(e)` instead of placed
by `_sequenceNum`. In a freshly-created channel, where the bootstrap
floor stays null until the next refresh, the floor-less branch ran for
every send — leaving the in-memory array's order dependent on when
each optimistic event arrived rather than on its placeholder sequence.

Collapse the branches into a single `loadStreamEvents` helper that
range-scans the same `[streamId+_sequenceNum]` index and applies the
count cap only when no floor is known. Merge the unsent optimistic
sweep into the main array and re-sort the result so position is
determined by `_sequenceNum` alone, not insertion path.

Also fix a pre-existing backend type error: import `AttachmentSummary`
from `@threa/types` directly in the context-bag resolver and types so
the messaging barrel doesn't need to re-export it.

Tests cover the optimistic→real swap on a fresh channel, mixed
pending+real windows on a channel with history, and the defensive sort
for unsent events that fall below the count cap.

https://claude.ai/code/session_018AMsZ8sca5UKgTk3GbNjEz