### PR TITLE
fix: refresh streams on navigation

### DIFF
--- a/.claude/plans/e12d6dab.md
+++ b/.claude/plans/e12d6dab.md
@@ -52,6 +52,11 @@ Added tests for the mobile/PWA-style already-connected navigation path:
 **Chose:** Track active route-change refreshes by stream id.
 **Why:** Rapid route/effect churn should not fan out duplicate bootstrap requests for the same stream. This mirrors the existing workspace bootstrap singleflight behavior.
 
+### Merge against current cache on write
+
+**Chose:** Use the functional `setQueryData` updater and merge append responses into the cache value present at write time.
+**Why:** Socket handlers or other observers can update stream bootstrap cache while the navigation refresh is awaiting room join, cursor lookup, bootstrap fetch, or IndexedDB writes. Merging against the current cache avoids overwriting those concurrent updates, and append-mode cache conversion keeps the highest known `latestSequence`.
+
 ## Design Evolution
 
 - **Initial suspicion:** React Query invalidation might be enough.
@@ -71,6 +76,7 @@ None.
 
 - [x] Route stream changes trigger subscribe-then-bootstrap refresh.
 - [x] Delta and full bootstrap paths are selected based on cache state.
+- [x] Navigation refresh cache writes preserve concurrent cache updates.
 - [x] Regression tests cover stale query cache and IDB-only navigation.
 - [x] Focused frontend sync tests pass.
 - [x] Frontend typecheck passes.

--- a/.claude/plans/e12d6dab.md
+++ b/.claude/plans/e12d6dab.md
@@ -1,0 +1,76 @@
+# Stream Navigation Freshness
+
+## Goal
+
+Ensure opening a stream in an already-running client performs a fresh subscribe-then-bootstrap pass instead of trusting an infinitely fresh React Query bootstrap cache or IndexedDB-only data. This fixes cases where a PWA/mobile client navigates to a long-running DM and renders stale local messages until a hard refresh.
+
+## What Was Built
+
+### Navigation-triggered stream refresh
+
+The frontend sync engine now treats `currentStreamId` changes as freshness boundaries. When the route stream changes and a socket is available, it joins the stream room with an ack, fetches the stream bootstrap, applies it to IndexedDB, updates the stream bootstrap query cache, and updates stream sync status.
+
+**Files:**
+- `apps/frontend/src/sync/sync-engine.ts` — adds route-change stream refresh, singleflight protection per stream, subscribe-then-bootstrap ordering, IDB application, and React Query cache update.
+
+### Bootstrap mode selection
+
+The refresh path chooses the bootstrap shape based on available cache state:
+
+- Existing stream bootstrap query cache: fetch with `after: latestPersistedSequence` and append into the previous cached bootstrap window.
+- IndexedDB-only state: fetch a full bootstrap without `after`, avoiding an incoherent query window where appended events would be cached without the server's current bootstrap floor.
+
+**Files:**
+- `apps/frontend/src/sync/sync-engine.ts` — checks for previous cached bootstrap before using a delta fetch.
+
+### Regression tests
+
+Added tests for the mobile/PWA-style already-connected navigation path:
+
+- Navigating to a stream with stale React Query bootstrap cache fetches a delta from the latest local event sequence and writes the new event/cache state.
+- Navigating to a stream with only IndexedDB data performs a full bootstrap.
+
+**Files:**
+- `apps/frontend/src/sync/sync-engine.test.ts` — adds stream bootstrap fixtures and route-change refresh coverage.
+
+## Design Decisions
+
+### Refresh in the sync engine
+
+**Chose:** Handle route-change freshness in `SyncEngine.setCurrentStreamId`.
+**Why:** The sync engine already owns socket lifecycle, room joins, bootstrap application, reconnect behavior, and sync status. Keeping this there preserves INV-53 and avoids scattering freshness logic across route components.
+**Alternatives considered:** Relying on `useStreamBootstrap` invalidation. That would still be easy to bypass because several UI paths render from IndexedDB and stream bootstrap queries use `staleTime: Infinity`.
+
+### Delta only when query cache exists
+
+**Chose:** Use `after` only when a previous stream bootstrap query cache exists.
+**Why:** `toCachedStreamBootstrap` can append delta events into an existing cached bootstrap window. With only IndexedDB data, a delta response would not contain the full authoritative bootstrap window, so the query cache could become misleading for timeline floor calculations.
+**Alternatives considered:** Always using `after` from IndexedDB. Rejected because IndexedDB and React Query serve different roles in the current read model.
+
+### Keep refresh singleflight per stream
+
+**Chose:** Track active route-change refreshes by stream id.
+**Why:** Rapid route/effect churn should not fan out duplicate bootstrap requests for the same stream. This mirrors the existing workspace bootstrap singleflight behavior.
+
+## Design Evolution
+
+- **Initial suspicion:** React Query invalidation might be enough.
+- **Final approach:** Add sync-engine-owned navigation refresh, because hard refresh and in-app navigation differ specifically in React Query cache lifetime while IndexedDB may still render immediately.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No backend sync changes. The observed issue is addressed in the frontend navigation/bootstrap path.
+- No changes to service worker background sync. Resume/background freshness remains complementary to this route-change refresh.
+- No global change to stream bootstrap `staleTime`. Other paths still rely on the cache remaining stable unless explicitly refreshed.
+
+## Status
+
+- [x] Route stream changes trigger subscribe-then-bootstrap refresh.
+- [x] Delta and full bootstrap paths are selected based on cache state.
+- [x] Regression tests cover stale query cache and IDB-only navigation.
+- [x] Focused frontend sync tests pass.
+- [x] Frontend typecheck passes.

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -379,6 +379,30 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect(replace.windowVersion).toBe(1)
   })
 
+  it("keeps the newer cached latestSequence when appending an older catch-up response", () => {
+    const streamId = "stream_latest"
+    const current = toCachedStreamBootstrap(
+      {
+        ...makeBootstrap([makeEvent({ id: "evt_C", streamId, sequence: "30" })], streamId),
+        latestSequence: "30",
+      },
+      undefined,
+      { incrementWindowVersionOnReplace: false }
+    )
+    const append = toCachedStreamBootstrap(
+      {
+        ...makeBootstrap([makeEvent({ id: "evt_B", streamId, sequence: "20" })], streamId),
+        syncMode: "append",
+        latestSequence: "20",
+      },
+      current,
+      { incrementWindowVersionOnReplace: false }
+    )
+
+    expect(append.latestSequence).toBe("30")
+    expect(append.events.map((event) => event.id)).toEqual(["evt_B", "evt_C"])
+  })
+
   it("derives the reconnect cursor from the latest persisted non-optimistic event", async () => {
     const streamId = "stream_cursor"
     await db.events.bulkPut([

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -44,6 +44,10 @@ function dedupeAndSortEvents(events: StreamEvent[]): StreamEvent[] {
   })
 }
 
+function maxSequence(a: string, b: string): string {
+  return BigInt(a) >= BigInt(b) ? a : b
+}
+
 export function toCachedStreamBootstrap(
   bootstrap: StreamBootstrap,
   previous?: CachedStreamBootstrap,
@@ -51,14 +55,15 @@ export function toCachedStreamBootstrap(
 ): CachedStreamBootstrap {
   const nextStream = preserveDmDisplayName(bootstrap.stream, previous?.stream)
   const shouldIncrementWindowVersion = bootstrap.syncMode === "replace" && options?.incrementWindowVersionOnReplace
+  const shouldAppend = bootstrap.syncMode === "append" && previous
   return {
     ...bootstrap,
     stream: nextStream,
-    events:
-      bootstrap.syncMode === "append" && previous
-        ? dedupeAndSortEvents([...previous.events, ...bootstrap.events])
-        : bootstrap.events,
-    hasOlderEvents: bootstrap.syncMode === "append" && previous ? previous.hasOlderEvents : bootstrap.hasOlderEvents,
+    events: shouldAppend ? dedupeAndSortEvents([...previous.events, ...bootstrap.events]) : bootstrap.events,
+    latestSequence: shouldAppend
+      ? maxSequence(previous.latestSequence, bootstrap.latestSequence)
+      : bootstrap.latestSequence,
+    hasOlderEvents: shouldAppend ? previous.hasOlderEvents : bootstrap.hasOlderEvents,
     windowVersion: shouldIncrementWindowVersion ? (previous?.windowVersion ?? 0) + 1 : (previous?.windowVersion ?? 0),
   }
 }

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -112,9 +112,69 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
   } satisfies WorkspaceBootstrap
 }
 
+function makeStreamBootstrap(streamId = "stream_1", sequence = "2"): StreamBootstrap {
+  const now = new Date().toISOString()
+  return {
+    stream: {
+      id: streamId,
+      workspaceId: "ws_1",
+      type: "dm",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: null,
+      parentMessageId: null,
+      rootStreamId: null,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "user_1",
+      createdAt: now,
+      updatedAt: now,
+      archivedAt: null,
+    },
+    events: [
+      {
+        id: `evt_${sequence}`,
+        streamId,
+        sequence,
+        eventType: "message_created",
+        payload: {
+          messageId: `msg_${sequence}`,
+          contentMarkdown: "new",
+          contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: now,
+      },
+    ],
+    members: [],
+    botMemberIds: [],
+    membership: {
+      streamId,
+      memberId: "user_1",
+      pinned: false,
+      pinnedAt: null,
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: now,
+    },
+    latestSequence: sequence,
+    hasOlderEvents: false,
+    syncMode: "append",
+    unreadCount: 0,
+    mentionCount: 0,
+    activityCount: 0,
+    sharedMessages: {},
+    contextBag: { bag: null, refs: [] },
+  } satisfies StreamBootstrap
+}
+
 function makeDeps() {
   const workspaceBootstrap = vi.fn(async () => makeWorkspaceBootstrap())
-  const streamBootstrap = vi.fn(async () => ({}) as StreamBootstrap)
+  const streamBootstrap = vi.fn(async (_workspaceId: string, streamId: string) => makeStreamBootstrap(streamId))
   return {
     workspaceId: "ws_1",
     syncStatus: new SyncStatusStore(),
@@ -141,6 +201,8 @@ describe("SyncEngine.handlePageResume", () => {
       db.unreadState.clear(),
       db.userPreferences.clear(),
       db.workspaceMetadata.clear(),
+      db.events.clear(),
+      db.pendingMessages.clear(),
     ])
   })
 
@@ -247,5 +309,73 @@ describe("SyncEngine.handlePageResume", () => {
     // at most 2 bootstrap fetches for overlapping calls (active + 1 queued).
     // Two rapid resume calls should NOT fan out to 3+ fetches.
     expect(deps.workspaceService.bootstrap.mock.calls.length).toBeLessThanOrEqual(2)
+  })
+
+  it("refreshes the current stream when navigating to it in an already-connected app", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    deps.streamService.bootstrap.mockClear()
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "stream_1"], makeStreamBootstrap("stream_1", "1"))
+    await db.events.put({
+      id: "evt_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1",
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_1",
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+    })
+
+    expect(await db.events.get("evt_2")).toBeTruthy()
+    expect(deps.queryClient.getQueryData(["streams", "bootstrap", "ws_1", "stream_1"])).toMatchObject({
+      latestSequence: "2",
+    })
+  })
+
+  it("uses a full bootstrap on navigation when only IndexedDB has stream data", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    deps.streamService.bootstrap.mockClear()
+    await db.events.put({
+      id: "evt_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1",
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_1",
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", undefined)
+    })
   })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -340,11 +340,59 @@ describe("SyncEngine.handlePageResume", () => {
     engine.setCurrentStreamId("stream_1")
     await vi.waitFor(() => {
       expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+      expect(deps.queryClient.getQueryData(["streams", "bootstrap", "ws_1", "stream_1"])).toMatchObject({
+        latestSequence: "2",
+      })
     })
 
     expect(await db.events.get("evt_2")).toBeTruthy()
-    expect(deps.queryClient.getQueryData(["streams", "bootstrap", "ws_1", "stream_1"])).toMatchObject({
-      latestSequence: "2",
+  })
+
+  it("merges navigation refresh results against concurrent query cache updates", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    let resolveBootstrap: (bootstrap: StreamBootstrap) => void = () => {}
+    const bootstrapPromise = new Promise<StreamBootstrap>((resolve) => {
+      resolveBootstrap = resolve
+    })
+
+    deps.streamService.bootstrap.mockClear()
+    deps.streamService.bootstrap.mockImplementationOnce(() => bootstrapPromise)
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "stream_1"], makeStreamBootstrap("stream_1", "1"))
+    await db.events.put({
+      id: "evt_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1",
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_1",
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+    })
+
+    const concurrentBootstrap = makeStreamBootstrap("stream_1", "3")
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "stream_1"], concurrentBootstrap)
+
+    resolveBootstrap(makeStreamBootstrap("stream_1", "2"))
+    await vi.waitFor(() => {
+      const cached = deps.queryClient.getQueryData<StreamBootstrap>(["streams", "bootstrap", "ws_1", "stream_1"])
+      expect(cached?.latestSequence).toBe("3")
+      expect(cached?.events.map((event) => event.id)).toEqual(["evt_2", "evt_3"])
     })
   })
 

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -311,6 +311,23 @@ describe("SyncEngine.handlePageResume", () => {
     expect(deps.workspaceService.bootstrap.mock.calls.length).toBeLessThanOrEqual(2)
   })
 
+  it("does not refresh a route stream while the socket transport is disconnected", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    deps.streamService.bootstrap.mockClear()
+    socket.connected = false
+    engine.onDisconnect()
+
+    engine.setCurrentStreamId("stream_1")
+    await Promise.resolve()
+
+    expect(deps.streamService.bootstrap).not.toHaveBeenCalled()
+    expect(socket.emittedEvents.filter((event) => event.event === "join")).toHaveLength(1)
+  })
+
   it("refreshes the current stream when navigating to it in an already-connected app", async () => {
     const deps = makeDeps()
     const engine = new SyncEngine(deps)

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -445,7 +445,13 @@ export class SyncEngine {
   }
 
   private refreshStreamAfterNavigation(streamId: string): Promise<void> {
-    if (this.isDestroyed || !this.socket || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
+    if (
+      this.isDestroyed ||
+      !this.socket ||
+      !this.socket.connected ||
+      streamId.startsWith("draft_") ||
+      streamId.startsWith("draft:")
+    ) {
       return Promise.resolve()
     }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -478,9 +478,8 @@ export class SyncEngine {
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
       await applyStreamBootstrap(workspaceId, streamId, bootstrap)
 
-      queryClient.setQueryData(
-        queryKey,
-        toCachedStreamBootstrap(bootstrap, previousBootstrap, {
+      queryClient.setQueryData<CachedStreamBootstrap>(queryKey, (currentBootstrap) =>
+        toCachedStreamBootstrap(bootstrap, currentBootstrap ?? previousBootstrap, {
           incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
         })
       )

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -11,6 +11,7 @@ import {
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import {
+  applyStreamBootstrap,
   registerStreamSocketHandlers,
   getLatestPersistedSequence,
   toCachedStreamBootstrap,
@@ -70,6 +71,7 @@ export class SyncEngine {
   private workspaceHandlerCleanup: (() => void) | null = null
   private activeBootstrap: Promise<void> | null = null
   private queuedReconnectBootstrap: Promise<void> | null = null
+  private activeStreamRefreshes = new Map<string, Promise<void>>()
   private hasEverConnected = false
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
@@ -89,7 +91,11 @@ export class SyncEngine {
 
   /** Update the current stream ID (called from React when route changes). */
   setCurrentStreamId(id: string | undefined): void {
+    if (this.currentStreamId === id) return
     this.currentStreamId = id
+    if (id) {
+      void this.refreshStreamAfterNavigation(id)
+    }
   }
 
   setVisibleStreamIds(ids: string[]): void {
@@ -436,6 +442,53 @@ export class SyncEngine {
     }
 
     joinRoomFireAndForget(this.socket, room, new AbortController().signal, "SyncEngine")
+  }
+
+  private refreshStreamAfterNavigation(streamId: string): Promise<void> {
+    if (this.isDestroyed || !this.socket || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
+      return Promise.resolve()
+    }
+
+    const existing = this.activeStreamRefreshes.get(streamId)
+    if (existing) return existing
+
+    const refresh = this.performStreamRefresh(streamId).finally(() => {
+      if (this.activeStreamRefreshes.get(streamId) === refresh) {
+        this.activeStreamRefreshes.delete(streamId)
+      }
+    })
+    this.activeStreamRefreshes.set(streamId, refresh)
+    return refresh
+  }
+
+  private async performStreamRefresh(streamId: string): Promise<void> {
+    const { workspaceId, syncStatus, streamService, queryClient } = this.deps
+    const key = `stream:${streamId}`
+
+    syncStatus.set(key, "syncing")
+    syncStatus.setError(key, null)
+
+    try {
+      await this.ensureStreamSubscription(streamId, { awaitJoin: true })
+      if (this.isDestroyed) return
+
+      const queryKey = streamKeys.bootstrap(workspaceId, streamId)
+      const previousBootstrap = queryClient.getQueryData<CachedStreamBootstrap>(queryKey)
+      const after = previousBootstrap ? await getLatestPersistedSequence(streamId) : null
+      const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+
+      queryClient.setQueryData(
+        queryKey,
+        toCachedStreamBootstrap(bootstrap, previousBootstrap, {
+          incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
+        })
+      )
+      syncStatus.set(key, "synced")
+    } catch (error) {
+      this.applyReconnectStreamError(streamId, error)
+      syncStatus.set(key, syncStatus.getError(key) ? "error" : "stale")
+    }
   }
 
   private applyReconnectStreamError(streamId: string, error: unknown): void {


### PR DESCRIPTION
**Linear:** N/A

## Problem

Stream bootstraps are cached with an infinite stale time, while the timeline can render directly from IndexedDB. In an already-running PWA/mobile client, navigating to a previously cached long-running DM could therefore show stale local messages without issuing a new stream bootstrap. A hard refresh did not hit the same path because the React Query cache starts empty and the active stream bootstrap runs again.

## Solution

Treat active route stream changes as freshness boundaries inside the sync engine. When `currentStreamId` changes in a connected client, the engine joins the stream room, fetches the stream bootstrap, applies it to IndexedDB, updates the stream bootstrap query cache, and marks stream sync status.

### How it works

1. `WorkspaceLayout` continues to feed the route stream id into `SyncEngine.setCurrentStreamId`.
2. A changed real stream id starts a per-stream singleflight refresh.
3. The engine joins `ws:{workspaceId}:stream:{streamId}` with ack before fetching.
4. If a previous stream bootstrap query cache exists, the engine fetches with `after: latestPersistedSequence` and appends into that cached bootstrap.
5. If only IndexedDB has local data, the engine performs a full bootstrap so the query window remains coherent.
6. The bootstrap is written to IndexedDB and mirrored into React Query.

### Key design decisions

**1. Own navigation freshness in SyncEngine**

The sync engine already owns socket lifecycle, room subscriptions, bootstrap application, reconnect behavior, and sync status. Keeping the route-change refresh there preserves INV-53 and avoids relying on individual UI hooks to invalidate correctly.

**2. Delta fetch only with existing query cache**

A delta bootstrap can append safely only when there is an existing cached bootstrap window. IDB-only state needs a full bootstrap because React Query and IndexedDB serve different roles in the current read model.

**3. Per-stream singleflight**

Rapid route/effect churn should not fan out duplicate bootstrap requests for the same stream, so active route-change refreshes are deduplicated by stream id.

## New files

| File | Purpose |
| ---- | ------- |
| `.claude/plans/e12d6dab.md` | Review plan describing the implemented stream navigation freshness fix. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | Adds route-change stream refresh with subscribe-then-bootstrap ordering, cache-aware delta/full bootstrap selection, IDB application, query cache update, and sync status handling. |
| `apps/frontend/src/sync/sync-engine.test.ts` | Adds regression coverage for stale query-cache navigation and IDB-only navigation. |

## Deleted files

| File | Reason |
| ---- | ------ |
| N/A | No files deleted. |

## Test plan

- [x] `bun run setup:worktree`
- [x] `bun run --cwd apps/frontend test src/sync/sync-engine.test.ts src/sync/stream-sync.test.ts`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] Commit hook: backend/control-plane/frontend/backoffice lint, Dockerfile workspace check, workspace typechecks, OpenAPI check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->