### PR TITLE
fix(sync): preserve socket-patched events over stale bootstrap enrichments

### DIFF
--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -651,6 +651,15 @@ export function createStreamHandlers({
 
       const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
+      // Captured BEFORE the parallel queries fire. Shipped on the wire as the
+      // bootstrap's freshness watermark. The frontend stamps `_patchedAt` on
+      // any IDB row mutated by a socket handler, and at apply time skips
+      // bootstrap merge for rows whose `_patchedAt` is newer than this — so a
+      // stale enrichment subquery (e.g. `getThreadSummaries` reading just
+      // before a reply commits) can't clobber a fresher socket-delivered
+      // value. See `writeBootstrapEventsAndStream` in stream-sync.ts.
+      const snapshotAt = new Date().toISOString()
+
       const [members, botMemberIds, membership, threadDataMap, threadSummaryMap, latestSequence, activityCounts] =
         await Promise.all([
           streamService.getMembers(streamId),
@@ -706,6 +715,7 @@ export function createStreamHandlers({
           botMemberIds,
           membership,
           latestSequence: (latestSequence ?? 0n).toString(),
+          snapshotAt,
           hasOlderEvents,
           syncMode,
           unreadCount,

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -118,6 +118,16 @@ export interface CachedEvent {
   _clientId?: string
   _status?: "pending" | "sent" | "failed" | "editing"
   _cachedAt: number
+  /**
+   * Client wall-clock (ms) of the most recent socket-driven payload patch
+   * applied to this row by `updateMessageEvent`. Compared against the
+   * bootstrap response's `snapshotAt` so a freshly-arrived patch (e.g. a
+   * reaction added between the backend's snapshot and the client's apply)
+   * isn't clobbered by a stale enrichment value carried in the bootstrap
+   * payload. Distinct from `_cachedAt`, which is bumped on bootstrap apply
+   * too — `_patchedAt` is bumped only by socket-handler patches.
+   */
+  _patchedAt?: number
 }
 
 /**

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -287,6 +287,206 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     })
   })
 
+  it("preserves a row whose _patchedAt is newer than the bootstrap snapshot (stale-but-present field)", async () => {
+    // CodeRabbit's race: bootstrap CARRIES a value for a field that the
+    // socket already updated more recently (e.g. reactions enrichment ran
+    // before a reaction:added committed; bootstrap therefore ships an
+    // older reactions map than what's in IDB). Per-field merge alone would
+    // overwrite the fresher value because bootstrap "wins" on the spread.
+    // The freshness watermark catches this case: existing._patchedAt is
+    // greater than snapshotMs, so the merge is skipped entirely.
+    const streamId = "stream_freshness_skip"
+
+    const snapshotAt = new Date(Date.now() - 1000).toISOString()
+    const fresherPatchAt = Date.now() // socket patch happened after the snapshot
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_M",
+        streamId,
+        sequence: "100",
+        payload: {
+          messageId: "evt_M",
+          contentMarkdown: "react to me",
+          // The reaction the socket just added — bootstrap doesn't know yet.
+          reactions: { "🎉": ["user_2"] },
+        },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: fresherPatchAt,
+      _patchedAt: fresherPatchAt,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap(
+        [
+          makeEvent({
+            id: "evt_M",
+            streamId,
+            sequence: "100",
+            payload: {
+              messageId: "evt_M",
+              contentMarkdown: "react to me",
+              // Stale enrichment — empty reactions, taken before the patch.
+              reactions: {},
+            },
+          }),
+        ],
+        streamId
+      ),
+      snapshotAt,
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_M")
+    expect((merged?.payload as { reactions: Record<string, string[]> }).reactions).toEqual({ "🎉": ["user_2"] })
+  })
+
+  it("applies bootstrap normally when _patchedAt is older than the snapshot", async () => {
+    // Symmetry check: a patch that landed BEFORE the snapshot means the
+    // backend's enrichment had a chance to read the patched state, so the
+    // bootstrap value is canonical and should win on the merge.
+    const streamId = "stream_freshness_apply"
+
+    const oldPatchAt = Date.now() - 5000
+    const snapshotAt = new Date().toISOString()
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_M",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "evt_M", contentMarkdown: "old", reactions: { "👀": ["user_3"] } },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: oldPatchAt,
+      _patchedAt: oldPatchAt,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap(
+        [
+          makeEvent({
+            id: "evt_M",
+            streamId,
+            sequence: "100",
+            payload: {
+              messageId: "evt_M",
+              contentMarkdown: "old",
+              reactions: { "👀": ["user_3"], "🚀": ["user_4"] },
+            },
+          }),
+        ],
+        streamId
+      ),
+      snapshotAt,
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_M")
+    expect((merged?.payload as { reactions: Record<string, string[]> }).reactions).toEqual({
+      "👀": ["user_3"],
+      "🚀": ["user_4"],
+    })
+  })
+
+  it("preserves _patchedAt across bootstrap merge so subsequent bootstraps still see the watermark", async () => {
+    // After a merge that doesn't skip (bootstrap is canonical for this
+    // window), the row's _patchedAt must carry over — otherwise the next
+    // bootstrap that arrives during a still-newer socket patch would lose
+    // the freshness signal.
+    const streamId = "stream_watermark_carry"
+
+    const patchAt = Date.now() - 3000
+    const snapshotAt = new Date().toISOString() // newer than patch
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_M",
+        streamId,
+        sequence: "100",
+        payload: { messageId: "evt_M", contentMarkdown: "x", replyCount: 1 },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: patchAt,
+      _patchedAt: patchAt,
+    })
+
+    const bootstrap = {
+      ...makeBootstrap(
+        [
+          makeEvent({
+            id: "evt_M",
+            streamId,
+            sequence: "100",
+            payload: { messageId: "evt_M", contentMarkdown: "x", replyCount: 2 },
+          }),
+        ],
+        streamId
+      ),
+      snapshotAt,
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_M")
+    expect(merged?._patchedAt).toBe(patchAt)
+    expect((merged?.payload as { replyCount: number }).replyCount).toBe(2)
+  })
+
+  it("falls back to per-field merge when snapshotAt is missing (older response)", async () => {
+    // Backwards compat: cached responses written before snapshotAt landed
+    // on the wire don't carry it. The merge path should still work and
+    // behave like the previous PR — preserve fields that bootstrap omits.
+    const streamId = "stream_legacy"
+
+    const fresherPatchAt = Date.now()
+
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_M",
+        streamId,
+        sequence: "100",
+        payload: {
+          messageId: "evt_M",
+          contentMarkdown: "x",
+          threadSummary: { participants: [], latestReply: null, lastReplyAt: null },
+        },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: fresherPatchAt,
+      _patchedAt: fresherPatchAt,
+    })
+
+    // No snapshotAt on the bootstrap.
+    const bootstrap = makeBootstrap(
+      [
+        makeEvent({
+          id: "evt_M",
+          streamId,
+          sequence: "100",
+          payload: { messageId: "evt_M", contentMarkdown: "x", threadId: "thread_1", replyCount: 1 },
+        }),
+      ],
+      streamId
+    )
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const merged = await db.events.get("evt_M")
+    const payload = merged?.payload as Record<string, unknown>
+    // Per-field merge: bootstrap fields applied, omitted fields preserved.
+    expect(payload.threadId).toBe("thread_1")
+    expect(payload.replyCount).toBe(1)
+    expect(payload.threadSummary).toEqual({ participants: [], latestReply: null, lastReplyAt: null })
+  })
+
   it("preserves optimistic events that are still in the send queue", async () => {
     const streamId = "stream_pending"
 
@@ -448,6 +648,24 @@ describe("updateMessageEvent", () => {
 
     const event = await db.events.get("evt_1")
     expect((event?.payload as Record<string, unknown>).replyCount).toBe(5)
+  })
+
+  it("stamps _patchedAt on every update so bootstrap can see the freshness watermark", async () => {
+    const streamId = "stream_patched_at"
+    const messageId = "msg_patched"
+    const before = Date.now()
+    await db.events.put({
+      ...makeEvent({ id: "evt_patched", streamId, sequence: "100", payload: { messageId, contentMarkdown: "x" } }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: before - 10000,
+    })
+
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
+
+    const event = await db.events.get("evt_patched")
+    expect(event?._patchedAt).toBeDefined()
+    expect(event?._patchedAt).toBeGreaterThanOrEqual(before)
   })
 
   it("does not lose fields when multiple concurrent updates target the same message", async () => {

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,4 +1,4 @@
-import { db, sequenceToNum } from "@/db"
+import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   StreamTypes,
   type StreamEvent,
@@ -151,37 +151,64 @@ async function writeBootstrapEventsAndStream(
   }
 
   if (bootstrap.events.length > 0) {
-    // For message_created events, merge per-field rather than overwriting the
-    // whole row. The bootstrap snapshot can race against socket updates that
-    // already landed in IDB (e.g. a reply commits between the backend's
-    // getThreadsWithReplyCounts and getThreadSummaries snapshots, so the
-    // bootstrap payload omits threadSummary while a socket-delivered
-    // message:updated has already written it to IDB). A wholesale bulkPut
-    // would clobber those fields. Per-field merge makes bootstrap commutative
-    // with socket writes: fields the bootstrap explicitly carries take
-    // effect; fields it omits fall through to the existing IDB payload.
+    // For message_created events, the bootstrap snapshot can race against
+    // socket updates that already landed in IDB. We resolve this in two
+    // tiers:
+    //
+    //   1. Freshness skip — if the row was patched by a socket handler
+    //      AFTER the backend's snapshot was taken (`_patchedAt > snapshotMs`),
+    //      bootstrap's enrichment for that row may be stale, so we preserve
+    //      the existing row entirely. Example: a reaction:added arrives at
+    //      the client before the bootstrap response; the bootstrap's
+    //      reactions enrichment query ran before the reaction committed, so
+    //      its payload omits the reaction — overwriting would lose it.
+    //
+    //   2. Per-field merge — if the row wasn't patched after the snapshot
+    //      (or no snapshotAt is on the wire), we still merge per-field so
+    //      bootstrap-internal-inconsistency races (e.g.
+    //      getThreadsWithReplyCounts and getThreadSummaries seeing different
+    //      snapshots of the same reply) can't omit a field that was already
+    //      populated in IDB.
+    //
     // Other event types' payloads are immutable post-creation, so a plain
-    // overwrite is equivalent to merge for them.
+    // overwrite is equivalent for them.
+    const snapshotMs = bootstrap.snapshotAt ? Date.parse(bootstrap.snapshotAt) : null
     const existingRows = await db.events.bulkGet(bootstrap.events.map((e) => e.id))
     const existingById = new Map(
       existingRows.filter((row): row is NonNullable<typeof row> => row != null).map((row) => [row.id, row] as const)
     )
 
-    await db.events.bulkPut(
-      bootstrap.events.map((e) => {
-        const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
-        if (e.eventType !== "message_created") return base
-        const existing = existingById.get(e.id)
-        if (!existing) return base
-        return {
-          ...base,
-          payload: {
-            ...(existing.payload as Record<string, unknown>),
-            ...(e.payload as Record<string, unknown>),
-          },
-        }
+    const toWrite: CachedEvent[] = []
+    for (const e of bootstrap.events) {
+      const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+      if (e.eventType !== "message_created") {
+        toWrite.push(base)
+        continue
+      }
+      const existing = existingById.get(e.id)
+      if (!existing) {
+        toWrite.push(base)
+        continue
+      }
+      if (snapshotMs !== null && existing._patchedAt !== undefined && existing._patchedAt > snapshotMs) {
+        // Skip the put — existing row is fresher than this snapshot.
+        continue
+      }
+      toWrite.push({
+        ...base,
+        payload: {
+          ...(existing.payload as Record<string, unknown>),
+          ...(e.payload as Record<string, unknown>),
+        },
+        // Preserve the patch watermark so subsequent bootstraps still see
+        // that this row has been touched by socket activity.
+        _patchedAt: existing._patchedAt,
       })
-    )
+    }
+
+    if (toWrite.length > 0) {
+      await db.events.bulkPut(toWrite)
+    }
   }
 
   // Merge stream metadata without destroying fields that only exist on the
@@ -363,8 +390,14 @@ export async function updateMessageEvent(
     .filter((e) => (e.payload as { messageId?: string })?.messageId === messageId)
     .modify((event) => {
       const updatedPayload = updater(event.payload as Record<string, unknown>)
+      const now = Date.now()
       event.payload = updatedPayload
-      event._cachedAt = Date.now()
+      event._cachedAt = now
+      // Freshness watermark — see `_patchedAt` doc on CachedEvent. Only
+      // bumped by socket-handler patches (and the optimistic helpers below
+      // that mirror them); bootstrap apply leaves it alone so a later
+      // bootstrap response can decide whether its enrichment is stale.
+      event._patchedAt = now
     })
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -102,6 +102,16 @@ export interface StreamBootstrap {
   botMemberIds: string[]
   membership: StreamMember | null
   latestSequence: string
+  /**
+   * Server wall-clock (ISO) captured immediately before the bootstrap's
+   * parallel queries fire. The frontend uses it as a freshness watermark:
+   * any IDB row patched by a socket handler after this instant is preserved
+   * over the bootstrap's enrichment values, since the snapshot may have
+   * read stale data for that row. Optional for backwards compatibility
+   * with cached responses written before this field landed — when missing,
+   * the merge path falls through to per-field overlay only.
+   */
+  snapshotAt?: string
   hasOlderEvents: boolean
   syncMode: "append" | "replace"
   unreadCount: number


### PR DESCRIPTION
## Problem

Follow-up to #473. That PR made bootstrap apply commutative with socket writes via per-field merge — fields the bootstrap **omits** fall through to existing IDB. But it didn't address the case CodeRabbit flagged: bootstrap **carries** a stale-but-present value for a field a socket handler updated more recently.

The race:

1. User reacts to a message on another tab. Backend commits the reaction.
2. This client's `enrichBootstrapEvents` reads `reactions` for the bootstrap (snapshot A — pre-commit, empty).
3. Backend's `latestSequence` query runs (snapshot B — post-commit, sees the new sequence).
4. Backend returns the bootstrap with `latestSequence` ≥ reaction.seq, but `reactions: {}` for that row.
5. Meanwhile the client's `reaction:added` socket handler has already written `reactions: { "🎉": ["user_2"] }` into IDB.
6. Bootstrap applies. Per-field merge spreads `bootstrap.payload` last → empty `reactions` clobbers the socket-written value.

Same shape applies to `editedAt` / `contentJson` / `contentMarkdown`, `linkPreviews`, `attachments` processingStatus, and `threadSummary` when stale-but-present rather than omitted. The previous PR's `_sequenceNum` comparison wouldn't help — `_sequenceNum` is stamped at insert and never bumped by `modify()`, so for the same event ID, `existing._sequenceNum === base._sequenceNum` always.

## Solution

Add a freshness watermark so the merge can detect when an IDB row was patched **after** the backend's snapshot, and preserve that row entirely.

### How it works

- **Backend** (`apps/backend/src/features/streams/handlers.ts:654`) captures `snapshotAt = new Date().toISOString()` immediately before the parallel enrichment queries fire. Ships it on the `StreamBootstrap` response.
- **Frontend** stamps `CachedEvent._patchedAt: number` (client wall-clock) inside `updateMessageEvent`'s atomic `modify()`. Every socket-handler patch and the optimistic helpers that mirror them touch this field; bootstrap apply does **not**.
- **`writeBootstrapEventsAndStream`** does a two-tier resolution per row:
  1. **Freshness skip** — if `existing._patchedAt > Date.parse(snapshotAt)`, the row was patched after the backend's snapshot was taken; skip the put entirely (preserve everything in IDB).
  2. **Per-field merge** — otherwise, fall back to `{ ...existing.payload, ...bootstrap.payload }` from PR #473 so bootstrap-internal-inconsistency races (e.g. `getThreadsWithReplyCounts` and `getThreadSummaries` seeing different snapshots) can't clobber a field already populated in IDB.
- `_patchedAt` is preserved across merges so subsequent bootstraps still see the watermark.

### Key design decisions

**1. Server timestamp + client timestamp, not sequence numbers**

Sequence-based causality is appealing — `latestSequence` is already on the wire — but enrichment freshness isn't actually correlated with `latestSequence`. The bootstrap can capture `latestSequence = 100` while a separate enrichment subquery reads pre-commit data for sequence 99. We need a signal tied to **enrichment query time**, not stream sequence.

A wall-clock `snapshotAt` taken right before the parallel queries fire is the right granularity. Clock skew between server and client is tolerated as graceful degradation: worst case we fall through to per-field merge (the prior PR's behavior), never strictly worse.

**2. `snapshotAt` is optional on the wire**

Older cached `StreamBootstrap` responses written before this field landed don't carry it. When missing, `Date.parse` returns `NaN`, the comparison is `false`, and the merge path falls through to per-field overlay — same as PR #473. Backwards compatible without a Dexie version bump.

**3. Skip the put entirely on freshness**

Alternative was to copy bootstrap fields except patched ones, but the patched-field set is implicit (any payload key a socket handler might touch). Skipping the put preserves correctness without enumerating the protected fields. Other event types still go through the normal path; only `message_created` rows (the only ones with patchable payloads) get the freshness check.

**4. `_patchedAt` is non-indexed**

We never query by it — only compare against snapshot timestamps inside the merge. No Dexie schema version bump needed; Dexie's schema string only declares indexes.

## Modified files

| File                                            | Change                                                                            |
| ----------------------------------------------- | --------------------------------------------------------------------------------- |
| `apps/backend/src/features/streams/handlers.ts` | Capture `snapshotAt` before the parallel enrichment queries; ship on the response |
| `packages/types/src/api.ts`                     | Add optional `snapshotAt: string` to `StreamBootstrap`                            |
| `apps/frontend/src/db/database.ts`              | Add optional `_patchedAt: number` to `CachedEvent`                                |
| `apps/frontend/src/sync/stream-sync.ts`         | Stamp `_patchedAt` in `updateMessageEvent`; freshness skip + merge in writeBootstrapEventsAndStream |
| `apps/frontend/src/sync/stream-sync.test.ts`    | 4 new merge cases + a stamp test on `updateMessageEvent`                          |

## Test plan

- [x] `bun run test src/sync/stream-sync.test.ts` — 22/22 pass
- [x] `bun run test` (frontend) — 1550/1550 pass
- [x] `bun run test` (backend) — 1161/1162 (one unrelated flake in `persona-repository.test.ts`, passes individually with and without these changes)
- [x] `bun run typecheck` — clean across all 9 workspaces
- [x] Lint clean (auto-run via lint-staged)
- [ ] Manual: hard to repro the race deterministically — requires a reaction/edit committing during the bootstrap's enrichment-query window. Will rely on the unit tests + watch for regressions in PR #473's user-reported scenario after merge.

https://claude.ai/code/session_011PCATLN4eR3Mkqi4iKuLLM


---
_Generated by [Claude Code](https://claude.ai/code/session_011PCATLN4eR3Mkqi4iKuLLM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->