### PR TITLE
fix: clear stale host-only session cookies

### DIFF
--- a/.claude/plans/firefox-android-login-bug.md
+++ b/.claude/plans/firefox-android-login-bug.md
@@ -1,0 +1,67 @@
+# Firefox Android Login Redirect Fix
+
+## Goal
+
+Fix a mobile Firefox login loop where WorkOS authentication succeeds, but the app redirects back to login after returning from the callback because the authenticated session is not recognized.
+
+## What Was Built
+
+### Session cookie helpers
+
+Centralized session cookie set and clear behavior in `backend-common`. When the configured session cookie is domain-scoped, setting a new session now first clears the host-only cookie variant with the same name, and clearing a session clears both variants.
+
+**Files:**
+
+- `packages/backend-common/src/cookies.ts` — adds `setSessionCookie` and `clearSessionCookie`.
+- `packages/backend-common/src/index.ts` — exports the new helpers and option type.
+- `packages/backend-common/src/cookies.test.ts` — verifies host-only cleanup when domain-scoped cookies are set or cleared.
+
+### Auth path adoption
+
+Updated all session-writing auth paths touched by this bug to use the shared helpers.
+
+**Files:**
+
+- `apps/control-plane/src/features/auth/handlers.ts` — WorkOS callback uses `setSessionCookie`; logout uses `clearSessionCookie`.
+- `packages/backend-common/src/auth/middleware.ts` — session refresh and expired-session cleanup use the shared helpers.
+- `apps/control-plane/src/features/auth/stub-handlers.ts` — control-plane stub login uses `setSessionCookie`.
+- `apps/backend/src/auth/auth-stub-handlers.ts` — regional backend stub login uses `setSessionCookie` with its existing test/dev secure override.
+
+## Design Decisions
+
+### Clear host-only shadow cookies at write time
+
+**Chose:** Clear the host-only variant before setting the domain-scoped session cookie.
+
+**Why:** The staging-specific cookie work made `SESSION_COOKIE_NAME` and `COOKIE_DOMAIN` configurable. A browser can retain an older host-only cookie and also store the newer `.threa.io` cookie under the same name. If Firefox Android sends those duplicates in an order where the stale value is parsed first, `/api/auth/me` sees an invalid session and the frontend returns to login.
+
+**Alternatives considered:** Parsing duplicate cookie headers server-side and trying later values. That would make request handling depend on browser ordering and still leave stale cookies in the jar.
+
+### Keep cookie behavior centralized
+
+**Chose:** Add helpers in `packages/backend-common/src/cookies.ts` instead of patching only the WorkOS callback.
+
+**Why:** The same session cookie is written during callback login, stub login, and session refresh, and cleared during logout or failed authentication. Keeping all paths on one helper prevents future divergence.
+
+## Design Evolution
+
+- **Root cause narrowed:** Initial suspicion was a WorkOS redirect problem, but the callback already authenticates and redirects correctly. The app-side 401 after callback pointed to session cookie scope/selection instead.
+- **Patch scope narrowed:** No frontend redirect change was needed; the fix belongs at the session cookie boundary.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No WorkOS dashboard/configuration change.
+- No frontend login-flow changes.
+- No server-side fallback that accepts multiple possible session cookie names.
+
+## Status
+
+- [x] Add centralized session cookie set/clear helpers.
+- [x] Apply helpers to WorkOS callback, logout, session refresh, and stub login paths.
+- [x] Add focused cookie helper coverage.
+- [x] Run focused unit test and relevant typechecks.
+- [ ] Run control-plane auth E2E once Docker/test database is available.

--- a/apps/backend/src/auth/auth-stub-handlers.ts
+++ b/apps/backend/src/auth/auth-stub-handlers.ts
@@ -4,8 +4,8 @@ import {
   renderLoginPage,
   decodeAndSanitizeRedirectState,
   displayNameFromWorkos,
-  SESSION_COOKIE_NAME,
   SESSION_COOKIE_CONFIG,
+  setSessionCookie,
   type StubAuthService,
 } from "@threa/backend-common"
 import type { WorkspaceService } from "../features/workspaces"
@@ -53,7 +53,7 @@ export function createAuthStubHandlers(deps: Dependencies): AuthStubHandlers {
       name: user.name,
     })
 
-    res.cookie(SESSION_COOKIE_NAME, session, { ...SESSION_COOKIE_CONFIG, secure: false })
+    setSessionCookie(res, session, { ...SESSION_COOKIE_CONFIG, secure: false })
 
     // If user was accepted into exactly one workspace, redirect to setup
     if (acceptedWorkspaceIds.length === 1) {
@@ -69,7 +69,7 @@ export function createAuthStubHandlers(deps: Dependencies): AuthStubHandlers {
 
     const { user, session } = await authStubService.devLogin({ email, name })
 
-    res.cookie(SESSION_COOKIE_NAME, session, { ...SESSION_COOKIE_CONFIG, secure: false })
+    setSessionCookie(res, session, { ...SESSION_COOKIE_CONFIG, secure: false })
 
     res.json({ user })
   }

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -3,9 +3,10 @@ import { z } from "zod/v4"
 import {
   HttpError,
   SESSION_COOKIE_NAME,
-  SESSION_COOKIE_CONFIG,
+  clearSessionCookie,
   decodeAndSanitizeRedirectState,
   displayNameFromWorkos,
+  setSessionCookie,
   type AuthService,
 } from "@threa/backend-common"
 
@@ -119,15 +120,14 @@ export function createControlPlaneAuthHandlers({
         redirectUrl = frontendUrl ? `${frontendUrl}${path}` : path
       }
 
-      res.cookie(SESSION_COOKIE_NAME, result.sealedSession, SESSION_COOKIE_CONFIG)
+      setSessionCookie(res, result.sealedSession)
       res.redirect(redirectUrl)
     },
 
     async logout(req: Request, res: Response) {
       const session = req.cookies[SESSION_COOKIE_NAME]
 
-      const { maxAge: _, ...clearOpts } = SESSION_COOKIE_CONFIG
-      res.clearCookie(SESSION_COOKIE_NAME, clearOpts)
+      clearSessionCookie(res)
 
       const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
 

--- a/apps/control-plane/src/features/auth/stub-handlers.ts
+++ b/apps/control-plane/src/features/auth/stub-handlers.ts
@@ -2,10 +2,9 @@ import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import {
   HttpError,
-  SESSION_COOKIE_NAME,
-  SESSION_COOKIE_CONFIG,
   decodeAndSanitizeRedirectState,
   renderLoginPage,
+  setSessionCookie,
   type StubAuthService,
 } from "@threa/backend-common"
 
@@ -41,7 +40,7 @@ export function createAuthStubHandlers({ authStubService }: Dependencies) {
 
       const redirectUrl = state ? decodeAndSanitizeRedirectState(state) : "/"
 
-      res.cookie(SESSION_COOKIE_NAME, result.session, SESSION_COOKIE_CONFIG)
+      setSessionCookie(res, result.session)
       res.redirect(redirectUrl)
     },
 
@@ -51,7 +50,7 @@ export function createAuthStubHandlers({ authStubService }: Dependencies) {
         throw new HttpError("Invalid login parameters", { status: 400, code: "INVALID_LOGIN" })
       }
       const result = await authStubService.devLogin(parsed.data)
-      res.cookie(SESSION_COOKIE_NAME, result.session, SESSION_COOKIE_CONFIG)
+      setSessionCookie(res, result.session)
       res.json({ user: result.user })
     },
   }

--- a/packages/backend-common/src/auth/middleware.ts
+++ b/packages/backend-common/src/auth/middleware.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express"
 import type { AuthService } from "./auth-service"
-import { SESSION_COOKIE_NAME, SESSION_COOKIE_CONFIG } from "../cookies"
+import { SESSION_COOKIE_NAME, clearSessionCookie, setSessionCookie } from "../cookies"
 
 interface AuthenticatedUser {
   id: string
@@ -35,16 +35,12 @@ export function createAuthMiddleware({ authService }: Dependencies) {
     const result = await authService.authenticateSession(session)
 
     if (!result.success || !result.user) {
-      // Pass domain/path from SESSION_COOKIE_CONFIG so the browser actually
-      // drops the cookie when COOKIE_DOMAIN is set — clearCookie needs the
-      // same attributes that set it.
-      const { maxAge: _, ...clearOpts } = SESSION_COOKIE_CONFIG
-      res.clearCookie(SESSION_COOKIE_NAME, clearOpts)
+      clearSessionCookie(res)
       return res.status(401).json({ error: "Session expired" })
     }
 
     if (result.refreshed && result.sealedSession) {
-      res.cookie(SESSION_COOKIE_NAME, result.sealedSession, SESSION_COOKIE_CONFIG)
+      setSessionCookie(res, result.sealedSession)
     }
 
     req.workosUserId = result.user.id

--- a/packages/backend-common/src/cookies.test.ts
+++ b/packages/backend-common/src/cookies.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import type { Response } from "express"
+import type { SessionCookieOptions } from "./cookies"
+
+type CookieCall =
+  | { type: "clear"; name: string; options: SessionCookieOptions }
+  | { type: "set"; name: string; value: string; options: SessionCookieOptions }
+
+function makeResponseRecorder(): { res: Response; calls: CookieCall[] } {
+  const calls: CookieCall[] = []
+  const res = {
+    clearCookie(name: string, options: SessionCookieOptions) {
+      calls.push({ type: "clear", name, options })
+      return this
+    },
+    cookie(name: string, value: string, options: SessionCookieOptions) {
+      calls.push({ type: "set", name, value, options })
+      return this
+    },
+  } as unknown as Response
+
+  return { res, calls }
+}
+
+describe("session cookies", () => {
+  let SESSION_COOKIE_NAME: string
+  let setSessionCookie: typeof import("./cookies").setSessionCookie
+  let clearSessionCookie: typeof import("./cookies").clearSessionCookie
+
+  beforeAll(async () => {
+    process.env.SESSION_COOKIE_NAME = "wos_session_test"
+    const cookies = await import("./cookies")
+    SESSION_COOKIE_NAME = cookies.SESSION_COOKIE_NAME
+    setSessionCookie = cookies.setSessionCookie
+    clearSessionCookie = cookies.clearSessionCookie
+  })
+
+  test("setting a domain-scoped session first clears a host-only cookie with the same name", () => {
+    const { res, calls } = makeResponseRecorder()
+    const options = {
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax" as const,
+      maxAge: 123,
+      domain: ".threa.io",
+    }
+
+    setSessionCookie(res, "sealed-session", options)
+
+    expect(calls).toEqual([
+      {
+        type: "clear",
+        name: SESSION_COOKIE_NAME,
+        options: { path: "/", httpOnly: true, secure: true, sameSite: "lax" },
+      },
+      { type: "set", name: SESSION_COOKIE_NAME, value: "sealed-session", options },
+    ])
+  })
+
+  test("clearing a domain-scoped session also clears the host-only variant", () => {
+    const { res, calls } = makeResponseRecorder()
+    const options = {
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax" as const,
+      maxAge: 123,
+      domain: ".threa.io",
+    }
+
+    clearSessionCookie(res, options)
+
+    expect(calls).toEqual([
+      {
+        type: "clear",
+        name: SESSION_COOKIE_NAME,
+        options: { path: "/", httpOnly: true, secure: true, sameSite: "lax", domain: ".threa.io" },
+      },
+      {
+        type: "clear",
+        name: SESSION_COOKIE_NAME,
+        options: { path: "/", httpOnly: true, secure: true, sameSite: "lax" },
+      },
+    ])
+  })
+})

--- a/packages/backend-common/src/cookies.ts
+++ b/packages/backend-common/src/cookies.ts
@@ -1,3 +1,5 @@
+import type { CookieOptions, Response } from "express"
+
 const isProduction = process.env.NODE_ENV === "production"
 
 export const parseCookies = (cookieHeader: string): Record<string, string> => {
@@ -44,4 +46,34 @@ export const SESSION_COOKIE_CONFIG = {
   // session set at staging.threa.io during the WorkOS callback is visible on
   // sibling PR subdomains like pr-204-staging.threa.io.
   ...(process.env.COOKIE_DOMAIN ? { domain: process.env.COOKIE_DOMAIN } : {}),
+}
+
+export type SessionCookieOptions = CookieOptions
+
+function clearOptions(options: SessionCookieOptions): SessionCookieOptions {
+  const { maxAge: _, ...rest } = options
+  return rest
+}
+
+function hostOnlyOptions(options: SessionCookieOptions): SessionCookieOptions {
+  const { domain: _, ...rest } = options
+  return rest
+}
+
+export function setSessionCookie(
+  res: Response,
+  session: string,
+  options: SessionCookieOptions = SESSION_COOKIE_CONFIG
+): void {
+  if (options.domain) {
+    res.clearCookie(SESSION_COOKIE_NAME, clearOptions(hostOnlyOptions(options)))
+  }
+  res.cookie(SESSION_COOKIE_NAME, session, options)
+}
+
+export function clearSessionCookie(res: Response, options: SessionCookieOptions = SESSION_COOKIE_CONFIG): void {
+  res.clearCookie(SESSION_COOKIE_NAME, clearOptions(options))
+  if (options.domain) {
+    res.clearCookie(SESSION_COOKIE_NAME, clearOptions(hostOnlyOptions(options)))
+  }
 }

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -86,7 +86,14 @@ export {
   contextSummaryId,
   leaseId,
 } from "./id"
-export { parseCookies, SESSION_COOKIE_NAME, SESSION_COOKIE_CONFIG } from "./cookies"
+export {
+  parseCookies,
+  SESSION_COOKIE_NAME,
+  SESSION_COOKIE_CONFIG,
+  setSessionCookie,
+  clearSessionCookie,
+} from "./cookies"
+export type { SessionCookieOptions } from "./cookies"
 export { generateSlug, generateUniqueSlug } from "./slug"
 
 // Outbox infrastructure


### PR DESCRIPTION
## Problem

Firefox on Android can complete WorkOS login, return to the app, and then land back on the login page. The callback itself succeeds; the failure happens when the app subsequently treats the user as unauthenticated.

The likely regression came from making the session cookie environment-specific and domain-scoped for staging. Browsers can retain an older host-only cookie with the same `SESSION_COOKIE_NAME` while also storing the newer `.threa.io` domain cookie. If Firefox Android sends the duplicate cookies in an order where the stale value is parsed, `/api/auth/me` returns 401 and the frontend redirects to login.

## Solution

Centralize session cookie writes and clears so domain-scoped sessions actively clean up stale host-only cookie variants.

### How it works

- `setSessionCookie` clears the host-only variant before setting the configured session cookie when `COOKIE_DOMAIN` is present.
- `clearSessionCookie` clears both the configured domain-scoped cookie and the host-only variant.
- WorkOS callback login, logout, session refresh, expired-session cleanup, and stub login paths now use these helpers.

### Key design decisions

**1. Clear stale cookies at the cookie boundary**

This keeps the fix independent of browser-specific duplicate cookie ordering and removes the stale cookie from the browser jar instead of trying to guess which duplicate value to trust server-side.

**2. Use shared helpers instead of a callback-only patch**

The same session cookie is written by callback login, stub login, and session refresh, and cleared during logout or auth failure. Routing those paths through one helper avoids future divergence.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/firefox-android-login-bug.md` | Plan context for reviewers and Greptile. |
| `packages/backend-common/src/cookies.test.ts` | Focused coverage for clearing host-only cookie variants. |

## Modified files

| File | Change |
| --- | --- |
| `packages/backend-common/src/cookies.ts` | Adds shared session cookie set/clear helpers. |
| `packages/backend-common/src/index.ts` | Exports the new helpers and option type. |
| `packages/backend-common/src/auth/middleware.ts` | Uses helpers for refresh and failed-session cleanup. |
| `apps/control-plane/src/features/auth/handlers.ts` | Uses helpers for WorkOS callback and logout. |
| `apps/control-plane/src/features/auth/stub-handlers.ts` | Uses helper for control-plane stub auth. |
| `apps/backend/src/auth/auth-stub-handlers.ts` | Uses helper for backend stub auth while preserving secure override. |

## Deleted files

None.

## Test plan

- [x] `bun test ./packages/backend-common/src/cookies.test.ts`
- [x] `bun run --cwd packages/backend-common typecheck`
- [x] `bun run --cwd apps/control-plane typecheck`
- [x] `bun run --cwd apps/backend typecheck`
- [x] Commit hook: repo lint chain, full monorepo typecheck, Dockerfile workspace check, API docs check
- [ ] `bun test --preload ./apps/control-plane/tests/setup.ts ./apps/control-plane/tests/e2e/auth.test.ts` once Docker/test DB is available. Current environment timed out in `beforeAll`; `docker ps` and `docker compose -f docker-compose.test.yml ps` also hung, consistent with Docker/test DB being unavailable.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
