### PR TITLE
test(backend): stop spy leak from quote-resolver/message-formatter into PersonaRepository

### DIFF
--- a/apps/backend/src/features/agents/quote-resolver.test.ts
+++ b/apps/backend/src/features/agents/quote-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test"
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
 import type { JSONContent } from "@threa/types"
 import type { Querier } from "../../db"
 import { MessageRepository, type Message } from "../messaging"
@@ -72,6 +72,8 @@ describe("resolveQuoteReplies", () => {
     spyOn(UserRepository, "findByIds").mockImplementation(mockFindUsersByIds as never)
     spyOn(PersonaRepository, "findByIds").mockImplementation(mockFindPersonasByIds as never)
   })
+
+  afterEach(() => mock.restore())
 
   test("resolves a single direct precursor", async () => {
     const seed = createMessage({

--- a/apps/backend/src/lib/ai/message-formatter.test.ts
+++ b/apps/backend/src/lib/ai/message-formatter.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test"
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
 import { MessageFormatter } from "./message-formatter"
 import { UserRepository } from "../../features/workspaces"
 import { PersonaRepository } from "../../features/agents"
@@ -48,6 +48,8 @@ describe("MessageFormatter", () => {
 
     formatter = new MessageFormatter()
   })
+
+  afterEach(() => mock.restore())
 
   test("should return empty wrapper for empty message list", async () => {
     const result = await formatter.formatMessages(mockClient, "ws_test", [])


### PR DESCRIPTION
## Summary

Backend CI on the new Blacksmith runners has been flaking on `PersonaRepository built-in agent config > batch-resolves built-in overrides in findByIds` (e.g. [run 25458766979](https://github.com/threahq/threa/actions/runs/25458766979/job/74695184618)). Reproduced locally 100% of the time with:

```
bun test apps/backend/src/features/agents/quote-resolver.test.ts \
         apps/backend/src/features/agents/persona-repository.test.ts
```

## Root cause

`apps/backend/src/features/agents/quote-resolver.test.ts` and `apps/backend/src/lib/ai/message-formatter.test.ts` both install `spyOn(PersonaRepository, "findByIds").mockImplementation(...)` inside `beforeEach`, but neither file restores the spy. Bun runs every backend test file sequentially in a single process and modules are cached across files, so the spy stays installed on the singleton `PersonaRepository` for the rest of the run. When persona-repository.test.ts then exercises the real `findByIds`, it gets the leaked mock returning `[]` and the assertion `expect(personas.map(...)).toEqual([ARIADNE_AGENT_ID, "persona_workspace_helper"])` fails with `Received: []`.

The flake only surfaced after the move to Blacksmith because file scheduling/order changed enough to land the leaking files before persona-repository.test.ts more often.

## Fix

Add `afterEach(() => mock.restore())` inside the describe block that owns each leaking spy (matching INV-48 — scoped `spyOn` rather than `mock.module()`).

## Verification

- Targeted pairing (`quote-resolver` → `persona-repository`) — failed every time before, 5/5 clean after.
- Full backend suite (`bun test`, 1162 tests / 113 files) — 10/10 clean stress runs after the fix.

## Test plan

- [ ] CI Tests job goes green (and stays green across re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxUgDXjn4zVM2DFhvTMw2J)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->