### PR TITLE
fix: add solid background to attachment pills in floating composer

### DIFF
--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -41,9 +41,9 @@ export interface AttachmentPillProps {
 }
 
 const STATUS_STYLES: Record<AttachmentPillStatus, string> = {
-  default: "border border-primary/30 bg-primary/10 text-primary",
-  pending: "border border-dashed border-muted-foreground/40 bg-transparent text-muted-foreground",
-  error: "border border-destructive bg-destructive/10 text-destructive",
+  default: "border border-primary/30 bg-card text-primary",
+  pending: "border border-dashed border-muted-foreground/40 bg-card text-muted-foreground",
+  error: "border border-destructive bg-card text-destructive",
 }
 
 const STATUS_REMOVE_HOVER: Record<AttachmentPillStatus, string> = {


### PR DESCRIPTION
## Problem

When the composer is floating (positioned over existing messages), attachment pills were visually messy because their backgrounds were transparent or near-transparent. Message text would bleed through the pill surface, making them hard to read.

The three status styles had:
- `default` — `bg-primary/10` (10% opacity, nearly invisible)
- `pending` — `bg-transparent` (fully transparent)
- `error` — `bg-destructive/10` (10% opacity)

This was fine when the composer sat below the message list, but broke once it started floating.

## Solution

Replace all three transparent/semi-transparent backgrounds with `bg-card`, giving every pill a solid opaque surface. The colored borders (`border-primary/30`, `border-dashed border-muted-foreground/40`, `border-destructive`) still communicate status clearly — the background no longer needs to carry that signal.

This matches how the sent-message file buttons in `<AttachmentList>` are styled (`<Button variant="outline">` uses `bg-background`/`bg-card` as its base), so the before→after visual transition as a pill "moves" from composer to timeline stays consistent.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/components/composer/attachment-pill.tsx` | Replace `bg-primary/10`, `bg-transparent`, `bg-destructive/10` with `bg-card` in `STATUS_STYLES` |

## Test plan

- [ ] Attach a file in the floating composer — pill should have a solid white/card background, not show message text through it
- [ ] Uploading state (spinner) shows the dashed-border pending pill with solid background
- [ ] Error state shows the red-border pill with solid background
- [ ] Light and dark mode both look correct

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2MJDpJboZxwLedqg3hGJn)_