### PR TITLE
Replace Blacksmith runners with ubuntu-latest in GitHub Actions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   browser-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     continue-on-error: true
     env:
@@ -199,7 +199,7 @@ jobs:
           retention-days: 7
 
   evaluate-results:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: browser-tests
     if: always()
     continue-on-error: true
@@ -251,7 +251,7 @@ jobs:
           fi
 
   merge-playwright-reports:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: browser-tests
     if: always()
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -119,7 +119,7 @@ jobs:
 
   workos-permissions:
     name: WorkOS Permissions
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy-frontend:
     name: Deploy Frontend
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-frontend
@@ -47,7 +47,7 @@ jobs:
 
   deploy-workspace-router:
     name: Deploy Workspace Router
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-workspace-router
@@ -82,7 +82,7 @@ jobs:
 
   deploy-backoffice:
     name: Deploy Backoffice
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-backoffice
@@ -120,7 +120,7 @@ jobs:
 
   deploy-backoffice-router:
     name: Deploy Backoffice Router
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-backoffice-router
@@ -155,7 +155,7 @@ jobs:
 
   deploy-backoffice-staging:
     name: Deploy Backoffice (Staging)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-backoffice-staging
@@ -193,7 +193,7 @@ jobs:
 
   deploy-backoffice-router-staging:
     name: Deploy Backoffice Router (Staging)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-backoffice-router-staging
@@ -228,7 +228,7 @@ jobs:
 
   deploy-frontend-staging:
     name: Deploy Frontend (Staging)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-frontend-staging
@@ -271,7 +271,7 @@ jobs:
 
   deploy-workspace-router-staging:
     name: Deploy Workspace Router (Staging)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-workspace-router-staging

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   notify:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Send Threa notification
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.action != 'closed' &&
       github.event.action != 'unlabeled' &&
       contains(github.event.pull_request.labels.*.name, 'staging')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
@@ -155,7 +155,7 @@ jobs:
     if: |
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'staging')) ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'staging')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
This PR replaces all custom Blacksmith runner instances with the standard `ubuntu-latest` GitHub Actions runner across multiple workflow files.

## Key Changes
- **deploy-cloudflare.yml**: Updated 8 deployment jobs from `blacksmith-2vcpu-ubuntu-2404` to `ubuntu-latest`
  - Frontend, Workspace Router, Backoffice, Backoffice Router deployments
  - Staging variants for Backoffice, Backoffice Router, Frontend, and Workspace Router
  
- **browser-tests.yml**: Updated 3 jobs from Blacksmith runners to `ubuntu-latest`
  - `browser-tests` job (changed from `blacksmith-4vcpu-ubuntu-2404`)
  - `evaluate-results` job
  - `merge-playwright-reports` job

- **ci.yml**: Updated 3 jobs from Blacksmith runners to `ubuntu-latest`
  - `lint` job
  - `test` job (changed from `blacksmith-4vcpu-ubuntu-2404`)
  - `workos-permissions` job

- **staging.yml**: Updated 2 jobs from `blacksmith-2vcpu-ubuntu-2404` to `ubuntu-latest`
  - Staging deployment job
  - Staging cleanup job

- **notify.yml**: Updated 1 job from `blacksmith-2vcpu-ubuntu-2404` to `ubuntu-latest`
  - Notification job

## Implementation Details
All changes are straightforward runner replacements with no modifications to job logic, steps, or configuration. This standardizes the CI/CD infrastructure to use GitHub's managed runners instead of custom Blacksmith instances.

https://claude.ai/code/session_01RmM86xKGLm27JScCKoZHqk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->