### PR TITLE
fix: emit stream:member_added for thread parent message author

### DIFF
--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -6,6 +6,7 @@ import { StreamMemberRepository } from "./member-repository"
 import { StreamEventRepository } from "./event-repository"
 import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
+import { MessageRepository } from "../messaging"
 import * as idModule from "../../lib/id"
 import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
@@ -324,5 +325,160 @@ describe("StreamService.findOrCreateDm", () => {
     expect(error).toBeInstanceOf(HttpError)
     expect((error as HttpError).status).toBe(404)
     expect((error as HttpError).message).toBe("Both users must belong to this workspace")
+  })
+})
+
+describe("StreamService.createThread (via create)", () => {
+  let service: StreamService
+
+  const parentStream = {
+    id: "stream_channel",
+    workspaceId: "ws_1",
+    type: "channel",
+    visibility: "private",
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+  }
+
+  const thread = {
+    id: "stream_new",
+    workspaceId: "ws_1",
+    type: "thread",
+    visibility: "private",
+    parentStreamId: "stream_channel",
+    parentMessageId: "msg_1",
+    rootStreamId: "stream_channel",
+    createdBy: "member_creator",
+    createdAt: new Date().toISOString(),
+  }
+
+  const mockInsertThreadOrFind = spyOn(StreamRepository, "insertThreadOrFind")
+  const mockMessageFindById = spyOn(MessageRepository, "findById")
+  const mockIsMember = spyOn(StreamMemberRepository, "isMember")
+  const mockFindByStreamAndMember = spyOn(StreamMemberRepository, "findByStreamAndMember")
+  const mockUpdateMember = spyOn(StreamMemberRepository, "update")
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockFindById.mockReset().mockResolvedValue(parentStream as never)
+    mockInsertThreadOrFind.mockReset().mockResolvedValue({ stream: thread, created: true } as never)
+    mockIsMember.mockReset().mockResolvedValue(false)
+    mockInsertMember.mockReset().mockResolvedValue({
+      streamId: thread.id,
+      memberId: "member_creator",
+      pinned: false,
+      pinnedAt: null,
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date(),
+    } as never)
+    mockFindByStreamAndMember.mockReset().mockResolvedValue(null)
+    mockInsertEvent.mockReset().mockResolvedValue({
+      id: "evt_1",
+      streamId: thread.id,
+      sequence: 1n,
+      eventType: "member_added",
+      payload: {},
+      actorId: "member_author",
+      actorType: "user",
+      createdAt: new Date(),
+    } as never)
+    mockUpdateMember.mockReset().mockResolvedValue(undefined as never)
+    mockInsertOutbox.mockReset().mockResolvedValue({ id: 1n } as never)
+  })
+
+  test("emits stream:member_added for parent message author so they see the thread in real-time", async () => {
+    mockMessageFindById.mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_channel",
+      authorType: "user",
+      authorId: "member_author",
+    } as never)
+
+    await service.create({
+      workspaceId: "ws_1",
+      type: "thread",
+      parentStreamId: "stream_channel",
+      parentMessageId: "msg_1",
+      createdBy: "member_creator",
+    })
+
+    expect(mockInsertOutbox).toHaveBeenCalledWith(
+      {},
+      "stream:member_added",
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        streamId: thread.id,
+        memberId: "member_author",
+      })
+    )
+  })
+
+  test("does not emit stream:member_added when author is the thread creator", async () => {
+    mockMessageFindById.mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_channel",
+      authorType: "user",
+      authorId: "member_creator",
+    } as never)
+
+    await service.create({
+      workspaceId: "ws_1",
+      type: "thread",
+      parentStreamId: "stream_channel",
+      parentMessageId: "msg_1",
+      createdBy: "member_creator",
+    })
+
+    const memberAddedCalls = mockInsertOutbox.mock.calls.filter(([, type]) => type === "stream:member_added")
+    expect(memberAddedCalls).toHaveLength(0)
+  })
+
+  test("does not emit stream:member_added for bot-authored parent messages", async () => {
+    mockMessageFindById.mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_channel",
+      authorType: "bot",
+      authorId: "bot_1",
+    } as never)
+
+    await service.create({
+      workspaceId: "ws_1",
+      type: "thread",
+      parentStreamId: "stream_channel",
+      parentMessageId: "msg_1",
+      createdBy: "member_creator",
+    })
+
+    const memberAddedCalls = mockInsertOutbox.mock.calls.filter(([, type]) => type === "stream:member_added")
+    expect(memberAddedCalls).toHaveLength(0)
+  })
+
+  test("emits stream:created to parent stream room when thread is newly created", async () => {
+    mockMessageFindById.mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_channel",
+      authorType: "user",
+      authorId: "member_author",
+    } as never)
+
+    await service.create({
+      workspaceId: "ws_1",
+      type: "thread",
+      parentStreamId: "stream_channel",
+      parentMessageId: "msg_1",
+      createdBy: "member_creator",
+    })
+
+    expect(mockInsertOutbox).toHaveBeenCalledWith(
+      {},
+      "stream:created",
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        streamId: "stream_channel",
+      })
+    )
   })
 })

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -528,12 +528,11 @@ export class StreamService {
         await StreamMemberRepository.insert(client, stream.id, params.createdBy)
       }
 
-      // Add parent message author as member so they can participate in the thread
+      // Add parent message author as member and emit stream:member_added so they
+      // discover the thread in real-time (the stream:created event only surfaces
+      // private streams for the creator, not for other members).
       if (parentMessage.authorType === "user" && parentMessage.authorId !== params.createdBy) {
-        const authorIsMember = await StreamMemberRepository.isMember(client, stream.id, parentMessage.authorId)
-        if (!authorIsMember) {
-          await StreamMemberRepository.insert(client, stream.id, parentMessage.authorId)
-        }
+        await this.addToStream(client, stream, parentMessage.authorId, params.createdBy)
       }
 
       // Only broadcast if we created a new thread


### PR DESCRIPTION
## Problem

When person A writes a message in a private channel and person B starts a thread on it, person A (the parent message author) is correctly added to `stream_members` in the database — but they never receive a `stream:member_added` socket event.

The frontend's `stream:created` handler only adds private streams to the sidebar for the thread creator (`isCreator` check in `workspace-sync.ts`). Other members are expected to be notified via `stream:member_added`. Without that event being emitted, the parent message author:

- Never sees the thread appear in their sidebar in real-time
- Must reload the page to discover the thread they should be aware of
- Miss real-time messages sent in the thread

Public threads are unaffected (they're visible to all via `visibility = 'public'`). The bug only impacts private threads in private channels or DMs.

## Solution

Replace the raw `StreamMemberRepository.insert()` call for the parent message author in `createThread` with `this.addToStream()` — the same internal method already used by `addMember`.

`addToStream` does three things the raw insert was skipping:
1. Creates a `member_added` timeline event in the thread (sets the read cursor so it's not shown as unread)
2. Emits a `stream:member_added` outbox event

The broadcast handler delivers `stream:member_added` to both the thread's socket room **and** the added user's personal room (`ws:{workspaceId}:user:{memberId}`), so the author receives it even before subscribing to the thread socket room. The frontend `handleStreamMemberAdded` handler then adds the stream to their sidebar and subscribes them to the room.

### Key design decisions

**1. Use `addToStream` instead of a raw insert**

`addToStream` is already used by `addMember` and encapsulates the correct membership + notification pattern. The alternative (manually emitting the outbox event after the insert) would duplicate logic and risk drift.

**2. Don't use `addToStream` for the thread creator**

The creator is already notified via the `stream:created` event, which triggers sidebar addition + socket subscription in the frontend. Using `addToStream` for them would produce a redundant `member_added` timeline entry in the thread.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/streams/service.ts` | Replace raw `StreamMemberRepository.insert` with `this.addToStream` for parent message author in `createThread` |
| `apps/backend/src/features/streams/service.test.ts` | Add 4 tests for `createThread` membership and notification behavior |

## Test plan

- [x] Author (≠ creator) receives `stream:member_added` outbox event
- [x] Author = creator: no `stream:member_added` emitted (creator path unchanged)
- [x] Bot-authored parent message: no `stream:member_added` emitted
- [x] `stream:created` is always emitted to parent stream room
- [x] All 16 service unit tests pass
- [x] TypeScript type-checks pass (pre-commit hook)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->