### PR TITLE
docs: add pi remote v2 adapter reference

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -347,6 +347,22 @@ export const BotRuntimeSessionLinkRepository = {
     )
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
+
+  async findActiveByRuntimeSession(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      runtimeKind: BotRuntimeKind
+      instanceId: string
+      runtimeSessionId: string
+    }
+  ): Promise<BotRuntimeSessionLink | null> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`SELECT * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND runtime_kind = ${params.runtimeKind} AND instance_id = ${params.instanceId} AND runtime_session_id = ${params.runtimeSessionId} AND status = 'active'`
+    )
+    return result.rows[0] ? mapSessionLink(result.rows[0]) : null
+  },
 }
 
 export const BotInvocationRepository = {

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -431,6 +431,24 @@ export const BotInvocationRepository = {
     return result.rows[0] ? mapInvocation(result.rows[0]) : null
   },
 
+  async renewClaim(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      invocationId: string
+      instanceId: string
+      claimToken: string
+      claimTtlSeconds: number
+    }
+  ): Promise<BotInvocation | null> {
+    const result =
+      await db.query<BotInvocationRow>(sql`UPDATE bot_invocations SET claim_expires_at = NOW() + (${params.claimTtlSeconds} || ' seconds')::interval, updated_at = NOW()
+      WHERE id = ${params.invocationId} AND workspace_id = ${params.workspaceId} AND actor_type = 'bot' AND actor_id = ${params.botId} AND status = 'claimed' AND claimed_by_instance_id = ${params.instanceId} AND claim_token = ${params.claimToken} AND claim_expires_at > NOW()
+      RETURNING *`)
+    return result.rows[0] ? mapInvocation(result.rows[0]) : null
+  },
+
   async completeClaim(
     db: Querier,
     params: { workspaceId: string; botId: string; invocationId: string; instanceId: string; claimToken: string }

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -178,6 +178,17 @@ export class BotRuntimeService {
     return BotInvocationRepository.findActiveClaimForUpdate(db, params)
   }
 
+  async renewInvocationClaim(params: {
+    workspaceId: string
+    botId: string
+    invocationId: string
+    instanceId: string
+    claimToken: string
+    claimTtlSeconds: number
+  }): Promise<BotInvocation | null> {
+    return BotInvocationRepository.renewClaim(this.pool, params)
+  }
+
   async completeInvocation(params: {
     workspaceId: string
     botId: string

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -63,6 +63,18 @@ export class BotRuntimeService {
     })
   }
 
+  async findActivePiRemoteSession(params: {
+    workspaceId: string
+    botId: string
+    instanceId: string
+    runtimeSessionId: string
+  }): Promise<BotRuntimeSessionLink | null> {
+    return BotRuntimeSessionLinkRepository.findActiveByRuntimeSession(this.pool, {
+      ...params,
+      runtimeKind: "pi-local",
+    })
+  }
+
   async createOrLinkPiRemoteSession(params: {
     workspaceId: string
     botId: string

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -448,6 +448,24 @@ export function createPublicApiHandlers({
         })
       }
 
+      const existingLink = await botRuntimeService.findActivePiRemoteSession({
+        workspaceId: req.workspaceId!,
+        botId: bot.id,
+        instanceId: result.data.instanceId,
+        runtimeSessionId: result.data.runtimeSessionId,
+      })
+      if (existingLink) {
+        return res.json({
+          data: {
+            linkId: existingLink.id,
+            rootStreamId: existingLink.rootStreamId,
+            activeStreamId: existingLink.activeStreamId,
+            runtimeSessionId: existingLink.runtimeSessionId,
+            streamUrlPath: `/streams/${existingLink.activeStreamId}`,
+          },
+        })
+      }
+
       const stream = await streamService.createScratchpad({
         workspaceId: req.workspaceId!,
         displayName: result.data.displayName,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -62,7 +62,9 @@ import {
   searchAttachmentsSchema,
   findMessagesByMetadataSchema,
   upsertPresenceSchema,
+  createRuntimeSessionSchema,
   claimInvocationSchema,
+  renewInvocationClaimSchema,
   completeInvocationSchema,
   failInvocationSchema,
 } from "./schemas"
@@ -431,6 +433,49 @@ export function createPublicApiHandlers({
       })
     },
 
+    async createBotRuntimeSession(req: Request, res: Response) {
+      if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
+      const result = createRuntimeSessionSchema.safeParse(req.body)
+      if (!result.success) {
+        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
+      }
+      const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
+      if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
+      if (bot.type !== "personal") {
+        throw new HttpError("Runtime sessions require a personal bot owner", {
+          status: 400,
+          code: "PERSONAL_BOT_REQUIRED",
+        })
+      }
+
+      const stream = await streamService.createScratchpad({
+        workspaceId: req.workspaceId!,
+        displayName: result.data.displayName,
+        createdBy: bot.ownerUserId,
+      })
+      await streamService.addBotToStream(stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
+      const link = await botRuntimeService.createOrLinkPiRemoteSession({
+        workspaceId: req.workspaceId!,
+        botId: bot.id,
+        instanceId: result.data.instanceId,
+        runtimeSessionId: result.data.runtimeSessionId,
+        rootStreamId: stream.id,
+        activeStreamId: stream.id,
+        linkedBy: bot.ownerUserId,
+        metadata: { displayName: result.data.displayName, localCwd: result.data.localCwd ?? null },
+      })
+
+      res.json({
+        data: {
+          linkId: link.id,
+          rootStreamId: link.rootStreamId,
+          activeStreamId: link.activeStreamId,
+          runtimeSessionId: link.runtimeSessionId,
+          streamUrlPath: `/streams/${stream.id}`,
+        },
+      })
+    },
+
     async claimBotInvocation(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
       const result = claimInvocationSchema.safeParse(req.body)
@@ -465,6 +510,30 @@ export function createPublicApiHandlers({
           claimToken: invocation.claimToken!,
           claimExpiresAt: invocation.claimExpiresAt!.toISOString(),
           runtimeSessionId: invocation.targetRuntimeSessionId,
+        },
+      })
+    },
+
+    async renewBotInvocationClaim(req: Request, res: Response) {
+      if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
+      const result = renewInvocationClaimSchema.safeParse(req.body)
+      if (!result.success) {
+        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
+      }
+      const renewed = await botRuntimeService.renewInvocationClaim({
+        workspaceId: req.workspaceId!,
+        botId: req.botApiKey.botId,
+        invocationId: req.params.invocationId,
+        instanceId: result.data.instanceId,
+        claimToken: result.data.claimToken,
+        claimTtlSeconds: result.data.claimTtlSeconds,
+      })
+      if (!renewed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
+      res.json({
+        data: {
+          invocationId: renewed.id,
+          status: renewed.status,
+          claimExpiresAt: renewed.claimExpiresAt?.toISOString() ?? null,
         },
       })
     },

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -34,7 +34,9 @@ import {
   searchAttachmentsSchema,
   findMessagesByMetadataSchema,
   upsertPresenceSchema,
+  createRuntimeSessionSchema,
   claimInvocationSchema,
+  renewInvocationClaimSchema,
   completeInvocationSchema,
   failInvocationSchema,
 } from "./schemas"
@@ -292,7 +294,16 @@ const claimedInvocationSchema = z.object({
   runtimeSessionId: z.string().nullable(),
 })
 
+const runtimeSessionLinkSchema = z.object({
+  linkId: z.string(),
+  rootStreamId: z.string(),
+  activeStreamId: z.string(),
+  runtimeSessionId: z.string(),
+  streamUrlPath: z.string(),
+})
+
 const invocationStatusSchema = z.object({ invocationId: z.string(), status: z.string() })
+const renewedInvocationSchema = invocationStatusSchema.extend({ claimExpiresAt: z.string().datetime().nullable() })
 const completedInvocationSchema = z.object({ invocationId: z.string(), message: messageSchema })
 
 const errorSchema = z.object({
@@ -484,6 +495,18 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
   },
   {
     method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-runtime/sessions",
+    operationId: "createBotRuntimeSession",
+    summary: "Create or link a bot runtime session",
+    tags: ["Bot runtimes"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE],
+    parameters: [workspaceIdParam],
+    requestSchema: createRuntimeSessionSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(runtimeSessionLinkSchema),
+  },
+  {
+    method: "post",
     path: "/api/v1/workspaces/{workspaceId}/bot-invocations/claim",
     operationId: "claimBotInvocation",
     summary: "Claim one pending bot invocation",
@@ -493,6 +516,22 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     requestSchema: claimInvocationSchema,
     requestIn: "body",
     responseSchema: z.object({ data: claimedInvocationSchema.nullable() }),
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/renew",
+    operationId: "renewBotInvocationClaim",
+    summary: "Renew a claimed bot invocation",
+    tags: ["Bot invocations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE],
+    parameters: [
+      workspaceIdParam,
+      { name: "invocationId", in: "path", required: true, schema: { type: "string" }, description: "Invocation ID" },
+    ],
+    requestSchema: renewInvocationClaimSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(renewedInvocationSchema),
+    canReturn404: true,
   },
   {
     method: "post",

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -73,10 +73,24 @@ export const upsertPresenceSchema = z.object({
   statusText: z.string().max(200).optional(),
 })
 
+export const createRuntimeSessionSchema = z.object({
+  runtimeKind: z.enum(BOT_RUNTIME_KINDS),
+  instanceId: z.string().min(1).max(128),
+  runtimeSessionId: z.string().min(1).max(256),
+  displayName: z.string().min(1).max(100),
+  localCwd: z.string().max(1000).optional(),
+})
+
 export const claimInvocationSchema = z.object({
   runtimeKind: z.enum(BOT_RUNTIME_KINDS),
   instanceId: z.string().min(1).max(128),
   supportedCapabilities: z.array(z.enum(BOT_INVOCATION_CAPABILITIES)).min(1),
+  claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
+})
+
+export const renewInvocationClaimSchema = z.object({
+  instanceId: z.string().min(1).max(128),
+  claimToken: z.string().min(1).max(256),
   claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
 })
 

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -74,7 +74,7 @@ export const upsertPresenceSchema = z.object({
 })
 
 export const createRuntimeSessionSchema = z.object({
-  runtimeKind: z.enum(BOT_RUNTIME_KINDS),
+  runtimeKind: z.literal("pi-local"),
   instanceId: z.string().min(1).max(128),
   runtimeSessionId: z.string().min(1).max(256),
   displayName: z.string().min(1).max(100),

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -599,10 +599,22 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     publicApi.upsertBotRuntimePresence
   )
   app.post(
+    "/api/v1/workspaces/:workspaceId/bot-runtime/sessions",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
+    publicApi.createBotRuntimeSession
+  )
+  app.post(
     "/api/v1/workspaces/:workspaceId/bot-invocations/claim",
     ...publicMiddleware,
     requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
     publicApi.claimBotInvocation
+  )
+  app.post(
+    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/renew",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
+    publicApi.renewBotInvocationClaim
   )
   app.post(
     "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/complete",

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -62,6 +62,10 @@ function ensureInstanceId(): string {
   return config.instanceId
 }
 
+function setRemoteStatus(ctx: ExtensionContext, text: string): void {
+  ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("muted", text))
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!config) throw new Error("Threa remote config not loaded")
   const response = await fetch(`${config.baseUrl.replace(/\/$/, "")}${path}`, {
@@ -123,7 +127,7 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
   saveConfig()
 
   ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
-  ctx.ui.setStatus(STATUS_KEY, `Threa remote: ${displayName}`)
+  setRemoteStatus(ctx, `Threa remote: ${displayName}`)
   await heartbeat("available")
 }
 
@@ -160,7 +164,7 @@ async function disableRemote(ctx: ExtensionContext): Promise<void> {
   pending = undefined
   pendingAssistantTexts = []
   await heartbeat("offline").catch(() => undefined)
-  ctx.ui.setStatus(STATUS_KEY, "Threa remote: off")
+  setRemoteStatus(ctx, "Threa remote: off")
   ctx.ui.notify("Threa remote disabled", "info")
 }
 
@@ -199,7 +203,7 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<voi
   pending = body.data
   pendingAssistantTexts = []
   await heartbeat("busy", `Working on ${body.data.id}`)
-  ctx.ui.setStatus(STATUS_KEY, `Threa remote: running ${body.data.id}`)
+  setRemoteStatus(ctx, `Threa remote: running ${body.data.id}`)
   pi.sendUserMessage(
     [
       `Remote Threa invocation ${body.data.id}.`,
@@ -315,7 +319,7 @@ export default function (pi: ExtensionAPI): void {
     config = readConfig()
     if (!config) return
     if (!isEnabled()) {
-      ctx.ui.setStatus(STATUS_KEY, "Threa remote: off")
+      setRemoteStatus(ctx, "Threa remote: off")
       return
     }
     await heartbeat("available")
@@ -335,7 +339,7 @@ export default function (pi: ExtensionAPI): void {
       await completePending(
         pendingAssistantTexts.length > 0 ? pendingAssistantTexts.join("\n\n") : textFromAgentMessages(event.messages)
       )
-      ctx.ui.setStatus(STATUS_KEY, "Threa remote: linked")
+      setRemoteStatus(ctx, "Threa remote: linked")
     } catch (error) {
       ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
       await failPending(error)

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -195,12 +195,16 @@ function textFromContent(content: unknown): string {
 
 function textFromAgentMessages(messages: unknown): string {
   if (!Array.isArray(messages)) return "Done."
-  const text = messages
-    .map((message) => {
-      if (typeof message === "string") return message
-      if (message && typeof message === "object" && "content" in message) return textFromContent(message.content)
-      return ""
-    })
+  const assistantMessages = messages.filter(
+    (message): message is { role: "assistant"; content: unknown } =>
+      Boolean(message) &&
+      typeof message === "object" &&
+      "role" in message &&
+      message.role === "assistant" &&
+      "content" in message
+  )
+  const text = assistantMessages
+    .map((message) => textFromContent(message.content))
     .filter(Boolean)
     .join("\n\n")
     .trim()

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -235,6 +235,22 @@ async function completePending(markdown: string): Promise<void> {
   await heartbeat("available")
 }
 
+async function failPending(error: unknown): Promise<void> {
+  if (!config || !pending) return
+  const invocation = pending
+  pending = undefined
+  pendingAssistantTexts = []
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/fail`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      claimToken: invocation.claimToken,
+      errorMessage: String(error).slice(0, 1000),
+    }),
+  }).catch(() => undefined)
+  await heartbeat("available").catch(() => undefined)
+}
+
 export default function (pi: ExtensionAPI): void {
   pi.registerCommand("remote-control", {
     description: "Create or link a Threa scratchpad to this Pi session",
@@ -272,7 +288,7 @@ export default function (pi: ExtensionAPI): void {
       ctx.ui.setStatus(STATUS_KEY, "Threa remote: linked")
     } catch (error) {
       ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
-      await heartbeat("error", String(error)).catch(() => undefined)
+      await failPending(error)
     }
   })
 

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -29,6 +29,7 @@ type ClaimedInvocation = {
   sourceMessageId: string
   promptMarkdown: string
   claimToken: string
+  claimExpiresAt: string | null
 }
 
 let config: Config | undefined
@@ -124,8 +125,29 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
   await heartbeat("available")
 }
 
+async function renewPendingClaim(): Promise<void> {
+  if (!config || !pending) return
+  const body = await request<{ data: { claimExpiresAt: string | null } }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-invocations/${pending.id}/renew`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        instanceId: ensureInstanceId(),
+        claimToken: pending.claimToken,
+        claimTtlSeconds: 120,
+      }),
+    }
+  )
+  pending.claimExpiresAt = body.data.claimExpiresAt
+}
+
 async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
-  if (!config || pending || !ctx.isIdle()) return
+  if (!config) return
+  if (pending) {
+    await renewPendingClaim()
+    return
+  }
+  if (!ctx.isIdle()) return
   await heartbeat("available")
 
   const body = await request<{ data: ClaimedInvocation | null }>(

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -13,6 +13,7 @@ type Config = {
   pollMs?: number
   instanceId?: string
   defaultDisplayName?: string
+  enabled?: boolean
   linkedSessions?: Record<string, RuntimeSessionLink>
 }
 
@@ -142,8 +143,38 @@ async function renewPendingClaim(): Promise<void> {
   pending.claimExpiresAt = body.data.claimExpiresAt
 }
 
-async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+function isEnabled(): boolean {
+  return config?.enabled !== false
+}
+
+function stopPolling(): void {
+  if (timer) clearInterval(timer)
+  timer = undefined
+}
+
+async function disableRemote(ctx: ExtensionContext): Promise<void> {
   if (!config) return
+  config.enabled = false
+  saveConfig()
+  stopPolling()
+  pending = undefined
+  pendingAssistantTexts = []
+  await heartbeat("offline").catch(() => undefined)
+  ctx.ui.setStatus(STATUS_KEY, "Threa remote: off")
+  ctx.ui.notify("Threa remote disabled", "info")
+}
+
+async function enableRemote(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  if (!config) return
+  config.enabled = true
+  saveConfig()
+  await heartbeat("available")
+  startPolling(pi, ctx)
+  ctx.ui.notify("Threa remote enabled", "info")
+}
+
+async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  if (!config || !isEnabled()) return
   if (pending) {
     await renewPendingClaim()
     return
@@ -208,7 +239,8 @@ function textFromAgentMessages(messages: unknown): string {
 }
 
 function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
-  if (timer) clearInterval(timer)
+  if (!isEnabled()) return
+  stopPolling()
   const poll = () =>
     claimIfIdle(pi, ctx).catch((error) => ctx.ui.notify(`Threa remote poll failed: ${String(error)}`, "warning"))
   timer = setInterval(poll, Math.max(1000, config?.pollMs ?? 3000))
@@ -260,6 +292,20 @@ export default function (pi: ExtensionAPI): void {
         ctx.ui.notify(`Missing ${CONFIG_PATH}`, "warning")
         return
       }
+      const command = args.trim().toLowerCase()
+      if (command === "off" || command === "disable") {
+        await disableRemote(ctx)
+        return
+      }
+      if (command === "on" || command === "enable") {
+        await enableRemote(pi, ctx)
+        return
+      }
+      if (command === "status") {
+        ctx.ui.notify(`Threa remote is ${isEnabled() ? "on" : "off"}${pending ? ` (${pending.id})` : ""}`, "info")
+        return
+      }
+      config.enabled = true
       await createRemoteSession(ctx, args)
       startPolling(pi, ctx)
     },
@@ -268,6 +314,10 @@ export default function (pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     config = readConfig()
     if (!config) return
+    if (!isEnabled()) {
+      ctx.ui.setStatus(STATUS_KEY, "Threa remote: off")
+      return
+    }
     await heartbeat("available")
     startPolling(pi, ctx)
   })
@@ -293,8 +343,7 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    if (timer) clearInterval(timer)
-    timer = undefined
+    stopPolling()
     await heartbeat("offline").catch(() => undefined)
     ctx.ui.setStatus(STATUS_KEY, undefined)
   })

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -1,0 +1,224 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir, hostname } from "node:os"
+import { dirname, join } from "node:path"
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent"
+
+const CONFIG_PATH = join(homedir(), ".pi", "agent", "threa-remote.json")
+const STATUS_KEY = "threa-remote"
+
+type Config = {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+  pollMs?: number
+  instanceId?: string
+  defaultDisplayName?: string
+  linkedSessions?: Record<string, RuntimeSessionLink>
+}
+
+type RuntimeSessionLink = {
+  linkId: string
+  rootStreamId: string
+  activeStreamId: string
+  runtimeSessionId: string
+  streamUrlPath: string
+}
+
+type ClaimedInvocation = {
+  id: string
+  sourceMessageId: string
+  promptMarkdown: string
+  claimToken: string
+}
+
+let config: Config | undefined
+let timer: ReturnType<typeof setInterval> | undefined
+let pending: ClaimedInvocation | undefined
+
+function readConfig(): Config | undefined {
+  if (!existsSync(CONFIG_PATH)) return undefined
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Config
+}
+
+function saveConfig(): void {
+  if (!config) return
+  mkdirSync(dirname(CONFIG_PATH), { recursive: true })
+  writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+}
+
+function ensureInstanceId(): string {
+  if (!config) throw new Error("Threa remote config not loaded")
+  if (config.instanceId) return config.instanceId
+  config.instanceId = `pi-${hostname()}-${crypto.randomUUID().slice(0, 8)}`
+  saveConfig()
+  return config.instanceId
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  if (!config) throw new Error("Threa remote config not loaded")
+  const response = await fetch(`${config.baseUrl.replace(/\/$/, "")}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`Threa API ${response.status}: ${body || response.statusText}`)
+  }
+  return (await response.json()) as T
+}
+
+async function heartbeat(status: "available" | "busy" | "offline" | "error", statusText?: string): Promise<void> {
+  if (!config) return
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-runtime/presence`, {
+    method: "POST",
+    body: JSON.stringify({
+      runtimeKind: "pi-local",
+      instanceId: ensureInstanceId(),
+      displayName: config.defaultDisplayName,
+      status,
+      acceptingInvocations: status === "available",
+      capabilities: {
+        supportsActiveScratchpad: true,
+        supportsPersistentSessions: true,
+        supportsMentionInvocations: false,
+      },
+      statusText,
+    }),
+  })
+}
+
+async function createRemoteSession(ctx: ExtensionCommandContext, args: string): Promise<void> {
+  if (!config) throw new Error("Threa remote config not loaded")
+  const runtimeSessionId = ctx.sessionManager.getSessionId() ?? `pi-session-${Date.now()}`
+  const displayName = args.trim() || config.defaultDisplayName || ctx.cwd.split("/").pop() || "Pi"
+
+  const body = await request<{ data: RuntimeSessionLink }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        runtimeKind: "pi-local",
+        instanceId: ensureInstanceId(),
+        runtimeSessionId,
+        displayName,
+        localCwd: ctx.cwd,
+      }),
+    }
+  )
+
+  config.linkedSessions ??= {}
+  config.linkedSessions[runtimeSessionId] = body.data
+  saveConfig()
+
+  ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
+  ctx.ui.setStatus(STATUS_KEY, `Threa remote: ${displayName}`)
+  await heartbeat("available")
+}
+
+async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  if (!config || pending || !ctx.isIdle()) return
+  await heartbeat("available")
+
+  const body = await request<{ data: ClaimedInvocation | null }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-invocations/claim`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        runtimeKind: "pi-local",
+        instanceId: ensureInstanceId(),
+        supportedCapabilities: ["active-scratchpad"],
+        claimTtlSeconds: 120,
+      }),
+    }
+  )
+
+  if (!body.data) return
+  pending = body.data
+  await heartbeat("busy", `Working on ${body.data.id}`)
+  ctx.ui.setStatus(STATUS_KEY, `Threa remote: running ${body.data.id}`)
+  pi.sendUserMessage(
+    [
+      `Remote Threa invocation ${body.data.id}.`,
+      `Source message: ${body.data.sourceMessageId}`,
+      "Respond normally; the extension will post your final answer back to Threa.",
+      "",
+      body.data.promptMarkdown,
+    ].join("\n")
+  )
+}
+
+function textFromAgentMessages(messages: unknown): string {
+  if (!Array.isArray(messages)) return "Done."
+  return messages
+    .map((message) => {
+      if (typeof message === "string") return message
+      if (message && typeof message === "object" && "content" in message) return String(message.content)
+      return ""
+    })
+    .filter(Boolean)
+    .join("\n\n")
+    .trim()
+}
+
+async function completePending(markdown: string): Promise<void> {
+  if (!config || !pending) return
+  const invocation = pending
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      claimToken: invocation.claimToken,
+      finalMessageMarkdown: markdown || "Done.",
+      metadata: {
+        "pi.remote.invocationId": invocation.id,
+        "pi.remote.instanceId": ensureInstanceId(),
+      },
+    }),
+  })
+  pending = undefined
+  await heartbeat("available")
+}
+
+export default function (pi: ExtensionAPI): void {
+  pi.registerCommand("remote-control", {
+    description: "Create or link a Threa scratchpad to this Pi session",
+    handler: async (args, ctx) => {
+      config = readConfig()
+      if (!config) {
+        ctx.ui.notify(`Missing ${CONFIG_PATH}`, "warning")
+        return
+      }
+      await createRemoteSession(ctx, args)
+      await claimIfIdle(pi, ctx)
+    },
+  })
+
+  pi.on("session_start", async (_event, ctx) => {
+    config = readConfig()
+    if (!config) return
+    await heartbeat("available")
+    timer = setInterval(() => void claimIfIdle(pi, ctx), Math.max(1000, config.pollMs ?? 3000))
+  })
+
+  pi.on("agent_end", async (event, ctx) => {
+    if (!pending) return
+    try {
+      await completePending(textFromAgentMessages(event.messages))
+      ctx.ui.setStatus(STATUS_KEY, "Threa remote: linked")
+    } catch (error) {
+      ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
+      await heartbeat("error", String(error)).catch(() => undefined)
+    }
+  })
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    if (timer) clearInterval(timer)
+    timer = undefined
+    await heartbeat("offline").catch(() => undefined)
+    ctx.ui.setStatus(STATUS_KEY, undefined)
+  })
+}

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -37,7 +37,12 @@ let pending: ClaimedInvocation | undefined
 
 function readConfig(): Config | undefined {
   if (!existsSync(CONFIG_PATH)) return undefined
-  return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Config
+  try {
+    return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Config
+  } catch (error) {
+    console.error(`Failed to parse ${CONFIG_PATH}: ${String(error)}`)
+    return undefined
+  }
 }
 
 function saveConfig(): void {
@@ -151,17 +156,33 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<voi
   )
 }
 
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part
+      if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+        return String(part.text)
+      }
+      return ""
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
 function textFromAgentMessages(messages: unknown): string {
   if (!Array.isArray(messages)) return "Done."
-  return messages
+  const text = messages
     .map((message) => {
       if (typeof message === "string") return message
-      if (message && typeof message === "object" && "content" in message) return String(message.content)
+      if (message && typeof message === "object" && "content" in message) return textFromContent(message.content)
       return ""
     })
     .filter(Boolean)
     .join("\n\n")
     .trim()
+  return text || "Done."
 }
 
 async function completePending(markdown: string): Promise<void> {

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -35,6 +35,7 @@ type ClaimedInvocation = {
 let config: Config | undefined
 let timer: ReturnType<typeof setInterval> | undefined
 let pending: ClaimedInvocation | undefined
+let pendingAssistantTexts: string[] = []
 
 function readConfig(): Config | undefined {
   if (!existsSync(CONFIG_PATH)) return undefined
@@ -165,6 +166,7 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<voi
 
   if (!body.data) return
   pending = body.data
+  pendingAssistantTexts = []
   await heartbeat("busy", `Working on ${body.data.id}`)
   ctx.ui.setStatus(STATUS_KEY, `Threa remote: running ${body.data.id}`)
   pi.sendUserMessage(
@@ -193,21 +195,15 @@ function textFromContent(content: unknown): string {
     .join("\n")
 }
 
+function textFromAssistantMessage(message: unknown): string {
+  if (!message || typeof message !== "object" || !("role" in message) || message.role !== "assistant") return ""
+  if (!("content" in message)) return ""
+  return textFromContent(message.content).trim()
+}
+
 function textFromAgentMessages(messages: unknown): string {
   if (!Array.isArray(messages)) return "Done."
-  const assistantMessages = messages.filter(
-    (message): message is { role: "assistant"; content: unknown } =>
-      Boolean(message) &&
-      typeof message === "object" &&
-      "role" in message &&
-      message.role === "assistant" &&
-      "content" in message
-  )
-  const text = assistantMessages
-    .map((message) => textFromContent(message.content))
-    .filter(Boolean)
-    .join("\n\n")
-    .trim()
+  const text = messages.map(textFromAssistantMessage).filter(Boolean).join("\n\n").trim()
   return text || "Done."
 }
 
@@ -235,6 +231,7 @@ async function completePending(markdown: string): Promise<void> {
     }),
   })
   pending = undefined
+  pendingAssistantTexts = []
   await heartbeat("available")
 }
 
@@ -259,10 +256,19 @@ export default function (pi: ExtensionAPI): void {
     startPolling(pi, ctx)
   })
 
+  pi.on("message_end", async (event) => {
+    if (!pending) return
+    const text = textFromAssistantMessage(event.message)
+    if (!text) return
+    pendingAssistantTexts.push(text)
+  })
+
   pi.on("agent_end", async (event, ctx) => {
     if (!pending) return
     try {
-      await completePending(textFromAgentMessages(event.messages))
+      await completePending(
+        pendingAssistantTexts.length > 0 ? pendingAssistantTexts.join("\n\n") : textFromAgentMessages(event.messages)
+      )
       ctx.ui.setStatus(STATUS_KEY, "Threa remote: linked")
     } catch (error) {
       ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -207,6 +207,14 @@ function textFromAgentMessages(messages: unknown): string {
   return text || "Done."
 }
 
+function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  if (timer) clearInterval(timer)
+  const poll = () =>
+    claimIfIdle(pi, ctx).catch((error) => ctx.ui.notify(`Threa remote poll failed: ${String(error)}`, "warning"))
+  timer = setInterval(poll, Math.max(1000, config?.pollMs ?? 3000))
+  setTimeout(poll, 0)
+}
+
 async function completePending(markdown: string): Promise<void> {
   if (!config || !pending) return
   const invocation = pending
@@ -236,7 +244,7 @@ export default function (pi: ExtensionAPI): void {
         return
       }
       await createRemoteSession(ctx, args)
-      await claimIfIdle(pi, ctx)
+      startPolling(pi, ctx)
     },
   })
 
@@ -244,7 +252,7 @@ export default function (pi: ExtensionAPI): void {
     config = readConfig()
     if (!config) return
     await heartbeat("available")
-    timer = setInterval(() => void claimIfIdle(pi, ctx), Math.max(1000, config.pollMs ?? 3000))
+    startPolling(pi, ctx)
   })
 
   pi.on("agent_end", async (event, ctx) => {

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -35,13 +35,31 @@ type ClaimedInvocation = {
 
 let config: Config | undefined
 let timer: ReturnType<typeof setInterval> | undefined
+let pollInFlight = false
 let pending: ClaimedInvocation | undefined
 let pendingAssistantTexts: string[] = []
+
+function validateConfig(value: unknown): Config | undefined {
+  if (!value || typeof value !== "object") {
+    console.error(`Invalid ${CONFIG_PATH}: expected an object`)
+    return undefined
+  }
+  const candidate = value as Partial<Config>
+  const invalidFields = ["baseUrl", "workspaceId", "apiKey"].filter((field) => {
+    const fieldValue = candidate[field as keyof Config]
+    return typeof fieldValue !== "string" || fieldValue.trim().length === 0
+  })
+  if (invalidFields.length > 0) {
+    console.error(`Invalid ${CONFIG_PATH}: missing or invalid ${invalidFields.join(", ")}`)
+    return undefined
+  }
+  return candidate as Config
+}
 
 function readConfig(): Config | undefined {
   if (!existsSync(CONFIG_PATH)) return undefined
   try {
-    return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as Config
+    return validateConfig(JSON.parse(readFileSync(CONFIG_PATH, "utf8")))
   } catch (error) {
     console.error(`Failed to parse ${CONFIG_PATH}: ${String(error)}`)
     return undefined
@@ -154,6 +172,7 @@ function isEnabled(): boolean {
 function stopPolling(): void {
   if (timer) clearInterval(timer)
   timer = undefined
+  pollInFlight = false
 }
 
 async function disableRemote(ctx: ExtensionContext): Promise<void> {
@@ -161,8 +180,7 @@ async function disableRemote(ctx: ExtensionContext): Promise<void> {
   config.enabled = false
   saveConfig()
   stopPolling()
-  pending = undefined
-  pendingAssistantTexts = []
+  await failPending("Threa remote disabled")
   await heartbeat("offline").catch(() => undefined)
   setRemoteStatus(ctx, "Threa remote: off")
   ctx.ui.notify("Threa remote disabled", "info")
@@ -245,10 +263,19 @@ function textFromAgentMessages(messages: unknown): string {
 function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
   if (!isEnabled()) return
   stopPolling()
-  const poll = () =>
-    claimIfIdle(pi, ctx).catch((error) => ctx.ui.notify(`Threa remote poll failed: ${String(error)}`, "warning"))
-  timer = setInterval(poll, Math.max(1000, config?.pollMs ?? 3000))
-  setTimeout(poll, 0)
+  const poll = async () => {
+    if (pollInFlight) return
+    pollInFlight = true
+    try {
+      await claimIfIdle(pi, ctx)
+    } catch (error) {
+      ctx.ui.notify(`Threa remote poll failed: ${String(error)}`, "warning")
+    } finally {
+      pollInFlight = false
+    }
+  }
+  timer = setInterval(() => void poll(), Math.max(1000, config?.pollMs ?? 3000))
+  void poll()
 }
 
 async function completePending(markdown: string): Promise<void> {
@@ -348,6 +375,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     stopPolling()
+    await failPending("Pi session shut down")
     await heartbeat("offline").catch(() => undefined)
     ctx.ui.setStatus(STATUS_KEY, undefined)
   })

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -921,6 +921,98 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/bot-runtime/sessions": {
+      "post": {
+        "operationId": "createBotRuntimeSession",
+        "summary": "Create or link a bot runtime session",
+        "tags": ["Bot runtimes"],
+        "security": [{ "apiKey": ["bot-runtime:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "runtimeKind": {
+                    "type": "string",
+                    "enum": ["pi-local", "hermes", "openclaw", "claude-code-channel", "custom"]
+                  },
+                  "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
+                  "displayName": { "type": "string", "minLength": 1, "maxLength": 100 },
+                  "localCwd": { "type": "string", "maxLength": 1000 }
+                },
+                "required": ["runtimeKind", "instanceId", "runtimeSessionId", "displayName"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "linkId": { "type": "string" },
+                        "rootStreamId": { "type": "string" },
+                        "activeStreamId": { "type": "string" },
+                        "runtimeSessionId": { "type": "string" },
+                        "streamUrlPath": { "type": "string" }
+                      },
+                      "required": ["linkId", "rootStreamId", "activeStreamId", "runtimeSessionId", "streamUrlPath"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/bot-invocations/claim": {
       "post": {
         "operationId": "claimBotInvocation",
@@ -1055,6 +1147,99 @@
           },
           "401": { "description": "Missing or invalid API key" },
           "403": { "description": "Insufficient permissions or inaccessible resource" }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/renew": {
+      "post": {
+        "operationId": "renewBotInvocationClaim",
+        "summary": "Renew a claimed bot invocation",
+        "tags": ["Bot invocations"],
+        "security": [{ "apiKey": ["bot-invocations:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "invocationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Invocation ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "claimToken": { "type": "string", "minLength": 1, "maxLength": 256 },
+                  "claimTtlSeconds": { "default": 60, "type": "integer", "minimum": 15, "maximum": 300 }
+                },
+                "required": ["instanceId", "claimToken", "claimTtlSeconds"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "invocationId": { "type": "string" },
+                        "status": { "type": "string" },
+                        "claimExpiresAt": { "anyOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }] }
+                      },
+                      "required": ["invocationId", "status", "claimExpiresAt"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
         }
       }
     },

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -944,10 +944,7 @@
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
                 "properties": {
-                  "runtimeKind": {
-                    "type": "string",
-                    "enum": ["pi-local", "hermes", "openclaw", "claude-code-channel", "custom"]
-                  },
+                  "runtimeKind": { "type": "string", "const": "pi-local" },
                   "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
                   "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "displayName": { "type": "string", "minLength": 1, "maxLength": 100 },
@@ -1089,10 +1086,8 @@
                             "promptMarkdown": { "type": "string" },
                             "authorUserId": { "type": "string" },
                             "mentionedActorSlugs": { "type": "array", "items": { "type": "string" } },
-                            "claimToken": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
-                            "claimExpiresAt": {
-                              "anyOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
-                            },
+                            "claimToken": { "type": "string" },
+                            "claimExpiresAt": { "type": "string", "format": "date-time" },
                             "runtimeSessionId": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
                           },
                           "required": [


### PR DESCRIPTION
## Problem

The Pi adapter needs to move from ad-hoc message polling to the runtime protocol.

## Solution

Adds a checked-in reference Pi extension for `/remote-control`, runtime heartbeat, targeted claim polling while idle, and completion/failure through the public runtime API.

## Test plan

- [x] Pre-commit lint/typecheck/OpenAPI check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->