### PR TITLE
feat(invitations): role_slug end-to-end + backoffice pending invitations

### DIFF
--- a/apps/backend/src/features/invitations/shadow-sync-outbox-handler.ts
+++ b/apps/backend/src/features/invitations/shadow-sync-outbox-handler.ts
@@ -87,7 +87,7 @@ export class InvitationShadowSyncHandler implements OutboxHandler {
           }
 
           if (isOutboxEventType(event, "invitation:sent")) {
-            const { invitationId, workspaceId, email, inviterWorkosUserId } = event.payload
+            const { invitationId, workspaceId, email, role, inviterWorkosUserId } = event.payload
             const invitation = await InvitationRepository.findById(this.db, invitationId)
             if (!invitation) {
               logger.warn({ invitationId }, "Invitation not found for shadow sync, skipping")
@@ -102,11 +102,12 @@ export class InvitationShadowSyncHandler implements OutboxHandler {
               kind: "email",
               email,
               tokenHash: null,
+              roleSlug: role,
               expiresAt: invitation.expiresAt,
               inviterWorkosUserId,
             })
           } else if (isOutboxEventType(event, "invitation:link-created")) {
-            const { invitationId, workspaceId, tokenHash } = event.payload
+            const { invitationId, workspaceId, tokenHash, role } = event.payload
             const invitation = await InvitationRepository.findById(this.db, invitationId)
             if (!invitation) {
               logger.warn({ invitationId }, "Link invitation not found for shadow sync, skipping")
@@ -121,6 +122,7 @@ export class InvitationShadowSyncHandler implements OutboxHandler {
               kind: "link",
               email: null,
               tokenHash,
+              roleSlug: role,
               expiresAt: invitation.expiresAt,
             })
           } else if (isOutboxEventType(event, "invitation:link-claimed")) {

--- a/apps/backend/src/lib/control-plane-client.ts
+++ b/apps/backend/src/lib/control-plane-client.ts
@@ -1,5 +1,6 @@
 import { logger } from "./logger"
 import { INTERNAL_API_KEY_HEADER } from "@threa/backend-common"
+import type { WorkspaceInvitableRole } from "@threa/types"
 
 const REQUEST_TIMEOUT_MS = 10_000
 
@@ -20,6 +21,7 @@ export class ControlPlaneClient {
     email: string | null
     /** Required for kind="link", null for kind="email". */
     tokenHash: string | null
+    roleSlug: WorkspaceInvitableRole
     inviterWorkosUserId?: string
   }): Promise<void> {
     const url = `${this.baseUrl}/internal/invitation-shadows`

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -11,6 +11,7 @@ import type {
   Bot as WireBot,
   SavedMessageView,
   ScheduledMessageView,
+  WorkspaceInvitableRole,
 } from "@threa/types"
 
 /**
@@ -369,21 +370,21 @@ export interface UserPreferencesUpdatedOutboxPayload extends WorkspaceScopedPayl
 export interface InvitationSentOutboxPayload extends WorkspaceScopedPayload {
   invitationId: string
   email: string
-  role: string
+  role: WorkspaceInvitableRole
   inviterWorkosUserId?: string
 }
 
 export interface InvitationLinkCreatedOutboxPayload extends WorkspaceScopedPayload {
   invitationId: string
   tokenHash: string
-  role: string
+  role: WorkspaceInvitableRole
   expiresAt: string
 }
 
 export interface InvitationLinkClaimedOutboxPayload extends WorkspaceScopedPayload {
   invitationId: string
   email: string
-  role: string
+  role: WorkspaceInvitableRole
   inviterWorkosUserId?: string
 }
 

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.12",
+    "@threa/types": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.561.0",

--- a/apps/backoffice/src/api/backoffice.ts
+++ b/apps/backoffice/src/api/backoffice.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceInvitableRole } from "@threa/types"
 import { api } from "./client"
 
 /**
@@ -67,7 +68,7 @@ export interface WorkspaceInvitation {
   id: string
   kind: "email" | "link"
   email: string | null
-  roleSlug: string
+  roleSlug: WorkspaceInvitableRole
   expiresAt: string
   createdAt: string
   inviter: {

--- a/apps/backoffice/src/api/backoffice.ts
+++ b/apps/backoffice/src/api/backoffice.ts
@@ -63,10 +63,25 @@ export interface WorkspaceMember {
   lastEventAt: string
 }
 
+export interface WorkspaceInvitation {
+  id: string
+  kind: "email" | "link"
+  email: string | null
+  roleSlug: string
+  expiresAt: string
+  createdAt: string
+  inviter: {
+    workosUserId: string
+    email: string | null
+    name: string | null
+  } | null
+}
+
 export const backofficeKeys = {
   workspaces: ["backoffice", "workspaces"] as const,
   workspace: (id: string) => ["backoffice", "workspaces", id] as const,
   workspaceMembers: (id: string) => ["backoffice", "workspaces", id, "members"] as const,
+  workspaceInvitations: (id: string) => ["backoffice", "workspaces", id, "invitations"] as const,
   invitations: ["backoffice", "invitations"] as const,
   config: ["backoffice", "config"] as const,
 }
@@ -115,4 +130,10 @@ export function listWorkspaceMembers(id: string): Promise<WorkspaceMember[]> {
   return api
     .get<{ members: WorkspaceMember[] }>(`/api/backoffice/workspaces/${encodeURIComponent(id)}/members`)
     .then((r) => r.members)
+}
+
+export function listWorkspaceInvitations(id: string): Promise<WorkspaceInvitation[]> {
+  return api
+    .get<{ invitations: WorkspaceInvitation[] }>(`/api/backoffice/workspaces/${encodeURIComponent(id)}/invitations`)
+    .then((r) => r.invitations)
 }

--- a/apps/backoffice/src/pages/workspace-detail-members.test.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-members.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { describe, it, expect, afterEach, vi } from "vitest"
 import { render, screen, waitFor, cleanup } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { WorkspaceDetailMembersPage } from "./workspace-detail-members"
-import { backofficeKeys, type WorkspaceDetail } from "@/api/backoffice"
+import { backofficeKeys, type WorkspaceDetail, type WorkspaceInvitation, type WorkspaceMember } from "@/api/backoffice"
 
 function renderAt(path: string, opts: { workspace?: WorkspaceDetail } = {}) {
   const queryClient = new QueryClient({
@@ -39,24 +39,52 @@ function makeWorkspace(overrides: Partial<WorkspaceDetail> = {}): WorkspaceDetai
   }
 }
 
-describe("WorkspaceDetailMembersPage", () => {
-  const fetchMock = vi.fn()
-  beforeEach(() => {
-    fetchMock.mockReset()
-    vi.stubGlobal("fetch", fetchMock)
+type RouteOverrides = {
+  members?: { status?: number; body?: { members?: WorkspaceMember[]; error?: string; code?: string } }
+  invitations?: { status?: number; body?: { invitations?: WorkspaceInvitation[]; error?: string; code?: string } }
+}
+
+/**
+ * Backoffice members tab fires two queries in parallel (members + invitations).
+ * Route by URL so tests don't depend on fetch order.
+ */
+function installBackofficeFetch(routes: RouteOverrides): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString()
+    if (url.includes("/invitations")) {
+      const { status = 200, body = { invitations: [] } } = routes.invitations ?? {}
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+    if (url.includes("/members")) {
+      const { status = 200, body = { members: [] } } = routes.members ?? {}
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+    throw new Error(`unexpected fetch: ${url}`)
   })
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+describe("WorkspaceDetailMembersPage", () => {
   afterEach(() => {
     cleanup()
     vi.unstubAllGlobals()
   })
 
-  it("renders the empty state when there are no members", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ members: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
-    )
+  function daysFromNow(days: number): string {
+    // Half-day padding so floor() doesn't drift to N-1 due to ms between
+    // `Date.now()` here and `Date.now()` inside the formatter.
+    return new Date(Date.now() + (days + 0.5) * 86_400_000).toISOString()
+  }
+
+  it("renders the members empty state when there are no members", async () => {
+    const fetchMock = installBackofficeFetch({})
     renderAt("/workspaces/ws_abc/members")
 
     await screen.findByText(/No members yet/)
@@ -67,9 +95,9 @@ describe("WorkspaceDetailMembersPage", () => {
   })
 
   it("renders one row per member with role chips, status, and email", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
+    installBackofficeFetch({
+      members: {
+        body: {
           members: [
             {
               workosUserId: "user_01",
@@ -90,10 +118,9 @@ describe("WorkspaceDetailMembersPage", () => {
               lastEventAt: new Date().toISOString(),
             },
           ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    )
+        },
+      },
+    })
 
     renderAt("/workspaces/ws_abc/members")
 
@@ -110,12 +137,7 @@ describe("WorkspaceDetailMembersPage", () => {
   })
 
   it("shows the not-linked empty state when the workspace has no WorkOS organization", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ members: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
-    )
+    installBackofficeFetch({})
 
     renderAt("/workspaces/ws_abc/members", {
       workspace: makeWorkspace({ workosOrganizationId: null }),
@@ -124,16 +146,64 @@ describe("WorkspaceDetailMembersPage", () => {
     await screen.findByText(/isn't linked to a WorkOS organization/)
   })
 
-  it("shows an error state when the request fails", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: "boom", code: "INTERNAL" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      })
-    )
+  it("shows an error state when the members request fails", async () => {
+    installBackofficeFetch({
+      members: { status: 500, body: { error: "boom", code: "INTERNAL" } },
+    })
 
     renderAt("/workspaces/ws_abc/members")
 
     await screen.findByText(/Couldn't load members/)
+  })
+
+  it("renders pending invitations with kind, role, inviter, and expiry", async () => {
+    installBackofficeFetch({
+      invitations: {
+        body: {
+          invitations: [
+            {
+              id: "inv_email_admin",
+              kind: "email",
+              email: "bob@example.com",
+              roleSlug: "admin",
+              expiresAt: daysFromNow(3),
+              createdAt: new Date().toISOString(),
+              inviter: { workosUserId: "user_01", email: "alice@example.com", name: "Alice Anderson" },
+            },
+            {
+              id: "inv_link_member",
+              kind: "link",
+              email: null,
+              roleSlug: "member",
+              expiresAt: daysFromNow(7),
+              createdAt: new Date().toISOString(),
+              inviter: null,
+            },
+          ],
+        },
+      },
+    })
+
+    renderAt("/workspaces/ws_abc/members")
+
+    await waitFor(() => {
+      expect(screen.getByText("bob@example.com")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Unclaimed link")).toBeInTheDocument()
+    expect(screen.getByText("email")).toBeInTheDocument()
+    expect(screen.getByText("link")).toBeInTheDocument()
+    expect(screen.getByText("admin")).toBeInTheDocument()
+    expect(screen.getByText("member")).toBeInTheDocument()
+    expect(screen.getByText(/Invited by Alice Anderson/)).toBeInTheDocument()
+    // 3 days out from the fake-now clock
+    expect(screen.getByText("Expires in 3d")).toBeInTheDocument()
+    // 7 days out
+    expect(screen.getByText("Expires in 7d")).toBeInTheDocument()
+  })
+
+  it("shows the pending-invitations empty state when there are none", async () => {
+    installBackofficeFetch({})
+    renderAt("/workspaces/ws_abc/members")
+    await screen.findByText("No pending invitations.")
   })
 })

--- a/apps/backoffice/src/pages/workspace-detail-members.test.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-members.test.tsx
@@ -206,4 +206,28 @@ describe("WorkspaceDetailMembersPage", () => {
     renderAt("/workspaces/ws_abc/members")
     await screen.findByText("No pending invitations.")
   })
+
+  it("renders 'Invited by Unknown' when the inviter lookup misses", async () => {
+    installBackofficeFetch({
+      invitations: {
+        body: {
+          invitations: [
+            {
+              id: "inv_unknown_inviter",
+              kind: "email",
+              email: "anon@example.com",
+              roleSlug: "member",
+              expiresAt: daysFromNow(2),
+              createdAt: new Date().toISOString(),
+              inviter: { workosUserId: "user_missing", email: null, name: null },
+            },
+          ],
+        },
+      },
+    })
+
+    renderAt("/workspaces/ws_abc/members")
+
+    await screen.findByText(/Invited by Unknown/)
+  })
 })

--- a/apps/backoffice/src/pages/workspace-detail-members.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-members.tsx
@@ -1,7 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useParams } from "react-router-dom"
 import { Section } from "@/components/layout/section"
-import { backofficeKeys, listWorkspaceMembers, type WorkspaceDetail, type WorkspaceMember } from "@/api/backoffice"
+import {
+  backofficeKeys,
+  listWorkspaceInvitations,
+  listWorkspaceMembers,
+  type WorkspaceDetail,
+  type WorkspaceInvitation,
+  type WorkspaceMember,
+} from "@/api/backoffice"
 import { ApiError } from "@/api/client"
 import { cn } from "@/lib/utils"
 import { formatDateTime } from "@/lib/format"
@@ -24,6 +31,24 @@ function formatRelativeTimestamp(iso: string): string {
   return new Date(iso).toLocaleDateString("en-GB", { year: "numeric", month: "short", day: "2-digit" })
 }
 
+function formatRelativeFuture(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return iso
+  const seconds = Math.floor((then - Date.now()) / 1000)
+  if (seconds <= 0) return "expired"
+  if (seconds < 3600) {
+    const m = Math.max(1, Math.floor(seconds / 60))
+    return `in ${m}m`
+  }
+  if (seconds < 86_400) {
+    const h = Math.floor(seconds / 3600)
+    return `in ${h}h`
+  }
+  const d = Math.floor(seconds / 86_400)
+  if (d < 30) return `in ${d}d`
+  return new Date(iso).toLocaleDateString("en-GB", { year: "numeric", month: "short", day: "2-digit" })
+}
+
 function memberDisplayName(m: WorkspaceMember): string | null {
   const parts = [m.firstName, m.lastName].filter((x): x is string => !!x && x.length > 0)
   if (parts.length > 0) return parts.join(" ")
@@ -43,6 +68,15 @@ export function WorkspaceDetailMembersPage() {
     enabled: !!id,
   })
 
+  const invitationsQ = useQuery({
+    queryKey: id ? backofficeKeys.workspaceInvitations(id) : ["backoffice", "workspaces", "missing", "invitations"],
+    queryFn: () => {
+      if (!id) throw new Error("Missing workspace id")
+      return listWorkspaceInvitations(id)
+    },
+    enabled: !!id,
+  })
+
   // Cache-only observer (the layout owns the actual fetch). We read the
   // workspace to differentiate "not linked to WorkOS" from "linked but empty"
   // in the empty state, since both currently come back as `members: []`.
@@ -56,12 +90,20 @@ export function WorkspaceDetailMembersPage() {
   const notLinked = workspaceQ.data ? workspaceQ.data.workosOrganizationId === null : false
 
   return (
-    <Section
-      label="Members"
-      description="Mirror of WorkOS organization memberships. Updates within ~5s of changes in the WorkOS dashboard."
-    >
-      <MembersBody loading={query.isLoading} error={query.error} members={query.data} notLinked={notLinked} />
-    </Section>
+    <div className="flex flex-col gap-10">
+      <Section
+        label="Pending invitations"
+        description="Invitations sent but not yet accepted. Link invitations stay here until someone claims them."
+      >
+        <InvitationsBody loading={invitationsQ.isLoading} error={invitationsQ.error} invitations={invitationsQ.data} />
+      </Section>
+      <Section
+        label="Members"
+        description="Mirror of WorkOS organization memberships. Updates within ~5s of changes in the WorkOS dashboard."
+      >
+        <MembersBody loading={query.isLoading} error={query.error} members={query.data} notLinked={notLinked} />
+      </Section>
+    </div>
   )
 }
 
@@ -149,6 +191,89 @@ function RoleChips({ roles }: { roles: string[] }) {
           {role}
         </span>
       ))}
+    </span>
+  )
+}
+
+function InvitationsBody({
+  loading,
+  error,
+  invitations,
+}: {
+  loading: boolean
+  error: unknown
+  invitations: WorkspaceInvitation[] | undefined
+}) {
+  if (loading) {
+    return <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">Loading invitations…</div>
+  }
+
+  if (error) {
+    const notFound = ApiError.isApiError(error) && error.status === 404
+    return (
+      <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">
+        {notFound ? "That workspace doesn't exist." : "Couldn't load invitations."}
+      </div>
+    )
+  }
+
+  if (!invitations || invitations.length === 0) {
+    return <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">No pending invitations.</div>
+  }
+
+  return (
+    <ul className="divide-y border-y">
+      {invitations.map((inv) => (
+        <InvitationRow key={inv.id} invitation={inv} />
+      ))}
+    </ul>
+  )
+}
+
+function InvitationRow({ invitation }: { invitation: WorkspaceInvitation }) {
+  const primary = invitation.email ?? "Unclaimed link"
+  const inviterName = invitation.inviter?.name ?? invitation.inviter?.email ?? null
+  return (
+    <li className="flex items-center justify-between gap-4 py-4 pl-1 pr-3">
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate text-sm font-medium text-foreground">{primary}</span>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+          <KindBadge kind={invitation.kind} />
+          <RoleChips roles={[invitation.roleSlug]} />
+          {inviterName ? (
+            <>
+              <span className="text-muted-foreground/50">·</span>
+              <span className="truncate">Invited by {inviterName}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        <span
+          className="hidden text-xs tabular-nums text-muted-foreground sm:inline"
+          title={formatDateTime(invitation.expiresAt)}
+        >
+          Expires {formatRelativeFuture(invitation.expiresAt)}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+const KIND_VARIANTS: Record<WorkspaceInvitation["kind"], string> = {
+  email: "bg-sky-500/15 text-sky-700 dark:text-sky-300",
+  link: "bg-violet-500/15 text-violet-700 dark:text-violet-300",
+}
+
+function KindBadge({ kind }: { kind: WorkspaceInvitation["kind"] }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+        KIND_VARIANTS[kind]
+      )}
+    >
+      {kind}
     </span>
   )
 }

--- a/apps/backoffice/src/pages/workspace-detail-members.tsx
+++ b/apps/backoffice/src/pages/workspace-detail-members.tsx
@@ -232,7 +232,7 @@ function InvitationsBody({
 
 function InvitationRow({ invitation }: { invitation: WorkspaceInvitation }) {
   const primary = invitation.email ?? "Unclaimed link"
-  const inviterName = invitation.inviter?.name ?? invitation.inviter?.email ?? null
+  const inviterName = invitation.inviter ? (invitation.inviter.name ?? invitation.inviter.email ?? "Unknown") : null
   return (
     <li className="flex items-center justify-between gap-4 py-4 pl-1 pr-3">
       <div className="flex min-w-0 flex-col gap-1">

--- a/apps/control-plane/src/db/migrations/008_invitation_shadow_role_slug.sql
+++ b/apps/control-plane/src/db/migrations/008_invitation_shadow_role_slug.sql
@@ -1,0 +1,6 @@
+-- Workspace role applied when CP sends the WorkOS invitation and when
+-- materializing the organization membership on accept. The 'member' default
+-- exists so legacy rows (inserted before this column existed) stay valid.
+
+ALTER TABLE invitation_shadows
+  ADD COLUMN role_slug TEXT NOT NULL DEFAULT 'member';

--- a/apps/control-plane/src/features/backoffice/handlers.ts
+++ b/apps/control-plane/src/features/backoffice/handlers.ts
@@ -98,6 +98,15 @@ export function createBackofficeHandlers({ backofficeService }: Dependencies) {
       res.json({ members })
     },
 
+    async listWorkspaceInvitations(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) {
+        throw new HttpError("Missing workspace id", { status: 400, code: "VALIDATION_ERROR" })
+      }
+      const invitations = await backofficeService.listWorkspaceInvitations(id)
+      res.json({ invitations })
+    },
+
     async getConfig(_req: Request, res: Response) {
       res.json({ config: backofficeService.getConfig() })
     },

--- a/apps/control-plane/src/features/backoffice/service.ts
+++ b/apps/control-plane/src/features/backoffice/service.ts
@@ -7,9 +7,11 @@ import {
   type WorkosOrgService,
   type WorkosUserSummary,
 } from "@threa/backend-common"
+import type { WorkspaceInvitableRole } from "@threa/types"
 import { PlatformRoleRepository } from "./repository"
 import { WorkspaceRegistryRepository } from "../workspaces"
 import { WorkosAuthzRepository } from "../workos-authz"
+import { InvitationShadowRepository } from "../invitation-shadows"
 
 /** Platform roles recognised by the backoffice gate. */
 export const PLATFORM_ROLES = ["admin"] as const
@@ -103,6 +105,26 @@ export interface WorkspaceMemberSummary {
   status: string
   roleSlugs: string[]
   lastEventAt: string
+}
+
+/**
+ * Pending invitation_shadows row decorated with inviter metadata. Email is
+ * null for link invitations until someone claims the token. `inviter` is null
+ * when the shadow predates the inviter column or the user lookup fails — the
+ * UI falls back to "Unknown".
+ */
+export interface WorkspaceInvitationSummary {
+  id: string
+  kind: "email" | "link"
+  email: string | null
+  roleSlug: WorkspaceInvitableRole
+  expiresAt: string
+  createdAt: string
+  inviter: {
+    workosUserId: string
+    email: string | null
+    name: string | null
+  } | null
 }
 
 /**
@@ -329,6 +351,53 @@ export class BackofficeService {
     })
   }
 
+  /**
+   * Pending invitations for a workspace, surfaced separately from the WorkOS
+   * mirror so admins can see link invitations (never reach WorkOS until
+   * claimed) and the role each invite was sent at. Inviter user is looked up
+   * in parallel; failures degrade to `inviter: null` rather than failing the
+   * whole list.
+   */
+  async listWorkspaceInvitations(workspaceId: string): Promise<WorkspaceInvitationSummary[]> {
+    const workspace = await WorkspaceRegistryRepository.findById(this.pool, workspaceId)
+    if (!workspace) {
+      throw new HttpError("Workspace not found", { status: 404, code: "NOT_FOUND" })
+    }
+
+    const rows = await InvitationShadowRepository.listPendingByWorkspace(this.pool, workspaceId)
+    if (rows.length === 0) return []
+
+    const uniqueInviterIds = Array.from(
+      new Set(rows.map((r) => r.inviter_workos_user_id).filter((id): id is string => id != null))
+    )
+    const inviterById = new Map<string, WorkosUserSummary>()
+    if (uniqueInviterIds.length > 0) {
+      const lookups = await Promise.all(
+        uniqueInviterIds.map(async (id) => {
+          try {
+            return await this.workosOrgService.getUser(id)
+          } catch (err) {
+            logger.warn({ err, workosUserId: id, workspaceId }, "Backoffice: failed to resolve inviter user")
+            return null
+          }
+        })
+      )
+      for (const user of lookups) {
+        if (user) inviterById.set(user.id, user)
+      }
+    }
+
+    return rows.map((row) => ({
+      id: row.id,
+      kind: row.kind === "link" ? "link" : "email",
+      email: row.email,
+      roleSlug: row.role_slug,
+      expiresAt: row.expires_at.toISOString(),
+      createdAt: row.created_at.toISOString(),
+      inviter: summarizeInviter(row.inviter_workos_user_id, inviterById),
+    }))
+  }
+
   // --- private helpers -----------------------------------------------------
 
   private rethrowWorkosInvitationError(error: unknown): never {
@@ -411,6 +480,20 @@ function summarizeOwner(workosUserId: string, user: WorkosUserSummary | null): W
   if (!user) {
     return { workosUserId, email: null, name: null }
   }
+  return {
+    workosUserId,
+    email: user.email,
+    name: displayNameFromWorkos({ email: user.email, firstName: user.firstName, lastName: user.lastName }),
+  }
+}
+
+function summarizeInviter(
+  workosUserId: string | null,
+  inviterById: Map<string, WorkosUserSummary>
+): WorkspaceInvitationSummary["inviter"] {
+  if (!workosUserId) return null
+  const user = inviterById.get(workosUserId)
+  if (!user) return { workosUserId, email: null, name: null }
   return {
     workosUserId,
     email: user.email,

--- a/apps/control-plane/src/features/invitation-shadows/handlers.ts
+++ b/apps/control-plane/src/features/invitation-shadows/handlers.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import { HttpError } from "@threa/backend-common"
+import { WORKSPACE_INVITABLE_ROLES, WORKSPACE_ROLE_SLUGS } from "@threa/types"
 import type { InvitationShadowService } from "./service"
 
 interface Dependencies {
@@ -16,6 +17,7 @@ const createShadowSchema = z
     kind: z.enum(["email", "link"]).default("email"),
     email: z.string().email().nullable().optional(),
     tokenHash: z.string().min(1).nullable().optional(),
+    roleSlug: z.enum(WORKSPACE_INVITABLE_ROLES).default(WORKSPACE_ROLE_SLUGS.MEMBER),
     inviterWorkosUserId: z.string().min(1).optional(),
   })
   .refine(
@@ -60,6 +62,7 @@ export function createInvitationShadowHandlers({ shadowService }: Dependencies) 
         kind: parsed.data.kind,
         email: parsed.data.email ?? null,
         tokenHash: parsed.data.tokenHash ?? null,
+        roleSlug: parsed.data.roleSlug,
         expiresAt: new Date(parsed.data.expiresAt),
         inviterWorkosUserId: parsed.data.inviterWorkosUserId,
       })

--- a/apps/control-plane/src/features/invitation-shadows/repository.ts
+++ b/apps/control-plane/src/features/invitation-shadows/repository.ts
@@ -1,4 +1,5 @@
 import type { Querier } from "@threa/backend-common"
+import type { WorkspaceInvitableRole } from "@threa/types"
 
 export interface InvitationShadowRow {
   id: string
@@ -10,6 +11,7 @@ export interface InvitationShadowRow {
   workos_invitation_id: string | null
   inviter_workos_user_id: string | null
   token_hash: string | null
+  role_slug: WorkspaceInvitableRole
   created_at: Date
   expires_at: Date
 }
@@ -29,7 +31,7 @@ export interface LinkLookupRow {
   expires_at: Date
 }
 
-const SELECT_FIELDS = `id, workspace_id, kind, email, region, status, workos_invitation_id, inviter_workos_user_id, token_hash, created_at, expires_at`
+const SELECT_FIELDS = `id, workspace_id, kind, email, region, status, workos_invitation_id, inviter_workos_user_id, token_hash, role_slug, created_at, expires_at`
 
 export const InvitationShadowRepository = {
   async findById(db: Querier, id: string): Promise<InvitationShadowRow | null> {
@@ -61,13 +63,14 @@ export const InvitationShadowRepository = {
       kind: "email" | "link"
       email: string | null
       tokenHash: string | null
+      roleSlug: WorkspaceInvitableRole
       expiresAt: Date
       inviterWorkosUserId?: string
     }
   ): Promise<InvitationShadowRow> {
     const result = await db.query<InvitationShadowRow>(
-      `INSERT INTO invitation_shadows (id, workspace_id, kind, email, region, expires_at, inviter_workos_user_id, token_hash)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      `INSERT INTO invitation_shadows (id, workspace_id, kind, email, region, expires_at, inviter_workos_user_id, token_hash, role_slug)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        ON CONFLICT (id) DO UPDATE SET
          expires_at = EXCLUDED.expires_at,
          inviter_workos_user_id = COALESCE(EXCLUDED.inviter_workos_user_id, invitation_shadows.inviter_workos_user_id)
@@ -81,6 +84,7 @@ export const InvitationShadowRepository = {
         shadow.expiresAt,
         shadow.inviterWorkosUserId ?? null,
         shadow.tokenHash,
+        shadow.roleSlug,
       ]
     )
     return result.rows[0]

--- a/apps/control-plane/src/features/invitation-shadows/repository.ts
+++ b/apps/control-plane/src/features/invitation-shadows/repository.ts
@@ -42,6 +42,16 @@ export const InvitationShadowRepository = {
     return result.rows[0] ?? null
   },
 
+  async listPendingByWorkspace(db: Querier, workspaceId: string): Promise<InvitationShadowRow[]> {
+    const result = await db.query<InvitationShadowRow>(
+      `SELECT ${SELECT_FIELDS} FROM invitation_shadows
+       WHERE workspace_id = $1 AND status = 'pending' AND expires_at > NOW()
+       ORDER BY created_at DESC`,
+      [workspaceId]
+    )
+    return result.rows
+  },
+
   async findPendingByEmailWithWorkspace(db: Querier, email: string): Promise<PendingInvitationRow[]> {
     const result = await db.query<PendingInvitationRow>(
       `SELECT s.id, s.workspace_id, wr.name AS workspace_name, s.expires_at

--- a/apps/control-plane/src/features/invitation-shadows/service.ts
+++ b/apps/control-plane/src/features/invitation-shadows/service.ts
@@ -11,7 +11,7 @@ import {
 import { InvitationShadowRepository } from "./repository"
 import { WorkspaceRegistryRepository } from "../workspaces"
 import { RegionalClaimError, type RegionalClient } from "../../lib/regional-client"
-import type { InvitationLinkLookupResponse, PendingInvitation } from "@threa/types"
+import type { InvitationLinkLookupResponse, PendingInvitation, WorkspaceInvitableRole } from "@threa/types"
 
 function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex")
@@ -118,7 +118,7 @@ export class InvitationShadowService {
         await this.workosOrgService.ensureOrganizationMembership({
           organizationId: orgId,
           userId: user.id,
-          roleSlug: "member",
+          roleSlug: shadow.role_slug,
         })
       } catch (error) {
         logger.warn({ err: error, workspaceId: shadow.workspace_id }, "Failed to sync WorkOS org membership on accept")
@@ -141,6 +141,7 @@ export class InvitationShadowService {
     kind: "email" | "link"
     email: string | null
     tokenHash: string | null
+    roleSlug: WorkspaceInvitableRole
     expiresAt: Date
     inviterWorkosUserId?: string
   }) {
@@ -162,6 +163,7 @@ export class InvitationShadowService {
         email: params.email,
         organizationId: orgId,
         inviterWorkosUserId: params.inviterWorkosUserId,
+        roleSlug: shadow.role_slug,
       })
     }
 
@@ -261,6 +263,7 @@ export class InvitationShadowService {
       email: params.email,
       organizationId: orgId,
       inviterWorkosUserId: params.inviterWorkosUserId,
+      roleSlug: updated.role_slug,
     })
   }
 
@@ -269,12 +272,14 @@ export class InvitationShadowService {
     email: string
     organizationId: string
     inviterWorkosUserId: string
+    roleSlug: WorkspaceInvitableRole
   }): Promise<void> {
     try {
       const workosInvitation = await this.workosOrgService.sendInvitation({
         organizationId: params.organizationId,
         email: params.email,
         inviterUserId: params.inviterWorkosUserId,
+        roleSlug: params.roleSlug,
       })
       await InvitationShadowRepository.setWorkosInvitationId(this.pool, params.shadowId, workosInvitation.id)
     } catch (error) {

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -112,6 +112,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/backoffice/workspaces", auth, requirePlatformAdmin, backoffice.listWorkspaces)
   app.get("/api/backoffice/workspaces/:id", auth, requirePlatformAdmin, backoffice.getWorkspace)
   app.get("/api/backoffice/workspaces/:id/members", auth, requirePlatformAdmin, backoffice.listWorkspaceMembers)
+  app.get("/api/backoffice/workspaces/:id/invitations", auth, requirePlatformAdmin, backoffice.listWorkspaceInvitations)
   app.get(
     "/api/backoffice/workspace-owner-invitations",
     auth,

--- a/apps/control-plane/tests/client.ts
+++ b/apps/control-plane/tests/client.ts
@@ -120,7 +120,14 @@ export async function createWorkspace(
 /** Create an invitation shadow via internal API */
 export async function createShadow(
   client: TestClient,
-  params: { id: string; workspaceId: string; email: string; region: string; expiresAt: string }
+  params: {
+    id: string
+    workspaceId: string
+    email: string
+    region: string
+    expiresAt: string
+    roleSlug?: string
+  }
 ) {
   const res = await client.internalRequest<{ shadow: unknown }>("POST", "/internal/invitation-shadows", params)
   if (res.status !== 201) {

--- a/apps/control-plane/tests/integration/backoffice-workspace-invitations.test.ts
+++ b/apps/control-plane/tests/integration/backoffice-workspace-invitations.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { HttpError, StubWorkosOrgService } from "@threa/backend-common"
+import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
+import { BackofficeService } from "../../src/features/backoffice/service"
+import { setupTestDatabase } from "./setup"
+
+/**
+ * The Members tab's "Pending invitations" section reads through
+ * `BackofficeService.listWorkspaceInvitations`. The contract:
+ *   - only `status='pending'` and non-expired rows surface,
+ *   - both `kind='email'` and `kind='link'` are returned (link rows have
+ *     `email: null`),
+ *   - `role_slug` is preserved on the wire,
+ *   - inviter user is resolved via WorkOS, with graceful null fallback.
+ */
+describe("BackofficeService.listWorkspaceInvitations", () => {
+  let pool: Pool
+  let workos: StubWorkosOrgService
+  let service: BackofficeService
+
+  const region = "us-east-1"
+  const workspaceId = "ws_invitations_test"
+  const orgId = "org_invitations_test"
+  const inviterUserId = "user_inviter_for_invs"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("TRUNCATE invitation_shadows, workspace_registry CASCADE")
+    workos = new StubWorkosOrgService()
+    service = new BackofficeService({
+      pool,
+      workosOrgService: workos,
+      workspaceAppBaseUrl: "",
+      workosEnvironmentId: null,
+    })
+
+    workos.users.set(inviterUserId, {
+      id: inviterUserId,
+      email: "inviter@example.com",
+      firstName: "In",
+      lastName: "Viter",
+    })
+
+    await pool.query(
+      `INSERT INTO workspace_registry (id, name, slug, region, created_by_workos_user_id, workos_organization_id)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [workspaceId, "Inv Test", "inv-test", region, inviterUserId, orgId]
+    )
+  })
+
+  async function seedShadow(params: {
+    id: string
+    kind: "email" | "link"
+    email: string | null
+    roleSlug?: string
+    status?: "pending" | "accepted" | "revoked"
+    expiresInDays?: number
+    inviterWorkosUserId?: string | null
+  }) {
+    await pool.query(
+      `INSERT INTO invitation_shadows
+        (id, workspace_id, kind, email, region, expires_at, role_slug, status, inviter_workos_user_id, token_hash)
+       VALUES ($1, $2, $3, $4, $5, NOW() + ($6 || ' days')::INTERVAL, $7, $8, $9, $10)`,
+      [
+        params.id,
+        workspaceId,
+        params.kind,
+        params.email,
+        region,
+        String(params.expiresInDays ?? 7),
+        params.roleSlug ?? WORKSPACE_ROLE_SLUGS.MEMBER,
+        params.status ?? "pending",
+        params.inviterWorkosUserId === null ? null : (params.inviterWorkosUserId ?? inviterUserId),
+        params.kind === "link" ? `h_${params.id}` : null,
+      ]
+    )
+  }
+
+  test("returns pending email and link invitations with role_slug and resolved inviter", async () => {
+    await seedShadow({
+      id: "inv_email_admin",
+      kind: "email",
+      email: "bob@example.com",
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+    })
+    await seedShadow({
+      id: "inv_link_member",
+      kind: "link",
+      email: null,
+      roleSlug: WORKSPACE_ROLE_SLUGS.MEMBER,
+    })
+
+    const invitations = await service.listWorkspaceInvitations(workspaceId)
+
+    expect(invitations).toContainEqual(
+      expect.objectContaining({
+        id: "inv_email_admin",
+        kind: "email",
+        email: "bob@example.com",
+        roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+        inviter: expect.objectContaining({
+          workosUserId: inviterUserId,
+          email: "inviter@example.com",
+          name: "In Viter",
+        }),
+      })
+    )
+    expect(invitations).toContainEqual(
+      expect.objectContaining({
+        id: "inv_link_member",
+        kind: "link",
+        email: null,
+        roleSlug: WORKSPACE_ROLE_SLUGS.MEMBER,
+      })
+    )
+  })
+
+  test("excludes accepted, revoked, and expired invitations", async () => {
+    await seedShadow({ id: "inv_pending", kind: "email", email: "ok@example.com" })
+    await seedShadow({ id: "inv_accepted", kind: "email", email: "done@example.com", status: "accepted" })
+    await seedShadow({ id: "inv_revoked", kind: "email", email: "no@example.com", status: "revoked" })
+    await seedShadow({ id: "inv_expired", kind: "email", email: "old@example.com", expiresInDays: -1 })
+
+    const invitations = await service.listWorkspaceInvitations(workspaceId)
+
+    expect(invitations.map((i) => i.id)).toEqual(["inv_pending"])
+  })
+
+  test("returns inviter: null when the shadow has no inviter recorded", async () => {
+    await seedShadow({
+      id: "inv_no_inviter",
+      kind: "email",
+      email: "anon@example.com",
+      inviterWorkosUserId: null,
+    })
+
+    const invitations = await service.listWorkspaceInvitations(workspaceId)
+
+    expect(invitations).toContainEqual(expect.objectContaining({ id: "inv_no_inviter", inviter: null }))
+  })
+
+  test("returns inviter with null name/email when the WorkOS user lookup misses", async () => {
+    await seedShadow({
+      id: "inv_unknown_inviter",
+      kind: "email",
+      email: "missing-inviter@example.com",
+      inviterWorkosUserId: "user_unknown",
+    })
+
+    const invitations = await service.listWorkspaceInvitations(workspaceId)
+
+    expect(invitations).toContainEqual(
+      expect.objectContaining({
+        id: "inv_unknown_inviter",
+        inviter: { workosUserId: "user_unknown", email: null, name: null },
+      })
+    )
+  })
+
+  test("throws 404 when the workspace does not exist", async () => {
+    let caught: unknown
+    try {
+      await service.listWorkspaceInvitations("ws_does_not_exist")
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(HttpError)
+    expect((caught as HttpError).status).toBe(404)
+  })
+})

--- a/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
+++ b/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { Pool } from "pg"
+import { StubWorkosOrgService } from "@threa/backend-common"
+import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
+import { InvitationShadowRepository, InvitationShadowService } from "../../src/features/invitation-shadows"
+import type { RegionalClient } from "../../src/lib/regional-client"
+import { setupTestDatabase } from "./setup"
+
+/**
+ * The role chosen at the regional `sendInvitations`/`createLink` call site
+ * must land on the WorkOS invitation and the resulting org membership — CP
+ * is not allowed to silently downgrade to "member".
+ */
+describe("InvitationShadowService role_slug propagation", () => {
+  let pool: Pool
+  let workos: StubWorkosOrgService
+  let regional: RegionalClient
+  let service: InvitationShadowService
+
+  const region = "us-east-1"
+  const workspaceId = "ws_role_slug_test"
+  const orgId = "org_role_slug_test"
+  const inviterUserId = "user_inviter_role_slug"
+  const inviteeUserId = "user_invitee_role_slug"
+  const inviteeEmail = "role-slug-invitee@example.com"
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    // Sibling tests share these tables; truncate to keep this suite hermetic.
+    await pool.query("TRUNCATE invitation_shadows, workspace_registry CASCADE")
+    workos = new StubWorkosOrgService()
+    // Service touches the regional client only on the accept path, which this
+    // suite doesn't exercise. A bare object satisfies the type without binding
+    // to a live region map.
+    regional = {} as RegionalClient
+    service = new InvitationShadowService({ pool, regionalClient: regional, workosOrgService: workos })
+
+    await pool.query(
+      `INSERT INTO workspace_registry (id, name, slug, region, created_by_workos_user_id, workos_organization_id)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [workspaceId, "Role Slug Test", "role-slug-test", region, inviterUserId, orgId]
+    )
+  })
+
+  test("createShadow persists role_slug and forwards it to WorkOS sendInvitation", async () => {
+    const shadow = await service.createShadow({
+      id: "inv_role_admin",
+      workspaceId,
+      region,
+      kind: "email",
+      email: inviteeEmail,
+      tokenHash: null,
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      inviterWorkosUserId: inviterUserId,
+    })
+
+    expect(shadow.role_slug).toBe(WORKSPACE_ROLE_SLUGS.ADMIN)
+
+    const sent = [...workos.sentInvitations.values()]
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toMatchObject({
+      organizationId: orgId,
+      email: inviteeEmail,
+      inviterUserId,
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+    })
+  })
+
+  test("createShadow with kind='link' persists role_slug without sending an invitation yet", async () => {
+    const shadow = await service.createShadow({
+      id: "inv_link_admin",
+      workspaceId,
+      region,
+      kind: "link",
+      email: null,
+      tokenHash: "h_link_admin",
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      inviterWorkosUserId: inviterUserId,
+    })
+
+    expect(shadow.role_slug).toBe(WORKSPACE_ROLE_SLUGS.ADMIN)
+    expect(workos.sentInvitations.size).toBe(0)
+  })
+
+  test("acceptLinkClaim binds the email and sends WorkOS invitation with the stored role_slug", async () => {
+    await service.createShadow({
+      id: "inv_link_for_claim",
+      workspaceId,
+      region,
+      kind: "link",
+      email: null,
+      tokenHash: "h_link_for_claim",
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      inviterWorkosUserId: inviterUserId,
+    })
+
+    await service.acceptLinkClaim({
+      id: "inv_link_for_claim",
+      email: inviteeEmail,
+      inviterWorkosUserId: inviterUserId,
+    })
+
+    const sent = [...workos.sentInvitations.values()]
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toMatchObject({
+      organizationId: orgId,
+      email: inviteeEmail,
+      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+    })
+  })
+
+  test("repository.insert defaults to member when caller omits role_slug via the DB default", async () => {
+    // Direct INSERT bypasses the application path so the column default is
+    // what's under test here — covers legacy rows that pre-date the column.
+    await pool.query(
+      `INSERT INTO invitation_shadows (id, workspace_id, kind, email, region, expires_at)
+       VALUES ($1, $2, 'email', $3, $4, NOW() + INTERVAL '7 days')`,
+      ["inv_legacy_no_role", workspaceId, "legacy@example.com", region]
+    )
+
+    const row = await InvitationShadowRepository.findById(pool, "inv_legacy_no_role")
+    expect(row?.role_slug).toBe(WORKSPACE_ROLE_SLUGS.MEMBER)
+  })
+
+  test("acceptShadow with stored role_slug='admin' grants the WorkOS membership at the admin role", async () => {
+    // Seed a shadow that's already been claimed (email bound) so we can hit
+    // acceptShadow without going through the regional accept hop.
+    await pool.query(
+      `INSERT INTO invitation_shadows
+        (id, workspace_id, kind, email, region, expires_at, role_slug, status)
+       VALUES ($1, $2, 'email', $3, $4, NOW() + INTERVAL '7 days', $5, 'pending')`,
+      ["inv_accept_admin", workspaceId, inviteeEmail, region, WORKSPACE_ROLE_SLUGS.ADMIN]
+    )
+
+    // Replace the regional accept path with a no-op so we don't hit HTTP.
+    service["regionalClient"] = {
+      acceptInvitation: async () => ({ workspaceId }),
+    } as unknown as RegionalClient
+
+    await service.acceptShadow("inv_accept_admin", {
+      id: inviteeUserId,
+      email: inviteeEmail,
+      firstName: "Role",
+      lastName: "Slug",
+    })
+
+    const memberships = await workos.listOrganizationMemberships(orgId)
+    const member = memberships.find((m) => m.userId === inviteeUserId)
+    expect(member).toBeDefined()
+    expect(member?.roleSlugs).toEqual([WORKSPACE_ROLE_SLUGS.ADMIN])
+  })
+})

--- a/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
+++ b/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
@@ -64,14 +64,14 @@ describe("InvitationShadowService role_slug propagation", () => {
 
     expect(shadow.role_slug).toBe(WORKSPACE_ROLE_SLUGS.ADMIN)
 
-    const sent = [...workos.sentInvitations.values()]
-    expect(sent).toHaveLength(1)
-    expect(sent[0]).toMatchObject({
-      organizationId: orgId,
-      email: inviteeEmail,
-      inviterUserId,
-      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
-    })
+    expect([...workos.sentInvitations.values()]).toContainEqual(
+      expect.objectContaining({
+        organizationId: orgId,
+        email: inviteeEmail,
+        inviterUserId,
+        roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+      })
+    )
   })
 
   test("createShadow with kind='link' persists role_slug without sending an invitation yet", async () => {
@@ -88,7 +88,7 @@ describe("InvitationShadowService role_slug propagation", () => {
     })
 
     expect(shadow.role_slug).toBe(WORKSPACE_ROLE_SLUGS.ADMIN)
-    expect(workos.sentInvitations.size).toBe(0)
+    expect([...workos.sentInvitations.values()]).not.toContainEqual(expect.objectContaining({ organizationId: orgId }))
   })
 
   test("acceptLinkClaim binds the email and sends WorkOS invitation with the stored role_slug", async () => {
@@ -110,13 +110,13 @@ describe("InvitationShadowService role_slug propagation", () => {
       inviterWorkosUserId: inviterUserId,
     })
 
-    const sent = [...workos.sentInvitations.values()]
-    expect(sent).toHaveLength(1)
-    expect(sent[0]).toMatchObject({
-      organizationId: orgId,
-      email: inviteeEmail,
-      roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
-    })
+    expect([...workos.sentInvitations.values()]).toContainEqual(
+      expect.objectContaining({
+        organizationId: orgId,
+        email: inviteeEmail,
+        roleSlug: WORKSPACE_ROLE_SLUGS.ADMIN,
+      })
+    )
   })
 
   test("repository.insert defaults to member when caller omits role_slug via the DB default", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.12",
+        "@threa/types": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.561.0",

--- a/packages/backend-common/src/auth/workos-org-service.stub.ts
+++ b/packages/backend-common/src/auth/workos-org-service.stub.ts
@@ -23,6 +23,14 @@ export class StubWorkosOrgService implements WorkosOrgService {
    * it via `setOrganizationMemberships`.
    */
   private membershipsByOrg = new Map<string, WorkosOrganizationMembership[]>()
+  /**
+   * Test helper: records every `sendInvitation` call by the returned id so
+   * tests can assert the exact role/org/email that landed at WorkOS.
+   */
+  public sentInvitations = new Map<
+    string,
+    { organizationId?: string; email: string; inviterUserId: string; roleSlug?: string }
+  >()
 
   async createOrganization(params: { name: string; externalId: string }): Promise<{ id: string }> {
     const id = `org_stub_${ulid()}`
@@ -44,6 +52,7 @@ export class StubWorkosOrgService implements WorkosOrgService {
     organizationId?: string
     email: string
     inviterUserId: string
+    roleSlug?: string
   }): Promise<{ id: string; expiresAt: Date }> {
     const id = `inv_stub_${ulid()}`
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
@@ -61,7 +70,16 @@ export class StubWorkosOrgService implements WorkosOrgService {
         acceptedUserId: null,
       })
     }
-    logger.info({ invitationId: id, email: params.email }, "Stub: Sent invitation (no email)")
+    this.sentInvitations.set(id, {
+      ...(params.organizationId ? { organizationId: params.organizationId } : {}),
+      email: params.email,
+      inviterUserId: params.inviterUserId,
+      ...(params.roleSlug ? { roleSlug: params.roleSlug } : {}),
+    })
+    logger.info(
+      { invitationId: id, email: params.email, roleSlug: params.roleSlug },
+      "Stub: Sent invitation (no email)"
+    )
     return { id, expiresAt }
   }
 
@@ -170,9 +188,7 @@ export class StubWorkosOrgService implements WorkosOrgService {
     logger.info({ organizationMembershipId }, "Stub: Removed organization membership")
   }
 
-  private findMembershipById(
-    organizationMembershipId: string
-  ): {
+  private findMembershipById(organizationMembershipId: string): {
     orgId: string
     memberships: WorkosOrganizationMembership[]
     index: number

--- a/packages/backend-common/src/auth/workos-org-service.ts
+++ b/packages/backend-common/src/auth/workos-org-service.ts
@@ -96,6 +96,8 @@ export interface WorkosOrgService {
     organizationId?: string
     email: string
     inviterUserId: string
+    /** WorkOS role slug applied when the invitation is accepted. */
+    roleSlug?: string
   }): Promise<{ id: string; expiresAt: Date }>
   revokeInvitation(invitationId: string): Promise<void>
   /** Resend an existing invitation. WorkOS issues a fresh token + expiry. */
@@ -199,13 +201,18 @@ export class WorkosOrgServiceImpl implements WorkosOrgService {
     organizationId?: string
     email: string
     inviterUserId: string
+    roleSlug?: string
   }): Promise<{ id: string; expiresAt: Date }> {
     const invitation = await this.workos.userManagement.sendInvitation({
       email: params.email,
       inviterUserId: params.inviterUserId,
       ...(params.organizationId ? { organizationId: params.organizationId } : {}),
+      ...(params.roleSlug ? { roleSlug: params.roleSlug } : {}),
     })
-    logger.info({ invitationId: invitation.id, email: params.email }, "Sent WorkOS invitation")
+    logger.info(
+      { invitationId: invitation.id, email: params.email, roleSlug: params.roleSlug },
+      "Sent WorkOS invitation"
+    )
     return {
       id: invitation.id,
       expiresAt: new Date(invitation.expiresAt),


### PR DESCRIPTION
## Problem

Two related gaps in the invitation surface, addressed together because PR-5b is the operator-visible verification that PR-5e is doing the right thing.

### PR-5e — `role_slug` was silently downgraded to `member`

- `InvitationShadowService.acceptShadow` hardcoded `roleSlug: "member"` when calling `ensureOrganizationMembership` regardless of which role the inviter actually picked at `sendInvitations` / `createInvitationLink` (`apps/control-plane/src/features/invitation-shadows/service.ts:121`, pre-PR).
- The outbox payloads (`invitation:sent`, `invitation:link-created`) already carry a `role` field, but `InvitationShadowSyncHandler` discarded it before calling CP.
- `CreateInvitationShadow` on the CP wire didn't accept `roleSlug` at all, so even if the backend forwarded it, CP would have ignored it and `sendInvitation` would hit WorkOS without a role.

Net effect: even after PR-5a wired backend role enforcement and PR-5c wired the regional accept membership at the right role, every WorkOS invitation (and therefore every freshly-accepted membership materialized by the CP-side ensure call) landed as `member`.

### PR-5b — pending invitations were invisible to platform admins

The WorkOS authz mirror (`workos_organization_memberships`, #479) only sees post-accept memberships. Pending `invitation_shadows` — and especially `kind='link'` rows which never touch WorkOS until somebody claims them — were not visible anywhere in the backoffice. We could not verify end-to-end that PR-5e actually persists the right `role_slug` without inspecting the database.

## Solution

### PR-5e: plumbing-only — thread `role_slug` end-to-end

```
Backend regional sendInvitations / createInvitationLink
  └─ writes invitation row (role: WorkspaceInvitableRole)
     └─ writes outbox event "invitation:sent" / "invitation:link-created"
        with payload.role: WorkspaceInvitableRole
           │
           │  shadow-sync outbox handler
           ▼
      POST /internal/invitation-shadows { ..., roleSlug }
           │
           │  CP InvitationShadowService.createShadow
           ▼
      INSERT invitation_shadows (..., role_slug)
           │
           │  CP InvitationShadowService.sendWorkosInvitationForShadow
           ▼
      workos.userManagement.sendInvitation({ ..., roleSlug })
```

On accept (`POST /api/invitations/:id/accept`):

```
CP InvitationShadowService.acceptShadow(shadow)
  └─ workos.ensureOrganizationMembership({ roleSlug: shadow.role_slug })
                                                       ▲
                                            no longer "member"
```

For link invitations, `role_slug` is persisted at link creation and re-read by `acceptLinkClaim` when an email finally binds — the WorkOS invite is sent with the role the creator chose.

### PR-5b: backoffice "Pending invitations" section

A new `GET /api/backoffice/workspaces/:id/invitations` returns pending, non-expired `invitation_shadows` rows — both `kind='email'` and `kind='link'` — with `roleSlug`, expiry, and a best-effort inviter lookup. The workspace Members tab gains a "Pending invitations" Section above the existing Members list. Each row shows the kind badge, role chip, inviter (when resolvable), and relative expiry.

### Key design decisions

**1. Migration default `'member'`**

`role_slug TEXT NOT NULL DEFAULT 'member'`. The default exists for rows inserted before the migration (none in practice, but enforced at the column level so a partial deploy can't break invariants). The application-path validator (`z.enum(WORKSPACE_INVITABLE_ROLES)`) is the authoritative source on write — the default is only a safety net for legacy direct-INSERT paths, which the test suite exercises.

**2. `role_slug` is typed as `WorkspaceInvitableRole`, not `string`**

The wire/zod boundary in `handlers.ts` already narrows via `z.enum(WORKSPACE_INVITABLE_ROLES)`, so the in-process types match. Tightening this also tightened the upstream outbox payload types (`InvitationSentOutboxPayload.role` etc.), which were already being written with `WorkspaceInvitableRole` but typed as `string` — that's now consistent end-to-end.

**3. `role_slug` is NOT updated on `ON CONFLICT` in the CP insert**

The repository's `ON CONFLICT (id) DO UPDATE SET` clause only touches `expires_at` and `inviter_workos_user_id`. `role_slug` is intentionally first-writer-wins — a replay or retry of an outbox event must not silently change the role on an existing shadow (INV-20).

**4. New stub surface: `StubWorkosOrgService.sentInvitations`**

Test assertion surface only. Records every `sendInvitation` call by its returned id so integration tests can verify the exact `{ organizationId, email, inviterUserId, roleSlug }` that reached WorkOS. No production caller reads from it.

**5. PR-5b inviter resolution is best-effort, not blocking**

`listWorkspaceInvitations` deduplicates inviter ids, fans out parallel `workosOrgService.getUser` calls, and falls back to `inviter: null` (or `inviter: { workosUserId, email: null, name: null }` when a single user lookup fails) instead of failing the whole list. A WorkOS hiccup must not blank out the operator view.

**6. PR-5b stacks on PR-5e instead of landing as a separate PR**

The natural verification path for PR-5e is "log into backoffice → look at the Members tab → see the admin invite I just sent with `roleSlug: admin`". Shipping the two together gives reviewers an end-to-end view in one diff rather than two round-trips.

## Sequencing

- **PR-5a** (#498, merged): backend invitations carry `role`, backend enforcement at send time.
- **PR-5c** (#499, merged): regional accept path materializes the workspace membership at the inviter-chosen role.
- **PR-5e + PR-5b** (this PR): CP shadow + WorkOS path stops hardcoding `member`, and backoffice surfaces pending invitations so the result is visible.
- **PR-5d** (next): regional API for role changes (with corresponding WorkOS `changeOrganizationMembershipRole`).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/control-plane/src/db/migrations/008_invitation_shadow_role_slug.sql` | Adds `role_slug TEXT NOT NULL DEFAULT 'member'` to `invitation_shadows`. |
| `apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts` | 5 integration tests covering admin-role propagation through email/link/accept paths + legacy-row DB default. |
| `apps/control-plane/tests/integration/backoffice-workspace-invitations.test.ts` | 5 integration tests covering the new `listWorkspaceInvitations` contract (pending email + link, exclusion of accepted/revoked/expired, null inviter fallback, missing-WorkOS-user fallback, 404 on unknown workspace). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/invitations/shadow-sync-outbox-handler.ts` | Destructure `role` from outbox payload, forward as `roleSlug` to `createInvitationShadow` for both email and link events. |
| `apps/backend/src/lib/control-plane-client.ts` | `createInvitationShadow` params gain required `roleSlug: WorkspaceInvitableRole`. |
| `apps/backend/src/lib/outbox/repository.ts` | `role` field on the three invitation outbox payloads typed as `WorkspaceInvitableRole`. |
| `apps/backoffice/src/api/backoffice.ts` | New `WorkspaceInvitation` type, `backofficeKeys.workspaceInvitations`, `listWorkspaceInvitations` fetcher. |
| `apps/backoffice/src/pages/workspace-detail-members.tsx` | New "Pending invitations" Section, `InvitationsBody`, `InvitationRow`, `KindBadge`, `formatRelativeFuture`. |
| `apps/backoffice/src/pages/workspace-detail-members.test.tsx` | URL-keyed fetch mock so the now-two-parallel queries are order-independent; 2 new tests for the pending invitations surface. |
| `apps/control-plane/src/features/backoffice/handlers.ts` | New `listWorkspaceInvitations` handler. |
| `apps/control-plane/src/features/backoffice/service.ts` | New `WorkspaceInvitationSummary` interface + `listWorkspaceInvitations` method with parallel inviter resolution. |
| `apps/control-plane/src/features/invitation-shadows/handlers.ts` | Zod schema accepts `roleSlug` (defaults to member). Forwarded into `service.createShadow`. |
| `apps/control-plane/src/features/invitation-shadows/repository.ts` | `InvitationShadowRow.role_slug`, SELECT_FIELDS, INSERT VALUES. First-writer-wins on conflict. New `listPendingByWorkspace` for the backoffice read path. |
| `apps/control-plane/src/features/invitation-shadows/service.ts` | `acceptShadow` uses `shadow.role_slug`; `createShadow`/`acceptLinkClaim` thread the role into the WorkOS send call. |
| `apps/control-plane/src/routes.ts` | Registers `GET /api/backoffice/workspaces/:id/invitations` under `requirePlatformAdmin`. |
| `apps/control-plane/tests/client.ts` | Test helper `createShadow` accepts optional `roleSlug`. |
| `packages/backend-common/src/auth/workos-org-service.ts` | `sendInvitation` interface + impl take optional `roleSlug`, forwarded to WorkOS SDK. |
| `packages/backend-common/src/auth/workos-org-service.stub.ts` | New public `sentInvitations` Map for test assertions. Records every `sendInvitation` call. |

## Test plan

- [x] `bun run typecheck` clean across all 9 packages
- [x] PR-5e: 5 role-slug propagation tests pass (admin role email, admin role link, link-claim accept, legacy DB default, end-to-end accept→ensureOrganizationMembership at admin)
- [x] PR-5b: 5 `listWorkspaceInvitations` integration tests pass
- [x] PR-5b: 6 frontend `workspace-detail-members` tests pass (4 existing refactored + 2 new for the pending invitations surface)
- [x] Full CP integration suite: 0 fail
- [x] Backend invitations service tests: 0 fail
- [x] Lint clean across all 4 apps
- [ ] Manual: send an admin invitation in staging → recipient lands in WorkOS org with `admin` role (not silently downgraded)
- [ ] Manual: create an admin invitation link, claim it with a fresh email → resulting WorkOS invitation has `roleSlug: admin`
- [ ] Manual: as platform admin, open a workspace's Members tab → pending email + link invitations render with kind, role, inviter, and expiry

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLeMwKzjMr8iztp8do67dP)_