### PR TITLE
feat: add stream-scoped asset explorer side panel

### DIFF
--- a/apps/backend/src/features/asset-explorer/cursor.test.ts
+++ b/apps/backend/src/features/asset-explorer/cursor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test"
+import { decodeCursor, encodeCursor } from "./cursor"
+
+describe("asset explorer cursor", () => {
+  it("round-trips a time cursor", () => {
+    const encoded = encodeCursor({
+      kind: "time",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      id: "attach_abc",
+    })
+    expect(decodeCursor(encoded)).toEqual({
+      kind: "time",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      id: "attach_abc",
+    })
+  })
+
+  it("round-trips an offset cursor", () => {
+    expect(decodeCursor(encodeCursor({ kind: "offset", offset: 30 }))).toEqual({ kind: "offset", offset: 30 })
+  })
+
+  it("returns null for malformed input", () => {
+    expect(decodeCursor("not-base64-json!")).toBeNull()
+    expect(decodeCursor(Buffer.from("{}", "utf8").toString("base64url"))).toBeNull()
+    expect(
+      decodeCursor(Buffer.from(JSON.stringify({ kind: "offset", offset: -1 }), "utf8").toString("base64url"))
+    ).toBeNull()
+  })
+})

--- a/apps/backend/src/features/asset-explorer/cursor.ts
+++ b/apps/backend/src/features/asset-explorer/cursor.ts
@@ -1,0 +1,35 @@
+/**
+ * Opaque cursor encoding for the asset explorer.
+ *
+ * Two cursor variants are defined so browse and search modes can paginate
+ * with the right strategy without changing the wire shape:
+ *
+ *   - `time`: keyset on `(created_at DESC, id DESC)` for browse mode.
+ *   - `offset`: numeric offset for query mode where rank-ordered keysets
+ *     would be fragile (rank ties + float precision).
+ *
+ * Cursors are JSON, base64url-encoded so they're URL-safe even though the
+ * endpoint is currently POST. Callers treat them as opaque strings.
+ */
+
+export type AssetCursor = { kind: "time"; createdAt: string; id: string } | { kind: "offset"; offset: number }
+
+export function encodeCursor(cursor: AssetCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
+}
+
+export function decodeCursor(raw: string): AssetCursor | null {
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8")
+    const parsed = JSON.parse(json)
+    if (parsed?.kind === "time" && typeof parsed.createdAt === "string" && typeof parsed.id === "string") {
+      return { kind: "time", createdAt: parsed.createdAt, id: parsed.id }
+    }
+    if (parsed?.kind === "offset" && Number.isInteger(parsed.offset) && parsed.offset >= 0) {
+      return { kind: "offset", offset: parsed.offset }
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/src/features/asset-explorer/handlers.ts
+++ b/apps/backend/src/features/asset-explorer/handlers.ts
@@ -1,0 +1,91 @@
+import { z } from "zod"
+import type { Request, Response } from "express"
+import type { Pool } from "pg"
+import { ASSET_KINDS, EXTRACTION_CONTENT_TYPES, type AssetSearchResponse } from "@threa/types"
+import type { AssetExplorerService } from "./service"
+import { resolveAssetSearchScope } from "./scope"
+
+const scopeSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("stream"),
+    streamId: z.string().min(1),
+  }),
+])
+
+const filtersSchema = z
+  .object({
+    from: z.string().min(1).optional(),
+    mimeGroups: z.array(z.enum(ASSET_KINDS)).optional(),
+    contentTypes: z.array(z.enum(EXTRACTION_CONTENT_TYPES)).optional(),
+    before: z.string().datetime().optional(),
+    after: z.string().datetime().optional(),
+  })
+  .optional()
+
+const requestSchema = z.object({
+  query: z.string().optional().default(""),
+  exact: z.boolean().optional().default(false),
+  scope: scopeSchema,
+  filters: filtersSchema,
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+})
+
+interface Dependencies {
+  pool: Pool
+  assetExplorerService: AssetExplorerService
+}
+
+export function createAssetExplorerHandlers({ pool, assetExplorerService }: Dependencies) {
+  return {
+    /**
+     * POST /api/workspaces/:workspaceId/assets/search
+     *
+     * Browse + search attachments accessible to the requester.
+     * Stream-scoped today; the `scope` discriminator is forward-compatible
+     * with workspace-wide scope (no wire change required).
+     */
+    async search(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const parsed = requestSchema.safeParse(req.body)
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: "Validation failed",
+          details: z.flattenError(parsed.error).fieldErrors,
+        })
+      }
+
+      const { query, exact, scope, filters, cursor, limit } = parsed.data
+
+      const accessibleStreamIds = await resolveAssetSearchScope(pool, workspaceId, userId, scope)
+      if (accessibleStreamIds === null) {
+        return res.status(404).json({ error: "Stream not found" })
+      }
+
+      const result = await assetExplorerService.search({
+        workspaceId,
+        permissions: { accessibleStreamIds },
+        scope,
+        query,
+        exact,
+        filters: {
+          uploadedBy: filters?.from,
+          mimeKinds: filters?.mimeGroups,
+          contentTypes: filters?.contentTypes,
+          before: filters?.before ? new Date(filters.before) : undefined,
+          after: filters?.after ? new Date(filters.after) : undefined,
+        },
+        cursor: cursor ?? null,
+        limit: limit ?? 30,
+      })
+
+      const response: AssetSearchResponse = {
+        results: result.results,
+        nextCursor: result.nextCursor,
+      }
+      res.json(response)
+    },
+  }
+}

--- a/apps/backend/src/features/asset-explorer/index.ts
+++ b/apps/backend/src/features/asset-explorer/index.ts
@@ -1,0 +1,11 @@
+// Asset explorer — read-side projection over attachments + extractions
+// powering the stream-scoped (and future workspace-scoped) browse/search UI.
+export { createAssetExplorerHandlers } from "./handlers"
+export { AssetExplorerService } from "./service"
+export type { AssetSearchParams, AssetSearchPermissions, AssetSearchOutput } from "./service"
+export { AssetExplorerRepository } from "./repository"
+export type { AssetSearchRepoResult, AssetSearchRepoParams } from "./repository"
+export { resolveAssetSearchScope } from "./scope"
+export { classifyAssetKind, mimePatternsForKinds } from "./mime-groups"
+export { encodeCursor, decodeCursor } from "./cursor"
+export type { AssetCursor } from "./cursor"

--- a/apps/backend/src/features/asset-explorer/mime-groups.test.ts
+++ b/apps/backend/src/features/asset-explorer/mime-groups.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test"
+import { AssetKinds } from "@threa/types"
+import { classifyAssetKind, mimePatternsForKinds } from "./mime-groups"
+
+describe("classifyAssetKind", () => {
+  it("buckets common mime prefixes", () => {
+    expect(classifyAssetKind("image/png")).toBe(AssetKinds.IMAGE)
+    expect(classifyAssetKind("image/svg+xml")).toBe(AssetKinds.IMAGE)
+    expect(classifyAssetKind("video/mp4")).toBe(AssetKinds.VIDEO)
+    expect(classifyAssetKind("application/pdf")).toBe(AssetKinds.PDF)
+    expect(classifyAssetKind("text/plain")).toBe(AssetKinds.TEXT)
+    expect(classifyAssetKind("application/json")).toBe(AssetKinds.TEXT)
+    expect(classifyAssetKind("text/csv")).toBe(AssetKinds.SPREADSHEET)
+  })
+
+  it("classifies office formats", () => {
+    expect(classifyAssetKind("application/vnd.openxmlformats-officedocument.wordprocessingml.document")).toBe(
+      AssetKinds.DOCUMENT
+    )
+    expect(classifyAssetKind("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).toBe(
+      AssetKinds.SPREADSHEET
+    )
+  })
+
+  it("treats octet-stream with video extension as video", () => {
+    expect(classifyAssetKind("application/octet-stream", "clip.mp4")).toBe(AssetKinds.VIDEO)
+    expect(classifyAssetKind("application/octet-stream", "noise.bin")).toBe(AssetKinds.OTHER)
+  })
+
+  it("falls back to other for unknown mime types", () => {
+    expect(classifyAssetKind("application/zip")).toBe(AssetKinds.OTHER)
+    expect(classifyAssetKind("application/octet-stream")).toBe(AssetKinds.OTHER)
+  })
+})
+
+describe("mimePatternsForKinds", () => {
+  it("returns prefixes for prefix-based kinds and exacts for fixed kinds", () => {
+    const { prefixes, exact } = mimePatternsForKinds([AssetKinds.IMAGE, AssetKinds.PDF])
+    expect(prefixes).toContain("image/%")
+    expect(exact).toContain("application/pdf")
+  })
+
+  it("includes csv as a spreadsheet exact match", () => {
+    const { exact } = mimePatternsForKinds([AssetKinds.SPREADSHEET])
+    expect(exact).toContain("text/csv")
+    expect(exact).toContain("application/vnd.ms-excel")
+  })
+
+  it("returns empty arrays when no kinds requested", () => {
+    expect(mimePatternsForKinds([])).toEqual({ prefixes: [], exact: [] })
+  })
+})

--- a/apps/backend/src/features/asset-explorer/mime-groups.ts
+++ b/apps/backend/src/features/asset-explorer/mime-groups.ts
@@ -1,0 +1,94 @@
+import { AssetKinds, type AssetKind } from "@threa/types"
+
+/**
+ * Map a mime type (and optional filename) to the coarse {@link AssetKind}
+ * bucket the explorer UI uses. Mirrors the granularity of the
+ * `is*Attachment` helpers in `features/attachments/*` but folds them into a
+ * single classification so handler/repo code doesn't have to OR several
+ * predicates together.
+ *
+ * The frontend uses the same bucket names for filter chips and icon
+ * selection — keep this list in sync with `AssetKinds`.
+ */
+export function classifyAssetKind(mimeType: string, filename?: string): AssetKind {
+  if (mimeType.startsWith("image/")) return AssetKinds.IMAGE
+  if (mimeType.startsWith("video/")) return AssetKinds.VIDEO
+  if (mimeType === "application/pdf") return AssetKinds.PDF
+
+  if (
+    mimeType === "application/msword" ||
+    mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    mimeType === "application/vnd.oasis.opendocument.text"
+  ) {
+    return AssetKinds.DOCUMENT
+  }
+
+  if (
+    mimeType === "application/vnd.ms-excel" ||
+    mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    mimeType === "application/vnd.oasis.opendocument.spreadsheet" ||
+    mimeType === "text/csv"
+  ) {
+    return AssetKinds.SPREADSHEET
+  }
+
+  if (mimeType.startsWith("text/") || mimeType === "application/json") return AssetKinds.TEXT
+
+  // application/octet-stream with a known video extension is treated as video
+  // (matches `isVideoAttachment` behavior in the attachments feature).
+  if (mimeType === "application/octet-stream" && filename) {
+    const lower = filename.toLowerCase()
+    if (lower.endsWith(".mp4") || lower.endsWith(".mov") || lower.endsWith(".webm") || lower.endsWith(".mkv")) {
+      return AssetKinds.VIDEO
+    }
+  }
+
+  return AssetKinds.OTHER
+}
+
+/**
+ * Build a SQL fragment-friendly list of mime patterns (LIKE prefixes + exact
+ * matches) matching the requested kinds. Returns two arrays so the caller can
+ * pass them to a single SQL clause: `mime_type LIKE ANY(prefixes) OR mime_type = ANY(exact)`.
+ */
+export function mimePatternsForKinds(kinds: readonly AssetKind[]): { prefixes: string[]; exact: string[] } {
+  const prefixes = new Set<string>()
+  const exact = new Set<string>()
+
+  for (const kind of kinds) {
+    switch (kind) {
+      case AssetKinds.IMAGE:
+        prefixes.add("image/%")
+        break
+      case AssetKinds.VIDEO:
+        prefixes.add("video/%")
+        // octet-stream + video extension is handled in the SQL via filename ILIKE
+        break
+      case AssetKinds.PDF:
+        exact.add("application/pdf")
+        break
+      case AssetKinds.DOCUMENT:
+        exact.add("application/msword")
+        exact.add("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+        exact.add("application/vnd.oasis.opendocument.text")
+        break
+      case AssetKinds.SPREADSHEET:
+        exact.add("application/vnd.ms-excel")
+        exact.add("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        exact.add("application/vnd.oasis.opendocument.spreadsheet")
+        exact.add("text/csv")
+        break
+      case AssetKinds.TEXT:
+        prefixes.add("text/%")
+        exact.add("application/json")
+        break
+      case AssetKinds.OTHER:
+        // "Other" is the residual bucket; it can't be expressed as a simple
+        // pattern set without listing every other mime, so we encode it as
+        // NOT-IN-the-others in the SQL builder rather than here.
+        break
+    }
+  }
+
+  return { prefixes: [...prefixes], exact: [...exact] }
+}

--- a/apps/backend/src/features/asset-explorer/repository.ts
+++ b/apps/backend/src/features/asset-explorer/repository.ts
@@ -1,0 +1,231 @@
+import { sql, type Querier } from "../../db"
+import {
+  AttachmentSafetyStatuses,
+  AssetKinds,
+  type AssetKind,
+  type ExtractionContentType,
+  type ProcessingStatus,
+} from "@threa/types"
+import { mimePatternsForKinds } from "./mime-groups"
+
+/**
+ * Internal row shape returned from the explorer SQL — flattens the
+ * attachment ⨝ extraction join + the video transcode lookup into a single
+ * row per asset so the service layer doesn't have to do a second pass.
+ */
+interface AssetSearchRow {
+  id: string
+  filename: string
+  mime_type: string
+  size_bytes: string
+  created_at: Date
+  uploaded_by: string | null
+  stream_id: string | null
+  message_id: string | null
+  processing_status: string
+  extraction_summary: string | null
+  has_video_thumbnail: boolean
+  rank: number
+}
+
+export interface AssetSearchRepoResult {
+  id: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+  createdAt: Date
+  uploadedBy: string | null
+  streamId: string | null
+  messageId: string | null
+  processingStatus: ProcessingStatus
+  extractionSummary: string | null
+  hasVideoThumbnail: boolean
+  rank: number
+}
+
+export interface AssetSearchRepoParams {
+  /**
+   * Streams the caller has resolved as accessible. Empty list short-circuits
+   * to an empty result.
+   */
+  streamIds: string[]
+  /** Free-text query. Empty string ⇒ browse mode (recency-ordered). */
+  query: string
+  /** ILIKE substring matching on filename + extraction (case-insensitive). */
+  exact: boolean
+  filters: {
+    uploadedBy?: string
+    mimeKinds?: AssetKind[]
+    contentTypes?: ExtractionContentType[]
+    before?: Date
+    after?: Date
+  }
+  pagination:
+    | { kind: "time"; before: { createdAt: Date; id: string } | null; limit: number }
+    | { kind: "offset"; offset: number; limit: number }
+}
+
+function mapRow(row: AssetSearchRow): AssetSearchRepoResult {
+  return {
+    id: row.id,
+    filename: row.filename,
+    mimeType: row.mime_type,
+    sizeBytes: Number(row.size_bytes),
+    createdAt: row.created_at,
+    uploadedBy: row.uploaded_by,
+    streamId: row.stream_id,
+    messageId: row.message_id,
+    processingStatus: row.processing_status as ProcessingStatus,
+    extractionSummary: row.extraction_summary,
+    hasVideoThumbnail: row.has_video_thumbnail,
+    rank: row.rank,
+  }
+}
+
+/**
+ * Build the LIKE-pattern + exact-match clause for the configured mime kinds.
+ * Returns SQL fragments + parameter values; relies on the `OTHER` bucket being
+ * encoded as the residual (NOT IN the union of the other kinds).
+ */
+function buildMimeKindClause(kinds: readonly AssetKind[] | undefined) {
+  if (!kinds || kinds.length === 0) return null
+
+  const includesOther = kinds.includes(AssetKinds.OTHER)
+  const otherKinds = kinds.filter((k) => k !== AssetKinds.OTHER)
+  const { prefixes, exact } = mimePatternsForKinds(otherKinds)
+
+  // The residual "other" bucket = everything not matching the known patterns.
+  // We compute the residual by listing every non-other kind here so the
+  // WHERE clause stays a single OR group.
+  const residualPrefixes = includesOther
+    ? mimePatternsForKinds([AssetKinds.IMAGE, AssetKinds.VIDEO, AssetKinds.TEXT]).prefixes
+    : []
+  const residualExact = includesOther
+    ? mimePatternsForKinds([AssetKinds.PDF, AssetKinds.DOCUMENT, AssetKinds.SPREADSHEET, AssetKinds.TEXT]).exact
+    : []
+
+  return { prefixes, exact, includesOther, residualPrefixes, residualExact }
+}
+
+export const AssetExplorerRepository = {
+  /**
+   * Search/browse assets across the caller-resolved streams. The single SQL
+   * query handles three modes:
+   *
+   *   1. Browse (empty query): order by `(created_at DESC, id DESC)`,
+   *      keyset-paginated.
+   *   2. Exact search: ILIKE on filename + extraction, recency-ordered,
+   *      offset-paginated.
+   *   3. Full-text search (default): combine `to_tsvector` rank with a
+   *      filename-ILIKE boost so substring matches on filenames outrank
+   *      content matches (per the explorer spec). Offset-paginated.
+   *
+   * The same query also computes `has_video_thumbnail` via a LEFT JOIN on
+   * `video_transcode_jobs` so the frontend doesn't need a second round-trip
+   * to decide whether to fetch a thumbnail variant.
+   */
+  async search(db: Querier, params: AssetSearchRepoParams): Promise<AssetSearchRepoResult[]> {
+    const { streamIds, query, exact, filters, pagination } = params
+    if (streamIds.length === 0) return []
+
+    const trimmedQuery = query.trim()
+    const hasQuery = trimmedQuery.length > 0
+    const ilikePattern = hasQuery ? `%${trimmedQuery.replace(/[%_\\]/g, "\\$&")}%` : ""
+
+    const mime = buildMimeKindClause(filters.mimeKinds)
+    const hasMimeFilter = mime !== null
+    const hasUploaderFilter = filters.uploadedBy !== undefined
+    const hasBefore = filters.before !== undefined
+    const hasAfter = filters.after !== undefined
+    const hasContentTypeFilter = (filters.contentTypes?.length ?? 0) > 0
+
+    const limit = pagination.limit
+    const offset = pagination.kind === "offset" ? pagination.offset : 0
+    const cursorCreatedAt = pagination.kind === "time" && pagination.before ? pagination.before.createdAt : null
+    const cursorId = pagination.kind === "time" && pagination.before ? pagination.before.id : ""
+    const hasTimeCursor = pagination.kind === "time" && pagination.before !== null
+
+    // Rank expression varies by mode. We compute it inline so the ORDER BY
+    // clause can reference the same value without a subquery wrapper.
+    //
+    //   - Browse: rank = 0 (created_at carries the order).
+    //   - Exact: rank = 0 (recency carries the order).
+    //   - Full-text: ts_rank on the joined search vectors + filename-ILIKE
+    //     boost (1.0 added when the substring appears in the filename so
+    //     filename matches always rank above pure content matches).
+    const rows = await db.query<AssetSearchRow>(sql`
+      SELECT
+        a.id,
+        a.filename,
+        a.mime_type,
+        a.size_bytes,
+        a.created_at,
+        a.uploaded_by,
+        a.stream_id,
+        a.message_id,
+        a.processing_status,
+        e.summary AS extraction_summary,
+        (vtj.thumbnail_storage_path IS NOT NULL) AS has_video_thumbnail,
+        CASE
+          WHEN ${!hasQuery} OR ${exact} THEN 0
+          ELSE
+            COALESCE(ts_rank(a.search_vector, websearch_to_tsquery('english', ${trimmedQuery})), 0)
+            + COALESCE(ts_rank(e.search_vector, websearch_to_tsquery('english', ${trimmedQuery})), 0) * 0.5
+            + CASE WHEN a.filename ILIKE ${ilikePattern} THEN 1.0 ELSE 0 END
+        END AS rank
+      FROM attachments a
+      LEFT JOIN attachment_extractions e ON e.attachment_id = a.id
+      LEFT JOIN video_transcode_jobs vtj
+        ON vtj.attachment_id = a.id AND vtj.status = 'completed'
+      WHERE a.stream_id = ANY(${streamIds})
+        AND a.message_id IS NOT NULL
+        AND a.safety_status = ${AttachmentSafetyStatuses.CLEAN}
+        AND (${!hasQuery} OR ${exact === false} OR (
+          a.filename ILIKE ${ilikePattern}
+          OR e.summary ILIKE ${ilikePattern}
+          OR e.full_text ILIKE ${ilikePattern}
+        ))
+        AND (${!hasQuery} OR ${exact === true} OR (
+          a.search_vector @@ websearch_to_tsquery('english', ${trimmedQuery})
+          OR e.search_vector @@ websearch_to_tsquery('english', ${trimmedQuery})
+          OR a.filename ILIKE ${ilikePattern}
+        ))
+        AND (${!hasUploaderFilter} OR a.uploaded_by = ${filters.uploadedBy ?? ""})
+        AND (${!hasBefore} OR a.created_at < ${filters.before ?? new Date()})
+        AND (${!hasAfter} OR a.created_at >= ${filters.after ?? new Date(0)})
+        AND (${!hasContentTypeFilter} OR e.content_type = ANY(${filters.contentTypes ?? []}))
+        AND (
+          ${!hasMimeFilter}
+          OR a.mime_type LIKE ANY(${mime?.prefixes ?? []})
+          OR a.mime_type = ANY(${mime?.exact ?? []})
+          OR (
+            ${mime?.includesOther ?? false}
+            AND NOT (
+              a.mime_type LIKE ANY(${mime?.residualPrefixes ?? []})
+              OR a.mime_type = ANY(${mime?.residualExact ?? []})
+            )
+          )
+        )
+        AND (
+          ${!hasTimeCursor}
+          OR a.created_at < ${cursorCreatedAt ?? new Date()}
+          OR (a.created_at = ${cursorCreatedAt ?? new Date()} AND a.id < ${cursorId})
+        )
+      ORDER BY
+        CASE WHEN ${!hasQuery} OR ${exact} THEN 0 ELSE 1 END DESC,
+        CASE
+          WHEN ${!hasQuery} OR ${exact} THEN 0
+          ELSE
+            COALESCE(ts_rank(a.search_vector, websearch_to_tsquery('english', ${trimmedQuery})), 0)
+            + COALESCE(ts_rank(e.search_vector, websearch_to_tsquery('english', ${trimmedQuery})), 0) * 0.5
+            + CASE WHEN a.filename ILIKE ${ilikePattern} THEN 1.0 ELSE 0 END
+        END DESC,
+        a.created_at DESC,
+        a.id DESC
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `)
+
+    return rows.rows.map(mapRow)
+  },
+}

--- a/apps/backend/src/features/asset-explorer/scope.ts
+++ b/apps/backend/src/features/asset-explorer/scope.ts
@@ -1,0 +1,34 @@
+import type { Pool } from "pg"
+import type { AssetSearchScope } from "@threa/types"
+import { checkStreamAccess } from "../streams"
+import { SearchRepository } from "../search"
+
+/**
+ * Resolve an `AssetSearchScope` into the list of stream IDs the requester
+ * can read inside that scope. Returns `null` when the scope itself is
+ * inaccessible (e.g. the stream is in another workspace, or the viewer
+ * isn't a member of a private stream); the handler turns this into 404 so
+ * we don't leak existence.
+ *
+ * Today only `stream` is implemented; the discriminator + this helper are
+ * the seam where workspace-wide scope will land — same call site, new branch.
+ */
+export async function resolveAssetSearchScope(
+  pool: Pool,
+  workspaceId: string,
+  userId: string,
+  scope: AssetSearchScope
+): Promise<string[] | null> {
+  switch (scope.type) {
+    case "stream": {
+      const stream = await checkStreamAccess(pool, scope.streamId, workspaceId, userId)
+      if (!stream) return null
+
+      // Include the stream itself plus every thread that hangs off it. Threads
+      // inherit access from their root, and `attachments.stream_id` is the
+      // thread id when an attachment was uploaded inside a thread — without
+      // expanding here we'd silently miss those.
+      return SearchRepository.getStreamWithThreads(pool, scope.streamId)
+    }
+  }
+}

--- a/apps/backend/src/features/asset-explorer/service.test.ts
+++ b/apps/backend/src/features/asset-explorer/service.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { AssetKinds } from "@threa/types"
+import { AssetExplorerService } from "./service"
+import { AssetExplorerRepository, type AssetSearchRepoResult } from "./repository"
+import { encodeCursor } from "./cursor"
+
+function makeRepoRow(overrides: Partial<AssetSearchRepoResult> = {}): AssetSearchRepoResult {
+  return {
+    id: "attach_1",
+    filename: "file.png",
+    mimeType: "image/png",
+    sizeBytes: 1024,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    uploadedBy: "usr_1",
+    streamId: "stream_1",
+    messageId: "msg_1",
+    processingStatus: "completed",
+    extractionSummary: null,
+    hasVideoThumbnail: false,
+    rank: 0,
+    ...overrides,
+  }
+}
+
+describe("AssetExplorerService", () => {
+  afterEach(() => mock.restore())
+
+  it("returns an empty page when no streams are accessible", async () => {
+    const repoSpy = spyOn(AssetExplorerRepository, "search").mockResolvedValue([])
+    const service = new AssetExplorerService({} as any)
+
+    const result = await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: [] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "",
+      exact: false,
+      filters: {},
+      cursor: null,
+      limit: 30,
+    })
+
+    expect(result).toEqual({ results: [], nextCursor: null })
+    expect(repoSpy).not.toHaveBeenCalled()
+  })
+
+  it("maps repo rows into wire shape with classified kind and thumbnail flag", async () => {
+    spyOn(AssetExplorerRepository, "search").mockResolvedValue([
+      makeRepoRow({ id: "a", mimeType: "image/png" }),
+      makeRepoRow({ id: "b", mimeType: "video/mp4", hasVideoThumbnail: true }),
+      makeRepoRow({ id: "c", mimeType: "video/mp4", hasVideoThumbnail: false }),
+      makeRepoRow({ id: "d", mimeType: "application/pdf" }),
+    ])
+    const service = new AssetExplorerService({} as any)
+
+    const { results } = await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "",
+      exact: false,
+      filters: {},
+      cursor: null,
+      limit: 30,
+    })
+
+    expect(results.map((r) => [r.id, r.kind, r.hasThumbnail])).toEqual([
+      ["a", AssetKinds.IMAGE, true],
+      ["b", AssetKinds.VIDEO, true],
+      ["c", AssetKinds.VIDEO, false],
+      ["d", AssetKinds.PDF, false],
+    ])
+  })
+
+  it("emits a time cursor in browse mode when more results exist", async () => {
+    const last = makeRepoRow({
+      id: "attach_last",
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+    })
+    // Service requests `limit + 1` to detect overflow → 3 rows with limit=2 ⇒ hasMore.
+    spyOn(AssetExplorerRepository, "search").mockResolvedValue([
+      makeRepoRow({ id: "a" }),
+      last,
+      makeRepoRow({ id: "extra" }),
+    ])
+
+    const service = new AssetExplorerService({} as any)
+    const { results, nextCursor } = await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "",
+      exact: false,
+      filters: {},
+      cursor: null,
+      limit: 2,
+    })
+
+    expect(results).toHaveLength(2)
+    expect(nextCursor).toBe(encodeCursor({ kind: "time", createdAt: last.createdAt.toISOString(), id: last.id }))
+  })
+
+  it("emits an offset cursor when querying with overflow", async () => {
+    spyOn(AssetExplorerRepository, "search").mockResolvedValue([
+      makeRepoRow({ id: "a", rank: 1.0 }),
+      makeRepoRow({ id: "b", rank: 0.5 }),
+      makeRepoRow({ id: "extra", rank: 0.3 }),
+    ])
+
+    const service = new AssetExplorerService({} as any)
+    const { nextCursor } = await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "report",
+      exact: false,
+      filters: {},
+      cursor: null,
+      limit: 2,
+    })
+
+    expect(nextCursor).toBe(encodeCursor({ kind: "offset", offset: 2 }))
+  })
+
+  it("returns null cursor when results fit within the limit", async () => {
+    spyOn(AssetExplorerRepository, "search").mockResolvedValue([makeRepoRow({ id: "a" })])
+    const service = new AssetExplorerService({} as any)
+
+    const { nextCursor } = await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "",
+      exact: false,
+      filters: {},
+      cursor: null,
+      limit: 30,
+    })
+
+    expect(nextCursor).toBeNull()
+  })
+
+  it("forwards exact mode to the repository", async () => {
+    const repoSpy = spyOn(AssetExplorerRepository, "search").mockResolvedValue([])
+    const service = new AssetExplorerService({} as any)
+
+    await service.search({
+      workspaceId: "ws_1",
+      permissions: { accessibleStreamIds: ["stream_1"] },
+      scope: { type: "stream", streamId: "stream_1" },
+      query: "ERR_TIMEOUT",
+      exact: true,
+      filters: {},
+      cursor: null,
+      limit: 30,
+    })
+
+    expect(repoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ exact: true, query: "ERR_TIMEOUT" })
+    )
+  })
+})

--- a/apps/backend/src/features/asset-explorer/service.ts
+++ b/apps/backend/src/features/asset-explorer/service.ts
@@ -1,0 +1,134 @@
+import type { Pool } from "pg"
+import {
+  AssetKinds,
+  type AssetKind,
+  type AssetSearchResult,
+  type AssetSearchScope,
+  type ExtractionContentType,
+  type ProcessingStatus,
+} from "@threa/types"
+import { AssetExplorerRepository, type AssetSearchRepoResult } from "./repository"
+import { decodeCursor, encodeCursor } from "./cursor"
+import { classifyAssetKind } from "./mime-groups"
+
+/**
+ * Caller-resolved access boundary. The handler resolves what the requester
+ * can see (via existing stream-access helpers) and passes it here so the
+ * service stays auth-agnostic — same pattern as `SearchService`.
+ */
+export interface AssetSearchPermissions {
+  accessibleStreamIds: string[]
+}
+
+export interface AssetSearchParams {
+  workspaceId: string
+  permissions: AssetSearchPermissions
+  scope: AssetSearchScope
+  query: string
+  exact: boolean
+  filters: {
+    uploadedBy?: string
+    mimeKinds?: AssetKind[]
+    contentTypes?: ExtractionContentType[]
+    before?: Date
+    after?: Date
+  }
+  cursor: string | null
+  limit: number
+}
+
+export interface AssetSearchOutput {
+  results: AssetSearchResult[]
+  nextCursor: string | null
+}
+
+const DEFAULT_LIMIT = 30
+const MAX_LIMIT = 100
+
+export class AssetExplorerService {
+  constructor(private pool: Pool) {}
+
+  async search(params: AssetSearchParams): Promise<AssetSearchOutput> {
+    const limit = clampLimit(params.limit ?? DEFAULT_LIMIT)
+    const accessible = params.permissions.accessibleStreamIds
+    if (accessible.length === 0) return { results: [], nextCursor: null }
+
+    const trimmedQuery = params.query.trim()
+    const hasQuery = trimmedQuery.length > 0
+    const decoded = params.cursor ? decodeCursor(params.cursor) : null
+
+    // Browse mode → keyset on (created_at, id). Search mode → numeric offset
+    // (rank order is fragile under tie-breaking and float precision). The
+    // wire-level cursor is opaque so this strategy can change later without
+    // a contract break. Repository fetches `limit + 1` so we can detect the
+    // presence of another page without a COUNT.
+    const pagination = hasQuery
+      ? ({
+          kind: "offset" as const,
+          offset: decoded?.kind === "offset" ? decoded.offset : 0,
+          limit: limit + 1,
+        } as const)
+      : ({
+          kind: "time" as const,
+          before: decoded?.kind === "time" ? { createdAt: new Date(decoded.createdAt), id: decoded.id } : null,
+          limit: limit + 1,
+        } as const)
+
+    const rows = await AssetExplorerRepository.search(this.pool, {
+      streamIds: accessible,
+      query: trimmedQuery,
+      exact: params.exact,
+      filters: params.filters,
+      pagination,
+    })
+
+    const hasMore = rows.length > limit
+    const page = hasMore ? rows.slice(0, limit) : rows
+
+    return {
+      results: page.map(toWireResult),
+      nextCursor: hasMore ? buildNextCursor(pagination, page) : null,
+    }
+  }
+}
+
+function buildNextCursor(
+  pagination: { kind: "time" } | { kind: "offset"; offset: number },
+  page: AssetSearchRepoResult[]
+): string {
+  if (pagination.kind === "time") {
+    const last = page[page.length - 1]!
+    return encodeCursor({ kind: "time", createdAt: last.createdAt.toISOString(), id: last.id })
+  }
+  return encodeCursor({ kind: "offset", offset: pagination.offset + page.length })
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DEFAULT_LIMIT
+  return Math.min(MAX_LIMIT, Math.floor(limit))
+}
+
+function toWireResult(row: AssetSearchRepoResult): AssetSearchResult {
+  const kind = classifyAssetKind(row.mimeType, row.filename)
+  return {
+    id: row.id,
+    filename: row.filename,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    createdAt: row.createdAt.toISOString(),
+    uploadedBy: row.uploadedBy,
+    streamId: row.streamId,
+    messageId: row.messageId,
+    processingStatus: row.processingStatus as ProcessingStatus,
+    kind,
+    hasThumbnail: hasThumbnail(kind, row),
+    preview: row.extractionSummary,
+    rank: row.rank,
+  }
+}
+
+function hasThumbnail(kind: AssetKind, row: AssetSearchRepoResult): boolean {
+  if (kind === AssetKinds.IMAGE) return true
+  if (kind === AssetKinds.VIDEO) return row.hasVideoThumbnail
+  return false
+}

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -12,6 +12,7 @@ import { createStreamHandlers } from "./features/streams"
 import { createMessageHandlers } from "./features/messaging"
 import { createAttachmentHandlers } from "./features/attachments"
 import { createSearchHandlers } from "./features/search"
+import { createAssetExplorerHandlers } from "./features/asset-explorer"
 import { createMemoHandlers } from "./features/memos"
 import { createEmojiHandlers } from "./features/emoji"
 import { createConversationHandlers } from "./features/conversations"
@@ -45,6 +46,7 @@ import type { StreamService } from "./features/streams"
 import type { EventService } from "./features/messaging"
 import type { AttachmentService } from "./features/attachments"
 import type { SearchService } from "./features/search"
+import type { AssetExplorerService } from "./features/asset-explorer"
 import type { MemoExplorerService } from "./features/memos"
 import type { ConversationService } from "./features/conversations"
 import type { InvitationService } from "./features/invitations"
@@ -73,6 +75,7 @@ interface Dependencies {
   eventService: EventService
   attachmentService: AttachmentService
   searchService: SearchService
+  assetExplorerService: AssetExplorerService
   memoExplorerService: MemoExplorerService
   conversationService: ConversationService
   userPreferencesService: UserPreferencesService
@@ -108,6 +111,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     eventService,
     attachmentService,
     searchService,
+    assetExplorerService,
     memoExplorerService,
     conversationService,
     userPreferencesService,
@@ -159,6 +163,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const message = createMessageHandlers({ pool, eventService, streamService, commandRegistry })
   const attachment = createAttachmentHandlers({ attachmentService, streamService, storage, pool })
   const search = createSearchHandlers({ pool, searchService })
+  const assetExplorer = createAssetExplorerHandlers({ pool, assetExplorerService })
   const memo = createMemoHandlers({ pool, memoExplorerService })
   const emoji = createEmojiHandlers()
   const conversation = createConversationHandlers({ conversationService, streamService })
@@ -255,6 +260,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/search", ...authed, rateLimits.search, search.search)
   app.post("/api/workspaces/:workspaceId/memos/search", ...authed, rateLimits.search, memo.search)
   app.get("/api/workspaces/:workspaceId/memos/:memoId", ...authed, memo.getById)
+
+  // Asset explorer — browse + search attachments scoped to a stream (today)
+  // or workspace (future); the request body's `scope` discriminator decides.
+  app.post("/api/workspaces/:workspaceId/assets/search", ...authed, rateLimits.search, assetExplorer.search)
 
   app.post("/api/workspaces/:workspaceId/messages", ...authed, rateLimits.messageCreate, message.create)
   app.post(

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -34,6 +34,7 @@ import { EventService } from "./features/messaging"
 import { AttachmentService } from "./features/attachments"
 import { MessageFormatter } from "./lib/ai/message-formatter"
 import { SearchService } from "./features/search"
+import { AssetExplorerService } from "./features/asset-explorer"
 import {
   MemoService,
   MemoExplorerService,
@@ -235,6 +236,7 @@ export async function startServer(): Promise<ServerInstance> {
   // Search and embedding services
   const embeddingService = config.useStubAI ? new StubEmbeddingService() : new EmbeddingService({ ai })
   const searchService = new SearchService({ pool, embeddingService })
+  const assetExplorerService = new AssetExplorerService(pool)
   const memoExplorerService = new MemoExplorerService({ pool, embeddingService })
 
   // Job queue for durable background work (companion responses, etc.).
@@ -411,6 +413,7 @@ export async function startServer(): Promise<ServerInstance> {
     eventService,
     attachmentService,
     searchService,
+    assetExplorerService,
     memoExplorerService,
     conversationService,
     userPreferencesService,

--- a/apps/frontend/src/api/asset-explorer.ts
+++ b/apps/frontend/src/api/asset-explorer.ts
@@ -1,0 +1,12 @@
+import api from "./client"
+import type { AssetSearchRequest, AssetSearchResponse } from "@threa/types"
+
+export type { AssetSearchRequest, AssetSearchResponse, AssetSearchResult } from "@threa/types"
+
+/**
+ * Search/browse assets the requester can access. Stream-scoped today; the
+ * `scope` discriminator is forward-compatible with workspace-wide search.
+ */
+export async function searchAssets(workspaceId: string, request: AssetSearchRequest): Promise<AssetSearchResponse> {
+  return api.post<AssetSearchResponse>(`/api/workspaces/${workspaceId}/assets/search`, request)
+}

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -20,6 +20,12 @@ export {
   type ArchiveStatus,
 } from "./search"
 export {
+  searchAssets,
+  type AssetSearchRequest,
+  type AssetSearchResponse,
+  type AssetSearchResult,
+} from "./asset-explorer"
+export {
   searchMemos,
   getMemo,
   type MemoExplorerStreamRef,

--- a/apps/frontend/src/components/asset-explorer/asset-explorer-panel.tsx
+++ b/apps/frontend/src/components/asset-explorer/asset-explorer-panel.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Search, X, Loader2, Image as ImageIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Toggle } from "@/components/ui/toggle"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { useWorkspaceUsers, useWorkspaceStreams } from "@/stores/workspace-store"
+import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { AssetItem } from "./asset-item"
+import { AssetFilters } from "./asset-filters"
+import { AssetGalleryHost } from "./asset-gallery-host"
+import { useAssetExplorer, initialAssetFilters, type AssetExplorerFilters } from "./use-asset-explorer"
+import type { AssetSearchResult, StreamType } from "@threa/types"
+
+interface AssetExplorerPanelProps {
+  workspaceId: string
+  streamId: string
+  open: boolean
+  onClose: () => void
+}
+
+const QUERY_DEBOUNCE_MS = 250
+
+export function AssetExplorerPanel({ workspaceId, streamId, open, onClose }: AssetExplorerPanelProps) {
+  // Filter state intentionally persists across open/close within a session.
+  // Reopening the panel after applying filters lands the user back where
+  // they were — closing is for "out of sight" not "throw work away".
+  const [filters, setFilters] = useState<AssetExplorerFilters>(initialAssetFilters)
+  const [queryDraft, setQueryDraft] = useState("")
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Reset draft when streamId changes — different stream = different scope,
+  // so previous query no longer makes sense.
+  useEffect(() => {
+    setFilters(initialAssetFilters)
+    setQueryDraft("")
+  }, [streamId])
+
+  // Auto-focus the search input on open; matches how `/search` opens
+  // already-focused. Skipped on mobile where the soft keyboard popping is
+  // disruptive when the panel is meant for browsing.
+  useEffect(() => {
+    if (!open) return
+    // Small delay so the slide-in transition finishes before focus moves.
+    const handle = setTimeout(() => {
+      if (window.matchMedia("(min-width: 640px)").matches) {
+        searchInputRef.current?.focus()
+      }
+    }, 150)
+    return () => clearTimeout(handle)
+  }, [open])
+
+  // Escape closes — matches conversation panel + thread panel UX.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [open, onClose])
+
+  // Debounce query input → committed filter so the search hook sees stable
+  // updates and we don't issue a request per keystroke.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setFilters((f) => (f.query === queryDraft ? f : { ...f, query: queryDraft }))
+    }, QUERY_DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [queryDraft])
+
+  const explorer = useAssetExplorer({
+    workspaceId,
+    scope: { type: "stream", streamId },
+    filters,
+    enabled: open,
+  })
+
+  const flatResults = useMemo<AssetSearchResult[]>(
+    () => explorer.data?.pages.flatMap((p) => p.results) ?? [],
+    [explorer.data]
+  )
+
+  const workspaceUsers = useWorkspaceUsers(workspaceId)
+  const userById = useMemo(() => new Map(workspaceUsers.map((u) => [u.id, u])), [workspaceUsers])
+  const streams = useWorkspaceStreams(workspaceId)
+  const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!open) return
+    const el = sentinelRef.current
+    if (!el) return
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0]
+      if (entry?.isIntersecting && explorer.hasNextPage && !explorer.isFetchingNextPage) {
+        explorer.fetchNextPage()
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [open, explorer])
+
+  const isInitialLoading = explorer.isPending
+  const hasError = explorer.isError
+  const isEmpty = !isInitialLoading && !hasError && flatResults.length === 0
+  const hasActiveFilters =
+    filters.query.length > 0 ||
+    filters.exact ||
+    filters.mimeGroups.length > 0 ||
+    filters.contentTypes.length > 0 ||
+    filters.before !== null ||
+    filters.after !== null ||
+    filters.uploadedBy !== null
+
+  return (
+    <>
+      {/* Full-viewport backdrop — matches the conversation panel pattern in
+          stream.tsx so panel UX stays consistent across the app. */}
+      <div
+        className={cn(
+          "fixed inset-0 z-40 bg-black/60 transition-opacity duration-300",
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        )}
+        onClick={onClose}
+        aria-hidden
+      />
+      <aside
+        role="dialog"
+        aria-label="Asset explorer"
+        aria-hidden={!open}
+        className={cn(
+          "fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l bg-background shadow-lg sm:w-[28rem]",
+          "transition-transform duration-300 ease-out",
+          open ? "translate-x-0" : "translate-x-full"
+        )}
+      >
+        <header className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <ImageIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <h2 className="truncate text-base font-semibold">Assets</h2>
+          </div>
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={onClose} aria-label="Close asset explorer">
+            <X className="h-4 w-4" />
+          </Button>
+        </header>
+
+        <div className="flex shrink-0 flex-col gap-2 border-b px-3 py-2">
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                ref={searchInputRef}
+                value={queryDraft}
+                onChange={(e) => setQueryDraft(e.target.value)}
+                placeholder="Search filenames and content…"
+                className="h-8 pl-7 text-sm"
+                aria-label="Search assets"
+              />
+            </div>
+            <Toggle
+              size="sm"
+              pressed={filters.exact}
+              onPressedChange={(pressed) => setFilters((f) => ({ ...f, exact: pressed }))}
+              className={cn("h-8 px-2 text-xs", filters.exact && "bg-primary/10 text-primary")}
+              aria-label="Toggle exact matching"
+              title="Exact (case-insensitive substring) matching"
+            >
+              Exact
+            </Toggle>
+          </div>
+          <AssetFilters filters={filters} onChange={setFilters} />
+        </div>
+
+        <ScrollArea className="flex-1">
+          <div className="flex flex-col gap-0.5 p-2">
+            {isInitialLoading && (
+              <div className="flex h-32 items-center justify-center" role="status" aria-label="Loading assets">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+            {hasError && (
+              <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                <p>Failed to load assets.</p>
+                <Button variant="outline" size="sm" onClick={() => explorer.refetch()}>
+                  Try again
+                </Button>
+              </div>
+            )}
+            {isEmpty && (
+              <div className="flex h-40 flex-col items-center justify-center gap-1 px-4 text-center text-sm text-muted-foreground">
+                <ImageIcon className="h-6 w-6" />
+                {hasActiveFilters ? (
+                  <p>No assets match these filters.</p>
+                ) : (
+                  <>
+                    <p className="font-medium text-foreground/80">No assets yet</p>
+                    <p>Files shared in this stream will appear here.</p>
+                  </>
+                )}
+              </div>
+            )}
+            {flatResults.map((asset) => {
+              const uploader = asset.uploadedBy ? userById.get(asset.uploadedBy) : null
+              const stream = asset.streamId ? streamById.get(asset.streamId) : null
+              const streamName = stream
+                ? (getStreamName(stream) ?? streamFallbackLabel(stream.type as StreamType, "generic"))
+                : null
+              return (
+                <AssetItem
+                  key={asset.id}
+                  asset={asset}
+                  workspaceId={workspaceId}
+                  uploaderName={uploader?.name ?? null}
+                  streamName={streamName}
+                />
+              )
+            })}
+            {explorer.hasNextPage && (
+              <div ref={sentinelRef} className="flex items-center justify-center py-3">
+                {explorer.isFetchingNextPage ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                ) : (
+                  <span className="text-xs text-muted-foreground">Scroll for more</span>
+                )}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </aside>
+
+      {/* Gallery host claims `?media=` ownership only when one of our results
+          matches, so it cohabits with `AttachmentList` instances in the
+          underlying timeline without conflict. */}
+      {open && <AssetGalleryHost workspaceId={workspaceId} results={flatResults} />}
+    </>
+  )
+}

--- a/apps/frontend/src/components/asset-explorer/asset-filters.tsx
+++ b/apps/frontend/src/components/asset-explorer/asset-filters.tsx
@@ -1,0 +1,98 @@
+import { Image as ImageIcon, Film, FileText, FileType, FileSpreadsheet, File } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Toggle } from "@/components/ui/toggle"
+import { cn } from "@/lib/utils"
+import { AssetKinds, type AssetKind } from "@threa/types"
+import { initialAssetFilters, type AssetExplorerFilters } from "./use-asset-explorer"
+
+interface AssetFiltersProps {
+  filters: AssetExplorerFilters
+  onChange: (next: AssetExplorerFilters) => void
+}
+
+const KIND_OPTIONS: { kind: AssetKind; label: string; Icon: React.ComponentType<{ className?: string }> }[] = [
+  { kind: AssetKinds.IMAGE, label: "Images", Icon: ImageIcon },
+  { kind: AssetKinds.VIDEO, label: "Videos", Icon: Film },
+  { kind: AssetKinds.PDF, label: "PDFs", Icon: FileText },
+  { kind: AssetKinds.DOCUMENT, label: "Documents", Icon: FileType },
+  { kind: AssetKinds.SPREADSHEET, label: "Spreadsheets", Icon: FileSpreadsheet },
+  { kind: AssetKinds.TEXT, label: "Text", Icon: FileText },
+  { kind: AssetKinds.OTHER, label: "Other", Icon: File },
+]
+
+export function AssetFilters({ filters, onChange }: AssetFiltersProps) {
+  const toggleKind = (kind: AssetKind) => {
+    const next = filters.mimeGroups.includes(kind)
+      ? filters.mimeGroups.filter((k) => k !== kind)
+      : [...filters.mimeGroups, kind]
+    onChange({ ...filters, mimeGroups: next })
+  }
+
+  const setBefore = (v: string) => onChange({ ...filters, before: v ? new Date(v).toISOString() : null })
+  const setAfter = (v: string) => onChange({ ...filters, after: v ? new Date(v).toISOString() : null })
+
+  const hasFilters =
+    filters.mimeGroups.length > 0 ||
+    filters.uploadedBy !== null ||
+    filters.before !== null ||
+    filters.after !== null ||
+    filters.exact ||
+    filters.query.length > 0
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-1">
+        {KIND_OPTIONS.map(({ kind, label, Icon }) => {
+          const active = filters.mimeGroups.includes(kind)
+          return (
+            <Toggle
+              key={kind}
+              size="sm"
+              pressed={active}
+              onPressedChange={() => toggleKind(kind)}
+              className={cn("h-7 gap-1.5 px-2 text-xs", active && "bg-primary/10 text-primary")}
+              aria-label={`Filter by ${label}`}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span>{label}</span>
+            </Toggle>
+          )
+        })}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          After
+          <Input
+            type="date"
+            value={filters.after ? filters.after.slice(0, 10) : ""}
+            onChange={(e) => setAfter(e.target.value)}
+            className="h-7 w-[140px] text-xs"
+            aria-label="Uploaded after"
+          />
+        </label>
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          Before
+          <Input
+            type="date"
+            value={filters.before ? filters.before.slice(0, 10) : ""}
+            onChange={(e) => setBefore(e.target.value)}
+            className="h-7 w-[140px] text-xs"
+            aria-label="Uploaded before"
+          />
+        </label>
+        {hasFilters && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={() => onChange(initialAssetFilters)}
+          >
+            Clear filters
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/asset-explorer/asset-gallery-host.tsx
+++ b/apps/frontend/src/components/asset-explorer/asset-gallery-host.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react"
+import { attachmentsApi } from "@/api"
+import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
+import { useMediaGallery } from "@/contexts"
+import { AssetKinds, type AssetSearchResult } from "@threa/types"
+
+/**
+ * Renders a `MediaGallery` for the previewable subset of an asset-explorer
+ * page (images + completed videos). Each visible asset's URL is fetched on
+ * demand so a flat result list with thousands of images doesn't fan out
+ * thousands of presigned-URL requests up front.
+ *
+ * Lifts the URL-bookkeeping pattern out of `AttachmentList` into a single
+ * place so the explorer doesn't need to coordinate per-item registration —
+ * it just hands over the result list.
+ *
+ * Listens for the `?media=<attachmentId>` URL param via {@link useMediaGallery}.
+ * Only claims ownership when the param matches one of our previewable assets,
+ * so this doesn't fight `AttachmentList` instances rendered for messages.
+ */
+interface AssetGalleryHostProps {
+  workspaceId: string
+  results: AssetSearchResult[]
+}
+
+export function AssetGalleryHost({ workspaceId, results }: AssetGalleryHostProps) {
+  const { mediaAttachmentId, openMedia, closeMedia } = useMediaGallery()
+
+  const previewable = useMemo(
+    () =>
+      results.filter(
+        (r) => r.kind === AssetKinds.IMAGE || (r.kind === AssetKinds.VIDEO && r.processingStatus === "completed")
+      ),
+    [results]
+  )
+
+  const previewableIds = useMemo(() => new Set(previewable.map((p) => p.id)), [previewable])
+  const ownsGallery = mediaAttachmentId !== null && previewableIds.has(mediaAttachmentId)
+
+  // URL caches keyed by attachmentId. Maps are only mutated through `set` so
+  // shallow equality holds across React renders that don't actually change
+  // the entry — the Map is recreated on insert (matches AttachmentList's
+  // pattern).
+  const [imageUrls, setImageUrls] = useState<Map<string, string>>(() => new Map())
+  const [videoUrls, setVideoUrls] = useState<Map<string, string>>(() => new Map())
+  const [thumbnailUrls, setThumbnailUrls] = useState<Map<string, string>>(() => new Map())
+
+  // Hydrate the active item's URL when the gallery opens or the user navigates.
+  useEffect(() => {
+    if (!ownsGallery || mediaAttachmentId === null) return
+    const asset = previewable.find((p) => p.id === mediaAttachmentId)
+    if (!asset) return
+
+    let active = true
+    if (asset.kind === AssetKinds.IMAGE) {
+      if (imageUrls.has(asset.id)) return
+      ;(async () => {
+        try {
+          const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id)
+          if (active) setImageUrls((prev) => new Map(prev).set(asset.id, url))
+        } catch {
+          /* gallery falls back to its own loading/error state */
+        }
+      })()
+    } else if (asset.kind === AssetKinds.VIDEO) {
+      // Video: fetch processed URL + thumbnail in parallel.
+      if (!videoUrls.has(asset.id)) {
+        ;(async () => {
+          try {
+            const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id, { variant: "processed" })
+            if (active) setVideoUrls((prev) => new Map(prev).set(asset.id, url))
+          } catch {
+            try {
+              const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id)
+              if (active) setVideoUrls((prev) => new Map(prev).set(asset.id, url))
+            } catch {
+              /* swallow */
+            }
+          }
+        })()
+      }
+      if (!thumbnailUrls.has(asset.id)) {
+        ;(async () => {
+          try {
+            const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id, { variant: "thumbnail" })
+            if (active) setThumbnailUrls((prev) => new Map(prev).set(asset.id, url))
+          } catch {
+            /* swallow */
+          }
+        })()
+      }
+    }
+
+    return () => {
+      active = false
+    }
+  }, [ownsGallery, mediaAttachmentId, previewable, workspaceId, imageUrls, videoUrls, thumbnailUrls])
+
+  const items: GalleryItem[] = useMemo(() => {
+    return previewable.map((asset) =>
+      asset.kind === AssetKinds.IMAGE
+        ? {
+            type: "image" as const,
+            url: imageUrls.get(asset.id) ?? "",
+            filename: asset.filename,
+            attachmentId: asset.id,
+          }
+        : {
+            type: "video" as const,
+            url: videoUrls.get(asset.id) ?? "",
+            thumbnailUrl: thumbnailUrls.get(asset.id) ?? "",
+            filename: asset.filename,
+            attachmentId: asset.id,
+          }
+    )
+  }, [previewable, imageUrls, videoUrls, thumbnailUrls])
+
+  const initialIndex = ownsGallery ? items.findIndex((i) => i.attachmentId === mediaAttachmentId) : -1
+
+  if (!ownsGallery || initialIndex === -1) return null
+
+  return (
+    <MediaGallery
+      isOpen
+      onClose={closeMedia}
+      items={items}
+      initialIndex={Math.max(0, initialIndex)}
+      workspaceId={workspaceId}
+      onItemChange={openMedia}
+    />
+  )
+}

--- a/apps/frontend/src/components/asset-explorer/asset-item.tsx
+++ b/apps/frontend/src/components/asset-explorer/asset-item.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState, useCallback } from "react"
+import { Download, FileText, File, Image as ImageIcon, Film, FileSpreadsheet, FileType } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { attachmentsApi } from "@/api"
+import { triggerDownload } from "@/lib/image-utils"
+import { RelativeTime } from "@/components/relative-time"
+import { Button } from "@/components/ui/button"
+import { useMediaGallery } from "@/contexts"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { AssetKinds, type AssetSearchResult } from "@threa/types"
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function KindIcon({ kind }: { kind: AssetSearchResult["kind"] }) {
+  switch (kind) {
+    case AssetKinds.IMAGE:
+      return <ImageIcon className="h-5 w-5 text-muted-foreground" />
+    case AssetKinds.VIDEO:
+      return <Film className="h-5 w-5 text-muted-foreground" />
+    case AssetKinds.PDF:
+      return <FileText className="h-5 w-5 text-muted-foreground" />
+    case AssetKinds.DOCUMENT:
+      return <FileType className="h-5 w-5 text-muted-foreground" />
+    case AssetKinds.SPREADSHEET:
+      return <FileSpreadsheet className="h-5 w-5 text-muted-foreground" />
+    case AssetKinds.TEXT:
+      return <FileText className="h-5 w-5 text-muted-foreground" />
+    default:
+      return <File className="h-5 w-5 text-muted-foreground" />
+  }
+}
+
+interface AssetThumbnailProps {
+  asset: AssetSearchResult
+  workspaceId: string
+}
+
+function AssetThumbnail({ asset, workspaceId }: AssetThumbnailProps) {
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
+  const [errored, setErrored] = useState(false)
+
+  const wantsImage = asset.kind === AssetKinds.IMAGE && asset.hasThumbnail
+  const wantsVideoThumb = asset.kind === AssetKinds.VIDEO && asset.hasThumbnail
+
+  useEffect(() => {
+    if (!wantsImage && !wantsVideoThumb) return
+    let active = true
+    ;(async () => {
+      try {
+        const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id, {
+          variant: wantsVideoThumb ? "thumbnail" : undefined,
+        })
+        if (active) setThumbnailUrl(url)
+      } catch {
+        if (active) setErrored(true)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [asset.id, workspaceId, wantsImage, wantsVideoThumb])
+
+  if ((!wantsImage && !wantsVideoThumb) || errored) {
+    return (
+      <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+        <KindIcon kind={asset.kind} />
+      </div>
+    )
+  }
+
+  if (!thumbnailUrl) {
+    return <div className="h-11 w-11 shrink-0 animate-pulse rounded-md border bg-muted" />
+  }
+
+  return (
+    <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-md border bg-muted">
+      <img src={thumbnailUrl} alt="" className="h-full w-full object-cover" loading="lazy" />
+      {asset.kind === AssetKinds.VIDEO && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+          <Film className="h-3.5 w-3.5 text-white" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface AssetItemProps {
+  asset: AssetSearchResult
+  workspaceId: string
+  uploaderName: string | null
+  /** Stream display name for the asset's source stream, when known. */
+  streamName: string | null
+}
+
+export function AssetItem({ asset, workspaceId, uploaderName, streamName }: AssetItemProps) {
+  const { openMedia } = useMediaGallery()
+  const isMobile = useIsMobile()
+
+  const isPreviewable = asset.kind === AssetKinds.IMAGE || asset.kind === AssetKinds.VIDEO
+
+  const handleOpen = useCallback(async () => {
+    if (isPreviewable) {
+      openMedia(asset.id)
+      return
+    }
+    // Non-previewable: open in a new tab for PDFs (browsers preview them
+    // natively); fall back to a download attribute for everything else.
+    try {
+      const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id)
+      if (asset.mimeType === "application/pdf") {
+        window.open(url, "_blank", "noopener,noreferrer")
+      } else {
+        triggerDownload(url, asset.filename)
+      }
+    } catch {
+      console.error("Failed to fetch download URL for asset", asset.id)
+    }
+  }, [asset, isPreviewable, openMedia, workspaceId])
+
+  const handleDownload = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation()
+      try {
+        const url = await attachmentsApi.getDownloadUrl(workspaceId, asset.id, { download: true })
+        triggerDownload(url, asset.filename)
+      } catch {
+        console.error("Failed to download asset", asset.id)
+      }
+    },
+    [asset.id, asset.filename, workspaceId]
+  )
+
+  // Show extraction summary only when it's both present and meaningfully
+  // different from the filename — for an image named "chart.png" with a
+  // summary "Chart of Q3 sales" the snippet is useful; for a doc whose
+  // summary just repeats the filename it'd be noise.
+  const showPreview =
+    asset.preview !== null &&
+    asset.preview.trim().length > 0 &&
+    asset.preview.trim().toLowerCase() !== asset.filename.trim().toLowerCase()
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleOpen}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          handleOpen()
+        }
+      }}
+      className={cn(
+        "group flex items-start gap-3 rounded-md px-2 py-2 transition-colors cursor-pointer",
+        "hover:bg-muted/50",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      )}
+    >
+      <AssetThumbnail asset={asset} workspaceId={workspaceId} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium" title={asset.filename}>
+            {asset.filename}
+          </span>
+          <span className="shrink-0 text-xs text-muted-foreground tabular-nums">{formatFileSize(asset.sizeBytes)}</span>
+        </div>
+        <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RelativeTime date={asset.createdAt} terse />
+          {uploaderName && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="truncate" title={uploaderName}>
+                {uploaderName}
+              </span>
+            </>
+          )}
+          {streamName && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="truncate" title={streamName}>
+                in {streamName}
+              </span>
+            </>
+          )}
+        </div>
+        {showPreview && (
+          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground/80" title={asset.preview ?? undefined}>
+            {asset.preview}
+          </p>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn(
+          "h-8 w-8 shrink-0 transition-opacity",
+          // Hover affordance hides the action on desktop until the user
+          // intends to interact, but keep it visible on touch where there
+          // is no hover state to reveal it.
+          isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+        )}
+        onClick={handleDownload}
+        aria-label={`Download ${asset.filename}`}
+      >
+        <Download className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/asset-explorer/index.ts
+++ b/apps/frontend/src/components/asset-explorer/index.ts
@@ -1,0 +1,3 @@
+export { AssetExplorerPanel } from "./asset-explorer-panel"
+export { useAssetExplorer, assetExplorerKeys, initialAssetFilters } from "./use-asset-explorer"
+export type { AssetExplorerFilters } from "./use-asset-explorer"

--- a/apps/frontend/src/components/asset-explorer/use-asset-explorer.ts
+++ b/apps/frontend/src/components/asset-explorer/use-asset-explorer.ts
@@ -1,0 +1,93 @@
+import { useInfiniteQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
+import { searchAssets, type AssetSearchRequest, type AssetSearchResponse } from "@/api"
+import type { AssetKind, AssetSearchScope, ExtractionContentType } from "@threa/types"
+
+export const assetExplorerKeys = {
+  all: ["asset-explorer"] as const,
+  search: (workspaceId: string, scopeKey: string, body: SerializableSearchBody) =>
+    [...assetExplorerKeys.all, "search", workspaceId, scopeKey, body] as const,
+}
+
+export interface AssetExplorerFilters {
+  query: string
+  exact: boolean
+  uploadedBy: string | null
+  mimeGroups: AssetKind[]
+  contentTypes: ExtractionContentType[]
+  before: string | null
+  after: string | null
+}
+
+interface SerializableSearchBody {
+  query: string
+  exact: boolean
+  uploadedBy: string | null
+  mimeGroups: AssetKind[]
+  contentTypes: ExtractionContentType[]
+  before: string | null
+  after: string | null
+}
+
+const PAGE_SIZE = 30
+
+export function useAssetExplorer(opts: {
+  workspaceId: string
+  scope: AssetSearchScope
+  filters: AssetExplorerFilters
+  enabled: boolean
+}) {
+  const { workspaceId, scope, filters, enabled } = opts
+
+  // Stable cache key — scope identity + the serializable filter state. Distinct
+  // searches share no cache (key includes filters), but pagination of the same
+  // search shares a single key (and `pageParam` carries the cursor).
+  const scopeKey = scope.type === "stream" ? `stream:${scope.streamId}` : "unknown"
+  const body: SerializableSearchBody = useMemo(
+    () => ({
+      query: filters.query,
+      exact: filters.exact,
+      uploadedBy: filters.uploadedBy,
+      mimeGroups: filters.mimeGroups,
+      contentTypes: filters.contentTypes,
+      before: filters.before,
+      after: filters.after,
+    }),
+    [filters]
+  )
+
+  return useInfiniteQuery<AssetSearchResponse, Error>({
+    queryKey: assetExplorerKeys.search(workspaceId, scopeKey, body),
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) => {
+      const req: AssetSearchRequest = {
+        scope,
+        query: body.query || undefined,
+        exact: body.exact || undefined,
+        cursor: typeof pageParam === "string" ? pageParam : undefined,
+        limit: PAGE_SIZE,
+        filters: {
+          from: body.uploadedBy ?? undefined,
+          mimeGroups: body.mimeGroups.length > 0 ? body.mimeGroups : undefined,
+          contentTypes: body.contentTypes.length > 0 ? body.contentTypes : undefined,
+          before: body.before ?? undefined,
+          after: body.after ?? undefined,
+        },
+      }
+      return searchAssets(workspaceId, req)
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 30_000,
+  })
+}
+
+export const initialAssetFilters: AssetExplorerFilters = {
+  query: "",
+  exact: false,
+  uploadedBy: null,
+  mimeGroups: [],
+  contentTypes: [],
+  before: null,
+  after: null,
+}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -1,6 +1,16 @@
 import { useState, useRef, useEffect } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
-import { MoreHorizontal, Pencil, Archive, MessageCircle, X, ArchiveX, Search, CornerDownRight } from "lucide-react"
+import {
+  MoreHorizontal,
+  Pencil,
+  Archive,
+  MessageCircle,
+  X,
+  ArchiveX,
+  Search,
+  CornerDownRight,
+  Image as ImageIcon,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -21,6 +31,7 @@ import { TimelineView } from "@/components/timeline"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
+import { AssetExplorerPanel } from "@/components/asset-explorer"
 import { StreamErrorView } from "@/components/stream-error-view"
 import { StreamTypes, type StreamType } from "@threa/types"
 import { getStreamName, resolveDmDisplayName, streamFallbackLabel } from "@/lib/streams"
@@ -77,6 +88,20 @@ export function StreamPage() {
         newParams.set("convView", "open")
       } else {
         newParams.delete("convView")
+      }
+      return newParams
+    })
+  }
+
+  const isAssetExplorerOpen = searchParams.get("assets") === "open"
+
+  const setAssetExplorerOpen = (open: boolean) => {
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev)
+      if (open) {
+        newParams.set("assets", "open")
+      } else {
+        newParams.delete("assets")
       }
       return newParams
     })
@@ -288,6 +313,17 @@ export function StreamPage() {
               <MessageCircle className="h-4 w-4" />
             </Button>
           )}
+          {!isThread && !isDraft && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title="Browse assets"
+              onClick={() => setAssetExplorerOpen(!isAssetExplorerOpen)}
+            >
+              <ImageIcon className="h-4 w-4" />
+            </Button>
+          )}
           {stream &&
             !isDraft &&
             !(isArchived && !isScratchpad) &&
@@ -406,6 +442,15 @@ export function StreamPage() {
     </>
   )
 
+  const assetExplorerPanel = stream && !isThread && !isDraft && (
+    <AssetExplorerPanel
+      workspaceId={workspaceId!}
+      streamId={streamId!}
+      open={isAssetExplorerOpen}
+      onClose={() => setAssetExplorerOpen(false)}
+    />
+  )
+
   // On mobile, thread panel takes over the full screen
   if (isMobile && isPanelOpen) {
     return (
@@ -414,6 +459,7 @@ export function StreamPage() {
           <StreamPanel key={panelId} workspaceId={workspaceId} onClose={closePanel} />
         </div>
         {conversationPanel}
+        {assetExplorerPanel}
       </>
     )
   }
@@ -439,6 +485,7 @@ export function StreamPage() {
         </ThreadPanelSlot>
       </div>
       {conversationPanel}
+      {assetExplorerPanel}
     </>
   )
 }

--- a/packages/types/src/asset-explorer.ts
+++ b/packages/types/src/asset-explorer.ts
@@ -1,0 +1,104 @@
+/**
+ * Asset explorer API contracts.
+ *
+ * The asset explorer surface is intentionally separate from the attachment
+ * upload/lifecycle API: attachments are a primitive (write/own), while the
+ * explorer is a read-side projection that joins attachments with their
+ * extractions to power browse + search.
+ *
+ * The {@link AssetSearchScope} discriminator is forward-compatible: today the
+ * only variant is `stream`, but the same wire shape supports a future
+ * `workspace` (or `stream-tree`) variant without a breaking change. Backend
+ * scope resolvers convert the variant into a list of accessible stream IDs;
+ * everything below that layer is scope-agnostic.
+ */
+
+import type { ExtractionContentType, ProcessingStatus } from "./constants"
+
+/**
+ * Coarse buckets the frontend uses to render type filters and pick icons.
+ * Stable wire enum — backend maps mime types to one of these via a single
+ * helper so the mapping stays consistent across browse/search results.
+ */
+export const ASSET_KINDS = ["image", "video", "pdf", "document", "spreadsheet", "text", "other"] as const
+export type AssetKind = (typeof ASSET_KINDS)[number]
+
+export const AssetKinds = {
+  IMAGE: "image",
+  VIDEO: "video",
+  PDF: "pdf",
+  DOCUMENT: "document",
+  SPREADSHEET: "spreadsheet",
+  TEXT: "text",
+  OTHER: "other",
+} as const satisfies Record<string, AssetKind>
+
+/**
+ * Where to search. Forward-compatible: workspace-wide search lands as a
+ * second variant, no wire-shape change required.
+ */
+export type AssetSearchScope = { type: "stream"; streamId: string }
+
+export interface AssetSearchFilters {
+  /** Single uploader user id. */
+  from?: string
+  /** Coarse kind filter (OR within the array). */
+  mimeGroups?: AssetKind[]
+  /** Extraction content-type filter (OR within the array). */
+  contentTypes?: ExtractionContentType[]
+  /** Exclusive upper bound. */
+  before?: string
+  /** Inclusive lower bound. */
+  after?: string
+}
+
+export interface AssetSearchRequest {
+  /** Free-text query. Empty/missing → recent-first browse. */
+  query?: string
+  /**
+   * If true, use case-insensitive substring matching on filename + extracted
+   * content (mirrors `/search`'s `exact` toggle).
+   */
+  exact?: boolean
+  scope: AssetSearchScope
+  filters?: AssetSearchFilters
+  /** Opaque cursor returned by a previous response. */
+  cursor?: string
+  /** Max results (1-100). */
+  limit?: number
+}
+
+export interface AssetSearchResult {
+  id: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+  /** ISO timestamp. */
+  createdAt: string
+  uploadedBy: string | null
+  streamId: string | null
+  messageId: string | null
+  processingStatus: ProcessingStatus
+  /** Coarse bucket — frontend uses this for icon + type-filter UI. */
+  kind: AssetKind
+  /**
+   * Whether a thumbnail variant is available via
+   * `GET /attachments/:id/url?variant=thumbnail`. Images are always self-thumbnailable;
+   * videos require a completed transcode.
+   */
+  hasThumbnail: boolean
+  /**
+   * Optional preview snippet. Today this surfaces the extraction summary when
+   * available; future iterations can add highlight snippets on query matches.
+   */
+  preview: string | null
+  /**
+   * Relevance score for the request. 0 in browse mode (recency-ordered).
+   */
+  rank: number
+}
+
+export interface AssetSearchResponse {
+  results: AssetSearchResult[]
+  nextCursor: string | null
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -319,6 +319,17 @@ export type {
 // Push Notifications
 export { DEVICE_KEY_LENGTH } from "./api"
 
+// Asset explorer (read-side projection over attachments)
+export { ASSET_KINDS, AssetKinds } from "./asset-explorer"
+export type {
+  AssetKind,
+  AssetSearchScope,
+  AssetSearchFilters,
+  AssetSearchRequest,
+  AssetSearchResult,
+  AssetSearchResponse,
+} from "./asset-explorer"
+
 // Command kind constants
 export { CommandKinds } from "./api"
 


### PR DESCRIPTION
## Summary

Adds a browse + search side panel for attachments accessible from a stream view. Triggered from a new asset icon button in the stream header (next to the search and conversations buttons).

- **Backend** — new `features/asset-explorer/` feature folder. One endpoint, `POST /api/workspaces/:workspaceId/assets/search`, accepts a discriminated `scope` (today: `{type: "stream", streamId}`) so a future workspace-wide variant lands without a wire-shape break. Repository joins `attachments ⨝ attachment_extractions ⨝ video_transcode_jobs` in a single SQL query. Three modes: keyset-paginated browse (recency), full-text search with a filename-ILIKE boost so filename matches outrank content matches, and an `exact` toggle that mirrors `/search`. Results carry a coarse `kind` bucket (image/video/pdf/document/spreadsheet/text/other) and a `hasThumbnail` flag so the frontend doesn't need a second round-trip.
- **Frontend** — `components/asset-explorer/` panel slides in from the right (mirrors the conversation panel pattern in `stream.tsx`). Debounced search input with an "Exact" toggle, kind filter chips, and date range. Infinite scroll via TanStack `useInfiniteQuery` + IntersectionObserver. Thumbnails: images fetch their own URL; videos fetch the MediaConvert `thumbnail` variant; everything else gets a kind icon. Clicking an image/video opens the existing `MediaGallery` via `useMediaGallery()`; a dedicated `AssetGalleryHost` only claims `?media=<id>` ownership when the id is in the explorer's results, so it cohabits with timeline-rendered `AttachmentList` instances without conflict. Filters persist within a session and reset only when the stream changes.

### Wire shape

```ts
{
  query?: string                   // empty/missing ⇒ recent-first browse
  exact?: boolean                  // ILIKE substring matching
  scope: { type: "stream", streamId }   // future: workspace | stream-tree
  filters?: { from?, mimeGroups?, contentTypes?, before?, after? }
  cursor?: string                  // opaque (time-keyset for browse, offset for search)
  limit?: number                   // default 30, max 100
}
```

Result: `{ id, filename, mimeType, sizeBytes, createdAt, uploadedBy, streamId, messageId, processingStatus, kind, hasThumbnail, preview, rank }` plus `nextCursor`.

### Notes

- Stream scope expands to `getStreamWithThreads(streamId)` so attachments uploaded inside threads of the stream surface in the panel.
- Only `safety_status='clean'` and `message_id IS NOT NULL` rows are exposed (pending uploads stay hidden).
- Semantic search is intentionally deferred — `attachment_extractions` has no embedding column today, and the existing `exact`/`full-text` shape mirrors `/search` so an embedding column + RRF can be added later without changing the wire shape.

## Test plan

- [x] `bun test apps/backend/src/features/asset-explorer/` — 16 tests pass (cursor round-trip, mime classification, service pagination + cursor emission)
- [x] `bun run typecheck` (full monorepo) — clean
- [x] `bun run --cwd apps/frontend lint` and `apps/backend lint` — clean
- [x] `bun run --cwd apps/frontend test` — 1475 tests pass
- [ ] Manual: open the panel from a stream header, browse, search, toggle Exact, apply kind/date filters, infinite-scroll, click an image to preview in the gallery, click a PDF to open in a new tab, download a non-previewable file

https://claude.ai/code/session_01ChFyjXRbMNJQsPuQv8cLJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChFyjXRbMNJQsPuQv8cLJj)_