### PR TITLE
fix(push): route notifications to attended device using interaction signal

### DIFF
--- a/apps/backend/src/db/migrations/20260503213727_user_sessions_last_interaction_at.sql
+++ b/apps/backend/src/db/migrations/20260503213727_user_sessions_last_interaction_at.sql
@@ -1,0 +1,4 @@
+-- Track when a device last had a real user interaction (pointer/key/touch).
+-- A focused window can sit idle for hours; interaction is what proves the user
+-- is actually there. Used by push routing to pick the device the user is on.
+ALTER TABLE user_sessions ADD COLUMN last_interaction_at TIMESTAMPTZ;

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -20,8 +20,23 @@ const MAX_SUBSCRIPTIONS_PER_USER = 10
 /** How recently a device must have sent a heartbeat to be considered "active" */
 const ACTIVE_SESSION_WINDOW_MS = 60_000
 
-/** How recently a device must have been focused to consider the user "at their computer" */
-const RECENTLY_FOCUSED_WINDOW_MS = 10 * 60 * 1_000 // 10 minutes
+/**
+ * How recently `last_focused_at` must have been bumped for us to treat the
+ * device as currently focused. Heartbeats fire every 30s while focused (and
+ * immediately on focus change), so a 60s window catches the focused state with
+ * at most one heartbeat of lag.
+ */
+const CURRENTLY_FOCUSED_WINDOW_MS = 60_000
+
+/**
+ * How recently the device must have seen a real user interaction
+ * (pointerdown/keydown/touchstart) to count as "the device the user is on".
+ * A focused-but-untouched window (e.g. PWA open in another desktop space)
+ * shouldn't claim the user's attention indefinitely — without interaction we
+ * fall through to fanout so the user gets notified on whichever device they
+ * pick up next.
+ */
+const RECENT_INTERACTION_WINDOW_MS = 2 * 60 * 1_000 // 2 minutes
 
 /**
  * Per-device session expiry window. If a specific device has not sent a heartbeat
@@ -188,15 +203,16 @@ export class PushService {
     userId: string
     deviceKey: string
     focused?: boolean
+    interacted?: boolean
   }): Promise<UserSession> {
     return UserSessionRepository.upsert(this.pool, params)
   }
 
   async upsertSessionsBatch(
     entries: Array<{ workspaceId: string; userId: string; deviceKey: string }>,
-    focused?: boolean
+    options?: { focused?: boolean; interacted?: boolean }
   ): Promise<void> {
-    return UserSessionRepository.upsertBatch(this.pool, entries, focused)
+    return UserSessionRepository.upsertBatch(this.pool, entries, options)
   }
 
   /**
@@ -464,11 +480,16 @@ export class PushService {
    * on devices with no session within SESSION_EXPIRY_WINDOW_MS — these get a
    * session-expired push and are cleaned up).
    *
-   * Four-tier strategy for active subscriptions (SW handles focus-based suppression):
-   * 1. Threa focused       → push to active device, SW suppresses (user sees nothing)
-   * 2. Threa open, unfocused (<10m) → push to active device, SW shows notification
-   * 3. Threa open, unfocused 10m+   → push to ALL active devices (user walked away)
-   * 4. Offline 60s+                  → push to ALL active devices
+   * Routing rule for active subscriptions:
+   *   - If any device is currently focused AND has had a real user interaction
+   *     in the last 2 minutes, push only to those device(s) — the SW on a
+   *     focused device suppresses display since the user can already see Threa,
+   *     and other devices stay quiet so the user doesn't get duplicate alerts
+   *     where they aren't looking.
+   *   - Otherwise (no focused-and-interacting device, or the user has put the
+   *     phone down / walked away), fan out to every device with a live
+   *     heartbeat so the user gets the notification on whichever device they
+   *     pick up next.
    */
   private async getTargetSubscriptions(
     workspaceId: string,
@@ -515,27 +536,38 @@ export class PushService {
 
     if (activeSubs.length === 0) return { active: [], expired: expiredSubs }
 
-    // Apply four-tier targeting to active subscriptions only
-    // Tier 4: No active sessions (within 60s) → user is offline → push to all active devices
+    // No live heartbeats anywhere → user is offline; fan out so they see the
+    // notification on whichever device they pick up next.
     if (activeSessions.length === 0) return { active: activeSubs, expired: expiredSubs }
 
-    // Check if any active session was focused recently (within 10m).
-    // If not, the user likely walked away from their computer with Threa open.
+    // Identify devices the user is actually on right now: focused window AND a
+    // real user interaction within the last 2m. A focused-but-idle window
+    // (PWA running in the background of another desktop space, tab the user
+    // tabbed to and then walked off) doesn't qualify.
     const now = Date.now()
-    const hasRecentlyFocused = activeSessions.some(
-      (s) => s.lastFocusedAt && now - s.lastFocusedAt.getTime() < RECENTLY_FOCUSED_WINDOW_MS
+    const attendedDeviceKeys = new Set(
+      activeSessions
+        .filter(
+          (s) =>
+            s.lastFocusedAt !== null &&
+            now - s.lastFocusedAt.getTime() < CURRENTLY_FOCUSED_WINDOW_MS &&
+            s.lastInteractionAt !== null &&
+            now - s.lastInteractionAt.getTime() < RECENT_INTERACTION_WINDOW_MS
+        )
+        .map((s) => s.deviceKey)
     )
 
-    // Tier 3: Active sessions but none focused recently → user walked away → push to all active
-    if (!hasRecentlyFocused) return { active: activeSubs, expired: expiredSubs }
+    if (attendedDeviceKeys.size === 0) {
+      // No device proves the user is on it — fan out to every active device.
+      return { active: activeSubs, expired: expiredSubs }
+    }
 
-    // Tiers 1 & 2: User is at their computer → push to devices with active sessions.
-    // The SW on each device decides whether to display (focused = suppress).
-    // Fall back to all active subscriptions if the intersection is empty — a session can
-    // exist on a device without a subscription (e.g. second browser, or subscription
-    // registered on a device that no longer has an active socket).
-    const activeDeviceKeys = new Set(activeSessions.map((s) => s.deviceKey))
-    const matched = activeSubs.filter((sub) => activeDeviceKeys.has(sub.deviceKey))
+    // Push only to the attended device(s). The SW on each device decides
+    // whether to display (focused window = suppress, since the user can
+    // already see Threa). If the intersection is empty (a session exists on
+    // a device without a registered push subscription), fall back to fanout
+    // so we still notify *something*.
+    const matched = activeSubs.filter((sub) => attendedDeviceKeys.has(sub.deviceKey))
     const active = matched.length > 0 ? matched : activeSubs
     return { active, expired: expiredSubs }
   }

--- a/apps/backend/src/features/push/session-repository.ts
+++ b/apps/backend/src/features/push/session-repository.ts
@@ -9,6 +9,7 @@ interface UserSessionRow {
   device_key: string
   last_active_at: Date
   last_focused_at: Date | null
+  last_interaction_at: Date | null
   created_at: Date
 }
 
@@ -19,6 +20,7 @@ export interface UserSession {
   deviceKey: string
   lastActiveAt: Date
   lastFocusedAt: Date | null
+  lastInteractionAt: Date | null
   createdAt: Date
 }
 
@@ -30,6 +32,7 @@ function mapRowToSession(row: UserSessionRow): UserSession {
     deviceKey: row.device_key,
     lastActiveAt: row.last_active_at,
     lastFocusedAt: row.last_focused_at,
+    lastInteractionAt: row.last_interaction_at,
     createdAt: row.created_at,
   }
 }
@@ -37,18 +40,26 @@ function mapRowToSession(row: UserSessionRow): UserSession {
 export const UserSessionRepository = {
   async upsert(
     db: Querier,
-    params: { workspaceId: string; userId: string; deviceKey: string; focused?: boolean }
+    params: {
+      workspaceId: string
+      userId: string
+      deviceKey: string
+      focused?: boolean
+      interacted?: boolean
+    }
   ): Promise<UserSession> {
     const id = userSessionId()
     const focusedAt = params.focused ? new Date() : null
+    const interactedAt = params.interacted ? new Date() : null
 
     const result = await db.query<UserSessionRow>(sql`
-      INSERT INTO user_sessions (id, workspace_id, user_id, device_key, last_active_at, last_focused_at)
-      VALUES (${id}, ${params.workspaceId}, ${params.userId}, ${params.deviceKey}, now(), ${focusedAt})
+      INSERT INTO user_sessions (id, workspace_id, user_id, device_key, last_active_at, last_focused_at, last_interaction_at)
+      VALUES (${id}, ${params.workspaceId}, ${params.userId}, ${params.deviceKey}, now(), ${focusedAt}, ${interactedAt})
       ON CONFLICT (workspace_id, user_id, device_key)
       DO UPDATE SET
         last_active_at = now(),
-        last_focused_at = COALESCE(${focusedAt}, user_sessions.last_focused_at)
+        last_focused_at = COALESCE(${focusedAt}, user_sessions.last_focused_at),
+        last_interaction_at = COALESCE(${interactedAt}, user_sessions.last_interaction_at)
       RETURNING *
     `)
     return mapRowToSession(result.rows[0])
@@ -57,16 +68,16 @@ export const UserSessionRepository = {
   /**
    * Batch upsert sessions in a single SQL statement (INV-56).
    * Used by heartbeat handler to avoid N individual upserts per workspace.
-   * All entries in a batch share the same focused state (same browser tab).
+   * All entries in a batch share the same focused/interacted state (same browser tab).
    */
   async upsertBatch(
     db: Querier,
     entries: Array<{ workspaceId: string; userId: string; deviceKey: string }>,
-    focused?: boolean
+    options?: { focused?: boolean; interacted?: boolean }
   ): Promise<void> {
     if (entries.length === 0) return
     if (entries.length === 1) {
-      await this.upsert(db, { ...entries[0], focused })
+      await this.upsert(db, { ...entries[0], focused: options?.focused, interacted: options?.interacted })
       return
     }
 
@@ -74,15 +85,17 @@ export const UserSessionRepository = {
     const workspaceIds = entries.map((e) => e.workspaceId)
     const userIds = entries.map((e) => e.userId)
     const deviceKeys = entries.map((e) => e.deviceKey)
-    const focusedAt = focused ? new Date() : null
+    const focusedAt = options?.focused ? new Date() : null
+    const interactedAt = options?.interacted ? new Date() : null
 
     await db.query(sql`
-      INSERT INTO user_sessions (id, workspace_id, user_id, device_key, last_active_at, last_focused_at)
-      SELECT unnest(${ids}::text[]), unnest(${workspaceIds}::text[]), unnest(${userIds}::text[]), unnest(${deviceKeys}::text[]), now(), ${focusedAt}
+      INSERT INTO user_sessions (id, workspace_id, user_id, device_key, last_active_at, last_focused_at, last_interaction_at)
+      SELECT unnest(${ids}::text[]), unnest(${workspaceIds}::text[]), unnest(${userIds}::text[]), unnest(${deviceKeys}::text[]), now(), ${focusedAt}, ${interactedAt}
       ON CONFLICT (workspace_id, user_id, device_key)
       DO UPDATE SET
         last_active_at = now(),
-        last_focused_at = COALESCE(${focusedAt}, user_sessions.last_focused_at)
+        last_focused_at = COALESCE(${focusedAt}, user_sessions.last_focused_at),
+        last_interaction_at = COALESCE(${interactedAt}, user_sessions.last_interaction_at)
     `)
   },
 

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -2,7 +2,7 @@ import type { Server, Socket } from "socket.io"
 import crypto from "crypto"
 import { parseCookies, SESSION_COOKIE_NAME } from "@threa/backend-common"
 import type { AuthService } from "@threa/backend-common"
-import { DEVICE_KEY_LENGTH } from "@threa/types"
+import { DEVICE_KEY_LENGTH, HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
 import type { StreamService } from "./features/streams"
 import type { PushService } from "./features/push"
 import type { UserSocketRegistry } from "./lib/user-socket-registry"
@@ -360,7 +360,6 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
     // Heartbeat for push notification session tracking
     // =========================================================================
     let lastHeartbeatAt = 0
-    const HEARTBEAT_MIN_INTERVAL_MS = 15_000 // Server-side throttle: ignore heartbeats faster than 15s
     // Interaction-driven heartbeats bypass the throttle: the client only emits
     // them on the first interaction after a quiet stretch, and we want the
     // backend to learn about renewed activity within seconds, not up to 30s.
@@ -368,7 +367,7 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
       if (!pushService.isEnabled()) return
       const interacted = payload?.interacted === true
       const now = Date.now()
-      if (!interacted && now - lastHeartbeatAt < HEARTBEAT_MIN_INTERVAL_MS) return
+      if (!interacted && now - lastHeartbeatAt < HEARTBEAT_INTERACTION_THROTTLE_MS) return
       lastHeartbeatAt = now
       const deviceKey = deriveDeviceKey(socket.handshake.headers["user-agent"])
       const focused = payload?.focused === true

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -361,10 +361,14 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
     // =========================================================================
     let lastHeartbeatAt = 0
     const HEARTBEAT_MIN_INTERVAL_MS = 15_000 // Server-side throttle: ignore heartbeats faster than 15s
-    socket.on("heartbeat", (payload?: { focused?: boolean }) => {
+    // Interaction-driven heartbeats bypass the throttle: the client only emits
+    // them on the first interaction after a quiet stretch, and we want the
+    // backend to learn about renewed activity within seconds, not up to 30s.
+    socket.on("heartbeat", (payload?: { focused?: boolean; interacted?: boolean }) => {
       if (!pushService.isEnabled()) return
+      const interacted = payload?.interacted === true
       const now = Date.now()
-      if (now - lastHeartbeatAt < HEARTBEAT_MIN_INTERVAL_MS) return
+      if (!interacted && now - lastHeartbeatAt < HEARTBEAT_MIN_INTERVAL_MS) return
       lastHeartbeatAt = now
       const deviceKey = deriveDeviceKey(socket.handshake.headers["user-agent"])
       const focused = payload?.focused === true
@@ -374,7 +378,7 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         deviceKey,
       }))
       if (entries.length === 0) return
-      pushService.upsertSessionsBatch(entries, focused).catch((err) => {
+      pushService.upsertSessionsBatch(entries, { focused, interacted }).catch((err) => {
         logger.warn({ err }, "Failed to upsert sessions on heartbeat")
       })
     })

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -223,6 +223,27 @@ describe("Push Notifications", () => {
       expect(updated.lastFocusedAt!.getTime()).toBe(session.lastFocusedAt!.getTime())
     })
 
+    test("upsert with interacted=true sets lastInteractionAt; preserved across non-interacting upserts", async () => {
+      const session = await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-interaction-1",
+        interacted: true,
+      })
+
+      expect(session.lastInteractionAt).toBeInstanceOf(Date)
+
+      const updated = await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-interaction-1",
+        interacted: false,
+      })
+
+      expect(updated.lastInteractionAt).toBeInstanceOf(Date)
+      expect(updated.lastInteractionAt!.getTime()).toBe(session.lastInteractionAt!.getTime())
+    })
+
     test("upsert updates lastActiveAt on conflict", async () => {
       const first = await UserSessionRepository.upsert(pool, {
         workspaceId: testWorkspaceId,
@@ -602,7 +623,7 @@ describe("Push Notifications", () => {
       })
     })
 
-    test("active + recently focused session → only pushes to active device", async () => {
+    test("focused device with recent interaction → only pushes to that device", async () => {
       const service = createServiceWithLookups()
 
       // Two subscriptions on different devices, both with recent sessions
@@ -623,13 +644,15 @@ describe("Push Notifications", () => {
         deviceKey: "device-2",
       })
 
-      // Both devices have recent sessions (not expired), but only device-1 is actively focused
+      // device-2 has a recent session but isn't currently active (background PWA)
       await createRecentInactiveSession(testWorkspaceId, testUserId, "device-2")
+      // device-1 is the device the user is on: focused and just interacted
       await UserSessionRepository.upsert(pool, {
         workspaceId: testWorkspaceId,
         userId: testUserId,
         deviceKey: "device-1",
         focused: true,
+        interacted: true,
       })
 
       await service.deliverPushForActivity(makePayload())
@@ -641,10 +664,10 @@ describe("Push Notifications", () => {
       })
     })
 
-    test("active session on device without subscription → falls back to all active subscriptions", async () => {
+    test("focused but idle (no recent interaction) → fans out to all active devices", async () => {
       const service = createServiceWithLookups()
 
-      // Subscription on device-1, but active session only on device-2
+      // Two subscriptions on different devices
       await PushSubscriptionRepository.insert(pool, {
         workspaceId: testWorkspaceId,
         userId: testUserId,
@@ -653,28 +676,45 @@ describe("Push Notifications", () => {
         auth: "a1",
         deviceKey: "device-1",
       })
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/device-2",
+        p256dh: "p2",
+        auth: "a2",
+        deviceKey: "device-2",
+      })
 
-      // device-1 has a recent (but not active) session so it's not expired
-      await createRecentInactiveSession(testWorkspaceId, testUserId, "device-1")
-
-      // Active, recently focused session on device-2 (no subscription here)
+      // device-1 is focused but the user hasn't touched it recently
+      // (e.g. they walked away leaving Threa focused, or the PWA bug where
+      // hasFocus() reports true on a background window). Without an interaction
+      // signal we don't trust focus alone.
+      await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-1",
+        focused: true,
+      })
+      // device-2 is also live (heartbeat recent) but not focused
       await UserSessionRepository.upsert(pool, {
         workspaceId: testWorkspaceId,
         userId: testUserId,
         deviceKey: "device-2",
-        focused: true,
       })
 
       await service.deliverPushForActivity(makePayload())
 
-      // Intersection is empty (device-2 has active session, device-1 has sub) → falls back to all active
-      expect(sendSpy).toHaveBeenCalledTimes(1)
-      expect(sendSpy.mock.calls[0][0]).toMatchObject({
-        endpoint: "https://push.example.com/sub/device-1",
-      })
+      // No device proves the user is on it → push everywhere so they see it
+      // on whichever device they pick up next.
+      expect(sendSpy).toHaveBeenCalledTimes(2)
+      const calledEndpoints = sendSpy.mock.calls.map((c) => c[0].endpoint).sort()
+      expect(calledEndpoints).toEqual([
+        "https://push.example.com/sub/device-1",
+        "https://push.example.com/sub/device-2",
+      ])
     })
 
-    test("active session but not focused for 10m+ → pushes to all active devices", async () => {
+    test("interaction goes stale (>2m) → fans out to all active devices", async () => {
       const service = createServiceWithLookups()
 
       await PushSubscriptionRepository.insert(pool, {
@@ -694,29 +734,68 @@ describe("Push Notifications", () => {
         deviceKey: "device-2",
       })
 
-      // Both devices have recent sessions (not expired)
-      await createRecentInactiveSession(testWorkspaceId, testUserId, "device-2")
-
-      // device-1 has active session (heartbeat recent) but was focused 15m ago
+      // device-1 was focused and interacted with, but the interaction was 5m ago
+      // (user got up to use the toilet and left their laptop focused).
       const s1 = await UserSessionRepository.upsert(pool, {
         workspaceId: testWorkspaceId,
         userId: testUserId,
         deviceKey: "device-1",
         focused: true,
+        interacted: true,
       })
-      await pool.query(`UPDATE user_sessions SET last_focused_at = now() - interval '15 minutes' WHERE id = $1`, [
+      await pool.query(`UPDATE user_sessions SET last_interaction_at = now() - interval '5 minutes' WHERE id = $1`, [
         s1.id,
       ])
+      // device-2 is live (heartbeat fresh) but not focused
+      await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-2",
+      })
 
       await service.deliverPushForActivity(makePayload())
 
-      // User walked away → push to all devices
+      // Interaction stale → fanout so the user gets it on whichever device they pick up
       expect(sendSpy).toHaveBeenCalledTimes(2)
       const calledEndpoints = sendSpy.mock.calls.map((c) => c[0].endpoint).sort()
       expect(calledEndpoints).toEqual([
         "https://push.example.com/sub/device-1",
         "https://push.example.com/sub/device-2",
       ])
+    })
+
+    test("attended device has session but no push subscription → falls back to all active subscriptions", async () => {
+      const service = createServiceWithLookups()
+
+      // Subscription on device-1 only
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/device-1",
+        p256dh: "p1",
+        auth: "a1",
+        deviceKey: "device-1",
+      })
+
+      // device-1 has a recent (but not active) session so it's not expired
+      await createRecentInactiveSession(testWorkspaceId, testUserId, "device-1")
+
+      // The attended device (device-2) has no push subscription registered
+      await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-2",
+        focused: true,
+        interacted: true,
+      })
+
+      await service.deliverPushForActivity(makePayload())
+
+      // Intersection is empty → falls back to all active subs (only device-1)
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][0]).toMatchObject({
+        endpoint: "https://push.example.com/sub/device-1",
+      })
     })
 
     test("no active sessions but recent session exists → pushes to all devices (not session_expired)", async () => {

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -644,8 +644,13 @@ describe("Push Notifications", () => {
         deviceKey: "device-2",
       })
 
-      // device-2 has a recent session but isn't currently active (background PWA)
-      await createRecentInactiveSession(testWorkspaceId, testUserId, "device-2")
+      // device-2 is live (heartbeat fresh) but unattended — proves attended
+      // routing wins over a live-but-idle peer, not just over a stale session.
+      await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-2",
+      })
       // device-1 is the device the user is on: focused and just interacted
       await UserSessionRepository.upsert(pool, {
         workspaceId: testWorkspaceId,
@@ -777,8 +782,13 @@ describe("Push Notifications", () => {
         deviceKey: "device-1",
       })
 
-      // device-1 has a recent (but not active) session so it's not expired
-      await createRecentInactiveSession(testWorkspaceId, testUserId, "device-1")
+      // device-1 is live (heartbeat fresh) but unattended — confirms the
+      // fallback target is a real online device, not a stale-but-non-expired one.
+      await UserSessionRepository.upsert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        deviceKey: "device-1",
+      })
 
       // The attended device (device-2) has no push subscription registered
       await UserSessionRepository.upsert(pool, {

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useRef, type ReactNode 
 import { io, Socket } from "socket.io-client"
 import { api } from "@/api/client"
 import { usePageActivity } from "@/hooks/use-page-activity"
+import { usePageInteraction } from "@/hooks/use-page-interaction"
 
 /**
  * Socket connection status.
@@ -41,6 +42,7 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
   const [status, setStatus] = useState<SocketStatus>("connecting")
   const [reconnectCount, setReconnectCount] = useState(0)
   const pageActivity = usePageActivity()
+  const pageInteraction = usePageInteraction()
 
   // Track if we've ever been connected (to distinguish initial connect from reconnect)
   const hasEverConnectedRef = useRef(false)
@@ -139,9 +141,12 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
     }
   }, [workspaceId])
 
-  // Heartbeat for push notification session tracking.
-  // Sends { focused } so the backend can distinguish "user is here" from "tab is open but idle."
+  // Heartbeat for push notification session tracking. Sends { focused, interacted }
+  // so the backend can pick the device the user is actually on (focused window
+  // with a recent interaction) and avoid pushing to background PWAs.
+  const lastFocusChangeHeartbeatRef = useRef(0)
   const lastInteractionHeartbeatRef = useRef(0)
+  const lastHeartbeatInteractionAtRef = useRef(0)
   const previousPageActivityRef = useRef(pageActivity)
   const pageFocusedRef = useRef(pageActivity.isFocused)
   pageFocusedRef.current = pageActivity.isFocused
@@ -149,16 +154,33 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
   useEffect(() => {
     if (!socket || status !== "connected") return
 
-    const emitHeartbeat = () => socket.emit("heartbeat", { focused: pageFocusedRef.current })
+    const emitHeartbeat = () => {
+      const lastInteractionAt = pageInteraction.getLastInteractionAt()
+      const interacted = lastInteractionAt > lastHeartbeatInteractionAtRef.current
+      if (interacted) lastHeartbeatInteractionAtRef.current = lastInteractionAt
+      socket.emit("heartbeat", { focused: pageFocusedRef.current, interacted })
+    }
 
     // Emit immediately so the backend knows this tab is active right away
     emitHeartbeat()
     const heartbeatInterval = setInterval(emitHeartbeat, 30_000)
 
+    // Fire an immediate heartbeat on the first interaction after a quiet
+    // stretch so the backend learns about renewed activity within seconds,
+    // not up to 30s. The 15s throttle matches the server-side floor in
+    // socket.ts; interaction-flagged heartbeats bypass that throttle there.
+    const unsubscribe = pageInteraction.subscribe(() => {
+      const now = Date.now()
+      if (now - lastInteractionHeartbeatRef.current < 15_000) return
+      lastInteractionHeartbeatRef.current = now
+      emitHeartbeat()
+    })
+
     return () => {
       clearInterval(heartbeatInterval)
+      unsubscribe()
     }
-  }, [socket, status])
+  }, [socket, status, pageInteraction])
 
   useEffect(() => {
     const previousPageActivity = previousPageActivityRef.current
@@ -178,9 +200,9 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
     // heartbeat (focused=false) from blocking the closely-following gainedFocus
     // heartbeat (focused=true) via the 10s throttle window.
     const now = Date.now()
-    if (gainedFocus || now - lastInteractionHeartbeatRef.current > 10_000) {
-      lastInteractionHeartbeatRef.current = now
-      socket.emit("heartbeat", { focused: pageActivity.isFocused })
+    if (gainedFocus || now - lastFocusChangeHeartbeatRef.current > 10_000) {
+      lastFocusChangeHeartbeatRef.current = now
+      socket.emit("heartbeat", { focused: pageActivity.isFocused, interacted: false })
     }
   }, [socket, status, pageActivity])
 

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -1,8 +1,15 @@
 import { createContext, useContext, useEffect, useState, useRef, type ReactNode } from "react"
 import { io, Socket } from "socket.io-client"
+import { HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
 import { api } from "@/api/client"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
+
+/** Periodic heartbeat tick for session liveness — must be < ACTIVE_SESSION_WINDOW_MS on the backend (60s). */
+const PERIODIC_HEARTBEAT_INTERVAL_MS = 30_000
+
+/** Throttle for focus-change-driven heartbeats so a flicker of blur/focus events doesn't flood the socket. */
+const FOCUS_CHANGE_HEARTBEAT_THROTTLE_MS = 10_000
 
 /**
  * Socket connection status.
@@ -144,9 +151,9 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
   // Heartbeat for push notification session tracking. Sends { focused, interacted }
   // so the backend can pick the device the user is actually on (focused window
   // with a recent interaction) and avoid pushing to background PWAs.
-  const lastFocusChangeHeartbeatRef = useRef(0)
-  const lastInteractionHeartbeatRef = useRef(0)
-  const lastHeartbeatInteractionAtRef = useRef(0)
+  const focusChangeThrottleRef = useRef(0)
+  const interactionThrottleRef = useRef(0)
+  const lastSentInteractionAtRef = useRef(0)
   const previousPageActivityRef = useRef(pageActivity)
   const pageFocusedRef = useRef(pageActivity.isFocused)
   pageFocusedRef.current = pageActivity.isFocused
@@ -156,23 +163,22 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
 
     const emitHeartbeat = () => {
       const lastInteractionAt = pageInteraction.getLastInteractionAt()
-      const interacted = lastInteractionAt > lastHeartbeatInteractionAtRef.current
-      if (interacted) lastHeartbeatInteractionAtRef.current = lastInteractionAt
+      const interacted = lastInteractionAt > lastSentInteractionAtRef.current
+      if (interacted) lastSentInteractionAtRef.current = lastInteractionAt
       socket.emit("heartbeat", { focused: pageFocusedRef.current, interacted })
     }
 
     // Emit immediately so the backend knows this tab is active right away
     emitHeartbeat()
-    const heartbeatInterval = setInterval(emitHeartbeat, 30_000)
+    const heartbeatInterval = setInterval(emitHeartbeat, PERIODIC_HEARTBEAT_INTERVAL_MS)
 
     // Fire an immediate heartbeat on the first interaction after a quiet
     // stretch so the backend learns about renewed activity within seconds,
-    // not up to 30s. The 15s throttle matches the server-side floor in
-    // socket.ts; interaction-flagged heartbeats bypass that throttle there.
+    // not up to 30s.
     const unsubscribe = pageInteraction.subscribe(() => {
       const now = Date.now()
-      if (now - lastInteractionHeartbeatRef.current < 15_000) return
-      lastInteractionHeartbeatRef.current = now
+      if (now - interactionThrottleRef.current < HEARTBEAT_INTERACTION_THROTTLE_MS) return
+      interactionThrottleRef.current = now
       emitHeartbeat()
     })
 
@@ -196,12 +202,11 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
 
     if (!gainedFocus && !becameVisible) return
 
-    // Focus gains always emit — bypassing the throttle prevents a becameVisible
-    // heartbeat (focused=false) from blocking the closely-following gainedFocus
-    // heartbeat (focused=true) via the 10s throttle window.
+    // Focus gains bypass the throttle so a becameVisible heartbeat
+    // (focused=false) doesn't block the closely-following gainedFocus heartbeat.
     const now = Date.now()
-    if (gainedFocus || now - lastFocusChangeHeartbeatRef.current > 10_000) {
-      lastFocusChangeHeartbeatRef.current = now
+    if (gainedFocus || now - focusChangeThrottleRef.current > FOCUS_CHANGE_HEARTBEAT_THROTTLE_MS) {
+      focusChangeThrottleRef.current = now
       socket.emit("heartbeat", { focused: pageActivity.isFocused, interacted: false })
     }
   }, [socket, status, pageActivity])

--- a/apps/frontend/src/hooks/use-page-interaction.ts
+++ b/apps/frontend/src/hooks/use-page-interaction.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react"
+
+export interface PageInteractionTracker {
+  /** Timestamp of the most recent user interaction (ms since epoch), or 0. */
+  getLastInteractionAt: () => number
+  /** Subscribe to interaction events. Returns an unsubscribe function. */
+  subscribe: (cb: () => void) => () => void
+}
+
+/**
+ * Tracks pointer/key/touch interactions on the document. State is stored in
+ * refs so mouse movement doesn't re-render consumers — callers read the
+ * timestamp at heartbeat time and may subscribe to the event stream to drive
+ * their own throttled "user resumed activity" signal.
+ */
+export function usePageInteraction(): PageInteractionTracker {
+  const lastInteractionAtRef = useRef(0)
+  const listenersRef = useRef(new Set<() => void>())
+  const trackerRef = useRef<PageInteractionTracker>({
+    getLastInteractionAt: () => lastInteractionAtRef.current,
+    subscribe: (cb) => {
+      listenersRef.current.add(cb)
+      return () => {
+        listenersRef.current.delete(cb)
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const handle = () => {
+      lastInteractionAtRef.current = Date.now()
+      for (const cb of listenersRef.current) cb()
+    }
+
+    const opts: AddEventListenerOptions = { passive: true, capture: true }
+    window.addEventListener("pointerdown", handle, opts)
+    window.addEventListener("keydown", handle, opts)
+    window.addEventListener("touchstart", handle, opts)
+
+    return () => {
+      window.removeEventListener("pointerdown", handle, opts)
+      window.removeEventListener("keydown", handle, opts)
+      window.removeEventListener("touchstart", handle, opts)
+    }
+  }, [])
+
+  return trackerRef.current
+}

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -558,3 +558,11 @@ export const ShareErrorCodes = {
 
 // Inter-service authentication header (control-plane ↔ regional backend ↔ workspace-router)
 export const INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key"
+
+/**
+ * Floor for interaction-driven socket heartbeats. The frontend throttles
+ * interaction-flagged heartbeats to this interval; the backend ignores
+ * non-interaction heartbeats faster than this. Shared so the two sides
+ * cannot drift.
+ */
+export const HEARTBEAT_INTERACTION_THROTTLE_MS = 15_000

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -157,6 +157,8 @@ export {
   ShareErrorCodes,
   // Inter-service authentication
   INTERNAL_API_KEY_HEADER,
+  // Socket heartbeat
+  HEARTBEAT_INTERACTION_THROTTLE_MS,
 } from "./constants"
 
 // Domain entities (wire format)


### PR DESCRIPTION
## Problem

Push notifications were going spotty when Threa was open on more than one device. Concrete failure mode: laptop with Threa as a background PWA + phone in active use → the user would miss notifications on the phone (the device they were actually on) while the laptop quietly displayed them in a window the user couldn't see.

The previous routing logic only knew about **focus**. Each device's heartbeat reported `focused: true/false`, and the backend used a four-tier strategy that pushed to "every device with an active session" whenever any device had been focused in the last 10 minutes. The service worker then locally suppressed display on the focused device. Three things conspired:

1. A PWA running in the background of another desktop space stays socket-connected and keeps heartbeating, so it counted as an "active device".
2. Focus is too sticky — `last_focused_at` could be 9 minutes old and still claim the user was at the computer, so the laptop got pushed even when the user had walked away from it.
3. With both phone and laptop "active", the focused phone's SW suppressed the notification while the unfocused laptop displayed it. The user, looking at the phone, saw nothing.

## Solution

Replace focus-only routing with **focus + recent interaction**. A device is "attended" iff it has both a fresh focused heartbeat AND a real user interaction (`pointerdown` / `keydown` / `touchstart`) within the last 2 minutes. Push to attended devices only; if no device qualifies, fan out to every device with a live heartbeat.

This handles the cases the user cares about:

- **Active on phone, laptop PWA in background** → only the phone is attended → phone gets the push (laptop doesn't display a stale notification the user can't see).
- **User goes to the toilet (or anywhere)** → after 2m of no interaction, no device is attended → fanout, so the user sees the notification on whichever device they pick up next.
- **Multiple devices both being used** → all qualifying devices get the push (rare but supported).

### How it works

```
Frontend (per tab):
  usePageInteraction → captures pointerdown/keydown/touchstart on window
  socket-context heartbeat → emits { focused, interacted } every 30s,
                              plus an immediate emit on first interaction
                              after 15s of quiet (15s shared throttle)

Backend (per heartbeat):
  user_sessions row updated with last_active_at = now(),
  last_focused_at and last_interaction_at preserved-or-bumped via COALESCE

Backend (push routing, getTargetSubscriptions):
  attended = sessions where last_focused_at < 60s old
                          AND last_interaction_at < 2m old
  if attended is non-empty → push to those device(s) only
  else                    → push to every device with a live heartbeat
```

### Key design decisions

**1. Focus alone isn't enough; interaction is the signal that proves "the user is on this device".**

Rejected: relying purely on `document.hasFocus()`. A focused window can sit idle for hours (user walked off, PWA reporting `focused: true` from a background space). Adding an interaction window grounds the routing in observable user behavior, not just window state.

**2. Two-minute interaction window.**

Long enough to absorb normal think-time at the keyboard; short enough that "user got up and walked away" reliably falls through to fanout. The user explicitly asked for this behavior ("if I go to the toilet I want pushes on my phone").

**3. Interaction-driven heartbeats bypass the 15s server throttle.**

Without this, resumed activity could go up to 30s before the backend learns about it, which is too slow for routing the next notification. The frontend self-throttles to 15s so the bypass can't be abused by a correctly-functioning client; non-interaction heartbeats still hit the server-side floor.

**4. SW suppression behavior is unchanged.**

The service worker still suppresses display when it finds a focused window of the same origin. Combined with the new routing, the focused-attended device gets the push but suppresses (the user can already see Threa); other devices stay quiet. This is correct because the user is actively using the focused device — they'd be doubly notified otherwise.

**5. Schema change is additive only.**

A new nullable `last_interaction_at` column on `user_sessions`, populated via the same `COALESCE` pattern as `last_focused_at`. No data backfill needed; sessions without an interaction signal naturally fall through to fanout, which is the safe default.

**6. Shared throttle constant in `@threa/types`.**

The 15s floor governs both client emission cadence and server acceptance — drift between the two would either lose interaction signals (server too strict) or let a buggy client hammer the DB (server too loose). Putting it in the shared types package makes the contract explicit.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260503213727_user_sessions_last_interaction_at.sql` | Adds nullable `last_interaction_at TIMESTAMPTZ` to `user_sessions` |
| `apps/frontend/src/hooks/use-page-interaction.ts` | Tracks `pointerdown` / `keydown` / `touchstart` on `window` with a subscribe API; ref-based to avoid re-renders on mouse movement |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/push/service.ts` | Replaces 4-tier routing with focus+interaction "attended device" rule; adds `CURRENTLY_FOCUSED_WINDOW_MS` (60s) and `RECENT_INTERACTION_WINDOW_MS` (2m) constants |
| `apps/backend/src/features/push/session-repository.ts` | `upsert` / `upsertBatch` accept `interacted` and persist `last_interaction_at` with the same COALESCE-preserve semantics as `last_focused_at` |
| `apps/backend/src/socket.ts` | Heartbeat handler accepts `{focused, interacted}`; interaction-flagged heartbeats bypass the 15s server-side throttle |
| `apps/frontend/src/contexts/socket-context.tsx` | Heartbeat sends `{focused, interacted}`; emits an immediate heartbeat on first interaction after 15s of quiet; named timing constants |
| `apps/backend/tests/integration/push.test.ts` | New routing tests: focused + interacted → exclusive; focused + idle → fanout; interaction stale (>2m, the toilet case) → fanout; attended without sub → fallback fanout. Plus `last_interaction_at` upsert parity test |
| `packages/types/src/constants.ts` + `index.ts` | Exports `HEARTBEAT_INTERACTION_THROTTLE_MS` (15s) shared between backend and frontend |

## Test plan

- [x] `bun run typecheck` clean across all 9 workspaces
- [x] `bun run --cwd apps/frontend test` — 1528 tests pass
- [x] New backend integration tests added for the routing rule (run on CI; local sandbox has no Postgres)
- [x] Lint, prettier, OpenAPI docs check (via pre-commit hooks)
- [ ] **Manual:** open Threa on laptop (PWA, leave focused but don't interact for 2m+) and on phone; send a message from another account → confirm phone receives the notification, laptop does not
- [ ] **Manual:** repeat the above but actively interact on the laptop within the 2m window → confirm laptop is the only device that sees the push (and SW suppresses display since it's focused)
- [ ] **Manual:** with both devices online but user idle on both (no interactions in last 2m) → confirm fanout to both
- [ ] **Manual:** verify the migration applies cleanly in staging and that existing sessions without `last_interaction_at` route via the fanout fallback rather than disappearing

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012P9kdPN6s291uH7Mcq8sXu)_