### PR TITLE
Offline-first boot: indexed cached-timeline read (no cold-open tiering)

### DIFF
--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -40,17 +40,21 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
   // (defensive — the current placeholder scheme uses `Date.now()` so they
   // sort to the very top and are already in-window). Re-sort the full list
   // so order is determined solely by `_sequenceNum`, not insertion path.
+  //
+  // Drive this off the `_status` index (Dexie only indexes rows where the
+  // value is present, so pending/failed is the entire keyspace here — a
+  // handful of unsent rows app-wide), then narrow to this stream in JS.
+  // The obvious `.where("streamId").equals(streamId).filter(...)` instead
+  // materialises and walks the stream's *entire* cached history on every
+  // call; `useLiveQuery` re-runs this on every write to `db.events`, so on
+  // a long chat that O(history) scan — paid repeatedly during the
+  // bootstrap/sync write burst when a chat opens — is what stalls the
+  // cached-events read past the skeleton delay.
   const loadedIds = new Set(reversed.map((e) => e.id))
-  const unsent = await db.events
-    .where("streamId")
-    .equals(streamId)
-    .filter(
-      (e) =>
-        (e._status === "pending" || e._status === "failed") &&
-        !loadedIds.has(e.id) &&
-        (fromSequenceNum == null || e._sequenceNum >= fromSequenceNum)
-    )
-    .toArray()
+  const unsent = (await db.events.where("_status").anyOf(["pending", "failed"]).toArray()).filter(
+    (e) =>
+      e.streamId === streamId && !loadedIds.has(e.id) && (fromSequenceNum == null || e._sequenceNum >= fromSequenceNum)
+  )
 
   const merged = unsent.length > 0 ? [...reversed, ...unsent] : reversed
   merged.sort((a, b) => a._sequenceNum - b._sequenceNum)


### PR DESCRIPTION
## Summary

Follow-up to #539 (offline-first boot S1–S5, squash-merged to `main`). The S1–S5 gates land you on the cached chat instantly, but the timeline's *own* IndexedDB read still wasn't near-instant on a long chat, so a cold app open into a long, fully-cached chat showed a tiered `blank → skeleton → blank → populated` flicker instead of just rendering the cached messages.

**Root cause:** `loadStreamEvents` merged optimistic (pending/failed) rows via `db.events.where("streamId").equals(streamId).filter(...)`, which materialises and walks the stream's *entire* cached history in JS. `useStreamEvents` wraps this in `useLiveQuery`, which re-runs the whole read on **every** write to `db.events`. A cold open fires a write burst into `db.events` (workspace bootstrap, stream bootstrap `applyStreamBootstrap` bulk-write, socket catch-up), so on a long chat the O(history) JS scan is recomputed repeatedly under write-lock contention — blowing past `IDB_SKELETON_DELAY_MS` and producing the tiering.

**Fix:** source the optimistic rows from the existing `_status` index (Dexie only indexes rows where the value is present, so pending/failed is the entire keyspace — a handful of unsent rows app-wide) and narrow to the stream in JS. Identical result set and ordering (final `merged.sort()` is the sole order authority); per-call cost is now O(unsent) instead of O(stream history), and each `useLiveQuery` re-run during the open burst is cheap.

Single-file change: `apps/frontend/src/stores/stream-store.ts` (14 insertions, 10 deletions).

## Correctness

- `_status` is a live single-column index in the Dexie schema (events store, v20; later versions don't redefine `events`, so it persists — verified against current `main` after #540).
- `.anyOf(["pending","failed"])` reproduces exactly the set the old `e._status === "pending" || e._status === "failed"` predicate matched; `streamId`, `loadedIds` dedupe, and the `fromSequenceNum` floor predicate are unchanged.
- Behaviour-preserving: all locked `stores/stream-store.test.ts` cases (out-of-window low pending, floor exclusion below `fromSequenceNum`, optimistic→real swap ordering) still pass.

## Test plan

- [x] `cd apps/frontend && bun run typecheck` — clean (on rebased base, post-#540)
- [x] `bun run test -- src/stores/stream-store.test.ts src/hooks/use-events.test.ts` — 29 passed, 0 failing
- [x] Full frontend suite previously green (1649 passed) on this change
- [ ] Manual (Chrome DevTools → Slow 3G): after one good-network load, a throttled **cold app open** into a long cached chat renders the cached timeline within ~1 frame with no `blank → skeleton → blank` tiering (only the ≤1-frame stamp-guard blank on first IDB resolve, which is expected/acceptable)

https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D)_