### PR TITLE
refactor(frontend): gate remaining settings on viewer permissions + dedup bootstrap observer

### DIFF
--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -19,10 +19,12 @@ import {
 } from "@/components/ui/responsive-alert-dialog"
 import { X, UserPlus, BotIcon } from "lucide-react"
 import { useAddStreamMember, useRemoveStreamMember, streamKeys } from "@/hooks"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { useStreamService } from "@/contexts"
 import { botsApi } from "@/api/bots"
 import { useWorkspaceUsers, useWorkspaceBots } from "@/stores/workspace-store"
-import { StreamTypes, type StreamMember } from "@threa/types"
+import { hasPermission } from "@/lib/permissions"
+import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type StreamMember, type WorkspaceBootstrap } from "@threa/types"
 import { toast } from "sonner"
 
 interface MembersTabProps {
@@ -33,6 +35,7 @@ interface MembersTabProps {
 
 export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabProps) {
   const streamService = useStreamService()
+  const queryClient = useQueryClient()
   const [search, setSearch] = useState("")
   const addMutation = useAddStreamMember(workspaceId, streamId)
   const removeMutation = useRemoveStreamMember(workspaceId, streamId)
@@ -46,13 +49,21 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
     queryFn: () => streamService.bootstrap(workspaceId, streamId),
     staleTime: Infinity,
   })
+  const { data: workspaceBootstrap } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+  })
   const workspaceUsers = useWorkspaceUsers(workspaceId)
 
   const streamType = bootstrap?.stream?.type
   const canAddUserMembers = streamType === StreamTypes.CHANNEL
   const streamMembers = bootstrap?.members ?? []
-  const currentWorkspaceUser = workspaceUsers.find((u) => u.id === currentUserId)
-  const canManageMembers = currentWorkspaceUser?.role === "owner" || currentWorkspaceUser?.role === "admin"
+  const canManageMembers = hasPermission(
+    workspaceBootstrap?.viewerPermissions,
+    WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE
+  )
 
   // Bots can be managed on all stream types that have a members tab.
   // Threads inherit bot access from their root, so the UI is read-only.

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -52,12 +52,12 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   const workspaceUsers = useWorkspaceUsers(workspaceId)
 
   const streamType = bootstrap?.stream?.type
-  const canAddUserMembers = streamType === StreamTypes.CHANNEL
   const streamMembers = bootstrap?.members ?? []
   const canManageMembers = hasPermission(
     workspaceBootstrap?.viewerPermissions,
     WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE
   )
+  const canAddUserMembers = canManageMembers && streamType === StreamTypes.CHANNEL
 
   // Bots can be managed on all stream types that have a members tab.
   // Threads inherit bot access from their root, so the UI is read-only.
@@ -92,12 +92,13 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
 
   const handleAdd = useCallback(
     (user: (typeof workspaceUsers)[number]) => {
+      if (!canManageMembers) return
       addMutation.mutate(user.id, {
         onSuccess: () => toast.success("Member added"),
         onError: () => toast.error("Failed to add member"),
       })
     },
-    [addMutation]
+    [addMutation, canManageMembers]
   )
 
   const [removeMemberId, setRemoveMemberId] = useState<string | null>(null)

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -19,12 +19,12 @@ import {
 } from "@/components/ui/responsive-alert-dialog"
 import { X, UserPlus, BotIcon } from "lucide-react"
 import { useAddStreamMember, useRemoveStreamMember, streamKeys } from "@/hooks"
-import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { useStreamService } from "@/contexts"
 import { botsApi } from "@/api/bots"
 import { useWorkspaceUsers, useWorkspaceBots } from "@/stores/workspace-store"
 import { hasPermission } from "@/lib/permissions"
-import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type StreamMember, type WorkspaceBootstrap } from "@threa/types"
+import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type StreamMember } from "@threa/types"
 import { toast } from "sonner"
 
 interface MembersTabProps {
@@ -35,7 +35,6 @@ interface MembersTabProps {
 
 export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabProps) {
   const streamService = useStreamService()
-  const queryClient = useQueryClient()
   const [search, setSearch] = useState("")
   const addMutation = useAddStreamMember(workspaceId, streamId)
   const removeMutation = useRemoveStreamMember(workspaceId, streamId)
@@ -49,12 +48,7 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
     queryFn: () => streamService.bootstrap(workspaceId, streamId),
     staleTime: Infinity,
   })
-  const { data: workspaceBootstrap } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-  })
+  const workspaceBootstrap = useCachedWorkspaceBootstrap(workspaceId)
   const workspaceUsers = useWorkspaceUsers(workspaceId)
 
   const streamType = bootstrap?.stream?.type

--- a/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-channels-section.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { botsApi } from "@/api/bots"
-import { StreamTypes, type WorkspaceBootstrap } from "@threa/types"
-import { workspaceKeys } from "@/hooks/use-workspaces"
+import { StreamTypes } from "@threa/types"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { SearchableSelect } from "@/components/ui/searchable-select"
@@ -23,12 +23,7 @@ export function BotChannelsSection({ workspaceId, botId, isArchived }: BotChanne
     queryFn: () => botsApi.listStreamGrants(workspaceId, botId),
   })
 
-  const { data: wsBootstrap } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-  })
+  const wsBootstrap = useCachedWorkspaceBootstrap(workspaceId)
 
   const grantStreamMutation = useMutation({
     mutationFn: (streamId: string) => botsApi.grantStreamAccess(workspaceId, botId, streamId),

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Github, ExternalLink, RefreshCw } from "lucide-react"
-import { WORKSPACE_PERMISSION_SCOPES, type WorkspaceBootstrap } from "@threa/types"
+import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { integrationsApi } from "@/api/integrations"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { hasPermission } from "@/lib/permissions"
 
 interface IntegrationsTabProps {
@@ -24,12 +24,7 @@ function LinearIcon({ className }: { className?: string }) {
 export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   const queryClient = useQueryClient()
 
-  const { data: bootstrap } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-  })
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId)
   const canManage = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN)
 
   const query = useQuery({

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -63,7 +63,7 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   if (!canManage) {
     return (
       <div className="space-y-4 p-1">
-        <p className="text-sm text-muted-foreground">Only workspace admins and owners can manage integrations.</p>
+        <p className="text-sm text-muted-foreground">You need the Workspace Admin permission to manage integrations.</p>
       </div>
     )
   }

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -1,12 +1,12 @@
-import { useMemo } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Github, ExternalLink, RefreshCw } from "lucide-react"
-import { useAuth } from "@/auth/hooks"
+import { WORKSPACE_PERMISSION_SCOPES, type WorkspaceBootstrap } from "@threa/types"
 import { integrationsApi } from "@/api/integrations"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import { useWorkspaceUsers } from "@/stores/workspace-store"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { hasPermission } from "@/lib/permissions"
 
 interface IntegrationsTabProps {
   workspaceId: string
@@ -22,15 +22,15 @@ function LinearIcon({ className }: { className?: string }) {
 }
 
 export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
-  const { user } = useAuth()
   const queryClient = useQueryClient()
-  const workspaceUsers = useWorkspaceUsers(workspaceId)
 
-  const currentWorkspaceUser = useMemo(
-    () => workspaceUsers.find((workspaceUser) => workspaceUser.workosUserId === user?.id) ?? null,
-    [user?.id, workspaceUsers]
-  )
-  const canManage = currentWorkspaceUser?.role === "admin" || currentWorkspaceUser?.role === "owner"
+  const { data: bootstrap } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+  })
+  const canManage = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN)
 
   const query = useQuery({
     queryKey: ["workspace-integrations", workspaceId, "github"],

--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -1,12 +1,11 @@
 import { useMemo, useRef, useState } from "react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useMutation } from "@tanstack/react-query"
 import { Check, ChevronDown, Copy, KeyRound, Link as LinkIcon, Mail, MoreHorizontal } from "lucide-react"
 import { toast } from "sonner"
 import {
   roleDisplayName,
   WORKSPACE_PERMISSION_SCOPES,
   WORKSPACE_USER_ROLES,
-  type WorkspaceBootstrap,
   type WorkspaceRoleSlug,
 } from "@threa/types"
 import { Button } from "@/components/ui/button"
@@ -28,7 +27,7 @@ import { invitationsApi } from "@/api/invitations"
 import { ApiError } from "@/api/client"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { useFormattedDate } from "@/hooks"
-import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { useChangeWorkspaceMemberRole, useRemoveWorkspaceMember } from "@/hooks/use-workspace-member-management"
 import { hasPermission } from "@/lib/permissions"
 import { useUser } from "@/auth"
@@ -101,19 +100,13 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
   const { formatDate } = useFormattedDate()
 
   const authUser = useUser()
-  const queryClient = useQueryClient()
   const workspaceUsers = useWorkspaceUsers(workspaceId)
   const users = useMemo(
     () => workspaceUsers.slice().sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug)),
     [workspaceUsers]
   )
 
-  const { data: bootstrap } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-  })
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId)
   const canManageMembers = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)
 
   const changeRoleMutation = useChangeWorkspaceMemberRole(workspaceId)

--- a/apps/frontend/src/hooks/use-workspaces.ts
+++ b/apps/frontend/src/hooks/use-workspaces.ts
@@ -143,6 +143,23 @@ export function useWorkspaceBootstrap(workspaceId: string) {
   return { ...query, loadState, retryBootstrap }
 }
 
+/**
+ * Cache-only observer for the workspace bootstrap. Returns the cached value
+ * (or `null`) without ever fetching — pair with `useWorkspaceBootstrap` higher
+ * in the tree to populate the cache. Use this in surfaces that only need to
+ * read bootstrap-derived state (e.g. `viewerPermissions`, `streams`).
+ */
+export function useCachedWorkspaceBootstrap(workspaceId: string): WorkspaceBootstrap | null {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+  })
+  return data ?? null
+}
+
 export function useRegions() {
   const workspaceService = useWorkspaceService()
 


### PR DESCRIPTION
## Problem

Two settings surfaces still gated their UI on the role-hierarchy strings (`role === "admin" || role === "owner"`) instead of the WorkOS-backed `viewerPermissions` carried by the workspace bootstrap:

- `workspace-settings/integrations-tab.tsx` (GitHub / Linear connect)
- `stream-settings/members-tab.tsx` (add / remove stream members)

This is the last patch of Phase 2 of the permissions refactor (`.claude/plans/2-workos-authz-enforcement-and-fan-out.md`, PR-6). The codebase had already migrated `workspace-settings/users-tab.tsx` to `hasPermission(bootstrap?.viewerPermissions, …)` but missed these two surfaces.

While migrating, the cache-only TanStack Query observer that reads `workspaceKeys.bootstrap(workspaceId)` got duplicated, putting it at four call sites:

- `users-tab.tsx`
- `integrations-tab.tsx` (new)
- `stream-settings/members-tab.tsx` (new)
- `bot-channels-section.tsx` (pre-existing)

INV-35 / INV-37 (reuse helpers, avoid parallel implementations) — this needed an abstraction.

## Solution

**Commit 1 — `refactor(frontend): gate settings tabs on viewer permissions`**

Flip the two stragglers to permission-based gating:

- `integrations-tab.tsx`: gate on `WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN`. Dropped `useAuth`, `useWorkspaceUsers`, and the `useMemo` lookup of `currentWorkspaceUser`; bootstrap is read via a cache-only observer.
- `stream-settings/members-tab.tsx`: gate on `WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE`. Bootstrap observer added alongside the existing stream-bootstrap query; `currentUserId` and `workspaceUsers` retained because they're still used for the self-remove suppression and the enriched member / available-to-add lists.

**Commit 2 — `refactor(frontend): extract useCachedWorkspaceBootstrap hook`**

Surface a single hook in `apps/frontend/src/hooks/use-workspaces.ts`:

```ts
export function useCachedWorkspaceBootstrap(workspaceId: string): WorkspaceBootstrap | null {
  const queryClient = useQueryClient()
  const { data } = useQuery({
    queryKey: workspaceKeys.bootstrap(workspaceId),
    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
    enabled: false,
    staleTime: Infinity,
  })
  return data ?? null
}
```

All four call sites now use it. Each site decides what to pull off the bootstrap (`viewerPermissions` for the three permission gates, `streams` for `bot-channels-section`).

### Key design decisions

**1. One hook, not two**

Considered `useViewerPermissions(workspaceId)` as a thinner wrapper over `useCachedWorkspaceBootstrap`. Rejected because `bot-channels-section` consumes `bootstrap.streams`, not permissions, so a permissions-only hook leaves duplication behind. A single bootstrap hook covers both cases and the call sites stay terse.

**2. Hook lives next to `useWorkspaceBootstrap`**

Both observers operate on the same query key; colocating them in `hooks/use-workspaces.ts` keeps the cache-only pattern discoverable from the fetcher.

**3. Return `WorkspaceBootstrap | null`, not `undefined`**

Matches the existing call-site idiom (`bootstrap?.viewerPermissions`) and avoids a discriminated-union return that callers would have to destructure.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/hooks/use-workspaces.ts` | Add `useCachedWorkspaceBootstrap` |
| `apps/frontend/src/components/workspace-settings/users-tab.tsx` | Use new hook; drop unused `useQueryClient` |
| `apps/frontend/src/components/workspace-settings/integrations-tab.tsx` | Permission-based gating + new hook |
| `apps/frontend/src/components/workspace-settings/bot-channels-section.tsx` | Use new hook |
| `apps/frontend/src/components/stream-settings/members-tab.tsx` | Permission-based gating + new hook; drop unused `useQueryClient` in `MembersTab` |

## Test plan

- [x] `bun run typecheck` — all 9 workspaces clean
- [x] `bun ./scripts/test-silent.ts frontend` — 1617 tests passing
- [x] Pre-commit (prettier / eslint / typecheck / docs check) passes
- [ ] Smoke-test the four surfaces locally: workspace users tab, integrations tab, stream members tab, bot channels section — verify each renders with cached bootstrap and gates the action affordances correctly

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLeMwKzjMr8iztp8do67dP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->