### PR TITLE
Reorder and group message context menu actions

### DIFF
--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -370,6 +370,14 @@ describe("groupVisibleActions", () => {
     expect(copyGroup.members.map((m) => m.id)).toEqual(["copy-as-markdown", "copy-as-plain-text"])
   })
 
+  it("groups reply actions with reply-in-thread as the default when quote reply is available", () => {
+    const ctx = createContext({ onQuoteReply: () => {} })
+    const items = groupVisibleActions(getVisibleActions(ctx))
+    const replyGroup = items.find((i) => i.kind === "group" && i.members[0]?.id === "reply-in-thread")
+    expect(replyGroup).toBeDefined()
+    if (replyGroup?.kind !== "group") throw new Error("expected reply group")
+    expect(replyGroup.members.map((m) => m.id)).toEqual(["reply-in-thread", "quote-reply"])
+  })
   it("groups save and reminder with save as the default when both are visible", () => {
     const ctx = createContext({ onToggleSave: () => {}, onRequestReminder: () => {} })
     const items = groupVisibleActions(getVisibleActions(ctx))

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -218,26 +218,32 @@ export const messageActions: MessageAction[] = [
     getHref: (ctx) => ctx.traceUrl,
   },
   {
+    id: "edit-message",
+    label: "Edit message",
+    icon: Pencil,
+    when: (ctx) => ctx.actorType === "user" && !!ctx.authorId && ctx.authorId === ctx.currentUserId,
+    action: (ctx) => ctx.onEdit?.(),
+  },
+  {
+    id: "see-revisions",
+    label: "See revisions",
+    icon: History,
+    when: (ctx) => !!ctx.editedAt,
+    action: (ctx) => ctx.onShowHistory?.(),
+  },
+  {
     id: "reply-in-thread",
     label: "Reply in thread",
     icon: MessageSquareReply,
+    groupId: "reply",
     when: (ctx) => !ctx.isThreadParent,
     getHref: (ctx) => ctx.replyUrl,
-  },
-  {
-    // Seed a private scratchpad that has this message's thread pre-loaded as
-    // context — lets the user poke at a thread without polluting it with
-    // @mentions.
-    id: "discuss-with-ariadne",
-    label: "Discuss with Ariadne",
-    icon: Sparkles,
-    when: (ctx) => !!ctx.onDiscussWithAriadne && !!ctx.streamId,
-    action: (ctx) => ctx.onDiscussWithAriadne?.(),
   },
   {
     id: "quote-reply",
     label: "Quote reply",
     icon: Quote,
+    groupId: "reply",
     when: (ctx) => !!ctx.onQuoteReply,
     action: (ctx) => ctx.onQuoteReply?.(),
   },
@@ -300,6 +306,16 @@ export const messageActions: MessageAction[] = [
     action: (ctx) => ctx.onToggleSave?.(),
   },
   {
+    // Seed a private scratchpad that has this message's thread pre-loaded as
+    // context — lets the user poke at a thread without polluting it with
+    // @mentions.
+    id: "discuss-with-ariadne",
+    label: "Discuss with Ariadne",
+    icon: Sparkles,
+    when: (ctx) => !!ctx.onDiscussWithAriadne && !!ctx.streamId,
+    action: (ctx) => ctx.onDiscussWithAriadne?.(),
+  },
+  {
     // Per-message entry into the move-to-thread flow. Mirrors the stream
     // header entry but seeds the selection with this single message so the
     // common "I just want this one in a thread" path is one tap shorter.
@@ -318,20 +334,6 @@ export const messageActions: MessageAction[] = [
     icon: CornerDownRight,
     when: (ctx) => !!ctx.onShowMoveDetails,
     action: (ctx) => ctx.onShowMoveDetails?.(),
-  },
-  {
-    id: "edit-message",
-    label: "Edit message",
-    icon: Pencil,
-    when: (ctx) => ctx.actorType === "user" && !!ctx.authorId && ctx.authorId === ctx.currentUserId,
-    action: (ctx) => ctx.onEdit?.(),
-  },
-  {
-    id: "see-revisions",
-    label: "See revisions",
-    icon: History,
-    when: (ctx) => !!ctx.editedAt,
-    action: (ctx) => ctx.onShowHistory?.(),
   },
   {
     id: "copy-as-markdown",
@@ -389,7 +391,6 @@ export const messageActions: MessageAction[] = [
     action: (ctx) => ctx.onDelete?.(),
   },
 ]
-
 /** Filter actions that should be shown for a given message context. */
 export function getVisibleActions(context: MessageActionContext): MessageAction[] {
   return messageActions.filter((a) => a.when(context))


### PR DESCRIPTION
### Motivation
- Improve the context-menu flow so related actions are colocated and the menu reads more naturally.
- Reuse the existing split-button grouping approach (used for copy/save) to present reply variants together. 
- Preserve all existing visibility and callback/business logic while improving UX ordering.

### Description
- Reordered the `messageActions` array in `apps/frontend/src/components/timeline/message-actions.ts` to place edit/revisions before reply actions, then share/save/discuss/move, copy options, and delete at the end. 
- Added `groupId: "reply"` to both `reply-in-thread` and `quote-reply` so they collapse into a split-button group with `reply-in-thread` as the primary default. 
- Moved the `discuss-with-ariadne` entry and adjusted ordering of a few entries without changing any `when`, `action`, or `getHref` logic. 
- Added a regression unit test in `apps/frontend/src/components/timeline/message-actions.test.ts` that asserts reply actions are grouped with `reply-in-thread` as the default.

### Testing
- Ran `bun test ./apps/frontend/src/components/timeline/message-actions.test.ts`; the suite ran 47 tests with 0 failures and the new reply-group regression test passed. 
- Verified `groupVisibleActions(getVisibleActions(...))` behavior via the updated unit tests. 
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b2486d0c832d9a0ff1c6f3429966)