### PR TITLE
fix(frontend): dedupe version-update toast by build, not per mount

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { shouldNotifyUpdate } from "./use-app-update"
+
+const RUNNING = "abc1234"
+
+describe("shouldNotifyUpdate", () => {
+  it("notifies when the server build is newer and not yet announced", () => {
+    expect(shouldNotifyUpdate("def5678", RUNNING, null)).toBe(true)
+  })
+
+  it("stays silent when the server build matches what's running", () => {
+    expect(shouldNotifyUpdate(RUNNING, RUNNING, null)).toBe(false)
+  })
+
+  it("stays silent for a deploy already announced (the remount/refocus re-toast bug)", () => {
+    // User saw the toast for def5678, dismissed it, kept working on the old
+    // build. A remount + refocus re-runs the check with the same delta.
+    expect(shouldNotifyUpdate("def5678", RUNNING, "def5678")).toBe(false)
+  })
+
+  it("notifies again only for a genuinely newer build", () => {
+    expect(shouldNotifyUpdate("ghi9012", RUNNING, "def5678")).toBe(true)
+  })
+
+  it("stays silent on an empty/missing server version", () => {
+    expect(shouldNotifyUpdate("", RUNNING, null)).toBe(false)
+  })
+})

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useCallback } from "react"
+import { useEffect, useCallback } from "react"
 import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
+import { getNotifiedVersion, setNotifiedVersion } from "@/lib/app-update-version"
 
 const POLL_INTERVAL = 300_000 // 5 minutes
 const TOAST_ID = "app-update"
@@ -79,13 +80,27 @@ async function reloadForUpdate(): Promise<void> {
   }
 }
 
+/**
+ * Whether to surface the update toast. True only for a build that is both newer
+ * than what's running and not one we've already notified the user about — so a
+ * remount or a refocus/reconnect/poll on an already-announced deploy stays
+ * silent, while a genuinely newer build (whose version matches neither the
+ * running bundle nor the persisted marker) still notifies.
+ */
+export function shouldNotifyUpdate(
+  serverVersion: string,
+  runningVersion: string,
+  notifiedVersion: string | null
+): boolean {
+  return Boolean(serverVersion) && serverVersion !== runningVersion && serverVersion !== notifiedVersion
+}
+
 export function useAppUpdate(): void {
-  const toastShownRef = useRef(false)
   const { isVisible } = usePageActivity()
   const reconnectCount = useSocketReconnectCount()
 
   const checkForUpdate = useCallback(async () => {
-    if (IS_DEV || toastShownRef.current) return
+    if (IS_DEV) return
 
     try {
       // Trigger SW update check in parallel with version check
@@ -95,8 +110,8 @@ export function useAppUpdate(): void {
       if (!res.ok) return
 
       const { version } = (await res.json()) as { version: string }
-      if (version && version !== __APP_VERSION__) {
-        toastShownRef.current = true
+      if (shouldNotifyUpdate(version, __APP_VERSION__, getNotifiedVersion())) {
+        setNotifiedVersion(version)
         toast("A new version of Threa is available", {
           id: TOAST_ID,
           duration: Infinity,

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react"
+import { useEffect, useRef, useCallback } from "react"
 import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
@@ -98,6 +98,11 @@ export function shouldNotifyUpdate(
 export function useAppUpdate(): void {
   const { isVisible } = usePageActivity()
   const reconnectCount = useSocketReconnectCount()
+  // In-memory fallback so dedup still holds for this mount when localStorage is
+  // unavailable (private mode / disabled) — the persisted marker is the
+  // cross-mount/session guard; this keeps the no-storage path no worse than
+  // the previous per-mount ref.
+  const toastedVersionRef = useRef<string | null>(null)
 
   const checkForUpdate = useCallback(async () => {
     if (IS_DEV) return
@@ -110,7 +115,8 @@ export function useAppUpdate(): void {
       if (!res.ok) return
 
       const { version } = (await res.json()) as { version: string }
-      if (shouldNotifyUpdate(version, __APP_VERSION__, getNotifiedVersion())) {
+      if (toastedVersionRef.current !== version && shouldNotifyUpdate(version, __APP_VERSION__, getNotifiedVersion())) {
+        toastedVersionRef.current = version
         setNotifiedVersion(version)
         toast("A new version of Threa is available", {
           id: TOAST_ID,

--- a/apps/frontend/src/lib/app-update-version.test.ts
+++ b/apps/frontend/src/lib/app-update-version.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { getNotifiedVersion, setNotifiedVersion } from "./app-update-version"
+
+describe("app-update-version", () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it("returns null when no version has been notified", () => {
+    expect(getNotifiedVersion()).toBeNull()
+  })
+
+  it("round-trips the notified build version", () => {
+    setNotifiedVersion("abc1234")
+    expect(getNotifiedVersion()).toBe("abc1234")
+  })
+
+  it("overwrites with the latest notified version", () => {
+    setNotifiedVersion("abc1234")
+    setNotifiedVersion("def5678")
+    expect(getNotifiedVersion()).toBe("def5678")
+  })
+})

--- a/apps/frontend/src/lib/app-update-version.ts
+++ b/apps/frontend/src/lib/app-update-version.ts
@@ -1,0 +1,26 @@
+// The build version we've already surfaced the "new version available" toast
+// for. The toast's only in-memory guard is a per-mount ref, but its host
+// (`AppUpdateChecker` inside `WorkspaceLayout`) remounts on workspace switch
+// and layout route changes, and the check re-fires on every tab focus, socket
+// reconnect, and 5-min poll. Without a stable marker, a single deploy the user
+// doesn't immediately reload past gets re-toasted on every remount + trigger.
+// Persisting the notified version dedupes to at most one toast per distinct
+// build, across remounts and sessions, while a genuinely newer build (whose
+// version won't match this marker) still notifies.
+const STORAGE_KEY = "threa-app-update-notified-version"
+
+export function getNotifiedVersion(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setNotifiedVersion(version: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, version)
+  } catch {
+    // Storage unavailable — degrades to per-mount dedup, no worse than before.
+  }
+}

--- a/apps/frontend/src/lib/app-update-version.ts
+++ b/apps/frontend/src/lib/app-update-version.ts
@@ -1,12 +1,11 @@
 // The build version we've already surfaced the "new version available" toast
-// for. The toast's only in-memory guard is a per-mount ref, but its host
-// (`AppUpdateChecker` inside `WorkspaceLayout`) remounts on workspace switch
-// and layout route changes, and the check re-fires on every tab focus, socket
-// reconnect, and 5-min poll. Without a stable marker, a single deploy the user
-// doesn't immediately reload past gets re-toasted on every remount + trigger.
-// Persisting the notified version dedupes to at most one toast per distinct
-// build, across remounts and sessions, while a genuinely newer build (whose
-// version won't match this marker) still notifies.
+// for. `AppUpdateChecker` (inside `WorkspaceLayout`) remounts on workspace
+// switch and layout route changes, and its check re-fires on every tab focus,
+// socket reconnect, and 5-min poll. A purely in-memory guard resets on those
+// remounts, so a single deploy the user doesn't immediately reload past gets
+// re-toasted repeatedly. Persisting the notified version dedupes to at most
+// one toast per distinct build across remounts and sessions; a genuinely newer
+// build (whose version won't match this marker) still notifies.
 const STORAGE_KEY = "threa-app-update-notified-version"
 
 export function getNotifiedVersion(): string | null {


### PR DESCRIPTION
The "new version available" toast's only guard was a per-component-mount
ref. AppUpdateChecker lives inside WorkspaceLayout, which remounts on
workspace switch and layout route changes, resetting the ref; combined
with checks firing on every tab focus, socket reconnect, and 5-min poll,
a single deploy the user didn't immediately reload past re-popped the
toast repeatedly — one deploy felt like many.

Dedupe by the actual detected build version, persisted across mounts and
sessions, so the user is notified at most once per distinct new build. A
genuinely newer deploy still notifies; the Reload escape hatch is
unchanged.

https://claude.ai/code/session_01BoBvL5e8wMoH9XnebaRX4d

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->