### PR TITLE
feat: create active bot invocations from messages

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -93,14 +93,24 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
 
     const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
-    if (mentionedSlugs.length > 0 && bot.slug != null && !mentionedSlugs.includes(bot.slug)) return
+    const mentionedBots = await BotRepository.findBySlugs(this.pool, message.workspaceId, mentionedSlugs)
+    const explicitMentionableBot = mentionedBots.some((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
+    if (explicitMentionableBot && bot.slug != null && !mentionedSlugs.includes(bot.slug)) return
 
-    const link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
+    let link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
       workspaceId: message.workspaceId,
       botId: bot.id,
       rootStreamId: rootStream.id,
       activeStreamId: stream.id,
     })
+    if (!link && stream.id !== rootStream.id) {
+      link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
+        workspaceId: message.workspaceId,
+        botId: bot.id,
+        rootStreamId: rootStream.id,
+        activeStreamId: rootStream.id,
+      })
+    }
     if (!link) return
 
     await this.service.createInvocation({

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -1,0 +1,123 @@
+import type { Pool } from "pg"
+import { AuthorTypes, StreamTypes, botHasCapability } from "@threa/types"
+import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
+import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../lib/outbox"
+import { logger } from "../../lib/logger"
+import { StreamRepository } from "../streams"
+import { BotRepository } from "../public-api/bot-repository"
+import { BotRuntimeService } from "./service"
+import { BotRuntimeSessionLinkRepository, StreamActiveActorRepository } from "./repository"
+
+const DEFAULT_CONFIG = {
+  batchSize: 100,
+  debounceMs: 50,
+  maxWaitMs: 200,
+  lockDurationMs: 10_000,
+  refreshIntervalMs: 5_000,
+  maxRetries: 5,
+  baseBackoffMs: 1_000,
+}
+
+function extractMentionSlugs(markdown: string): string[] {
+  return Array.from(markdown.matchAll(/@([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})/g), (match) => match[1]!.toLowerCase())
+}
+
+export class BotInvocationOutboxHandler implements OutboxHandler {
+  readonly listenerId = "bot-invocations"
+
+  private readonly pool: Pool
+  private readonly cursorLock: CursorLock
+  private readonly debouncer: DebounceWithMaxWait
+  private readonly service: BotRuntimeService
+
+  constructor(pool: Pool) {
+    this.pool = pool
+    this.service = new BotRuntimeService({ pool })
+    this.cursorLock = new CursorLock({
+      pool,
+      listenerId: this.listenerId,
+      lockDurationMs: DEFAULT_CONFIG.lockDurationMs,
+      refreshIntervalMs: DEFAULT_CONFIG.refreshIntervalMs,
+      maxRetries: DEFAULT_CONFIG.maxRetries,
+      baseBackoffMs: DEFAULT_CONFIG.baseBackoffMs,
+      batchSize: DEFAULT_CONFIG.batchSize,
+    })
+    this.debouncer = new DebounceWithMaxWait(
+      () => this.processEvents(),
+      DEFAULT_CONFIG.debounceMs,
+      DEFAULT_CONFIG.maxWaitMs,
+      (err) => logger.error({ err, listenerId: this.listenerId }, "BotInvocationOutboxHandler debouncer error")
+    )
+  }
+
+  async ensureListener(): Promise<void> {
+    await ensureListenerFromLatest(this.pool, this.listenerId)
+  }
+
+  handle(): void {
+    this.debouncer.trigger()
+  }
+
+  private async processEvents(): Promise<void> {
+    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
+      const events = await OutboxRepository.fetchAfterId(this.pool, cursor, DEFAULT_CONFIG.batchSize, processedIds)
+      if (events.length === 0) return { status: "no_events" }
+
+      const seen: bigint[] = []
+      for (const event of events) {
+        if (event.eventType === "message:created") {
+          await this.processMessageCreated(event.payload)
+        }
+        seen.push(event.id)
+      }
+      return { status: "processed", processedIds: seen }
+    })
+  }
+
+  private async processMessageCreated(payload: unknown): Promise<void> {
+    const message = parseMessagePayload(payload)
+    if (!message) return
+    if (message.event.actorType !== AuthorTypes.USER || !message.event.actorId) return
+
+    const stream = await StreamRepository.findById(this.pool, message.streamId)
+    if (!stream || stream.workspaceId !== message.workspaceId || stream.archivedAt) return
+
+    const rootStreamId = stream.rootStreamId ?? stream.id
+    const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
+    if (!rootStream || rootStream.type !== StreamTypes.SCRATCHPAD || rootStream.archivedAt) return
+
+    const active = await StreamActiveActorRepository.findByRootStream(this.pool, message.workspaceId, rootStream.id)
+    if (!active || active.actorType !== "bot") return
+
+    const bot = await BotRepository.findById(this.pool, message.workspaceId, active.actorId)
+    if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
+
+    const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
+    if (mentionedSlugs.length > 0 && bot.slug != null && !mentionedSlugs.includes(bot.slug)) return
+
+    const link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
+      workspaceId: message.workspaceId,
+      botId: bot.id,
+      rootStreamId: rootStream.id,
+      activeStreamId: stream.id,
+    })
+    if (!link) return
+
+    await this.service.createInvocation({
+      workspaceId: message.workspaceId,
+      rootStreamId: rootStream.id,
+      activeStreamId: stream.id,
+      sourceMessageId: message.event.payload.messageId,
+      responseStreamId: stream.id,
+      actorId: bot.id,
+      trigger: "active-scratchpad",
+      requiredCapability: "active-scratchpad",
+      promptMarkdown: message.event.payload.contentMarkdown,
+      authorUserId: message.event.actorId,
+      mentionedActorSlugs: mentionedSlugs,
+      targetInstanceId: link.instanceId,
+      targetRuntimeSessionId: link.runtimeSessionId,
+      metadata: {},
+    })
+  }
+}

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -1,5 +1,6 @@
 import type { Pool } from "pg"
 import { AuthorTypes, StreamTypes, botHasCapability } from "@threa/types"
+import { parseMarkdown } from "@threa/prosemirror"
 import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
 import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
@@ -7,6 +8,7 @@ import { StreamRepository } from "../streams"
 import { BotRepository } from "../public-api/bot-repository"
 import { BotRuntimeService } from "./service"
 import { BotRuntimeSessionLinkRepository, StreamActiveActorRepository } from "./repository"
+import { EventService } from "../messaging"
 
 const DEFAULT_CONFIG = {
   batchSize: 100,
@@ -29,10 +31,12 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
   private readonly cursorLock: CursorLock
   private readonly debouncer: DebounceWithMaxWait
   private readonly service: BotRuntimeService
+  private readonly eventService: EventService
 
-  constructor(pool: Pool) {
+  constructor(pool: Pool, eventService = new EventService(pool)) {
     this.pool = pool
     this.service = new BotRuntimeService({ pool })
+    this.eventService = eventService
     this.cursorLock = new CursorLock({
       pool,
       listenerId: this.listenerId,
@@ -93,7 +97,12 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
 
     const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
-    const mentionedBots = await BotRepository.findBySlugs(this.pool, message.workspaceId, mentionedSlugs)
+    const mentionedBots = await BotRepository.findVisibleBySlugs(
+      this.pool,
+      message.workspaceId,
+      message.event.actorId,
+      mentionedSlugs
+    )
     const explicitMentionableBot = mentionedBots.some((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
     if (explicitMentionableBot && bot.slug != null && !mentionedSlugs.includes(bot.slug)) return
 
@@ -111,7 +120,16 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
         activeStreamId: rootStream.id,
       })
     }
-    if (!link) return
+    if (!link) {
+      await this.createMissingLinkNotice({
+        workspaceId: message.workspaceId,
+        streamId: stream.id,
+        botName: bot.name,
+        rootStreamId: rootStream.id,
+        sourceMessageId: message.event.payload.messageId,
+      })
+      return
+    }
 
     await this.service.createInvocation({
       workspaceId: message.workspaceId,
@@ -128,6 +146,26 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
       targetInstanceId: link.instanceId,
       targetRuntimeSessionId: link.runtimeSessionId,
       metadata: {},
+    })
+  }
+
+  private async createMissingLinkNotice(params: {
+    workspaceId: string
+    streamId: string
+    botName: string
+    rootStreamId: string
+    sourceMessageId: string
+  }): Promise<void> {
+    const contentMarkdown = `**${params.botName} is not linked to this scratchpad.** Run \`/remote-control\` in Pi to link a session.`
+    await this.eventService.createMessage({
+      workspaceId: params.workspaceId,
+      streamId: params.streamId,
+      authorId: AuthorTypes.SYSTEM,
+      authorType: AuthorTypes.SYSTEM,
+      contentJson: parseMarkdown(contentMarkdown),
+      contentMarkdown,
+      clientMessageId: `bot-runtime-unlinked:${params.rootStreamId}:${params.sourceMessageId}`,
+      metadata: { "bot_runtime.notice": "missing_session_link" },
     })
   }
 }

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -97,14 +97,13 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
 
     const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
-    const mentionedBots = await BotRepository.findVisibleBySlugs(
-      this.pool,
-      message.workspaceId,
-      message.event.actorId,
-      mentionedSlugs
-    )
+    const mentionedBots =
+      mentionedSlugs.length > 0
+        ? await BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs)
+        : []
     const explicitMentionableBot = mentionedBots.some((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
-    if (explicitMentionableBot && bot.slug != null && !mentionedSlugs.includes(bot.slug)) return
+    const activeExplicitlyMentioned = bot.slug != null && mentionedSlugs.includes(bot.slug)
+    if (explicitMentionableBot && !activeExplicitlyMentioned) return
 
     let link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
       workspaceId: message.workspaceId,

--- a/apps/backend/src/features/public-api/bot-repository.ts
+++ b/apps/backend/src/features/public-api/bot-repository.ts
@@ -158,6 +158,20 @@ export const BotRepository = {
     return result.rows.map(mapRowToBot)
   },
 
+  async findVisibleBySlugs(db: Querier, workspaceId: string, userId: string, slugs: string[]): Promise<Bot[]> {
+    if (slugs.length === 0) return []
+
+    const result = await db.query<BotRow>(sql`
+      SELECT ${sql.raw(BOT_COLUMNS)}
+      FROM bots
+      WHERE workspace_id = ${workspaceId}
+        AND slug = ANY(${slugs})
+        AND archived_at IS NULL
+        AND (type = ${BotTypes.SHARED} OR (type = ${BotTypes.PERSONAL} AND owner_user_id = ${userId}))
+    `)
+    return result.rows.map(mapRowToBot)
+  },
+
   async create(
     db: Querier,
     params: {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -893,7 +893,7 @@ export async function startServer(): Promise<ServerInstance> {
   const attachmentEmbeddingHandler = new AttachmentEmbeddingHandler(pool, jobQueue)
   const systemMessageOutboxHandler = new SystemMessageOutboxHandler(pool, systemMessageService)
   const activityFeedHandler = new ActivityFeedHandler(pool, activityService)
-  const botInvocationOutboxHandler = new BotInvocationOutboxHandler(pool)
+  const botInvocationOutboxHandler = new BotInvocationOutboxHandler(pool, eventService)
   const pushNotificationHandler = pushService.isEnabled()
     ? new PushNotificationHandler({ pool: pools.realtime, pushService })
     : null

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -90,6 +90,7 @@ import {
 import { EmojiUsageHandler } from "./features/emoji"
 import { SystemMessageService, SystemMessageOutboxHandler } from "./features/system-messages"
 import { ActivityService, ActivityFeedHandler } from "./features/activity"
+import { BotInvocationOutboxHandler } from "./features/bot-runtimes/invocation-outbox-handler"
 import { SavedMessagesService, createSavedReminderWorker } from "./features/saved-messages"
 import { ScheduledMessagesService, createScheduledMessageSendWorker } from "./features/scheduled-messages"
 import { PushService, PushNotificationHandler, createPushSessionCleanup } from "./features/push"
@@ -892,6 +893,7 @@ export async function startServer(): Promise<ServerInstance> {
   const attachmentEmbeddingHandler = new AttachmentEmbeddingHandler(pool, jobQueue)
   const systemMessageOutboxHandler = new SystemMessageOutboxHandler(pool, systemMessageService)
   const activityFeedHandler = new ActivityFeedHandler(pool, activityService)
+  const botInvocationOutboxHandler = new BotInvocationOutboxHandler(pool)
   const pushNotificationHandler = pushService.isEnabled()
     ? new PushNotificationHandler({ pool: pools.realtime, pushService })
     : null
@@ -916,6 +918,7 @@ export async function startServer(): Promise<ServerInstance> {
     attachmentEmbeddingHandler,
     systemMessageOutboxHandler,
     activityFeedHandler,
+    botInvocationOutboxHandler,
     linkPreviewOutboxHandler,
     ...(pushNotificationHandler ? [pushNotificationHandler] : []),
     ...(shadowSyncHandler ? [shadowSyncHandler] : []),


### PR DESCRIPTION
## Problem

Active bot scratchpads need to turn user-authored messages into provider-neutral invocation rows that runtime adapters can claim.

## Solution

Adds the Phase 3 outbox consumer for `message:created` events. It resolves scratchpad-root active bot bindings, suppresses bot-authored messages, looks up the active runtime session link, and creates targeted `active-scratchpad` invocations idempotently through the Phase 1 service.

## Test plan

- [x] `bun run --cwd apps/backend typecheck`
- [x] Pre-commit lint/typecheck/OpenAPI check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->