### PR TITLE
feat: add active bot status strip component

### DIFF
--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -1,0 +1,37 @@
+import type { BotRuntimeStatus } from "@threa/types"
+import { cn } from "../../lib/utils"
+
+interface ActiveBotStatusStripProps {
+  botName: string
+  runtimeDisplayName: string | null
+  status: BotRuntimeStatus | "unknown"
+  className?: string
+}
+
+const STATUS_COPY: Record<BotRuntimeStatus | "unknown", string> = {
+  available: "available",
+  busy: "busy",
+  offline: "offline",
+  error: "error",
+  unknown: "not linked",
+}
+
+export function ActiveBotStatusStrip({ botName, runtimeDisplayName, status, className }: ActiveBotStatusStripProps) {
+  const detail = runtimeDisplayName ? `linked to ${runtimeDisplayName}` : "run /remote-control in Pi to connect"
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-sm text-muted-foreground",
+        className
+      )}
+      aria-live="polite"
+    >
+      <span className="font-medium text-foreground">{botName}</span>
+      <span aria-hidden="true"> · </span>
+      <span>{STATUS_COPY[status]}</span>
+      <span aria-hidden="true"> · </span>
+      <span>{detail}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

Users need a small, stable UI primitive to understand active bot/runtime presence in scratchpads.

## Solution

Adds a reusable `ActiveBotStatusStrip` component that renders bot name, runtime status, and reconnect guidance without layout-shifting behavior.

## Test plan

- [x] Pre-commit lint/typecheck/OpenAPI check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->