### PR TITLE
fix(pwa): keep Threa links inside the installed PWA on Android

### DIFF
--- a/apps/frontend/public/manifest.json
+++ b/apps/frontend/public/manifest.json
@@ -3,9 +3,14 @@
   "short_name": "Threa",
   "description": "AI-powered knowledge chat — where critical information comes to thrive",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#0a0a0a",
   "theme_color": "#C8A055",
+  "handle_links": "preferred",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  },
   "share_target": {
     "action": "/share",
     "method": "POST",

--- a/apps/frontend/src/components/ui/markdown-content.test.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.test.tsx
@@ -1,8 +1,22 @@
 import { beforeEach, describe, it, expect, vi } from "vitest"
 import { spyOnExport } from "@/test/spy"
-import { render, screen } from "@testing-library/react"
+import { render as rtlRender, screen } from "@testing-library/react"
+import type { ReactElement } from "react"
+import { MemoryRouter } from "react-router-dom"
 import { MarkdownContent } from "./markdown-content"
 import * as codeBlockModule from "@/lib/markdown/code-block"
+
+// MarkdownLink intercepts same-origin links through useNavigate, which requires
+// a Router context. Wrap every render with MemoryRouter so existing tests
+// continue to exercise the real component tree. rerender is wrapped too so
+// the memoization test stays a true rerender of the same root.
+const render = (ui: ReactElement) => {
+  const result = rtlRender(<MemoryRouter>{ui}</MemoryRouter>)
+  return {
+    ...result,
+    rerender: (next: ReactElement) => result.rerender(<MemoryRouter>{next}</MemoryRouter>),
+  }
+}
 
 describe("MarkdownContent", () => {
   beforeEach(() => {
@@ -128,6 +142,22 @@ describe("MarkdownContent", () => {
       render(<MarkdownContent content="Visit www.example.com today" />)
       const link = screen.getByRole("link")
       expect(link).toHaveAttribute("href", "http://www.example.com")
+    })
+
+    it("should keep same-origin links in-app instead of opening a new tab", () => {
+      const internalUrl = `${window.location.origin}/w/ws_1/s/stream_1?m=msg_1`
+      render(<MarkdownContent content={`See [the message](${internalUrl})`} />)
+      const link = screen.getByRole("link", { name: "the message" })
+      expect(link).toHaveAttribute("href", internalUrl)
+      expect(link).not.toHaveAttribute("target")
+      expect(link).not.toHaveAttribute("rel")
+    })
+
+    it("should still open cross-origin links in a new tab", () => {
+      render(<MarkdownContent content="[outside](https://example.com/x)" />)
+      const link = screen.getByRole("link", { name: "outside" })
+      expect(link).toHaveAttribute("target", "_blank")
+      expect(link).toHaveAttribute("rel", "noopener noreferrer")
     })
   })
 

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -1,5 +1,6 @@
 import type { Components } from "react-markdown"
 import { Suspense, lazy, Component, Children, isValidElement, type ReactNode, type MouseEvent } from "react"
+import { useNavigate } from "react-router-dom"
 import { parseQuoteHref, parseSharedMessageHref } from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -10,6 +11,22 @@ import { useLinkPreviewContext } from "./link-preview-context"
 import { QuoteReplyBlock } from "./quote-reply-block"
 import { BlockquoteBlock } from "./blockquote-block"
 import { SharedMessagePointerBlock } from "./shared-message-block"
+
+/**
+ * Treat any link to our own origin as in-app navigation. Without this, a
+ * markdown link like `https://app.threa.io/w/.../s/...?m=msg_xxx` rendered
+ * inside the installed PWA on Android hops to a Custom Tab (browser chrome,
+ * "open in Firefox") because `target="_blank"` forces a new browsing context.
+ */
+function resolveInternalAppPath(href: string): string | null {
+  try {
+    const url = new URL(href, window.location.origin)
+    if (url.origin !== window.location.origin) return null
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return null
+  }
+}
 
 const CodeBlock = lazy(() => import("./code-block"))
 
@@ -115,6 +132,7 @@ function extractTextFromChildren(children: ReactNode): string {
 function MarkdownLink({ href, children }: { href?: string; children: ReactNode }) {
   const attachmentContext = useAttachmentContext()
   const linkPreviewContext = useLinkPreviewContext()
+  const navigate = useNavigate()
 
   // Check if this is an attachment link
   if (href?.startsWith("attachment:")) {
@@ -153,6 +171,29 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
 
   const handleMouseLeave = () => {
     linkPreviewContext?.setHoveredLinkUrl(null)
+  }
+
+  const internalPath = href ? resolveInternalAppPath(href) : null
+  if (internalPath) {
+    // Modifier-clicks and middle-clicks fall through to the native <a> so the
+    // user still gets "open in new tab" / right-click menu semantics.
+    const handleInternalClick = (e: MouseEvent<HTMLAnchorElement>) => {
+      if (e.defaultPrevented) return
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+      e.preventDefault()
+      navigate(internalPath)
+    }
+    return (
+      <a
+        href={href}
+        onClick={handleInternalClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        className="break-all text-primary underline underline-offset-4 hover:text-primary/80 [&_span]:[text-decoration:inherit]"
+      >
+        <ProcessedChildren>{children}</ProcessedChildren>
+      </a>
+    )
   }
 
   // The message-level long-press hook skips its timer when the touch starts


### PR DESCRIPTION
## Summary

Clicking a Threa message link (`app.threa.io/...`) from inside the installed Android PWA opened a Chrome Custom Tab (X-close button, "Open in Firefox" chip) instead of staying in-app. Fixed by closing both directions of the gap:

1. **In-PWA clicks** (root cause of the reported symptom): `MarkdownLink` rendered every href with `target="_blank" rel="noopener noreferrer"`, which forces a new browsing context — and from a standalone-display PWA, Android resolves that to a Custom Tab. The fix intercepts same-origin hrefs and routes them through `react-router`'s `navigate()` so they stay in the running window. Cross-origin links still open in a new tab.
2. **Out-of-PWA arrivals**: Even with #1, a Threa link clicked in another app or in a regular browser tab will only land in the installed PWA if the manifest opts in. Added `handle_links: "preferred"`, `launch_handler.client_mode: "navigate-existing"`, and explicit `scope: "/"`.

The same-origin intercept respects modifier keys and middle-clicks (Cmd/Ctrl/Shift/Alt/middle-click fall through to native `<a>` behavior so the user can still open a link in a new tab on purpose). `attachment:` hrefs still hit the existing `attachmentContext.openAttachment` branch — that check runs before the same-origin probe.

## Files

- `apps/frontend/src/lib/markdown/components.tsx` — `resolveInternalAppPath` helper + new same-origin branch in `MarkdownLink` that calls `navigate()` on plain left-clicks.
- `apps/frontend/public/manifest.json` — `scope`, `handle_links`, `launch_handler` PWA fields.
- `apps/frontend/src/components/ui/markdown-content.test.tsx` — wraps the existing test render in `MemoryRouter` (needed for `useNavigate`) and adds two tests: same-origin link has no `target="_blank"`, cross-origin link still does.

## Test plan

- [x] `bunx vitest run src/components/ui/markdown-content.test.tsx` — 50/50 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual on Android Chrome PWA: install Threa, share a message link, click it from within the PWA → stays in-app (no Custom Tab)
- [ ] Manual on Android Chrome PWA: click a Threa link from outside the PWA (e.g. in Gmail or another browser tab) → opens the installed PWA, not a Custom Tab
- [ ] Manual: long-press on a same-origin link still surfaces the native "Open in new tab" / "Copy link" menu (modifier-key escape verified by `e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey` falling through)
- [ ] Manual: external link (e.g. `https://example.com`) still opens in a new tab

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWCBrTeALhxBem3vLaS9d)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->