### PR TITLE
fix(agents): kill circular-import TDZ that flaked the integration suite

### DIFF
--- a/apps/backend/src/features/agents/tools/load-excel-section-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/load-excel-section-tool.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test"
+import { EXCEL_MAX_ROWS_PER_REQUEST } from "../../attachments"
+import { createLoadExcelSectionTool } from "./load-excel-section-tool"
+import type { WorkspaceToolDeps } from "./tool-deps"
+
+function makeDeps(): WorkspaceToolDeps {
+  return {
+    db: {} as WorkspaceToolDeps["db"],
+    workspaceId: "workspace_test",
+    accessibleStreamIds: ["stream_1"],
+    invokingUserId: "usr_test",
+    searchService: {} as WorkspaceToolDeps["searchService"],
+    storage: {} as WorkspaceToolDeps["storage"],
+    attachmentService: {} as WorkspaceToolDeps["attachmentService"],
+    memoExplorer: {} as WorkspaceToolDeps["memoExplorer"],
+  }
+}
+
+describe("load_excel_section schema", () => {
+  const schema = createLoadExcelSectionTool(makeDeps()).config.inputSchema
+
+  it("rejects a row range exceeding the per-request maximum with a message stating the limit", () => {
+    const result = schema.safeParse({
+      attachmentId: "attach_1",
+      sheetName: "Sheet1",
+      startRow: 0,
+      endRow: EXCEL_MAX_ROWS_PER_REQUEST + 1,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({
+        path: ["endRow"],
+        message: `Cannot load more than ${EXCEL_MAX_ROWS_PER_REQUEST} rows at once`,
+      })
+    )
+  })
+
+  it("accepts a row range at the per-request maximum", () => {
+    const result = schema.safeParse({
+      attachmentId: "attach_1",
+      sheetName: "Sheet1",
+      startRow: 0,
+      endRow: EXCEL_MAX_ROWS_PER_REQUEST,
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/backend/src/features/agents/tools/load-excel-section-tool.ts
+++ b/apps/backend/src/features/agents/tools/load-excel-section-tool.ts
@@ -32,7 +32,11 @@ const LoadExcelSectionSchema = z
       return true
     },
     {
-      message: `Cannot load more than ${EXCEL_MAX_ROWS_PER_REQUEST} rows at once`,
+      // Lazy callback: evaluated at parse time, not schema-construction time.
+      // Reading EXCEL_MAX_ROWS_PER_REQUEST at module init races a circular
+      // import through the attachments barrel and throws a TDZ ReferenceError
+      // depending on module load order.
+      error: () => `Cannot load more than ${EXCEL_MAX_ROWS_PER_REQUEST} rows at once`,
       path: ["endRow"],
     }
   )


### PR DESCRIPTION
## Summary

The integration suite was flaking run-to-run with ~35 spurious failures. Root cause was a single circular-import temporal-dead-zone bug, not 35 independent flaky tests.

`load_excel_section`'s Zod input schema interpolated `EXCEL_MAX_ROWS_PER_REQUEST` into the `.refine()` message **eagerly at schema-construction time**. That constant is imported through the `attachments` barrel; depending on Bun's module evaluation order the barrel binding was still in its temporal dead zone when this module evaluated, throwing `ReferenceError: Cannot access 'EXCEL_MAX_ROWS_PER_REQUEST' before initialization`. That crashed the integration server bootstrap, so migrations never completed and the suite collapsed into "Unable to connect" + `relation "outbox" does not exist` TRUNCATE noise. Load-order dependent → flaky.

## Fix

- Move the constant read into Zod v4's lazy `error` callback so it resolves at parse time, after the module graph is fully initialized.
- The `.refine` predicate (real constraint) was already lazy; the message template was the only module-init access. After this change the module has zero init-time reads of the constant.
- Barrel import preserved (INV-52). Message text unchanged.
- Added `load-excel-section-tool.test.ts` regression test.

## Notes / caveat

The unit test guards **behavior parity** (correct `path` + message, acceptance at the max), not laziness itself — reverting to an eager `message:` would still pass it. The real TDZ guard is the integration suite going green plus the inline comment warning future editors against re-inlining the constant. A direct "is it lazy" assertion would be brittle, so it was left out deliberately.

Scope: this fixes the single root cause demonstrated by the CI log. No other distinct flaky signatures were addressed.

## Test plan

- [x] `bun run --cwd apps/backend typecheck` (full monorepo typecheck via pre-commit hook)
- [x] `bun run --cwd apps/backend lint` (+ full lint suite via pre-commit hook)
- [x] New regression test passes (`load-excel-section-tool.test.ts`, 2 tests)
- [x] All 88 agents-tools tests pass
- [ ] CI integration suite green across multiple runs (verifies flake is gone)

https://claude.ai/code/session_01A2RtkTukuxBPoztz2zfg1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2RtkTukuxBPoztz2zfg1t)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->