### PR TITLE
fix(frontend): make the "new version" toast reload onto the new build in one click

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -36,12 +36,6 @@ async function triggerSwUpdate(): Promise<void> {
  * reload, and time-bounded.
  */
 async function reloadForUpdate(): Promise<void> {
-  const registration = await navigator.serviceWorker?.getRegistration()
-  if (!registration) {
-    window.location.reload()
-    return
-  }
-
   let reloaded = false
   const reloadOnce = (): void => {
     if (reloaded) return
@@ -49,33 +43,40 @@ async function reloadForUpdate(): Promise<void> {
     window.location.reload()
   }
 
-  // Subscribe before update() so a fast activate→claim can't fire the event
-  // before we are listening.
-  navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
-
+  // Any unexpected failure must still reload — this is the user's escape hatch
+  // onto the new build, so it can never silently do nothing.
   try {
+    const registration = await navigator.serviceWorker?.getRegistration()
+    if (!registration) {
+      reloadOnce()
+      return
+    }
+
+    // Subscribe before update() so a fast activate→claim can't fire the event
+    // before we are listening.
+    navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
+
     await registration.update()
+
+    const pending = registration.installing ?? registration.waiting
+    if (!pending) {
+      // The new SW already installed and took control in the background — a
+      // plain reload now serves its precached shell.
+      reloadOnce()
+      return
+    }
+
+    // Backstop for controllerchange in case it does not fire for this client:
+    // reload as soon as the new SW reaches `activated`.
+    pending.addEventListener("statechange", () => {
+      if (pending.state === "activated") reloadOnce()
+    })
+
+    // Last resort so a stuck install can't strand the toast indefinitely.
+    setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
   } catch {
     reloadOnce()
-    return
   }
-
-  const pending = registration.installing ?? registration.waiting
-  if (!pending) {
-    // The new SW already installed and took control in the background — a
-    // plain reload now serves its precached shell.
-    reloadOnce()
-    return
-  }
-
-  // Backstop for controllerchange in case it does not fire for this client:
-  // reload as soon as the new SW reaches `activated`.
-  pending.addEventListener("statechange", () => {
-    if (pending.state === "activated") reloadOnce()
-  })
-
-  // Last resort so a stuck install can't strand the toast indefinitely.
-  setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
 }
 
 export function useAppUpdate(): void {

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -7,6 +7,9 @@ const POLL_INTERVAL = 300_000 // 5 minutes
 const TOAST_ID = "app-update"
 const IS_DEV = import.meta.env.DEV
 
+/** Cap how long the Reload action waits for the new SW before reloading anyway. */
+const UPDATE_RELOAD_FALLBACK_MS = 10_000
+
 /**
  * Tell the browser to check for a new service worker. The SW's install handler
  * calls skipWaiting() unconditionally, so it activates immediately — no need
@@ -19,14 +22,60 @@ async function triggerSwUpdate(): Promise<void> {
 }
 
 /**
- * Reload the page to pick up the new service worker's precached assets.
- * By the time this runs, triggerSwUpdate() has already activated the new SW
- * (which cleans stale caches on activate). A plain reload is enough — the new
- * SW serves fresh assets from its precache. Clearing caches here would break
- * offline refresh, so we intentionally leave them for the SW to manage.
+ * Reload onto the new build.
+ *
+ * The SW serves navigations cache-first from the build-atomic precache, so a
+ * plain reload returns whatever build the *currently controlling* SW precached.
+ * If the new SW hasn't installed and claimed this page yet, that is still the
+ * old build and the version toast just reappears — which is why an
+ * unconditional reload needed "a bunch of refreshes". So force the update now
+ * and reload exactly once when the new SW takes control: it self-activates via
+ * skipWaiting + clients.claim, firing `controllerchange`. Fall back to a plain
+ * reload when there is no registration, no pending worker (the new SW already
+ * claimed in the background), or the update stalls — never worse than a bare
+ * reload, and time-bounded.
  */
-function reloadForUpdate(): void {
-  window.location.reload()
+async function reloadForUpdate(): Promise<void> {
+  const registration = await navigator.serviceWorker?.getRegistration()
+  if (!registration) {
+    window.location.reload()
+    return
+  }
+
+  let reloaded = false
+  const reloadOnce = (): void => {
+    if (reloaded) return
+    reloaded = true
+    window.location.reload()
+  }
+
+  // Subscribe before update() so a fast activate→claim can't fire the event
+  // before we are listening.
+  navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
+
+  try {
+    await registration.update()
+  } catch {
+    reloadOnce()
+    return
+  }
+
+  const pending = registration.installing ?? registration.waiting
+  if (!pending) {
+    // The new SW already installed and took control in the background — a
+    // plain reload now serves its precached shell.
+    reloadOnce()
+    return
+  }
+
+  // Backstop for controllerchange in case it does not fire for this client:
+  // reload as soon as the new SW reaches `activated`.
+  pending.addEventListener("statechange", () => {
+    if (pending.state === "activated") reloadOnce()
+  })
+
+  // Last resort so a stuck install can't strand the toast indefinitely.
+  setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
 }
 
 export function useAppUpdate(): void {
@@ -52,7 +101,7 @@ export function useAppUpdate(): void {
           duration: Infinity,
           action: {
             label: "Reload",
-            onClick: () => reloadForUpdate(),
+            onClick: () => void reloadForUpdate(),
           },
         })
       }


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the offline-first SW change (#539): the **"A new version of Threa is available"** toast no longer cleared on the first reload — it took a bunch of refreshes.

**Root cause.** #539 switched the SW navigation handler to **cache-first** (`matchPrecache("/index.html")`). The toast's Reload action was still a bare `window.location.reload()`, and `registration.update()` only ran fire-and-forget from the 5-min poll. The toast is driven by `version.json` (SW-bypassed, `cache: "no-cache"`, always fresh), so it appears the instant a new build deploys — while the old SW is usually still controlling the page. A plain reload is then served the **old** precached shell, `__APP_VERSION__` stays old, the version still mismatches, and the toast reappears. Only once the new SW independently finished installing/activating did a reload finally land on the new build — hence "a bunch of refreshes". Pre-#539 network-first fetched fresh HTML each reload, so one reload sufficed.

**Fix** (single file, `apps/frontend/src/hooks/use-app-update.ts`): the Reload action now forces `registration.update()` and reloads **exactly once** when control flips to the new worker (`controllerchange`, with a `statechange→activated` backstop). A single guarding `try/catch` plus a `reloadOnce` guard make every path bounded and idempotent:

- no SW / no registration → plain reload
- new SW already claimed in the background → plain reload (cache-first now serves the new shell)
- `getRegistration()`/`update()` rejects or any unexpected throw → plain reload (the user's escape hatch can never silently no-op)
- stuck install → 10s last-resort reload

`sw.ts` is intentionally untouched: its unconditional `skipWaiting()` already guarantees no `waiting`-worker stall, so no `SKIP_WAITING` message protocol is needed — minimal patch. No rendering/timeline changes, so no flicker risk; on the common path (SW already warmed by the poll) it's a single snappy reload onto the new build.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` (frontend) — 1651/1651 green
- [ ] Manual: deploy build B, on a throttled network click **Reload** on the toast once → page returns on build B and the toast does not reappear. (SW update lifecycle is not unit-tested — brittle in jsdom; consistent with the offline-first plan's stated posture for the SW surface.)

https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5KwsDcRHh7tT2CZxQZ84D)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->