### PR TITLE
fix(timeline): match code-block placeholder line-height to shiki output

### DIFF
--- a/apps/frontend/src/lib/markdown/code-block.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.tsx
@@ -189,11 +189,17 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
         data-native-context="true"
       >
         {header}
+        {/* Match the exact font sizing/line-height shiki applies to its <pre> (via
+         * [&>pre]:* below) so swapping placeholder → highlighted HTML doesn't
+         * shift row height — that shift was the small post-load jump. */}
         <pre
-          className={cn("px-2.5 py-2 overflow-x-auto", bodyTogglesExpand && "cursor-pointer")}
+          className={cn(
+            "px-2.5 py-2 overflow-x-auto text-xs font-mono leading-snug",
+            bodyTogglesExpand && "cursor-pointer"
+          )}
           onClick={bodyClickHandler}
         >
-          <code className="text-xs font-mono leading-snug">{displayCode}</code>
+          <code>{displayCode}</code>
         </pre>
       </div>
     )


### PR DESCRIPTION
## Problem

After #510 fixed the cold-boot collapse-cache mega jump, staging still showed a small post-load jump on streams containing code blocks. Reliably reproducible: open a stream, watch rows below a code block shift up a few pixels once the block highlights.

## Solution

Equalize the line-box height of the code-block placeholder with shiki's output so swapping plain → highlighted HTML is layout-neutral.

### How it works

`CodeBlock` renders in two phases:

1. **Placeholder** (while `codeToHtml()` is async): a raw `<pre><code>{displayCode}</code></pre>` so the user sees text immediately.
2. **Highlighted**: `dangerouslySetInnerHTML` swaps in shiki's `<pre class="shiki">…</pre>` output, with utility classes applied via `[&>pre]:px-2.5 [&>pre]:py-2 [&>pre]:text-xs [&>pre]:leading-snug …`.

The placeholder previously put `text-xs leading-snug` on the inner `<code>`. Because `<code>` is inline, the **strut** of the line box is determined by the block-level `<pre>` — which inherited `text-sm` (14px) from the message body and used the browser's "normal" line-height (~1.2 → ~17px per line). Shiki's `<pre>` lays out at 12px × 1.375 = 16.5px per line.

That ~0.5px-per-line delta accumulated across each block, and Virtuoso re-measured the row when `codeToHtml` resolved, pushing siblings up — the small jump.

### Key design decisions

**1. Move `text-xs font-mono leading-snug` onto the placeholder `<pre>` instead of the inner `<code>`**

The strut is set by the block, so putting these classes on `<pre>` is what makes line-box height match shiki's. The inline `<code>` inherits font-size and line-height, so per-glyph layout is unchanged. Smallest possible change that fixes the strut mismatch.

**2. Don't touch the post-highlight wrapper**

Considered mirroring `font-mono` onto the shiki wrapper for symmetry, but shiki's `<pre>` picks up the browser-default `pre { font-family: monospace }` user-agent rule. Since `line-height` is explicit on both sides, font-family only affects glyph width — not row height — so equalizing it isn't needed for the jump fix and would expand blast radius without benefit.

**3. Leave the placeholder phase as-is**

Removing the placeholder entirely (e.g., pre-warming shiki at app startup) would also fix the jump but moves load-time cost into the critical path. Matching dimensions is the cheaper fix.

## Modified files

| File                                              | Change                                                                                                                                                          |
| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `apps/frontend/src/lib/markdown/code-block.tsx`   | Apply `text-xs font-mono leading-snug` to the placeholder `<pre>` so its strut matches shiki's post-resolve. Drop the now-redundant classes from inline `<code>`. |

## Test plan

- [x] `bun run test src/lib/markdown` — 91 tests passing (code-block collapse + persistence suites still green)
- [x] `bun run typecheck` — clean
- [ ] On staging: open a stream containing a long code block from a cold IDB. Verify no row-shift after shiki resolves.
- [ ] On staging: open a stream with only short prose (no code blocks). Confirm we haven't regressed the baseline case.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWmTEwHwL3nNG1se1AiwdK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->