### PR TITLE
fix: hide membership events from thread timelines

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -669,7 +669,7 @@ export function StreamContent({
     disableAutoScroll: plainDisableAutoScroll,
   } = useScrollBehavior({
     isLoading,
-    itemCount: !useVirtualized ? events.length : 0,
+    itemCount: !useVirtualized ? displayEvents.length : 0,
     onScrollNearTop: !useVirtualized && hasOlderEvents ? fetchOlderEvents : undefined,
     onScrollNearBottom: !useVirtualized && hasNewerEvents ? fetchNewerEvents : undefined,
     isFetchingOlder,
@@ -904,9 +904,13 @@ export function StreamContent({
   // Track live-arriving messages from other users for brief "new" indicator.
   const newMessageIds = useNewMessageIndicator(events, currentWorkspaceUserId ?? undefined, streamId, lastReadEventId)
 
-  // Unread divider state management (also handles scroll-to-first-unread)
+  // Unread divider state management (also handles scroll-to-first-unread).
+  // Pass `displayEvents` so the divider's first-unread search skips events we
+  // hide from this stream's render (e.g. thread membership rows) — otherwise
+  // the divider can target an event id that never matches a rendered row and
+  // silently fails to show.
   const { dividerEventId, isFading: isDividerFading } = useUnreadDivider({
-    events,
+    events: displayEvents,
     lastReadEventId,
     currentUserId: currentWorkspaceUserId ?? undefined,
     streamId,

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1094,7 +1094,7 @@ export function StreamContent({
                       event={parentMessage}
                       workspaceId={workspaceId}
                       streamId={parentStreamId}
-                      replyCount={events.length}
+                      replyCount={displayEvents.length}
                     />
                   )}
                   {isFetchingOlder && (

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -75,6 +75,9 @@ import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
 
+/** Event types suppressed in threads — see displayEvents memo below. */
+const THREAD_HIDDEN_EVENT_TYPES = new Set<string>(["member_joined", "member_added", "member_left"])
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -307,13 +310,18 @@ export function StreamContent({
   // Compute timeline items in StreamContent so the virtualizer can use count + keys.
   // After grouping commands/sessions, annotate consecutive same-author message runs
   // with `groupContinuation` so MessageEvent can collapse the repeated header row.
+  // Membership events are suppressed in threads: thread participation is implicit
+  // (replying joins you, the parent author is auto-added), so "X was added to the
+  // conversation" reads as noise next to the author who clearly is here.
   const displayEvents = useMemo(() => {
     if (!isThread) return events
-    return [...events].sort((a, b) => {
-      const timeDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      if (timeDelta !== 0) return timeDelta
-      return a.id.localeCompare(b.id)
-    })
+    return [...events]
+      .filter((e) => !THREAD_HIDDEN_EVENT_TYPES.has(e.eventType))
+      .sort((a, b) => {
+        const timeDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        if (timeDelta !== 0) return timeDelta
+        return a.id.localeCompare(b.id)
+      })
   }, [events, isThread])
 
   const timelineItems = useMemo(

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -75,8 +75,8 @@ import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
 
-/** Event types suppressed in threads — see displayEvents memo below. */
-const THREAD_HIDDEN_EVENT_TYPES = new Set<string>(["member_joined", "member_added", "member_left"])
+/** Membership events; suppressed in threads (see displayEvents memo). */
+const THREAD_HIDDEN_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["member_joined", "member_added", "member_left"])
 
 interface StreamContentProps {
   workspaceId: string


### PR DESCRIPTION
## Problem

In thread timelines, we render system rows like "Kristoffer Remback was added to the conversation" for every `member_added` / `member_joined` / `member_left` event. In a thread this reads as noise — thread participation is implicit (replying joins you, the parent author is auto-added on thread create — see `59c1e76 fix: emit stream:member_added for thread parent message author`), so the user the row names is by definition already visible right above as the thread author. Channels still legitimately need these rows.

## Solution

Filter membership events out of the thread `displayEvents` memo in `StreamContent`. Channels are untouched.

### Why filter at `displayEvents` (not at `EventItem`)

`displayEvents` is already the thread-only branch of the memo (it's where threads get their custom `(createdAt, id)` sort, distinct from the channel sequence ordering). The filter sits next to its sibling concern with no prop drilling, and every downstream consumer — `timelineItems`, the virtualizer keys, `messageEventMeta` — reads from `displayEvents` and inherits the behavior automatically. `messageEventMeta` only iterates `message_created` events, so it's unaffected; `annotateAuthorGroups` only groups message events, so removing membership rows can't break author-run continuation.

The alternative — returning `null` from the membership cases of `EventItem`'s switch when `isThread` — would have required threading an `isThread` prop through `EventList`, `TimelineItemContent`, and `EventItem`, plus a decision at `ThreadParentMessage`'s direct `EventItem` use (the parent message lives in the channel, not the thread, so it'd want the channel behavior). Filtering at the source avoids the prop drilling and the per-call-site decision.

### Why all three membership types, not just `member_added`

The reporter's example was `member_added`, but the same "implicit participation" reasoning applies to `member_joined` and `member_left` in a thread context. All three render through `MembershipEvent` with the same "<actor> <verb> the conversation" shape and feel equally redundant when the actor is clearly already participating.

### Typing

`THREAD_HIDDEN_EVENT_TYPES` is typed as `Set<StreamEvent["eventType"]>` to match the existing `MESSAGE_EVENT_TYPES` constant in `event-list.tsx` — a typo in a literal would fail at compile time. I considered extracting a shared `MEMBERSHIP_EVENT_TYPES` constant to `packages/types/src/constants.ts` (alongside `COMMAND_EVENT_TYPES` and `AGENT_SESSION_EVENT_TYPES`), but with only one consumer that's speculative grouping (INV-36); easy to extract later if a second use case appears.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Add `THREAD_HIDDEN_EVENT_TYPES` set; filter it out of `displayEvents` when `isThread`. |

## Test plan

- [x] `bun run --cwd apps/frontend tsc --noEmit` clean
- [x] `event-item.test.tsx` and `event-list.test.ts` still pass (24/24)
- [x] Pre-commit lint + monorepo typecheck pass
- [ ] Manual: open a thread where the parent author has a `member_added` event — verify the system row no longer renders. Open the parent channel — verify membership rows still render there. Reply in the thread to make sure author-run continuation grouping still collapses correctly across the gap where the membership row used to be.

I did not add a unit test. The change is a 3-line filter inside an inline `useMemo` in a 1000+ line component; an isolated test would either require extracting a helper just for the test (INV-36 — not worth the abstraction for one consumer) or mounting the full `StreamContent` with mocked thread bootstrap (heavier than the change warrants). Happy to add one if reviewers prefer.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWQvokFYqTr7dxpeQ6t98X)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->