### PR TITLE
PR-5: account switcher UX — switch / add / remove signed-in accounts

### DIFF
--- a/.claude/plans/glowing-discovering-locket.md
+++ b/.claude/plans/glowing-discovering-locket.md
@@ -202,7 +202,7 @@ this slice). Match the PR-3 / PR-4b sections' terseness.
 | `apps/frontend/src/pages/workspace-layout.tsx` | mount `<AccountSwitcherDialog />` after `:385` |
 | `apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx` | **NEW** — render real component, states + actions |
 | `apps/frontend/src/auth/context.test.tsx` | extend — `intent=add` URL + `accountError` toast/strip |
-| `apps/control-plane/src/features/accounts/*.test.ts` | add a `remove("stale:alt_<slot>")` case if not already covered |
+| `apps/control-plane/tests/e2e/accounts.test.ts` | add/verify a `remove("stale:alt_<slot>")` case |
 | `docs/plans/multi-account-login-split.md` | append PR-5 section |
 
 **Reuse (no reimplementation):** PR-4a `useAccountScope().switchAccount` +

--- a/.claude/plans/glowing-discovering-locket.md
+++ b/.claude/plans/glowing-discovering-locket.md
@@ -1,297 +1,288 @@
-# PR-4b — Cross-account entry resolver (backend primitive + frontend bare-link guard)
+# PR-5 — Account Switcher UX (sidebar entry → dialog: switch / add / remove)
 
 ## Context
 
-Fifth implementation slice of the multi-account login split
-(`docs/plans/multi-account-login-split.md`). Prior slices are **merged to
-`origin/main`** (HEAD `6782e487`): PR-1 (#537 cookie/auth primitives), PR-3
-(#538 `/api/accounts` contract + OAuth `intent=add`), and **PR-4a (#540
-AccountScope foundation — account-scoped data layer + in-place
-`switchAccount` + keyed remount, no UI)**. Offline-first boot (#539) is also
-merged and underneath PR-4a.
+Sixth implementation slice of the multi-account login split
+(`docs/plans/multi-account-login-split.md`). Merged to `origin/main`
+(HEAD `765d6fb1`): PR-1 (#537 cookie/auth primitives), PR-3 (#538
+`/api/accounts` contract + OAuth `intent=add`), PR-4a (#540 AccountScope —
+account-scoped data layer + in-place `switchAccount` + keyed remount),
+**PR-4b (#542 cross-account entry resolver)**, offline-first (#539).
 
-**Problem PR-4b solves:** opening an entry point that belongs to a *parked*
-(non-active) account dead-ends — the active account's workspace bootstrap
-returns `403/404` and `workspace-layout.tsx` bounces to `/workspaces` even
-though this browser is signed into an account that owns it. PR-4b adds the
-**resolve→flip→route primitive** so the right account can be flipped in
-place (PR-4a `switchAccount`, keyed remount, no reload), preserving the
-original deep link.
+**The gap PR-5 closes:** every backend primitive for multi-account is
+shipped and tested, but there is **no UI**. `GET /api/accounts` (list),
+`POST /api/accounts/switch`, `POST /api/accounts/remove`, and the OAuth
+`GET /api/auth/login?intent=add` flow (parks the active account, returns
+`?accountError=MAX_ACCOUNTS_REACHED` at the cap) all work — verified:
+`grep` finds **zero** frontend consumers of `accountError`, `intent=add`,
+`accountsApi.list`, or `accountsApi.remove`. A user signed into two
+accounts on this browser cannot see, switch between, add, or remove them.
 
-**Two distinct entry points (the key correctness distinction):**
+PR-5 adds the **only user-facing surface**: a sidebar-footer menu entry
+that opens an account-switcher dialog listing every signed-in account
+(active / parked / stale) with switch, add-account, and remove actions.
+No new backend code — PR-5 is a pure frontend consumer of contracts that
+already exist on `origin/main`.
 
-1. **Member-scoped entry (notification — PR-6 reuses this).** A notification
-   is tied to an Activity already scoped to a *specific recipient member*,
-   so its payload carries that member's `workosUserId`. The resolver MUST
-   flip to **exactly that account** and **never substitute** a different
-   signed-in account that merely also has read access (e.g. signed into
-   both A and B, B also in the workspace, mention is A's — must land as A,
-   not B). If that exact account is not signed into this browser → 404 →
-   caller does a full login as that user (no silent substitution).
-2. **Bare workspace deep-link (PR-4b's only frontend trigger).** A shared
-   `/w/:workspaceId` link with *no* member context. Membership is the only
-   available selector and it can be ambiguous, so per product decision:
-   resolve **only if exactly one** signed-in account is a member; **0 or
-   2+ → 404** (caller keeps today's bounce; PR-5's switcher disambiguates
-   the multi-member case). Never guess an arbitrary account.
+**Two correctness anchors carried from prior slices:**
 
-So PR-4b's backend owns **one endpoint with two forms** — an exact-identity
-form (the PR-6 primitive, fully built+tested now though PR-4b has no
-notification UI) and a unique-membership form (consumed by PR-4b's frontend
-guard). PR-6 becomes a trivial caller of the identity form.
+1. **Switch is no-reload.** PR-4a's `useAccountScope().switchAccount(id)`
+   already does the full flow (POST `/switch` → flush module caches →
+   `setSwitchedId` → keyed remount → BroadcastChannel). PR-5 must call
+   *that*, never re-implement the fetch and never `window.location`.
+2. **`MAX_ACCOUNTS` (4) is load-bearing.** The cookie-size compile-time
+   guard (`packages/backend-common/src/cookies.ts:53-79`) has zero
+   headroom — bumping to 5 trips it. PR-5 keeps 4 and reads the cap from
+   the `list` response (`maxAccounts`), never hardcodes it (INV-33).
 
-**Correction to the PR-4a follow-up sketch (verified against
-`origin/main`):** the sketch said the resolver "checks membership via the
-`/internal/workspaces/:id/members/:uid` path." That internal route is for
-the **regional backend → control plane** self-heal direction
-(`apps/control-plane/src/routes.ts:190`, `internalAuth`). The resolve
-endpoint itself lives **in the control plane**, the source of truth for
-`workspace_memberships` (`ControlPlaneWorkspaceService.isMember`,
-`apps/control-plane/src/features/workspaces/service.ts:69-71` →
-`WorkspaceRegistryRepository.isMember`). PR-4b calls `isMember`
-**in-process** — no internal HTTP hop, same data. Strictly better than the
-sketch; the only material deviation.
+## Step 0 — branch reset (mandatory first; non-destructive here)
+
+PR-4b was squash-merged. The local branch's `acc8087e`, `ae9caf72`,
+`6782e487` are the **pre-squash** PR-4b/PR-4a commits — their content is
+byte-identical to `origin/main` `1cc499cc (#542)` and `6782e487 (#540)`.
+Per the standing constraint we develop/push **only** to
+`claude/review-multi-account-auth-4eC4g`, so reset that branch onto the
+updated main (do **not** create a new branch):
+
+```
+git fetch origin main
+git checkout claude/review-multi-account-auth-4eC4g
+git reset --hard origin/main          # discards only superseded pre-squash commits
+git log --oneline -1                   # expect 765d6fb1 (#545)
+git status --porcelain                 # expect empty (clean tree already confirmed)
+```
+
+No work lost — PR-4b is fully in `origin/main`. All PR-5 commits/pushes go
+to `claude/review-multi-account-auth-4eC4g`. Do **not** open a PR unless
+explicitly asked.
 
 ## Approach
 
-### 1. Backend — `AccountsService.resolve` (control plane)
+### 1. API client — add `list` + `remove` (`switch` stays in PR-4a)
 
-`apps/control-plane/src/features/accounts/service.ts`
+`apps/frontend/src/api/accounts.ts` (extend; alongside existing `resolve`):
 
-- Add a narrow injected dep (avoids INV-52 cross-feature concrete coupling;
-  satisfies INV-10/12/13):
-  ```ts
-  interface MembershipChecker {
-    isMember(workspaceId: string, workosUserId: string): Promise<boolean>
-  }
-  interface Dependencies { authService: AuthService; membership: MembershipChecker }
-  ```
-  `ControlPlaneWorkspaceService` already structurally satisfies
-  `MembershipChecker` via its existing `isMember` — no new control-plane
-  code, just wiring.
-- One public method, branching on which form. Reuses the existing private
-  `resolveAlts` (`service.ts:62-71`) verbatim and the file's
-  **parallel-not-serial** idiom (INV-56):
-  ```ts
-  async resolve(
-    cookies: Record<string, string>,
-    activeUser: ActiveUser,
-    q: { userId?: string; workspaceId?: string }
-  ): Promise<{ ownerUserId: string }> {
-    const alts = await this.resolveAlts(cookies)
-    const seen = new Set<string>()
-    const signedInIds = [activeUser.id, ...alts.flatMap((a) => (a.ok && a.user ? [a.user.id] : []))]
-      .filter((id) => (seen.has(id) ? false : (seen.add(id), true)))
-
-    if (q.userId) {
-      // Identity form (PR-6 primitive): exact match, never substitute.
-      if (!signedInIds.includes(q.userId)) {
-        throw new HttpError("Account not signed in on this browser", {
-          status: 404, code: "ACCOUNT_NOT_SIGNED_IN",
-        })
-      }
-      // Defence-in-depth for a stale notification: the named account is
-      // signed in but was removed from the workspace.
-      if (q.workspaceId && !(await this.membership.isMember(q.workspaceId, q.userId))) {
-        throw new HttpError("Account can no longer access this workspace", {
-          status: 404, code: "WORKSPACE_NOT_RESOLVABLE",
-        })
-      }
-      return { ownerUserId: q.userId }
-    }
-
-    // Bare workspace-link form (PR-4b): switch only if exactly one
-    // signed-in account is a member; 0 or 2+ -> caller bounces.
-    const wid = q.workspaceId!  // Zod refine guarantees one of the two
-    const flags = await Promise.all(signedInIds.map((id) => this.membership.isMember(wid, id)))
-    const members = signedInIds.filter((_, i) => flags[i])
-    if (members.length !== 1) {
-      throw new HttpError("No unique signed-in account can access this workspace", {
-        status: 404, code: "WORKSPACE_NOT_RESOLVABLE",
-      })
-    }
-    return { ownerUserId: members[0] }
-  }
-  ```
-  Active id is enumerated first then alts in slot order; coalesced alts that
-  repeat the active id are de-duped; stale alts (`ok:false`) skipped.
-  `HttpError`/codes per INV-32 (same pattern as `switch`).
-
-### 2. Backend — handler + route
-
-- `apps/control-plane/src/features/accounts/handlers.ts`: add `resolve`
-  mirroring `list`/`switch` (INV-34 thin, INV-55 Zod **query**, INV-32):
-  ```ts
-  const resolveQuerySchema = z
-    .object({ userId: z.string().min(1).optional(), workspaceId: z.string().min(1).optional() })
-    .refine((d) => !!d.userId || !!d.workspaceId, { message: "userId or workspaceId required" })
-  async resolve(req, res) {
-    if (!req.workosUserId || !req.authUser)
-      throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
-    const parsed = resolveQuerySchema.safeParse(req.query)
-    if (!parsed.success)
-      throw new HttpError("Invalid query", { status: 400, code: "VALIDATION_ERROR" })
-    res.json(await accountsService.resolve(req.cookies, req.authUser, parsed.data))
-  }
-  ```
-- `apps/control-plane/src/routes.ts`:
-  - `:71` → `new AccountsService({ authService, workspaceService })`
-    (`workspaceService` already a destructured `deps` member in scope, used
-    at `:79`/`:81`).
-  - Register in the multi-account group (after `:121`), extend the comment:
-    `app.get("/api/accounts/resolve", auth, authLimit, accounts.resolve)`.
-
-### 3. Frontend — resolve API client (workspace form only)
-
-`apps/frontend/src/api/accounts.ts` (**NEW**, mirrors `api/workspaces.ts:40-42`):
 ```ts
-import { api } from "./client"
+export interface AccountSummary {
+  id: string
+  email: string
+  name: string
+  state: "active" | "parked" | "stale"
+}
+
 export const accountsApi = {
-  resolve(workspaceId: string): Promise<{ ownerUserId: string }> {
-    return api.get(`/api/accounts/resolve?workspaceId=${encodeURIComponent(workspaceId)}`)
+  resolve(workspaceId: string) { /* unchanged */ },
+  list(): Promise<{ accounts: AccountSummary[]; maxAccounts: number }> {
+    return api.get("/api/accounts")
+  },
+  remove(targetUserId: string): Promise<{ removedId: string }> {
+    return api.post("/api/accounts/remove", { targetUserId })
   },
 }
 ```
-PR-4b's frontend only uses the bare-workspace form (no notification UI).
-The identity (`userId`) form is backend-built + tested now but its frontend
-caller arrives in PR-6 — adding a `userId` param here with no consumer
-would be speculative (INV-36). `api.get` already does `API_BASE` +
-`credentials:"include"` + throws `ApiError` on non-2xx.
 
-### 4. Frontend — replace the bounce with resolve→switch
+- `apps/frontend/src/api/index.ts`: change the existing line to
+  `export { accountsApi, type AccountSummary } from "./accounts"`.
+- **Do NOT add `switch` here.** PR-4a owns the switch path inside
+  `account-scope.tsx` (raw fetch + cache flush + remount + broadcast);
+  duplicating it as an api-client method forks the contract
+  (INV-35/37/49). PR-5 calls `useAccountScope().switchAccount`.
+- `AccountSummary` is declared frontend-local: control-plane's interface
+  is in `apps/control-plane/src/features/accounts/service.ts:25-30`, not
+  in a shared `@threa/types` package, so the frontend mirrors the shape
+  (accepted duplication — R1). `api.get`/`api.post` already do
+  `API_BASE` + `credentials:"include"` + `ApiError` on non-2xx.
 
-`apps/frontend/src/pages/workspace-layout.tsx` — the `WorkspaceSyncHandler`
-terminal-error effect at **`:241-254`** is the documented seam. Extract the
-orchestration into a small colocated hook
-`useResolveOrBounce(workspaceId, syncEngine)` (keeps the component thin —
-INV-15 — and makes it unit-testable without mounting the full SyncEngine):
+### 2. Auth — thread `intent=add` + surface `accountError`
 
-- Reads `useAccountScope()` for `switchAccount` + `activeWorkosUserId`
-  (`workspace-layout` is inside `AccountScopeProvider` per the PR-4a App
-  tree — confirmed available).
-- On `workspaceSyncStatus === "error"` and `syncEngine.lastWorkspaceError`
-  is an `ApiError` with `status` 403/404 (unchanged trigger):
-  1. Ref keyed to `workspaceId` so resolve is attempted **at most once per
-     workspace error**; `ignore`/cleanup flag drops a late result after
-     unmount/workspace-change.
-  2. `await accountsApi.resolve(workspaceId)`.
-     - `{ ownerUserId }` with `ownerUserId !== activeWorkosUserId` →
-       `await switchAccount(ownerUserId)`. Do **not** clear last-workspace,
-       do **not** navigate. PR-4a's keyed remount re-bootstraps the same
-       `workspaceId` (URL unchanged) under the owning account and succeeds.
-       INV-53 satisfied structurally by the remount.
-     - `ApiError` (404 — none **or** 2+ ambiguous; backend already enforced
-       "unique only", so the frontend needs no count logic), or
-       `ownerUserId === activeWorkosUserId` (defensive no-op-switch guard) →
-       the **exact current behavior**: guarded `clearLastWorkspaceId()` +
-       `navigate("/workspaces", { replace: true })`.
-- The "switch only if unique" rule lives **backend-side** (single source of
-  truth: returns 404 on 0 or 2+); the frontend stays simple. The bounce
-  branch keeps the `getLastWorkspaceId() === workspaceId` guard byte-identical.
+`apps/frontend/src/auth/context.tsx`:
 
-No router-config change (React Router v7, no loaders; route stays
-`/w/:workspaceId`). No reload anywhere.
+- Widen `login` in `AuthContextValue` and the `useCallback`:
+  `login: (redirectTo?: string, opts?: { intent?: "add" }) => void`.
+  When `opts?.intent === "add"`, append `intent=add` to the built URL
+  (alongside the existing optional `redirect_to`). The only existing
+  caller is `login.tsx:24` (`login()` — no args), unaffected (R2).
+- In `AuthProvider` (sits **above** the router — must use
+  `window.location`, not `useSearchParams`): on mount, if
+  `window.location.search` contains `accountError=MAX_ACCOUNTS_REACHED`,
+  fire `toast.error(...)` (sonner — app-wide) and strip the param via
+  `window.history.replaceState` so a refresh doesn't re-toast (R3). No
+  existing consumer — net new, no migration.
 
-### 5. Doc
+### 3. New component — `AccountSwitcherDialog`
 
-Append a **PR-4b** section to `docs/plans/multi-account-login-split.md`
-(the split doc has no PR-4b section yet): the two-form resolve contract,
-the "never substitute on identity form" and "unique-only on bare-link
-form" rules, and that PR-6's notification-click is a trivial caller of the
-identity form. Match the PR-3 section's terseness.
+`apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx`
+(+ `index.ts` barrel). **Mirror `WorkspaceSettingsDialog`**
+(`apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx`)
+for wiring:
+
+- `useSearchParams()`; param key `account-switcher`; `mounted` guard
+  (`useState`+`useEffect`, `if (!mounted) return null`); `isOpen = param
+  !== null`; `close()` deletes the param with `setSearchParams(_, {
+  replace: true })`. **Direct `setSearchParams`, no React context** — URL
+  is the single source of truth (INV-59); matches the workspace-settings
+  precedent (not the SettingsDialog context pattern).
+- `ResponsiveDialog`/`ResponsiveDialogContent`/`…Header`/`…Title`/`…Description`
+  (INV-14 — desktop dialog / mobile drawer automatically).
+- Data: TanStack `useQuery({ queryKey: ["accounts","list"], queryFn: () =>
+  accountsApi.list(), enabled: isOpen })`. `useAccountScope()` for
+  `switchAccount` + `activeWorkosUserId`; `useAuth()` for `login`;
+  `useQueryClient()` to invalidate `["accounts","list"]` after a remove.
+- **Module-scope** `AccountRow` sub-component (INV-18 — never define a
+  component inside another), branching on `account.state`:
+  - `active`: avatar + name/email + a non-interactive check / "This
+    account" label. No action.
+  - `parked`: row is a `<button>` → `await scope.switchAccount(id)`.
+    PR-4a's keyed remount unmounts this dialog with the per-account
+    subtree, so no explicit close needed (R4). Errors bubble to the
+    caller's `try/catch` → `toast.error`.
+  - `stale`: placeholder ("Signed-out account", no email) + two
+    affordances — **"Sign in again"** → `login(undefined, { intent:
+    "add" })`; **"Remove"** → `accountsApi.remove(account.id)` (the
+    verbatim `stale:alt_<slot>` id — backend `STALE_ID_RE` parses it)
+    then `invalidateQueries(["accounts","list"])`.
+  - Each non-active **parked** row also gets a secondary "Remove" →
+    `accountsApi.remove(id)` + invalidate.
+  - Footer "Add account" button (shown only while
+    `accounts.length < maxAccounts`) → `login(undefined, { intent:
+    "add" })`. Cap read from `maxAccounts`, never hardcoded (INV-33);
+    backend still enforces it server-side regardless.
+  - Active-account removal (logout-of-this-account with next-account
+    promotion) is **out of scope** — the existing footer "Log out" stays
+    the all-accounts logout. Remove is offered on parked + stale only.
+- All actions mutate session state → `<button>` (INV-40). "Add account" /
+  "Sign in again" trigger an OAuth redirect via `login` (programmatic
+  navigation that must run cleanup) — buttons, consistent with the
+  existing `login.tsx` button.
+
+### 4. Sidebar entry point
+
+`apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx`:
+
+- Add an `openAccountSwitcher` `useCallback` mirroring the existing
+  `openWorkspaceSettings` (`:84-94`): `collapseOnMobile()` then
+  `setSearchParams` setting `account-switcher`.
+- Add a `menuActions` entry (`SidebarActionItem` —
+  `sidebar-actions.tsx:19-27`) **above "Log out"**:
+  `{ id: "switch-account", label: "Switch account", icon: <Users>,
+  onSelect: openAccountSwitcher, separatorBefore: true }`, and adjust
+  logout's `separatorBefore` so divider grouping stays clean. Add
+  `openAccountSwitcher` to the `useMemo` deps (`:133`).
+  `runSidebarAction` already wraps `onSelect` in try/catch + `toast.error`.
+
+### 5. Mount the dialog
+
+`apps/frontend/src/pages/workspace-layout.tsx`: add
+`<AccountSwitcherDialog />` to the always-mounted dialog cluster
+immediately after `<WorkspaceSettingsDialog workspaceId={workspaceId} />`
+(`:385`). No props — account switching is workspace-agnostic; the dialog
+reads the URL param itself like the other dialogs there.
+
+### 6. Doc
+
+`docs/plans/multi-account-login-split.md`, PR-5 section: record the
+switcher contract (sidebar entry → `?account-switcher` dialog; list via
+`GET /api/accounts`; switch via PR-4a `switchAccount`; remove via
+`POST /api/accounts/remove` incl. verbatim `stale:alt_<slot>`;
+add / sign-in-again via `login(intent:"add")`; cap surfaced from
+`maxAccounts` + `accountError` toast), and one line that **MAX_ACCOUNTS
+stays 4** (cookie-size guard `cookies.ts:53-79` load-bearing — no bump in
+this slice). Match the PR-3 / PR-4b sections' terseness.
 
 ## Critical files
 
 | File | Change |
 |---|---|
-| `apps/control-plane/src/features/accounts/service.ts` | add `MembershipChecker` dep + `resolve()` (identity + unique-membership forms); reuse `resolveAlts` |
-| `apps/control-plane/src/features/accounts/handlers.ts` | add `resolve` handler (Zod query refine, `HttpError`) |
-| `apps/control-plane/src/routes.ts` | inject `workspaceService` into `AccountsService` (`:71`); register `GET /api/accounts/resolve` (after `:121`) |
-| `apps/frontend/src/api/accounts.ts` | **NEW** — `accountsApi.resolve(workspaceId)` (workspace form) |
-| `apps/frontend/src/pages/workspace-layout.tsx` | replace `:241-254` bounce with `useResolveOrBounce` |
-| `apps/control-plane/src/features/accounts/service.test.ts` | **NEW** — both forms incl. the never-substitute case |
-| `apps/control-plane/src/features/accounts/handlers.test.ts` | **NEW** — handler tests (mirror `workspaces/handlers.test.ts:1-57`) |
-| `apps/frontend/src/pages/use-resolve-or-bounce.test.tsx` | **NEW** — resolve→switch vs bounce |
-| `docs/plans/multi-account-login-split.md` | append PR-4b section |
+| `apps/frontend/src/api/accounts.ts` | add `AccountSummary` type + `list()` + `remove()` |
+| `apps/frontend/src/api/index.ts` | re-export `accountsApi`, `type AccountSummary` |
+| `apps/frontend/src/auth/context.tsx` | `login(redirectTo?, {intent?})`; `accountError` toast (window.location + history.replaceState) |
+| `apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx` | **NEW** — ResponsiveDialog, `?account-switcher`, useQuery list, module-scope `AccountRow` per state |
+| `apps/frontend/src/components/account-switcher/index.ts` | **NEW** — barrel |
+| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | `openAccountSwitcher` + "Switch account" menu entry |
+| `apps/frontend/src/pages/workspace-layout.tsx` | mount `<AccountSwitcherDialog />` after `:385` |
+| `apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx` | **NEW** — render real component, states + actions |
+| `apps/frontend/src/auth/context.test.tsx` | extend — `intent=add` URL + `accountError` toast/strip |
+| `apps/control-plane/src/features/accounts/*.test.ts` | add a `remove("stale:alt_<slot>")` case if not already covered |
+| `docs/plans/multi-account-login-split.md` | append PR-5 section |
 
-**Reuse (no reimplementation):** `AccountsService.resolveAlts`
-(`service.ts:62-71`); `ControlPlaneWorkspaceService.isMember`
-(`workspaces/service.ts:69-71`); PR-4a `useAccountScope().switchAccount` +
-keyed remount; `api.get`/`ApiError` (`api/client.ts`);
-`api/workspaces.ts:40-42` client shape; existing
-`clearLastWorkspaceId`/`getLastWorkspaceId` on the bounce path.
+**Reuse (no reimplementation):** PR-4a `useAccountScope().switchAccount` +
+keyed remount; `api.get`/`api.post`/`ApiError` (`api/client.ts`);
+`ResponsiveDialog` (INV-14); `WorkspaceSettingsDialog` URL-param dialog
+pattern (`?ws-settings`, `mounted` guard, `{replace:true}` close);
+`SidebarActionItem` + `runSidebarAction` (`sidebar-actions.tsx`) and the
+existing `openWorkspaceSettings` callback shape; backend `list` / `remove`
+/ `addAndParkActive` / `accountError` (all on `origin/main`); sonner
+`toast`.
 
 ## Verification
 
-**First step (explicit user request — rebase on updated `origin/main`):**
-PR-4a is squash-merged as `origin/main` `6782e487`; the local branch's
-`2142f6a8`+`cc4f799a` are exactly that squashed work. Reset to a clean
-PR-4b base:
+**Tests** (test-first per CLAUDE.md; INV-22/23/24/39/48):
+
+- `account-switcher-dialog.test.tsx` (mount the real component with a
+  `QueryClient` + `MemoryRouter`; `spyOn` namespace imports for
+  `accountsApi.list/remove` and `useAccountScope().switchAccount`; assert
+  observable behavior, **never** event counts; **no `window.location`**
+  assignment assertion, mirroring `account-scope.test.tsx`):
+  - list with active+parked+stale → all three rows render with the right
+    affordances.
+  - click a parked row → `switchAccount(parkedId)` called.
+  - "Remove" on a stale row → `accountsApi.remove("stale:alt_1")` then a
+    refetch of `["accounts","list"]`.
+  - "Add account" / "Sign in again" → `login(undefined,{intent:"add"})`.
+  - `?account-switcher` absent → renders nothing.
+- `auth/context.test.tsx`: `login(undefined,{intent:"add"})` sets
+  `window.location.href` containing `intent=add`;
+  `?accountError=MAX_ACCOUNTS_REACHED` on load → `toast.error` fired and
+  the param removed via `history.replaceState`.
+- Control-plane: confirm the accounts suite covers `remove` of a
+  `stale:alt_<slot>` id (clears slot, returns `{removedId}`); add the
+  case if absent. No new backend production code in PR-5.
+
+**Commands (all green incl. new tests):**
+
 ```
-git fetch origin main
-git checkout claude/review-multi-account-auth-4eC4g
-git reset --hard origin/main      # discards only the pre-squash PR-4a commits, now in main
-git log --oneline -1              # expect 6782e487 (PR-4a #540)
-git diff origin/main -- apps/frontend/src/auth/account-scope.tsx  # expect empty
+bun run --cwd apps/frontend test
+bun run --cwd apps/control-plane test
+bun run --cwd apps/frontend typecheck
+bun run --cwd apps/control-plane typecheck
 ```
-No work lost (PR-4a content is fully in `6782e487`). Develop/push **only**
-to `claude/review-multi-account-auth-4eC4g`.
 
-**Backend tests** (`bun:test`, mirror `workspaces/handlers.test.ts:1-57`
-mock-recorder; stub `authService.authenticateSession` per-alt + a
-`membership.isMember` mock; INV-23/24 assert content not counts):
-- Identity form: `userId` = active → `{ownerUserId: active}`; `userId` =
-  parked alt → `{ownerUserId: alt}`.
-- **Never-substitute (the case the user raised):** signed into A & B, both
-  members of W, ask `userId=C` → 404 `ACCOUNT_NOT_SIGNED_IN`; assert the
-  response is **not** A or B.
-- Identity + stale membership: `userId` signed in but `isMember(ws,userId)`
-  false → 404 `WORKSPACE_NOT_RESOLVABLE`.
-- Bare-workspace form: exactly one signed-in member → that id; zero members
-  → 404; **2+ members → 404** and response is **neither** id.
-- Stale alt (`ok:false`) skipped; coalesced alt duplicating active id
-  de-duped (one `isMember` per distinct id, issued in parallel).
-- Handler: neither `userId` nor `workspaceId` → 400 `VALIDATION_ERROR`;
-  unauthenticated → 401.
-
-**Frontend test** (`use-resolve-or-bounce.test.tsx`, real hook via
-`renderHook`; spy `useSyncStatus`/`useAccountScope` per
-`coordinated-loading-context.test.tsx`; stub `accountsApi.resolve`; assert
-no `window.location` assignment per `account-scope.test.tsx`):
-- 403 + resolve `{ownerUserId:"workos_B"}` (≠ active) → `switchAccount("workos_B")`
-  called, `navigate` **not** called, last-workspace **not** cleared.
-- 403 + resolve rejects `ApiError(404)` (none / ambiguous) →
-  `navigate("/workspaces",{replace:true})`, `switchAccount` **not** called,
-  guarded `clearLastWorkspaceId` preserved.
-- Resolve attempted at most once while status stays `"error"`.
-
-**Commands:** `bun run --cwd apps/control-plane test`,
-`bun run --cwd apps/frontend test`, `bun run --cwd apps/control-plane typecheck`,
-`bun run --cwd apps/frontend typecheck` — all green incl. new tests. Then
-commit + push to `claude/review-multi-account-auth-4eC4g` (do **not** open
-a PR unless explicitly asked).
+**Manual UI smoke (CLAUDE.md frontend rule):** dev server → sidebar
+footer menu → "Switch account" opens the dialog (URL gains
+`?account-switcher`); a parked row flips accounts **without a page
+reload** and re-bootstraps; "Add account" redirects to
+`/api/auth/login?intent=add`; hitting the cap returns
+`?accountError=MAX_ACCOUNTS_REACHED` → toast + param stripped; "Remove"
+on a parked/stale row drops it from the list. Then commit + push to
+`claude/review-multi-account-auth-4eC4g` (backoff retry on network
+error). Do **not** open a PR unless explicitly asked.
 
 ## Risks / accepted trade-offs
 
-- **R1 — Bare workspace deep-link with 2+ signed-in members → 404 (bounce)
-  by design.** No arbitrary-account guess; PR-5's switcher disambiguates.
-  Single-member links flip seamlessly.
-- **R2 — Identity form never substitutes.** A notification for an account
-  not signed into this browser → 404 → full login (no silent fallback to a
-  different account that can read the workspace). This is the intended
-  correctness behavior, not a regression.
-- **R3 — switch path is a full keyed-subtree remount** (inherited from
-  PR-4a): a brief UI flash on the cross-account deep-link flip. Acceptable
-  for this infra slice; PR-5 owns switch UX.
-- **R4 — single resolve attempt per workspace error** (ref-guarded).
-  Post-remount the fresh mount may resolve again and 404→bounce — terminal,
-  not a loop (`ownerUserId===active` guard prevents a self-switch loop).
-- **R5 — in-process `isMember`** vs the sketch's internal HTTP route:
-  documented in Context; strictly better (source-of-truth, no extra hop).
+- **R1 — `AccountSummary` duplicated frontend-side.** No shared
+  control-plane↔frontend types package for this contract; the shape is
+  small and stable. Moving it to `@threa/types` is a larger refactor, out
+  of scope (INV-36).
+- **R2 — `login` signature widened.** Optional trailing arg; the sole
+  existing caller (`login.tsx:24`) passes nothing — no churn.
+- **R3 — `accountError` handled above the router.** `AuthProvider` can't
+  use `useSearchParams`; reading `window.location.search` + stripping via
+  `history.replaceState` is the correct seam and prevents a re-toast on
+  refresh.
+- **R4 — switch = full keyed-subtree remount** (inherited from PR-4a):
+  brief flash; the dialog unmounts with the subtree, so close-on-success
+  is implicit (no extra close call, no race).
+- **R5 — `MAX_ACCOUNTS` cookie-size guard is load-bearing.** PR-5 keeps
+  it at 4 and surfaces the cap from the `list` response, never hardcoded.
+- **R6 — Step 0 `git reset --hard`** discards local commits; safe only
+  because they are byte-identical to merged `1cc499cc (#542)` /
+  `6782e487 (#540)` — verify via `git log` before reset; clean tree
+  confirmed (`git status --porcelain` empty).
 
 ## Out of scope (later slices)
 
-Switcher UI, `intent=add` "Add account" entry point, account-list
-rendering, `MAX_ACCOUNTS` relaxation, logout-all (**PR-5**); cross-account
-push + notification-click — a thin caller of this slice's **identity**
-resolve form (**PR-6**); backoffice cookie rename (**PR-2**).
+PR-6 cross-account push + notification-click (thin caller of PR-4b's
+identity `resolve` form); PR-2 backoffice cookie rename; extracting
+`switch` into the api client; any `MAX_ACCOUNTS` bump; active-account
+"remove" / next-account-promotion UX (the existing footer "Log out"
+remains the all-accounts logout).

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -255,6 +255,47 @@ describe("Multi-account /api/accounts", () => {
     })
   })
 
+  test("removing a stale alt by its opaque slot id clears the slot without a revoke", async () => {
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-stale-a")
+    const bEmail = uniqueEmail("acc-stale-b")
+    const a = await loginAs(client, aEmail, "Stale A")
+    const { user: b, client: subB } = await addAccount(client, bEmail, "Stale B")
+
+    // Make A active so B is the parked alt on `client`.
+    await client.post("/api/accounts/switch", { targetUserId: a.id })
+
+    // Revoke B's WorkOS session at the provider WITHOUT touching `client`'s
+    // cookie jar: subB independently holds B's real sealed session and removes
+    // its own active account. `client`'s alt slot still points at that now-dead
+    // sealed string, so the next read surfaces it as a stale alt.
+    const subRemoved = await subB.post<{ removedId: string }>("/api/accounts/remove", { targetUserId: b.id })
+    expect(subRemoved.status).toBe(200)
+
+    const stale = await client.get<AccountsResponse>("/api/accounts")
+    expect(stale.data).toEqual({
+      accounts: [
+        { id: a.id, email: aEmail, name: "Stale A", state: "active" },
+        { id: "stale:alt_0", email: "", name: "", state: "stale" },
+      ],
+      maxAccounts: MAX_ACCOUNTS,
+    })
+
+    // Removing by the opaque slot id clears the slot and echoes the id back —
+    // no revoke (the sealed session already failed validation).
+    const removed = await client.post<{ removedId: string }>("/api/accounts/remove", {
+      targetUserId: "stale:alt_0",
+    })
+    expect(removed.status).toBe(200)
+    expect(removed.data).toEqual({ removedId: "stale:alt_0" })
+
+    const after = await client.get<AccountsResponse>("/api/accounts")
+    expect(after.data).toEqual({
+      accounts: [{ id: a.id, email: aEmail, name: "Stale A", state: "active" }],
+      maxAccounts: MAX_ACCOUNTS,
+    })
+  })
+
   test("logout clears the active session and every parked alt", async () => {
     const client = new TestClient()
     const a = await loginAs(client, uniqueEmail("acc-logout-a"), "Logout A")

--- a/apps/frontend/src/api/accounts.ts
+++ b/apps/frontend/src/api/accounts.ts
@@ -1,10 +1,32 @@
 import { api } from "./client"
 
+/**
+ * One account as seen by the multi-account switcher. Mirrors the control
+ * plane's `AccountSummary` (`apps/control-plane/src/features/accounts/service.ts`);
+ * there is no shared types package across that boundary, so the shape is
+ * declared here too. `id` is opaque — a WorkOS user id for live accounts,
+ * `stale:alt_<slot>` for an alt whose sealed session failed validation.
+ */
+export interface AccountSummary {
+  id: string
+  email: string
+  name: string
+  state: "active" | "parked" | "stale"
+}
+
 export const accountsApi = {
   // Bare-workspace form only: "which signed-in account owns this workspace?"
   // (used by the cross-account deep-link guard). The identity (`userId`) form
   // is backend-only until its notification-click caller lands.
   resolve(workspaceId: string): Promise<{ ownerUserId: string }> {
     return api.get<{ ownerUserId: string }>(`/api/accounts/resolve?workspaceId=${encodeURIComponent(workspaceId)}`)
+  },
+
+  list(): Promise<{ accounts: AccountSummary[]; maxAccounts: number }> {
+    return api.get("/api/accounts")
+  },
+
+  remove(targetUserId: string): Promise<{ removedId: string }> {
+    return api.post("/api/accounts/remove", { targetUserId })
   },
 }

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -1,5 +1,5 @@
 export { api, ApiError } from "./client"
-export { accountsApi } from "./accounts"
+export { accountsApi, type AccountSummary } from "./accounts"
 export { workspacesApi, type WorkspaceBootstrap } from "./workspaces"
 export { streamsApi, type StreamBootstrap, type CreateStreamInput, type UpdateStreamInput } from "./streams"
 export { messagesApi, type CreateMessageInput, type UpdateMessageInput } from "./messages"

--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -158,7 +158,9 @@ describe("AuthProvider login / accountError", () => {
     )
 
     await waitFor(() => {
-      expect(toastSpy).toHaveBeenCalledTimes(1)
+      expect(toastSpy).toHaveBeenCalledWith(
+        "You're signed in to the maximum number of accounts. Remove one to add another."
+      )
     })
     expect(replaceSpy).toHaveBeenCalledWith(null, "", "/w/workspace_1?foo=bar")
   })

--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, render, spyOnExport } from "@/test"
+import { toast } from "sonner"
+import { act, render, spyOnExport, waitFor } from "@/test"
 import { AuthProvider, useAuth } from "@/auth"
 import * as dbModule from "@/db"
 
 let triggerLogout: () => void
+let captureLogin: ReturnType<typeof useAuth>["login"]
+
+function LoginProbe() {
+  captureLogin = useAuth().login
+  return null
+}
 
 function LogoutProbe() {
   triggerLogout = useAuth().logout
@@ -68,5 +75,107 @@ describe("AuthProvider logout", () => {
     })
 
     expect(window.location.href).toBe("/api/auth/logout")
+  })
+})
+
+describe("AuthProvider login / accountError", () => {
+  const originalLocation = window.location
+  let hrefValues: string[]
+
+  function stubLocation(search: string) {
+    hrefValues = []
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        pathname: "/w/workspace_1",
+        search,
+        hash: "",
+        set href(v: string) {
+          hrefValues.push(v)
+        },
+        get href() {
+          return hrefValues[hrefValues.length - 1] ?? ""
+        },
+      } as unknown as Location,
+    })
+  }
+
+  beforeEach(() => {
+    captureLogin = undefined as unknown as ReturnType<typeof useAuth>["login"]
+    // The mount effect calls /api/auth/me; keep it from throwing.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 401, ok: false, json: async () => ({}) }) as unknown as Response)
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+  })
+
+  it("threads intent=add onto the login URL", async () => {
+    stubLocation("")
+    render(
+      <AuthProvider>
+        <LoginProbe />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      captureLogin(undefined, { intent: "add" })
+    })
+
+    expect(hrefValues[hrefValues.length - 1]).toBe("/api/auth/login?intent=add")
+  })
+
+  it("builds a plain login URL with no options", async () => {
+    stubLocation("")
+    render(
+      <AuthProvider>
+        <LoginProbe />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      captureLogin()
+    })
+
+    expect(hrefValues[hrefValues.length - 1]).toBe("/api/auth/login")
+  })
+
+  it("surfaces accountError once and strips the param", async () => {
+    stubLocation("?accountError=MAX_ACCOUNTS_REACHED&foo=bar")
+    const toastSpy = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+    const replaceSpy = vi.spyOn(window.history, "replaceState").mockImplementation(() => {})
+
+    render(
+      <AuthProvider>
+        <LoginProbe />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith(null, "", "/w/workspace_1?foo=bar")
+  })
+
+  it("does not toast when there is no accountError param", async () => {
+    stubLocation("?foo=bar")
+    const toastSpy = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+
+    render(
+      <AuthProvider>
+        <LoginProbe />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(toastSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from "react"
+import { toast } from "sonner"
 import { API_BASE } from "@/api/client"
 import { clearAllCachedData } from "@/db"
 import { getCachedUser, setCachedUser, clearCachedUser } from "@/lib/cached-user"
@@ -12,10 +13,15 @@ declare global {
 }
 
 interface AuthContextValue extends AuthState {
-  login: (redirectTo?: string) => void
+  login: (redirectTo?: string, opts?: { intent?: "add" }) => void
   logout: () => void
   refetch: () => Promise<void>
 }
+
+// The OAuth add-account callback appends this when every alt slot is full
+// (control plane returns it gracefully rather than erroring mid-flight).
+const ACCOUNT_ERROR_PARAM = "accountError"
+const MAX_ACCOUNTS_REACHED = "MAX_ACCOUNTS_REACHED"
 
 // Best-effort push cleanup must never delay the logout redirect for long.
 // When the SW is healthy this completes in well under a second; the cap only
@@ -117,11 +123,28 @@ export function AuthProvider({ children }: AuthProviderProps) {
     fetchUser()
   }, [fetchUser])
 
-  const login = useCallback((redirectTo?: string) => {
-    const url = redirectTo
-      ? `${API_BASE}/api/auth/login?redirect_to=${encodeURIComponent(redirectTo)}`
-      : `${API_BASE}/api/auth/login`
-    window.location.href = url
+  // AuthProvider sits above the router, so the add-account refusal can't be
+  // read via useSearchParams. Surface it once and strip the param so a
+  // refresh doesn't re-toast.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get(ACCOUNT_ERROR_PARAM) !== MAX_ACCOUNTS_REACHED) return
+    toast.error("You're signed in to the maximum number of accounts. Remove one to add another.")
+    params.delete(ACCOUNT_ERROR_PARAM)
+    const query = params.toString()
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`
+    )
+  }, [])
+
+  const login = useCallback((redirectTo?: string, opts?: { intent?: "add" }) => {
+    const query = new URLSearchParams()
+    if (redirectTo) query.set("redirect_to", redirectTo)
+    if (opts?.intent === "add") query.set("intent", "add")
+    const qs = query.toString()
+    window.location.href = `${API_BASE}/api/auth/login${qs ? `?${qs}` : ""}`
   }, [])
 
   const logout = useCallback(async () => {

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { render, screen, userEvent, waitFor } from "@/test"
+import { AccountSwitcherDialog } from "./account-switcher-dialog"
+import { accountsApi, type AccountSummary } from "@/api"
+import * as authModule from "@/auth"
+
+const mockLogin = vi.fn()
+const mockSwitchAccount = vi.fn(async () => {})
+
+function mockAccounts(accounts: AccountSummary[], maxAccounts = 4) {
+  vi.spyOn(accountsApi, "list").mockResolvedValue({ accounts, maxAccounts })
+}
+
+function renderDialog(open = true) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={[open ? "/?account-switcher=" : "/"]}>
+      <QueryClientProvider client={queryClient}>
+        <AccountSwitcherDialog />
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("AccountSwitcherDialog", () => {
+  let hrefValues: string[]
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockLogin.mockReset()
+    mockSwitchAccount.mockReset()
+
+    hrefValues = []
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/",
+        search: "?account-switcher=",
+        set href(v: string) {
+          hrefValues.push(v)
+        },
+        get href() {
+          return hrefValues[hrefValues.length - 1] ?? ""
+        },
+      } as unknown as Location,
+    })
+
+    vi.spyOn(authModule, "useAuth").mockReturnValue({
+      login: mockLogin,
+    } as unknown as ReturnType<typeof authModule.useAuth>)
+    vi.spyOn(authModule, "useAccountScope").mockReturnValue({
+      activeWorkosUserId: "workos_A",
+      switchAccount: mockSwitchAccount,
+    } as unknown as ReturnType<typeof authModule.useAccountScope>)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+  })
+
+  it("renders active, parked, and stale accounts with the right affordances", async () => {
+    mockAccounts([
+      { id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" },
+      { id: "workos_B", email: "b@example.com", name: "Ben Parked", state: "parked" },
+      { id: "stale:alt_1", email: "", name: "", state: "stale" },
+    ])
+
+    renderDialog()
+
+    expect(await screen.findByText("Ada Active")).toBeInTheDocument()
+    expect(screen.getByLabelText("Current account")).toBeInTheDocument()
+    expect(screen.getByText("Ben Parked")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Remove Ben Parked" })).toBeInTheDocument()
+    expect(screen.getByText("Signed-out account")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Sign in again" })).toBeInTheDocument()
+  })
+
+  it("flips a parked account in place via switchAccount (no navigation)", async () => {
+    mockAccounts([
+      { id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" },
+      { id: "workos_B", email: "b@example.com", name: "Ben Parked", state: "parked" },
+    ])
+
+    renderDialog()
+
+    await userEvent.click(await screen.findByRole("button", { name: /b@example\.com/ }))
+
+    await waitFor(() => {
+      expect(mockSwitchAccount).toHaveBeenCalledWith("workos_B")
+    })
+    expect(mockLogin).not.toHaveBeenCalled()
+    expect(hrefValues).toEqual([])
+  })
+
+  it("removes a parked account and refetches the list", async () => {
+    const removeSpy = vi.spyOn(accountsApi, "remove").mockResolvedValue({ removedId: "workos_B" })
+    vi.spyOn(accountsApi, "list")
+      .mockResolvedValueOnce({
+        accounts: [
+          { id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" },
+          { id: "workos_B", email: "b@example.com", name: "Ben Parked", state: "parked" },
+        ],
+        maxAccounts: 4,
+      })
+      .mockResolvedValue({
+        accounts: [{ id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" }],
+        maxAccounts: 4,
+      })
+
+    renderDialog()
+
+    await userEvent.click(await screen.findByRole("button", { name: "Remove Ben Parked" }))
+
+    expect(removeSpy).toHaveBeenCalledWith("workos_B")
+    await waitFor(() => {
+      expect(screen.queryByText("Ben Parked")).not.toBeInTheDocument()
+    })
+  })
+
+  it("removes a stale account by its opaque slot id", async () => {
+    const removeSpy = vi.spyOn(accountsApi, "remove").mockResolvedValue({ removedId: "stale:alt_2" })
+    mockAccounts([
+      { id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" },
+      { id: "stale:alt_2", email: "", name: "", state: "stale" },
+    ])
+
+    renderDialog()
+
+    await userEvent.click(await screen.findByRole("button", { name: "Remove account" }))
+
+    expect(removeSpy).toHaveBeenCalledWith("stale:alt_2")
+  })
+
+  it("surfaces a switch failure as a toast and stays put", async () => {
+    const toastSpy = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+    mockSwitchAccount.mockRejectedValue(new Error("Account switch failed (409)"))
+    mockAccounts([
+      { id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" },
+      { id: "workos_B", email: "b@example.com", name: "Ben Parked", state: "parked" },
+    ])
+
+    renderDialog()
+
+    await userEvent.click(await screen.findByRole("button", { name: /b@example\.com/ }))
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith("Account switch failed (409)")
+    })
+    expect(hrefValues).toEqual([])
+  })
+
+  it("starts the add-account OAuth flow from the footer button", async () => {
+    mockAccounts([{ id: "workos_A", email: "a@example.com", name: "Ada Active", state: "active" }])
+
+    renderDialog()
+
+    await userEvent.click(await screen.findByRole("button", { name: "Add account" }))
+
+    expect(mockLogin).toHaveBeenCalledWith(undefined, { intent: "add" })
+  })
+
+  it("disables Add account at the cap", async () => {
+    mockAccounts(
+      [
+        { id: "workos_A", email: "a@example.com", name: "A", state: "active" },
+        { id: "workos_B", email: "b@example.com", name: "B", state: "parked" },
+        { id: "workos_C", email: "c@example.com", name: "C", state: "parked" },
+        { id: "workos_D", email: "d@example.com", name: "D", state: "parked" },
+      ],
+      4
+    )
+
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Add account" })).toBeDisabled()
+    })
+  })
+
+  it("renders nothing when the search param is absent", () => {
+    mockAccounts([])
+    renderDialog(false)
+    expect(screen.queryByText("Switch account")).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
@@ -181,6 +181,15 @@ describe("AccountSwitcherDialog", () => {
     })
   })
 
+  it("shows an error message when the account list fails to load", async () => {
+    vi.spyOn(accountsApi, "list").mockRejectedValue(new Error("network down"))
+
+    renderDialog()
+
+    expect(await screen.findByText(/Couldn't load your accounts/)).toBeInTheDocument()
+    expect(screen.queryByLabelText("Current account")).not.toBeInTheDocument()
+  })
+
   it("renders nothing when the search param is absent", () => {
     mockAccounts([])
     renderDialog(false)

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
@@ -130,7 +130,7 @@ describe("AccountSwitcherDialog", () => {
 
     renderDialog()
 
-    await userEvent.click(await screen.findByRole("button", { name: "Remove account" }))
+    await userEvent.click(await screen.findByRole("button", { name: "Remove stale:alt_2" }))
 
     expect(removeSpy).toHaveBeenCalledWith("stale:alt_2")
   })

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
@@ -7,6 +7,7 @@ import { accountsApi, type AccountSummary } from "@/api"
 import { useAccountScope, useAuth } from "@/auth"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   ResponsiveDialog,
   ResponsiveDialogBody,
@@ -54,7 +55,7 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
 
   if (account.state === "active") {
     return (
-      <div className="flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
+      <div className="flex items-center gap-3 rounded-lg bg-muted px-3 py-2.5">
         <Avatar className="h-9 w-9">
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
@@ -72,7 +73,7 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
       <button
         type="button"
         onClick={() => onSwitch(account.id)}
-        className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/50"
+        className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/60"
       >
         <Avatar className="h-9 w-9">
           <AvatarFallback>{initials}</AvatarFallback>
@@ -89,6 +90,22 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
   )
 }
 
+function AccountListSkeleton() {
+  return (
+    <div className="flex flex-col gap-1" aria-hidden>
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex items-center gap-3 px-3 py-2.5">
+          <Skeleton className="h-9 w-9 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-32" />
+            <Skeleton className="h-3 w-44" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function AccountSwitcherDialog() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [mounted, setMounted] = useState(false)
@@ -98,7 +115,7 @@ export function AccountSwitcherDialog() {
   const scope = useAccountScope()
   const queryClient = useQueryClient()
 
-  const { data } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ACCOUNTS_LIST_KEY,
     queryFn: () => accountsApi.list(),
     enabled: isOpen,
@@ -152,17 +169,25 @@ export function AccountSwitcherDialog() {
         </ResponsiveDialogHeader>
 
         <ResponsiveDialogBody className="py-3">
-          <div className="flex flex-col gap-1">
-            {accounts.map((account) => (
-              <AccountRow
-                key={account.id}
-                account={account}
-                onSwitch={handleSwitch}
-                onRemove={handleRemove}
-                onReauth={addAccount}
-              />
-            ))}
-          </div>
+          {isLoading && <AccountListSkeleton />}
+          {isError && (
+            <p className="px-3 py-8 text-center text-sm text-muted-foreground">
+              Couldn&apos;t load your accounts. Close and try again.
+            </p>
+          )}
+          {!isLoading && !isError && (
+            <div className="flex flex-col gap-1">
+              {accounts.map((account) => (
+                <AccountRow
+                  key={account.id}
+                  account={account}
+                  onSwitch={handleSwitch}
+                  onRemove={handleRemove}
+                  onReauth={addAccount}
+                />
+              ))}
+            </div>
+          )}
         </ResponsiveDialogBody>
 
         <ResponsiveDialogFooter className="border-t px-4 py-3 sm:px-6">

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
@@ -44,7 +44,12 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
           <LogIn className="mr-1.5 h-4 w-4" />
           Sign in again
         </Button>
-        <Button variant="ghost" size="icon" aria-label="Remove account" onClick={() => onRemove(account.id)}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={`Remove ${account.email || account.id || "account"}`}
+          onClick={() => onRemove(account.id)}
+        >
           <Trash2 className="h-4 w-4" />
         </Button>
       </div>
@@ -83,7 +88,12 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
           <p className="truncate text-xs text-muted-foreground">{account.email}</p>
         </div>
       </button>
-      <Button variant="ghost" size="icon" aria-label={`Remove ${account.name}`} onClick={() => onRemove(account.id)}>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label={`Remove ${account.name || account.email || account.id || "account"}`}
+        onClick={() => onRemove(account.id)}
+      >
         <Trash2 className="h-4 w-4" />
       </Button>
     </div>

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { Check, LogIn, Trash2, UserPlus } from "lucide-react"
+import { toast } from "sonner"
+import { accountsApi, type AccountSummary } from "@/api"
+import { useAccountScope, useAuth } from "@/auth"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { getInitials } from "@/lib/initials"
+
+const ACCOUNTS_LIST_KEY = ["accounts", "list"]
+const SEARCH_PARAM = "account-switcher"
+
+interface AccountRowProps {
+  account: AccountSummary
+  onSwitch: (id: string) => void
+  onRemove: (id: string) => void
+  onReauth: () => void
+}
+
+function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) {
+  if (account.state === "stale") {
+    return (
+      <div className="flex items-center gap-2 rounded-lg px-3 py-2.5">
+        <Avatar className="h-9 w-9">
+          <AvatarFallback>?</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">Signed-out account</p>
+          <p className="truncate text-xs text-muted-foreground">Session expired — sign in again</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onReauth}>
+          <LogIn className="mr-1.5 h-4 w-4" />
+          Sign in again
+        </Button>
+        <Button variant="ghost" size="icon" aria-label="Remove account" onClick={() => onRemove(account.id)}>
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  const initials = getInitials(account.name || account.email) || "?"
+
+  if (account.state === "active") {
+    return (
+      <div className="flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
+        <Avatar className="h-9 w-9">
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">{account.name}</p>
+          <p className="truncate text-xs text-muted-foreground">{account.email}</p>
+        </div>
+        <Check className="h-4 w-4 shrink-0 text-primary" aria-label="Current account" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onSwitch(account.id)}
+        className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/50"
+      >
+        <Avatar className="h-9 w-9">
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">{account.name}</p>
+          <p className="truncate text-xs text-muted-foreground">{account.email}</p>
+        </div>
+      </button>
+      <Button variant="ghost" size="icon" aria-label={`Remove ${account.name}`} onClick={() => onRemove(account.id)}>
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+export function AccountSwitcherDialog() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [mounted, setMounted] = useState(false)
+  const isOpen = searchParams.get(SEARCH_PARAM) !== null
+
+  const { login } = useAuth()
+  const scope = useAccountScope()
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: ACCOUNTS_LIST_KEY,
+    queryFn: () => accountsApi.list(),
+    enabled: isOpen,
+  })
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  const close = () => {
+    const next = new URLSearchParams(searchParams)
+    next.delete(SEARCH_PARAM)
+    setSearchParams(next, { replace: true })
+  }
+
+  const accounts = data?.accounts ?? []
+  const maxAccounts = data?.maxAccounts ?? accounts.length
+  const canAddAccount = accounts.length < maxAccounts
+
+  const addAccount = () => {
+    login(undefined, { intent: "add" })
+  }
+
+  const handleSwitch = async (id: string) => {
+    try {
+      await scope.switchAccount(id)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to switch account")
+    }
+  }
+
+  const handleRemove = async (id: string) => {
+    try {
+      await accountsApi.remove(id)
+      await queryClient.invalidateQueries({ queryKey: ACCOUNTS_LIST_KEY })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to remove account")
+    }
+  }
+
+  return (
+    <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && close()}>
+      <ResponsiveDialogContent desktopClassName="sm:max-w-md p-0 gap-0" drawerClassName="flex flex-col gap-0">
+        <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
+          <ResponsiveDialogTitle>Switch account</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            Switch between, add, or remove the accounts signed in on this browser.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <ResponsiveDialogBody className="py-3">
+          <div className="flex flex-col gap-1">
+            {accounts.map((account) => (
+              <AccountRow
+                key={account.id}
+                account={account}
+                onSwitch={handleSwitch}
+                onRemove={handleRemove}
+                onReauth={addAccount}
+              />
+            ))}
+          </div>
+        </ResponsiveDialogBody>
+
+        <ResponsiveDialogFooter className="border-t px-4 py-3 sm:px-6">
+          <Button variant="outline" className="w-full" onClick={addAccount} disabled={!canAddAccount}>
+            <UserPlus className="mr-2 h-4 w-4" />
+            Add account
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/account-switcher/index.ts
+++ b/apps/frontend/src/components/account-switcher/index.ts
@@ -1,0 +1,1 @@
+export { AccountSwitcherDialog } from "./account-switcher-dialog"

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useMemo, useState, type ComponentPropsWithoutRef } from "react"
-import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon } from "lucide-react"
+import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon, Users } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useSettings, useSidebar } from "@/contexts"
@@ -93,6 +93,18 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
     )
   }, [collapseOnMobile, setSearchParams])
 
+  const openAccountSwitcher = useCallback(() => {
+    collapseOnMobile()
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.set("account-switcher", "")
+        return next
+      },
+      { replace: true }
+    )
+  }, [collapseOnMobile, setSearchParams])
+
   const avatarSrc = currentUser ? getAvatarUrl(workspaceId, currentUser.avatarUrl, 64) : null
   const menuActions = useMemo<SidebarActionItem[]>(
     () => [
@@ -123,14 +135,20 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
         separatorBefore: true,
       },
       {
+        id: "switch-account",
+        label: "Switch account",
+        icon: Users,
+        onSelect: openAccountSwitcher,
+        separatorBefore: true,
+      },
+      {
         id: "logout",
         label: "Log out",
         icon: LogOut,
         onSelect: () => logout(),
-        separatorBefore: true,
       },
     ],
-    [handleOpenSettings, openWorkspaceSettings, collapseOnMobile, logout, workspaceId]
+    [handleOpenSettings, openWorkspaceSettings, openAccountSwitcher, collapseOnMobile, logout, workspaceId]
   )
 
   if (!currentUser) return null

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -60,6 +60,7 @@ import { messagesApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { SettingsDialog } from "@/components/settings"
 import { WorkspaceSettingsDialog } from "@/components/workspace-settings/workspace-settings-dialog"
+import { AccountSwitcherDialog } from "@/components/account-switcher"
 import { StreamSettingsDialog } from "@/components/stream-settings/stream-settings-dialog"
 import { CreateChannelDialog } from "@/components/create-channel"
 import { AttachmentExplorer, useExplorerUrlState } from "@/components/attachment-explorer"
@@ -383,6 +384,7 @@ export function WorkspaceLayout() {
                                     />
                                     <SettingsDialog />
                                     <WorkspaceSettingsDialog workspaceId={workspaceId} />
+                                    <AccountSwitcherDialog />
                                     <StreamSettingsDialog workspaceId={workspaceId} />
                                     <CreateChannelDialog workspaceId={workspaceId} />
                                     <AttachmentExplorer workspaceId={workspaceId} />

--- a/docs/plans/multi-account-login-split.md
+++ b/docs/plans/multi-account-login-split.md
@@ -395,6 +395,23 @@ dialog/menu primitives (INV-14); navigation via links / actions via buttons
 - Dead alt → re-auth affordance works and re-coalesces the account.
 - Header-size measurement documented; cap confirmed.
 
+**Implementation (this slice):** Sidebar-footer "Switch account" entry →
+`?account-switcher` URL param opens `AccountSwitcherDialog`
+(`apps/frontend/src/components/account-switcher/`), mirroring the
+`WorkspaceSettingsDialog` direct-`setSearchParams` pattern (no context).
+List via `GET /api/accounts` (`accountsApi.list`); active row =
+non-interactive check; parked row = click → PR-4a
+`useAccountScope().switchAccount` (no reload, keyed remount); parked/stale
+"Remove" → `POST /api/accounts/remove` (`accountsApi.remove`, verbatim
+`stale:alt_<slot>` id) + list invalidate; stale "Sign in again" and footer
+"Add account" → `login(undefined, { intent: "add" })`. The
+`?accountError=MAX_ACCOUNTS_REACHED` callback param is surfaced once as a
+toast from `AuthProvider` (above the router → `window.location` +
+`history.replaceState` to strip it). **`MAX_ACCOUNTS` stays 4** — the
+cookie-size compile-time guard (`packages/backend-common/src/cookies.ts`)
+has no headroom; the cap is read from the `list` response's `maxAccounts`,
+never hardcoded. No new backend code (PR-3/PR-4a contracts only).
+
 ---
 
 ### PR-6 — Cross-account push + notification-click switch (depends PR-4b; parallel with PR-5)


### PR DESCRIPTION
## Summary

Sixth slice of the multi-account login split (`docs/plans/multi-account-login-split.md`). Every backend primitive shipped in PR-1/3/4a/4b, but there was **no UI** — a user signed into two accounts on a browser could not see, switch, add, or remove them. PR-5 adds the only user-facing surface: a sidebar-footer **"Switch account"** entry that opens a `?account-switcher` dialog.

- **List** via `GET /api/accounts` — active / parked / stale rows. Cap read from `maxAccounts`, never hardcoded; `MAX_ACCOUNTS` stays **4** (the cookie-size compile-time guard is load-bearing).
- **Switch** reuses PR-4a `useAccountScope().switchAccount` — no page reload, keyed remount, BroadcastChannel. Never re-implements the fetch, never touches `window.location`.
- **Add / sign-in-again** via `login(undefined, { intent: "add" })` → OAuth `?intent=add`. Hitting the cap returns `?accountError=MAX_ACCOUNTS_REACHED`, surfaced as a toast and stripped from the URL above the router (`window.location` + `history.replaceState`).
- **Remove** (parked + stale only) via `POST /api/accounts/remove`, including the verbatim opaque `stale:alt_<slot>` id. Active-account removal is out of scope — the footer **"Log out"** remains the all-accounts logout.

No new backend code — a pure frontend consumer of contracts already on `main`.

A frontend-design pass (within the existing Shadcn token system) adds: a loading skeleton so the dialog no longer opens into an empty box, an inline error line for a failed list, and a clearer active-row hierarchy that no longer reads identically to a parked-row hover.

## Files

- `apps/frontend/src/api/accounts.ts` — `AccountSummary` + `list()` + `remove()`; barrel re-export
- `apps/frontend/src/auth/context.tsx` — `login(redirectTo?, {intent?})`; `accountError` toast + URL strip
- `apps/frontend/src/components/account-switcher/*` — **new** dialog (ResponsiveDialog, URL-param driven, module-scope rows + skeleton) + tests
- `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` — "Switch account" menu entry
- `apps/frontend/src/pages/workspace-layout.tsx` — mount the dialog in the always-mounted cluster
- `apps/control-plane/tests/e2e/accounts.test.ts` — new `remove(stale:alt_<slot>)` e2e case
- `docs/plans/multi-account-login-split.md` — PR-5 contract recorded
- `.claude/plans/glowing-discovering-locket.md` — PR-5 implementation plan (artifact; reflowed)

## Test plan

- [x] `bun run --cwd apps/control-plane test` — 173 pass (incl. new `remove("stale:alt_<slot>")` case: stale slot manufactured by revoking a parked account's provider session out-of-band, then asserting it clears the slot and echoes `{removedId}`)
- [x] `bun run --cwd apps/frontend test` — 1670 pass (dialog: states / switch / remove parked+stale / add / cap / error / closed; `auth/context`: `intent=add` URL + `accountError` toast & strip)
- [x] `bun run --cwd apps/frontend typecheck` and `bun run --cwd apps/control-plane typecheck` — clean
- [x] Pre-commit gauntlet (monorepo lint + typecheck + OpenAPI up-to-date) — clean
- [ ] Manual UI smoke (real OAuth `intent=add` redirect, live no-reload switch, cap → `accountError` toast) — not runnable in a headless container; covered by the e2e + component tests above

https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->