### PR TITLE
feat: create mentionable bot invocations

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -88,6 +88,31 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
 
     const rootStreamId = stream.rootStreamId ?? stream.id
     const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
+    const invocationRootStreamId = rootStream?.id ?? stream.id
+    const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
+    const mentionableBots = (
+      mentionedSlugs.length > 0
+        ? await BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs)
+        : []
+    ).filter((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
+
+    for (const mentionedBot of mentionableBots) {
+      await this.service.createInvocation({
+        workspaceId: message.workspaceId,
+        rootStreamId: invocationRootStreamId,
+        activeStreamId: stream.id,
+        sourceMessageId: message.event.payload.messageId,
+        responseStreamId: stream.id,
+        actorId: mentionedBot.id,
+        trigger: "mention",
+        requiredCapability: "mentionable",
+        promptMarkdown: message.event.payload.contentMarkdown,
+        authorUserId: message.event.actorId,
+        mentionedActorSlugs: mentionedSlugs,
+        metadata: {},
+      })
+    }
+
     if (!rootStream || rootStream.type !== StreamTypes.SCRATCHPAD || rootStream.archivedAt) return
 
     const active = await StreamActiveActorRepository.findByRootStream(this.pool, message.workspaceId, rootStream.id)
@@ -95,15 +120,8 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
 
     const bot = await BotRepository.findById(this.pool, message.workspaceId, active.actorId)
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
-
-    const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
-    const mentionedBots =
-      mentionedSlugs.length > 0
-        ? await BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs)
-        : []
-    const explicitMentionableBot = mentionedBots.some((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
     const activeExplicitlyMentioned = bot.slug != null && mentionedSlugs.includes(bot.slug)
-    if (explicitMentionableBot && !activeExplicitlyMentioned) return
+    if (mentionableBots.length > 0 && !activeExplicitlyMentioned) return
 
     let link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
       workspaceId: message.workspaceId,

--- a/docs/plans/pi-remote-protocol-implementation.md
+++ b/docs/plans/pi-remote-protocol-implementation.md
@@ -1037,6 +1037,14 @@ async function resolveResponseStreamForMention(params: {
 
 Use this carefully in the outbox handler: if `StreamService.createThread()` owns its own transaction, call it outside the invocation insert transaction or refactor a repository-level helper that can run inside a caller-owned transaction.
 
+### Follow-up notes from Phase 6 dogfood
+
+These are intentionally deferred from the initial mentionable-invocation PR, but should be addressed before treating remote mentions as complete:
+
+- **Pi mention claims:** the backend can create `trigger: "mention"` / `requiredCapability: "mentionable"` invocations for `@pi-remote` in channels, but the V2 Pi adapter currently claims only `supportedCapabilities: ["active-scratchpad"]`. Either teach the adapter to claim/respond to `mentionable` invocations or avoid creating mention invocations for Pi runtimes until they support them.
+- **Persona mention suppression:** active scratchpad auto-invocation is suppressed for explicit mentionable bot mentions, but not for persona mentions such as `@ariadne`. Mention resolution/suppression should include personas so `@ariadne` does not also trigger the active Pi bot unless Pi is explicitly mentioned too.
+- **Non-user context without automatic replies:** the active Pi bot should be able to observe persona/bot replies as context, but should not automatically respond to every non-user message. A follow-up orchestration rule should decide when an active bot may react to Ariadne's reply; the current handler's blanket user-only trigger is safe but too coarse for richer collaboration.
+
 ---
 
 ## Phase 7 — Threa-first pairing code flow


### PR DESCRIPTION
## Problem

Explicit `@bot` mentions should use the same provider-neutral invocation path as active scratchpads.

## Solution

Extends the bot invocation outbox handler to resolve mentioned bot slugs visible to the author and create `mention` invocations with the `mentionable` capability.

## Test plan

- [x] `bun run --cwd apps/backend typecheck`
- [x] Pre-commit lint/typecheck/OpenAPI check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->