### PR TITLE
feat(attachments): semantic search via summary embeddings

### DIFF
--- a/apps/backend/src/db/migrations/20260510174136_attachment_extractions_embedding.sql
+++ b/apps/backend/src/db/migrations/20260510174136_attachment_extractions_embedding.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- Attachment Extraction Embeddings for Semantic Search
+-- =============================================================================
+--
+-- Adds a 1536-dimension embedding of the AI-generated `summary` so attachments
+-- (PDFs, Word docs, text/markdown/code, captioned images) can be retrieved by
+-- semantic similarity in addition to the existing tsvector full-text search.
+--
+-- We embed the summary rather than `full_text` because (1) it stays under the
+-- 8K-token input cap for every extraction, (2) the summary captures the doc's
+-- gist far better than raw text for high-recall "which doc is about X?"
+-- queries, and (3) FTS already handles exact-phrase lookups on `full_text`.
+-- Per-section/per-page chunked embeddings are out of scope for this pass.
+--
+-- Photo and "other" content_types are excluded from embedding (their summaries
+-- are too generic to help retrieval); the worker enforces this at runtime.
+
+ALTER TABLE attachment_extractions ADD COLUMN summary_embedding vector(1536);
+
+-- HNSW index for approximate nearest neighbor search.
+-- Cosine distance matches the message embeddings index (idx_messages_embedding)
+-- so callers can build hybrid queries with consistent distance semantics.
+CREATE INDEX idx_attachment_extractions_summary_embedding ON attachment_extractions
+    USING hnsw (summary_embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);

--- a/apps/backend/src/db/migrations/20260510174647_backfill_attachment_embeddings.sql
+++ b/apps/backend/src/db/migrations/20260510174647_backfill_attachment_embeddings.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Backfill: enqueue summary-embedding jobs for existing attachment extractions
+-- =============================================================================
+--
+-- Pairs with `20260510174136_attachment_extractions_embedding.sql`. Pre-existing
+-- extractions never went through `AttachmentEmbeddingHandler`, so this migration
+-- re-uses the queue table itself as the backfill mechanism — once committed the
+-- normal `attachment.embed` worker drains the rows like any other job.
+--
+-- Re-enqueue pattern: future migrations can use the same shape (filtering by
+-- whatever needs reprocessing — content_type, model version, time window) to
+-- replay extractions without bespoke backfill scripts. Keep the WHERE clause
+-- aligned with `isContentTypeEmbeddable()` in
+-- `apps/backend/src/features/attachments/embedding-config.ts` so we don't queue
+-- jobs the worker will immediately discard. The worker re-checks eligibility,
+-- so the alignment is an optimisation not a correctness requirement.
+--
+-- ID shape `queue_<uuid hex>` follows the established migration-backfill
+-- convention (see `20260428120000_attachment_references.sql`); production
+-- enqueues use ULIDs via `queueId()` in code.
+
+INSERT INTO queue_messages (
+    id,
+    queue_name,
+    workspace_id,
+    payload,
+    process_after,
+    inserted_at
+)
+SELECT
+    'queue_' || replace(gen_random_uuid()::text, '-', ''),
+    'attachment.embed',
+    workspace_id,
+    jsonb_build_object(
+        'attachmentId', attachment_id,
+        'workspaceId', workspace_id
+    ),
+    NOW(),
+    NOW()
+FROM attachment_extractions
+WHERE summary_embedding IS NULL
+  AND content_type NOT IN ('photo', 'other')
+  AND length(trim(summary)) >= 10;

--- a/apps/backend/src/features/attachments/embedding-config.test.ts
+++ b/apps/backend/src/features/attachments/embedding-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test"
+import { ExtractionContentTypes } from "@threa/types"
+import { isContentTypeEmbeddable } from "./embedding-config"
+
+describe("isContentTypeEmbeddable", () => {
+  it("returns true for content types whose summary carries domain-specific signal", () => {
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.CHART)).toBe(true)
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.TABLE)).toBe(true)
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.DIAGRAM)).toBe(true)
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.SCREENSHOT)).toBe(true)
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.DOCUMENT)).toBe(true)
+  })
+
+  it("returns false for content types whose summary tends to be too generic to retrieve on", () => {
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.PHOTO)).toBe(false)
+    expect(isContentTypeEmbeddable(ExtractionContentTypes.OTHER)).toBe(false)
+  })
+})

--- a/apps/backend/src/features/attachments/embedding-config.ts
+++ b/apps/backend/src/features/attachments/embedding-config.ts
@@ -1,0 +1,32 @@
+import { ExtractionContentTypes, type ExtractionContentType } from "@threa/types"
+
+/**
+ * Content types whose AI-generated summary is too generic to make embedding
+ * worthwhile. A casual photo's summary ("a sunset over mountains") doesn't
+ * disambiguate one photo from the next, so semantic recall is no better than
+ * filename FTS — and we'd be paying per-attachment embedding cost for no gain.
+ *
+ * Charts, tables, diagrams, screenshots, and documents (the typical PDF/Word
+ * extraction shape) all carry domain-specific summaries and stay eligible.
+ */
+const INELIGIBLE_CONTENT_TYPES = new Set<ExtractionContentType>([
+  ExtractionContentTypes.PHOTO,
+  ExtractionContentTypes.OTHER,
+])
+
+/**
+ * Whether an extraction's `content_type` warrants generating a summary
+ * embedding. Used by both the outbox handler (short-circuit before enqueue)
+ * and the worker (defensive — content_type can change between enqueue and
+ * execution if an extraction is reprocessed).
+ */
+export function isContentTypeEmbeddable(contentType: ExtractionContentType): boolean {
+  return !INELIGIBLE_CONTENT_TYPES.has(contentType)
+}
+
+/**
+ * Minimum summary length to bother embedding. Anything shorter is almost
+ * always a stub like "Image" or "Document" and produces near-zero-info
+ * vectors. Mirrors the message embedding worker's threshold.
+ */
+export const MIN_SUMMARY_LENGTH = 10

--- a/apps/backend/src/features/attachments/embedding-outbox-handler.ts
+++ b/apps/backend/src/features/attachments/embedding-outbox-handler.ts
@@ -1,0 +1,131 @@
+import type { Pool } from "pg"
+import { logger } from "../../lib/logger"
+import { JobQueues, type QueueManager } from "../../lib/queue"
+import {
+  isOutboxEventType,
+  OutboxRepository,
+  type OutboxHandler,
+  type AttachmentExtractionCompletedOutboxPayload,
+} from "../../lib/outbox"
+import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
+import { isContentTypeEmbeddable } from "./embedding-config"
+
+export interface AttachmentEmbeddingHandlerConfig {
+  batchSize?: number
+  debounceMs?: number
+  maxWaitMs?: number
+  lockDurationMs?: number
+  refreshIntervalMs?: number
+  maxRetries?: number
+  baseBackoffMs?: number
+}
+
+const DEFAULT_CONFIG = {
+  batchSize: 100,
+  debounceMs: 50,
+  maxWaitMs: 200,
+  lockDurationMs: 10_000,
+  refreshIntervalMs: 5_000,
+  maxRetries: 5,
+  baseBackoffMs: 1_000,
+}
+
+/**
+ * Watches the outbox for `attachment:extraction_completed` events and
+ * enqueues `ATTACHMENT_EMBED` jobs so the embedding worker can populate
+ * `attachment_extractions.summary_embedding` out-of-band.
+ *
+ * Enqueue is filtered by `contentType` from the event payload so we don't
+ * pay for queue churn on `photo`/`other` extractions; the worker re-checks
+ * the same eligibility against the freshly-fetched extraction as a defence
+ * against reprocessed content.
+ */
+export class AttachmentEmbeddingHandler implements OutboxHandler {
+  readonly listenerId = "attachment-embedding"
+
+  private readonly db: Pool
+  private readonly jobQueue: QueueManager
+  private readonly cursorLock: CursorLock
+  private readonly debouncer: DebounceWithMaxWait
+  private readonly batchSize: number
+
+  constructor(db: Pool, jobQueue: QueueManager, config?: AttachmentEmbeddingHandlerConfig) {
+    this.db = db
+    this.jobQueue = jobQueue
+    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+
+    this.cursorLock = new CursorLock({
+      pool: db,
+      listenerId: this.listenerId,
+      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
+      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
+      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
+      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
+      batchSize: this.batchSize,
+    })
+
+    this.debouncer = new DebounceWithMaxWait(
+      () => this.processEvents(),
+      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
+      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
+      (err) => logger.error({ err, listenerId: this.listenerId }, "AttachmentEmbeddingHandler debouncer error")
+    )
+  }
+
+  async ensureListener(): Promise<void> {
+    await ensureListenerFromLatest(this.db, this.listenerId)
+  }
+
+  handle(): void {
+    this.debouncer.trigger()
+  }
+
+  private async processEvents(): Promise<void> {
+    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
+      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+
+      if (events.length === 0) {
+        return { status: "no_events" }
+      }
+
+      const seen: bigint[] = []
+
+      try {
+        for (const event of events) {
+          if (!isOutboxEventType(event, "attachment:extraction_completed")) {
+            seen.push(event.id)
+            continue
+          }
+
+          const payload: AttachmentExtractionCompletedOutboxPayload = event.payload
+
+          if (!isContentTypeEmbeddable(payload.contentType)) {
+            logger.debug(
+              { attachmentId: payload.attachmentId, contentType: payload.contentType },
+              "Skipping embedding job for ineligible content type"
+            )
+            seen.push(event.id)
+            continue
+          }
+
+          await this.jobQueue.send(JobQueues.ATTACHMENT_EMBED, {
+            attachmentId: payload.attachmentId,
+            workspaceId: payload.workspaceId,
+          })
+
+          seen.push(event.id)
+        }
+
+        return { status: "processed", processedIds: seen }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+
+        if (seen.length > 0) {
+          return { status: "error", error, processedIds: seen }
+        }
+
+        return { status: "error", error }
+      }
+    })
+  }
+}

--- a/apps/backend/src/features/attachments/embedding-worker.test.ts
+++ b/apps/backend/src/features/attachments/embedding-worker.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { ExtractionContentTypes } from "@threa/types"
+import { AttachmentExtractionRepository, type AttachmentExtraction } from "./extraction-repository"
+import { createAttachmentEmbeddingWorker } from "./embedding-worker"
+import type { EmbeddingServiceLike } from "../memos"
+import type { Job, AttachmentEmbeddingJobData } from "../../lib/queue"
+
+function makeExtraction(overrides: Partial<AttachmentExtraction> = {}): AttachmentExtraction {
+  return {
+    id: "extract_1",
+    attachmentId: "attach_1",
+    workspaceId: "ws_1",
+    contentType: ExtractionContentTypes.DOCUMENT,
+    summary: "A quarterly revenue report broken down by product line.",
+    fullText: "Revenue grew 17% year-over-year, driven by enterprise renewals.",
+    structuredData: null,
+    sourceType: "pdf",
+    pdfMetadata: null,
+    textMetadata: null,
+    wordMetadata: null,
+    excelMetadata: null,
+    hasSummaryEmbedding: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function makeEmbeddingService(): EmbeddingServiceLike & { embed: ReturnType<typeof mock> } {
+  return {
+    embed: mock(async () => new Array(1536).fill(0.1)),
+    embedBatch: mock(async (texts: string[]) => texts.map(() => new Array(1536).fill(0.1))),
+  } as unknown as EmbeddingServiceLike & { embed: ReturnType<typeof mock> }
+}
+
+function makeJob(): Job<AttachmentEmbeddingJobData> {
+  return {
+    id: "queue_1",
+    name: "attachment.embed",
+    data: { attachmentId: "attach_1", workspaceId: "ws_1" },
+  }
+}
+
+describe("createAttachmentEmbeddingWorker", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("generates and stores an embedding for an eligible extraction", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(makeExtraction())
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).toHaveBeenCalledTimes(1)
+    expect(embeddingService.embed).toHaveBeenCalledWith("A quarterly revenue report broken down by product line.", {
+      workspaceId: "ws_1",
+      functionId: "attachment-summary-embedding",
+    })
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    expect(updateSpy.mock.calls[0]?.[1]).toBe("attach_1")
+    expect(updateSpy.mock.calls[0]?.[2]).toHaveLength(1536)
+  })
+
+  it("skips when the extraction is missing", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(null)
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it("skips ineligible content types (photo) even if a job slips through the handler filter", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(
+      makeExtraction({ contentType: ExtractionContentTypes.PHOTO })
+    )
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it("skips ineligible content types (other)", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(
+      makeExtraction({ contentType: ExtractionContentTypes.OTHER })
+    )
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it("skips when the summary is too short to carry signal", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(makeExtraction({ summary: "  hi  " }))
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it("refuses to write when the workspace in the payload doesn't match the extraction (INV-8)", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(
+      makeExtraction({ workspaceId: "ws_other" })
+    )
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(true)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it("tolerates the extraction being deleted between fetch and write", async () => {
+    spyOn(AttachmentExtractionRepository, "findByAttachmentId").mockResolvedValue(makeExtraction())
+    const updateSpy = spyOn(AttachmentExtractionRepository, "updateSummaryEmbedding").mockResolvedValue(false)
+    const embeddingService = makeEmbeddingService()
+
+    const worker = createAttachmentEmbeddingWorker({ pool: {} as any, embeddingService })
+    await worker(makeJob())
+
+    expect(embeddingService.embed).toHaveBeenCalledTimes(1)
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/features/attachments/embedding-worker.test.ts
+++ b/apps/backend/src/features/attachments/embedding-worker.test.ts
@@ -60,8 +60,9 @@ describe("createAttachmentEmbeddingWorker", () => {
       functionId: "attachment-summary-embedding",
     })
     expect(updateSpy).toHaveBeenCalledTimes(1)
-    expect(updateSpy.mock.calls[0]?.[1]).toBe("attach_1")
-    expect(updateSpy.mock.calls[0]?.[2]).toHaveLength(1536)
+    expect(updateSpy.mock.calls[0]?.[1]).toBe("ws_1")
+    expect(updateSpy.mock.calls[0]?.[2]).toBe("attach_1")
+    expect(updateSpy.mock.calls[0]?.[3]).toHaveLength(1536)
   })
 
   it("skips when the extraction is missing", async () => {

--- a/apps/backend/src/features/attachments/embedding-worker.ts
+++ b/apps/backend/src/features/attachments/embedding-worker.ts
@@ -1,0 +1,75 @@
+import type { Pool } from "pg"
+import type { AttachmentEmbeddingJobData, JobHandler } from "../../lib/queue"
+import type { EmbeddingServiceLike } from "../memos"
+import { logger } from "../../lib/logger"
+import { AttachmentExtractionRepository } from "./extraction-repository"
+import { isContentTypeEmbeddable, MIN_SUMMARY_LENGTH } from "./embedding-config"
+
+export interface AttachmentEmbeddingWorkerDeps {
+  pool: Pool
+  embeddingService: EmbeddingServiceLike
+}
+
+/**
+ * Generate a summary embedding for an attachment extraction so it becomes
+ * semantically searchable.
+ *
+ * Three-phase pattern (INV-41) — embeddings call out to the model provider
+ * and we must not hold a DB connection during that hop:
+ *   Phase 1: fetch extraction (single query)
+ *   Phase 2: generate embedding (no connection)
+ *   Phase 3: write embedding (single query)
+ *
+ * Idempotent: re-running for the same attachment overwrites the column. The
+ * worker re-applies the eligibility check defensively — even though the outbox
+ * handler filters at enqueue time, an extraction can be reprocessed with a
+ * different `content_type` between enqueue and execution.
+ */
+export function createAttachmentEmbeddingWorker(
+  deps: AttachmentEmbeddingWorkerDeps
+): JobHandler<AttachmentEmbeddingJobData> {
+  const { pool, embeddingService } = deps
+
+  return async (job) => {
+    const { attachmentId, workspaceId } = job.data
+    const log = logger.child({ jobId: job.id, attachmentId, workspaceId })
+
+    const extraction = await AttachmentExtractionRepository.findByAttachmentId(pool, attachmentId)
+    if (!extraction) {
+      log.warn("Extraction not found, skipping embedding")
+      return
+    }
+
+    if (extraction.workspaceId !== workspaceId) {
+      // Sanity check — workspace shard boundary (INV-8). A mismatched workspace
+      // means the job payload is stale or corrupt; refusing to embed is safer
+      // than indexing under the wrong tenant.
+      log.error({ extractionWorkspaceId: extraction.workspaceId }, "Workspace mismatch on embedding job")
+      return
+    }
+
+    if (!isContentTypeEmbeddable(extraction.contentType)) {
+      log.debug({ contentType: extraction.contentType }, "Skipping embedding for ineligible content type")
+      return
+    }
+
+    const summary = extraction.summary.trim()
+    if (summary.length < MIN_SUMMARY_LENGTH) {
+      log.debug({ summaryLength: summary.length }, "Skipping embedding for very short summary")
+      return
+    }
+
+    const embedding = await embeddingService.embed(summary, {
+      workspaceId,
+      functionId: "attachment-summary-embedding",
+    })
+
+    const updated = await AttachmentExtractionRepository.updateSummaryEmbedding(pool, attachmentId, embedding)
+    if (!updated) {
+      log.info("Extraction was deleted between fetch and write, embedding discarded")
+      return
+    }
+
+    log.info({ contentType: extraction.contentType }, "Attachment summary embedding stored")
+  }
+}

--- a/apps/backend/src/features/attachments/embedding-worker.ts
+++ b/apps/backend/src/features/attachments/embedding-worker.ts
@@ -64,7 +64,12 @@ export function createAttachmentEmbeddingWorker(
       functionId: "attachment-summary-embedding",
     })
 
-    const updated = await AttachmentExtractionRepository.updateSummaryEmbedding(pool, attachmentId, embedding)
+    const updated = await AttachmentExtractionRepository.updateSummaryEmbedding(
+      pool,
+      workspaceId,
+      attachmentId,
+      embedding
+    )
     if (!updated) {
       log.info("Extraction was deleted between fetch and write, embedding discarded")
       return

--- a/apps/backend/src/features/attachments/extraction-repository.ts
+++ b/apps/backend/src/features/attachments/extraction-repository.ts
@@ -25,6 +25,10 @@ interface AttachmentExtractionRow {
   text_metadata: unknown | null
   word_metadata: unknown | null
   excel_metadata: unknown | null
+  // SELECT paths project `(summary_embedding IS NOT NULL)` to avoid shipping
+  // the 30KB-ish vector literal on every read; callers only ever need a
+  // presence check.
+  summary_embedding: boolean
   created_at: Date
   updated_at: Date
 }
@@ -56,6 +60,13 @@ export interface AttachmentExtraction {
   textMetadata: TextMetadata | null
   wordMetadata: WordMetadata | null
   excelMetadata: ExcelMetadata | null
+  /**
+   * Whether the summary embedding has been generated. Surfaced as a boolean so
+   * callers can route around an in-flight backfill without parsing the vector
+   * literal. The vector itself is never read by the application — semantic
+   * search runs as a SQL distance comparison against the column directly.
+   */
+  hasSummaryEmbedding: boolean
   createdAt: Date
   updatedAt: Date
 }
@@ -89,15 +100,20 @@ function mapRowToExtraction(row: AttachmentExtractionRow): AttachmentExtraction 
     textMetadata: row.text_metadata as TextMetadata | null,
     wordMetadata: row.word_metadata as WordMetadata | null,
     excelMetadata: row.excel_metadata as ExcelMetadata | null,
+    hasSummaryEmbedding: row.summary_embedding,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
 }
 
+// `summary_embedding IS NOT NULL` is cheaper to ship than the vector literal,
+// which can be 30KB of text per row, and the application never reads the
+// embedding itself — only its presence.
 const SELECT_FIELDS = `
   id, attachment_id, workspace_id,
   content_type, summary, full_text, structured_data,
   source_type, pdf_metadata, text_metadata, word_metadata, excel_metadata,
+  (summary_embedding IS NOT NULL) AS summary_embedding,
   created_at, updated_at
 `
 
@@ -183,6 +199,23 @@ export const AttachmentExtractionRepository = {
   async deleteByAttachmentId(client: Querier, attachmentId: string): Promise<boolean> {
     const result = await client.query(sql`
       DELETE FROM attachment_extractions WHERE attachment_id = ${attachmentId}
+    `)
+    return (result.rowCount ?? 0) > 0
+  },
+
+  /**
+   * Persist the summary embedding for an extraction. Idempotent — re-running
+   * the embedding worker overwrites the column without further coordination.
+   * Returns `true` if a row was matched (the extraction may have been deleted
+   * between enqueue and execution).
+   */
+  async updateSummaryEmbedding(client: Querier, attachmentId: string, embedding: number[]): Promise<boolean> {
+    const embeddingLiteral = `[${embedding.join(",")}]`
+    const result = await client.query(sql`
+      UPDATE attachment_extractions
+      SET summary_embedding = ${embeddingLiteral}::vector,
+          updated_at = NOW()
+      WHERE attachment_id = ${attachmentId}
     `)
     return (result.rowCount ?? 0) > 0
   },

--- a/apps/backend/src/features/attachments/extraction-repository.ts
+++ b/apps/backend/src/features/attachments/extraction-repository.ts
@@ -207,15 +207,26 @@ export const AttachmentExtractionRepository = {
    * Persist the summary embedding for an extraction. Idempotent — re-running
    * the embedding worker overwrites the column without further coordination.
    * Returns `true` if a row was matched (the extraction may have been deleted
-   * between enqueue and execution).
+   * between enqueue and execution, or the workspace check below may have
+   * filtered it out).
+   *
+   * The `workspace_id` predicate enforces the workspace shard boundary
+   * (INV-8) at the data layer so a future caller can't accidentally embed
+   * across workspaces even if it skips the worker's pre-check.
    */
-  async updateSummaryEmbedding(client: Querier, attachmentId: string, embedding: number[]): Promise<boolean> {
+  async updateSummaryEmbedding(
+    client: Querier,
+    workspaceId: string,
+    attachmentId: string,
+    embedding: number[]
+  ): Promise<boolean> {
     const embeddingLiteral = `[${embedding.join(",")}]`
     const result = await client.query(sql`
       UPDATE attachment_extractions
       SET summary_embedding = ${embeddingLiteral}::vector,
           updated_at = NOW()
       WHERE attachment_id = ${attachmentId}
+        AND workspace_id = ${workspaceId}
     `)
     return (result.rowCount ?? 0) > 0
   },

--- a/apps/backend/src/features/attachments/index.ts
+++ b/apps/backend/src/features/attachments/index.ts
@@ -39,8 +39,15 @@ export type { CreateAttachmentParams } from "./service"
 // Handlers
 export { createAttachmentHandlers } from "./handlers"
 
-// Outbox handler
+// Outbox handlers
 export { AttachmentUploadedHandler } from "./uploaded-outbox-handler"
+export { AttachmentEmbeddingHandler } from "./embedding-outbox-handler"
+export type { AttachmentEmbeddingHandlerConfig } from "./embedding-outbox-handler"
+
+// Embedding worker
+export { createAttachmentEmbeddingWorker } from "./embedding-worker"
+export type { AttachmentEmbeddingWorkerDeps } from "./embedding-worker"
+export { isContentTypeEmbeddable, MIN_SUMMARY_LENGTH } from "./embedding-config"
 
 // Await processing
 export { awaitAttachmentProcessing, hasPendingAttachmentProcessing } from "./await-processing"

--- a/apps/backend/src/features/attachments/pdf/service.stub.ts
+++ b/apps/backend/src/features/attachments/pdf/service.stub.ts
@@ -22,6 +22,7 @@ import {
 import { logger } from "../../../lib/logger"
 import { PDF_SIZE_THRESHOLDS } from "./config"
 import type { PdfProcessingServiceLike } from "./types"
+import { OutboxRepository } from "../../../lib/outbox"
 
 export interface StubPdfProcessingServiceDeps {
   pool: Pool
@@ -133,6 +134,11 @@ export class StubPdfProcessingService implements PdfProcessingServiceLike {
 
       await PdfProcessingJobRepository.updateStatus(client, pdfJobId, PdfJobStatuses.COMPLETED)
       await AttachmentRepository.updateProcessingStatus(client, attachmentId, ProcessingStatuses.COMPLETED)
+      await OutboxRepository.insert(client, "attachment:extraction_completed", {
+        workspaceId: attachment.workspaceId,
+        attachmentId,
+        contentType: "document",
+      })
     })
 
     log.info({ pageCount: pages.length }, "Stub PDF processing complete")

--- a/apps/backend/src/features/attachments/pdf/service.ts
+++ b/apps/backend/src/features/attachments/pdf/service.ts
@@ -26,6 +26,7 @@ import type { QueueManager } from "../../../lib/queue"
 import { ProcessingStatuses, PdfJobStatuses, PdfPageClassifications, PdfSizeTiers } from "@threa/types"
 import type { PdfPageClassification, PdfSizeTier } from "@threa/types"
 import { JobQueues } from "../../../lib/queue"
+import { OutboxRepository } from "../../../lib/outbox"
 import { logger } from "../../../lib/logger"
 import { classifyPage, type ClassificationInput, type TextItemWithPosition } from "./classifier"
 import {
@@ -507,6 +508,15 @@ export class PdfProcessingService implements PdfProcessingServiceLike {
 
       // Mark attachment as completed
       await AttachmentRepository.updateProcessingStatus(client, attachmentId, ProcessingStatuses.COMPLETED)
+
+      // Emit the same extraction-completed event the shared `processAttachment`
+      // path emits, so PDFs flow through `AttachmentEmbeddingHandler` for the
+      // summary embedding (INV-7 — atomic with the extraction insert).
+      await OutboxRepository.insert(client, "attachment:extraction_completed", {
+        workspaceId: attachment.workspaceId,
+        attachmentId,
+        contentType: "document",
+      })
     })
 
     log.info({ sizeTier, totalPages: pages.length }, "PDF processing complete")

--- a/apps/backend/src/features/attachments/process-attachment.ts
+++ b/apps/backend/src/features/attachments/process-attachment.ts
@@ -16,6 +16,7 @@ import { AttachmentRepository, type Attachment } from "./repository"
 import { AttachmentExtractionRepository, type InsertAttachmentExtractionParams } from "./extraction-repository"
 import { ProcessingStatuses } from "@threa/types"
 import { logger } from "../../lib/logger"
+import { OutboxRepository } from "../../lib/outbox"
 
 export type ExtractionData = Omit<InsertAttachmentExtractionParams, "id" | "attachmentId" | "workspaceId">
 
@@ -80,6 +81,15 @@ export async function processAttachment(
     })
 
     await AttachmentRepository.updateProcessingStatus(client, attachmentId, ProcessingStatuses.COMPLETED)
+
+    // Outbox-driven follow-up: AttachmentEmbeddingHandler enqueues a summary
+    // embedding job. Writing the event in the same transaction keeps the
+    // extraction insert and the embedding trigger atomic (INV-7).
+    await OutboxRepository.insert(client, "attachment:extraction_completed", {
+      workspaceId: attachment.workspaceId,
+      attachmentId,
+      contentType: extractionData.contentType,
+    })
   })
 
   log.info("Attachment extraction saved successfully")

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -30,6 +30,7 @@ export {
   type StreamArchivedOutboxPayload,
   type StreamUnarchivedOutboxPayload,
   type AttachmentUploadedOutboxPayload,
+  type AttachmentExtractionCompletedOutboxPayload,
   type WorkspaceUserAddedOutboxPayload,
   type WorkspaceUserRemovedOutboxPayload,
   type WorkspaceUserUpdatedOutboxPayload,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -34,6 +34,7 @@ export type OutboxEventType =
   | "stream:read_all"
   | "stream:activity"
   | "attachment:uploaded"
+  | "attachment:extraction_completed"
   | "workspace_user:added"
   | "workspace_user:removed"
   | "workspace_user:updated"
@@ -103,6 +104,7 @@ export type WorkspaceScopedEventType =
   | "stream:archived"
   | "stream:unarchived"
   | "attachment:uploaded"
+  | "attachment:extraction_completed"
   | "workspace_user:added"
   | "workspace_user:removed"
   | "workspace_user:updated"
@@ -250,6 +252,19 @@ export interface AttachmentTranscodedOutboxPayload extends WorkspaceScopedPayloa
   processingStatus: string
   streamId?: string
   messageId?: string
+}
+
+/**
+ * Fired in the same transaction as the `attachment_extractions` insert,
+ * across all extraction pipelines (text/word/image-caption via
+ * `processAttachment`, plus the PDF assemble path). The
+ * `AttachmentEmbeddingHandler` consumes it to enqueue summary-embedding
+ * jobs; carries `contentType` so the handler can short-circuit ineligible
+ * extractions (`photo`, `other`) before paying for an enqueue.
+ */
+export interface AttachmentExtractionCompletedOutboxPayload extends WorkspaceScopedPayload {
+  attachmentId: string
+  contentType: import("@threa/types").ExtractionContentType
 }
 
 export interface WorkspaceUserAddedOutboxPayload extends WorkspaceScopedPayload {
@@ -528,6 +543,7 @@ export interface OutboxEventPayloadMap {
   "link_preview:ready": LinkPreviewReadyOutboxPayload
   "link_preview:dismissed": LinkPreviewDismissedOutboxPayload
   "attachment:transcoded": AttachmentTranscodedOutboxPayload
+  "attachment:extraction_completed": AttachmentExtractionCompletedOutboxPayload
 }
 
 export type OutboxEventPayload<T extends OutboxEventType> = OutboxEventPayloadMap[T]

--- a/apps/backend/src/lib/queue/index.ts
+++ b/apps/backend/src/lib/queue/index.ts
@@ -21,6 +21,7 @@ export {
   type MemoBatchProcessJobData,
   type CommandExecuteJobData,
   type ImageCaptionJobData,
+  type AttachmentEmbeddingJobData,
   type PdfPrepareJobData,
   type PdfProcessPageJobData,
   type PdfAssembleJobData,

--- a/apps/backend/src/lib/queue/job-queue.ts
+++ b/apps/backend/src/lib/queue/job-queue.ts
@@ -31,6 +31,7 @@ export const JobQueues = {
   TEXT_PROCESS: "text.process",
   WORD_PROCESS: "word.process",
   EXCEL_PROCESS: "excel.process",
+  ATTACHMENT_EMBED: "attachment.embed",
   AVATAR_PROCESS: "avatar.process",
   LINK_PREVIEW_EXTRACT: "link_preview.extract",
   VIDEO_TRANSCODE_SUBMIT: "video.transcode_submit",
@@ -145,6 +146,21 @@ export interface ExcelProcessJobData {
   storagePath: string
 }
 
+/**
+ * Attachment summary embedding job — generates a vector embedding for an
+ * extraction's `summary` so attachments become semantically searchable.
+ *
+ * Enqueued by `AttachmentEmbeddingHandler` once an
+ * `attachment:extraction_completed` outbox event lands. The worker fetches
+ * the latest extraction state, applies the eligibility check (skips
+ * `photo`/`other` content types), and updates `summary_embedding` in place.
+ * Idempotent: a re-run for the same attachment overwrites the column.
+ */
+export interface AttachmentEmbeddingJobData {
+  attachmentId: string
+  workspaceId: string
+}
+
 /** Avatar processing job - resizes raw upload into WebP variants */
 export interface AvatarProcessJobData {
   workspaceId: string
@@ -231,6 +247,7 @@ export interface JobDataMap {
   [JobQueues.TEXT_PROCESS]: TextProcessJobData
   [JobQueues.WORD_PROCESS]: WordProcessJobData
   [JobQueues.EXCEL_PROCESS]: ExcelProcessJobData
+  [JobQueues.ATTACHMENT_EMBED]: AttachmentEmbeddingJobData
   [JobQueues.AVATAR_PROCESS]: AvatarProcessJobData
   [JobQueues.LINK_PREVIEW_EXTRACT]: LinkPreviewExtractJobData
   [JobQueues.VIDEO_TRANSCODE_SUBMIT]: VideoTranscodeSubmitJobData

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -89,7 +89,7 @@ import { ActivityService, ActivityFeedHandler } from "./features/activity"
 import { SavedMessagesService, createSavedReminderWorker } from "./features/saved-messages"
 import { ScheduledMessagesService, createScheduledMessageSendWorker } from "./features/scheduled-messages"
 import { PushService, PushNotificationHandler, createPushSessionCleanup } from "./features/push"
-import { AttachmentUploadedHandler } from "./features/attachments"
+import { AttachmentUploadedHandler, AttachmentEmbeddingHandler } from "./features/attachments"
 import { AICostService, AIBudgetService } from "./features/ai-usage"
 import { CommandRegistry, InviteCommand, createCommandWorker, CommandHandler } from "./features/commands"
 import {
@@ -102,6 +102,7 @@ import {
   createExcelProcessingWorker,
   createVideoTranscodeSubmitWorker,
   createVideoTranscodeCheckWorker,
+  createAttachmentEmbeddingWorker,
   ImageCaptionService,
   StubImageCaptionService,
   PdfProcessingService,
@@ -595,6 +596,14 @@ export async function startServer(): Promise<ServerInstance> {
     fairness: QueueFairness.NONE,
   })
 
+  // Attachment summary embeddings — same tier as message embeddings (LIGHT,
+  // single network call to the embedding provider, no heavy local work).
+  const attachmentEmbeddingWorker = createAttachmentEmbeddingWorker({ pool, embeddingService })
+  jobQueue.registerHandler(JobQueues.ATTACHMENT_EMBED, attachmentEmbeddingWorker, {
+    tier: QueueTiers.LIGHT,
+    fairness: QueueFairness.NONE,
+  })
+
   // Boundary extraction
   const boundaryExtractor = config.useStubBoundaryExtraction
     ? new StubBoundaryExtractor()
@@ -845,6 +854,7 @@ export async function startServer(): Promise<ServerInstance> {
   const mentionInvokeHandler = new MentionInvokeHandler(pool, jobQueue)
   const agentMessageMutationHandler = new AgentMessageMutationHandler(pool, jobQueue, eventService)
   const attachmentUploadedHandler = new AttachmentUploadedHandler(pool, jobQueue)
+  const attachmentEmbeddingHandler = new AttachmentEmbeddingHandler(pool, jobQueue)
   const systemMessageOutboxHandler = new SystemMessageOutboxHandler(pool, systemMessageService)
   const activityFeedHandler = new ActivityFeedHandler(pool, activityService)
   const pushNotificationHandler = pushService.isEnabled()
@@ -868,6 +878,7 @@ export async function startServer(): Promise<ServerInstance> {
     mentionInvokeHandler,
     agentMessageMutationHandler,
     attachmentUploadedHandler,
+    attachmentEmbeddingHandler,
     systemMessageOutboxHandler,
     activityFeedHandler,
     linkPreviewOutboxHandler,


### PR DESCRIPTION
## Summary

Make attachments semantically searchable by embedding their AI-generated extraction summaries into a `vector(1536)` column on `attachment_extractions`, populated asynchronously via the existing outbox + job-queue pipeline.

- New migration adds `summary_embedding` + an HNSW cosine index (matches the message-embeddings index so callers can build hybrid queries with consistent distance semantics).
- New `attachment:extraction_completed` outbox event is written in the same transaction as every extraction insert (text/word/image-caption via `processAttachment`, plus the PDF assemble path — both real and stub services). Atomic with the state change per INV-7.
- New `AttachmentEmbeddingHandler` consumes those events and enqueues `attachment.embed` jobs, filtering on `contentType` (`photo` and `other` are skipped — generic captions don't carry retrievable signal).
- New `createAttachmentEmbeddingWorker` follows the three-phase pattern (INV-41): fetch extraction → embed (no DB conn) → write. Defensively re-checks workspace match (INV-8), eligibility, and a 10-char minimum summary length, and tolerates the extraction being deleted between fetch and write.
- Backfill is itself a SQL migration that inserts directly into `queue_messages`, establishing a re-enqueue pattern future migrations can reuse to replay extractions when models or eligibility rules change.

### Design choices

- **Embed the summary, not `full_text`:** the summary stays under the 8K-token input cap for every extraction, captures the doc's gist far better for high-recall "which doc is about X?" queries, and FTS already handles exact-phrase lookups on `full_text`. Per-section/per-page chunked embeddings are deferred.
- **Project `summary_embedding` as a boolean (`IS NOT NULL`) on reads:** the application never reads the raw vector (semantic search runs as a SQL distance comparison against the column directly), and shipping ~30KB of vector literal on every SELECT would be wasteful. Surfaced as `hasSummaryEmbedding` on the domain type so callers can route around an in-flight backfill.
- **Eligibility checked twice (handler + worker):** handler check is the optimisation (don't pay for queue churn on `photo`/`other`); worker check is defence against extractions being reprocessed with a different `content_type` between enqueue and execution.
- **Worker `UPDATE` returns boolean:** lets the worker log when an extraction was deleted between fetch and write rather than silently dropping the embedding.

## Test plan

- [x] `bun test apps/backend/src/features/attachments/embedding-config.test.ts apps/backend/src/features/attachments/embedding-worker.test.ts` — 9 tests, all passing
- [x] `bun run typecheck` — clean across all workspaces
- [x] `bun run lint` — clean (initial INV-52 violation on memos internal import was caught by the pre-commit hook and fixed to import from the `../memos` barrel)
- [ ] Manual: trigger an extraction, verify the outbox event lands, the handler enqueues, the worker writes a vector, and `hasSummaryEmbedding` flips to `true`
- [ ] Manual: run the backfill migration on a database with existing extractions and confirm jobs drain through the worker

https://claude.ai/code/session_01Ss2EXLZH46AnPFcaYdKSDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss2EXLZH46AnPFcaYdKSDS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->