### PR TITLE
fix: register HorizontalRule extension so paste of --- does not silently fail

### DIFF
--- a/.claude/plans/fix-markdown-copy-paste.md
+++ b/.claude/plans/fix-markdown-copy-paste.md
@@ -1,0 +1,38 @@
+# Fix: Markdown paste silently fails when content contains horizontal rules
+
+## Goal
+
+Fix a bug where pasting markdown content containing `---` (horizontal rules) into the message composer results in nothing being pasted — the entire paste content is silently dropped.
+
+## What Was Built
+
+### Added HorizontalRule extension to the TipTap editor
+
+`parseMarkdown` from `@threa/prosemirror` correctly parses `---` into `{ type: "horizontalRule" }` nodes. However, the TipTap editor had no `HorizontalRule` extension registered, so when `insertContent` tried to create nodes from the parsed JSON, `schema.nodeType("horizontalRule")` threw `RangeError: Unknown node type: horizontalRule`.
+
+TipTap's `createNodeFromContent` catches this error internally and returns empty content (when `errorOnInvalidContent` is false). The command then succeeds with nothing to insert, and the paste handler calls `event.preventDefault()` thinking it handled the paste. The user sees nothing pasted.
+
+**Files:**
+- `apps/frontend/package.json` — Added `@tiptap/extension-horizontal-rule` dependency
+- `apps/frontend/src/components/editor/editor-extensions.ts` — Imported and registered `HorizontalRule` extension in the editor
+
+## Design Decisions
+
+### Register HorizontalRule as a standard block extension
+
+**Chose:** Added `@tiptap/extension-horizontal-rule` to the editor extensions array alongside other block-level extensions (Blockquote, CodeBlock, etc.)
+**Why:** The parser already handles `---` correctly; the gap was only in the editor schema. Adding the extension is the minimal, correct fix that makes paste work for any content containing horizontal rules.
+**Alternatives considered:** Filtering `horizontalRule` nodes out of parsed content before insertion — this would silently drop content, which is worse UX. Adding a try-catch in the paste handler — this would treat the symptom, not the cause.
+
+## What's NOT Included
+
+- No changes to the markdown parser/serializer — those correctly handle horizontal rules already
+- No CSS changes — the existing ProseMirror prose styling handles `<hr>` elements
+- No keyboard shortcut additions — `---` already auto-converts via input rules if the HorizontalRule extension is present
+
+## Status
+
+- [x] Added `@tiptap/extension-horizontal-rule` to `apps/frontend/package.json`
+- [x] Imported and registered `HorizontalRule` in `editor-extensions.ts`
+- [x] TypeScript typecheck passes
+- [x] All 104 markdown test pass (including existing horizontal rule round-trip tests)

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -56,6 +56,7 @@
     "@tiptap/extension-hard-break": "^3.22.3",
     "@tiptap/extension-heading": "^3.22.3",
     "@tiptap/extension-history": "^3.22.3",
+    "@tiptap/extension-horizontal-rule": "^3.22.3",
     "@tiptap/extension-italic": "^3.22.3",
     "@tiptap/extension-link": "^3.22.3",
     "@tiptap/extension-list-item": "^3.22.3",

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -11,6 +11,7 @@ import Placeholder from "@tiptap/extension-placeholder"
 import { AtomAwareBold, AtomAwareItalic, AtomAwareStrike, AtomAwareCode, BoundaryAwareLink } from "./atom-aware-marks"
 
 // Block extensions
+import HorizontalRule from "@tiptap/extension-horizontal-rule"
 import Blockquote from "@tiptap/extension-blockquote"
 import BulletList from "@tiptap/extension-bullet-list"
 import OrderedList from "@tiptap/extension-ordered-list"
@@ -81,6 +82,7 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
     OrderedList,
     ListItem,
     Blockquote,
+    HorizontalRule,
     CodeBlockLowlight.configure({
       lowlight,
       defaultLanguage: "plaintext",

--- a/bun.lock
+++ b/bun.lock
@@ -210,6 +210,7 @@
         "@tiptap/extension-hard-break": "^3.22.3",
         "@tiptap/extension-heading": "^3.22.3",
         "@tiptap/extension-history": "^3.22.3",
+        "@tiptap/extension-horizontal-rule": "^3.22.3",
         "@tiptap/extension-italic": "^3.22.3",
         "@tiptap/extension-link": "^3.22.3",
         "@tiptap/extension-list-item": "^3.22.3",


### PR DESCRIPTION
## Problem

Pasting markdown content that includes `---` (horizontal rules) into the message composer silently fails — nothing appears. This happens because `parseMarkdown` correctly produces `{ type: "horizontalRule" }` nodes, but the TipTap editor has no `HorizontalRule` extension registered. When `insertContent` tries to create nodes from the parsed JSON, `schema.nodeType("horizontalRule")` throws `RangeError: Unknown node type: horizontalRule`.

TipTap's `createNodeFromContent` catches this error internally (when `errorOnInvalidContent` is false) and returns empty content. The command then succeeds with nothing to insert, and the paste handler calls `event.preventDefault()` thinking it handled the paste. The user sees nothing pasted — no error, no feedback.

## Solution

Import and register `@tiptap/extension-horizontal-rule` in the editor extensions alongside other block-level extensions (Blockquote, CodeBlock, etc.).

### How it works

- The `parseMarkdown` parser already handles `---` → `{ type: "horizontalRule" }` correctly (with round-trip tests)
- The serializer already handles `horizontalRule` → `---` correctly
- The only gap was the missing extension registration in the editor schema
- Adding the extension means `insertContent` can create the node, and paste works end-to-end

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/package.json` | Added `@tiptap/extension-horizontal-rule` dependency |
| `apps/frontend/src/components/editor/editor-extensions.ts` | Imported and registered `HorizontalRule` extension |
| `bun.lock` | Lockfile update |

## Test plan

- [x] TypeScript typecheck passes across all packages
- [x] All 104 markdown editor tests pass (including horizontal rule parsing, serialization, and round-trip tests)
- [x] All lint checks pass
- [x] Pre-existing frontend date test failures are timezone-related and unrelated

## Notes

No new CSS, keyboard shortcuts, or parser changes needed — the TipTap extension handles rendering and the existing prose styling covers `<hr>` elements.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->