### PR TITLE
fix(timeline): re-arm Virtuoso reveal gate on stream navigation

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1514,6 +1514,15 @@ function VirtuosoMessageList({
 
   return (
     <Virtuoso
+      // Remount per stream. Virtuoso's hidden-until-stable reveal gate is
+      // mount-only; navigating between streams reuses this instance (only the
+      // streamId prop changes — see the empty-state comment above), so the
+      // gate never re-arms and the new stream's content paints at the wrong
+      // offset then scroll-corrects (the "loads in too low then jumps" report).
+      // A fresh mount re-runs the exact cold-boot path: mounts with an empty
+      // sizeTree (gate closed), measures the window while hidden, reveals only
+      // once scroll-to-LAST settles on real sizes.
+      key={streamId}
       ref={virtuosoRef}
       scrollerRef={handleVirtuosoScrollerRef}
       className={cn("h-full", batch?.enabled && "select-none")}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1497,10 +1497,8 @@ function VirtuosoMessageList({
 
   // Only render the empty state when we're *certain* the stream has no events.
   // Without this guard, the mid-switch gap where visibleItems is briefly [] (IDB
-  // re-subscribing after a streamId change) flashes the empty state before the
-  // real data arrives. When visibleItems is empty but !isConfirmedEmpty, we
-  // fall through and render <Virtuoso data={[]} /> — a blank scroll area that
-  // doesn't visually disrupt the transition.
+  // re-subscribing after a streamId change) would flash the empty state before
+  // the real data arrives.
   if (visibleItems.length === 0 && isConfirmedEmpty) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -1512,16 +1510,29 @@ function VirtuosoMessageList({
     )
   }
 
+  // Grace-window gap: !isLoading, !isConfirmedEmpty, but events haven't been
+  // re-subscribed from IDB yet (the "render briefly blank, no skeleton flash"
+  // path in computeTimelineLoadState). Render a blank scroll area rather than
+  // mounting <Virtuoso data={[]} />. Virtuoso's hidden-until-stable reveal gate
+  // arms only at didMount, and only when initialTopMostItemIndex is set — which
+  // it is NOT while itemCount is 0 (the scroll hook returns undefined). A
+  // Virtuoso mounted empty therefore reveals immediately, so the populate +
+  // scroll-to-LAST a frame later is visible (the "loads in too low then jumps"
+  // report). Deferring the mount until data exists makes the keyed instance
+  // mount already-populated, exactly like cold boot, so the gate arms.
+  if (visibleItems.length === 0) {
+    return <div className="h-full" aria-hidden />
+  }
+
   return (
     <Virtuoso
-      // Remount per stream. Virtuoso's hidden-until-stable reveal gate is
-      // mount-only; navigating between streams reuses this instance (only the
-      // streamId prop changes — see the empty-state comment above), so the
-      // gate never re-arms and the new stream's content paints at the wrong
-      // offset then scroll-corrects (the "loads in too low then jumps" report).
-      // A fresh mount re-runs the exact cold-boot path: mounts with an empty
-      // sizeTree (gate closed), measures the window while hidden, reveals only
-      // once scroll-to-LAST settles on real sizes.
+      // Remount per stream so the mount-only reveal gate re-arms. Navigating
+      // between streams otherwise reuses this instance (only the streamId prop
+      // changes), leaving the gate latched-open from the previous stream. A
+      // fresh mount with populated data (guaranteed by the grace-window guard
+      // above) re-runs the exact cold-boot path: didMount sees
+      // initialTopMostItemIndex=LAST so the gate arms, the window is measured
+      // while hidden, and reveal waits until scroll-to-LAST settles.
       key={streamId}
       ref={virtuosoRef}
       scrollerRef={handleVirtuosoScrollerRef}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1521,7 +1521,11 @@ function VirtuosoMessageList({
       firstItemIndex={firstItemIndex}
       initialTopMostItemIndex={initialTopMostItemIndex}
       data={visibleItems}
-      defaultItemHeight={120}
+      // Intentionally no defaultItemHeight: it makes Virtuoso skip the probe
+      // measure and reveal the list using the estimate, so a tall code block
+      // measured one frame after reveal triggers a "size increased" re-scroll
+      // (the down-then-back jump). Without it, the window is measured while
+      // hidden and reveal waits until scroll-to-LAST settles on real sizes.
       skipAnimationFrameInResizeObserver
       itemContent={itemContent}
       computeItemKey={computeItemKey}


### PR DESCRIPTION
## Problem

Follow-up to #543 (drop `defaultItemHeight` so code blocks mount at real
size). That fixed **cold boot**, but navigating to the same code-block
stream from another stream still **loads in too low then corrects** — the
same uninvited reveal-time jump, via a different entry point.

Root cause, traced through the patched `react-virtuoso@4.18.5` engine:

1. **The hidden-until-stable reveal gate is mount-only.** The `me`
   initial-location system arms the gate only at `didMount`, via
   `L(I(i, $(c), G(([m,x]) => x !== 0), Bt(!1)), l/d)` — i.e. only if
   `initialTopMostItemIndex !== 0` at the instant `didMount` fires. The
   reveal predicate is `m && (!J(p) || Ae(T)) && !x && !w` (`p` =
   sizeTree); with `defaultItemHeight` gone, `Ae(T)` is false, so reveal
   correctly waits for a measured (non-empty) sizeTree — *once the gate is
   armed*.

2. **`<StreamContent>`/`<Virtuoso>` are reused across streams.** React
   Router doesn't remount on a param change; only the `streamId` prop
   changes. So the gate stays latched-open from the previous stream and
   never re-arms — the new stream's taller content paints at the old
   offset, then `scroll-to-LAST` corrects it visibly.

3. **Even keyed, a naive remount mounts during the empty grace window.**
   `computeTimelineLoadState` deliberately reports
   `isLoading:false, isConfirmedEmpty:false` with empty events on fast
   stream switches ("render briefly blank, no skeleton flash"). The scroll
   hook returns `initialTopMostItemIndex=undefined` while `itemCount===0`,
   leaving the engine's `c` stream at its default `0` — so the gate's
   `x !== 0` arming check fails and the gate never arms. Cold boot avoids
   this only because it mounts already-populated.

## Solution

Make every stream entry reproduce the exact known-good cold-boot mount:

1. **`key={streamId}` on `<Virtuoso>`** — forces a fresh mount per stream
   so the mount-only gate re-arms.
2. **Defer that mount until data is populated** — during the empty
   grace-window gap, render a blank `h-full` scroll area instead of
   `<Virtuoso data={[]} />`. The keyed instance now only ever mounts with
   populated data, so `initialTopMostItemIndex={index:"LAST"}` is set at
   its `didMount`, the gate arms, the window is measured while hidden, and
   reveal waits until `scroll-to-LAST` settles on real sizes.

Both parts are one mechanism: enter a stream → fresh Virtuoso, mounted
populated, gated exactly like cold boot.

### Key design decisions

**1. Why not `key` alone.** Verified against the engine: a Virtuoso
mounted empty (the grace window) has `c=0` at `didMount`, so the `me`
gate's `x !== 0` arming check never fires and it reveals immediately. The
deferred mount is required, not optional.

**2. Blank `<div>` vs empty `<Virtuoso>` during the gap.** An empty
Virtuoso was already just a blank `h-full` scroll area; a blank `h-full`
div is visually identical, sub-frame, and mirrors cold boot (skeleton →
populated mount — never an empty Virtuoso that then populates visibly).
Unmounting Virtuoso during the gap is an already-supported lifecycle: the
scroll hook stores the scroller in state and re-runs its ResizeObserver
effect when Virtuoso re-mounts its scroller (explicitly designed for
"after an isLoading skeleton is replaced").

**3. Keyed by `streamId` only.** Same-stream deep-link repeat-clicks key
off `location.key`, not `streamId`, so they don't remount; cross-stream
deep-link mounts fresh with `skipInitialScroll` exactly as cold-boot
deep-link does, and the dedicated `scrollToMessage` retry loop owns final
positioning. Prepend math is unaffected — the hook resets
`firstItemIndex`/prepend-detection on `resetKey: streamId` before the
first populated render.

**4. Out of scope (unchanged, separate axis).** Async resize of a
*visible* item >150ms post-reveal (shiki swap / image / link preview) is
expected movement and already mitigated by the height-stable shiki
placeholder.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Drop `defaultItemHeight={120}`; add `key={streamId}` to `<Virtuoso>`; render a blank scroll area during the IDB grace-window gap so the keyed instance mounts already-populated and the reveal gate arms |

## Test plan

- [x] `bunx tsc --noEmit` (frontend) — clean
- [x] Monorepo lint + typecheck pre-commit hooks — clean
- [x] `bunx vitest run` — `use-virtuoso-scroll`, `use-events`, all
      `components/timeline/` — 22 files, 226 tests pass
- [ ] Manual: navigate from another stream into a stream with a tall
      non-collapsed code block — confirm it lands at the bottom with no
      down/too-low correction
- [ ] Manual: cold boot the same stream — still great (no regression)
- [ ] Manual: fast-switch between several streams — no skeleton flash, no
      empty-state flash, no jump
- [ ] Manual: deep-link (`?m=`) into a stream — still centers the target
- [ ] Manual: scroll up to load older messages — prepend still smooth
- [ ] Manual: receive a message while at bottom — still sticks to bottom

> Note: could not be visually verified in the remote execution
> environment (no DB / real stream data); the manual steps are for the
> reviewer.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZPPrSVSmX23RH3aZoGi56)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->