### PR TITLE
fix(ci): pass explicit ASCII commit metadata to Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name threa-frontend --branch main
+          command: pages deploy dist --project-name threa-frontend --branch main --commit-hash ${{ github.event.workflow_run.head_sha }} --commit-message "deploy ${{ github.event.workflow_run.head_sha }}" --commit-dirty=true
           workingDirectory: apps/frontend
           packageManager: bun
 
@@ -114,7 +114,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name threa-backoffice --branch main
+          command: pages deploy dist --project-name threa-backoffice --branch main --commit-hash ${{ github.event.workflow_run.head_sha }} --commit-message "deploy ${{ github.event.workflow_run.head_sha }}" --commit-dirty=true
           workingDirectory: apps/backoffice
           packageManager: bun
 
@@ -187,7 +187,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name threa-backoffice-staging --branch main
+          command: pages deploy dist --project-name threa-backoffice-staging --branch main --commit-hash ${{ github.event.workflow_run.head_sha }} --commit-message "deploy ${{ github.event.workflow_run.head_sha }}" --commit-dirty=true
           workingDirectory: apps/backoffice
           packageManager: bun
 
@@ -265,7 +265,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name threa-staging --branch main
+          command: pages deploy dist --project-name threa-staging --branch main --commit-hash ${{ github.event.workflow_run.head_sha }} --commit-message "deploy ${{ github.event.workflow_run.head_sha }}" --commit-dirty=true
           workingDirectory: apps/frontend
           packageManager: bun
 


### PR DESCRIPTION
## Problem

The `Deploy Cloudflare` workflow fails at the **Deploy to Cloudflare Pages** step:

```
✘ [ERROR] A request to the Cloudflare API (.../pages/projects/threa-frontend/deployments) failed.
  Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]
```

(Observed on [run 25986308731](https://github.com/threahq/threa/actions/runs/25986308731/job/76391822924).)

Root cause is a server-side Cloudflare Pages API bug ([cloudflare/workers-sdk#11749](https://github.com/cloudflare/workers-sdk/issues/11749)):

- `wrangler pages deploy` auto-detects git metadata and sends the **full multi-line HEAD commit message** to the Pages deployments API.
- That API truncates commit messages at **byte 380** when the message has ≥5 lines.
- The triggering squash-merge commit (`PR-6: cross-account push ... (#557)`) has a long body containing em-dash characters (`—`, bytes `E2 80 94`). One straddles the 380-byte boundary, so the server cuts a 3-byte UTF-8 sequence in half → invalid UTF-8 → `code: 8000111`.

This recurs for any merge to `main` whose commit body is long and contains a multibyte character (em-dash, emoji, smart quotes) near the boundary — common in the repo's squash-merge messages.

## Solution

Stop relying on wrangler's git auto-detection. Each of the four `pages deploy` jobs now passes explicit, single-line, pure-ASCII commit metadata:

```
--commit-hash ${{ github.event.workflow_run.head_sha }}
--commit-message "deploy ${{ github.event.workflow_run.head_sha }}"
--commit-dirty=true
```

### Key design decisions

**1. SHA-only commit message**

A single-line `deploy <40-hex-sha>` message is well under 380 bytes and pure ASCII, so it cannot trigger the boundary-truncation bug regardless of what the squash-merge body contains. The SHA is still recorded via `--commit-hash`, so the Cloudflare dashboard links the deployment back to the exact commit. `github.event.workflow_run.head_sha` is already used as the checkout `ref` in this workflow, so the value is consistent.

**2. `--commit-dirty=true`**

The build/install steps dirty the working tree, which previously emitted a warning. Setting this explicitly silences it now that we're managing commit metadata ourselves.

**3. Scope limited to `pages deploy` jobs**

The Workers `deploy` jobs (`workspace-router`, `backoffice-router`) do not call the Pages deployments API and are left unchanged.

## Modified files

| File | Change |
| ---- | ------ |
| `.github/workflows/deploy-cloudflare.yml` | Add explicit `--commit-hash` / `--commit-message` / `--commit-dirty=true` to the 4 `pages deploy` jobs (frontend, backoffice, backoffice-staging, frontend-staging) |

## Test plan

- [x] `lint` + monorepo `typecheck` pass via pre-commit hooks
- [ ] Merge to `main`; confirm the next `Deploy Cloudflare` run completes the Pages deploy steps without the `8000111` error (this workflow is `workflow_run`-triggered and cannot run from a branch)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dwvrbd7MzAGAEVtiQuMRWB)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->