### PR TITLE
ci: run Cloudflare deploys on Node 22

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -53,6 +58,11 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -82,6 +92,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -116,6 +131,11 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -145,6 +165,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -179,6 +204,11 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -208,6 +238,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -246,6 +281,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -154,6 +158,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Problem

Cloudflare deploys and staging workflows started failing because Wrangler now requires Node.js v22+, but `ubuntu-latest` GitHub Actions runners only ship with Node v20 by default. The missing explicit Node setup caused `bunx wrangler` invocations to error out during deployment.

## Solution

Add `actions/setup-node@v4` with `node-version: 22` to all Cloudflare deploy jobs and both staging workflow jobs that invoke Wrangler.

### Key design decisions

**1. Pin to Node 22 (not "latest")**

Using an explicit major version avoids surprise breakages when the runner or action defaults change. Node 22 is the current LTS and matches Wrangler's stated requirement.

**2. Setup Node before Bun**

Node is installed before Bun so that any `bunx` calls that spawn Node processes (e.g., `wrangler`) inherit the correct version.

## Modified files

| File | Change |
| ---- | ------ |
| `.github/workflows/deploy-cloudflare.yml` | Added `actions/setup-node@v4` (node-version: 22) to all 8 deploy jobs |
| `.github/workflows/staging.yml` | Added `actions/setup-node@v4` (node-version: 22) to the `deploy` and `teardown` jobs |

## Test plan

- [ ] Merge and verify the next staging deploy succeeds
- [ ] Verify Cloudflare Pages deploys complete without Node version errors

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
