### PR TITLE
Group Save + Reminder actions and adjust Save/Unsave behavior

### DIFF
--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -359,7 +359,7 @@ describe("groupVisibleActions", () => {
   it("returns single items for ungrouped actions and groups same-id ones", () => {
     const ctx = createContext()
     const items = groupVisibleActions(getVisibleActions(ctx))
-    // No share/copy-link callbacks, so just reply + copy-as-markdown + copy-as-plain-text.
+    // No share/save/copy-link callbacks, so just reply + copy-as-markdown + copy-as-plain-text.
     // copy-as-markdown + copy-as-plain-text share groupId="copy" → one group.
     expect(items.map((i) => i.kind)).toEqual(["single", "group"])
     const reply = items[0]
@@ -368,6 +368,23 @@ describe("groupVisibleActions", () => {
     if (copyGroup.kind !== "group") throw new Error("expected group")
     // Members include the default first.
     expect(copyGroup.members.map((m) => m.id)).toEqual(["copy-as-markdown", "copy-as-plain-text"])
+  })
+
+  it("groups save and reminder with save as the default when both are visible", () => {
+    const ctx = createContext({ onToggleSave: () => {}, onRequestReminder: () => {} })
+    const items = groupVisibleActions(getVisibleActions(ctx))
+    const saveGroup = items.find((i) => i.kind === "group" && i.members[0]?.id === "save-message")
+    expect(saveGroup).toBeDefined()
+    if (saveGroup?.kind !== "group") throw new Error("expected save group")
+    expect(saveGroup.members.map((m) => m.id)).toEqual(["save-message", "set-reminder"])
+  })
+
+  it("degrades to standalone reminder when the message is already saved", () => {
+    const ctx = createContext({ isSaved: true, onToggleSave: () => {}, onRequestReminder: () => {} })
+    const items = groupVisibleActions(getVisibleActions(ctx))
+    expect(items.find((i) => i.kind === "group" && i.members[0]?.id === "save-message")).toBeUndefined()
+    expect(items.find((i) => i.kind === "single" && i.action.id === "set-reminder")).toBeDefined()
+    expect(items.find((i) => i.kind === "single" && i.action.id === "unsave-message")).toBeDefined()
   })
 
   it("collapses adjacent same-groupId actions into a group whose first member is the default", () => {

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -270,20 +270,15 @@ export const messageActions: MessageAction[] = [
     action: (ctx) => ctx.onShareToParent?.(),
   },
   {
-    // Split into two rows (save / unsave) so the menu entry always matches
-    // the action that will fire — a single "Save for later" row on an
-    // already-saved message was misleading and silently unsaved things.
+    // Save is the primary action in the save/reminder split group. Once a
+    // message is already saved this row disappears; "Remove from Saved" stays
+    // as a separate explicit action so we never silently unsave via a mislabeled
+    // "Save for later" row.
     id: "save-message",
     label: "Save for later",
     icon: Bookmark,
+    groupId: "save",
     when: (ctx) => !!ctx.onToggleSave && !ctx.isSaved,
-    action: (ctx) => ctx.onToggleSave?.(),
-  },
-  {
-    id: "unsave-message",
-    label: "Remove from Saved",
-    icon: BookmarkX,
-    when: (ctx) => !!ctx.onToggleSave && !!ctx.isSaved,
     action: (ctx) => ctx.onToggleSave?.(),
   },
   {
@@ -293,8 +288,16 @@ export const messageActions: MessageAction[] = [
     // custom-time dialog.
     label: "Set reminder…",
     icon: Bell,
+    groupId: "save",
     when: (ctx) => !!ctx.onRequestReminder,
     action: (ctx) => ctx.onRequestReminder?.(),
+  },
+  {
+    id: "unsave-message",
+    label: "Remove from Saved",
+    icon: BookmarkX,
+    when: (ctx) => !!ctx.onToggleSave && !!ctx.isSaved,
+    action: (ctx) => ctx.onToggleSave?.(),
   },
   {
     // Per-message entry into the move-to-thread flow. Mirrors the stream


### PR DESCRIPTION
### Motivation

- Group the "Save for later" and "Set reminder…" actions so "Save" is the primary/visible entry while keeping "Remove from Saved" explicit when a message is already saved to avoid silently unsaving.

### Description

- Added `groupId: "save"` to the `save-message` and `set-reminder` actions and moved `unsave-message` to render separately when a message is already saved.  
- Reworded the inline comment for the save-related actions to clarify that the save row disappears once saved and unsave remains explicit.  
- Added unit tests to cover grouping behavior: `groups save and reminder with save as the default when both are visible` and `degrades to standalone reminder when the message is already saved`.  
- Updated an existing test comment to reflect the presence of the save action in the set of possible top-level actions.

### Testing

- Ran the frontend unit tests for `apps/frontend/src/components/timeline/message-actions.test.ts` with Vitest and the new tests passed.  
- Existing tests in that file were re-run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a934cab8832da9eadda8d47e723c)