### PR TITLE
fix(timeline): remove layout shift on send and tighten head spacing

### DIFF
--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -534,7 +534,14 @@ function MessageLayout({
   // accessible name; heads already have a visible author label.
   const rowAriaLabel = renderAsContinuation ? `Message from ${actorName}` : undefined
   const rowDataGroupContinuation = renderAsContinuation ? "true" : undefined
-  const rowVerticalPadding = renderAsContinuation ? "py-0.5" : "py-3"
+  // Heads keep a generous top pad to separate groups visually, but a tight
+  // bottom pad so the gap from the head body to the first continuation body
+  // matches the cont-to-cont gap (4px). Without this, heads with a follow-up
+  // continuation got 12px+2px = 14px below them and the first message in a
+  // group felt detached. Group separation is preserved by the next head's
+  // pt-3 (2px + 12px = 14px between groups, consistent regardless of whether
+  // the previous group ended with a head or a continuation).
+  const rowVerticalPadding = renderAsContinuation ? "py-0.5" : "pt-3 pb-0.5"
   const isSelected = batch?.selectedMessageIds.has(payload.messageId) ?? false
   const isInvalidTarget = batch?.invalidTargetIds.has(payload.messageId) ?? false
   const isHoveredTarget = batch?.hoveredTargetId === payload.messageId
@@ -644,7 +651,8 @@ function MessageLayout({
               // Floats at the top of the row so hover interactions on heads and
               // continuations share the same toolbar. The 20px upward overlap keeps
               // the toolbar readable on py-0.5 continuations without pushing past
-              // the viewport — on heads (py-3) it sits just above the header row.
+              // the viewport — on heads (pt-3 pb-0.5) it sits just above the
+              // header row.
               "pointer-events-none absolute right-4 z-10 hidden sm:block",
               "bottom-[calc(100%-20px)] opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
               "has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100",
@@ -1368,8 +1376,15 @@ function PendingMessageEvent({
             </span>
           ) : null
         }
-        actions={
-          <div className="flex gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex">
+        // Edit/Delete live in the floating hover toolbar — same slot sent
+        // messages use — so the inline header height matches sent rows. Without
+        // this, the h-6 buttons inflated the `items-baseline` header row of a
+        // pending head, then collapsed when the message confirmed, shifting
+        // surrounding rows by a few pixels at the moment of send. The hover
+        // toolbar also renders for grouped continuations (where the header row
+        // is collapsed), which the inline `actions` slot couldn't.
+        hoverActions={
+          <>
             <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => void markEditing(event.id)}>
               Edit
             </Button>
@@ -1381,7 +1396,7 @@ function PendingMessageEvent({
             >
               Delete
             </Button>
-          </div>
+          </>
         }
         footer={null}
       />

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -655,6 +655,12 @@ function MessageLayout({
               // header row.
               "pointer-events-none absolute right-4 z-10 hidden sm:block",
               "bottom-[calc(100%-20px)] opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
+              // Keyboard users tabbing through the timeline land on the toolbar
+              // buttons even while it's visually hidden (opacity-0 doesn't
+              // remove descendants from the tab order, and `pointer-events-none`
+              // only affects mouse/touch). Reveal on `focus-within` so the
+              // focused control is visible.
+              "focus-within:pointer-events-auto focus-within:opacity-100",
               "has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100",
               "transition-opacity",
               isEditing && "pointer-events-none opacity-0"


### PR DESCRIPTION
## Problem

Sending a message in a stream caused a small but noticeable vertical layout shift right at the moment the message confirmed, and the first message in a same-author group sat awkwardly far from the rest of the group.

Two underlying causes, both in `apps/frontend/src/components/timeline/message-event.tsx`:

1. **Pending → sent height shift.** `PendingMessageEvent` passed its Edit/Delete buttons (`h-6` = 24 px tall) into the inline `actions` slot, which renders inside the header row's `flex items-baseline`. Those buttons inflated the row's baseline metrics by a few pixels even when `opacity-0`. When the message confirmed and re-rendered as `SentMessageEvent`, the inline actions were gone (sent rows use the absolutely-positioned `hoverActions` toolbar), so the row visibly shrank and shifted nearby rows.

2. **"Oddly spaced first message" in a group.** Heads used `py-3` (12 px top + 12 px bottom) and continuations used `py-0.5` (2 px). That left a 14 px gap from a head's body to its first continuation, but only 4 px between subsequent continuations — the head felt detached from the rest of the run.

A side effect of (1) also worth noting: because `actions` renders inside the header row and the header row is suppressed on continuations, pending Edit/Delete were never reachable on a pending continuation in a same-author run.

## Solution

### How it works

**Fix 1 — Move pending hover actions to the floating toolbar.** `PendingMessageEvent` now passes Edit/Delete to the same `hoverActions` slot that `SentMessageEvent` uses. The toolbar is absolutely positioned (`bottom-[calc(100%-20px)]`) so it doesn't contribute to inline header height. Pending and sent rows now have identical inline header metrics, eliminating the on-send shift. As a bonus, the toolbar also renders for grouped pending continuations.

**Fix 2 — Tight bottom padding on heads.** Heads now use `pt-3 pb-0.5` instead of `py-3` (continuations remain `py-0.5`):

|                                                  | Before          | After                  |
| ------------------------------------------------ | --------------- | ---------------------- |
| Within-group gap (head → first cont)             | 14 px           | **4 px**               |
| Within-group gap (cont → cont)                   | 4 px            | 4 px                   |
| Between-group gap (prev group ends with cont)    | 14 px           | 14 px                  |
| Between-group gap (prev group ends with head)    | 24 px           | **14 px** (consistent) |

Group separation is preserved by the next head's `pt-3` (2 px + 12 px = 14 px), now consistent regardless of whether the previous group ended with a head or a continuation.

### Key design decisions

**1. `hoverActions` instead of "make `actions` not take vertical space".**
Two cheaper-looking alternatives were considered: switch the inline wrapper from `opacity-0 group-hover:opacity-100` to `hidden group-hover:flex` (no inline space when hidden, but the row grows on hover — just moves the shift to a different trigger), or absolutely-position the inline actions wrapper (no shift, but a parallel implementation of the same toolbar pattern that already exists). Using `hoverActions` reuses the existing pattern, gives pending messages the same hover affordance as sent ones, and fixes the missing-on-continuation behavior as a freebie.

**2. Uniform `pt-3 pb-0.5` on every head, no `hasContinuationAfter` plumbing.**
Considered threading a `hasContinuationAfter` flag through `annotateAuthorGroups` so single-message "groups" could keep their wider `py-3` bottom. Rejected — between-group spacing was already inconsistent today (14 px or 24 px depending on whether the prior group ended with a head or a continuation), so unifying to 14 px is itself a fix. 14 px is in line with typical chat UIs and keeps groups clearly distinct without the extra plumbing.

**3. Failed messages left on the inline `actions` slot.**
`FailedMessageEvent` keeps its Retry/Edit/Delete inline. Failed is a terminal state that doesn't transition into sent, so the layout-shift concern doesn't apply, and the always-visible buttons are part of the "Failed to send" affordance.

## Modified files

| File                                                       | Change                                                                                                                                                                                                                              |
| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `apps/frontend/src/components/timeline/message-event.tsx`  | `rowVerticalPadding` for heads switched from `py-3` to `pt-3 pb-0.5`; `PendingMessageEvent` Edit/Delete moved from `actions` to `hoverActions`; updated comments referencing the old padding.                                       |

## Test plan

- [x] `bun run --filter=@threa/frontend test message-event` — 22 tests pass (includes the pending-message Edit/Delete render + click assertions)
- [x] `bun run --filter=@threa/frontend test timeline` — 199 tests pass
- [x] `bun run typecheck` — clean across the monorepo
- [ ] Manual verification: send a message at the bottom of a stream and confirm the row does not jump vertically as the timestamp appears
- [ ] Manual verification: send several messages back-to-back from the same author and confirm the first message of the group hugs its continuations (no extra gap below the head)
- [ ] Manual verification: hover a pending message on desktop and confirm Edit/Delete appear in the floating toolbar; click each to confirm they still call `markEditing` / `deleteMessage`
- [ ] Manual verification: pending message inside a same-author run shows the hover toolbar (previously didn't, because the inline `actions` slot was inside the suppressed header row)
- [ ] Manual verification: visual gap between two distinct same-author groups still reads as a clear separator (now uniformly 14 px regardless of prior group's last item)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013XM3zsevivgTEVjg2dBzru)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->