### PR TITLE
fix(frontend): merge bootstrap event payloads instead of overwriting

### DIFF
--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -168,6 +168,125 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect(await db.events.get("evt_A")).toBeDefined()
   })
 
+  it("preserves payload fields from a socket update when the bootstrap omits them", async () => {
+    // Backend bootstrap takes getThreadsWithReplyCounts and getThreadSummaries
+    // as separate non-transactional snapshots. If a reply commits between
+    // them, the bootstrap can include threadId+replyCount but omit
+    // threadSummary. Meanwhile the message:updated socket handler has already
+    // written the full threadSummary into IDB. Per-field merge must keep the
+    // socket-written threadSummary in place.
+    const streamId = "stream_merge_omit"
+
+    const threadSummary = {
+      participants: [{ id: "user_2", name: "Alice", avatarUrl: null }],
+      latestReply: {
+        actor: { id: "user_2", name: "Alice", avatarUrl: null },
+        contentMarkdown: "first reply",
+      },
+      lastReplyAt: new Date().toISOString(),
+    }
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_parent",
+        streamId,
+        sequence: "100",
+        payload: {
+          messageId: "evt_parent",
+          contentMarkdown: "parent",
+          threadId: "stream_thread",
+          replyCount: 1,
+          threadSummary,
+        },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+    })
+
+    const bootstrap = makeBootstrap(
+      [
+        makeEvent({
+          id: "evt_parent",
+          streamId,
+          sequence: "100",
+          payload: {
+            messageId: "evt_parent",
+            contentMarkdown: "parent",
+            threadId: "stream_thread",
+            replyCount: 1,
+            // threadSummary deliberately missing — snapshot race
+          },
+        }),
+      ],
+      streamId
+    )
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_parent")
+    expect(merged?.payload).toMatchObject({
+      threadId: "stream_thread",
+      replyCount: 1,
+      threadSummary,
+    })
+  })
+
+  it("overwrites existing payload fields when the bootstrap explicitly carries them", async () => {
+    // Symmetry check: when the bootstrap snapshot is fresher than the IDB
+    // value (e.g. the user opened a stream that already had thread activity
+    // from another session), bootstrap fields should win.
+    const streamId = "stream_merge_present"
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_parent",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "evt_parent", contentMarkdown: "parent", replyCount: 0 },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+    })
+
+    const freshSummary = {
+      participants: [{ id: "user_2", name: "Alice", avatarUrl: null }],
+      latestReply: {
+        actor: { id: "user_2", name: "Alice", avatarUrl: null },
+        contentMarkdown: "fresh from server",
+      },
+      lastReplyAt: new Date().toISOString(),
+    }
+
+    const bootstrap = makeBootstrap(
+      [
+        makeEvent({
+          id: "evt_parent",
+          streamId,
+          sequence: "100",
+          payload: {
+            messageId: "evt_parent",
+            contentMarkdown: "parent",
+            threadId: "stream_thread",
+            replyCount: 3,
+            threadSummary: freshSummary,
+          },
+        }),
+      ],
+      streamId
+    )
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_parent")
+    expect(merged?.payload).toMatchObject({
+      threadId: "stream_thread",
+      replyCount: 3,
+      threadSummary: freshSummary,
+    })
+  })
+
   it("preserves optimistic events that are still in the send queue", async () => {
     const streamId = "stream_pending"
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -146,8 +146,36 @@ async function writeBootstrapEventsAndStream(
   }
 
   if (bootstrap.events.length > 0) {
+    // For message_created events, merge per-field rather than overwriting the
+    // whole row. The bootstrap snapshot can race against socket updates that
+    // already landed in IDB (e.g. a reply commits between the backend's
+    // getThreadsWithReplyCounts and getThreadSummaries snapshots, so the
+    // bootstrap payload omits threadSummary while a socket-delivered
+    // message:updated has already written it to IDB). A wholesale bulkPut
+    // would clobber those fields. Per-field merge makes bootstrap commutative
+    // with socket writes: fields the bootstrap explicitly carries take
+    // effect; fields it omits fall through to the existing IDB payload.
+    // Other event types' payloads are immutable post-creation, so a plain
+    // overwrite is equivalent to merge for them.
+    const existingRows = await db.events.bulkGet(bootstrap.events.map((e) => e.id))
+    const existingById = new Map(
+      existingRows.filter((row): row is NonNullable<typeof row> => row != null).map((row) => [row.id, row] as const)
+    )
+
     await db.events.bulkPut(
-      bootstrap.events.map((e) => ({ ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }))
+      bootstrap.events.map((e) => {
+        const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+        if (e.eventType !== "message_created") return base
+        const existing = existingById.get(e.id)
+        if (!existing) return base
+        return {
+          ...base,
+          payload: {
+            ...(existing.payload as Record<string, unknown>),
+            ...(e.payload as Record<string, unknown>),
+          },
+        }
+      })
     )
   }
 


### PR DESCRIPTION
## Summary

Bootstrap apply was the only IDB write path that didn't compose with socket handlers. Every other path uses `updateMessageEvent` (atomic `modify()`) and only touches the fields it knows about; bootstrap's `bulkPut` overwrote the whole `message_created` row, including fields a socket handler had already patched. This PR makes the bootstrap path commutative with socket writes by merging per-field on existing rows.

## The race this fixes

User-visible symptom: replying to a message on desktop sometimes left the parent's thread card showing only the reply count, missing avatars / time-since-last-reply / preview text. PR #462 made each individual `modify()` atomic, but didn't touch the bootstrap path.

The remaining race:

1. User sends a thread reply (draft → real promotion). Backend commits the reply, emits `message:updated` for the parent.
2. Frontend `handleMessageUpdated` writes `replyCount` + `threadSummary` into the parent's IDB payload via atomic `modify()`. ThreadCard renders the full preview.
3. Some refetch — focus, reconnect, coordinated query — fires the parent stream's bootstrap.
4. Backend bootstrap (`apps/backend/src/features/streams/handlers.ts:654`) runs `getThreadsWithReplyCounts` and `getThreadSummaries` as **separate non-transactional snapshots** in `Promise.all`. If the reply commits between them, the bootstrap returns `threadId` + `replyCount` from snapshot A but no entry in snapshot B → `enrichBootstrapEvents` only sets `threadSummary` when present, so the field is **omitted** from the wire payload.
5. Frontend `applyStreamBootstrap` → `bulkPut` overwrites the parent's IDB event row with the bootstrap payload, **clobbering** the `threadSummary` that step 2 wrote. ThreadCard reverts to the bare reply-count branch and stays there.

## The fix

Per-field merge for `message_created` payloads when an existing IDB row is found:

```ts
payload: { ...existing.payload, ...bootstrap.payload }
```

- Fields the bootstrap explicitly carries take effect (bootstrap-newer-than-IDB still wins).
- Fields the bootstrap omits fall through to the existing IDB payload (no clobber).
- Other event types' payloads are immutable post-creation, so plain overwrite still applies.

This removes the ordering requirement entirely: whichever writer touched a given field last, that value sticks. No backend changes; no `await` reshuffling on the optimistic paths needed for correctness.

## Tests

Two new tests in `apps/frontend/src/sync/stream-sync.test.ts`:
- bootstrap omits `threadSummary` while IDB has it from a socket → merge preserves it
- bootstrap explicitly carries a fresher `threadSummary` → bootstrap wins

All 36 sync tests pass. Typecheck + lint clean.

## Test plan

- [x] `bun run test src/sync/` — 36/36
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: in dev, open a DM with a draft thread panel attached, send a reply, force a parent-stream bootstrap refetch (focus blur/refocus, or socket reconnect), confirm the thread card preview persists.

https://claude.ai/code/session_011PCATLN4eR3Mkqi4iKuLLM

---
_Generated by [Claude Code](https://claude.ai/code/session_011PCATLN4eR3Mkqi4iKuLLM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->