### PR TITLE
fix(workos-sync): paginate listings and reconcile 409s

### DIFF
--- a/scripts/sync-workos-permissions.ts
+++ b/scripts/sync-workos-permissions.ts
@@ -54,6 +54,17 @@ interface WorkOSPermission {
   system: boolean
 }
 
+class WorkOSHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly method: string,
+    public readonly path: string,
+    public readonly body: string
+  ) {
+    super(`WorkOS ${method} ${path} → ${status}: ${body}`)
+  }
+}
+
 async function workosRequest<T>(apiKey: string, method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${WORKOS_BASE}${path}`, {
     method,
@@ -66,15 +77,37 @@ async function workosRequest<T>(apiKey: string, method: string, path: string, bo
 
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`WorkOS ${method} ${path} → ${res.status}: ${text}`)
+    throw new WorkOSHttpError(res.status, method, path, text)
   }
 
   return res.json() as Promise<T>
 }
 
+// WorkOS list endpoints default to ~10 results per page; without pagination,
+// listings silently truncate and the drift detector marks already-remote
+// permissions as "missing", which then 409s on create.
+interface WorkOSListPage<T> {
+  data: T[]
+  list_metadata?: { before?: string | null; after?: string | null }
+  listMetadata?: { before?: string | null; after?: string | null }
+}
+
+async function listAllPages<T>(apiKey: string, basePath: string): Promise<T[]> {
+  const results: T[] = []
+  let after: string | undefined
+  for (;;) {
+    const params = new URLSearchParams({ limit: "100" })
+    if (after) params.set("after", after)
+    const sep = basePath.includes("?") ? "&" : "?"
+    const page = await workosRequest<WorkOSListPage<T>>(apiKey, "GET", `${basePath}${sep}${params.toString()}`)
+    results.push(...page.data)
+    after = page.list_metadata?.after ?? page.listMetadata?.after ?? undefined
+    if (!after) return results
+  }
+}
+
 async function listPermissions(apiKey: string): Promise<WorkOSPermission[]> {
-  const data = await workosRequest<{ data: WorkOSPermission[] }>(apiKey, "GET", "/authorization/permissions")
-  return data.data
+  return listAllPages<WorkOSPermission>(apiKey, "/authorization/permissions")
 }
 
 async function createPermission(
@@ -127,8 +160,7 @@ interface WorkOSRole {
 }
 
 async function listRoles(apiKey: string): Promise<WorkOSRole[]> {
-  const data = await workosRequest<{ data: WorkOSRole[] }>(apiKey, "GET", "/authorization/roles")
-  return data.data
+  return listAllPages<WorkOSRole>(apiKey, "/authorization/roles")
 }
 
 async function createRole(
@@ -354,11 +386,24 @@ async function sync(dryRun: boolean) {
     if (isMissing) {
       if (dryRun) {
         console.log(`  [CREATE] ${local.slug} — "${local.name}"`)
+        created++
       } else {
-        await createPermission(apiKey, { slug: local.slug, name: local.name, description: local.description })
-        console.log(`  [CREATED] ${local.slug} — "${local.name}"`)
+        try {
+          await createPermission(apiKey, { slug: local.slug, name: local.name, description: local.description })
+          console.log(`  [CREATED] ${local.slug} — "${local.name}"`)
+          created++
+        } catch (err) {
+          // Concurrent run or stale list: slug already exists remotely. Reconcile
+          // by updating instead of failing the sync.
+          if (err instanceof WorkOSHttpError && err.status === 409) {
+            await updatePermission(apiKey, local.slug, { name: local.name, description: local.description })
+            console.log(`  [RECONCILED] ${local.slug} — already existed, updated name/description`)
+            updated++
+          } else {
+            throw err
+          }
+        }
       }
-      created++
     } else if (staleEntry) {
       if (dryRun) {
         console.log(`  [UPDATE] ${local.slug} (${staleEntry.fields.join(", ")})`)
@@ -395,9 +440,22 @@ async function sync(dryRun: boolean) {
       if (dryRun) {
         console.log(`  [CREATE] role "${local.slug}" — "${local.name}"`)
       } else {
-        await createRole(apiKey, { slug: local.slug, name: local.name, description: local.description })
+        let reconciled = false
+        try {
+          await createRole(apiKey, { slug: local.slug, name: local.name, description: local.description })
+        } catch (err) {
+          // Concurrent run or stale list: role slug already exists. Fall through to
+          // updateRole + setRolePermissions so we still reconcile.
+          if (err instanceof WorkOSHttpError && err.status === 409) {
+            await updateRole(apiKey, local.slug, { name: local.name, description: local.description })
+            reconciled = true
+          } else {
+            throw err
+          }
+        }
         await setRolePermissions(apiKey, local.slug, local.permissions)
-        console.log(`  [CREATED] role "${local.slug}" with permissions: [${local.permissions.join(", ")}]`)
+        const tag = reconciled ? "RECONCILED" : "CREATED"
+        console.log(`  [${tag}] role "${local.slug}" with permissions: [${local.permissions.join(", ")}]`)
       }
       continue
     }

--- a/scripts/sync-workos-permissions.ts
+++ b/scripts/sync-workos-permissions.ts
@@ -65,6 +65,19 @@ class WorkOSHttpError extends Error {
   }
 }
 
+// WorkOS 409 bodies include a machine-readable `code` like
+// `permission_slug_conflict` (observed; the role API uses the same convention).
+// Narrowing the reconcile path to slug-conflict keeps unrelated 409s loud.
+function isSlugConflict(err: WorkOSHttpError): boolean {
+  if (err.status !== 409) return false
+  try {
+    const parsed = JSON.parse(err.body) as { code?: unknown }
+    return typeof parsed.code === "string" && parsed.code.includes("slug_conflict")
+  } catch {
+    return false
+  }
+}
+
 async function workosRequest<T>(apiKey: string, method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${WORKOS_BASE}${path}`, {
     method,
@@ -395,7 +408,7 @@ async function sync(dryRun: boolean) {
         } catch (err) {
           // Concurrent run or stale list: slug already exists remotely. Reconcile
           // by updating instead of failing the sync.
-          if (err instanceof WorkOSHttpError && err.status === 409) {
+          if (err instanceof WorkOSHttpError && isSlugConflict(err)) {
             await updatePermission(apiKey, local.slug, { name: local.name, description: local.description })
             console.log(`  [RECONCILED] ${local.slug} — already existed, updated name/description`)
             updated++
@@ -446,7 +459,7 @@ async function sync(dryRun: boolean) {
         } catch (err) {
           // Concurrent run or stale list: role slug already exists. Fall through to
           // updateRole + setRolePermissions so we still reconcile.
-          if (err instanceof WorkOSHttpError && err.status === 409) {
+          if (err instanceof WorkOSHttpError && isSlugConflict(err)) {
             await updateRole(apiKey, local.slug, { name: local.name, description: local.description })
             reconciled = true
           } else {


### PR DESCRIPTION
## Problem

The post-merge `workos:sync` job in CI failed on main:

```
Found 10 permissions in WorkOS (8 non-system)
Local definitions: 14

Failed: WorkOS POST /authorization/permissions → 409:
{"code":"permission_slug_conflict","message":"Permission slug already in use."}
```

[Failing run](https://github.com/threahq/threa/actions/runs/25633868141/job/75242229204)

`scripts/sync-workos-permissions.ts` called `GET /authorization/permissions` (and `/authorization/roles`) without pagination params. WorkOS's default page size is ~10, so once the catalog grew past that, the listing silently truncated. The drift detector then marked already-remote permissions as `missing`, the `sync` path POSTed them, and WorkOS rejected the duplicates with `409 permission_slug_conflict`.

The branch name says it: the sync was not idempotent.

## Solution

Two changes, both in `scripts/sync-workos-permissions.ts`:

**1. Paginate `listPermissions` and `listRoles`.**

A shared `listAllPages<T>` helper walks the WorkOS cursor (`limit=100` + `list_metadata.after`) until the cursor is null. It tolerates both the raw HTTP shape (`list_metadata`) and the SDK shape (`listMetadata`) because we hit the API directly here while the rest of the codebase goes through `@workos-inc/node`.

**2. Treat create-time 409 as "already exists" and reconcile.**

Even with correct pagination, two concurrent CI jobs (or a stale list against an eventually-consistent backend) could race. A typed `WorkOSHttpError` carries the status code so the sync loop can branch on it: on 409 from `createPermission`, fall through to `updatePermission` and log `[RECONCILED]` instead of failing. Same for `createRole` — on 409 we still call `updateRole` + `setRolePermissions` so the role ends up in the desired state regardless of who created it first.

### Key design decisions

**Defensive 409 handling on top of the pagination fix.**
Pagination alone closes the observed failure, but "idempotent" means re-running must succeed under any race. Catching 409 and routing to update is cheap and removes a class of future flake.

**Counter accuracy.**
`created++` was inside the success path; on 409 reconciliation we increment `updated++` and tag the log line `[RECONCILED]` so the summary line (`N created, N updated, N unchanged`) still reflects what actually happened.

**Both `list_metadata` and `listMetadata` accepted.**
The raw WorkOS HTTP API returns `list_metadata` (snake case). The Node SDK exposes `listMetadata` (camel case). Since this script uses raw `fetch`, the live shape is `list_metadata`, but accepting either keeps the helper robust if WorkOS ever normalizes.

## Modified files

| File | Change |
| --- | --- |
| `scripts/sync-workos-permissions.ts` | Paginate `listPermissions` / `listRoles` via shared `listAllPages` helper; introduce typed `WorkOSHttpError`; reconcile 409 on create by falling through to update. |

## Test plan

- [x] `bun run typecheck` clean across all workspaces
- [x] Pre-commit hooks (lint, typecheck, dockerfile check, OpenAPI check) all pass
- [x] Smoke run (`WORKOS_API_KEY=invalid bun scripts/sync-workos-permissions.ts --dry-run`) confirms the request now hits `/authorization/permissions?limit=100` and that the typed error carries the status code
- [ ] CI `workos-permissions` job (drift check on this PR) passes
- [ ] Post-merge sync run against production WorkOS lists all 8+ existing non-system permissions, creates the 6 actually-missing ones, and exits 0

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGLP6THJEZkW3aC5RLwnTv)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->