### PR TITLE
feat(attachment-explorer): expand/copy full extract, skip mobile autofocus

### DIFF
--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -4,6 +4,7 @@ import type { Pool } from "pg"
 import { buildContentDisposition, type AttachmentService } from "./service"
 import { isAttachmentReadableViaShareOrReference } from "./access"
 import { AttachmentRepository, type AttachmentSearchCursor, type AttachmentSearchRow } from "./repository"
+import { AttachmentExtractionRepository } from "./extraction-repository"
 import type { StreamService } from "../streams"
 import { VideoTranscodeJobRepository } from "./video"
 import type { StorageProvider } from "../../lib/storage/s3-client"
@@ -148,6 +149,44 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
 
       await attachmentService.delete(attachmentId)
       res.status(204).send()
+    },
+
+    /**
+     * Return the full extracted text for an attachment so the explorer
+     * preview pane can show the complete content (and copy it). Reuses the
+     * same access fast-path as `getDownloadUrl` — direct stream access first,
+     * then share-grant + inline-reference fallback.
+     */
+    async getExtraction(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { attachmentId } = req.params
+
+      const attachment = await attachmentService.getById(attachmentId)
+      if (!attachment || attachment.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Attachment not found" })
+      }
+
+      if (attachment.streamId) {
+        const accessible = await streamService.tryAccess(attachment.streamId, workspaceId, userId)
+        if (!accessible) {
+          const granted = await isAttachmentReadableViaShareOrReference(pool, attachment, workspaceId, userId)
+          if (!granted) {
+            return res.status(403).json({ error: "Access denied" })
+          }
+        }
+      }
+
+      const extraction = await AttachmentExtractionRepository.findByAttachmentId(pool, attachmentId)
+      if (!extraction) {
+        return res.status(404).json({ error: "Extraction not found" })
+      }
+
+      res.json({
+        contentType: extraction.contentType,
+        summary: extraction.summary,
+        fullText: extraction.fullText,
+      })
     },
 
     /**

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -285,6 +285,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/attachments", ...authed, rateLimits.upload, upload, attachment.upload)
   app.post("/api/workspaces/:workspaceId/attachments/search", ...authed, rateLimits.search, attachment.search)
   app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/url", ...authed, attachment.getDownloadUrl)
+  app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/extraction", ...authed, attachment.getExtraction)
   app.delete("/api/workspaces/:workspaceId/attachments/:attachmentId", ...authed, attachment.delete)
 
   // Conversations

--- a/apps/frontend/src/api/attachments.ts
+++ b/apps/frontend/src/api/attachments.ts
@@ -6,6 +6,12 @@ export interface AttachmentSearchExtractionExcerpt {
   summary: string
 }
 
+export interface AttachmentExtractionContent {
+  contentType: string
+  summary: string
+  fullText: string | null
+}
+
 export interface AttachmentSearchItem extends Attachment {
   extraction: AttachmentSearchExtractionExcerpt | null
   streamSlug: string | null
@@ -130,5 +136,14 @@ export const attachmentsApi = {
    */
   search(workspaceId: string, body: AttachmentSearchRequest): Promise<AttachmentSearchResponse> {
     return api.post<AttachmentSearchResponse>(`/api/workspaces/${workspaceId}/attachments/search`, body)
+  },
+
+  /**
+   * Fetch the full extracted text for an attachment. Used by the explorer
+   * preview pane when the user expands the truncated summary or copies the
+   * full content.
+   */
+  getExtraction(workspaceId: string, attachmentId: string): Promise<AttachmentExtractionContent> {
+    return api.get<AttachmentExtractionContent>(`/api/workspaces/${workspaceId}/attachments/${attachmentId}/extraction`)
   },
 }

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -25,10 +25,15 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const [isTruncated, setIsTruncated] = useState(false)
   const previewRef = useRef<HTMLPreElement | null>(null)
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Tracks which attachment is currently selected so handleCopy can drop
+  // post-await state writes (setCopied, timer) when the user switched items
+  // mid-flight.
+  const currentAttachmentIdRef = useRef<string | null>(item?.id ?? null)
 
   // Reset per-item UI state so a fresh selection never inherits the previous
   // item's expanded view or "Copied" badge.
   useEffect(() => {
+    currentAttachmentIdRef.current = item?.id ?? null
     setExpanded(false)
     setCopied(false)
     setIsTruncated(false)
@@ -71,10 +76,15 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
 
   const handleCopy = useCallback(async () => {
     if (!item) return
+    const copiedAttachmentId = item.id
     try {
       const data = fullExtraction.data ?? (await attachmentsApi.getExtraction(workspaceId, item.id))
       const text = data.fullText ?? data.summary
       await navigator.clipboard.writeText(text)
+      // Drop the result if the user switched attachments while we were awaiting
+      // the fetch or the clipboard write — otherwise the badge and reset timer
+      // would attach to the newly selected item.
+      if (currentAttachmentIdRef.current !== copiedAttachmentId) return
       setCopied(true)
       if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current)
       copyResetTimerRef.current = setTimeout(() => {

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery, type UseQueryResult } from "@tanstack/react-query"
 import { categoryFromMime } from "@threa/types"
@@ -22,13 +22,30 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const [previewError, setPreviewError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [isTruncated, setIsTruncated] = useState(false)
+  const previewRef = useRef<HTMLPreElement | null>(null)
 
   // Reset per-item UI state so a fresh selection never inherits the previous
   // item's expanded view or "Copied" badge.
   useEffect(() => {
     setExpanded(false)
     setCopied(false)
+    setIsTruncated(false)
   }, [item?.id])
+
+  // Hide the Expand button when the line-clamped preview already fits the
+  // full content — toggling it would just rerender the same text. Re-measures
+  // on resize so the panel-resize handle keeps the button in sync.
+  useLayoutEffect(() => {
+    if (expanded) return
+    const el = previewRef.current
+    if (!el) return
+    const measure = () => setIsTruncated(el.scrollHeight > el.clientHeight + 1)
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [expanded, item?.id, item?.extraction?.summary])
 
   const fullExtraction = useQuery<AttachmentExtractionContent>({
     queryKey: ["attachment-extraction", workspaceId, item?.id],
@@ -171,25 +188,27 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
               <div className="flex items-center justify-between gap-2">
                 <div className="text-xs font-medium text-muted-foreground">Extract</div>
                 <div className="flex items-center gap-1">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-6 px-2 text-xs"
-                    onClick={() => setExpanded((v) => !v)}
-                    aria-expanded={expanded}
-                  >
-                    {expanded ? (
-                      <>
-                        <ChevronUp className="h-3 w-3" />
-                        Collapse
-                      </>
-                    ) : (
-                      <>
-                        <ChevronDown className="h-3 w-3" />
-                        Expand
-                      </>
-                    )}
-                  </Button>
+                  {isTruncated || expanded ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => setExpanded((v) => !v)}
+                      aria-expanded={expanded}
+                    >
+                      {expanded ? (
+                        <>
+                          <ChevronUp className="h-3 w-3" />
+                          Collapse
+                        </>
+                      ) : (
+                        <>
+                          <ChevronDown className="h-3 w-3" />
+                          Expand
+                        </>
+                      )}
+                    </Button>
+                  ) : null}
                   <Button
                     size="sm"
                     variant="ghost"
@@ -205,9 +224,12 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
               {expanded ? (
                 <ExpandedExtract item={item} query={fullExtraction} />
               ) : (
-                <p className="line-clamp-5 text-xs leading-relaxed text-foreground/80">
+                <pre
+                  ref={previewRef}
+                  className="line-clamp-5 whitespace-pre-wrap rounded-card bg-muted/40 p-3 text-xs leading-relaxed text-foreground/80"
+                >
                   {stripMarkdownToInline(item.extraction.summary)}
-                </p>
+                </pre>
               )}
             </div>
           ) : null}

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -33,7 +33,7 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const fullExtraction = useQuery<AttachmentExtractionContent>({
     queryKey: ["attachment-extraction", workspaceId, item?.id],
     queryFn: () => attachmentsApi.getExtraction(workspaceId, item!.id),
-    enabled: Boolean(item?.id) && (expanded || copied),
+    enabled: Boolean(item?.id) && expanded,
     staleTime: 5 * 60_000,
   })
 

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
+import { useQuery, type UseQueryResult } from "@tanstack/react-query"
 import { categoryFromMime } from "@threa/types"
-import { Download, ExternalLink, Hash } from "lucide-react"
-import { attachmentsApi, type AttachmentSearchItem } from "@/api/attachments"
+import { Check, ChevronDown, ChevronUp, Copy, Download, ExternalLink, Hash } from "lucide-react"
+import { attachmentsApi, type AttachmentExtractionContent, type AttachmentSearchItem } from "@/api/attachments"
 import { Button } from "@/components/ui/button"
 import { useFormattedDate } from "@/hooks"
 import { stripMarkdownToInline } from "@/lib/markdown"
@@ -19,6 +20,36 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const [rawUrl, setRawUrl] = useState<string | null>(null)
   const [processedUrl, setProcessedUrl] = useState<string | null>(null)
   const [previewError, setPreviewError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  // Reset per-item UI state so a fresh selection never inherits the previous
+  // item's expanded view or "Copied" badge.
+  useEffect(() => {
+    setExpanded(false)
+    setCopied(false)
+  }, [item?.id])
+
+  const fullExtraction = useQuery<AttachmentExtractionContent>({
+    queryKey: ["attachment-extraction", workspaceId, item?.id],
+    queryFn: () => attachmentsApi.getExtraction(workspaceId, item!.id),
+    enabled: Boolean(item?.id) && (expanded || copied),
+    staleTime: 5 * 60_000,
+  })
+
+  const handleCopy = useCallback(async () => {
+    if (!item) return
+    try {
+      const data = fullExtraction.data ?? (await attachmentsApi.getExtraction(workspaceId, item.id))
+      const text = data.fullText ?? data.summary
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable or fetch failed — silent: the user can still
+      // open the original via the Download button if they need the contents.
+    }
+  }, [item, workspaceId, fullExtraction.data])
 
   const category = item ? categoryFromMime(item.mimeType) : null
 
@@ -137,10 +168,47 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
 
           {item.extraction?.summary ? (
             <div className="space-y-1">
-              <div className="text-xs font-medium text-muted-foreground">Extract</div>
-              <p className="line-clamp-5 text-xs leading-relaxed text-foreground/80">
-                {stripMarkdownToInline(item.extraction.summary)}
-              </p>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs font-medium text-muted-foreground">Extract</div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => setExpanded((v) => !v)}
+                    aria-expanded={expanded}
+                  >
+                    {expanded ? (
+                      <>
+                        <ChevronUp className="h-3 w-3" />
+                        Collapse
+                      </>
+                    ) : (
+                      <>
+                        <ChevronDown className="h-3 w-3" />
+                        Expand
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 px-2 text-xs"
+                    onClick={handleCopy}
+                    aria-label="Copy full extraction"
+                  >
+                    {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
+                </div>
+              </div>
+              {expanded ? (
+                <ExpandedExtract item={item} query={fullExtraction} />
+              ) : (
+                <p className="line-clamp-5 text-xs leading-relaxed text-foreground/80">
+                  {stripMarkdownToInline(item.extraction.summary)}
+                </p>
+              )}
             </div>
           ) : null}
 
@@ -179,5 +247,25 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
         </div>
       </div>
     </div>
+  )
+}
+
+function ExpandedExtract({
+  item,
+  query,
+}: {
+  item: AttachmentSearchItem
+  query: UseQueryResult<AttachmentExtractionContent>
+}) {
+  if (query.isLoading) {
+    return <p className="text-xs leading-relaxed text-muted-foreground">Loading…</p>
+  }
+  if (query.isError) {
+    return <p className="text-xs leading-relaxed text-muted-foreground">Couldn't load the full extract.</p>
+  }
+  return (
+    <pre className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap rounded-card bg-muted/40 p-3 text-xs leading-relaxed text-foreground/80">
+      {stripMarkdownToInline(query.data?.fullText ?? query.data?.summary ?? item.extraction?.summary ?? "")}
+    </pre>
   )
 }

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -24,6 +24,7 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const [copied, setCopied] = useState(false)
   const [isTruncated, setIsTruncated] = useState(false)
   const previewRef = useRef<HTMLPreElement | null>(null)
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Reset per-item UI state so a fresh selection never inherits the previous
   // item's expanded view or "Copied" badge.
@@ -31,7 +32,17 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
     setExpanded(false)
     setCopied(false)
     setIsTruncated(false)
+    if (copyResetTimerRef.current) {
+      clearTimeout(copyResetTimerRef.current)
+      copyResetTimerRef.current = null
+    }
   }, [item?.id])
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current)
+    }
+  }, [])
 
   // Hide the Expand button when the line-clamped preview already fits the
   // full content — toggling it would just rerender the same text. Re-measures
@@ -47,10 +58,14 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
     return () => ro.disconnect()
   }, [expanded, item?.id, item?.extraction?.summary])
 
+  const attachmentId = item?.id
   const fullExtraction = useQuery<AttachmentExtractionContent>({
-    queryKey: ["attachment-extraction", workspaceId, item?.id],
-    queryFn: () => attachmentsApi.getExtraction(workspaceId, item!.id),
-    enabled: Boolean(item?.id) && expanded,
+    queryKey: ["attachment-extraction", workspaceId, attachmentId],
+    queryFn: () => {
+      if (!attachmentId) throw new Error("Missing attachment id")
+      return attachmentsApi.getExtraction(workspaceId, attachmentId)
+    },
+    enabled: Boolean(attachmentId) && expanded,
     staleTime: 5 * 60_000,
   })
 
@@ -61,7 +76,11 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
       const text = data.fullText ?? data.summary
       await navigator.clipboard.writeText(text)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current)
+      copyResetTimerRef.current = setTimeout(() => {
+        setCopied(false)
+        copyResetTimerRef.current = null
+      }, 2000)
     } catch {
       // Clipboard API unavailable or fetch failed — silent: the user can still
       // open the original via the Download button if they need the contents.
@@ -272,13 +291,12 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   )
 }
 
-function ExpandedExtract({
-  item,
-  query,
-}: {
+interface ExpandedExtractProps {
   item: AttachmentSearchItem
   query: UseQueryResult<AttachmentExtractionContent>
-}) {
+}
+
+function ExpandedExtract({ item, query }: ExpandedExtractProps) {
   if (query.isLoading) {
     return <p className="text-xs leading-relaxed text-muted-foreground">Loading…</p>
   }

--- a/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-shell.tsx
@@ -161,7 +161,10 @@ export function ExplorerShell({ workspaceId, mode, enabled }: ExplorerShellProps
           <Search className="h-4 w-4 flex-none text-muted-foreground" aria-hidden />
         )}
         <Input
-          autoFocus={mode === "modal"}
+          // Skip autoFocus on mobile — it pops the on-screen keyboard the
+          // moment the explorer mounts, which is jarring for a surface the
+          // user often opens just to browse.
+          autoFocus={mode === "modal" && !isMobile}
           value={filters.queryText}
           onChange={(e) => update({ queryText: e.target.value })}
           placeholder="Search filename, content, or use “quoted phrase” for exact"


### PR DESCRIPTION
## Summary

- Preview pane now has Expand/Collapse and Copy buttons for the full extracted text. Both lazy-fetch via a new `GET /api/workspaces/:workspaceId/attachments/:attachmentId/extraction` endpoint; copy falls through to `navigator.clipboard.writeText`. The endpoint reuses the same access fast-path as `getDownloadUrl` (direct stream access → share-grant + inline-reference fallback).
- Search input no longer autofocuses on mobile when the explorer opens — that was popping the on-screen keyboard the moment the surface mounted, which is jarring for users who came in just to browse. Desktop modal autofocus is unchanged; the `/files` page already opted out via `mode="page"`.
- Per-item UI state (`expanded`, `copied`) resets when the selected attachment changes so a fresh row never inherits the previous item's open extract or stale "Copied" badge.

Note: semantic search was scoped out of this change — attachments don't have embeddings yet and adding them was substantially larger than the rest of this batch. We can land that separately when there's appetite for the migration + backfill + hybrid-search wiring.

## Test plan

- [ ] Open the explorer modal on desktop → search input is focused.
- [ ] Open the explorer on mobile (or with `useIsMobile()` returning true) → search input is NOT focused, on-screen keyboard stays down.
- [ ] Select a file with an extracted summary → "Extract" header shows Expand and Copy buttons.
- [ ] Click Expand → fetches full text, shows it in a scrollable `<pre>`. Click Collapse → returns to the line-clamped summary.
- [ ] Click Copy → "Copied" appears for 2s; pasted content is the full extracted text (or summary fallback).
- [ ] Switch to a different file → expanded/copied state resets.
- [ ] Files in streams the caller can't read return 403 from the extraction endpoint (mirrors `getDownloadUrl`).
- [ ] Files without an extraction row return 404.

https://claude.ai/code/session_0125kyVUFCbFCm9pXQ3zgvJH

---
_Generated by [Claude Code](https://claude.ai/code/session_0125kyVUFCbFCm9pXQ3zgvJH)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->