### PR TITLE
fix(frontend): stop iOS composer floating after keyboard close

### DIFF
--- a/apps/frontend/src/hooks/use-visual-viewport.test.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.test.ts
@@ -232,6 +232,60 @@ describe("useVisualViewport", () => {
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("712px")
   })
 
+  it("does not let a mid-animation visualViewport scroll freeze a stale height (iOS keyboard close)", async () => {
+    // iOS Safari emits visualViewport `scroll` events while the keyboard-hide
+    // animation un-pans the page. Those must not cancel the in-flight
+    // focus-transition poll: if they did, --viewport-height would freeze at the
+    // still-collapsed mid-animation height and the bottom-anchored composer
+    // would float above a dead keyboard-sized gap (the reported iOS bug).
+    const getVH = () => document.documentElement.style.getPropertyValue("--viewport-height")
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    fakeVV.height = 800
+    const { result } = renderHook(() => useVisualViewport(true))
+    expect(getVH()).toBe("800px")
+
+    // Composer is a contenteditable. Dismissing the keyboard by scrolling the
+    // message list keeps it focused, so the phantom-shrink clamp (which only
+    // applies when nothing is focused) cannot mask a stale height here.
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    Object.defineProperty(editable, "isContentEditable", { configurable: true, get: () => true })
+    editable.tabIndex = 0
+    document.body.appendChild(editable)
+    editable.focus()
+
+    // Keyboard opens.
+    act(() => {
+      fakeVV.height = 500
+      fakeVV.emitResize()
+    })
+    expect(getVH()).toBe("500px")
+    expect(result.current).toBe(true)
+
+    await act(async () => {
+      // Focus churn around dismissal starts the keyboard-transition poll.
+      editable.dispatchEvent(new FocusEvent("focusout", { bubbles: true }))
+      await nextFrame()
+
+      // visualViewport scroll fires while height is still collapsed. With the
+      // old shared raf handle this cancelled the poll and pinned 500px.
+      fakeVV.dispatchEvent(new Event("scroll"))
+      await nextFrame()
+
+      // Viewport settles to full height but iOS emits no further resize
+      // (page is idle; html/body overflow:hidden blocks scroll recovery).
+      // Only a still-alive poll can pick this up.
+      fakeVV.height = 800
+      for (let i = 0; i < 6; i++) await nextFrame()
+    })
+
+    expect(getVH()).toBe("800px")
+    expect(result.current).toBe(false)
+
+    editable.remove()
+  })
+
   it("cleans up listeners and removes --viewport-height on unmount", () => {
     fakeVV.height = 800
     const { unmount } = renderHook(() => useVisualViewport(true))

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -36,7 +36,14 @@ const VIEWPORT_HEIGHT_VAR = "--viewport-height"
  */
 export function useVisualViewport(enabled: boolean): boolean {
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
-  const rafId = useRef(0)
+  // Separate handles: the focus-transition poll must not share a raf slot with
+  // scroll coalescing. iOS Safari emits visualViewport `scroll` events while
+  // the keyboard hide animation un-pans the page; if that cancelled the poll
+  // it would freeze --viewport-height at the still-collapsed mid-animation
+  // height, leaving the composer floating above a dead keyboard gap.
+  const pollRafId = useRef(0)
+  const scrollRafId = useRef(0)
+  const settleTimeoutId = useRef(0)
   // Baseline height = innerHeight when keyboard is known to be closed.
   // Used as fallback for browsers that resize both viewports together (Firefox).
   const baseHeight = useRef(typeof window !== "undefined" ? window.innerHeight : 0)
@@ -105,23 +112,32 @@ export function useVisualViewport(enabled: boolean): boolean {
       }
     }
 
-    // Poll every frame for a duration to catch keyboard open/close animation
+    // Poll every frame for a duration to catch keyboard open/close animation.
+    // After the rAF window closes, re-measure once more on a timer: iOS Safari
+    // can settle visualViewport.height a few hundred ms after the keyboard
+    // hide animation visually completes, and once the page is idle (no scroll
+    // possible under html/body overflow:hidden) no other event would correct a
+    // stale, too-short --viewport-height.
     const pollForDuration = (ms: number) => {
-      cancelAnimationFrame(rafId.current)
+      cancelAnimationFrame(pollRafId.current)
+      clearTimeout(settleTimeoutId.current)
       const start = performance.now()
       const poll = () => {
         update()
         if (performance.now() - start < ms) {
-          rafId.current = requestAnimationFrame(poll)
+          pollRafId.current = requestAnimationFrame(poll)
         }
       }
-      rafId.current = requestAnimationFrame(poll)
+      pollRafId.current = requestAnimationFrame(poll)
+      settleTimeoutId.current = window.setTimeout(update, ms + 200)
     }
 
-    // Coalesce viewport scroll events via rAF
+    // Coalesce viewport scroll events via rAF. Uses its own handle so it can
+    // never cancel an in-flight focus-transition poll (the poll already calls
+    // update() every frame, so scroll updates during it are redundant anyway).
     const onScroll = () => {
-      cancelAnimationFrame(rafId.current)
-      rafId.current = requestAnimationFrame(update)
+      cancelAnimationFrame(scrollRafId.current)
+      scrollRafId.current = requestAnimationFrame(update)
     }
 
     // Poll across focus transitions on editable elements — covers both keyboard
@@ -156,7 +172,9 @@ export function useVisualViewport(enabled: boolean): boolean {
     window.addEventListener("pageshow", onPageShow)
 
     return () => {
-      cancelAnimationFrame(rafId.current)
+      cancelAnimationFrame(pollRafId.current)
+      cancelAnimationFrame(scrollRafId.current)
+      clearTimeout(settleTimeoutId.current)
       if (vv) {
         vv.removeEventListener("resize", update)
         vv.removeEventListener("scroll", onScroll)


### PR DESCRIPTION
## Problem

On iOS Safari, after the on-screen keyboard closes, the message composer stayed pushed up the screen with a dead, keyboard-sized gap between it and Safari's bottom toolbar (reported by a real iOS user — screenshot showed the `Type a message...` pill floating mid-screen with the keyboard closed).

Root cause is in `useVisualViewport`. The hook drives `--viewport-height` (which `AppShell` sizes its root container to, and the composer is anchored to via `absolute bottom-0`). Two concerns shared a **single `rafId` ref**:

- `pollForDuration()` — the per-frame poll that tracks the keyboard open/close animation across focus transitions.
- `onScroll()` — the rAF coalescer for `visualViewport` scroll events.

iOS Safari emits `visualViewport` **`scroll`** events while the keyboard-hide animation un-pans the page (`offsetTop` returning to 0). One of those mid-animation scrolls called `cancelAnimationFrame(rafId.current)` and replaced the in-flight close poll with a single `update()`. That update ran while `visualViewport.height` was still collapsed, wrote a too-short `--viewport-height`, and then nothing re-measured: the keyboard was fully gone (no more resize), and `html, body { overflow: hidden }` blocks any scroll-driven recompute. The container stayed sized to the keyboard-open height, so the `bottom-0` composer floated above the gap.

## Solution

Give the focus-transition poll its own rAF handle so scroll coalescing can never abort it. Scroll updates during a poll are redundant anyway — the poll already calls `update()` every frame.

Also added a single trailing `setTimeout` re-measure after the rAF window: iOS Safari can settle `visualViewport.height` a few hundred ms after the hide animation visually completes, and once the page is idle under `overflow: hidden` no other event would correct a stale value.

### Key design decisions

**1. Separate rAF/timer handles, not a "poll in progress" guard.**
Three independent refs (`pollRafId`, `scrollRafId`, `settleTimeoutId`) keep the fix local and obvious, and the cleanup path tears all three down. A shared-handle-with-flag approach would reintroduce the same coupling that caused the bug.

**2. Did not touch the phantom-shrink clamp, `AppShell`, or the composer shell.**
The `innerHeight` vs `visualViewport.height` clamp exists specifically for the documented Android-Chrome-`dvh` / PWA phantom-shrink path. Scoping the change to the hook's rAF bookkeeping fixes iOS without risking that path (minimal-patch precedence per `CLAUDE.md`).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-visual-viewport.ts` | Split shared `rafId` into `pollRafId` / `scrollRafId`; added `settleTimeoutId` trailing re-measure; cleanup tears down all three |
| `apps/frontend/src/hooks/use-visual-viewport.test.ts` | Added regression test reproducing the iOS keyboard-close freeze |

## Test plan

- [x] `bunx vitest run src/hooks/use-visual-viewport.test.ts` — 11/11 pass
- [x] Regression test is a genuine guard: with the fix reverted it fails at `Received: "500px"` (the stale keyboard-open height — the exact screenshot symptom); with the fix it settles to `800px`
- [x] Full monorepo lint + typecheck (pre-commit hooks) pass
- [ ] Manual: on a physical iPhone in Safari, open the composer, focus it (keyboard up), dismiss the keyboard — composer returns flush to the bottom with no gap

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012H4isEiKiep2JKrp2kS6qW)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->