### PR TITLE
docs: describe interactive bot scratchpads

### DIFF
--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -275,6 +275,65 @@ Relevant ideas to borrow:
 
 Claude channels require an active Claude Code session and are currently research-preview functionality, so they should inform the contract rather than define the Threa product surface.
 
+## Presence and availability
+
+Some interactive actors are always available from Threa's perspective, while others depend on an external runtime being online:
+
+- Ariadne can be treated as available when Threa's own agent workers are healthy.
+- Hermes/OpenClaw bots are available when their gateway/adapter is connected.
+- Local Pi and Claude Code channel bots are available only while the relevant local session/extension/channel server is running.
+
+Threa should distinguish the existence of a bot from the availability of a runtime that can currently serve it.
+
+### Presence model
+
+Runtime adapters should be able to publish lightweight presence for the bot identities they can serve:
+
+```ts
+type BotRuntimePresence = {
+  botId: string
+  runtimeKind: "pi-local" | "hermes" | "openclaw" | "claude-code-channel" | "custom"
+  instanceId: string
+  status: "available" | "busy" | "offline" | "error"
+  acceptingInvocations: boolean
+  lastSeenAt: string
+  capabilities?: {
+    supportsStop?: boolean
+    supportsPermissionRelay?: boolean
+    supportsStreaming?: boolean
+  }
+  statusText?: string
+}
+```
+
+Presence should be advisory, not the security boundary. Bot API keys, stream access, and invocation claims remain the source of truth for what a runtime may do.
+
+### Invocation behavior when offline
+
+The simplest product behavior should be:
+
+- If an explicitly mentioned bot has no available runtime, Threa should create a clear failure/notice rather than silently dropping the message.
+- If the active actor for a dedicated bot scratchpad is offline, the scratchpad should show an availability indicator and avoid making the user wonder why no reply arrived.
+- Threa may keep a short pending/unclaimed window for transient reconnects, but it should eventually mark the invocation as unclaimed/offline.
+- Queueing for offline runtimes should be opt-in per adapter. A local Pi or Claude Code session may prefer "fail fast"; a Hermes/OpenClaw gateway may prefer queueing.
+
+### Multiple runtime instances
+
+Presence is also how Threa avoids duplicate local adapters racing:
+
+- More than one runtime instance may advertise that it can serve the same bot.
+- Invocation claiming must still be atomic; presence only tells Threa which runtimes appear eligible.
+- Runtime instances should have stable `instanceId`s so users can distinguish "Kris's MacBook Pi" from "VPS OpenClaw" if needed.
+
+### UI implications
+
+Presence should surface in a few low-noise places:
+
+- bot mention autocomplete can show available/busy/offline,
+- a dedicated bot chat scratchpad can show a small active actor status,
+- failed invocations can render as a system notice or bot-status message,
+- detailed runtime metadata can remain deferred to the future artifacts/status model.
+
 ## Metadata, status, and artifacts
 
 Interactive runtimes will eventually want to expose more than plain chat text:
@@ -312,12 +371,17 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
    - atomic claim/dedupe,
    - response target chosen by Threa.
 
-3. **Support one external adapter path first**
+3. **Add lightweight runtime presence**
+   - adapters heartbeat availability for the bot identities they can serve,
+   - UI can show online/busy/offline,
+   - invocations fail clearly when no runtime claims them.
+
+4. **Support one external adapter path first**
    - likely the local Pi bridge or OpenClaw channel plugin,
    - use polling if needed,
    - keep the runtime session binding adapter-owned.
 
-4. **Defer artifacts/status**
+5. **Defer artifacts/status**
    - use normal bot messages initially,
    - reserve a clean path for typed runtime references later.
 
@@ -327,6 +391,8 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
 - Should an active actor ever auto-comment on messages that mention a different actor, or is mention-suppression always the right default?
 - Should multiple active actors in one scratchpad ever be supported, or should multi-actor conversations stay explicit via mentions?
 - What exact UI should show that a scratchpad is a dedicated bot chat and that its active actor is inherited into descendant threads?
+- What is the right offline behavior per runtime: fail fast, short pending window, or queue until the runtime reconnects?
+- Should runtime presence be per bot, per bot+stream, or per runtime instance with advertised bot ids?
 - Should runtime status/artifacts be modeled as a separate table, message attachments, context refs, or a combination?
 - What is the minimum realtime surface for adapters: polling public API, Socket.io/SSE, or a dedicated invocation stream?
 

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -1,0 +1,81 @@
+# Interactive bot scratchpads
+
+## Problem
+
+Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically as part of the scratchpad flow. That works for the built-in assistant, but it does not generalize cleanly to personal bots such as Hermes, OpenClaw, NanoClaw, or local developer agents.
+
+Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but Threa does not yet have a provider-agnostic product model for starting a scratchpad with one of those bots and routing invocations to the appropriate runtime on the other side.
+
+The missing concept is an interactive bot scratchpad where Threa owns the conversation and permissions, while the actual bot runtime may be Ariadne, a local Pi/OpenClaw process, Hermes, or another adapter.
+
+## Direction
+
+Extend scratchpads so they can include one or more passive interactive bots. A bot with the `interactive` trait can be selected when creating a scratchpad. From Threa's perspective, the bot is a member of the scratchpad, but it is passive by default and only responds when invoked, for example by mentioning `@ariadne` or `@openclaw`.
+
+This makes Ariadne one implementation of the same interactive-bot participant model rather than a scratchpad-specific special case.
+
+## How it could work
+
+```text
+User creates scratchpad with an interactive bot
+  ↓
+Threa records the bot as a scratchpad participant/member
+  ↓
+User sends a message mentioning @bot
+  ↓
+Threa emits a provider-agnostic bot invocation
+  ↓
+The matching bot runtime claims/processes the invocation
+  ↓
+Runtime posts progress/final responses back as the bot
+```
+
+For local agents, the runtime might be a long-running bridge process on the user's machine. That bridge would map Threa scratchpads to local runtime sessions and decide whether to reuse an existing process, spawn a new process, or create a worktree.
+
+## Key design principles
+
+**1. Provider-agnostic Threa model**
+
+Threa should not know whether a bot is backed by Ariadne, Hermes, OpenClaw, Pi, or another runtime. It should model bot membership, invocations, permissions, and messages. Runtime-specific concerns stay behind adapters.
+
+**2. Passive by default**
+
+Interactive bots should not automatically respond to every scratchpad message. They become passive participants and respond only when invoked by mention or another explicit trigger. This avoids noisy multi-bot conversations and gives users control.
+
+**3. Runtime session binding**
+
+The runtime side likely needs a binding between a Threa scratchpad and a local/provider session:
+
+```text
+workspaceId + scratchpadId + botId → runtimeSessionId
+```
+
+For a local coding bot, that binding might include a Pi session file, working directory, optional git worktree, model/provider config, and live process/socket state.
+
+**4. Local runtime owns process/worktree policy**
+
+Whether a bot creates a worktree, reuses the current checkout, spawns a process per task, or maintains a daemon is runtime-specific. Threa should not encode those policies in the core scratchpad model.
+
+**5. Safe claiming and deduplication**
+
+If multiple runtimes can service the same bot, invocations need a claim/dedup mechanism so only one runtime handles a given message. The initial local prototype can use polling and conservative message metadata, but a first-class invocation/claim API may be needed.
+
+## Open questions
+
+- Is one Threa scratchpad mapped to one runtime session, or can multiple local sessions exist per scratchpad?
+- Should creating a scratchpad with a local coding bot automatically create a git worktree, or should that be opt-in per bot/runtime?
+- Should bot invocations be represented as ordinary messages plus metadata, or as a first-class invocation resource?
+- How should users target a specific runtime instance when multiple machines are online?
+- Should Ariadne continue to support an auto-reply mode, or should she become mention-only in scratchpads too?
+- What is the minimum realtime surface needed: polling public API, Socket.io, SSE, or a dedicated bot-runtime event stream?
+
+## Non-goals for this note
+
+- No implementation in this PR.
+- No schema or API changes yet.
+- No frontend UI changes yet.
+- No decision on the local process/worktree model yet.
+
+## Suggested next step
+
+Prototype the product semantics first: allow scratchpads to include an `interactive` bot participant and invoke that bot explicitly via mention. Once the Threa-side semantics are clear, define the runtime adapter contract for local Pi/OpenClaw/Hermes-style integrations.

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -4,7 +4,7 @@
 
 Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically in the scratchpad and in scratchpad-rooted threads. That works for the built-in assistant, but it does not generalize cleanly to user-owned bots such as a user-named Hermes-backed bot (for example `@hermit`), an OpenClaw-backed coding agent, or a local Pi bridge.
 
-Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but that trait is too coarse for the product model Threa needs:
+Personal bots now have the backend foundation to be user-owned and tagged with capability traits, but a single coarse `interactive` trait would not be enough for the product model Threa needs:
 
 - mentioning an owned bot anywhere the user is allowed to talk,
 - creating a dedicated chat scratchpad for a user-named bot where that bot responds without being mentioned every time,
@@ -32,7 +32,7 @@ The capability split matters because the integration requirements are different:
 | `mentionable`       | User writes `@bot ...`; bot answers once in this context                                      | Resolve mention, create one invocation, read bounded context, post a reply                                       | Stateless helpers, PR/status bots, local tools that should not become ambient chat partners |
 | `active-scratchpad` | User opens a dedicated bot chat scratchpad; bot responds turn-by-turn without being mentioned | Persistent session binding, runtime presence, concurrency policy, thread inheritance, in-flight message handling | Ariadne-style companions, Hermes/OpenClaw/Pi coding sessions                                |
 
-The exact stored trait names are still provisional. One reasonable direction is to add a `mentionable` trait and reserve/rename `interactive` for active scratchpad participation. Another is to make both explicit (`mentionable`, `active-scratchpad`) so the product does not rely on implicit hierarchy. A fully interactive chat bot would normally have both traits, while a mentionable-only bot would not appear as a dedicated scratchpad companion.
+The exact stored trait names are still provisional, but the recommended direction is to make both explicit (`mentionable`, `active-scratchpad`) so the product does not rely on implicit hierarchy. A fully interactive chat bot would normally have both traits, while a mentionable-only bot would not appear as a dedicated scratchpad companion.
 
 ## Vocabulary
 
@@ -419,7 +419,6 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
 
 ## Open questions
 
-- Should the stored trait names be `mentionable` + `active-scratchpad`, or should the existing `interactive` name be preserved for active scratchpad participation?
 - Should `active-scratchpad` imply `mentionable` at validation time, or should fully interactive bots explicitly carry both traits?
 - Should personal bot mention in a shared channel create a persistent bot access grant, or should the first version send an invocation-scoped context snapshot only?
 - Should an active actor ever auto-comment on messages that mention a different actor, or is mention-suppression always the right default?

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -46,7 +46,7 @@ The process/plugin/API bridge that turns a Threa invocation into work performed 
 The adapter-owned mapping from a Threa conversation surface to a runtime session:
 
 ```text
-workspaceId + botId/personaId + rootStreamId + activeStreamId → runtimeSessionId
+workspaceId + rootStreamId + activeStreamId + actor.id → runtimeSessionId
 ```
 
 For a top-level scratchpad, `rootStreamId` and `activeStreamId` are the same. For a thread under that scratchpad, `rootStreamId` stays the scratchpad and `activeStreamId` is the thread. This mirrors Ariadne's current behavior: the scratchpad's companion is inherited into scratchpad-rooted threads, but the response lands in the current thread.
@@ -185,7 +185,7 @@ Adapter responsibilities:
 
 - discover supported bot/runtime identities,
 - claim invocations atomically so multiple local processes do not race,
-- map `rootStreamId + activeStreamId + actor.id` to a runtime session,
+- map `workspaceId + rootStreamId + activeStreamId + actor.id` to a runtime session,
 - fetch/receive the context it is allowed to see,
 - run the provider-specific agent loop,
 - post progress and final messages back to `responseStreamId`,

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -12,7 +12,7 @@ Personal bots now have the backend foundation to be user-owned and tagged with t
 - keeping the same behavior in threads under the scratchpad,
 - routing those invocations to provider-specific runtimes without making Threa know whether the other side is Hermes, OpenClaw, Claude Code channels, or a custom Pi adapter.
 
-This note describes the product/runtime contract only. It intentionally contains no implementation.
+This note describes the product/runtime contract only. It intentionally contains no implementation. For a concrete staged implementation plan focused on the local Pi remote adapter, see [`pi-remote-protocol-implementation.md`](./pi-remote-protocol-implementation.md).
 
 ## Product direction
 

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -1,81 +1,339 @@
-# Interactive bot scratchpads
+# Interactive bot scratchpads and mentions
 
 ## Problem
 
-Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically as part of the scratchpad flow. That works for the built-in assistant, but it does not generalize cleanly to personal bots such as Hermes, OpenClaw, NanoClaw, or local developer agents.
+Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically in the scratchpad and in scratchpad-rooted threads. That works for the built-in assistant, but it does not generalize cleanly to user-owned bots such as a Hermes bot (`@hermit`), an OpenClaw-backed coding agent, or a local Pi bridge.
 
-Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but Threa does not yet have a provider-agnostic product model for starting a scratchpad with one of those bots and routing invocations to the appropriate runtime on the other side.
+Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but Threa still needs a product model for:
 
-The missing concept is an interactive bot scratchpad where Threa owns the conversation and permissions, while the actual bot runtime may be Ariadne, a local Pi/OpenClaw process, Hermes, or another adapter.
+- mentioning an owned bot anywhere the user is allowed to talk,
+- creating a "Chat with Hermit"-style scratchpad where Hermit responds without being mentioned every time,
+- invoking Ariadne or another bot inside that same scratchpad when explicitly mentioned,
+- keeping the same behavior in threads under the scratchpad,
+- routing those invocations to provider-specific runtimes without making Threa know whether the other side is Hermes, OpenClaw, Claude Code channels, or a custom Pi adapter.
 
-## Direction
+This note describes the product/runtime contract only. It intentionally contains no implementation.
 
-Extend scratchpads so they can include one or more passive interactive bots. A bot with the `interactive` trait can be selected when creating a scratchpad. From Threa's perspective, the bot is a member of the scratchpad, but it is passive by default and only responds when invoked, for example by mentioning `@ariadne` or `@openclaw`.
+## Product direction
 
-This makes Ariadne one implementation of the same interactive-bot participant model rather than a scratchpad-specific special case.
+Interactive bots should be modeled as actors that can be invoked in two ways:
 
-## How it could work
+1. **Active scratchpad participant** — a scratchpad can have one primary interactive actor that responds to normal user messages without requiring an `@mention`. This is the "Chat with Hermit" experience.
+2. **Mention target** — any available interactive actor can be explicitly invoked with `@slug` from a scratchpad, thread, channel, or DM. This is how a user can mention `@ariadne` inside a Hermit scratchpad or mention `@hermit` from an unrelated stream.
+
+Ariadne becomes one implementation of this model rather than the only special companion path.
+
+## Vocabulary
+
+**Interactive actor**
+
+A persona or bot that is allowed to participate conversationally. Ariadne is a persona; personal/shared bots with the `interactive` trait are bot-backed actors.
+
+**Active actor**
+
+The primary interactive actor attached to a scratchpad. The active actor is invoked automatically for ordinary user messages in that scratchpad and its descendant threads.
+
+**Mention invocation**
+
+A one-off invocation created by an explicit `@actor` mention. Mention invocations should work in any stream where the user can write and the actor is available to that user.
+
+**Runtime adapter**
+
+The process/plugin/API bridge that turns a Threa invocation into work performed by Hermes, OpenClaw, Claude Code, local Pi, or another runtime.
+
+**Runtime session binding**
+
+The adapter-owned mapping from a Threa conversation surface to a runtime session:
 
 ```text
-User creates scratchpad with an interactive bot
-  ↓
-Threa records the bot as a scratchpad participant/member
-  ↓
-User sends a message mentioning @bot
-  ↓
-Threa emits a provider-agnostic bot invocation
-  ↓
-The matching bot runtime claims/processes the invocation
-  ↓
-Runtime posts progress/final responses back as the bot
+workspaceId + botId/personaId + rootStreamId + activeStreamId → runtimeSessionId
 ```
 
-For local agents, the runtime might be a long-running bridge process on the user's machine. That bridge would map Threa scratchpads to local runtime sessions and decide whether to reuse an existing process, spawn a new process, or create a worktree.
+For a top-level scratchpad, `rootStreamId` and `activeStreamId` are the same. For a thread under that scratchpad, `rootStreamId` stays the scratchpad and `activeStreamId` is the thread. This mirrors Ariadne's current behavior: the scratchpad's companion is inherited into scratchpad-rooted threads, but the response lands in the current thread.
 
-## Key design principles
+## User-facing behavior
 
-**1. Provider-agnostic Threa model**
+### 1. Mention your own bot anywhere
 
-Threa should not know whether a bot is backed by Ariadne, Hermes, OpenClaw, Pi, or another runtime. It should model bot membership, invocations, permissions, and messages. Runtime-specific concerns stay behind adapters.
-
-**2. Passive by default**
-
-Interactive bots should not automatically respond to every scratchpad message. They become passive participants and respond only when invoked by mention or another explicit trigger. This avoids noisy multi-bot conversations and gives users control.
-
-**3. Runtime session binding**
-
-The runtime side likely needs a binding between a Threa scratchpad and a local/provider session:
+A user who owns a personal interactive bot should be able to mention it by slug, for example:
 
 ```text
-workspaceId + scratchpadId + botId → runtimeSessionId
+@hermit can you look at this thread and summarize the plan?
 ```
 
-For a local coding bot, that binding might include a Pi session file, working directory, optional git worktree, model/provider config, and live process/socket state.
+Expected behavior:
 
-**4. Local runtime owns process/worktree policy**
+- Threa resolves `@hermit` as the user's personal bot.
+- If the current stream is a top-level channel, the bot response should follow existing Ariadne mention behavior and happen in a thread for that message.
+- If the current stream is a scratchpad, DM, or thread, the bot responds in the current stream.
+- The bot invocation is scoped to the current stream/thread context and must not grant hidden workspace-wide access.
 
-Whether a bot creates a worktree, reuses the current checkout, spawns a process per task, or maintains a daemon is runtime-specific. Threa should not encode those policies in the core scratchpad model.
+### 2. Create a "Chat with Hermit" scratchpad
 
-**5. Safe claiming and deduplication**
+When the user creates a scratchpad with an interactive bot selected, that bot becomes the active actor for the scratchpad.
 
-If multiple runtimes can service the same bot, invocations need a claim/dedup mechanism so only one runtime handles a given message. The initial local prototype can use polling and conservative message metadata, but a first-class invocation/claim API may be needed.
+Expected behavior:
+
+```text
+User creates "Chat with Hermit"
+  ↓
+Hermit is attached as the active actor
+  ↓
+User sends "hiya"
+  ↓
+Hermit responds without requiring @hermit
+```
+
+This is intentionally different from a passive mention-only participant. Requiring `@hermit` on every message in a dedicated Hermit scratchpad would make the scratchpad feel broken.
+
+### 3. Mention Ariadne inside a Hermit scratchpad
+
+The active actor should not prevent explicit mention invocations of other actors.
+
+Example:
+
+```text
+User, in Chat with Hermit:
+@ariadne can you sanity-check Hermit's plan?
+```
+
+Default activation rule:
+
+- Because the message explicitly mentions `@ariadne`, Threa invokes Ariadne.
+- Hermit does **not** also auto-respond unless the message also mentions `@hermit` or a later product setting asks active actors to comment on all mentions.
+- This avoids duplicate/noisy responses while still letting the user deliberately ask multiple actors by mentioning multiple actors.
+
+### 4. Active scratchpad behavior applies in threads
+
+If a thread is created under a scratchpad with an active actor, that actor should be active in the thread too.
+
+Expected behavior:
+
+```text
+Chat with Hermit scratchpad
+  └─ Thread under a message
+       ├─ User sends a normal message
+       └─ Hermit responds in that thread
+```
+
+The active actor inherits from the scratchpad root. The reply target is the current thread. This matches the existing Ariadne companion behavior for scratchpad-rooted threads.
+
+## Activation resolution
+
+For each user-authored message, Threa should resolve invocations with a deterministic algorithm:
+
+1. Ignore messages authored by bots/personas/system actors to avoid loops.
+2. Resolve explicit `@slug` mentions against available personas and interactive bots.
+3. Resolve the active actor, if any, from the current stream:
+   - current stream is a scratchpad with an active actor, or
+   - current stream is a thread whose `rootStreamId` points to a scratchpad with an active actor.
+4. If the message contains no explicit interactive-actor mentions, invoke the active actor if one exists.
+5. If the message contains explicit interactive-actor mentions:
+   - invoke each mentioned actor once,
+   - do not additionally auto-invoke the active actor unless the active actor was explicitly mentioned.
+6. Pick the response target:
+   - top-level channel mention → create/use a thread on the source message,
+   - scratchpad, DM, or existing thread → respond in the current stream,
+   - active scratchpad/thread invocation → respond in the current scratchpad/thread.
+7. Create provider-neutral invocation records and let runtime adapters claim/process them.
+
+This keeps the common case simple while supporting multi-actor conversations when the user asks for them explicitly.
+
+## Access and safety model
+
+Interactive bots are more powerful than decorative participants because they may read context, call tools, create PRs, and post as themselves. The product model should make access explicit enough to be safe without making normal use tedious.
+
+### Personal bots
+
+- A personal bot is primarily invokable by its owner.
+- The owner can mention it from streams where they can write.
+- A successful mention or scratchpad attachment should create a scoped bot access relationship for the target stream/root, or an invocation-scoped context snapshot, depending on the runtime surface.
+- Long-lived access grants should be visible and revocable. Threa should not silently give a personal bot permanent access to every stream the owner can read.
+
+### Shared bots
+
+- Shared bots are workspace-managed and can be mentionable by members according to workspace policy.
+- Admins should control where a shared bot can be active by default.
+- Mentioning a shared bot should still respect stream visibility and membership.
+
+### Runtime identity
+
+External runtimes should post back using bot-scoped API keys. Threa should verify that the key belongs to the bot being invoked, not merely to some arbitrary workspace integration.
+
+## Runtime adapter contract
+
+Threa should produce a small, provider-neutral invocation contract. Runtimes implement adapters around it.
+
+```ts
+type BotInvocation = {
+  id: string
+  workspaceId: string
+  rootStreamId: string
+  activeStreamId: string
+  sourceMessageId: string
+  responseStreamId: string
+  actor: { type: "persona" | "bot"; id: string; slug: string }
+  trigger: "active-scratchpad" | "mention"
+  promptMarkdown: string
+  authorUserId: string
+  mentionedActorSlugs: string[]
+  createdAt: string
+}
+```
+
+Adapter responsibilities:
+
+- discover supported bot/runtime identities,
+- claim invocations atomically so multiple local processes do not race,
+- map `rootStreamId + activeStreamId + actor.id` to a runtime session,
+- fetch/receive the context it is allowed to see,
+- run the provider-specific agent loop,
+- post progress and final messages back to `responseStreamId`,
+- mark the invocation completed/failed/cancelled,
+- optionally expose status/artifacts back to Threa.
+
+The claim step is important for local Pi and Claude Code channel-style adapters where multiple local sessions may be open at once.
+
+## Runtime examples
+
+### Custom Pi adapter
+
+A personal Pi bridge is an active local session adapter:
+
+```text
+Threa invocation
+  → local Pi extension/poller claims it
+  → Pi maps stream/thread to a local Pi session
+  → Pi injects the prompt into the active session
+  → Pi posts the result back as the bot
+```
+
+Constraints:
+
+- The local Pi instance must be online.
+- Multiple Pi instances need claim/dedupe or instance targeting.
+- Process/worktree policy is local and should not be encoded in Threa.
+- This is the fastest iteration path for personal use.
+
+### Hermes
+
+Hermes is best treated as a gateway/runtime adapter:
+
+```text
+Threa invocation
+  → Hermes Threa platform adapter or Hermes API bridge
+  → Hermes gateway session
+  → Hermes AIAgent
+  → reply back to Threa
+```
+
+Constraints:
+
+- Hermes owns sessions, memory, tools, background jobs, and process policy.
+- Threa maps scratchpads/threads to Hermes session keys.
+- A native Hermes platform adapter is the long-term fit; an OpenAI-compatible API bridge can be the quick prototype.
+
+### OpenClaw
+
+OpenClaw is best treated as a native channel plugin:
+
+```text
+Threa invocation
+  → OpenClaw Threa channel plugin
+  → OpenClaw Gateway
+  → selected OpenClaw agentId
+  → embedded Pi AgentSession
+  → reply back to Threa
+```
+
+Constraints:
+
+- OpenClaw owns workspace/session/tool/sandbox policy.
+- Threa bot identity can map to OpenClaw `agentId`.
+- Threa scratchpad/thread identity maps to OpenClaw channel session grammar.
+- Mention gating, sender gating, and reply-thread behavior should live in the OpenClaw channel plugin.
+
+### Claude Code channels
+
+Claude Code channels are a useful protocol precedent for local active-session adapters:
+
+```text
+Threa event
+  → local MCP channel server
+  → active Claude Code session receives <channel ...>
+  → Claude calls a reply tool
+  → MCP channel server posts back to Threa
+```
+
+Relevant ideas to borrow:
+
+- capability declaration: the local server advertises that it can receive channel events,
+- event notification: external events are injected into an active session as structured channel messages,
+- reply tool: the runtime sends outbound messages through a tool exposed by the channel,
+- sender gating: inbound messages must be authorized before reaching the agent,
+- permission relay: tool approval prompts can be mirrored to the remote chat while the local prompt stays open.
+
+Claude channels require an active Claude Code session and are currently research-preview functionality, so they should inform the contract rather than define the Threa product surface.
+
+## Metadata, status, and artifacts
+
+Interactive runtimes will eventually want to expose more than plain chat text:
+
+- usage quotas and model/account status,
+- created pull requests,
+- hosted implementation plans,
+- worktree/branch/session links,
+- deployment URLs,
+- long-running task progress,
+- approval prompts and decisions.
+
+This should be treated as an extension of Threa's reference/context model, not as arbitrary rich blobs in message metadata.
+
+Recommended direction:
+
+1. **V1**: keep runtime output as normal bot messages. Use message metadata only for small bookkeeping such as invocation/run ids, not rich artifacts.
+2. **Later**: introduce typed bot artifacts or runtime references that can render as chips/cards and be included in AI context when referenced.
+3. **Later**: allow active scratchpads to show a runtime status strip, for example quota remaining or current worktree, without requiring the bot to post noisy status messages.
+
+This parallels the existing `ContextBag` direction: references are typed pointers that can be resolved for display and for AI context, rather than unstructured text copied everywhere.
+
+## Minimal implementation shape
+
+A first implementation should avoid a broad multi-agent orchestration platform. The smallest useful shape is:
+
+1. **Generalize activation semantics**
+   - keep one active actor slot for scratchpads,
+   - resolve mentions across personas and interactive bots,
+   - inherit the active actor into scratchpad-rooted threads,
+   - suppress active auto-response when a different actor is explicitly mentioned.
+
+2. **Create provider-neutral invocations**
+   - one invocation per target actor per source message,
+   - atomic claim/dedupe,
+   - response target chosen by Threa.
+
+3. **Support one external adapter path first**
+   - likely the local Pi bridge or OpenClaw channel plugin,
+   - use polling if needed,
+   - keep the runtime session binding adapter-owned.
+
+4. **Defer artifacts/status**
+   - use normal bot messages initially,
+   - reserve a clean path for typed runtime references later.
 
 ## Open questions
 
-- Is one Threa scratchpad mapped to one runtime session, or can multiple local sessions exist per scratchpad?
-- Should creating a scratchpad with a local coding bot automatically create a git worktree, or should that be opt-in per bot/runtime?
-- Should bot invocations be represented as ordinary messages plus metadata, or as a first-class invocation resource?
-- How should users target a specific runtime instance when multiple machines are online?
-- Should Ariadne continue to support an auto-reply mode, or should she become mention-only in scratchpads too?
-- What is the minimum realtime surface needed: polling public API, Socket.io, SSE, or a dedicated bot-runtime event stream?
+- Should personal bot mention in a shared channel create a persistent bot access grant, or should the first version send an invocation-scoped context snapshot only?
+- Should an active actor ever auto-comment on messages that mention a different actor, or is mention-suppression always the right default?
+- Should multiple active actors in one scratchpad ever be supported, or should multi-actor conversations stay explicit via mentions?
+- What exact UI should show that a scratchpad is "Chat with Hermit" and that Hermit is active in descendant threads?
+- Should runtime status/artifacts be modeled as a separate table, message attachments, context refs, or a combination?
+- What is the minimum realtime surface for adapters: polling public API, Socket.io/SSE, or a dedicated invocation stream?
 
 ## Non-goals for this note
 
 - No implementation in this PR.
 - No schema or API changes yet.
 - No frontend UI changes yet.
-- No decision on the local process/worktree model yet.
-
-## Suggested next step
-
-Prototype the product semantics first: allow scratchpads to include an `interactive` bot participant and invoke that bot explicitly via mention. Once the Threa-side semantics are clear, define the runtime adapter contract for local Pi/OpenClaw/Hermes-style integrations.
+- No decision on the local process/worktree model.
+- No NemoClaw-specific design; NemoClaw is a sandbox/deployment layer for other runtimes rather than a bot interactivity model.

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -4,7 +4,7 @@
 
 Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically in the scratchpad and in scratchpad-rooted threads. That works for the built-in assistant, but it does not generalize cleanly to user-owned bots such as a user-named Hermes-backed bot (for example `@hermit`), an OpenClaw-backed coding agent, or a local Pi bridge.
 
-Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but Threa still needs a product model for:
+Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but that trait is too coarse for the product model Threa needs:
 
 - mentioning an owned bot anywhere the user is allowed to talk,
 - creating a dedicated chat scratchpad for a user-named bot where that bot responds without being mentioned every time,
@@ -16,22 +16,41 @@ This note describes the product/runtime contract only. It intentionally contains
 
 ## Product direction
 
-Interactive bots should be modeled as actors that can be invoked in two ways:
+Bot interactivity should be split into separate capabilities instead of overloading one `interactive` trait for every conversational use case:
 
-1. **Active scratchpad participant** — a scratchpad can have one primary interactive actor that responds to normal user messages without requiring an `@mention`. This is the "Chat with <bot name>" experience.
-2. **Mention target** — any available interactive actor can be explicitly invoked with `@slug` from a scratchpad, thread, channel, or DM. This is how a user can mention `@ariadne` inside another bot's scratchpad or mention a user-named bot such as `@hermit` from an unrelated stream.
+1. **Mentionable** — an actor can be explicitly invoked with `@slug` for a one-shot response in the current context. This is how Ariadne works outside scratchpads today.
+2. **Active scratchpad participant** — an actor can be selected as the primary participant in a dedicated scratchpad and responds to normal user messages without requiring an `@mention`. This is the "Chat with <bot name>" experience.
 
-Ariadne becomes one implementation of this model rather than the only special companion path.
+Ariadne has both capabilities: she can be mentioned from arbitrary contexts, and she can be active in scratchpads. A user-owned bot should be able to support either one or both, depending on what its runtime can safely provide.
+
+## Capability granularity
+
+The capability split matters because the integration requirements are different:
+
+| Capability          | User experience                                                                               | Runtime requirements                                                                                             | Good fit                                                                                    |
+| ------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mentionable`       | User writes `@bot ...`; bot answers once in this context                                      | Resolve mention, create one invocation, read bounded context, post a reply                                       | Stateless helpers, PR/status bots, local tools that should not become ambient chat partners |
+| `active-scratchpad` | User opens a dedicated bot chat scratchpad; bot responds turn-by-turn without being mentioned | Persistent session binding, runtime presence, concurrency policy, thread inheritance, in-flight message handling | Ariadne-style companions, Hermes/OpenClaw/Pi coding sessions                                |
+
+The exact stored trait names are still provisional. One reasonable direction is to add a `mentionable` trait and reserve/rename `interactive` for active scratchpad participation. Another is to make both explicit (`mentionable`, `active-scratchpad`) so the product does not rely on implicit hierarchy. A fully interactive chat bot would normally have both traits, while a mentionable-only bot would not appear as a dedicated scratchpad companion.
 
 ## Vocabulary
 
 **Interactive actor**
 
-A persona or bot that is allowed to participate conversationally. Ariadne is a persona; personal/shared bots with the `interactive` trait are bot-backed actors.
+Umbrella term for a persona or bot with at least one conversational capability. Ariadne is a persona; personal/shared bots can become interactive actors when they carry `mentionable`, `active-scratchpad`, or equivalent traits.
+
+**Mentionable actor**
+
+A persona or bot that can be invoked by explicit `@slug` mention for a one-shot response in the current stream/thread context.
+
+**Active-capable actor**
+
+A persona or bot that can be attached to a scratchpad as the primary participant and respond without being mentioned on every turn.
 
 **Active actor**
 
-The primary interactive actor attached to a scratchpad. The active actor is invoked automatically for ordinary user messages in that scratchpad and its descendant threads.
+The primary active-capable actor attached to a scratchpad. The active actor is invoked automatically for ordinary user messages in that scratchpad and its descendant threads.
 
 **Mention invocation**
 
@@ -55,7 +74,7 @@ For a top-level scratchpad, `rootStreamId` and `activeStreamId` are the same. Fo
 
 ### 1. Mention your own bot anywhere
 
-A user who owns a personal interactive bot should be able to mention it by its user-chosen slug. For example, if the user created a bot named Hermit with slug `hermit`:
+A user who owns a personal mentionable bot should be able to mention it by its user-chosen slug. For example, if the user created a bot named Hermit with slug `hermit`:
 
 ```text
 @hermit can you look at this thread and summarize the plan?
@@ -70,7 +89,7 @@ Expected behavior:
 
 ### 2. Create a dedicated bot chat scratchpad
 
-When the user creates a scratchpad with an interactive bot selected, that bot becomes the active actor for the scratchpad.
+When the user creates a scratchpad with an active-scratchpad-capable bot selected, that bot becomes the active actor for the scratchpad.
 
 Expected behavior:
 
@@ -123,12 +142,12 @@ The active actor inherits from the scratchpad root. The reply target is the curr
 For each user-authored message, Threa should resolve invocations with a deterministic algorithm:
 
 1. Ignore messages authored by bots/personas/system actors to avoid loops.
-2. Resolve explicit `@slug` mentions against available personas and interactive bots.
+2. Resolve explicit `@slug` mentions against available personas and mentionable bots.
 3. Resolve the active actor, if any, from the current stream:
    - current stream is a scratchpad with an active actor, or
    - current stream is a thread whose `rootStreamId` points to a scratchpad with an active actor.
-4. If the message contains no explicit interactive-actor mentions, invoke the active actor if one exists.
-5. If the message contains explicit interactive-actor mentions:
+4. If the message contains no explicit mentionable-actor mentions, invoke the active actor if one exists.
+5. If the message contains explicit mentionable-actor mentions:
    - invoke each mentioned actor once,
    - do not additionally auto-invoke the active actor unless the active actor was explicitly mentioned.
 6. Pick the response target:
@@ -141,7 +160,7 @@ This keeps the common case simple while supporting multi-actor conversations whe
 
 ## Access and safety model
 
-Interactive bots are more powerful than decorative participants because they may read context, call tools, create PRs, and post as themselves. The product model should make access explicit enough to be safe without making normal use tedious.
+Mentionable and active-scratchpad bots are more powerful than decorative participants because they may read context, call tools, create PRs, and post as themselves. The product model should make access explicit enough to be safe without making normal use tedious.
 
 ### Personal bots
 
@@ -174,12 +193,15 @@ type BotInvocation = {
   responseStreamId: string
   actor: { type: "persona" | "bot"; id: string; slug: string }
   trigger: "active-scratchpad" | "mention"
+  requiredCapability: "active-scratchpad" | "mentionable"
   promptMarkdown: string
   authorUserId: string
   mentionedActorSlugs: string[]
   createdAt: string
 }
 ```
+
+`trigger` describes why the invocation exists. `requiredCapability` makes the scheduling requirement explicit: mention invocations require `mentionable`, while ambient scratchpad turns require `active-scratchpad`. A mentionable-only adapter may handle each invocation independently; an active-scratchpad adapter should expect persistent session and concurrency concerns.
 
 Adapter responsibilities:
 
@@ -198,7 +220,7 @@ The claim step is important for local Pi and Claude Code channel-style adapters 
 
 ### Custom Pi adapter
 
-A personal Pi bridge is an active local session adapter:
+A personal Pi bridge can be either mentionable-only or active-scratchpad-capable. The current local bridge prototype behaves like an active local session adapter:
 
 ```text
 Threa invocation
@@ -211,13 +233,15 @@ Threa invocation
 Constraints:
 
 - The local Pi instance must be online.
+- A mentionable-only Pi bot could fail fast when offline and avoid dedicated scratchpad/session semantics.
+- An active Pi bot needs persistent session binding, in-flight message handling, and visible presence.
 - Multiple Pi instances need claim/dedupe or instance targeting.
 - Process/worktree policy is local and should not be encoded in Threa.
 - This is the fastest iteration path for personal use.
 
 ### Hermes
 
-Hermes is best treated as a gateway/runtime adapter:
+Hermes is best treated as a gateway/runtime adapter. It likely supports both mentionable and active-scratchpad modes:
 
 ```text
 Threa invocation
@@ -230,12 +254,14 @@ Threa invocation
 Constraints:
 
 - Hermes owns sessions, memory, tools, background jobs, and process policy.
+- Mentionable Hermes invocations can map to one-off gateway turns.
+- Active Hermes scratchpads should map to stable Hermes sessions.
 - Threa maps scratchpads/threads to Hermes session keys.
 - A native Hermes platform adapter is the long-term fit; an OpenAI-compatible API bridge can be the quick prototype.
 
 ### OpenClaw
 
-OpenClaw is best treated as a native channel plugin:
+OpenClaw is best treated as a native channel plugin. Like Hermes, it can support both mentionable and active-scratchpad modes:
 
 ```text
 Threa invocation
@@ -249,13 +275,15 @@ Threa invocation
 Constraints:
 
 - OpenClaw owns workspace/session/tool/sandbox policy.
+- Mentionable OpenClaw invocations can route to a selected `agentId` for one response.
+- Active OpenClaw scratchpads should map to durable channel/session grammar for that `agentId`.
 - Threa bot identity can map to OpenClaw `agentId`.
 - Threa scratchpad/thread identity maps to OpenClaw channel session grammar.
 - Mention gating, sender gating, and reply-thread behavior should live in the OpenClaw channel plugin.
 
 ### Claude Code channels
 
-Claude Code channels are a useful protocol precedent for local active-session adapters:
+Claude Code channels are a useful protocol precedent for local active-session adapters. They also show why mentionable and active modes should be separate:
 
 ```text
 Threa event
@@ -271,13 +299,14 @@ Relevant ideas to borrow:
 - event notification: external events are injected into an active session as structured channel messages,
 - reply tool: the runtime sends outbound messages through a tool exposed by the channel,
 - sender gating: inbound messages must be authorized before reaching the agent,
-- permission relay: tool approval prompts can be mirrored to the remote chat while the local prompt stays open.
+- permission relay: tool approval prompts can be mirrored to the remote chat while the local prompt stays open,
+- a channel can be useful for one-shot mention delivery even if it should not become an ambient active scratchpad participant.
 
 Claude channels require an active Claude Code session and are currently research-preview functionality, so they should inform the contract rather than define the Threa product surface.
 
 ## Presence and availability
 
-Some interactive actors are always available from Threa's perspective, while others depend on an external runtime being online:
+Some mentionable/active actors are always available from Threa's perspective, while others depend on an external runtime being online:
 
 - Ariadne can be treated as available when Threa's own agent workers are healthy.
 - Hermes/OpenClaw bots are available when their gateway/adapter is connected.
@@ -298,6 +327,9 @@ type BotRuntimePresence = {
   acceptingInvocations: boolean
   lastSeenAt: string
   capabilities?: {
+    supportsMentionInvocations?: boolean
+    supportsActiveScratchpad?: boolean
+    supportsPersistentSessions?: boolean
     supportsStop?: boolean
     supportsPermissionRelay?: boolean
     supportsStreaming?: boolean
@@ -362,7 +394,7 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
 
 1. **Generalize activation semantics**
    - keep one active actor slot for scratchpads,
-   - resolve mentions across personas and interactive bots,
+   - resolve mentions across personas and mentionable bots,
    - inherit the active actor into scratchpad-rooted threads,
    - suppress active auto-response when a different actor is explicitly mentioned.
 
@@ -387,6 +419,8 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
 
 ## Open questions
 
+- Should the stored trait names be `mentionable` + `active-scratchpad`, or should the existing `interactive` name be preserved for active scratchpad participation?
+- Should `active-scratchpad` imply `mentionable` at validation time, or should fully interactive bots explicitly carry both traits?
 - Should personal bot mention in a shared channel create a persistent bot access grant, or should the first version send an invocation-scoped context snapshot only?
 - Should an active actor ever auto-comment on messages that mention a different actor, or is mention-suppression always the right default?
 - Should multiple active actors in one scratchpad ever be supported, or should multi-actor conversations stay explicit via mentions?

--- a/docs/plans/interactive-bot-scratchpads.md
+++ b/docs/plans/interactive-bot-scratchpads.md
@@ -2,12 +2,12 @@
 
 ## Problem
 
-Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically in the scratchpad and in scratchpad-rooted threads. That works for the built-in assistant, but it does not generalize cleanly to user-owned bots such as a Hermes bot (`@hermit`), an OpenClaw-backed coding agent, or a local Pi bridge.
+Threa's scratchpad experience currently treats Ariadne as a special active companion: when companion mode is enabled, she responds automatically in the scratchpad and in scratchpad-rooted threads. That works for the built-in assistant, but it does not generalize cleanly to user-owned bots such as a user-named Hermes-backed bot (for example `@hermit`), an OpenClaw-backed coding agent, or a local Pi bridge.
 
 Personal bots now have the backend foundation to be user-owned and tagged with traits such as `interactive`, but Threa still needs a product model for:
 
 - mentioning an owned bot anywhere the user is allowed to talk,
-- creating a "Chat with Hermit"-style scratchpad where Hermit responds without being mentioned every time,
+- creating a dedicated chat scratchpad for a user-named bot where that bot responds without being mentioned every time,
 - invoking Ariadne or another bot inside that same scratchpad when explicitly mentioned,
 - keeping the same behavior in threads under the scratchpad,
 - routing those invocations to provider-specific runtimes without making Threa know whether the other side is Hermes, OpenClaw, Claude Code channels, or a custom Pi adapter.
@@ -18,8 +18,8 @@ This note describes the product/runtime contract only. It intentionally contains
 
 Interactive bots should be modeled as actors that can be invoked in two ways:
 
-1. **Active scratchpad participant** — a scratchpad can have one primary interactive actor that responds to normal user messages without requiring an `@mention`. This is the "Chat with Hermit" experience.
-2. **Mention target** — any available interactive actor can be explicitly invoked with `@slug` from a scratchpad, thread, channel, or DM. This is how a user can mention `@ariadne` inside a Hermit scratchpad or mention `@hermit` from an unrelated stream.
+1. **Active scratchpad participant** — a scratchpad can have one primary interactive actor that responds to normal user messages without requiring an `@mention`. This is the "Chat with <bot name>" experience.
+2. **Mention target** — any available interactive actor can be explicitly invoked with `@slug` from a scratchpad, thread, channel, or DM. This is how a user can mention `@ariadne` inside another bot's scratchpad or mention a user-named bot such as `@hermit` from an unrelated stream.
 
 Ariadne becomes one implementation of this model rather than the only special companion path.
 
@@ -55,7 +55,7 @@ For a top-level scratchpad, `rootStreamId` and `activeStreamId` are the same. Fo
 
 ### 1. Mention your own bot anywhere
 
-A user who owns a personal interactive bot should be able to mention it by slug, for example:
+A user who owns a personal interactive bot should be able to mention it by its user-chosen slug. For example, if the user created a bot named Hermit with slug `hermit`:
 
 ```text
 @hermit can you look at this thread and summarize the plan?
@@ -63,44 +63,44 @@ A user who owns a personal interactive bot should be able to mention it by slug,
 
 Expected behavior:
 
-- Threa resolves `@hermit` as the user's personal bot.
+- Threa resolves `@hermit` as that user's personal bot.
 - If the current stream is a top-level channel, the bot response should follow existing Ariadne mention behavior and happen in a thread for that message.
 - If the current stream is a scratchpad, DM, or thread, the bot responds in the current stream.
 - The bot invocation is scoped to the current stream/thread context and must not grant hidden workspace-wide access.
 
-### 2. Create a "Chat with Hermit" scratchpad
+### 2. Create a dedicated bot chat scratchpad
 
 When the user creates a scratchpad with an interactive bot selected, that bot becomes the active actor for the scratchpad.
 
 Expected behavior:
 
 ```text
-User creates "Chat with Hermit"
+User creates "Chat with <bot name>" (for example, "Chat with Hermit")
   ↓
-Hermit is attached as the active actor
+The selected bot is attached as the active actor
   ↓
 User sends "hiya"
   ↓
-Hermit responds without requiring @hermit
+The selected bot responds without requiring @slug
 ```
 
-This is intentionally different from a passive mention-only participant. Requiring `@hermit` on every message in a dedicated Hermit scratchpad would make the scratchpad feel broken.
+This is intentionally different from a passive mention-only participant. Requiring `@slug` on every message in a dedicated bot chat scratchpad would make the scratchpad feel broken.
 
-### 3. Mention Ariadne inside a Hermit scratchpad
+### 3. Mention Ariadne inside another bot's scratchpad
 
 The active actor should not prevent explicit mention invocations of other actors.
 
 Example:
 
 ```text
-User, in Chat with Hermit:
-@ariadne can you sanity-check Hermit's plan?
+User, in a scratchpad whose active actor is their bot:
+@ariadne can you sanity-check this plan?
 ```
 
 Default activation rule:
 
 - Because the message explicitly mentions `@ariadne`, Threa invokes Ariadne.
-- Hermit does **not** also auto-respond unless the message also mentions `@hermit` or a later product setting asks active actors to comment on all mentions.
+- The active bot does **not** also auto-respond unless the message also mentions that bot or a later product setting asks active actors to comment on all mentions.
 - This avoids duplicate/noisy responses while still letting the user deliberately ask multiple actors by mentioning multiple actors.
 
 ### 4. Active scratchpad behavior applies in threads
@@ -110,10 +110,10 @@ If a thread is created under a scratchpad with an active actor, that actor shoul
 Expected behavior:
 
 ```text
-Chat with Hermit scratchpad
+Chat with <bot name> scratchpad
   └─ Thread under a message
        ├─ User sends a normal message
-       └─ Hermit responds in that thread
+       └─ The active bot responds in that thread
 ```
 
 The active actor inherits from the scratchpad root. The reply target is the current thread. This matches the existing Ariadne companion behavior for scratchpad-rooted threads.
@@ -326,7 +326,7 @@ A first implementation should avoid a broad multi-agent orchestration platform. 
 - Should personal bot mention in a shared channel create a persistent bot access grant, or should the first version send an invocation-scoped context snapshot only?
 - Should an active actor ever auto-comment on messages that mention a different actor, or is mention-suppression always the right default?
 - Should multiple active actors in one scratchpad ever be supported, or should multi-actor conversations stay explicit via mentions?
-- What exact UI should show that a scratchpad is "Chat with Hermit" and that Hermit is active in descendant threads?
+- What exact UI should show that a scratchpad is a dedicated bot chat and that its active actor is inherited into descendant threads?
 - Should runtime status/artifacts be modeled as a separate table, message attachments, context refs, or a combination?
 - What is the minimum realtime surface for adapters: polling public API, Socket.io/SSE, or a dedicated invocation stream?
 

--- a/docs/plans/pi-remote-protocol-implementation.md
+++ b/docs/plans/pi-remote-protocol-implementation.md
@@ -1,0 +1,1216 @@
+# Minimal bot invocation protocol and Pi remote implementation plan
+
+## Context
+
+This plan turns the high-level model in [`interactive-bot-scratchpads.md`](./interactive-bot-scratchpads.md) into a minimal, reviewable implementation that can replace the current global Pi polling plugin at `~/.pi/agent/extensions/threa-remote.ts`.
+
+The current plugin works for a personal prototype, but it has the wrong long-term shape:
+
+- every configured Pi instance polls the same Threa stream,
+- messages are detected by ad-hoc `/pi ...` text parsing rather than provider-neutral invocation records,
+- there is no atomic claim/dedupe protocol,
+- there is no runtime presence/handshake,
+- the Pi session binding lives only in local JSON, so Threa cannot show whether the active runtime is online,
+- a Threa-created "new Pi session" would imply spawning/managing local processes, which is OpenClaw-shaped work and should not be built into Threa's minimal Pi adapter.
+
+## Recommended V1 product shape
+
+Use a **Pi-session-initiated remote-control flow** for local Pi and Claude-Code-channel-style runtimes.
+
+```text
+User opens Pi in the repo/session they want to expose
+  ↓
+User runs /remote-control in Pi
+  ↓
+Pi heartbeats a runtime instance and asks Threa to create/link a dedicated scratchpad
+  ↓
+Threa creates "Pi Remote: <cwd/session>" for the bot owner,
+attaches that personal bot as the active actor,
+grants the bot access to the scratchpad root,
+and binds the scratchpad to this Pi instance/session
+  ↓
+User chats in Threa scratchpad
+  ↓
+Threa creates targeted BotInvocation rows
+  ↓
+Only the linked Pi instance can claim those rows
+```
+
+This avoids building a bad OpenClaw clone. Threa can create a chat surface and route invocations, but it does **not** spawn local processes or decide local worktree/session policy. If a future product needs "start a fresh coding agent from Threa", that is the OpenClaw integration path.
+
+A later phase can add a Threa-first pairing flow for an already-open Pi session:
+
+```text
+User creates/selects a Pi bot scratchpad in Threa
+  ↓
+User runs /remote-control --pair in Pi, receives a short code
+  ↓
+User runs /link-pi-remote <code> in that Threa scratchpad
+  ↓
+Threa binds the existing scratchpad to that Pi instance/session
+```
+
+That flow is useful, but it should not block V1. It is also the likely shape for Claude Code channels, because the MCP/channel server must run inside an already-active local session.
+
+## Protocol invariants
+
+- **Workspace is always part of every key.** Runtime session keys and claims must include `workspaceId` to avoid cross-workspace collisions.
+- **The bot API key is the runtime identity.** Threa verifies that a runtime claiming an invocation is authenticated as the target bot.
+- **Presence is advisory.** Atomic invocation claims and stream access checks remain the security boundary.
+- **Invocations are provider-neutral.** Pi, Hermes, OpenClaw, and Claude Code channels all consume the same `BotInvocation` shape.
+- **Active scratchpad bindings target local instances.** A Pi active scratchpad should carry a session link with `targetInstanceId`; unlinked or offline scratchpads should fail visibly instead of being consumed by a random Pi process.
+- **Adapters never poll arbitrary messages.** They heartbeat and claim invocations. Threa owns message → invocation resolution.
+- **No rich runtime blobs in message metadata.** Use metadata only for small external ids such as `pi.remote.invocationId`; typed runtime artifacts can come later.
+
+## Stacked PR plan
+
+Each phase should be a separate PR stacked on the previous one. For every phase:
+
+1. Plan the phase in the PR description.
+2. Build the smallest complete slice.
+3. Self-review for correctness, security, concurrency, and UX.
+4. Run focused tests plus repo typecheck/lint as appropriate.
+5. Create the PR.
+6. Before starting the next phase, check the previous PR for CodeRabbit/GitHub Actions failures and address valid feedback.
+
+---
+
+## Phase 1 — Backend protocol primitives
+
+### Goal
+
+Add storage, constants, repositories, and service methods for bot capabilities, active scratchpad bindings, runtime presence, runtime session links, and provider-neutral invocation claims. This PR should not change frontend UX and should not yet invoke Pi.
+
+### Suggested files
+
+| File                                                                     | Change                                                                                |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `packages/types/src/constants.ts`                                        | Add explicit bot traits and runtime/invocation constants                              |
+| `packages/types/src/domain.ts`                                           | Add exported runtime/invocation domain types if frontend/public API clients need them |
+| `packages/backend-common/src/id.ts`                                      | Add id helpers for invocation/runtime rows                                            |
+| `apps/backend/src/lib/id.ts`                                             | Re-export new id helpers                                                              |
+| `apps/backend/src/db/migrations/<timestamp>_bot_runtime_invocations.sql` | Add protocol tables                                                                   |
+| `apps/backend/src/features/bot-runtimes/repository.ts`                   | Data access for active actors, presence, session links, invocations                   |
+| `apps/backend/src/features/bot-runtimes/service.ts`                      | Transaction-owning domain operations                                                  |
+| `apps/backend/src/features/bot-runtimes/index.ts`                        | Feature barrel                                                                        |
+| `apps/backend/src/features/bot-runtimes/*.test.ts`                       | Repository/service tests for claim races, idempotency, workspace scoping              |
+
+### Trait constants
+
+Keep `interactive` temporarily as a legacy alias so existing bots do not break, but move new behavior to explicit traits.
+
+```ts
+// packages/types/src/constants.ts
+export const BOT_TRAITS = ["interactive", "mentionable", "active-scratchpad"] as const
+export type BotTrait = (typeof BOT_TRAITS)[number]
+
+export const BotTraits = {
+  /** Legacy alias. Treat as mentionable + active-scratchpad until migrated. */
+  INTERACTIVE: "interactive",
+  MENTIONABLE: "mentionable",
+  ACTIVE_SCRATCHPAD: "active-scratchpad",
+} as const satisfies Record<string, BotTrait>
+
+export const BOT_RUNTIME_KINDS = ["pi-local", "hermes", "openclaw", "claude-code-channel", "custom"] as const
+export type BotRuntimeKind = (typeof BOT_RUNTIME_KINDS)[number]
+
+export const BOT_RUNTIME_STATUSES = ["available", "busy", "offline", "error"] as const
+export type BotRuntimeStatus = (typeof BOT_RUNTIME_STATUSES)[number]
+
+export const BOT_INVOCATION_STATUSES = ["pending", "claimed", "completed", "failed", "cancelled", "expired"] as const
+export type BotInvocationStatus = (typeof BOT_INVOCATION_STATUSES)[number]
+
+export const BOT_INVOCATION_TRIGGERS = ["mention", "active-scratchpad"] as const
+export type BotInvocationTrigger = (typeof BOT_INVOCATION_TRIGGERS)[number]
+
+export const BOT_INVOCATION_CAPABILITIES = ["mentionable", "active-scratchpad"] as const
+export type BotInvocationCapability = (typeof BOT_INVOCATION_CAPABILITIES)[number]
+```
+
+Use a helper instead of sprinkling legacy checks:
+
+```ts
+export function botHasCapability(bot: { traits: readonly BotTrait[] }, capability: BotInvocationCapability): boolean {
+  if (bot.traits.includes(capability)) return true
+  // Compatibility only. New code should write explicit traits.
+  return bot.traits.includes(BotTraits.INTERACTIVE)
+}
+```
+
+### Migration sketch
+
+Do not add foreign keys or DB enums. Keep all rows workspace-scoped and validate text vocabularies in application code.
+
+```sql
+CREATE TABLE stream_active_actors (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  root_stream_id TEXT NOT NULL,
+  actor_type TEXT NOT NULL, -- 'persona' | 'bot'
+  actor_id TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workspace_id, root_stream_id)
+);
+
+CREATE INDEX idx_stream_active_actors_actor
+  ON stream_active_actors (workspace_id, actor_type, actor_id);
+
+CREATE TABLE bot_runtime_instances (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  bot_id TEXT NOT NULL,
+  runtime_kind TEXT NOT NULL,
+  instance_id TEXT NOT NULL,
+  display_name TEXT,
+  status TEXT NOT NULL,
+  accepting_invocations BOOLEAN NOT NULL DEFAULT FALSE,
+  capabilities JSONB NOT NULL DEFAULT '{}',
+  status_text TEXT,
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workspace_id, bot_id, instance_id)
+);
+
+CREATE INDEX idx_bot_runtime_instances_lookup
+  ON bot_runtime_instances (workspace_id, bot_id, status, accepting_invocations);
+
+CREATE TABLE bot_runtime_session_links (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  bot_id TEXT NOT NULL,
+  runtime_kind TEXT NOT NULL,
+  instance_id TEXT NOT NULL,
+  runtime_session_id TEXT NOT NULL,
+  root_stream_id TEXT NOT NULL,
+  active_stream_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active', -- 'active' | 'paused' | 'ended'
+  linked_by TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  last_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workspace_id, bot_id, root_stream_id, active_stream_id),
+  UNIQUE (workspace_id, bot_id, runtime_kind, instance_id, runtime_session_id)
+);
+
+CREATE INDEX idx_bot_runtime_session_links_instance
+  ON bot_runtime_session_links (workspace_id, bot_id, instance_id, status);
+
+CREATE TABLE bot_invocations (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  root_stream_id TEXT NOT NULL,
+  active_stream_id TEXT NOT NULL,
+  source_message_id TEXT NOT NULL,
+  response_stream_id TEXT NOT NULL,
+  actor_type TEXT NOT NULL, -- V1 external adapter rows should be 'bot'
+  actor_id TEXT NOT NULL,
+  trigger TEXT NOT NULL,
+  required_capability TEXT NOT NULL,
+  prompt_markdown TEXT NOT NULL,
+  author_user_id TEXT NOT NULL,
+  mentioned_actor_slugs TEXT[] NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending',
+  target_instance_id TEXT,
+  target_runtime_session_id TEXT,
+  claimed_by_instance_id TEXT,
+  claim_token TEXT,
+  claim_expires_at TIMESTAMPTZ,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  UNIQUE (workspace_id, source_message_id, actor_type, actor_id, trigger)
+);
+
+CREATE INDEX idx_bot_invocations_claimable
+  ON bot_invocations (workspace_id, actor_id, status, created_at)
+  WHERE status IN ('pending', 'claimed');
+
+CREATE INDEX idx_bot_invocations_source_message
+  ON bot_invocations (workspace_id, source_message_id);
+
+-- Optional compatibility migration. Keep `interactive` too for older clients.
+UPDATE bots
+SET traits = ARRAY(
+  SELECT DISTINCT unnest(traits || ARRAY['mentionable', 'active-scratchpad']::text[])
+)
+WHERE 'interactive' = ANY(traits);
+```
+
+### Repository claim pattern
+
+The claim path is the most important correctness boundary. It must be a single atomic update, not select-then-update.
+
+```ts
+async claimOne(
+  db: Querier,
+  params: {
+    workspaceId: string
+    botId: string
+    instanceId: string
+    claimToken: string
+    supportedCapabilities: BotInvocationCapability[]
+    claimTtlSeconds: number
+  }
+): Promise<BotInvocation | null> {
+  const result = await db.query<BotInvocationRow>(sql`
+    WITH candidate AS (
+      SELECT id
+      FROM bot_invocations
+      WHERE workspace_id = ${params.workspaceId}
+        AND actor_type = 'bot'
+        AND actor_id = ${params.botId}
+        AND required_capability = ANY(${params.supportedCapabilities})
+        AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
+        AND (
+          status = 'pending'
+          OR (status = 'claimed' AND claim_expires_at < NOW())
+        )
+      ORDER BY created_at ASC, id ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    )
+    UPDATE bot_invocations i
+    SET status = 'claimed',
+        claimed_by_instance_id = ${params.instanceId},
+        claim_token = ${params.claimToken},
+        claim_expires_at = NOW() + (${params.claimTtlSeconds} || ' seconds')::interval,
+        attempts = attempts + 1,
+        updated_at = NOW()
+    FROM candidate
+    WHERE i.id = candidate.id
+    RETURNING i.*
+  `)
+  return result.rows[0] ? mapInvocationRow(result.rows[0]) : null
+}
+```
+
+Completion must verify both `claimed_by_instance_id` and `claim_token` so a stale local process cannot complete a re-claimed invocation.
+
+### Service responsibilities
+
+`BotRuntimeService` should own transactions for cross-table operations:
+
+- `upsertPresenceFromBotKey(...)`
+- `createOrLinkPiRemoteSession(...)`
+- `createInvocation(...)`
+- `claimNextInvocation(...)`
+- `completeInvocation(...)`
+- `failInvocation(...)`
+- `expireStaleClaims(...)` if needed later
+
+### Self-review checklist
+
+- Does every table and query include `workspace_id`?
+- Are writes idempotent where they may be retried?
+- Is claiming a single SQL statement with `FOR UPDATE SKIP LOCKED`?
+- Are stale claims reclaimable only after `claim_expires_at`?
+- Can a bot key only claim invocations for its own bot id?
+- Does `interactive` compatibility avoid breaking current bots while explicit traits become canonical?
+
+### Validation
+
+- Repository tests for duplicate invocation insert, presence upsert, and concurrent claim.
+- `bun run --cwd apps/backend test -- bot-runtimes`
+- `bun run --cwd packages/types typecheck`
+- `bun run --cwd apps/backend typecheck`
+
+---
+
+## Phase 2 — Public runtime API and bot stream access inheritance
+
+### Goal
+
+Expose a narrow public API for runtime adapters and make bot access grants work for scratchpad-rooted threads.
+
+### Suggested files
+
+| File                                                                            | Change                                                                        |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `packages/types/src/workspace-permissions.ts`                                   | Add API-key scopes for runtime invocation/presence                            |
+| `packages/types/src/api-keys.ts`                                                | Include the new scopes in `API_KEY_ELIGIBLE_SCOPES` if selectable by bot keys |
+| `apps/backend/src/features/public-api/schemas.ts`                               | Add runtime request schemas                                                   |
+| `apps/backend/src/features/public-api/routes.ts`                                | Add OpenAPI route definitions and response schemas                            |
+| `apps/backend/src/features/public-api/handlers.ts` or `bot-runtime-handlers.ts` | Add handlers; prefer a separate file if `handlers.ts` grows too much          |
+| `apps/backend/src/routes.ts`                                                    | Register public API routes with `requireApiKeyScope(...)`                     |
+| `apps/backend/src/features/api-keys/service.ts`                                 | Treat explicit root grants as access to descendant threads for bots           |
+| `apps/backend/src/features/api-keys/repository.ts`                              | Add efficient root/ancestor grant lookup if needed                            |
+| `apps/backend/src/features/public-api/*.test.ts`                                | API tests for auth/scope/ownership                                            |
+
+### New public API scopes
+
+Suggested scope names:
+
+```ts
+WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_READ = "bot-runtime:read"
+WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE = "bot-runtime:write"
+WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_READ = "bot-invocations:read"
+WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE = "bot-invocations:write"
+```
+
+If scope sprawl feels too heavy for V1, collapse to:
+
+```ts
+WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS = "bot-invocations"
+```
+
+but keep read/write split in the handler code so it can be split later without large rewrites.
+
+### Runtime endpoints
+
+All endpoints below are authenticated with public API keys. V1 should require **bot-scoped keys** for claim/complete/fail/session-link routes. User-scoped keys can be added later for admin dashboards.
+
+```text
+POST /api/v1/workspaces/:workspaceId/bot-runtime/presence
+POST /api/v1/workspaces/:workspaceId/bot-runtime/sessions
+POST /api/v1/workspaces/:workspaceId/bot-invocations/claim
+POST /api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/heartbeat
+POST /api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/complete
+POST /api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/fail
+```
+
+#### Presence request
+
+```ts
+const upsertPresenceSchema = z.object({
+  runtimeKind: z.enum(BOT_RUNTIME_KINDS),
+  instanceId: z.string().min(1).max(128),
+  displayName: z.string().max(100).optional(),
+  status: z.enum(BOT_RUNTIME_STATUSES),
+  acceptingInvocations: z.boolean(),
+  capabilities: z
+    .object({
+      supportsMentionInvocations: z.boolean().optional(),
+      supportsActiveScratchpad: z.boolean().optional(),
+      supportsPersistentSessions: z.boolean().optional(),
+      supportsStop: z.boolean().optional(),
+      supportsPermissionRelay: z.boolean().optional(),
+      supportsStreaming: z.boolean().optional(),
+    })
+    .optional()
+    .default({}),
+  statusText: z.string().max(200).optional(),
+})
+```
+
+#### Create/link Pi remote session request
+
+This is the endpoint used by Pi `/remote-control`. It is intentionally bot-key scoped and limited to personal bots in V1.
+
+```ts
+const createRuntimeSessionSchema = z.object({
+  runtimeKind: z.literal("pi-local"),
+  instanceId: z.string().min(1).max(128),
+  runtimeSessionId: z.string().min(1).max(256),
+  displayName: z.string().min(1).max(100).optional(),
+  localCwd: z.string().max(500).optional(),
+  model: z.string().max(100).optional(),
+})
+```
+
+Response:
+
+```ts
+type RuntimeSessionResponse = {
+  data: {
+    linkId: string
+    workspaceId: string
+    botId: string
+    rootStreamId: string
+    activeStreamId: string
+    responseStreamId: string
+    runtimeKind: "pi-local"
+    instanceId: string
+    runtimeSessionId: string
+    streamUrlPath: string // e.g. /w/:workspaceId/s/:rootStreamId
+  }
+}
+```
+
+Server behavior:
+
+1. Verify `req.botApiKey` exists.
+2. Fetch the bot by `workspaceId + botId`.
+3. Require `bot.type === "personal"` for V1.
+4. Require `botHasCapability(bot, "active-scratchpad")`.
+5. Create or reuse a scratchpad owned by `bot.ownerUserId` and named `Pi Remote: <displayName>`.
+6. Insert/upsert `stream_active_actors` for the scratchpad root.
+7. Grant the bot access to the scratchpad root via the existing bot stream grant table.
+8. Insert/upsert `bot_runtime_session_links` with `instanceId + runtimeSessionId`.
+9. Return the stream id/path.
+
+Implementation note: do this in a `BotRuntimeService` transaction with repositories directly. Do **not** call `StreamService.createScratchpad()` inside another transaction unless `StreamService` is refactored to accept a caller-owned transaction.
+
+#### Claim request
+
+```ts
+const claimInvocationSchema = z.object({
+  runtimeKind: z.enum(BOT_RUNTIME_KINDS),
+  instanceId: z.string().min(1).max(128),
+  supportedCapabilities: z.array(z.enum(BOT_INVOCATION_CAPABILITIES)).min(1),
+  claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
+})
+```
+
+Response includes at most one invocation for V1. Keeping it one-at-a-time makes local Pi busy handling simple.
+
+```ts
+type ClaimedInvocationResponse = {
+  data: null | {
+    id: string
+    workspaceId: string
+    rootStreamId: string
+    activeStreamId: string
+    sourceMessageId: string
+    responseStreamId: string
+    actor: { type: "bot"; id: string; slug: string }
+    trigger: "active-scratchpad" | "mention"
+    requiredCapability: "active-scratchpad" | "mentionable"
+    promptMarkdown: string
+    authorUserId: string
+    mentionedActorSlugs: string[]
+    claimToken: string
+    claimExpiresAt: string
+    runtimeSessionId: string | null
+  }
+}
+```
+
+#### Complete request
+
+Let the completion endpoint post the final bot message and mark the invocation complete in one transaction.
+
+```ts
+const completeInvocationSchema = z.object({
+  instanceId: z.string().min(1).max(128),
+  claimToken: z.string().min(1).max(256),
+  finalMessageMarkdown: z.string().min(1).max(50_000),
+  metadata: messageMetadataSchema.optional(),
+})
+```
+
+Server behavior:
+
+1. Verify invocation belongs to `workspaceId` and target bot id from `req.botApiKey`.
+2. Verify `status === "claimed"`, `claimed_by_instance_id`, `claim_token`, and non-expired claim.
+3. Verify bot still has access to `responseStreamId`.
+4. Create the bot message in `responseStreamId`.
+5. Mark invocation `completed` with `completed_at`.
+
+### Bot access inheritance for threads
+
+The existing table is called `bot_channel_access`, but it stores `stream_id`. For minimal implementation, keep the table and service names to avoid a rename PR, but make access semantics stream-root aware:
+
+```ts
+async isStreamAccessibleForBot(workspaceId: string, botId: string, streamId: string): Promise<boolean> {
+  const stream = await StreamRepository.findById(this.pool, streamId)
+  if (!stream || stream.workspaceId !== workspaceId || stream.archivedAt) return false
+
+  if (stream.visibility === "public") return true
+
+  if (await BotChannelAccessRepository.hasGrant(this.pool, workspaceId, botId, stream.id)) return true
+
+  if (stream.rootStreamId) {
+    return BotChannelAccessRepository.hasGrant(this.pool, workspaceId, botId, stream.rootStreamId)
+  }
+
+  return false
+}
+```
+
+`getAccessibleStreamIdsForBot` should also include descendant threads of granted roots if adapters need list/search across threads. If that is expensive, keep V1 precise for `isStreamAccessibleForBot` and add a repository method that expands granted roots using a set-based query.
+
+### Self-review checklist
+
+- Can a user-scoped API key claim bot invocations? It should not in V1.
+- Can a bot key create a remote scratchpad for someone other than its owner? It should not.
+- Can a shared bot create personal scratchpads? Defer; reject in V1.
+- Are scope checks registered in `routes.ts` and documented in `PUBLIC_API_ROUTES`?
+- Does OpenAPI generation pass?
+- Do bot thread access checks cover scratchpad-rooted threads?
+
+### Validation
+
+- Public API tests for presence, session creation, claim, complete, fail.
+- Access tests for root scratchpad grant → descendant thread read/write.
+- `bun apps/backend/scripts/generate-api-docs.ts --check` after route registry updates.
+
+---
+
+## Phase 3 — Active bot invocation producer
+
+### Goal
+
+Create `BotInvocation` rows from user-authored messages in active bot scratchpads. This is the first phase where Threa messages become runtime work, but the old Pi plugin can still coexist.
+
+### Suggested files
+
+| File                                                                       | Change                                                  |
+| -------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts`      | New outbox listener for `message:created`               |
+| `apps/backend/src/features/bot-runtimes/active-actor-repository.ts`        | Active actor lookup by root stream                      |
+| `apps/backend/src/features/bot-runtimes/service.ts`                        | Invocation creation and active actor resolution helpers |
+| `apps/backend/src/server.ts`                                               | Register the new outbox handler                         |
+| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts` | Suppression, dedupe, thread inheritance tests           |
+
+### V1 activation scope
+
+Keep this phase intentionally narrow:
+
+- support active bot scratchpads and scratchpad-rooted threads,
+- ignore bot/persona/system-authored messages,
+- suppress active auto-invocation when explicit mentionable actor mentions exist,
+- do not yet implement arbitrary channel `@bot` mention invocation unless it fits comfortably.
+
+Mentionable bot support can be a follow-up PR using the same invocation table.
+
+### Active actor resolution
+
+```ts
+async function resolveActiveBotActor(db: Querier, stream: Stream) {
+  const rootStreamId = stream.rootStreamId ?? stream.id
+  const root = rootStreamId === stream.id ? stream : await StreamRepository.findById(db, rootStreamId)
+  if (!root || root.type !== StreamTypes.SCRATCHPAD) return null
+
+  const active = await StreamActiveActorRepository.findByRootStream(db, stream.workspaceId, root.id)
+  if (!active || active.actorType !== "bot") return null
+
+  const bot = await BotRepository.findById(db, stream.workspaceId, active.actorId)
+  if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return null
+
+  return { rootStream: root, bot }
+}
+```
+
+### Invocation creation sketch
+
+```ts
+if (messageEvent.actorType !== AuthorTypes.USER) return seen
+
+const stream = await StreamRepository.findById(db, streamId)
+if (!stream || stream.archivedAt) return seen
+
+const mentionedSlugs = extractMentionSlugs(messageEvent.payload.contentMarkdown)
+const mentionedBots = await resolveMentionableBotsVisibleToAuthor(db, {
+  workspaceId,
+  authorUserId: messageEvent.actorId,
+  slugs: mentionedSlugs,
+})
+
+const active = await resolveActiveBotActor(db, stream)
+
+// Mention suppression: if any explicit mentionable actor is present, do not
+// auto-invoke the active actor unless that active actor was explicitly mentioned.
+const activeMentioned = active?.bot.slug != null && mentionedSlugs.includes(active.bot.slug)
+const shouldInvokeActive = active && (mentionedBots.length === 0 || activeMentioned)
+
+if (shouldInvokeActive) {
+  const link = await BotRuntimeSessionRepository.findActiveByStream(db, {
+    workspaceId,
+    botId: active.bot.id,
+    rootStreamId: active.rootStream.id,
+    activeStreamId: stream.id,
+  })
+
+  await BotInvocationRepository.insertIdempotent(db, {
+    id: botInvocationId(),
+    workspaceId,
+    rootStreamId: active.rootStream.id,
+    activeStreamId: stream.id,
+    sourceMessageId: messageEvent.payload.messageId,
+    responseStreamId: stream.id,
+    actorType: "bot",
+    actorId: active.bot.id,
+    trigger: "active-scratchpad",
+    requiredCapability: "active-scratchpad",
+    promptMarkdown: messageEvent.payload.contentMarkdown,
+    authorUserId: messageEvent.actorId,
+    mentionedActorSlugs: mentionedSlugs,
+    targetInstanceId: link?.instanceId ?? null,
+    targetRuntimeSessionId: link?.runtimeSessionId ?? null,
+    metadata: {},
+  })
+}
+```
+
+If `link` is missing, either:
+
+- create the invocation with no `targetInstanceId` and let any eligible Pi claim it, **or**
+- create a failed/offline notice.
+
+For Pi V1, prefer **failed/offline notice** for active scratchpads that are expected to be bound to one local session. Untargeted active-scratchpad claims are how multiple Pi instances accidentally consume the wrong scratchpad.
+
+### Offline behavior
+
+Minimal V1 can be:
+
+- if no active session link exists: create a bot/system notice like "Pi is not linked to this scratchpad. Run `/remote-control` in Pi to link a session." and do not create a claimable invocation;
+- if a link exists but presence is stale/offline: create an invocation targeted to that instance, allow a short pending window, then mark expired/offline via a cleanup worker or the next claim attempt.
+
+Do not silently drop the message.
+
+### Self-review checklist
+
+- Does the handler ignore bot-authored messages to avoid loops?
+- Does it dedupe via `UNIQUE (workspace_id, source_message_id, actor_type, actor_id, trigger)`?
+- Does it include `workspaceId + rootStreamId + activeStreamId + actor.id` in session lookup?
+- Does mention suppression match the high-level plan?
+- Do scratchpad-rooted threads inherit the active actor but reply in the current thread?
+
+### Validation
+
+- Unit tests for:
+  - user message in active bot scratchpad creates one invocation,
+  - bot message creates no invocation,
+  - descendant thread creates invocation with root scratchpad + active thread ids,
+  - explicit `@ariadne` suppresses active bot invocation,
+  - duplicate outbox processing does not create duplicate invocations.
+
+---
+
+## Phase 4 — Rewrite the global Pi remote extension against the protocol
+
+### Goal
+
+Replace ad-hoc stream polling with a Pi extension that:
+
+- registers `/remote-control`,
+- heartbeats runtime presence,
+- creates/links one dedicated Threa scratchpad for this Pi session,
+- claims only targeted invocation rows,
+- injects a claimed invocation into Pi,
+- completes/fails the invocation through the public runtime API.
+
+This phase can be developed outside the repo as the global file, but the PR should include a checked-in reference copy or documentation snippet so reviewers can evaluate the protocol.
+
+Suggested repo location for the reference copy:
+
+```text
+docs/examples/pi-remote/threa-remote-v2.ts
+```
+
+### Local config
+
+The existing config can evolve from fixed `streamId` to runtime-session state.
+
+```ts
+type Config = {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string // bot-scoped key
+  pollMs?: number
+  instanceId?: string
+  defaultDisplayName?: string
+  linkedSessions?: Record<
+    string,
+    {
+      linkId: string
+      rootStreamId: string
+      activeStreamId: string
+      runtimeSessionId: string
+      streamUrlPath: string
+    }
+  >
+}
+```
+
+Generate `instanceId` once and persist it. A good default is hostname + stable random suffix, not a process id:
+
+```ts
+const ensureInstanceId = () => {
+  if (config.instanceId) return config.instanceId
+  config.instanceId = `pi-${hostname()}-${crypto.randomUUID().slice(0, 8)}`
+  saveConfig()
+  return config.instanceId
+}
+```
+
+### Extension skeleton
+
+```ts
+import { readFileSync, writeFileSync } from "node:fs"
+import { hostname } from "node:os"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent"
+
+const CONFIG_PATH = join(homedir(), ".pi", "agent", "threa-remote.json")
+const STATUS_KEY = "threa-remote"
+
+let config: Config | undefined
+let timer: ReturnType<typeof setInterval> | undefined
+let pending: { invocation: ClaimedInvocation; claimToken: string } | undefined
+let activeCtx: ExtensionContext | undefined
+let activeRuntimeSessionId: string | undefined
+
+const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  if (!config) throw new Error("Threa remote config not loaded")
+  const response = await fetch(`${config.baseUrl.replace(/\/$/, "")}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`Threa API ${response.status}: ${body || response.statusText}`)
+  }
+  if (response.status === 204) return undefined as T
+  return (await response.json()) as T
+}
+
+async function heartbeat(status: "available" | "busy" | "error", statusText?: string) {
+  if (!config) return
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-runtime/presence`, {
+    method: "POST",
+    body: JSON.stringify({
+      runtimeKind: "pi-local",
+      instanceId: ensureInstanceId(),
+      displayName: config.defaultDisplayName,
+      status,
+      acceptingInvocations: status === "available",
+      capabilities: {
+        supportsActiveScratchpad: true,
+        supportsPersistentSessions: true,
+        supportsMentionInvocations: false,
+      },
+      statusText,
+    }),
+  })
+}
+
+async function createRemoteSession(ctx: ExtensionCommandContext, args: string) {
+  if (!config) throw new Error("Threa remote config not loaded")
+  const runtimeSessionId = ctx.sessionManager.getSessionId() ?? `pi-session-${Date.now()}`
+  const displayName = args.trim() || config.defaultDisplayName || ctx.cwd.split("/").pop() || "Pi"
+
+  const body = await request<{ data: RuntimeSessionLink }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        runtimeKind: "pi-local",
+        instanceId: ensureInstanceId(),
+        runtimeSessionId,
+        displayName,
+        localCwd: ctx.cwd,
+      }),
+    }
+  )
+
+  activeRuntimeSessionId = runtimeSessionId
+  config.linkedSessions ??= {}
+  config.linkedSessions[runtimeSessionId] = body.data
+  saveConfig()
+
+  ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
+  ctx.ui.setStatus(STATUS_KEY, `Threa remote: ${displayName}`)
+  await heartbeat("available")
+}
+
+async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext) {
+  if (!config || pending || !ctx.isIdle()) return
+
+  await heartbeat("available")
+
+  const body = await request<{ data: ClaimedInvocation | null }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-invocations/claim`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        runtimeKind: "pi-local",
+        instanceId: ensureInstanceId(),
+        supportedCapabilities: ["active-scratchpad"],
+        claimTtlSeconds: 120,
+      }),
+    }
+  )
+
+  if (!body.data) return
+
+  pending = { invocation: body.data, claimToken: body.data.claimToken }
+  await heartbeat("busy", `Working on ${body.data.id}`)
+  ctx.ui.setStatus(STATUS_KEY, `Threa remote: running ${body.data.id}`)
+
+  pi.sendUserMessage(
+    [
+      `Remote Threa invocation ${body.data.id}.`,
+      `Source message: ${body.data.sourceMessageId}`,
+      `Respond normally; the extension will post your final answer back to Threa.`,
+      "",
+      body.data.promptMarkdown,
+    ].join("\n")
+  )
+}
+
+async function completePending(markdown: string) {
+  if (!config || !pending) return
+  const { invocation, claimToken } = pending
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      claimToken,
+      finalMessageMarkdown: markdown || "Done.",
+      metadata: {
+        "pi.remote.invocationId": invocation.id,
+        "pi.remote.instanceId": ensureInstanceId(),
+      },
+    }),
+  })
+  pending = undefined
+  await heartbeat("available")
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("remote-control", {
+    description: "Create or link a Threa scratchpad to this Pi session",
+    handler: async (args, ctx) => {
+      config = readConfig()
+      if (!config) {
+        ctx.ui.notify(`Missing ${CONFIG_PATH}`, "warning")
+        return
+      }
+      await createRemoteSession(ctx, args)
+      await claimIfIdle(pi, ctx)
+    },
+  })
+
+  pi.on("session_start", async (_event, ctx) => {
+    activeCtx = ctx
+    config = readConfig()
+    if (!config) return
+    await heartbeat("available")
+    timer = setInterval(() => void claimIfIdle(pi, ctx), Math.max(1000, config.pollMs ?? 3000))
+  })
+
+  pi.on("agent_end", async (event, ctx) => {
+    if (!pending) return
+    const text = textFromAgentMessages(event.messages) || "Done."
+    try {
+      await completePending(text)
+      ctx.ui.setStatus(STATUS_KEY, "Threa remote: linked")
+    } catch (error) {
+      ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
+      await heartbeat("error", String(error))
+    }
+  })
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    if (timer) clearInterval(timer)
+    timer = undefined
+    activeCtx = undefined
+    await heartbeat("offline").catch(() => undefined)
+    ctx.ui.setStatus(STATUS_KEY, undefined)
+  })
+}
+```
+
+The final implementation needs the helper types/functions (`readConfig`, `saveConfig`, `textFromAgentMessages`, `ensureInstanceId`) filled in, but the important behavior is:
+
+- no message polling,
+- one claim at a time,
+- only claim while idle,
+- heartbeat `busy` after claim,
+- completion endpoint posts the bot result and marks the invocation complete,
+- no `/pi` command prefix in Threa.
+
+### Self-review checklist
+
+- Does the extension ever poll stream messages? It should not.
+- Does it claim only while idle and only one invocation at a time?
+- Does it persist a stable `instanceId`?
+- Does `/remote-control` create/link a dedicated scratchpad rather than expecting all Pi instances to watch one stream?
+- Does it use bot-runtime endpoints instead of direct ad-hoc messages for completion?
+- Does shutdown heartbeat `offline` best-effort without blocking Pi exit?
+
+### Manual validation
+
+1. Create/update a personal bot with `active-scratchpad` capability.
+2. Create a bot API key with runtime + messages scopes.
+3. Configure `~/.pi/agent/threa-remote.json`.
+4. Start Pi and run `/remote-control`.
+5. Verify Threa scratchpad is created and visible to the bot owner.
+6. Send `hiya` in that scratchpad.
+7. Verify exactly one `bot_invocations` row is created and targeted to this Pi `instanceId`.
+8. Verify exactly one Pi instance claims it.
+9. Verify Pi response posts back to the scratchpad and invocation becomes `completed`.
+10. Start a second Pi instance with the same bot key and verify it does **not** claim the first session's targeted invocation.
+
+---
+
+## Phase 5 — Minimal frontend presence and active-bot UX
+
+### Goal
+
+Make the feature understandable in Threa without building the full multi-runtime UI.
+
+### Suggested files
+
+| File                                                             | Change                                                                                        |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `packages/types/src/domain.ts`                                   | Wire active actor/presence types if needed in bootstrap                                       |
+| `apps/backend/src/features/workspaces/handlers.ts`               | Include active actor bindings and runtime presence in bootstrap, or expose a focused endpoint |
+| `apps/backend/src/features/streams/handlers.ts`                  | Include active actor for stream bootstrap if not in workspace bootstrap                       |
+| `apps/frontend/src/api/*`                                        | API client for active actor/presence endpoint if not bootstrapped                             |
+| `apps/frontend/src/components/stream-settings/companion-tab.tsx` | Show active bot actor where appropriate, or split to an `Actors` section later                |
+| `apps/frontend/src/components/timeline/stream-content.tsx`       | Small status strip for active bot scratchpads                                                 |
+| `apps/frontend/src/components/quick-switcher/commands.ts`        | Optional "Open latest Pi remote" command if labels/session links exist                        |
+
+### Minimal UI
+
+For a scratchpad with active bot `Pi Remote`:
+
+```text
+Pi Remote · available · linked to Kris's MacBook Pi
+```
+
+If stale/offline:
+
+```text
+Pi Remote · offline · run /remote-control in Pi to reconnect
+```
+
+Avoid noisy chat messages for routine status. Use chat messages only for failed invocations that need the user's attention.
+
+### Self-review checklist
+
+- Does the status strip avoid layout shift?
+- Does it distinguish "bot exists" from "runtime online"?
+- Is offline state clear enough that a missing response is not mysterious?
+- Are user-owned personal bots hidden from other users?
+
+---
+
+## Phase 6 — Mentionable bot invocations
+
+### Goal
+
+Use the same invocation table for explicit `@bot` one-shot invocations outside active bot scratchpads.
+
+This can ship after Pi remote active scratchpads. It exercises the `mentionable` capability and is useful for stateless helpers.
+
+### Suggested files
+
+| File                                                                  | Change                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | Add mentionable bot resolution                                  |
+| `apps/backend/src/features/public-api/bot-repository.ts`              | Add owner-aware slug lookup helper if needed                    |
+| `apps/backend/src/features/streams/service.ts`                        | Create/use thread for top-level channel mention response target |
+| `apps/backend/src/features/bot-runtimes/*.test.ts`                    | Mention tests                                                   |
+
+### Mention resolution rules
+
+- Resolve slugs against personas and mentionable bots.
+- A personal bot is visible only to its owner.
+- A shared bot is visible according to workspace policy and stream access.
+- Top-level channel mention should create/use a thread for `responseStreamId`.
+- Scratchpad, DM, and existing thread mention should respond in current stream.
+- If the message also has an active actor, mention suppression applies.
+
+### Response target helper
+
+```ts
+async function resolveResponseStreamForMention(params: {
+  workspaceId: string
+  sourceStream: Stream
+  sourceMessageId: string
+  authorUserId: string
+}): Promise<string> {
+  if (params.sourceStream.type === StreamTypes.CHANNEL) {
+    const thread = await streamService.createThread({
+      workspaceId: params.workspaceId,
+      parentStreamId: params.sourceStream.id,
+      parentMessageId: params.sourceMessageId,
+      createdBy: params.authorUserId,
+    })
+    return thread.id
+  }
+  return params.sourceStream.id
+}
+```
+
+Use this carefully in the outbox handler: if `StreamService.createThread()` owns its own transaction, call it outside the invocation insert transaction or refactor a repository-level helper that can run inside a caller-owned transaction.
+
+---
+
+## Phase 7 — Threa-first pairing code flow
+
+### Goal
+
+Allow a user to create/select a Pi bot scratchpad in Threa first, then link an already-open Pi session with an authorization code.
+
+This is optional for V1 but useful for Claude Code channel parity.
+
+### Suggested files
+
+| File                                                                       | Change                                              |
+| -------------------------------------------------------------------------- | --------------------------------------------------- |
+| `apps/backend/src/db/migrations/<timestamp>_bot_runtime_pairing_codes.sql` | Pairing code table                                  |
+| `apps/backend/src/features/bot-runtimes/service.ts`                        | Create/consume code                                 |
+| `apps/backend/src/features/commands/link-pi-remote-command.ts`             | `/link-pi-remote <code>` server command             |
+| `apps/backend/src/server.ts`                                               | Register the command                                |
+| `apps/frontend/src/components/editor/triggers/*`                           | Optional conditional slash-command visibility later |
+| `docs/examples/pi-remote/threa-remote-v2.ts`                               | Add `/remote-control --pair`                        |
+
+### Pairing table sketch
+
+```sql
+CREATE TABLE bot_runtime_pairing_codes (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  bot_id TEXT NOT NULL,
+  runtime_kind TEXT NOT NULL,
+  instance_id TEXT NOT NULL,
+  runtime_session_id TEXT NOT NULL,
+  code_hash TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_by_user_id TEXT,
+  consumed_stream_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workspace_id, bot_id, code_hash)
+);
+```
+
+### Flow
+
+1. Pi `/remote-control --pair` calls `POST /bot-runtime/pairing-codes` with bot key.
+2. Server stores a hashed short code with `instanceId + runtimeSessionId`, expires in 10 minutes.
+3. Pi displays: `Run /link-pi-remote 8F4K-2JQ9 in the Threa scratchpad you want to link.`
+4. User runs `/link-pi-remote <code>` in a scratchpad.
+5. Command verifies:
+   - stream is a scratchpad or scratchpad-rooted thread,
+   - current user owns the personal bot tied to the code,
+   - scratchpad active actor is that bot, or no active actor exists and command sets it,
+   - code is unexpired and unconsumed.
+6. Command creates `bot_runtime_session_links` and grants bot access.
+
+### Conditional slash command note
+
+Threa's current command registry returns global commands in bootstrap. Do backend validation first and add conditional frontend surfacing later. A future command shape could include:
+
+```ts
+type CommandInfo = {
+  name: string
+  description: string
+  kind: "server" | "client-action"
+  availability?: {
+    streamTypes?: StreamType[]
+    activeActorCapabilities?: BotInvocationCapability[]
+    activeActorRuntimeKinds?: BotRuntimeKind[]
+  }
+}
+```
+
+Do not block pairing on this UI improvement.
+
+---
+
+## Phase 8 — Stream labels for remote sessions and scratchpad organization
+
+### Goal
+
+Add a general labeling system that makes Pi remote scratchpads easy to find without baking Pi-specific fields into streams.
+
+This should be a generic product primitive, not a bot-runtime-only feature.
+
+### Minimal label model
+
+```sql
+CREATE TABLE stream_labels (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  owner_user_id TEXT, -- null = workspace label, non-null = personal label
+  slug TEXT NOT NULL,
+  name TEXT NOT NULL,
+  color TEXT,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workspace_id, owner_user_id, slug)
+);
+
+CREATE TABLE stream_label_assignments (
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  assigned_by TEXT NOT NULL,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (workspace_id, stream_id, label_id)
+);
+
+CREATE INDEX idx_stream_label_assignments_label
+  ON stream_label_assignments (workspace_id, label_id);
+```
+
+For Pi remote, `createOrLinkPiRemoteSession` can create/use a personal label for the bot owner:
+
+```text
+slug: pi-remote
+name: Pi remote
+color: muted violet/blue
+```
+
+Then assign it to the created scratchpad. Quick switcher/search can later support `label:pi-remote`.
+
+### Why this is a later phase
+
+A display name like `Pi Remote: threa` is enough for the protocol V1. Labels are valuable but should not delay the invocation/claim correctness path.
+
+---
+
+## Suggested minimal PR order
+
+1. **PR 1: Runtime protocol tables and repositories**
+   - constants, migration, repositories, claim tests.
+2. **PR 2: Runtime public API**
+   - presence/session/claim/complete endpoints, OpenAPI, bot thread access inheritance.
+3. **PR 3: Active bot scratchpad invocation producer**
+   - active actor lookup, invocation creation, mention suppression for active bots.
+4. **PR 4: Pi remote v2 adapter**
+   - `/remote-control`, heartbeat, targeted claims, completion.
+5. **PR 5: Minimal frontend presence**
+   - status strip and offline messaging.
+6. **PR 6: Mentionable bot invocations**
+   - explicit `@bot` one-shot behavior.
+7. **PR 7: Pairing code flow**
+   - Threa-first existing-session linking.
+8. **PR 8: Stream labels**
+   - generic labels; auto-label Pi remote scratchpads.
+
+If schedule is tight, PRs 1–4 are the minimum needed to replace the current global plugin safely.
+
+## Review cadence
+
+Before opening each next PR:
+
+```bash
+gh pr view <previous-pr> --json statusCheckRollup,reviewDecision,url
+```
+
+Then inspect comments/check failures. Treat every CodeRabbit/Greptile finding as one of:
+
+- **Accept**: fix in the current/top PR if it affects shared code,
+- **Acknowledge**: real but intentionally deferred to a later stacked PR,
+- **Dispute**: incorrect, with a specific technical reason.
+
+Do not build on a previous PR with unresolved correctness/security feedback in the protocol, claim, or access-control layers.
+
+## Non-goals for the minimal Pi adapter
+
+- Starting/spawning a new local Pi process from Threa.
+- Worktree management in Threa.
+- Multi-agent orchestration.
+- Rich runtime artifacts/cards.
+- Streaming token-by-token remote output.
+- Permission relay for tool approvals.
+- Replacing OpenClaw for hosted/sandboxed coding sessions.

--- a/docs/plans/pi-remote-protocol-implementation.md
+++ b/docs/plans/pi-remote-protocol-implementation.md
@@ -97,16 +97,14 @@ Add storage, constants, repositories, and service methods for bot capabilities, 
 
 ### Trait constants
 
-Keep `interactive` temporarily as a legacy alias so existing bots do not break, but move new behavior to explicit traits.
+Replace the coarse `interactive` capability with explicit traits. There is no compatibility alias in the runtime path; any prototype/dev rows that still contain `interactive` should be rewritten by migration.
 
 ```ts
 // packages/types/src/constants.ts
-export const BOT_TRAITS = ["interactive", "mentionable", "active-scratchpad"] as const
+export const BOT_TRAITS = ["mentionable", "active-scratchpad"] as const
 export type BotTrait = (typeof BOT_TRAITS)[number]
 
 export const BotTraits = {
-  /** Legacy alias. Treat as mentionable + active-scratchpad until migrated. */
-  INTERACTIVE: "interactive",
   MENTIONABLE: "mentionable",
   ACTIVE_SCRATCHPAD: "active-scratchpad",
 } as const satisfies Record<string, BotTrait>
@@ -127,13 +125,11 @@ export const BOT_INVOCATION_CAPABILITIES = ["mentionable", "active-scratchpad"] 
 export type BotInvocationCapability = (typeof BOT_INVOCATION_CAPABILITIES)[number]
 ```
 
-Use a helper instead of sprinkling legacy checks:
+Use a helper only for readability at call sites:
 
 ```ts
 export function botHasCapability(bot: { traits: readonly BotTrait[] }, capability: BotInvocationCapability): boolean {
-  if (bot.traits.includes(capability)) return true
-  // Compatibility only. New code should write explicit traits.
-  return bot.traits.includes(BotTraits.INTERACTIVE)
+  return bot.traits.includes(capability)
 }
 ```
 
@@ -235,10 +231,11 @@ CREATE INDEX idx_bot_invocations_claimable
 CREATE INDEX idx_bot_invocations_source_message
   ON bot_invocations (workspace_id, source_message_id);
 
--- Optional compatibility migration. Keep `interactive` too for older clients.
+-- One-way cleanup for any prototype/dev rows created before the split.
+-- Do not keep `interactive` as a runtime alias.
 UPDATE bots
 SET traits = ARRAY(
-  SELECT DISTINCT unnest(traits || ARRAY['mentionable', 'active-scratchpad']::text[])
+  SELECT DISTINCT unnest(array_remove(traits, 'interactive') || ARRAY['mentionable', 'active-scratchpad']::text[])
 )
 WHERE 'interactive' = ANY(traits);
 ```
@@ -312,7 +309,7 @@ Completion must verify both `claimed_by_instance_id` and `claim_token` so a stal
 - Is claiming a single SQL statement with `FOR UPDATE SKIP LOCKED`?
 - Are stale claims reclaimable only after `claim_expires_at`?
 - Can a bot key only claim invocations for its own bot id?
-- Does `interactive` compatibility avoid breaking current bots while explicit traits become canonical?
+- Does the migration remove/replace any prototype `interactive` rows instead of preserving a runtime alias?
 
 ### Validation
 


### PR DESCRIPTION
## Problem

Threa currently treats Ariadne as a special active companion in scratchpads. That behavior is useful, but it does not yet generalize to user-owned or runtime-backed bots: users should be able to name their own bots and invoke them by their chosen slugs, whether the runtime is Hermes, OpenClaw, Claude Code channels, or a custom local Pi bridge.

Some runtimes are also only conditionally available. Local Pi and Claude Code channel bots require an active local session/extension/channel server; Hermes and OpenClaw require their gateway/adapter to be connected.

We need a provider-agnostic product model for:

- mentioning an owned bot anywhere the user can talk,
- distinguishing mentionable one-shot bots from active scratchpad participants,
- creating a dedicated bot chat scratchpad where the selected active bot responds without requiring `@slug` every time,
- invoking Ariadne or another actor inside that same scratchpad by explicit mention,
- inheriting active scratchpad behavior into threads,
- surfacing runtime availability so offline bots do not fail silently,
- letting runtime adapters claim and process invocations without Threa owning provider-specific process/worktree policy.

## Solution

Update the planning notes for interactive bot scratchpads, mentions, and the minimal Pi remote-control implementation. This is documentation only; there is no implementation in this PR.

### Key design decisions

**1. User-named bots are first-class**

`@hermit` is only an example of a user-chosen bot slug. The model supports arbitrary user-defined bot names/slugs.

**2. Split mentionable from active scratchpad participation**

The existing `interactive` trait is too coarse. The plan separates `mentionable` one-shot invocation from `active-scratchpad` ambient participation, because they have different runtime/session/presence requirements.

**3. Active scratchpad actor + mention target**

A scratchpad can have one active actor that responds to normal user messages. Separately, any mentionable actor can be invoked by explicit `@slug` mention.

**4. Pi remote should be session-initiated, not Threa-spawned**

The concrete implementation plan recommends Pi `/remote-control` creating/linking a dedicated Threa scratchpad for the current local Pi session. Threa routes invocations to that linked instance, but does not spawn/manage local processes. Threa-first pairing with an auth code is deferred to a later phase.

**5. Invocation claiming replaces ad-hoc message polling**

Runtime adapters heartbeat presence and atomically claim `BotInvocation` rows. Active Pi scratchpads target a specific `instanceId`, so multiple running Pi instances do not all listen to all changes.

**6. Mention suppression avoids noisy duplicate replies**

If a dedicated bot chat scratchpad message explicitly mentions `@ariadne`, Ariadne is invoked and the active bot does not also auto-respond unless that bot is explicitly mentioned too.

**7. Scratchpad-rooted threads inherit the active actor**

Threads under a scratchpad with an active actor behave like the top-level scratchpad: normal user messages invoke the active actor, but the reply lands in the current thread.

**8. Runtime presence is lightweight and advisory**

Adapters should heartbeat whether they can currently serve a bot (`available`, `busy`, `offline`, `error`) and whether they support mention invocations, active scratchpads, persistent sessions, streaming, permission relay, etc. Presence informs UI/offline handling, but invocation claims and API-key auth remain the source of truth.

**9. Runtime metadata/artifacts are future references, not message-metadata blobs**

Usage quotas, PRs, hosted plans, worktrees, and run logs should eventually become typed references/artifacts rather than arbitrary rich data stuffed into flat message metadata.

## Files changed

| File | Change |
| --- | --- |
| `docs/plans/interactive-bot-scratchpads.md` | Product/runtime design for mentionable vs active bot capabilities, active scratchpad bots, mention behavior, runtime adapter contracts, user-defined bot naming, lightweight presence, and future metadata/artifacts |
| `docs/plans/pi-remote-protocol-implementation.md` | Detailed stacked-PR implementation plan for backend invocation primitives, runtime public APIs, active bot invocation production, Pi `/remote-control` adapter rewrite, optional pairing codes, and stream labels |

## Test plan

- [x] Documentation-only change
- [x] `prettier --write` via pre-commit
- [x] Pre-commit lint/typecheck hooks passed
- [x] OpenAPI check passed

---

🤖 _PR by Claude Code_
