### PR TITLE
feat(emoji): expand picker through Unicode 16.0 + coverage tests

### DIFF
--- a/apps/backend/src/features/emoji/emoji-data.json
+++ b/apps/backend/src/features/emoji/emoji-data.json
@@ -8343,20 +8343,20 @@
     {
       "emoji": "🩷",
       "shortcodes": ["pink_heart", "heart_pink"],
-      "group": "symbols",
-      "order": 308
+      "group": "smileys",
+      "order": 195
     },
     {
       "emoji": "🩵",
       "shortcodes": ["light_blue_heart", "heart_light_blue"],
-      "group": "symbols",
-      "order": 309
+      "group": "smileys",
+      "order": 196
     },
     {
       "emoji": "🩶",
       "shortcodes": ["grey_heart", "heart_grey", "gray_heart", "heart_gray"],
-      "group": "symbols",
-      "order": 310
+      "group": "smileys",
+      "order": 197
     },
     {
       "emoji": "🐦‍🔥",

--- a/apps/backend/src/features/emoji/emoji-data.json
+++ b/apps/backend/src/features/emoji/emoji-data.json
@@ -2,7 +2,7 @@
   "emojis": [
     {
       "emoji": "😀",
-      "shortcodes": ["grinning"],
+      "shortcodes": ["grinning", "happy"],
       "group": "smileys",
       "order": 0
     },
@@ -20,7 +20,7 @@
     },
     {
       "emoji": "😁",
-      "shortcodes": ["grin"],
+      "shortcodes": ["grin", "happy_grin"],
       "group": "smileys",
       "order": 3
     },
@@ -38,19 +38,19 @@
     },
     {
       "emoji": "🤣",
-      "shortcodes": ["rofl"],
+      "shortcodes": ["rofl", "lol", "lmao"],
       "group": "smileys",
       "order": 6
     },
     {
       "emoji": "😂",
-      "shortcodes": ["joy"],
+      "shortcodes": ["joy", "laughing_tears", "tears_of_joy"],
       "group": "smileys",
       "order": 7
     },
     {
       "emoji": "🙂",
-      "shortcodes": ["slightly_smiling_face"],
+      "shortcodes": ["slightly_smiling_face", "smile_face"],
       "group": "smileys",
       "order": 8
     },
@@ -68,7 +68,7 @@
     },
     {
       "emoji": "😊",
-      "shortcodes": ["blush"],
+      "shortcodes": ["blush", "smiling", "happy_blush"],
       "group": "smileys",
       "order": 12
     },
@@ -128,7 +128,7 @@
     },
     {
       "emoji": "🥲",
-      "shortcodes": ["smiling_face_with_tear"],
+      "shortcodes": ["smiling_face_with_tear", "smiling_tear"],
       "group": "smileys",
       "order": 23
     },
@@ -188,7 +188,7 @@
     },
     {
       "emoji": "🤔",
-      "shortcodes": ["thinking"],
+      "shortcodes": ["thinking", "hmm"],
       "group": "smileys",
       "order": 35
     },
@@ -236,7 +236,7 @@
     },
     {
       "emoji": "🙄",
-      "shortcodes": ["roll_eyes"],
+      "shortcodes": ["roll_eyes", "eye_roll"],
       "group": "smileys",
       "order": 47
     },
@@ -278,7 +278,7 @@
     },
     {
       "emoji": "😴",
-      "shortcodes": ["sleeping"],
+      "shortcodes": ["sleeping", "sleeping_face", "snooze"],
       "group": "smileys",
       "order": 60
     },
@@ -434,7 +434,7 @@
     },
     {
       "emoji": "🥺",
-      "shortcodes": ["pleading_face"],
+      "shortcodes": ["pleading_face", "pleading"],
       "group": "smileys",
       "order": 90
     },
@@ -476,13 +476,13 @@
     },
     {
       "emoji": "😭",
-      "shortcodes": ["sob"],
+      "shortcodes": ["sob", "crying", "sobbing"],
       "group": "smileys",
       "order": 98
     },
     {
       "emoji": "😱",
-      "shortcodes": ["scream"],
+      "shortcodes": ["scream", "screaming", "shocked"],
       "group": "smileys",
       "order": 99
     },
@@ -566,7 +566,7 @@
     },
     {
       "emoji": "💀",
-      "shortcodes": ["skull"],
+      "shortcodes": ["skull", "dead", "rip"],
       "group": "smileys",
       "order": 113
     },
@@ -824,7 +824,7 @@
     },
     {
       "emoji": "💯",
-      "shortcodes": ["100"],
+      "shortcodes": ["100", "hundred", "perfect", "full_marks"],
       "group": "smileys",
       "order": 166
     },
@@ -902,7 +902,7 @@
     },
     {
       "emoji": "👋",
-      "shortcodes": ["wave"],
+      "shortcodes": ["wave", "hello", "hi", "bye"],
       "group": "people",
       "order": 0
     },
@@ -1052,13 +1052,13 @@
     },
     {
       "emoji": "👏",
-      "shortcodes": ["clap"],
+      "shortcodes": ["clap", "clapping", "applause"],
       "group": "people",
       "order": 201
     },
     {
       "emoji": "🙌",
-      "shortcodes": ["raised_hands"],
+      "shortcodes": ["raised_hands", "praise"],
       "group": "people",
       "order": 207
     },
@@ -1076,13 +1076,13 @@
     },
     {
       "emoji": "🤝",
-      "shortcodes": ["handshake"],
+      "shortcodes": ["handshake", "handshake_deal", "agreement"],
       "group": "people",
       "order": 231
     },
     {
       "emoji": "🙏",
-      "shortcodes": ["pray"],
+      "shortcodes": ["pray", "please", "thanks", "thank_you"],
       "group": "people",
       "order": 257
     },
@@ -1106,7 +1106,7 @@
     },
     {
       "emoji": "💪",
-      "shortcodes": ["muscle"],
+      "shortcodes": ["muscle", "strong", "flex"],
       "group": "people",
       "order": 282
     },
@@ -1184,7 +1184,7 @@
     },
     {
       "emoji": "👀",
-      "shortcodes": ["eyes"],
+      "shortcodes": ["eyes", "looking", "watching"],
       "group": "people",
       "order": 325
     },
@@ -1328,7 +1328,7 @@
     },
     {
       "emoji": "🤷",
-      "shortcodes": ["shrug"],
+      "shortcodes": ["shrug", "shrug_person"],
       "group": "people",
       "order": 793
     },
@@ -2420,7 +2420,7 @@
     },
     {
       "emoji": "🐛",
-      "shortcodes": ["bug"],
+      "shortcodes": ["bug", "bug_fix"],
       "group": "animals",
       "order": 119
     },
@@ -4184,7 +4184,7 @@
     },
     {
       "emoji": "🚀",
-      "shortcodes": ["rocket"],
+      "shortcodes": ["rocket", "launch", "blast_off"],
       "group": "travel",
       "order": 163
     },
@@ -4658,7 +4658,7 @@
     },
     {
       "emoji": "🔥",
-      "shortcodes": ["fire"],
+      "shortcodes": ["fire", "lit", "hot"],
       "group": "travel",
       "order": 264
     },
@@ -4718,13 +4718,13 @@
     },
     {
       "emoji": "🎉",
-      "shortcodes": ["tada"],
+      "shortcodes": ["tada", "celebration", "party", "celebrate"],
       "group": "activities",
       "order": 7
     },
     {
       "emoji": "🎊",
-      "shortcodes": ["confetti_ball"],
+      "shortcodes": ["confetti_ball", "party_popper2"],
       "group": "activities",
       "order": 8
     },
@@ -5000,7 +5000,7 @@
     },
     {
       "emoji": "🎯",
-      "shortcodes": ["dart"],
+      "shortcodes": ["dart", "bullseye", "on_target"],
       "group": "activities",
       "order": 58
     },
@@ -5798,7 +5798,7 @@
     },
     {
       "emoji": "💡",
-      "shortcodes": ["bulb"],
+      "shortcodes": ["bulb", "idea", "lightbulb_idea"],
       "group": "objects",
       "order": 124
     },
@@ -6182,7 +6182,7 @@
     },
     {
       "emoji": "📌",
-      "shortcodes": ["pushpin"],
+      "shortcodes": ["pushpin", "pin"],
       "group": "objects",
       "order": 201
     },
@@ -6764,7 +6764,7 @@
     },
     {
       "emoji": "⚠️",
-      "shortcodes": ["warning"],
+      "shortcodes": ["warning", "warning_sign", "caution"],
       "group": "symbols",
       "order": 13
     },
@@ -7322,7 +7322,7 @@
     },
     {
       "emoji": "❓",
-      "shortcodes": ["question"],
+      "shortcodes": ["question", "question_mark", "huh"],
       "group": "symbols",
       "order": 151
     },
@@ -7406,7 +7406,7 @@
     },
     {
       "emoji": "✅",
-      "shortcodes": ["white_check_mark"],
+      "shortcodes": ["white_check_mark", "done", "yes", "checkmark", "check_done"],
       "group": "symbols",
       "order": 169
     },
@@ -7424,7 +7424,7 @@
     },
     {
       "emoji": "❌",
-      "shortcodes": ["x"],
+      "shortcodes": ["x", "no", "wrong", "cross_mark"],
       "group": "symbols",
       "order": 174
     },
@@ -8051,6 +8051,402 @@
       "shortcodes": ["pirate_flag"],
       "group": "flags",
       "order": 12
+    },
+    {
+      "emoji": "🥹",
+      "shortcodes": ["face_holding_back_tears", "holding_back_tears"],
+      "group": "smileys",
+      "order": 185
+    },
+    {
+      "emoji": "🫠",
+      "shortcodes": ["melting_face", "melting"],
+      "group": "smileys",
+      "order": 186
+    },
+    {
+      "emoji": "🫡",
+      "shortcodes": ["saluting_face", "salute", "saluting"],
+      "group": "smileys",
+      "order": 187
+    },
+    {
+      "emoji": "🫢",
+      "shortcodes": ["face_with_open_eyes_and_hand_over_mouth", "shocked_gasp", "gasp_face"],
+      "group": "smileys",
+      "order": 188
+    },
+    {
+      "emoji": "🫣",
+      "shortcodes": ["face_with_peeking_eye", "peeking", "peek"],
+      "group": "smileys",
+      "order": 189
+    },
+    {
+      "emoji": "🫤",
+      "shortcodes": ["face_with_diagonal_mouth", "meh", "diagonal_mouth"],
+      "group": "smileys",
+      "order": 190
+    },
+    {
+      "emoji": "🫥",
+      "shortcodes": ["dotted_line_face", "invisible", "dotted_face"],
+      "group": "smileys",
+      "order": 191
+    },
+    {
+      "emoji": "🫰",
+      "shortcodes": ["hand_with_index_finger_and_thumb_crossed", "finger_heart", "money_fingers"],
+      "group": "people",
+      "order": 3290
+    },
+    {
+      "emoji": "🫱",
+      "shortcodes": ["rightwards_hand", "open_hand_right", "palm_right", "hand_right"],
+      "group": "people",
+      "order": 3291
+    },
+    {
+      "emoji": "🫲",
+      "shortcodes": ["leftwards_hand", "open_hand_left", "palm_left", "hand_left"],
+      "group": "people",
+      "order": 3292
+    },
+    {
+      "emoji": "🫳",
+      "shortcodes": ["palm_down_hand", "hand_palm_down"],
+      "group": "people",
+      "order": 3293
+    },
+    {
+      "emoji": "🫴",
+      "shortcodes": ["palm_up_hand", "hand_palm_up", "offer", "give"],
+      "group": "people",
+      "order": 3294
+    },
+    {
+      "emoji": "🫵",
+      "shortcodes": ["index_pointing_at_viewer", "you", "pointing_at_you"],
+      "group": "people",
+      "order": 3295
+    },
+    {
+      "emoji": "🫶",
+      "shortcodes": ["heart_hands", "hand_heart", "love_hands"],
+      "group": "people",
+      "order": 3296
+    },
+    {
+      "emoji": "🫅",
+      "shortcodes": ["person_with_crown", "royalty", "monarch"],
+      "group": "people",
+      "order": 3297
+    },
+    {
+      "emoji": "🫃",
+      "shortcodes": ["pregnant_man"],
+      "group": "people",
+      "order": 3298
+    },
+    {
+      "emoji": "🫄",
+      "shortcodes": ["pregnant_person"],
+      "group": "people",
+      "order": 3299
+    },
+    {
+      "emoji": "🪺",
+      "shortcodes": ["nest_with_eggs", "nest_eggs"],
+      "group": "animals",
+      "order": 165
+    },
+    {
+      "emoji": "🪹",
+      "shortcodes": ["empty_nest", "nest_empty"],
+      "group": "animals",
+      "order": 166
+    },
+    {
+      "emoji": "🫘",
+      "shortcodes": ["beans"],
+      "group": "food",
+      "order": 133
+    },
+    {
+      "emoji": "🫗",
+      "shortcodes": ["pouring_liquid", "pour"],
+      "group": "food",
+      "order": 134
+    },
+    {
+      "emoji": "🫙",
+      "shortcodes": ["jar"],
+      "group": "food",
+      "order": 135
+    },
+    {
+      "emoji": "🛞",
+      "shortcodes": ["wheel", "wheel_general"],
+      "group": "travel",
+      "order": 267
+    },
+    {
+      "emoji": "🩼",
+      "shortcodes": ["crutch"],
+      "group": "objects",
+      "order": 313
+    },
+    {
+      "emoji": "🩻",
+      "shortcodes": ["x_ray", "xray"],
+      "group": "objects",
+      "order": 314
+    },
+    {
+      "emoji": "🪪",
+      "shortcodes": ["id_card", "identification", "passport_card"],
+      "group": "objects",
+      "order": 315
+    },
+    {
+      "emoji": "🪫",
+      "shortcodes": ["low_battery", "battery_low"],
+      "group": "objects",
+      "order": 316
+    },
+    {
+      "emoji": "🪩",
+      "shortcodes": ["mirror_ball", "disco_ball", "disco"],
+      "group": "activities",
+      "order": 96
+    },
+    {
+      "emoji": "🛟",
+      "shortcodes": ["ring_buoy", "lifebuoy", "life_ring"],
+      "group": "travel",
+      "order": 268
+    },
+    {
+      "emoji": "🪬",
+      "shortcodes": ["hamsa", "hand_of_fatima"],
+      "group": "objects",
+      "order": 317
+    },
+    {
+      "emoji": "🫧",
+      "shortcodes": ["bubbles"],
+      "group": "smileys",
+      "order": 192
+    },
+    {
+      "emoji": "🟰",
+      "shortcodes": ["heavy_equals_sign", "equals"],
+      "group": "symbols",
+      "order": 305
+    },
+    {
+      "emoji": "🫨",
+      "shortcodes": ["shaking_face", "shaking", "vibrating_face"],
+      "group": "smileys",
+      "order": 193
+    },
+    {
+      "emoji": "🫷",
+      "shortcodes": ["leftwards_pushing_hand", "push_left", "stop_left"],
+      "group": "people",
+      "order": 3300
+    },
+    {
+      "emoji": "🫸",
+      "shortcodes": ["rightwards_pushing_hand", "push_right", "stop_right", "high_five_left"],
+      "group": "people",
+      "order": 3301
+    },
+    {
+      "emoji": "🪿",
+      "shortcodes": ["goose"],
+      "group": "animals",
+      "order": 167
+    },
+    {
+      "emoji": "🪼",
+      "shortcodes": ["jellyfish"],
+      "group": "animals",
+      "order": 168
+    },
+    {
+      "emoji": "🐦‍⬛",
+      "shortcodes": ["black_bird", "blackbird"],
+      "group": "animals",
+      "order": 169
+    },
+    {
+      "emoji": "🪽",
+      "shortcodes": ["wing"],
+      "group": "animals",
+      "order": 170
+    },
+    {
+      "emoji": "🪻",
+      "shortcodes": ["hyacinth", "lavender_flower"],
+      "group": "animals",
+      "order": 171
+    },
+    {
+      "emoji": "🫚",
+      "shortcodes": ["ginger_root", "ginger"],
+      "group": "food",
+      "order": 136
+    },
+    {
+      "emoji": "🫛",
+      "shortcodes": ["pea_pod", "peas", "pod"],
+      "group": "food",
+      "order": 137
+    },
+    {
+      "emoji": "🪈",
+      "shortcodes": ["flute"],
+      "group": "activities",
+      "order": 97
+    },
+    {
+      "emoji": "🪇",
+      "shortcodes": ["maraca", "maracas"],
+      "group": "activities",
+      "order": 98
+    },
+    {
+      "emoji": "🪯",
+      "shortcodes": ["khanda"],
+      "group": "symbols",
+      "order": 306
+    },
+    {
+      "emoji": "🪭",
+      "shortcodes": ["folding_hand_fan", "hand_fan", "folding_fan"],
+      "group": "objects",
+      "order": 318
+    },
+    {
+      "emoji": "🪮",
+      "shortcodes": ["hair_pick", "afro_pick"],
+      "group": "objects",
+      "order": 319
+    },
+    {
+      "emoji": "🛜",
+      "shortcodes": ["wireless", "wifi"],
+      "group": "symbols",
+      "order": 307
+    },
+    {
+      "emoji": "🩷",
+      "shortcodes": ["pink_heart", "heart_pink"],
+      "group": "symbols",
+      "order": 308
+    },
+    {
+      "emoji": "🩵",
+      "shortcodes": ["light_blue_heart", "heart_light_blue"],
+      "group": "symbols",
+      "order": 309
+    },
+    {
+      "emoji": "🩶",
+      "shortcodes": ["grey_heart", "heart_grey", "gray_heart", "heart_gray"],
+      "group": "symbols",
+      "order": 310
+    },
+    {
+      "emoji": "🐦‍🔥",
+      "shortcodes": ["phoenix", "bird_on_fire"],
+      "group": "animals",
+      "order": 172
+    },
+    {
+      "emoji": "🍋‍🟩",
+      "shortcodes": ["lime", "green_lemon"],
+      "group": "food",
+      "order": 138
+    },
+    {
+      "emoji": "🍄‍🟫",
+      "shortcodes": ["brown_mushroom", "mushroom_brown"],
+      "group": "food",
+      "order": 139
+    },
+    {
+      "emoji": "⛓️‍💥",
+      "shortcodes": ["broken_chain", "chain_break", "chains_broken"],
+      "group": "objects",
+      "order": 320
+    },
+    {
+      "emoji": "🫩",
+      "shortcodes": ["face_with_bags_under_eyes", "tired_eyes", "bags_under_eyes"],
+      "group": "smileys",
+      "order": 194
+    },
+    {
+      "emoji": "🫆",
+      "shortcodes": ["fingerprint", "print"],
+      "group": "objects",
+      "order": 321
+    },
+    {
+      "emoji": "🪾",
+      "shortcodes": ["leafless_tree", "bare_tree", "winter_tree"],
+      "group": "animals",
+      "order": 173
+    },
+    {
+      "emoji": "🫜",
+      "shortcodes": ["root_vegetable", "radish", "turnip"],
+      "group": "food",
+      "order": 140
+    },
+    {
+      "emoji": "🪉",
+      "shortcodes": ["harp"],
+      "group": "activities",
+      "order": 99
+    },
+    {
+      "emoji": "🪏",
+      "shortcodes": ["shovel", "spade_tool"],
+      "group": "objects",
+      "order": 322
+    },
+    {
+      "emoji": "🫟",
+      "shortcodes": ["splatter", "paint_splatter", "splat"],
+      "group": "objects",
+      "order": 323
+    },
+    {
+      "emoji": "🪷",
+      "shortcodes": ["lotus", "lotus_flower"],
+      "group": "animals",
+      "order": 174
+    },
+    {
+      "emoji": "🪸",
+      "shortcodes": ["coral"],
+      "group": "animals",
+      "order": 175
+    },
+    {
+      "emoji": "🫎",
+      "shortcodes": ["moose"],
+      "group": "animals",
+      "order": 176
+    },
+    {
+      "emoji": "🫏",
+      "shortcodes": ["donkey"],
+      "group": "animals",
+      "order": 177
     }
   ]
 }

--- a/apps/backend/src/features/emoji/emoji.test.ts
+++ b/apps/backend/src/features/emoji/emoji.test.ts
@@ -130,30 +130,30 @@ describe("Emoji Library", () => {
       // shortcode and the emojis fighting over it.
       const owners = new Map<string, string[]>()
       for (const { emoji, shortcodes } of emojiData.emojis) {
-        for (const sc of shortcodes) {
-          const list = owners.get(sc) ?? []
+        for (const shortcode of shortcodes) {
+          const list = owners.get(shortcode) ?? []
           if (!list.includes(emoji)) list.push(emoji)
-          owners.set(sc, list)
+          owners.set(shortcode, list)
         }
       }
       const collisions = Array.from(owners.entries())
         .filter(([, emojis]) => emojis.length > 1)
-        .map(([sc, emojis]) => `${sc} -> ${emojis.join(", ")}`)
+        .map(([shortcode, emojis]) => `${shortcode} -> ${emojis.join(", ")}`)
       expect(collisions).toEqual([])
     })
 
     test("every shortcode satisfies the wire-format regex", () => {
       const invalid: string[] = []
       for (const { emoji, shortcodes } of emojiData.emojis) {
-        for (const sc of shortcodes) {
-          if (!SHORTCODE_BODY.test(sc)) invalid.push(`${emoji} -> "${sc}"`)
+        for (const shortcode of shortcodes) {
+          if (!SHORTCODE_BODY.test(shortcode)) invalid.push(`${emoji} -> "${shortcode}"`)
         }
       }
       expect(invalid).toEqual([])
     })
 
     test("every emoji has at least one shortcode", () => {
-      const empty = emojiData.emojis.filter((e) => e.shortcodes.length === 0).map((e) => e.emoji)
+      const empty = emojiData.emojis.filter((entry) => entry.shortcodes.length === 0).map((entry) => entry.emoji)
       expect(empty).toEqual([])
     })
 
@@ -183,12 +183,12 @@ describe("Emoji Library", () => {
     // the dataset, not the exact version. If a label is slightly off
     // (some borderline characters move between 14.0 and 15.0 in different
     // sources), the test still passes as long as the emoji is present.
-    const dataset = new Set(emojiData.emojis.map((e) => e.emoji))
-    const has = (emojis: string[]) => emojis.filter((e) => !dataset.has(e))
+    const dataset = new Set(emojiData.emojis.map((entry) => entry.emoji))
+    const findMissing = (emojis: string[]) => emojis.filter((emoji) => !dataset.has(emoji))
 
     // Emoji 14.0 (Sept 2021)
     test("supports Emoji 14.0 (2021)", () => {
-      const set = [
+      const expected = [
         // Faces
         "🥹",
         "🫠",
@@ -234,12 +234,12 @@ describe("Emoji Library", () => {
         "🟰",
         "🫧",
       ]
-      expect(has(set)).toEqual([])
+      expect(findMissing(expected)).toEqual([])
     })
 
     // Emoji 15.0 (Sept 2022)
     test("supports Emoji 15.0 (2022)", () => {
-      const set = [
+      const expected = [
         // Faces
         "🫨",
         // Hands
@@ -262,31 +262,32 @@ describe("Emoji Library", () => {
         "🪇",
         // Objects
         "🪭",
-        // Symbols
+        // Hearts & symbols
         "🛜",
         "🩷",
         "🩵",
         "🩶",
       ]
-      expect(has(set)).toEqual([])
+      expect(findMissing(expected)).toEqual([])
     })
 
     // Emoji 15.1 (Sept 2023) — small release of ZWJ sequences
     test("supports Emoji 15.1 (2023)", () => {
-      const set = ["🐦‍🔥", "🍋‍🟩", "🍄‍🟫", "⛓️‍💥"]
-      expect(has(set)).toEqual([])
+      const expected = ["🐦‍🔥", "🍋‍🟩", "🍄‍🟫", "⛓️‍💥"]
+      expect(findMissing(expected)).toEqual([])
     })
 
     // Emoji 16.0 (Sept 2024)
     test("supports Emoji 16.0 (2024)", () => {
-      const set = ["🫩", "🫆", "🪾", "🫜", "🪉", "🪏", "🫟"]
-      expect(has(set)).toEqual([])
+      const expected = ["🫩", "🫆", "🪾", "🫜", "🪉", "🪏", "🫟"]
+      expect(findMissing(expected)).toEqual([])
     })
 
-    // Sanity: the user's reported gap that triggered this expansion.
-    // Keep this regardless of version groupings above.
+    // Explicit guard for the rightwards-hand family. The version blocks
+    // above could be reorganized or split; this test pins the specific
+    // hand emojis and their canonical/aliased shortcode lookups.
     test("supports the rightwards-hand family (regression guard)", () => {
-      expect(has(["🫱", "🫲", "🫳", "🫴", "🫵", "🫶"])).toEqual([])
+      expect(findMissing(["🫱", "🫲", "🫳", "🫴", "🫵", "🫶"])).toEqual([])
       expect(toEmoji(":rightwards_hand:")).toBe("🫱")
       expect(toEmoji(":open_hand_right:")).toBe("🫱")
     })

--- a/apps/backend/src/features/emoji/emoji.test.ts
+++ b/apps/backend/src/features/emoji/emoji.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { toShortcode, toEmoji, isValidShortcode, getShortcodeNames, normalizeMessage } from "./emoji"
+import emojiData from "./emoji-data.json"
 
 describe("Emoji Library", () => {
   describe("toShortcode", () => {
@@ -112,6 +113,167 @@ describe("Emoji Library", () => {
         expect(toEmoji(shortcode)).toBe(emoji)
       })
     }
+  })
+
+  describe("dataset integrity", () => {
+    // The shortcode regex used everywhere a shortcode crosses the wire
+    // (composer input rule, toShortcode/toEmoji APIs). If a shortcode in
+    // the JSON doesn't satisfy this, it cannot round-trip through the
+    // system — catch it here rather than at runtime.
+    const SHORTCODE_BODY = /^[a-z0-9_+-]+$/
+
+    test("no shortcode collisions across emojis", () => {
+      // Every shortcode (primary or alias) must map to exactly one emoji.
+      // Without this, toEmoji() becomes ambiguous and which mapping wins
+      // depends on JSON insertion order — a silent footgun when expanding
+      // aliases. If this fails, the failure message lists every offending
+      // shortcode and the emojis fighting over it.
+      const owners = new Map<string, string[]>()
+      for (const { emoji, shortcodes } of emojiData.emojis) {
+        for (const sc of shortcodes) {
+          const list = owners.get(sc) ?? []
+          if (!list.includes(emoji)) list.push(emoji)
+          owners.set(sc, list)
+        }
+      }
+      const collisions = Array.from(owners.entries())
+        .filter(([, emojis]) => emojis.length > 1)
+        .map(([sc, emojis]) => `${sc} -> ${emojis.join(", ")}`)
+      expect(collisions).toEqual([])
+    })
+
+    test("every shortcode satisfies the wire-format regex", () => {
+      const invalid: string[] = []
+      for (const { emoji, shortcodes } of emojiData.emojis) {
+        for (const sc of shortcodes) {
+          if (!SHORTCODE_BODY.test(sc)) invalid.push(`${emoji} -> "${sc}"`)
+        }
+      }
+      expect(invalid).toEqual([])
+    })
+
+    test("every emoji has at least one shortcode", () => {
+      const empty = emojiData.emojis.filter((e) => e.shortcodes.length === 0).map((e) => e.emoji)
+      expect(empty).toEqual([])
+    })
+  })
+
+  describe("Unicode version coverage", () => {
+    // Guards against silently falling behind Unicode releases. When a new
+    // Emoji version ships, add a block below for it AND add the emojis to
+    // emoji-data.json — this test fails on either half being missing.
+    //
+    // Version labels are best-effort; the test only asserts presence in
+    // the dataset, not the exact version. If a label is slightly off
+    // (some borderline characters move between 14.0 and 15.0 in different
+    // sources), the test still passes as long as the emoji is present.
+    const dataset = new Set(emojiData.emojis.map((e) => e.emoji))
+    const has = (emojis: string[]) => emojis.filter((e) => !dataset.has(e))
+
+    // Emoji 14.0 (Sept 2021)
+    test("supports Emoji 14.0 (2021)", () => {
+      const set = [
+        // Faces
+        "🥹",
+        "🫠",
+        "🫡",
+        "🫢",
+        "🫣",
+        "🫤",
+        "🫥",
+        // Hands
+        "🫰",
+        "🫱",
+        "🫲",
+        "🫳",
+        "🫴",
+        "🫵",
+        "🫶",
+        // Person
+        "🫅",
+        "🫃",
+        "🫄",
+        // Animals & nature
+        "🪺",
+        "🪹",
+        "🪷",
+        "🪸",
+        // Food & drink
+        "🫘",
+        "🫗",
+        "🫙",
+        // Travel
+        "🛞",
+        // Objects
+        "🩼",
+        "🩻",
+        "🪪",
+        "🪫",
+        "🪩",
+        "🛟",
+        "🪬",
+        "🪮",
+        "🪯",
+        // Symbols
+        "🟰",
+        "🫧",
+      ]
+      expect(has(set)).toEqual([])
+    })
+
+    // Emoji 15.0 (Sept 2022)
+    test("supports Emoji 15.0 (2022)", () => {
+      const set = [
+        // Faces
+        "🫨",
+        // Hands
+        "🫷",
+        "🫸",
+        // Animals
+        "🐦‍⬛",
+        "🪿",
+        "🪼",
+        "🪽",
+        "🫎",
+        "🫏",
+        // Plants
+        "🪻",
+        // Food
+        "🫚",
+        "🫛",
+        // Activities
+        "🪈",
+        "🪇",
+        // Objects
+        "🪭",
+        // Symbols
+        "🛜",
+        "🩷",
+        "🩵",
+        "🩶",
+      ]
+      expect(has(set)).toEqual([])
+    })
+
+    // Emoji 15.1 (Sept 2023) — small release of ZWJ sequences
+    test("supports Emoji 15.1 (2023)", () => {
+      const set = ["🐦‍🔥", "🍋‍🟩", "🍄‍🟫", "⛓️‍💥"]
+      expect(has(set)).toEqual([])
+    })
+
+    // Emoji 16.0 (Sept 2024)
+    test("supports Emoji 16.0 (2024)", () => {
+      const set = ["🫩", "🫆", "🪾", "🫜", "🪉", "🪏", "🫟"]
+      expect(has(set)).toEqual([])
+    })
+
+    // Sanity: the user's reported gap that triggered this expansion.
+    // Keep this regardless of version groupings above.
+    test("supports the rightwards-hand family (regression guard)", () => {
+      expect(has(["🫱", "🫲", "🫳", "🫴", "🫵", "🫶"])).toEqual([])
+      expect(toEmoji(":rightwards_hand:")).toBe("🫱")
+      expect(toEmoji(":open_hand_right:")).toBe("🫱")
+    })
   })
 
   describe("normalizeMessage", () => {

--- a/apps/backend/src/features/emoji/emoji.test.ts
+++ b/apps/backend/src/features/emoji/emoji.test.ts
@@ -156,6 +156,22 @@ describe("Emoji Library", () => {
       const empty = emojiData.emojis.filter((e) => e.shortcodes.length === 0).map((e) => e.emoji)
       expect(empty).toEqual([])
     })
+
+    test("primary shortcode is canonical for toShortcode()", () => {
+      // shortcodes[0] is the wire-format primary that toShortcode() returns
+      // and is what gets persisted, displayed in tooltips, and rendered into
+      // markdown. Reordering aliases (e.g. swapping a synonym to first) would
+      // silently rewrite normalized output and break message-history parity.
+      const mismatches = emojiData.emojis
+        .map(({ emoji, shortcodes }) => ({
+          emoji,
+          expected: `:${shortcodes[0]}:`,
+          actual: toShortcode(emoji),
+        }))
+        .filter(({ expected, actual }) => actual !== expected)
+        .map(({ emoji, expected, actual }) => `${emoji}: expected ${expected}, got ${actual}`)
+      expect(mismatches).toEqual([])
+    })
   })
 
   describe("Unicode version coverage", () => {


### PR DESCRIPTION
## Summary

The emoji dataset was effectively frozen at Unicode 13.0, so common modern emojis like 🫱 (rightwards hand), 🫶 (heart hands), 🫡 (saluting face), 🩷 (pink heart), 🪿 (goose), and the 15.1 ZWJ phoenix 🐦‍🔥 / lime 🍋‍🟩 simply weren't reachable from the picker or shortcode input. Sparked by a user noting that "open hand to the right" wasn't selectable.

This PR is **pure data + tests** — no picker, search, or shortcode-handling code changes. Search/grid/render already handle whatever the JSON contains.

### What changed

- **66 new emojis** added covering Emoji 14.0 → 16.0 (faces, hands, hearts, animals, plants, food, objects, plus the 15.1 ZWJ sequences).
- **~30 high-traffic existing emojis** got synonym aliases so search recall matches user intuition: `happy` → 😀, `lol`/`lmao` → 🤣, `celebration`/`party` → 🎉, `hello`/`hi`/`bye` → 👋, `lit`/`hot` → 🔥, `done`/`yes` → ✅, etc.
- **Dataset integrity tests** that fail CI if the JSON ever drifts:
  - shortcode collision detection (every alias maps to exactly one emoji)
  - shortcode wire-format conformance (matches the regex used at the system boundary)
  - non-empty shortcode list per emoji
- **Unicode-version coverage tests** for 14.0 / 15.0 / 15.1 / 16.0. Adding a new release without also adding emojis (or vice versa) fails CI. When Unicode 17 ships, drop in a new block here.
- **Regression guard** for the rightwards-hand family that triggered this work.

`apps/backend/src/features/emoji/emoji.test.ts` goes from 42 → 50 passing tests.

### Design notes

- **Why JSON only.** The picker's frontend grid sorts by `(group, order)` from the JSON; the backend's `toEmoji`/`toShortcode` lookup maps are built at module load from the same JSON. Touching only data keeps the blast radius minimal and lets the existing tests (now reinforced) protect both producers and consumers.
- **Primary shortcode = first in `shortcodes[]`.** Backend `getEmojiList()` and `toShortcode()` both rely on this. New entries put canonical Unicode names first (`rightwards_hand`, `melting_face`, `saluting_face`) so the wire format stays predictable; everyday synonyms come after for search.
- **Skin-tone modifiers and gendered ZWJ variants for 14.0 People are intentionally out of scope.** The dataset doesn't carry any today; adding them is a separate, much larger decision (per-tone storage, picker UI for tone selection).
- **Unicode 17.0 (Sept 2025) deferred.** It exists but the codepoint table needs careful cross-checking and the small set (~8 emojis) didn't justify expanding scope here. The new coverage tests make adding it later a one-block change.
- **Categorization follows existing conventions:** plants/trees go in `animals` (the codebase uses it as the "Animals & Nature" bucket — see existing 🌹 🌻 🌵), bubbles 🫧 sits in `smileys` next to 💭/💬.

### Out of scope (not done in this PR)

- Skin-tone variants for hand emojis.
- ZWJ family-composition emojis from 14.0/15.0/15.1.
- Workspace custom emoji upload (the `type: "native"` field in `EmojiEntry` hints at a future "custom" path; untouched here).

## Test plan

- [x] `bun test apps/backend/src/features/emoji/emoji.test.ts` — 50/50 pass
- [x] Frontend test suite (`bun run --cwd apps/frontend test`) — 1577/1577 pass
- [x] Synthetic-collision spike: injecting `heart` as an alias on 🔥 fails the new collision test as expected
- [x] Synthetic-removal spike: deleting 🫱 from the JSON fails both the 14.0 coverage test and the rightwards-hand regression guard as expected
- [ ] Manual: open the reaction picker in the running app, search for "happy" / "lol" / "open" / "right" and confirm new emojis surface
- [ ] Manual: type `:rightwards_hand:` and `:open_hand_right:` in the composer and confirm the input rule expands both to 🫱

https://claude.ai/code/session_01JTkeBtSNoee7BjRdCuGfqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTkeBtSNoee7BjRdCuGfqQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->