### PR TITLE
refactor(frontend): remove filename overlays from image and video previews in stream view

### DIFF
--- a/apps/frontend/src/components/timeline/attachment-list.test.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.test.tsx
@@ -84,8 +84,8 @@ describe("AttachmentList", () => {
         expect(mockGetDownloadUrl).toHaveBeenCalledWith(workspaceId, "img_1")
       })
 
-      // Should show filename in overlay
-      expect(screen.getByText("photo.png")).toBeInTheDocument()
+      // Image should be present with alt text for accessibility
+      expect(screen.getByAltText("photo.png")).toBeInTheDocument()
     })
 
     it("should defer image URL hydration when requested", async () => {
@@ -119,7 +119,7 @@ describe("AttachmentList", () => {
 
       // Both should be rendered
       await waitFor(() => {
-        expect(screen.getByText("photo.jpg")).toBeInTheDocument()
+        expect(screen.getByAltText("photo.jpg")).toBeInTheDocument()
       })
       expect(screen.getByText("doc.pdf")).toBeInTheDocument()
     })
@@ -148,7 +148,7 @@ describe("AttachmentList", () => {
       })
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
-      expect(screen.getByText("clip.mov")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "clip.mov" })).toBeInTheDocument()
       await waitFor(() => {
         expect(mockGetDownloadUrl).not.toHaveBeenCalled()
       })

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -182,14 +182,6 @@ function ImageAttachment({
     },
   }
 
-  const handleDownload = useCallback(() => {
-    downloadImage(workspaceId, attachment.id, attachment.filename)
-  }, [workspaceId, attachment.id, attachment.filename])
-
-  const handleCopy = useCallback(() => {
-    if (imageUrl) copyImage(imageUrl)
-  }, [imageUrl])
-
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.target !== e.currentTarget) return
@@ -230,36 +222,6 @@ function ImageAttachment({
         ) : (
           <img src={imageUrl!} alt={attachment.filename} className="h-32 w-auto max-w-xs object-cover" loading="lazy" />
         )}
-        {/* Desktop: show action buttons on hover; Mobile: just filename */}
-        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-1.5">
-          <div className="flex items-center gap-1">
-            <span className="block truncate text-xs text-white flex-1">{attachment.filename}</span>
-            <div className="hidden sm:flex items-center gap-0.5 shrink-0 opacity-0 group-hover/image:opacity-100 transition-opacity">
-              <button
-                type="button"
-                className="rounded p-1 text-white/80 hover:text-white hover:bg-white/20 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleDownload()
-                }}
-                title="Download image"
-              >
-                <Download className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                className="rounded p-1 text-white/80 hover:text-white hover:bg-white/20 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleCopy()
-                }}
-                title="Copy image"
-              >
-                <Copy className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          </div>
-        </div>
       </div>
       {isMobile && imageUrl && (
         <ImageActionDrawer
@@ -411,6 +373,7 @@ function VideoAttachment({
   return (
     <div
       role="button"
+      aria-label={attachment.filename}
       tabIndex={isProcessing || isLoading ? -1 : 0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -431,9 +394,6 @@ function VideoAttachment({
         filename={attachment.filename}
         onThumbnailError={() => setError(true)}
       />
-      <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-1.5">
-        <span className="block truncate text-xs text-white">{attachment.filename}</span>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Image and video previews in the message stream view displayed filenames in a bottom overlay. This cluttered the visual appearance and partially obscured the preview content, making the stream look busy.

## Solution

Remove the filename overlays from image and video attachment previews in the stream view. Filenames continue to be shown in the media gallery component, which is the dedicated full-screen viewing experience.

### Key design decisions

**1. Remove entire overlay from image previews**

The previous overlay contained both the filename and desktop hover action buttons (download / copy). Removing the entire overlay keeps previews cleanest. Users can still:
- Click to open the gallery and download/copy from there
- Long-press on mobile to trigger the action drawer

**2. Add explicit `aria-label` to video attachment button**

Since the visible filename is removed, an `aria-label` is added to the video `role="button"` so screen readers still announce the filename for accessibility.

**3. Keep `alt` text on images**

Image thumbnails retain their `alt={attachment.filename}` attribute, preserving accessibility without visual clutter.

**4. Leave file attachments unchanged**

Non-image/video file attachments (PDFs, text files, etc.) still show their filenames because they render as download buttons rather than visual previews.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/attachment-list.tsx` | Removed filename overlay from `ImageAttachment` and `VideoAttachment`; added `aria-label` to video button; removed now-unused `handleDownload`/`handleCopy` callbacks |
| `apps/frontend/src/components/timeline/attachment-list.test.tsx` | Updated assertions to query by `alt` text and `role` instead of visible filename text |

## Test plan

- [x] Unit tests pass (`attachment-list.test.tsx` — 19/19)
- [x] TypeScript type checking passes
- [x] ESLint passes

---

🤖 _PR by [OpenCode](https://opencode.ai)_
