### PR TITLE
fix(timeline): drop defaultItemHeight so code blocks mount at real size

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1521,7 +1521,11 @@ function VirtuosoMessageList({
       firstItemIndex={firstItemIndex}
       initialTopMostItemIndex={initialTopMostItemIndex}
       data={visibleItems}
-      defaultItemHeight={120}
+      // Intentionally no defaultItemHeight: it makes Virtuoso skip the probe
+      // measure and reveal the list using the estimate, so a tall code block
+      // measured one frame after reveal triggers a "size increased" re-scroll
+      // (the down-then-back jump). Without it, the window is measured while
+      // hidden and reveal waits until scroll-to-LAST settles on real sizes.
       skipAnimationFrameInResizeObserver
       itemContent={itemContent}
       computeItemKey={computeItemKey}


### PR DESCRIPTION
## Problem

Loading a stream that contains an open (non-collapsed) code block renders
nearly instantly (thanks to the offline-first cache fix), then **jumps down
for one frame and snaps back** to the correct position. The timeline must
only move when the user expects it to (a received message at the bottom, a
user-initiated toggle, a lazy-loaded link preview on a visible message) —
never as an uninvited reveal-time correction.

## Root cause

`<Virtuoso>` in `stream-content.tsx` was passed `defaultItemHeight={120}`.
Tracing the patched `react-virtuoso@4.18.5` engine
(`node_modules/.../react-virtuoso/dist/index.mjs`), that single prop changes
two reveal-critical code paths:

1. **Size system (`Lt`) seeds the size tree with the estimate.** When
   `defaultItemSize !== undefined && isEmpty(sizeTree)`, Virtuoso pushes a
   synthetic `{ startIndex: 0, endIndex: 0, size: 120 }` range. The list
   then renders the *full* window using the 120px estimate instead of the
   "render one probe item, measure it, expand the window from real sizes"
   path it uses when no estimate exists.

2. **Initial-location reveal gate (`me`) opens early.** The reveal
   predicate `m && (!isEmpty(sizeTree) || defaultItemSizeIsSet) && !x && !w`
   is satisfied at didMount via the `defaultItemSizeIsSet` branch — the
   list is revealed against the *estimate*, before real heights are known.

A non-collapsed code block is much taller than 120px. It is measured one
frame after the (early, estimate-based) reveal, the size delta propagates
through the deviation/`followOutput` system (`Uo`), and the
`"SIZE_INCREASED"` branch issues a corrective scroll-to-bottom — the
visible down-then-back jump.

## Solution

Remove `defaultItemHeight={120}`. With no estimate:

- `Lt` leaves the size tree empty, so listState renders a single probe
  item, measures it, then expands the window using **measured** sizes via
  the existing measurement-driven `scrollToIndex(LAST)` retry loop (`fe`,
  stable-until-150ms via `Go(150)`).
- The `me` reveal gate stays closed until the size tree is non-empty *and*
  the scroll-to-LAST has settled on real sizes, so the list is revealed
  already at the correct offset. The window is measured while hidden
  (`visibility:hidden` in `Cn` until `initialItemFinalLocationReached`),
  so the user never sees the pre-measurement layout.

This makes messages mount at their real size in the first place rather than
being revealed at an estimate and corrected afterward.

### Key design decisions

**1. Remove the estimate instead of tuning it.** A "better default"
(e.g. 200px, or a content-derived guess) cannot be correct for every item
— any block whose real height differs from the estimate reproduces the
same reveal-time snap. The only robust fix is to not reveal against an
estimate at all. Removing the prop is what restores the
measure-while-hidden → reveal-when-stable path.

**2. Patch left untouched.** `patches/react-virtuoso@4.18.5.patch`
(synchronous `marginTop` deviation for prepend smoothness) operates on a
different axis (prepend/older-message loading) and is complementary; it is
not involved in the first-paint reveal and was deliberately not modified.

**3. Residual risks are a separate axis and already mitigated.** An async
resize of a *visible* item more than 150ms after reveal (shiki highlight
swap, image, link preview) can still shift layout — but that is expected
movement, and the shiki cold path already renders a height-identical
invisible `<pre>` placeholder (same padding/font/line-height/line-count),
so the highlight swap is height-neutral. The synchronous localStorage
collapse cache (`collapse-cache.ts`) keeps collapsed/expanded state correct
on the very first paint. No change needed here.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Remove `defaultItemHeight={120}` from `<Virtuoso>`; add a comment explaining why the prop must stay absent |

## Test plan

- [x] `bunx tsc --noEmit` in `apps/frontend` — clean
- [x] `bunx vitest run src/hooks/use-virtuoso-scroll.test.tsx src/components/timeline/` — 21 files, 204 tests pass
- [ ] Manual: load a stream with a tall non-collapsed code block; confirm no down-then-back jump on first paint
- [ ] Manual: scroll up to load older messages; confirm prepend is still smooth (patch path unaffected)
- [ ] Manual: receive a message while at the bottom; confirm it still sticks to bottom
- [ ] Manual: toggle a code block collapse; confirm only that interaction moves content

> Note: the change could not be visually verified in the remote execution
> environment (no DB / real stream data); the manual steps above are for
> the reviewer.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZPPrSVSmX23RH3aZoGi56)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->