### PR TITLE
PR-3: /api/accounts contract + OAuth intent=add park/coalesce

### DIFF
--- a/apps/control-plane/src/features/accounts/handlers.ts
+++ b/apps/control-plane/src/features/accounts/handlers.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from "express"
+import { z } from "zod/v4"
+import { HttpError, SESSION_COOKIE_NAME } from "@threa/backend-common"
+import type { AccountsService } from "./service"
+
+interface Dependencies {
+  accountsService: AccountsService
+}
+
+const targetSchema = z.object({
+  targetUserId: z.string().min(1),
+})
+
+export function createAccountsHandlers({ accountsService }: Dependencies) {
+  return {
+    async list(req: Request, res: Response) {
+      if (!req.workosUserId || !req.authUser) {
+        throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
+      }
+      res.json(await accountsService.list(req.cookies, req.authUser))
+    },
+
+    async switch(req: Request, res: Response) {
+      if (!req.workosUserId || !req.authUser) {
+        throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
+      }
+      const parsed = targetSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+      }
+      const activeSealed = req.cookies[SESSION_COOKIE_NAME]
+      res.json(await accountsService.switch(res, req.cookies, activeSealed, req.authUser, parsed.data.targetUserId))
+    },
+
+    async remove(req: Request, res: Response) {
+      if (!req.workosUserId || !req.authUser) {
+        throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
+      }
+      const parsed = targetSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+      }
+      const activeSealed = req.cookies[SESSION_COOKIE_NAME]
+      res.json(await accountsService.remove(res, req.cookies, activeSealed, req.authUser, parsed.data.targetUserId))
+    },
+  }
+}

--- a/apps/control-plane/src/features/accounts/index.ts
+++ b/apps/control-plane/src/features/accounts/index.ts
@@ -1,0 +1,3 @@
+export { AccountsService } from "./service"
+export type { AccountSummary } from "./service"
+export { createAccountsHandlers } from "./handlers"

--- a/apps/control-plane/src/features/accounts/service.ts
+++ b/apps/control-plane/src/features/accounts/service.ts
@@ -70,6 +70,74 @@ export class AccountsService {
     })
   }
 
+  /**
+   * OAuth add-account: make the freshly authenticated session active and park
+   * the previous active session into a free alt slot. Idempotent — a re-auth
+   * of the still-active account or one already parked coalesces in place
+   * (no slot consumed), and a slot whose cookie failed validation is
+   * reclaimed. Returns `MAX_ACCOUNTS_REACHED` instead of throwing when every
+   * slot holds a distinct valid account, so the OAuth callback can 302
+   * gracefully rather than render an error page mid-flight.
+   */
+  async addAndParkActive(
+    res: Response,
+    cookies: Record<string, string>,
+    prevActiveSealed: string | undefined,
+    newSealed: string,
+    newUserId: string
+  ): Promise<{ ok: true } | { ok: false; code: "MAX_ACCOUNTS_REACHED" }> {
+    // No prior session — treat as a normal first login (no slot consumed).
+    if (!prevActiveSealed) {
+      setSessionCookie(res, newSealed)
+      return { ok: true }
+    }
+
+    const prevAuth = await this.authService.authenticateSession(prevActiveSealed)
+    // Prev cookie no longer valid, or a re-auth of the same account: there is
+    // nothing worth parking — just replace the active session in place.
+    if (!prevAuth.success || !prevAuth.user || prevAuth.user.id === newUserId) {
+      setSessionCookie(res, newSealed)
+      return { ok: true }
+    }
+
+    const alts = await this.resolveAlts(cookies)
+    const validAlts = alts.filter((a) => a.ok && a.user)
+
+    // The new account is already parked: promote it, park the previous active
+    // into the slot it vacated, and clear any duplicate slots of the new user.
+    const existing = validAlts.find((a) => a.user?.id === newUserId)
+    if (existing) {
+      setSessionCookie(res, newSealed)
+      setAltSessionCookie(res, existing.slot, prevActiveSealed)
+      for (const a of validAlts) {
+        if (a.slot !== existing.slot && a.user?.id === newUserId) {
+          clearAltSessionCookie(res, a.slot)
+        }
+      }
+      return { ok: true }
+    }
+
+    // Lowest free slot. A slot whose cookie failed validation is reclaimable
+    // (not "occupied"), self-healing corrupt/expired alts.
+    const occupied = new Set(validAlts.map((a) => a.slot))
+    let freeSlot = -1
+    for (let s = 0; s < MAX_ALT_SLOTS; s++) {
+      if (!occupied.has(s)) {
+        freeSlot = s
+        break
+      }
+    }
+    if (freeSlot === -1) {
+      // Every slot holds a distinct valid account — adding would exceed
+      // MAX_ACCOUNTS. Refuse gracefully; the prev-active cookie is untouched.
+      return { ok: false, code: "MAX_ACCOUNTS_REACHED" }
+    }
+
+    setAltSessionCookie(res, freeSlot, prevActiveSealed)
+    setSessionCookie(res, newSealed)
+    return { ok: true }
+  }
+
   async list(
     cookies: Record<string, string>,
     activeUser: ActiveUser
@@ -161,14 +229,13 @@ export class AccountsService {
       // Removing the active account: kill its WorkOS session for real, plus
       // any duplicate alt slots holding the same account, then promote the
       // lowest-slot remaining distinct account (or full logout if none).
-      await this.authService.revokeSession(activeSealed)
-      clearSessionCookie(res)
-
       const dups = alts.filter((a) => a.ok && a.user?.id === activeUser.id)
-      for (const dup of dups) {
-        await this.authService.revokeSession(dup.sealed)
-        clearAltSessionCookie(res, dup.slot)
-      }
+      await Promise.all([
+        this.authService.revokeSession(activeSealed),
+        ...dups.map((dup) => this.authService.revokeSession(dup.sealed)),
+      ])
+      clearSessionCookie(res)
+      for (const dup of dups) clearAltSessionCookie(res, dup.slot)
 
       const promote = alts
         .filter((a) => a.ok && a.user && a.user.id !== activeUser.id)
@@ -188,10 +255,8 @@ export class AccountsService {
     if (matches.length === 0) {
       throw new HttpError("Account not found", { status: 404, code: "ACCOUNT_NOT_FOUND" })
     }
-    for (const m of matches) {
-      await this.authService.revokeSession(m.sealed)
-      clearAltSessionCookie(res, m.slot)
-    }
+    await Promise.all(matches.map((m) => this.authService.revokeSession(m.sealed)))
+    for (const m of matches) clearAltSessionCookie(res, m.slot)
 
     return { removedId: targetUserId }
   }

--- a/apps/control-plane/src/features/accounts/service.ts
+++ b/apps/control-plane/src/features/accounts/service.ts
@@ -1,0 +1,198 @@
+import type { Response } from "express"
+import {
+  HttpError,
+  MAX_ACCOUNTS,
+  MAX_ALT_SLOTS,
+  clearAltSessionCookie,
+  clearSessionCookie,
+  displayNameFromWorkos,
+  readAltSessionCookies,
+  setAltSessionCookie,
+  setSessionCookie,
+  type AuthService,
+} from "@threa/backend-common"
+
+/**
+ * One account as seen by the multi-account switcher.
+ *
+ * `id` is a stable opaque identifier — for live accounts it is the WorkOS user
+ * id; for an alt whose sealed session failed validation it is
+ * `stale:alt_<slot>` (the raw slot index never crosses the wire). `state` is a
+ * single discriminant because the three states are mutually exclusive: the
+ * active account is always validated upstream by the `auth` middleware, so an
+ * `active && stale` combination is structurally impossible.
+ */
+export interface AccountSummary {
+  id: string
+  email: string
+  name: string
+  state: "active" | "parked" | "stale"
+}
+
+interface ActiveUser {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+}
+
+interface ResolvedAlt {
+  slot: number
+  sealed: string
+  ok: boolean
+  user?: { id: string; email: string; firstName: string | null; lastName: string | null }
+}
+
+interface Dependencies {
+  authService: AuthService
+}
+
+const STALE_ID_RE = /^stale:alt_(\d+)$/
+
+export class AccountsService {
+  private authService: AuthService
+
+  constructor({ authService }: Dependencies) {
+    this.authService = authService
+  }
+
+  // Validate every parked alt cookie in parallel (never a serial loop). A
+  // slot whose sealed session fails validation comes back `ok:false` and is
+  // reclaimable on the next write (self-heals corrupt/expired alts).
+  private async resolveAlts(cookies: Record<string, string>): Promise<ResolvedAlt[]> {
+    const alts = readAltSessionCookies(cookies)
+    const auths = await Promise.all(alts.map((a) => this.authService.authenticateSession(a.sealed)))
+    return alts.map((a, i) => {
+      const r = auths[i]
+      return r.success && r.user
+        ? { slot: a.slot, sealed: a.sealed, ok: true, user: r.user }
+        : { slot: a.slot, sealed: a.sealed, ok: false }
+    })
+  }
+
+  async list(
+    cookies: Record<string, string>,
+    activeUser: ActiveUser
+  ): Promise<{ accounts: AccountSummary[]; maxAccounts: number }> {
+    const accounts: AccountSummary[] = [
+      {
+        id: activeUser.id,
+        email: activeUser.email,
+        name: displayNameFromWorkos(activeUser),
+        state: "active",
+      },
+    ]
+
+    // Coalesce on read: hide any alt that resolves to the active account or to
+    // an account already surfaced by an earlier (lower) slot. GET stays
+    // Set-Cookie-free; slot reconciliation is deferred to the next write.
+    const seen = new Set<string>([activeUser.id])
+    for (const alt of await this.resolveAlts(cookies)) {
+      if (alt.ok && alt.user) {
+        if (seen.has(alt.user.id)) continue
+        seen.add(alt.user.id)
+        accounts.push({
+          id: alt.user.id,
+          email: alt.user.email,
+          name: displayNameFromWorkos(alt.user),
+          state: "parked",
+        })
+      } else {
+        accounts.push({ id: `stale:alt_${alt.slot}`, email: "", name: "", state: "stale" })
+      }
+    }
+
+    return { accounts, maxAccounts: MAX_ACCOUNTS }
+  }
+
+  async switch(
+    res: Response,
+    cookies: Record<string, string>,
+    activeSealed: string,
+    activeUser: ActiveUser,
+    targetUserId: string
+  ): Promise<{ activeUserId: string }> {
+    if (targetUserId === activeUser.id) {
+      throw new HttpError("Account is already active", { status: 409, code: "ALREADY_ACTIVE" })
+    }
+
+    const alts = await this.resolveAlts(cookies)
+    const target = alts.find((a) => a.ok && a.user?.id === targetUserId)
+    if (!target || !target.user) {
+      throw new HttpError("Account not found", { status: 404, code: "ACCOUNT_NOT_FOUND" })
+    }
+
+    // Deterministic Set-Cookie order so a mid-flight failure never strands a
+    // session: promote target, park the old active into the slot the target
+    // just vacated (always free), then drop any duplicate slots.
+    setSessionCookie(res, target.sealed)
+    setAltSessionCookie(res, target.slot, activeSealed)
+    for (const alt of alts) {
+      if (alt.slot === target.slot || !alt.ok || !alt.user) continue
+      if (alt.user.id === targetUserId || alt.user.id === activeUser.id) {
+        clearAltSessionCookie(res, alt.slot)
+      }
+    }
+
+    return { activeUserId: targetUserId }
+  }
+
+  async remove(
+    res: Response,
+    cookies: Record<string, string>,
+    activeSealed: string,
+    activeUser: ActiveUser,
+    targetUserId: string
+  ): Promise<{ removedId: string }> {
+    const staleMatch = STALE_ID_RE.exec(targetUserId)
+    if (staleMatch) {
+      const slot = Number(staleMatch[1])
+      if (!Number.isInteger(slot) || slot < 0 || slot >= MAX_ALT_SLOTS) {
+        throw new HttpError("Account not found", { status: 404, code: "ACCOUNT_NOT_FOUND" })
+      }
+      // The sealed session already failed validation — nothing to revoke.
+      clearAltSessionCookie(res, slot)
+      return { removedId: targetUserId }
+    }
+
+    const alts = await this.resolveAlts(cookies)
+
+    if (targetUserId === activeUser.id) {
+      // Removing the active account: kill its WorkOS session for real, plus
+      // any duplicate alt slots holding the same account, then promote the
+      // lowest-slot remaining distinct account (or full logout if none).
+      await this.authService.revokeSession(activeSealed)
+      clearSessionCookie(res)
+
+      const dups = alts.filter((a) => a.ok && a.user?.id === activeUser.id)
+      for (const dup of dups) {
+        await this.authService.revokeSession(dup.sealed)
+        clearAltSessionCookie(res, dup.slot)
+      }
+
+      const promote = alts
+        .filter((a) => a.ok && a.user && a.user.id !== activeUser.id)
+        .sort((a, b) => a.slot - b.slot)[0]
+      if (promote) {
+        setSessionCookie(res, promote.sealed)
+        clearAltSessionCookie(res, promote.slot)
+      } else {
+        // No survivor — clear every parked alt so nothing is stranded.
+        for (const alt of alts) clearAltSessionCookie(res, alt.slot)
+      }
+
+      return { removedId: activeUser.id }
+    }
+
+    const matches = alts.filter((a) => a.ok && a.user?.id === targetUserId)
+    if (matches.length === 0) {
+      throw new HttpError("Account not found", { status: 404, code: "ACCOUNT_NOT_FOUND" })
+    }
+    for (const m of matches) {
+      await this.authService.revokeSession(m.sealed)
+      clearAltSessionCookie(res, m.slot)
+    }
+
+    return { removedId: targetUserId }
+  }
+}

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -2,18 +2,16 @@ import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import {
   HttpError,
-  MAX_ALT_SLOTS,
   SESSION_COOKIE_NAME,
   clearAltSessionCookie,
   clearSessionCookie,
   decodeAndSanitizeRedirectState,
   displayNameFromWorkos,
   readAltSessionCookies,
-  setAltSessionCookie,
   setSessionCookie,
-  type AuthResult,
   type AuthService,
 } from "@threa/backend-common"
+import type { AccountsService } from "../accounts"
 
 const callbackSchema = z.object({
   code: z.string().min(1),
@@ -40,6 +38,8 @@ function isAllowedForwardedHost(host: string, allowedDomain: string): boolean {
 
 interface Dependencies {
   authService: AuthService
+  /** Owns the park/coalesce cookie-mutation sequence for the add-account flow. */
+  accountsService: AccountsService
   /** Base URL of the frontend app (e.g. "https://threa-staging.pages.dev"). Empty string for same-origin. */
   frontendUrl: string
   /** Allowed staging domain for forwarded-host redirects (e.g. "staging.threa.io") */
@@ -80,86 +80,9 @@ function parseCallbackState(state: string | undefined): { isAdd: boolean; innerS
   return { isAdd: false, innerState: state }
 }
 
-/**
- * Add-account: park the current active session into a free alt slot and make
- * the newly authenticated session active. Idempotently re-resolves the cookie
- * jar each call (no server-side account state) and coalesces duplicates of the
- * same WorkOS user. Returns `MAX_ACCOUNTS_REACHED` instead of throwing when
- * every slot is taken by a distinct account, so the OAuth callback can 302
- * gracefully rather than render an error page mid-flight.
- */
-async function parkActiveAndSetNew(
-  authService: AuthService,
-  req: Request,
-  res: Response,
-  result: AuthResult
-): Promise<{ ok: true } | { ok: false; code: "MAX_ACCOUNTS_REACHED" }> {
-  const newSealed = result.sealedSession as string
-  const newUserId = result.user!.id
-  const prevActiveSealed = req.cookies[SESSION_COOKIE_NAME] as string | undefined
-
-  // No prior session — treat as a normal first login (no slot consumed).
-  if (!prevActiveSealed) {
-    setSessionCookie(res, newSealed)
-    return { ok: true }
-  }
-
-  const prevAuth = await authService.authenticateSession(prevActiveSealed)
-  // Prev cookie no longer valid: nothing worth parking, just replace it.
-  if (!prevAuth.success || !prevAuth.user) {
-    setSessionCookie(res, newSealed)
-    return { ok: true }
-  }
-
-  // Re-auth of the same account: refresh in place, no new slot.
-  if (prevAuth.user.id === newUserId) {
-    setSessionCookie(res, newSealed)
-    return { ok: true }
-  }
-
-  const alts = readAltSessionCookies(req.cookies)
-  const altAuths = await Promise.all(alts.map((a) => authService.authenticateSession(a.sealed)))
-  const validAlts = alts
-    .map((a, i) => ({ slot: a.slot, sealed: a.sealed, auth: altAuths[i] }))
-    .filter((a) => a.auth.success && a.auth.user)
-
-  // The new account is already parked: promote it, park the previous active
-  // into the slot it vacated, and clear any duplicate slots of the new user.
-  const existing = validAlts.find((a) => a.auth.user!.id === newUserId)
-  if (existing) {
-    setSessionCookie(res, newSealed)
-    setAltSessionCookie(res, existing.slot, prevActiveSealed)
-    for (const a of validAlts) {
-      if (a.slot !== existing.slot && a.auth.user!.id === newUserId) {
-        clearAltSessionCookie(res, a.slot)
-      }
-    }
-    return { ok: true }
-  }
-
-  // Lowest free slot. A slot whose cookie failed validation is reclaimable
-  // (not "occupied"), self-healing corrupt/expired alts.
-  const occupied = new Set(validAlts.map((a) => a.slot))
-  let freeSlot = -1
-  for (let s = 0; s < MAX_ALT_SLOTS; s++) {
-    if (!occupied.has(s)) {
-      freeSlot = s
-      break
-    }
-  }
-  if (freeSlot === -1) {
-    // Every slot holds a distinct valid account — adding would exceed
-    // MAX_ACCOUNTS. Refuse gracefully; the prev-active cookie is untouched.
-    return { ok: false, code: "MAX_ACCOUNTS_REACHED" }
-  }
-
-  setAltSessionCookie(res, freeSlot, prevActiveSealed)
-  setSessionCookie(res, newSealed)
-  return { ok: true }
-}
-
 export function createControlPlaneAuthHandlers({
   authService,
+  accountsService,
   frontendUrl,
   allowedRedirectDomain,
   dedicatedRedirectHosts,
@@ -238,7 +161,13 @@ export function createControlPlaneAuthHandlers({
       }
 
       if (isAdd) {
-        const parked = await parkActiveAndSetNew(authService, req, res, result)
+        const parked = await accountsService.addAndParkActive(
+          res,
+          req.cookies,
+          req.cookies[SESSION_COOKIE_NAME] as string | undefined,
+          result.sealedSession,
+          result.user.id
+        )
         if (!parked.ok) {
           // No throw mid-OAuth-callback: the user keeps their existing session
           // and the frontend surfaces the refusal from the query param.

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -2,11 +2,16 @@ import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import {
   HttpError,
+  MAX_ALT_SLOTS,
   SESSION_COOKIE_NAME,
+  clearAltSessionCookie,
   clearSessionCookie,
   decodeAndSanitizeRedirectState,
   displayNameFromWorkos,
+  readAltSessionCookies,
+  setAltSessionCookie,
   setSessionCookie,
+  type AuthResult,
   type AuthService,
 } from "@threa/backend-common"
 
@@ -55,6 +60,104 @@ function isTrustedHost(host: string, allowedDomain: string, dedicatedHosts: stri
   return false
 }
 
+/**
+ * Peel the optional `add|` multi-account sentinel off the OAuth `state`.
+ *
+ * `login` prefixes a literal `add|` onto the *plaintext* state when
+ * `intent=add`; `getAuthorizationUrl` then base64-encodes the whole thing.
+ * Here we decode once, strip the sentinel, and re-encode the inner plaintext
+ * so the existing host/path decode logic runs on a byte-identical payload.
+ * For the non-add path `innerState` is the original `state` untouched, keeping
+ * single-account decoding exactly as it was.
+ */
+function parseCallbackState(state: string | undefined): { isAdd: boolean; innerState: string | undefined } {
+  if (!state) return { isAdd: false, innerState: state }
+  const decoded = Buffer.from(state, "base64").toString("utf-8")
+  if (decoded.startsWith("add|")) {
+    const inner = decoded.slice("add|".length)
+    return { isAdd: true, innerState: Buffer.from(inner, "utf-8").toString("base64") }
+  }
+  return { isAdd: false, innerState: state }
+}
+
+/**
+ * Add-account: park the current active session into a free alt slot and make
+ * the newly authenticated session active. Idempotently re-resolves the cookie
+ * jar each call (no server-side account state) and coalesces duplicates of the
+ * same WorkOS user. Returns `MAX_ACCOUNTS_REACHED` instead of throwing when
+ * every slot is taken by a distinct account, so the OAuth callback can 302
+ * gracefully rather than render an error page mid-flight.
+ */
+async function parkActiveAndSetNew(
+  authService: AuthService,
+  req: Request,
+  res: Response,
+  result: AuthResult
+): Promise<{ ok: true } | { ok: false; code: "MAX_ACCOUNTS_REACHED" }> {
+  const newSealed = result.sealedSession as string
+  const newUserId = result.user!.id
+  const prevActiveSealed = req.cookies[SESSION_COOKIE_NAME] as string | undefined
+
+  // No prior session — treat as a normal first login (no slot consumed).
+  if (!prevActiveSealed) {
+    setSessionCookie(res, newSealed)
+    return { ok: true }
+  }
+
+  const prevAuth = await authService.authenticateSession(prevActiveSealed)
+  // Prev cookie no longer valid: nothing worth parking, just replace it.
+  if (!prevAuth.success || !prevAuth.user) {
+    setSessionCookie(res, newSealed)
+    return { ok: true }
+  }
+
+  // Re-auth of the same account: refresh in place, no new slot.
+  if (prevAuth.user.id === newUserId) {
+    setSessionCookie(res, newSealed)
+    return { ok: true }
+  }
+
+  const alts = readAltSessionCookies(req.cookies)
+  const altAuths = await Promise.all(alts.map((a) => authService.authenticateSession(a.sealed)))
+  const validAlts = alts
+    .map((a, i) => ({ slot: a.slot, sealed: a.sealed, auth: altAuths[i] }))
+    .filter((a) => a.auth.success && a.auth.user)
+
+  // The new account is already parked: promote it, park the previous active
+  // into the slot it vacated, and clear any duplicate slots of the new user.
+  const existing = validAlts.find((a) => a.auth.user!.id === newUserId)
+  if (existing) {
+    setSessionCookie(res, newSealed)
+    setAltSessionCookie(res, existing.slot, prevActiveSealed)
+    for (const a of validAlts) {
+      if (a.slot !== existing.slot && a.auth.user!.id === newUserId) {
+        clearAltSessionCookie(res, a.slot)
+      }
+    }
+    return { ok: true }
+  }
+
+  // Lowest free slot. A slot whose cookie failed validation is reclaimable
+  // (not "occupied"), self-healing corrupt/expired alts.
+  const occupied = new Set(validAlts.map((a) => a.slot))
+  let freeSlot = -1
+  for (let s = 0; s < MAX_ALT_SLOTS; s++) {
+    if (!occupied.has(s)) {
+      freeSlot = s
+      break
+    }
+  }
+  if (freeSlot === -1) {
+    // Every slot holds a distinct valid account — adding would exceed
+    // MAX_ACCOUNTS. Refuse gracefully; the prev-active cookie is untouched.
+    return { ok: false, code: "MAX_ACCOUNTS_REACHED" }
+  }
+
+  setAltSessionCookie(res, freeSlot, prevActiveSealed)
+  setSessionCookie(res, newSealed)
+  return { ok: true }
+}
+
 export function createControlPlaneAuthHandlers({
   authService,
   frontendUrl,
@@ -84,7 +187,19 @@ export function createControlPlaneAuthHandlers({
         }
       }
 
-      const url = authService.getAuthorizationUrl(statePayload, redirectUriOverride)
+      // Multi-account add flow: prefix an `add|` sentinel onto the plaintext
+      // state (callback peels it back off) and force an AuthKit re-prompt so
+      // the hosted session isn't silently reused for the second account.
+      const isAdd = typeof req.query.intent === "string" && req.query.intent === "add"
+      if (isAdd) {
+        statePayload = `add|${statePayload ?? ""}`
+      }
+
+      const url = authService.getAuthorizationUrl(
+        statePayload,
+        redirectUriOverride,
+        isAdd ? { prompt: "login" } : undefined
+      )
       res.redirect(url)
     },
 
@@ -102,8 +217,10 @@ export function createControlPlaneAuthHandlers({
         throw new HttpError("Authentication failed", { status: 401, code: "AUTH_FAILED" })
       }
 
+      const { isAdd, innerState } = parseCallbackState(state)
+
       let redirectUrl: string
-      const decoded = state ? Buffer.from(state, "base64").toString("utf-8") : ""
+      const decoded = innerState ? Buffer.from(innerState, "base64").toString("utf-8") : ""
       const pipeIndex = decoded.indexOf("|")
 
       if (pipeIndex !== -1) {
@@ -116,11 +233,20 @@ export function createControlPlaneAuthHandlers({
           redirectUrl = frontendUrl ? `${frontendUrl}${path}` : path
         }
       } else {
-        const path = state ? decodeAndSanitizeRedirectState(state) : "/"
+        const path = innerState ? decodeAndSanitizeRedirectState(innerState) : "/"
         redirectUrl = frontendUrl ? `${frontendUrl}${path}` : path
       }
 
-      setSessionCookie(res, result.sealedSession)
+      if (isAdd) {
+        const parked = await parkActiveAndSetNew(authService, req, res, result)
+        if (!parked.ok) {
+          // No throw mid-OAuth-callback: the user keeps their existing session
+          // and the frontend surfaces the refusal from the query param.
+          redirectUrl += `${redirectUrl.includes("?") ? "&" : "?"}accountError=${parked.code}`
+        }
+      } else {
+        setSessionCookie(res, result.sealedSession)
+      }
       res.redirect(redirectUrl)
     },
 
@@ -128,6 +254,13 @@ export function createControlPlaneAuthHandlers({
       const session = req.cookies[SESSION_COOKIE_NAME]
 
       clearSessionCookie(res)
+
+      // Logout ≠ remove: clear every parked alt cookie too, but leave their
+      // WorkOS sessions intact (explicit revoke is the /api/accounts/remove
+      // path). This just empties the local cookie jar of all accounts.
+      for (const { slot } of readAltSessionCookies(req.cookies)) {
+        clearAltSessionCookie(res, slot)
+      }
 
       const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
 

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -9,6 +9,7 @@ import {
   StubAuthService,
 } from "@threa/backend-common"
 import { createControlPlaneAuthHandlers, createAuthStubHandlers } from "./features/auth"
+import { createAccountsHandlers, AccountsService } from "./features/accounts"
 import { createIntegrationHandlers } from "./features/integrations"
 import { createWorkspaceHandlers, type ControlPlaneWorkspaceService } from "./features/workspaces"
 import { createInvitationShadowHandlers, type InvitationShadowService } from "./features/invitation-shadows"
@@ -79,6 +80,8 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const backoffice = createBackofficeHandlers({ backofficeService })
   const backofficeAuthz = createBackofficeAuthzAdminHandlers({ pool, adminService: workosAuthzAdminService })
   const internalAuthz = createInternalAuthzAdminHandlers({ pool, adminService: workosAuthzAdminService })
+  const accountsService = new AccountsService({ authService })
+  const accounts = createAccountsHandlers({ accountsService })
 
   // Readiness probe
   app.get("/readyz", (_, res) => res.json({ status: "ok" }))
@@ -108,6 +111,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/auth/me", auth, authHandlers.me)
   app.get("/api/integrations/github/callback", auth, integrations.githubCallback)
   app.get("/api/integrations/linear/callback", auth, integrations.linearCallback)
+
+  // Multi-account: list/switch/remove run *after* the existing `auth`
+  // middleware, which validates only the single active session cookie. Parked
+  // alt slots are storage-only and read solely by these handlers.
+  app.get("/api/accounts", auth, authLimit, accounts.list)
+  app.post("/api/accounts/switch", auth, authLimit, accounts.switch)
+  app.post("/api/accounts/remove", auth, authLimit, accounts.remove)
 
   // Workspace routes
   app.get("/api/workspaces", auth, workspace.list)

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -68,8 +68,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   })
   const authLimit = createRateLimit({ name: "cp-auth", windowMs: 60_000, max: deps.rateLimits.authMax, key: ipKey })
 
+  const accountsService = new AccountsService({ authService })
   const authHandlers = createControlPlaneAuthHandlers({
     authService,
+    accountsService,
     frontendUrl: deps.frontendUrl,
     allowedRedirectDomain: deps.allowedRedirectDomain,
     dedicatedRedirectHosts: deps.workosDedicatedRedirectHosts,
@@ -80,7 +82,6 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const backoffice = createBackofficeHandlers({ backofficeService })
   const backofficeAuthz = createBackofficeAuthzAdminHandlers({ pool, adminService: workosAuthzAdminService })
   const internalAuthz = createInternalAuthzAdminHandlers({ pool, adminService: workosAuthzAdminService })
-  const accountsService = new AccountsService({ authService })
   const accounts = createAccountsHandlers({ accountsService })
 
   // Readiness probe

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -152,26 +152,29 @@ describe("Multi-account /api/accounts", () => {
 
   test("reaching MAX_ACCOUNTS refuses the add gracefully (302, no error page)", async () => {
     const client = new TestClient()
-    const aEmail = uniqueEmail("acc-cap-a")
-    await loginAs(client, aEmail, "Cap A")
-    await addAccount(client, uniqueEmail("acc-cap-b"), "Cap B")
-    await addAccount(client, uniqueEmail("acc-cap-c"), "Cap C")
-    const { user: d } = await addAccount(client, uniqueEmail("acc-cap-d"), "Cap D")
+    const first = await loginAs(client, uniqueEmail("acc-cap-0"), "Cap 0")
+    // Fill every slot: 1 active + (MAX_ACCOUNTS - 1) parked alts. The last
+    // account added stays active and must survive the refused overflow add.
+    let lastActiveId = first.id
+    for (let i = 1; i < MAX_ACCOUNTS; i++) {
+      const { user } = await addAccount(client, uniqueEmail(`acc-cap-${i}`), `Cap ${i}`)
+      lastActiveId = user.id
+    }
 
-    // Four distinct accounts now occupy the active slot + all alt slots.
+    // Every slot occupied by a distinct account.
     const before = await client.get<AccountsResponse>("/api/accounts")
-    expect(before.data.accounts).toHaveLength(4)
+    expect(before.data.accounts).toHaveLength(MAX_ACCOUNTS)
 
-    const fifth = await addAccount(client, uniqueEmail("acc-cap-e"), "Cap E")
-    expect(fifth.res.status).toBe(302)
-    expect(fifth.res.headers.get("location")).toContain("accountError=MAX_ACCOUNTS_REACHED")
+    const overflow = await addAccount(client, uniqueEmail("acc-cap-overflow"), "Cap Overflow")
+    expect(overflow.res.status).toBe(302)
+    expect(overflow.res.headers.get("location")).toContain("accountError=MAX_ACCOUNTS_REACHED")
 
-    // The pre-add account is still active and no fifth account leaked in.
+    // The pre-add account is still active and no extra account leaked in.
     const me = await client.get<MeResponse>("/api/auth/me")
-    expect(me.data.id).toBe(d.id)
+    expect(me.data.id).toBe(lastActiveId)
     const after = await client.get<AccountsResponse>("/api/accounts")
-    expect(after.data.accounts).toHaveLength(4)
-    expect(after.data.accounts.some((acc) => acc.id === fifth.user.id)).toBe(false)
+    expect(after.data.accounts).toHaveLength(MAX_ACCOUNTS)
+    expect(after.data.accounts.some((acc) => acc.id === overflow.user.id)).toBe(false)
   })
 
   test("removing a parked account revokes its real WorkOS session", async () => {

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from "bun:test"
+import { TestClient, loginAs } from "../client"
+
+// The shared test server runs one StubAuthService for the whole suite, so its
+// user map and revoked-session set persist across tests. Every account uses a
+// unique email (=> unique WorkOS id => unique sealed token) so a revoke in one
+// test can never make another test's session look dead.
+let seq = 0
+function uniqueEmail(prefix: string): string {
+  seq += 1
+  return `${prefix}-${Date.now()}-${seq}@example.com`
+}
+
+interface MeResponse {
+  id: string
+  email: string
+  name: string
+}
+
+interface AccountsResponse {
+  accounts: Array<{ id: string; email: string; name: string; state: string }>
+  maxAccounts: number
+}
+
+/**
+ * Drive the OAuth add-account flow for `main`. A throwaway client registers the
+ * user in the shared stub (devLogin), then we hit the callback directly with an
+ * `add|`-prefixed state — the stub's `/test-auth-login` page bypasses the
+ * callback, so the park/coalesce path must be exercised through `/api/auth/callback`.
+ * Returns the registered user, the registering client (its jar still holds that
+ * user's real sealed session — used to prove revoke), and the callback response.
+ */
+async function addAccount(
+  main: TestClient,
+  email: string,
+  name: string
+): Promise<{
+  user: { id: string; email: string }
+  client: TestClient
+  res: { status: number; headers: Headers }
+}> {
+  const sub = new TestClient()
+  const user = await loginAs(sub, email, name)
+  const state = Buffer.from("add|/").toString("base64")
+  const res = await main.get(`/api/auth/callback?code=test_code_${user.id}&state=${state}`)
+  return { user, client: sub, res }
+}
+
+describe("Multi-account /api/accounts", () => {
+  test("GET /api/accounts returns just the active account after login", async () => {
+    const client = new TestClient()
+    const email = uniqueEmail("acc-single")
+    const a = await loginAs(client, email, "Single A")
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.status).toBe(200)
+    expect(res.data).toEqual({
+      accounts: [{ id: a.id, email, name: "Single A", state: "active" }],
+      maxAccounts: 4,
+    })
+  })
+
+  test("GET /api/auth/login?intent=add forces prompt=login and an add| state", async () => {
+    const client = new TestClient()
+
+    const add = await client.get("/api/auth/login?intent=add")
+    expect(add.status).toBe(302)
+    const addUrl = new URL(add.headers.get("location")!, "http://localhost")
+    expect(addUrl.searchParams.get("prompt")).toBe("login")
+    expect(Buffer.from(addUrl.searchParams.get("state") || "", "base64").toString()).toBe("add|")
+
+    // Non-add login is unchanged: no prompt forced.
+    const plain = await client.get("/api/auth/login")
+    expect(plain.status).toBe(302)
+    const plainUrl = new URL(plain.headers.get("location")!, "http://localhost")
+    expect(plainUrl.searchParams.get("prompt")).toBeNull()
+  })
+
+  test("adding a second account parks the first", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-park-a")
+    const bEmail = uniqueEmail("acc-park-b")
+    const a = await loginAs(client, aEmail, "Park A")
+    const { user: b } = await addAccount(client, bEmail, "Park B")
+
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.id).toBe(b.id)
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.data).toEqual({
+      accounts: [
+        { id: b.id, email: bEmail, name: "Park B", state: "active" },
+        { id: a.id, email: aEmail, name: "Park A", state: "parked" },
+      ],
+      maxAccounts: 4,
+    })
+  })
+
+  test("switch promotes a parked account and parks the previously active one", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-switch-a")
+    const bEmail = uniqueEmail("acc-switch-b")
+    const a = await loginAs(client, aEmail, "Switch A")
+    const { user: b } = await addAccount(client, bEmail, "Switch B")
+
+    const switched = await client.post<{ activeUserId: string }>("/api/accounts/switch", {
+      targetUserId: a.id,
+    })
+    expect(switched.status).toBe(200)
+    expect(switched.data).toEqual({ activeUserId: a.id })
+
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.id).toBe(a.id)
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.data).toEqual({
+      accounts: [
+        { id: a.id, email: aEmail, name: "Switch A", state: "active" },
+        { id: b.id, email: bEmail, name: "Switch B", state: "parked" },
+      ],
+      maxAccounts: 4,
+    })
+
+    const already = await client.post("/api/accounts/switch", { targetUserId: a.id })
+    expect(already.status).toBe(409)
+
+    const missing = await client.post("/api/accounts/switch", { targetUserId: "user_does_not_exist" })
+    expect(missing.status).toBe(404)
+  })
+
+  test("re-authenticating an already-known account coalesces (no extra slot)", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-coalesce-a")
+    const bEmail = uniqueEmail("acc-coalesce-b")
+    const a = await loginAs(client, aEmail, "Coalesce A")
+    const { user: b } = await addAccount(client, bEmail, "Coalesce B")
+
+    // A is parked; re-add A. It must coalesce into the existing slot, not
+    // consume a new one — still exactly two accounts.
+    await addAccount(client, aEmail, "Coalesce A")
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.data).toEqual({
+      accounts: [
+        { id: a.id, email: aEmail, name: "Coalesce A", state: "active" },
+        { id: b.id, email: bEmail, name: "Coalesce B", state: "parked" },
+      ],
+      maxAccounts: 4,
+    })
+  })
+
+  test("reaching MAX_ACCOUNTS refuses the add gracefully (302, no error page)", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-cap-a")
+    await loginAs(client, aEmail, "Cap A")
+    await addAccount(client, uniqueEmail("acc-cap-b"), "Cap B")
+    await addAccount(client, uniqueEmail("acc-cap-c"), "Cap C")
+    const { user: d } = await addAccount(client, uniqueEmail("acc-cap-d"), "Cap D")
+
+    // Four distinct accounts now occupy the active slot + all alt slots.
+    const before = await client.get<AccountsResponse>("/api/accounts")
+    expect(before.data.accounts).toHaveLength(4)
+
+    const fifth = await addAccount(client, uniqueEmail("acc-cap-e"), "Cap E")
+    expect(fifth.res.status).toBe(302)
+    expect(fifth.res.headers.get("location")).toContain("accountError=MAX_ACCOUNTS_REACHED")
+
+    // The pre-add account is still active and no fifth account leaked in.
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.id).toBe(d.id)
+    const after = await client.get<AccountsResponse>("/api/accounts")
+    expect(after.data.accounts).toHaveLength(4)
+    expect(after.data.accounts.some((acc) => acc.id === fifth.user.id)).toBe(false)
+  })
+
+  test("removing a parked account revokes its real WorkOS session", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-rm-a")
+    const bEmail = uniqueEmail("acc-rm-b")
+    const a = await loginAs(client, aEmail, "Remove A")
+    const { user: b, client: subB } = await addAccount(client, bEmail, "Remove B")
+
+    // Make A active so B is the parked target.
+    await client.post("/api/accounts/switch", { targetUserId: a.id })
+
+    // subB independently holds B's sealed session and was never cookie-cleared.
+    const beforeMe = await subB.get("/api/auth/me")
+    expect(beforeMe.status).toBe(200)
+
+    const removed = await client.post<{ removedId: string }>("/api/accounts/remove", {
+      targetUserId: b.id,
+    })
+    expect(removed.status).toBe(200)
+    expect(removed.data).toEqual({ removedId: b.id })
+
+    // The session is dead at the auth provider, not merely cookie-cleared.
+    const afterMe = await subB.get("/api/auth/me")
+    expect(afterMe.status).toBe(401)
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.data).toEqual({
+      accounts: [{ id: a.id, email: aEmail, name: "Remove A", state: "active" }],
+      maxAccounts: 4,
+    })
+  })
+
+  test("removing the active account revokes it and promotes a parked account", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-rmactive-a")
+    const bEmail = uniqueEmail("acc-rmactive-b")
+    const a = await loginAs(client, aEmail, "RmActive A")
+    const { user: b, client: subB } = await addAccount(client, bEmail, "RmActive B")
+
+    // B is currently active, A is parked.
+    const removed = await client.post<{ removedId: string }>("/api/accounts/remove", {
+      targetUserId: b.id,
+    })
+    expect(removed.status).toBe(200)
+    expect(removed.data).toEqual({ removedId: b.id })
+
+    const subMe = await subB.get("/api/auth/me")
+    expect(subMe.status).toBe(401)
+
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.id).toBe(a.id)
+
+    const res = await client.get<AccountsResponse>("/api/accounts")
+    expect(res.data).toEqual({
+      accounts: [{ id: a.id, email: aEmail, name: "RmActive A", state: "active" }],
+      maxAccounts: 4,
+    })
+  })
+
+  test("logout clears the active session and every parked alt", async () => {
+    const client = new TestClient()
+    const a = await loginAs(client, uniqueEmail("acc-logout-a"), "Logout A")
+    await addAccount(client, uniqueEmail("acc-logout-b"), "Logout B")
+    expect(a.id).toBeTruthy()
+
+    const logout = await client.get("/api/auth/logout")
+    expect(logout.status).toBe(302)
+
+    // No active session and no alt cookie survives — the endpoint 401s.
+    const res = await client.get("/api/accounts")
+    expect(res.status).toBe(401)
+  })
+
+  test("unauthenticated requests to every accounts route are rejected", async () => {
+    const client = new TestClient()
+
+    expect((await client.get("/api/accounts")).status).toBe(401)
+    expect((await client.post("/api/accounts/switch", { targetUserId: "x" })).status).toBe(401)
+    expect((await client.post("/api/accounts/remove", { targetUserId: "x" })).status).toBe(401)
+  })
+})

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test"
+import { MAX_ACCOUNTS } from "@threa/backend-common"
 import { TestClient, loginAs } from "../client"
 
 // The shared test server runs one StubAuthService for the whole suite, so its
@@ -56,7 +57,7 @@ describe("Multi-account /api/accounts", () => {
     expect(res.status).toBe(200)
     expect(res.data).toEqual({
       accounts: [{ id: a.id, email, name: "Single A", state: "active" }],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
   })
 
@@ -92,7 +93,7 @@ describe("Multi-account /api/accounts", () => {
         { id: b.id, email: bEmail, name: "Park B", state: "active" },
         { id: a.id, email: aEmail, name: "Park A", state: "parked" },
       ],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
   })
 
@@ -118,7 +119,7 @@ describe("Multi-account /api/accounts", () => {
         { id: a.id, email: aEmail, name: "Switch A", state: "active" },
         { id: b.id, email: bEmail, name: "Switch B", state: "parked" },
       ],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
 
     const already = await client.post("/api/accounts/switch", { targetUserId: a.id })
@@ -145,7 +146,7 @@ describe("Multi-account /api/accounts", () => {
         { id: a.id, email: aEmail, name: "Coalesce A", state: "active" },
         { id: b.id, email: bEmail, name: "Coalesce B", state: "parked" },
       ],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
   })
 
@@ -200,7 +201,7 @@ describe("Multi-account /api/accounts", () => {
     const res = await client.get<AccountsResponse>("/api/accounts")
     expect(res.data).toEqual({
       accounts: [{ id: a.id, email: aEmail, name: "Remove A", state: "active" }],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
   })
 
@@ -227,7 +228,7 @@ describe("Multi-account /api/accounts", () => {
     const res = await client.get<AccountsResponse>("/api/accounts")
     expect(res.data).toEqual({
       accounts: [{ id: a.id, email: aEmail, name: "RmActive A", state: "active" }],
-      maxAccounts: 4,
+      maxAccounts: MAX_ACCOUNTS,
     })
   })
 

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -22,6 +22,7 @@ export interface DevLoginResult {
 export class StubAuthService implements AuthService {
   private users: Map<string, { id: string; email: string; firstName: string | null; lastName: string | null }> =
     new Map()
+  private revoked = new Set<string>()
 
   /**
    * Dev login endpoint - creates/ensures in-memory auth user and registers session.
@@ -64,6 +65,13 @@ export class StubAuthService implements AuthService {
 
   clearUsers(): void {
     this.users.clear()
+    this.revoked.clear()
+  }
+
+  async revokeSession(sealedSession: string): Promise<boolean> {
+    if (!/^test_session_(.+)$/.test(sealedSession)) return false
+    this.revoked.add(sealedSession)
+    return true
   }
 
   async authenticateSession(sealedSession: string): Promise<AuthResult> {
@@ -78,6 +86,10 @@ export class StubAuthService implements AuthService {
     const match = sealedSession.match(/^test_session_(.+)$/)
     if (!match) {
       return { success: false, refreshed: false, reason: "invalid_session_format" }
+    }
+
+    if (this.revoked.has(sealedSession)) {
+      return { success: false, refreshed: false, reason: "session_revoked" }
     }
 
     const userId = match[1]

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -57,6 +57,13 @@ export interface AuthService {
    *                      it can't share cookies with the default.
    */
   getLogoutUrl(sealedSession: string, returnTo?: string): Promise<string | null>
+  /**
+   * Revoke the real WorkOS session backing a sealed session cookie. Used by
+   * the multi-account remove flow so a forgotten account's session is dead at
+   * WorkOS, not merely cookie-cleared. Returns `true` if a session was
+   * revoked, `false` if the value couldn't be unsealed/authenticated.
+   */
+  revokeSession(sealedSession: string): Promise<boolean>
 }
 
 export class WorkosAuthService implements AuthService {
@@ -191,6 +198,23 @@ export class WorkosAuthService implements AuthService {
     } catch (error) {
       logger.error({ err: error }, "Failed to get logout URL")
       return null
+    }
+  }
+
+  async revokeSession(sealedSession: string): Promise<boolean> {
+    if (!sealedSession) return false
+    try {
+      const session = this.workos.userManagement.loadSealedSession({
+        sessionData: sealedSession,
+        cookiePassword: this.cookiePassword,
+      })
+      const authRes = await session.authenticate()
+      if (!authRes.authenticated) return false
+      await this.workos.userManagement.revokeSession({ sessionId: authRes.sessionId })
+      return true
+    } catch (error) {
+      logger.error({ err: error }, "Failed to revoke WorkOS session")
+      return false
     }
   }
 }

--- a/packages/backend-common/src/auth/middleware.test.ts
+++ b/packages/backend-common/src/auth/middleware.test.ts
@@ -16,6 +16,9 @@ class FakeAuthService implements AuthService {
   async getLogoutUrl(): Promise<string | null> {
     return null
   }
+  async revokeSession(): Promise<boolean> {
+    return false
+  }
 }
 
 function makeRes(): Response {


### PR DESCRIPTION
## Summary

Third slice of the multi-account login split (builds on PR-1, merged as #537). Lets one browser hold several authenticated WorkOS accounts and switch between them without logging out.

- **`/api/accounts` server contract** — new `AccountsService` + thin factory handlers behind the existing `auth` middleware:
  - `GET /api/accounts` — active account first, parked alts coalesced on read (no `Set-Cookie`), failed slots surfaced as opaque `stale:alt_<n>` (raw slot index never crosses the wire), `maxAccounts` from the shared `MAX_ACCOUNTS` constant.
  - `POST /api/accounts/switch` — promotes a parked account, parks the previously active one into the slot it vacated; `409 ALREADY_ACTIVE` / `404 ACCOUNT_NOT_FOUND`.
  - `POST /api/accounts/remove` — revokes the real WorkOS session (not just a cookie clear), then promotes the lowest-slot survivor or fully logs out.
- **OAuth `intent=add` flow** — `login` prefixes an `add|` state sentinel and forces an AuthKit `prompt=login`; the callback delegates the park/coalesce cookie-mutation sequence to `AccountsService.addAndParkActive`, which idempotently coalesces re-auth/duplicate slots and returns `MAX_ACCOUNTS_REACHED` (graceful 302 with `?accountError=`, no mid-flight error page) when every slot holds a distinct account.
- **`logout`** now clears every parked alt cookie too (sessions left intact — explicit revoke is the `remove` path).
- **`revokeSession`** added to `AuthService` (real `workos.userManagement.revokeSession` by session id) + stub support.

Invariants preserved: `auth/middleware.ts` is byte-unchanged; every cookie name derives from the env-scoped `SESSION_COOKIE_NAME` (no hardcoded `wos_session`), so prod and staging sessions + their parked alts coexist with zero collision. Alt cookies are storage-only; the auth middleware still reads exactly the single active cookie. The ordered cookie-mutation sequence is owned by the service (INV-6/34), reusing one alt-resolution path (INV-35).

## Test plan

- [x] `apps/control-plane` e2e: new `accounts.test.ts` (10 cases — list, park, switch, coalesce, MAX_ACCOUNTS refusal, real-revoke proof via independent client, logout-clears-alts, unauth) + `auth.test.ts` regression — 23/23 green
- [x] Full `apps/control-plane` suite — 163/163 green
- [x] `packages/backend-common` units (cookies, auth-service stub, middleware) — 13/13 green
- [x] `tsc --noEmit` clean for control-plane and backend-common; pre-commit hooks (typecheck + OpenAPI spec check) pass
- [ ] Pre-merge: one-off empirical sealed-session sizing confirmation against staging WorkOS (records observed bytes vs `WORST_CASE_SEALED_BYTES`)

https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->