### PR TITLE
fix(agents): recover captured content when a session ends in keep_response

### DIFF
--- a/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.test.ts
@@ -200,6 +200,67 @@ describe("AgentRuntime message counting", () => {
     })
   })
 
+  it("commits captured content text when a supersede rerun ends in keep_response", async () => {
+    // Reproduces the bug where a scratchpad rerun produces real assistant
+    // text alongside a keep_response tool call, then resolves with no message
+    // sent. The runtime should fall back to committing the captured text.
+    const events: AgentEvent[] = []
+    const sendMessage = mock(async (input: { content: string }) => ({
+      messageId: "msg_recovered",
+      operation: "created" as const,
+      content: input.content,
+    }))
+
+    const generateTextWithTools = mock(async () => ({
+      text: "Found it! You shared this in your Casual Greeting conversation.",
+      toolCalls: [
+        {
+          toolCallId: "tool_keep",
+          toolName: "keep_response",
+          input: { reason: "Previous response still fits." },
+        },
+      ],
+      response: {
+        messages: [
+          {
+            role: "assistant",
+            content: "Found it! You shared this in your Casual Greeting conversation.",
+          } as any,
+        ],
+      },
+    }))
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "I sent a picture of my daughter, can you find it?" }],
+      tools: [],
+      allowNoMessageOutput: true,
+      sendMessage,
+      observers: [
+        {
+          handle: async (event: AgentEvent) => {
+            events.push(event)
+          },
+        },
+      ],
+    })
+
+    const result = await runtime.run()
+
+    expect(result.messagesSent).toBe(1)
+    expect(result.sentMessageIds).toEqual(["msg_recovered"])
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage.mock.calls[0]?.[0].content).toBe(
+      "Found it! You shared this in your Casual Greeting conversation."
+    )
+    // We sent a message, so we must NOT also have emitted a misleading
+    // "kept previous response" trace step.
+    expect(events.some((event) => event.type === "response:kept")).toBe(false)
+    expect(events.some((event) => event.type === "message:sent")).toBe(true)
+  })
+
   it("stops early when rerun keeps returning empty final decisions", async () => {
     const generateTextWithTools = mock(async () => ({
       text: " ",

--- a/apps/backend/src/features/agents/runtime/agent-runtime.ts
+++ b/apps/backend/src/features/agents/runtime/agent-runtime.ts
@@ -211,10 +211,15 @@ export class AgentRuntime {
     let sources: SourceItem[] = []
     let retrievedContext: string | null = null
     let lastAssistantText: string | undefined
+    // Most recent non-empty assistant text observed across the loop, including
+    // text emitted alongside tool calls. Used as a fallback so that a session
+    // can never end with 0 messages when the model actually said something
+    // user-facing — covers the case where reconsideration ends in keep_response
+    // but earlier iterations produced real content.
+    let lastContentStep: string | null = null
     let hasTextReconsidered = false
     let lastProcessedSequence = nm?.lastProcessedSequence ?? BigInt(0)
     let keptResponseReason: string | null = null
-    let responseKeptEmitted = false
     let repeatedInvalidDraftCount = 0
     let lastInvalidDraft: string | null = null
     let emptyFinalDecisionAttempts = 0
@@ -251,6 +256,10 @@ export class AgentRuntime {
           ? result.text
           : JSON.stringify({ toolPlan: result.toolCalls.map((tc: { toolName: string }) => tc.toolName) })
         await this.emit({ type: "thinking", content: thinkingContent, durationMs })
+      }
+
+      if (result.text.trim()) {
+        lastContentStep = result.text.trim()
       }
 
       // Add assistant message to conversation
@@ -404,11 +413,10 @@ export class AgentRuntime {
         } else if (execResult.keepResponseReason) {
           if (newMessages.length === 0) {
             keptResponseReason = execResult.keepResponseReason
-            await this.emit({
-              type: "response:kept",
-              reason: keptResponseReason,
-            })
-            responseKeptEmitted = true
+            // Don't emit response:kept here — defer until after the loop so
+            // that, if we end up falling back to a captured content step, the
+            // trace reflects the message we sent rather than a misleading
+            // "kept previous response" step.
             break
           }
 
@@ -459,13 +467,26 @@ export class AgentRuntime {
 
         if (execResult.keepResponseReason) {
           keptResponseReason = execResult.keepResponseReason
-          await this.emit({
-            type: "response:kept",
-            reason: keptResponseReason,
-          })
-          responseKeptEmitted = true
+          // Defer response:kept emit; see equivalent comment above.
           break
         }
+      }
+    }
+
+    // Fallback: if the loop ended without committing a message but the model
+    // produced real assistant text along the way (e.g. a thinking step that
+    // was actually user-directed content like "Found it! You shared this in
+    // your Casual Greeting conversation"), commit that content. Otherwise an
+    // edit-triggered rerun whose chain ends in a reconsider/keep_response
+    // would silently emit nothing.
+    if (sent.ids.length === 0 && lastContentStep) {
+      const validationError = this.config.validateFinalResponse
+        ? await this.config.validateFinalResponse(lastContentStep)
+        : null
+      if (!validationError) {
+        const committed = await this.commitMessage({ content: lastContentStep, sources }, sent)
+        messagesSent += committed
+        keptResponseReason = null
       }
     }
 
@@ -474,12 +495,10 @@ export class AgentRuntime {
         const noMessageReason =
           keptResponseReason ?? "The existing response still fit the updated context, so no message changes were made."
 
-        if (!responseKeptEmitted) {
-          await this.emit({
-            type: "response:kept",
-            reason: noMessageReason,
-          })
-        }
+        await this.emit({
+          type: "response:kept",
+          reason: noMessageReason,
+        })
 
         logger.info(
           { sessionId: nm?.sessionId, streamId: nm?.streamId, iterations: this.maxIterations },


### PR DESCRIPTION
Track the most recent non-empty assistant text across the runtime loop
(including text emitted alongside tool calls) and fall back to committing
it when the session would otherwise end with 0 messages sent. Defer the
response:kept emit until after the fallback decision so the trace reflects
the message we actually delivered.

Fixes the case where editing the root message of a scratchpad triggered a
rerun whose chain ended in a reconsider/keep_response step, silently
dropping real user-facing content the model had produced.

https://claude.ai/code/session_01XoK2SCuV8qY4wMQJWK6fQS