### PR TITLE
fix(timeline): render bootstrap events as fallback when IDB is empty

### DIFF
--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -4,6 +4,7 @@ import {
   filterEventsForDisplay,
   getCachedWindowFloor,
   getDisplayFloor,
+  getEffectiveEvents,
   getMinimumSequence,
   getNextBootstrapFloorState,
   getOldestSequence,
@@ -144,5 +145,32 @@ describe("computeTimelineLoadState", () => {
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: false, isConfirmedEmpty: false })
+  })
+})
+
+describe("getEffectiveEvents", () => {
+  it("returns nothing while IDB is unresolved", () => {
+    expect(getEffectiveEvents(false, [], [{ sequence: "100" }])).toEqual([])
+  })
+
+  it("prefers IDB events once IDB has resolved with content", () => {
+    const idbEvents = [{ sequence: "200", _status: "pending" as const }]
+    const bootstrapEvents = [{ sequence: "100" }]
+    expect(getEffectiveEvents(true, idbEvents, bootstrapEvents)).toBe(idbEvents)
+  })
+
+  it("falls back to bootstrap events when IDB resolved empty but bootstrap has events", () => {
+    // The blank-render bug: bootstrap query has finished, applyStreamBootstrap
+    // has written events, but useLiveQuery hasn't re-emitted yet (typical on
+    // cold load with empty IDB and on the rekey transient when the bootstrap
+    // floor flips). Without the fallback, the timeline goes blank with no
+    // skeleton and no empty state — neither isLoading nor isConfirmedEmpty
+    // fires because the (now-stale) hasAnyEvents check trusts bootstrap.
+    const bootstrapEvents = [{ sequence: "100" }, { sequence: "120" }]
+    expect(getEffectiveEvents(true, [], bootstrapEvents)).toBe(bootstrapEvents)
+  })
+
+  it("returns empty when IDB resolved empty and bootstrap has no events", () => {
+    expect(getEffectiveEvents(true, [], [])).toEqual([])
   })
 })

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -132,6 +132,37 @@ export function filterEventsForDisplay<T extends DisplayableEvent>(events: T[], 
   })
 }
 
+/**
+ * Pick the source of events to render in the timeline.
+ *
+ * IDB is the primary read model — once it has events, it always wins because
+ * it carries socket-arrived events and optimistic pending/failed rows that
+ * the bootstrap snapshot doesn't.
+ *
+ * The bootstrap fallback closes a narrow but visible race on cold load: the
+ * bootstrap query writes events to IDB inside its queryFn, then resolves and
+ * triggers a re-render. `useLiveQuery` only refreshes once Dexie's change
+ * notifications propagate, which can land one or more renders later (and on
+ * mobile Safari has been observed to miss the change entirely until the next
+ * page-resume). Without the fallback, that interim render computes
+ * `hasAnyEvents=true` from `bootstrap.events` while the rendered array stays
+ * empty — neither the skeleton nor the empty state fires and the user sees
+ * a blank scroll area.
+ *
+ * Falling back to bootstrap is safe specifically because IDB is empty: there
+ * are no socket-arrived or pending events to hide. As soon as `useLiveQuery`
+ * picks up the bootstrap writes, control flips back to IDB seamlessly.
+ */
+export function getEffectiveEvents<T extends DisplayableEvent>(
+  idbResolved: boolean,
+  idbEvents: T[],
+  bootstrapEvents: T[]
+): T[] {
+  if (!idbResolved) return []
+  if (idbEvents.length > 0) return idbEvents
+  return bootstrapEvents
+}
+
 export function getOldestSequence(events: SequencedEvent[] | null | undefined): string | null {
   if (!events || events.length === 0) return null
 
@@ -344,12 +375,14 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   const hasIdbEvents = idbResolved && idbEvents.length > 0
   const suppressBootstrapError = shouldSuppressBootstrapError(error, hasIdbEvents)
 
-  // IDB is the primary read model. While useLiveQuery resolves (typically <10ms),
-  // treat it as a brief loading state rather than falling back to stale bootstrap
-  // events. The bootstrap cache only contains the original snapshot and would hide
-  // messages sent or received via socket after the first bootstrap.
-  const effectiveEvents: DisplayableEvent[] = idbResolved ? idbEvents : []
-  const hasAnyEvents = effectiveEvents.length > 0 || (bootstrap?.events ?? []).length > 0
+  // IDB is the primary read model. When useLiveQuery resolves with content,
+  // we always use it — it carries socket-arrived events and optimistic
+  // pending/failed rows the bootstrap snapshot doesn't. The bootstrap-events
+  // fallback only fires when IDB is genuinely empty, closing the cold-load
+  // race where bootstrap has finished but Dexie change events haven't yet
+  // propagated to useLiveQuery (see getEffectiveEvents docstring).
+  const effectiveEvents: DisplayableEvent[] = getEffectiveEvents(idbResolved, idbEvents ?? [], bootstrap?.events ?? [])
+  const hasAnyEvents = effectiveEvents.length > 0
 
   const cachedWindowFloor = useMemo(() => getCachedWindowFloor(effectiveEvents, EVENT_PAGE_SIZE), [effectiveEvents])
   const displayFloor = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes a cold-load race where the timeline rendered a completely blank scroll area — no skeleton, no empty state, no messages — on the last-open stream. The user had to background and foreground the app a few times before messages appeared.

## Root cause

In `useEvents` (`apps/frontend/src/hooks/use-events.ts`), the `hasAnyEvents` check was asymmetric with the rendered `events` array:

```ts
const effectiveEvents: DisplayableEvent[] = idbResolved ? idbEvents : []
const hasAnyEvents = effectiveEvents.length > 0 || (bootstrap?.events ?? []).length > 0
```

`hasAnyEvents` trusted `bootstrap.events` while the rendered array only came from IDB. On cold load with empty IDB:

1. `useStreamBootstrap` runs `applyStreamBootstrap` inside its `queryFn`, writing events to IDB before resolving.
2. TanStack publishes the bootstrap, React re-renders. `hasAnyEvents=true`, `isBootstrapLoading=false`.
3. `useLiveQuery` has not yet re-emitted (Dexie change notifications can land a render or more later; on mobile Safari they have been observed to miss entirely until page-resume).
4. `effectiveEvents=[]`, so the rendered `events` array is `[]`. `computeTimelineLoadState` returns `{isLoading: false, isConfirmedEmpty: false}` — and Virtuoso renders a blank `data=[]`.

The 5s recovery window the user reported lines up with `usePageResumeRefresh`'s threshold, which invalidates the bootstrap query and forces a fresh path through `applyStreamBootstrap`.

## Fix

Introduce a pure `getEffectiveEvents(idbResolved, idbEvents, bootstrapEvents)` helper that prefers IDB when it has content (so socket-arrived and optimistic events still win) and falls back to the bootstrap snapshot when IDB resolves empty. Once Dexie's change notifications catch up, control flips back to IDB seamlessly.

The fallback is safe specifically because IDB is empty: there are no socket-arrived or pending events to hide.

## Test plan

- [x] Added four `getEffectiveEvents` unit tests covering all four branches (unresolved, IDB-wins, bootstrap-fallback, both-empty)
- [x] Existing `computeTimelineLoadState` and `useEvents` helper tests still pass
- [x] Full frontend suite: 1581 / 1581 tests pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Manual: open app on stream that previously triggered the blank state — confirm skeleton or bootstrap content shows instead of blank scroll area

https://claude.ai/code/session_015RZqBxNPixLtu1BtnLY1n6

---
_Generated by [Claude Code](https://claude.ai/code/session_015RZqBxNPixLtu1BtnLY1n6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->