### PR TITLE
fix(accounts): land add-account on the new account instead of bouncing back

### DIFF
--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -176,7 +176,7 @@ export function createControlPlaneAuthHandlers({
         } else {
           // No throw mid-OAuth-callback: the user keeps their existing session
           // and the frontend surfaces the refusal from the query param.
-          redirectPath += `${redirectPath.includes("?") ? "&" : "?"}accountError=${parked.code}`
+          redirectPath += `${redirectPath.includes("?") ? "&" : "?"}accountError=${encodeURIComponent(parked.code)}`
         }
       } else {
         setSessionCookie(res, result.sealedSession)

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -142,22 +142,19 @@ export function createControlPlaneAuthHandlers({
 
       const { isAdd, innerState } = parseCallbackState(state)
 
-      let redirectUrl: string
+      let appOrigin: string
+      let redirectPath: string
       const decoded = innerState ? Buffer.from(innerState, "base64").toString("utf-8") : ""
       const pipeIndex = decoded.indexOf("|")
 
       if (pipeIndex !== -1) {
         // State contains "host|path" — redirect to the original forwarded host
         const host = decoded.substring(0, pipeIndex)
-        const path = decodeAndSanitizeRedirectState(Buffer.from(decoded.substring(pipeIndex + 1)).toString("base64"))
-        if (isTrustedHost(host, allowedRedirectDomain, dedicatedRedirectHosts)) {
-          redirectUrl = `https://${host}${path}`
-        } else {
-          redirectUrl = frontendUrl ? `${frontendUrl}${path}` : path
-        }
+        redirectPath = decodeAndSanitizeRedirectState(Buffer.from(decoded.substring(pipeIndex + 1)).toString("base64"))
+        appOrigin = isTrustedHost(host, allowedRedirectDomain, dedicatedRedirectHosts) ? `https://${host}` : frontendUrl
       } else {
-        const path = innerState ? decodeAndSanitizeRedirectState(innerState) : "/"
-        redirectUrl = frontendUrl ? `${frontendUrl}${path}` : path
+        redirectPath = innerState ? decodeAndSanitizeRedirectState(innerState) : "/"
+        appOrigin = frontendUrl
       }
 
       if (isAdd) {
@@ -168,15 +165,23 @@ export function createControlPlaneAuthHandlers({
           result.sealedSession,
           result.user.id
         )
-        if (!parked.ok) {
+        if (parked.ok) {
+          // A successful add makes the just-authenticated account active. The
+          // pre-add state path belongs to the previous (now parked) account;
+          // routing there 403s and bounces straight back via the workspace
+          // resolve→switchAccount path, silently undoing the add. Land on the
+          // workspace picker instead; ?accountAdded=1 lets the app drop its
+          // stale last-workspace pointer so it can't redirect into the old account.
+          redirectPath = "/workspaces?accountAdded=1"
+        } else {
           // No throw mid-OAuth-callback: the user keeps their existing session
           // and the frontend surfaces the refusal from the query param.
-          redirectUrl += `${redirectUrl.includes("?") ? "&" : "?"}accountError=${parked.code}`
+          redirectPath += `${redirectPath.includes("?") ? "&" : "?"}accountError=${parked.code}`
         }
       } else {
         setSessionCookie(res, result.sealedSession)
       }
-      res.redirect(redirectUrl)
+      res.redirect(`${appOrigin}${redirectPath}`)
     },
 
     async logout(req: Request, res: Response) {

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -117,6 +117,20 @@ describe("Multi-account /api/accounts", () => {
     })
   })
 
+  test("a successful add redirects to the workspace picker with ?accountAdded=1", async () => {
+    const client = new TestClient()
+    await loginAs(client, uniqueEmail("acc-redirect-a"), "Redirect A")
+    const { res } = await addAccount(client, uniqueEmail("acc-redirect-b"), "Redirect B")
+
+    // The add makes the new account active. The pre-add state path belongs to
+    // the previous account; routing there 403s and bounces straight back via
+    // resolve→switchAccount, silently undoing the add. The callback must land
+    // on the workspace picker so the app can drop its stale last-workspace
+    // pointer (?accountAdded=1) instead of routing into the old account.
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toContain("/workspaces?accountAdded=1")
+  })
+
   test("switch promotes a parked account and parks the previously active one", async () => {
     const client = new TestClient()
     const aEmail = uniqueEmail("acc-switch-a")

--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -113,6 +113,7 @@ describe("AuthProvider login / accountError", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+    localStorage.clear()
     Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
   })
 
@@ -163,6 +164,23 @@ describe("AuthProvider login / accountError", () => {
       )
     })
     expect(replaceSpy).toHaveBeenCalledWith(null, "", "/w/workspace_1?foo=bar")
+  })
+
+  it("clears the stale last-workspace pointer on accountAdded and strips the param", async () => {
+    stubLocation("?accountAdded=1&foo=bar")
+    localStorage.setItem("threa-last-workspace", "workspace_old")
+    const replaceSpy = vi.spyOn(window.history, "replaceState").mockImplementation(() => {})
+
+    render(
+      <AuthProvider>
+        <LoginProbe />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith(null, "", "/w/workspace_1?foo=bar")
+    })
+    expect(localStorage.getItem("threa-last-workspace")).toBeNull()
   })
 
   it("does not toast when there is no accountError param", async () => {

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -23,6 +23,11 @@ interface AuthContextValue extends AuthState {
 const ACCOUNT_ERROR_PARAM = "accountError"
 const MAX_ACCOUNTS_REACHED = "MAX_ACCOUNTS_REACHED"
 
+// A successful add-account redirect carries this (control plane sends the
+// browser to /workspaces?accountAdded=1 so the app drops its stale
+// last-workspace pointer instead of routing back into the old account).
+const ACCOUNT_ADDED_PARAM = "accountAdded"
+
 // Best-effort push cleanup must never delay the logout redirect for long.
 // When the SW is healthy this completes in well under a second; the cap only
 // fires when `serviceWorker.ready` never settles (stranded worker).
@@ -123,14 +128,30 @@ export function AuthProvider({ children }: AuthProviderProps) {
     fetchUser()
   }, [fetchUser])
 
-  // AuthProvider sits above the router, so the add-account refusal can't be
-  // read via useSearchParams. Surface it once and strip the param so a
-  // refresh doesn't re-toast.
+  // AuthProvider sits above the router, so the add-account callback outcome
+  // can't be read via useSearchParams. Handle it once on mount and strip the
+  // param so a refresh doesn't re-fire.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    if (params.get(ACCOUNT_ERROR_PARAM) !== MAX_ACCOUNTS_REACHED) return
-    toast.error("You're signed in to the maximum number of accounts. Remove one to add another.")
-    params.delete(ACCOUNT_ERROR_PARAM)
+    let changed = false
+
+    if (params.get(ACCOUNT_ERROR_PARAM) === MAX_ACCOUNTS_REACHED) {
+      toast.error("You're signed in to the maximum number of accounts. Remove one to add another.")
+      params.delete(ACCOUNT_ERROR_PARAM)
+      changed = true
+    }
+
+    // A successful add makes the just-added account the active session. The
+    // last-workspace pointer still names the *previous* account's workspace;
+    // clearing it stops RootRedirect from routing into a workspace the new
+    // account can't see (which 403s and bounces back to the old account).
+    if (params.get(ACCOUNT_ADDED_PARAM) === "1") {
+      clearLastWorkspaceId()
+      params.delete(ACCOUNT_ADDED_PARAM)
+      changed = true
+    }
+
+    if (!changed) return
     const query = params.toString()
     window.history.replaceState(
       null,


### PR DESCRIPTION
## Summary

Adding a second account on the same browser authenticated the new account
server-side (its session cookie was set by `addAndParkActive`), but the
OAuth callback redirected the browser to the **pre-add state path**. That
path belongs to the *previous* account, so:

1. `RootRedirect` followed the stale **global** `last-workspace` pointer
   into a workspace the new account can't see,
2. workspace bootstrap 403'd,
3. the `accounts/resolve → switchAccount` fallback flipped the active
   session **straight back to the old account**.

Net effect the user reported: the add was silently undone, the sidebar
still showed the old account's data, a hard refresh didn't help (cookie +
last-workspace now both pointed at the old account again), and the failed
bootstrap left `currentUser` null so the sidebar footer disappeared —
stranding the user with no way to log out or switch accounts.

The only reasonable outcome of a successful add is to **land on the newly
added account**. This PR makes that happen with a minimal two-part fix:

- **control-plane callback** (`features/auth/handlers.ts`): on a
  successful `intent=add`, redirect to `/workspaces?accountAdded=1`
  instead of the pre-add state path. Refactored the redirect builder to
  compute `appOrigin` + `redirectPath` separately; the non-add
  (`setSessionCookie` + original path) and add-failure (`accountError`)
  paths are byte-for-byte unchanged (`appOrigin` never contains `?`, so
  the existing `includes("?")` separator logic is equivalent).
- **`AuthProvider`** (`auth/context.tsx`): on `accountAdded=1`, clear the
  stale `last-workspace` pointer and strip the param (so a refresh can't
  re-fire and `RootRedirect` can't route back into the old account). The
  existing `accountError` toast/strip behavior is preserved exactly; both
  outcomes now share one mount effect with a single `replaceState`.

`/workspaces` is a safe landing: it is self-healing, not gated on a
failing bootstrap, and does not run `useResolveOrBounce`, so it renders
the **new** (now-active) account's workspace list without bouncing.

No `MAX_ACCOUNTS` change; the cap path is untouched.

## Test plan

- [x] `bun run --cwd apps/frontend test` — 1685 passing, incl. the new
      `context.test.tsx` case (asserts `accountAdded=1` clears
      `threa-last-workspace` and strips the param via `replaceState`;
      added `localStorage.clear()` to the block's `afterEach` for
      hermeticity).
- [x] `bun run --cwd apps/frontend typecheck` — clean.
- [x] `bun run --cwd apps/control-plane typecheck` — clean.
- [x] Added control-plane e2e case asserting the add-success redirect
      `location` contains `/workspaces?accountAdded=1` (mirrors the
      existing overflow test's origin-agnostic `toContain` style).
- [ ] `bun run --cwd apps/control-plane test` — **not runnable in the
      authoring sandbox** (no Docker/Postgres; every one of the 108
      pre-existing e2e tests fails identically with `ConnectionRefused`).
      The change is a behavior-preserving refactor verified by typecheck
      and traced against the existing `accountError`/redirect assertions;
      please confirm green in CI.
- [ ] Manual smoke: signed into account A, "Add account" → authenticate
      B → app lands on `/workspaces` as **B** (not bounced back to A),
      sidebar footer present; hitting the cap still surfaces the
      `MAX_ACCOUNTS_REACHED` toast.

https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgU1HyqK518giRMfAoFeVm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->