### PR TITLE
chore: upgrade gpt-4.1-mini to gpt-5.4-nano

### DIFF
--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -82,7 +82,7 @@ suites:
 
   # Same suite, different provider
   - name: companion
-    title: "GPT-4.1-mini"
+    title: "gpt-5.4-nano"
     components:
       companion:
         model: openrouter:openai/gpt-5.4-nano
@@ -118,7 +118,7 @@ suites:
         temperature: 0.7
 
   - name: companion
-    title: "GPT-4.1-mini"
+    title: "gpt-5.4-nano"
     components:
       companion:
         model: openrouter:openai/gpt-5.4-nano

--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -15,7 +15,7 @@ bun run eval -- -s companion
 bun run eval -- -s companion -c scratchpad-companion-greeting-001
 
 # Compare models
-bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-4.1-mini
+bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-5.4-nano
 
 # Run from config file
 bun run eval -- --config evals/example-config.yaml
@@ -85,7 +85,7 @@ suites:
     title: "GPT-4.1-mini"
     components:
       companion:
-        model: openrouter:openai/gpt-4.1-mini
+        model: openrouter:openai/gpt-5.4-nano
 ```
 
 ### Component Keys by Suite
@@ -121,7 +121,7 @@ suites:
     title: "GPT-4.1-mini"
     components:
       companion:
-        model: openrouter:openai/gpt-4.1-mini
+        model: openrouter:openai/gpt-5.4-nano
         temperature: 0.5
 
   # Run stream-naming with specific cases only

--- a/apps/backend/evals/framework/eval-config-resolver.test.ts
+++ b/apps/backend/evals/framework/eval-config-resolver.test.ts
@@ -13,7 +13,7 @@ describe("EvalConfigResolver", () => {
     const resolver = createEvalConfigResolver({ base })
 
     const config = await resolver.resolve(COMPONENT_PATHS.BOUNDARY_EXTRACTION)
-    expect(config.modelId).toBe("openrouter:openai/gpt-4.1-mini")
+    expect(config.modelId).toBe("openrouter:openai/gpt-5.4-nano")
     expect(config.temperature).toBe(0.2)
   })
 
@@ -66,14 +66,14 @@ describe("convertYamlOverrides", () => {
   test("should handle partial overrides", () => {
     const yamlOverrides = {
       researcher: {
-        model: "openrouter:openai/gpt-4.1-mini",
+        model: "openrouter:openai/gpt-5.4-nano",
       },
     }
 
     const converted = convertYamlOverrides(yamlOverrides)
 
     expect(converted.researcher).toEqual({
-      modelId: "openrouter:openai/gpt-4.1-mini",
+      modelId: "openrouter:openai/gpt-5.4-nano",
     })
   })
 

--- a/apps/backend/evals/framework/evaluators/llm-judge.ts
+++ b/apps/backend/evals/framework/evaluators/llm-judge.ts
@@ -38,15 +38,15 @@ export interface LLMJudgeOptions {
  * @example
  * llmJudgeEvaluator({
  *   criteria: "The output preserves all factual information from the input",
- *   model: "openrouter:openai/gpt-4.1-mini",
+ *   model: "openrouter:openai/gpt-5.4-nano",
  * })
  */
 export function llmJudgeEvaluator<TOutput, TExpected>(options: LLMJudgeOptions): Evaluator<TOutput, TExpected> {
   const {
     name = "llm-judge",
     criteria,
-    // Use GPT-4.1-mini for reliable structured output through OpenRouter
-    model = "openrouter:openai/gpt-4.1-mini",
+    // Use GPT-5.4-nano for reliable structured output through OpenRouter
+    model = "openrouter:openai/gpt-5.4-nano",
     passThreshold = 0.7,
     context: additionalContext,
   } = options

--- a/apps/backend/evals/framework/evaluators/llm-judge.ts
+++ b/apps/backend/evals/framework/evaluators/llm-judge.ts
@@ -24,7 +24,7 @@ export interface LLMJudgeOptions {
   name?: string
   /** Criteria to evaluate against */
   criteria: string
-  /** Model to use for judging (default: uses context's AI wrapper) */
+  /** Model to use for judging (default: "openrouter:openai/gpt-5.4-nano") */
   model?: string
   /** Pass threshold (default: 0.7) */
   passThreshold?: number

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -6,7 +6,7 @@
  *   bun run evals/run.ts                         # Run all suites
  *   bun run evals/run.ts -s companion             # Run specific suite
  *   bun run evals/run.ts -s companion -c case-001  # Run specific case
- *   bun run evals/run.ts -m openrouter:openai/gpt-4.1-mini  # Override model
+ *   bun run evals/run.ts -m openrouter:openai/gpt-5.4-nano  # Override model
  *   bun run evals/run.ts --no-langfuse           # Skip Langfuse recording
  */
 
@@ -58,10 +58,10 @@ Examples:
   bun run evals/run.ts -s ${allSuites[1]?.name || "suite-name"} -c case-001,case-002
     Run specific test cases
 
-  bun run evals/run.ts -m openrouter:openai/gpt-4.1-mini
+  bun run evals/run.ts -m openrouter:openai/gpt-5.4-nano
     Override model for all suites
 
-  bun run evals/run.ts -m openrouter:openai/gpt-4.1-mini,openrouter:anthropic/claude-haiku-4.5 -p 2
+  bun run evals/run.ts -m openrouter:openai/gpt-5.4-nano,openrouter:anthropic/claude-haiku-4.5 -p 2
     Compare models in parallel
 
   bun run evals/run.ts --config companion-config.yaml

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -13,7 +13,7 @@
  *   bun run eval -- -s boundary-extraction -c new-topic-fresh-stream-001
  *
  *   # Compare models
- *   bun run eval -- -s boundary-extraction -m openrouter:openai/gpt-4.1-mini,openrouter:anthropic/claude-haiku-4.5
+ *   bun run eval -- -s boundary-extraction -m openrouter:openai/gpt-5.4-nano,openrouter:anthropic/claude-haiku-4.5
  *
  * ## Key Evaluators
  *

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -13,7 +13,7 @@
  *   bun run eval -- -s companion -c scratchpad-companion-greeting-001
  *
  *   # Compare models
- *   bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-4.1-mini
+ *   bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-5.4-nano
  *
  * ## Case ID Format
  *

--- a/apps/backend/evals/suites/stream-naming/suite.ts
+++ b/apps/backend/evals/suites/stream-naming/suite.ts
@@ -13,7 +13,7 @@
  *   bun run eval -- -s stream-naming -c technical-api-discussion-001
  *
  *   # Compare models
- *   bun run eval -- -s stream-naming -m openrouter:openai/gpt-4.1-mini,openrouter:anthropic/claude-haiku-4.5
+ *   bun run eval -- -s stream-naming -m openrouter:openai/gpt-5.4-nano,openrouter:anthropic/claude-haiku-4.5
  *
  * ## Key Evaluators
  *

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -9,7 +9,7 @@ import { z } from "zod"
 import { CONVERSATION_STATUSES } from "@threa/types"
 
 /** Default model for boundary extraction */
-export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-4.1-mini"
+export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
 
 /** Temperature for classification - low for consistency */
 export const BOUNDARY_EXTRACTION_TEMPERATURE = 0.2

--- a/apps/backend/src/features/streams/naming-config.ts
+++ b/apps/backend/src/features/streams/naming-config.ts
@@ -6,7 +6,7 @@
  */
 
 /** Default model for stream naming */
-export const STREAM_NAMING_MODEL_ID = "openrouter:openai/gpt-4.1-mini"
+export const STREAM_NAMING_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
 
 /** Temperature for name generation - low for consistency */
 export const STREAM_NAMING_TEMPERATURE = 0.3

--- a/apps/backend/src/lib/ai/config-resolver.test.ts
+++ b/apps/backend/src/lib/ai/config-resolver.test.ts
@@ -7,12 +7,12 @@ describe("StaticConfigResolver", () => {
     const resolver = createStaticConfigResolver()
 
     const boundaryConfig = await resolver.resolve(COMPONENT_PATHS.BOUNDARY_EXTRACTION)
-    expect(boundaryConfig.modelId).toBe("openrouter:openai/gpt-4.1-mini")
+    expect(boundaryConfig.modelId).toBe("openrouter:openai/gpt-5.4-nano")
     expect(boundaryConfig.temperature).toBe(0.2)
     expect(boundaryConfig.systemPrompt).toBeDefined()
 
     const streamNamingConfig = await resolver.resolve(COMPONENT_PATHS.STREAM_NAMING)
-    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-4.1-mini")
+    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.4-nano")
     expect(streamNamingConfig.temperature).toBe(0.3)
 
     const memoClassifierConfig = await resolver.resolve(COMPONENT_PATHS.MEMO_CLASSIFIER)
@@ -71,6 +71,6 @@ describe("StaticConfigResolver", () => {
 
     // Non-overridden path should have default
     const streamNamingConfig = await resolver.resolve(COMPONENT_PATHS.STREAM_NAMING)
-    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-4.1-mini")
+    expect(streamNamingConfig.modelId).toBe("openrouter:openai/gpt-5.4-nano")
   })
 })


### PR DESCRIPTION
## Problem

`gpt-4.1-mini` is no longer the best option for our lightweight AI tasks. Per `docs/model-reference.md`, `gpt-5.4-nano` supersedes it — cheaper (~$0.20/$1.25 vs higher for 4.1-mini), faster (lower latency), and higher quality on benchmarks despite the lower cost.

## Solution

Replace all `openrouter:openai/gpt-4.1-mini` references with `openrouter:openai/gpt-5.4-nano` across production configs, tests, and eval tooling.

### Key design decision

`gpt-5.4-nano` is model-reference.md's recommended replacement for `gpt-4.1-mini` (and `gpt-4o-mini`) — it targets exactly the same use cases: classification, extraction, ranking, and high-volume batch work at low cost. No behavior changes are expected; this is a drop-in model swap.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/boundary-extraction/config.ts` | Update `BOUNDARY_EXTRACTION_MODEL_ID` |
| `apps/backend/src/features/streams/naming-config.ts` | Update `STREAM_NAMING_MODEL_ID` |
| `apps/backend/src/lib/ai/config-resolver.test.ts` | Update test assertions |
| `apps/backend/evals/framework/eval-config-resolver.test.ts` | Update test assertions |
| `apps/backend/evals/framework/evaluators/llm-judge.ts` | Update default model and comment |
| `apps/backend/evals/run.ts` | Update example comments |
| `apps/backend/evals/README.md` | Update example model references |
| `apps/backend/evals/suites/boundary-extraction/suite.ts` | Update example comment |
| `apps/backend/evals/suites/companion/suite.ts` | Update example comment |
| `apps/backend/evals/suites/stream-naming/suite.ts` | Update example comment |

## Test plan

- [x] `bun test src/lib/ai/config-resolver.test.ts` — 4 pass
- [x] `bun test evals/framework/eval-config-resolver.test.ts` — 8 pass
- [x] Pre-commit hook: lint + typecheck passes

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ9eQsccFqwRkpn5AU7KB9)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->