### PR TITLE
test(backend): restore module-level spies to stop cross-file pollution

### DIFF
--- a/apps/backend/src/features/agents/conversation-summary-service.test.ts
+++ b/apps/backend/src/features/agents/conversation-summary-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import type { AI } from "../../lib/ai/ai"
 import type { Message } from "../messaging"
 import { MessageRepository } from "../messaging"
@@ -26,6 +26,13 @@ function makeMessage(sequence: bigint, content: string): Message {
 }
 
 describe("ConversationSummaryService", () => {
+  // Module-level spies on shared repositories leak past this file's tests
+  // unless we tear them down. Bun's `spyOn` returns the existing spy when a
+  // method is already patched, so a downstream file calling
+  // `spyOn(MessageRepository, "list")` would inherit our call history and
+  // break `expect(...).not.toHaveBeenCalled()` assertions.
+  afterAll(() => mock.restore())
+
   const TEST_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
   const TEST_TEMPERATURE = 0.1
 

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, spyOn, beforeEach } from "bun:test"
+import { afterAll, describe, test, expect, mock, spyOn, beforeEach } from "bun:test"
 import type { PoolClient } from "pg"
 import { StreamService } from "./service"
 import { StreamRepository } from "./repository"
@@ -23,6 +23,13 @@ spyOn(idModule, "eventId").mockReturnValue("evt_1")
 spyOn(idModule, "streamId").mockReturnValue("stream_new")
 spyOn(db, "withClient").mockImplementation((_pool, fn) => fn({} as PoolClient))
 spyOn(db, "withTransaction").mockImplementation((_pool, fn) => fn({} as PoolClient))
+
+// Module-level spies (declared via `const x = spyOn(...)`) stay attached to the
+// target methods for the lifetime of this test file. Without this teardown the
+// spies leak into the next test file in the worker — since Bun's `spyOn`
+// returns the existing spy when a method is already patched, the next file
+// inherits the call history and breaks `expect(...).not.toHaveBeenCalled()`.
+afterAll(() => mock.restore())
 
 describe("StreamService.joinPublicChannel", () => {
   let service: StreamService


### PR DESCRIPTION
## Summary

Fixes the CI failure in [run 25511529099](https://github.com/threahq/threa/actions/runs/25511529099/job/74871295716):

```
(fail) MessageRepository.findThreadRoot > returns null when the stream has no parentMessageId
  Expected number of calls: 0
  Received number of calls: 4
```

## Root cause

This is **not flake** — it's a deterministic cross-file test-pollution bug. Reproduces locally every time when the right two files run in CI order.

`apps/backend/src/features/streams/service.test.ts` declares `spyOn(MessageRepository, "findById")` at describe scope and never restores it. Its 4 tests in the `createThread (via create)` block each call `service.create(...)` which invokes `findById` once → the spy ends the file with exactly 4 accumulated calls.

The next file in the worker, `messaging/repository.test.ts`, then does:

```ts
const findById = spyOn(MessageRepository, "findById").mockResolvedValue(makeMessage())
// ...
expect(findById).not.toHaveBeenCalled()  // ❌ already has 4 calls
```

In Bun, `spyOn` returns the **existing** spy when the method is already patched, so the new test inherits the call history.

## Fix

Add `afterAll(() => mock.restore())` to the two backend test files that hold module-/describe-scope spies on shared repos without any teardown:

- `apps/backend/src/features/streams/service.test.ts` — proven cause of the CI failure (spies on `MessageRepository.findById`, `StreamRepository.*`, `StreamMemberRepository.*`, `OutboxRepository.insert`, `db.withClient/withTransaction`, `idModule.*`)
- `apps/backend/src/features/agents/conversation-summary-service.test.ts` — same pattern (spies on `MessageRepository.list`, `MessageRepository.listBySequenceRange`, `ConversationSummaryRepository.*`)

This mirrors the pattern PR #480 introduced for `quote-resolver.test.ts` and `message-formatter.test.ts`.

## Was the recent stability work incomplete?

Partly. PR #480 fixed two files; these two had the same class of bug and were missed. A scan of the rest of the backend turned up a few more module-scope-spy files without `mock.restore()` (`invitations/service.test.ts`, `workspaces/service.test.ts`, `middleware/metrics.test.ts`, etc.). They didn't trigger this CI failure, but they're latent landmines for any future test asserting "not called" on the methods they patch — happy to do that broader sweep in a follow-up.

## Test plan

- [x] Reproduced the failure locally by running `bun test ./src/features/streams/service.test.ts ./src/features/messaging/repository.test.ts` — same `Received number of calls: 4` error.
- [x] After fix, the same command passes (22/22).
- [x] Full backend unit suite green: `bun run test:unit` → 1162 pass, 0 fail.
- [x] Lint, typecheck, and prettier all pass via the husky pre-commit hooks.

🤖 _Generated with [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017xnf94zArVRGMnXTQPXSZG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->