### PR TITLE
feat(share): recency-default sort with A–Z toggle in share pickers

### DIFF
--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -10,7 +10,8 @@ import { useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { calculateUrgency, getActivityTime } from "@/components/layout/sidebar/utils"
+import { calculateUrgency } from "@/components/layout/sidebar/utils"
+import { compareStreamEntries, scoreStreamMatch } from "@/lib/stream-sort"
 import { FilterSelect } from "./filter-select"
 import {
   parseSearchQuery,
@@ -20,7 +21,6 @@ import {
   type FilterType,
 } from "./search-query-parser"
 import type { ModeContext, ModeResult, QuickSwitcherItem, WorkspaceStream } from "./types"
-import type { UrgencyLevel } from "@/components/layout/sidebar/types"
 
 const FILTER_TYPES: { type: FilterType; label: string; icon: React.ReactNode }[] = [
   { type: "type", label: "Stream type", icon: <Hash className="h-4 w-4" /> },
@@ -40,9 +40,6 @@ const ARCHIVE_STATUS_OPTIONS: { value: "active" | "archived"; label: string }[] 
 
 /** Stream with optional sidebar preview (CachedStream has it, API Stream doesn't) */
 type StreamLike = Stream & { lastMessagePreview?: WorkspaceStream["lastMessagePreview"] }
-
-/** Urgency priority for sorting: mentions > ai > activity > quiet */
-const URGENCY_ORDER: Record<UrgencyLevel, number> = { mentions: 0, ai: 1, activity: 2, quiet: 3 }
 
 function getStreamTypeLabel(type: StreamType): string {
   switch (type) {
@@ -166,23 +163,12 @@ export function useStreamItems(context: ModeContext): ModeResult {
       filteredStreams = filteredStreams.filter((s) => typeFilters.includes(s.type))
     }
 
-    // Score streams by match quality (lower = better)
-    const scoreStream = (stream: StreamLike): number => {
-      if (!searchText) return 0
-      const name = (getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")).toLowerCase()
-      if (name === lowerQuery) return 0 // Exact match
-      if (name.startsWith(lowerQuery)) return 1 // Starts with
-      if (name.includes(lowerQuery)) return 2 // Contains
-      if (stream.id.toLowerCase().includes(lowerQuery)) return 3 // ID match
-      return Infinity // No match
-    }
-
     const isSearching = searchText.length > 0
 
     // Pre-compute urgency and counts once per stream (used by both sort and item builder)
     const enriched = filteredStreams
       .map((stream) => {
-        const score = scoreStream(stream)
+        const score = scoreStreamMatch(stream, lowerQuery)
         const unreadCount = getUnreadCount(stream.id)
         const mentionCount = getMentionCount(stream.id)
         const isMuted = mutedStreamIds.has(stream.id)
@@ -191,25 +177,10 @@ export function useStreamItems(context: ModeContext): ModeResult {
       })
       .filter(({ score }) => score !== Infinity)
 
+    // Quick-switcher always uses the recency-style browsing order; the share
+    // pickers expose a toggle but reuse the same comparator.
     const streamItems = enriched
-      .sort((a, b) => {
-        if (isSearching) {
-          if (a.score !== b.score) return a.score - b.score
-          const aName = getStreamName(a.stream) ?? streamFallbackLabel(a.stream.type, "generic")
-          const bName = getStreamName(b.stream) ?? streamFallbackLabel(b.stream.type, "generic")
-          return aName.localeCompare(bName)
-        }
-
-        // When browsing (no query): sort like the sidebar
-        // Mentions first, then AI activity, then unread, then by recency, then alphabetically
-        const urgencyDiff = URGENCY_ORDER[a.urgency] - URGENCY_ORDER[b.urgency]
-        if (urgencyDiff !== 0) return urgencyDiff
-        const timeDiff = getActivityTime(b.stream) - getActivityTime(a.stream)
-        if (timeDiff !== 0) return timeDiff
-        const aName = getStreamName(a.stream) ?? streamFallbackLabel(a.stream.type, "generic")
-        const bName = getStreamName(b.stream) ?? streamFallbackLabel(b.stream.type, "generic")
-        return aName.localeCompare(bName)
-      })
+      .sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: "recency" }))
       .map(({ stream, unreadCount, mentionCount, urgency }): QuickSwitcherItem => {
         const href = `/w/${workspaceId}/s/${stream.id}`
         const isArchived = stream.archivedAt != null

--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -31,6 +31,11 @@ beforeEach(() => {
   // Default to desktop unless a test overrides — keeps the picker-rendering
   // tests pinned to one surface so cmdk-item assertions are stable.
   vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  // No unread state in these picker tests; the modal reads counts/mute from
+  // here for urgency-based sorting and would otherwise hit Dexie on mount.
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue(
+    undefined as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUnreadState>
+  )
 })
 
 afterEach(() => {
@@ -48,6 +53,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: "general",
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "ch_priv_member",
@@ -57,6 +63,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: "team",
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "ch_priv_outsider",
@@ -66,6 +73,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: "secret",
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "ch_archived",
@@ -75,6 +83,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: "old",
         archivedAt: "2026-01-01",
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "thread_a",
@@ -84,6 +93,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: null,
         archivedAt: null,
         rootStreamId: "ch_pub",
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "dm_self",
@@ -93,6 +103,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: null,
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
         id: "scratch_self",
@@ -102,6 +113,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: null,
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
     ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
     vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue([
@@ -147,6 +159,7 @@ describe("ShareMessageModal — picker filtering", () => {
         slug: "general",
         archivedAt: null,
         rootStreamId: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
     ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
     vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 import { Clock, ArrowDownAZ } from "lucide-react"
 import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
@@ -13,13 +13,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
-import {
-  compareStreamEntries,
-  readStoredStreamSortMode,
-  scoreStreamMatch,
-  writeStoredStreamSortMode,
-  type StreamSortMode,
-} from "@/lib/stream-sort"
+import { compareStreamEntries, scoreStreamMatch, useStoredStreamSortMode } from "@/lib/stream-sort"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
 import { navigateAfterShareHandoff } from "@/lib/share-navigation"
@@ -65,7 +59,7 @@ interface ShareMessageModalProps {
  */
 export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
-  const [sortMode, setSortMode] = useState<StreamSortMode>(() => readStoredStreamSortMode())
+  const [sortMode, setSortMode] = useStoredStreamSortMode()
   const navigate = useNavigate()
   const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
@@ -77,10 +71,6 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   // The Drawer/Dialog split is owned by ResponsiveDialog; isMobile here only
   // governs the post-select navigation contract (mobile strips `?panel=…`).
   const isMobile = useIsMobile()
-
-  useEffect(() => {
-    writeStoredStreamSortMode(sortMode)
-  }, [sortMode])
 
   const memberStreamIds = useMemo(() => {
     const ids = new Set<string>()

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
+import { Clock, ArrowDownAZ } from "lucide-react"
 import { StreamTypes, Visibilities, type StreamType } from "@threa/types"
 import {
   ResponsiveDialog,
@@ -9,8 +10,17 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
+import {
+  compareStreamEntries,
+  readStoredStreamSortMode,
+  scoreStreamMatch,
+  writeStoredStreamSortMode,
+  type StreamSortMode,
+} from "@/lib/stream-sort"
+import { calculateUrgency } from "@/components/layout/sidebar/utils"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
 import { navigateAfterShareHandoff } from "@/lib/share-navigation"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -40,7 +50,10 @@ interface ShareMessageModalProps {
  * Renders through `ResponsiveDialog`, which routes to a centered Dialog
  * on desktop and a snap-pointed Drawer on mobile — same primitive the
  * quick-switcher (a sibling stream picker) uses, so the affordance stays
- * consistent.
+ * consistent. Sort order is shared with the quick-switcher via
+ * `compareStreamEntries`: defaults to recency (urgency → activity time →
+ * alphabetical) so the streams the user is most likely to share to bubble
+ * up first, with an alphabetical toggle persisted to localStorage.
  *
  * Privacy boundaries are enforced at send time: the backend rejects with
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
@@ -48,13 +61,22 @@ interface ShareMessageModalProps {
  */
 export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
+  const [sortMode, setSortMode] = useState<StreamSortMode>(() => readStoredStreamSortMode())
   const navigate = useNavigate()
   const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
   const memberships = useWorkspaceStreamMemberships(workspaceId)
+  const unreadState = useWorkspaceUnreadState(workspaceId)
+  const unreadCounts = unreadState?.unreadCounts ?? {}
+  const mentionCounts = unreadState?.mentionCounts ?? {}
+  const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   // The Drawer/Dialog split is owned by ResponsiveDialog; isMobile here only
   // governs the post-select navigation contract (mobile strips `?panel=…`).
   const isMobile = useIsMobile()
+
+  useEffect(() => {
+    writeStoredStreamSortMode(sortMode)
+  }, [sortMode])
 
   const memberStreamIds = useMemo(() => {
     const ids = new Set<string>()
@@ -64,35 +86,42 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
 
   const streamsByGroup = useMemo(() => {
     const lower = search.toLowerCase()
+    const isSearching = lower.length > 0
     const matchable = streams.filter((s) => {
       if (s.archivedAt) return false
       if (s.rootStreamId) return false
       if (s.type === StreamTypes.THREAD || s.type === StreamTypes.SYSTEM) return false
       const accessible = s.visibility === Visibilities.PUBLIC || memberStreamIds.has(s.id)
-      if (!accessible) return false
-      if (!lower) return true
-      const name = (getStreamName(s) ?? streamFallbackLabel(s.type, "generic")).toLowerCase()
-      return name.includes(lower)
+      return accessible
     })
-    const byType = new Map<StreamType, typeof matchable>()
-    for (const s of matchable) {
-      const list = byType.get(s.type) ?? []
-      list.push(s)
-      byType.set(s.type, list)
+
+    const enriched = matchable
+      .map((stream) => {
+        const score = scoreStreamMatch(stream, lower)
+        const unreadCount = unreadCounts[stream.id] ?? 0
+        const mentionCount = mentionCounts[stream.id] ?? 0
+        const isMuted = mutedStreamIds.has(stream.id)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        return { stream, score, urgency }
+      })
+      .filter(({ score }) => score !== Infinity)
+
+    const byType = new Map<StreamType, typeof enriched>()
+    for (const entry of enriched) {
+      const list = byType.get(entry.stream.type) ?? []
+      list.push(entry)
+      byType.set(entry.stream.type, list)
     }
     for (const [, list] of byType) {
-      list.sort((a, b) => {
-        const an = getStreamName(a) ?? streamFallbackLabel(a.type, "generic")
-        const bn = getStreamName(b) ?? streamFallbackLabel(b.type, "generic")
-        return an.localeCompare(bn)
-      })
+      list.sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: sortMode }))
     }
     return byType
-  }, [streams, memberStreamIds, search])
+  }, [streams, memberStreamIds, search, sortMode, unreadCounts, mentionCounts, mutedStreamIds])
 
   // Wrap the parent's open-change so search resets on every close path
   // (Esc, backdrop, X, programmatic). Without this, dismissing without
   // selecting leaves the previous query in place when the modal reopens.
+  // Sort mode intentionally persists across opens — it's a user preference.
   const handleOpenChange = (next: boolean) => {
     if (!next) setSearch("")
     onOpenChange(next)
@@ -118,10 +147,31 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
         drawerClassName="flex flex-col"
       >
         <ResponsiveDialogHeader className="border-b px-4 py-3">
-          <ResponsiveDialogTitle className="text-base">Share message</ResponsiveDialogTitle>
-          <ResponsiveDialogDescription>
-            Pick a stream to insert this share into the composer.
-          </ResponsiveDialogDescription>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <ResponsiveDialogTitle className="text-base">Share message</ResponsiveDialogTitle>
+              <ResponsiveDialogDescription>
+                Pick a stream to insert this share into the composer.
+              </ResponsiveDialogDescription>
+            </div>
+            <ToggleGroup
+              type="single"
+              size="sm"
+              value={sortMode}
+              onValueChange={(value) => {
+                if (value === "recency" || value === "alphabetical") setSortMode(value)
+              }}
+              aria-label="Sort streams"
+              className="shrink-0"
+            >
+              <ToggleGroupItem value="recency" aria-label="Sort by recency" title="Recent activity">
+                <Clock className="h-4 w-4" aria-hidden="true" />
+              </ToggleGroupItem>
+              <ToggleGroupItem value="alphabetical" aria-label="Sort alphabetically" title="A–Z">
+                <ArrowDownAZ className="h-4 w-4" aria-hidden="true" />
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
         </ResponsiveDialogHeader>
         <Command shouldFilter={false} className="rounded-none">
           <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
@@ -132,7 +182,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
               if (!list || list.length === 0) return null
               return (
                 <CommandGroup key={group.id} heading={group.heading}>
-                  {list.map((stream) => {
+                  {list.map(({ stream }) => {
                     const Icon = STREAM_ICONS[stream.type]
                     const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
                     return (

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -32,6 +32,10 @@ const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; typ
   { id: "scratchpad", heading: "Your scratchpads", type: StreamTypes.SCRATCHPAD },
 ]
 
+// Stable identity for the no-unread-state case so the streamsByGroup memo doesn't
+// re-sort on every render when the workspace has no cached unread bootstrap yet.
+const EMPTY_COUNTS: Record<string, number> = Object.freeze({}) as Record<string, number>
+
 interface ShareMessageModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -67,8 +71,8 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   const streams = useWorkspaceStreams(workspaceId)
   const memberships = useWorkspaceStreamMemberships(workspaceId)
   const unreadState = useWorkspaceUnreadState(workspaceId)
-  const unreadCounts = unreadState?.unreadCounts ?? {}
-  const mentionCounts = unreadState?.mentionCounts ?? {}
+  const unreadCounts = unreadState?.unreadCounts ?? EMPTY_COUNTS
+  const mentionCounts = unreadState?.mentionCounts ?? EMPTY_COUNTS
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   // The Drawer/Dialog split is owned by ResponsiveDialog; isMobile here only
   // governs the post-select navigation contract (mobile strips `?panel=…`).

--- a/apps/frontend/src/lib/stream-sort.test.ts
+++ b/apps/frontend/src/lib/stream-sort.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest"
+import { StreamTypes } from "@threa/types"
+import type { Stream } from "@threa/types"
+import type { UrgencyLevel } from "@/components/layout/sidebar/types"
+import {
+  compareStreamEntries,
+  scoreStreamMatch,
+  type SortableEntry,
+  type SortableStream,
+  type StreamSortMode,
+} from "./stream-sort"
+
+function makeStream(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: overrides.id ?? "stream_x",
+    workspaceId: "ws_1",
+    type: overrides.type ?? StreamTypes.CHANNEL,
+    displayName: overrides.displayName ?? null,
+    slug: overrides.slug ?? null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_a",
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    archivedAt: null,
+  }
+}
+
+function makeSortable(overrides: Partial<Stream> & { lastMessageAt?: string } = {}): SortableStream {
+  const stream = makeStream(overrides)
+  return {
+    ...stream,
+    lastMessagePreview: overrides.lastMessageAt ? { createdAt: overrides.lastMessageAt } : null,
+  }
+}
+
+function makeEntry<S extends SortableStream>(
+  stream: S,
+  overrides: { score?: number; urgency?: UrgencyLevel } = {}
+): SortableEntry<S> {
+  return { stream, score: overrides.score ?? 0, urgency: overrides.urgency ?? "quiet" }
+}
+
+function sort<S extends SortableStream>(
+  entries: SortableEntry<S>[],
+  options: { isSearching: boolean; mode: StreamSortMode }
+): string[] {
+  return [...entries].sort((a, b) => compareStreamEntries(a, b, options)).map((e) => e.stream.id)
+}
+
+describe("scoreStreamMatch", () => {
+  it("returns 0 for empty query (no scoring required)", () => {
+    expect(scoreStreamMatch(makeStream({ slug: "general" }), "")).toBe(0)
+  })
+
+  it("ranks exact match best, then prefix, then substring, then id-fallback", () => {
+    const general = makeStream({ id: "stream_a", slug: "general" })
+    const generic = makeStream({ id: "stream_b", slug: "generic" })
+    const ageneral = makeStream({ id: "stream_c", slug: "ageneral" })
+    const idMatch = makeStream({ id: "stream_general_id", slug: "elsewhere" })
+
+    expect(scoreStreamMatch(general, "#general")).toBe(0)
+    expect(scoreStreamMatch(generic, "#gen")).toBe(1)
+    expect(scoreStreamMatch(ageneral, "general")).toBe(2)
+    expect(scoreStreamMatch(idMatch, "general")).toBe(3)
+  })
+
+  it("returns Infinity when no part of the stream matches", () => {
+    expect(scoreStreamMatch(makeStream({ slug: "general" }), "zzz")).toBe(Infinity)
+  })
+})
+
+describe("compareStreamEntries — searching", () => {
+  it("orders by score then alphabetical (mode is ignored)", () => {
+    const entries = [
+      makeEntry(makeSortable({ id: "s_b", slug: "beta" }), { score: 2 }),
+      makeEntry(makeSortable({ id: "s_a", slug: "alpha" }), { score: 1 }),
+      makeEntry(makeSortable({ id: "s_c", slug: "charlie" }), { score: 1 }),
+    ]
+    expect(sort(entries, { isSearching: true, mode: "recency" })).toEqual(["s_a", "s_c", "s_b"])
+    // The toggle is ignored when searching: same order.
+    expect(sort(entries, { isSearching: true, mode: "alphabetical" })).toEqual(["s_a", "s_c", "s_b"])
+  })
+})
+
+describe("compareStreamEntries — browsing in recency mode", () => {
+  it("prioritizes urgency before recency", () => {
+    const old = makeSortable({
+      id: "s_old_mention",
+      slug: "old",
+      lastMessageAt: "2025-01-01T00:00:00.000Z",
+    })
+    const recent = makeSortable({
+      id: "s_recent_quiet",
+      slug: "recent",
+      lastMessageAt: "2026-04-29T00:00:00.000Z",
+    })
+
+    const result = sort([makeEntry(recent, { urgency: "quiet" }), makeEntry(old, { urgency: "mentions" })], {
+      isSearching: false,
+      mode: "recency",
+    })
+    expect(result).toEqual(["s_old_mention", "s_recent_quiet"])
+  })
+
+  it("falls through to activity time when urgency ties", () => {
+    const olderQuiet = makeSortable({
+      id: "s_older",
+      slug: "older",
+      lastMessageAt: "2026-01-01T00:00:00.000Z",
+    })
+    const newerQuiet = makeSortable({
+      id: "s_newer",
+      slug: "newer",
+      lastMessageAt: "2026-04-29T00:00:00.000Z",
+    })
+
+    const result = sort([makeEntry(olderQuiet, { urgency: "quiet" }), makeEntry(newerQuiet, { urgency: "quiet" })], {
+      isSearching: false,
+      mode: "recency",
+    })
+    expect(result).toEqual(["s_newer", "s_older"])
+  })
+
+  it("falls back to alphabetical when urgency and activity time tie", () => {
+    const sameTime = "2026-04-01T00:00:00.000Z"
+    const beta = makeSortable({ id: "s_beta", slug: "beta", lastMessageAt: sameTime })
+    const alpha = makeSortable({ id: "s_alpha", slug: "alpha", lastMessageAt: sameTime })
+
+    const result = sort([makeEntry(beta), makeEntry(alpha)], { isSearching: false, mode: "recency" })
+    expect(result).toEqual(["s_alpha", "s_beta"])
+  })
+
+  it("uses createdAt when lastMessagePreview is missing", () => {
+    const older = makeSortable({ id: "s_older", slug: "older", createdAt: "2025-01-01T00:00:00.000Z" })
+    const newer = makeSortable({ id: "s_newer", slug: "newer", createdAt: "2026-03-01T00:00:00.000Z" })
+
+    const result = sort([makeEntry(older), makeEntry(newer)], { isSearching: false, mode: "recency" })
+    expect(result).toEqual(["s_newer", "s_older"])
+  })
+})
+
+describe("compareStreamEntries — browsing in alphabetical mode", () => {
+  it("ignores urgency and recency", () => {
+    const recentMention = makeSortable({
+      id: "s_zoo",
+      slug: "zoo",
+      lastMessageAt: "2026-04-29T00:00:00.000Z",
+    })
+    const oldQuiet = makeSortable({
+      id: "s_aaa",
+      slug: "aaa",
+      lastMessageAt: "2025-01-01T00:00:00.000Z",
+    })
+
+    const result = sort(
+      [makeEntry(recentMention, { urgency: "mentions" }), makeEntry(oldQuiet, { urgency: "quiet" })],
+      { isSearching: false, mode: "alphabetical" }
+    )
+    expect(result).toEqual(["s_aaa", "s_zoo"])
+  })
+})

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -1,0 +1,96 @@
+import type { Stream } from "@threa/types"
+import type { UrgencyLevel } from "@/components/layout/sidebar/types"
+import { getActivityTime } from "@/components/layout/sidebar/utils"
+import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+
+/** Sort modes used by stream pickers (quick switcher, share modal, share picker). */
+export type StreamSortMode = "recency" | "alphabetical"
+
+/** Urgency priority for sorting: mentions > ai > activity > quiet (lower wins). */
+export const URGENCY_ORDER: Record<UrgencyLevel, number> = { mentions: 0, ai: 1, activity: 2, quiet: 3 }
+
+/** Minimal shape pickers need for sorting — name lookup + activity time. */
+export type SortableStream = Pick<Stream, "id" | "type" | "createdAt"> & {
+  displayName?: string | null
+  slug?: string | null
+  lastMessagePreview?: { createdAt: string } | null
+}
+
+/**
+ * Score a stream against a lowercased query. Lower = better match.
+ * Returns Infinity for non-matches. Mirrors the quick-switcher heuristic so
+ * search results land in the same order across every picker surface.
+ */
+export function scoreStreamMatch(
+  stream: Pick<Stream, "id" | "type" | "displayName" | "slug">,
+  lowerQuery: string
+): number {
+  if (!lowerQuery) return 0
+  const name = (getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")).toLowerCase()
+  if (name === lowerQuery) return 0
+  if (name.startsWith(lowerQuery)) return 1
+  if (name.includes(lowerQuery)) return 2
+  if (stream.id.toLowerCase().includes(lowerQuery)) return 3
+  return Infinity
+}
+
+function compareNames(a: SortableStream, b: SortableStream): number {
+  const aName = getStreamName(a) ?? streamFallbackLabel(a.type, "generic")
+  const bName = getStreamName(b) ?? streamFallbackLabel(b.type, "generic")
+  return aName.localeCompare(bName)
+}
+
+export interface SortableEntry<S extends SortableStream> {
+  stream: S
+  /** Match score from scoreStreamMatch; ignored when not searching. */
+  score: number
+  /** Pre-computed urgency level for this stream. */
+  urgency: UrgencyLevel
+}
+
+/**
+ * Comparator for stream picker entries. Mirrors the quick-switcher behavior so
+ * the share dialog and share-target picker stay visually aligned with it.
+ *
+ *   - searching:         score → alphabetical (mode is ignored)
+ *   - browsing/recency:  urgency → activity time → alphabetical
+ *   - browsing/alpha:    alphabetical
+ */
+export function compareStreamEntries<S extends SortableStream>(
+  a: SortableEntry<S>,
+  b: SortableEntry<S>,
+  options: { isSearching: boolean; mode: StreamSortMode }
+): number {
+  if (options.isSearching) {
+    if (a.score !== b.score) return a.score - b.score
+    return compareNames(a.stream, b.stream)
+  }
+  if (options.mode === "alphabetical") {
+    return compareNames(a.stream, b.stream)
+  }
+  const urgencyDiff = URGENCY_ORDER[a.urgency] - URGENCY_ORDER[b.urgency]
+  if (urgencyDiff !== 0) return urgencyDiff
+  const timeDiff = getActivityTime(b.stream) - getActivityTime(a.stream)
+  if (timeDiff !== 0) return timeDiff
+  return compareNames(a.stream, b.stream)
+}
+
+const SORT_PREFERENCE_KEY = "threa-stream-picker-sort"
+
+/** Persisted picker sort preference. Falls back to "recency" when absent or invalid. */
+export function readStoredStreamSortMode(): StreamSortMode {
+  try {
+    const value = localStorage.getItem(SORT_PREFERENCE_KEY)
+    return value === "alphabetical" ? "alphabetical" : "recency"
+  } catch {
+    return "recency"
+  }
+}
+
+export function writeStoredStreamSortMode(mode: StreamSortMode): void {
+  try {
+    localStorage.setItem(SORT_PREFERENCE_KEY, mode)
+  } catch {
+    // Storage unavailable
+  }
+}

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react"
 import type { Stream } from "@threa/types"
 import type { UrgencyLevel } from "@/components/layout/sidebar/types"
 import { getActivityTime } from "@/components/layout/sidebar/utils"
@@ -93,4 +94,19 @@ export function writeStoredStreamSortMode(mode: StreamSortMode): void {
   } catch {
     // Storage unavailable
   }
+}
+
+/**
+ * Hook for stream pickers (share modal, share-target page) that owns the
+ * sort-mode state and its localStorage persistence in one place. Keeps the
+ * caller free of direct storage access (INV-15) and avoids duplicating the
+ * useState + useEffect pair across surfaces.
+ */
+export function useStoredStreamSortMode(): [StreamSortMode, (next: StreamSortMode) => void] {
+  const [sortMode, setSortModeState] = useState<StreamSortMode>(() => readStoredStreamSortMode())
+  const setSortMode = useCallback((next: StreamSortMode) => {
+    setSortModeState(next)
+    writeStoredStreamSortMode(next)
+  }, [])
+  return [sortMode, setSortMode]
 }

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -33,13 +33,7 @@ import { Input } from "@/components/ui/input"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { ItemList } from "@/components/quick-switcher/item-list"
 import type { QuickSwitcherItem } from "@/components/quick-switcher/types"
-import {
-  compareStreamEntries,
-  readStoredStreamSortMode,
-  scoreStreamMatch,
-  writeStoredStreamSortMode,
-  type StreamSortMode,
-} from "@/lib/stream-sort"
+import { compareStreamEntries, scoreStreamMatch, useStoredStreamSortMode } from "@/lib/stream-sort"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
 
 const STREAM_ICONS: Record<StreamType, React.ComponentType<{ className?: string }>> = {
@@ -80,15 +74,11 @@ export function SharePickerPage() {
   const { createShareDraft, saveShareContent } = useShareTarget()
 
   const [query, setQuery] = useState("")
-  const [sortMode, setSortMode] = useState<StreamSortMode>(() => readStoredStreamSortMode())
+  const [sortMode, setSortMode] = useStoredStreamSortMode()
   const [selectedIndex, setSelectedIndex] = useState(0)
   // null = not yet loaded, [] = loaded but empty/unavailable
   const [files, setFiles] = useState<File[] | null>(null)
   const [submitting, setSubmitting] = useState(false)
-
-  useEffect(() => {
-    writeStoredStreamSortMode(sortMode)
-  }, [sortMode])
 
   // Only lightweight text metadata comes from navigation state — files stay in Cache API
   // to avoid hitting browser history.state serialization limits (~640 KB in Firefox).

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -56,6 +56,10 @@ const TYPE_LABELS: Partial<Record<StreamType, string>> = {
   [StreamTypes.DM]: "Direct Message",
 }
 
+// Stable identity for the no-unread-state case so the items memo doesn't
+// re-sort on every render when the workspace has no cached unread bootstrap yet.
+const EMPTY_COUNTS: Record<string, number> = Object.freeze({}) as Record<string, number>
+
 /**
  * Share destination picker — workspace-scoped page shown when content is shared to Threa.
  *
@@ -70,21 +74,21 @@ export function SharePickerPage() {
   const idbDmPeers = useWorkspaceDmPeers(workspaceId!)
   const idbUsers = useWorkspaceUsers(workspaceId!)
   const unreadState = useWorkspaceUnreadState(workspaceId!)
-  const unreadCounts = unreadState?.unreadCounts ?? {}
-  const mentionCounts = unreadState?.mentionCounts ?? {}
+  const unreadCounts = unreadState?.unreadCounts ?? EMPTY_COUNTS
+  const mentionCounts = unreadState?.mentionCounts ?? EMPTY_COUNTS
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   const { createShareDraft, saveShareContent } = useShareTarget()
 
   const [query, setQuery] = useState("")
   const [sortMode, setSortMode] = useState<StreamSortMode>(() => readStoredStreamSortMode())
   const [selectedIndex, setSelectedIndex] = useState(0)
+  // null = not yet loaded, [] = loaded but empty/unavailable
+  const [files, setFiles] = useState<File[] | null>(null)
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     writeStoredStreamSortMode(sortMode)
   }, [sortMode])
-  // null = not yet loaded, [] = loaded but empty/unavailable
-  const [files, setFiles] = useState<File[] | null>(null)
-  const [submitting, setSubmitting] = useState(false)
 
   // Only lightweight text metadata comes from navigation state — files stay in Cache API
   // to avoid hitting browser history.state serialization limits (~640 KB in Firefox).

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -1,9 +1,26 @@
 import { useState, useMemo, useCallback, useEffect } from "react"
 import { useNavigate, useParams, useLocation } from "react-router-dom"
-import { FileText, Hash, MessageSquare, Bell, Search, Plus, Link as LinkIcon, Image, Paperclip } from "lucide-react"
+import {
+  FileText,
+  Hash,
+  MessageSquare,
+  Bell,
+  Search,
+  Plus,
+  Link as LinkIcon,
+  Image,
+  Paperclip,
+  Clock,
+  ArrowDownAZ,
+} from "lucide-react"
 import { StreamTypes, getAvatarUrl } from "@threa/types"
-import type { Stream, StreamType } from "@threa/types"
-import { useWorkspaceStreams, useWorkspaceDmPeers, useWorkspaceUsers } from "@/stores/workspace-store"
+import type { StreamType } from "@threa/types"
+import {
+  useWorkspaceStreams,
+  useWorkspaceDmPeers,
+  useWorkspaceUsers,
+  useWorkspaceUnreadState,
+} from "@/stores/workspace-store"
 import {
   useShareTarget,
   clearShareTargetCache,
@@ -13,8 +30,17 @@ import {
 } from "@/hooks/use-share-target"
 import { getStreamName, streamFallbackLabel } from "@/lib/streams"
 import { Input } from "@/components/ui/input"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { ItemList } from "@/components/quick-switcher/item-list"
 import type { QuickSwitcherItem } from "@/components/quick-switcher/types"
+import {
+  compareStreamEntries,
+  readStoredStreamSortMode,
+  scoreStreamMatch,
+  writeStoredStreamSortMode,
+  type StreamSortMode,
+} from "@/lib/stream-sort"
+import { calculateUrgency } from "@/components/layout/sidebar/utils"
 
 const STREAM_ICONS: Record<StreamType, React.ComponentType<{ className?: string }>> = {
   [StreamTypes.SCRATCHPAD]: FileText,
@@ -43,10 +69,19 @@ export function SharePickerPage() {
   const idbStreams = useWorkspaceStreams(workspaceId!)
   const idbDmPeers = useWorkspaceDmPeers(workspaceId!)
   const idbUsers = useWorkspaceUsers(workspaceId!)
+  const unreadState = useWorkspaceUnreadState(workspaceId!)
+  const unreadCounts = unreadState?.unreadCounts ?? {}
+  const mentionCounts = unreadState?.mentionCounts ?? {}
+  const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   const { createShareDraft, saveShareContent } = useShareTarget()
 
   const [query, setQuery] = useState("")
+  const [sortMode, setSortMode] = useState<StreamSortMode>(() => readStoredStreamSortMode())
   const [selectedIndex, setSelectedIndex] = useState(0)
+
+  useEffect(() => {
+    writeStoredStreamSortMode(sortMode)
+  }, [sortMode])
   // null = not yet loaded, [] = loaded but empty/unavailable
   const [files, setFiles] = useState<File[] | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -162,26 +197,19 @@ export function SharePickerPage() {
         (s.type === StreamTypes.SCRATCHPAD || s.type === StreamTypes.CHANNEL || s.type === StreamTypes.DM)
     )
 
-    // Score and sort
-    const scoreStream = (stream: Stream): number => {
-      if (!query) return 0
-      const name = (getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")).toLowerCase()
-      if (name === lowerQuery) return 0
-      if (name.startsWith(lowerQuery)) return 1
-      if (name.includes(lowerQuery)) return 2
-      return Infinity
-    }
-
+    const isSearching = lowerQuery.length > 0
     const streamItems = filteredStreams
-      .map((stream) => ({ stream, score: scoreStream(stream) }))
-      .filter(({ score }) => score !== Infinity)
-      .sort((a, b) => {
-        if (a.score !== b.score) return a.score - b.score
-        const aName = getStreamName(a.stream) ?? streamFallbackLabel(a.stream.type, "generic")
-        const bName = getStreamName(b.stream) ?? streamFallbackLabel(b.stream.type, "generic")
-        return aName.localeCompare(bName)
+      .map((stream) => {
+        const score = scoreStreamMatch(stream, lowerQuery)
+        const unreadCount = unreadCounts[stream.id] ?? 0
+        const mentionCount = mentionCounts[stream.id] ?? 0
+        const isMuted = mutedStreamIds.has(stream.id)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        return { stream, score, urgency, unreadCount, mentionCount }
       })
-      .map(({ stream }): QuickSwitcherItem => {
+      .filter(({ score }) => score !== Infinity)
+      .sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: sortMode }))
+      .map(({ stream, urgency, unreadCount, mentionCount }): QuickSwitcherItem => {
         let avatarUrl: string | undefined
         if (stream.type === StreamTypes.DM) {
           const peerUserId = dmPeerByStreamId.get(stream.id)
@@ -197,12 +225,27 @@ export function SharePickerPage() {
           description: typeLabel,
           icon: STREAM_ICONS[stream.type],
           avatarUrl,
+          urgency,
+          unreadCount,
+          mentionCount,
           onSelect: () => handleSelectStream(stream.id),
         }
       })
 
     return [newScratchpadItem, ...streamItems]
-  }, [streams, dmPeers, users, query, workspaceId, handleNewScratchpad, handleSelectStream])
+  }, [
+    streams,
+    dmPeers,
+    users,
+    query,
+    sortMode,
+    workspaceId,
+    handleNewScratchpad,
+    handleSelectStream,
+    unreadCounts,
+    mentionCounts,
+    mutedStreamIds,
+  ])
 
   const isLoading = filesLoading || submitting
 
@@ -235,8 +278,8 @@ export function SharePickerPage() {
         </div>
 
         {/* Search */}
-        <div className="px-4 pb-3">
-          <div className="relative">
+        <div className="px-4 pb-3 flex items-center gap-2">
+          <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               value={query}
@@ -259,6 +302,23 @@ export function SharePickerPage() {
               }}
             />
           </div>
+          <ToggleGroup
+            type="single"
+            size="sm"
+            value={sortMode}
+            onValueChange={(value) => {
+              if (value === "recency" || value === "alphabetical") setSortMode(value)
+            }}
+            aria-label="Sort streams"
+            className="shrink-0"
+          >
+            <ToggleGroupItem value="recency" aria-label="Sort by recency" title="Recent activity">
+              <Clock className="h-4 w-4" aria-hidden="true" />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="alphabetical" aria-label="Sort alphabetically" title="A–Z">
+              <ArrowDownAZ className="h-4 w-4" aria-hidden="true" />
+            </ToggleGroupItem>
+          </ToggleGroup>
         </div>
 
         {/* Stream list */}


### PR DESCRIPTION
## Summary

The two share surfaces (the "Share message" modal and the OS-level "Share to Threa" page) sorted streams alphabetically. That forced you to scroll past quiet A-named streams to find the scratchpad or channel you'd actually been working in — exactly the streams you usually want to share into.

Both surfaces now default to the same browsing order the quick-switcher uses (urgency → activity time → alphabetical) and expose a Clock / A–Z `ToggleGroup` to flip to alphabetical, persisted to `localStorage`.

- New `apps/frontend/src/lib/stream-sort.ts` — `compareStreamEntries`, `scoreStreamMatch`, `URGENCY_ORDER`, plus `read/writeStoredStreamSortMode`. Single comparator used by all three pickers (INV-37).
- `share-message-modal.tsx`: keeps the existing per-type grouping (Channels / DMs / Scratchpads); within each group, the new comparator runs. Toggle sits in the dialog header beside the title.
- `share-picker.tsx`: flat list, toggle sits beside the search input. New-scratchpad CTA stays pinned at the top.
- `quick-switcher/use-stream-items.tsx`: drops its private comparator and imports the shared one. Behavior identical (verified by the existing 207 quick-switcher tests).
- Stable `EMPTY_COUNTS` fallback so the sort memo doesn't churn when no unread state is cached yet.

When the user types a search query, both pickers fall through to the quick-switcher's score → alphabetical ordering regardless of toggle, matching how QS already behaves.

## Test plan

- [x] `bunx tsc --noEmit` (frontend) — clean
- [x] `bun run test src/lib/stream-sort.test.ts` — 9 new comparator tests covering scoring, search ordering, urgency precedence, recency tie-breakers, and alphabetical mode
- [x] `bun run test src/components/share/share-message-modal.test.tsx` — existing tests pass; added `useWorkspaceUnreadState` mock + `createdAt` on mock streams
- [x] `bun run test src/components/quick-switcher` — 207 tests still pass after the refactor
- [x] Full frontend suite: 1515 / 1515 green
- [x] eslint clean on changed files
- [ ] Manual: open share-from-message in dev, verify recent scratchpads/channels float to the top of their groups; flip to A–Z and confirm names sort regardless of activity; confirm preference persists across modal opens
- [ ] Manual: OS share target (`/w/:id/share`) — same checks on a flat list


---
_Generated by [Claude Code](https://claude.ai/code/session_01DewVR6vDAyfiDkM2K3PXh6)_