### PR TITLE
fix(workspace-router): route /api/accounts* to the control-plane

### DIFF
--- a/apps/workspace-router/src/index.test.ts
+++ b/apps/workspace-router/src/index.test.ts
@@ -227,6 +227,12 @@ describe("workspace-router", () => {
       expect(await getJson<{ error: string }>(res)).toEqual({ error: "Not found" })
     })
 
+    test("account routes return 404 when no CONTROL_PLANE_URL", async () => {
+      const res = await worker.fetch(makeRequest("/api/accounts"), makeEnv())
+      expect(res.status).toBe(404)
+      expect(await getJson<{ error: string }>(res)).toEqual({ error: "Not found" })
+    })
+
     test("unknown paths return 404", async () => {
       const res = await worker.fetch(makeRequest("/api/unknown"), makeEnv())
       expect(res.status).toBe(404)
@@ -325,6 +331,53 @@ describe("workspace-router", () => {
       try {
         await worker.fetch(makeRequest("/api/regions"), makeEnv({ CONTROL_PLANE_URL: CP_URL }))
         expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/regions")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("proxies GET /api/accounts to control-plane", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        await worker.fetch(makeRequest("/api/accounts"), makeEnv({ CONTROL_PLANE_URL: CP_URL }))
+        expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/accounts")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("proxies GET /api/accounts/resolve (with query) to control-plane", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        await worker.fetch(
+          makeRequest("/api/accounts/resolve?workspaceId=ws_123"),
+          makeEnv({ CONTROL_PLANE_URL: CP_URL })
+        )
+        expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/accounts/resolve?workspaceId=ws_123")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("proxies POST /api/accounts/switch to control-plane", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        await worker.fetch(makeRequest("/api/accounts/switch", "POST"), makeEnv({ CONTROL_PLANE_URL: CP_URL }))
+        expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/accounts/switch")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("proxies POST /api/accounts/remove to control-plane", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        await worker.fetch(makeRequest("/api/accounts/remove", "POST"), makeEnv({ CONTROL_PLANE_URL: CP_URL }))
+        expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/accounts/remove")
       } finally {
         globalThis.fetch = originalFetch
       }

--- a/apps/workspace-router/src/index.ts
+++ b/apps/workspace-router/src/index.ts
@@ -30,6 +30,8 @@ const AUTH_ROUTE_RE = /^\/api\/auth\//
 const INTEGRATION_CALLBACK_RE = /^\/api\/integrations\/[^/]+\/callback\/?$/
 const WORKSPACES_COLLECTION_RE = /^\/api\/workspaces\/?$/
 const REGIONS_ROUTE_RE = /^\/api\/regions\/?$/
+/** Multi-account switcher API (list/resolve/switch/remove) — control-plane only */
+const ACCOUNTS_ROUTE_RE = /^\/api\/accounts(?:\/.*)?$/
 /** Dev auth routes that the control-plane handles in stub mode */
 const DEV_AUTH_ROUTE_RE = /^\/(?:test-auth-login|api\/dev\/login)\/?$/
 /** User-facing invitation acceptance (handled by control-plane) */
@@ -124,6 +126,7 @@ export default {
         const method = request.method
         if (
           AUTH_ROUTE_RE.test(path) ||
+          ACCOUNTS_ROUTE_RE.test(path) ||
           INTEGRATION_CALLBACK_RE.test(path) ||
           (WORKSPACES_COLLECTION_RE.test(path) && (method === "GET" || method === "POST")) ||
           REGIONS_ROUTE_RE.test(path) ||
@@ -169,6 +172,7 @@ export default {
       const method = request.method
       if (
         AUTH_ROUTE_RE.test(path) ||
+        ACCOUNTS_ROUTE_RE.test(path) ||
         INTEGRATION_CALLBACK_RE.test(path) ||
         (WORKSPACES_COLLECTION_RE.test(path) && (method === "GET" || method === "POST")) ||
         REGIONS_ROUTE_RE.test(path) ||


### PR DESCRIPTION
## Summary

The multi-account switcher always renders **"Couldn't load your accounts. Close and try again."** in every environment (local dev, staging, production).

Root cause: the multi-account API (`GET /api/accounts`, `/resolve`, `POST /switch`, `/remove`) added in PR-3 (#538) lives **only** on the control-plane, but the edge router's control-plane allowlist was never taught about `/api/accounts`. Every request fell through past all route matchers to the Pages/`404` fallback instead of reaching the CP:

- Standard path → `404 Not found`.
- Staging-pinned path → proxied to the *regional* backend (no accounts handler) → `404`, or fell through to the SPA HTML → frontend `response.json()` fails with `PARSE_ERROR`.

Either way the switcher's `useQuery` lands in `isError`. This is environment-independent and affects every user — it is **not** a session/cookie issue (the primary `wos_session` cookie name/format is unchanged by PR-1; the rest of the app works normally).

## Changes

- Add `ACCOUNTS_ROUTE_RE = /^\/api\/accounts(?:\/.*)?$/` and wire it into **both** control-plane routing blocks — the standard block and the staging-pinned block. The staging-pinned entry is essential: without it, `/api/accounts` on `staging.threa.io` / `pr-N-staging.threa.io` would be proxied to the regional backend (which has no accounts handler).
- No method gating — all four account routes (GET list/resolve, POST switch/remove) belong to the control-plane, consistent with how `AUTH_ROUTE_RE` is handled.
- 5 router tests: 4 proxy-target assertions (incl. query-string preservation on `/resolve`) + a "404 when no CONTROL_PLANE_URL" regression guard.

The regex is tightly scoped: it matches `/api/accounts` and `/api/accounts/...` but not `/api/accountsfoo`, and does not overlap `/api/workspaces/*`.

## Test plan

- [x] `bun test src/index.test.ts` in `apps/workspace-router` — 50/50 pass (5 new)
- [x] `bun run typecheck` (workspace-router app + test configs) — clean
- [x] Pre-commit suite (monorepo lint + typecheck + dockerfile/API-doc checks) — green
- [ ] Post-deploy: confirm the account switcher loads on staging (router is a Cloudflare Worker — fix takes effect only after the worker is deployed)

> Note: this fixes only the routing gap. The switcher will keep failing on live environments until the workspace-router Worker is deployed; no user-side action (re-login etc.) is needed once it is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->