### PR TITLE
fix: read membership tab users from workspace store instead of bootstrap cache

### DIFF
--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -1,15 +1,14 @@
 import { useRef, useState } from "react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useMutation } from "@tanstack/react-query"
 import { Check, ChevronDown, Copy, KeyRound, Link as LinkIcon, Mail } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { invitationsApi } from "@/api/invitations"
-import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { useFormattedDate } from "@/hooks"
 import { InviteDialog } from "./invite-dialog"
 import { CreateInviteLinkDialog } from "./create-invite-link-dialog"
-import type { User, WorkspaceInvitation } from "@threa/types"
 
 function CopyLinkLabel({ isCopied, tokenInMemory }: { isCopied: boolean; tokenInMemory: boolean }) {
   if (isCopied) {
@@ -55,21 +54,9 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
   // discards the map — there's no API to retrieve a token after creation.
   const tokensRef = useRef<Map<string, string>>(new Map())
 
-  const queryClient = useQueryClient()
   const { formatDate } = useFormattedDate()
 
-  const { data: bootstrapData } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () =>
-      queryClient.getQueryData<{
-        users: User[]
-        invitations?: WorkspaceInvitation[]
-      }>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-  })
-
-  const users = bootstrapData?.users ?? []
+  const users = useWorkspaceUsers(workspaceId)
 
   const invitationsQuery = useQuery({
     queryKey: ["invitations", workspaceId],


### PR DESCRIPTION
## Problem

The workspace settings membership tab consistently showed 0 members.

`WorkspaceSettingsDialog` is rendered **outside** the `CoordinatedLoadingGate` in `workspace-layout.tsx`, which means it can mount and display before the workspace bootstrap fetch completes. The `UsersTab` was reading members from a TanStack Query cache-only observer (`enabled: false`) on the bootstrap key:

```ts
const { data: bootstrapData } = useQuery({
  queryKey: workspaceKeys.bootstrap(workspaceId),
  queryFn: () => queryClient.getQueryData<{ users: User[] }>(workspaceKeys.bootstrap(workspaceId)) ?? null,
  enabled: false,
  staleTime: Infinity,
})
const users = bootstrapData?.users ?? []
```

When the dialog opens before the bootstrap queryFn resolves, `bootstrapData` is `undefined` and `users` falls back to `[]` — zero members displayed.

## Solution

Replace the bootstrap cache read with `useWorkspaceUsers(workspaceId)` from `workspace-store`. This is a one-line swap that eliminates the race condition and is the canonical pattern used throughout the codebase for reading workspace users reactively.

### How it works

`useWorkspaceUsers` is backed by two layers:

1. **Synchronous in-memory cache** — populated by `seedWorkspaceCache` which runs synchronously inside `applyWorkspaceBootstrap` after IDB writes. The tab gets real data on its very first render, even if IDB hasn't resolved yet.
2. **`useLiveQuery` on IndexedDB** — reactive to `db.workspaceUsers` changes from both bootstrap writes and socket events (`workspace:user_added`, `workspace:user_updated`, `workspace:user_removed`).

### Key design decision

**Why not fix the cache-only observer pattern instead?**

The `enabled: false` observer approach would require either (a) a loading gate in front of the dialog or (b) additional null-state UI. `useWorkspaceUsers` already solves both correctness and reactivity with zero extra plumbing — it's the established pattern and the right tool for this surface.

## Modified files

| File | Change |
|------|--------|
| `apps/frontend/src/components/workspace-settings/users-tab.tsx` | Replace TanStack Query cache-only observer with `useWorkspaceUsers` from workspace-store; remove unused `useQueryClient`, `workspaceKeys`, `User`, `WorkspaceInvitation` imports |

## Test plan

- [x] TypeScript passes (`bun tsc --noEmit`)
- [x] Lint passes
- [ ] Open workspace settings → Members tab → confirm all workspace members are listed
- [ ] Open settings before workspace fully loads (e.g. direct URL with `?ws-settings=users`) → confirm members appear once data is available

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjsA3onzYHkJAnM8TuUsFF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->