### PR TITLE
feat: comprehensive stream settings for all stream types

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -181,7 +181,7 @@ describe("StreamItem", () => {
     expect(preview).not.toHaveClass("group-hover:flex")
   })
 
-  it("opens a preview-only drawer for DMs on mobile", async () => {
+  it("opens the action drawer for DMs on mobile", async () => {
     const stream = createStream({
       id: "stream_dm_1",
       type: StreamTypes.DM,
@@ -213,8 +213,10 @@ describe("StreamItem", () => {
 
     expect(screen.getAllByText("Taylor")).toHaveLength(2)
     expect(screen.getByText("Latest update from the stream")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Stream actions" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+    expect(openStreamSettings).toHaveBeenCalledWith("stream_dm_1")
   })
 
   it("shows a no-messages fallback preview for DMs without a last message", async () => {
@@ -250,10 +252,10 @@ describe("StreamItem", () => {
 
     expect(screen.getByText("No messages yet")).toBeInTheDocument()
     expect(screen.queryByText("Ariadne")).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument()
   })
 
-  it("does not render a desktop context-menu trigger for DMs", () => {
+  it("renders a desktop context-menu trigger for DMs", () => {
     mobileState.isMobileValue = false
 
     const stream = createStream({
@@ -275,6 +277,6 @@ describe("StreamItem", () => {
       />
     )
 
-    expect(screen.queryByRole("button", { name: "Stream actions" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Stream actions" })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -221,7 +221,7 @@ export function StreamItem({
 
   const actions = useMemo<SidebarActionItem[]>(
     () =>
-      isVirtualDraft || stream.type === StreamTypes.DM
+      isVirtualDraft
         ? []
         : [
             {
@@ -231,7 +231,7 @@ export function StreamItem({
               onSelect: () => openStreamSettings(stream.id),
             },
           ],
-    [isVirtualDraft, openStreamSettings, stream.id, stream.type]
+    [isVirtualDraft, openStreamSettings, stream.id]
   )
 
   let drawerPreview: SidebarActionPreview | null = null

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -25,6 +25,7 @@ import {
   type Stream,
   type StreamType,
   type NotificationLevel,
+  type Visibility,
 } from "@threa/types"
 import { toast } from "sonner"
 
@@ -33,43 +34,114 @@ interface GeneralTabProps {
   stream: Stream
   currentUserId: string
   notificationLevel: NotificationLevel | null
+  dmDisplayName?: string | null
+  rootStream?: Stream | null
 }
 
-export function GeneralTab({ workspaceId, stream, currentUserId, notificationLevel }: GeneralTabProps) {
+export function GeneralTab({
+  workspaceId,
+  stream,
+  currentUserId,
+  notificationLevel,
+  dmDisplayName,
+  rootStream,
+}: GeneralTabProps) {
   const isChannel = stream.type === StreamTypes.CHANNEL
   const isScratchpad = stream.type === StreamTypes.SCRATCHPAD
+  const isDm = stream.type === StreamTypes.DM
+  const isThread = stream.type === StreamTypes.THREAD
+  const isSystem = stream.type === StreamTypes.SYSTEM
 
-  return (
-    <div className="space-y-6 p-1">
-      <NotificationSection
-        workspaceId={workspaceId}
-        streamId={stream.id}
-        streamType={stream.type}
-        notificationLevel={notificationLevel}
-      />
+  // Build sections dynamically so we never render orphan or stacked dividers
+  const sections: React.ReactNode[] = []
 
-      <Separator />
-
-      {isChannel && <VisibilitySection workspaceId={workspaceId} stream={stream} />}
-      {isScratchpad && <VisibilityDisplay />}
-
-      <Separator />
-
-      {isChannel && <SlugSection workspaceId={workspaceId} stream={stream} />}
-      {isScratchpad && <DisplayNameSection workspaceId={workspaceId} stream={stream} />}
-
-      {isChannel && (
-        <>
-          <Separator />
-          <DescriptionSection workspaceId={workspaceId} stream={stream} />
-        </>
-      )}
-
-      <Separator />
-      <ArchiveSection workspaceId={workspaceId} stream={stream} currentUserId={currentUserId} />
-    </div>
+  // 1. Notifications — all stream types
+  sections.push(
+    <NotificationSection
+      key="notifications"
+      workspaceId={workspaceId}
+      streamId={stream.id}
+      streamType={stream.type}
+      notificationLevel={notificationLevel}
+    />
   )
+
+  // 2. Visibility
+  if (isChannel) {
+    sections.push(<VisibilitySection key="visibility" workspaceId={workspaceId} stream={stream} />)
+  } else if (isScratchpad) {
+    sections.push(<VisibilityDisplay key="visibility" label="Visibility" hint="Scratchpads are always private" />)
+  } else if (isDm) {
+    sections.push(<VisibilityDisplay key="visibility" label="Visibility" hint="DMs are always private" />)
+  } else if (isThread && rootStream) {
+    sections.push(
+      <ThreadVisibilityDisplay
+        key="visibility"
+        inheritedVisibility={rootStream.visibility}
+        rootStreamName={rootStream.slug ? `#${rootStream.slug}` : (rootStream.displayName ?? "parent stream")}
+      />
+    )
+  } else if (isSystem) {
+    sections.push(<VisibilityDisplay key="visibility" label="Visibility" hint="System messages are always private" />)
+  }
+
+  // 3. Name / Slug / Display name
+  if (isChannel) {
+    sections.push(<SlugSection key="name" workspaceId={workspaceId} stream={stream} />)
+  } else if (isScratchpad) {
+    sections.push(<DisplayNameSection key="name" workspaceId={workspaceId} stream={stream} />)
+  } else if (isDm) {
+    sections.push(
+      <DmDisplayNameSection key="name" displayName={dmDisplayName ?? stream.displayName ?? "Direct message"} />
+    )
+  } else if (isThread) {
+    sections.push(<ThreadDisplayNameSection key="name" displayName={stream.displayName ?? "Thread"} />)
+  }
+
+  // 4. Description
+  if (isChannel || isDm) {
+    sections.push(<DescriptionSection key="description" workspaceId={workspaceId} stream={stream} />)
+  }
+
+  // 5. System disclaimer
+  if (isSystem) {
+    sections.push(<SystemDisclaimerSection key="disclaimer" />)
+  }
+
+  // 6. Archive (danger zone)
+  if (isChannel || isScratchpad || isThread) {
+    let archiveLabel: string
+    if (isChannel) {
+      archiveLabel = "channel"
+    } else if (isScratchpad) {
+      archiveLabel = "scratchpad"
+    } else {
+      archiveLabel = "thread"
+    }
+    sections.push(
+      <ArchiveSection
+        key="archive"
+        workspaceId={workspaceId}
+        stream={stream}
+        currentUserId={currentUserId}
+        streamTypeLabel={archiveLabel}
+      />
+    )
+  }
+
+  // Render with separators between consecutive sections only
+  const nodes: React.ReactNode[] = []
+  for (let i = 0; i < sections.length; i++) {
+    if (i > 0) {
+      nodes.push(<Separator key={`sep-${i}`} />)
+    }
+    nodes.push(sections[i])
+  }
+
+  return <div className="space-y-6 p-1">{nodes}</div>
 }
+
+// ─── Notification Section ───────────────────────────────────────────────────
 
 const NOTIFICATION_OPTION_META: Record<string, { label: string; description: string }> = {
   default: { label: "Default", description: "Use workspace notification settings" },
@@ -134,6 +206,8 @@ function NotificationSection({
   )
 }
 
+// ─── Visibility Sections ────────────────────────────────────────────────────
+
 function VisibilitySection({ workspaceId, stream }: { workspaceId: string; stream: Stream }) {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [pendingVisibility, setPendingVisibility] = useState<"public" | "private" | null>(null)
@@ -188,15 +262,33 @@ function VisibilitySection({ workspaceId, stream }: { workspaceId: string; strea
   )
 }
 
-function VisibilityDisplay() {
+function VisibilityDisplay({ label, hint }: { label: string; hint: string }) {
   return (
     <div className="space-y-3">
-      <Label className="text-sm font-medium">Visibility</Label>
+      <Label className="text-sm font-medium">{label}</Label>
       <VisibilityPicker value="private" onChange={() => {}} disabled />
-      <p className="text-xs text-muted-foreground">Scratchpads are always private</p>
+      <p className="text-xs text-muted-foreground">{hint}</p>
     </div>
   )
 }
+
+function ThreadVisibilityDisplay({
+  inheritedVisibility,
+  rootStreamName,
+}: {
+  inheritedVisibility: Visibility
+  rootStreamName: string
+}) {
+  return (
+    <div className="space-y-3">
+      <Label className="text-sm font-medium">Visibility</Label>
+      <VisibilityPicker value={inheritedVisibility} onChange={() => {}} disabled />
+      <p className="text-xs text-muted-foreground">Threads inherit visibility from {rootStreamName}</p>
+    </div>
+  )
+}
+
+// ─── Name / Slug / Display Name Sections ────────────────────────────────────
 
 function SlugSection({ workspaceId, stream }: { workspaceId: string; stream: Stream }) {
   const [slug, setSlug] = useState(stream.slug ?? "")
@@ -264,6 +356,27 @@ function DisplayNameSection({ workspaceId, stream }: { workspaceId: string; stre
   )
 }
 
+function DmDisplayNameSection({ displayName }: { displayName: string }) {
+  return (
+    <div className="space-y-3">
+      <Label className="text-sm font-medium">Virtual stream name</Label>
+      <Input value={displayName} disabled readOnly className="bg-muted/50" />
+      <p className="text-xs text-muted-foreground">This name is for display only and cannot be edited.</p>
+    </div>
+  )
+}
+
+function ThreadDisplayNameSection({ displayName }: { displayName: string }) {
+  return (
+    <div className="space-y-3">
+      <Label className="text-sm font-medium">Display name</Label>
+      <Input value={displayName} disabled readOnly className="bg-muted/50" />
+    </div>
+  )
+}
+
+// ─── Description Section ────────────────────────────────────────────────────
+
 function DescriptionSection({ workspaceId, stream }: { workspaceId: string; stream: Stream }) {
   const [description, setDescription] = useState(stream.description ?? "")
   const updateMutation = useUpdateStream(workspaceId, stream.id)
@@ -286,7 +399,7 @@ function DescriptionSection({ workspaceId, stream }: { workspaceId: string; stre
       <Textarea
         value={description}
         onChange={(e) => setDescription(e.target.value)}
-        placeholder="What is this channel about?"
+        placeholder={stream.type === StreamTypes.CHANNEL ? "What is this channel about?" : "Add a description…"}
         maxLength={500}
         rows={3}
       />
@@ -302,14 +415,32 @@ function DescriptionSection({ workspaceId, stream }: { workspaceId: string; stre
   )
 }
 
+// ─── System Disclaimer Section ──────────────────────────────────────────────
+
+function SystemDisclaimerSection() {
+  return (
+    <div className="space-y-3">
+      <Label className="text-sm font-medium">About</Label>
+      <p className="text-sm text-muted-foreground">
+        This stream contains automated system messages. It is read-only and cannot be configured beyond notification
+        preferences.
+      </p>
+    </div>
+  )
+}
+
+// ─── Archive Section ────────────────────────────────────────────────────────
+
 function ArchiveSection({
   workspaceId,
   stream,
   currentUserId,
+  streamTypeLabel,
 }: {
   workspaceId: string
   stream: Stream
   currentUserId: string
+  streamTypeLabel: string
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const archiveMutation = useArchiveStream(workspaceId)
@@ -322,19 +453,19 @@ function ArchiveSection({
   const handleAction = () => {
     if (isArchived) {
       unarchiveMutation.mutate(stream.id, {
-        onSuccess: () => toast.success("Stream unarchived"),
+        onSuccess: () => toast.success(`${capitalize(streamTypeLabel)} unarchived`),
         onError: () => toast.error("Failed to unarchive"),
       })
     } else {
       archiveMutation.mutate(stream.id, {
-        onSuccess: () => toast.success("Stream archived"),
+        onSuccess: () => toast.success(`${capitalize(streamTypeLabel)} archived`),
         onError: () => toast.error("Failed to archive"),
       })
     }
     setConfirmOpen(false)
   }
 
-  const streamName = stream.slug ? `#${stream.slug}` : (stream.displayName ?? "this stream")
+  const streamName = stream.slug ? `#${stream.slug}` : (stream.displayName ?? `this ${streamTypeLabel}`)
 
   return (
     <div className="space-y-3">
@@ -342,11 +473,13 @@ function ArchiveSection({
       <div className="rounded-lg border border-destructive/20 p-4">
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-sm font-medium">{isArchived ? "Unarchive" : "Archive"} stream</p>
+            <p className="text-sm font-medium">
+              {isArchived ? "Unarchive" : "Archive"} {streamTypeLabel}
+            </p>
             <p className="text-xs text-muted-foreground mt-1">
               {isArchived
-                ? "Restore this stream to the sidebar for all members."
-                : "Hide this stream from the sidebar. You can unarchive it later."}
+                ? `Restore this ${streamTypeLabel} to the sidebar for all members.`
+                : `Hide this ${streamTypeLabel} from the sidebar. You can unarchive it later.`}
             </p>
           </div>
           <Button
@@ -382,4 +515,8 @@ function ArchiveSection({
       </ResponsiveAlertDialog>
     </div>
   )
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
 }

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -81,6 +81,14 @@ export function GeneralTab({
         rootStreamName={rootStream.slug ? `#${rootStream.slug}` : (rootStream.displayName ?? "parent stream")}
       />
     )
+  } else if (isThread) {
+    sections.push(
+      <VisibilityDisplay
+        key="visibility"
+        label="Visibility"
+        hint="Threads inherit visibility from their parent stream"
+      />
+    )
   } else if (isSystem) {
     sections.push(<VisibilityDisplay key="visibility" label="Visibility" hint="System messages are always private" />)
   }

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -52,10 +52,15 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   const workspaceUsers = useWorkspaceUsers(workspaceId)
 
   const streamType = bootstrap?.stream?.type
-  const canAddMembers = streamType === StreamTypes.CHANNEL || streamType === StreamTypes.THREAD
+  const canAddUserMembers = streamType === StreamTypes.CHANNEL
   const streamMembers = bootstrap?.members ?? []
   const currentWorkspaceUser = workspaceUsers.find((u) => u.id === currentUserId)
   const canManageMembers = currentWorkspaceUser?.role === "owner" || currentWorkspaceUser?.role === "admin"
+
+  // Bots can be managed on all stream types that have a members tab.
+  // Threads inherit bot access from their root, so the UI is read-only.
+  const canManageBots = canManageMembers && streamType !== undefined
+  const botsReadOnly = streamType === StreamTypes.THREAD
 
   const streamMemberIds = useMemo(() => new Set(streamMembers.map((m) => m.memberId)), [streamMembers])
 
@@ -174,7 +179,7 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
         </div>
       </div>
 
-      {canAddMembers && (
+      {canAddUserMembers && (
         <div className="space-y-3">
           <Label className="text-sm font-medium">Add member</Label>
           <SearchableList
@@ -190,10 +195,10 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
         </div>
       )}
 
-      {canManageMembers && streamType === StreamTypes.CHANNEL && (
+      {canManageBots && (
         <>
           <Separator />
-          <StreamBotsSection workspaceId={workspaceId} streamId={streamId} />
+          <StreamBotsSection workspaceId={workspaceId} streamId={streamId} readOnly={botsReadOnly} />
         </>
       )}
 
@@ -217,7 +222,15 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
 
 // ─── Stream Bots Section ────────────────────────────────────────────────────
 
-function StreamBotsSection({ workspaceId, streamId }: { workspaceId: string; streamId: string }) {
+function StreamBotsSection({
+  workspaceId,
+  streamId,
+  readOnly,
+}: {
+  workspaceId: string
+  streamId: string
+  readOnly?: boolean
+}) {
   const queryClient = useQueryClient()
   const [botSearch, setBotSearch] = useState("")
   const allBots = useWorkspaceBots(workspaceId)
@@ -276,29 +289,31 @@ function StreamBotsSection({ workspaceId, streamId }: { workspaceId: string; str
                   {bot.slug && <span className="text-xs text-muted-foreground">@{bot.slug}</span>}
                 </div>
               </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0"
-                onClick={() => revokeMutation.mutate(bot.id)}
-                disabled={revokeMutation.isPending}
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
+              {!readOnly && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0"
+                  onClick={() => revokeMutation.mutate(bot.id)}
+                  disabled={revokeMutation.isPending}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              )}
             </div>
           ))}
         </div>
       )}
 
       {botsWithAccess.length === 0 && allBots.length > 0 && (
-        <p className="text-xs text-muted-foreground">No bots have been added to this channel.</p>
+        <p className="text-xs text-muted-foreground">No bots have been added to this stream.</p>
       )}
 
       {allBots.length === 0 && (
         <p className="text-xs text-muted-foreground">No bots in this workspace. Create one in workspace settings.</p>
       )}
 
-      {allBots.length > 0 && (
+      {!readOnly && allBots.length > 0 && (
         <div className="space-y-1.5">
           <Input
             placeholder="Search bots to add..."

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -117,11 +117,11 @@ describe("StreamSettingsDialog", () => {
     )
 
     expect(await screen.findByText("Direct chat Settings")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /General/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Companion/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Members/i })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /General/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /Companion/i })).not.toBeInTheDocument()
-    expect(screen.getByText("People and bot access")).toBeInTheDocument()
-    expect(screen.getByText("Members panel")).toBeVisible()
+    expect(screen.getByText("Notifications and stream details")).toBeInTheDocument()
+    expect(screen.getByText("General panel")).toBeVisible()
 
     const tabs = document.body.querySelector('[data-slot="settings-tabs"]')
     const panels = document.body.querySelector('[data-slot="settings-panels"]')

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -14,8 +14,14 @@ import { GeneralTab } from "./general-tab"
 import { CompanionTab } from "./companion-tab"
 import { MembersTab } from "./members-tab"
 import { streamKeys } from "@/hooks"
-import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
+import {
+  useWorkspaceStreams,
+  useWorkspaceStreamMemberships,
+  useWorkspaceUsers,
+  useWorkspaceDmPeers,
+} from "@/stores/workspace-store"
 import { StreamTypes, type Stream, type StreamBootstrap, type NotificationLevel } from "@threa/types"
+import { resolveDmDisplayName } from "@/lib/streams"
 
 const TAB_CONFIG: Record<StreamSettingsTab, { label: string; description: string }> = {
   general: { label: "General", description: "Notifications and stream details" },
@@ -55,16 +61,29 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
   const currentUserId = currentMembership?.memberId ?? null
   const currentNotificationLevel: NotificationLevel | null = currentMembership?.notificationLevel ?? null
 
+  const workspaceUsers = useWorkspaceUsers(workspaceId)
+  const dmPeers = useWorkspaceDmPeers(workspaceId)
+
+  const dmDisplayName = useMemo(() => {
+    if (!resolvedStream || resolvedStream.type !== StreamTypes.DM || !streamId) return null
+    return resolveDmDisplayName(streamId, workspaceUsers, dmPeers) ?? resolvedStream.displayName ?? null
+  }, [resolvedStream, streamId, workspaceUsers, dmPeers])
+
+  const rootStream = useMemo(() => {
+    if (!resolvedStream || resolvedStream.type !== StreamTypes.THREAD || !resolvedStream.rootStreamId) return null
+    return idbStreams.find((s) => s.id === resolvedStream.rootStreamId) ?? null
+  }, [resolvedStream, idbStreams])
+
   // Determine available tabs based on stream type
   const availableTabs: readonly StreamSettingsTab[] = useMemo(() => {
     if (!resolvedStream) return STREAM_SETTINGS_TABS
     switch (resolvedStream.type) {
       case StreamTypes.CHANNEL:
-        return ["general", "companion", "members"]
       case StreamTypes.SCRATCHPAD:
-        return ["general", "companion", "members"]
       case StreamTypes.DM:
-        return ["members"]
+      case StreamTypes.THREAD:
+        return ["general", "companion", "members"]
+      case StreamTypes.SYSTEM:
       default:
         return ["general"]
     }
@@ -114,6 +133,8 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
                     stream={resolvedStream}
                     currentUserId={currentUserId}
                     notificationLevel={currentNotificationLevel}
+                    dmDisplayName={dmDisplayName}
+                    rootStream={rootStream}
                   />
                 </TabsContent>
                 <TabsContent value="companion" className="mt-0">

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -196,24 +196,21 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     dispatchStartBatchSelect(panelId)
   }, [panelId])
 
-  const isDm = stream?.type === StreamTypes.DM
   const panelMenuActions: SidebarActionItem[] = []
-  if (!isDm) {
-    panelMenuActions.push({
-      id: "stream-settings",
-      label: "Settings",
-      icon: Settings,
-      onSelect: () => {
-        if (panelId) openStreamSettings(panelId)
-      },
-    })
-  }
+  panelMenuActions.push({
+    id: "stream-settings",
+    label: "Settings",
+    icon: Settings,
+    onSelect: () => {
+      if (panelId) openStreamSettings(panelId)
+    },
+  })
   panelMenuActions.push({
     id: "move-messages",
     label: "Move messages…",
     icon: CornerDownRight,
     onSelect: handleSelectMessages,
-    separatorBefore: !isDm,
+    separatorBefore: true,
   })
   const setDraftPortalTarget = useCallback((el: HTMLElement | null) => {
     draftPortalTargetRef.current = el
@@ -436,17 +433,15 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-40">
-                {!isDm && (
-                  <DropdownMenuItem
-                    onClick={() => {
-                      if (panelId) openStreamSettings(panelId)
-                    }}
-                  >
-                    <Settings className="mr-2 h-4 w-4" />
-                    Settings
-                  </DropdownMenuItem>
-                )}
-                {!isDm && <DropdownMenuSeparator />}
+                <DropdownMenuItem
+                  onClick={() => {
+                    if (panelId) openStreamSettings(panelId)
+                  }}
+                >
+                  <Settings className="mr-2 h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleSelectMessages} disabled={!!stream.archivedAt}>
                   <CornerDownRight className="mr-2 h-4 w-4" />
                   Move messages…

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -174,21 +174,19 @@ export function StreamPage() {
   // end since the move endpoints reject the source stream.
   const isSystem = stream?.type === StreamTypes.SYSTEM
   const streamMenuActions: SidebarActionItem[] = []
-  if (!isDm) {
-    streamMenuActions.push({
-      id: "stream-settings",
-      label: "Settings",
-      icon: Settings,
-      onSelect: () => openStreamSettings(streamId),
-    })
-  }
+  streamMenuActions.push({
+    id: "stream-settings",
+    label: "Settings",
+    icon: Settings,
+    onSelect: () => openStreamSettings(streamId),
+  })
   if (!isArchived && !isSystem) {
     streamMenuActions.push({
       id: "move-messages",
       label: "Move messages…",
       icon: CornerDownRight,
       onSelect: handleSelectMessages,
-      separatorBefore: !isDm,
+      separatorBefore: true,
     })
   }
   if (isScratchpad) {
@@ -347,12 +345,10 @@ export function StreamPage() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-40">
-                  {!isDm && (
-                    <DropdownMenuItem onClick={() => openStreamSettings(streamId)}>
-                      <Settings className="mr-2 h-4 w-4" />
-                      Settings
-                    </DropdownMenuItem>
-                  )}
+                  <DropdownMenuItem onClick={() => openStreamSettings(streamId)}>
+                    <Settings className="mr-2 h-4 w-4" />
+                    Settings
+                  </DropdownMenuItem>
                   {/* Hide "Move messages…" entirely on archived/system streams
                     to match the mobile drawer (which builds via
                     `streamMenuActions` and skips the entry in both cases).
@@ -361,7 +357,7 @@ export function StreamPage() {
                     can never be a valid source. */}
                   {!isArchived && !isSystem && (
                     <>
-                      {!isDm && <DropdownMenuSeparator />}
+                      <DropdownMenuSeparator />
                       <DropdownMenuItem onClick={handleSelectMessages}>
                         <CornerDownRight className="mr-2 h-4 w-4" />
                         Move messages…


### PR DESCRIPTION
## Problem

Stream settings were underdeveloped and inconsistent across stream types:

- **DMs** had no settings access at all — neither in the sidebar context menu nor in the top-right stream menu.
- **Threads** and **system streams** only had a General tab, missing Members and Companion.
- The **General tab** rendered `<Separator />` elements unconditionally between conditionally-rendered sections, creating stacked or trailing orphan dividers when sections were hidden for certain stream types.
- **Archive copy** was generic ("Archive stream") regardless of whether the stream was a channel, scratchpad, or thread.
- **Bot management** was only available for channels, even though DMs and scratchpads also benefit from bot access.

## Solution

Unify and expand stream settings so every stream type has appropriate, contextual settings.

### Sidebar & top-right menus
- Removed the DM exclusion from sidebar context menus (`StreamItem`), topbar stream menus (`pages/stream.tsx`), and thread panel menus (`components/thread/stream-panel.tsx`).
- Settings now appears consistently on all non-draft streams.

### Tab availability
| Stream type | Tabs |
|-------------|------|
| Channel | General, Companion, Members |
| Scratchpad | General, Companion, Members |
| DM | General, Companion, Members |
| Thread | General, Companion, Members |
| System | General only |

### General tab refactor
- **Fixed divider bug**: sections are collected into an array and separators are only rendered *between* visible sections. No more trailing or stacked dividers.
- **Channel**: Notifications, editable Visibility, Channel name (slug), Description, Danger zone (Archive channel).
- **DM**: Notifications, read-only Virtual stream name (resolved peer name), disabled Visibility ("DMs are always private"), editable Description.
- **Scratchpad**: Notifications, disabled Visibility ("Scratchpads are always private"), editable Display name, Danger zone (Archive scratchpad).
- **Thread**: Notifications, disabled Visibility showing the inherited value from the root stream ("Threads inherit visibility from {root stream name}"), read-only Display name, Danger zone (Archive thread).
- **System**: Notifications, disabled Visibility ("System messages are always private"), disclaimer block explaining the non-interactive nature of system streams.

### Members tab updates
- **User invites** are now restricted to channels only (DMs, scratchpads, and threads show the member list without an add UI).
- **Bot management** is now shown for all stream types that have a Members tab.
- **Thread bots** are displayed read-only: the list is visible but grant/revoke actions are hidden because access is inherited from the root stream.

### Key design decisions

**1. Array-based section rendering for GeneralTab**

Instead of interleaving `<Separator />` between conditionally-rendered JSX, the tab builds an array of section nodes, filters out nulls, and then maps over them with separators injected only between consecutive items. This eliminates the divider bug entirely and makes the layout robust as new stream types or sections are added.

**2. DM name resolution in the settings dialog**

The dialog resolves the DM peer's display name using the same `resolveDmDisplayName` utility that the sidebar and page title use, ensuring consistency even when IDB cached data has a stale `displayName`.

**3. Thread visibility inheritance**

The dialog looks up the thread's root stream from the workspace IDB cache and passes its visibility into `GeneralTab`. This lets the UI show the actual inherited visibility value (public/private) rather than a generic placeholder.

## Modified files

| File | Change |
|------|--------|
| `stream-item.tsx` | Remove DM exclusion from sidebar actions |
| `stream.tsx` | Remove DM exclusion from top-right stream menu |
| `stream-panel.tsx` | Remove DM exclusion from thread panel menu; remove unused `isDm` variable |
| `stream-settings-dialog.tsx` | Update tab availability for DM/Thread/System; add DM name and root stream resolution |
| `general-tab.tsx` | Complete refactor: fix dividers, add per-type sections (DM, Thread, System) |
| `members-tab.tsx` | Expand bots to DM/Scratchpad; thread bots read-only; restrict user invite to channels |
| `stream-item.test.tsx` | Update tests to expect Settings on DMs |
| `stream-settings-dialog.test.tsx` | Update test to expect all tabs for DMs |

## Test plan

- [x] TypeScript type-check passes across the entire monorepo
- [x] Frontend build succeeds
- [x] Unit tests for modified components pass (`stream-settings-dialog`, `stream-item`, `scratchpad-item`)
- [x] ESLint passes

---

🤖 _PR by [OpenCode](https://opencode.ai)_
