### PR TITLE
fix(auth): self-heal missing regional user from control plane on login

### DIFF
--- a/apps/backend/src/features/workspaces/service.test.ts
+++ b/apps/backend/src/features/workspaces/service.test.ts
@@ -221,4 +221,17 @@ describe("WorkspaceService.ensureUserProvisioned", () => {
 
     await expect(service.ensureUserProvisioned(params)).rejects.toThrow("connection reset")
   })
+
+  test("throws an explicit error when the raced row cannot be found after a unique collision", async () => {
+    const cause = { code: "23505", constraint: "users_workspace_workos_user_key" }
+    mockFindUser.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    mockWithTransaction.mockRejectedValueOnce(cause)
+    const service = createWorkspaceService(false)
+
+    const err = await service.ensureUserProvisioned(params).catch((e) => e)
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toContain("users row vanished after unique-constraint collision")
+    expect(err.cause).toBe(cause)
+  })
 })

--- a/apps/backend/src/features/workspaces/service.test.ts
+++ b/apps/backend/src/features/workspaces/service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { WorkspaceService } from "./service"
+import { UserRepository } from "./user-repository"
 import * as db from "../../db"
 
 type MockWorkosOrgService = {
@@ -156,5 +157,68 @@ describe("WorkspaceService.createWorkspace invite gating", () => {
     expect(workspace).toEqual(mockWorkspace)
     expect(workosOrgService.hasAcceptedWorkspaceCreationInvitation).toHaveBeenCalledWith("user@example.com")
     expect(mockWithTransaction).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("WorkspaceService.ensureUserProvisioned", () => {
+  const params = {
+    workspaceId: "ws_1",
+    workosUserId: "workos_user_1",
+    email: "user@example.com",
+    name: "User",
+    role: "member" as const,
+  }
+  const existingUser = { id: "usr_existing", workspaceId: "ws_1" }
+  const createdUser = { id: "usr_created", workspaceId: "ws_1" }
+
+  const mockFindUser = spyOn(UserRepository, "findByWorkosUserIdInWorkspace")
+  const mockWithTransaction = spyOn(db, "withTransaction")
+
+  beforeEach(() => {
+    mockFindUser.mockReset()
+    mockWithTransaction.mockReset()
+  })
+
+  test("returns the existing row without opening a transaction", async () => {
+    mockFindUser.mockResolvedValueOnce(existingUser as never)
+    const service = createWorkspaceService(false)
+
+    const user = await service.ensureUserProvisioned(params)
+
+    expect(user).toEqual(existingUser as never)
+    expect(mockWithTransaction).not.toHaveBeenCalled()
+  })
+
+  test("provisions a new row when none exists", async () => {
+    mockFindUser.mockResolvedValueOnce(null)
+    mockWithTransaction.mockResolvedValueOnce(createdUser as never)
+    const service = createWorkspaceService(false)
+
+    const user = await service.ensureUserProvisioned(params)
+
+    expect(user).toEqual(createdUser as never)
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  test("re-reads and returns the winner when a concurrent request wins the unique constraint", async () => {
+    mockFindUser.mockResolvedValueOnce(null).mockResolvedValueOnce(createdUser as never)
+    mockWithTransaction.mockRejectedValueOnce({
+      code: "23505",
+      constraint: "users_workspace_workos_user_key",
+    })
+    const service = createWorkspaceService(false)
+
+    const user = await service.ensureUserProvisioned(params)
+
+    expect(user).toEqual(createdUser as never)
+    expect(mockFindUser).toHaveBeenCalledTimes(2)
+  })
+
+  test("propagates non-unique-violation transaction errors", async () => {
+    mockFindUser.mockResolvedValueOnce(null)
+    mockWithTransaction.mockRejectedValueOnce(new Error("connection reset"))
+    const service = createWorkspaceService(false)
+
+    await expect(service.ensureUserProvisioned(params)).rejects.toThrow("connection reset")
   })
 })

--- a/apps/backend/src/features/workspaces/service.ts
+++ b/apps/backend/src/features/workspaces/service.ts
@@ -189,6 +189,54 @@ export class WorkspaceService {
     })
   }
 
+  /**
+   * Idempotently ensure a regional `users` row exists for a confirmed member.
+   * Drives the same creation path as invite-accept (system stream + outbox
+   * fan-out) so a self-healed user is indistinguishable from a normally
+   * provisioned one. `setupCompleted: false` routes them through first-run
+   * setup, which fills in the details the failed sync never delivered.
+   *
+   * Concurrent first requests race on the `(workspace_id, workos_user_id)`
+   * unique constraint; the loser re-reads and returns the winner (INV-20).
+   */
+  async ensureUserProvisioned(params: {
+    workspaceId: string
+    workosUserId: string
+    email: string
+    name: string
+    role: User["role"]
+  }): Promise<User> {
+    const existing = await UserRepository.findByWorkosUserIdInWorkspace(
+      this.pool,
+      params.workspaceId,
+      params.workosUserId
+    )
+    if (existing) return existing
+
+    try {
+      return await withTransaction(this.pool, async (client) =>
+        this.createUserInTransaction(client, {
+          workspaceId: params.workspaceId,
+          workosUserId: params.workosUserId,
+          email: params.email,
+          name: params.name,
+          role: params.role,
+          setupCompleted: false,
+        })
+      )
+    } catch (error) {
+      if (isUniqueViolation(error, "users_workspace_workos_user_key")) {
+        const raced = await UserRepository.findByWorkosUserIdInWorkspace(
+          this.pool,
+          params.workspaceId,
+          params.workosUserId
+        )
+        if (raced) return raced
+      }
+      throw error
+    }
+  }
+
   async createUserInTransaction(
     client: Querier,
     params: {

--- a/apps/backend/src/features/workspaces/service.ts
+++ b/apps/backend/src/features/workspaces/service.ts
@@ -232,6 +232,10 @@ export class WorkspaceService {
           params.workosUserId
         )
         if (raced) return raced
+        throw new Error(
+          `users row vanished after unique-constraint collision for workspace ${params.workspaceId}, workosUser ${params.workosUserId}`,
+          { cause: error }
+        )
       }
       throw error
     }

--- a/apps/backend/src/lib/control-plane-client.test.ts
+++ b/apps/backend/src/lib/control-plane-client.test.ts
@@ -75,3 +75,40 @@ describe("ControlPlaneClient error translation", () => {
     })
   })
 })
+
+describe("ControlPlaneClient.getWorkspaceMembership", () => {
+  let client: ControlPlaneClient
+
+  beforeEach(() => {
+    client = new ControlPlaneClient("https://cp.test", "secret")
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+  })
+
+  test("returns the member flag from the control plane", async () => {
+    globalThis.fetch = mock(async () => makeResponse(200, JSON.stringify({ member: true }))) as unknown as typeof fetch
+
+    await expect(
+      client.getWorkspaceMembership({ workspaceId: "ws_1", workosUserId: "workos_user_1" })
+    ).resolves.toEqual({ member: true })
+  })
+
+  test("coerces a missing/non-true member field to false", async () => {
+    globalThis.fetch = mock(async () => makeResponse(200, JSON.stringify({}))) as unknown as typeof fetch
+
+    await expect(
+      client.getWorkspaceMembership({ workspaceId: "ws_1", workosUserId: "workos_user_1" })
+    ).resolves.toEqual({ member: false })
+  })
+
+  test("throws on a non-2xx response so callers fail closed", async () => {
+    globalThis.fetch = mock(async () => makeResponse(503, "unavailable")) as unknown as typeof fetch
+
+    await expect(client.getWorkspaceMembership({ workspaceId: "ws_1", workosUserId: "workos_user_1" })).rejects.toThrow(
+      "Control-plane returned 503"
+    )
+  })
+})

--- a/apps/backend/src/lib/control-plane-client.ts
+++ b/apps/backend/src/lib/control-plane-client.ts
@@ -95,6 +95,35 @@ export class ControlPlaneClient {
     }
   }
 
+  /**
+   * Ask the control plane (source of truth for membership) whether a WorkOS
+   * user belongs to a workspace. Used by the regional auth path to self-heal a
+   * missing `users` row when this region's DB has drifted behind the control
+   * plane. Throws on any non-2xx / transport failure so callers fail closed.
+   */
+  async getWorkspaceMembership(params: { workspaceId: string; workosUserId: string }): Promise<{ member: boolean }> {
+    const url = `${this.baseUrl}/internal/workspaces/${params.workspaceId}/members/${params.workosUserId}`
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        [INTERNAL_API_KEY_HEADER]: this.internalApiKey,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      logger.error(
+        { workspaceId: params.workspaceId, workosUserId: params.workosUserId, status: res.status, body },
+        "Failed to confirm workspace membership with control plane"
+      )
+      throw new Error(`Control-plane returned ${res.status}: ${body}`)
+    }
+
+    const data = (await res.json()) as { member?: unknown }
+    return { member: data.member === true }
+  }
+
   async changeWorkspaceMemberRole(params: {
     workspaceId: string
     targetUserId: string

--- a/apps/backend/src/lib/control-plane-client.ts
+++ b/apps/backend/src/lib/control-plane-client.ts
@@ -102,7 +102,7 @@ export class ControlPlaneClient {
    * plane. Throws on any non-2xx / transport failure so callers fail closed.
    */
   async getWorkspaceMembership(params: { workspaceId: string; workosUserId: string }): Promise<{ member: boolean }> {
-    const url = `${this.baseUrl}/internal/workspaces/${params.workspaceId}/members/${params.workosUserId}`
+    const url = `${this.baseUrl}/internal/workspaces/${encodeURIComponent(params.workspaceId)}/members/${encodeURIComponent(params.workosUserId)}`
     const res = await fetch(url, {
       method: "GET",
       headers: {

--- a/apps/backend/src/middleware/workspace.test.ts
+++ b/apps/backend/src/middleware/workspace.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import type { NextFunction, Request, Response } from "express"
+import { createWorkspaceUserMiddleware } from "./workspace"
+import { UserRepository } from "../features/workspaces"
+
+const mockFindAccess = spyOn(UserRepository, "findWorkspaceUserAccess")
+
+afterEach(() => {
+  mockFindAccess.mockReset()
+})
+
+const POOL = {} as never
+
+const AUTH_USER = {
+  id: "workos_user_1",
+  email: "user@example.com",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  permissions: null,
+}
+
+function createReq(overrides: Partial<Request> = {}): Request {
+  return {
+    params: { workspaceId: "ws_1" },
+    workosUserId: "workos_user_1",
+    authUser: AUTH_USER,
+    ...overrides,
+  } as Request
+}
+
+interface RunResult {
+  status: number | null
+  body: unknown
+  nextCalled: boolean
+  req: Request
+}
+
+function runMiddleware(middleware: ReturnType<typeof createWorkspaceUserMiddleware>, req: Request): Promise<RunResult> {
+  return new Promise((resolve) => {
+    let status: number | null = null
+    let body: unknown = null
+    let settled = false
+    const settle = (nextCalled: boolean) => {
+      if (settled) return
+      settled = true
+      resolve({ status, body, nextCalled, req })
+    }
+
+    const res = {
+      status(code: number) {
+        status = code
+        return this
+      },
+      json(payload: unknown) {
+        body = payload
+        settle(false)
+        return this
+      },
+    } as unknown as Response
+
+    const next: NextFunction = () => settle(true)
+
+    Promise.resolve(middleware(req, res, next)).then(() => {
+      if (!settled) settle(false)
+    })
+  })
+}
+
+function provisionedService(user: unknown) {
+  return { ensureUserProvisioned: async () => user } as never
+}
+
+describe("createWorkspaceUserMiddleware", () => {
+  test("passes through when there is no workspaceId param", async () => {
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: null,
+    })
+    const { nextCalled, status } = await runMiddleware(mw, createReq({ params: {} as Request["params"] }))
+
+    expect(nextCalled).toBe(true)
+    expect(status).toBeNull()
+  })
+
+  test("401 when not authenticated", async () => {
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: null,
+    })
+    const { status, nextCalled } = await runMiddleware(mw, createReq({ workosUserId: undefined }))
+
+    expect(status).toBe(401)
+    expect(nextCalled).toBe(false)
+  })
+
+  test("404 when the workspace does not exist", async () => {
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: false, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: null,
+    })
+    const { status } = await runMiddleware(mw, createReq())
+
+    expect(status).toBe(404)
+  })
+
+  test("attaches the existing user and calls next", async () => {
+    const user = { id: "usr_1", workspaceId: "ws_1" }
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: user as never })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: null,
+    })
+    const { nextCalled, req } = await runMiddleware(mw, createReq())
+
+    expect(nextCalled).toBe(true)
+    expect(req.user).toEqual(user as never)
+    expect(req.workspaceId).toBe("ws_1")
+  })
+
+  test("403 when the user is missing and no control-plane client is configured", async () => {
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: null,
+    })
+    const { status } = await runMiddleware(mw, createReq())
+
+    expect(status).toBe(403)
+  })
+
+  test("403 when the control plane reports the user is not a member", async () => {
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: { getWorkspaceMembership: async () => ({ member: false }) } as never,
+    })
+    const { status } = await runMiddleware(mw, createReq())
+
+    expect(status).toBe(403)
+  })
+
+  test("403 (fail closed) when the control plane lookup throws", async () => {
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(null),
+      controlPlaneClient: {
+        getWorkspaceMembership: async () => {
+          throw new Error("control-plane unreachable")
+        },
+      } as never,
+    })
+    const { status } = await runMiddleware(mw, createReq())
+
+    expect(status).toBe(403)
+  })
+
+  test("self-heals and calls next when the control plane confirms membership", async () => {
+    const healed = { id: "usr_healed", workspaceId: "ws_1" }
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService(healed),
+      controlPlaneClient: { getWorkspaceMembership: async () => ({ member: true }) } as never,
+    })
+    const { nextCalled, status, req } = await runMiddleware(mw, createReq())
+
+    expect(status).toBeNull()
+    expect(nextCalled).toBe(true)
+    expect(req.user).toEqual(healed as never)
+    expect(req.workspaceId).toBe("ws_1")
+  })
+
+  test("403 when the user is missing and there is no WorkOS identity to provision from", async () => {
+    mockFindAccess.mockResolvedValueOnce({ workspaceExists: true, user: null })
+    const mw = createWorkspaceUserMiddleware({
+      pool: POOL,
+      workspaceService: provisionedService({ id: "usr_x" }),
+      controlPlaneClient: { getWorkspaceMembership: async () => ({ member: true }) } as never,
+    })
+    const { status } = await runMiddleware(mw, createReq({ authUser: undefined }))
+
+    expect(status).toBe(403)
+  })
+})

--- a/apps/backend/src/middleware/workspace.ts
+++ b/apps/backend/src/middleware/workspace.ts
@@ -1,6 +1,9 @@
 import type { Request, Response, NextFunction } from "express"
 import type { Pool } from "pg"
-import { UserRepository, type User } from "../features/workspaces"
+import { displayNameFromWorkos, logger } from "@threa/backend-common"
+import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
+import { UserRepository, type User, type WorkspaceService } from "../features/workspaces"
+import type { ControlPlaneClient } from "../lib/control-plane-client"
 
 declare global {
   namespace Express {
@@ -13,9 +16,11 @@ declare global {
 
 interface Dependencies {
   pool: Pool
+  workspaceService: WorkspaceService
+  controlPlaneClient: ControlPlaneClient | null
 }
 
-export function createWorkspaceUserMiddleware({ pool }: Dependencies) {
+export function createWorkspaceUserMiddleware({ pool, workspaceService, controlPlaneClient }: Dependencies) {
   return async function workspaceUserMiddleware(req: Request, res: Response, next: NextFunction) {
     const { workspaceId } = req.params
 
@@ -33,7 +38,21 @@ export function createWorkspaceUserMiddleware({ pool }: Dependencies) {
       return res.status(404).json({ error: "Workspace not found" })
     }
 
-    const user = access.user
+    let user = access.user
+    if (!user) {
+      // No regional `users` row. The control plane is the source of truth for
+      // membership: if this region's DB drifted behind it (failed accept-sync,
+      // restored snapshot) a confirmed member would otherwise be permanently
+      // 403'd. Self-heal by re-provisioning from the CP's confirmation.
+      user = await selfHealMissingUser({
+        workspaceService,
+        controlPlaneClient,
+        workspaceId,
+        workosUserId,
+        authUser: req.authUser,
+      })
+    }
+
     if (!user) {
       return res.status(403).json({ error: "Not a user in this workspace" })
     }
@@ -42,4 +61,47 @@ export function createWorkspaceUserMiddleware({ pool }: Dependencies) {
     req.user = user
     next()
   }
+}
+
+async function selfHealMissingUser(params: {
+  workspaceService: WorkspaceService
+  controlPlaneClient: ControlPlaneClient | null
+  workspaceId: string
+  workosUserId: string
+  authUser: Request["authUser"]
+}): Promise<User | null> {
+  const { workspaceService, controlPlaneClient, workspaceId, workosUserId, authUser } = params
+
+  // Need WorkOS identity to provision (email/name) and the CP client to
+  // confirm membership. Without either, fail closed with the 403.
+  if (!authUser || !controlPlaneClient) {
+    return null
+  }
+
+  let member: boolean
+  try {
+    const result = await controlPlaneClient.getWorkspaceMembership({ workspaceId, workosUserId })
+    member = result.member
+  } catch (error) {
+    // CP unreachable / non-2xx — fail closed rather than fabricate access.
+    logger.error(
+      { err: error, workspaceId, workosUserId },
+      "Self-heal aborted: could not confirm workspace membership with control plane"
+    )
+    return null
+  }
+
+  if (!member) {
+    return null
+  }
+
+  const user = await workspaceService.ensureUserProvisioned({
+    workspaceId,
+    workosUserId,
+    email: authUser.email,
+    name: displayNameFromWorkos(authUser),
+    role: WORKSPACE_ROLE_SLUGS.MEMBER,
+  })
+  logger.info({ workspaceId, workosUserId, userId: user.id }, "Self-healed missing regional user from control plane")
+  return user
 }

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -146,7 +146,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   } = deps
 
   const auth = createAuthMiddleware({ authService })
-  const workspaceUser = createWorkspaceUserMiddleware({ pool })
+  const workspaceUser = createWorkspaceUserMiddleware({ pool, workspaceService, controlPlaneClient })
   const upload = createUploadMiddleware({ s3Config })
   // Express natively chains handlers - spread array at usage sites
   const authed: RequestHandler[] = [auth, workspaceUser]
@@ -503,12 +503,27 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     avatarUpload,
     botHandlers.uploadAvatar
   )
-  app.delete("/api/workspaces/:workspaceId/bots/:botId/avatar", ...authed, requireBotManagement(), botHandlers.removeAvatar)
+  app.delete(
+    "/api/workspaces/:workspaceId/bots/:botId/avatar",
+    ...authed,
+    requireBotManagement(),
+    botHandlers.removeAvatar
+  )
   // Bot avatar serving (unauthenticated — S3 keys contain unguessable ULIDs)
   app.get("/api/workspaces/:workspaceId/bots/:botId/avatar/:file", botHandlers.serveAvatarFile)
   // Bot channel access grants
-  app.get("/api/workspaces/:workspaceId/bots/:botId/streams", ...authed, requireBotManagement(), botHandlers.listStreamGrants)
-  app.post("/api/workspaces/:workspaceId/bots/:botId/streams/:streamId/grant", ...authed, requireBotManagement(), botHandlers.grantStreamAccess)
+  app.get(
+    "/api/workspaces/:workspaceId/bots/:botId/streams",
+    ...authed,
+    requireBotManagement(),
+    botHandlers.listStreamGrants
+  )
+  app.post(
+    "/api/workspaces/:workspaceId/bots/:botId/streams/:streamId/grant",
+    ...authed,
+    requireBotManagement(),
+    botHandlers.grantStreamAccess
+  )
   app.delete(
     "/api/workspaces/:workspaceId/bots/:botId/streams/:streamId/grant",
     ...authed,

--- a/apps/control-plane/src/features/workspaces/handlers.test.ts
+++ b/apps/control-plane/src/features/workspaces/handlers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { Request, Response } from "express"
+import { createWorkspaceHandlers } from "./handlers"
+
+function createResponse() {
+  const res: any = { statusCode: 200 }
+  res.status = mock((code: number) => {
+    res.statusCode = code
+    return res
+  })
+  res.json = mock((body: unknown) => {
+    res.body = body
+    return res
+  })
+  return res as Response & { body: unknown; statusCode: number }
+}
+
+function createHandlers(isMember: (workspaceId: string, workosUserId: string) => Promise<boolean>) {
+  const workspaceService = { isMember: mock(isMember) } as any
+  const shadowService = {} as any
+  return { handlers: createWorkspaceHandlers({ workspaceService, shadowService }), workspaceService }
+}
+
+describe("workspace.confirmMembership", () => {
+  test("returns { member: true } when the registry has the membership", async () => {
+    const { handlers, workspaceService } = createHandlers(async () => true)
+    const req = { params: { workspaceId: "ws_1", workosUserId: "workos_user_1" } } as unknown as Request
+    const res = createResponse()
+
+    await handlers.confirmMembership(req, res)
+
+    expect(workspaceService.isMember).toHaveBeenCalledWith("ws_1", "workos_user_1")
+    expect(res.body).toEqual({ member: true })
+  })
+
+  test("returns { member: false } when there is no membership", async () => {
+    const { handlers } = createHandlers(async () => false)
+    const req = { params: { workspaceId: "ws_1", workosUserId: "workos_user_2" } } as unknown as Request
+    const res = createResponse()
+
+    await handlers.confirmMembership(req, res)
+
+    expect(res.body).toEqual({ member: false })
+  })
+
+  test("rejects with a 400 HttpError when params are missing", async () => {
+    const { handlers } = createHandlers(async () => true)
+    const req = { params: { workspaceId: "ws_1" } } as unknown as Request
+    const res = createResponse()
+
+    await expect(handlers.confirmMembership(req, res)).rejects.toMatchObject({
+      name: "HttpError",
+      status: 400,
+      code: "VALIDATION_ERROR",
+    })
+  })
+})

--- a/apps/control-plane/src/features/workspaces/handlers.ts
+++ b/apps/control-plane/src/features/workspaces/handlers.ts
@@ -59,5 +59,14 @@ export function createWorkspaceHandlers({ workspaceService, shadowService }: Dep
       }
       res.json({ region })
     },
+
+    async confirmMembership(req: Request, res: Response) {
+      const { workspaceId, workosUserId } = req.params
+      if (!workspaceId || !workosUserId) {
+        throw new HttpError("Missing workspaceId or workosUserId", { status: 400, code: "VALIDATION_ERROR" })
+      }
+      const member = await workspaceService.isMember(workspaceId, workosUserId)
+      res.json({ member })
+    },
   }
 }

--- a/apps/control-plane/src/features/workspaces/repository.ts
+++ b/apps/control-plane/src/features/workspaces/repository.ts
@@ -211,6 +211,17 @@ export const WorkspaceRegistryRepository = {
     await db.query("DELETE FROM workspace_registry WHERE id = $1", [id])
   },
 
+  async isMember(db: Querier, workspaceId: string, workosUserId: string): Promise<boolean> {
+    const result = await db.query<{ exists: boolean }>(
+      `SELECT EXISTS(
+         SELECT 1 FROM workspace_memberships
+         WHERE workspace_id = $1 AND workos_user_id = $2
+       ) AS exists`,
+      [workspaceId, workosUserId]
+    )
+    return result.rows[0]?.exists ?? false
+  },
+
   async insertMembership(db: Querier, workspaceId: string, workosUserId: string): Promise<void> {
     await db.query(
       `INSERT INTO workspace_memberships (workspace_id, workos_user_id)

--- a/apps/control-plane/src/features/workspaces/service.ts
+++ b/apps/control-plane/src/features/workspaces/service.ts
@@ -60,6 +60,16 @@ export class ControlPlaneWorkspaceService {
     return WorkspaceRegistryRepository.getRegion(this.pool, workspaceId)
   }
 
+  /**
+   * Confirm whether a WorkOS user holds a membership in this workspace. The
+   * control plane is the source of truth for membership: the regional backend
+   * calls this to self-heal a missing `users` row when its DB has drifted
+   * behind the control plane (failed accept-sync, restored snapshot).
+   */
+  async isMember(workspaceId: string, workosUserId: string): Promise<boolean> {
+    return WorkspaceRegistryRepository.isMember(this.pool, workspaceId, workosUserId)
+  }
+
   async listForUser(workosUserId: string) {
     const rows = await WorkspaceRegistryRepository.listByUser(this.pool, workosUserId)
     return rows.map((row) => ({

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -176,6 +176,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
   // Internal API (inter-service)
   app.get("/internal/workspaces/:workspaceId/region", internalAuth, workspace.getRegion)
+  app.get("/internal/workspaces/:workspaceId/members/:workosUserId", internalAuth, workspace.confirmMembership)
   app.post("/internal/invitation-shadows", internalAuth, shadow.create)
   app.patch("/internal/invitation-shadows/:id", internalAuth, shadow.update)
   app.post("/internal/invitation-shadows/:id/claim", internalAuth, shadow.notifyClaim)

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -208,6 +208,7 @@ WebSocket connections bypass the router entirely. The frontend fetches `/api/wor
 **Internal endpoints (called by workspace router and regional backend):**
 
 - `GET /internal/workspaces/:id/region` — resolve workspace region (used by router on KV miss)
+- `GET /internal/workspaces/:id/members/:workosUserId` — confirm membership (regional backend self-heals a missing `users` row when its DB drifted behind the control plane)
 - `POST /internal/invitation-shadows` — create invitation shadow (called by backend)
 - `PATCH /internal/invitation-shadows/:id` — update invitation shadow
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -208,7 +208,7 @@ WebSocket connections bypass the router entirely. The frontend fetches `/api/wor
 **Internal endpoints (called by workspace router and regional backend):**
 
 - `GET /internal/workspaces/:id/region` — resolve workspace region (used by router on KV miss)
-- `GET /internal/workspaces/:id/members/:workosUserId` — confirm membership (regional backend self-heals a missing `users` row when its DB drifted behind the control plane)
+- `GET /internal/workspaces/:workspaceId/members/:workosUserId` — confirm membership (regional backend self-heals a missing `users` row when its DB drifted behind the control plane)
 - `POST /internal/invitation-shadows` — create invitation shadow (called by backend)
 - `PATCH /internal/invitation-shadows/:id` — update invitation shadow
 


### PR DESCRIPTION
## Problem

On staging, the regional backend drifted behind the control plane for an invited user. When a user accepts an invite, the control plane records the membership and **synchronously** calls the regional backend to create the `users` row — there is no outbox/retry for this step. If that sync call fails, the invitation shadow is still marked terminally `accepted`, so there is **no recovery path**: the regional `users` row never gets created and the `workspaceUser` middleware returns `403 "Not a user in this workspace"` on every request, permanently. This is the observed incident.

## Fix

Add a self-heal path. The control plane is the source of truth for membership, so the regional auth middleware now reconciles itself against it when a confirmed member is missing locally.

**Control plane** — expose a membership oracle (shared-secret `internalAuth`, returns only `{ member: boolean }`, no PII):
- `WorkspaceRegistryRepository.isMember` → `EXISTS` against `workspace_memberships`
- `ControlPlaneWorkspaceService.isMember` + `confirmMembership` handler
- `GET /internal/workspaces/:workspaceId/members/:workosUserId`

**Regional backend**:
- `ControlPlaneClient.getWorkspaceMembership` — throws on any non-2xx / transport failure so callers **fail closed**
- `WorkspaceService.ensureUserProvisioned` — idempotent: read → create → on `users_workspace_workos_user_key` unique violation re-read and return the winner (INV-20). Drives the exact same path as invite-accept (system stream + outbox fan-out) so a healed user is indistinguishable from a normally provisioned one. `setupCompleted: false` routes them through first-run setup, filling in the details the failed sync never delivered.
- `workspaceUser` middleware: when the workspace exists but the local `users` row is missing, confirm membership with the CP and re-provision; otherwise keep the existing 403.

### Fail-closed matrix
| Condition | Result |
|---|---|
| Workspace missing | `404` (unchanged) |
| Local user present | normal path (unchanged) |
| No WorkOS identity on request | `403` |
| No control-plane client configured | `403` |
| CP says not a member | `403` |
| CP unreachable / non-2xx | `403` (logged) |
| CP confirms member | provision + `next()` |
| Provisioning itself errors | propagates → `errorHandler` (`500`, honest — not masked as 403) |

## Self-review notes (for reviewers)

- **Effective role is unaffected.** Healed users get `users.role = member` as a fallback, but the regional effective role is derived from the WorkOS authz mirror (`workspace_user_permissions` via `pickMirroredRole` / `JOIN_AUTHZ_MIRROR`), with `users.role` only a fallback. The `member` default was a deliberate choice to avoid a `workspaces ↔ workos-authz` import cycle and does not over- or under-privilege.
- **Hot path is untouched.** The self-heal branch only runs when `access.user` is null, so healthy users pay zero added latency.
- **Known trade-off / suggested follow-up:** an authenticated caller hitting a workspace they're not a member of now incurs a CP round-trip per request (previously a single DB query → 403). Mitigated by the global baseline rate limiter and the fact that the caller must hold a valid session and know a valid workspace ULID. A short-TTL negative cache (`workspaceId+workosUserId → not-member`) is a sensible follow-up but was intentionally left out to keep this a minimal patch (INV-36).
- **Diff noise:** the pre-commit prettier hook reflowed three unrelated bot routes in `routes.ts` (line-wrapping only, no behavior change).

## Tests

New unit tests, all passing (scoped `spyOn` against namespace imports per INV-48, object comparisons per INV-24):
- `WorkspaceService.ensureUserProvisioned` — existing-return, provision, race re-read on unique violation, propagate non-unique errors
- `workspaceUser` middleware — pass-through, 401, 404, existing user, no-CP-client → 403, not-member → 403, CP-throws → 403, CP-confirms → self-heal + next, no-identity → 403
- `ControlPlaneClient.getWorkspaceMembership` — member flag, missing-field coercion, non-2xx throws
- CP `confirmMembership` — member true/false, missing-params 400

Targeted suites green (backend middleware/workspaces/CP-client + workspace-members: 58 pass; CP workspaces: 3 pass). The pre-commit hook ran lint + typecheck across all 9 packages + prettier + OpenAPI check — all passing.

> Note: a full `bun test` shows ~213 failures, all `ECONNREFUSED` — integration/E2E suites that require Postgres, which the CI sandbox here lacks. They are pre-existing and unrelated; none are in changed areas.

## Test plan

- [ ] Reproduce drift on a staging-like env (accept invite, drop/skip the regional `users` row), confirm the user is `403`'d before and successfully self-heals into first-run setup after
- [ ] Verify a genuine non-member still gets `403`
- [ ] Verify CP-down → `403` (fail closed), not a fabricated session
- [ ] Confirm healed user's effective permissions match their authz-mirror role, not the `member` fallback

https://claude.ai/code/session_01HXi1ReXQ85hzWYVsvxHCha

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXi1ReXQ85hzWYVsvxHCha)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->