### PR TITLE
docs: add "sweep before concluding absent" search guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ Read this before asking the user anything.
 
 **Search before you ask.** If a question has a factual answer in the repo ("is there a sync path from control-plane to backend?", "which model does persona X use?", "how does auth flow through the workspace-router?"), it is your job to find it. Use Grep, Glob, and the Agent tool. Start from `docs/system-overview.md`, `docs/architecture.md`, `docs/core-concepts.md`, then `apps/*/src/` and the relevant feature folder under `apps/backend/src/features/`. Escalate to the user only when (a) the search genuinely came back empty, (b) the decision is a preference the code cannot reveal, or (c) the action is destructive or irreversible.
 
+**Sweep before concluding absent.** Before claiming a UI or feature is missing, sweep `apps/*/src/{components,pages,features,stores,lib}/` with contains-match globs (`*settings*`, not `settings*` — the latter misses `workspace-settings`). A wrong negative compounded by confidence is worse than asking.
+
 **Prove you looked.** When you do ask, name what you already searched — file paths, grep patterns, docs read — so the user can redirect you instead of repeating the search. An unjustified clarifying question is worse than silence.
 
 **Follow instructions verbatim.** When CLAUDE.md, a skill, or the user says "always use X", "never do Y", or "use the /foo skill for Z", that is a binding constraint, not a suggestion. Re-read the relevant rule before acting in its domain — especially invariants (INV-*), the Greptile rule, and skill invocation rules.


### PR DESCRIPTION
## Problem

During PR-5d planning, I confidently told the user the main-app workspace member management UI didn't exist and proposed building it from scratch. It actually lives in `apps/frontend/src/components/workspace-settings/users-tab.tsx`. The mistake compounded a 2-PR split that should have been a single PR.

Root cause: my searches were too narrow.

1. Only checked `apps/frontend/src/pages/` (missed `components/`).
2. Checked `components/settings/` (personal settings) instead of `components/workspace-settings/`.
3. Used `find -name "settings*"` (prefix-match) which silently skipped `workspace-settings`.

The existing "Search before you ask." guidance in CLAUDE.md tells me to search before asking, but doesn't push back on a wrong negative result from a too-narrow sweep.

## Solution

Add a short follow-up paragraph in the Working Style section that codifies the lesson: sweep the candidate roots with contains-match globs before concluding a surface is missing.

```markdown
**Sweep before concluding absent.** Before claiming a UI or feature is missing,
sweep `apps/*/src/{components,pages,features,stores,lib}/` with contains-match
globs (`*settings*`, not `settings*` — the latter misses `workspace-settings`).
A wrong negative compounded by confidence is worse than asking.
```

### Key design decisions

**1. Land it next to "Search before you ask." rather than as a new top-level section**

The rule is a corollary to the existing "search first" guidance, not an independent principle. Keeping it adjacent keeps the Working Style section coherent.

**2. Keep it short**

An earlier draft included rhetorical framing ("Not in my first three searches is not the same as doesn't exist") and example failure phrases ("we'd need to build this from scratch"). Trimmed to the action (sweep these roots, use contains-match globs) plus the one-line lesson. CLAUDE.md is dense; new paragraphs need to earn their length.

**3. Name the specific glob trap**

`*settings*` vs `settings*` is the concrete failure mode that bit me — a future agent reading this should be able to identify it immediately in their own search history.

## Modified files

| File        | Change                                                                |
| ----------- | --------------------------------------------------------------------- |
| `CLAUDE.md` | +2 lines: "Sweep before concluding absent" paragraph in Working Style |

## Test plan

- [x] Verified diff is the 2-line addition only
- [x] Reread Working Style section in context to confirm the new paragraph flows

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLeMwKzjMr8iztp8do67dP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->