### PR TITLE
PR-6: cross-account push + notification-click account switch

### DIFF
--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -53,6 +53,12 @@ interface CrossFeatureLookups {
   getUserNotificationLevel: (workspaceId: string, userId: string) => Promise<PrefNotificationLevel>
   /** Resolve a stream's type by ID within a workspace. Returns null if not found. */
   getStreamType: (workspaceId: string, streamId: string) => Promise<StreamType | null>
+  /**
+   * Resolve the workspace-scoped user's global WorkOS user id. Stamped on the
+   * push payload so the recipient device can flip to the right signed-in
+   * account before opening the deep link. Returns null if the user is not found.
+   */
+  getWorkosUserId: (workspaceId: string, userId: string) => Promise<string | null>
 }
 
 interface PushServiceDeps {
@@ -276,6 +282,12 @@ export class PushService {
       return
     }
 
+    // Recipient's global WorkOS user id — lets the SW flip the active account
+    // before opening the deep link when this push is for a parked account.
+    // Resolved after the no-subscriptions early-return so we never pay the
+    // lookup for a delivery that won't happen.
+    const recipientWorkosUserId = await this.lookups.getWorkosUserId(workspaceId, targetUserId)
+
     // 4. Build structured push payload — display text is formatted by the service worker (INV-46)
     const context = activity.context as
       | { contentPreview?: string; streamName?: string; authorName?: string }
@@ -284,6 +296,7 @@ export class PushService {
     const pushPayload = JSON.stringify({
       data: {
         workspaceId,
+        workosUserId: recipientWorkosUserId ?? undefined,
         streamId: activity.streamId,
         messageId: activity.messageId,
         activityType: activity.activityType,

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -21,6 +21,7 @@ import {
   AvatarProcessingService,
   createAvatarProcessWorker,
   createAvatarProcessOnDLQ,
+  UserRepository,
 } from "./features/workspaces"
 import { InvitationService, InvitationShadowSyncHandler } from "./features/invitations"
 import { WorkosOrgServiceImpl, StubWorkosOrgService } from "@threa/backend-common"
@@ -441,6 +442,11 @@ export async function startServer(): Promise<ServerInstance> {
         const stream = await streamService.getStreamById(streamId)
         if (!stream || stream.workspaceId !== workspaceId) return null
         return stream.type
+      },
+      getWorkosUserId: async (workspaceId, userId) => {
+        // Single query (INV-30): pass the pool directly, no withClient.
+        const user = await UserRepository.findById(pool, workspaceId, userId)
+        return user?.workosUserId ?? null
       },
     },
   })

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -337,6 +337,7 @@ describe("Push Notifications", () => {
         lookups: {
           getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
           getStreamType: async () => StreamTypes.CHANNEL,
+          getWorkosUserId: async () => null,
         },
       })
     }
@@ -473,6 +474,7 @@ describe("Push Notifications", () => {
     function createServiceWithLookups(overrides?: {
       notificationLevel?: PrefNotificationLevel
       streamType?: StreamType | null
+      workosUserId?: string | null
     }) {
       return new PushService({
         pool,
@@ -484,6 +486,7 @@ describe("Push Notifications", () => {
         lookups: {
           getUserNotificationLevel: async () => overrides?.notificationLevel ?? PrefNotificationLevels.ALL,
           getStreamType: async (_workspaceId) => overrides?.streamType ?? StreamTypes.CHANNEL,
+          getWorkosUserId: async () => overrides?.workosUserId ?? null,
         },
       })
     }
@@ -621,6 +624,46 @@ describe("Push Notifications", () => {
       expect(sendSpy.mock.calls[0][0]).toMatchObject({
         endpoint: "https://push.example.com/sub/all-activity",
       })
+    })
+
+    test("activity payload carries the recipient's workosUserId for cross-account routing", async () => {
+      const service = createServiceWithLookups({ workosUserId: "user_01HRECIPIENTWORKOS" })
+
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/workos-id",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d",
+      })
+      await createRecentInactiveSession(testWorkspaceId, testUserId)
+
+      await service.deliverPushForActivity(makePayload())
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse(sendSpy.mock.calls[0][1] as string)
+      expect(payload.data.workosUserId).toBe("user_01HRECIPIENTWORKOS")
+    })
+
+    test("activity payload omits workosUserId when the recipient is unresolvable", async () => {
+      const service = createServiceWithLookups({ workosUserId: null })
+
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/no-workos-id",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d",
+      })
+      await createRecentInactiveSession(testWorkspaceId, testUserId)
+
+      await service.deliverPushForActivity(makePayload())
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse(sendSpy.mock.calls[0][1] as string)
+      expect(payload.data).not.toHaveProperty("workosUserId")
     })
 
     test("focused device with recent interaction → only pushes to that device", async () => {
@@ -1087,6 +1130,7 @@ describe("Push Notifications", () => {
         lookups: {
           getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
           getStreamType: async () => StreamTypes.CHANNEL,
+          getWorkosUserId: async () => null,
         },
       })
     }
@@ -1170,6 +1214,7 @@ describe("Push Notifications", () => {
         lookups: {
           getUserNotificationLevel: async () => PrefNotificationLevels.ALL,
           getStreamType: async () => StreamTypes.CHANNEL,
+          getWorkosUserId: async () => null,
         },
       })
       await expect(service.deliverTestPush(testWorkspaceId, testUserId)).rejects.toThrow(/not enabled/i)

--- a/apps/frontend/src/api/accounts.test.ts
+++ b/apps/frontend/src/api/accounts.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { accountsApi } from "./accounts"
+import * as client from "./client"
+
+describe("accountsApi.resolveIdentity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("requests the identity resolve form with both params URL-encoded", async () => {
+    const getSpy = vi.spyOn(client.api, "get").mockResolvedValue({ ownerUserId: "user_owner" })
+
+    const result = await accountsApi.resolveIdentity("user_01H/ABC", "ws_a&b")
+
+    expect(result).toEqual({ ownerUserId: "user_owner" })
+    expect(getSpy).toHaveBeenCalledWith("/api/accounts/resolve?userId=user_01H%2FABC&workspaceId=ws_a%26b")
+  })
+
+  it("resolve (bare-workspace form) still omits the userId param", async () => {
+    const getSpy = vi.spyOn(client.api, "get").mockResolvedValue({ ownerUserId: "user_owner" })
+
+    await accountsApi.resolve("ws_x y")
+
+    expect(getSpy).toHaveBeenCalledWith("/api/accounts/resolve?workspaceId=ws_x%20y")
+  })
+})

--- a/apps/frontend/src/api/accounts.ts
+++ b/apps/frontend/src/api/accounts.ts
@@ -15,11 +15,22 @@ export interface AccountSummary {
 }
 
 export const accountsApi = {
-  // Bare-workspace form only: "which signed-in account owns this workspace?"
-  // (used by the cross-account deep-link guard). The identity (`userId`) form
-  // is backend-only until its notification-click caller lands.
+  // Bare-workspace form: "which signed-in account owns this workspace?" — used
+  // by the cross-account deep-link guard. 404s on ambiguity (a workspace more
+  // than one signed-in account can see).
   resolve(workspaceId: string): Promise<{ ownerUserId: string }> {
     return api.get<{ ownerUserId: string }>(`/api/accounts/resolve?workspaceId=${encodeURIComponent(workspaceId)}`)
+  },
+
+  // Identity form: "is this specific account signed in on this browser, and
+  // does it own this workspace?" — used by the notification-click switch so a
+  // push for a parked account disambiguates a workspace both accounts can see.
+  // 404 ACCOUNT_NOT_SIGNED_IN if that account isn't signed in here; never
+  // substitutes another account.
+  resolveIdentity(userId: string, workspaceId: string): Promise<{ ownerUserId: string }> {
+    return api.get<{ ownerUserId: string }>(
+      `/api/accounts/resolve?userId=${encodeURIComponent(userId)}&workspaceId=${encodeURIComponent(workspaceId)}`
+    )
   },
 
   list(): Promise<{ accounts: AccountSummary[]; maxAccounts: number }> {

--- a/apps/frontend/src/lib/notification-intent.test.ts
+++ b/apps/frontend/src/lib/notification-intent.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import { setNotificationIntent, takeNotificationIntent } from "./notification-intent"
+
+describe("notification-intent", () => {
+  it("take returns the stashed id once, then null (one-shot)", () => {
+    setNotificationIntent("ws_1", "user_recipient")
+
+    expect(takeNotificationIntent("ws_1")).toBe("user_recipient")
+    // Consumed — a second take for the same workspace yields nothing
+    expect(takeNotificationIntent("ws_1")).toBeNull()
+  })
+
+  it("take returns null when the workspace does not match the stashed intent", () => {
+    setNotificationIntent("ws_a", "user_recipient")
+
+    // Mismatched workspace must not consume the pending intent
+    expect(takeNotificationIntent("ws_b")).toBeNull()
+    // The original workspace can still claim it
+    expect(takeNotificationIntent("ws_a")).toBe("user_recipient")
+  })
+
+  it("a newer intent overwrites an unconsumed one", () => {
+    setNotificationIntent("ws_1", "user_first")
+    setNotificationIntent("ws_2", "user_second")
+
+    expect(takeNotificationIntent("ws_1")).toBeNull()
+    expect(takeNotificationIntent("ws_2")).toBe("user_second")
+  })
+
+  it("take returns null when nothing was stashed", () => {
+    expect(takeNotificationIntent("ws_none")).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/notification-intent.ts
+++ b/apps/frontend/src/lib/notification-intent.ts
@@ -1,0 +1,23 @@
+// One-shot, workspace-keyed handoff from the SW-message handler (which runs
+// outside React, with no AccountScope context) to WorkspaceLayout's
+// account-switch hook. The notification carries the recipient account's WorkOS
+// user id; the hook reads it once on mount and resolves/flips the active
+// account so the deep link opens under the right identity.
+
+let pending: { workspaceId: string; workosUserId: string } | null = null
+
+export function setNotificationIntent(workspaceId: string, workosUserId: string): void {
+  pending = { workspaceId, workosUserId }
+}
+
+/**
+ * Returns the pending recipient WorkOS user id iff it was set for this exact
+ * workspace, clearing it so it fires at most once. A mismatched workspace (a
+ * later, unrelated mount) leaves the intent untouched and returns null.
+ */
+export function takeNotificationIntent(workspaceId: string): string | null {
+  if (pending?.workspaceId !== workspaceId) return null
+  const id = pending.workosUserId
+  pending = null
+  return id
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client"
 import { App } from "./App"
 import { router } from "./routes"
 import { SW_MSG_NOTIFICATION_CLICK, SW_MSG_SUBSCRIPTION_CHANGED } from "./lib/sw-messages"
+import { setNotificationIntent } from "./lib/notification-intent"
 import { hydrateCollapseCache } from "./lib/markdown/collapse-cache"
 import { applyPersistedComposerHeight } from "./lib/composer-height-storage"
 import "./index.css"
@@ -18,6 +19,14 @@ navigator.serviceWorker?.addEventListener("message", (event) => {
     // Client-side navigation preserves React tree, TanStack Query cache, and socket connection
     const url = event.data.url as string
     if (url.startsWith("/")) {
+      // Stash the notification's intended recipient *before* navigating so the
+      // freshly-mounted WorkspaceLayout's switch hook sees it. The hook flips
+      // the active account in place if the click landed under a different one.
+      const workosUserId = event.data.workosUserId as string | undefined
+      const workspaceMatch = /^\/w\/([^/]+)/.exec(url)
+      if (workosUserId && workspaceMatch) {
+        setNotificationIntent(workspaceMatch[1], workosUserId)
+      }
       router.navigate(url)
     }
   }

--- a/apps/frontend/src/pages/use-notification-account-switch.test.tsx
+++ b/apps/frontend/src/pages/use-notification-account-switch.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { useNotificationAccountSwitch } from "./use-notification-account-switch"
+import { ApiError } from "@/api/client"
+import { accountsApi } from "@/api"
+import * as accountScopeModule from "@/auth/account-scope"
+import * as authModule from "@/auth"
+import type { AccountScopeValue } from "@/auth/account-scope"
+import { setNotificationIntent, takeNotificationIntent } from "@/lib/notification-intent"
+
+const WS = "ws_deeplink"
+
+const switchAccountMock = vi.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined)
+const loginMock = vi.fn<(redirectTo?: string) => void>()
+let mockActiveId: string | null = "workos_A"
+
+function installSpies() {
+  vi.spyOn(accountScopeModule, "useAccountScope").mockImplementation(
+    () =>
+      ({
+        activeWorkosUserId: mockActiveId,
+        switchAccount: switchAccountMock,
+        getDb: () => {
+          throw new Error("not used")
+        },
+        getQueryClient: () => {
+          throw new Error("not used")
+        },
+        scopedKey: (s: string) => s,
+      }) satisfies AccountScopeValue
+  )
+  vi.spyOn(authModule, "useAuth").mockReturnValue({
+    login: loginMock,
+  } as unknown as ReturnType<typeof authModule.useAuth>)
+}
+
+beforeEach(() => {
+  mockActiveId = "workos_A"
+  switchAccountMock.mockClear().mockResolvedValue(undefined)
+  loginMock.mockReset()
+  // Drain any intent a prior test stashed but did not consume.
+  takeNotificationIntent(WS)
+  installSpies()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useNotificationAccountSwitch", () => {
+  it("resolves the parked owner and flips in place when the intent names a different account", async () => {
+    setNotificationIntent(WS, "workos_B")
+    const resolveSpy = vi.spyOn(accountsApi, "resolveIdentity").mockResolvedValue({ ownerUserId: "workos_B" })
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await waitFor(() => expect(switchAccountMock).toHaveBeenCalledWith("workos_B"))
+    expect(resolveSpy).toHaveBeenCalledWith("workos_B", WS)
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when there is no pending intent", async () => {
+    const resolveSpy = vi.spyOn(accountsApi, "resolveIdentity").mockResolvedValue({ ownerUserId: "workos_B" })
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await Promise.resolve()
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("does not resolve or switch when the intent already names the active account", async () => {
+    setNotificationIntent(WS, "workos_A")
+    const resolveSpy = vi.spyOn(accountsApi, "resolveIdentity").mockResolvedValue({ ownerUserId: "workos_A" })
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await Promise.resolve()
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("full re-auth back to the deep link when that account is not signed in here", async () => {
+    setNotificationIntent(WS, "workos_B")
+    vi.spyOn(accountsApi, "resolveIdentity").mockRejectedValue(
+      new ApiError(404, "ACCOUNT_NOT_SIGNED_IN", "not signed in")
+    )
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await waitFor(() => expect(loginMock).toHaveBeenCalledWith(`/w/${WS}`))
+    expect(switchAccountMock).not.toHaveBeenCalled()
+  })
+
+  it("benign no-op on an ambiguous/unresolvable workspace (no switch, no login, no throw)", async () => {
+    setNotificationIntent(WS, "workos_B")
+    vi.spyOn(accountsApi, "resolveIdentity").mockRejectedValue(
+      new ApiError(404, "WORKSPACE_NOT_RESOLVABLE", "ambiguous")
+    )
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("benign no-op on a network failure", async () => {
+    setNotificationIntent(WS, "workos_B")
+    vi.spyOn(accountsApi, "resolveIdentity").mockRejectedValue(new Error("network down"))
+
+    renderHook(() => useNotificationAccountSwitch(WS))
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a late resolve after unmount (ignore-flag cleanup)", async () => {
+    setNotificationIntent(WS, "workos_B")
+    let resolveLate: (v: { ownerUserId: string }) => void = () => {}
+    const pending = new Promise<{ ownerUserId: string }>((r) => {
+      resolveLate = r
+    })
+    vi.spyOn(accountsApi, "resolveIdentity").mockReturnValue(pending)
+
+    const { unmount } = renderHook(() => useNotificationAccountSwitch(WS))
+    unmount()
+    resolveLate({ ownerUserId: "workos_B" })
+    await pending
+    await Promise.resolve()
+
+    expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/pages/use-notification-account-switch.test.tsx
+++ b/apps/frontend/src/pages/use-notification-account-switch.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { StrictMode } from "react"
 import { renderHook, waitFor } from "@testing-library/react"
 import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 import { ApiError } from "@/api/client"
@@ -135,6 +136,17 @@ describe("useNotificationAccountSwitch", () => {
     await Promise.resolve()
 
     expect(switchAccountMock).not.toHaveBeenCalled()
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it("survives StrictMode's throwaway first mount (intent handed back, switch still fires)", async () => {
+    setNotificationIntent(WS, "workos_B")
+    const resolveSpy = vi.spyOn(accountsApi, "resolveIdentity").mockResolvedValue({ ownerUserId: "workos_B" })
+
+    renderHook(() => useNotificationAccountSwitch(WS), { wrapper: StrictMode })
+
+    await waitFor(() => expect(switchAccountMock).toHaveBeenCalledWith("workos_B"))
+    expect(resolveSpy).toHaveBeenCalledWith("workos_B", WS)
     expect(loginMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/pages/use-notification-account-switch.ts
+++ b/apps/frontend/src/pages/use-notification-account-switch.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react"
+import { accountsApi } from "@/api"
+import { ApiError } from "@/api/client"
+import { useAccountScope } from "@/auth/account-scope"
+import { useAuth } from "@/auth"
+import { takeNotificationIntent } from "@/lib/notification-intent"
+
+/**
+ * Cross-account notification-click handler. A push for a *parked* account
+ * carries that account's WorkOS user id; `main.tsx` stashes it (keyed to the
+ * workspace) and navigates the deep link, so on mount the URL is already
+ * correct but the active account may be the wrong one.
+ *
+ * This hook reads the one-shot intent and, if it names a different account,
+ * asks the control plane (identity `resolve` form) which signed-in account
+ * owns it, then flips in place (PR-4a `switchAccount`). The keyed remount
+ * re-bootstraps the same `workspaceId` under the owning account — no
+ * navigation here (`main.tsx` already navigated; the module-singleton router's
+ * location survives the remount).
+ *
+ * - intent === active account, or no intent -> no-op (common case).
+ * - 404 `ACCOUNT_NOT_SIGNED_IN`: that account isn't on this browser -> full
+ *   re-auth that lands back on the deep link.
+ * - other resolve errors (network / `WORKSPACE_NOT_RESOLVABLE`) -> benign
+ *   no-op; `useResolveOrBounce` is the safety net for the already-navigated
+ *   URL.
+ *
+ * The intent is one-shot (`takeNotificationIntent` clears it), so the effect
+ * re-running can't re-trigger; a cleanup flag drops a late resolve after
+ * unmount or workspace change. Mirrors `useResolveOrBounce`.
+ */
+export function useNotificationAccountSwitch(workspaceId: string): void {
+  const { switchAccount, activeWorkosUserId } = useAccountScope()
+  const { login } = useAuth()
+
+  useEffect(() => {
+    const intentUserId = takeNotificationIntent(workspaceId)
+    if (!intentUserId || intentUserId === activeWorkosUserId) return
+
+    let ignore = false
+    void (async () => {
+      try {
+        const { ownerUserId } = await accountsApi.resolveIdentity(intentUserId, workspaceId)
+        if (ignore || ownerUserId === activeWorkosUserId) return
+        await switchAccount(ownerUserId)
+      } catch (e) {
+        if (!ignore && ApiError.isApiError(e) && e.code === "ACCOUNT_NOT_SIGNED_IN") {
+          login(`/w/${workspaceId}`)
+        }
+      }
+    })()
+    return () => {
+      ignore = true
+    }
+  }, [workspaceId, activeWorkosUserId, switchAccount, login])
+}

--- a/apps/frontend/src/pages/use-notification-account-switch.ts
+++ b/apps/frontend/src/pages/use-notification-account-switch.ts
@@ -3,7 +3,7 @@ import { accountsApi } from "@/api"
 import { ApiError } from "@/api/client"
 import { useAccountScope } from "@/auth/account-scope"
 import { useAuth } from "@/auth"
-import { takeNotificationIntent } from "@/lib/notification-intent"
+import { setNotificationIntent, takeNotificationIntent } from "@/lib/notification-intent"
 
 /**
  * Cross-account notification-click handler. A push for a *parked* account
@@ -27,7 +27,10 @@ import { takeNotificationIntent } from "@/lib/notification-intent"
  *
  * The intent is one-shot (`takeNotificationIntent` clears it), so the effect
  * re-running can't re-trigger; a cleanup flag drops a late resolve after
- * unmount or workspace change. Mirrors `useResolveOrBounce`.
+ * unmount or workspace change. If the effect tears down before the attempt
+ * settles (StrictMode's throwaway first mount, or a fast unmount), the cleanup
+ * hands the unconsumed intent back so the retained mount still sees it.
+ * Mirrors `useResolveOrBounce`.
  */
 export function useNotificationAccountSwitch(workspaceId: string): void {
   const { switchAccount, activeWorkosUserId } = useAccountScope()
@@ -38,19 +41,25 @@ export function useNotificationAccountSwitch(workspaceId: string): void {
     if (!intentUserId || intentUserId === activeWorkosUserId) return
 
     let ignore = false
+    let settled = false
     void (async () => {
       try {
         const { ownerUserId } = await accountsApi.resolveIdentity(intentUserId, workspaceId)
-        if (ignore || ownerUserId === activeWorkosUserId) return
+        if (ignore) return
+        settled = true
+        if (ownerUserId === activeWorkosUserId) return
         await switchAccount(ownerUserId)
       } catch (e) {
-        if (!ignore && ApiError.isApiError(e) && e.code === "ACCOUNT_NOT_SIGNED_IN") {
+        if (ignore) return
+        settled = true
+        if (ApiError.isApiError(e) && e.code === "ACCOUNT_NOT_SIGNED_IN") {
           login(`/w/${workspaceId}`)
         }
       }
     })()
     return () => {
       ignore = true
+      if (!settled) setNotificationIntent(workspaceId, intentUserId)
     }
   }, [workspaceId, activeWorkosUserId, switchAccount, login])
 }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -68,6 +68,7 @@ import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
 import { SyncStatusStore, SyncStatusContext } from "@/sync/sync-status"
 import { useResolveOrBounce } from "./use-resolve-or-bounce"
+import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 
 interface WorkspaceKeyboardHandlerProps {
   onOpenSwitcher: (mode: QuickSwitcherMode) => void
@@ -234,6 +235,10 @@ function WorkspaceSyncHandler({
   // No destroy effect — StrictMode's effect cleanup cycle would destroy the
   // engine before the socket connect effect re-runs. The engine is destroyed
   // on workspace change (line above) and on page unload (browser handles it).
+
+  // A push for a parked account stashes its recipient id (notification-intent);
+  // flip the active account in place before this deep link bootstraps wrong.
+  useNotificationAccountSwitch(workspaceId)
 
   // Terminal workspace error (404/403): a different signed-in account may own
   // this deep link — resolve→flip in place, else bounce to the list.

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -444,6 +444,14 @@ self.addEventListener("fetch", (event) => {
 /** Structured push payload — display text is formatted here, not on the backend (INV-46). */
 interface PushData {
   workspaceId?: string
+  /**
+   * Recipient account's WorkOS user id. Lets the app flip the active account
+   * in place before opening the deep link when the click lands under a
+   * different signed-in account. Stamped by the backend (push/service.ts);
+   * duplicated here because there is no shared types package for this wire
+   * contract (mirrors the rest of PushData).
+   */
+  workosUserId?: string
   streamId?: string
   messageId?: string
   activityType?: string
@@ -601,7 +609,11 @@ self.addEventListener("notificationclick", (event) => {
       for (const client of clients) {
         if (new URL(client.url).origin === self.location.origin) {
           await client.focus()
-          client.postMessage({ type: SW_MSG_NOTIFICATION_CLICK, url: targetUrl })
+          client.postMessage({
+            type: SW_MSG_NOTIFICATION_CLICK,
+            url: targetUrl,
+            workosUserId: data?.workosUserId,
+          })
           return
         }
       }

--- a/docs/plans/multi-account-login-split.md
+++ b/docs/plans/multi-account-login-split.md
@@ -420,35 +420,55 @@ never hardcoded. No new backend code (PR-3/PR-4a contracts only).
 work — PR #487's service worker navigates to `/w/${workspaceId}/…` with no
 identity awareness and `PushData` carries no `workosUserId`.
 
-**Changes:**
+**Shipped:**
 
-- Push payload carries the **target account identity** (at least
-  `workosUserId` + `workspaceId`).
-- `apps/frontend/src/sw.ts` `notificationclick`: call PR-4b's resolve
-  **identity form** (`?userId=`) with the payload's `workosUserId`, **flip
-  AccountScope** (PR-4a) to that account if it is parked, then route to the
-  deep link. No reload. Not signed in here → full login as that user (the
-  resolver never substitutes a different readable account).
-- Per-`(account, workspace)` push opt-out re-key (matches PR-4a localStorage
-  re-keying).
-- Single sign-out does a **surgical push-row cleanup** for that account only
-  (the existing `deleteByEndpointForUser` join via `workos_user_id` already
-  scopes correctly — confirmed no migration needed).
-- On add-account, subscribe the existing browser push endpoint for the newly
-  added account so its notifications arrive without re-granting permission.
+- Activity push payload carries `workosUserId` (recipient member's WorkOS id)
+  alongside `workspaceId`. Resolved once per target user via the existing
+  `UserRepository.findById` behind a new `CrossFeatureLookups.getWorkosUserId`
+  seam (INV-52/35); no migration. Only the activity payload — `clear` /
+  `session_expired` / `test` / reminder payloads have no cross-account deep
+  link so they carry no identity.
+- `apps/frontend/src/sw.ts` `notificationclick` (warm path) forwards
+  `workosUserId` in the `SW_MSG_NOTIFICATION_CLICK` postMessage. `main.tsx`
+  stashes it via a one-shot, workspace-keyed `notification-intent` module
+  **before** `router.navigate(url)` (the SW message handler has no React
+  context — same hand-off shape as the existing `pushsubscriptionchanged`
+  forward). `useNotificationAccountSwitch(workspaceId)` (colocated with
+  `workspace-layout`, mounted beside `useResolveOrBounce`) reads the intent,
+  calls PR-4b's resolve **identity form** (`accountsApi.resolveIdentity`), and
+  on a different owner flips in place via PR-4a `switchAccount` — the keyed
+  remount re-bootstraps the already-navigated URL, no extra navigation. Not
+  signed in here (`404 ACCOUNT_NOT_SIGNED_IN`) → full re-login back to the deep
+  link; `WORKSPACE_NOT_RESOLVABLE` / network → benign no-op
+  (`useResolveOrBounce` remains the safety net).
+- Per-`(account, workspace)` push opt-out re-key — **verify-only, already on
+  `main`** (`use-push-notifications.ts` `pushOptOutKey(workspaceId, accountId)`
+  via `useAccountScopeOptional()`).
+- Surgical single sign-out push-row cleanup — **verify-only, already on
+  `main`**: `deleteByEndpointForUser` scopes by `endpoint AND user_id IN
+(… workos_user_id = $2)`, i.e. one account across workspaces. No migration.
+- Auto-subscribe a newly added account's push endpoint — **deferred**.
+  `usePushNotifications` mounts only in the notification-settings panel; there
+  is no always-on subscribe path, so add-account auto-subscribe is a separate
+  subscribe-lifecycle change. The new account subscribes on next settings
+  open, exactly as a new workspace does today — no regression.
 
 **Reuse:** Existing `push_subscriptions` schema (`UNIQUE (workspace_id,
 user_id, endpoint)` already account-scoped — **no migration**); existing
-endpoint-cleanup query; PR-4b resolve identity form; PR-4a AccountScope flip.
+endpoint-cleanup query; PR-4b resolve identity form; PR-4a AccountScope flip;
+`useResolveOrBounce` ignore-flag/attempt-once structure; the `main.tsx`
+SW-message → hand-off pattern.
 
-**Verification:**
-
-- Notification for parked account B while A is active → click → app flips to B
-  and lands on the correct deep link, no reload, no A-data flash.
-- Opt-out is per `(account, workspace)`; toggling one does not affect another.
-- Sign out of A only → A's push rows gone, B's intact, B still receives push.
-- Add account on a browser with push already granted → new account receives
-  push without a second permission prompt.
+**Verification (shipped):** Backend push suite — an activity delivery's
+serialized `data.workosUserId` equals the target's `workos_user_id`, and is
+omitted when unresolvable. Frontend — `notification-intent` is one-shot and
+workspace-keyed; `resolveIdentity` requests the `?userId=&workspaceId=`
+form URL-encoded; `useNotificationAccountSwitch` flips on a parked owner, is a
+no-op with no intent / intent === active, re-logins on
+`ACCOUNT_NOT_SIGNED_IN`, no-ops on `WORKSPACE_NOT_RESOLVABLE`/network, and
+drops a late resolve after unmount. Manual two-account smoke — notification for
+parked B while A is focused → click flips to B in place (no reload), lands on
+the deep link; single-account navigation unaffected.
 
 ---
 


### PR DESCRIPTION
## Summary

Final slice of the multi-account login split (`docs/plans/multi-account-login-split.md`). A push for a *parked* account now carries that account's WorkOS user id end-to-end so clicking the notification flips to the owning account **in place** (PR-4a `switchAccount` — no page reload) before the deep link bootstraps under the wrong account.

- **Backend:** `push/service.ts` resolves the recipient's WorkOS user id via a new `getWorkosUserId` `CrossFeatureLookups` seam (single query, INV-30/52) and includes it in the activity push payload; omitted when unresolvable.
- **Service worker:** `PushData.workosUserId` threaded through `notificationclick` → warm-client `postMessage`.
- **Frontend routing seam:** `main.tsx` stashes a one-shot, workspace-keyed notification intent (`lib/notification-intent.ts`) then navigates the deep link.
- **In-place switch:** new `useNotificationAccountSwitch` hook (mounted in `WorkspaceLayout` alongside `useResolveOrBounce`) reads the intent, asks the control plane's identity `resolve` form which signed-in account owns it, and flips via PR-4a `switchAccount`. `ACCOUNT_NOT_SIGNED_IN` → full re-auth back to the deep link; network / `WORKSPACE_NOT_RESOLVABLE` → benign no-op (`useResolveOrBounce` is the safety net).
- **API client:** added `accountsApi.resolveIdentity(userId, workspaceId)` (identity form); existing bare-workspace `resolve` retained.
- Self-review fix included: the cleanup hands the unconsumed one-shot intent back when an attempt tears down before settling, so StrictMode's throwaway first mount can't drain it (would have silently broken the dev-server smoke).

No new backend production contracts — this is a consumer of `/api/accounts/resolve` and the push pipeline already on `main`. `MAX_ACCOUNTS` unchanged.

## Test plan

- [x] `apps/frontend` unit tests — full suite green, incl. new `use-notification-account-switch.test.tsx` (8 cases: switch, no-op paths, full re-auth, benign errors, late-resolve-after-unmount, StrictMode double-invoke), `notification-intent.test.ts` (one-shot semantics), `accounts.test.ts` (URL encoding of both resolve forms)
- [x] `apps/frontend` typecheck
- [x] Backend + full monorepo typecheck + OpenAPI check (pre-commit hook)
- [ ] `apps/backend` integration tests (`push.test.ts` — 2 new cases asserting the payload carries / omits `workosUserId`) — **not runnable in this environment (no Docker/Postgres); runs in CI**
- [ ] Manual smoke: push to a parked account → click notification → active account flips in place (no reload), deep link re-bootstraps under the owner; account-not-signed-in → re-auth lands back on the deep link

https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->