### PR TITLE
fix(timeline): keyboard-resize scroll drift + cold-boot collapse-cache mega jump

### DIFF
--- a/apps/frontend/src/hooks/use-scroll-behavior.test.tsx
+++ b/apps/frontend/src/hooks/use-scroll-behavior.test.tsx
@@ -1,8 +1,92 @@
-import { describe, it, expect } from "vitest"
-import { act, renderHook } from "@testing-library/react"
+import { describe, it, expect, afterEach } from "vitest"
+import { act, render, renderHook } from "@testing-library/react"
 import { useScrollBehavior } from "./use-scroll-behavior"
 
+type ResizeCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
+
+function installManualResizeObserver(): { trigger: () => void; restore: () => void } {
+  let lastCallback: ResizeCallback | null = null
+  const original = global.ResizeObserver
+  class ManualResizeObserver {
+    constructor(cb: ResizeCallback) {
+      lastCallback = cb
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.ResizeObserver = ManualResizeObserver as unknown as typeof ResizeObserver
+  return {
+    trigger: () => lastCallback?.([], {} as ResizeObserver),
+    restore: () => {
+      global.ResizeObserver = original
+    },
+  }
+}
+
+function makeScrollableDiv(initial: { scrollHeight: number; clientHeight: number; scrollTop?: number }) {
+  const el = document.createElement("div")
+  let scrollTop = initial.scrollTop ?? 0
+  let clientHeight = initial.clientHeight
+  const scrollHeight = initial.scrollHeight
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight })
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+  })
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v
+    },
+  })
+  return {
+    el,
+    get scrollTop() {
+      return scrollTop
+    },
+    setClientHeight: (h: number) => {
+      clientHeight = h
+    },
+  }
+}
+
+type HookApi = ReturnType<typeof useScrollBehavior>
+
+/**
+ * Mounts useScrollBehavior with `element` pre-attached to its scroll container
+ * ref. Direct-assigning the ref in the render body — rather than after
+ * renderHook returns — guarantees the hook's `useEffect` sees a populated ref
+ * on mount, which is what happens in production when JSX attaches the ref to a
+ * DOM element. Without this, the resize observer effect short-circuits on
+ * `if (!el) return` and the test exercises the wrong branch.
+ */
+function renderHookWithElement(
+  options: Parameters<typeof useScrollBehavior>[0],
+  element: HTMLDivElement
+): { current: HookApi } {
+  // Box the latest hook return through a stable wrapper so callers always see
+  // the post-update value after React re-renders — the local snapshot stays
+  // stale and reads like `isScrolledFarFromBottom` would never flip.
+  const ref: { current: HookApi | undefined } = { current: undefined }
+  function Probe() {
+    const api = useScrollBehavior(options)
+    api.scrollContainerRef.current = element
+    ref.current = api
+    return null
+  }
+  render(<Probe />)
+  if (!ref.current) throw new Error("Probe did not capture the hook return value")
+  return ref as { current: HookApi }
+}
+
 describe("useScrollBehavior", () => {
+  afterEach(() => {
+    // installManualResizeObserver returns a restore() function — tests that
+    // need cleanup call it directly so this hook stays defensive only.
+  })
+
   it("clears the jump-to-latest state when force-scrolling to the bottom", () => {
     const { result } = renderHook(() =>
       useScrollBehavior({
@@ -45,5 +129,54 @@ describe("useScrollBehavior", () => {
 
     expect(scrollTop).toBe(1000)
     expect(result.current.isScrolledFarFromBottom).toBe(false)
+  })
+
+  it("shifts scrollTop by the height delta when the container shrinks and user is not at bottom", async () => {
+    // Captures the keyboard-open scenario: container goes 800→500, user was
+    // scrolled away from the bottom. Without compensation the previously-
+    // visible bottom row would drift up by the 300px the container lost;
+    // the resize handler adds the delta to scrollTop so the bottom anchor
+    // tracks the same content.
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+      const apiRef = renderHookWithElement({ isLoading: false, itemCount: 100 }, scrollable.el)
+
+      // Initial mount triggers the auto-scroll useLayoutEffect, which pins
+      // scrollTop to scrollHeight (5000) and starts a 150ms grace period
+      // during which handleScroll won't clear shouldAutoScroll. Wait it out,
+      // then place the user mid-list and let handleScroll flip the flag.
+      await new Promise((r) => setTimeout(r, 200))
+      scrollable.el.scrollTop = 1000
+      act(() => apiRef.current.handleScroll())
+      expect(apiRef.current.isScrolledFarFromBottom).toBe(true)
+
+      // Container shrinks (keyboard opened): clientHeight 800 → 500.
+      scrollable.setClientHeight(500)
+      act(() => trigger())
+
+      expect(scrollable.scrollTop).toBe(1300)
+    } finally {
+      restore()
+    }
+  })
+
+  it("anchors to the bottom on resize when shouldAutoScroll is true", () => {
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ scrollHeight: 5000, clientHeight: 800 })
+      renderHookWithElement({ isLoading: false, itemCount: 100 }, scrollable.el)
+
+      // Initial mount auto-scrolls to bottom (scrollTop=scrollHeight=5000) and
+      // leaves shouldAutoScroll=true. Keyboard opens (clientHeight 800→500);
+      // the resize handler must pin scrollTop to scrollHeight rather than
+      // shift by the delta, so the latest message stays anchored above the
+      // composer.
+      scrollable.setClientHeight(500)
+      act(() => trigger())
+      expect(scrollable.scrollTop).toBe(5000)
+    } finally {
+      restore()
+    }
   })
 })

--- a/apps/frontend/src/hooks/use-scroll-behavior.ts
+++ b/apps/frontend/src/hooks/use-scroll-behavior.ts
@@ -178,8 +178,13 @@ export function useScrollBehavior({
     }
   })
 
-  // Auto-scroll to bottom when the container shrinks (e.g. mobile keyboard opens).
-  // This keeps the latest messages visible instead of being pushed off-screen.
+  // Re-anchor scroll position when the container resizes (e.g. mobile keyboard
+  // opens/closes). Goal: the bottom-most visible row stays glued to the bottom
+  // of the new viewport, so the message the user was reading doesn't drift
+  // behind the keyboard. When the container shrinks the browser preserves
+  // scrollTop, so the visible-area bottom moves UP relative to content by
+  // exactly the height delta — compensate by shifting scrollTop by that delta.
+  // Mirrors on grow so behavior is symmetric when the keyboard closes.
   useEffect(() => {
     const el = scrollContainerRef.current
     if (!el) return
@@ -188,10 +193,15 @@ export function useScrollBehavior({
 
     const observer = new ResizeObserver(() => {
       const newHeight = el.clientHeight
-      if (newHeight < prevHeight && shouldAutoScroll.current) {
-        el.scrollTop = el.scrollHeight
-      }
+      if (newHeight === prevHeight) return
+      const delta = prevHeight - newHeight
       prevHeight = newHeight
+
+      if (shouldAutoScroll.current) {
+        el.scrollTop = el.scrollHeight
+      } else if (delta !== 0) {
+        el.scrollTop += delta
+      }
     })
 
     observer.observe(el)

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -179,8 +179,20 @@ export function useVirtuosoScroll({
     [itemCount]
   )
 
-  // Re-scroll to bottom when the scroll container resizes (e.g. mobile keyboard
-  // opens/closes). Debounced to avoid fighting with the resize animation.
+  // Re-anchor scroll position when the scroll container resizes (e.g. mobile
+  // keyboard opens/closes). Two cases:
+  //  - User at bottom: scroll to LAST so the latest message stays glued
+  //    above the composer. Debounced because Chrome with
+  //    `interactive-widget=resizes-content` fires resize on every animation
+  //    frame, and scrollToIndex during the animation can fight Virtuoso's
+  //    own intra-resize reflow.
+  //  - User scrolled away from bottom: shift the scroller's scrollTop by
+  //    the height delta so the previously-visible bottom row stays anchored
+  //    at the new visible-area bottom. Browsers preserve scrollTop across
+  //    container shrink, so the bottom of the view otherwise drifts upward
+  //    relative to content and the message the user was reading slides
+  //    behind the keyboard. Applied synchronously across animation frames so
+  //    the anchor tracks continuously, not in a single jump at the end.
   const resizeTimerRef = useRef<number | undefined>(undefined)
 
   const handleScrollerRef = useCallback((ref: HTMLElement | Window | null) => {
@@ -197,16 +209,26 @@ export function useVirtuosoScroll({
   useEffect(() => {
     if (!scrollerEl) return
 
+    let prevHeight = scrollerEl.clientHeight
+
     const observer = new ResizeObserver(() => {
-      if (!isAtBottomRef.current) return
-      window.clearTimeout(resizeTimerRef.current)
-      resizeTimerRef.current = window.setTimeout(() => {
-        virtuosoRef.current?.scrollToIndex({
-          index: "LAST",
-          align: "end",
-          behavior: "auto",
-        })
-      }, 100)
+      const newHeight = scrollerEl.clientHeight
+      if (newHeight === prevHeight) return
+      const delta = prevHeight - newHeight
+      prevHeight = newHeight
+
+      if (isAtBottomRef.current) {
+        window.clearTimeout(resizeTimerRef.current)
+        resizeTimerRef.current = window.setTimeout(() => {
+          virtuosoRef.current?.scrollToIndex({
+            index: "LAST",
+            align: "end",
+            behavior: "auto",
+          })
+        }, 100)
+      } else if (delta !== 0) {
+        scrollerEl.scrollTop += delta
+      }
     })
 
     observer.observe(scrollerEl)

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -213,11 +213,15 @@ export function useVirtuosoScroll({
 
     const observer = new ResizeObserver(() => {
       const newHeight = scrollerEl.clientHeight
-      if (newHeight === prevHeight) return
       const delta = prevHeight - newHeight
       prevHeight = newHeight
 
       if (isAtBottomRef.current) {
+        // Always (re)arm the LAST scroll on every fire, including the initial
+        // observe() callback where delta is 0. Virtuoso's own
+        // initialTopMostItemIndex is not always sufficient when the scroller
+        // mounts inside a coordinated-loading gate; this acts as a safety net
+        // that lands the user at the bottom on first paint.
         window.clearTimeout(resizeTimerRef.current)
         resizeTimerRef.current = window.setTimeout(() => {
           virtuosoRef.current?.scrollToIndex({

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -45,13 +45,19 @@ if ("serviceWorker" in navigator) {
 // their first render, eliminating the post-mount resize cascade that Virtuoso
 // otherwise compensates for by shifting sibling rows.
 //
-// We race hydration against a short timeout: when IDB is healthy (the common
-// case, ~5–20ms) the await guarantees a populated cache on first paint; when
-// IDB is pathologically slow (busy disk, locked database, etc.) we mount
-// anyway and accept the original flip rather than block boot indefinitely.
-// `hydrateCollapseCache()` continues running and `notify()` wakes subscribers
-// once it finishes, so even after the timeout the cache eventually heals.
-const HYDRATION_CAP_MS = 100
+// We race hydration against a deadline: when IDB is healthy (the common case,
+// ~5–20ms) the await returns almost immediately; the deadline only fires when
+// `db.open()` itself is slow — cold-boot schema migrations, a contended IDB
+// connection, or a multi-thousand-row collapse table. 500ms is the headroom
+// we need to clear those cases without bailing too early; the previous 100ms
+// cap was tight enough that returning users with large collapse tables would
+// mount with an empty cache and then flip a previously-expanded long code
+// block from `defaultCollapsed=true` (small preview) to `persistedOverride=
+// false` (full block) on the next render — the "mega jump" reported in prod.
+// At the deadline we mount with whatever the cache holds; `hydrateCollapseCache`
+// keeps running and `notify()` still wakes subscribers, so the cache heals
+// even if the deadline fired.
+const HYDRATION_CAP_MS = 500
 
 async function bootstrap() {
   try {


### PR DESCRIPTION
## Summary

Two related fixes for first-load and mobile-keyboard layout instability.

### 1. Mobile keyboard resize anchors content (`2f08bf9`)

When the iOS/Android keyboard opens, the scroll container shrinks but the browser preserves `scrollTop`, so the bottom of the visible area drifts upward relative to content — the message the user is replying to slides behind the keyboard. The previous code only re-pinned to bottom when `shouldAutoScroll` was true, leaving the not-at-bottom case unhandled.

Both scroll hooks now react to the height delta:

- **At bottom**: snap to `scrollHeight` (plain) or `scrollToIndex("LAST")` (Virtuoso, debounced 100ms to avoid fighting Chrome's `interactive-widget=resizes-content` per-frame resizes).
- **Not at bottom**: shift `scrollTop` by `prevHeight - newHeight` so the previously-visible bottom row stays anchored at the new viewport bottom.

Mirrors on grow so behavior is symmetric when the keyboard closes.

### 2. Widen collapse-cache hydration deadline (`ebe5513`)

`HYDRATION_CAP_MS = 100` was tight enough that returning users with sizable `markdownBlockCollapse` tables or a pending IDB migration could mount React with an empty in-memory cache. A previously-expanded long code block would then paint with `defaultCollapsed=true` (3-line preview, ~60px) and immediately flip to `persistedOverride=false` (full block) once hydration completed — the "mega jump" reported in prod.

500ms covers the realistic worst case (cold-boot schema migration + a multi-thousand-row read) while still bailing on truly pathological IDB contention. The existing safety net is unchanged: `hydrateCollapseCache()` keeps running past the deadline and `notify()` still wakes subscribers, so the cache always heals even if we mount early.

## Test plan

- [x] `bun run test` for `use-scroll-behavior.test.tsx` (new tests for shrink-not-at-bottom and shrink-at-bottom branches via a manual `ResizeObserver` mock).
- [x] Collapse-cache + markdown-block tests (`code-block`, `blockquote-block`, `quote-reply-block`, `use-link-preview-collapse`) still pass.
- [x] `bun run typecheck` clean.
- [ ] Manual: open a thread on mobile (iOS Safari), focus the composer, verify the parent message stays anchored above the keyboard. Repeat in a channel (Virtuoso branch).
- [ ] Manual: with a previously-expanded long code block, hard refresh and confirm no visible "mega jump" cascade.

https://claude.ai/code/session_01UWmTEwHwL3nNG1se1AiwdK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWmTEwHwL3nNG1se1AiwdK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->