### PR TITLE
fix(timeline): re-trigger scroll on repeat clicks of same message link

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useCallback, useRef, useState } from "react"
-import { useSearchParams } from "react-router-dom"
+import { useLocation, useSearchParams } from "react-router-dom"
 import { Virtuoso } from "react-virtuoso"
 import { MessageSquare, ArrowDown, X, Move, Loader2, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -98,9 +98,14 @@ export function StreamContent({
   autoFocus,
 }: StreamContentProps) {
   const [, setSearchParams] = useSearchParams()
+  const location = useLocation()
   const socket = useSocket()
   const messageService = useMessageService()
-  const jumpTriggeredRef = useRef<string | null>(null)
+  // Tracks the location key we've already handled for a highlight jump. Using
+  // the key (not the message id) lets re-clicking the same message link
+  // re-trigger the scroll — react-router generates a fresh key on every
+  // navigation even when the URL is identical, which it auto-replaces.
+  const jumpTriggeredKeyRef = useRef<string | null>(null)
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [batchMode, setBatchMode] = useState(false)
@@ -848,10 +853,14 @@ export function StreamContent({
     }
   }, [events, isLoading, scrollToMessage])
 
-  // Jump to highlighted message if it's not in the current event window
+  // Jump to highlighted message if it's not in the current event window.
+  // The guard uses location.key so repeat clicks on the same message link
+  // (which produce identical URLs and would otherwise not change any state)
+  // still re-trigger — react-router stamps each navigation with a fresh key.
   useEffect(() => {
     if (!highlightMessageId || isLoading || isDraft) return
-    if (jumpTriggeredRef.current === highlightMessageId) return
+    if (jumpTriggeredKeyRef.current === location.key) return
+    jumpTriggeredKeyRef.current = location.key
 
     // Disable auto-scroll so highlight scroll-into-view isn't overridden
     disableAutoScroll()
@@ -868,28 +877,25 @@ export function StreamContent({
     }
 
     if (events.length > 0) {
-      jumpTriggeredRef.current = highlightMessageId
       pendingScrollTarget.current = highlightMessageId
       jumpToEvent(highlightMessageId)
         .then((success) => {
           if (!success) {
-            jumpTriggeredRef.current = null
             pendingScrollTarget.current = null
           }
         })
         .catch(() => {
-          jumpTriggeredRef.current = null
           pendingScrollTarget.current = null
         })
     }
-  }, [highlightMessageId, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
+  }, [highlightMessageId, location.key, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
 
   // Reset jump and search state when switching streams (component stays mounted).
   // Also abort any in-flight scrollToMessage retry loop so its stale closure
   // (holding an index from the previous stream) doesn't scroll the new stream
   // to the wrong position.
   useEffect(() => {
-    jumpTriggeredRef.current = null
+    jumpTriggeredKeyRef.current = null
     scrollAbortRef.current?.()
     pendingScrollTarget.current = null
     exitJumpMode()


### PR DESCRIPTION
## Summary

Clicking a message link to a message in the current stream a second time was a no-op. Reported flow:

1. Friend sends a link to a message in the same channel.
2. Click it → scrolls up to the message.
3. Scroll back down to recent messages.
4. Click the same link again → nothing happens.

## Root cause

The scroll-to-highlighted-message effect in `stream-content.tsx` was keyed on the message id via `jumpTriggeredRef`:

```ts
if (jumpTriggeredRef.current === highlightMessageId) return
```

The `<Link to="/w/.../s/.../?m=<id>">` produces the current URL on a repeat click. React Router auto-converts a Link-to-current-URL into a `REPLACE` navigation, but the `?m=` query stays the same — so `searchParams.get("m")` still returns the same id, the effect dep never changes, and the guard above stays satisfied. Scroll never re-fires.

## Fix

Key the guard on `location.key` instead of the message id. React Router stamps a fresh `key` on every navigation (verified in `react-router@7.14.0` — `createLocation` always calls `createKey()`, including for replaces of the current URL). Each click is therefore a distinct event for the effect, and the scroll re-fires.

```ts
if (jumpTriggeredKeyRef.current === location.key) return
jumpTriggeredKeyRef.current = location.key
```

Side effects:
- Removed the now-redundant `jumpTriggeredRef.current = null` resets on `jumpToEvent` failure. Each new click brings a new `location.key`, so the next attempt is naturally allowed.
- The existing 3s `?m=` URL-clearing timer is unchanged — it's cosmetic cleanup, no longer load-bearing for re-trigger behavior.
- Stream-change reset still clears the ref so a stale key from the previous stream doesn't block the new stream's first highlight.

## Test plan

- [x] `bun run --cwd apps/frontend typecheck` clean
- [x] `bun run --cwd apps/frontend lint` clean
- [x] `bun run --cwd apps/frontend test src/components/timeline/` — 199 passing
- [ ] Manual: open a stream, click a message link to that same stream, scroll back to bottom, click the same link again → scrolls up to the message both times.
- [ ] Manual: cross-stream links still work (different stream + `?m=`).
- [ ] Manual: deep-link load (open a `?m=` URL directly) still scrolls/highlights on first paint.

https://claude.ai/code/session_01P66VfoW1aiqhuTfi8uWZg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01P66VfoW1aiqhuTfi8uWZg2)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->