### PR TITLE
fix: make mobile emoji deletion reliable

### DIFF
--- a/.claude/plans/mobile-emoji-delete.md
+++ b/.claude/plans/mobile-emoji-delete.md
@@ -1,0 +1,102 @@
+# Mobile Emoji Delete
+
+## Goal
+
+Fix Firefox Android composer deletion around emoji without regressing the editor's core rich-text behavior. The composer should stop relying on contenteditable=false emoji atoms for new input, preserve canonical shortcode markdown at system boundaries, and keep local LAN testing usable from a phone.
+
+## What Was Built
+
+### Composer Emoji Editing
+
+New emoji input in the rich editor is represented as editable text instead of new inline emoji atom nodes. Legacy emoji atom nodes remain in the schema for old JSON content and round trips, but composer surfaces convert them to text on load.
+
+**Files:**
+- `apps/frontend/src/components/editor/triggers/emoji-extension.ts` - inserts emoji suggestion/input-rule results as text and keeps legacy atom rendering.
+- `apps/frontend/src/components/editor/rich-editor.tsx` - parses composer markdown with `emojiAsText`, converts legacy emoji atoms in incoming editor JSON, and wires grapheme deletion into `beforeinput`.
+- `apps/frontend/src/components/editor/document-editor-modal.tsx` - uses the same editable emoji parsing and grapheme delete handling in the expanded document editor.
+- `packages/prosemirror/src/markdown.ts` - adds `emojiAsText` parse option so callers can choose text emoji rather than atom nodes.
+
+### Firefox Android Delete Handling
+
+The mobile delete path now has two scoped safeguards:
+
+- Inline atom deletion remains for legacy mention/channel/emoji atoms, including pending DOM selection flush before handling Android `beforeinput`.
+- Multi-code-unit text graphemes are deleted as one visible character before Firefox can split surrogate pairs or ZWJ sequences.
+
+**Files:**
+- `apps/frontend/src/components/editor/multiline-blocks.ts` - adds inline atom deletion hardening and grapheme-aware delete handling.
+- `apps/frontend/src/components/editor/multiline-blocks.test.ts` - covers legacy atom deletion, typed emoji-as-text, adjacent emoji, split surrogate recovery, selected ranges ending inside an emoji, and ZWJ emoji sequences.
+
+### Markdown Normalization
+
+Rich clients may now send raw emoji text in `contentJson`, so backend message handlers normalize the derived markdown projection to existing shortcode form.
+
+**Files:**
+- `apps/backend/src/features/messaging/handlers.ts` - normalizes JSON-derived `contentMarkdown` through `normalizeMessage`.
+- `packages/prosemirror/src/markdown.test.ts` - covers `emojiAsText` parsing while preserving default atom parsing for wire-format round trips.
+
+### LAN Dev And Worktree Setup
+
+The dev stack can be run on an explicit LAN host for phone testing, and worktree setup now repairs existing but unseeded cloned databases.
+
+**Files:**
+- `scripts/dev.ts` - accepts `LAN_HOST`/`LAN_IP`, treats those as LAN mode, and feeds the host into dev service environment.
+- `apps/workspace-router/src/index.ts` - preserves upstream forwarding headers only for local proxy targets so Tailscale auth redirects work without trusting spoofed production headers.
+- `apps/workspace-router/src/index.test.ts` - covers local forwarded header preservation and remote forwarded header spoof protection.
+- `scripts/setup-worktree.ts` - detects empty existing target databases and clones from the source DB.
+- `.gitignore` - ignores `.wrangler/` local worker output.
+
+## Design Decisions
+
+### Use Editable Emoji Text For New Composer Input
+
+**Chose:** Insert resolved native emoji as text for new shortcode conversion and emoji picker selection.
+
+**Why:** Firefox Android struggles with deleting adjacent contenteditable=false inline atoms. Mentions and channels are still atoms, but their visible text is ASCII chip content; emoji expose surrogate pair and ZWJ deletion problems that Firefox can split.
+
+**Alternatives considered:** Keep emoji as atoms and intercept harder. This improved one path but still required multiple backspaces and created broken selection states between adjacent emoji.
+
+### Keep The Emoji Atom Schema For Compatibility
+
+**Chose:** Preserve the existing `emoji` node type and default shared markdown parser behavior.
+
+**Why:** Older message JSON and wire-format round trips may still contain emoji nodes. Removing the node would be a larger data compatibility change.
+
+**Alternatives considered:** Delete the emoji node entirely. That would reduce code but risk breaking legacy content hydration.
+
+### Normalize Markdown At The Backend Boundary
+
+**Chose:** Allow editable emoji text in `contentJson`, but normalize `contentMarkdown` to shortcodes.
+
+**Why:** The editor needs text for mobile deletion, while storage, usage tracking, and external consumers already expect canonical shortcode markdown.
+
+### Limit Forwarded Header Trust To Local Targets
+
+**Chose:** Preserve incoming `X-Forwarded-*` headers only when proxying to a local backend/control-plane target.
+
+**Why:** Local Vite to Wrangler proxying needs the original Tailscale host for auth redirects. Production must not trust client-supplied forwarding headers.
+
+## Design Evolution
+
+- **Atom tuning to text model:** The initial attempt tried to make emoji atoms easier to delete on Android. That still fought browser selection behavior and caused editor regressions, so the final implementation avoids creating new emoji atoms.
+- **Text model plus grapheme guard:** Plain emoji text fixed the atom selection problem but Firefox could still delete one UTF-16 code unit at a time. The final `beforeinput` handler deletes whole multi-code-unit graphemes only when needed.
+- **Header preservation hardened:** The local auth redirect fix originally preserved forwarding headers too broadly. Self-review changed this to local-target-only preservation.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- Custom image emoji support. Image emoji would need a separate design that avoids reintroducing inline contenteditable=false atoms in the composer.
+- A production data migration for existing emoji atom JSON. Existing content is converted when loaded into composer surfaces.
+- Browser automation for Firefox Android. The behavior was manually tested through the LAN dev server and covered with unit tests for the ProseMirror input paths.
+
+## Status
+
+- [x] New composer emoji are editable text.
+- [x] Legacy emoji atom JSON still hydrates.
+- [x] Firefox Android grapheme deletion path is covered by focused tests.
+- [x] LAN dev auth redirects can use a Tailscale host.
+- [x] Worktree setup handles empty existing cloned databases.
+- [x] Router forwarding header trust is scoped to local proxy targets.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 dev-dist/
+.wrangler/
 .env
 .env.*
 !.env.remote-dev

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -107,7 +107,7 @@ export {
 
 /**
  * Normalize input to both JSON and markdown formats.
- * - If JSON provided: serialize to markdown
+ * - If JSON provided: serialize to markdown, then normalize the markdown projection
  * - If markdown provided: normalize emoji, parse to JSON
  * Emoji normalization converts raw emoji (👍) to shortcodes (:+1:).
  */
@@ -116,8 +116,10 @@ function normalizeContent(input: z.infer<typeof createMessageSchema> | z.infer<t
   contentMarkdown: string
 } {
   if ("contentJson" in input) {
-    // Rich client: JSON provided, trust it and derive markdown
-    const contentMarkdown = input.contentMarkdown ?? serializeToMarkdown(input.contentJson)
+    // Rich client: JSON provided, trust the structure but still normalize the
+    // markdown projection so editable raw emoji text becomes canonical shortcode
+    // content for storage, usage tracking, and external consumers.
+    const contentMarkdown = normalizeMessage(input.contentMarkdown ?? serializeToMarkdown(input.contentJson))
     return { contentJson: input.contentJson, contentMarkdown }
   } else {
     // AI/external: Markdown provided, normalize and parse to JSON

--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -34,6 +34,7 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { LinkEditor } from "./link-editor"
 import {
   handleBeforeInputAtomDelete,
+  handleBeforeInputGraphemeDelete,
   handleBeforeInputKeyboardPaste,
   handleBeforeInputNewline,
   insertPastedText,
@@ -91,6 +92,7 @@ export function DocumentEditorModal({
   initContentRef.current = initialContent
   getMentionTypeRef.current = getMentionType
   toEmojiRef.current = toEmoji
+  const markdownParseOptions = useMemo(() => ({ emojiAsText: true }), [])
 
   // Ref for handleSubmit without re-creating extensions
   const handleSubmitRef = useRef(() => {})
@@ -131,7 +133,7 @@ export function DocumentEditorModal({
 
   const editor = useEditor({
     extensions,
-    content: parseMarkdown(initialContent, getMentionType, toEmoji),
+    content: parseMarkdown(initialContent, getMentionType, toEmoji, markdownParseOptions),
     editorProps: {
       attributes: {
         class: cn(
@@ -155,7 +157,13 @@ export function DocumentEditorModal({
           return false
         }
 
-        const handled = insertPastedText(editorRef.current, text, getMentionTypeRef.current, toEmojiRef.current)
+        const handled = insertPastedText(
+          editorRef.current,
+          text,
+          getMentionTypeRef.current,
+          toEmojiRef.current,
+          markdownParseOptions
+        )
         if (handled) {
           event.preventDefault()
         }
@@ -173,9 +181,21 @@ export function DocumentEditorModal({
             return true
           }
 
+          // Firefox Android can delete emoji text by code unit, leaving a
+          // broken half-grapheme. Delete the whole grapheme before native input.
+          if (handleBeforeInputGraphemeDelete(editor, event as InputEvent)) {
+            return true
+          }
+
           // Gboard / SwiftKey clipboard-bar paste arrives as insertText, not paste.
           if (
-            handleBeforeInputKeyboardPaste(editor, event as InputEvent, getMentionTypeRef.current, toEmojiRef.current)
+            handleBeforeInputKeyboardPaste(
+              editor,
+              event as InputEvent,
+              getMentionTypeRef.current,
+              toEmojiRef.current,
+              markdownParseOptions
+            )
           ) {
             return true
           }
@@ -227,7 +247,9 @@ export function DocumentEditorModal({
 
     if (isNewlyOpened && editor && !editor.isDestroyed) {
       isInternalUpdate.current = true
-      editor.commands.setContent(parseMarkdown(initContentRef.current, getMentionTypeRef.current, toEmojiRef.current))
+      editor.commands.setContent(
+        parseMarkdown(initContentRef.current, getMentionTypeRef.current, toEmojiRef.current, markdownParseOptions)
+      )
       isInternalUpdate.current = false
       editor.commands.focus("end")
     }

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -7,6 +7,7 @@ import { NodeSelection } from "@tiptap/pm/state"
 import {
   deleteAdjacentInlineAtom,
   handleBeforeInputAtomDelete,
+  handleBeforeInputGraphemeDelete,
   handleBeforeInputKeyboardPaste,
   handleBeforeInputNewline,
   insertPastedText,
@@ -30,7 +31,7 @@ function createTestEditor(content: string | JSONContent) {
       items: () => [],
       render: () => ({ onStart: () => {}, onUpdate: () => {}, onExit: () => {}, onKeyDown: () => false }),
     },
-    toEmoji: () => null,
+    toEmoji: (code) => (code === "rocket" ? "🚀" : null),
   })
 
   return new Editor({
@@ -45,6 +46,22 @@ function createTestEditor(content: string | JSONContent) {
           )
         : content,
   })
+}
+
+function insertText(editor: Editor, text: string) {
+  let handled = false
+
+  editor.view.someProp("handleTextInput", (handleTextInput) => {
+    if (
+      handleTextInput(editor.view, editor.state.selection.from, editor.state.selection.to, text, () => editor.state.tr)
+    ) {
+      handled = true
+      return true
+    }
+    return false
+  })
+
+  return handled
 }
 
 function createBlockquote(lines: string[]): JSONContent {
@@ -621,6 +638,8 @@ describe("handleBeforeInputKeyboardPaste (Gboard suggestion-bar paste)", () => {
 
     expect(handled).toBe(true)
     expect(event.prevented).toBe(true)
+    expect(editor.getJSON().content?.[0]?.content?.[0]).toEqual({ type: "text", text: "🚀 launching" })
+    expect(serializeToMarkdown(editor.getJSON())).toBe("🚀 launching")
     editor.destroy()
   })
 
@@ -750,6 +769,23 @@ describe("handleBeforeInputAtomDelete (Android atom deletion)", () => {
     editor.destroy()
   })
 
+  it("renders emoji atoms with text-like inline layout", () => {
+    const editor = createTestEditor(emojiDoc("", ""))
+    const emoji = editor.view.dom.querySelector<HTMLElement>('span[data-type="emoji"]')
+
+    expect(emoji?.className).toBe("inline")
+    editor.destroy()
+  })
+
+  it("converts typed shortcode emoji to editable text instead of a new atom", () => {
+    const editor = createTestEditor(":rocket")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    expect(insertText(editor, ":")).toBe(true)
+    expect(editor.getJSON().content?.[0]?.content?.[0]).toEqual({ type: "text", text: "🚀" })
+    editor.destroy()
+  })
+
   it("deletes the inline atom on deleteContentForward when caret sits right before it", () => {
     const editor = createTestEditor(emojiDoc("hi ", " end"))
     // Caret at end of "hi " — i.e. immediately before the emoji atom.
@@ -801,6 +837,22 @@ describe("handleBeforeInputAtomDelete (Android atom deletion)", () => {
     editor.destroy()
   })
 
+  it("deletes a non-empty selection containing an inline atom", () => {
+    const editor = createTestEditor(emojiDoc("hi ", " end"))
+    editor.commands.setTextSelection({
+      from: findTextPosition(editor, "hi "),
+      to: findTextPosition(editor, " end"),
+    })
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputAtomDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe(" end")
+    editor.destroy()
+  })
+
   it("ignores non-delete input types", () => {
     const editor = createTestEditor(emojiDoc("hi ", ""))
     editor.commands.setTextSelection(editor.state.doc.content.size)
@@ -840,6 +892,55 @@ describe("handleBeforeInputAtomDelete (Android atom deletion)", () => {
     editor.destroy()
   })
 
+  it("keeps the direct keymap fallback inactive while composing", () => {
+    const editor = createTestEditor(emojiDoc("hi ", " end"))
+    editor.commands.setTextSelection(findTextPosition(editor, " end"))
+    ;(editor.view as unknown as { input: { composing: boolean } }).input.composing = true
+
+    const handled = deleteAdjacentInlineAtom(editor, "backward")
+
+    expect(handled).toBe(false)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi :rocket: end")
+    editor.destroy()
+  })
+
+  it("deletes the adjacent atom from beforeinput while composing", () => {
+    const editor = createTestEditor(emojiDoc("hi ", " end"))
+    editor.commands.setTextSelection(findTextPosition(editor, " end"))
+    ;(editor.view as unknown as { input: { composing: boolean } }).input.composing = true
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputAtomDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
+  it("flushes a pending DOM selection before checking the delete target", () => {
+    const editor = createTestEditor(emojiDoc("hi ", " end"))
+    editor.commands.setTextSelection(findTextPosition(editor, "hi "))
+    const domObserver = (editor.view as unknown as { domObserver: { flush: () => void } }).domObserver
+    const originalFlush = domObserver.flush.bind(domObserver)
+    let flushed = false
+
+    domObserver.flush = () => {
+      flushed = true
+      editor.commands.setTextSelection(findTextPosition(editor, " end"))
+    }
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputAtomDelete(editor, event)
+    domObserver.flush = originalFlush
+
+    expect(flushed).toBe(true)
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
   it("ignores a NodeSelection on a non-atom (defensive)", () => {
     const editor = createTestEditor("plain")
     // No atoms in this doc, so NodeSelection branch shouldn't fire — fall through
@@ -849,6 +950,102 @@ describe("handleBeforeInputAtomDelete (Android atom deletion)", () => {
     const handled = deleteAdjacentInlineAtom(editor, "backward")
 
     expect(handled).toBe(false)
+    editor.destroy()
+  })
+})
+
+describe("handleBeforeInputGraphemeDelete (mobile emoji text deletion)", () => {
+  it("deletes a text emoji as one grapheme on deleteContentBackward", () => {
+    const editor = createTestEditor("hi 🚀 end")
+    editor.commands.setTextSelection(findTextPosition(editor, " end"))
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
+  it("deletes a text emoji as one grapheme on deleteContentForward", () => {
+    const editor = createTestEditor("hi 🚀 end")
+    editor.commands.setTextSelection(findTextPosition(editor, "🚀"))
+
+    const event = makeBeforeInput("deleteContentForward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
+  it("deletes only one emoji when two text emoji are adjacent", () => {
+    const editor = createTestEditor("🚀🚀")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("🚀")
+    editor.destroy()
+  })
+
+  it("recovers when the native selection lands inside a surrogate pair", () => {
+    const editor = createTestEditor("hi 🚀 end")
+    const emojiStart = findTextPosition(editor, "🚀")
+    editor.commands.setTextSelection(emojiStart + 1)
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
+  it("expands a selection that ends inside a surrogate pair", () => {
+    const editor = createTestEditor("a🚀b")
+    const start = findTextPosition(editor, "a")
+    const emojiStart = findTextPosition(editor, "🚀")
+    editor.commands.setTextSelection({ from: start, to: emojiStart + 1 })
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("b")
+    editor.destroy()
+  })
+
+  it("deletes a zwj emoji sequence as one grapheme", () => {
+    const editor = createTestEditor("hi 👨‍👩‍👧‍👦 end")
+    editor.commands.setTextSelection(findTextPosition(editor, " end"))
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hi  end")
+    editor.destroy()
+  })
+
+  it("falls through for ordinary single-code-unit text", () => {
+    const editor = createTestEditor("hello")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    const event = makeBeforeInput("deleteContentBackward")
+    const handled = handleBeforeInputGraphemeDelete(editor, event)
+
+    expect(handled).toBe(false)
+    expect(event.prevented).toBe(false)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("hello")
     editor.destroy()
   })
 })

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -9,6 +9,12 @@ export interface BeforeInputEventLike {
   preventDefault(): void
 }
 
+interface GraphemeSegment {
+  from: number
+  to: number
+  text: string
+}
+
 // `@`/`#` cover mention and channel refs — emails like `a@b` are safe because
 // the parser only converts the strict `@slug` shape. `[` covers markdown-link
 // pair start; `<` covers our pointer URL syntax.
@@ -30,8 +36,285 @@ interface SelectedBlockRange {
   blocks: SelectedBlockInfo[]
 }
 
+interface DeleteAdjacentInlineAtomOptions {
+  allowDuringComposition?: boolean
+}
+
+interface EditorViewWithDomObserver {
+  domObserver?: {
+    flush?: () => void
+  }
+}
+
+interface IntlSegmenterLike {
+  segment(text: string): Iterable<{ segment: string; index: number }>
+}
+
+type IntlWithSegmenter = typeof Intl & {
+  Segmenter?: new (
+    locale?: string | string[],
+    options?: { granularity: "grapheme" | "word" | "sentence" }
+  ) => IntlSegmenterLike
+}
+
+let graphemeSegmenter: IntlSegmenterLike | null | undefined
+
+function getGraphemeSegmenter(): IntlSegmenterLike | null {
+  if (graphemeSegmenter !== undefined) return graphemeSegmenter
+
+  const Segmenter = (Intl as IntlWithSegmenter).Segmenter
+  graphemeSegmenter = Segmenter ? new Segmenter(undefined, { granularity: "grapheme" }) : null
+  return graphemeSegmenter
+}
+
+function codePointSize(codePoint: number): number {
+  return codePoint > 0xffff ? 2 : 1
+}
+
+function codePointAt(text: string, index: number): number | null {
+  return index < text.length ? (text.codePointAt(index) ?? null) : null
+}
+
+function isVariationSelector(codePoint: number): boolean {
+  return codePoint === 0xfe0e || codePoint === 0xfe0f || (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+}
+
+function isEmojiModifier(codePoint: number): boolean {
+  return codePoint >= 0x1f3fb && codePoint <= 0x1f3ff
+}
+
+function isRegionalIndicator(codePoint: number): boolean {
+  return codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff
+}
+
+function isCombiningMark(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f)
+  )
+}
+
+function consumeGraphemeExtenders(text: string, index: number): number {
+  let cursor = index
+
+  while (cursor < text.length) {
+    const codePoint = codePointAt(text, cursor)
+    if (
+      codePoint === null ||
+      (!isVariationSelector(codePoint) &&
+        !isEmojiModifier(codePoint) &&
+        !isCombiningMark(codePoint) &&
+        codePoint !== 0x20e3)
+    ) {
+      break
+    }
+    cursor += codePointSize(codePoint)
+  }
+
+  return cursor
+}
+
+function fallbackGraphemeSegments(text: string): GraphemeSegment[] {
+  const segments: GraphemeSegment[] = []
+  let index = 0
+
+  while (index < text.length) {
+    const from = index
+    const firstCodePoint = codePointAt(text, index)
+    if (firstCodePoint === null) break
+
+    index += codePointSize(firstCodePoint)
+    index = consumeGraphemeExtenders(text, index)
+
+    // Flags are pairs of regional indicators.
+    if (isRegionalIndicator(firstCodePoint)) {
+      const nextCodePoint = codePointAt(text, index)
+      if (nextCodePoint !== null && isRegionalIndicator(nextCodePoint)) {
+        index += codePointSize(nextCodePoint)
+        index = consumeGraphemeExtenders(text, index)
+      }
+    }
+
+    // Emoji ZWJ sequences should delete as one visible character.
+    while (text.charCodeAt(index) === 0x200d) {
+      index += 1
+      const joinedCodePoint = codePointAt(text, index)
+      if (joinedCodePoint === null) break
+      index += codePointSize(joinedCodePoint)
+      index = consumeGraphemeExtenders(text, index)
+    }
+
+    segments.push({ from, to: index, text: text.slice(from, index) })
+  }
+
+  return segments
+}
+
+function getGraphemeSegments(text: string): GraphemeSegment[] {
+  const segmenter = getGraphemeSegmenter()
+  if (!segmenter) return fallbackGraphemeSegments(text)
+
+  return Array.from(segmenter.segment(text), ({ index, segment }) => ({
+    from: index,
+    to: index + segment.length,
+    text: segment,
+  }))
+}
+
+function isMultiCodeUnitGrapheme(segment: GraphemeSegment): boolean {
+  return segment.to - segment.from > 1
+}
+
+function findGraphemeForDelete(
+  text: string,
+  offset: number,
+  direction: "backward" | "forward"
+): GraphemeSegment | null {
+  const safeOffset = Math.max(0, Math.min(offset, text.length))
+  const segments = getGraphemeSegments(text)
+
+  if (direction === "backward") {
+    for (let i = segments.length - 1; i >= 0; i -= 1) {
+      const segment = segments[i]
+      if (segment.from < safeOffset && segment.to >= safeOffset) return segment
+      if (segment.to < safeOffset) return segment
+    }
+    return null
+  }
+
+  for (const segment of segments) {
+    if (segment.from <= safeOffset && segment.to > safeOffset) return segment
+    if (segment.from > safeOffset) return segment
+  }
+  return null
+}
+
+function findSplitGraphemeBoundary(text: string, offset: number): GraphemeSegment | null {
+  if (offset <= 0 || offset >= text.length) return null
+  return getGraphemeSegments(text).find((segment) => segment.from < offset && segment.to > offset) ?? null
+}
+
 function isEmptyParagraphNode(node: ProseMirrorNode | null | undefined): boolean {
   return !!node && node.type.name === "paragraph" && node.content.size === 0
+}
+
+function isDeletableInlineAtom(node: ProseMirrorNode): boolean {
+  // Text nodes are leaf/atom nodes in ProseMirror, but normal character
+  // deletion must stay on the browser/ProseMirror text path.
+  return !node.isText && node.isInline && node.isAtom
+}
+
+function rangeContainsInlineAtom(state: EditorState, from: number, to: number): boolean {
+  const docEnd = state.doc.content.size
+  const rangeFrom = Math.max(0, Math.min(from, docEnd))
+  const rangeTo = Math.max(rangeFrom, Math.min(to, docEnd))
+  let containsAtom = false
+
+  state.doc.nodesBetween(rangeFrom, rangeTo, (node) => {
+    if (isDeletableInlineAtom(node)) {
+      containsAtom = true
+      return false
+    }
+    return !containsAtom
+  })
+
+  return containsAtom
+}
+
+function flushPendingDomSelection(editor: Editor): void {
+  const domObserver = (editor.view as unknown as EditorViewWithDomObserver).domObserver
+  domObserver?.flush?.()
+}
+
+function deleteSelectionContainingInlineAtom(editor: Editor): boolean {
+  const { state, view } = editor
+  const { selection } = state
+  if (selection.empty) return false
+  if (!rangeContainsInlineAtom(state, selection.from, selection.to)) return false
+
+  view.dispatch(state.tr.deleteSelection().scrollIntoView())
+  return true
+}
+
+function expandPositionToGraphemeBoundary(state: EditorState, pos: number, side: "from" | "to"): number {
+  let expanded = pos
+
+  state.doc.descendants((node, nodePos) => {
+    if (!node.isText || !node.text) return true
+
+    const start = nodePos
+    const end = nodePos + node.text.length
+    if (pos <= start || pos >= end) return true
+
+    const splitGrapheme = findSplitGraphemeBoundary(node.text, pos - start)
+    if (splitGrapheme) {
+      expanded = start + (side === "from" ? splitGrapheme.from : splitGrapheme.to)
+      return false
+    }
+
+    return true
+  })
+
+  return expanded
+}
+
+function selectedRangeContainsMultiCodeUnitGrapheme(state: EditorState, from: number, to: number): boolean {
+  let containsGrapheme = false
+
+  state.doc.nodesBetween(from, to, (node, nodePos) => {
+    if (!node.isText || !node.text) return !containsGrapheme
+
+    const textFrom = Math.max(0, from - nodePos)
+    const textTo = Math.min(node.text.length, to - nodePos)
+    const selectedText = node.text.slice(textFrom, textTo)
+
+    if (
+      getGraphemeSegments(selectedText).some(isMultiCodeUnitGrapheme) ||
+      !!findSplitGraphemeBoundary(node.text, textFrom) ||
+      !!findSplitGraphemeBoundary(node.text, textTo)
+    ) {
+      containsGrapheme = true
+      return false
+    }
+
+    return !containsGrapheme
+  })
+
+  return containsGrapheme
+}
+
+function deleteSelectionContainingMultiCodeUnitGrapheme(editor: Editor): boolean {
+  const { state, view } = editor
+  const { selection } = state
+  if (selection.empty) return false
+  if (!selectedRangeContainsMultiCodeUnitGrapheme(state, selection.from, selection.to)) return false
+
+  const from = expandPositionToGraphemeBoundary(state, selection.from, "from")
+  const to = expandPositionToGraphemeBoundary(state, selection.to, "to")
+
+  view.dispatch(state.tr.delete(from, to).scrollIntoView())
+  return true
+}
+
+function deleteAdjacentMultiCodeUnitGrapheme(editor: Editor, direction: "backward" | "forward"): boolean {
+  const { state, view } = editor
+  const { selection } = state
+  if (!selection.empty) return false
+
+  const $from = selection.$from
+  if (!$from.parent.isTextblock) return false
+
+  const parentText = $from.parent.textBetween(0, $from.parent.content.size, undefined, "\ufffc")
+  const target = findGraphemeForDelete(parentText, $from.parentOffset, direction)
+  if (!target || !isMultiCodeUnitGrapheme(target)) return false
+
+  const from = $from.start() + target.from
+  const to = $from.start() + target.to
+  view.dispatch(state.tr.delete(from, to).scrollIntoView())
+  return true
 }
 
 function getSelectedBlockRange(editor: Editor): SelectedBlockRange | null {
@@ -405,7 +688,7 @@ function getParsedContent(
   getEmoji?: EmojiLookup,
   parseOptions?: ParseMarkdownOptions
 ): JSONContent[] | undefined {
-  return parseMarkdown(text, getMentionType, getEmoji, parseOptions).content
+  return parseMarkdown(text, getMentionType, getEmoji, { emojiAsText: true, ...parseOptions }).content
 }
 
 export function insertPastedText(
@@ -572,12 +855,16 @@ export function handleBeforeInputNewline(editor: Editor, event: BeforeInputEvent
  * `NodeSelection`). Covers Firefox Android's first-Backspace promote-to-
  * selection step so the second tap isn't needed.
  */
-export function deleteAdjacentInlineAtom(editor: Editor, direction: "backward" | "forward"): boolean {
+export function deleteAdjacentInlineAtom(
+  editor: Editor,
+  direction: "backward" | "forward",
+  options: DeleteAdjacentInlineAtomOptions = {}
+): boolean {
   const { state, view } = editor
-  if (view.composing) return false
+  if (view.composing && !options.allowDuringComposition) return false
 
   const { selection } = state
-  if (selection instanceof NodeSelection && selection.node.isInline && selection.node.isAtom) {
+  if (selection instanceof NodeSelection && isDeletableInlineAtom(selection.node)) {
     view.dispatch(state.tr.deleteSelection().scrollIntoView())
     return true
   }
@@ -585,8 +872,7 @@ export function deleteAdjacentInlineAtom(editor: Editor, direction: "backward" |
 
   const $from = selection.$from
   const adjacent = direction === "backward" ? $from.nodeBefore : $from.nodeAfter
-  // Text nodes report `isAtom === true` (leaves), so skip them explicitly.
-  if (!adjacent || adjacent.isText || !adjacent.isAtom || !adjacent.isInline) return false
+  if (!adjacent || !isDeletableInlineAtom(adjacent)) return false
 
   const from = direction === "backward" ? $from.pos - adjacent.nodeSize : $from.pos
   const to = direction === "backward" ? $from.pos : $from.pos + adjacent.nodeSize
@@ -602,7 +888,42 @@ export function deleteAdjacentInlineAtom(editor: Editor, direction: "backward" |
 export function handleBeforeInputAtomDelete(editor: Editor, event: BeforeInputEventLike): boolean {
   if (event.inputType !== "deleteContentBackward" && event.inputType !== "deleteContentForward") return false
   const direction = event.inputType === "deleteContentBackward" ? "backward" : "forward"
-  if (!deleteAdjacentInlineAtom(editor, direction)) return false
+
+  // Firefox Android can update the native selection around an inline atom
+  // before ProseMirror has observed it. Flush first so a native atom/range
+  // selection becomes editor state before deciding whether to intercept.
+  flushPendingDomSelection(editor)
+
+  if (
+    !deleteSelectionContainingInlineAtom(editor) &&
+    !deleteAdjacentInlineAtom(editor, direction, { allowDuringComposition: true })
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  return true
+}
+
+/**
+ * Firefox Android can delete a text emoji one UTF-16 code unit at a time,
+ * leaving a broken surrogate/variation fragment that shows up as the square
+ * highlight. Only intercept multi-code-unit graphemes so normal text deletion
+ * stays on the native ProseMirror path.
+ */
+export function handleBeforeInputGraphemeDelete(editor: Editor, event: BeforeInputEventLike): boolean {
+  if (event.inputType !== "deleteContentBackward" && event.inputType !== "deleteContentForward") return false
+  const direction = event.inputType === "deleteContentBackward" ? "backward" : "forward"
+
+  flushPendingDomSelection(editor)
+
+  if (
+    !deleteSelectionContainingMultiCodeUnitGrapheme(editor) &&
+    !deleteAdjacentMultiCodeUnitGrapheme(editor, direction)
+  ) {
+    return false
+  }
+
   event.preventDefault()
   return true
 }

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -15,6 +15,7 @@ import { EmojiPluginKey } from "./triggers/emoji-extension"
 import { shouldRemoveTriggerOnToggle, type SuggestionPluginState } from "./trigger-toggle"
 import {
   handleBeforeInputAtomDelete,
+  handleBeforeInputGraphemeDelete,
   handleBeforeInputKeyboardPaste,
   handleBeforeInputNewline,
   insertPastedText,
@@ -108,6 +109,27 @@ function isEditorCompletelyEmpty(editor: import("@tiptap/react").Editor | null |
   )
 }
 
+function emojiAtomToEditableText(node: JSONContent, toEmoji?: (shortcode: string) => string | null): JSONContent {
+  if (node.type === "emoji") {
+    const shortcode = typeof node.attrs?.shortcode === "string" ? node.attrs.shortcode : ""
+    const emoji = typeof node.attrs?.emoji === "string" ? node.attrs.emoji : toEmoji?.(shortcode)
+    return {
+      type: "text",
+      text: emoji ?? (shortcode ? `:${shortcode}:` : "\uFFFC"),
+      marks: node.marks,
+    }
+  }
+
+  if (!node.content) {
+    return node
+  }
+
+  return {
+    ...node,
+    content: node.content.map((child) => emojiAtomToEditableText(child, toEmoji)),
+  }
+}
+
 export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function RichEditor(
   {
     value,
@@ -199,8 +221,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       enableChannels,
       enableSlashCommands: enableCommands,
       enableEmoji,
+      emojiAsText: true,
     }),
     [enableMentions, enableChannels, enableCommands, enableEmoji]
+  )
+  const editableValue = useMemo(
+    () => emojiAtomToEditableText(value, enableEmoji ? toEmoji : undefined),
+    [value, enableEmoji, toEmoji]
   )
 
   // Ref to avoid stale closure for file upload callback
@@ -350,7 +377,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
   const editor = useEditor({
     extensions,
-    content: value,
+    content: editableValue,
     editable: !disabled,
     autofocus: autoFocus ? "end" : false,
     onUpdate: ({ editor }) => {
@@ -443,6 +470,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           // Android atom deletion: keymap doesn't fire for Backspace, so delete
           // adjacent inline atoms here before the browser's two-step selection.
           if (handleBeforeInputAtomDelete(editor, event as InputEvent)) {
+            return true
+          }
+
+          // Firefox Android can delete emoji text by code unit, leaving a
+          // broken half-grapheme. Delete the whole grapheme before native input.
+          if (handleBeforeInputGraphemeDelete(editor, event as InputEvent)) {
             return true
           }
 
@@ -556,11 +589,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
     // Compare JSON content - use string comparison for simplicity
     const currentJson = JSON.stringify(editor.getJSON())
-    const newJson = JSON.stringify(value)
+    const newJson = JSON.stringify(editableValue)
     if (newJson !== currentJson) {
       const hadFocus = editor.isFocused
       isInternalUpdate.current = true
-      editor.commands.setContent(value)
+      editor.commands.setContent(editableValue)
       isInternalUpdate.current = false
       // Mobile browsers can drop focus when contenteditable content is replaced.
       // Restore it to keep the virtual keyboard open.
@@ -568,7 +601,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
         editor.commands.focus()
       }
     }
-  }, [value, editor])
+  }, [editableValue, editor])
 
   // Re-parse content when mentionables load or currentUser becomes known (for correct mention type colors)
   useEffect(() => {

--- a/apps/frontend/src/components/editor/triggers/emoji-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/emoji-extension.ts
@@ -32,8 +32,8 @@ export interface EmojiExtensionOptions {
  *
  * Features:
  * - Suggestion popup when typing ":" followed by query
- * - Input rule to auto-convert :shortcode: to emoji node
- * - Displays emoji character, serializes as :shortcode:
+ * - Input rule to auto-convert :shortcode: to editable emoji text
+ * - Renders legacy emoji atom nodes from older message JSON
  */
 export const EmojiExtension = Node.create<EmojiExtensionOptions>({
   name: "emoji",
@@ -86,7 +86,9 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
       "span",
       mergeAttributes(HTMLAttributes, {
         "data-type": "emoji",
-        class: "inline-block",
+        // Match trigger atoms' text-like inline layout; Firefox Android handles
+        // adjacent contenteditable=false inline-block emoji spans poorly.
+        class: "inline",
       }),
       node.attrs.emoji, // Display the emoji character
     ]
@@ -100,7 +102,9 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
   addInputRules() {
     const { toEmoji } = this.options
 
-    // Auto-convert :shortcode: to emoji node when closing colon is typed
+    // Auto-convert :shortcode: to emoji text when closing colon is typed.
+    // Legacy emoji atom rendering remains above for old content, but new
+    // composer input uses text so mobile browsers delete it natively.
     return [
       new InputRule({
         find: /:([a-z0-9_+-]+):$/,
@@ -112,8 +116,6 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
           // Suppress inside an unclosed inline-code word (see markdown-guards).
           if (isInBacktickWord(state, range.from)) return null
 
-          const nodeType = this.type
-
           // Get marks at current position to preserve styling
           const $from = state.doc.resolve(range.from)
           const { storedMarks } = state
@@ -123,10 +125,10 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
             attrs: mark.attrs,
           }))
 
-          // Replace the :shortcode: with an emoji node using chain
+          // Replace the :shortcode: with editable emoji text.
           chain()
             .deleteRange(range)
-            .insertContent([{ type: nodeType.name, attrs: { shortcode, emoji }, marks }])
+            .insertContent([{ type: "text", text: emoji, marks }])
             .run()
         },
       }),
@@ -175,10 +177,6 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
         ...this.options.suggestion,
         command: ({ editor, range, props }) => {
           const item = props as EmojiEntry
-          const attrs: EmojiNodeAttrs = {
-            shortcode: item.shortcode,
-            emoji: item.emoji,
-          }
 
           // Get marks at the current position to preserve styling
           const { $from } = editor.state.selection
@@ -194,7 +192,7 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
             .focus()
             .deleteRange(range)
             .insertContent([
-              { type: "emoji", attrs, marks },
+              { type: "text", text: item.emoji, marks },
               { type: "text", text: " ", marks },
             ])
             .run()

--- a/apps/workspace-router/src/index.test.ts
+++ b/apps/workspace-router/src/index.test.ts
@@ -380,6 +380,48 @@ describe("workspace-router", () => {
       }
     })
 
+    test("preserves upstream X-Forwarded-Host and X-Forwarded-Proto for local dev targets", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        const req = new Request("http://localhost:3001/api/workspaces/ws_123/messages", {
+          headers: {
+            "X-Forwarded-Host": "100.112.117.108:3000",
+            "X-Forwarded-Proto": "http",
+            "X-Forwarded-Port": "3000",
+          },
+        })
+        await worker.fetch(req, makeEnvWithKv())
+        const headers = new Headers(getProxiedInit(fn).headers as Record<string, string>)
+        expect(headers.get("X-Forwarded-Host")).toBe("100.112.117.108:3000")
+        expect(headers.get("X-Forwarded-Proto")).toBe("http")
+        expect(headers.get("X-Forwarded-Port")).toBe("3000")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("ignores spoofed upstream forwarding headers for remote targets", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        const req = new Request("https://app.threa.io/api/workspaces/ws_123/messages", {
+          headers: {
+            "X-Forwarded-Host": "evil.example",
+            "X-Forwarded-Proto": "http",
+            "X-Forwarded-Port": "1234",
+          },
+        })
+        await worker.fetch(req, makeEnvWithKv("eu-north-1"))
+        const headers = new Headers(getProxiedInit(fn).headers as Record<string, string>)
+        expect(headers.get("X-Forwarded-Host")).toBe("app.threa.io")
+        expect(headers.get("X-Forwarded-Proto")).toBe("https")
+        expect(headers.get("X-Forwarded-Port")).toBeNull()
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
     test("forwards CF-Connecting-IP as X-Forwarded-For", async () => {
       const originalFetch = globalThis.fetch
       const fn = mockFetchFn()

--- a/apps/workspace-router/src/index.ts
+++ b/apps/workspace-router/src/index.ts
@@ -251,13 +251,35 @@ async function routeWorkspaceRequest(
   return proxyRequest(request, config.apiUrl)
 }
 
+function isLocalProxyTarget(targetBaseUrl: string): boolean {
+  try {
+    const { hostname } = new URL(targetBaseUrl)
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  } catch {
+    return false
+  }
+}
+
 async function proxyRequest(request: Request, targetBaseUrl: string): Promise<Response> {
   const url = new URL(request.url)
   const targetUrl = new URL(url.pathname + url.search, targetBaseUrl)
 
   const headers = new Headers(request.headers)
-  headers.set("X-Forwarded-Host", url.host)
-  headers.set("X-Forwarded-Proto", url.protocol.replace(":", ""))
+  const preserveUpstreamForwardedHeaders = isLocalProxyTarget(targetBaseUrl)
+  const forwardedHost = preserveUpstreamForwardedHeaders ? request.headers.get("X-Forwarded-Host") : null
+  const forwardedProto = preserveUpstreamForwardedHeaders ? request.headers.get("X-Forwarded-Proto") : null
+  const forwardedPort = preserveUpstreamForwardedHeaders ? request.headers.get("X-Forwarded-Port") : null
+
+  headers.set("X-Forwarded-Host", forwardedHost ?? url.host)
+  headers.set("X-Forwarded-Proto", forwardedProto ?? url.protocol.replace(":", ""))
+
+  if (forwardedPort) {
+    headers.set("X-Forwarded-Port", forwardedPort)
+  } else if (url.port) {
+    headers.set("X-Forwarded-Port", url.port)
+  } else {
+    headers.delete("X-Forwarded-Port")
+  }
 
   // Only trust CF-Connecting-IP (set by Cloudflare, not spoofable by clients).
   // Strip any client-supplied X-Forwarded-For to prevent rate limit bypass.

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -130,6 +130,29 @@ describe("@threa/prosemirror markdown attachment metadata", () => {
   })
 })
 
+describe("@threa/prosemirror emoji parsing", () => {
+  it("can parse emoji shortcodes as editable text for composer surfaces", () => {
+    const parsed = parseMarkdown(":rocket: launch", undefined, (shortcode) => (shortcode === "rocket" ? "🚀" : null), {
+      emojiAsText: true,
+    })
+
+    expect(parsed.content?.[0]?.content).toEqual([
+      { type: "text", text: "🚀" },
+      { type: "text", text: " launch" },
+    ])
+    expect(serializeToMarkdown(parsed)).toBe("🚀 launch")
+  })
+
+  it("parses emoji shortcodes as atom nodes by default for wire-format round trips", () => {
+    const parsed = parseMarkdown(":rocket:", undefined, (shortcode) => (shortcode === "rocket" ? "🚀" : null))
+
+    expect(parsed.content?.[0]?.content?.[0]).toEqual({
+      type: "emoji",
+      attrs: { shortcode: "rocket", emoji: "🚀" },
+    })
+  })
+})
+
 describe("@threa/prosemirror quote reply round-trip", () => {
   it("serializes quoteReply to blockquote with attribution link", () => {
     const doc: JSONContent = {

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -370,6 +370,12 @@ export interface ParseMarkdownOptions {
   enableChannels?: boolean
   enableSlashCommands?: boolean
   enableEmoji?: boolean
+  /**
+   * Keep resolved emoji shortcodes as editable text instead of atom nodes.
+   * Useful for composer surfaces where mobile browsers struggle with deleting
+   * adjacent contenteditable=false emoji atoms.
+   */
+  emojiAsText?: boolean
 }
 
 interface ParseOptions extends ParseMarkdownOptions {
@@ -581,6 +587,7 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
   const allowChannels = options.enableChannels ?? true
   const allowSlashCommands = options.enableSlashCommands ?? true
   const allowEmoji = options.enableEmoji ?? true
+  const emojiAsText = options.emojiAsText ?? false
 
   // Default lookup for mention types (without context, can't determine "me")
   const lookupMentionType: MentionTypeLookup =
@@ -721,6 +728,12 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
       const shortcode = match[23]
       const emoji = allowEmoji ? getEmoji?.(shortcode) : null
       if (allowEmoji && emoji) {
+        if (emojiAsText) {
+          result.push({ type: "text", text: emoji })
+          lastIndex = match.index + match[0].length
+          continue
+        }
+
         // Store both `shortcode` (the wire-format id) and `emoji` (the
         // resolved character). The TipTap `EmojiExtension` reads
         // `attrs.emoji` for `renderHTML`, so omitting it would render an

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -89,6 +89,25 @@ function deriveDatabaseName(dirPath: string): string {
   return sanitized || "threa"
 }
 
+function getExplicitLanHost(): string | undefined {
+  const raw = process.env.LAN_HOST ?? process.env.LAN_IP
+  if (!raw) return undefined
+
+  try {
+    const url = new URL(raw.includes("://") ? raw : `http://${raw}`)
+    return url.hostname
+  } catch {
+    console.error(`Invalid LAN_HOST/LAN_IP value: ${raw}`)
+    process.exit(1)
+  }
+}
+
+function getDefaultLanHost(): string | undefined {
+  return Object.values(os.networkInterfaces())
+    .flat()
+    .find((i) => i && i.family === "IPv4" && !i.internal)?.address
+}
+
 async function ensureWorktreeEnv(): Promise<void> {
   const cwd = process.cwd()
   const backendEnvPath = path.join(cwd, "apps/backend/.env")
@@ -313,13 +332,12 @@ async function main() {
   }
 
   // LAN mode: bind to WiFi IP so the app is reachable from phones
-  const lanMode = process.env.LAN_MODE === "true" || process.argv.includes("--lan")
+  const explicitLanHost = getExplicitLanHost()
+  const lanMode = process.env.LAN_MODE === "true" || process.argv.includes("--lan") || !!explicitLanHost
   let lanIp: string | undefined
 
   if (lanMode) {
-    lanIp = Object.values(os.networkInterfaces())
-      .flat()
-      .find((i) => i && i.family === "IPv4" && !i.internal)?.address
+    lanIp = explicitLanHost ?? getDefaultLanHost()
 
     if (!lanIp) {
       console.error("LAN_MODE enabled but no LAN IP found — are you connected to WiFi?")

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -176,6 +176,42 @@ async function cloneDatabase(container: string, sourceDb: string, targetDb: stri
   console.log(`Database '${targetDb}' cloned from '${sourceDb}'`)
 }
 
+async function countTableRows(container: string, dbName: string, tableName: string): Promise<number> {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(tableName)) {
+    throw new Error(`Invalid table name: ${tableName}`)
+  }
+
+  const sql = `
+    SELECT CASE
+      WHEN to_regclass('public.${tableName}') IS NULL THEN -1
+      ELSE (SELECT count(*) FROM public.${tableName})
+    END
+  `
+  const result = await $`docker exec ${container} psql -U threa -d ${dbName} -Atc ${sql}`.quiet().nothrow()
+  if (result.exitCode !== 0) {
+    throw new Error(`Could not count ${dbName}.${tableName}: ${result.stderr.toString().trim()}`)
+  }
+
+  const count = Number(result.stdout.toString().trim())
+  if (!Number.isFinite(count)) {
+    throw new Error(`Invalid row count for ${dbName}.${tableName}: ${result.stdout.toString().trim()}`)
+  }
+  return count
+}
+
+async function existingDatabaseNeedsClone(
+  container: string,
+  sourceDb: string,
+  targetDb: string,
+  markerTable: string
+): Promise<boolean> {
+  const sourceCount = await countTableRows(container, sourceDb, markerTable)
+  const targetCount = await countTableRows(container, targetDb, markerTable)
+
+  if (sourceCount <= 0) return false
+  return targetCount <= 0
+}
+
 function copyMcpServers(mainWorktreePath: string, targetWorktreePath: string): void {
   const claudeConfigPath = path.join(os.homedir(), ".claude.json")
 
@@ -313,10 +349,16 @@ async function main() {
 
     const created = await createDatabaseIfNotExists(targetDbName)
     const forceClone = process.env.FORCE_DB_CLONE === "1"
+    const needsClone =
+      !created && !forceClone
+        ? await existingDatabaseNeedsClone(container, sourceDbName, targetDbName, "workspaces")
+        : false
 
-    if (created || forceClone) {
+    if (created || forceClone || needsClone) {
       if (!created && forceClone) {
         console.log(`FORCE_DB_CLONE=1 set, cloning into existing database '${targetDbName}'...`)
+      } else if (needsClone) {
+        console.log(`Existing database '${targetDbName}' appears unseeded; cloning from '${sourceDbName}'...`)
       }
       await cloneDatabase(container, sourceDbName, targetDbName)
     } else {
@@ -328,10 +370,16 @@ async function main() {
     const cpDbName = `${targetDbName}_cp`
     const sourceCpDbName = `${sourceDbName}_cp`
     const cpCreated = await createDatabaseIfNotExists(cpDbName)
+    const cpNeedsClone =
+      !cpCreated && !forceClone
+        ? await existingDatabaseNeedsClone(container, sourceCpDbName, cpDbName, "workspace_registry")
+        : false
 
-    if (cpCreated || forceClone) {
+    if (cpCreated || forceClone || cpNeedsClone) {
       if (!cpCreated && forceClone) {
         console.log(`FORCE_DB_CLONE=1 set, cloning into existing database '${cpDbName}'...`)
+      } else if (cpNeedsClone) {
+        console.log(`Existing database '${cpDbName}' appears unseeded; cloning from '${sourceCpDbName}'...`)
       }
       await cloneDatabase(container, sourceCpDbName, cpDbName)
     } else {


### PR DESCRIPTION
**Linear:** N/A

## Problem

Firefox Android mishandles deletion around emoji in the composer. The previous emoji model used inline contenteditable=false atom nodes, which led to multi-step Backspace behavior, stuck square-highlight selection states, and especially bad behavior with adjacent emoji. During local phone testing, the worktree setup and auth redirect flow also needed fixes so the dev server could be reached through the Tailscale host.

## Solution

New composer emoji input now resolves to editable Unicode text instead of creating new emoji atom nodes. Legacy emoji atoms remain supported for existing JSON content and wire-format compatibility, but composer surfaces convert those atoms to editable text on load. The mobile beforeinput delete path now handles two narrow cases: legacy inline atom deletion and whole-grapheme deletion for multi-code-unit text emoji before Firefox can split surrogate pairs or ZWJ sequences.

The backend still normalizes the derived markdown projection to shortcode form, so rich clients can edit raw emoji text while storage, usage tracking, and external consumers keep the existing canonical markdown format.

### How it works

1. Emoji suggestions and shortcode input rules insert text emoji, not new emoji nodes.
2. Rich editor/document editor parsing uses `emojiAsText` for composer-facing markdown.
3. Incoming legacy `emoji` nodes are converted to text in the composer before TipTap content is set.
4. `beforeinput` delete handling removes legacy adjacent atoms or whole multi-code-unit graphemes, then prevents the native Firefox split-delete path.
5. Message handlers normalize JSON-derived markdown through `normalizeMessage` before persistence.
6. LAN dev routing preserves upstream forwarded host/proto only when proxying to local targets, keeping Tailscale auth redirects working without trusting spoofed forwarding headers in remote environments.

### Key design decisions

**1. Editable emoji text instead of new atoms**

The final fix avoids creating new contenteditable=false emoji atoms because Firefox Android selection/deletion around those nodes is unreliable. This is why mentions/channels can remain atoms while emoji move to text: mention/channel visible content is ASCII chip text, while emoji introduce surrogate-pair and ZWJ grapheme deletion behavior.

**2. Keep legacy emoji atoms**

The `emoji` node schema remains so old message JSON and default parser round trips do not break. Composer surfaces convert those atoms into editable text at the edge.

**3. Normalize markdown at the backend boundary**

The frontend can send raw emoji text in `contentJson`, but `contentMarkdown` is normalized to shortcode format for storage, tracking, and external API expectations.

**4. Trust forwarded headers only for local proxy targets**

Local Vite to Wrangler proxying needs `X-Forwarded-Host` for Tailscale auth redirects, but remote/prod proxy targets should not preserve client-supplied forwarding headers.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/mobile-emoji-delete.md` | Greptile/reviewer plan context for this branch. |

## Modified files

| File | Change |
| --- | --- |
| `.gitignore` | Ignores `.wrangler/` local worker output. |
| `apps/backend/src/features/messaging/handlers.ts` | Normalizes JSON-derived markdown projection through `normalizeMessage`. |
| `apps/frontend/src/components/editor/document-editor-modal.tsx` | Uses text emoji parsing and grapheme delete handling. |
| `apps/frontend/src/components/editor/multiline-blocks.ts` | Adds legacy atom delete hardening and whole-grapheme delete handling. |
| `apps/frontend/src/components/editor/multiline-blocks.test.ts` | Adds coverage for atom deletion, adjacent emoji, split surrogate recovery, selections, and ZWJ emoji. |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Converts legacy emoji atoms to text and wires text emoji parsing/delete behavior. |
| `apps/frontend/src/components/editor/triggers/emoji-extension.ts` | Inserts emoji suggestion/input-rule results as editable text. |
| `apps/workspace-router/src/index.ts` | Preserves forwarded headers for local proxy targets only. |
| `apps/workspace-router/src/index.test.ts` | Covers local forwarded header preservation and remote spoof protection. |
| `packages/prosemirror/src/markdown.ts` | Adds `emojiAsText` parser option. |
| `packages/prosemirror/src/markdown.test.ts` | Covers emoji-as-text parsing and default atom parsing. |
| `scripts/dev.ts` | Adds explicit `LAN_HOST`/`LAN_IP` support. |
| `scripts/setup-worktree.ts` | Re-clones existing target DBs when marker tables show they are unseeded. |

## Deleted files

None.

## Test plan

- [x] Self-review pass completed; fixed remote forwarded-header spoofing risk before PR.
- [x] `bunx vitest run src/components/editor/multiline-blocks.test.ts`
- [x] `bunx vitest run src/components/editor src/components/timeline/message-input.test.tsx src/hooks/use-stream-or-draft.test.tsx`
- [x] `bun test ./packages/prosemirror/src/markdown.test.ts`
- [x] `bun test ./apps/workspace-router/src/index.test.ts`
- [x] `bun test ./apps/backend/src/features/emoji/emoji.test.ts`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun run --cwd apps/workspace-router typecheck`
- [x] `bun run --cwd packages/prosemirror typecheck`
- [x] `bun run --cwd apps/backend typecheck`
- [x] Commit hook: root lint, full workspace typecheck, Dockerfile workspace check, API docs check
- [x] Manual Firefox Android testing via Tailscale LAN dev server

---

_PR by Codex_
