### PR TITLE
fix: don't trigger quote-reply when scrolling wide code blocks on mobile

### DIFF
--- a/apps/frontend/src/hooks/use-swipe-action.test.tsx
+++ b/apps/frontend/src/hooks/use-swipe-action.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useSwipeAction } from "./use-swipe-action"
+
+function touchEvent(target: EventTarget, x: number, y: number): React.TouchEvent {
+  return {
+    target,
+    touches: [{ clientX: x, clientY: y }],
+  } as unknown as React.TouchEvent
+}
+
+function makeScroller({
+  overflowX,
+  scrollWidth,
+  clientWidth,
+}: {
+  overflowX: string
+  scrollWidth: number
+  clientWidth: number
+}) {
+  const el = document.createElement("div")
+  el.style.overflowX = overflowX
+  Object.defineProperty(el, "scrollWidth", { value: scrollWidth, configurable: true })
+  Object.defineProperty(el, "clientWidth", { value: clientWidth, configurable: true })
+  const child = document.createElement("span")
+  el.appendChild(child)
+  document.body.appendChild(el)
+  return { el, child }
+}
+
+describe("useSwipeAction", () => {
+  it("ignores touches that start inside a horizontally-scrollable ancestor", () => {
+    const onSwipe = vi.fn()
+    const { result } = renderHook(() => useSwipeAction({ onSwipe }))
+    const { el, child } = makeScroller({ overflowX: "auto", scrollWidth: 500, clientWidth: 200 })
+
+    act(() => {
+      result.current.handlers.onTouchStart(touchEvent(child, 200, 100))
+      result.current.handlers.onTouchMove(touchEvent(child, 80, 100))
+      result.current.handlers.onTouchEnd()
+    })
+
+    expect(onSwipe).not.toHaveBeenCalled()
+    expect(result.current.offset).toBe(0)
+    expect(result.current.isLocked).toBe(false)
+
+    el.remove()
+  })
+
+  it("still tracks swipes when the ancestor has overflow-x:auto but no actual horizontal overflow", () => {
+    const onSwipe = vi.fn()
+    const { result } = renderHook(() => useSwipeAction({ onSwipe }))
+    const { el, child } = makeScroller({ overflowX: "auto", scrollWidth: 200, clientWidth: 200 })
+
+    act(() => {
+      result.current.handlers.onTouchStart(touchEvent(child, 200, 100))
+      result.current.handlers.onTouchMove(touchEvent(child, 80, 100))
+      result.current.handlers.onTouchEnd()
+    })
+
+    expect(onSwipe).toHaveBeenCalledTimes(1)
+
+    el.remove()
+  })
+
+  it("triggers onSwipe for a leftward swipe past threshold outside any scroller", () => {
+    const onSwipe = vi.fn()
+    const { result } = renderHook(() => useSwipeAction({ onSwipe, threshold: 80 }))
+    const target = document.createElement("div")
+    document.body.appendChild(target)
+
+    act(() => {
+      result.current.handlers.onTouchStart(touchEvent(target, 200, 100))
+      result.current.handlers.onTouchMove(touchEvent(target, 100, 100))
+      result.current.handlers.onTouchEnd()
+    })
+
+    expect(onSwipe).toHaveBeenCalledTimes(1)
+
+    target.remove()
+  })
+})

--- a/apps/frontend/src/hooks/use-swipe-action.ts
+++ b/apps/frontend/src/hooks/use-swipe-action.ts
@@ -24,6 +24,24 @@ interface UseSwipeActionReturn {
 }
 
 /**
+ * True when the touch began inside an element that can scroll horizontally
+ * (e.g. a wide code block's `<pre>` with `overflow-x: auto`). Those elements
+ * consume the horizontal gesture for scrolling, so the swipe-to-quote action
+ * must stay out of the way.
+ */
+function startedInHorizontalScroller(target: EventTarget | null): boolean {
+  let node = target instanceof Element ? target : null
+  while (node) {
+    const overflowX = window.getComputedStyle(node).overflowX
+    if ((overflowX === "auto" || overflowX === "scroll") && node.scrollWidth > node.clientWidth) {
+      return true
+    }
+    node = node.parentElement
+  }
+  return false
+}
+
+/**
  * Swipe-from-right gesture for mobile quote reply.
  * The user swipes left on a message; once they cross the threshold,
  * haptic feedback fires and the action locks in. Releasing triggers the callback.
@@ -53,6 +71,7 @@ export function useSwipeAction({
   const onTouchStart = useCallback(
     (e: React.TouchEvent) => {
       if (!enabled) return
+      if (startedInHorizontalScroller(e.target)) return
       const touch = e.touches[0]
       startPos.current = { x: touch.clientX, y: touch.clientY }
       isHorizontalRef.current = null


### PR DESCRIPTION
## Summary

On mobile, side-swiping inside a wide code block to scroll its contents horizontally was also pulling the message row's swipe-to-quote-reply gesture along for the ride — so once the user scrolled past ~80px the quote-reply would fire instead of (or in addition to) scrolling the code.

The fix: at `onTouchStart`, `useSwipeAction` walks up from the touch target and bails out if any ancestor is a horizontally-scrollable element (`overflow-x: auto|scroll` **and** `scrollWidth > clientWidth`). That keeps native horizontal scroll uncontested inside `<pre>` blocks (and any other horizontal scroller, e.g. wide tables) while leaving the swipe-to-quote gesture intact everywhere else.

Notes:
- Short code blocks with no actual horizontal overflow still respond to swipe-to-quote, because the `scrollWidth > clientWidth` check requires real overflow.
- Long-press is unaffected — it has its own `onTouchStart` and the fix is scoped to the swipe hook only.

## Test plan

- [x] Added unit coverage for `useSwipeAction` (`apps/frontend/src/hooks/use-swipe-action.test.tsx`): ignores swipes that start in a horizontally-overflowing ancestor; still tracks swipes when the ancestor declares `overflow-x: auto` but isn't actually overflowing; baseline left-swipe-past-threshold still triggers `onSwipe`.
- [ ] Manual mobile check: open a thread with a wide code block, scroll the code horizontally — quote-reply should not trigger. Swipe-left on the message body (outside the code block) — quote-reply should still trigger.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ju913RFwvA9YNuhpZP2gc)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->