### PR TITLE
fix: push history on image gallery open so OS back closes it

### DIFF
--- a/apps/frontend/src/components/timeline/attachment-list.data-router.test.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.data-router.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { MediaGalleryProvider } from "@/contexts"
+import { attachmentsApi } from "@/api"
+import { AttachmentList } from "./attachment-list"
+import type { AttachmentSummary } from "@threa/types"
+
+const mockGetDownloadUrl = vi.fn()
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockGetDownloadUrl.mockReset()
+  mockGetDownloadUrl.mockResolvedValue("https://example.com/download")
+  vi.spyOn(attachmentsApi, "getDownloadUrl").mockImplementation(
+    (...args: Parameters<typeof attachmentsApi.getDownloadUrl>) => mockGetDownloadUrl(...args)
+  )
+})
+
+const workspaceId = "ws_123"
+
+const img = (id: string, filename: string): AttachmentSummary => ({
+  id,
+  filename,
+  mimeType: "image/png",
+  sizeBytes: 1024,
+})
+
+function renderWithDataRouter() {
+  const attachments = [img("img_1", "photo1.png"), img("img_2", "photo2.png"), img("img_3", "photo3.png")]
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/s",
+        element: (
+          <MediaGalleryProvider>
+            <AttachmentList attachments={attachments} workspaceId={workspaceId} />
+          </MediaGalleryProvider>
+        ),
+      },
+    ],
+    { initialEntries: ["/s"] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe("AttachmentList gallery under a data router (createBrowserRouter machinery)", () => {
+  it("opens the clicked image, not the first, on first open", async () => {
+    const user = userEvent.setup()
+    renderWithDataRouter()
+
+    const third = await screen.findByRole("button", { name: /photo3\.png/i })
+    await user.click(third)
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+    expect(screen.getByText("3 / 3")).toBeInTheDocument()
+  })
+
+  it("opens the correct image after closing a previous one via the back button", async () => {
+    const user = userEvent.setup()
+    const router = renderWithDataRouter()
+
+    // Open the 3rd image.
+    await user.click(await screen.findByRole("button", { name: /photo3\.png/i }))
+    await waitFor(() => expect(screen.getByText("3 / 3")).toBeInTheDocument())
+
+    // Close it — closeMedia pops history (navigate(-1)).
+    const closeButtons = screen.getAllByRole("button", { name: /close/i })
+    await user.click(closeButtons[0])
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+    expect(router.state.location.search).toBe("")
+
+    // Re-open a different image — must land on it, not the first.
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+    expect(screen.getByText("2 / 3")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/timeline/attachment-list.test.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.test.tsx
@@ -259,6 +259,25 @@ describe("AttachmentList", () => {
       })
     })
 
+    it("should open the lightbox on the clicked image, not the first", async () => {
+      const user = userEvent.setup()
+      const attachments = [
+        createAttachment({ id: "img_1", filename: "photo1.png", mimeType: "image/png" }),
+        createAttachment({ id: "img_2", filename: "photo2.png", mimeType: "image/png" }),
+        createAttachment({ id: "img_3", filename: "photo3.png", mimeType: "image/png" }),
+      ]
+      render(<AttachmentList attachments={attachments} workspaceId={workspaceId} />, renderOpts)
+
+      const thirdImage = await screen.findByRole("button", { name: /photo3\.png/i })
+      await user.click(thirdImage)
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument()
+      })
+      // Counter is "<index+1> / <total>" — clicking the third image must land on 3.
+      expect(screen.getByText("3 / 3")).toBeInTheDocument()
+    })
+
     it("should close lightbox when close button is clicked", async () => {
       const user = userEvent.setup()
       const attachment = createAttachment({

--- a/apps/frontend/src/contexts/media-gallery-context.test.tsx
+++ b/apps/frontend/src/contexts/media-gallery-context.test.tsx
@@ -9,6 +9,7 @@ function Harness() {
   const location = useLocation()
   return (
     <div>
+      <span data-testid="path">{location.pathname}</span>
       <span data-testid="search">{location.search}</span>
       <button onClick={() => openMedia("a")}>open-a</button>
       <button onClick={() => openMedia("b")}>open-b</button>
@@ -17,9 +18,9 @@ function Harness() {
   )
 }
 
-function renderHarness(initialEntries: string[]) {
+function renderHarness(initialEntries: string[], initialIndex?: number) {
   return render(
-    <MemoryRouter initialEntries={initialEntries}>
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
       <MediaGalleryProvider>
         <Routes>
           <Route path="/w/:workspaceId" element={<Harness />} />
@@ -39,8 +40,9 @@ describe("MediaGalleryProvider", () => {
     await user.click(screen.getByText("open-a"))
     expect(screen.getByTestId("search").textContent).toBe("?media=a")
 
+    // If open had replaced instead of pushed there would be nothing to pop
+    // and the param would survive the close; reaching "" proves the pop.
     await user.click(screen.getByText("close"))
-    // navigate(-1) returned to the pre-open entry rather than rewriting it
     expect(screen.getByTestId("search").textContent).toBe("")
   })
 
@@ -58,14 +60,18 @@ describe("MediaGalleryProvider", () => {
     expect(screen.getByTestId("search").textContent).toBe("")
   })
 
-  it("strips the param in place for deep-linked opens without escaping the app", async () => {
+  it("strips the param in place for deep-linked opens without popping history", async () => {
     const user = userEvent.setup()
-    renderHarness(["/w/ws_1?media=a"])
+    // Prior entry is a distinct path: a buggy navigate(-1) would land there.
+    renderHarness(["/w/other", "/w/ws_1?media=a"], 1)
 
+    expect(screen.getByTestId("path").textContent).toBe("/w/ws_1")
     expect(screen.getByTestId("search").textContent).toBe("?media=a")
 
     await user.click(screen.getByText("close"))
+    // Stayed on the current entry with the param removed instead of popping
+    // back to /w/other (which would also risk escaping the app).
+    expect(screen.getByTestId("path").textContent).toBe("/w/ws_1")
     expect(screen.getByTestId("search").textContent).toBe("")
-    expect(window.location.pathname).not.toBe("about:blank")
   })
 })

--- a/apps/frontend/src/contexts/media-gallery-context.test.tsx
+++ b/apps/frontend/src/contexts/media-gallery-context.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
+
+function Harness() {
+  const { openMedia, closeMedia } = useMediaGallery()
+  const location = useLocation()
+  return (
+    <div>
+      <span data-testid="search">{location.search}</span>
+      <button onClick={() => openMedia("a")}>open-a</button>
+      <button onClick={() => openMedia("b")}>open-b</button>
+      <button onClick={() => closeMedia()}>close</button>
+    </div>
+  )
+}
+
+function renderHarness(initialEntries: string[]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <MediaGalleryProvider>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<Harness />} />
+        </Routes>
+      </MediaGalleryProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("MediaGalleryProvider", () => {
+  it("pushes on open and pops on close so OS back closes the gallery", async () => {
+    const user = userEvent.setup()
+    renderHarness(["/w/ws_1"])
+
+    expect(screen.getByTestId("search").textContent).toBe("")
+
+    await user.click(screen.getByText("open-a"))
+    expect(screen.getByTestId("search").textContent).toBe("?media=a")
+
+    await user.click(screen.getByText("close"))
+    // navigate(-1) returned to the pre-open entry rather than rewriting it
+    expect(screen.getByTestId("search").textContent).toBe("")
+  })
+
+  it("replaces when navigating between items so back skips intermediate images", async () => {
+    const user = userEvent.setup()
+    renderHarness(["/w/ws_1"])
+
+    await user.click(screen.getByText("open-a"))
+    await user.click(screen.getByText("open-b"))
+    expect(screen.getByTestId("search").textContent).toBe("?media=b")
+
+    // Only the open pushed an entry; item navigation replaced it, so a single
+    // back step lands before the gallery, not on the previously viewed image.
+    await user.click(screen.getByText("close"))
+    expect(screen.getByTestId("search").textContent).toBe("")
+  })
+
+  it("strips the param in place for deep-linked opens without escaping the app", async () => {
+    const user = userEvent.setup()
+    renderHarness(["/w/ws_1?media=a"])
+
+    expect(screen.getByTestId("search").textContent).toBe("?media=a")
+
+    await user.click(screen.getByText("close"))
+    expect(screen.getByTestId("search").textContent).toBe("")
+    expect(window.location.pathname).not.toBe("about:blank")
+  })
+})

--- a/apps/frontend/src/contexts/media-gallery-context.tsx
+++ b/apps/frontend/src/contexts/media-gallery-context.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useCallback, useMemo, type ReactNode } from "react"
-import { useSearchParams } from "react-router-dom"
+import { createContext, useContext, useCallback, useMemo, useRef, type ReactNode } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
 
 interface MediaGalleryContextValue {
   /** Attachment ID from the ?media= search param, or null */
@@ -18,26 +18,45 @@ interface MediaGalleryProviderProps {
 
 export function MediaGalleryProvider({ children }: MediaGalleryProviderProps) {
   const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
 
   const mediaAttachmentId = useMemo(() => {
     return searchParams.get("media")
   }, [searchParams])
 
+  // Tracks whether opening the gallery pushed a history entry we can pop on
+  // close. False when the gallery was deep-linked (?media= present on load),
+  // where there is no entry to go back to without leaving the app.
+  const pushedOnOpenRef = useRef(false)
+
   const openMedia = useCallback(
     (attachmentId: string) => {
+      // Opening the gallery deepens history (push) so the OS back button
+      // closes it; navigating between items replaces so the back stack
+      // doesn't fill with every viewed image.
+      const isNavigatingItems = searchParams.get("media") !== null
+      if (!isNavigatingItems) pushedOnOpenRef.current = true
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev)
           next.set("media", attachmentId)
           return next
         },
-        { replace: true }
+        { replace: isNavigatingItems }
       )
     },
-    [setSearchParams]
+    [searchParams, setSearchParams]
   )
 
   const closeMedia = useCallback(() => {
+    // Closing is "navigating up the tree": pop the entry opening pushed so
+    // history stays clean. Deep-linked opens have nothing to pop, so strip
+    // the param in place instead of escaping the app.
+    if (pushedOnOpenRef.current) {
+      pushedOnOpenRef.current = false
+      navigate(-1)
+      return
+    }
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
@@ -46,7 +65,7 @@ export function MediaGalleryProvider({ children }: MediaGalleryProviderProps) {
       },
       { replace: true }
     )
-  }, [setSearchParams])
+  }, [navigate, setSearchParams])
 
   const value = useMemo<MediaGalleryContextValue>(
     () => ({


### PR DESCRIPTION
## Summary

Opening the image gallery previously used `setSearchParams(..., { replace: true })` for both opening and item navigation, and closing also replaced. That overwrote history, so the device/OS back button could not close the modal — awkward on mobile.

This makes gallery navigation feel like going deeper into the app and back up the tree:

- **Open** (`?media=` absent): **push** a history entry, so the OS back button closes the gallery.
- **Navigate between items** (`?media=` already set): **replace**, so the back stack isn't polluted with every viewed image.
- **Close** (X / Escape / backdrop / swipe-down — all route through the Dialog `onOpenChange`): pop the pushed entry via `navigate(-1)` ("navigating up the tree"), keeping history clean.
- **Deep-linked opens** (`?media=` present on load): no entry was pushed, so the param is stripped in place rather than `navigate(-1)`-ing out of the app. Tracked via `pushedOnOpenRef`.

Scope is limited to `apps/frontend/src/contexts/media-gallery-context.tsx`; the gallery component and call sites are unchanged (`openMedia` is still the single entry point for both open and item-change — it now distinguishes them by whether `?media=` is already present).

## Behavior note

Opening, swiping through several images, then pressing OS back closes the gallery in one step and returns to the pre-gallery URL — it does not step back image-by-image. This matches the intended "replace on item navigation" design.

## Test plan

- [x] `apps/frontend/src/contexts/media-gallery-context.test.tsx` — 3 tests: push-on-open/pop-on-close, replace-on-item-navigation, deep-link close strips in place without popping history (uses a distinct prior entry to prove no escape). All passing.
- [x] Dependent `src/components/timeline/message-event.test.tsx` still green (22 passing).
- [x] Pre-commit hooks: full monorepo lint + typecheck + OpenAPI check passed.

https://claude.ai/code/session_01Tnb8PkBU4a3SXMaFCbrbXx