### PR TITLE
fix(timeline): never render a non-empty stream as blank or "No messages yet"

### DIFF
--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -8,6 +8,7 @@ import {
   getMinimumSequence,
   getNextBootstrapFloorState,
   getOldestSequence,
+  getRenderableEvents,
 } from "./use-events"
 
 describe("useEvents helpers", () => {
@@ -86,7 +87,7 @@ describe("computeTimelineLoadState", () => {
       computeTimelineLoadState({
         idbResolved: false,
         hasAnyEvents: false,
-        isBootstrapLoading: true,
+        bootstrapSettled: false,
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: false, isConfirmedEmpty: false })
@@ -97,7 +98,7 @@ describe("computeTimelineLoadState", () => {
       computeTimelineLoadState({
         idbResolved: false,
         hasAnyEvents: false,
-        isBootstrapLoading: false,
+        bootstrapSettled: false,
         idbResolveTimedOut: true,
       })
     ).toEqual({ isLoading: true, isConfirmedEmpty: false })
@@ -108,18 +109,35 @@ describe("computeTimelineLoadState", () => {
       computeTimelineLoadState({
         idbResolved: true,
         hasAnyEvents: false,
-        isBootstrapLoading: true,
+        bootstrapSettled: false,
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: true, isConfirmedEmpty: false })
   })
 
-  it("shows confirmed-empty once IDB is resolved and bootstrap has settled", () => {
+  it("keeps a skeleton (never 'No messages yet') when IDB is empty and the socket-gated bootstrap has not answered", () => {
+    // The reported bug: open a stream from a push notification on a cold PWA.
+    // The bootstrap query is `enabled: false` until the socket connects, so it
+    // reports not-loading. The old contract read that as "bootstrap not
+    // loading => stream confirmed empty" and rendered "No messages yet" for a
+    // stream with thousands of messages, stuck until a hard refresh.
+    // bootstrapSettled stays false until the bootstrap actually answers.
     expect(
       computeTimelineLoadState({
         idbResolved: true,
         hasAnyEvents: false,
-        isBootstrapLoading: false,
+        bootstrapSettled: false,
+        idbResolveTimedOut: true,
+      })
+    ).toEqual({ isLoading: true, isConfirmedEmpty: false })
+  })
+
+  it("shows confirmed-empty only once the bootstrap has produced a definitive answer", () => {
+    expect(
+      computeTimelineLoadState({
+        idbResolved: true,
+        hasAnyEvents: false,
+        bootstrapSettled: true,
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: false, isConfirmedEmpty: true })
@@ -130,7 +148,7 @@ describe("computeTimelineLoadState", () => {
       computeTimelineLoadState({
         idbResolved: true,
         hasAnyEvents: true,
-        isBootstrapLoading: true,
+        bootstrapSettled: false,
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: false, isConfirmedEmpty: false })
@@ -141,10 +159,42 @@ describe("computeTimelineLoadState", () => {
       computeTimelineLoadState({
         idbResolved: true,
         hasAnyEvents: true,
-        isBootstrapLoading: false,
+        bootstrapSettled: true,
         idbResolveTimedOut: false,
       })
     ).toEqual({ isLoading: false, isConfirmedEmpty: false })
+  })
+})
+
+describe("getRenderableEvents", () => {
+  it("applies the display floor normally when events remain in-window", () => {
+    const rendered = getRenderableEvents(
+      [{ sequence: "10" }, { sequence: "50" }, { sequence: "100" }, { sequence: "150" }],
+      100n
+    )
+
+    expect(rendered.map((event) => event.sequence)).toEqual(["100", "150"])
+  })
+
+  it("renders the full cached set rather than nothing when the floor would hide every event", () => {
+    // Offline-first invariant: IDB has the stream's events and useLiveQuery
+    // delivered them, but a freshly-fetched bootstrap floor landed above the
+    // entire stale cached window before useLiveQuery re-emitted the bootstrap
+    // writes. filterEventsForDisplay alone strips everything and the timeline
+    // commits to a permanent blank scroll area. getRenderableEvents must keep
+    // the cached events visible until the background refresh widens the window.
+    const cached = [{ sequence: "10" }, { sequence: "20" }, { sequence: "30" }]
+    expect(getRenderableEvents(cached, 100n)).toBe(cached)
+  })
+
+  it("returns empty when there genuinely are no cached events", () => {
+    expect(getRenderableEvents([], 100n)).toEqual([])
+  })
+
+  it("keeps optimistic events visible even when persisted events are all below the floor", () => {
+    const rendered = getRenderableEvents([{ sequence: "10" }, { sequence: "20", _status: "pending" }], 100n)
+
+    expect(rendered.map((event) => [event.sequence, event._status ?? null])).toEqual([["20", "pending"]])
   })
 })
 

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -5,7 +5,7 @@ import { useQueryClient, useInfiniteQuery } from "@tanstack/react-query"
 import { db, sequenceToNum } from "@/db"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
-import { shouldSuppressBootstrapError } from "@/lib/query-load-state"
+import { isTerminalBootstrapError, shouldSuppressBootstrapError } from "@/lib/query-load-state"
 import type { StreamEvent, EventsAroundResponse, SharedMessageHydration } from "@threa/types"
 
 export const eventKeys = {
@@ -67,8 +67,19 @@ export interface TimelineLoadStateInput {
   idbResolved: boolean
   /** `true` when either IDB or the cached bootstrap snapshot has something to render. */
   hasAnyEvents: boolean
-  /** `true` while the stream bootstrap query is in-flight. */
-  isBootstrapLoading: boolean
+  /**
+   * `true` once the bootstrap query has produced a *definitive* answer for
+   * this stream: it succeeded, hit a terminal 403/404, or the caller disabled
+   * it (drafts). It is `false` while the bootstrap is pending, fetching, or
+   * blocked waiting for the socket to connect.
+   *
+   * Critical: a disabled / socket-gated bootstrap is NOT an empty stream.
+   * Treating "bootstrap not currently loading" as "stream confirmed empty" is
+   * what makes a stream with thousands of messages render "No messages yet"
+   * after a cold push-notification open. Only the bootstrap's own definitive
+   * answer can confirm emptiness; until then an empty IDB stays a skeleton.
+   */
+  bootstrapSettled: boolean
   /**
    * `true` once IDB has been unresolved for `IDB_SKELETON_DELAY_MS`. Callers
    * pass `false` until the timeout fires so fast stream switches don't flash
@@ -94,7 +105,7 @@ export interface TimelineLoadState {
 export function computeTimelineLoadState({
   idbResolved,
   hasAnyEvents,
-  isBootstrapLoading,
+  bootstrapSettled,
   idbResolveTimedOut,
 }: TimelineLoadStateInput): TimelineLoadState {
   if (!idbResolved) {
@@ -103,10 +114,14 @@ export function computeTimelineLoadState({
     // the skeleton so slow devices don't appear frozen.
     return { isLoading: idbResolveTimedOut, isConfirmedEmpty: false }
   }
-  return {
-    isLoading: !hasAnyEvents && isBootstrapLoading,
-    isConfirmedEmpty: !hasAnyEvents && !isBootstrapLoading,
+  if (hasAnyEvents) {
+    return { isLoading: false, isConfirmedEmpty: false }
   }
+  // IDB resolved empty. Keep a skeleton until the bootstrap actually answers —
+  // a pending / socket-gated bootstrap must never be reported as a confirmed
+  // empty stream. Only the bootstrap's definitive answer flips this to the
+  // empty state.
+  return { isLoading: !bootstrapSettled, isConfirmedEmpty: bootstrapSettled }
 }
 
 export function getDisplayFloor(bootstrapFloor: bigint | null, olderFloor: bigint | null): bigint | null {
@@ -130,6 +145,33 @@ export function filterEventsForDisplay<T extends DisplayableEvent>(events: T[], 
     if (event._status === "pending" || event._status === "failed") return true
     return BigInt(event.sequence) >= displayFloor
   })
+}
+
+/**
+ * Offline-first render guarantee: a non-empty local cache must never render as
+ * a blank timeline.
+ *
+ * `displayFloor` exists to trim *pre-session* history so the unread divider
+ * and pagination cursors stay correct — it is an optimisation for narrowing
+ * the window, never a reason to render nothing. But the floor is derived from
+ * the bootstrap's latest page, and a freshly-fetched bootstrap floor can land
+ * entirely above a stale cached window before `useLiveQuery` re-emits the
+ * bootstrap's own writes (Dexie change-propagation lag; on mobile Safari the
+ * change can be missed until the next page-resume). In that gap
+ * `filterEventsForDisplay` would strip every cached event, the rendered array
+ * goes empty while `hasAnyEvents` (computed from the unfiltered set) stays
+ * true, and the timeline commits to a permanent blank scroll area — no
+ * skeleton, no empty state — until a hard refresh.
+ *
+ * The invariant: if IndexedDB has events for this stream, the user sees them.
+ * If applying the floor would hide the entire cached set, show the full
+ * cached set instead and let the background bootstrap refresh widen/correct
+ * the window on its next emit.
+ */
+export function getRenderableEvents<T extends DisplayableEvent>(events: T[], displayFloor: bigint | null): T[] {
+  const filtered = filterEventsForDisplay(events, displayFloor)
+  if (filtered.length === 0 && events.length > 0) return events
+  return filtered
 }
 
 /**
@@ -237,12 +279,19 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   // Bootstrap query still drives the fetch lifecycle (loading/error states)
   // and triggers IDB writes via applyStreamBootstrap in its queryFn.
   const {
-    isLoading: isBootstrapLoading,
+    status: bootstrapStatus,
     error,
     data: bootstrap,
   } = useStreamBootstrap(workspaceId, streamId, {
     enabled: shouldFetch,
   })
+
+  // The bootstrap has a *definitive* answer only when it succeeded, hit a
+  // terminal 403/404, or the caller never asked for it (drafts). While it is
+  // pending / fetching / blocked on the socket connecting, it has NOT
+  // confirmed the stream is empty — an empty IDB must stay a skeleton, not
+  // flip to "No messages yet" for a stream that actually has history.
+  const bootstrapSettled = !shouldFetch || bootstrapStatus === "success" || isTerminalBootstrapError(error)
   const streamService = useStreamService()
   const queryClient = useQueryClient()
 
@@ -405,8 +454,10 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     // Before bootstrap resolves, show only a bootstrap-sized cached window so
     // users cannot scroll into extra cached history that later disappears when
     // the bootstrap floor arrives. If bootstrap fails and we fall back to the
-    // local cache, widen back out to the full cached timeline.
-    return filterEventsForDisplay(effectiveEvents, displayFloor) as unknown as StreamEvent[]
+    // local cache, widen back out to the full cached timeline. The floor must
+    // never hide the entire cached set — a non-empty IDB always renders
+    // something (see getRenderableEvents).
+    return getRenderableEvents(effectiveEvents, displayFloor) as unknown as StreamEvent[]
   }, [effectiveEvents, olderData, newerData, jumpState, displayFloor])
 
   // When IDB has been unresolved long enough that a user would notice, flip
@@ -426,7 +477,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   const { isLoading, isConfirmedEmpty } = computeTimelineLoadState({
     idbResolved,
     hasAnyEvents,
-    isBootstrapLoading,
+    bootstrapSettled,
     idbResolveTimedOut,
   })
 


### PR DESCRIPTION
## Problem

Opening a stream from a push notification on a cold/resumed PWA could leave the timeline **permanently empty** — no messages, no skeleton, sometimes a misleading "No messages yet" for a stream with thousands of messages. Waiting did nothing; pull-to-refresh did nothing; only a hard browser refresh recovered it. This recurred and is not slow data — it's a state race.

The architecture is offline-first by design: IndexedDB is the single read model (`useStreamEvents` → Dexie `useLiveQuery`); bootstrap and socket events both *write into IDB*, and the UI reads only from IDB. The bug is that the **render was coupled to the bootstrap state machine** instead of being driven by the IDB cache, so when bootstrap couldn't produce an answer, the cache that *did* have the messages never got shown.

Two compounding defects:

1. **A socket-gated bootstrap was misread as "stream is empty."** `useStreamBootstrap` is `enabled: ... && !!socket` (intentional — INV-53, don't miss updates). On a cold push-notification open the socket is still doing its config handshake, so the query is *disabled*, and a disabled TanStack query reports `isLoading=false`. `computeTimelineLoadState` treated "bootstrap not loading" as "stream confirmed empty" → rendered "No messages yet" (or a blank scroll area). It only recovered on hard refresh because that tears down the socket provider and clears the query cache.

2. **The display floor could hide the entire cached set.** The floor is derived from the bootstrap's latest page. A freshly-fetched floor can land entirely above a stale cached window before `useLiveQuery` re-emits the bootstrap's own writes (Dexie change-propagation lag; on mobile Safari the change can be missed until page-resume). `filterEventsForDisplay` then stripped every cached event while `hasAnyEvents` (computed from the unfiltered set) stayed true — a permanent blank scroll area with no skeleton and no empty state.

## Solution

Keep the socket→bootstrap ordering exactly as-is (INV-53 preserved — we still don't miss updates); only decouple the **render** from the bootstrap state machine so IndexedDB stays the authoritative read model.

### Key design decisions

**1. Confirm "empty" only on a definitive bootstrap answer.**
`computeTimelineLoadState` now takes `bootstrapSettled` instead of `isBootstrapLoading`. The empty state fires only when the bootstrap has truly answered: success, terminal 403/404, or the caller disabled it (drafts). While the bootstrap is pending / fetching / blocked on the socket, an empty IDB stays a **skeleton**, never a false "No messages yet". It self-heals the moment the socket connects (or via page-resume / reconnect invalidation). A genuine hard error with nothing cached still surfaces the existing `ErrorView` (`stream-content.tsx:971`), so this is not a dead skeleton.

**2. A non-empty IndexedDB is un-blankable.**
New pure helper `getRenderableEvents`: the display floor may narrow the window but can never hide the *entire* cached set. If filtering would remove everything while the cache is non-empty, render the full cached set and let the background bootstrap refresh re-narrow on its next emit. This enforces the offline-first invariant directly: if IDB has events for the stream, the user sees them.

**Alternative considered and rejected:** decoupling the bootstrap fetch from the socket entirely. Rejected because the socket-before-bootstrap ordering is the mechanism that guarantees we don't miss realtime updates (INV-53). The fix keeps that ordering and instead makes the render independent of it.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-events.ts` | `computeTimelineLoadState` driven by `bootstrapSettled` (definitive answer) instead of `isBootstrapLoading`; new `getRenderableEvents` offline-first guarantee; `useEvents` derives `bootstrapSettled` from bootstrap status / terminal error / caller-disabled and routes the normal-mode render through `getRenderableEvents` |
| `apps/frontend/src/hooks/use-events.test.ts` | Updated `computeTimelineLoadState` cases to the `bootstrapSettled` contract; added regression test for the socket-gated cold-open case; added `getRenderableEvents` coverage (floor applies normally, never blanks a non-empty cache, optimistic events preserved) |

## Test plan

- [x] `bunx vitest run src/hooks/use-events.test.ts` — 22/22 pass
- [x] `bunx vitest run src/hooks src/components/timeline` — 463/463 pass (no regressions)
- [x] Monorepo typecheck clean (all workspaces)
- [x] ESLint + prettier + API-docs pre-commit hooks green
- [ ] Manual: open a stream via push notification on a cold iOS PWA with a flaky/connecting socket — timeline shows cached messages (or a skeleton, never a false "No messages yet" / permanent blank); confirm it self-heals without a hard refresh once the socket connects

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014Jv8HvwW3HkP4dbEcriyj1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->