### PR TITLE
Discoverable user/bot pickers and real avatars in settings

### DIFF
--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -5,8 +5,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
-import { SearchableList } from "@/components/ui/searchable-list"
-import { renderUserListItem, type UserListItem } from "@/components/ui/user-list-item"
+import { SearchableSelect } from "@/components/ui/searchable-select"
 import {
   ResponsiveAlertDialog,
   ResponsiveAlertDialogAction,
@@ -36,7 +35,6 @@ interface MembersTabProps {
 export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabProps) {
   const streamService = useStreamService()
   const [search, setSearch] = useState("")
-  const [addSearch, setAddSearch] = useState("")
   const addMutation = useAddStreamMember(workspaceId, streamId)
   const removeMutation = useRemoveStreamMember(workspaceId, streamId)
 
@@ -81,29 +79,14 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
     return enrichedMembers.filter((m) => m.name.toLowerCase().includes(q) || m.slug.toLowerCase().includes(q))
   }, [enrichedMembers, search])
 
-  const availableToAdd = useMemo((): UserListItem[] => {
-    if (!addSearch) return []
-    const q = addSearch.toLowerCase()
-    return workspaceUsers
-      .filter(
-        (m) => !streamMemberIds.has(m.id) && (m.name.toLowerCase().includes(q) || m.slug.toLowerCase().includes(q))
-      )
-      .map((m) => ({
-        id: m.id,
-        label: m.name || m.slug,
-        description: `@${m.slug}`,
-        slug: m.slug,
-        name: m.name,
-      }))
-  }, [workspaceUsers, streamMemberIds, addSearch])
+  const availableToAdd = useMemo(() => {
+    return workspaceUsers.filter((m) => !streamMemberIds.has(m.id))
+  }, [workspaceUsers, streamMemberIds])
 
   const handleAdd = useCallback(
-    (item: UserListItem) => {
-      addMutation.mutate(item.id, {
-        onSuccess: () => {
-          toast.success("Member added")
-          setAddSearch("")
-        },
+    (user: (typeof workspaceUsers)[number]) => {
+      addMutation.mutate(user.id, {
+        onSuccess: () => toast.success("Member added"),
         onError: () => toast.error("Failed to add member"),
       })
     },
@@ -180,17 +163,36 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
       </div>
 
       {canAddUserMembers && (
-        <div className="space-y-3">
+        <div className="space-y-2">
           <Label className="text-sm font-medium">Add member</Label>
-          <SearchableList
+          <SearchableSelect
             items={availableToAdd}
-            renderItem={renderUserListItem}
-            onSelect={handleAdd}
-            search={addSearch}
-            onSearchChange={setAddSearch}
-            placeholder="Search workspace users..."
+            value={null}
+            onChange={handleAdd}
+            getKey={(u) => u.id}
+            getKeywords={(u) => [u.name, u.slug, `@${u.slug}`]}
+            placeholder={availableToAdd.length === 0 ? "All workspace users are members" : "Add member..."}
+            searchPlaceholder="Search workspace users..."
             emptyMessage="No matching users"
-            icon={UserPlus}
+            triggerIcon={UserPlus}
+            disabled={availableToAdd.length === 0}
+            showAvailableCount
+            availableLabel={(n) => `${n} ${n === 1 ? "user" : "users"} available`}
+            renderItem={(user) => {
+              const initials = getInitials(user.name || user.slug)
+              const color = getAvatarColor(user.id)
+              return (
+                <>
+                  <div
+                    className={`flex items-center justify-center h-6 w-6 rounded-full text-[10px] font-medium shrink-0 ${color}`}
+                  >
+                    {initials}
+                  </div>
+                  <span className="text-sm font-medium truncate">{user.name || user.slug}</span>
+                  <span className="ml-auto text-xs text-muted-foreground shrink-0">@{user.slug}</span>
+                </>
+              )
+            }}
           />
         </div>
       )}
@@ -232,7 +234,6 @@ function StreamBotsSection({
   readOnly?: boolean
 }) {
   const queryClient = useQueryClient()
-  const [botSearch, setBotSearch] = useState("")
   const allBots = useWorkspaceBots(workspaceId)
 
   // Single query: which bots have been granted access to this stream
@@ -246,25 +247,14 @@ function StreamBotsSection({
 
   const botsWithAccess = useMemo(() => allBots.filter((b) => grantedBotIdSet.has(b.id)), [allBots, grantedBotIdSet])
 
-  const availableToGrant = useMemo(() => {
-    if (!botSearch) return []
-    const q = botSearch.toLowerCase()
-    return allBots
-      .filter(
-        (b) =>
-          !b.archivedAt &&
-          !grantedBotIdSet.has(b.id) &&
-          (b.name.toLowerCase().includes(q) || b.slug?.toLowerCase().includes(q))
-      )
-      .slice(0, 10)
-  }, [allBots, grantedBotIdSet, botSearch])
+  const availableToGrant = useMemo(
+    () => allBots.filter((b) => !b.archivedAt && !grantedBotIdSet.has(b.id)),
+    [allBots, grantedBotIdSet]
+  )
 
   const grantMutation = useMutation({
     mutationFn: (botId: string) => botsApi.grantStreamAccess(workspaceId, botId, streamId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: streamBotsQueryKey })
-      setBotSearch("")
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: streamBotsQueryKey }),
   })
 
   const revokeMutation = useMutation({
@@ -314,34 +304,29 @@ function StreamBotsSection({
       )}
 
       {!readOnly && allBots.length > 0 && (
-        <div className="space-y-1.5">
-          <Input
-            placeholder="Search bots to add..."
-            value={botSearch}
-            onChange={(e) => setBotSearch(e.target.value)}
-            className="h-8"
-          />
-          {availableToGrant.length > 0 && (
-            <div className="rounded-md border divide-y max-h-40 overflow-y-auto">
-              {availableToGrant.map((bot) => (
-                <button
-                  key={bot.id}
-                  className="w-full flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors text-left"
-                  onClick={() => grantMutation.mutate(bot.id)}
-                >
-                  <div className="flex items-center justify-center h-6 w-6 rounded-full bg-emerald-500/10 text-emerald-600 text-xs shrink-0">
-                    {bot.avatarEmoji ?? <BotIcon className="h-3 w-3" />}
-                  </div>
-                  <span className="text-sm truncate">{bot.name}</span>
-                  {bot.slug && <span className="text-xs text-muted-foreground">@{bot.slug}</span>}
-                </button>
-              ))}
-            </div>
+        <SearchableSelect
+          items={availableToGrant}
+          value={null}
+          onChange={(bot) => grantMutation.mutate(bot.id)}
+          getKey={(b) => b.id}
+          getKeywords={(b) => [b.name, b.slug ?? "", b.slug ? `@${b.slug}` : ""].filter(Boolean)}
+          placeholder={availableToGrant.length === 0 ? "All bots have access" : "Add bot..."}
+          searchPlaceholder="Search bots..."
+          emptyMessage="No matching bots"
+          triggerIcon={BotIcon}
+          disabled={availableToGrant.length === 0 || grantMutation.isPending}
+          showAvailableCount
+          availableLabel={(n) => `${n} ${n === 1 ? "bot" : "bots"} available`}
+          renderItem={(bot) => (
+            <>
+              <div className="flex items-center justify-center h-6 w-6 rounded-full bg-emerald-500/10 text-emerald-600 text-xs shrink-0">
+                {bot.avatarEmoji ?? <BotIcon className="h-3 w-3" />}
+              </div>
+              <span className="text-sm font-medium truncate">{bot.name}</span>
+              {bot.slug && <span className="ml-auto text-xs text-muted-foreground shrink-0">@{bot.slug}</span>}
+            </>
           )}
-          {botSearch && availableToGrant.length === 0 && (
-            <p className="text-xs text-muted-foreground py-1">No matching bots</p>
-          )}
-        </div>
+        />
       )}
     </div>
   )

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -62,7 +62,7 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   const streamMemberIds = useMemo(() => new Set(streamMembers.map((m) => m.memberId)), [streamMembers])
 
   const enrichedMembers = useMemo(() => {
-    return streamMembers
+    const enriched = streamMembers
       .map((sm) => {
         const workspaceUser = workspaceUsers.find((u) => u.id === sm.memberId)
         return workspaceUser
@@ -70,6 +70,7 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
           : null
       })
       .filter(Boolean) as (StreamMember & { name: string; slug: string; role: string })[]
+    return enriched.sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug))
   }, [streamMembers, workspaceUsers])
 
   const filteredMembers = useMemo(() => {
@@ -79,7 +80,9 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   }, [enrichedMembers, search])
 
   const availableToAdd = useMemo(() => {
-    return workspaceUsers.filter((m) => !streamMemberIds.has(m.id))
+    return workspaceUsers
+      .filter((m) => !streamMemberIds.has(m.id))
+      .sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug))
   }, [workspaceUsers, streamMemberIds])
 
   const handleAdd = useCallback(
@@ -241,10 +244,14 @@ function StreamBotsSection({
 
   const grantedBotIdSet = useMemo(() => new Set(grantedBotIds), [grantedBotIds])
 
-  const botsWithAccess = useMemo(() => allBots.filter((b) => grantedBotIdSet.has(b.id)), [allBots, grantedBotIdSet])
+  const botsWithAccess = useMemo(
+    () => allBots.filter((b) => grantedBotIdSet.has(b.id)).sort((a, b) => a.name.localeCompare(b.name)),
+    [allBots, grantedBotIdSet]
+  )
 
   const availableToGrant = useMemo(
-    () => allBots.filter((b) => !b.archivedAt && !grantedBotIdSet.has(b.id)),
+    () =>
+      allBots.filter((b) => !b.archivedAt && !grantedBotIdSet.has(b.id)).sort((a, b) => a.name.localeCompare(b.name)),
     [allBots, grantedBotIdSet]
   )
 

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { SearchableSelect } from "@/components/ui/searchable-select"
+import { ActorAvatar } from "@/components/actor-avatar"
 import {
   ResponsiveAlertDialog,
   ResponsiveAlertDialogAction,
@@ -22,8 +23,6 @@ import { useStreamService } from "@/contexts"
 import { botsApi } from "@/api/bots"
 import { useWorkspaceUsers, useWorkspaceBots } from "@/stores/workspace-store"
 import { StreamTypes, type StreamMember } from "@threa/types"
-import { getInitials } from "@/lib/initials"
-import { getAvatarColor } from "@/lib/avatar-color"
 import { toast } from "sonner"
 
 interface MembersTabProps {
@@ -123,17 +122,16 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
 
         <div className="space-y-1 max-h-64 overflow-y-auto">
           {filteredMembers.map((member) => {
-            const initials = getInitials(member.name || member.slug)
-            const color = getAvatarColor(member.memberId)
-
             return (
               <div key={member.memberId} className="flex items-center justify-between rounded-md border px-3 py-2">
                 <div className="flex items-center gap-2.5 min-w-0">
-                  <div
-                    className={`flex items-center justify-center h-7 w-7 rounded-full text-xs font-medium shrink-0 ${color}`}
-                  >
-                    {initials}
-                  </div>
+                  <ActorAvatar
+                    actorId={member.memberId}
+                    actorType="user"
+                    workspaceId={workspaceId}
+                    size="sm"
+                    alt={member.name || member.slug}
+                  />
                   <div className="flex items-center gap-1.5 min-w-0">
                     <span className="text-sm font-medium truncate">{member.name || member.slug}</span>
                     <span className="text-xs text-muted-foreground">@{member.slug}</span>
@@ -178,21 +176,19 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
             disabled={availableToAdd.length === 0}
             showAvailableCount
             availableLabel={(n) => `${n} ${n === 1 ? "user" : "users"} available`}
-            renderItem={(user) => {
-              const initials = getInitials(user.name || user.slug)
-              const color = getAvatarColor(user.id)
-              return (
-                <>
-                  <div
-                    className={`flex items-center justify-center h-6 w-6 rounded-full text-[10px] font-medium shrink-0 ${color}`}
-                  >
-                    {initials}
-                  </div>
-                  <span className="text-sm font-medium truncate">{user.name || user.slug}</span>
-                  <span className="ml-auto text-xs text-muted-foreground shrink-0">@{user.slug}</span>
-                </>
-              )
-            }}
+            renderItem={(user) => (
+              <>
+                <ActorAvatar
+                  actorId={user.id}
+                  actorType="user"
+                  workspaceId={workspaceId}
+                  size="xs"
+                  alt={user.name || user.slug}
+                />
+                <span className="text-sm font-medium truncate">{user.name || user.slug}</span>
+                <span className="ml-auto text-xs text-muted-foreground shrink-0">@{user.slug}</span>
+              </>
+            )}
           />
         </div>
       )}
@@ -271,9 +267,7 @@ function StreamBotsSection({
           {botsWithAccess.map((bot) => (
             <div key={bot.id} className="flex items-center justify-between rounded-md border px-3 py-2 group">
               <div className="flex items-center gap-2.5 min-w-0">
-                <div className="flex items-center justify-center h-7 w-7 rounded-full bg-emerald-500/10 text-emerald-600 text-xs font-medium shrink-0">
-                  {bot.avatarEmoji ?? <BotIcon className="h-3.5 w-3.5" />}
-                </div>
+                <ActorAvatar actorId={bot.id} actorType="bot" workspaceId={workspaceId} size="sm" alt={bot.name} />
                 <div className="flex items-center gap-1.5 min-w-0">
                   <span className="text-sm font-medium truncate">{bot.name}</span>
                   {bot.slug && <span className="text-xs text-muted-foreground">@{bot.slug}</span>}
@@ -319,9 +313,7 @@ function StreamBotsSection({
           availableLabel={(n) => `${n} ${n === 1 ? "bot" : "bots"} available`}
           renderItem={(bot) => (
             <>
-              <div className="flex items-center justify-center h-6 w-6 rounded-full bg-emerald-500/10 text-emerald-600 text-xs shrink-0">
-                {bot.avatarEmoji ?? <BotIcon className="h-3 w-3" />}
-              </div>
+              <ActorAvatar actorId={bot.id} actorType="bot" workspaceId={workspaceId} size="xs" alt={bot.name} />
               <span className="text-sm font-medium truncate">{bot.name}</span>
               {bot.slug && <span className="ml-auto text-xs text-muted-foreground shrink-0">@{bot.slug}</span>}
             </>

--- a/apps/frontend/src/components/ui/searchable-select.tsx
+++ b/apps/frontend/src/components/ui/searchable-select.tsx
@@ -113,13 +113,19 @@ export function SearchableSelect<T>({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className={cn("w-[--radix-popover-trigger-width] min-w-[260px] p-0", contentClassName)}
+        className={cn("w-[--radix-popover-trigger-width] max-w-[calc(100vw-1rem)] p-0", contentClassName)}
         align={align}
         onWheel={(e) => e.stopPropagation()}
       >
         <Command>
           <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
-          <CommandList>
+          {/*
+           * Override cmdk's default 300px ceiling so the list shows more rows on
+           * tall viewports and stays inside the screen on short ones (mobile,
+           * landscape phones). overscroll-contain prevents body scroll-chaining
+           * once the user reaches the top/bottom of the list.
+           */}
+          <CommandList className="max-h-[min(60vh,360px)] overscroll-contain">
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             {prefixContent && <CommandGroup>{prefixContent({ close: () => setOpen(false) })}</CommandGroup>}
             <CommandGroup>

--- a/apps/frontend/src/components/ui/searchable-select.tsx
+++ b/apps/frontend/src/components/ui/searchable-select.tsx
@@ -1,0 +1,141 @@
+import { type ReactNode, useState, useEffect } from "react"
+import { ChevronsUpDown } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+interface SearchableSelectProps<T> {
+  items: T[]
+  value: T | null
+  onChange: (item: T) => void
+  /** Stable unique id for the item — used as React key and cmdk value. */
+  getKey: (item: T) => string
+  /** Search keywords matched by the cmdk fuzzy filter (e.g. [name, `@${slug}`]). */
+  getKeywords: (item: T) => string[]
+  /** Row rendered inside the popover list. */
+  renderItem: (item: T, isSelected: boolean) => ReactNode
+  /** Trigger label when a value is selected. Defaults to renderItem with selected=true. */
+  renderSelected?: (item: T) => ReactNode
+  /** Trigger label when no value is selected. */
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyMessage?: string
+  /** Optional icon left of the trigger label. */
+  triggerIcon?: LucideIcon
+  /**
+   * When no value is selected, append a subtle "· N available" hint to the trigger
+   * so users can see how many options exist before opening.
+   */
+  showAvailableCount?: boolean
+  availableLabel?: (n: number) => string
+  disabled?: boolean
+  className?: string
+  contentClassName?: string
+  align?: "start" | "center" | "end"
+  /** Extra rows rendered above the items list (e.g. a "device timezone" suggestion). */
+  prefixContent?: (helpers: { close: () => void }) => ReactNode
+  /** Test id forwarded to the trigger. */
+  "data-testid"?: string
+}
+
+export function SearchableSelect<T>({
+  items,
+  value,
+  onChange,
+  getKey,
+  getKeywords,
+  renderItem,
+  renderSelected,
+  placeholder = "Select...",
+  searchPlaceholder = "Search...",
+  emptyMessage = "No results found.",
+  triggerIcon: TriggerIcon,
+  showAvailableCount = false,
+  availableLabel = (n) => `${n} available`,
+  disabled = false,
+  className,
+  contentClassName,
+  align = "start",
+  prefixContent,
+  "data-testid": testId,
+}: SearchableSelectProps<T>) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  // Reset filter input each time the popover closes so the next open shows the full list.
+  useEffect(() => {
+    if (!open) setSearch("")
+  }, [open])
+
+  const handleSelect = (item: T) => {
+    onChange(item)
+    setOpen(false)
+  }
+
+  const triggerContent = value ? (
+    <span className="flex items-center gap-2 min-w-0 flex-1 truncate">
+      {TriggerIcon && <TriggerIcon className="h-4 w-4 shrink-0 text-muted-foreground" />}
+      <span className="truncate">{(renderSelected ?? ((v: T) => renderItem(v, true)))(value)}</span>
+    </span>
+  ) : (
+    <span className="flex items-center gap-2 min-w-0 flex-1 truncate font-normal text-muted-foreground">
+      {TriggerIcon && <TriggerIcon className="h-4 w-4 shrink-0" />}
+      <span className="truncate">{placeholder}</span>
+      {showAvailableCount && items.length > 0 && (
+        <span className="ml-auto pl-2 text-xs text-muted-foreground/70 shrink-0 tabular-nums">
+          {availableLabel(items.length)}
+        </span>
+      )}
+    </span>
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen} modal={false}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          data-testid={testId}
+          className={cn("w-full justify-between gap-2 font-normal", className)}
+        >
+          {triggerContent}
+          <ChevronsUpDown
+            className={cn(
+              "h-4 w-4 shrink-0 opacity-50 transition-transform duration-150",
+              open && "rotate-180 opacity-80"
+            )}
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn("w-[--radix-popover-trigger-width] min-w-[260px] p-0", contentClassName)}
+        align={align}
+        onWheel={(e) => e.stopPropagation()}
+      >
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            {prefixContent && <CommandGroup>{prefixContent({ close: () => setOpen(false) })}</CommandGroup>}
+            <CommandGroup>
+              {items.map((item) => {
+                const key = getKey(item)
+                const isSelected = value !== null && getKey(value) === key
+                return (
+                  <CommandItem key={key} value={key} keywords={getKeywords(item)} onSelect={() => handleSelect(item)}>
+                    {renderItem(item, isSelected)}
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/frontend/src/components/ui/searchable-select.tsx
+++ b/apps/frontend/src/components/ui/searchable-select.tsx
@@ -4,6 +4,8 @@ import type { LucideIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 
 interface SearchableSelectProps<T> {
@@ -61,10 +63,11 @@ export function SearchableSelect<T>({
   prefixContent,
   "data-testid": testId,
 }: SearchableSelectProps<T>) {
+  const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState("")
 
-  // Reset filter input each time the popover closes so the next open shows the full list.
+  // Reset filter input each time the popover/drawer closes so the next open shows the full list.
   useEffect(() => {
     if (!open) setSearch("")
   }, [open])
@@ -91,27 +94,63 @@ export function SearchableSelect<T>({
     </span>
   )
 
+  const triggerButton = (
+    <Button
+      type="button"
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      disabled={disabled}
+      data-testid={testId}
+      className={cn("w-full justify-between gap-2 font-normal", className)}
+    >
+      {triggerContent}
+      <ChevronsUpDown
+        className={cn("h-4 w-4 shrink-0 opacity-50 transition-transform duration-150", open && "rotate-180 opacity-80")}
+      />
+    </Button>
+  )
+
+  const commandList = (
+    <>
+      <CommandEmpty>{emptyMessage}</CommandEmpty>
+      {prefixContent && <CommandGroup>{prefixContent({ close: () => setOpen(false) })}</CommandGroup>}
+      <CommandGroup>
+        {items.map((item) => {
+          const key = getKey(item)
+          const isSelected = value !== null && getKey(value) === key
+          return (
+            <CommandItem key={key} value={key} keywords={getKeywords(item)} onSelect={() => handleSelect(item)}>
+              {renderItem(item, isSelected)}
+            </CommandItem>
+          )
+        })}
+      </CommandGroup>
+    </>
+  )
+
+  if (isMobile) {
+    // Drawer (vaul) on mobile: native touch-scroll works inside the list, and
+    // the dvh-based max height shrinks correctly when the on-screen keyboard
+    // appears (the parent Drawer is configured with repositionInputs={false}
+    // so vaul does not also try to set inline heights).
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+        <DrawerContent className={cn("flex h-[85dvh] flex-col pb-[env(safe-area-inset-bottom)]", contentClassName)}>
+          <DrawerTitle className="sr-only">{searchPlaceholder}</DrawerTitle>
+          <Command className="flex flex-1 flex-col overflow-hidden">
+            <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
+            <CommandList className="flex-1 overflow-y-auto overscroll-contain">{commandList}</CommandList>
+          </Command>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen} modal={false}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          disabled={disabled}
-          data-testid={testId}
-          className={cn("w-full justify-between gap-2 font-normal", className)}
-        >
-          {triggerContent}
-          <ChevronsUpDown
-            className={cn(
-              "h-4 w-4 shrink-0 opacity-50 transition-transform duration-150",
-              open && "rotate-180 opacity-80"
-            )}
-          />
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
       <PopoverContent
         className={cn("w-[--radix-popover-trigger-width] max-w-[calc(100vw-1rem)] p-0", contentClassName)}
         align={align}
@@ -121,25 +160,11 @@ export function SearchableSelect<T>({
           <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
           {/*
            * Override cmdk's default 300px ceiling so the list shows more rows on
-           * tall viewports and stays inside the screen on short ones (mobile,
-           * landscape phones). overscroll-contain prevents body scroll-chaining
-           * once the user reaches the top/bottom of the list.
+           * tall viewports and stays inside the screen on short ones. overscroll-
+           * contain prevents body scroll-chaining once the user reaches the
+           * top/bottom of the list.
            */}
-          <CommandList className="max-h-[min(60vh,360px)] overscroll-contain">
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            {prefixContent && <CommandGroup>{prefixContent({ close: () => setOpen(false) })}</CommandGroup>}
-            <CommandGroup>
-              {items.map((item) => {
-                const key = getKey(item)
-                const isSelected = value !== null && getKey(value) === key
-                return (
-                  <CommandItem key={key} value={key} keywords={getKeywords(item)} onSelect={() => handleSelect(item)}>
-                    {renderItem(item, isSelected)}
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
-          </CommandList>
+          <CommandList className="max-h-[min(60vh,360px)] overscroll-contain">{commandList}</CommandList>
         </Command>
       </PopoverContent>
     </Popover>

--- a/apps/frontend/src/components/ui/searchable-select.tsx
+++ b/apps/frontend/src/components/ui/searchable-select.tsx
@@ -130,18 +130,19 @@ export function SearchableSelect<T>({
   )
 
   if (isMobile) {
-    // Drawer (vaul) on mobile: native touch-scroll works inside the list, and
-    // the dvh-based max height shrinks correctly when the on-screen keyboard
-    // appears (the parent Drawer is configured with repositionInputs={false}
-    // so vaul does not also try to set inline heights).
+    // Drawer (vaul) on mobile. The drawer itself is content-driven (no fixed
+    // height) so a 4-row list gives a 4-row drawer instead of an empty 85dvh
+    // sheet. The CommandList caps at 70dvh, which lets the keyboard shrink
+    // available space without pushing rows off-screen — vaul is configured
+    // with repositionInputs={false}, so dvh is the single source of truth.
     return (
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-        <DrawerContent className={cn("flex h-[85dvh] flex-col pb-[env(safe-area-inset-bottom)]", contentClassName)}>
+        <DrawerContent className={cn("pb-[env(safe-area-inset-bottom)]", contentClassName)}>
           <DrawerTitle className="sr-only">{searchPlaceholder}</DrawerTitle>
-          <Command className="flex flex-1 flex-col overflow-hidden">
+          <Command>
             <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
-            <CommandList className="flex-1 overflow-y-auto overscroll-contain">{commandList}</CommandList>
+            <CommandList className="max-h-[70dvh] overscroll-contain">{commandList}</CommandList>
           </Command>
         </DrawerContent>
       </Drawer>

--- a/apps/frontend/src/components/ui/timezone-picker.tsx
+++ b/apps/frontend/src/components/ui/timezone-picker.tsx
@@ -81,7 +81,7 @@ export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
             }}
             className="font-medium"
           >
-            <Check className={cn("mr-2 h-4 w-4", value === detectedTimezone ? "opacity-100" : "opacity-0")} />
+            <Check className="mr-2 h-4 w-4 opacity-0" aria-hidden="true" />
             <span className="font-mono">{formatTimezoneLabel(detectedTimezone)}</span>
             <span className="ml-2 text-muted-foreground">(device)</span>
           </CommandItem>

--- a/apps/frontend/src/components/ui/timezone-picker.tsx
+++ b/apps/frontend/src/components/ui/timezone-picker.tsx
@@ -72,7 +72,6 @@ export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
       getKeywords={(tz) => [tz, tz.replace(/_/g, " "), labelFor(tz)]}
       searchPlaceholder="Search timezone..."
       emptyMessage="No timezone found."
-      contentClassName="w-[400px]"
       renderSelected={(tz) => <span className="font-mono">{labelFor(tz)}</span>}
       renderItem={(tz, isSelected) => (
         <>

--- a/apps/frontend/src/components/ui/timezone-picker.tsx
+++ b/apps/frontend/src/components/ui/timezone-picker.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { Check } from "lucide-react"
 import { CommandItem } from "@/components/ui/command"
 import { SearchableSelect } from "@/components/ui/searchable-select"
@@ -53,6 +53,15 @@ interface TimezonePickerProps {
 export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
   const detectedTimezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, [])
   const timezones = useMemo(() => getAvailableTimezones(), [])
+  // Precompute the formatted label for every timezone once. formatTimezoneLabel
+  // spins up a fresh Intl.DateTimeFormat per call, and this list has 400+
+  // entries — caching keeps every keystroke during search cheap.
+  const labelByTz = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const tz of timezones) map.set(tz, formatTimezoneLabel(tz))
+    return map
+  }, [timezones])
+  const labelFor = useCallback((tz: string) => labelByTz.get(tz) ?? formatTimezoneLabel(tz), [labelByTz])
 
   return (
     <SearchableSelect
@@ -60,15 +69,15 @@ export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
       value={value}
       onChange={onChange}
       getKey={(tz) => tz}
-      getKeywords={(tz) => [tz, tz.replace(/_/g, " "), formatTimezoneLabel(tz)]}
+      getKeywords={(tz) => [tz, tz.replace(/_/g, " "), labelFor(tz)]}
       searchPlaceholder="Search timezone..."
       emptyMessage="No timezone found."
       contentClassName="w-[400px]"
-      renderSelected={(tz) => <span className="font-mono">{formatTimezoneLabel(tz)}</span>}
+      renderSelected={(tz) => <span className="font-mono">{labelFor(tz)}</span>}
       renderItem={(tz, isSelected) => (
         <>
           <Check className={cn("mr-2 h-4 w-4", isSelected ? "opacity-100" : "opacity-0")} />
-          <span className="font-mono">{formatTimezoneLabel(tz)}</span>
+          <span className="font-mono">{labelFor(tz)}</span>
         </>
       )}
       prefixContent={({ close }) =>
@@ -82,7 +91,7 @@ export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
             className="font-medium"
           >
             <Check className="mr-2 h-4 w-4 opacity-0" aria-hidden="true" />
-            <span className="font-mono">{formatTimezoneLabel(detectedTimezone)}</span>
+            <span className="font-mono">{labelFor(detectedTimezone)}</span>
             <span className="ml-2 text-muted-foreground">(device)</span>
           </CommandItem>
         ) : null

--- a/apps/frontend/src/components/ui/timezone-picker.tsx
+++ b/apps/frontend/src/components/ui/timezone-picker.tsx
@@ -1,8 +1,7 @@
-import { useMemo, useState } from "react"
-import { Check, ChevronsUpDown } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { useMemo } from "react"
+import { Check } from "lucide-react"
+import { CommandItem } from "@/components/ui/command"
+import { SearchableSelect } from "@/components/ui/searchable-select"
 import { cn } from "@/lib/utils"
 
 /**
@@ -52,50 +51,42 @@ interface TimezonePickerProps {
 }
 
 export function TimezonePicker({ value, onChange }: TimezonePickerProps) {
-  const [open, setOpen] = useState(false)
   const detectedTimezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, [])
   const timezones = useMemo(() => getAvailableTimezones(), [])
 
-  function handleSelect(selectedTimezone: string) {
-    onChange(selectedTimezone)
-    setOpen(false)
-  }
-
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={false}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" role="combobox" aria-expanded={open} className="w-full justify-between">
-          <span className="truncate font-mono">{formatTimezoneLabel(value)}</span>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[400px] p-0" align="start" onWheel={(e) => e.stopPropagation()}>
-        <Command>
-          <CommandInput placeholder="Search timezone..." />
-          <CommandList>
-            <CommandEmpty>No timezone found.</CommandEmpty>
-            <CommandGroup>
-              {detectedTimezone !== value && (
-                <CommandItem
-                  value={`device-${detectedTimezone}`}
-                  onSelect={() => handleSelect(detectedTimezone)}
-                  className="font-medium"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === detectedTimezone ? "opacity-100" : "opacity-0")} />
-                  <span className="font-mono">{formatTimezoneLabel(detectedTimezone)}</span>
-                  <span className="ml-2 text-muted-foreground">(device)</span>
-                </CommandItem>
-              )}
-              {timezones.map((tz) => (
-                <CommandItem key={tz} value={tz} onSelect={() => handleSelect(tz)}>
-                  <Check className={cn("mr-2 h-4 w-4", value === tz ? "opacity-100" : "opacity-0")} />
-                  <span className="font-mono">{formatTimezoneLabel(tz)}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchableSelect
+      items={timezones}
+      value={value}
+      onChange={onChange}
+      getKey={(tz) => tz}
+      getKeywords={(tz) => [tz, tz.replace(/_/g, " "), formatTimezoneLabel(tz)]}
+      searchPlaceholder="Search timezone..."
+      emptyMessage="No timezone found."
+      contentClassName="w-[400px]"
+      renderSelected={(tz) => <span className="font-mono">{formatTimezoneLabel(tz)}</span>}
+      renderItem={(tz, isSelected) => (
+        <>
+          <Check className={cn("mr-2 h-4 w-4", isSelected ? "opacity-100" : "opacity-0")} />
+          <span className="font-mono">{formatTimezoneLabel(tz)}</span>
+        </>
+      )}
+      prefixContent={({ close }) =>
+        detectedTimezone !== value ? (
+          <CommandItem
+            value={`device-${detectedTimezone}`}
+            onSelect={() => {
+              onChange(detectedTimezone)
+              close()
+            }}
+            className="font-medium"
+          >
+            <Check className={cn("mr-2 h-4 w-4", value === detectedTimezone ? "opacity-100" : "opacity-0")} />
+            <span className="font-mono">{formatTimezoneLabel(detectedTimezone)}</span>
+            <span className="ml-2 text-muted-foreground">(device)</span>
+          </CommandItem>
+        ) : null
+      }
+    />
   )
 }

--- a/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { botsApi } from "@/api/bots"
 import { StreamTypes, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
+import { SearchableSelect } from "@/components/ui/searchable-select"
 import { Hash, X } from "lucide-react"
 
 interface BotChannelsSectionProps {
@@ -16,7 +16,6 @@ interface BotChannelsSectionProps {
 
 export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChannelsSectionProps) {
   const queryClient = useQueryClient()
-  const [channelSearch, setChannelSearch] = useState("")
 
   const grantsQueryKey = ["bot-stream-grants", workspaceId, botId]
   const { data: streamGrants = [] } = useQuery({
@@ -33,10 +32,7 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
 
   const grantStreamMutation = useMutation({
     mutationFn: (streamId: string) => botsApi.grantStreamAccess(workspaceId, botId, streamId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: grantsQueryKey })
-      setChannelSearch("")
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: grantsQueryKey }),
   })
 
   const revokeStreamMutation = useMutation({
@@ -47,18 +43,11 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
   const grantedStreamIds = useMemo(() => new Set(streamGrants.map((g) => g.streamId)), [streamGrants])
 
   const availableChannels = useMemo(() => {
-    if (!channelSearch || !wsBootstrap?.streams) return []
-    const q = channelSearch.toLowerCase()
-    return wsBootstrap.streams
-      .filter(
-        (s) =>
-          s.type === StreamTypes.CHANNEL &&
-          !s.archivedAt &&
-          !grantedStreamIds.has(s.id) &&
-          (s.slug?.toLowerCase().includes(q) || s.displayName?.toLowerCase().includes(q))
-      )
-      .slice(0, 10)
-  }, [wsBootstrap, channelSearch, grantedStreamIds])
+    if (!wsBootstrap?.streams) return []
+    return wsBootstrap.streams.filter(
+      (s) => s.type === StreamTypes.CHANNEL && !s.archivedAt && !grantedStreamIds.has(s.id)
+    )
+  }, [wsBootstrap, grantedStreamIds])
 
   const grantedStreams = useMemo(() => {
     if (!wsBootstrap?.streams) return []
@@ -113,34 +102,31 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
       )}
 
       {!isArchived && (
-        <div className="space-y-1.5">
-          <Input
-            placeholder="Search channels to grant access..."
-            value={channelSearch}
-            onChange={(e) => setChannelSearch(e.target.value)}
-            className="h-8"
-          />
-          {availableChannels.length > 0 && (
-            <div className="rounded-md border divide-y max-h-40 overflow-y-auto">
-              {availableChannels.map((stream) => (
-                <button
-                  key={stream.id}
-                  className="w-full flex items-center gap-2 px-3 py-2 hover:bg-accent/50 transition-colors text-left"
-                  onClick={() => grantStreamMutation.mutate(stream.id)}
-                >
-                  <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                  <span className="text-sm truncate">{stream.slug ?? stream.displayName}</span>
-                  <Badge variant="outline" className="ml-auto text-[10px] shrink-0">
-                    {stream.visibility}
-                  </Badge>
-                </button>
-              ))}
-            </div>
+        <SearchableSelect
+          items={availableChannels}
+          value={null}
+          onChange={(stream) => grantStreamMutation.mutate(stream.id)}
+          getKey={(s) => s.id}
+          getKeywords={(s) =>
+            [s.slug ?? "", s.slug ? `#${s.slug}` : "", s.displayName ?? ""].filter(Boolean) as string[]
+          }
+          placeholder={availableChannels.length === 0 ? "All channels granted" : "Grant channel access..."}
+          searchPlaceholder="Search channels..."
+          emptyMessage="No matching channels"
+          triggerIcon={Hash}
+          disabled={availableChannels.length === 0 || grantStreamMutation.isPending}
+          showAvailableCount
+          availableLabel={(n) => `${n} ${n === 1 ? "channel" : "channels"} available`}
+          renderItem={(stream) => (
+            <>
+              <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <span className="text-sm truncate">{stream.slug ?? stream.displayName}</span>
+              <Badge variant="outline" className="ml-auto text-[10px] shrink-0">
+                {stream.visibility}
+              </Badge>
+            </>
           )}
-          {channelSearch && availableChannels.length === 0 && (
-            <p className="text-xs text-muted-foreground py-1">No matching channels</p>
-          )}
-        </div>
+        />
       )}
     </section>
   )

--- a/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
@@ -44,14 +44,14 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
 
   const availableChannels = useMemo(() => {
     if (!wsBootstrap?.streams) return []
-    return wsBootstrap.streams.filter(
-      (s) => s.type === StreamTypes.CHANNEL && !s.archivedAt && !grantedStreamIds.has(s.id)
-    )
+    return wsBootstrap.streams
+      .filter((s) => s.type === StreamTypes.CHANNEL && !s.archivedAt && !grantedStreamIds.has(s.id))
+      .sort((a, b) => (a.slug ?? a.displayName ?? "").localeCompare(b.slug ?? b.displayName ?? ""))
   }, [wsBootstrap, grantedStreamIds])
 
   const grantedStreams = useMemo(() => {
     if (!wsBootstrap?.streams) return []
-    return streamGrants
+    const enriched = streamGrants
       .map((g) => {
         const stream = wsBootstrap.streams.find((s) => s.id === g.streamId)
         return stream ? { ...g, slug: stream.slug, displayName: stream.displayName } : null
@@ -63,6 +63,7 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
       slug: string | null
       displayName: string | null
     }>
+    return enriched.sort((a, b) => (a.slug ?? a.displayName ?? "").localeCompare(b.slug ?? b.displayName ?? ""))
   }, [streamGrants, wsBootstrap])
 
   return (

--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { useQuery, useMutation } from "@tanstack/react-query"
 import { Check, ChevronDown, Copy, KeyRound, Link as LinkIcon, Mail } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -57,7 +57,11 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
 
   const { formatDate } = useFormattedDate()
 
-  const users = useWorkspaceUsers(workspaceId)
+  const workspaceUsers = useWorkspaceUsers(workspaceId)
+  const users = useMemo(
+    () => workspaceUsers.slice().sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug)),
+    [workspaceUsers]
+  )
 
   const invitationsQuery = useQuery({
     queryKey: ["invitations", workspaceId],

--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown, Copy, KeyRound, Link as LinkIcon, Mail } from "luci
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { ActorAvatar } from "@/components/actor-avatar"
 import { invitationsApi } from "@/api/invitations"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { useFormattedDate } from "@/hooks"
@@ -117,9 +118,18 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
       <div className="space-y-2">
         {users.map((user) => (
           <div key={user.id} className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
-            <div className="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2 min-w-0">
-              <span className="text-sm font-medium truncate">{user.name || user.slug}</span>
-              <span className="text-xs text-muted-foreground truncate">@{user.slug}</span>
+            <div className="flex items-center gap-2.5 min-w-0">
+              <ActorAvatar
+                actorId={user.id}
+                actorType="user"
+                workspaceId={workspaceId}
+                size="sm"
+                alt={user.name || user.slug}
+              />
+              <div className="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2 min-w-0">
+                <span className="text-sm font-medium truncate">{user.name || user.slug}</span>
+                <span className="text-xs text-muted-foreground truncate">@{user.slug}</span>
+              </div>
             </div>
             <Badge variant={user.role === "owner" ? "default" : "secondary"} className="shrink-0">
               {user.role}


### PR DESCRIPTION
## Summary

The "add member", "add bot", and "grant channel access" controls in stream and workspace settings were typeaheads with zero discoverability — you had to start typing before any options appeared, with no hint of how many existed. While we were in there, the existing member/bot/user lists were also showing colored initial circles instead of users' actual avatars or bots' configured emojis.

This PR does two things:

### 1. New `SearchableSelect` component

Extracted the timezone picker's Popover + cmdk pattern into a generic, reusable `apps/frontend/src/components/ui/searchable-select.tsx`:

- Opens to the **full list on click**, filters as you type (cmdk fuzzy match against caller-supplied keywords).
- Shows a subtle **"· N available"** count hint right in the trigger so users see option counts up front.
- Animated chevron, disabled-trigger fallback copy ("All workspace users are members" / "All channels granted") so empty states never look broken.
- Caller supplies `getKey`, `getKeywords`, `renderItem` — no item-shape coupling.

Refactored `TimezonePicker` to use it (now ~50 lines instead of ~100, identical behavior — device-timezone suggestion preserved via the new `prefixContent` slot). Three settings surfaces migrated:

| Surface | File |
|---|---|
| Add member to channel | `stream-settings/members-tab.tsx` |
| Add bot to stream | `stream-settings/members-tab.tsx` |
| Grant channel access to bot | `workspace-settings/bot-channels-section.tsx` |

### 2. Real avatars in member, bot, and workspace user lists

Routed five rendering surfaces through the existing `ActorAvatar` component, so:

- Stream **members list** + **add-member dropdown rows** show user avatars (initials fallback).
- Stream **bots list** + **add-bot dropdown rows** show bot avatar URLs / emojis (initials fallback).
- Workspace settings **users list** shows user avatars.

`ActorAvatar` already handles all the type-specific fallback logic (emerald tint for bots, emoji-as-fallback for bots without an image, initials with avatar-color tint for users), so this is a pure render swap — no data changes needed.

### Out of scope (deliberate)

- `create-channel/user-picker.tsx` still uses the old `SearchableList` because it's a multi-select-with-chips flow inside a dialog — different UX problem. Worth a separate pass if we want to give it the same discoverability.
- The "Filter members…" input above the existing-members list stays a plain text filter (it's filtering an already-visible list, not an opaque source).

## Test plan

- [x] `tsc --noEmit` clean across the monorepo
- [x] `eslint` clean
- [x] All existing tests pass for the touched files (`stream-settings-dialog.test.tsx`, `user-setup.test.tsx`, frontend timezone tests)
- [ ] Manual: open channel settings → Members tab → click "Add member" — see full list of addable users with avatars and "N users available" hint
- [ ] Manual: open channel settings → Members tab → click "Add bot" — see full list with bot avatars/emojis
- [ ] Manual: open workspace settings → Bots → bot detail → "Grant channel access" — see full list with channel hash icons
- [ ] Manual: open workspace settings → Users — verify users render with their real avatars
- [ ] Manual: open user preferences → Date & time — verify timezone picker still works (search, device-timezone suggestion, selection)

https://claude.ai/code/session_01CaNLiAXXecouGVHMTehWkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaNLiAXXecouGVHMTehWkZ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->