### PR TITLE
fix: update OG/Twitter meta tags from threa.app to app.threa.io

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -39,26 +39,26 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://threa.app/" />
+    <meta property="og:url" content="https://app.threa.io/" />
     <meta property="og:title" content="Threa — AI-Powered Knowledge Chat" />
     <meta
       property="og:description"
       content="Where critical information comes to thrive. AI-powered knowledge management that grows with you."
     />
-    <meta property="og:image" content="https://threa.app/threa-logo-512.png" />
+    <meta property="og:image" content="https://app.threa.io/threa-logo-512.png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:site_name" content="Threa" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:url" content="https://threa.app/" />
+    <meta name="twitter:url" content="https://app.threa.io/" />
     <meta name="twitter:title" content="Threa — AI-Powered Knowledge Chat" />
     <meta
       name="twitter:description"
       content="Where critical information comes to thrive. AI-powered knowledge management that grows with you."
     />
-    <meta name="twitter:image" content="https://threa.app/threa-logo-512.png" />
+    <meta name="twitter:image" content="https://app.threa.io/threa-logo-512.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Link unfurlers (Messenger, Slack, iMessage, etc.) read og:url and og:image
to build link previews. All four tags were hardcoded to threa.app — a domain
we don't own — so every shared link showed threa.app as the source domain.
Updated og:url, og:image, twitter:url, and twitter:image to app.threa.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-sonnet-4-6 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->