### PR TITLE
fix(accounts): force the account chooser on the add-account flow

### DIFF
--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -91,8 +91,13 @@ export function createControlPlaneAuthHandlers({
       }
 
       // Multi-account add flow: prefix an `add|` sentinel onto the plaintext
-      // state (callback peels it back off) and force an AuthKit re-prompt so
-      // the hosted session isn't silently reused for the second account.
+      // state (callback peels it back off) and force an account chooser.
+      // `login` alone re-authenticates the *existing* hosted session silently
+      // (no account/username field when a session is live), so the callback
+      // gets the same WorkOS user and the add coalesces in place. The
+      // OIDC-standard space-delimited `login select_account` forces both a
+      // fresh credential prompt and the account picker so a *different*
+      // account can actually be added.
       const isAdd = typeof req.query.intent === "string" && req.query.intent === "add"
       if (isAdd) {
         statePayload = `add|${statePayload ?? ""}`
@@ -101,7 +106,7 @@ export function createControlPlaneAuthHandlers({
       const url = authService.getAuthorizationUrl(
         statePayload,
         redirectUriOverride,
-        isAdd ? { prompt: "login" } : undefined
+        isAdd ? { prompt: "login select_account" } : undefined
       )
       res.redirect(url)
     },

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -83,13 +83,15 @@ describe("Multi-account /api/accounts", () => {
     })
   })
 
-  test("GET /api/auth/login?intent=add forces prompt=login and an add| state", async () => {
+  test("GET /api/auth/login?intent=add forces an account chooser and an add| state", async () => {
     const client = new TestClient()
 
     const add = await client.get("/api/auth/login?intent=add")
     expect(add.status).toBe(302)
     const addUrl = new URL(add.headers.get("location")!, "http://localhost")
-    expect(addUrl.searchParams.get("prompt")).toBe("login")
+    // `login` alone silently re-auths the live session; `select_account`
+    // forces the picker so a *different* account can be added.
+    expect(addUrl.searchParams.get("prompt")).toBe("login select_account")
     expect(Buffer.from(addUrl.searchParams.get("state") || "", "base64").toString()).toBe("add|")
 
     // Non-add login is unchanged: no prompt forced.

--- a/packages/backend-common/src/auth/auth-service.stub.test.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.test.ts
@@ -12,14 +12,16 @@ describe("StubAuthService.getAuthorizationUrl prompt plumbing", () => {
     expect(params.get("redirect_uri")).toBe("https://app.example.com/callback")
   })
 
-  test("encodes prompt into the stub login URL when provided", () => {
+  test("encodes a space-delimited multi-value prompt into the stub login URL", () => {
     const svc = new StubAuthService()
     const url = svc.getAuthorizationUrl("/redirect-here", "https://app.example.com/callback", {
-      prompt: "login",
+      prompt: "login select_account",
     })
     const params = new URLSearchParams(url.split("?")[1])
 
-    expect(params.get("prompt")).toBe("login")
+    // The add-account flow sends the OIDC space-delimited form; the space
+    // must survive URL encoding and decode back intact.
+    expect(params.get("prompt")).toBe("login select_account")
     expect(params.get("state")).toBe(Buffer.from("/redirect-here").toString("base64"))
     expect(params.get("redirect_uri")).toBe("https://app.example.com/callback")
   })

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -40,9 +40,11 @@ export interface AuthService {
    *                    backoffice on a different TLD) without cookie-domain
    *                    gymnastics.
    * @param options.prompt Passed through to WorkOS as the OIDC `prompt`. The
-   *                    add-account flow passes `"login"` to force an AuthKit
-   *                    re-prompt instead of silently reusing the existing
-   *                    hosted session.
+   *                    add-account flow passes `"login select_account"` (the
+   *                    space-delimited OIDC form) to force both a fresh
+   *                    credential prompt and the account picker, so the
+   *                    existing hosted session isn't silently reused for the
+   *                    second account.
    */
   getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { prompt?: string }): string
   /**


### PR DESCRIPTION
## Problem

Follow-up to #561. On real-WorkOS environments (`app.threa.io`), clicking **Add account** still immediately logged the user back in as the *same* account, with no way to add a second one.

Root cause is the WorkOS authorization step, **not** the park/coalesce logic:

- The add-account flow sent `prompt=login` to WorkOS (`handlers.ts` `login`, `intent=add`).
- With a live AuthKit hosted session, OIDC `prompt=login` re-authenticates the **existing** identity silently — it does not render an account/username field when a session is already active. So WorkOS handed back the same user.
- `authenticateWithCode` returned that same user, and `addAndParkActive` hit the `prevAuth.user.id === newUserId` branch (`apps/control-plane/src/features/accounts/service.ts:111`) which by design "replaces in place, nothing to park". Net effect: you stay on the same account.

This is a **different code path** from #561. That PR fixed the stub/staging interactive-login path; this is the real WorkOS OAuth path through `handlers.ts`.

## Solution

Send the OIDC-standard **space-delimited** prompt `login select_account` for the add-account flow instead of `login` alone. This forces WorkOS to show both a fresh credential prompt **and** the account picker, so a genuinely different account can be authenticated and then parked by the existing `addAndParkActive` logic (which is correct and unchanged).

### Key design decisions

**1. `login select_account`, not just `select_account`**

`select_account` alone can still resolve the live session in some provider configurations; combining it with `login` (valid OIDC space-delimited multi-value) forces re-auth *and* the chooser, which is the most robust form. Chosen over a code-side WorkOS-logout dance (that would revoke the very session we need to park).

**2. No change to the park/coalesce logic**

`addAndParkActive` was already correct — the bug was strictly that the second account was never authenticated as a *different* user. Keeping the fix at the authorization-URL boundary keeps it minimal and auth-surface-contained.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/control-plane/src/features/auth/handlers.ts` | `prompt: "login select_account"` for `intent=add`; comment explains why `login` alone is insufficient |
| `packages/backend-common/src/auth/auth-service.ts` | `getAuthorizationUrl` doc comment updated to match |
| `apps/control-plane/tests/e2e/accounts.test.ts` | Asserts the new `login select_account` prompt value |
| `packages/backend-common/src/auth/auth-service.stub.test.ts` | Plumbing test now exercises the space-delimited multi-value form (verifies the space round-trips through URL encoding) |

## Test plan

- [x] `bun test ./packages/backend-common/src/auth/auth-service.stub.test.ts` — passing (2/2; covers the space-delimited prompt encoding)
- [x] `bun run typecheck` clean (full monorepo)
- [x] `bun run lint` clean (pre-commit hook: lint, typecheck, Dockerfile + OpenAPI checks)
- [ ] Control-plane e2e (`bun run test:e2e`) not runnable here — Docker/Postgres unavailable (same documented limitation as #560/#561)
- [ ] Manual on a real-WorkOS environment: log in as A, **Add account**, confirm WorkOS now shows the chooser/credential prompt and signing in as B lands you as B with A parked & switchable
- [ ] Caveat to validate: relies on WorkOS AuthKit honoring `select_account` for the configured connection. If the picker still doesn't appear, next lever is forwarding an account-chooser param to the upstream IdP via `provider_query_params`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tq2e7AnFQymQeLaJAyqqXH)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->