### PR TITLE
Offline-first boot: render from cache, bound every request

### DIFF
--- a/.claude/plans/snoopy-twirling-quasar.md
+++ b/.claude/plans/snoopy-twirling-quasar.md
@@ -1,0 +1,271 @@
+# Offline-First Boot Performance
+
+## Context
+
+The mobile/PWA app is fast when fully online and predictable when fully
+offline, but **slow and janky on the typical "out and about" flaky/slow
+network**. Root cause: the app's _data_ layer is already offline-first
+(IndexedDB priming + a gate that bypasses the network — see
+`coordinated-loading-context.tsx`), but **every gate upstream of that layer is
+an unbounded network wait with no cache and no timeout**. On a cold PWA launch
+they run roughly serially, so a returning user stares at blank/spinner screens
+for 15–30s when each round trip is 2–8s.
+
+Goal: make the boot truly offline-first — render instantly from local state,
+treat the network as background revalidation, and bound every request so a slow
+network can never stall first paint. Decisions confirmed with the user:
+**full offline-first boot** in one pass, and — for the service-worker app
+shell — **serve the workbox-precached `/index.html` via the standard
+`NavigationRoute(createHandlerBoundToURL('/index.html'))` recipe**: zero
+network on the boot critical path, fully offline, and (critically) the
+post-deploy "broken shell" failure is made **structurally impossible** rather
+than merely recovered-from. A workbox precache manifest is build-atomic —
+`index.html` and the hashed JS/CSS it references always come from the same
+build — so you can never serve build-A's HTML against build-B's missing
+assets. Post-deploy freshness comes for free from the SW update lifecycle
+(`sw.ts` already calls `skipWaiting()` + `clients.claim()`); the existing
+`useAppUpdate`/`version.json` toast stays purely as a "newer build exists,
+reload when convenient" nicety, **not** a safety mechanism.
+
+## Root-Cause Map (boot order) + online-first classification
+
+The user asked that each online-first gate be classified as a _mistake/incidental_
+vs _purposeful_ (and if purposeful, the why).
+
+1. **App shell** — `apps/frontend/src/sw.ts:54-78`. Navigations served
+   network-first via `fetch(req).catch(fallback)`; only falls back to cache when
+   `fetch` _throws_ (fully offline), so a slow network hangs with no bound.
+   **Verdict: PURPOSEFUL, real and serious rationale, over-corrected
+   mechanism.** The concern is NOT soft "stale UX" — it is a hard boot
+   failure. `public/_redirects` is `/* /index.html 200`: post-deploy, a
+   cached old `index.html` requests its old hashed assets, those URLs are no
+   longer in the current Cloudflare Pages deployment, and the SPA catch-all
+   returns **`index.html` (200, `text/html`)** in their place. The browser
+   executes HTML as a JS module (parse failure → React never mounts) and
+   parses HTML as CSS (0 rules → unstyled). That is precisely the documented
+   "post-deploy unstyled page" bug. A React-rendered toast can never fix this
+   because React never mounts — so freshness-via-toast is not even a candidate
+   here. Network-first does prevent it (always fetch fresh, build-consistent
+   HTML when online) but pays for it by putting an unbounded network wait on
+   every boot — throwing away offline speed to dodge a problem that the
+   **build-atomic workbox precache already solves for free**: serving the
+   precached `/index.html` guarantees the shell and the hashed assets it
+   references are the same build. The fix is therefore not "invert to a
+   bespoke SWR + toast" (an earlier draft of this plan — wrong, the toast
+   can't run) but "use workbox's own precache navigation handler", which is
+   cache-first, instant, offline, and makes the broken state impossible by
+   construction. The existing React-independent recovery (index.html CSS
+   watchdog → `sw-recovery` → `/recover`, capped at 2) remains the graceful
+   backstop for any residual catastrophic case and is left untouched.
+
+2. **Auth identity** — `index.html:106` eager `/api/auth/me` fetch (no timeout,
+   no cached identity) + `auth/context.tsx` starts `loading:true` +
+   `workspace-layout.tsx:336` `if (authLoading) return null`. Blank until the
+   network resolves; offline it bounces to `/login`.
+   **Verdict: INCIDENTAL (online-first by omission).** The only rationale comment
+   is about overlapping the fetch with bundle parse — never made offline-aware.
+
+3. **Workspace discovery** — PWA `start_url` `/` → `routes/index.tsx:13`
+   unconditional `<Navigate to="/workspaces">` → `workspace-select.tsx:66`
+   full-screen "Loading…" spinner gated on `/api/workspaces` (control-plane
+   round trip just to learn which workspace to open).
+   **Verdict: INCIDENTAL.** `useWorkspaces` already writes the list to IDB but
+   never reads it back — a write-only cache with the loop never closed. No
+   deliberate rationale.
+
+4. **Socket config** — `socket-context.tsx:64` `await api.get(.../config)`
+   before the socket is created (retries 1s/2s/4s).
+   **Verdict: INCIDENTAL.** wsUrl/region is assigned at workspace creation and
+   stable (per `docs/system-overview.md`); nothing prevents caching it. No
+   deliberate rationale.
+
+5. **No request timeout anywhere** — `api/client.ts:52` `apiFetch` has no
+   `AbortController`/timeout; every request is unbounded.
+   **Verdict: INCIDENTAL.** Never designed for flaky networks; lets background
+   revalidations pile up forever instead of settling to cached state.
+
+## Approach (5 surfaces, minimal patch each)
+
+Reuse the existing pattern (cache → render → revalidate, like
+`coordinated-loading-context.tsx` + the IDB store). New persistence helpers
+mirror `lib/last-stream.ts` (tiny try/catch localStorage modules, key is the
+single source of truth — INV-33).
+
+### Helper modules (pure, already drafted pre-plan; keep)
+
+- `apps/frontend/src/lib/cached-user.ts` — `getCachedUser/setCachedUser/clearCachedUser`
+  (caches `{id,email,name}` only; the httpOnly cookie remains the credential).
+- `apps/frontend/src/lib/last-workspace.ts` — `get/set/clearLastWorkspaceId`.
+- `apps/frontend/src/lib/cached-ws-config.ts` — `get/setCachedWsConfig(workspaceId)`.
+
+### S1 — SW app shell: workbox build-atomic precache navigation
+
+The cached shell must always be served from the **same build** as the hashed
+assets it references. Workbox's precache manifest already guarantees this
+(`vite.config.ts:85` globs `html` + `js` + `css` into `self.__WB_MANIFEST`);
+the current bespoke `fetch`-first handler was *shadowing* that precached,
+already-revisioned `/index.html`. The minimal correct change is to delete the
+hand-rolled handler and use the standard workbox SPA recipe.
+
+- `apps/frontend/src/sw.ts`:
+  - Delete the network-first navigation `fetch` listener (lines 54/62-78,
+    including its now-stale rationale comment — INV-25/38).
+  - Add (it already imports from `workbox-precaching`):
+    ```ts
+    import { NavigationRoute, registerRoute } from "workbox-routing"
+    import { createHandlerBoundToURL } from "workbox-precaching"
+    registerRoute(
+      new NavigationRoute(createHandlerBoundToURL("/index.html"), {
+        denylist: [/^\/api\//, /^\/recover/, /^\/sw\.js$/, /^\/version\.json$/],
+      })
+    )
+    ```
+    `createHandlerBoundToURL` returns the precached (build-consistent)
+    `/index.html` — cache-first, instant, offline. `NavigationRoute` only
+    matches top-level navigations. The **denylist is correctness, not
+    polish**: today's `mode !== "navigate"` guard let full-page navigations
+    to `/api/auth/login` (OAuth redirect) and `/recover.html` (the
+    React-independent recovery page, `globIgnores`'d from precache) fall
+    through to the network; serving them the SPA shell instead would break
+    auth and disable recovery. The denylist preserves that.
+  - No new `APP_SHELL_CACHE` and no entry in the `activate` keep-set:
+    workbox owns the `workbox-precache-*` bucket, which `activate` already
+    preserves (`!name.startsWith("workbox-precache-")`) and
+    `cleanupOutdatedCaches()` already revisions atomically across SW
+    versions.
+- `index.html` CSS watchdog / `lib/sw-recovery.ts` / `/recover` / the
+  router-level `ChunkLoadError` boundary — **all left untouched**. With a
+  build-atomic precache the poison shell is structurally impossible, so these
+  no longer fire on the routine post-deploy path; they remain solely as the
+  catastrophic backstop (corrupted/partially-evicted cache). This is the
+  "graceful handling" of the missing-asset boot failure the user asked for —
+  it is React-independent (runs from `index.html` / a static page) precisely
+  because, in that failure mode, React cannot mount to show anything.
+- `hooks/use-app-update.ts` — **no change**. Because every precached build is
+  internally consistent, a user "one build behind" is fully functional
+  (just old), not broken, so the existing toast's
+  `reloadForUpdate()` → `window.location.reload()` is sufficient: by the time
+  the ≤5-min `version.json` poll surfaces the toast, the new SW (installed via
+  `skipWaiting()` on first post-deploy navigation, `clients.claim()` on
+  activate) has already taken over, so the reload serves the new build. No
+  new toast, no SW-side diffing, no `refreshAppShellCache` — `version.json`
+  stays the single change detector and the toast is reused verbatim
+  (INV-33/36: no parallel mechanism).
+
+Net effect: zero network on the boot critical path (vs. today's unbounded
+wait), the post-deploy broken-shell failure made impossible by construction
+rather than recovered-from, and one fewer module than the earlier draft
+(no `lib/sw-app-shell.ts`).
+
+### S2 — Auth: cached identity, render now, revalidate in background
+
+`apps/frontend/src/auth/context.tsx`:
+- Initialise `state` from `getCachedUser()` → `{ user, loading: !cached }`
+  (cached user ⇒ no blank, no `authLoading` gate).
+- `fetchUser`: success ⇒ `setCachedUser` + state; **401** ⇒ `clearCachedUser` +
+  `{user:null,loading:false}` (→ login); **network error/timeout** ⇒ keep the
+  cached user (stay usable offline), only set `{user:null}` when there was no
+  cached user.
+- `logout`: add `clearCachedUser()` alongside the existing
+  `clearAllCachedData()` + `clearLastWorkspaceId()`.
+- Add an `AbortController` timeout to the context's fallback fetch and to the
+  `index.html` eager fetch so revalidation can't hang indefinitely.
+
+### S3 — `/` entry → last-workspace redirect + cached picker
+
+- `apps/frontend/src/routes/index.tsx`: replace the `/` element with a
+  module-scope `RootRedirect` (INV-18): `getLastWorkspaceId()` ⇒
+  `<Navigate to={/w/:id} replace>` else `<Navigate to="/workspaces" replace>`.
+- `apps/frontend/src/pages/workspace-layout.tsx`: effect to
+  `setLastWorkspaceId(workspaceId)` once `user` + `workspaceId` are known.
+- `apps/frontend/src/pages/workspace-select.tsx`: when the list query is still
+  loading, render the IDB-cached workspaces (Dexie `useLiveQuery` over
+  `db.workspaces`) instead of the full-screen spinner; the query revalidates in
+  the background. (Closes the write-only-cache loop in `useWorkspaces`.)
+
+### S4 — Socket config cache (fast socket connect)
+
+`apps/frontend/src/contexts/socket-context.tsx`:
+- On connect, if `getCachedWsConfig(workspaceId)` exists, create the socket
+  immediately from it and skip awaiting the fetch; still fetch config in the
+  background, `setCachedWsConfig` on success, and if `wsUrl` changed close and
+  reconnect to the fresh URL. No cache ⇒ current fetch+retry path unchanged.
+
+### S5 — Global fetch timeout
+
+`apps/frontend/src/api/client.ts`:
+- `apiFetch` wraps fetch in an `AbortController` with a generous default
+  (`DEFAULT_TIMEOUT_MS = 20000`, overridable via `options`). On abort throw a
+  non-`ApiError` (network-like) so `handleGlobalError` does **not** treat it as
+  a 401 redirect; queries fall back to cached/IDB state. Uploads use raw fetch
+  (not `apiFetch`) so they are unaffected.
+
+## Files to modify / add
+
+- add: `lib/cached-user.ts`, `lib/last-workspace.ts`, `lib/cached-ws-config.ts`
+  (+ `.test.ts` for each). No `lib/sw-app-shell.ts` — S1 is now the stock
+  workbox recipe in `sw.ts`, nothing bespoke to unit-test.
+- edit: `sw.ts` (S1, navigation route only — no keep-set change),
+  `auth/context.tsx`, `index.html` (S2 eager-fetch timeout only; the CSS
+  watchdog is untouched), `routes/index.tsx`, `pages/workspace-layout.tsx`,
+  `pages/workspace-select.tsx`, `contexts/socket-context.tsx`,
+  `api/client.ts`. **Not** edited: `hooks/use-app-update.ts`,
+  `lib/sw-recovery.ts`, `components/error-boundary.tsx`, `/recover` page.
+- tests: new `lib/*.test.ts`; new `auth/context.offline.test.tsx`; extend
+  `api/client.test.ts` (timeout); extend `pages/workspace-select.test.tsx`
+  (cached list) and add a routes redirect test. SW navigation is the stock
+  workbox recipe (covered by workbox's own tests); verify it via the manual
+  throttled-reload + post-deploy steps below rather than a brittle SW unit
+  test. Respect INV-22/26/39.
+
+## Verification
+
+- `cd apps/frontend && bun run typecheck`
+- `bun run test` (frontend unit/integration) — all green, no `.skip`.
+- Targeted: new `lib` helper tests; auth offline cases (cached user renders
+  with `loading:false`, network-fail keeps user, 401 clears + redirects);
+  client timeout aborts as non-ApiError; workspace-select renders cached list;
+  `/` redirects to `/w/:lastId` when set.
+- Manual (dev, Chrome DevTools → Network → "Slow 3G", repeat launches): after a
+  first good-network load, a throttled reload paints the cached shell + cached
+  identity + last workspace + IDB data within ~1s (the SW serves the shell with
+  zero network on the critical path), with sync catching up in the background;
+  verify a real 401 still redirects to login and logout clears all cached
+  identity/workspace state.
+- Post-deploy correctness (the critical S1 check): build, serve, load once
+  (SW precaches build-A). Rebuild with a changed asset hash + bumped
+  `version.json`, redeploy/serve, then **hard-reload offline-throttled**.
+  Expect: app boots fully (workbox serves build-A's consistent precached
+  shell+assets — NOT a broken/unstyled page), the CSS watchdog does **not**
+  fire, then the new SW activates and the `version.json` toast appears; click
+  **Reload** and confirm it comes back on build-B in one reload. Also confirm
+  a navigation to `/api/auth/login` and to `/recover.html` still hit the
+  network (not the SPA shell) — i.e. the `NavigationRoute` denylist works.
+- Root-level `bun run test:e2e` if boot-path E2E exists; otherwise note manual
+  throttled-network verification explicitly.
+
+## Risks / Notes
+
+- Auth caching is display-only; security unchanged (cookie is the credential).
+  Account-switch safety: logout clears cached user + last workspace + IDB;
+  fresh login overwrites; a real 401 always clears + redirects.
+- SW serves the workbox-precached `/index.html` (zero network on the boot
+  critical path). The post-deploy "broken/unstyled shell" failure the
+  original network-first code existed to prevent is **structurally
+  impossible** here: a workbox precache manifest is build-atomic, so the
+  shell and the hashed assets it references are always the same build (even
+  offline, even immediately post-deploy on the old SW — old but consistent
+  and fully functional, never broken). This matters because that failure
+  mode kills React before it can mount, so a React toast could never have
+  been the fix — the safety net has to be (and remains) the
+  React-independent index.html CSS watchdog → `sw-recovery` → `/recover`
+  (capped at 2) plus the router `ChunkLoadError` boundary, all left
+  untouched. With atomic precache they should no longer fire on the routine
+  post-deploy path. Freshness is delivered by the SW update lifecycle
+  (`skipWaiting`/`clients.claim`, already present) surfaced via the existing
+  `version.json` toast (≤5-min poll + visibility/reconnect); residual
+  staleness for a never-backgrounded tab is bounded by that poll interval
+  and the app stays fully functional throughout — strictly better than the
+  old unbounded slow-network hang on every boot.
+- 3 helper files were created moments before plan mode engaged; they are pure
+  and inert (nothing imports them yet) and are part of this plan.

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -104,7 +104,9 @@
         // 401 resolves to null (unauthenticated). Other errors reject so
         // AuthProvider can fall through to a normal fetch with proper error handling.
         // Bounded so a dead/slow network rejects (→ cached identity) instead of
-        // leaving AuthProvider awaiting a promise that never settles.
+        // leaving AuthProvider awaiting a promise that never settles. Keep this
+        // 15000 in sync with AUTH_REVALIDATE_TIMEOUT_MS in src/auth/context.tsx
+        // — index.html can't import the TS constant, so the two are unlinked.
         var eagerAuthController = new AbortController()
         var eagerAuthTimeout = setTimeout(function () {
           eagerAuthController.abort()

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -103,11 +103,24 @@
         // round-trip overlaps with script parse/eval instead of running after it.
         // 401 resolves to null (unauthenticated). Other errors reject so
         // AuthProvider can fall through to a normal fetch with proper error handling.
-        window.__eagerAuthPromise = fetch("/api/auth/me", { credentials: "include" }).then(function (res) {
-          if (res.status === 401) return null
-          if (!res.ok) throw new Error("Failed to fetch user")
-          return res.json()
+        // Bounded so a dead/slow network rejects (→ cached identity) instead of
+        // leaving AuthProvider awaiting a promise that never settles.
+        var eagerAuthController = new AbortController()
+        var eagerAuthTimeout = setTimeout(function () {
+          eagerAuthController.abort()
+        }, 15000)
+        window.__eagerAuthPromise = fetch("/api/auth/me", {
+          credentials: "include",
+          signal: eagerAuthController.signal,
         })
+          .then(function (res) {
+            if (res.status === 401) return null
+            if (!res.ok) throw new Error("Failed to fetch user")
+            return res.json()
+          })
+          .finally(function () {
+            clearTimeout(eagerAuthTimeout)
+          })
       })()
     </script>
   </head>

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -62,6 +62,47 @@ describe("apiFetch error parsing", () => {
   })
 })
 
+describe("apiFetch request timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Never settles on its own — only the AbortController timeout ends it.
+    globalThis.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")))
+      })
+    }) as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.fetch = originalFetch
+  })
+
+  it("aborts a hung request as a non-ApiError so it is not mistaken for a 401 redirect", async () => {
+    const p = api.get("/slow", { timeoutMs: 50 }).catch((e) => e)
+    await vi.advanceTimersByTimeAsync(50)
+    const err = (await p) as Error
+
+    expect(err).toBeInstanceOf(Error)
+    expect(ApiError.isApiError(err)).toBe(false)
+    expect(err.message).toBe("Request timed out after 50ms")
+  })
+
+  it("does not abort before the timeout elapses", async () => {
+    const p = api.get("/slow", { timeoutMs: 1000 }).catch((e) => e)
+    let settled = false
+    void p.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(((await p) as Error).message).toBe("Request timed out after 1000ms")
+  })
+})
+
 describe("parseApiError — for raw fetch callers (multipart uploads)", () => {
   it("uses the supplied fallback when the body is empty", async () => {
     const response = new Response("", { status: 500, headers: { "Content-Type": "application/json" } })

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -48,16 +48,55 @@ export async function parseApiError(
  */
 export const API_BASE = import.meta.env.VITE_API_BASE_URL ?? ""
 
+// Bound every request so a flaky/slow network can't leave a fetch hanging
+// forever — background revalidations must settle (to cached state) instead of
+// piling up. Generous because it's a safety net, not a latency budget;
+// override per-call via `options.timeoutMs`.
+const DEFAULT_TIMEOUT_MS = 20000
+
+export type ApiRequestInit = RequestInit & { timeoutMs?: number }
+
 // Base fetch wrapper with error handling
-async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...options,
-    credentials: "include", // Include cookies for auth
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-  })
+async function apiFetch<T>(path: string, options: ApiRequestInit = {}): Promise<T> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...init } = options
+
+  const controller = new AbortController()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+
+  const onCallerAbort = () => controller.abort()
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort()
+    else callerSignal.addEventListener("abort", onCallerAbort, { once: true })
+  }
+
+  let response: Response
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      credentials: "include", // Include cookies for auth
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...init.headers,
+      },
+    })
+  } catch (err) {
+    // A timeout is a network-like failure, not an auth signal. Throw a plain
+    // Error (NOT an ApiError) so `handleGlobalError` can't mistake it for a
+    // 401 and bounce the user to login — queries fall back to cached/IDB
+    // state instead. A caller-driven abort rethrows unchanged.
+    if (timedOut) {
+      throw new Error(`Request timed out after ${timeoutMs}ms`)
+    }
+    throw err
+  } finally {
+    clearTimeout(timeout)
+    if (callerSignal) callerSignal.removeEventListener("abort", onCallerAbort)
+  }
 
   // Handle non-JSON responses (like 204 No Content)
   if (response.status === 204) {
@@ -80,11 +119,11 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
 
 // HTTP method helpers
 export const api = {
-  get<T>(path: string, options?: RequestInit): Promise<T> {
+  get<T>(path: string, options?: ApiRequestInit): Promise<T> {
     return apiFetch<T>(path, { ...options, method: "GET" })
   },
 
-  post<T>(path: string, body?: unknown, options?: RequestInit): Promise<T> {
+  post<T>(path: string, body?: unknown, options?: ApiRequestInit): Promise<T> {
     return apiFetch<T>(path, {
       ...options,
       method: "POST",
@@ -92,7 +131,7 @@ export const api = {
     })
   },
 
-  patch<T>(path: string, body?: unknown, options?: RequestInit): Promise<T> {
+  patch<T>(path: string, body?: unknown, options?: ApiRequestInit): Promise<T> {
     return apiFetch<T>(path, {
       ...options,
       method: "PATCH",
@@ -100,7 +139,7 @@ export const api = {
     })
   },
 
-  put<T>(path: string, body?: unknown, options?: RequestInit): Promise<T> {
+  put<T>(path: string, body?: unknown, options?: ApiRequestInit): Promise<T> {
     return apiFetch<T>(path, {
       ...options,
       method: "PUT",
@@ -108,7 +147,7 @@ export const api = {
     })
   },
 
-  delete<T>(path: string, options?: RequestInit): Promise<T> {
+  delete<T>(path: string, options?: ApiRequestInit): Promise<T> {
     return apiFetch<T>(path, { ...options, method: "DELETE" })
   },
 }

--- a/apps/frontend/src/auth/context.offline.test.tsx
+++ b/apps/frontend/src/auth/context.offline.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, screen, waitFor, spyOnExport } from "@/test"
+import { AuthProvider, useAuth } from "@/auth"
+import * as dbModule from "@/db"
+import { getCachedUser, setCachedUser } from "@/lib/cached-user"
+import { getLastWorkspaceId, setLastWorkspaceId } from "@/lib/last-workspace"
+
+const CACHED = { id: "user_1", email: "a@b.co", name: "Ada" }
+
+function Probe() {
+  const auth = useAuth()
+  return (
+    <div>
+      <span data-testid="user">{auth.user?.name ?? "none"}</span>
+      <span data-testid="loading">{String(auth.loading)}</span>
+      <span data-testid="error">{auth.error ?? "none"}</span>
+    </div>
+  )
+}
+
+describe("AuthProvider — offline-first identity", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.__eagerAuthPromise = undefined
+    spyOnExport(dbModule, "clearAllCachedData").mockReturnValue((async () => {}) as typeof dbModule.clearAllCachedData)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it("renders instantly from the cached identity with no network gate", () => {
+    setCachedUser(CACHED)
+    // Revalidation never resolves — the first paint must not wait on it.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {}))
+    )
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+
+    expect(screen.getByTestId("user")).toHaveTextContent("Ada")
+    expect(screen.getByTestId("loading")).toHaveTextContent("false")
+  })
+
+  it("keeps the cached user when background revalidation fails (stays usable offline)", async () => {
+    setCachedUser(CACHED)
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down")
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("Ada")
+      expect(screen.getByTestId("loading")).toHaveTextContent("false")
+      expect(screen.getByTestId("error")).toHaveTextContent("none")
+    })
+    expect(getCachedUser()).toEqual(CACHED)
+  })
+
+  it("clears the cached identity and drops the user on a 401", async () => {
+    setCachedUser(CACHED)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 401, ok: false, json: async () => ({}) }) as unknown as Response)
+    )
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId("user")).toHaveTextContent("none"))
+    expect(screen.getByTestId("loading")).toHaveTextContent("false")
+    expect(getCachedUser()).toBeNull()
+  })
+})
+
+describe("AuthProvider — logout clears local identity", () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+    window.__eagerAuthPromise = undefined
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "" } as Location,
+    })
+    spyOnExport(dbModule, "clearAllCachedData").mockReturnValue((async () => {}) as typeof dbModule.clearAllCachedData)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    localStorage.clear()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+  })
+
+  it("clears the cached user and last workspace on logout", async () => {
+    setCachedUser(CACHED)
+    setLastWorkspaceId("ws_1")
+    // Pending revalidation so the mount fetch can't clear state first — only
+    // logout should.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {}))
+    )
+
+    let logout!: () => void
+    function LogoutProbe() {
+      logout = useAuth().logout
+      return null
+    }
+
+    render(
+      <AuthProvider>
+        <LogoutProbe />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      logout()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(window.location.href).toBe("/api/auth/logout")
+    expect(getCachedUser()).toBeNull()
+    expect(getLastWorkspaceId()).toBeNull()
+  })
+})

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -1,6 +1,8 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from "react"
 import { API_BASE } from "@/api/client"
 import { clearAllCachedData } from "@/db"
+import { getCachedUser, setCachedUser, clearCachedUser } from "@/lib/cached-user"
+import { clearLastWorkspaceId } from "@/lib/last-workspace"
 import type { AuthState, User } from "./types"
 
 declare global {
@@ -20,6 +22,11 @@ interface AuthContextValue extends AuthState {
 // fires when `serviceWorker.ready` never settles (stranded worker).
 const PUSH_CLEANUP_TIMEOUT_MS = 2000
 
+// Identity revalidation is a background refresh — the UI already rendered from
+// the cached user — so its only job here is to never leak a hung request on a
+// dead network. Generous because it never blocks first paint.
+const AUTH_REVALIDATE_TIMEOUT_MS = 15000
+
 export const AuthContext = createContext<AuthContextValue | null>(null)
 
 interface AuthProviderProps {
@@ -27,33 +34,68 @@ interface AuthProviderProps {
 }
 
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [state, setState] = useState<AuthState>({
-    user: null,
-    loading: true,
-    error: null,
+  // Render instantly from the cached display identity (the httpOnly cookie is
+  // still the credential — this is display-only). `loading` stays true only
+  // for a genuinely cold first visit so the app doesn't gate on the network.
+  const [state, setState] = useState<AuthState>(() => {
+    const cachedUser = getCachedUser()
+    return { user: cachedUser, loading: !cachedUser, error: null }
   })
 
   const fetchUser = useCallback(async () => {
+    // A 401 is the only authoritative "you are signed out" signal: clear the
+    // cached identity and drop to the login redirect.
+    const onUnauthenticated = () => {
+      clearCachedUser()
+      setState({ user: null, loading: false, error: null })
+    }
+    // Network failure / timeout / 5xx during background revalidation must not
+    // sign a returning user out — keep the cached identity so the app stays
+    // usable offline. Only a cold visit with no cache falls through to login.
+    const onRevalidateFailure = (message: string) => {
+      const cachedUser = getCachedUser()
+      setState({
+        user: cachedUser,
+        loading: false,
+        error: cachedUser ? null : message,
+      })
+    }
+
     try {
-      // Consume the eager auth promise started in index.html before the bundle loaded.
-      // If the eager promise rejected (network error, 500, etc.) we fall through
-      // to a fresh fetch so error handling works correctly.
+      // Consume the eager auth promise started in index.html before the bundle
+      // loaded. It resolves to the User, or null on 401; it rejects on network
+      // error / 5xx, in which case we fall through to a fresh, bounded fetch.
       const eagerPromise = window.__eagerAuthPromise
       if (eagerPromise) {
         window.__eagerAuthPromise = undefined
         try {
           const user = await eagerPromise
-          setState({ user, loading: false, error: null })
+          if (user) {
+            setCachedUser(user)
+            setState({ user, loading: false, error: null })
+          } else {
+            onUnauthenticated()
+          }
           return
         } catch {
           // Eager fetch failed — fall through to regular fetch
         }
       }
 
-      const res = await fetch(`${API_BASE}/api/auth/me`, { credentials: "include" })
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), AUTH_REVALIDATE_TIMEOUT_MS)
+      let res: Response
+      try {
+        res = await fetch(`${API_BASE}/api/auth/me`, {
+          credentials: "include",
+          signal: controller.signal,
+        })
+      } finally {
+        clearTimeout(timeout)
+      }
 
       if (res.status === 401) {
-        setState({ user: null, loading: false, error: null })
+        onUnauthenticated()
         return
       }
 
@@ -62,13 +104,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       const user: User = await res.json()
+      setCachedUser(user)
       setState({ user, loading: false, error: null })
     } catch (err) {
-      setState({
-        user: null,
-        loading: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      })
+      onRevalidateFailure(err instanceof Error ? err.message : "Unknown error")
     }
   }, [])
 
@@ -109,6 +148,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       pushCleanup,
       new Promise<void>((resolve) => setTimeout(resolve, PUSH_CLEANUP_TIMEOUT_MS)),
     ]).catch(() => {})
+    clearCachedUser()
+    clearLastWorkspaceId()
     await clearAllCachedData().catch(() => {})
     window.location.href = `${API_BASE}/api/auth/logout`
   }, [])

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -24,7 +24,9 @@ const PUSH_CLEANUP_TIMEOUT_MS = 2000
 
 // Identity revalidation is a background refresh — the UI already rendered from
 // the cached user — so its only job here is to never leak a hung request on a
-// dead network. Generous because it never blocks first paint.
+// dead network. Generous because it never blocks first paint. The eager
+// pre-bundle fetch in index.html bounds itself with the same value as a raw
+// 15000 (it can't import this constant) — keep the two in sync.
 const AUTH_REVALIDATE_TIMEOUT_MS = 15000
 
 export const AuthContext = createContext<AuthContextValue | null>(null)

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useRef, type ReactNode 
 import { io, Socket } from "socket.io-client"
 import { HEARTBEAT_INTERACTION_THROTTLE_MS } from "@threa/types"
 import { api } from "@/api/client"
+import { getCachedWsConfig, setCachedWsConfig } from "@/lib/cached-ws-config"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
 
@@ -56,77 +57,102 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
 
   useEffect(() => {
     let cancelled = false
-    let newSocket: Socket | null = null
+    let activeSocket: Socket | null = null
+    // Raw (pre-dev-rewrite) wsUrl the active socket was built from, so a
+    // background revalidation can tell whether it actually moved.
+    let activeWsUrl: string | null = null
     let retryTimer: ReturnType<typeof setTimeout> | null = null
 
-    async function connect(attempt = 0) {
+    function buildSocket(config: WorkspaceConfig): Socket {
+      // In dev, the router returns ws://localhost:PORT but we may be accessing
+      // from a different host (e.g. phone over WiFi). Rewrite to match the actual host.
+      const wsUrl = import.meta.env.DEV ? config.wsUrl.replace("localhost", window.location.hostname) : config.wsUrl
+
+      const s = io(wsUrl, {
+        path: "/socket.io/",
+        withCredentials: true,
+        autoConnect: true,
+      })
+
+      s.on("connect", () => {
+        const wasReconnecting = hasEverConnectedRef.current
+        hasEverConnectedRef.current = true
+        setStatus("connected")
+
+        if (wasReconnecting) {
+          setReconnectCount((c) => c + 1)
+          console.log("[Socket] Reconnected successfully")
+        } else {
+          console.log("[Socket] Connected to", config.region)
+        }
+      })
+
+      s.on("disconnect", (reason) => {
+        if (hasEverConnectedRef.current) {
+          setStatus("reconnecting")
+          console.log("[Socket] Disconnected:", reason)
+        } else {
+          setStatus("disconnected")
+        }
+      })
+
+      s.on("error", (error: { message: string }) => {
+        console.error("[Socket] Error:", error.message)
+      })
+
+      // Socket.io manager events for reconnection tracking
+      s.io.on("reconnect_attempt", (socketAttempt) => {
+        setStatus("reconnecting")
+        console.log(`[Socket] Reconnect attempt ${socketAttempt}`)
+      })
+
+      s.io.on("reconnect_error", (error) => {
+        console.error("[Socket] Reconnect error:", error.message)
+      })
+
+      s.io.on("reconnect_failed", () => {
+        console.error("[Socket] Reconnect failed - giving up")
+        setStatus("disconnected")
+      })
+
+      return s
+    }
+
+    function start(config: WorkspaceConfig) {
+      activeSocket?.close()
+      activeSocket = buildSocket(config)
+      activeWsUrl = config.wsUrl
+      setSocket(activeSocket)
+    }
+
+    async function fetchConfig(attempt = 0) {
       try {
         const config = await api.get<WorkspaceConfig>(`/api/workspaces/${workspaceId}/config`)
         if (cancelled) return
+        setCachedWsConfig(workspaceId, config)
 
-        // In dev, the router returns ws://localhost:PORT but we may be accessing
-        // from a different host (e.g. phone over WiFi). Rewrite to match the actual host.
-        const wsUrl = import.meta.env.DEV ? config.wsUrl.replace("localhost", window.location.hostname) : config.wsUrl
-
-        newSocket = io(wsUrl, {
-          path: "/socket.io/",
-          withCredentials: true,
-          autoConnect: true,
-        })
-
-        newSocket.on("connect", () => {
-          const wasReconnecting = hasEverConnectedRef.current
-          hasEverConnectedRef.current = true
-          setStatus("connected")
-
-          if (wasReconnecting) {
-            setReconnectCount((c) => c + 1)
-            console.log("[Socket] Reconnected successfully")
-          } else {
-            console.log("[Socket] Connected to", config.region)
-          }
-        })
-
-        newSocket.on("disconnect", (reason) => {
-          if (hasEverConnectedRef.current) {
-            setStatus("reconnecting")
-            console.log("[Socket] Disconnected:", reason)
-          } else {
-            setStatus("disconnected")
-          }
-        })
-
-        newSocket.on("error", (error: { message: string }) => {
-          console.error("[Socket] Error:", error.message)
-        })
-
-        // Socket.io manager events for reconnection tracking
-        newSocket.io.on("reconnect_attempt", (socketAttempt) => {
-          setStatus("reconnecting")
-          console.log(`[Socket] Reconnect attempt ${socketAttempt}`)
-        })
-
-        newSocket.io.on("reconnect_error", (error) => {
-          console.error("[Socket] Reconnect error:", error.message)
-        })
-
-        newSocket.io.on("reconnect_failed", () => {
-          console.error("[Socket] Reconnect failed - giving up")
-          setStatus("disconnected")
-        })
-
-        setSocket(newSocket)
+        // Cold boot (no cache) ⇒ connect now. Warm boot ⇒ only swap if the
+        // (effectively immutable) URL actually moved; otherwise keep the
+        // socket that already connected from cache — no needless reconnect.
+        if (!activeSocket || config.wsUrl !== activeWsUrl) {
+          start(config)
+        }
       } catch (error) {
         console.error("[Socket] Failed to fetch workspace config:", error)
         if (cancelled) return
 
-        // Retry with exponential backoff (1s, 2s, 4s, then give up)
+        // A warm boot already has a working socket from the cached config — a
+        // failed background revalidation is harmless, so don't churn status or
+        // burn retries; the socket's own reconnection logic handles drops.
+        if (activeSocket) return
+
+        // Cold boot: retry with exponential backoff (1s, 2s, 4s, then give up)
         if (attempt < 3) {
           const delay = 1000 * Math.pow(2, attempt)
           console.log(`[Socket] Retrying config fetch in ${delay}ms (attempt ${attempt + 1}/3)`)
           setStatus("reconnecting")
           retryTimer = setTimeout(() => {
-            if (!cancelled) connect(attempt + 1)
+            if (!cancelled) fetchConfig(attempt + 1)
           }, delay)
         } else {
           console.error("[Socket] Config fetch failed after 3 retries — giving up")
@@ -135,13 +161,20 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
       }
     }
 
-    connect()
+    // The region/wsUrl is assigned at workspace creation and effectively
+    // immutable, so a cached value lets the socket connect with zero round
+    // trip on a returning launch. The fetch still runs to revalidate.
+    const cached = getCachedWsConfig(workspaceId)
+    if (cached) {
+      start(cached)
+    }
+    fetchConfig()
 
     return () => {
       cancelled = true
       hasEverConnectedRef.current = false
       if (retryTimer) clearTimeout(retryTimer)
-      newSocket?.close()
+      activeSocket?.close()
       setSocket(null)
       setStatus("connecting")
       setReconnectCount(0)

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -74,7 +74,15 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
         autoConnect: true,
       })
 
+      // Only the socket that is still the active instance may drive provider
+      // state. A socket that was superseded (wsUrl moved → start() built a
+      // replacement) or torn down (workspace change) still emits a
+      // close-disconnect; without this guard that stale instance would
+      // backfire status/reconnectCount onto the socket that replaced it.
+      const isStale = () => cancelled || activeSocket !== s
+
       s.on("connect", () => {
+        if (isStale()) return
         const wasReconnecting = hasEverConnectedRef.current
         hasEverConnectedRef.current = true
         setStatus("connected")
@@ -88,6 +96,7 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
       })
 
       s.on("disconnect", (reason) => {
+        if (isStale()) return
         if (hasEverConnectedRef.current) {
           setStatus("reconnecting")
           console.log("[Socket] Disconnected:", reason)
@@ -97,20 +106,24 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
       })
 
       s.on("error", (error: { message: string }) => {
+        if (isStale()) return
         console.error("[Socket] Error:", error.message)
       })
 
       // Socket.io manager events for reconnection tracking
       s.io.on("reconnect_attempt", (socketAttempt) => {
+        if (isStale()) return
         setStatus("reconnecting")
         console.log(`[Socket] Reconnect attempt ${socketAttempt}`)
       })
 
       s.io.on("reconnect_error", (error) => {
+        if (isStale()) return
         console.error("[Socket] Reconnect error:", error.message)
       })
 
       s.io.on("reconnect_failed", () => {
+        if (isStale()) return
         console.error("[Socket] Reconnect failed - giving up")
         setStatus("disconnected")
       })
@@ -119,9 +132,13 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
     }
 
     function start(config: WorkspaceConfig) {
-      activeSocket?.close()
+      // Swap the active ref to the replacement before closing the previous
+      // socket, so the previous socket's synchronous close-disconnect is
+      // rejected by isStale() instead of clobbering the new socket's status.
+      const previous = activeSocket
       activeSocket = buildSocket(config)
       activeWsUrl = config.wsUrl
+      previous?.close()
       setSocket(activeSocket)
     }
 

--- a/apps/frontend/src/hooks/use-workspaces.ts
+++ b/apps/frontend/src/hooks/use-workspaces.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useLiveQuery } from "dexie-react-hooks"
 import { useSocket, useWorkspaceService } from "@/contexts"
 import { useUser } from "@/auth"
 import { debugBootstrap } from "@/lib/bootstrap-debug"
@@ -37,9 +38,15 @@ export function useWorkspaces() {
     },
   })
 
+  // Read back the IDB cache the query above writes — this closes the
+  // previously write-only loop so a returning user can render their
+  // workspaces instantly while the list query revalidates in the background.
+  const cachedWorkspaces = useLiveQuery(() => db.workspaces.toArray(), [])
+
   return {
     ...query,
     workspaces: query.data?.workspaces,
+    cachedWorkspaces,
     pendingInvitations: query.data?.pendingInvitations ?? [],
   }
 }

--- a/apps/frontend/src/lib/cached-user.test.ts
+++ b/apps/frontend/src/lib/cached-user.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { clearCachedUser, getCachedUser, setCachedUser } from "./cached-user"
+
+describe("cached-user", () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it("round-trips the display identity", () => {
+    setCachedUser({ id: "user_1", email: "a@b.co", name: "Ada" })
+    expect(getCachedUser()).toEqual({ id: "user_1", email: "a@b.co", name: "Ada" })
+  })
+
+  it("returns null when nothing is cached", () => {
+    expect(getCachedUser()).toBeNull()
+  })
+
+  it("clears the cached identity", () => {
+    setCachedUser({ id: "user_1", email: "a@b.co", name: "Ada" })
+    clearCachedUser()
+    expect(getCachedUser()).toBeNull()
+  })
+
+  it("rejects a partial / malformed payload instead of returning a half user", () => {
+    localStorage.setItem("threa-cached-user", JSON.stringify({ id: "user_1", email: "a@b.co" }))
+    expect(getCachedUser()).toBeNull()
+  })
+
+  it("returns null on unparseable JSON rather than throwing", () => {
+    localStorage.setItem("threa-cached-user", "{not json")
+    expect(getCachedUser()).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/cached-user.ts
+++ b/apps/frontend/src/lib/cached-user.ts
@@ -1,0 +1,38 @@
+import type { User } from "@/auth/types"
+
+// The session credential is the httpOnly WorkOS cookie — never this value.
+// We cache only the display identity so a returning user renders instantly
+// from local state while `/api/auth/me` revalidates in the background. A 401
+// on revalidation clears this and bounces to login; a network failure keeps
+// it so the app stays usable offline / on a flaky connection.
+const STORAGE_KEY = "threa-cached-user"
+
+export function getCachedUser(): User | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<User>
+    if (typeof parsed?.id !== "string" || typeof parsed?.email !== "string" || typeof parsed?.name !== "string") {
+      return null
+    }
+    return { id: parsed.id, email: parsed.email, name: parsed.name }
+  } catch {
+    return null
+  }
+}
+
+export function setCachedUser(user: User): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ id: user.id, email: user.email, name: user.name }))
+  } catch {
+    // Storage unavailable — degrade to network-first auth, no crash.
+  }
+}
+
+export function clearCachedUser(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Storage unavailable
+  }
+}

--- a/apps/frontend/src/lib/cached-ws-config.test.ts
+++ b/apps/frontend/src/lib/cached-ws-config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { getCachedWsConfig, setCachedWsConfig } from "./cached-ws-config"
+
+describe("cached-ws-config", () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it("round-trips per-workspace socket config", () => {
+    setCachedWsConfig("ws_1", { region: "us-east", wsUrl: "wss://edge.example/ws" })
+    expect(getCachedWsConfig("ws_1")).toEqual({ region: "us-east", wsUrl: "wss://edge.example/ws" })
+  })
+
+  it("scopes config by workspace id", () => {
+    setCachedWsConfig("ws_1", { region: "us-east", wsUrl: "wss://a" })
+    setCachedWsConfig("ws_2", { region: "eu-west", wsUrl: "wss://b" })
+    expect(getCachedWsConfig("ws_1")).toEqual({ region: "us-east", wsUrl: "wss://a" })
+    expect(getCachedWsConfig("ws_2")).toEqual({ region: "eu-west", wsUrl: "wss://b" })
+  })
+
+  it("returns null for an uncached workspace", () => {
+    expect(getCachedWsConfig("ws_unknown")).toBeNull()
+  })
+
+  it("rejects a malformed payload instead of returning a partial config", () => {
+    localStorage.setItem("threa-ws-config:ws_1", JSON.stringify({ region: "us-east" }))
+    expect(getCachedWsConfig("ws_1")).toBeNull()
+  })
+
+  it("returns null on unparseable JSON rather than throwing", () => {
+    localStorage.setItem("threa-ws-config:ws_1", "{not json")
+    expect(getCachedWsConfig("ws_1")).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/cached-ws-config.ts
+++ b/apps/frontend/src/lib/cached-ws-config.ts
@@ -1,0 +1,36 @@
+// Per-workspace socket connection config (`{ region, wsUrl }`). The region is
+// assigned at workspace creation and never moves, so the wsUrl is stable —
+// caching it lets the socket connect immediately on a returning launch instead
+// of blocking the connection on the `/api/workspaces/:id/config` round trip.
+// The fetch still runs in the background to revalidate; if the URL changed the
+// socket reconnects to the fresh one.
+const STORAGE_PREFIX = "threa-ws-config"
+
+export interface CachedWsConfig {
+  region: string
+  wsUrl: string
+}
+
+function key(workspaceId: string): string {
+  return `${STORAGE_PREFIX}:${workspaceId}`
+}
+
+export function getCachedWsConfig(workspaceId: string): CachedWsConfig | null {
+  try {
+    const raw = localStorage.getItem(key(workspaceId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<CachedWsConfig>
+    if (typeof parsed?.region !== "string" || typeof parsed?.wsUrl !== "string") return null
+    return { region: parsed.region, wsUrl: parsed.wsUrl }
+  } catch {
+    return null
+  }
+}
+
+export function setCachedWsConfig(workspaceId: string, config: CachedWsConfig): void {
+  try {
+    localStorage.setItem(key(workspaceId), JSON.stringify(config))
+  } catch {
+    // Storage unavailable
+  }
+}

--- a/apps/frontend/src/lib/last-workspace.test.ts
+++ b/apps/frontend/src/lib/last-workspace.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { clearLastWorkspaceId, getLastWorkspaceId, setLastWorkspaceId } from "./last-workspace"
+
+describe("last-workspace", () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it("round-trips the last workspace id", () => {
+    setLastWorkspaceId("ws_123")
+    expect(getLastWorkspaceId()).toBe("ws_123")
+  })
+
+  it("returns null when no workspace has been recorded", () => {
+    expect(getLastWorkspaceId()).toBeNull()
+  })
+
+  it("clears the recorded workspace (logout / account switch)", () => {
+    setLastWorkspaceId("ws_123")
+    clearLastWorkspaceId()
+    expect(getLastWorkspaceId()).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/last-workspace.ts
+++ b/apps/frontend/src/lib/last-workspace.ts
@@ -1,0 +1,31 @@
+// Last workspace the user had open. Read at the `/` entry route so a returning
+// user is redirected straight to `/w/:id` (which renders from IndexedDB)
+// instead of waiting on the control-plane `/api/workspaces` round trip just to
+// discover where to go. Purely a navigation hint: the workspace layout still
+// enforces auth and membership, and a stale/wrong id simply falls back to the
+// normal bootstrap path. Cleared on logout so a different account can't inherit it.
+const STORAGE_KEY = "threa-last-workspace"
+
+export function getLastWorkspaceId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setLastWorkspaceId(workspaceId: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, workspaceId)
+  } catch {
+    // Storage unavailable
+  }
+}
+
+export function clearLastWorkspaceId(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Storage unavailable
+  }
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -52,7 +52,7 @@ import {
   useBackgroundBootstrapSync,
 } from "@/hooks"
 import { usePageResume } from "@/hooks/use-page-resume"
-import { setLastWorkspaceId } from "@/lib/last-workspace"
+import { clearLastWorkspaceId, getLastWorkspaceId, setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext } from "@/sync/sync-engine"
@@ -242,9 +242,16 @@ function WorkspaceSyncHandler({
     if (workspaceSyncStatus !== "error") return
     const err = syncEngine.lastWorkspaceError
     if (err && ApiError.isApiError(err) && (err.status === 404 || err.status === 403)) {
+      // This workspace is terminally inaccessible for this user (removed /
+      // deleted). Stop pinning it as the "last workspace" or the `/` entry
+      // route would bounce back through this failing bootstrap on every cold
+      // launch. Guarded so a concurrently-set id isn't clobbered.
+      if (getLastWorkspaceId() === workspaceId) {
+        clearLastWorkspaceId()
+      }
       navigate("/workspaces", { replace: true })
     }
-  }, [workspaceSyncStatus, syncEngine, navigate])
+  }, [workspaceSyncStatus, syncEngine, navigate, workspaceId])
 
   return <SyncEngineContext.Provider value={syncEngine}>{children}</SyncEngineContext.Provider>
 }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -52,6 +52,7 @@ import {
   useBackgroundBootstrapSync,
 } from "@/hooks"
 import { usePageResume } from "@/hooks/use-page-resume"
+import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext } from "@/sync/sync-engine"
@@ -320,6 +321,16 @@ export function WorkspaceLayout() {
   const streams = useWorkspaceStreams(workspaceId ?? "")
 
   usePersistLastStream(workspaceId, streamId)
+
+  // Remember the workspace the user is in so the `/` entry route can redirect
+  // straight here on a returning launch (renders from IndexedDB) instead of
+  // routing through the control-plane workspace list. Only once auth resolved
+  // to a real user so a pre-auth render can't pin a workspace.
+  useEffect(() => {
+    if (workspaceId && user) {
+      setLastWorkspaceId(workspaceId)
+    }
+  }, [workspaceId, user])
 
   const openSwitcher = useCallback((mode: QuickSwitcherMode) => {
     setSwitcherMode(mode)

--- a/apps/frontend/src/pages/workspace-select.test.tsx
+++ b/apps/frontend/src/pages/workspace-select.test.tsx
@@ -161,6 +161,51 @@ describe("WorkspaceSelectPage", () => {
     expect(screen.getByRole("link", { name: "Beta" })).toHaveAttribute("href", "/w/workspace_2")
   })
 
+  it("renders the IDB-cached workspaces instead of a spinner while the list query is still loading", () => {
+    mockUseWorkspaces.mockReturnValue({
+      workspaces: undefined,
+      cachedWorkspaces: [makeWorkspace("workspace_1", "Alpha"), makeWorkspace("workspace_2", "Beta")],
+      pendingInvitations: [],
+      isLoading: true,
+      error: null,
+    })
+
+    renderPage()
+
+    expect(screen.getByRole("link", { name: "Alpha" })).toHaveAttribute("href", "/w/workspace_1")
+    expect(screen.getByRole("link", { name: "Beta" })).toHaveAttribute("href", "/w/workspace_2")
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+  })
+
+  it("auto-redirects to a single cached workspace while the list query is still loading", async () => {
+    mockUseWorkspaces.mockReturnValue({
+      workspaces: undefined,
+      cachedWorkspaces: [makeWorkspace("workspace_solo", "Solo")],
+      pendingInvitations: [],
+      isLoading: true,
+      error: null,
+    })
+
+    renderPage()
+
+    expect(await screen.findByTestId("workspace-route")).toHaveTextContent("workspace_solo")
+  })
+
+  it("keeps showing the cached list when revalidation errors instead of blanking to the error screen", () => {
+    mockUseWorkspaces.mockReturnValue({
+      workspaces: undefined,
+      cachedWorkspaces: [makeWorkspace("workspace_1", "Alpha"), makeWorkspace("workspace_2", "Beta")],
+      pendingInvitations: [],
+      isLoading: false,
+      error: new Error("network down"),
+    })
+
+    renderPage()
+
+    expect(screen.getByRole("link", { name: "Alpha" })).toBeInTheDocument()
+    expect(screen.queryByText("Failed to load workspaces")).not.toBeInTheDocument()
+  })
+
   it("should show invite-only message when invite is required", () => {
     mockUseWorkspaces.mockReturnValue({
       workspaces: [],

--- a/apps/frontend/src/pages/workspace-select.test.tsx
+++ b/apps/frontend/src/pages/workspace-select.test.tsx
@@ -177,7 +177,10 @@ describe("WorkspaceSelectPage", () => {
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
   })
 
-  it("auto-redirects to a single cached workspace while the list query is still loading", async () => {
+  it("does not auto-redirect off a single cached workspace until the list is authoritative", async () => {
+    // A pending invitation isn't known until the network list resolves; the
+    // cached single workspace renders as a selectable entry meanwhile so the
+    // redirect can't skip an invite the user hasn't been shown yet.
     mockUseWorkspaces.mockReturnValue({
       workspaces: undefined,
       cachedWorkspaces: [makeWorkspace("workspace_solo", "Solo")],
@@ -188,7 +191,9 @@ describe("WorkspaceSelectPage", () => {
 
     renderPage()
 
-    expect(await screen.findByTestId("workspace-route")).toHaveTextContent("workspace_solo")
+    expect(await screen.findByRole("link", { name: "Solo" })).toHaveAttribute("href", "/w/workspace_solo")
+    expect(screen.queryByTestId("workspace-route")).not.toBeInTheDocument()
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
   })
 
   it("keeps showing the cached list when revalidation errors instead of blanking to the error screen", () => {

--- a/apps/frontend/src/pages/workspace-select.tsx
+++ b/apps/frontend/src/pages/workspace-select.tsx
@@ -26,7 +26,10 @@ export function WorkspaceSelectPage() {
   // Prefer the freshly fetched list; fall back to the IDB-cached one so a
   // returning user sees their workspaces instantly while the list query
   // revalidates in the background instead of staring at a full-screen spinner
-  // on a slow network.
+  // on a slow network. `useLiveQuery` yields `undefined` until the IDB read
+  // resolves, then an array (possibly empty) — that distinction is
+  // load-bearing in the loading states below so neither boot path flashes.
+  const cacheResolved = cachedWorkspaces !== undefined
   const displayWorkspaces = workspaces ?? cachedWorkspaces
   const { data: regions } = useRegions()
   const createWorkspace = useCreateWorkspace()
@@ -68,17 +71,26 @@ export function WorkspaceSelectPage() {
     return <Navigate to="/login" replace />
   }
 
-  // Only block on a spinner for a genuinely cold visit — no cached list to
-  // render yet. With a cache we render it immediately and revalidate behind it.
-  if ((authLoading || workspacesLoading) && !displayWorkspaces) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="flex flex-col items-center gap-4">
-          <ThreaLogo size="lg" className="animate-pulse" />
-          <p className="text-muted-foreground text-sm">Loading...</p>
+  if (!displayWorkspaces?.length && !error) {
+    // First tick of a warm boot: the IDB read hasn't resolved yet and there's
+    // no fresh data, but a cached list is about to appear. Render nothing for
+    // that sub-frame (~16ms, imperceptible) rather than a spinner we'd
+    // immediately replace — flashing the spinner on and off *is* the flicker.
+    if (workspaces === undefined && !cacheResolved && workspacesLoading && !authLoading) {
+      return null
+    }
+    // Genuine cold visit: auth still resolving, or the IDB cache resolved
+    // empty and we're still waiting on the network. Nothing to show → spinner.
+    if (authLoading || workspacesLoading) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background">
+          <div className="flex flex-col items-center gap-4">
+            <ThreaLogo size="lg" className="animate-pulse" />
+            <p className="text-muted-foreground text-sm">Loading...</p>
+          </div>
         </div>
-      </div>
-    )
+      )
+    }
   }
 
   // A failed revalidation must not blank out a usable cached list (offline /
@@ -94,9 +106,13 @@ export function WorkspaceSelectPage() {
     )
   }
 
-  // Auto-redirect when there's exactly one workspace and no pending invitations
-  if (displayWorkspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId) {
-    return <Navigate to={`/w/${displayWorkspaces[0].id}`} replace />
+  // Auto-redirect when there's exactly one workspace and no pending
+  // invitations. Gate on the *authoritative* network list, not the cached
+  // one: redirecting off the cache while `pendingInvitations` is still its
+  // pre-fetch `[]` default would skip the invitation UI for a returning user
+  // who has one workspace and a freshly-issued invite.
+  if (workspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId) {
+    return <Navigate to={`/w/${workspaces[0].id}`} replace />
   }
 
   return (

--- a/apps/frontend/src/pages/workspace-select.tsx
+++ b/apps/frontend/src/pages/workspace-select.tsx
@@ -22,7 +22,12 @@ function getCreateWorkspaceErrorMessage(error: unknown): string | null {
 
 export function WorkspaceSelectPage() {
   const { user, loading: authLoading } = useAuth()
-  const { workspaces, pendingInvitations, isLoading: workspacesLoading, error } = useWorkspaces()
+  const { workspaces, cachedWorkspaces, pendingInvitations, isLoading: workspacesLoading, error } = useWorkspaces()
+  // Prefer the freshly fetched list; fall back to the IDB-cached one so a
+  // returning user sees their workspaces instantly while the list query
+  // revalidates in the background instead of staring at a full-screen spinner
+  // on a slow network.
+  const displayWorkspaces = workspaces ?? cachedWorkspaces
   const { data: regions } = useRegions()
   const createWorkspace = useCreateWorkspace()
   const acceptInvitation = useAcceptInvitation()
@@ -63,9 +68,9 @@ export function WorkspaceSelectPage() {
     return <Navigate to="/login" replace />
   }
 
-  const isLoading = authLoading || workspacesLoading
-
-  if (isLoading) {
+  // Only block on a spinner for a genuinely cold visit — no cached list to
+  // render yet. With a cache we render it immediately and revalidate behind it.
+  if ((authLoading || workspacesLoading) && !displayWorkspaces) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-4">
@@ -76,7 +81,9 @@ export function WorkspaceSelectPage() {
     )
   }
 
-  if (error) {
+  // A failed revalidation must not blank out a usable cached list (offline /
+  // flaky network). Only surface the hard error when there's nothing to show.
+  if (error && !displayWorkspaces?.length) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
@@ -88,8 +95,8 @@ export function WorkspaceSelectPage() {
   }
 
   // Auto-redirect when there's exactly one workspace and no pending invitations
-  if (workspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId) {
-    return <Navigate to={`/w/${workspaces[0].id}`} replace />
+  if (displayWorkspaces?.length === 1 && pendingInvitations.length === 0 && !acceptingId) {
+    return <Navigate to={`/w/${displayWorkspaces[0].id}`} replace />
   }
 
   return (
@@ -121,9 +128,9 @@ export function WorkspaceSelectPage() {
           </div>
         )}
 
-        {workspaces && workspaces.length > 0 && (
+        {displayWorkspaces && displayWorkspaces.length > 0 && (
           <div className="flex flex-col gap-2">
-            {workspaces.map((workspace) => (
+            {displayWorkspaces.map((workspace) => (
               <Button key={workspace.id} asChild variant="outline" className="w-64 justify-start">
                 <Link to={`/w/${workspace.id}`}>
                   <span className="truncate">{workspace.name}</span>

--- a/apps/frontend/src/routes/index.test.tsx
+++ b/apps/frontend/src/routes/index.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
-import { LegacyMemoRedirect, WorkspaceHome } from "./index"
+import { LegacyMemoRedirect, RootRedirect, WorkspaceHome } from "./index"
 import * as useLastStreamModule from "@/hooks/use-last-stream"
 import * as sidebarContextModule from "@/contexts/sidebar-context"
+import { clearLastWorkspaceId, setLastWorkspaceId } from "@/lib/last-workspace"
 
 const mockUseLastStream = vi.fn()
 const mockTogglePinned = vi.fn()
@@ -12,6 +13,44 @@ function SearchEcho() {
   const location = useLocation()
   return <div data-testid="search">{location.search}</div>
 }
+
+function PathEcho() {
+  const location = useLocation()
+  return <div data-testid="path">{location.pathname}</div>
+}
+
+describe("RootRedirect", () => {
+  beforeEach(() => clearLastWorkspaceId())
+
+  it("sends a returning user straight to their last workspace", async () => {
+    setLastWorkspaceId("ws_abc")
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<RootRedirect />} />
+          <Route path="/w/:workspaceId" element={<PathEcho />} />
+          <Route path="/workspaces" element={<PathEcho />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("path")).toHaveTextContent("/w/ws_abc")
+  })
+
+  it("falls back to the workspace picker when no last workspace is recorded", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<RootRedirect />} />
+          <Route path="/w/:workspaceId" element={<PathEcho />} />
+          <Route path="/workspaces" element={<PathEcho />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("path")).toHaveTextContent("/workspaces")
+  })
+})
 
 describe("WorkspaceHome", () => {
   beforeEach(() => {

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "@/components/error-boundary"
 import { FallbackLoader } from "@/components/fallback-loader"
 import { useSidebar } from "@/contexts"
 import { useLastStream } from "@/hooks"
+import { getLastWorkspaceId } from "@/lib/last-workspace"
 
 // Route-level code splitting: each page lazy-loads its own chunk so heavy
 // dependencies (tiptap/prosemirror, recharts, limax/pinyin-pro, etc.) ride
@@ -11,7 +12,7 @@ import { useLastStream } from "@/hooks"
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <Navigate to="/workspaces" replace />,
+    element: <RootRedirect />,
     errorElement: <ErrorBoundary />,
   },
   {
@@ -115,6 +116,20 @@ export const router = createBrowserRouter([
     ],
   },
 ])
+
+// PWA `start_url` is `/`. A returning user almost always wants the workspace
+// they last had open, which renders instantly from IndexedDB — so jump
+// straight there instead of routing through `/workspaces` and blocking on the
+// control-plane list round trip just to rediscover it. Purely a navigation
+// hint: WorkspaceLayout still enforces auth/membership and a stale/unknown id
+// falls back to the normal bootstrap path. No cached id ⇒ unchanged behavior.
+export function RootRedirect() {
+  const lastWorkspaceId = getLastWorkspaceId()
+  if (lastWorkspaceId) {
+    return <Navigate to={`/w/${lastWorkspaceId}`} replace />
+  }
+  return <Navigate to="/workspaces" replace />
+}
 
 /** Workspace index route — redirects to a stream or opens the sidebar. */
 export function WorkspaceHome() {

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching"
+import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import { resolveTag } from "./lib/sw-notification-format"
 import {
@@ -51,29 +51,42 @@ self.addEventListener("activate", (event) => {
 // linger and consume storage quota.
 cleanupOutdatedCaches()
 
-// Network-first for navigation requests. This is the critical fix for the
-// "unstyled page" bug: workbox's precacheAndRoute uses cache-first for
-// everything, including index.html. When a new build deploys with different
-// asset filenames, a stale precache serves old HTML that references old
-// CSS/JS filenames which no longer exist on the server — resulting in 404s
-// and an unstyled page. By handling navigations network-first, users always
-// get the latest HTML with correct asset references. The precache still
-// serves as an offline fallback.
+// Serve the build-atomic precached app shell for navigations. workbox's
+// precache manifest pins index.html and the content-hashed JS/CSS it
+// references to the same build, so a returning launch can never get build-A's
+// HTML against build-B's now-missing assets — the post-deploy "unstyled page"
+// failure (where _redirects' `/* /index.html 200` SPA fallback serves HTML in
+// place of deleted asset URLs, so React never mounts). Zero network on the
+// boot critical path; post-deploy freshness comes from the SW update
+// lifecycle (skipWaiting/clients.claim above) surfaced by the in-app
+// version.json update toast.
 self.addEventListener("fetch", (event) => {
   // Only app-shell GET navigations belong here. Web Share Target launches use
   // a POST navigation to /share, which must fall through to the handler below.
   if (event.request.mode !== "navigate" || event.request.method !== "GET") return
 
+  // Real server navigations must reach the network, not the SPA shell:
+  // /api/* (OAuth redirect), /recover (the SW-unregister recovery page,
+  // deliberately excluded from the precache), and the SW/version probes.
+  const { pathname } = new URL(event.request.url)
+  if (
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/recover") ||
+    pathname === "/sw.js" ||
+    pathname === "/version.json"
+  ) {
+    return
+  }
+
   event.respondWith(
-    fetch(event.request).catch(async () => {
-      // Offline: fall back to precached HTML
-      const cached = await caches.match(event.request)
-      if (cached) return cached
-      // Last resort: try precached index.html for SPA routing
-      const fallback = await caches.match("/index.html")
-      if (fallback) return fallback
-      return Response.error()
-    })
+    (async () => {
+      // matchPrecache resolves workbox's revisioned cache key, so this is the
+      // exact index.html that ships with the precached asset bundle.
+      const precached = await matchPrecache("/index.html")
+      if (precached) return precached
+      // First ever launch / precache unavailable — go to network.
+      return fetch(event.request)
+    })()
   )
 })
 


### PR DESCRIPTION
## Summary

Makes the mobile/PWA boot truly offline-first so a returning user paints instantly from local state on a flaky/slow network instead of staring at blank/spinner screens for 15–30s while every upstream gate does an unbounded network wait. The data layer was already offline-first; this fixes the five gates *above* it.

Each previously online-first gate was classified mistake-vs-purposeful (details in `.claude/plans/snoopy-twirling-quasar.md`):

- **S1 — App shell** (`sw.ts`): replace the bespoke network-first navigation handler with the build-atomic workbox precache of `/index.html` (cache-first, instant, offline). This *structurally* eliminates the post-deploy "broken/unstyled shell" failure (the precache manifest guarantees the HTML and the hashed assets it references are always the same build) instead of paying an unbounded network wait on every boot to dodge it. The React-independent CSS-watchdog → `sw-recovery` → `/recover` backstop is left untouched as the catastrophic-only safety net.
- **S2 — Auth identity** (`auth/context.tsx`, `index.html`): render instantly from a cached display identity (the httpOnly cookie is still the credential), revalidate in the background, bound the fetch. 401 clears the cache + redirects; network failure keeps the user usable offline.
- **S3 — Workspace discovery** (`routes/index.tsx`, `workspace-layout.tsx`, `workspace-select.tsx`, `use-workspaces.ts`): `/` redirects straight to the last workspace (renders from IndexedDB) instead of routing through the control-plane list; the picker renders the IDB-cached list instead of a full-screen spinner (closes the previously write-only cache loop). Also clears a stale last-workspace id on a terminal 403/404 so a removed/deleted workspace can't bounce the cold-launch path forever.
- **S4 — Socket config** (`socket-context.tsx`): connect immediately from a cached wsUrl/region; revalidate in the background and only rebuild if the (effectively immutable) URL actually moved — no reconnect churn.
- **S5 — Global fetch timeout** (`api/client.ts`): `apiFetch` is now `AbortController`-bounded; a timeout throws a non-`ApiError` so it is never mistaken for a 401 redirect and queries fall back to cached state.

New pure `localStorage` helpers (`lib/cached-user`, `lib/last-workspace`, `lib/cached-ws-config`) mirror the existing `lib/last-stream` pattern.

Self-reviewed for correctness with an explicit no-flicker / stay-snappy bar: the cold-boot critical path (cached auth → RootRedirect → `/w/:lastId` → cached socket + IDB data) has no spinner and no flash; the only residual is a ≤1-frame spinner on an *explicit* in-app navigation to `/workspaces`, which the cold-boot path bypasses entirely and which is strictly better than the pre-change full-RTT spinner.

## Test plan

- [x] `cd apps/frontend && bun run typecheck` — clean
- [x] `bun run test` — 1649 passed, 0 failing, no `.skip`
- [x] New unit tests: `lib/{cached-user,last-workspace,cached-ws-config}.test.ts`, `auth/context.offline.test.tsx`, `api/client.test.ts` (timeout), `pages/workspace-select.test.tsx` (cached list), `routes/index.test.tsx` (RootRedirect)
- [ ] Manual (Chrome DevTools → Slow 3G, repeat launches): after one good-network load, a throttled reload paints cached shell + identity + last workspace + IDB data within ~1s; a real 401 still redirects to login; logout clears all cached identity/workspace state
- [ ] Post-deploy correctness: build A, load (precache), rebuild B with changed asset hashes, hard-reload offline-throttled — app boots on consistent build-A precache (not a broken/unstyled page), CSS watchdog does not fire, then the `version.json` toast offers reload to build B; confirm `/api/auth/login` and `/recover.html` still hit the network (NavigationRoute denylist)

https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->