### PR TITLE
fix(frontend): prevent lost thread indicator updates during concurrent socket events

### DIFF
--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db } from "@/db"
-import { applyStreamBootstrap, getLatestPersistedSequence, toCachedStreamBootstrap } from "./stream-sync"
+import {
+  applyStreamBootstrap,
+  getLatestPersistedSequence,
+  toCachedStreamBootstrap,
+  updateMessageEvent,
+} from "./stream-sync"
 import type { StreamBootstrap, StreamEvent } from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
@@ -274,6 +279,65 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     ])
 
     expect(await getLatestPersistedSequence(streamId)).toBe("200")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateMessageEvent — atomic payload updates
+// ---------------------------------------------------------------------------
+
+describe("updateMessageEvent", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("updates a message payload in place", async () => {
+    const streamId = "stream_update"
+    const messageId = "msg_1"
+    await db.events.put({
+      ...makeEvent({ id: "evt_1", streamId, sequence: "100", payload: { messageId, contentMarkdown: "hello" } }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+    })
+
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
+
+    const event = await db.events.get("evt_1")
+    expect((event?.payload as Record<string, unknown>).replyCount).toBe(5)
+  })
+
+  it("does not lose fields when multiple concurrent updates target the same message", async () => {
+    const streamId = "stream_race_update"
+    const messageId = "msg_race"
+    await db.events.put({
+      ...makeEvent({ id: "evt_race", streamId, sequence: "100", payload: { messageId, contentMarkdown: "hello" } }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+    })
+
+    // Simulate the race that happens when messages:moved, stream:created and
+    // message:updated socket handlers all update the same parent message
+    // concurrently. With the old read-then-update implementation the last
+    // write would overwrite earlier ones and lose fields.
+    await Promise.all([
+      updateMessageEvent(streamId, messageId, (p) => ({
+        ...p,
+        replyCount: 3,
+        threadSummary: { lastReplyContentMarkdown: "hi", participantIds: ["u1"] },
+      })),
+      updateMessageEvent(streamId, messageId, (p) => ({
+        ...p,
+        threadId: "thread_123",
+      })),
+    ])
+
+    const event = await db.events.get("evt_race")
+    const payload = event?.payload as Record<string, unknown>
+    expect(payload.threadId).toBe("thread_123")
+    expect(payload.replyCount).toBe(3)
+    expect(payload.threadSummary).toEqual({ lastReplyContentMarkdown: "hi", participantIds: ["u1"] })
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -313,23 +313,26 @@ interface LinkPreviewReadyPayload {
 // Helper: find and update a message_created event in IndexedDB
 // ============================================================================
 
-async function updateMessageEvent(
+export async function updateMessageEvent(
   streamId: string,
   messageId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
 ): Promise<void> {
   // Use compound index to narrow to message_created events for this stream,
   // then filter by messageId in the payload (not indexed but over a small set).
-  const events = await db.events
+  // modify() runs the callback inside a readwrite cursor so the read and write
+  // are atomic. This prevents lost updates when multiple socket handlers
+  // (messages:moved, stream:created, message:updated) update the same parent
+  // message concurrently — the second transaction sees the first's writes.
+  await db.events
     .where("[streamId+eventType]")
     .equals([streamId, "message_created"])
     .filter((e) => (e.payload as { messageId?: string })?.messageId === messageId)
-    .toArray()
-
-  if (events.length === 0) return
-  const event = events[0]
-  const updatedPayload = updater(event.payload as Record<string, unknown>)
-  await db.events.update(event.id, { payload: updatedPayload, _cachedAt: Date.now() })
+    .modify((event) => {
+      const updatedPayload = updater(event.payload as Record<string, unknown>)
+      event.payload = updatedPayload
+      event._cachedAt = Date.now()
+    })
 }
 
 /**


### PR DESCRIPTION
## Problem

When moving messages onto a message to create a new thread, the thread indicator (ThreadCard with reply count, participant preview, and last message preview) does not appear until the page is refreshed.

### Root cause

The backend emits three outbox events in quick succession when a thread is created by moving messages:

1. `message:updated`
2. `stream:created` (only when the thread is newly created)
3. `messages:moved`

All three frontend socket handlers call `updateMessageEvent` to patch the same parent `message_created` event in IndexedDB. The old implementation used a **non-atomic read-then-write** pattern:

```
1. Read payload from IDB  (implicit readonly transaction)
2. Compute new payload     (JS)
3. Write payload back      (implicit readwrite transaction)
```

Because Socket.io dispatches async handlers concurrently, the reads can all happen before any write commits:

- `messages:moved` reads stale payload → computes `{ threadId, replyCount: 3, threadSummary }`
- `stream:created` reads stale payload → computes `{ threadId }` (no replyCount or threadSummary!)
- `messages:moved` writes first
- `stream:created` writes second → **clobbers replyCount and threadSummary**

The `ThreadSlot` component requires both `replyCount > 0` and `threadId` to render, so the indicator disappears. A page refresh fetches a fresh bootstrap with the correct enriched payload, restoring the indicator.

**Why existing threads work:** `stream:created` is not emitted for existing threads, so only `message:updated` and `messages:moved` race — and both set `replyCount`/`threadSummary`. Even if they overwrite each other, the final state has those fields.

## Solution

Switch `updateMessageEvent` to use Dexie\'s `Collection.modify()`, which runs the read-compute-write cycle inside a single readwrite cursor transaction. IndexedDB serializes readwrite transactions on the same object store, so overlapping handlers see each other\'s writes and no field is lost.

### Key design decisions

**1. Why `modify()` instead of explicit `db.transaction('rw', ...)`?**

`modify()` is the idiomatic Dexie primitive for atomic conditional updates. It maps directly to an IndexedDB readwrite cursor and avoids the extra boilerplate of manual transaction management. The callback receives the live object reference, so mutations are persisted atomically.

**2. Why not merge payloads during bootstrap instead?**

An earlier theory was that a stale in-flight bootstrap HTTP response was overwriting socket-enriched events. However, `useStreamBootstrap` uses `staleTime: Infinity` with all refetch flags disabled, so no bootstrap is in-flight while the user is already viewing the channel. The race is purely between concurrent socket handlers.

**3. Why export `updateMessageEvent`?**

Exported to enable direct unit testing of the atomic behavior. The regression test fires two concurrent updates via `Promise.all()` and asserts all fields survive — this would fail with the old read-then-write implementation.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/sync/stream-sync.ts` | `updateMessageEvent` now uses Dexie `modify()` for atomic read-compute-write; exported for testing |
| `apps/frontend/src/sync/stream-sync.test.ts` | Added regression test covering concurrent socket handler updates |

## Test plan

- [x] Regression test: concurrent updates preserve all fields
- [x] Existing `applyStreamBootstrap` tests pass
- [x] Frontend typecheck passes
- [x] Frontend lint passes
- [x] Full monorepo typecheck passes

---

🤖 _PR by [OpenCode](https://opencode.ai)_
