### PR TITLE
Phase 1 / PR B: WorkOS authz mirror in control plane (passive event polling)

### DIFF
--- a/apps/control-plane/scripts/backfill-workos-authz.ts
+++ b/apps/control-plane/scripts/backfill-workos-authz.ts
@@ -1,0 +1,61 @@
+/**
+ * Re-runnable WorkOS authz backfill.
+ *
+ * Reads workspace_registry.workos_organization_id rows, asks WorkOS for each
+ * org's full membership list, and upserts every membership into
+ * workos_organization_memberships. Idempotent. Stamps
+ * workos_event_poller_state.last_backfill_at so first-boot logic in
+ * server.ts knows backfill has happened at least once.
+ *
+ * Usage:
+ *   bun apps/control-plane/scripts/backfill-workos-authz.ts
+ *
+ * Connects using the same env-driven config loader as the CP itself
+ * (DATABASE_URL, WORKOS_API_KEY, USE_STUB_AUTH, ...).
+ */
+
+import { createDatabasePool, runMigrations, WorkosOrgServiceImpl, StubWorkosOrgService } from "@threa/backend-common"
+import path from "path"
+import { loadControlPlaneConfig } from "../src/config"
+import { WorkosAuthzBackfill } from "../src/features/workos-authz"
+import { WorkosEventPollerLock } from "../src/lib/workos-event-poller-lock"
+
+const WORKOS_EVENT_POLLER_NAME = "workos-events"
+
+async function main() {
+  const config = loadControlPlaneConfig()
+  const pool = createDatabasePool(config.databaseUrl, { max: 4 })
+
+  // Make sure the schema is up to date so a freshly cloned DB can run this
+  // without first booting the CP.
+  const migrationsGlob = path.join(import.meta.dirname, "../src/db/migrations/*.sql")
+  await runMigrations(pool, migrationsGlob)
+
+  const workosOrgService = config.useStubAuth ? new StubWorkosOrgService() : new WorkosOrgServiceImpl(config.workos)
+
+  const lock = new WorkosEventPollerLock({
+    pool,
+    name: WORKOS_EVENT_POLLER_NAME,
+    lockDurationMs: 10_000,
+    refreshIntervalMs: 5_000,
+    maxRetries: 5,
+    baseBackoffMs: 1_000,
+  })
+  await lock.ensureRow()
+
+  const backfill = new WorkosAuthzBackfill({ pool, workosOrgService, lock })
+
+  try {
+    const result = await backfill.run()
+    console.log(
+      `Backfill complete: orgsScanned=${result.orgsScanned} membershipsUpserted=${result.membershipsUpserted}`
+    )
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err)
+  process.exit(1)
+})

--- a/apps/control-plane/src/db/migrations/006_workos_authz_mirror.sql
+++ b/apps/control-plane/src/db/migrations/006_workos_authz_mirror.sql
@@ -1,0 +1,50 @@
+-- WorkOS authz mirror — passive read-side mirror of organization memberships
+-- driven by WorkOS event polling.
+--
+-- Design notes:
+-- - Keys on (workos_organization_id, workos_user_id) so the table is a true
+--   mirror of WorkOS state. Workspace scoping is implicit via the join to
+--   workspace_registry.workos_organization_id when callers need it.
+-- - last_event_at is the timestamp guard for race-safe upserts (INV-20):
+--   regular event upserts use a `WHERE existing.last_event_at < EXCLUDED.last_event_at`
+--   guard so out-of-order or duplicated events never clobber newer state.
+--   Backfill stamps NOW() and last_event_id = NULL — backfill is an explicit
+--   operator action, last-write-wins is intentional there.
+-- - status is TEXT (validated in app code, INV-3): 'active' | 'inactive' | 'pending'.
+-- - role_slugs is TEXT[] so we can mirror WorkOS' multi-role membership shape
+--   even though Phase 1 still has a single role per membership in practice.
+-- - workos_event_poller_state is keyed by `name` so additional pollers can be
+--   added later without a schema change. Phase 1 uses one row: 'workos-events'.
+
+CREATE TABLE workos_event_poller_state (
+    name TEXT PRIMARY KEY,
+    last_event_id TEXT,
+    last_event_at TIMESTAMPTZ,
+    last_backfill_at TIMESTAMPTZ,
+    locked_until TIMESTAMPTZ,
+    lock_run_id TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    retry_after TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE workos_organization_memberships (
+    workos_organization_id TEXT NOT NULL,
+    workos_user_id TEXT NOT NULL,
+    organization_membership_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    role_slugs TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    last_event_id TEXT,
+    last_event_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workos_organization_id, workos_user_id)
+);
+
+CREATE INDEX workos_org_memberships_user_idx
+    ON workos_organization_memberships (workos_user_id);
+
+CREATE INDEX workos_org_memberships_org_status_idx
+    ON workos_organization_memberships (workos_organization_id, status);

--- a/apps/control-plane/src/features/workos-authz/backfill.ts
+++ b/apps/control-plane/src/features/workos-authz/backfill.ts
@@ -36,10 +36,7 @@ export class WorkosAuthzBackfill {
   }
 
   async run(): Promise<WorkosAuthzBackfillResult> {
-    const workspaces = await WorkspaceRegistryRepository.listAllWithMemberCounts(this.pool)
-    const orgIds = Array.from(
-      new Set(workspaces.map((w) => w.workos_organization_id).filter((id): id is string => id != null && id.length > 0))
-    )
+    const orgIds = await WorkspaceRegistryRepository.listWorkosOrganizationIds(this.pool)
 
     let membershipsUpserted = 0
     for (const orgId of orgIds) {

--- a/apps/control-plane/src/features/workos-authz/backfill.ts
+++ b/apps/control-plane/src/features/workos-authz/backfill.ts
@@ -1,0 +1,71 @@
+import type { Pool } from "pg"
+import { logger, type WorkosOrgService } from "@threa/backend-common"
+import { WorkspaceRegistryRepository } from "../workspaces"
+import { WorkosAuthzRepository } from "./repository"
+import type { WorkosEventPollerLock } from "../../lib/workos-event-poller-lock"
+
+interface Dependencies {
+  pool: Pool
+  workosOrgService: WorkosOrgService
+  /** Optional — when provided, backfill stamps `last_backfill_at` after a successful run. */
+  lock?: WorkosEventPollerLock
+}
+
+export interface WorkosAuthzBackfillResult {
+  orgsScanned: number
+  membershipsUpserted: number
+}
+
+/**
+ * Read every workspace with a non-null `workos_organization_id`, ask WorkOS
+ * for its full membership list, and upsert each row via the backfill path.
+ *
+ * Backfill is idempotent and re-runnable. It does NOT touch the poller's
+ * `last_event_id` cursor: the regular event poller has its own timestamp
+ * guard so a stale event replay can't clobber freshly backfilled state.
+ */
+export class WorkosAuthzBackfill {
+  private pool: Pool
+  private workosOrgService: WorkosOrgService
+  private lock?: WorkosEventPollerLock
+
+  constructor({ pool, workosOrgService, lock }: Dependencies) {
+    this.pool = pool
+    this.workosOrgService = workosOrgService
+    this.lock = lock
+  }
+
+  async run(): Promise<WorkosAuthzBackfillResult> {
+    const workspaces = await WorkspaceRegistryRepository.listAllWithMemberCounts(this.pool)
+    const orgIds = Array.from(
+      new Set(workspaces.map((w) => w.workos_organization_id).filter((id): id is string => id != null && id.length > 0))
+    )
+
+    let membershipsUpserted = 0
+    for (const orgId of orgIds) {
+      try {
+        const memberships = await this.workosOrgService.listOrganizationMemberships(orgId)
+        for (const m of memberships) {
+          await WorkosAuthzRepository.upsertMembershipFromBackfill(this.pool, {
+            organizationMembershipId: m.id,
+            workosOrganizationId: m.organizationId,
+            workosUserId: m.userId,
+            status: m.status,
+            roleSlugs: m.roleSlugs,
+            observedAt: new Date(),
+          })
+          membershipsUpserted++
+        }
+      } catch (err) {
+        logger.error({ err, organizationId: orgId }, "Failed to backfill WorkOS memberships for organization")
+      }
+    }
+
+    if (this.lock) {
+      await this.lock.stampBackfill()
+    }
+
+    logger.info({ orgsScanned: orgIds.length, membershipsUpserted }, "WorkOS authz backfill complete")
+    return { orgsScanned: orgIds.length, membershipsUpserted }
+  }
+}

--- a/apps/control-plane/src/features/workos-authz/index.ts
+++ b/apps/control-plane/src/features/workos-authz/index.ts
@@ -1,0 +1,6 @@
+export { WorkosAuthzService } from "./service"
+export { WorkosAuthzBackfill } from "./backfill"
+export type { WorkosAuthzBackfillResult } from "./backfill"
+export { WorkosAuthzPoller } from "./poller"
+export { WorkosAuthzRepository } from "./repository"
+export type { WorkosOrgMembershipRow } from "./repository"

--- a/apps/control-plane/src/features/workos-authz/poller.ts
+++ b/apps/control-plane/src/features/workos-authz/poller.ts
@@ -1,0 +1,129 @@
+import { logger, type WorkosOrgService } from "@threa/backend-common"
+import type { WorkosEventPollerLock } from "../../lib/workos-event-poller-lock"
+import type { WorkosAuthzService } from "./service"
+
+interface Dependencies {
+  workosOrgService: WorkosOrgService
+  authzService: WorkosAuthzService
+  lock: WorkosEventPollerLock
+  /** Time between ticks when there is no work and we hold no lease. */
+  pollIntervalMs: number
+  /** Per-page event batch size. */
+  batchSize: number
+}
+
+/**
+ * Long-lived loop that drains WorkOS membership events into the local mirror.
+ *
+ * Modeled on the outbox dispatcher in `apps/control-plane/src/server.ts:75-87`:
+ * a single instance owns the lease at any time, but multiple control-plane
+ * instances are safe — losers just no-op until the lease frees up.
+ *
+ * Per tick:
+ *   1. Try to claim the lease. Skip if held / in backoff.
+ *   2. Start the lease-refresh timer.
+ *   3. Drain WorkOS pages until empty, calling the authz service for each
+ *      event, advancing the cursor after every successful event.
+ *   4. Release the lease and stop the refresh timer.
+ *
+ * Errors are reported via `lock.recordError`, which applies exponential
+ * backoff. Forward progress on any tick resets the retry counter via
+ * `lock.advance` so transient hiccups don't snowball.
+ */
+export class WorkosAuthzPoller {
+  private readonly workosOrgService: WorkosOrgService
+  private readonly authzService: WorkosAuthzService
+  private readonly lock: WorkosEventPollerLock
+  private readonly pollIntervalMs: number
+  private readonly batchSize: number
+
+  private running = false
+  private currentTick: Promise<void> | null = null
+  private tickTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor({ workosOrgService, authzService, lock, pollIntervalMs, batchSize }: Dependencies) {
+    this.workosOrgService = workosOrgService
+    this.authzService = authzService
+    this.lock = lock
+    this.pollIntervalMs = pollIntervalMs
+    this.batchSize = batchSize
+  }
+
+  start(): void {
+    if (this.running) return
+    this.running = true
+    void this.scheduleNext(0)
+  }
+
+  /** Stops scheduling new ticks and waits for the current tick to finish. */
+  async stop(): Promise<void> {
+    this.running = false
+    if (this.tickTimer) {
+      clearTimeout(this.tickTimer)
+      this.tickTimer = null
+    }
+    if (this.currentTick) {
+      try {
+        await this.currentTick
+      } catch {
+        // already logged
+      }
+    }
+  }
+
+  /**
+   * Run a single tick on demand. Useful for tests and the bootstrap path
+   * (`server.ts` calls this once on startup so the mirror catches up before
+   * accepting traffic, when a lease is available).
+   */
+  async tick(): Promise<void> {
+    const claim = await this.lock.tryAcquire()
+    if (!claim) return
+
+    this.lock.startRefreshTimer()
+    try {
+      let cursor: string | null = claim.lastEventId
+      let drained = false
+      while (!drained) {
+        const page = await this.workosOrgService.listMirrorEvents({
+          ...(cursor ? { after: cursor } : {}),
+          limit: this.batchSize,
+        })
+        if (page.data.length === 0) {
+          drained = true
+          break
+        }
+        for (const event of page.data) {
+          await this.authzService.processEvent(event)
+          await this.lock.advance(event.id, event.createdAt)
+          cursor = event.id
+        }
+        if (page.after === null) {
+          drained = true
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error({ err }, "WorkOS event poller tick failed")
+      await this.lock.recordError(message)
+    } finally {
+      this.lock.stopRefreshTimer()
+      await this.lock.release()
+    }
+  }
+
+  private scheduleNext(delayMs: number): void {
+    if (!this.running) return
+    this.tickTimer = setTimeout(() => {
+      this.tickTimer = null
+      this.currentTick = this.tick()
+        .catch((err) => {
+          logger.error({ err }, "WorkOS event poller tick raised")
+        })
+        .finally(() => {
+          this.currentTick = null
+          this.scheduleNext(this.pollIntervalMs)
+        })
+    }, delayMs)
+  }
+}

--- a/apps/control-plane/src/features/workos-authz/poller.ts
+++ b/apps/control-plane/src/features/workos-authz/poller.ts
@@ -105,7 +105,10 @@ export class WorkosAuthzPoller {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       logger.error({ err }, "WorkOS event poller tick failed")
-      await this.lock.recordError(message)
+      const { shouldRetry } = await this.lock.recordError(message)
+      if (!shouldRetry) {
+        logger.error({ lastError: message }, "WorkOS event poller exhausted retries — manual intervention required")
+      }
     } finally {
       this.lock.stopRefreshTimer()
       await this.lock.release()

--- a/apps/control-plane/src/features/workos-authz/repository.ts
+++ b/apps/control-plane/src/features/workos-authz/repository.ts
@@ -1,0 +1,174 @@
+import type { Querier } from "@threa/backend-common"
+
+export interface WorkosOrgMembershipRow {
+  workos_organization_id: string
+  workos_user_id: string
+  organization_membership_id: string
+  status: string
+  role_slugs: string[]
+  last_event_id: string | null
+  last_event_at: Date
+  created_at: Date
+  updated_at: Date
+}
+
+export interface UpsertMembershipFromEventInput {
+  organizationMembershipId: string
+  workosOrganizationId: string
+  workosUserId: string
+  status: string
+  roleSlugs: string[]
+  eventId: string
+  eventCreatedAt: Date
+}
+
+export interface UpsertMembershipFromBackfillInput {
+  organizationMembershipId: string
+  workosOrganizationId: string
+  workosUserId: string
+  status: string
+  roleSlugs: string[]
+  /** Stamped onto last_event_at; backfill is last-write-wins. */
+  observedAt: Date
+}
+
+const SELECT_FIELDS = `
+  workos_organization_id,
+  workos_user_id,
+  organization_membership_id,
+  status,
+  role_slugs,
+  last_event_id,
+  last_event_at,
+  created_at,
+  updated_at
+`
+
+export const WorkosAuthzRepository = {
+  /**
+   * Race-safe upsert from a WorkOS event (INV-20). A `last_event_at` timestamp
+   * guard rejects stale or duplicated events: we only overwrite when the
+   * incoming event is strictly newer than what we've already persisted.
+   * Returns the row only when an actual change was applied — useful for
+   * tests and metrics.
+   */
+  async upsertMembershipFromEvent(
+    db: Querier,
+    input: UpsertMembershipFromEventInput
+  ): Promise<WorkosOrgMembershipRow | null> {
+    const result = await db.query<WorkosOrgMembershipRow>(
+      `INSERT INTO workos_organization_memberships (
+         workos_organization_id,
+         workos_user_id,
+         organization_membership_id,
+         status,
+         role_slugs,
+         last_event_id,
+         last_event_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (workos_organization_id, workos_user_id) DO UPDATE SET
+         organization_membership_id = EXCLUDED.organization_membership_id,
+         status = EXCLUDED.status,
+         role_slugs = EXCLUDED.role_slugs,
+         last_event_id = EXCLUDED.last_event_id,
+         last_event_at = EXCLUDED.last_event_at,
+         updated_at = NOW()
+       WHERE workos_organization_memberships.last_event_at < EXCLUDED.last_event_at
+       RETURNING ${SELECT_FIELDS}`,
+      [
+        input.workosOrganizationId,
+        input.workosUserId,
+        input.organizationMembershipId,
+        input.status,
+        input.roleSlugs,
+        input.eventId,
+        input.eventCreatedAt,
+      ]
+    )
+    return result.rows[0] ?? null
+  },
+
+  /**
+   * Backfill upsert: last-write-wins, no timestamp guard. The operator running
+   * backfill is the source of truth for that moment. Stamps `last_event_id`
+   * to NULL so a subsequent event-driven update can compare timestamps cleanly.
+   */
+  async upsertMembershipFromBackfill(
+    db: Querier,
+    input: UpsertMembershipFromBackfillInput
+  ): Promise<WorkosOrgMembershipRow> {
+    const result = await db.query<WorkosOrgMembershipRow>(
+      `INSERT INTO workos_organization_memberships (
+         workos_organization_id,
+         workos_user_id,
+         organization_membership_id,
+         status,
+         role_slugs,
+         last_event_id,
+         last_event_at
+       )
+       VALUES ($1, $2, $3, $4, $5, NULL, $6)
+       ON CONFLICT (workos_organization_id, workos_user_id) DO UPDATE SET
+         organization_membership_id = EXCLUDED.organization_membership_id,
+         status = EXCLUDED.status,
+         role_slugs = EXCLUDED.role_slugs,
+         last_event_id = NULL,
+         last_event_at = EXCLUDED.last_event_at,
+         updated_at = NOW()
+       RETURNING ${SELECT_FIELDS}`,
+      [
+        input.workosOrganizationId,
+        input.workosUserId,
+        input.organizationMembershipId,
+        input.status,
+        input.roleSlugs,
+        input.observedAt,
+      ]
+    )
+    return result.rows[0]
+  },
+
+  /**
+   * Delete with the same timestamp guard as upsert (INV-20). Only removes the
+   * row when the deletion event is newer than the persisted state.
+   */
+  async deleteMembership(
+    db: Querier,
+    params: { workosOrganizationId: string; workosUserId: string; eventCreatedAt: Date }
+  ): Promise<boolean> {
+    const result = await db.query(
+      `DELETE FROM workos_organization_memberships
+       WHERE workos_organization_id = $1
+         AND workos_user_id = $2
+         AND last_event_at < $3`,
+      [params.workosOrganizationId, params.workosUserId, params.eventCreatedAt]
+    )
+    return (result.rowCount ?? 0) > 0
+  },
+
+  async listByOrganization(db: Querier, workosOrganizationId: string): Promise<WorkosOrgMembershipRow[]> {
+    const result = await db.query<WorkosOrgMembershipRow>(
+      `SELECT ${SELECT_FIELDS}
+       FROM workos_organization_memberships
+       WHERE workos_organization_id = $1
+       ORDER BY created_at ASC`,
+      [workosOrganizationId]
+    )
+    return result.rows
+  },
+
+  async getByOrgAndUser(
+    db: Querier,
+    workosOrganizationId: string,
+    workosUserId: string
+  ): Promise<WorkosOrgMembershipRow | null> {
+    const result = await db.query<WorkosOrgMembershipRow>(
+      `SELECT ${SELECT_FIELDS}
+       FROM workos_organization_memberships
+       WHERE workos_organization_id = $1 AND workos_user_id = $2`,
+      [workosOrganizationId, workosUserId]
+    )
+    return result.rows[0] ?? null
+  },
+}

--- a/apps/control-plane/src/features/workos-authz/service.ts
+++ b/apps/control-plane/src/features/workos-authz/service.ts
@@ -1,0 +1,64 @@
+import type { Pool } from "pg"
+import { logger, type WorkosMembershipEvent } from "@threa/backend-common"
+import { WorkosAuthzRepository } from "./repository"
+
+interface Dependencies {
+  pool: Pool
+}
+
+/**
+ * Service that applies WorkOS membership events to the local mirror.
+ *
+ * Phase 1 is read-only — no fan-out to regional backends, no enforcement,
+ * no write paths back to WorkOS. The poller calls `processEvent` for each
+ * event in order and the service routes it to the correct repo method.
+ *
+ * INV-6: services own transaction boundaries. Each event is one upsert/delete,
+ * which is already atomic at the row level, so no explicit transaction is
+ * needed here.
+ */
+export class WorkosAuthzService {
+  private pool: Pool
+
+  constructor({ pool }: Dependencies) {
+    this.pool = pool
+  }
+
+  async processEvent(event: WorkosMembershipEvent): Promise<void> {
+    const { membership } = event
+    switch (event.type) {
+      case "organization_membership.created":
+      case "organization_membership.updated": {
+        const updated = await WorkosAuthzRepository.upsertMembershipFromEvent(this.pool, {
+          organizationMembershipId: membership.id,
+          workosOrganizationId: membership.organizationId,
+          workosUserId: membership.userId,
+          status: membership.status,
+          roleSlugs: membership.roleSlugs,
+          eventId: event.id,
+          eventCreatedAt: event.createdAt,
+        })
+        if (!updated) {
+          logger.debug(
+            {
+              eventId: event.id,
+              eventType: event.type,
+              organizationId: membership.organizationId,
+              userId: membership.userId,
+            },
+            "WorkOS authz event ignored as stale"
+          )
+        }
+        return
+      }
+      case "organization_membership.deleted": {
+        await WorkosAuthzRepository.deleteMembership(this.pool, {
+          workosOrganizationId: membership.organizationId,
+          workosUserId: membership.userId,
+          eventCreatedAt: event.createdAt,
+        })
+        return
+      }
+    }
+  }
+}

--- a/apps/control-plane/src/features/workspaces/repository.ts
+++ b/apps/control-plane/src/features/workspaces/repository.ts
@@ -116,6 +116,20 @@ export const WorkspaceRegistryRepository = {
     return result.rows.map((row) => ({ ...row, member_count: Number(row.member_count) }))
   },
 
+  /**
+   * List the distinct WorkOS organization ids registered for any workspace.
+   * Used by the WorkOS authz backfill to enumerate orgs without paying for
+   * the membership-count join in {@link listAllWithMemberCounts}.
+   */
+  async listWorkosOrganizationIds(db: Querier): Promise<string[]> {
+    const result = await db.query<{ workos_organization_id: string }>(
+      `SELECT DISTINCT workos_organization_id
+       FROM workspace_registry
+       WHERE workos_organization_id IS NOT NULL`
+    )
+    return result.rows.map((row) => row.workos_organization_id)
+  },
+
   async listByUser(db: Querier, workosUserId: string): Promise<WorkspaceRegistryRow[]> {
     const result = await db.query<WorkspaceRegistryRow>(
       `SELECT wr.id, wr.name, wr.slug, wr.region, wr.created_by_workos_user_id, wr.workos_organization_id, wr.created_at, wr.updated_at

--- a/apps/control-plane/src/lib/workos-event-poller-lock.ts
+++ b/apps/control-plane/src/lib/workos-event-poller-lock.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "crypto"
+import type { Pool } from "pg"
+import { calculateBackoffMs, logger, sql } from "@threa/backend-common"
+
+export interface WorkosEventPollerLockConfig {
+  pool: Pool
+  /** Identifier for the poller — Phase 1 uses "workos-events". */
+  name: string
+  lockDurationMs: number
+  refreshIntervalMs: number
+  maxRetries: number
+  baseBackoffMs: number
+}
+
+interface PollerStateRow {
+  name: string
+  last_event_id: string | null
+  last_event_at: Date | null
+  retry_count: number
+  retry_after: Date | null
+}
+
+/**
+ * Time-based lease for the WorkOS event poller. Modeled on
+ * `packages/backend-common/src/outbox/cursor-lock.ts` but simpler:
+ *
+ * - Cursor type is `string | null` (WorkOS opaque event id), not `bigint`.
+ * - No sliding-window dedup — WorkOS event ids are globally unique and
+ *   idempotency in the mirror comes from the row-level `last_event_at` guard
+ *   on upsert (see `WorkosAuthzRepository.upsertMembershipFromEvent`).
+ *
+ * Atomic claim uses `UPDATE ... WHERE locked_until IS NULL OR locked_until < now()`
+ * (with a small clock-drift pad) so multiple control-plane instances can compete
+ * safely without `pg_advisory_lock` (which the repo explicitly avoids per
+ * `apps/backend/docs/distributed-cron-design.md`).
+ */
+export class WorkosEventPollerLock {
+  private readonly pool: Pool
+  private readonly name: string
+  private readonly lockDurationMs: number
+  private readonly refreshIntervalMs: number
+  private readonly maxRetries: number
+  private readonly baseBackoffMs: number
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null
+  private runId: string | null = null
+
+  constructor(config: WorkosEventPollerLockConfig) {
+    this.pool = config.pool
+    this.name = config.name
+    this.lockDurationMs = config.lockDurationMs
+    this.refreshIntervalMs = config.refreshIntervalMs
+    this.maxRetries = config.maxRetries
+    this.baseBackoffMs = config.baseBackoffMs
+  }
+
+  /** Ensure the poller-state row exists. Idempotent — safe to call on every boot. */
+  async ensureRow(): Promise<void> {
+    await this.pool.query(sql`
+      INSERT INTO workos_event_poller_state (name)
+      VALUES (${this.name})
+      ON CONFLICT (name) DO NOTHING
+    `)
+  }
+
+  /**
+   * Try to claim the lease. Returns the persisted cursor on success, or
+   * `null` if the lease is held by someone else or this poller is in retry
+   * backoff. Holder must call {@link release} when done.
+   */
+  async tryAcquire(now: Date = new Date()): Promise<{ lastEventId: string | null; lastEventAt: Date | null } | null> {
+    const ready = await this.isReadyToProcess(now)
+    if (!ready) return null
+
+    const lockedUntil = new Date(now.getTime() + this.lockDurationMs)
+    const clockDriftPadMs = 100
+    this.runId = randomUUID()
+
+    const result = await this.pool.query<PollerStateRow>(sql`
+      UPDATE workos_event_poller_state
+      SET
+        locked_until = ${lockedUntil},
+        lock_run_id = ${this.runId},
+        updated_at = ${now}
+      WHERE name = ${this.name}
+        AND (locked_until IS NULL OR locked_until < ${new Date(now.getTime() + clockDriftPadMs)})
+      RETURNING name, last_event_id, last_event_at, retry_count, retry_after
+    `)
+
+    if (result.rows.length === 0) {
+      this.runId = null
+      return null
+    }
+
+    const row = result.rows[0]
+    return { lastEventId: row.last_event_id, lastEventAt: row.last_event_at }
+  }
+
+  /** Persist cursor advance. Resets retry state because forward progress proves health. */
+  async advance(lastEventId: string, lastEventAt: Date, now: Date = new Date()): Promise<void> {
+    if (!this.runId) return
+    await this.pool.query(sql`
+      UPDATE workos_event_poller_state
+      SET
+        last_event_id = ${lastEventId},
+        last_event_at = ${lastEventAt},
+        retry_count = 0,
+        retry_after = NULL,
+        last_error = NULL,
+        updated_at = ${now}
+      WHERE name = ${this.name}
+        AND lock_run_id = ${this.runId}
+    `)
+  }
+
+  /** Stamp last_backfill_at after a successful backfill. */
+  async stampBackfill(at: Date = new Date()): Promise<void> {
+    await this.pool.query(sql`
+      UPDATE workos_event_poller_state
+      SET last_backfill_at = ${at}, updated_at = ${at}
+      WHERE name = ${this.name}
+    `)
+  }
+
+  /**
+   * Record a poller error and apply exponential backoff via `retry_after`.
+   * Returns whether to keep retrying (false once `maxRetries` is exceeded —
+   * the caller should fall back to whatever escalation it wants; this lock
+   * does not have a DLQ analog).
+   */
+  async recordError(message: string, now: Date = new Date()): Promise<{ shouldRetry: boolean }> {
+    const result = await this.pool.query<{ retry_count: number }>(sql`
+      UPDATE workos_event_poller_state
+      SET
+        retry_count = retry_count + 1,
+        last_error = ${message},
+        updated_at = ${now}
+      WHERE name = ${this.name}
+      RETURNING retry_count
+    `)
+    if (result.rows.length === 0) return { shouldRetry: false }
+
+    const newRetryCount = result.rows[0].retry_count
+    if (newRetryCount > this.maxRetries) {
+      return { shouldRetry: false }
+    }
+
+    const backoffMs = calculateBackoffMs({ baseMs: this.baseBackoffMs, retryCount: newRetryCount })
+    const retryAfter = new Date(now.getTime() + backoffMs)
+    await this.pool.query(sql`
+      UPDATE workos_event_poller_state
+      SET retry_after = ${retryAfter}, updated_at = ${now}
+      WHERE name = ${this.name}
+    `)
+    logger.warn(
+      { name: this.name, retryCount: newRetryCount, retryAfter: retryAfter.toISOString() },
+      "WorkOS event poller error, will retry after backoff"
+    )
+    return { shouldRetry: true }
+  }
+
+  /** Release the lease. Idempotent — safe to call on shutdown even if nothing held. */
+  async release(): Promise<void> {
+    if (!this.runId) return
+    await this.pool.query(sql`
+      UPDATE workos_event_poller_state
+      SET locked_until = NULL, lock_run_id = NULL, updated_at = NOW()
+      WHERE name = ${this.name} AND lock_run_id = ${this.runId}
+    `)
+    this.runId = null
+  }
+
+  /** Start the lease-refresh timer. Caller is responsible for calling {@link stopRefreshTimer}. */
+  startRefreshTimer(): void {
+    if (this.refreshTimer) return
+    this.refreshTimer = setInterval(() => {
+      this.refreshLock().catch((err) => {
+        logger.error({ err, name: this.name }, "Failed to refresh WorkOS event poller lock")
+      })
+    }, this.refreshIntervalMs)
+  }
+
+  stopRefreshTimer(): void {
+    if (!this.refreshTimer) return
+    clearInterval(this.refreshTimer)
+    this.refreshTimer = null
+  }
+
+  private async refreshLock(): Promise<void> {
+    if (!this.runId) return
+    const now = new Date()
+    const lockedUntil = new Date(now.getTime() + this.lockDurationMs)
+    await this.pool.query(sql`
+      UPDATE workos_event_poller_state
+      SET locked_until = ${lockedUntil}, updated_at = ${now}
+      WHERE name = ${this.name} AND lock_run_id = ${this.runId}
+    `)
+  }
+
+  private async isReadyToProcess(now: Date): Promise<boolean> {
+    const result = await this.pool.query<{ retry_after: Date | null }>(sql`
+      SELECT retry_after FROM workos_event_poller_state WHERE name = ${this.name}
+    `)
+    if (result.rows.length === 0) return false
+    const retryAfter = result.rows[0].retry_after
+    return retryAfter === null || now >= retryAfter
+  }
+}

--- a/apps/control-plane/src/lib/workos-event-poller-lock.ts
+++ b/apps/control-plane/src/lib/workos-event-poller-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto"
 import type { Pool } from "pg"
-import { calculateBackoffMs, logger, sql } from "@threa/backend-common"
+import { calculateBackoffMs, logger, sql, withClient } from "@threa/backend-common"
 
 export interface WorkosEventPollerLockConfig {
   pool: Pool
@@ -127,36 +127,50 @@ export class WorkosEventPollerLock {
    * Returns whether to keep retrying (false once `maxRetries` is exceeded —
    * the caller should fall back to whatever escalation it wants; this lock
    * does not have a DLQ analog).
+   *
+   * SELECT-then-UPDATE runs on the same client (see `CursorLock.recordError`)
+   * so retry_count and retry_after are written together in one round-trip,
+   * and the `lock_run_id` guard ensures only the current lease holder writes.
    */
   async recordError(message: string, now: Date = new Date()): Promise<{ shouldRetry: boolean }> {
-    const result = await this.pool.query<{ retry_count: number }>(sql`
-      UPDATE workos_event_poller_state
-      SET
-        retry_count = retry_count + 1,
-        last_error = ${message},
-        updated_at = ${now}
-      WHERE name = ${this.name}
-      RETURNING retry_count
-    `)
-    if (result.rows.length === 0) return { shouldRetry: false }
+    if (!this.runId) return { shouldRetry: false }
+    const runId = this.runId
 
-    const newRetryCount = result.rows[0].retry_count
-    if (newRetryCount > this.maxRetries) {
-      return { shouldRetry: false }
-    }
+    return withClient(this.pool, async (client) => {
+      const current = await client.query<{ retry_count: number }>(sql`
+        SELECT retry_count
+        FROM workos_event_poller_state
+        WHERE name = ${this.name} AND lock_run_id = ${runId}
+      `)
+      if (current.rows.length === 0) return { shouldRetry: false }
 
-    const backoffMs = calculateBackoffMs({ baseMs: this.baseBackoffMs, retryCount: newRetryCount })
-    const retryAfter = new Date(now.getTime() + backoffMs)
-    await this.pool.query(sql`
-      UPDATE workos_event_poller_state
-      SET retry_after = ${retryAfter}, updated_at = ${now}
-      WHERE name = ${this.name}
-    `)
-    logger.warn(
-      { name: this.name, retryCount: newRetryCount, retryAfter: retryAfter.toISOString() },
-      "WorkOS event poller error, will retry after backoff"
-    )
-    return { shouldRetry: true }
+      const newRetryCount = current.rows[0].retry_count + 1
+      if (newRetryCount > this.maxRetries) {
+        await client.query(sql`
+          UPDATE workos_event_poller_state
+          SET retry_count = ${newRetryCount}, last_error = ${message}, updated_at = ${now}
+          WHERE name = ${this.name} AND lock_run_id = ${runId}
+        `)
+        return { shouldRetry: false }
+      }
+
+      const backoffMs = calculateBackoffMs({ baseMs: this.baseBackoffMs, retryCount: newRetryCount })
+      const retryAfter = new Date(now.getTime() + backoffMs)
+      await client.query(sql`
+        UPDATE workos_event_poller_state
+        SET
+          retry_count = ${newRetryCount},
+          retry_after = ${retryAfter},
+          last_error = ${message},
+          updated_at = ${now}
+        WHERE name = ${this.name} AND lock_run_id = ${runId}
+      `)
+      logger.warn(
+        { name: this.name, retryCount: newRetryCount, retryAfter: retryAfter.toISOString() },
+        "WorkOS event poller error, will retry after backoff"
+      )
+      return { shouldRetry: true }
+    })
   }
 
   /** Release the lease. Idempotent — safe to call on shutdown even if nothing held. */

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -31,9 +31,12 @@ import {
 } from "./features/workspaces"
 import { InvitationShadowService } from "./features/invitation-shadows"
 import { BackofficeService, seedPlatformAdmins } from "./features/backoffice"
+import { WorkosAuthzService, WorkosAuthzBackfill, WorkosAuthzPoller } from "./features/workos-authz"
+import { WorkosEventPollerLock } from "./lib/workos-event-poller-lock"
 
 const MIGRATIONS_GLOB = path.join(import.meta.dirname, "db/migrations/*.sql")
 const LISTENER_ID = "control-plane"
+const WORKOS_EVENT_POLLER_NAME = "workos-events"
 
 export interface ControlPlaneInstance {
   server: Server
@@ -125,6 +128,45 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   outboxDispatcher.register(outboxHandler)
   await outboxDispatcher.start()
 
+  // WorkOS authz mirror — passive polling, no fan-out yet (Phase 1).
+  // Multi-instance safe via the time-based lease in WorkosEventPollerLock,
+  // mirroring the pattern used for the outbox CursorLock above.
+  const workosEventLock = new WorkosEventPollerLock({
+    pool,
+    name: WORKOS_EVENT_POLLER_NAME,
+    lockDurationMs: 10_000,
+    refreshIntervalMs: 5_000,
+    maxRetries: 5,
+    baseBackoffMs: 1_000,
+  })
+  await workosEventLock.ensureRow()
+
+  const authzService = new WorkosAuthzService({ pool })
+  const authzBackfill = new WorkosAuthzBackfill({ pool, workosOrgService, lock: workosEventLock })
+  const authzPoller = new WorkosAuthzPoller({
+    workosOrgService,
+    authzService,
+    lock: workosEventLock,
+    pollIntervalMs: 5_000,
+    batchSize: 100,
+  })
+
+  // First-boot backfill: only run when we've never backfilled before. Re-runs
+  // happen via the bun script so an operator decides when to refresh.
+  const lastBackfillRow = await pool.query<{ last_backfill_at: Date | null }>(
+    "SELECT last_backfill_at FROM workos_event_poller_state WHERE name = $1",
+    [WORKOS_EVENT_POLLER_NAME]
+  )
+  if (lastBackfillRow.rows[0]?.last_backfill_at == null) {
+    try {
+      await authzBackfill.run()
+    } catch (err) {
+      // Non-fatal: poller still starts; operator can run the backfill script later.
+      logger.error({ err }, "Initial WorkOS authz backfill failed; poller will still start")
+    }
+  }
+  authzPoller.start()
+
   const isProduction = process.env.NODE_ENV === "production"
   const app = createApp({ corsAllowedOrigins: config.corsAllowedOrigins })
 
@@ -157,6 +199,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
     if (config.fastShutdown) {
       logger.info("Fast shutdown - skipping graceful shutdown")
       server.close()
+      await authzPoller.stop()
       await outboxDispatcher.stop()
       await listenPool.end()
       await pool.end()
@@ -169,6 +212,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
         server.close((err) => (err ? reject(err) : resolve()))
       })
     }
+    await authzPoller.stop()
     await outboxDispatcher.stop()
     await listenPool.end()
     await pool.end()

--- a/apps/control-plane/tests/integration/setup.ts
+++ b/apps/control-plane/tests/integration/setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared setup for control-plane integration tests.
+ *
+ * Provides a real Postgres pool against `threa_control_plane_test` with the
+ * CP migrations applied. Tests use this when they need to exercise SQL paths
+ * (race-safe upserts, atomic lock claims) rather than HTTP-level behavior.
+ */
+
+import path from "path"
+import { Pool } from "pg"
+import { createDatabasePool, runMigrations } from "@threa/backend-common"
+
+const ADMIN_DATABASE_URL = "postgresql://threa:threa@localhost:5454/postgres"
+const TEST_DATABASE_URL = "postgresql://threa:threa@localhost:5454/threa_control_plane_test"
+const MIGRATIONS_GLOB = path.resolve(import.meta.dirname, "../../src/db/migrations/*.sql")
+
+export async function ensureTestDatabaseExists(): Promise<void> {
+  const adminPool = new Pool({ connectionString: ADMIN_DATABASE_URL })
+  try {
+    const result = await adminPool.query("SELECT 1 FROM pg_database WHERE datname = 'threa_control_plane_test'")
+    if (result.rows.length === 0) {
+      await adminPool.query("CREATE DATABASE threa_control_plane_test")
+    }
+  } finally {
+    await adminPool.end()
+  }
+}
+
+export function createTestPool(): Pool {
+  return createDatabasePool(process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL)
+}
+
+export async function setupTestDatabase(): Promise<Pool> {
+  await ensureTestDatabaseExists()
+  const pool = createTestPool()
+  await runMigrations(pool, MIGRATIONS_GLOB)
+  return pool
+}

--- a/apps/control-plane/tests/integration/workos-authz-poller.test.ts
+++ b/apps/control-plane/tests/integration/workos-authz-poller.test.ts
@@ -1,0 +1,183 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import type { Pool } from "pg"
+import { StubWorkosOrgService, type WorkosMembershipEvent } from "@threa/backend-common"
+import { WorkosAuthzRepository, WorkosAuthzPoller, WorkosAuthzService } from "../../src/features/workos-authz"
+import { WorkosEventPollerLock } from "../../src/lib/workos-event-poller-lock"
+import { setupTestDatabase } from "./setup"
+
+describe("WorkosAuthzPoller", () => {
+  let pool: Pool
+  const orgId = "org_test_authz_poller"
+  const userId = "user_test_authz_poller"
+  const lockName = "test-workos-events-poller"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM workos_event_poller_state WHERE name = $1", [lockName])
+    await pool.query("DELETE FROM workos_organization_memberships WHERE workos_organization_id = $1", [orgId])
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  function makeEvent(
+    id: string,
+    type: WorkosMembershipEvent["type"],
+    createdAt: Date,
+    overrides: Partial<{ status: string; roleSlugs: string[] }> = {}
+  ): WorkosMembershipEvent {
+    return {
+      id,
+      type,
+      createdAt,
+      membership: {
+        id: "om_1",
+        organizationId: orgId,
+        userId,
+        status: (overrides.status as WorkosMembershipEvent["membership"]["status"]) ?? "active",
+        roleSlugs: overrides.roleSlugs ?? ["member"],
+        updatedAt: createdAt,
+      },
+    }
+  }
+
+  function makeStack({
+    pollIntervalMs = 50,
+    batchSize = 10,
+    lockDurationMs = 5_000,
+  }: { pollIntervalMs?: number; batchSize?: number; lockDurationMs?: number } = {}) {
+    const stub = new StubWorkosOrgService()
+    const lock = new WorkosEventPollerLock({
+      pool,
+      name: lockName,
+      lockDurationMs,
+      refreshIntervalMs: 1_000,
+      maxRetries: 3,
+      baseBackoffMs: 100,
+    })
+    const service = new WorkosAuthzService({ pool })
+    const poller = new WorkosAuthzPoller({
+      workosOrgService: stub,
+      authzService: service,
+      lock,
+      pollIntervalMs,
+      batchSize,
+    })
+    return { stub, lock, service, poller }
+  }
+
+  test("happy path: drains pages, processes each event, advances cursor", async () => {
+    const { stub, lock, poller } = makeStack({ batchSize: 2 })
+    await lock.ensureRow()
+
+    const t0 = new Date("2026-01-01T00:00:00Z")
+    const t1 = new Date("2026-01-01T00:00:01Z")
+    const t2 = new Date("2026-01-01T00:00:02Z")
+    stub.pushMirrorEvent(makeEvent("event_01", "organization_membership.created", t0))
+    stub.pushMirrorEvent(makeEvent("event_02", "organization_membership.updated", t1, { roleSlugs: ["admin"] }))
+    stub.pushMirrorEvent(makeEvent("event_03", "organization_membership.updated", t2, { roleSlugs: ["owner"] }))
+
+    await poller.tick()
+
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row!.role_slugs).toEqual(["owner"])
+    expect(row!.last_event_id).toBe("event_03")
+
+    const cursor = await pool.query<{ last_event_id: string | null; locked_until: Date | null }>(
+      "SELECT last_event_id, locked_until FROM workos_event_poller_state WHERE name = $1",
+      [lockName]
+    )
+    expect(cursor.rows[0].last_event_id).toBe("event_03")
+    expect(cursor.rows[0].locked_until).toBeNull()
+  })
+
+  test("no-events tick: claims, drains nothing, releases", async () => {
+    const { lock, poller } = makeStack()
+    await lock.ensureRow()
+
+    await poller.tick()
+
+    const state = await pool.query<{ last_event_id: string | null; locked_until: Date | null }>(
+      "SELECT last_event_id, locked_until FROM workos_event_poller_state WHERE name = $1",
+      [lockName]
+    )
+    expect(state.rows[0].last_event_id).toBeNull()
+    expect(state.rows[0].locked_until).toBeNull()
+  })
+
+  test("error path: records error and releases the lock", async () => {
+    const { stub, lock, poller } = makeStack()
+    await lock.ensureRow()
+
+    const boom = new Error("WorkOS unavailable")
+    stub.listMirrorEvents = mock(async () => {
+      throw boom
+    }) as typeof stub.listMirrorEvents
+
+    await poller.tick()
+
+    const state = await pool.query<{
+      retry_count: number
+      retry_after: Date | null
+      last_error: string | null
+      locked_until: Date | null
+    }>("SELECT retry_count, retry_after, last_error, locked_until FROM workos_event_poller_state WHERE name = $1", [
+      lockName,
+    ])
+    expect(state.rows[0].retry_count).toBe(1)
+    expect(state.rows[0].retry_after).not.toBeNull()
+    expect(state.rows[0].last_error).toBe("WorkOS unavailable")
+    expect(state.rows[0].locked_until).toBeNull()
+  })
+
+  test("lock contention: a second poller's tick is a no-op while the first holds", async () => {
+    const stack1 = makeStack()
+    const stack2 = makeStack()
+    await stack1.lock.ensureRow()
+
+    const t0 = new Date("2026-01-01T00:00:00Z")
+    stack2.stub.pushMirrorEvent(makeEvent("event_01", "organization_membership.created", t0))
+
+    // Stack 1 claims and holds the lock by manually claiming without releasing.
+    const claim = await stack1.lock.tryAcquire()
+    expect(claim).not.toBeNull()
+
+    try {
+      // Stack 2's tick should be a no-op because the lock is held.
+      await stack2.poller.tick()
+
+      const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+      expect(row).toBeNull()
+    } finally {
+      await stack1.lock.release()
+    }
+  })
+
+  test("stop waits for an in-flight tick to settle", async () => {
+    // Long pollIntervalMs guarantees only the immediate first tick runs before
+    // we call stop(). The first tick is scheduled at delay=0 in start().
+    const { stub, lock, poller } = makeStack({ pollIntervalMs: 60_000 })
+    await lock.ensureRow()
+
+    const t0 = new Date("2026-01-01T00:00:00Z")
+    stub.pushMirrorEvent(makeEvent("event_01", "organization_membership.created", t0))
+
+    poller.start()
+    // Give the scheduled tick a moment to start.
+    await new Promise((r) => setTimeout(r, 50))
+    await poller.stop()
+
+    // After stop, the first tick should have completed and persisted state.
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row).not.toBeNull()
+    expect(row!.last_event_id).toBe("event_01")
+  })
+})

--- a/apps/control-plane/tests/integration/workos-authz-repository.test.ts
+++ b/apps/control-plane/tests/integration/workos-authz-repository.test.ts
@@ -1,0 +1,265 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { WorkosAuthzRepository } from "../../src/features/workos-authz"
+import { setupTestDatabase } from "./setup"
+
+describe("WorkosAuthzRepository", () => {
+  let pool: Pool
+  const orgId = "org_test_authz_repo"
+  const userId = "user_test_authz_repo"
+  const otherUserId = "user_test_authz_repo_2"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM workos_organization_memberships WHERE workos_organization_id = $1", [orgId])
+  })
+
+  describe("upsertMembershipFromEvent", () => {
+    test("inserts a new membership when none exists", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z")
+      const result = await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t0,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result!.workos_organization_id).toBe(orgId)
+      expect(result!.workos_user_id).toBe(userId)
+      expect(result!.status).toBe("active")
+      expect(result!.role_slugs).toEqual(["member"])
+      expect(result!.last_event_id).toBe("event_01")
+    })
+
+    test("applies an event newer than the persisted state", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z")
+      const t1 = new Date("2026-01-01T00:00:01Z")
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t0,
+      })
+
+      const result = await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["admin"],
+        eventId: "event_02",
+        eventCreatedAt: t1,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result!.role_slugs).toEqual(["admin"])
+      expect(result!.last_event_id).toBe("event_02")
+    })
+
+    test("rejects a stale event with last_event_at older than persisted state (INV-20)", async () => {
+      const t1 = new Date("2026-01-01T00:00:10Z")
+      const t0 = new Date("2026-01-01T00:00:00Z")
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["admin"],
+        eventId: "event_02",
+        eventCreatedAt: t1,
+      })
+
+      const stale = await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t0,
+      })
+
+      expect(stale).toBeNull()
+
+      const persisted = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+      expect(persisted!.role_slugs).toEqual(["admin"])
+      expect(persisted!.last_event_id).toBe("event_02")
+    })
+
+    test("rejects a duplicate event with identical last_event_at", async () => {
+      const t = new Date("2026-01-01T00:00:00Z")
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t,
+      })
+
+      const dup = await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["admin"],
+        eventId: "event_01_dup",
+        eventCreatedAt: t,
+      })
+
+      expect(dup).toBeNull()
+    })
+  })
+
+  describe("upsertMembershipFromBackfill", () => {
+    test("inserts a new membership and clears last_event_id", async () => {
+      const observedAt = new Date("2026-01-01T00:00:00Z")
+
+      const row = await WorkosAuthzRepository.upsertMembershipFromBackfill(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        observedAt,
+      })
+
+      expect(row.last_event_id).toBeNull()
+      expect(row.role_slugs).toEqual(["member"])
+    })
+
+    test("overwrites existing rows unconditionally even if observedAt is older than last_event_at", async () => {
+      const tEvent = new Date("2026-02-01T00:00:00Z")
+      const tBackfill = new Date("2026-01-01T00:00:00Z") // older than persisted event
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["admin"],
+        eventId: "event_99",
+        eventCreatedAt: tEvent,
+      })
+
+      const row = await WorkosAuthzRepository.upsertMembershipFromBackfill(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "inactive",
+        roleSlugs: ["member"],
+        observedAt: tBackfill,
+      })
+
+      expect(row.status).toBe("inactive")
+      expect(row.role_slugs).toEqual(["member"])
+      expect(row.last_event_id).toBeNull()
+      expect(row.last_event_at.toISOString()).toBe(tBackfill.toISOString())
+    })
+  })
+
+  describe("deleteMembership", () => {
+    test("deletes when the deletion event is newer than persisted state", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z")
+      const t1 = new Date("2026-01-01T00:00:10Z")
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t0,
+      })
+
+      const deleted = await WorkosAuthzRepository.deleteMembership(pool, {
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        eventCreatedAt: t1,
+      })
+
+      expect(deleted).toBe(true)
+      const after = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+      expect(after).toBeNull()
+    })
+
+    test("ignores stale delete events (INV-20)", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z")
+      const tEvent = new Date("2026-01-01T00:00:10Z")
+      const tStaleDelete = new Date("2026-01-01T00:00:05Z") // between t0 and tEvent
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["admin"],
+        eventId: "event_02",
+        eventCreatedAt: tEvent,
+      })
+
+      const deleted = await WorkosAuthzRepository.deleteMembership(pool, {
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        eventCreatedAt: tStaleDelete,
+      })
+
+      expect(deleted).toBe(false)
+      const stillThere = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+      expect(stillThere).not.toBeNull()
+      expect(stillThere!.role_slugs).toEqual(["admin"])
+
+      // sanity: t0 was overwritten by tEvent
+      void t0
+    })
+  })
+
+  describe("listByOrganization", () => {
+    test("returns rows for the org in created_at order", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z")
+      const t1 = new Date("2026-01-01T00:00:01Z")
+
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_1",
+        workosOrganizationId: orgId,
+        workosUserId: userId,
+        status: "active",
+        roleSlugs: ["member"],
+        eventId: "event_01",
+        eventCreatedAt: t0,
+      })
+      await WorkosAuthzRepository.upsertMembershipFromEvent(pool, {
+        organizationMembershipId: "om_2",
+        workosOrganizationId: orgId,
+        workosUserId: otherUserId,
+        status: "pending",
+        roleSlugs: [],
+        eventId: "event_02",
+        eventCreatedAt: t1,
+      })
+
+      const rows = await WorkosAuthzRepository.listByOrganization(pool, orgId)
+      expect(rows).toHaveLength(2)
+      expect(rows.map((r) => r.workos_user_id)).toEqual([userId, otherUserId])
+    })
+  })
+})

--- a/apps/control-plane/tests/integration/workos-authz-service.test.ts
+++ b/apps/control-plane/tests/integration/workos-authz-service.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { WorkosAuthzRepository, WorkosAuthzService } from "../../src/features/workos-authz"
+import type { WorkosMembershipEvent } from "@threa/backend-common"
+import { setupTestDatabase } from "./setup"
+
+describe("WorkosAuthzService.processEvent", () => {
+  let pool: Pool
+  let service: WorkosAuthzService
+  const orgId = "org_test_authz_service"
+  const userId = "user_test_authz_service"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    service = new WorkosAuthzService({ pool })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM workos_organization_memberships WHERE workos_organization_id = $1", [orgId])
+  })
+
+  function makeEvent(
+    type: WorkosMembershipEvent["type"],
+    overrides: Partial<{ id: string; createdAt: Date; status: string; roleSlugs: string[] }> = {}
+  ): WorkosMembershipEvent {
+    return {
+      id: overrides.id ?? "event_01",
+      type,
+      createdAt: overrides.createdAt ?? new Date("2026-01-01T00:00:00Z"),
+      membership: {
+        id: "om_1",
+        organizationId: orgId,
+        userId,
+        status: (overrides.status as WorkosMembershipEvent["membership"]["status"]) ?? "active",
+        roleSlugs: overrides.roleSlugs ?? ["member"],
+        updatedAt: overrides.createdAt ?? new Date("2026-01-01T00:00:00Z"),
+      },
+    }
+  }
+
+  test("created upserts a new mirror row", async () => {
+    await service.processEvent(makeEvent("organization_membership.created"))
+
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row).not.toBeNull()
+    expect(row!.status).toBe("active")
+    expect(row!.role_slugs).toEqual(["member"])
+    expect(row!.last_event_id).toBe("event_01")
+  })
+
+  test("updated overwrites an existing row", async () => {
+    await service.processEvent(makeEvent("organization_membership.created"))
+    await service.processEvent(
+      makeEvent("organization_membership.updated", {
+        id: "event_02",
+        createdAt: new Date("2026-01-01T00:00:01Z"),
+        roleSlugs: ["admin"],
+      })
+    )
+
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row!.role_slugs).toEqual(["admin"])
+    expect(row!.last_event_id).toBe("event_02")
+  })
+
+  test("deleted removes the mirror row", async () => {
+    await service.processEvent(makeEvent("organization_membership.created"))
+    await service.processEvent(
+      makeEvent("organization_membership.deleted", {
+        id: "event_03",
+        createdAt: new Date("2026-01-01T00:00:01Z"),
+      })
+    )
+
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row).toBeNull()
+  })
+
+  test("stale events are silently ignored", async () => {
+    await service.processEvent(
+      makeEvent("organization_membership.updated", {
+        id: "event_recent",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        roleSlugs: ["admin"],
+      })
+    )
+
+    // Older event should be a no-op via the timestamp guard.
+    await service.processEvent(
+      makeEvent("organization_membership.updated", {
+        id: "event_stale",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        roleSlugs: ["member"],
+      })
+    )
+
+    const row = await WorkosAuthzRepository.getByOrgAndUser(pool, orgId, userId)
+    expect(row!.role_slugs).toEqual(["admin"])
+    expect(row!.last_event_id).toBe("event_recent")
+  })
+})

--- a/apps/control-plane/tests/integration/workos-event-poller-lock.test.ts
+++ b/apps/control-plane/tests/integration/workos-event-poller-lock.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { WorkosEventPollerLock } from "../../src/lib/workos-event-poller-lock"
+import { setupTestDatabase } from "./setup"
+
+describe("WorkosEventPollerLock", () => {
+  let pool: Pool
+  const lockName = "test-workos-events"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM workos_event_poller_state WHERE name = $1", [lockName])
+  })
+
+  function makeLock(overrides?: Partial<ConstructorParameters<typeof WorkosEventPollerLock>[0]>) {
+    return new WorkosEventPollerLock({
+      pool,
+      name: lockName,
+      lockDurationMs: 1_000,
+      refreshIntervalMs: 500,
+      maxRetries: 3,
+      baseBackoffMs: 100,
+      ...overrides,
+    })
+  }
+
+  async function getState() {
+    const result = await pool.query<{
+      last_event_id: string | null
+      last_event_at: Date | null
+      last_backfill_at: Date | null
+      locked_until: Date | null
+      lock_run_id: string | null
+      retry_count: number
+      retry_after: Date | null
+      last_error: string | null
+    }>(
+      `SELECT last_event_id, last_event_at, last_backfill_at, locked_until, lock_run_id,
+              retry_count, retry_after, last_error
+       FROM workos_event_poller_state WHERE name = $1`,
+      [lockName]
+    )
+    return result.rows[0] ?? null
+  }
+
+  test("ensureRow is idempotent", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+    await lock.ensureRow()
+    const state = await getState()
+    expect(state).not.toBeNull()
+    expect(state!.locked_until).toBeNull()
+  })
+
+  test("tryAcquire claims the lock and returns the persisted cursor", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+
+    const claim = await lock.tryAcquire()
+    expect(claim).not.toBeNull()
+    expect(claim!.lastEventId).toBeNull()
+    expect(claim!.lastEventAt).toBeNull()
+
+    const state = await getState()
+    expect(state!.locked_until).not.toBeNull()
+    expect(state!.lock_run_id).not.toBeNull()
+
+    await lock.release()
+    const after = await getState()
+    expect(after!.locked_until).toBeNull()
+    expect(after!.lock_run_id).toBeNull()
+  })
+
+  test("a second instance cannot claim while the first holds the lock", async () => {
+    const lockA = makeLock()
+    const lockB = makeLock()
+    await lockA.ensureRow()
+
+    const claimA = await lockA.tryAcquire()
+    expect(claimA).not.toBeNull()
+
+    const claimB = await lockB.tryAcquire()
+    expect(claimB).toBeNull()
+
+    await lockA.release()
+
+    const claimBAfter = await lockB.tryAcquire()
+    expect(claimBAfter).not.toBeNull()
+    await lockB.release()
+  })
+
+  test("a second instance can claim after the lease expires", async () => {
+    const lockA = makeLock({ lockDurationMs: 50 })
+    const lockB = makeLock({ lockDurationMs: 50 })
+    await lockA.ensureRow()
+
+    const claimA = await lockA.tryAcquire()
+    expect(claimA).not.toBeNull()
+
+    // Force the lease to expire by rewriting locked_until in the past.
+    await pool.query(
+      "UPDATE workos_event_poller_state SET locked_until = NOW() - INTERVAL '1 second' WHERE name = $1",
+      [lockName]
+    )
+
+    const claimB = await lockB.tryAcquire()
+    expect(claimB).not.toBeNull()
+    await lockB.release()
+  })
+
+  test("advance persists the cursor and resets retry state", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+
+    // Force a retry state then advance should clear it.
+    await pool.query(
+      "UPDATE workos_event_poller_state SET retry_count = 2, retry_after = NOW() - INTERVAL '1 hour', last_error = 'boom' WHERE name = $1",
+      [lockName]
+    )
+
+    const claim = await lock.tryAcquire()
+    expect(claim).not.toBeNull()
+
+    const eventAt = new Date("2026-01-01T00:00:00Z")
+    await lock.advance("event_42", eventAt)
+
+    const state = await getState()
+    expect(state!.last_event_id).toBe("event_42")
+    expect(state!.last_event_at!.toISOString()).toBe(eventAt.toISOString())
+    expect(state!.retry_count).toBe(0)
+    expect(state!.retry_after).toBeNull()
+    expect(state!.last_error).toBeNull()
+
+    await lock.release()
+  })
+
+  test("advance is a no-op when lock_run_id has been taken over", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+    const claim = await lock.tryAcquire()
+    expect(claim).not.toBeNull()
+
+    // Simulate another instance stealing the lock after lease expiry.
+    await pool.query(
+      "UPDATE workos_event_poller_state SET lock_run_id = 'other-run-id', locked_until = NOW() + INTERVAL '1 minute' WHERE name = $1",
+      [lockName]
+    )
+
+    await lock.advance("event_42", new Date())
+
+    const state = await getState()
+    expect(state!.last_event_id).toBeNull()
+  })
+
+  test("recordError applies exponential backoff and stops retrying after maxRetries", async () => {
+    const lock = makeLock({ maxRetries: 2, baseBackoffMs: 100 })
+    await lock.ensureRow()
+
+    const r1 = await lock.recordError("first")
+    expect(r1.shouldRetry).toBe(true)
+    let state = await getState()
+    expect(state!.retry_count).toBe(1)
+    expect(state!.retry_after).not.toBeNull()
+    expect(state!.last_error).toBe("first")
+
+    const r2 = await lock.recordError("second")
+    expect(r2.shouldRetry).toBe(true)
+    state = await getState()
+    expect(state!.retry_count).toBe(2)
+
+    const r3 = await lock.recordError("third")
+    expect(r3.shouldRetry).toBe(false)
+  })
+
+  test("isReadyToProcess gates tryAcquire on retry_after", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+    await pool.query("UPDATE workos_event_poller_state SET retry_after = NOW() + INTERVAL '1 hour' WHERE name = $1", [
+      lockName,
+    ])
+
+    const blocked = await lock.tryAcquire()
+    expect(blocked).toBeNull()
+  })
+
+  test("stampBackfill stamps last_backfill_at without claiming the lock", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+
+    await lock.stampBackfill()
+    const state = await getState()
+    expect(state!.last_backfill_at).not.toBeNull()
+    expect(state!.locked_until).toBeNull()
+  })
+
+  test("release without holding the lock is a no-op", async () => {
+    const lock = makeLock()
+    await lock.ensureRow()
+
+    await lock.release()
+    const state = await getState()
+    expect(state!.locked_until).toBeNull()
+  })
+})

--- a/apps/control-plane/tests/integration/workos-event-poller-lock.test.ts
+++ b/apps/control-plane/tests/integration/workos-event-poller-lock.test.ts
@@ -162,6 +162,9 @@ describe("WorkosEventPollerLock", () => {
   test("recordError applies exponential backoff and stops retrying after maxRetries", async () => {
     const lock = makeLock({ maxRetries: 2, baseBackoffMs: 100 })
     await lock.ensureRow()
+    // recordError is guarded by lock_run_id, so the lease must be held first.
+    const claim = await lock.tryAcquire()
+    expect(claim).not.toBeNull()
 
     const r1 = await lock.recordError("first")
     expect(r1.shouldRetry).toBe(true)
@@ -177,6 +180,8 @@ describe("WorkosEventPollerLock", () => {
 
     const r3 = await lock.recordError("third")
     expect(r3.shouldRetry).toBe(false)
+
+    await lock.release()
   })
 
   test("isReadyToProcess gates tryAcquire on retry_after", async () => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:backfill-cp": "bun scripts/backfill-control-plane.ts",
     "workos:sync": "bun scripts/sync-workos-permissions.ts",
     "workos:check": "bun scripts/sync-workos-permissions.ts --check",
+    "workos-authz:backfill": "bun apps/control-plane/scripts/backfill-workos-authz.ts",
     "monitoring:start": "docker compose -f docker-compose.monitoring.yml up -d",
     "monitoring:stop": "docker compose -f docker-compose.monitoring.yml stop",
     "monitoring:logs": "docker compose -f docker-compose.monitoring.yml logs -f",

--- a/packages/backend-common/src/auth/workos-org-service.stub.ts
+++ b/packages/backend-common/src/auth/workos-org-service.stub.ts
@@ -1,12 +1,28 @@
 import { ulid } from "ulid"
 import { logger } from "../logger"
-import type { WorkosAppInvitation, WorkosOrgService, WorkosUserSummary } from "./workos-org-service"
+import type {
+  WorkosAppInvitation,
+  WorkosMembershipEvent,
+  WorkosOrgService,
+  WorkosOrganizationMembership,
+  WorkosUserSummary,
+} from "./workos-org-service"
 
 export class StubWorkosOrgService implements WorkosOrgService {
   private orgsByExternalId = new Map<string, string>()
   private appInvitations: WorkosAppInvitation[] = []
   /** Test helper: let callers pre-populate a user lookup table. */
   public users = new Map<string, WorkosUserSummary>()
+  /**
+   * Test helper: in-memory stack of mirror events. Tests push into this with
+   * `pushMirrorEvent` and the poller drains via `listMirrorEvents`.
+   */
+  private mirrorEvents: WorkosMembershipEvent[] = []
+  /**
+   * Test helper: per-org membership listing returned by backfill. Tests seed
+   * it via `setOrganizationMemberships`.
+   */
+  private membershipsByOrg = new Map<string, WorkosOrganizationMembership[]>()
 
   async createOrganization(params: { name: string; externalId: string }): Promise<{ id: string }> {
     const id = `org_stub_${ulid()}`
@@ -99,5 +115,34 @@ export class StubWorkosOrgService implements WorkosOrgService {
 
   async getWidgetToken(_params: { organizationId: string; userId: string; scopes: string[] }): Promise<string> {
     return "stub_widget_token"
+  }
+
+  async listMirrorEvents(params: {
+    after?: string
+    limit?: number
+  }): Promise<{ data: WorkosMembershipEvent[]; after: string | null }> {
+    const startIdx = params.after ? this.mirrorEvents.findIndex((e) => e.id === params.after) + 1 : 0
+    const slice = this.mirrorEvents.slice(startIdx, startIdx + (params.limit ?? 100))
+    const next = startIdx + slice.length < this.mirrorEvents.length ? (slice[slice.length - 1]?.id ?? null) : null
+    return { data: slice, after: next }
+  }
+
+  async listOrganizationMemberships(organizationId: string): Promise<WorkosOrganizationMembership[]> {
+    return [...(this.membershipsByOrg.get(organizationId) ?? [])]
+  }
+
+  /** Test helper: append a mirror event to the stub queue. */
+  pushMirrorEvent(event: WorkosMembershipEvent): void {
+    this.mirrorEvents.push(event)
+  }
+
+  /** Test helper: replace the membership listing for an organization. */
+  setOrganizationMemberships(organizationId: string, memberships: WorkosOrganizationMembership[]): void {
+    this.membershipsByOrg.set(organizationId, [...memberships])
+  }
+
+  /** Test helper: clear all queued mirror events. */
+  clearMirrorEvents(): void {
+    this.mirrorEvents = []
   }
 }

--- a/packages/backend-common/src/auth/workos-org-service.ts
+++ b/packages/backend-common/src/auth/workos-org-service.ts
@@ -43,6 +43,38 @@ export interface WorkosUserSummary {
   lastName: string | null
 }
 
+/**
+ * The subset of organization-membership events the authz mirror cares about.
+ * Listed explicitly so the service contract makes the supported set obvious
+ * without leaking the full WorkOS event union.
+ */
+export const WORKOS_MIRROR_EVENT_TYPES = [
+  "organization_membership.created",
+  "organization_membership.updated",
+  "organization_membership.deleted",
+] as const
+
+export type WorkosMirrorEventType = (typeof WORKOS_MIRROR_EVENT_TYPES)[number]
+
+/** Decoded WorkOS organization membership event the mirror consumes. */
+export interface WorkosMembershipEvent {
+  id: string
+  type: WorkosMirrorEventType
+  createdAt: Date
+  membership: WorkosOrganizationMembership
+}
+
+/** Mirror-shaped membership returned from `listOrganizationMemberships`. */
+export interface WorkosOrganizationMembership {
+  id: string
+  organizationId: string
+  userId: string
+  status: "active" | "inactive" | "pending"
+  roleSlugs: string[]
+  /** WorkOS-side updated_at; used as last_event_at when backfill upserts. */
+  updatedAt: Date
+}
+
 export interface WorkosOrgService {
   createOrganization(params: { name: string; externalId: string }): Promise<{ id: string }>
   getOrganizationByExternalId(externalId: string): Promise<{ id: string } | null>
@@ -66,6 +98,19 @@ export interface WorkosOrgService {
   getOrganization(organizationId: string): Promise<{ id: string; domains: string[] } | null>
   ensureOrganizationMembership(params: { organizationId: string; userId: string; roleSlug: string }): Promise<void>
   getWidgetToken(params: { organizationId: string; userId: string; scopes: string[] }): Promise<string>
+  /**
+   * List WorkOS events for the authz mirror. Returns a normalized, mirror-shaped
+   * payload — callers don't need to know the WorkOS SDK union.
+   */
+  listMirrorEvents(params: {
+    after?: string
+    limit?: number
+  }): Promise<{ data: WorkosMembershipEvent[]; after: string | null }>
+  /**
+   * List every membership for an organization, paginated to completion. Used
+   * by backfill — low-frequency, run by an explicit operator action.
+   */
+  listOrganizationMemberships(organizationId: string): Promise<WorkosOrganizationMembership[]>
 }
 
 export class WorkosOrgServiceImpl implements WorkosOrgService {
@@ -266,5 +311,130 @@ export class WorkosOrgServiceImpl implements WorkosOrgService {
       scopes: params.scopes as WidgetScope[],
     })
     return token
+  }
+
+  async listMirrorEvents(params: {
+    after?: string
+    limit?: number
+  }): Promise<{ data: WorkosMembershipEvent[]; after: string | null }> {
+    const page = await this.workos.events.listEvents({
+      events: [...WORKOS_MIRROR_EVENT_TYPES],
+      ...(params.after ? { after: params.after } : {}),
+      ...(params.limit ? { limit: params.limit } : {}),
+    })
+
+    const data: WorkosMembershipEvent[] = []
+    for (const raw of page.data) {
+      const decoded = decodeMembershipEvent(raw)
+      if (decoded) data.push(decoded)
+    }
+    return { data, after: page.listMetadata.after ?? null }
+  }
+
+  async listOrganizationMemberships(organizationId: string): Promise<WorkosOrganizationMembership[]> {
+    const results: WorkosOrganizationMembership[] = []
+    let after: string | undefined
+
+    for (;;) {
+      const page = await this.workos.userManagement.listOrganizationMemberships({
+        organizationId,
+        limit: 100,
+        ...(after ? { after } : {}),
+      })
+
+      for (const m of page.data) {
+        results.push(toMirrorMembership(m))
+      }
+
+      after = page.listMetadata.after ?? undefined
+      if (!after) return results
+    }
+  }
+}
+
+interface MembershipEventLike {
+  id: string
+  event: string
+  createdAt: string
+  data: unknown
+}
+
+function decodeMembershipEvent(raw: unknown): WorkosMembershipEvent | null {
+  if (!raw || typeof raw !== "object") return null
+  const candidate = raw as MembershipEventLike
+  if (typeof candidate.id !== "string" || typeof candidate.event !== "string") return null
+  if (!isMirrorEventType(candidate.event)) return null
+  const membership = parseMembershipPayload(candidate.data)
+  if (!membership) return null
+  return {
+    id: candidate.id,
+    type: candidate.event,
+    createdAt: new Date(candidate.createdAt),
+    membership,
+  }
+}
+
+function isMirrorEventType(event: string): event is WorkosMirrorEventType {
+  return (WORKOS_MIRROR_EVENT_TYPES as readonly string[]).includes(event)
+}
+
+interface MembershipPayloadLike {
+  id?: unknown
+  organizationId?: unknown
+  userId?: unknown
+  status?: unknown
+  updatedAt?: unknown
+  role?: { slug?: unknown }
+  roles?: Array<{ slug?: unknown }>
+}
+
+function parseMembershipPayload(data: unknown): WorkosOrganizationMembership | null {
+  if (!data || typeof data !== "object") return null
+  const m = data as MembershipPayloadLike
+  if (typeof m.id !== "string" || typeof m.organizationId !== "string" || typeof m.userId !== "string") {
+    return null
+  }
+  if (m.status !== "active" && m.status !== "inactive" && m.status !== "pending") {
+    return null
+  }
+  return {
+    id: m.id,
+    organizationId: m.organizationId,
+    userId: m.userId,
+    status: m.status,
+    roleSlugs: extractRoleSlugs(m),
+    updatedAt: typeof m.updatedAt === "string" ? new Date(m.updatedAt) : new Date(),
+  }
+}
+
+function extractRoleSlugs(m: MembershipPayloadLike): string[] {
+  const slugs: string[] = []
+  if (Array.isArray(m.roles)) {
+    for (const r of m.roles) {
+      if (r && typeof r.slug === "string") slugs.push(r.slug)
+    }
+  }
+  if (slugs.length === 0 && m.role && typeof m.role.slug === "string") {
+    slugs.push(m.role.slug)
+  }
+  return slugs
+}
+
+function toMirrorMembership(m: {
+  id: string
+  organizationId: string
+  userId: string
+  status: "active" | "inactive" | "pending"
+  updatedAt: string
+  role: { slug: string }
+  roles?: Array<{ slug: string }>
+}): WorkosOrganizationMembership {
+  return {
+    id: m.id,
+    organizationId: m.organizationId,
+    userId: m.userId,
+    status: m.status,
+    roleSlugs: m.roles && m.roles.length > 0 ? m.roles.map((r) => r.slug) : [m.role.slug],
+    updatedAt: new Date(m.updatedAt),
   }
 }

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -3,8 +3,15 @@ export { WorkosAuthService } from "./auth/auth-service"
 export type { AuthResult, AuthService } from "./auth/auth-service"
 export { StubAuthService } from "./auth/auth-service.stub"
 export type { DevLoginResult } from "./auth/auth-service.stub"
-export { WorkosOrgServiceImpl, getWorkosErrorCode } from "./auth/workos-org-service"
-export type { WorkosOrgService, WorkosAppInvitation, WorkosUserSummary } from "./auth/workos-org-service"
+export { WorkosOrgServiceImpl, getWorkosErrorCode, WORKOS_MIRROR_EVENT_TYPES } from "./auth/workos-org-service"
+export type {
+  WorkosOrgService,
+  WorkosAppInvitation,
+  WorkosUserSummary,
+  WorkosMembershipEvent,
+  WorkosMirrorEventType,
+  WorkosOrganizationMembership,
+} from "./auth/workos-org-service"
 export { StubWorkosOrgService } from "./auth/workos-org-service.stub"
 export { createAuthMiddleware } from "./auth/middleware"
 export { WorkosApiKeyService } from "./auth/api-key-service"


### PR DESCRIPTION
## Summary

Phase 1 / PR B of the permissions-model unification (see [`.claude/plans/1-yes-please-backfill-async-sky.md`](.claude/plans/1-yes-please-backfill-async-sky.md), introduced in #477). Establishes a **passive** mirror of WorkOS organization memberships in the control plane so later phases can layer write paths and regional fan-out on stable mirror state. Nothing on the hot path changes yet.

> [!NOTE]
> This PR is **stacked on #477**. The "Files changed" tab includes commits from PR A. Review the latest commit only, or wait for PR A to merge first.

### What's in this PR

- **Migration `006_workos_authz_mirror.sql`**: two tables — `workos_event_poller_state` (singleton-ish, keyed by `name`) and `workos_organization_memberships` (PK on `(workos_organization_id, workos_user_id)`). `status` is `TEXT` validated in app code (INV-3); `last_event_at` is the timestamp guard for race-safe upserts (INV-20).
- **`WorkosEventPollerLock`**: a small time-based lease modeled on `CursorLock` but with a string cursor (the WorkOS opaque event id) and no sliding-window dedup. Uses the `locked_until` / `lock_run_id` pattern with a clock-drift pad so multiple CP instances compete safely without `pg_advisory_lock` (per `apps/backend/docs/distributed-cron-design.md`).
- **`features/workos-authz/`**: colocated `repository`, `service`, `backfill`, `poller`, and barrel (INV-51, INV-52). Repository upserts are race-safe via `WHERE workos_organization_memberships.last_event_at < EXCLUDED.last_event_at`; backfill upserts are unconditional last-write-wins with `last_event_id = NULL` so subsequent event-driven updates can compare timestamps cleanly. Delete respects the same timestamp guard.
- **`WorkosOrgService.listMirrorEvents` / `listOrganizationMemberships`**: returned in normalized mirror shape; stub adds queue + per-org seeding for tests.
- **`server.ts` wiring**: lock + backfill + poller alongside the existing outbox dispatcher. First-boot backfill runs only when `last_backfill_at IS NULL`, non-fatal on error so the poller still starts. Graceful + fast shutdown both stop the poller before closing pools.
- **`apps/control-plane/scripts/backfill-workos-authz.ts`** and root `workos-authz:backfill` script for re-runnable operator backfill.
- **Integration tests** (`tests/integration/`):
  - `workos-authz-repository.test.ts` — race-safe upsert, timestamp guard rejecting stale events / duplicates, delete guard, backfill unconditional overwrite.
  - `workos-event-poller-lock.test.ts` — claim/release, contention, lease expiry handover, advance resets retry state, advance no-op when lock_run_id stolen, exponential backoff state machine, `retry_after` gating, `stampBackfill`.
  - `workos-authz-service.test.ts` — created/updated/deleted event routing, stale events ignored.
  - `workos-authz-poller.test.ts` — happy path drains pages and advances cursor, no-events tick, error path records + releases, lock contention, `stop()` awaits in-flight tick.

### Phase 1 explicit non-goals

No write paths to WorkOS, no fan-out to regional backends, no enforcement on the hot path, no `viewerPermissions` in bootstrap, no `requireWorkspacePermission` middleware, no socket authz changes, no frontend role picker, no invitation `role_slug` migration, no expansion of the permission catalog. All Phase 2+.

## Test plan

- [x] `bun run typecheck` — clean across all workspaces
- [x] `bun run lint` — clean
- [x] `bun run --cwd apps/control-plane typecheck`
- [ ] `bun run --cwd apps/control-plane test:integration` (requires local Postgres on `:5454`; not runnable in this sandbox)
- [ ] On staging CP first boot: backfill runs once, mirror populated, poller advances `last_event_id` as memberships change in the WorkOS dashboard
- [ ] Two CP instances against same DB: only one holds the lock per tick

https://claude.ai/code/session_01WLeMwKzjMr8iztp8do67dP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLeMwKzjMr8iztp8do67dP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->