### PR TITLE
test(backend): stop event-sourcing outbox tests asserting on row counts

### DIFF
--- a/apps/backend/tests/integration/event-sourcing.test.ts
+++ b/apps/backend/tests/integration/event-sourcing.test.ts
@@ -300,8 +300,11 @@ describe("Event Sourcing", () => {
 
       const outboxEvents = await OutboxRepository.fetchAfterId(pool, baselineId)
 
-      expect(outboxEvents).toHaveLength(1)
-      expect(outboxEvents[0].eventType).toBe("message:edited")
+      // INV-23: assert presence of the specific event, not the row count.
+      // Background workers (boundary-extraction etc.) can land async outbox
+      // writes after baseline-capture, so a strict length assertion flakes.
+      const editedEvent = outboxEvents.find((e) => e.eventType === "message:edited")
+      expect(editedEvent).toBeDefined()
     })
   })
 
@@ -399,9 +402,10 @@ describe("Event Sourcing", () => {
 
       const outboxEvents = await OutboxRepository.fetchAfterId(pool, baselineId)
 
-      expect(outboxEvents).toHaveLength(1)
-      expect(outboxEvents[0].eventType).toBe("message:deleted")
-      expect(outboxEvents[0].payload).toMatchObject({
+      // INV-23: assert presence of the specific event, not the row count.
+      const deletedEvent = outboxEvents.find((e) => e.eventType === "message:deleted")
+      expect(deletedEvent).toBeDefined()
+      expect(deletedEvent!.payload).toMatchObject({
         messageId: message.id,
       })
     })
@@ -602,9 +606,14 @@ describe("Event Sourcing", () => {
 
       const outboxEvents = await OutboxRepository.fetchAfterId(pool, baselineId)
 
-      expect(outboxEvents).toHaveLength(2)
-      expect(outboxEvents[0].eventType).toBe("reaction:added")
-      expect(outboxEvents[1].eventType).toBe("reaction:removed")
+      // INV-23: assert presence of the specific events, not the row count or
+      // ordering — both reactions land on the outbox but background workers
+      // can interleave their own writes between them.
+      const addedEvent = outboxEvents.find((e) => e.eventType === "reaction:added")
+      const removedEvent = outboxEvents.find((e) => e.eventType === "reaction:removed")
+      expect(addedEvent).toBeDefined()
+      expect(removedEvent).toBeDefined()
+      expect(addedEvent!.id < removedEvent!.id).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary

Follow-up to #481. Fixes the integration-test flake from CI run [25517007650](https://github.com/threahq/threa/actions/runs/25517007650/job/74890752755):

```
(fail) Event Sourcing > Message Editing > should publish edit event to outbox
  Expected length: 1
  Received length: 3
```

The test captures `MAX(id) FROM outbox` after `createMessage`, runs `editMessage`, and expects exactly one new row. But the failure log shows the `boundary-extraction` queue worker landing async outbox writes between the baseline-capture and the assertion:

```
[19:20:51] INFO: Processing boundary extraction job ...
[19:20:51] WARN: Message or stream not found for boundary extraction
[19:20:51] WARN: Boundary extraction produced no conversation
```

Same SHA passed on rerun, so it's a real flake — not a regression introduced by #481.

## Why a count assertion was wrong here

[INV-23](../blob/main/CLAUDE.md): *"Don't assert event counts; assert presence/content of specific events."*

Three tests in `event-sourcing.test.ts` violated it (`edit`, `delete`, `reactions`). The `Message Creation > should publish to outbox for real-time delivery` test in the same file already follows the invariant — I borrowed its pattern.

## Fix

Convert each fragile assertion to `outboxEvents.find((e) => e.eventType === ...)`:

- **edit** — find `message:edited`, assert it's defined.
- **delete** — find `message:deleted`, assert payload `messageId`.
- **reactions** — find `reaction:added` and `reaction:removed`; additionally assert `addedEvent.id < removedEvent.id` so we still pin the relative ordering we care about.

`thread-summary.test.ts` already used this pattern; no other integration tests had the bug.

## Why not stop the worker from polling?

The deeper root cause is "why is a queue worker polling at all during integration tests?" — `tests/integration/setup.ts` doesn't start workers, so something earlier in the Bun process is starting them and they're still alive. That's worth investigating, but it's a more invasive change and orthogonal to this fix; INV-23 already says we shouldn't be asserting row counts regardless. Happy to spin up a separate investigation if you want.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [ ] Can't run `test:integration` locally (no Postgres on `:5454`); CI will exercise it.
- [x] Manually traced each test: the events asserted on are produced unconditionally by `editMessage` / `deleteMessage` / `addReaction` + `removeReaction`, so the new `find()` lookups will always succeed when the SUT behaves correctly.

🤖 _Generated with [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017xnf94zArVRGMnXTQPXSZG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->