### PR TITLE
fix(accounts): run add/park flow in the interactive stub login path

### DIFF
--- a/apps/control-plane/src/features/auth/callback-state.ts
+++ b/apps/control-plane/src/features/auth/callback-state.ts
@@ -1,0 +1,43 @@
+import { decodeAndSanitizeRedirectState } from "@threa/backend-common"
+
+/**
+ * Peel the optional `add|` multi-account sentinel off the OAuth `state`.
+ *
+ * `login` prefixes a literal `add|` onto the *plaintext* state when
+ * `intent=add`; `getAuthorizationUrl` then base64-encodes the whole thing.
+ * Here we decode once, strip the sentinel, and re-encode the inner plaintext
+ * so the existing host/path decode logic runs on a byte-identical payload.
+ * For the non-add path `innerState` is the original `state` untouched, keeping
+ * single-account decoding exactly as it was.
+ */
+export function parseCallbackState(state: string | undefined): { isAdd: boolean; innerState: string | undefined } {
+  if (!state) return { isAdd: false, innerState: state }
+  const decoded = Buffer.from(state, "base64").toString("utf-8")
+  if (decoded.startsWith("add|")) {
+    const inner = decoded.slice("add|".length)
+    return { isAdd: true, innerState: Buffer.from(inner, "utf-8").toString("base64") }
+  }
+  return { isAdd: false, innerState: state }
+}
+
+/**
+ * Decode the post-auth redirect target encoded in `innerState`.
+ *
+ * Two forms: the `host|path` forwarded-host form (the `host` is returned so a
+ * caller that crosses origins — the WorkOS callback — can build the absolute
+ * URL; same-origin callers like the stub login form ignore it) and the bare
+ * `path` form. Empty/absent state falls back to "/". `redirectPath` is always
+ * sanitized to a safe relative path.
+ */
+export function splitInnerState(innerState: string | undefined): { host: string | null; redirectPath: string } {
+  const decoded = innerState ? Buffer.from(innerState, "base64").toString("utf-8") : ""
+  const pipeIndex = decoded.indexOf("|")
+  if (pipeIndex !== -1) {
+    const host = decoded.substring(0, pipeIndex)
+    const redirectPath = decodeAndSanitizeRedirectState(
+      Buffer.from(decoded.substring(pipeIndex + 1)).toString("base64")
+    )
+    return { host, redirectPath }
+  }
+  return { host: null, redirectPath: innerState ? decodeAndSanitizeRedirectState(innerState) : "/" }
+}

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -5,13 +5,13 @@ import {
   SESSION_COOKIE_NAME,
   clearAltSessionCookie,
   clearSessionCookie,
-  decodeAndSanitizeRedirectState,
   displayNameFromWorkos,
   readAltSessionCookies,
   setSessionCookie,
   type AuthService,
 } from "@threa/backend-common"
 import type { AccountsService } from "../accounts"
+import { parseCallbackState, splitInnerState } from "./callback-state"
 
 const callbackSchema = z.object({
   code: z.string().min(1),
@@ -58,26 +58,6 @@ function isTrustedHost(host: string, allowedDomain: string, dedicatedHosts: stri
   if (dedicatedHosts.includes(host)) return true
   if (allowedDomain && isAllowedForwardedHost(host, allowedDomain)) return true
   return false
-}
-
-/**
- * Peel the optional `add|` multi-account sentinel off the OAuth `state`.
- *
- * `login` prefixes a literal `add|` onto the *plaintext* state when
- * `intent=add`; `getAuthorizationUrl` then base64-encodes the whole thing.
- * Here we decode once, strip the sentinel, and re-encode the inner plaintext
- * so the existing host/path decode logic runs on a byte-identical payload.
- * For the non-add path `innerState` is the original `state` untouched, keeping
- * single-account decoding exactly as it was.
- */
-function parseCallbackState(state: string | undefined): { isAdd: boolean; innerState: string | undefined } {
-  if (!state) return { isAdd: false, innerState: state }
-  const decoded = Buffer.from(state, "base64").toString("utf-8")
-  if (decoded.startsWith("add|")) {
-    const inner = decoded.slice("add|".length)
-    return { isAdd: true, innerState: Buffer.from(inner, "utf-8").toString("base64") }
-  }
-  return { isAdd: false, innerState: state }
 }
 
 export function createControlPlaneAuthHandlers({
@@ -142,20 +122,12 @@ export function createControlPlaneAuthHandlers({
 
       const { isAdd, innerState } = parseCallbackState(state)
 
-      let appOrigin: string
-      let redirectPath: string
-      const decoded = innerState ? Buffer.from(innerState, "base64").toString("utf-8") : ""
-      const pipeIndex = decoded.indexOf("|")
-
-      if (pipeIndex !== -1) {
-        // State contains "host|path" — redirect to the original forwarded host
-        const host = decoded.substring(0, pipeIndex)
-        redirectPath = decodeAndSanitizeRedirectState(Buffer.from(decoded.substring(pipeIndex + 1)).toString("base64"))
-        appOrigin = isTrustedHost(host, allowedRedirectDomain, dedicatedRedirectHosts) ? `https://${host}` : frontendUrl
-      } else {
-        redirectPath = innerState ? decodeAndSanitizeRedirectState(innerState) : "/"
-        appOrigin = frontendUrl
-      }
+      const { host, redirectPath: basePath } = splitInnerState(innerState)
+      let redirectPath = basePath
+      // "host|path" state redirects back to the original forwarded host when
+      // it's trusted; otherwise fall back to the canonical frontend origin.
+      const appOrigin =
+        host && isTrustedHost(host, allowedRedirectDomain, dedicatedRedirectHosts) ? `https://${host}` : frontendUrl
 
       if (isAdd) {
         const parked = await accountsService.addAndParkActive(

--- a/apps/control-plane/src/features/auth/stub-handlers.ts
+++ b/apps/control-plane/src/features/auth/stub-handlers.ts
@@ -2,11 +2,13 @@ import type { Request, Response } from "express"
 import { z } from "zod/v4"
 import {
   HttpError,
-  decodeAndSanitizeRedirectState,
+  SESSION_COOKIE_NAME,
   renderLoginPage,
   setSessionCookie,
   type StubAuthService,
 } from "@threa/backend-common"
+import type { AccountsService } from "../accounts"
+import { parseCallbackState, splitInnerState } from "./callback-state"
 
 const stubLoginSchema = z.object({
   email: z.email(),
@@ -21,9 +23,17 @@ const devLoginSchema = z.object({
 
 interface Dependencies {
   authStubService: StubAuthService
+  /**
+   * Same collaborator the real OAuth callback uses. The interactive stub
+   * login form is the only add-account entry point on stub-auth environments
+   * (dev / staging / PR previews), so it must run the identical park/coalesce
+   * sequence — otherwise `intent=add` silently overwrites the active session
+   * and the user can never hold two accounts.
+   */
+  accountsService: AccountsService
 }
 
-export function createAuthStubHandlers({ authStubService }: Dependencies) {
+export function createAuthStubHandlers({ authStubService, accountsService }: Dependencies) {
   return {
     async getLoginPage(req: Request, res: Response) {
       const state = (req.query.state as string) || ""
@@ -38,10 +48,35 @@ export function createAuthStubHandlers({ authStubService }: Dependencies) {
       const { email, name, state } = parsed.data
       const result = await authStubService.devLogin({ email, name })
 
-      const redirectUrl = state ? decodeAndSanitizeRedirectState(state) : "/"
+      // Mirror the real OAuth callback (handlers.ts `callback`). The stub form
+      // is served and submitted same-origin, so the forwarded host is ignored
+      // and the redirect stays relative.
+      const { isAdd, innerState } = parseCallbackState(state)
+      let redirectPath = splitInnerState(innerState).redirectPath
 
-      setSessionCookie(res, result.session)
-      res.redirect(redirectUrl)
+      if (isAdd) {
+        const parked = await accountsService.addAndParkActive(
+          res,
+          req.cookies,
+          req.cookies[SESSION_COOKIE_NAME] as string | undefined,
+          result.session,
+          result.user.id
+        )
+        if (parked.ok) {
+          // A successful add makes the just-authenticated account active. The
+          // pre-add state path belongs to the previous (now parked) account;
+          // routing there 403s and bounces straight back via the workspace
+          // resolve→switchAccount path, silently undoing the add. Land on the
+          // workspace picker instead; ?accountAdded=1 lets the app drop its
+          // stale last-workspace pointer so it can't redirect into the old account.
+          redirectPath = "/workspaces?accountAdded=1"
+        } else {
+          redirectPath += `${redirectPath.includes("?") ? "&" : "?"}accountError=${encodeURIComponent(parked.code)}`
+        }
+      } else {
+        setSessionCookie(res, result.session)
+      }
+      res.redirect(redirectPath)
     },
 
     async handleDevLogin(req: Request, res: Response) {

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -103,6 +103,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
     const authStub = createAuthStubHandlers({
       authStubService: authService,
+      accountsService,
     })
     app.get("/test-auth-login", authStub.getLoginPage)
     app.post("/test-auth-login", authLimit, authStub.handleLogin)

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -44,10 +44,12 @@ interface AccountsResponse {
 }
 
 /**
- * Drive the OAuth add-account flow for `main`. A throwaway client registers the
- * user in the shared stub (devLogin), then we hit the callback directly with an
- * `add|`-prefixed state — the stub's `/test-auth-login` page bypasses the
- * callback, so the park/coalesce path must be exercised through `/api/auth/callback`.
+ * Drive the OAuth add-account flow for `main` through the WorkOS callback. A
+ * throwaway client registers the user in the shared stub (devLogin), then we
+ * hit `/api/auth/callback` directly with an `add|`-prefixed state. The
+ * interactive stub login form (`/test-auth-login`) runs the identical
+ * park/coalesce sequence — that path is covered separately by
+ * "interactive stub add-account form parks the previous account".
  * Returns the registered user, the registering client (its jar still holds that
  * user's real sealed session — used to prove revoke), and the callback response.
  */
@@ -129,6 +131,39 @@ describe("Multi-account /api/accounts", () => {
     // pointer (?accountAdded=1) instead of routing into the old account.
     expect(res.status).toBe(302)
     expect(res.headers.get("location")).toContain("/workspaces?accountAdded=1")
+  })
+
+  test("interactive stub add-account form parks the previous account", async () => {
+    // The interactive stub login form is the only add-account entry point on
+    // stub-auth environments (dev / staging / PR previews). Driving it end to
+    // end (login?intent=add -> /test-auth-login POST) proves it runs the same
+    // park/coalesce + ?accountAdded=1 redirect as the real WorkOS callback,
+    // instead of silently overwriting the active session.
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-form-a")
+    const bEmail = uniqueEmail("acc-form-b")
+    const a = await loginAs(client, aEmail, "Form A")
+
+    const add = await client.get("/api/auth/login?intent=add")
+    expect(add.status).toBe(302)
+    const stubUrl = new URL(add.headers.get("location")!, "http://localhost")
+    const state = stubUrl.searchParams.get("state")!
+
+    const submitted = await client.post("/test-auth-login", { email: bEmail, name: "Form B", state })
+    expect(submitted.status).toBe(302)
+    expect(submitted.headers.get("location")).toContain("/workspaces?accountAdded=1")
+
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.email).toBe(bEmail)
+
+    const accounts = await client.get<AccountsResponse>("/api/accounts")
+    expect(accounts.data).toEqual({
+      accounts: [
+        { id: me.data.id, email: bEmail, name: "Form B", state: "active" },
+        { id: a.id, email: aEmail, name: "Form A", state: "parked" },
+      ],
+      maxAccounts: MAX_ACCOUNTS,
+    })
   })
 
   test("switch promotes a parked account and parks the previously active one", async () => {


### PR DESCRIPTION
## Problem

Multi-account login regressed: adding a second account immediately logged the user back in as the **same** account they already had, with no way to actually switch.

Root cause: on stub-auth environments (dev, staging, PR previews) the **only** add-account entry point is the interactive `/test-auth-login` form, but its `handleLogin` never implemented any multi-account logic. It ignored the `add|` state sentinel entirely and just called `setSessionCookie`, silently overwriting the active session.

The OAuth-callback park/coalesce fix — including #560's `/workspaces?accountAdded=1` redirect — only ever ran in `handlers.ts` (`/api/auth/callback`). The e2e suite hid the gap because it POSTed to `/api/auth/callback` directly, bypassing the stub form that real users (and PR previews) go through.

Net effect on exactly the environments users test on: `intent=add` could never produce a second parked session. A same-user re-auth (or the stale-last-workspace → 403 → resolve → `switchAccount` bounce) left the user sitting on the original account.

## Solution

Make the interactive stub login path run the identical park/coalesce sequence the real OAuth callback already runs.

### How it works

1. `login?intent=add` prefixes the `add|` sentinel onto the plaintext OAuth `state` (unchanged).
2. The stub `getAuthorizationUrl` redirects to `/test-auth-login?state=<b64>` (unchanged).
3. `handleLogin` now peels `add|` via the shared `parseCallbackState`, and on an add runs `accountsService.addAndParkActive(...)` — the same collaborator the real callback uses — parking the previous account into a free alt slot and making the just-authenticated account active.
4. Success lands on `/workspaces?accountAdded=1` (mirrors #560); a graceful refusal (e.g. `MAX_ACCOUNTS_REACHED`) appends `?accountError=<code>` instead of throwing mid-flow. The non-add path is unchanged (`setSessionCookie`).

### Key design decisions

**1. Extract shared `callback-state` module instead of duplicating**

`parseCallbackState` was inline in `handlers.ts`. Rather than copy it into the stub (parallel implementation — INV-35), I lifted it plus a new `splitInnerState` helper into `apps/control-plane/src/features/auth/callback-state.ts` as the single source of truth. `handlers.ts` was refactored onto it and is **behavior-preserving** for the real callback — verified across all `host|path`, bare-`path`, and empty-state cases.

**2. Mirror the real callback rather than invent stub-specific behavior**

The stub form is served and submitted same-origin, so the forwarded-host branch of the real callback is a no-op here and the redirect stays relative — but the park/coalesce/`addAndParkActive` sequence is byte-for-byte the same call the real callback makes, so the two entry points cannot drift again.

**Beneficial side-effect:** non-add stub login with a trusted forwarded host now redirects to the real decoded path instead of falling back to `/`. This was a latent bug in the old stub; no test asserted the old (buggy) behavior, so nothing breaks.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/control-plane/src/features/auth/callback-state.ts` | Single source of truth for `parseCallbackState` (peel `add|` sentinel) and `splitInnerState` (decode `host|path` redirect target) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/control-plane/src/features/auth/handlers.ts` | Removed inline `parseCallbackState`; imports the shared module. Real callback refactored onto `splitInnerState`, behavior-preserving |
| `apps/control-plane/src/features/auth/stub-handlers.ts` | `handleLogin` peels `add\|`, runs `accountsService.addAndParkActive`, lands on `/workspaces?accountAdded=1` / appends `accountError`; `accountsService` added to deps |
| `apps/control-plane/src/routes.ts` | Pass `accountsService` into `createAuthStubHandlers` |
| `apps/control-plane/tests/e2e/accounts.test.ts` | New test drives `login?intent=add` → `/test-auth-login` POST end to end; rewrote a stale helper comment |

## Test plan

- [x] Added e2e: "interactive stub add-account form parks the previous account" — `loginAs(A)` → `GET /api/auth/login?intent=add` → extract `state` → `POST /test-auth-login {email:B, state}` → asserts 302 → `/workspaces?accountAdded=1`, `/api/auth/me` is B, `/api/accounts` shows B active + A parked
- [x] `bun run typecheck` clean (full monorepo, via pre-commit hook)
- [x] `bun run lint` clean (full monorepo, via pre-commit hook)
- [ ] Control-plane e2e suite (`bun run test:e2e`) could not be executed in this environment — Docker/Postgres is unavailable here (same documented limitation as #560). Typecheck + lint are the executed verification; the new test should be run in CI/locally where Postgres is available
- [ ] Manual: on a stub-auth environment, log in as A, use the account switcher to add B, confirm you land on the workspace picker as B with A parked and switchable

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tq2e7AnFQymQeLaJAyqqXH)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->