### PR TITLE
fix(timeline): stop ResizeObserver from fighting deep-link scroll

### DIFF
--- a/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest"
+import { useLayoutEffect } from "react"
+import { act, render } from "@testing-library/react"
+import { useVirtuosoScroll } from "./use-virtuoso-scroll"
+import type { VirtuosoHandle } from "react-virtuoso"
+
+type ResizeCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
+
+function installManualResizeObserver(): { trigger: () => void; restore: () => void } {
+  let lastCallback: ResizeCallback | null = null
+  const original = global.ResizeObserver
+  class ManualResizeObserver {
+    constructor(cb: ResizeCallback) {
+      lastCallback = cb
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.ResizeObserver = ManualResizeObserver as unknown as typeof ResizeObserver
+  return {
+    trigger: () => lastCallback?.([], {} as ResizeObserver),
+    restore: () => {
+      global.ResizeObserver = original
+    },
+  }
+}
+
+function makeScrollableDiv(initial: { clientHeight: number; scrollTop?: number }) {
+  const el = document.createElement("div")
+  let scrollTop = initial.scrollTop ?? 0
+  let clientHeight = initial.clientHeight
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => clientHeight })
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v
+    },
+  })
+  return {
+    el,
+    get scrollTop() {
+      return scrollTop
+    },
+    setClientHeight: (h: number) => {
+      clientHeight = h
+    },
+  }
+}
+
+type HookApi = ReturnType<typeof useVirtuosoScroll>
+
+function renderHookWithScroller(
+  options: Parameters<typeof useVirtuosoScroll>[0],
+  scrollerEl: HTMLDivElement,
+  virtuosoHandle: VirtuosoHandle
+): { current: HookApi } {
+  const ref: { current: HookApi | undefined } = { current: undefined }
+  function Probe() {
+    const api = useVirtuosoScroll(options)
+    api.virtuosoRef.current = virtuosoHandle
+    ref.current = api
+    // handleScrollerRef setState — must run in an effect, not during render.
+    useLayoutEffect(() => {
+      api.handleScrollerRef(scrollerEl)
+    }, [api])
+    return null
+  }
+  render(<Probe />)
+  if (!ref.current) throw new Error("Probe did not capture the hook return value")
+  return ref as { current: HookApi }
+}
+
+describe("useVirtuosoScroll", () => {
+  it("does NOT keep snapping to LAST on every measurement fire during a deep-link jump", async () => {
+    // Regression: deep-link to an old message. skipInitialScroll=true keeps
+    // the user away from the bottom on initial render, but Virtuoso emits a
+    // burst of delta=0 ResizeObserver fires as it measures items during the
+    // scrollToMessage retry loop. The bug had the safety-net re-arm
+    // scrollToIndex({ index: "LAST" }) on every fire (regardless of delta),
+    // which fought the centering loop and dropped the user on the latest
+    // message instead of the linked one.
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800 })
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: true },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      // Consume the initial observe fire (browsers auto-fire ResizeObserver
+      // once on observe()). With skipInitialScroll=true → isAtBottomRef starts
+      // false, so this hits the not-at-bottom branch and does nothing.
+      act(() => trigger())
+      await new Promise((r) => setTimeout(r, 150))
+      expect(scrollToIndex).not.toHaveBeenCalled()
+
+      // Simulate the bootstrap→jumpState transition: Virtuoso reports atBottom
+      // briefly (e.g. the new shorter jump window clamps scrollTop to the new
+      // bottom), so isAtBottomRef flips to true.
+      act(() => apiRef.current.handleAtBottomChange(true))
+
+      // Now several delta=0 fires arrive as Virtuoso measures items in the
+      // around-target window. None of them should arm the LAST snap.
+      for (let i = 0; i < 5; i++) act(() => trigger())
+      await new Promise((r) => setTimeout(r, 150))
+
+      expect(scrollToIndex).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it("still snaps to LAST on the initial observe (cold-boot safety net)", async () => {
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800 })
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      // skipInitialScroll=false → isAtBottomRef starts true. The initial
+      // observe fire (delta=0) must still arm the safety-net snap so the
+      // timeline lands at the bottom even when the scroller mounts inside a
+      // coordinated-loading gate that doesn't produce a resize delta.
+      act(() => trigger())
+      await new Promise((r) => setTimeout(r, 150))
+
+      expect(scrollToIndex).toHaveBeenCalledWith({ index: "LAST", align: "end", behavior: "auto" })
+    } finally {
+      restore()
+    }
+  })
+
+  it("snaps to LAST when the container actually shrinks while at bottom (keyboard open)", async () => {
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800 })
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      // Consume the initial-fire safety net so we can isolate the keyboard-
+      // resize path.
+      act(() => trigger())
+      await new Promise((r) => setTimeout(r, 150))
+      scrollToIndex.mockClear()
+
+      // User scrolls back to the bottom, then keyboard opens.
+      act(() => apiRef.current.handleAtBottomChange(true))
+      scrollable.setClientHeight(500)
+      act(() => trigger())
+      await new Promise((r) => setTimeout(r, 150))
+
+      expect(scrollToIndex).toHaveBeenCalledWith({ index: "LAST", align: "end", behavior: "auto" })
+    } finally {
+      restore()
+    }
+  })
+
+  it("shifts scrollTop by the delta when scrolled away from the bottom (keyboard open)", () => {
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800, scrollTop: 1000 })
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      // Move user off the bottom so the not-at-bottom branch runs.
+      act(() => apiRef.current.handleAtBottomChange(false))
+
+      // Keyboard opens: container shrinks 800→500. scrollTop should shift by
+      // the 300px delta so the previously-visible bottom row stays anchored.
+      scrollable.setClientHeight(500)
+      act(() => trigger())
+
+      expect(scrollable.scrollTop).toBe(1300)
+    } finally {
+      restore()
+    }
+  })
+})

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -210,29 +210,39 @@ export function useVirtuosoScroll({
     if (!scrollerEl) return
 
     let prevHeight = scrollerEl.clientHeight
+    let isInitialFire = true
 
     const observer = new ResizeObserver(() => {
       const newHeight = scrollerEl.clientHeight
       const delta = prevHeight - newHeight
       prevHeight = newHeight
+      const wasInitialFire = isInitialFire
+      isInitialFire = false
 
-      if (isAtBottomRef.current) {
-        // Always (re)arm the LAST scroll on every fire, including the initial
-        // observe() callback where delta is 0. Virtuoso's own
-        // initialTopMostItemIndex is not always sufficient when the scroller
-        // mounts inside a coordinated-loading gate; this acts as a safety net
-        // that lands the user at the bottom on first paint.
-        window.clearTimeout(resizeTimerRef.current)
-        resizeTimerRef.current = window.setTimeout(() => {
-          virtuosoRef.current?.scrollToIndex({
-            index: "LAST",
-            align: "end",
-            behavior: "auto",
-          })
-        }, 100)
-      } else if (delta !== 0) {
-        scrollerEl.scrollTop += delta
+      if (!isAtBottomRef.current) {
+        if (delta !== 0) scrollerEl.scrollTop += delta
+        return
       }
+
+      // The LAST safety-net snap fires on two specific events: the initial
+      // observe() callback (cold-boot inside CoordinatedLoadingGate, where
+      // no resize delta occurs but the scroller needs to land at the bottom)
+      // and real height changes (mobile keyboard opens/closes). Intermediate,
+      // delta=0 fires from Virtuoso's own item-measurement passes must NOT
+      // re-arm the snap — when a deep-link jump is centering a target message,
+      // those measurement fires would otherwise repeatedly snap to LAST and
+      // fight scrollToMessage, ending the user on the latest message instead
+      // of the linked one.
+      if (!wasInitialFire && delta === 0) return
+
+      window.clearTimeout(resizeTimerRef.current)
+      resizeTimerRef.current = window.setTimeout(() => {
+        virtuosoRef.current?.scrollToIndex({
+          index: "LAST",
+          align: "end",
+          behavior: "auto",
+        })
+      }, 100)
     })
 
     observer.observe(scrollerEl)


### PR DESCRIPTION
## Summary

Deep-linking to an old message (`?m=msg_...`) made the timeline "jump around a lot" and then land on the latest message instead of the linked one. Regression introduced in #510, which made the `useVirtuosoScroll` ResizeObserver re-arm `scrollToIndex({ index: "LAST" })` on **every** fire when `isAtBottomRef` is true, as a cold-boot safety net inside `CoordinatedLoadingGate`.

The deep-link flow trips that safety net like this:
1. Bootstrap window loads → user is briefly at the bottom of the bootstrap-latest window → `isAtBottomRef.current = true`.
2. Jump-state swaps in a shorter around-target window; Virtuoso clamps `scrollTop` to the new bottom and `atBottomStateChange` reports `true` again.
3. The `scrollToMessage` retry loop starts firing item-measurement passes. Each pass triggers ResizeObserver with `delta=0`.
4. Every `delta=0` fire re-arms the 100ms-debounced `scrollToIndex(LAST)`. That fights the centering loop and wins — the user lands on the latest message.

Fix: gate the LAST snap behind `(wasInitialFire || delta !== 0)`. The cold-boot safety net (first `observe()` callback inside `CoordinatedLoadingGate`, where no delta exists but the scroller still needs to land at the bottom) and real container resizes (mobile keyboard open/close) still snap. Intermediate measurement passes no longer fight `scrollToMessage`.

`isInitialFire` is a closure local inside the `useEffect`, so it correctly resets whenever `scrollerEl` changes (Virtuoso unmount/remount inside the gate) — that's the scenario the safety net was built for.

## Files

- `apps/frontend/src/hooks/use-virtuoso-scroll.ts` — replace "always re-arm on every fire" with a gated re-arm; capture `isInitialFire` per-effect.
- `apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx` *(new)* — 4 tests using a manual `ResizeObserver` install + a `Probe` component that attaches the scroller via `useLayoutEffect`:
  1. Regression: 5 delta=0 fires after `atBottomChange(true)` must NOT call `scrollToIndex` (deep-link safety).
  2. Cold-boot: initial observe fire DOES call `scrollToIndex({ index: "LAST" })` (preserves #510's safety net).
  3. Real shrink while at bottom (keyboard open): snaps to LAST.
  4. Real shrink while away from bottom: shifts `scrollTop` by the delta (anchor preserved).

## Test plan

- [x] `bunx vitest run src/hooks/use-virtuoso-scroll.test.tsx` — 4/4 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: paste a deep-link to an old message into a stream that's already open → message centers on screen, no jump to bottom
- [ ] Manual on mobile: open the keyboard while at the bottom of a stream → latest message stays glued above the composer (cold-boot/keyboard path unchanged)
- [ ] Manual on mobile: open the keyboard while scrolled mid-stream → previously-visible message stays anchored (`scrollTop` shift path unchanged)
- [ ] Manual on cold app boot: open a stream → lands at the bottom (initial-fire safety net still works)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWCBrTeALhxBem3vLaS9d)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->