### PR TITLE
fix(auth): stop logout from hanging on stranded service worker

### DIFF
--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, render } from "@/test"
-import { spyOnExport } from "@/test"
+import { act, render, spyOnExport } from "@/test"
 import { AuthProvider, useAuth } from "@/auth"
 import * as dbModule from "@/db"
 

--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render } from "@/test"
+import { spyOnExport } from "@/test"
+import { AuthProvider, useAuth } from "@/auth"
+import * as dbModule from "@/db"
+
+let triggerLogout: () => void
+
+function LogoutProbe() {
+  triggerLogout = useAuth().logout
+  return null
+}
+
+describe("AuthProvider logout", () => {
+  const originalLocation = window.location
+  const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "" } as Location,
+    })
+
+    // The mount effect calls /api/auth/me; keep it from throwing.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 401, ok: false, json: async () => ({}) }) as unknown as Response)
+    )
+
+    spyOnExport(dbModule, "clearAllCachedData").mockReturnValue((async () => {}) as typeof dbModule.clearAllCachedData)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+    if (originalServiceWorker) {
+      Object.defineProperty(navigator, "serviceWorker", originalServiceWorker)
+    } else {
+      // @ts-expect-error — jsdom has no serviceWorker by default; remove our stub
+      delete navigator.serviceWorker
+    }
+  })
+
+  it("redirects to the logout endpoint even when navigator.serviceWorker.ready never resolves", async () => {
+    // Reproduces the desktop dev failure: an injectManifest module SW stranded
+    // in "installing" means navigator.serviceWorker.ready never settles. The
+    // push-cleanup step must not be able to block the logout redirect.
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { ready: new Promise<never>(() => {}) },
+    })
+
+    render(
+      <AuthProvider>
+        <LogoutProbe />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      triggerLogout()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(window.location.href).toBe("/api/auth/logout")
+  })
+})

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -15,6 +15,11 @@ interface AuthContextValue extends AuthState {
   refetch: () => Promise<void>
 }
 
+// Best-effort push cleanup must never delay the logout redirect for long.
+// When the SW is healthy this completes in well under a second; the cap only
+// fires when `serviceWorker.ready` never settles (stranded worker).
+const PUSH_CLEANUP_TIMEOUT_MS = 2000
+
 export const AuthContext = createContext<AuthContextValue | null>(null)
 
 interface AuthProviderProps {
@@ -82,7 +87,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Clean up push subscriptions on logout:
     // 1. Tell backend to remove all records for this browser's endpoint (cross-workspace)
     // 2. Unsubscribe from the browser push service to prevent post-logout notifications
-    try {
+    //
+    // `navigator.serviceWorker.ready` only resolves once a worker is active and
+    // never rejects, so a worker stranded in "installing" (common with the dev
+    // injectManifest module SW) would hang this step — and the redirect below —
+    // forever. Cap the whole best-effort block so logout always proceeds.
+    const pushCleanup = (async () => {
       const registration = await navigator.serviceWorker?.ready
       const subscription = await registration?.pushManager.getSubscription()
       if (subscription) {
@@ -94,9 +104,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }).catch(() => {})
         await subscription.unsubscribe()
       }
-    } catch {
-      // Best-effort — don't block logout if push cleanup fails
-    }
+    })()
+    await Promise.race([
+      pushCleanup,
+      new Promise<void>((resolve) => setTimeout(resolve, PUSH_CLEANUP_TIMEOUT_MS)),
+    ]).catch(() => {})
     await clearAllCachedData().catch(() => {})
     window.location.href = `${API_BASE}/api/auth/logout`
   }, [])


### PR DESCRIPTION
## Problem

The logout button does nothing on desktop. Users have to manually navigate to `/api/auth/logout` to sign out.

`logout()` in `apps/frontend/src/auth/context.tsx` runs best-effort push-subscription cleanup before redirecting, starting with:

```js
const registration = await navigator.serviceWorker?.ready
```

`navigator.serviceWorker.ready` only resolves once a service worker is **active** and **never rejects**. On desktop dev the injectManifest module SW frequently strands in `"installing"` — a hazard already documented in this codebase:

- `apps/frontend/vite.config.ts:88-91`: a stranded dev SW "strands the SW in 'installing' forever and **breaks `navigator.serviceWorker.ready`**"
- `apps/frontend/src/hooks/use-push-notifications.ts:239-246`: a hard timeout exists precisely because "a never-resolving SW activation ... leaves the UI in 'subscribing' forever"

When the worker is stranded, `.ready` hangs forever, so `logout()` never reaches `window.location.href = .../api/auth/logout`. The button silently does nothing while the manual URL still works. The `try/catch` and "best-effort — don't block logout" comment were a false promise: a hung (not rejected) promise is never caught. On mobile (installed PWA / staging where the SW is active) `.ready` resolves, so logout works there — matching the reported "doesn't work, at least not on desktop".

## Solution

Wrap the entire best-effort push-cleanup block in `Promise.race` against a short timeout so the logout redirect can never be blocked. This mirrors the existing `serviceWorker.ready` timeout guard already used in `use-push-notifications.ts`.

### Key design decisions

**1. Race the whole cleanup block, not just `.ready`**

The timeout caps `serviceWorker.ready`, `getSubscription()`, the cleanup `fetch`, and `unsubscribe()` together. Any of them hanging (not just `.ready`) would otherwise strand logout. `Promise.race` keeps a rejection handler attached to the cleanup promise, so a late rejection after the timeout fires does not surface as an unhandled rejection; the `.catch(() => {})` swallows an early one. This fully replaces the removed `try/catch`.

**2. 2s cap, centralized constant (INV-33)**

When the SW is healthy, cleanup completes in well under a second, so the cap only fires in the stranded-worker failure mode — at which point getting the user signed out takes priority over best-effort cleanup. `PUSH_CLEANUP_TIMEOUT_MS` is a named module constant with rationale, consistent with `SUBSCRIBE_TIMEOUT_MS` in `use-push-notifications.ts`.

**3. No `clearTimeout` on the fast path**

`window.location.href = ...` navigates away immediately after the race, unloading the page; the dangling timer's `resolve` is a no-op. Adding a `clearTimeout`/`finally` would only add complexity against the minimal-patch principle.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/auth/context.test.tsx` | Regression test: mounts the real `AuthProvider` and asserts `logout()` redirects even when `navigator.serviceWorker.ready` never resolves (INV-39, INV-48). Fails pre-fix, passes post-fix. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/auth/context.tsx` | Replace the unbounded `await navigator.serviceWorker?.ready` `try/catch` with a `Promise.race` against `PUSH_CLEANUP_TIMEOUT_MS`; add the centralized constant + why-comments. |

## Test plan

- [x] New regression test fails before the fix (`window.location.href` stays empty), passes after
- [x] Existing `sidebar-footer` tests still pass (logout wiring unchanged)
- [x] Full frontend typecheck clean (`tsc --noEmit`, exit 0)
- [x] Pre-commit hooks (monorepo lint + typecheck + dockerfile/openapi checks) pass
- [ ] Manual: in desktop dev with a stranded SW, click "Log out" → redirects within ~2s instead of hanging
- [ ] Manual: healthy SW path → push cleanup still runs, redirect is immediate

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKD77Sqyn4JonADiJuqyra)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->