### PR TITLE
PR-4a: AccountScope foundation — account-scoped data layer + in-place switch

### DIFF
--- a/.claude/plans/glowing-discovering-locket.md
+++ b/.claude/plans/glowing-discovering-locket.md
@@ -1,289 +1,276 @@
-# PR-1 — Backend-common multi-account primitives
+# PR-4a — AccountScope foundation (frontend, no UI)
 
 ## Context
 
-This is the first implementation slice of the multi-account login split
-(`docs/plans/multi-account-login-split.md`, PR #535). Multi-account login lets
-one browser/PWA hold several authenticated accounts at once and switch between
-them without logging out. The full feature is split into seven slices; PR-1 is
-the foundational primitive layer.
+Fourth implementation slice of the multi-account login split
+(`docs/plans/multi-account-login-split.md`, lines 264-308). PR-1 (#537,
+backend-common cookie/auth-URL primitives) and PR-3 (#538, `/api/accounts`
+contract + OAuth `intent=add` park/coalesce) are **merged to `origin/main`**
+(HEAD `44362916`). PR-4a is now unblocked.
 
-**Why this slice exists / intended outcome:** ship the cookie + auth-URL
-primitives every later slice depends on, as a *pure addition* with **no
-callers, no behavior change, and the auth middleware untouched** — so it merges
-risk-free and unblocks PR-3 (the `/api/accounts` contract). Concretely:
+**Why this slice exists / intended outcome:** give the frontend a reactive,
+fully account-isolated **AccountScope** so the active account can switch
+*in place with no page reload* and *zero cross-account data bleed* at the
+IndexedDB, TanStack-Query, and store layers — including across browser tabs.
+No switcher UI (that is PR-5); this slice only proves isolation + in-place
+switchability via a headline test.
 
-- "Parked alt" session cookies so a session can be stored without being active.
-- `prompt` plumbing into the WorkOS authorization URL so PR-3 can force an
-  AuthKit re-prompt on "add account" instead of silently reusing the hosted
-  session (`@workos-inc/node@7.82.0` already types `prompt`).
-- A conservative, measurement-backed `MAX_ACCOUNTS` cap so no later slice can
-  create a state that overflows the Cloudflare Workers request-header limit.
+**Two corrections to the spec's stated assumptions (verified against
+`origin/main`):** the spec was written as if the original monolithic PR #487
+had landed. It did not — only the split-plan doc (#535) merged. Therefore:
 
-Two invariants drive the design and are preserved end-to-end:
+- `resolveDbName()`, `ensureDbMatchesUser`, and any account-switch
+  `window.location.reload()` **do not exist** — nothing to delete. PR-4a is a
+  *greenfield* foundation, not a refactor of PR #487.
+- `window.__eagerAuthPromise` is **live and fully wired** (`index.html:106`
+  sets it; `auth/context.tsx:41-51` consumes it) — it is *not* dead code.
 
-- **Environment isolation:** every cookie derives its name from the env-scoped
-  `SESSION_COOKIE_NAME` (prod `wos_session`, staging `wos_session_staging`).
-  Prod sessions + their parked alts coexist in one browser with staging
-  sessions + their parked alts, zero collision. No hardcoded `wos_session`.
-- **Auth middleware unchanged:** `packages/backend-common/src/auth/middleware.ts`
-  still reads exactly `req.cookies[SESSION_COOKIE_NAME]`. Alt cookies are
-  storage-only; PR-1 adds no reader for them.
+**User decisions (this session):**
 
-## Current state (verified)
+1. **Keep `__eagerAuthPromise` untouched.** A sibling PR is open that reworks
+   the offline-first model and may touch this exact area; avoid churn there to
+   prevent merge conflicts. AccountScope derives the active id from
+   `useAuth().user?.id` (which already consumes the eager promise) — no change
+   to `index.html` or `auth/context.tsx`'s auth fetch.
+2. **Scope-proxy + keyed remount** (not the full 34-file importer rewrite).
+   Minimal blast radius, deliberately chosen to stay clear of the in-flight
+   offline-first PR.
 
-- `packages/backend-common/src/cookies.ts` (80 lines):
-  - `SESSION_COOKIE_NAME` = `resolveSessionCookieName()` reads
-    `process.env.SESSION_COOKIE_NAME`, loud INV-11 fallback to `wos_session`
-    (lines 27–37).
-  - `SESSION_COOKIE_CONFIG` (lines 39–49): path/httpOnly/secure/sameSite/maxAge
-    + conditional `domain` from `COOKIE_DOMAIN`.
-  - Private `clearOptions()` (strips `maxAge`, lines 53–56) and
-    `hostOnlyOptions()` (strips `domain`, lines 58–61).
-  - `setSessionCookie(res, session, options?)` (63–72): if `options.domain`,
-    first clears a host-only same-name cookie, then sets. **Name hardcoded to
-    `SESSION_COOKIE_NAME`.**
-  - `clearSessionCookie(res, options?)` (74–79): clears, then host-only clears
-    if domain. **Name hardcoded.**
-  - `parseCookies(cookieHeader)` (5–17): `Record<string,string>`.
-  - Exports: `parseCookies`, `SESSION_COOKIE_NAME`, `SESSION_COOKIE_CONFIG`,
-    `SessionCookieOptions` (type), `setSessionCookie`, `clearSessionCookie`.
-- `packages/backend-common/src/index.ts` (105–111): named re-export of those 6
-  symbols (`export { … } from "./cookies"` + `export type { … }`).
-- `packages/backend-common/src/auth/auth-service.ts`:
-  - `AuthService` interface `getAuthorizationUrl(redirectTo?, redirectUri?): string`
-    (line 43).
-  - `WorkosAuthService.getAuthorizationUrl` (168–175) calls
-    `this.workos.userManagement.getAuthorizationUrl({ provider:"authkit",
-    redirectUri, clientId, state })`.
-  - Constructed from `WorkosConfig` (ctor 64–69).
-- `packages/backend-common/src/auth/auth-service.stub.ts`
-  `getAuthorizationUrl` (128–137): returns `/test-auth-login?…` encoding
-  `state` and optional `redirect_uri` into query params.
-- WorkOS SDK `@workos-inc/node@7.82.0`,
-  `lib/user-management/interfaces/authorization-url-options.interface.d.ts`:
-  `UserManagementAuthorizationURLOptions` includes `prompt?: string`,
-  `loginHint?: string`, `screenHint?: 'sign-up'|'sign-in'`. No cast needed.
-- Only production caller of `getAuthorizationUrl`:
-  `apps/control-plane/src/features/auth/handlers.ts:87` (2 args). **Not changed
-  in PR-1** — `intent=add → prompt:"login"` wiring is PR-3.
-- Test conventions: `packages/backend-common/src/cookies.test.ts` uses
-  `bun:test` (`describe/test/expect`), a `makeResponseRecorder()` faking
-  `res.cookie/clearCookie` into a `calls[]` array, and `beforeAll` that sets
-  `process.env.SESSION_COOKIE_NAME="wos_session_test"` then dynamically
-  `import("./cookies")`. Whole-object `expect(calls).toEqual([...])` assertions
-  (INV-24).
+## Approach (scope-proxy + keyed remount, minimal churn)
 
-## Design
+### 1. `apps/frontend/src/db/database.ts` — name-parameterized class + scope-bound proxy
 
-### 1. `cookies.ts` — extract a name-parameterized core, then add alt helpers
+- `class ThreaDatabase` constructor takes a name:
+  `constructor(name: string) { super(name) … }`. Every `this.version(...)`
+  block (28 of them, `:497-745`) stays **byte-identical** (reuse existing
+  schema — spec requirement).
+- Replace `export const db = new ThreaDatabase()` (`:751`) with a **proxy**
+  that forwards every property access to the AccountScope-active
+  `ThreaDatabase` instance. The ~30 modules doing `import { db } from "@/db"`
+  stay **completely untouched** (this is the whole point of the proxy: zero
+  churn in the offline-first model files the sibling PR touches).
+- The proxy reads through a module-level `activeDb` pointer that is **owned
+  and mutated solely by AccountScope**, set synchronously in the provider
+  body *before* the keyed subtree (and its `useLiveQuery`/sync engine) mounts
+  or remounts. Pre-auth (no account yet) the pointer defaults to a
+  `ThreaDatabase("threa")` handle so the pre-mount `hydrateCollapseCache()`
+  in `main.tsx` keeps working with **no change to `main.tsx` or
+  `collapse-cache.ts`** (another offline-first-area file left alone). Document
+  the INV-9 reasoning inline: this is not hidden state — it is the deliberate,
+  single-owner scope bridge that avoids a 30-file rewrite which would conflict
+  with the in-flight offline-first PR.
+- `clearAllCachedData()` / `clearPendingMessages()` (`:754-792`) keep working
+  against the proxy (i.e. the active account's db) — **no signature change**.
+  Their `finally` block already calls `resetWorkspaceStoreCache` /
+  `resetStreamStoreCache` / `resetDraftStoreCache` — reuse as-is (INV-35).
 
-**Reuse, do not duplicate (INV-35, INV-29):** the host-only dual-clear logic
-must live on one path. Extract internal cores and rebind the existing public
-functions to them so their signatures/behavior are byte-identical (middleware
-and all current consumers untouched):
+### 2. `apps/frontend/src/auth/account-scope.tsx` (NEW) — context + provider
 
-```ts
-function setNamedSessionCookie(res, name, value, options = SESSION_COOKIE_CONFIG) {
-  if (options.domain) res.clearCookie(name, clearOptions(hostOnlyOptions(options)))
-  res.cookie(name, value, options)
-}
-function clearNamedSessionCookie(res, name, options = SESSION_COOKIE_CONFIG) {
-  res.clearCookie(name, clearOptions(options))
-  if (options.domain) res.clearCookie(name, clearOptions(hostOnlyOptions(options)))
-}
-export function setSessionCookie(res, session, options = SESSION_COOKIE_CONFIG) {
-  setNamedSessionCookie(res, SESSION_COOKIE_NAME, session, options)
-}
-export function clearSessionCookie(res, options = SESSION_COOKIE_CONFIG) {
-  clearNamedSessionCookie(res, SESSION_COOKIE_NAME, options)
-}
-```
+API: `{ activeWorkosUserId, getDb(), getQueryClient(), getStores(),
+switchAccount(targetUserId), scopedKey(suffix) }`.
 
-Add the constants (INV-33 source of truth, INV-31 derived type):
+- Reads `useAuth().user` (no eager-auth change). While `user` is
+  null/loading, renders children with a stable `"__no_account__"` key (login
+  /loading routes need no scope). Once `user.id` is known, provides the scope.
+- Per-account registries held as **provider instance state (`useRef` Maps)**,
+  not module-level (INV-9): `dbRegistry`, `qcRegistry`. `getDb(id)` lazily
+  `new ThreaDatabase("threa_" + id)`; `getQueryClient(id)` lazily
+  `makeQueryClient()` (exported from `query-client.tsx`).
+- Synchronously sets the `db` proxy's `activeDb` pointer to
+  `getDb(activeWorkosUserId)` in the provider body (idempotent registry
+  lookup) so it is correct *before* the keyed children render.
+- Renders a `<ScopedRoot key={activeWorkosUserId}>` remount boundary around
+  the per-account subtree. A switch ⇒ React unmounts the old subtree and
+  mounts a fresh one ⇒ atomic swap of db handle, QueryClient, socket,
+  SyncEngine, and all `useState`/`useRef`/`useLiveQuery` — the strongest
+  isolation guarantee (matches the acceptance bar; mirrors the spec's own
+  rejection of in-place key-prefixing).
+- `switchAccount(target)`: `POST ${API_BASE}/api/accounts/switch`
+  `{ targetUserId }` (PR-3 contract) → on `{ activeUserId }`: call
+  `resetWorkspaceStoreCache()` / `resetStreamStoreCache()` /
+  `resetDraftStoreCache()` (+ add a `resetShareHandoffStoreCache()` if
+  `share-handoff-store.ts` lacks one — small, colocated) to flush the
+  **module-level** store caches that survive a React remount, then
+  `setActiveWorkosUserId(activeUserId)` (triggers the keyed remount), then
+  `new BroadcastChannel("threa-auth").postMessage({ type:"switched",
+  activeWorkosUserId })`.
+- Cross-tab receiver (`useEffect`, `BroadcastChannel("threa-auth")`): on a
+  `switched` message for a different id → `qcRegistry.get(currentId)
+  ?.cancelQueries()` (abort in-flight on the now-stale client), reset the
+  module store caches, then `setActiveWorkosUserId(...)` → same keyed-remount
+  path. Storage isolation (distinct DB name + distinct QueryClient instance)
+  means late-resolving queries land in the orphaned client, never B's cache —
+  correctness is independent of flip timing (spec requirement).
 
-```ts
-// Module-private sizing inputs (NOT exported — internal derivation of the
-// cap; mirrors the slug.ts MAX_SLUG_LENGTH source-of-truth precedent).
-const WORST_CASE_SEALED_BYTES = 3072
-const PER_COOKIE_OVERHEAD_BYTES = 32
-const CONSERVATIVE_COOKIE_HEADER_BUDGET = 13312 // 13 KB, ~81% of ~16 KB CF per-header limit
-export const MAX_ACCOUNTS = 4   // (1 active + 3 alts)·3104 B = 12416 B ≤ 13312 B
-export const MAX_ALT_SLOTS = MAX_ACCOUNTS - 1   // always derived, never a literal
+### 3. `apps/frontend/src/contexts/query-client.tsx` — per-account client
 
-// Module-load guard = the CI enforcement: throws if the cap would overflow
-// the budget, so a successful `import("./cookies")` is itself the proof the
-// cap fits. The budget constants stay module-private; tests never re-state
-// the literals.
-if ((1 + MAX_ALT_SLOTS) * (WORST_CASE_SEALED_BYTES + PER_COOKIE_OVERHEAD_BYTES)
-    > CONSERVATIVE_COOKIE_HEADER_BUDGET) {
-  throw new Error("MAX_ACCOUNTS exceeds the conservative Cookie-header budget")
-}
-```
+- Keep + **export** `makeQueryClient()` and `handleGlobalError` (reuse).
+- Delete `queryClientSingleton` / `getQueryClient()` and the singleton
+  `QueryClientProvider`. Add `AccountQueryClientProvider` that takes the
+  client from `useAccountScope().getQueryClient()`. Verified: `getQueryClient`
+  has **no production consumers** beyond the `contexts/index.ts:1` re-export
+  and the provider itself — low churn. Update `contexts/index.ts:1`.
+- 401 redirect + its `sessionStorage` loop-guard keys stay global and
+  unchanged: only the active account's client is mounted at a time (keyed
+  remount), so the existing handler is correct as-is. Multi-client concurrent
+  401 handling is explicitly deferred to PR-5.
 
-Add the alt helpers, all routed through the env-scoped base:
+### 4. `apps/frontend/src/App.tsx` — provider tree
 
-```ts
-export function altSessionCookieName(slot: number): string {
-  assertSlot(slot)
-  return `${SESSION_COOKIE_NAME}_alt_${slot}`
-}
-export function assertSlot(slot: number): void {
-  if (!Number.isInteger(slot) || slot < 0 || slot >= MAX_ALT_SLOTS)
-    throw new RangeError(`alt slot out of range: ${slot} (0..${MAX_ALT_SLOTS - 1})`)
-}
-export function setAltSessionCookie(res, slot, session, options = SESSION_COOKIE_CONFIG) {
-  setNamedSessionCookie(res, altSessionCookieName(slot), session, options)
-}
-export function clearAltSessionCookie(res, slot, options = SESSION_COOKIE_CONFIG) {
-  clearNamedSessionCookie(res, altSessionCookieName(slot), options)
-}
-// Parse occupied alt slots out of already-parsed cookies, env-scoped:
-// ignores the active cookie and the *other* environment's alts.
-export function readAltSessionCookies(
-  cookies: Record<string, string>
-): Array<{ slot: number; sealed: string }>
-```
+Wrap as: `AuthProvider > AccountScopeProvider > ScopedRoot
+key={activeWorkosUserId} > AccountQueryClientProvider > ServicesProvider >
+PendingMessagesProvider > TooltipProvider > RouterProvider`. AuthProvider
+stays **outside** scope (it owns the cookie-session identity that selects the
+account). QC/Services/PendingMessages/Router move **inside** the keyed
+boundary so they are per-account.
 
-`readAltSessionCookies` reuses `parseCookies` upstream (callers pass
-`req.cookies` or `parseCookies(header)`); it matches exactly
-`^${SESSION_COOKIE_NAME}_alt_(\d+)$`, so a staging process (base
-`wos_session_staging`) never reads prod `wos_session_alt_*` and vice versa,
-and the active cookie is never mistaken for slot data. Returns slots sorted
-ascending, only those present and non-empty.
+### 5. Socket reconnect + bootstrap (INV-53) — structural, no socket-layer churn
 
-`MAX_ACCOUNTS` value: ship a conservative integer whose derivation is
-documented inline (worst-case sealed-session byte size × slots + cookie
-overhead must fit the Cloudflare Workers request-header budget). Exact number +
-methodology finalized from the sealed-session sizing investigation (see
-Verification → Sizing). PR-5 may only relax it upward with measured headroom.
+`SocketProvider` + `SyncEngine` live inside `workspace-layout.tsx`, inside the
+keyed subtree. A switch remounts that subtree ⇒ old socket `.close()`, fresh
+cookie-authed socket connects (PR-3 already promoted the new active cookie),
+fresh `SyncEngine` runs its first `onConnect` → `runBootstrap` → no event gap.
+INV-53 (subscribe paired with bootstrap, invalidated on resubscribe) is
+satisfied *structurally* by the remount — no `reconnectCount` plumbing change.
 
-### 2. `index.ts` — barrel re-export
+### 6. Router seam for PR-4b (no behavior change in PR-4a)
 
-Extend the existing named re-export block (lines 105–111) with
-`MAX_ACCOUNTS`, `MAX_ALT_SLOTS`, `altSessionCookieName`, `assertSlot`,
-`setAltSessionCookie`, `clearAltSessionCookie`, `readAltSessionCookies`. Same
-style (named `export { … } from "./cookies"`). No `export *`.
+PR-4a does **not** implement cross-account deep-link resolution, but must not
+preclude it. Two seam guarantees:
 
-### 3. `auth-service.ts` / `.stub.ts` — `prompt` plumbing
+- `switchAccount(targetUserId)` is exposed on the AccountScope context so a
+  future router guard / route loader can `await` an account flip *before* the
+  workspace subtree mounts (the keyed-remount path already supports a
+  programmatic, non-UI trigger — it is identical to the cross-tab receiver
+  path).
+- The current terminal-error dead-end at `workspace-layout.tsx:240-246` (on a
+  workspace `403/404` it `navigate("/workspaces", { replace:true })`) is the
+  exact extension point PR-4b replaces. PR-4a leaves it **unchanged** (still
+  bounces) but documents it inline as the PR-4b seam so the behavior is a
+  known, intentional gap, not a silent regression.
 
-- Interface (line 43):
-  `getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { prompt?: string }): string`
-  + a one-line JSDoc on `options.prompt` ("forces AuthKit re-prompt; used by
-  the add-account flow in PR-3").
-- `WorkosAuthService` impl (168–175): spread
-  `...(options?.prompt ? { prompt: options.prompt } : {})` into the SDK call
-  object. No `as any` — `prompt` is typed by 7.82.0.
-- Stub (128–137): accept the third arg; when `options?.prompt` is set, add
-  `params.set("prompt", options.prompt)` to the returned test URL (mirrors the
-  stub's existing state/redirect_uri encoding so stub-mode tests can assert).
-- `middleware.test.ts:13` `FakeAuthService` — widen its `getAuthorizationUrl`
-  signature to match the interface (compile-only; no behavior).
-- **No production call-site change.** `handlers.ts:87` keeps calling with 2
-  args; passing `prompt:"login"` on `intent=add` is PR-3.
+### 7. localStorage re-keying (separate from the offline-first db model)
 
-### 4. Tests
+| Concern | File | New key |
+|---|---|---|
+| Sidebar state | `contexts/sidebar-context.tsx:48,171,192` | `threa-sidebar-state:${workosUserId}:${workspaceId}` |
+| Push opt-out | `hooks/use-push-notifications.ts` `pushOptOutKey` | `threa:push-opted-out:${workosUserId}:${workspaceId}` |
+| Appearance | `contexts/preferences-context.tsx:16,31` (+ `index.html:82` pre-bundle reader) | authoritative `threa-appearance:${workosUserId}` **plus** retain global `threa-appearance` as a one-frame pre-auth fallback |
 
-`packages/backend-common/src/cookies.test.ts` — add to the existing file,
-reuse `makeResponseRecorder()` and the `beforeAll` dynamic-import pattern:
-
-- `MAX_ALT_SLOTS === MAX_ACCOUNTS - 1`; `MAX_ACCOUNTS` is a positive integer.
-- Header-budget enforcement is the **module-load guard** in `cookies.ts`, not
-  a test assertion: the budget constants stay module-private, so tests never
-  duplicate the literals. A successful `import("./cookies")` in `beforeAll`
-  already proves the guard passed; the test only pins the derivation above.
-- `assertSlot`: accepts `0..MAX_ALT_SLOTS-1`; throws `RangeError` for `-1`,
-  `MAX_ALT_SLOTS`, non-integers.
-- `altSessionCookieName` env-scoping: under `SESSION_COOKIE_NAME=wos_session_test`,
-  slot 0 → `wos_session_test_alt_0`. (A second `describe` with its own
-  `beforeAll` setting `wos_session_staging` asserting `wos_session_staging_alt_0`
-  ≠ the prod-style name — proves no collision.)
-- `setAltSessionCookie`/`clearAltSessionCookie` reproduce the exact host-only
-  dual-clear `calls[]` shape the existing active-cookie tests assert, but under
-  the alt name (whole-object `toEqual`, INV-24).
-- `readAltSessionCookies`: given a jar mixing active cookie, two occupied alt
-  slots, the *other environment's* alt cookie, and noise → returns only this
-  env's occupied slots, sorted, `{slot,sealed}` shape; ignores the active
-  cookie.
-
-`auth-service.stub.test.ts` (new, small, mirrors stub conventions) — or extend
-an existing stub test if the sizing investigation finds one:
-
-- `getAuthorizationUrl(to, uri)` → no `prompt` in URL.
-- `getAuthorizationUrl(to, uri, { prompt: "login" })` → `prompt=login` present.
+Sidebar/push hooks are inside the scoped subtree → take `workosUserId` from
+`useAccountScope()`. Appearance: the render-blocking inline script at
+`index.html:82` runs before any account is known, so it cannot be
+account-keyed; `preferences-context` writes both the scoped (authoritative)
+key and the global fallback, reads the scoped key — the only cross-account
+sharing is a single pre-auth frame of the prior theme, which `preferences-
+context` immediately corrects on mount.
 
 ## Critical files
 
 | File | Change |
 |---|---|
-| `packages/backend-common/src/cookies.ts` | extract `setNamedSessionCookie`/`clearNamedSessionCookie`; add `MAX_ACCOUNTS`, `MAX_ALT_SLOTS`, `altSessionCookieName`, `assertSlot`, `setAltSessionCookie`, `clearAltSessionCookie`, `readAltSessionCookies` |
-| `packages/backend-common/src/index.ts` | re-export the 7 new symbols (lines 105–111 block) |
-| `packages/backend-common/src/auth/auth-service.ts` | `options?: { prompt?: string }` on interface (43) + impl (168–175) |
-| `packages/backend-common/src/auth/auth-service.stub.ts` | mirror signature; encode `prompt` into stub URL (128–137) |
-| `packages/backend-common/src/auth/middleware.test.ts` | widen `FakeAuthService.getAuthorizationUrl` signature (13) |
-| `packages/backend-common/src/cookies.test.ts` | add alt-cookie + env-scoping + constants tests |
-| `packages/backend-common/src/auth/auth-service.stub.test.ts` | new: `prompt` plumbing tests |
+| `apps/frontend/src/db/database.ts` (+ `db/index.ts`) | `ThreaDatabase(name)`; replace `db` singleton with scope-bound proxy + default `"threa"` pre-auth handle; export `ThreaDatabase` |
+| `apps/frontend/src/auth/account-scope.tsx` | **NEW** — context, per-account `getDb/getQueryClient/getStores`, `switchAccount`, keyed `ScopedRoot`, `threa-auth` BroadcastChannel |
+| `apps/frontend/src/contexts/query-client.tsx` (+ `contexts/index.ts`) | export `makeQueryClient`; delete singleton; add `AccountQueryClientProvider` |
+| `apps/frontend/src/App.tsx` | insert `AccountScopeProvider` + keyed `ScopedRoot`; move QC/Services/PendingMessages/Router inside |
+| `apps/frontend/src/pages/workspace-layout.tsx` | pass `workosUserId` into sidebar/push keys; relies on remount for socket+bootstrap |
+| `apps/frontend/src/contexts/sidebar-context.tsx`, `contexts/preferences-context.tsx`, `hooks/use-push-notifications.ts` | localStorage re-keying |
+| `apps/frontend/src/stores/share-handoff-store.ts` | add `resetShareHandoffStoreCache()` if absent (reuse pattern from `workspace-store.ts:98`) |
+| `apps/frontend/src/test/setup.ts` | add in-memory `BroadcastChannel` shim (jsdom lacks it) |
+| `apps/frontend/src/auth/account-scope.test.tsx` | **NEW** — headline isolation + cross-tab test |
+| `apps/frontend/src/db/database.test.ts` | update for `ThreaDatabase(name)` (currently constructs the singleton) |
+
+**Untouched on purpose (sibling offline-first PR safety):** `index.html`
+eager-auth block, `auth/context.tsx` auth fetch, `main.tsx`,
+`lib/markdown/collapse-cache.ts`, and the ~30 `import { db } from "@/db"`
+consumer modules — all keep working unchanged via the proxy.
 
 ## Verification
 
-**Unit:** `bun run test` filtered to `packages/backend-common` (cookies +
-auth-service stub). All new tests green; existing cookies/middleware tests
-still green (proves the core extraction is behavior-preserving).
+**First step:** `git fetch origin && git checkout -b
+claude/review-multi-account-auth-4eC4g origin/main` (branch fresh off updated
+`origin/main`, post-PR-3 #538 — current HEAD `44362916`). Develop and push
+only to `claude/review-multi-account-auth-4eC4g`.
 
-**Typecheck:** `bun run --cwd packages/backend-common typecheck` and the
-control-plane typecheck (confirms the interface change is source-compatible at
-`handlers.ts:87` with no edit there).
+**Headline test** (`apps/frontend/src/auth/account-scope.test.tsx`, real
+components mounted — INV-39; `vi.spyOn`/`spyOnExport`, not `vi.mock` —
+INV-48; `fake-indexeddb/auto` already global via `test/setup.ts:1`):
 
-**No-behavior-change proof:** `git grep` shows zero new imports of the alt
-helpers in `apps/*` (PR-1 has no callers); `middleware.ts` diff is empty.
+1. Stub `fetch`: `/api/auth/me` → account A `{id:"workos_A",…}`;
+   `POST /api/accounts/switch {targetUserId:"workos_B"}` →
+   `{activeUserId:"workos_B"}` and flip `/api/auth/me` to B (mirrors the
+   `auth/context.test.tsx` fetch-stub pattern).
+2. Mount real `App`; seed A's layers: `getDb()` row, `getQueryClient()
+   .setQueryData(...)`, `getStores().seedWorkspaceCache(...)`.
+3. `switchAccount("workos_B")` via a probe; assert `window.location.reload`
+   and `window.location.href` were **never** assigned (no reload).
+4. Assert zero cross-account reads, three layers: B's `getDb()` →
+   `workspaces.count() === 0` while `threa_workos_A` still holds A's row
+   (isolation, not deletion; assert two DB names via
+   `indexedDB.databases()`); B's QueryClient `getQueryData` for A's key →
+   `undefined`; B's `getStores().hasSeededWorkspaceCache(A) === false`.
+5. Cross-tab: with the `BroadcastChannel` shim, mount two
+   `AccountScopeProvider` trees sharing the in-memory channel + the
+   process-shared fake-indexeddb backing; switch in tree 1 → assert tree 2
+   flipped to B, serves zero A data at all three layers, and tree 1's old
+   client had `cancelQueries()` called.
 
-**Sizing (set `MAX_ACCOUNTS`) — resolved approach:**
+**Commands:** `bun run --cwd apps/frontend test` (incl. new + updated tests
+all green) and `bun run --cwd apps/frontend typecheck` (the `ThreaDatabase`
+name param + provider tree must be type-clean).
 
-Facts: a real WorkOS sealed session is produced only by
-`workos.userManagement.authenticateWithCode({ session:{ sealSession:true,
-cookiePassword } })` (Iron-encrypted; needs live WorkOS creds — `auth-service.ts:133`).
-Cloudflare Workers limit ≈ 32 KB total request headers, ≈ 16 KB per single
-header; the browser concatenates **all** cookies for the origin into one
-`Cookie:` request header, so that combined header is the binding constraint.
-No header-limit constant exists in `apps/workspace-router`.
+## Risks / accepted trade-offs
 
-To keep PR-1 a risk-free pure addition (no live WorkOS dependency in CI), split
-"measurement-backed" into two parts:
+- **R1 — Scope-proxy `activeDb` pointer is module-level.** Mitigated:
+  single-owner (AccountScope), set synchronously before the keyed subtree
+  mounts; documented inline. Deliberate trade vs. a 30-file rewrite that
+  would conflict with the in-flight offline-first PR.
+- **R2 — Switch = full keyed-subtree remount**, not a same-socket
+  re-handshake. Strongest isolation; a brief UI flash on switch is acceptable
+  for infra-only PR-4a (PR-5 owns switch UX).
+- **R3 — `threa-appearance` one pre-auth frame** may show the prior account's
+  theme before `preferences-context` corrects it (inline script can't be
+  account-keyed). Authoritative store is fully per-account.
+- **R4 — Cross-account collapse-cache warm-up** lands in the default `"threa"`
+  db pre-auth; reads switch to `threa_<id>` after activation. Message IDs are
+  distinct ULIDs so no meaningful bleed; cache self-heals (already tolerated).
+- **R5 — BroadcastChannel jsdom shim** is a required `test/setup.ts` addition;
+  fake-indexeddb is process-shared so the two-tab test shares one IDB backing
+  — realistic for the cross-tab assertion.
+- **R6 — Logout cache teardown** clears only the active account's db (via the
+  existing `clearAllCachedData` against the proxy). Deleting *all* per-account
+  DBs on logout is deferred to PR-5 (logout-all).
 
-1. **Documented worst-case constants + a module-load guard (in PR-1, in CI).**
-   In `cookies.ts`, alongside `MAX_ACCOUNTS`, add module-private documented
-   constants: `WORST_CASE_SEALED_BYTES` (conservative upper bound for a WorkOS
-   sealed session — sealed access-JWT + refresh token + user, Iron base64
-   expansion; ~3 KB), `PER_COOKIE_OVERHEAD_BYTES` (name incl. longest env
-   prefix `wos_session_staging_alt_<n>` + `=` + `; ` ≈ 32 B), and
-   `CONSERVATIVE_COOKIE_HEADER_BUDGET` (defensive slice of the single `Cookie:`
-   header reserved for session cookies, well under the ~16 KB per-header limit
-   with room for non-session cookies — **13 KB / 13312 B**). Enforcement is a
-   **module-load guard** that throws when
-   `(1 + MAX_ALT_SLOTS) * (WORST_CASE_SEALED_BYTES + PER_COOKIE_OVERHEAD_BYTES)
-   > CONSERVATIVE_COOKIE_HEADER_BUDGET`; the constants stay private and no test
-   re-states the budget literals — a successful import is the CI proof. With
-   these numbers the cap is a conservative **`MAX_ACCOUNTS = 4`** (1 active + 3
-   alts · 3104 B = 12416 B ≤ 13312 B; the next bump, `MAX_ACCOUNTS = 5` →
-   15520 B, trips the guard). `MAX_ACCOUNTS` is an **intentional literal** whose
-   value is justified by — not computed from — these documented inputs and is
-   bounds-checked by the guard; `MAX_ALT_SLOTS` is the **derived** one
-   (`MAX_ACCOUNTS - 1`, INV-31). INV-33: the documented inputs are the source
-   of truth, mirroring the `slug.ts` `MAX_SLUG_LENGTH` precedent.
+## Follow-up: PR-4b — cross-account entry resolver (separate slice)
 
-2. **One-off empirical confirmation (pre-merge manual step, recorded — NOT in
-   CI).** Before merge, run `authenticateWithCode` once against the staging
-   WorkOS environment, log `Buffer.byteLength(sealedSession,"utf8")`, and
-   record the observed size in the PR description and the `cookies.ts` inline
-   comment. If the observed size exceeds `WORST_CASE_SEALED_BYTES`, lower
-   `MAX_ACCOUNTS` (re-run the static test). PR-5 relaxes the cap upward only
-   with a fresh measurement showing headroom.
+A new slice between PR-4a and `{PR-5 ‖ PR-6}`, owning the **cold-entry**
+resolve→flip→route primitive (a shared link / bookmark to a workspace owned by
+a *parked* account must work, not bounce to `/workspaces`). This is the same
+primitive PR-6's notification-click needs, so PR-6 becomes a trivial caller.
 
-This honors the split plan ("PR-1 owns the measurement-backed conservative
-default; PR-5 relaxes upward") while keeping PR-1's test suite hermetic.
+- **Backend (control-plane):** `GET /api/accounts/resolve?workspaceId=…` →
+  `{ ownerUserId }` or `404`. Reuses `AccountsService.resolveAlts` (active +
+  alt sealed sessions, exactly like `/api/accounts` via
+  `readAltSessionCookies`) to enumerate this browser's accounts, then checks
+  workspace membership per account via the existing
+  `workspace.confirmMembership` path (`/internal/workspaces/:id/members/:uid`
+  is already wired). Zod-validated query (INV-55), `HttpError` semantics
+  (INV-32), `auth`+`authLimit` like the other `/api/accounts/*` routes.
+- **Frontend:** a route guard replacing the `workspace-layout.tsx:240-246`
+  bounce — on a workspace `403/404`, call the resolver; if a parked account
+  owns it, `switchAccount(ownerUserId)` (PR-4a) and keep the original deep
+  link (no reload); only fall back to `/workspaces` when no account owns it.
+- **Reuse:** PR-4a `switchAccount` + keyed remount; PR-3 `AccountsService`
+  /`resolveAlts`; existing `confirmMembership`. **Consumed by** PR-5
+  (switcher) and PR-6 (notification-click resolves via the same endpoint).
+- **Verification:** while account A is active, open a link to a workspace
+  owned by parked account B → app flips to B and lands on the deep link, no
+  reload, no A-data flash; a link to a workspace no account owns still
+  bounces to `/workspaces`.
 
 ## Out of scope (later slices)
 
-`/api/accounts` endpoints, park/coalesce/switch logic, `intent=add` callback
-wiring, logout-clears-alts (PR-3); frontend AccountScope (PR-4a); switcher UX
-and the cap *relaxation* (PR-5); push (PR-6); backoffice cookie rename (PR-2).
+Cold-deep-link / notification-click resolver + router guard (**PR-4b**, above);
+switcher UI, `intent=add` "Add account" entry point, account list rendering,
+the `MAX_ACCOUNTS` cap *relaxation* (PR-5); cross-account push +
+notification-click switch (PR-6); backoffice cookie rename (PR-2).

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,21 +1,23 @@
 import { RouterProvider } from "react-router-dom"
-import { AuthProvider } from "./auth"
-import { QueryClientProvider, ServicesProvider, PendingMessagesProvider } from "./contexts"
+import { AuthProvider, AccountScopeProvider } from "./auth"
+import { AccountQueryClientProvider, ServicesProvider, PendingMessagesProvider } from "./contexts"
 import { router } from "./routes"
 import { TooltipProvider } from "./components/ui/tooltip"
 
 export function App() {
   return (
     <AuthProvider>
-      <QueryClientProvider>
-        <ServicesProvider>
-          <PendingMessagesProvider>
-            <TooltipProvider delayDuration={300}>
-              <RouterProvider router={router} />
-            </TooltipProvider>
-          </PendingMessagesProvider>
-        </ServicesProvider>
-      </QueryClientProvider>
+      <AccountScopeProvider>
+        <AccountQueryClientProvider>
+          <ServicesProvider>
+            <PendingMessagesProvider>
+              <TooltipProvider delayDuration={300}>
+                <RouterProvider router={router} />
+              </TooltipProvider>
+            </PendingMessagesProvider>
+          </ServicesProvider>
+        </AccountQueryClientProvider>
+      </AccountScopeProvider>
     </AuthProvider>
   )
 }

--- a/apps/frontend/src/auth/account-scope.test.tsx
+++ b/apps/frontend/src/auth/account-scope.test.tsx
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, waitFor } from "@/test"
+import { AuthProvider } from "@/auth"
+import { AccountScopeProvider, useAccountScope, type AccountScopeValue } from "@/auth/account-scope"
+import { hasSeededWorkspaceCache, seedWorkspaceCache } from "@/stores/workspace-store"
+import type { CachedWorkspace } from "@/db"
+
+// PR-4a headline test. Mounts the real AuthProvider + AccountScopeProvider
+// (not the full App: that drags in socket.io, the router, and every route
+// component, which are unrelated to PR-4a's logic and make the test brittle —
+// INV-22). The data layers under test (per-account IndexedDB, QueryClient,
+// module store caches) are exercised through their real implementations
+// (INV-39).
+
+const WORKSPACE: CachedWorkspace = {
+  id: "workspace_A",
+  name: "A workspace",
+  slug: "a-workspace",
+  createdAt: "2026-05-01T00:00:00Z",
+  updatedAt: "2026-05-01T00:00:00Z",
+  _cachedAt: Date.now(),
+}
+
+const QUERY_KEY = ["account-scope-test", "workspace_A"]
+
+function meResponse(id: string): Response {
+  return {
+    status: 200,
+    ok: true,
+    json: async () => ({ id, email: `${id}@example.com`, name: id }),
+  } as unknown as Response
+}
+
+/** Stub /api/auth/me (account A until switched) and /api/accounts/switch. */
+function installFetchStub() {
+  let activeId = "workos_A"
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString()
+    if (url.endsWith("/api/accounts/switch")) {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { targetUserId: string }
+      activeId = body.targetUserId
+      return { status: 200, ok: true, json: async () => ({ activeUserId: activeId }) } as unknown as Response
+    }
+    if (url.endsWith("/api/auth/me")) {
+      return meResponse(activeId)
+    }
+    return { status: 404, ok: false, json: async () => ({}) } as unknown as Response
+  })
+  vi.stubGlobal("fetch", fetchMock)
+}
+
+function mountScopeTree() {
+  const handle: { current: AccountScopeValue | null } = { current: null }
+  function Probe() {
+    handle.current = useAccountScope()
+    return null
+  }
+  const utils = render(
+    <AuthProvider>
+      <AccountScopeProvider>
+        <Probe />
+      </AccountScopeProvider>
+    </AuthProvider>
+  )
+  return { handle, utils }
+}
+
+async function waitForActive(handle: { current: AccountScopeValue | null }, id: string) {
+  await waitFor(() => {
+    expect(handle.current?.activeWorkosUserId).toBe(id)
+  })
+}
+
+describe("AccountScope", () => {
+  const originalLocation = window.location
+  let reloadSpy: ReturnType<typeof vi.fn>
+  let hrefValues: string[]
+
+  beforeEach(() => {
+    installFetchStub()
+    reloadSpy = vi.fn()
+    hrefValues = []
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/",
+        search: "",
+        reload: reloadSpy,
+        set href(v: string) {
+          hrefValues.push(v)
+        },
+        get href() {
+          return hrefValues[hrefValues.length - 1] ?? ""
+        },
+      } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+    for (const name of ["threa", "threa_workos_A", "threa_workos_B"]) {
+      indexedDB.deleteDatabase(name)
+    }
+  })
+
+  it("isolates db, query cache, and stores across an in-place switch (no reload)", async () => {
+    const { handle } = mountScopeTree()
+    await waitForActive(handle, "workos_A")
+
+    const scope = handle.current!
+    const dbA = scope.getDb()
+    const qcA = scope.getQueryClient()
+    await dbA.workspaces.put(WORKSPACE)
+    qcA.setQueryData(QUERY_KEY, { hello: "from-A" })
+    seedWorkspaceCache("workspace_A", {
+      workspace: WORKSPACE,
+      users: [],
+      streams: [],
+      memberships: [],
+      dmPeers: [],
+      personas: [],
+      bots: [],
+      unreadState: {
+        id: "workspace_A",
+        workspaceId: "workspace_A",
+        unreadCounts: {},
+        mentionCounts: {},
+        activityCounts: {},
+        unreadActivityCount: 0,
+        mutedStreamIds: [],
+        _cachedAt: Date.now(),
+      },
+      userPreferences: {
+        id: "workspace_A",
+        workspaceId: "workspace_A",
+        userId: "user_A",
+        theme: "system",
+        sendMode: "enter",
+        _cachedAt: Date.now(),
+      },
+      metadata: {
+        id: "workspace_A",
+        workspaceId: "workspace_A",
+        emojis: [],
+        emojiWeights: {},
+        commands: [],
+        _cachedAt: Date.now(),
+      },
+    })
+    expect(hasSeededWorkspaceCache("workspace_A")).toBe(true)
+
+    await act(async () => {
+      await scope.switchAccount("workos_B")
+    })
+    await waitForActive(handle, "workos_B")
+
+    // No page reload / location navigation happened.
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(hrefValues).toEqual([])
+
+    const scopeB = handle.current!
+    expect(scopeB.activeWorkosUserId).toBe("workos_B")
+
+    // Layer 1 — IndexedDB: B's db is empty; A's db is preserved (isolation,
+    // not deletion); the two are physically distinct named databases.
+    expect(await scopeB.getDb().workspaces.count()).toBe(0)
+    expect(await dbA.workspaces.count()).toBe(1)
+    expect(dbA.name).toBe("threa_workos_A")
+    expect(scopeB.getDb().name).toBe("threa_workos_B")
+
+    // Layer 2 — TanStack Query: B's client never sees A's cached entry.
+    expect(scopeB.getQueryClient().getQueryData(QUERY_KEY)).toBeUndefined()
+    expect(scopeB.getQueryClient()).not.toBe(qcA)
+
+    // Layer 3 — module store cache: flushed on switch.
+    expect(hasSeededWorkspaceCache("workspace_A")).toBe(false)
+  })
+
+  it("flips a second tab over BroadcastChannel and serves no cross-account data", async () => {
+    const tab1 = mountScopeTree()
+    const tab2 = mountScopeTree()
+    await waitForActive(tab1.handle, "workos_A")
+    await waitForActive(tab2.handle, "workos_A")
+
+    const tab2QcA = tab2.handle.current!.getQueryClient()
+    const cancelSpy = vi.spyOn(tab2QcA, "cancelQueries")
+    const tab2DbA = tab2.handle.current!.getDb()
+    await tab2DbA.workspaces.put(WORKSPACE)
+    tab2QcA.setQueryData(QUERY_KEY, { hello: "from-A" })
+
+    await act(async () => {
+      await tab1.handle.current!.switchAccount("workos_B")
+    })
+
+    // Tab 2 receives the broadcast and flips without its own switch call.
+    await waitForActive(tab2.handle, "workos_B")
+    const tab2B = tab2.handle.current!
+    expect(await tab2B.getDb().workspaces.count()).toBe(0)
+    expect(tab2B.getQueryClient().getQueryData(QUERY_KEY)).toBeUndefined()
+    expect(tab2B.getQueryClient()).not.toBe(tab2QcA)
+    // The now-stale client had its in-flight queries cancelled.
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/auth/account-scope.test.tsx
+++ b/apps/frontend/src/auth/account-scope.test.tsx
@@ -96,12 +96,21 @@ describe("AccountScope", () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.unstubAllGlobals()
     Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
-    for (const name of ["threa", "threa_workos_A", "threa_workos_B"]) {
-      indexedDB.deleteDatabase(name)
-    }
+    // Await deletion so a not-yet-dropped DB never bleeds into the next test.
+    await Promise.all(
+      ["threa", "threa_workos_A", "threa_workos_B"].map(
+        (name) =>
+          new Promise<void>((resolve) => {
+            const req = indexedDB.deleteDatabase(name)
+            req.onsuccess = () => resolve()
+            req.onerror = () => resolve()
+            req.onblocked = () => resolve()
+          })
+      )
+    )
   })
 
   it("isolates db, query cache, and stores across an in-place switch (no reload)", async () => {

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -1,0 +1,178 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react"
+import type { QueryClient } from "@tanstack/react-query"
+import { API_BASE } from "@/api/client"
+import { ThreaDatabase, setActiveDb } from "@/db"
+import { makeQueryClient } from "@/contexts/query-client"
+import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetStreamStoreCache } from "@/stores/stream-store"
+import { resetDraftStoreCache } from "@/stores/draft-store"
+import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
+import { useAuth } from "./hooks"
+
+const NO_ACCOUNT_KEY = "__no_account__"
+const PRE_AUTH_ID = "__pre_auth__"
+const AUTH_CHANNEL = "threa-auth"
+
+interface SwitchedMessage {
+  type: "switched"
+  activeWorkosUserId: string
+}
+
+export interface AccountScopeValue {
+  /** The active account's WorkOS user id, or null pre-auth. */
+  activeWorkosUserId: string | null
+  /** The active account's IndexedDB handle. */
+  getDb: () => ThreaDatabase
+  /** The active account's TanStack QueryClient. */
+  getQueryClient: () => QueryClient
+  /**
+   * Flip the active account in place (no page reload). Calls the PR-3
+   * `/api/accounts/switch` contract, then triggers the keyed remount so the
+   * whole per-account subtree (db, QueryClient, socket, SyncEngine) swaps
+   * atomically, and broadcasts to other tabs.
+   */
+  switchAccount: (targetUserId: string) => Promise<void>
+  /** Namespace a storage key to the active account. */
+  scopedKey: (suffix: string) => string
+}
+
+const AccountScopeContext = createContext<AccountScopeValue | null>(null)
+
+export function useAccountScope(): AccountScopeValue {
+  const ctx = useContext(AccountScopeContext)
+  if (!ctx) {
+    throw new Error("useAccountScope must be used within an AccountScopeProvider")
+  }
+  return ctx
+}
+
+/**
+ * Optional variant for leaf contexts (sidebar, push, preferences) that are
+ * also mounted in isolation by unit tests without the provider. Returns null
+ * outside a provider so those callers fall back to un-namespaced behavior.
+ */
+export function useAccountScopeOptional(): AccountScopeValue | null {
+  return useContext(AccountScopeContext)
+}
+
+// Module-level store caches survive a React remount, so a switch must flush
+// them or account A's cached workspaces/drafts/shares bleed into account B.
+function flushModuleStoreCaches(): void {
+  resetWorkspaceStoreCache()
+  resetStreamStoreCache()
+  resetDraftStoreCache()
+  resetShareHandoffStoreCache()
+}
+
+interface AccountScopeProviderProps {
+  children: ReactNode
+}
+
+export function AccountScopeProvider({ children }: AccountScopeProviderProps) {
+  const { user } = useAuth()
+  const authUserId = user?.id ?? null
+
+  // A programmatic / cross-tab switch moves the scope ahead of the cookie
+  // identity until the next /api/auth/me catches up; the scope is derived from
+  // the switch, never blocked on auth re-fetch.
+  const [switchedId, setSwitchedId] = useState<string | null>(null)
+  const effectiveId = switchedId ?? authUserId
+
+  const dbRegistry = useRef(new Map<string, ThreaDatabase>())
+  const qcRegistry = useRef(new Map<string, QueryClient>())
+
+  const resolveDb = useCallback((id: string): ThreaDatabase => {
+    let inst = dbRegistry.current.get(id)
+    if (!inst) {
+      inst = new ThreaDatabase(`threa_${id}`)
+      dbRegistry.current.set(id, inst)
+    }
+    return inst
+  }, [])
+
+  const resolveQueryClient = useCallback((id: string): QueryClient => {
+    let qc = qcRegistry.current.get(id)
+    if (!qc) {
+      qc = makeQueryClient()
+      qcRegistry.current.set(id, qc)
+    }
+    return qc
+  }, [])
+
+  // Redirect the shared `db` proxy at the active account *before* the keyed
+  // subtree (and its useLiveQuery / SyncEngine) renders. Idempotent registry
+  // lookup + pointer move; intentionally render-time so the swap is atomic
+  // w.r.t. children mounting (see db/database.ts INV-9 note). Pre-auth we
+  // leave the default "threa" handle in place.
+  if (effectiveId) {
+    setActiveDb(resolveDb(effectiveId))
+  }
+
+  const effectiveIdRef = useRef(effectiveId)
+  effectiveIdRef.current = effectiveId
+  const channelRef = useRef<BroadcastChannel | null>(null)
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(AUTH_CHANNEL)
+    channelRef.current = channel
+    channel.onmessage = (e: MessageEvent) => {
+      const data = e.data as Partial<SwitchedMessage> | null
+      if (data?.type !== "switched" || !data.activeWorkosUserId) return
+      const current = effectiveIdRef.current
+      if (data.activeWorkosUserId === current) return
+      // Abort in-flight queries on the now-stale client so a late response
+      // can never land in the orphaned cache. Storage isolation (distinct DB
+      // name + distinct QueryClient) makes correctness independent of timing;
+      // this is purely to stop wasted work.
+      if (current) qcRegistry.current.get(current)?.cancelQueries()
+      flushModuleStoreCaches()
+      setSwitchedId(data.activeWorkosUserId)
+    }
+    return () => {
+      channel.close()
+      channelRef.current = null
+    }
+  }, [])
+
+  const switchAccount = useCallback(async (targetUserId: string): Promise<void> => {
+    const res = await fetch(`${API_BASE}/api/accounts/switch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ targetUserId }),
+    })
+    if (!res.ok) {
+      throw new Error(`Account switch failed (${res.status})`)
+    }
+    const { activeUserId } = (await res.json()) as { activeUserId: string }
+    flushModuleStoreCaches()
+    setSwitchedId(activeUserId)
+    channelRef.current?.postMessage({ type: "switched", activeWorkosUserId: activeUserId } satisfies SwitchedMessage)
+  }, [])
+
+  const registryId = effectiveId ?? PRE_AUTH_ID
+  const getDb = useCallback(() => resolveDb(registryId), [resolveDb, registryId])
+  const getQueryClient = useCallback(() => resolveQueryClient(registryId), [resolveQueryClient, registryId])
+  const scopedKey = useCallback((suffix: string) => `${effectiveId ?? NO_ACCOUNT_KEY}:${suffix}`, [effectiveId])
+
+  const value: AccountScopeValue = {
+    activeWorkosUserId: effectiveId,
+    getDb,
+    getQueryClient,
+    switchAccount,
+    scopedKey,
+  }
+
+  // Keyed remount boundary: changing the active account unmounts the old
+  // per-account subtree and mounts a fresh one — atomic swap of QueryClient,
+  // socket, SyncEngine, and every useState/useRef/useLiveQuery below it.
+  return (
+    <AccountScopeContext.Provider value={value}>
+      <ScopedRoot key={effectiveId ?? NO_ACCOUNT_KEY}>{children}</ScopedRoot>
+    </AccountScopeContext.Provider>
+  )
+}
+
+function ScopedRoot({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -1,7 +1,11 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react"
 import type { QueryClient } from "@tanstack/react-query"
 import { API_BASE } from "@/api/client"
-import { ThreaDatabase, setActiveDb } from "@/db"
+import { ThreaDatabase } from "@/db"
+// Imported from the module directly, not the @/db barrel: AccountScope is the
+// sole writer of the active-db pointer, so the mutator is intentionally kept
+// off the shared barrel (INV-9 — single-owner scope bridge).
+import { setActiveDb } from "@/db/database"
 import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetStreamStoreCache } from "@/stores/stream-store"
@@ -77,6 +81,22 @@ export function AccountScopeProvider({ children }: AccountScopeProviderProps) {
   // the switch, never blocked on auth re-fetch.
   const [switchedId, setSwitchedId] = useState<string | null>(null)
   const effectiveId = switchedId ?? authUserId
+
+  // Collapse the transient switch override back into the cookie identity. On
+  // logout / session-loss (`authUserId` → null, no navigation — see
+  // auth/context.tsx 401 path) this drops the scope so a parked account's
+  // db/QueryClient is never served while unauthenticated; once /api/auth/me
+  // catches up to a programmatic switch (`switchedId === authUserId`) it
+  // retires the redundant override so a later logout can't strand a stale id.
+  useEffect(() => {
+    if (authUserId === null) {
+      setSwitchedId(null)
+      return
+    }
+    if (switchedId === authUserId) {
+      setSwitchedId(null)
+    }
+  }, [authUserId, switchedId])
 
   const dbRegistry = useRef(new Map<string, ThreaDatabase>())
   const qcRegistry = useRef(new Map<string, QueryClient>())

--- a/apps/frontend/src/auth/index.ts
+++ b/apps/frontend/src/auth/index.ts
@@ -1,3 +1,4 @@
 export { AuthProvider, AuthContext } from "./context"
 export { useAuth, useUser, useRequireAuth } from "./hooks"
+export { AccountScopeProvider, useAccountScope, useAccountScopeOptional, type AccountScopeValue } from "./account-scope"
 export type { User, AuthState } from "./types"

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -1,4 +1,4 @@
-export { QueryClientProvider, getQueryClient } from "./query-client"
+export { AccountQueryClientProvider, makeQueryClient } from "./query-client"
 export {
   ServicesProvider,
   useServices,

--- a/apps/frontend/src/contexts/preferences-context.tsx
+++ b/apps/frontend/src/contexts/preferences-context.tsx
@@ -5,6 +5,7 @@ import { preferencesApi } from "@/api"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { useWorkspaceUserPreferences } from "@/stores/workspace-store"
 import { db } from "@/db"
+import { useAccountScopeOptional } from "@/auth/account-scope"
 import { applyPreferencesToDOM, getResolvedTheme } from "@/lib/apply-preferences"
 import type {
   UserPreferences,
@@ -18,8 +19,15 @@ const APPEARANCE_STORAGE_KEY = "threa-appearance"
 /**
  * Caches appearance-related preferences to localStorage for early application
  * before React mounts. See index.html inline script.
+ *
+ * Writes the account-scoped key (authoritative per account) AND the global
+ * key: the render-blocking inline script in index.html runs before any
+ * account is known, so it can only read the un-namespaced key. The global
+ * copy is therefore a one-frame pre-auth fallback (it may briefly show the
+ * prior account's theme); this provider re-applies the correct per-account
+ * appearance on mount.
  */
-function cacheAppearanceToLocalStorage(prefs: UserPreferences) {
+function cacheAppearanceToLocalStorage(prefs: UserPreferences, accountId: string | null) {
   const appearance = {
     theme: prefs.theme,
     fontSize: prefs.accessibility.fontSize,
@@ -28,7 +36,11 @@ function cacheAppearanceToLocalStorage(prefs: UserPreferences) {
     highContrast: prefs.accessibility.highContrast,
     messageDisplay: prefs.messageDisplay,
   }
-  localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(appearance))
+  const serialized = JSON.stringify(appearance)
+  localStorage.setItem(APPEARANCE_STORAGE_KEY, serialized)
+  if (accountId) {
+    localStorage.setItem(`${APPEARANCE_STORAGE_KEY}:${accountId}`, serialized)
+  }
 }
 
 interface PreferencesContextValue {
@@ -64,12 +76,14 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
     return getResolvedTheme(preferences.theme)
   }, [preferences])
 
+  const accountId = useAccountScopeOptional()?.activeWorkosUserId ?? null
+
   // Apply preferences to DOM and cache for early application on next load
   useEffect(() => {
     if (!preferences) return
     applyPreferencesToDOM(preferences)
-    cacheAppearanceToLocalStorage(preferences)
-  }, [preferences])
+    cacheAppearanceToLocalStorage(preferences, accountId)
+  }, [preferences, accountId])
 
   // Listen for system theme changes when in "system" mode
   useEffect(() => {

--- a/apps/frontend/src/contexts/query-client.tsx
+++ b/apps/frontend/src/contexts/query-client.tsx
@@ -4,8 +4,9 @@ import {
   QueryCache,
   MutationCache,
 } from "@tanstack/react-query"
-import { ReactNode, useState } from "react"
+import { ReactNode } from "react"
 import { ApiError, API_BASE } from "@/api/client"
+import { useAccountScope } from "@/auth/account-scope"
 
 const AUTH_REDIRECT_KEY = "auth_redirect_count"
 const AUTH_REDIRECT_TIMESTAMP_KEY = "auth_redirect_ts"
@@ -36,7 +37,7 @@ function handleGlobalError(error: Error) {
   }
 }
 
-function makeQueryClient() {
+export function makeQueryClient() {
   return new QueryClient({
     queryCache: new QueryCache({
       onError: handleGlobalError,
@@ -54,21 +55,17 @@ function makeQueryClient() {
   })
 }
 
-let queryClientSingleton: QueryClient | undefined = undefined
-
-export function getQueryClient() {
-  if (!queryClientSingleton) {
-    queryClientSingleton = makeQueryClient()
-  }
-  return queryClientSingleton
-}
-
-interface QueryClientProviderProps {
+interface AccountQueryClientProviderProps {
   children: ReactNode
 }
 
-export function QueryClientProvider({ children }: QueryClientProviderProps) {
-  const [queryClient] = useState(getQueryClient)
-
-  return <TanStackQueryClientProvider client={queryClient}>{children}</TanStackQueryClientProvider>
+// Mounts the *active account's* QueryClient. Rendered inside AccountScope's
+// keyed remount boundary, so an account switch tears this down and remounts
+// it bound to the new account's client — caches never share an instance
+// across accounts. The 401 redirect + its sessionStorage loop-guard in
+// handleGlobalError stay global and correct: only one account's client is
+// ever mounted at a time.
+export function AccountQueryClientProvider({ children }: AccountQueryClientProviderProps) {
+  const { getQueryClient } = useAccountScope()
+  return <TanStackQueryClientProvider client={getQueryClient()}>{children}</TanStackQueryClientProvider>
 }

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useAccountScopeOptional } from "@/auth/account-scope"
 
 /**
  * Sidebar states:
@@ -166,9 +167,9 @@ function readSectionStates(
   return Object.keys(next).length > 0 ? next : DEFAULT_PERSISTED_STATE.sectionStates
 }
 
-function getStoredState(): SidebarPersistedState {
+function getStoredState(key: string): SidebarPersistedState {
   try {
-    const stored = localStorage.getItem(SIDEBAR_STATE_KEY)
+    const stored = localStorage.getItem(key)
     if (stored) {
       const parsed = JSON.parse(stored) as Partial<SidebarPersistedState> & LegacyPersistedShape
       return {
@@ -187,17 +188,25 @@ function getStoredState(): SidebarPersistedState {
   return DEFAULT_PERSISTED_STATE
 }
 
-function storeState(state: SidebarPersistedState): void {
+function storeState(key: string, state: SidebarPersistedState): void {
   try {
-    localStorage.setItem(SIDEBAR_STATE_KEY, JSON.stringify(state))
+    localStorage.setItem(key, JSON.stringify(state))
   } catch {
     // localStorage not available
   }
 }
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
+  // Account-scoped storage key so each logged-in account keeps its own sidebar
+  // layout. Falls back to the un-namespaced key pre-auth and in isolated unit
+  // tests (no AccountScopeProvider), preserving prior behavior there.
+  const accountScope = useAccountScopeOptional()
+  const storageKey = accountScope?.activeWorkosUserId
+    ? `${SIDEBAR_STATE_KEY}:${accountScope.activeWorkosUserId}`
+    : SIDEBAR_STATE_KEY
+
   // Load persisted state on mount
-  const [persistedState, setPersistedState] = useState<SidebarPersistedState>(getStoredState)
+  const [persistedState, setPersistedState] = useState<SidebarPersistedState>(() => getStoredState(storageKey))
 
   // Runtime state (preview is transient, not persisted)
   const isMobile = useIsMobile()
@@ -215,13 +224,16 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   const menuOpenCountRef = useRef(0)
 
   // Persist state changes
-  const updatePersistedState = useCallback((updates: Partial<SidebarPersistedState>) => {
-    setPersistedState((current) => {
-      const next = { ...current, ...updates }
-      storeState(next)
-      return next
-    })
-  }, [])
+  const updatePersistedState = useCallback(
+    (updates: Partial<SidebarPersistedState>) => {
+      setPersistedState((current) => {
+        const next = { ...current, ...updates }
+        storeState(storageKey, next)
+        return next
+      })
+    },
+    [storageKey]
+  )
 
   // Auto-collapse when transitioning to mobile
   useEffect(() => {
@@ -388,32 +400,38 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     [persistedState.sectionStates]
   )
 
-  const toggleSectionState = useCallback((section: string, defaultState: CollapseState = "open") => {
-    setPersistedState((current) => {
-      const fromState = current.sectionStates[section] ?? defaultState
-      const next = {
-        ...current,
-        sectionStates: {
-          ...current.sectionStates,
-          [section]: fromState === "open" ? "collapsed" : "open",
-        } satisfies Record<string, CollapseState>,
-      }
-      storeState(next)
-      return next
-    })
-  }, [])
+  const toggleSectionState = useCallback(
+    (section: string, defaultState: CollapseState = "open") => {
+      setPersistedState((current) => {
+        const fromState = current.sectionStates[section] ?? defaultState
+        const next = {
+          ...current,
+          sectionStates: {
+            ...current.sectionStates,
+            [section]: fromState === "open" ? "collapsed" : "open",
+          } satisfies Record<string, CollapseState>,
+        }
+        storeState(storageKey, next)
+        return next
+      })
+    },
+    [storageKey]
+  )
 
-  const setSectionState = useCallback((section: string, state: CollapseState) => {
-    setPersistedState((current) => {
-      if (current.sectionStates[section] === state) return current
-      const next = {
-        ...current,
-        sectionStates: { ...current.sectionStates, [section]: state },
-      }
-      storeState(next)
-      return next
-    })
-  }, [])
+  const setSectionState = useCallback(
+    (section: string, state: CollapseState) => {
+      setPersistedState((current) => {
+        if (current.sectionStates[section] === state) return current
+        const next = {
+          ...current,
+          sectionStates: { ...current.sectionStates, [section]: state },
+        }
+        storeState(storageKey, next)
+        return next
+      })
+    },
+    [storageKey]
+  )
 
   // Urgency block registration for position-matched strip with fade transitions
   const setUrgencyBlock = useCallback((streamId: string, block: Omit<UrgencyBlock, "opacity"> | null) => {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -468,7 +468,7 @@ export interface CachedWorkspaceMetadata {
 }
 
 // Database class with typed tables
-class ThreaDatabase extends Dexie {
+export class ThreaDatabase extends Dexie {
   workspaces!: EntityTable<CachedWorkspace, "id">
   workspaceUsers!: EntityTable<CachedWorkspaceUser, "id">
   streams!: EntityTable<CachedStream, "id">
@@ -491,8 +491,8 @@ class ThreaDatabase extends Dexie {
   savedMessages!: EntityTable<CachedSavedMessage, "id">
   scheduledMessages!: EntityTable<CachedScheduledMessage, "id">
 
-  constructor() {
-    super("threa")
+  constructor(name: string) {
+    super(name)
 
     this.version(1).stores({
       workspaces: "id, slug, _cachedAt",
@@ -747,8 +747,37 @@ class ThreaDatabase extends Dexie {
   }
 }
 
-// Single database instance
-export const db = new ThreaDatabase()
+// The active account's database. AccountScope owns this pointer and is its
+// only writer (see auth/account-scope.tsx). It is a deliberate, single-owner
+// scope bridge — NOT hidden mutable state (INV-9): every `import { db }`
+// consumer reads through the proxy below, so swapping the active account is a
+// single synchronous pointer move done before the keyed subtree mounts,
+// avoiding a ~30-file importer rewrite. Defaults to the "threa" handle so the
+// pre-React collapse-cache hydration in main.tsx (and login/loading routes,
+// which have no account yet) keep working unchanged.
+let activeDb: ThreaDatabase = new ThreaDatabase("threa")
+
+/** AccountScope-only: point the shared `db` proxy at an account's instance. */
+export function setActiveDb(instance: ThreaDatabase): void {
+  activeDb = instance
+}
+
+// Shared handle every feature imports as `import { db } from "@/db"`. Every
+// access resolves against the *current* active instance, so an account switch
+// (a `setActiveDb` call + keyed remount) atomically redirects all reads/writes
+// with zero churn in consumer modules.
+export const db: ThreaDatabase = new Proxy(Object.create(null) as ThreaDatabase, {
+  get(_t, prop) {
+    const value = Reflect.get(activeDb, prop, activeDb)
+    return typeof value === "function" ? value.bind(activeDb) : value
+  },
+  set(_t, prop, value) {
+    return Reflect.set(activeDb, prop, value, activeDb)
+  },
+  has(_t, prop) {
+    return Reflect.has(activeDb, prop)
+  },
+})
 
 // Helper to clear all cached data (useful for logout)
 export async function clearAllCachedData(): Promise<void> {

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -1,4 +1,4 @@
-export { db, ThreaDatabase, setActiveDb, clearAllCachedData, clearPendingMessages, sequenceToNum } from "./database"
+export { db, ThreaDatabase, clearAllCachedData, clearPendingMessages, sequenceToNum } from "./database"
 export type {
   CachedWorkspace,
   CachedWorkspaceUser,

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -1,4 +1,4 @@
-export { db, clearAllCachedData, clearPendingMessages, sequenceToNum } from "./database"
+export { db, ThreaDatabase, setActiveDb, clearAllCachedData, clearPendingMessages, sequenceToNum } from "./database"
 export type {
   CachedWorkspace,
   CachedWorkspaceUser,

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { DEVICE_KEY_LENGTH } from "@threa/types"
 import { ApiError, api } from "@/api/client"
+import { useAccountScopeOptional } from "@/auth/account-scope"
 
 type PushPermission = NotificationPermission | "unsupported"
 
@@ -103,8 +104,11 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   return outputArray
 }
 
-function pushOptOutKey(workspaceId: string): string {
-  return `threa:push-opted-out:${workspaceId}`
+// Account-scoped so a parked account's opt-out never suppresses push for the
+// active one. `accountId` is null pre-auth and in isolated unit tests (no
+// AccountScopeProvider), keeping the prior un-namespaced key there.
+function pushOptOutKey(workspaceId: string, accountId: string | null): string {
+  return accountId ? `threa:push-opted-out:${accountId}:${workspaceId}` : `threa:push-opted-out:${workspaceId}`
 }
 
 type SubscribeOutcome = { kind: "subscribed" } | { kind: "disabled-on-server" }
@@ -196,9 +200,10 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     if (typeof window === "undefined" || !("Notification" in window)) return "unsupported"
     return Notification.permission
   })
+  const accountId = useAccountScopeOptional()?.activeWorkosUserId ?? null
   const [isSubscribed, setIsSubscribed] = useState(false)
   const [optedOut, setOptedOut] = useState(() =>
-    workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId)) === "1" : false
+    workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId, accountId)) === "1" : false
   )
   const [pushDisabledOnServer, setPushDisabledOnServer] = useState(false)
   const [status, setStatus] = useState<SubscriptionStatus>("idle")
@@ -211,10 +216,10 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   const subscribeGenRef = useRef(0)
   const currentAbortRef = useRef<AbortController | null>(null)
 
-  // Re-sync opt-out state when workspaceId changes (initializer only runs on mount)
+  // Re-sync opt-out state when workspaceId/account changes (initializer only runs on mount)
   useEffect(() => {
-    setOptedOut(workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId)) === "1" : false)
-  }, [workspaceId])
+    setOptedOut(workspaceId ? localStorage.getItem(pushOptOutKey(workspaceId, accountId)) === "1" : false)
+  }, [workspaceId, accountId])
 
   // Cancel any in-flight subscribe on unmount
   useEffect(() => () => currentAbortRef.current?.abort(), [])
@@ -335,7 +340,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
 
       // Persist opt-out so auto-subscribe doesn't re-register on next mount
       setOptedOut(true)
-      localStorage.setItem(pushOptOutKey(workspaceId), "1")
+      localStorage.setItem(pushOptOutKey(workspaceId, accountId), "1")
     } catch (err) {
       // Failure surfaces only to the console — the "subscribed" UI doesn't
       // render the error field, so setting it would just leak stale state
@@ -343,7 +348,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       // toast (sonner is already wired in).
       console.error("[Push] Failed to unsubscribe:", err)
     }
-  }, [workspaceId])
+  }, [workspaceId, accountId])
 
   // Request permission and subscribe
   const requestPermission = useCallback(async () => {
@@ -356,7 +361,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       // Clear opt-out — user is explicitly re-enabling
       if (workspaceId) {
         setOptedOut(false)
-        localStorage.removeItem(pushOptOutKey(workspaceId))
+        localStorage.removeItem(pushOptOutKey(workspaceId, accountId))
       }
 
       const result = await Notification.requestPermission()
@@ -370,7 +375,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       setError(toSubscriptionError(err))
       setStatus("error")
     }
-  }, [subscribe, workspaceId])
+  }, [subscribe, workspaceId, accountId])
 
   // Manually retry the subscription flow after a failure. Clears the cached VAPID
   // config so a server config change (e.g. push enabled after env vars added) is

--- a/apps/frontend/src/stores/share-handoff-store.ts
+++ b/apps/frontend/src/stores/share-handoff-store.ts
@@ -88,8 +88,17 @@ export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | n
   return entry.attrs
 }
 
-/** Clears every queued handoff. Test helper; not used in production code. */
-export function __resetShareHandoffStoreForTesting(): void {
+/**
+ * Clears every queued handoff and subscriber. The cache is module-level so it
+ * survives an account-switch React remount; AccountScope calls this on switch
+ * so a share queued under one account never surfaces in another.
+ */
+export function resetShareHandoffStoreCache(): void {
   cache.clear()
   listeners.clear()
+}
+
+/** Clears every queued handoff. Test helper. */
+export function __resetShareHandoffStoreForTesting(): void {
+  resetShareHandoffStoreCache()
 }

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -10,6 +10,55 @@ beforeEach(() => {
   __resetCollapseCacheForTests()
 })
 
+// In-memory BroadcastChannel (jsdom lacks it). Cross-instance delivery within
+// the process lets the AccountScope cross-tab switch test exercise two
+// provider trees over one channel. Messages dispatch async (microtask) to
+// match the real API's "not delivered to the sender, delivered to others".
+if (typeof globalThis.BroadcastChannel === "undefined") {
+  const registry = new Map<string, Set<TestBroadcastChannel>>()
+
+  class TestBroadcastChannel {
+    readonly name: string
+    onmessage: ((ev: MessageEvent) => void) | null = null
+    private closed = false
+
+    constructor(name: string) {
+      this.name = name
+      let peers = registry.get(name)
+      if (!peers) {
+        peers = new Set()
+        registry.set(name, peers)
+      }
+      peers.add(this)
+    }
+
+    postMessage(data: unknown): void {
+      if (this.closed) return
+      const peers = registry.get(this.name)
+      if (!peers) return
+      for (const peer of peers) {
+        if (peer === this || peer.closed) continue
+        queueMicrotask(() => {
+          if (!peer.closed) peer.onmessage?.({ data } as MessageEvent)
+        })
+      }
+    }
+
+    close(): void {
+      this.closed = true
+      registry.get(this.name)?.delete(this)
+    }
+
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    dispatchEvent(): boolean {
+      return false
+    }
+  }
+
+  globalThis.BroadcastChannel = TestBroadcastChannel as unknown as typeof BroadcastChannel
+}
+
 // Mock scrollIntoView (not available in jsdom)
 Element.prototype.scrollIntoView = () => {}
 


### PR DESCRIPTION
## Summary

Fourth slice of the multi-account login split (builds on PR-1 #537 and PR-3 #538, both merged). Gives the frontend a reactive, fully account-isolated **AccountScope** so the active account can switch **in place with no page reload** and **zero cross-account data bleed** at the IndexedDB, TanStack-Query, and module-store-cache layers — including across browser tabs. No switcher UI (that is PR-5); this slice is infra only, proven by a headline isolation test.

Strategy is **scope-proxy + keyed remount** (deliberately *not* the 30-file importer rewrite) to keep blast radius minimal and avoid conflicts with the in-flight offline-first PR.

- **`db`**: `ThreaDatabase` now takes a `name`; the exported `db` is a single-owner scope-bound `Proxy` over the active account's instance (default `"threa"` handle pre-auth). The ~30 `import { db } from "@/db"` consumers are untouched — an account switch is one synchronous pointer move (`setActiveDb`) done before the keyed subtree mounts. INV-9 rationale documented inline (deliberate single-owner scope bridge, not hidden state).
- **`auth/account-scope`** (new): context + provider with per-account `dbRegistry`/`qcRegistry` (`useRef` Maps, not module singletons), render-time proxy retargeting, a keyed `<ScopedRoot>` remount boundary (atomic swap of db/QueryClient/socket/SyncEngine/all hooks), `switchAccount` (PR-3 `POST /api/accounts/switch`), and a cross-tab `threa-auth` `BroadcastChannel` receiver that cancels the now-stale client and flushes module store caches before flipping.
- **`query-client`**: dropped the module singleton; `AccountQueryClientProvider` mounts the active account's client inside the keyed boundary. The 401 redirect + its loop-guard stay global (only one account's client is ever mounted at a time).
- **localStorage re-keying**: sidebar state, push opt-out, and appearance are namespaced by WorkOS user id, with the un-namespaced key retained as a pre-auth / isolated-test fallback (appearance also keeps the global key as a one-frame fallback for the render-blocking `index.html` script).
- **Stores**: `share-handoff-store` gains `resetShareHandoffStoreCache()` (the existing workspace/stream/draft resets are reused) so module-level caches that survive a remount are flushed on switch.
- **Tests**: in-memory `BroadcastChannel` shim in `test/setup.ts` (jsdom lacks it); headline test mounts the real `AuthProvider + AccountScopeProvider` and asserts zero cross-account reads across all three layers **and** no reload (`window.location.reload`/`href` never touched), plus a cross-tab flip asserting the stale client was cancelled.

Socket reconnect + re-bootstrap (INV-53) is satisfied **structurally** by the keyed remount — no socket-layer churn. The `__eagerAuthPromise` block, `auth/context.tsx` auth fetch, `main.tsx`, and `collapse-cache.ts` are deliberately untouched (sibling offline-first PR safety); AccountScope derives the active id from `useAuth().user?.id`.

### Router seam for PR-4b (no behavior change here)

PR-4a does not implement cross-account deep-link resolution, but does not preclude it: `switchAccount` is exposed for a future router guard, and the `workspace-layout.tsx` 403/404 bounce is left unchanged and documented as the PR-4b extension point. The cross-account entry resolver (control-plane `GET /api/accounts/resolve` + router guard, reused by PR-5/PR-6) is split into a follow-up slice **PR-4b** (see the plan doc).

## Test plan

- [x] `bun run --cwd apps/frontend test` — full suite green (1627 passing), incl. the new headline isolation + cross-tab tests and the updated `db/database.test.ts`
- [x] `bun run --cwd apps/frontend typecheck` — clean (`ThreaDatabase` name param + provider tree type-clean)
- [x] Pre-commit hooks (prettier + full monorepo lint/typecheck/api-docs) green
- [ ] Reviewer: confirm the scope-proxy single-owner trade-off (vs. 30-file importer rewrite) is acceptable for this slice
- [ ] Reviewer: confirm the PR-4b split (cross-account entry resolver as a separate slice) is the right boundary

https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->