### PR TITLE
feat: workspace settings UI for personal bots

### DIFF
--- a/apps/frontend/src/api/bots.ts
+++ b/apps/frontend/src/api/bots.ts
@@ -2,6 +2,7 @@ import { api, API_BASE, parseApiError } from "./client"
 import type { Bot, BotApiKey, CreateBotApiKeyResponse } from "@threa/types"
 
 export interface CreateBotInput {
+  type?: "shared" | "personal"
   name: string
   slug: string
   description?: string | null

--- a/apps/frontend/src/components/workspace-settings/bots-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/bots-tab.tsx
@@ -3,12 +3,13 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { botsApi, type CreateBotInput } from "@/api/bots"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Textarea } from "@/components/ui/textarea"
-import { Plus, BotIcon } from "lucide-react"
+import { Plus, BotIcon, ChevronRight, Globe, User } from "lucide-react"
 import { BotAvatar } from "./bot-avatar"
 import { BotDetail } from "./bot-detail"
 import { useCachedWorkspaceBootstrap, workspaceKeys } from "@/hooks/use-workspaces"
@@ -78,9 +79,12 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
 
   if (showSharedSection && sharedLoading) {
     return (
-      <div className="space-y-3 p-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-20 w-full" />
+      <div className="space-y-6 p-1">
+        <div className="space-y-3">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-[52px] w-full rounded-lg" />
+          <Skeleton className="h-[52px] w-full rounded-lg" />
+        </div>
       </div>
     )
   }
@@ -88,21 +92,25 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
   return (
     <div className="space-y-6 p-1">
       {showSharedSection && (
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-medium">Workspace bots ({sharedBots.length})</h3>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                Shared integration identities managed by workspace admins.
-              </p>
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2 min-w-0">
+              <Globe className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <h3 className="text-sm font-medium truncate">Workspace bots</h3>
+              <Badge variant="secondary" className="text-[11px] px-1.5 py-0 h-4 font-normal tabular-nums shrink-0">
+                {sharedBots.length}
+              </Badge>
             </div>
             {!showCreateSharedForm && canCreateShared && (
-              <Button size="sm" className="shrink-0 ml-4" onClick={() => setShowCreateSharedForm(true)}>
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
+              <Button size="sm" className="shrink-0" onClick={() => setShowCreateSharedForm(true)}>
+                <Plus className="h-3.5 w-3.5 mr-1" />
                 New bot
               </Button>
             )}
           </div>
+          <p className="text-xs text-muted-foreground -mt-1">
+            Shared integration identities managed by workspace admins.
+          </p>
 
           {showCreateSharedForm && (
             <CreateBotForm
@@ -114,33 +122,44 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
             />
           )}
 
-          <BotListItems bots={sharedBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
-
-          {sharedBots.length === 0 && !showCreateSharedForm && <EmptyBotsState label="No workspace bots yet" />}
+          {sharedBots.length > 0 ? (
+            <BotListItems bots={sharedBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
+          ) : (
+            !showCreateSharedForm && (
+              <EmptyBotsState
+                label="No workspace bots yet"
+                description="Create a shared bot to post messages via the API."
+                action={
+                  canCreateShared
+                    ? { label: "Create workspace bot", onClick: () => setShowCreateSharedForm(true) }
+                    : undefined
+                }
+              />
+            )
+          )}
         </section>
       )}
 
       {showSharedSection && showPersonalSection && <Separator />}
 
       {showPersonalSection && (
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-medium">My bots ({personalBots.length})</h3>
-              <p className="text-xs text-muted-foreground mt-0.5">Personal bots you own and manage independently.</p>
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2 min-w-0">
+              <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <h3 className="text-sm font-medium truncate">My bots</h3>
+              <Badge variant="secondary" className="text-[11px] px-1.5 py-0 h-4 font-normal tabular-nums shrink-0">
+                {personalBots.length}
+              </Badge>
             </div>
             {!showCreatePersonalForm && (
-              <Button
-                size="sm"
-                variant="outline"
-                className="shrink-0 ml-4"
-                onClick={() => setShowCreatePersonalForm(true)}
-              >
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
+              <Button size="sm" variant="outline" className="shrink-0" onClick={() => setShowCreatePersonalForm(true)}>
+                <Plus className="h-3.5 w-3.5 mr-1" />
                 New bot
               </Button>
             )}
           </div>
+          <p className="text-xs text-muted-foreground -mt-1">Personal bots you own and manage independently.</p>
 
           {showCreatePersonalForm && (
             <CreateBotForm
@@ -152,14 +171,22 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
             />
           )}
 
-          <BotListItems bots={personalBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
-
-          {personalBots.length === 0 && !showCreatePersonalForm && <EmptyBotsState label="No personal bots yet" />}
+          {personalBots.length > 0 ? (
+            <BotListItems bots={personalBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
+          ) : (
+            !showCreatePersonalForm && (
+              <EmptyBotsState
+                label="No personal bots yet"
+                description="Create a personal bot to use with your own API keys and scratchpads."
+                action={{ label: "Create personal bot", onClick: () => setShowCreatePersonalForm(true) }}
+              />
+            )
+          )}
         </section>
       )}
 
       {!showSharedSection && !showPersonalSection && (
-        <EmptyBotsState label="You don't have permission to create or manage bots." />
+        <EmptyBotsState label="No access" description="You don't have permission to create or manage bots." />
       )}
     </div>
   )
@@ -191,45 +218,54 @@ function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: Cr
     }
   }
 
+  const canSubmit = name.trim().length > 0 && slug.trim().length > 0 && !isPending
+
   const handleCreate = () => {
-    if (!name.trim() || !slug.trim()) return
+    if (!canSubmit) return
     onCreate({ name: name.trim(), slug: slug.trim(), description: description.trim() || null })
   }
 
-  return (
-    <div className="rounded-lg border bg-card p-4 space-y-4">
-      <div className="space-y-1.5">
-        <Label htmlFor="bot-name" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Name
-        </Label>
-        <Input
-          id="bot-name"
-          placeholder={placeholder}
-          value={name}
-          onChange={(e) => handleNameChange(e.target.value)}
-          autoFocus
-        />
-      </div>
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleCreate()
+  }
 
-      <div className="space-y-1.5">
-        <Label htmlFor="bot-slug" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Slug
-        </Label>
-        <Input
-          id="bot-slug"
-          placeholder="e.g. github-bot"
-          value={slug}
-          onChange={(e) => {
-            setSlugTouched(true)
-            setSlug(e.target.value)
-          }}
-        />
-        <p className="text-xs text-muted-foreground">Unique identifier. Lowercase letters, numbers, and hyphens.</p>
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-4" onKeyDown={handleKeyDown}>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="bot-name" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Name
+          </Label>
+          <Input
+            id="bot-name"
+            placeholder={placeholder}
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="bot-slug" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Slug
+          </Label>
+          <Input
+            id="bot-slug"
+            placeholder="my-bot"
+            value={slug}
+            onChange={(e) => {
+              setSlugTouched(true)
+              setSlug(e.target.value)
+            }}
+          />
+        </div>
       </div>
+      <p className="text-xs text-muted-foreground -mt-2">
+        Slug is the unique identifier — lowercase letters, numbers, and hyphens.
+      </p>
 
       <div className="space-y-1.5">
         <Label htmlFor="bot-description" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Description
+          Description <span className="normal-case font-normal">(optional)</span>
         </Label>
         <Textarea
           id="bot-description"
@@ -240,22 +276,21 @@ function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: Cr
         />
       </div>
 
-      <Separator />
-
-      <div className="flex items-center justify-between">
-        <Button variant="ghost" size="sm" onClick={onCancel}>
+      <div className="flex items-center justify-between pt-1">
+        <Button variant="ghost" size="sm" onClick={onCancel} disabled={isPending}>
           Cancel
         </Button>
-        <Button size="sm" onClick={handleCreate} disabled={!name.trim() || !slug.trim() || isPending}>
-          {isPending ? "Creating..." : "Create bot"}
-        </Button>
+        <div className="flex items-center gap-2">
+          {error && (
+            <p className="text-xs text-destructive">
+              {error instanceof Error ? error.message : "Failed to create bot."}
+            </p>
+          )}
+          <Button size="sm" onClick={handleCreate} disabled={!canSubmit}>
+            {isPending ? "Creating..." : "Create bot"}
+          </Button>
+        </div>
       </div>
-
-      {error && (
-        <p className="text-sm text-destructive">
-          {error instanceof Error ? error.message : "Failed to create bot. Please try again."}
-        </p>
-      )}
     </div>
   )
 }
@@ -278,37 +313,53 @@ function BotListItems({
   workspaceId: string
   onSelectBot: (id: string) => void
 }) {
-  if (bots.length === 0) return null
-
   return (
-    <div className="rounded-lg border divide-y">
+    <div className="rounded-lg border divide-y overflow-hidden">
       {bots.map((bot) => (
         <button
           key={bot.id}
-          className="w-full flex items-center gap-3 px-3 py-3 hover:bg-accent/50 transition-colors text-left"
+          className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent/50 transition-colors text-left group"
           onClick={() => onSelectBot(bot.id)}
         >
-          <BotAvatar bot={bot} workspaceId={workspaceId} size={36} />
+          <BotAvatar bot={bot} workspaceId={workspaceId} size={32} />
           <div className="min-w-0 flex-1">
-            <div className="flex items-baseline gap-2">
+            <div className="flex items-baseline gap-1.5">
               <span className="text-sm font-medium truncate">{bot.name}</span>
               {bot.slug && (
-                <code className="text-[11px] text-muted-foreground/70 font-mono hidden sm:inline">@{bot.slug}</code>
+                <code className="text-[11px] text-muted-foreground/60 font-mono hidden sm:inline shrink-0">
+                  @{bot.slug}
+                </code>
               )}
             </div>
-            {bot.description && <p className="text-xs text-muted-foreground mt-0.5 truncate">{bot.description}</p>}
+            {bot.description && (
+              <p className="text-xs text-muted-foreground mt-0.5 truncate leading-snug">{bot.description}</p>
+            )}
           </div>
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0 group-hover:text-muted-foreground/70 transition-colors" />
         </button>
       ))}
     </div>
   )
 }
 
-function EmptyBotsState({ label }: { label: string }) {
+interface EmptyBotsStateProps {
+  label: string
+  description?: string
+  action?: { label: string; onClick: () => void }
+}
+
+function EmptyBotsState({ label, description, action }: EmptyBotsStateProps) {
   return (
-    <div className="rounded-lg border border-dashed py-8 flex flex-col items-center gap-2">
-      <BotIcon className="h-5 w-5 text-muted-foreground/50" />
-      <p className="text-sm text-muted-foreground">{label}</p>
+    <div className="rounded-lg border border-dashed py-8 flex flex-col items-center gap-1.5 text-center px-6">
+      <BotIcon className="h-5 w-5 text-muted-foreground/40 mb-0.5" />
+      <p className="text-sm font-medium text-foreground/70">{label}</p>
+      {description && <p className="text-xs text-muted-foreground max-w-[260px]">{description}</p>}
+      {action && (
+        <Button variant="ghost" size="sm" className="mt-2 h-7 text-xs" onClick={action.onClick}>
+          <Plus className="h-3 w-3 mr-1" />
+          {action.label}
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/workspace-settings/bots-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/bots-tab.tsx
@@ -56,13 +56,14 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
   // Personal bots come from the bootstrap-synced IDB cache filtered by type.
   const personalBots = allCachedBots.filter((b) => b.type === "personal" && !b.archivedAt)
 
-  const [showCreateSharedForm, setShowCreateSharedForm] = useState(false)
-  const [showCreatePersonalForm, setShowCreatePersonalForm] = useState(false)
+  // Single discriminant prevents both forms from being open simultaneously,
+  // which would produce duplicate element IDs in the DOM.
+  const [activeCreateForm, setActiveCreateForm] = useState<"shared" | "personal" | null>(null)
 
   const sharedCreateMutation = useMutation({
     mutationFn: (data: CreateBotInput) => botsApi.create(workspaceId, { ...data, type: "shared" }),
     onSuccess: (bot) => {
-      setShowCreateSharedForm(false)
+      setActiveCreateForm(null)
       queryClient.invalidateQueries({ queryKey: sharedBotsQueryKey })
       onSelectBot(bot.id)
     },
@@ -71,7 +72,7 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
   const personalCreateMutation = useMutation({
     mutationFn: (data: CreateBotInput) => botsApi.create(workspaceId, { ...data, type: "personal" }),
     onSuccess: (bot) => {
-      setShowCreatePersonalForm(false)
+      setActiveCreateForm(null)
       queryClient.invalidateQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) })
       onSelectBot(bot.id)
     },
@@ -101,8 +102,8 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
                 {sharedBots.length}
               </Badge>
             </div>
-            {!showCreateSharedForm && canCreateShared && (
-              <Button size="sm" className="shrink-0" onClick={() => setShowCreateSharedForm(true)}>
+            {activeCreateForm !== "shared" && canCreateShared && (
+              <Button size="sm" className="shrink-0" onClick={() => setActiveCreateForm("shared")}>
                 <Plus className="h-3.5 w-3.5 mr-1" />
                 New bot
               </Button>
@@ -112,12 +113,12 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
             Shared integration identities managed by workspace admins.
           </p>
 
-          {showCreateSharedForm && (
+          {activeCreateForm === "shared" && (
             <CreateBotForm
               placeholder="e.g. GitHub Bot, Deploy Notifier"
               isPending={sharedCreateMutation.isPending}
               error={sharedCreateMutation.error}
-              onCancel={() => setShowCreateSharedForm(false)}
+              onCancel={() => setActiveCreateForm(null)}
               onCreate={(data) => sharedCreateMutation.mutate(data)}
             />
           )}
@@ -125,13 +126,13 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
           {sharedBots.length > 0 ? (
             <BotListItems bots={sharedBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
           ) : (
-            !showCreateSharedForm && (
+            activeCreateForm !== "shared" && (
               <EmptyBotsState
                 label="No workspace bots yet"
                 description="Create a shared bot to post messages via the API."
                 action={
                   canCreateShared
-                    ? { label: "Create workspace bot", onClick: () => setShowCreateSharedForm(true) }
+                    ? { label: "Create workspace bot", onClick: () => setActiveCreateForm("shared") }
                     : undefined
                 }
               />
@@ -152,8 +153,8 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
                 {personalBots.length}
               </Badge>
             </div>
-            {!showCreatePersonalForm && (
-              <Button size="sm" variant="outline" className="shrink-0" onClick={() => setShowCreatePersonalForm(true)}>
+            {activeCreateForm !== "personal" && (
+              <Button size="sm" variant="outline" className="shrink-0" onClick={() => setActiveCreateForm("personal")}>
                 <Plus className="h-3.5 w-3.5 mr-1" />
                 New bot
               </Button>
@@ -161,12 +162,12 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
           </div>
           <p className="text-xs text-muted-foreground -mt-1">Personal bots you own and manage independently.</p>
 
-          {showCreatePersonalForm && (
+          {activeCreateForm === "personal" && (
             <CreateBotForm
               placeholder="e.g. OpenClaw, Hermes"
               isPending={personalCreateMutation.isPending}
               error={personalCreateMutation.error}
-              onCancel={() => setShowCreatePersonalForm(false)}
+              onCancel={() => setActiveCreateForm(null)}
               onCreate={(data) => personalCreateMutation.mutate(data)}
             />
           )}
@@ -174,11 +175,11 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
           {personalBots.length > 0 ? (
             <BotListItems bots={personalBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
           ) : (
-            !showCreatePersonalForm && (
+            activeCreateForm !== "personal" && (
               <EmptyBotsState
                 label="No personal bots yet"
                 description="Create a personal bot to use with your own API keys and scratchpads."
-                action={{ label: "Create personal bot", onClick: () => setShowCreatePersonalForm(true) }}
+                action={{ label: "Create personal bot", onClick: () => setActiveCreateForm("personal") }}
               />
             )
           )}

--- a/apps/frontend/src/components/workspace-settings/bots-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/bots-tab.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { botsApi, type CreateBotInput } from "@/api/bots"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -10,6 +11,9 @@ import { Textarea } from "@/components/ui/textarea"
 import { Plus, BotIcon } from "lucide-react"
 import { BotAvatar } from "./bot-avatar"
 import { BotDetail } from "./bot-detail"
+import { useCachedWorkspaceBootstrap, workspaceKeys } from "@/hooks/use-workspaces"
+import { hasPermission } from "@/lib/permissions"
+import { useWorkspaceBots } from "@/stores/workspace-store"
 
 interface BotsTabProps {
   workspaceId: string
@@ -27,32 +31,153 @@ export function BotsTab({ workspaceId }: BotsTabProps) {
 
 function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBot: (id: string) => void }) {
   const queryClient = useQueryClient()
-  const queryKey = ["bots", workspaceId]
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId)
+  const allCachedBots = useWorkspaceBots(workspaceId)
 
-  const { data: bots = [], isLoading } = useQuery({
-    queryKey,
+  const canManageShared = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.BOTS_MANAGE)
+  const canCreateShared = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.BOTS_CREATE_SHARED)
+  const canCreatePersonal = hasPermission(
+    bootstrap?.viewerPermissions,
+    WORKSPACE_PERMISSION_SCOPES.BOTS_CREATE_PERSONAL
+  )
+
+  const showSharedSection = canManageShared || canCreateShared
+  const showPersonalSection = canCreatePersonal
+
+  const sharedBotsQueryKey = ["bots", workspaceId, "shared"]
+  const { data: sharedBots = [], isLoading: sharedLoading } = useQuery({
+    queryKey: sharedBotsQueryKey,
     queryFn: () => botsApi.list(workspaceId),
+    enabled: showSharedSection,
     refetchOnMount: "always",
   })
 
-  const [showCreateForm, setShowCreateForm] = useState(false)
+  // Personal bots come from the bootstrap-synced IDB cache filtered by type.
+  const personalBots = allCachedBots.filter((b) => b.type === "personal" && !b.archivedAt)
+
+  const [showCreateSharedForm, setShowCreateSharedForm] = useState(false)
+  const [showCreatePersonalForm, setShowCreatePersonalForm] = useState(false)
+
+  const sharedCreateMutation = useMutation({
+    mutationFn: (data: CreateBotInput) => botsApi.create(workspaceId, { ...data, type: "shared" }),
+    onSuccess: (bot) => {
+      setShowCreateSharedForm(false)
+      queryClient.invalidateQueries({ queryKey: sharedBotsQueryKey })
+      onSelectBot(bot.id)
+    },
+  })
+
+  const personalCreateMutation = useMutation({
+    mutationFn: (data: CreateBotInput) => botsApi.create(workspaceId, { ...data, type: "personal" }),
+    onSuccess: (bot) => {
+      setShowCreatePersonalForm(false)
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) })
+      onSelectBot(bot.id)
+    },
+  })
+
+  if (showSharedSection && sharedLoading) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 p-1">
+      {showSharedSection && (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-medium">Workspace bots ({sharedBots.length})</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Shared integration identities managed by workspace admins.
+              </p>
+            </div>
+            {!showCreateSharedForm && canCreateShared && (
+              <Button size="sm" className="shrink-0 ml-4" onClick={() => setShowCreateSharedForm(true)}>
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                New bot
+              </Button>
+            )}
+          </div>
+
+          {showCreateSharedForm && (
+            <CreateBotForm
+              placeholder="e.g. GitHub Bot, Deploy Notifier"
+              isPending={sharedCreateMutation.isPending}
+              error={sharedCreateMutation.error}
+              onCancel={() => setShowCreateSharedForm(false)}
+              onCreate={(data) => sharedCreateMutation.mutate(data)}
+            />
+          )}
+
+          <BotListItems bots={sharedBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
+
+          {sharedBots.length === 0 && !showCreateSharedForm && <EmptyBotsState label="No workspace bots yet" />}
+        </section>
+      )}
+
+      {showSharedSection && showPersonalSection && <Separator />}
+
+      {showPersonalSection && (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-medium">My bots ({personalBots.length})</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">Personal bots you own and manage independently.</p>
+            </div>
+            {!showCreatePersonalForm && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="shrink-0 ml-4"
+                onClick={() => setShowCreatePersonalForm(true)}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                New bot
+              </Button>
+            )}
+          </div>
+
+          {showCreatePersonalForm && (
+            <CreateBotForm
+              placeholder="e.g. OpenClaw, Hermes"
+              isPending={personalCreateMutation.isPending}
+              error={personalCreateMutation.error}
+              onCancel={() => setShowCreatePersonalForm(false)}
+              onCreate={(data) => personalCreateMutation.mutate(data)}
+            />
+          )}
+
+          <BotListItems bots={personalBots} workspaceId={workspaceId} onSelectBot={onSelectBot} />
+
+          {personalBots.length === 0 && !showCreatePersonalForm && <EmptyBotsState label="No personal bots yet" />}
+        </section>
+      )}
+
+      {!showSharedSection && !showPersonalSection && (
+        <EmptyBotsState label="You don't have permission to create or manage bots." />
+      )}
+    </div>
+  )
+}
+
+interface CreateBotFormProps {
+  placeholder: string
+  isPending: boolean
+  error: Error | null
+  onCancel: () => void
+  onCreate: (data: Omit<CreateBotInput, "type">) => void
+}
+
+function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: CreateBotFormProps) {
   const [name, setName] = useState("")
   const [slug, setSlug] = useState("")
   const [description, setDescription] = useState("")
   const [slugTouched, setSlugTouched] = useState(false)
-
-  const createMutation = useMutation({
-    mutationFn: (data: CreateBotInput) => botsApi.create(workspaceId, data),
-    onSuccess: (bot) => {
-      setName("")
-      setSlug("")
-      setDescription("")
-      setSlugTouched(false)
-      setShowCreateForm(false)
-      queryClient.invalidateQueries({ queryKey })
-      onSelectBot(bot.id)
-    },
-  })
 
   const handleNameChange = (value: string) => {
     setName(value)
@@ -68,154 +193,122 @@ function BotList({ workspaceId, onSelectBot }: { workspaceId: string; onSelectBo
 
   const handleCreate = () => {
     if (!name.trim() || !slug.trim()) return
-    createMutation.mutate({
-      name: name.trim(),
-      slug: slug.trim(),
-      description: description.trim() || null,
-    })
-  }
-
-  if (isLoading) {
-    return (
-      <div className="space-y-3 p-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-20 w-full" />
-      </div>
-    )
+    onCreate({ name: name.trim(), slug: slug.trim(), description: description.trim() || null })
   }
 
   return (
-    <div className="space-y-4 p-1">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-sm font-medium">Bots ({bots.length})</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Integration identities that send messages via API keys.
-          </p>
-        </div>
-        {!showCreateForm && (
-          <Button size="sm" className="shrink-0 ml-4" onClick={() => setShowCreateForm(true)}>
-            <Plus className="h-3.5 w-3.5 mr-1.5" />
-            New bot
-          </Button>
-        )}
+    <div className="rounded-lg border bg-card p-4 space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="bot-name" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Name
+        </Label>
+        <Input
+          id="bot-name"
+          placeholder={placeholder}
+          value={name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          autoFocus
+        />
       </div>
 
-      {/* Create form */}
-      {showCreateForm && (
-        <div className="rounded-lg border bg-card p-4 space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="bot-name" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Name
-            </Label>
-            <Input
-              id="bot-name"
-              placeholder="e.g. GitHub Bot, Deploy Notifier"
-              value={name}
-              onChange={(e) => handleNameChange(e.target.value)}
-              autoFocus
-            />
-          </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="bot-slug" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Slug
+        </Label>
+        <Input
+          id="bot-slug"
+          placeholder="e.g. github-bot"
+          value={slug}
+          onChange={(e) => {
+            setSlugTouched(true)
+            setSlug(e.target.value)
+          }}
+        />
+        <p className="text-xs text-muted-foreground">Unique identifier. Lowercase letters, numbers, and hyphens.</p>
+      </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="bot-slug" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Slug
-            </Label>
-            <Input
-              id="bot-slug"
-              placeholder="e.g. github-bot"
-              value={slug}
-              onChange={(e) => {
-                setSlugTouched(true)
-                setSlug(e.target.value)
-              }}
-            />
-            <p className="text-xs text-muted-foreground">Unique identifier. Lowercase letters, numbers, and hyphens.</p>
-          </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="bot-description" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Description
+        </Label>
+        <Textarea
+          id="bot-description"
+          placeholder="What does this bot do?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+        />
+      </div>
 
-          <div className="space-y-1.5">
-            <Label
-              htmlFor="bot-description"
-              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
-            >
-              Description
-            </Label>
-            <Textarea
-              id="bot-description"
-              placeholder="What does this bot do?"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-            />
-          </div>
+      <Separator />
 
-          <Separator />
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleCreate} disabled={!name.trim() || !slug.trim() || isPending}>
+          {isPending ? "Creating..." : "Create bot"}
+        </Button>
+      </div>
 
-          <div className="flex items-center justify-between">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setShowCreateForm(false)
-                setName("")
-                setSlug("")
-                setDescription("")
-                setSlugTouched(false)
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleCreate}
-              disabled={!name.trim() || !slug.trim() || createMutation.isPending}
-            >
-              {createMutation.isPending ? "Creating..." : "Create bot"}
-            </Button>
-          </div>
-
-          {createMutation.error && (
-            <p className="text-sm text-destructive">
-              {createMutation.error instanceof Error
-                ? createMutation.error.message
-                : "Failed to create bot. Please try again."}
-            </p>
-          )}
-        </div>
+      {error && (
+        <p className="text-sm text-destructive">
+          {error instanceof Error ? error.message : "Failed to create bot. Please try again."}
+        </p>
       )}
+    </div>
+  )
+}
 
-      {/* Bot list */}
-      {bots.length > 0 && (
-        <div className="rounded-lg border divide-y">
-          {bots.map((bot) => (
-            <button
-              key={bot.id}
-              className="w-full flex items-center gap-3 px-3 py-3 hover:bg-accent/50 transition-colors text-left"
-              onClick={() => onSelectBot(bot.id)}
-            >
-              <BotAvatar bot={bot} workspaceId={workspaceId} size={36} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-sm font-medium truncate">{bot.name}</span>
-                  {bot.slug && (
-                    <code className="text-[11px] text-muted-foreground/70 font-mono hidden sm:inline">@{bot.slug}</code>
-                  )}
-                </div>
-                {bot.description && <p className="text-xs text-muted-foreground mt-0.5 truncate">{bot.description}</p>}
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
+interface BotListItem {
+  id: string
+  name: string
+  slug: string | null
+  description: string | null
+  avatarUrl: string | null
+  avatarEmoji: string | null
+}
 
-      {/* Empty state */}
-      {bots.length === 0 && !showCreateForm && (
-        <div className="rounded-lg border border-dashed py-8 flex flex-col items-center gap-2">
-          <BotIcon className="h-5 w-5 text-muted-foreground/50" />
-          <p className="text-sm text-muted-foreground">No bots yet</p>
-        </div>
-      )}
+function BotListItems({
+  bots,
+  workspaceId,
+  onSelectBot,
+}: {
+  bots: BotListItem[]
+  workspaceId: string
+  onSelectBot: (id: string) => void
+}) {
+  if (bots.length === 0) return null
+
+  return (
+    <div className="rounded-lg border divide-y">
+      {bots.map((bot) => (
+        <button
+          key={bot.id}
+          className="w-full flex items-center gap-3 px-3 py-3 hover:bg-accent/50 transition-colors text-left"
+          onClick={() => onSelectBot(bot.id)}
+        >
+          <BotAvatar bot={bot} workspaceId={workspaceId} size={36} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-sm font-medium truncate">{bot.name}</span>
+              {bot.slug && (
+                <code className="text-[11px] text-muted-foreground/70 font-mono hidden sm:inline">@{bot.slug}</code>
+              )}
+            </div>
+            {bot.description && <p className="text-xs text-muted-foreground mt-0.5 truncate">{bot.description}</p>}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function EmptyBotsState({ label }: { label: string }) {
+  return (
+    <div className="rounded-lg border border-dashed py-8 flex flex-col items-center gap-2">
+      <BotIcon className="h-5 w-5 text-muted-foreground/50" />
+      <p className="text-sm text-muted-foreground">{label}</p>
     </div>
   )
 }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -142,6 +142,9 @@ export function sequenceToNum(sequence: string): number {
 export interface CachedBot {
   id: string
   workspaceId: string
+  type: "shared" | "personal"
+  ownerUserId: string | null
+  traits: string[]
   slug: string | null
   name: string
   description: string | null

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -736,6 +736,13 @@ class ThreaDatabase extends Dexie {
         "id, workspaceId, streamId, status, [workspaceId+status+_scheduledForMs], [workspaceId+status+_statusChangedAtMs], [workspaceId+streamId+status+_scheduledForMs], _cachedAt",
     })
 
+    // v28: CachedBot gains required fields type/ownerUserId/traits (personal
+    // bots foundation). Clear stale rows so pre-v28 entries without these
+    // fields are removed; bootstrap rehydrates the table on next load.
+    this.version(28)
+      .stores({})
+      .upgrade((tx) => tx.table("bots").clear())
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }

--- a/apps/frontend/src/hooks/use-actors.test.ts
+++ b/apps/frontend/src/hooks/use-actors.test.ts
@@ -68,6 +68,9 @@ function createBot(overrides: Partial<Bot> & { _cachedAt?: number } = {}): Cache
   return {
     id: "bot_123",
     workspaceId: "ws_123",
+    type: "shared",
+    ownerUserId: null,
+    traits: [],
     slug: null,
     name: "Test Bot",
     description: null,


### PR DESCRIPTION
## Problem

PR #525 shipped the backend foundation for personal bots (type/owner/traits, permission-gated authz, `/me` endpoints) but left the workspace settings UI showing only shared (admin-managed) bots with no way for regular members to create or manage personal bots.

## Solution

Split the existing **Bots** tab in workspace settings into two permission-gated sections:

- **Workspace bots** — shared bots managed by admins. Shown only when the viewer holds `bots:manage` or `bots:create:shared`. The "New bot" button is further gated on `bots:create:shared` (a viewer with only `bots:manage` can see the list but not create).
- **My bots** — personal bots owned by the viewer. Shown when the viewer holds `bots:create:personal` (granted to all members by default, revocable per-workspace via WorkOS). Users without either section see a locked empty state.

### How it works

**Shared bots** are fetched fresh from `GET /api/workspaces/:wid/bots` (returns only `type='shared'`). **Personal bots** are read from the IDB-cached bootstrap — the backend already scopes `listVisibleTo` to `shared OR (personal AND owner_user_id = viewer)`, so no extra API call is needed. After creating a personal bot, the workspace bootstrap is invalidated to pull the new entry into the cache.

### Key design decisions

**1. Personal bots read from IDB cache, not a dedicated fetch**

There's no internal-auth route for listing a user's personal bots (the `/me/bots` public-API endpoint requires an API key, not a session). Rather than add a new internal route, we derive personal bots by filtering the bootstrap-synced IDB store. The bootstrap already contains exactly the right set. The trade-off: the list doesn't auto-refresh on mount — a fresh bootstrap fetch is only triggered on creation/mutation. This is fine for the settings panel use case.

**2. CachedBot gains `type`, `ownerUserId`, `traits`**

The IDB bot rows are hydrated via `{ ...bootstrapBot, workspaceId, _cachedAt }` spread, so the fields were always written to disk — they just weren't typed. Adding them to the `CachedBot` interface makes the filter (`b.type === "personal"`) type-safe and ensures future readers can narrow on the discriminated union.

**3. `CreateBotInput` gains optional `type`**

The create form calls the same `POST /api/workspaces/:wid/bots` endpoint for both types, passing `type: "shared"` or `type: "personal"`. The backend derives `ownerUserId` from the session (never from the request body), so this is safe.

**4. Section visibility mirrors permission model exactly**

| Viewer permissions | Workspace bots section | My bots section |
|---|---|---|
| `bots:manage` only | Visible (read-only) | Hidden |
| `bots:create:shared` | Visible + New bot | Hidden |
| `bots:create:personal` | Hidden | Visible + New bot |
| Both | Both visible | Both visible |
| Neither | — | Locked empty state |

## Modified files

| File | Change |
|---|---|
| `apps/frontend/src/db/database.ts` | `CachedBot` gains `type`, `ownerUserId`, `traits` fields |
| `apps/frontend/src/api/bots.ts` | `CreateBotInput` gains optional `type` field |
| `apps/frontend/src/components/workspace-settings/bots-tab.tsx` | Full rewrite: split into workspace/personal sections, permission-gated, design-polished |
| `apps/frontend/src/hooks/use-actors.test.ts` | Bot fixture updated with new required fields |

## Design polish (frontend-design pass)

- Name and slug fields placed side-by-side in the create form (reduces vertical height, scannable at a glance)
- `Cmd/Ctrl+Enter` submits the create form from any field
- Error message moved inline next to the submit button — visible without scrolling
- Section headers: `Globe` icon for workspace bots, `User` icon for personal bots — lightweight visual cue
- Bot count rendered as a `Badge` (tabular-nums) instead of parenthetical text
- Bot list rows: `ChevronRight` affordance + hover state makes rows clearly clickable; 32px avatar for tighter density
- Empty states: title + description + inline action button so the CTA is always co-located

## Test plan

- [x] TypeScript typecheck passes (all packages)
- [x] ESLint passes
- [x] `use-actors` test fixture updated and passes
- [ ] Manual: member (no `bots:create:shared`) sees only "My bots" section
- [ ] Manual: admin sees both sections
- [ ] Manual: create a personal bot → appears in "My bots" after bootstrap invalidation
- [ ] Manual: create a workspace bot → appears in "Workspace bots"
- [ ] Manual: clicking a bot from either section opens `BotDetail` correctly

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsUgCyE5aNbT8cYz3YKURd)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->