### PR TITLE
Render markdown for direct GitHub blob URLs to .md files

### DIFF
--- a/apps/backend/src/features/link-previews/github-preview.test.ts
+++ b/apps/backend/src/features/link-previews/github-preview.test.ts
@@ -488,4 +488,191 @@ describe("fetchGitHubPreview", () => {
       { route: "GET /repos/{owner}/{repo}/readme", params: { owner: "octocat", repo: "hello-world" } },
     ])
   })
+
+  test("renders blob URLs to .md files as markdown", async () => {
+    const preview = await fetchGitHubPreview(
+      "ws_123",
+      "https://github.com/octocat/hello-world/blob/main/docs/notes.md",
+      {
+        async getGithubClient() {
+          return {
+            async request(route: string, params?: Record<string, unknown>) {
+              if (route === "GET /repos/{owner}/{repo}") {
+                return {
+                  owner: { login: "octocat" },
+                  name: "hello-world",
+                  full_name: "octocat/hello-world",
+                  private: false,
+                }
+              }
+
+              if (route === "GET /repos/{owner}/{repo}/contents/{path}") {
+                if (params?.ref === "main" && params?.path === "docs/notes.md") {
+                  return {
+                    type: "file",
+                    content: Buffer.from("# Notes\n\nSome body text.").toString("base64"),
+                  }
+                }
+              }
+
+              throw new Error(`Unexpected route: ${route}`)
+            },
+          }
+        },
+      } as unknown as WorkspaceIntegrationService
+    )
+
+    expect(preview).toMatchObject({
+      previewType: "github_file",
+      title: "docs/notes.md",
+      previewData: {
+        data: {
+          renderMode: "markdown",
+          markdownContent: "# Notes\n\nSome body text.",
+          ref: "main",
+          path: "docs/notes.md",
+        },
+      },
+    })
+  })
+
+  test("renders .markdown blob URLs as markdown", async () => {
+    const preview = await fetchGitHubPreview(
+      "ws_123",
+      "https://github.com/octocat/hello-world/blob/main/CHANGELOG.markdown",
+      {
+        async getGithubClient() {
+          return {
+            async request(route: string, params?: Record<string, unknown>) {
+              if (route === "GET /repos/{owner}/{repo}") {
+                return {
+                  owner: { login: "octocat" },
+                  name: "hello-world",
+                  full_name: "octocat/hello-world",
+                  private: false,
+                }
+              }
+
+              if (
+                route === "GET /repos/{owner}/{repo}/contents/{path}" &&
+                params?.ref === "main" &&
+                params?.path === "CHANGELOG.markdown"
+              ) {
+                return {
+                  type: "file",
+                  content: Buffer.from("## v1\n\n- first release").toString("base64"),
+                }
+              }
+
+              throw new Error(`Unexpected route: ${route}`)
+            },
+          }
+        },
+      } as unknown as WorkspaceIntegrationService
+    )
+
+    expect(preview).toMatchObject({
+      previewType: "github_file",
+      previewData: {
+        data: {
+          renderMode: "markdown",
+          markdownContent: "## v1\n\n- first release",
+        },
+      },
+    })
+  })
+
+  test("keeps snippet view for blob URLs to .md files when a line range is requested", async () => {
+    const preview = await fetchGitHubPreview(
+      "ws_123",
+      "https://github.com/octocat/hello-world/blob/main/docs/notes.md#L2-L3",
+      {
+        async getGithubClient() {
+          return {
+            async request(route: string, params?: Record<string, unknown>) {
+              if (route === "GET /repos/{owner}/{repo}") {
+                return {
+                  owner: { login: "octocat" },
+                  name: "hello-world",
+                  full_name: "octocat/hello-world",
+                  private: false,
+                }
+              }
+
+              if (
+                route === "GET /repos/{owner}/{repo}/contents/{path}" &&
+                params?.ref === "main" &&
+                params?.path === "docs/notes.md"
+              ) {
+                return {
+                  type: "file",
+                  content: Buffer.from("# Notes\n\nSome body text.\nMore.").toString("base64"),
+                }
+              }
+
+              throw new Error(`Unexpected route: ${route}`)
+            },
+          }
+        },
+      } as unknown as WorkspaceIntegrationService
+    )
+
+    expect(preview).toMatchObject({
+      previewType: "github_file",
+      previewData: {
+        data: {
+          renderMode: "snippet",
+          markdownContent: null,
+          startLine: 2,
+          endLine: 3,
+          lines: [
+            { number: 2, text: "" },
+            { number: 3, text: "Some body text." },
+          ],
+        },
+      },
+    })
+  })
+
+  test("keeps snippet view for blob URLs to non-markdown files", async () => {
+    const preview = await fetchGitHubPreview("ws_123", "https://github.com/octocat/hello-world/blob/main/src/app.ts", {
+      async getGithubClient() {
+        return {
+          async request(route: string, params?: Record<string, unknown>) {
+            if (route === "GET /repos/{owner}/{repo}") {
+              return {
+                owner: { login: "octocat" },
+                name: "hello-world",
+                full_name: "octocat/hello-world",
+                private: false,
+              }
+            }
+
+            if (
+              route === "GET /repos/{owner}/{repo}/contents/{path}" &&
+              params?.ref === "main" &&
+              params?.path === "src/app.ts"
+            ) {
+              return {
+                type: "file",
+                content: Buffer.from("const x = 1").toString("base64"),
+              }
+            }
+
+            throw new Error(`Unexpected route: ${route}`)
+          },
+        }
+      },
+    } as unknown as WorkspaceIntegrationService)
+
+    expect(preview).toMatchObject({
+      previewType: "github_file",
+      previewData: {
+        data: {
+          renderMode: "snippet",
+          markdownContent: null,
+        },
+      },
+    })
+  })
 })

--- a/apps/backend/src/features/link-previews/github-preview.ts
+++ b/apps/backend/src/features/link-previews/github-preview.ts
@@ -343,7 +343,7 @@ async function fetchFilePreview(
   }))
   const truncated = parsed.lineStart == null ? allLines.length > endLine : false
   const language = detectProgrammingLanguage(resolved.path)
-  const renderMode = parsed.source === "blob" ? "snippet" : "markdown"
+  const renderMode = shouldRenderAsMarkdown(parsed, resolved.path) ? "markdown" : "snippet"
   const markdownContent = renderMode === "markdown" ? buildMarkdownPreview(lines, truncated) : null
 
   const preview: GitHubPreview = {
@@ -375,6 +375,15 @@ async function fetchFilePreview(
     status: "completed",
     expiresAt: minutesFromNow(15),
   }
+}
+
+const MARKDOWN_EXTENSIONS = new Set(["md", "markdown"])
+
+function shouldRenderAsMarkdown(parsed: Extract<GitHubUrlMatch, { type: "github_file" }>, path: string): boolean {
+  if (parsed.source !== "blob") return true
+  if (parsed.lineStart != null) return false
+  const extension = path.split(".").pop()?.toLowerCase() ?? ""
+  return MARKDOWN_EXTENSIONS.has(extension)
 }
 
 function buildMarkdownPreview(lines: Array<{ number: number; text: string }>, truncated: boolean): string | null {

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -577,7 +577,7 @@ function GitHubFileContent({ preview, data }: { preview: LinkPreviewSummary; dat
       {data.truncated && (
         <p className="mt-2 text-[11px] text-muted-foreground">
           {data.renderMode === "markdown"
-            ? "Showing the beginning of the README only."
+            ? "Showing the beginning of the file only."
             : "Showing the first snippet lines only."}
         </p>
       )}


### PR DESCRIPTION
## Summary

- Direct GitHub links to markdown files (e.g. `/blob/main/README.md`) currently render as a syntax-highlighted code snippet — users see raw `**bold**`, `# heading`, fenced code, etc. as characters. Tree and bare-repo URLs already route through the markdown renderer; this change extends that path to `/blob/.../foo.md` so the preview looks like GitHub's rendered file view.
- Restricted to `.md` and `.markdown` extensions. Blob URLs with an `#L…` line-range anchor keep the snippet view so the linked lines stay visible (matches GitHub's own "view rendered" vs. "view source" distinction).
- Generalized the truncation copy from "Showing the beginning of the README only." to "…of the file only." since non-README markdown files now hit the same code path.

## Implementation notes

- Extracted the render-mode decision into `shouldRenderAsMarkdown(parsed, path)` in `apps/backend/src/features/link-previews/github-preview.ts` so the policy is testable and readable. Non-blob → markdown (unchanged); blob with line range → snippet; blob to `.md`/`.markdown` without line range → markdown; everything else → snippet.
- Frontend renderer (`link-preview-card.tsx`) already routed `renderMode === "markdown"` through `<MarkdownContent>`, so no rendering changes were needed there — only the truncation hint copy.

## Test plan

- [x] `bun test apps/backend/src/features/link-previews/` — 127 pass, including four new cases for the blob-markdown path
- [x] `bun --filter @threa/backend typecheck` — clean
- [x] `bun --filter @threa/frontend typecheck` — clean
- [x] Pre-commit hooks (lint, typecheck, OpenAPI check) — clean
- [ ] Manual smoke: paste `https://github.com/<owner>/<repo>/blob/main/README.md` into a stream and confirm headings/lists render rather than appearing as raw markdown
- [ ] Manual smoke: paste a `.md` link with `#L14-L17` anchor and confirm it still renders as a code snippet
- [ ] Manual smoke: paste a `.ts` blob link and confirm snippet view is unchanged

https://claude.ai/code/session_01DYzwfJXmSxKDmGRHPhNJEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYzwfJXmSxKDmGRHPhNJEh)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->