### PR TITLE
fix: restore PWA share target POST handling

### DIFF
--- a/.claude/plans/fix-pwa-share-target.md
+++ b/.claude/plans/fix-pwa-share-target.md
@@ -1,0 +1,44 @@
+# Fix PWA Share Target
+
+## Goal
+
+Restore the installed PWA share target so OS-level shares sent to Threa via `POST /share` are handled by the service worker instead of being forwarded to Cloudflare Pages.
+
+## What Was Built
+
+### Service Worker Share Target Routing
+
+The generic app-shell navigation fallback now handles only `GET` navigations. Web Share Target launches use a `POST` navigation to `/share`, so those requests must fall through to the dedicated share-target fetch handler that reads multipart form data, stores it in the Cache API, and redirects to the share picker.
+
+**Files:**
+- `apps/frontend/src/sw.ts` - Adds a method guard to the network-first navigation handler so it ignores non-GET navigations.
+
+## Design Decisions
+
+### Keep Share Target Handling in the Existing Service Worker
+
+**Chose:** Narrow the broad navigation handler to `GET` requests.
+
+**Why:** The existing share-target implementation already handles `POST /share` correctly. The regression was caused by an earlier fetch listener intercepting all navigation requests before the share-target listener could respond.
+
+**Alternatives considered:** Adding server-side support for `POST /share` would not preserve the existing file/text handoff through the Cache API and would expand the change beyond the browser-only PWA path.
+
+## Design Evolution
+
+- No significant design pivot. Investigation confirmed `GET /share` is reachable in production, while direct `POST /share` returns `405` outside a service-worker-controlled PWA context.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No backend or Cloudflare Pages route changes.
+- No manifest changes; the existing manifest already points the share target at `POST /share`.
+- No UI changes to the workspace share picker.
+
+## Status
+
+- [x] Diagnosed the share-target POST interception issue.
+- [x] Updated the service worker navigation handler to only catch GET navigations.
+- [x] Verified the frontend production build and generated service worker compile successfully.

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -52,7 +52,9 @@ cleanupOutdatedCaches()
 // get the latest HTML with correct asset references. The precache still
 // serves as an offline fallback.
 self.addEventListener("fetch", (event) => {
-  if (event.request.mode !== "navigate") return
+  // Only app-shell GET navigations belong here. Web Share Target launches use
+  // a POST navigation to /share, which must fall through to the handler below.
+  if (event.request.mode !== "navigate" || event.request.method !== "GET") return
 
   event.respondWith(
     fetch(event.request).catch(async () => {


### PR DESCRIPTION
## Problem

The installed PWA share target uses `POST /share` with `multipart/form-data`. The service worker also has a broad network-first navigation handler for app-shell navigations. Because share-target launches are navigation requests too, that generic handler could intercept the POST first and forward it to Cloudflare Pages, where direct `POST /share` returns `405`. In the PWA this surfaces as a failed share launch.

## Solution

Restrict the generic service-worker navigation fallback to `GET` navigations only. That keeps normal SPA page loads on the existing network-first path while allowing `POST /share` to fall through to the dedicated Web Share Target handler.

### How it works

1. Browser launches the installed PWA share target with `POST /share`.
2. The app-shell navigation handler now ignores it because the method is not `GET`.
3. The existing share-target handler reads the multipart form data, stores metadata/files in the Cache API, and redirects to `GET /share`.
4. The React share-target route resolves the workspace and opens the workspace-scoped share picker.

### Key design decisions

**1. Narrow the broad fetch handler instead of changing the share target**

The manifest and share-target handler were already pointed at `POST /share`. The bug was event-handler routing inside the service worker, so the smallest correct fix is to keep non-GET navigations out of the app-shell fallback.

**2. No server-side POST fallback**

Direct production `POST /share` still returns `405` outside a service-worker-controlled PWA context. That is acceptable for this flow because file/text handoff is intentionally browser-local through the service worker Cache API.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/fix-pwa-share-target.md` | Greptile plan context for the PR |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/sw.ts` | Limits the generic navigation fetch handler to `GET` requests so `POST /share` reaches the share-target handler |

## Deleted files

None.

## Test plan

- [x] `curl -I -L --max-time 20 https://app.threa.io/share` returns `200`
- [x] Confirmed direct `POST /share` returns `405` outside SW control, matching the failure path
- [x] `bun run --cwd apps/frontend build`
- [x] Commit hooks: lint, monorepo typecheck, Dockerfile workspace check, API docs check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
