### PR TITLE
fix(timeline): stop deep-link scroll from crashing the route

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest"
 import type { StreamEvent } from "@threa/types"
-import { annotateAuthorGroups, findFirstMessageId, groupTimelineItems, type TimelineItem } from "./event-list"
+import {
+  annotateAuthorGroups,
+  findFirstMessageId,
+  findMessageItemIndex,
+  groupTimelineItems,
+  type TimelineItem,
+} from "./event-list"
 
 interface CreateEventParams {
   id: string
@@ -333,5 +339,51 @@ describe("findFirstMessageId", () => {
 
   it("returns undefined for an empty timeline so the badge stays in the composer strip", () => {
     expect(findFirstMessageId([])).toBeUndefined()
+  })
+})
+
+describe("findMessageItemIndex", () => {
+  function eventItem(id: string, messageId: string): TimelineItem {
+    return {
+      type: "event",
+      event: createEvent({ id, sequence: id, eventType: "message_created", payload: { messageId } }),
+    }
+  }
+
+  it("returns the index of the timeline item rendering the message", () => {
+    const items: TimelineItem[] = [
+      eventItem("evt_1", "msg_a"),
+      eventItem("evt_2", "msg_b"),
+      eventItem("evt_3", "msg_c"),
+    ]
+    expect(findMessageItemIndex(items, "msg_b")).toBe(1)
+  })
+
+  it("returns -1 when the message is not in the window (so callers never feed Virtuoso a stale index)", () => {
+    // The crash this guards: scrollToIndex with an out-of-range index drives
+    // react-virtuoso's offset-tree binary search to an undefined node.
+    const items: TimelineItem[] = [eventItem("evt_1", "msg_a")]
+    expect(findMessageItemIndex(items, "msg_gone")).toBe(-1)
+  })
+
+  it("returns -1 for an empty timeline (mid jump-window swap)", () => {
+    expect(findMessageItemIndex([], "msg_a")).toBe(-1)
+  })
+
+  it("skips command_group / session_group items when locating the message", () => {
+    const items: TimelineItem[] = [
+      { type: "command_group", commandId: "cmd_1", events: [] },
+      { type: "session_group", sessionId: "sess_1", sessionVersion: 1, events: [] },
+      eventItem("evt_1", "msg_target"),
+    ]
+    expect(findMessageItemIndex(items, "msg_target")).toBe(2)
+  })
+
+  it("ignores events without a messageId payload", () => {
+    const items: TimelineItem[] = [
+      { type: "event", event: createEvent({ id: "evt_1", sequence: "1", eventType: "member_joined", payload: {} }) },
+      eventItem("evt_2", "msg_real"),
+    ]
+    expect(findMessageItemIndex(items, "msg_real")).toBe(1)
   })
 })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -200,6 +200,24 @@ export function findFirstMessageId(items: TimelineItem[]): string | undefined {
   return undefined
 }
 
+/**
+ * Index of the timeline item whose event renders `messageId`, or -1 when the
+ * message is not in `items`.
+ *
+ * Deep-link scroll resolves this against the *current* timeline on every retry
+ * tick, not once up front: the event window shifts under the retry loop
+ * (infinite-scroll prepends, live messages, a jump-window swap), so a stale
+ * captured index can fall outside the array Virtuoso currently holds. Feeding
+ * an out-of-range index to `scrollToIndex` drives react-virtuoso's offset-tree
+ * binary search to an undefined node and crashes the whole route, so callers
+ * must re-resolve and bounds-check before every imperative scroll.
+ */
+export function findMessageItemIndex(items: TimelineItem[], messageId: string): number {
+  return items.findIndex(
+    (item) => item.type === "event" && (item.event.payload as { messageId?: string })?.messageId === messageId
+  )
+}
+
 /** Returns a stable key string for a timeline item */
 export function getTimelineItemKey(item: TimelineItem): string {
   switch (item.type) {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -56,6 +56,7 @@ import {
   groupTimelineItems,
   annotateAuthorGroups,
   findFirstMessageId,
+  findMessageItemIndex,
   getTimelineItemKey,
   filterVisibleItems,
   type TimelineItem,
@@ -634,6 +635,13 @@ export function StreamContent({
     [timelineItems, useVirtualized, isChannel]
   )
 
+  // Mirror of `visibleItems` for the long-lived scrollToMessage retry loop:
+  // its closure is created once per scroll but runs for up to ~1.2s, during
+  // which the event window can shift. Reading the ref keeps each retry tick
+  // resolving the target index against the array Virtuoso currently holds.
+  const visibleItemsRef = useRef(visibleItems)
+  visibleItemsRef.current = visibleItems
+
   const getItemKey = useCallback(
     (index: number) => {
       const item = visibleItems[index]
@@ -705,11 +713,7 @@ export function StreamContent({
   const scrollToMessage = useCallback(
     (messageId: string) => {
       if (!useVirtualized) return false
-      const idx = visibleItems.findIndex((item) => {
-        if (item.type !== "event") return false
-        return (item.event.payload as { messageId?: string })?.messageId === messageId
-      })
-      if (idx < 0) return false
+      if (findMessageItemIndex(visibleItems, messageId) < 0) return false
 
       // Cancel any previous retry loop
       if (scrollRetryTimerRef.current !== null) {
@@ -779,8 +783,27 @@ export function StreamContent({
             stableFrames = 0
           }
         } else {
-          // Target is virtualized out — ask Virtuoso to render it (0-based index)
-          virtuosoRef.current?.scrollToIndex({ index: idx, align: "center", behavior: "auto" })
+          // Target is virtualized out — ask Virtuoso to render it (0-based
+          // index). Re-resolve against the live timeline every tick: the
+          // window can shift under this loop, and a stale/out-of-range index
+          // makes react-virtuoso's offset-tree binary search dereference an
+          // undefined node, throwing "Cannot read properties of undefined
+          // (reading 'index')" which crashes the whole route.
+          const liveIdx = findMessageItemIndex(visibleItemsRef.current, messageId)
+          // liveIdx < 0 means the target is transiently out of the window
+          // (e.g. a jump-window swap mid-flight). Skip this tick rather than
+          // scroll to a wrong index; a later tick retries once it reappears,
+          // and MAX_MS still bounds the loop if it never does.
+          if (liveIdx >= 0) {
+            try {
+              virtuosoRef.current?.scrollToIndex({ index: liveIdx, align: "center", behavior: "auto" })
+            } catch {
+              // react-virtuoso can still throw internally on a freshly
+              // mounted, not-yet-measured list (no defaultItemHeight).
+              // Non-fatal: the next tick retries once the size tree is
+              // populated, or the DOM path takes over once the row renders.
+            }
+          }
           stableFrames = 0
         }
 


### PR DESCRIPTION
## Summary

Navigating to a message via `?m=` (opening the mobile app from a push notification, or clicking through from the Activities tab) could crash the **whole route** with the route error boundary ("Something Went Wrong"). The underlying throw:

```
TypeError: Cannot read properties of undefined (reading 'index')
  at Zl (emoji-grid-*.js)   ← minified react-virtuoso offset-tree comparator
```

The `emoji-grid` chunk name is a red herring — Vite bundled shared `react-virtuoso` code into that chunk. The crash is react-virtuoso's offset-tree binary-search comparator dereferencing an undefined tree node.

## Root cause

`scrollToMessage`'s retry loop resolved the target's timeline index **once up front**, then fed that captured index to `virtuosoRef.scrollToIndex(...)` on every retry tick for up to ~1.2s. The event window shifts under that loop — infinite-scroll prepends, live messages arriving, or a jump-window swap — so the captured index can fall outside the array Virtuoso currently holds. An out-of-range index drives react-virtuoso's offset-tree comparator to dereference an undefined node and **throw synchronously**, which React forwards straight to the route error boundary.

This was always latent; it surfaced now because navigation remounts a fresh, unmeasured `<Virtuoso key={streamId}>` (#546) with no `defaultItemHeight` (#543), so the size tree is empty exactly when the synchronous deep-link `scrollToIndex` fires.

## Fix

Targets the actual bug rather than unwinding the (deliberate) remount/no-`defaultItemHeight` fixes:

- Extract a single pure `findMessageItemIndex(items, messageId)` helper (with a doc comment spelling out the crash hazard) and use it for both the initial guard and the per-tick lookup.
- Re-resolve the target index against the **live** timeline on every retry tick via a `visibleItemsRef`, and bounds-check (`>= 0`) before calling `scrollToIndex`. A transient out-of-window state (jump-window swap mid-flight) just skips that tick; `MAX_MS` still bounds the loop.
- Wrap the imperative `scrollToIndex` in a defensive `try/catch` so a transient internal throw on a freshly-mounted, not-yet-measured list self-heals on a later tick instead of crashing the route.

## Test plan

- [x] `event-list.test.ts` — 22 passed (5 new `findMessageItemIndex` tests: correct index, message-absent guard, empty timeline, skips command/session groups, ignores payloads without `messageId`)
- [x] `tsc --noEmit` clean across all workspaces (pre-commit)
- [x] eslint clean on changed files (pre-commit)
- [ ] Manual: open app from push notification deep-link → lands on the linked message, no crash
- [ ] Manual: Activities tab → click into a message in a long stream → centers the message, no route crash

https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->