### PR TITLE
feat(auth): custom add-account picker (bypass AuthKit silent-refresh)

### DIFF
--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -9,8 +9,8 @@ import {
   readAltSessionCookies,
   setSessionCookie,
   type AuthService,
-  type SocialProvider,
 } from "@threa/backend-common"
+import { MAGIC_CODE_LENGTH, SOCIAL_PROVIDERS } from "@threa/types"
 import type { AccountsService } from "../accounts"
 import { parseCallbackState, splitInnerState } from "./callback-state"
 
@@ -19,17 +19,16 @@ const callbackSchema = z.object({
   state: z.string().optional(),
 })
 
-const SOCIAL_PROVIDERS = ["GoogleOAuth", "MicrosoftOAuth"] as const satisfies readonly SocialProvider[]
-
 const magicSendSchema = z.object({
   email: z.email(),
 })
 
+// `intent=add` is required: today the verify endpoint only powers the
+// add-account flow. If a plain magic-auth sign-in ever lands, widen this.
 const magicVerifySchema = z.object({
   email: z.email(),
-  code: z.string().min(4).max(10),
-  intent: z.literal("add").optional(),
-  redirectTo: z.string().optional(),
+  code: z.string().length(MAGIC_CODE_LENGTH),
+  intent: z.literal("add"),
 })
 
 /**
@@ -254,36 +253,28 @@ export function createControlPlaneAuthHandlers({
       if (!parsed.success) {
         throw new HttpError("Invalid verification payload", { status: 400, code: "INVALID_VERIFY" })
       }
-      const { email, code, intent, redirectTo } = parsed.data
+      const { email, code } = parsed.data
 
       const result = await authService.authenticateWithMagicAuth(email, code)
       if (!result.success || !result.user || !result.sealedSession) {
         throw new HttpError("Invalid or expired code", { status: 401, code: "INVALID_CODE" })
       }
 
-      if (intent === "add") {
-        const parked = await accountsService.addAndParkActive(
-          res,
-          req.cookies,
-          req.cookies[SESSION_COOKIE_NAME] as string | undefined,
-          result.sealedSession,
-          result.user.id
-        )
-        if (!parked.ok) {
-          // Surface the same code the OAuth callback uses so the frontend can
-          // render the same toast ("max accounts reached") without branching.
-          return res.status(409).json({ ok: false, code: parked.code })
-        }
-        // Mirror the OAuth callback's post-add landing: workspace picker with
-        // `accountAdded=1` so the SPA drops its stale last-workspace pointer.
-        return res.json({ ok: true, redirectPath: "/workspaces?accountAdded=1" })
+      const parked = await accountsService.addAndParkActive(
+        res,
+        req.cookies,
+        req.cookies[SESSION_COOKIE_NAME] as string | undefined,
+        result.sealedSession,
+        result.user.id
+      )
+      if (!parked.ok) {
+        // Surface the same code the OAuth callback uses so the frontend can
+        // render the same toast ("max accounts reached") without branching.
+        return res.status(409).json({ ok: false, code: parked.code })
       }
-
-      // Plain sign-in via magic auth (not yet wired in the UI — only the
-      // add-account flow links here today). Set the active session cookie and
-      // let the caller decide where to land.
-      setSessionCookie(res, result.sealedSession)
-      res.json({ ok: true, redirectPath: redirectTo || "/" })
+      // Mirror the OAuth callback's post-add landing: workspace picker with
+      // `accountAdded=1` so the SPA drops its stale last-workspace pointer.
+      res.json({ ok: true, redirectPath: "/workspaces?accountAdded=1" })
     },
   }
 }

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -9,6 +9,7 @@ import {
   readAltSessionCookies,
   setSessionCookie,
   type AuthService,
+  type SocialProvider,
 } from "@threa/backend-common"
 import type { AccountsService } from "../accounts"
 import { parseCallbackState, splitInnerState } from "./callback-state"
@@ -16,6 +17,19 @@ import { parseCallbackState, splitInnerState } from "./callback-state"
 const callbackSchema = z.object({
   code: z.string().min(1),
   state: z.string().optional(),
+})
+
+const SOCIAL_PROVIDERS = ["GoogleOAuth", "MicrosoftOAuth"] as const satisfies readonly SocialProvider[]
+
+const magicSendSchema = z.object({
+  email: z.email(),
+})
+
+const magicVerifySchema = z.object({
+  email: z.email(),
+  code: z.string().min(4).max(10),
+  intent: z.literal("add").optional(),
+  redirectTo: z.string().optional(),
 })
 
 /**
@@ -77,6 +91,23 @@ export function createControlPlaneAuthHandlers({
       const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
       const hostTrusted = !!forwardedHost && isTrustedHost(forwardedHost, allowedRedirectDomain, dedicatedRedirectHosts)
 
+      const isAdd = typeof req.query.intent === "string" && req.query.intent === "add"
+      const providerRaw = typeof req.query.provider === "string" ? req.query.provider : undefined
+      const provider = SOCIAL_PROVIDERS.find((p) => p === providerRaw)
+
+      // Bare `intent=add` with no provider: hand off to the in-app picker. The
+      // hosted AuthKit UI silent-refreshes through its own session cookie, so
+      // we can't reliably force an account picker through it. The picker page
+      // lets the user choose Google / Microsoft (provider-direct, bypasses
+      // AuthKit) or Email code (Magic Auth) instead.
+      if (isAdd && !provider) {
+        const targetOrigin = hostTrusted && forwardedHost ? `https://${forwardedHost}` : frontendUrl
+        const qs = new URLSearchParams()
+        if (redirectTo) qs.set("redirect_to", redirectTo)
+        const q = qs.toString()
+        return res.redirect(`${targetOrigin}/add-account${q ? `?${q}` : ""}`)
+      }
+
       let statePayload = redirectTo
       let redirectUriOverride: string | undefined
       if (hostTrusted && forwardedHost) {
@@ -91,14 +122,10 @@ export function createControlPlaneAuthHandlers({
       }
 
       // Multi-account add flow: prefix an `add|` sentinel onto the plaintext
-      // state (callback peels it back off) and force an account chooser.
-      // `login` alone re-authenticates the *existing* hosted session silently
-      // (no account/username field when a session is live), so the callback
-      // gets the same WorkOS user and the add coalesces in place. The
-      // OIDC-standard space-delimited `login select_account` forces both a
-      // fresh credential prompt and the account picker so a *different*
-      // account can actually be added.
-      const isAdd = typeof req.query.intent === "string" && req.query.intent === "add"
+      // state so the callback peels it back off and runs the park/coalesce
+      // path. With a social provider the IdP itself shows an account picker
+      // (we pass `prompt=select_account` through `getAuthorizationUrl`), so
+      // a *different* WorkOS user can actually land in the callback.
       if (isAdd) {
         statePayload = `add|${statePayload ?? ""}`
       }
@@ -106,7 +133,7 @@ export function createControlPlaneAuthHandlers({
       const url = authService.getAuthorizationUrl(
         statePayload,
         redirectUriOverride,
-        isAdd ? { prompt: "login select_account" } : undefined
+        provider ? { provider } : undefined
       )
       res.redirect(url)
     },
@@ -208,6 +235,55 @@ export function createControlPlaneAuthHandlers({
         email: authUser.email,
         name,
       })
+    },
+
+    async magicSend(req: Request, res: Response) {
+      const parsed = magicSendSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new HttpError("Invalid email", { status: 400, code: "INVALID_EMAIL" })
+      }
+      // Always reply 200 regardless of the underlying outcome — leaking
+      // "no user for this email" turns this into an account-existence oracle.
+      // Errors are logged inside the service.
+      await authService.sendMagicAuthCode(parsed.data.email)
+      res.json({ ok: true })
+    },
+
+    async magicVerify(req: Request, res: Response) {
+      const parsed = magicVerifySchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new HttpError("Invalid verification payload", { status: 400, code: "INVALID_VERIFY" })
+      }
+      const { email, code, intent, redirectTo } = parsed.data
+
+      const result = await authService.authenticateWithMagicAuth(email, code)
+      if (!result.success || !result.user || !result.sealedSession) {
+        throw new HttpError("Invalid or expired code", { status: 401, code: "INVALID_CODE" })
+      }
+
+      if (intent === "add") {
+        const parked = await accountsService.addAndParkActive(
+          res,
+          req.cookies,
+          req.cookies[SESSION_COOKIE_NAME] as string | undefined,
+          result.sealedSession,
+          result.user.id
+        )
+        if (!parked.ok) {
+          // Surface the same code the OAuth callback uses so the frontend can
+          // render the same toast ("max accounts reached") without branching.
+          return res.status(409).json({ ok: false, code: parked.code })
+        }
+        // Mirror the OAuth callback's post-add landing: workspace picker with
+        // `accountAdded=1` so the SPA drops its stale last-workspace pointer.
+        return res.json({ ok: true, redirectPath: "/workspaces?accountAdded=1" })
+      }
+
+      // Plain sign-in via magic auth (not yet wired in the UI — only the
+      // add-account flow links here today). Set the active session cookie and
+      // let the caller decide where to land.
+      setSessionCookie(res, result.sealedSession)
+      res.json({ ok: true, redirectPath: redirectTo || "/" })
     },
   }
 }

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -94,6 +94,11 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/auth/login", authLimit, authHandlers.login)
   app.all("/api/auth/callback", authLimit, authHandlers.callback)
   app.get("/api/auth/logout", authHandlers.logout)
+  // Custom add-account fallback. The hosted AuthKit UI silent-refreshes
+  // through its own cookie, so the add-account picker exposes Magic Auth as
+  // the cross-IdP fallback alongside provider-direct social buttons.
+  app.post("/api/auth/magic/send", authLimit, authHandlers.magicSend)
+  app.post("/api/auth/magic/verify", authLimit, authHandlers.magicVerify)
 
   // Dev/test auth stub routes
   if (authService instanceof StubAuthService) {

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -83,22 +83,36 @@ describe("Multi-account /api/accounts", () => {
     })
   })
 
-  test("GET /api/auth/login?intent=add forces an account chooser and an add| state", async () => {
+  test("GET /api/auth/login?intent=add hands off to the in-app picker", async () => {
     const client = new TestClient()
 
+    // Bare `intent=add` can't reliably use AuthKit (its hosted UI
+    // silent-refreshes through its own session cookie), so the backend
+    // redirects to the SPA `/add-account` page which exposes provider-direct
+    // social buttons + a Magic Auth fallback.
     const add = await client.get("/api/auth/login?intent=add")
     expect(add.status).toBe(302)
-    const addUrl = new URL(add.headers.get("location")!, "http://localhost")
-    // `login` alone silently re-auths the live session; `select_account`
-    // forces the picker so a *different* account can be added.
-    expect(addUrl.searchParams.get("prompt")).toBe("login select_account")
-    expect(Buffer.from(addUrl.searchParams.get("state") || "", "base64").toString()).toBe("add|")
+    expect(add.headers.get("location")).toContain("/add-account")
 
-    // Non-add login is unchanged: no prompt forced.
+    // Non-add login is unchanged: it goes to WorkOS (the stub URL prefix here).
     const plain = await client.get("/api/auth/login")
     expect(plain.status).toBe(302)
-    const plainUrl = new URL(plain.headers.get("location")!, "http://localhost")
-    expect(plainUrl.searchParams.get("prompt")).toBeNull()
+    expect(plain.headers.get("location")).toContain("/test-auth-login")
+  })
+
+  test("GET /api/auth/login?intent=add&provider=GoogleOAuth bypasses the picker", async () => {
+    const client = new TestClient()
+
+    // Social provider passed through (the in-app picker hits this with
+    // `provider=GoogleOAuth` after the user clicks "Continue with Google").
+    // The stub auth service records the provider on the redirect URL so we
+    // can assert it survives the round trip.
+    const add = await client.get("/api/auth/login?intent=add&provider=GoogleOAuth")
+    expect(add.status).toBe(302)
+    const url = new URL(add.headers.get("location")!, "http://localhost")
+    expect(url.pathname).toBe("/test-auth-login")
+    expect(url.searchParams.get("provider")).toBe("GoogleOAuth")
+    expect(Buffer.from(url.searchParams.get("state") || "", "base64").toString()).toBe("add|")
   })
 
   test("adding a second account parks the first", async () => {
@@ -138,15 +152,20 @@ describe("Multi-account /api/accounts", () => {
   test("interactive stub add-account form parks the previous account", async () => {
     // The interactive stub login form is the only add-account entry point on
     // stub-auth environments (dev / staging / PR previews). Driving it end to
-    // end (login?intent=add -> /test-auth-login POST) proves it runs the same
-    // park/coalesce + ?accountAdded=1 redirect as the real WorkOS callback,
-    // instead of silently overwriting the active session.
+    // end (login?intent=add&provider=… -> /test-auth-login POST) proves it
+    // runs the same park/coalesce + ?accountAdded=1 redirect as the real
+    // WorkOS callback, instead of silently overwriting the active session.
+    //
+    // The picker page sits in front of `login?intent=add` in the browser
+    // flow; we skip it here and hit the provider-direct path the picker
+    // buttons emit. Bare `intent=add` (no provider) is covered by the
+    // separate "hands off to the in-app picker" test.
     const client = new TestClient()
     const aEmail = uniqueEmail("acc-form-a")
     const bEmail = uniqueEmail("acc-form-b")
     const a = await loginAs(client, aEmail, "Form A")
 
-    const add = await client.get("/api/auth/login?intent=add")
+    const add = await client.get("/api/auth/login?intent=add&provider=GoogleOAuth")
     expect(add.status).toBe(302)
     const stubUrl = new URL(add.headers.get("location")!, "http://localhost")
     const state = stubUrl.searchParams.get("state")!
@@ -166,6 +185,54 @@ describe("Multi-account /api/accounts", () => {
       ],
       maxAccounts: MAX_ACCOUNTS,
     })
+  })
+
+  test("magic auth add-account parks the previous account", async () => {
+    // The Magic Auth path is the cross-IdP fallback when the second account
+    // wasn't signed up via a social provider. End-to-end coverage that
+    // /api/auth/magic/send + /api/auth/magic/verify runs the same
+    // park/coalesce + accountAdded redirect as the OAuth callback.
+    const client = new TestClient()
+    const aEmail = uniqueEmail("acc-magic-a")
+    const bEmail = uniqueEmail("acc-magic-b")
+    const a = await loginAs(client, aEmail, "Magic A")
+
+    const send = await client.post("/api/auth/magic/send", { email: bEmail })
+    expect(send.status).toBe(200)
+
+    const verify = await client.post<{ ok: boolean; redirectPath: string }>("/api/auth/magic/verify", {
+      email: bEmail,
+      code: "123456",
+      intent: "add",
+    })
+    expect(verify.status).toBe(200)
+    expect(verify.data.redirectPath).toBe("/workspaces?accountAdded=1")
+
+    const me = await client.get<MeResponse>("/api/auth/me")
+    expect(me.data.email).toBe(bEmail)
+
+    const accounts = await client.get<AccountsResponse>("/api/accounts")
+    expect(accounts.data).toEqual({
+      accounts: [
+        { id: me.data.id, email: bEmail, name: expect.any(String), state: "active" },
+        { id: a.id, email: aEmail, name: "Magic A", state: "parked" },
+      ],
+      maxAccounts: MAX_ACCOUNTS,
+    })
+  })
+
+  test("magic auth verify rejects a wrong code", async () => {
+    const client = new TestClient()
+    const bEmail = uniqueEmail("acc-magic-bad")
+
+    await client.post("/api/auth/magic/send", { email: bEmail })
+
+    const verify = await client.post("/api/auth/magic/verify", {
+      email: bEmail,
+      code: "000000",
+      intent: "add",
+    })
+    expect(verify.status).toBe(401)
   })
 
   test("switch promotes a parked account and parks the previously active one", async () => {

--- a/apps/control-plane/tests/e2e/accounts.test.ts
+++ b/apps/control-plane/tests/e2e/accounts.test.ts
@@ -225,7 +225,8 @@ describe("Multi-account /api/accounts", () => {
     const client = new TestClient()
     const bEmail = uniqueEmail("acc-magic-bad")
 
-    await client.post("/api/auth/magic/send", { email: bEmail })
+    const send = await client.post("/api/auth/magic/send", { email: bEmail })
+    expect(send.status).toBe(200)
 
     const verify = await client.post("/api/auth/magic/verify", {
       email: bEmail,

--- a/apps/frontend/src/auth/context.test.tsx
+++ b/apps/frontend/src/auth/context.test.tsx
@@ -117,7 +117,7 @@ describe("AuthProvider login / accountError", () => {
     Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
   })
 
-  it("threads intent=add onto the login URL", async () => {
+  it("routes intent=add to the in-app add-account picker", async () => {
     stubLocation("")
     render(
       <AuthProvider>
@@ -129,7 +129,10 @@ describe("AuthProvider login / accountError", () => {
       captureLogin(undefined, { intent: "add" })
     })
 
-    expect(hrefValues[hrefValues.length - 1]).toBe("/api/auth/login?intent=add")
+    // The picker bypasses AuthKit — AuthKit's hosted UI silent-refreshes and
+    // can't reliably show an account picker. The page itself routes the user
+    // to a provider-direct OAuth URL or magic-auth verify.
+    expect(hrefValues[hrefValues.length - 1]).toBe("/add-account")
   })
 
   it("builds a plain login URL with no options", async () => {

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -161,9 +161,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [])
 
   const login = useCallback((redirectTo?: string, opts?: { intent?: "add" }) => {
+    // The add-account flow hands off to the in-app picker first — AuthKit's
+    // hosted UI silent-refreshes through its own session cookie, so the only
+    // reliable way to add a *different* account is to bypass AuthKit. The
+    // picker exposes provider-direct social buttons and a Magic Auth fallback.
+    // Plain sign-in still goes straight to `/api/auth/login`.
+    if (opts?.intent === "add") {
+      const query = new URLSearchParams()
+      if (redirectTo) query.set("redirect_to", redirectTo)
+      const qs = query.toString()
+      window.location.href = `/add-account${qs ? `?${qs}` : ""}`
+      return
+    }
     const query = new URLSearchParams()
     if (redirectTo) query.set("redirect_to", redirectTo)
-    if (opts?.intent === "add") query.set("intent", "add")
     const qs = query.toString()
     window.location.href = `${API_BASE}/api/auth/login${qs ? `?${qs}` : ""}`
   }, [])

--- a/apps/frontend/src/pages/add-account.tsx
+++ b/apps/frontend/src/pages/add-account.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useState } from "react"
+import { useCallback, useState, type ReactNode } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
+import { ArrowLeft, Mail } from "lucide-react"
+import { MAGIC_CODE_LENGTH, type SocialProvider } from "@threa/types"
 import { API_BASE, ApiError, api } from "@/api/client"
 import { useAuth } from "@/auth"
 import { Button } from "@/components/ui/button"
@@ -11,8 +13,6 @@ import { ThreaLogo } from "@/components/threa-logo"
 import { clearLastWorkspaceId } from "@/lib/last-workspace"
 
 type Step = "picker" | "email" | "verify"
-
-const MAGIC_CODE_LENGTH = 6
 
 export function AddAccountPage() {
   const [search] = useSearchParams()
@@ -27,7 +27,7 @@ export function AddAccountPage() {
   const redirectTo = search.get("redirect_to") || undefined
 
   const goSocial = useCallback(
-    (provider: "GoogleOAuth" | "MicrosoftOAuth") => {
+    (provider: SocialProvider) => {
       // Same shape as the existing login flow: a full-page navigation to the
       // backend so the OAuth callback's cookie writes land before the SPA
       // boots. `intent=add` + a social provider together bypass AuthKit and
@@ -60,18 +60,13 @@ export function AddAccountPage() {
     if (code.length !== MAGIC_CODE_LENGTH) return
     setBusy(true)
     setError(null)
+    let result: { ok: boolean; redirectPath: string }
     try {
-      const result = await api.post<{ ok: boolean; redirectPath: string }>("/api/auth/magic/verify", {
+      result = await api.post<{ ok: boolean; redirectPath: string }>("/api/auth/magic/verify", {
         email,
         code,
         intent: "add",
       })
-      // A successful add makes the new account active; the stale last-workspace
-      // pointer would route us back into the *previous* account. Same dance
-      // the OAuth callback / AuthProvider mount-effect does on accountAdded=1.
-      clearLastWorkspaceId()
-      await refetch()
-      navigate(result.redirectPath, { replace: true })
     } catch (err) {
       if (err instanceof ApiError && err.code === "MAX_ACCOUNTS_REACHED") {
         toast.error("You're signed in to the maximum number of accounts. Remove one to add another.")
@@ -84,123 +79,315 @@ export function AddAccountPage() {
         return
       }
       setError("Couldn't verify the code right now. Please try again.")
+      return
     } finally {
       setBusy(false)
     }
+
+    // Server-side success — the cookie is set and the magic code has been
+    // consumed. From here on we must not surface an error: retrying would
+    // 401, because the code is single-use. A transient refetch failure is
+    // recoverable on the next route load.
+    //
+    // The stale last-workspace pointer would route us back into the
+    // *previous* account. Same dance the OAuth callback / AuthProvider
+    // mount-effect does on accountAdded=1.
+    clearLastWorkspaceId()
+    try {
+      await refetch()
+    } catch {
+      // Refetch will retry on next navigation; don't block the redirect.
+    }
+    navigate(result.redirectPath, { replace: true })
   }, [code, email, navigate, refetch])
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-8">
-        <div className="flex flex-col items-center gap-3">
-          <ThreaLogo size="lg" />
-          <div className="text-center">
-            <h1 className="text-xl font-light tracking-[0.15em] uppercase text-primary">Add account</h1>
-            <p className="mt-1 text-muted-foreground text-sm">
-              {step === "picker" && "Choose how to add another account."}
-              {step === "email" && "We'll email you a one-time code."}
-              {step === "verify" && `Enter the 6-digit code we sent to ${email}.`}
-            </p>
+    <AddAccountShell>
+      {/* `key={step}` re-mounts the step block on each transition so each one
+          fades in instead of swapping silently. The shell itself only animates
+          once on initial mount. */}
+      <div key={step} className="w-full animate-in fade-in duration-300">
+        {step === "picker" && (
+          <PickerStep onSocial={goSocial} onEmail={() => setStep("email")} onCancel={() => navigate(-1)} />
+        )}
+        {step === "email" && (
+          <EmailStep
+            email={email}
+            setEmail={setEmail}
+            busy={busy}
+            error={error}
+            onSubmit={sendCode}
+            onBack={() => {
+              setStep("picker")
+              setError(null)
+            }}
+          />
+        )}
+        {step === "verify" && (
+          <VerifyStep
+            email={email}
+            code={code}
+            setCode={setCode}
+            busy={busy}
+            error={error}
+            onSubmit={verifyCode}
+            onChangeEmail={() => {
+              setStep("email")
+              setCode("")
+              setError(null)
+            }}
+          />
+        )}
+      </div>
+    </AddAccountShell>
+  )
+}
+
+/**
+ * Centred shell shared by every step. Mirrors `JoinShell` in apps/frontend/src/pages/join.tsx
+ * so the multi-account add flow visually belongs to the same auth-landing
+ * family as the invitation accept and sign-in pages.
+ */
+function AddAccountShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_-10%,hsl(var(--primary)/0.10),transparent_55%)]"
+      />
+      <div className="relative flex w-full max-w-md flex-col items-center gap-10 p-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <ThreaLogo size="lg" />
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function PickerStep({
+  onSocial,
+  onEmail,
+  onCancel,
+}: {
+  onSocial: (provider: SocialProvider) => void
+  onEmail: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div className="w-full space-y-8">
+      <div className="space-y-3 text-center">
+        <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Add account</span>
+        <h1 className="text-2xl font-medium leading-tight">Sign in to another account</h1>
+        <p className="text-sm text-muted-foreground">
+          Your current sessions stay parked — you can switch between them anytime.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <ProviderButton onClick={() => onSocial("GoogleOAuth")} icon={<GoogleIcon />}>
+          Continue with Google
+        </ProviderButton>
+        <ProviderButton onClick={() => onSocial("MicrosoftOAuth")} icon={<MicrosoftIcon />}>
+          Continue with Microsoft
+        </ProviderButton>
+
+        <div className="relative py-1">
+          <div aria-hidden className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border/60" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-background px-3 text-[10px] uppercase tracking-[0.18em] text-muted-foreground">or</span>
           </div>
         </div>
 
-        {step === "picker" && (
-          <div className="flex w-full flex-col gap-3">
-            <Button onClick={() => goSocial("GoogleOAuth")} variant="outline" size="lg" className="justify-start gap-3">
-              <GoogleIcon />
-              <span>Continue with Google</span>
-            </Button>
-            <Button
-              onClick={() => goSocial("MicrosoftOAuth")}
-              variant="outline"
-              size="lg"
-              className="justify-start gap-3"
-            >
-              <MicrosoftIcon />
-              <span>Continue with Microsoft</span>
-            </Button>
-            <Button onClick={() => setStep("email")} variant="outline" size="lg" className="justify-start gap-3">
-              <MailIcon />
-              <span>Continue with email code</span>
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="mt-2">
-              Cancel
-            </Button>
-          </div>
-        )}
+        <ProviderButton onClick={onEmail} icon={<Mail className="text-muted-foreground" />}>
+          Continue with email code
+        </ProviderButton>
+      </div>
 
-        {step === "email" && (
-          <form
-            className="flex w-full flex-col gap-3"
-            onSubmit={(e) => {
-              e.preventDefault()
-              sendCode()
-            }}
-          >
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="add-account-email">Email</Label>
-              <Input
-                id="add-account-email"
-                type="email"
-                autoComplete="email"
-                required
-                autoFocus
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                disabled={busy}
-              />
-            </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" size="lg" disabled={busy || !email}>
-              {busy ? "Sending..." : "Send code"}
-            </Button>
-            <Button type="button" variant="ghost" size="sm" onClick={() => setStep("picker")} disabled={busy}>
-              Back
-            </Button>
-          </form>
-        )}
+      <div className="text-center">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs uppercase tracking-[0.14em] text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
 
-        {step === "verify" && (
-          <form
-            className="flex w-full flex-col items-center gap-4"
-            onSubmit={(e) => {
-              e.preventDefault()
-              verifyCode()
-            }}
+function EmailStep({
+  email,
+  setEmail,
+  busy,
+  error,
+  onSubmit,
+  onBack,
+}: {
+  email: string
+  setEmail: (v: string) => void
+  busy: boolean
+  error: string | null
+  onSubmit: () => void
+  onBack: () => void
+}) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit()
+      }}
+      className="w-full space-y-8"
+    >
+      <div className="space-y-3 text-center">
+        <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Add account</span>
+        <h1 className="text-2xl font-medium leading-tight">Use email instead</h1>
+        <p className="text-sm text-muted-foreground">We'll send a one-time code to verify it's you.</p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label
+            htmlFor="add-account-email"
+            className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground font-medium"
           >
-            <InputOTP
-              maxLength={MAGIC_CODE_LENGTH}
-              value={code}
-              onChange={setCode}
-              autoFocus
-              disabled={busy}
-              containerClassName="justify-center"
-            >
-              <InputOTPGroup>
-                {Array.from({ length: MAGIC_CODE_LENGTH }).map((_, i) => (
-                  <InputOTPSlot key={i} index={i} />
-                ))}
-              </InputOTPGroup>
-            </InputOTP>
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <Button type="submit" size="lg" disabled={busy || code.length !== MAGIC_CODE_LENGTH} className="w-full">
-              {busy ? "Verifying..." : "Verify"}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setStep("email")
-                setCode("")
-                setError(null)
-              }}
-              disabled={busy}
-            >
-              Use a different email
-            </Button>
-          </form>
-        )}
+            Email
+          </Label>
+          <Input
+            id="add-account-email"
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            required
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={busy}
+            className="h-11"
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <Button
+          type="submit"
+          className="h-11 w-full text-xs font-medium uppercase tracking-[0.14em]"
+          disabled={busy || !email}
+        >
+          {busy ? "Sending…" : "Send code"}
+        </Button>
+      </div>
+
+      <div className="text-center">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          <ArrowLeft className="size-3" />
+          Back
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function VerifyStep({
+  email,
+  code,
+  setCode,
+  busy,
+  error,
+  onSubmit,
+  onChangeEmail,
+}: {
+  email: string
+  code: string
+  setCode: (v: string) => void
+  busy: boolean
+  error: string | null
+  onSubmit: () => void
+  onChangeEmail: () => void
+}) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit()
+      }}
+      className="w-full space-y-8"
+    >
+      <div className="space-y-6 text-center">
+        <HaloMailIcon />
+        <div className="space-y-2">
+          <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Code sent</span>
+          <h1 className="text-2xl font-medium leading-tight">Check your inbox</h1>
+          <p className="text-sm text-muted-foreground">
+            We sent a 6-digit code to <span className="text-foreground">{email}</span>.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <InputOTP
+          maxLength={MAGIC_CODE_LENGTH}
+          value={code}
+          onChange={setCode}
+          autoFocus
+          disabled={busy}
+          containerClassName="justify-center"
+        >
+          <InputOTPGroup>
+            {Array.from({ length: MAGIC_CODE_LENGTH }).map((_, i) => (
+              <InputOTPSlot key={i} index={i} className="h-12 w-11 text-base font-medium" />
+            ))}
+          </InputOTPGroup>
+        </InputOTP>
+
+        {error && <p className="text-center text-sm text-destructive">{error}</p>}
+
+        <Button
+          type="submit"
+          className="h-11 w-full text-xs font-medium uppercase tracking-[0.14em]"
+          disabled={busy || code.length !== MAGIC_CODE_LENGTH}
+        >
+          {busy ? "Verifying…" : "Verify"}
+        </Button>
+      </div>
+
+      <div className="text-center">
+        <button
+          type="button"
+          onClick={onChangeEmail}
+          disabled={busy}
+          className="text-xs uppercase tracking-[0.14em] text-muted-foreground underline-offset-4 hover:text-foreground hover:underline disabled:opacity-50"
+        >
+          Use a different email
+        </button>
+      </div>
+    </form>
+  )
+}
+
+/** Provider button: tracked-uppercase typography would compete with brand names like "Google", so we keep these in sentence case to match the IdPs' own affordances. */
+function ProviderButton({ icon, children, onClick }: { icon: ReactNode; children: ReactNode; onClick: () => void }) {
+  return (
+    <Button onClick={onClick} variant="outline" className="h-11 w-full justify-start gap-3 text-sm font-medium">
+      {icon}
+      <span>{children}</span>
+    </Button>
+  )
+}
+
+/** Mirrors the HaloIcon used by `JoinPage`'s SubmittedState — same visual family. */
+function HaloMailIcon() {
+  return (
+    <div className="relative mx-auto flex h-16 w-16 items-center justify-center">
+      <div aria-hidden className="absolute inset-1 rounded-full bg-primary/15 blur-xl" />
+      <div className="relative flex h-14 w-14 items-center justify-center rounded-full border bg-background">
+        <Mail className="h-6 w-6 text-primary" />
       </div>
     </div>
   )
@@ -208,7 +395,7 @@ export function AddAccountPage() {
 
 function GoogleIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+    <svg viewBox="0 0 18 18" aria-hidden="true">
       <path
         fill="#4285F4"
         d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.614z"
@@ -231,30 +418,11 @@ function GoogleIcon() {
 
 function MicrosoftIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+    <svg viewBox="0 0 18 18" aria-hidden="true">
       <path fill="#F25022" d="M0 0h8.5v8.5H0z" />
       <path fill="#7FBA00" d="M9.5 0H18v8.5H9.5z" />
       <path fill="#00A4EF" d="M0 9.5h8.5V18H0z" />
       <path fill="#FFB900" d="M9.5 9.5H18V18H9.5z" />
-    </svg>
-  )
-}
-
-function MailIcon() {
-  return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect width="20" height="16" x="2" y="4" rx="2" />
-      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
     </svg>
   )
 }

--- a/apps/frontend/src/pages/add-account.tsx
+++ b/apps/frontend/src/pages/add-account.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useState } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
+import { toast } from "sonner"
+import { API_BASE, ApiError, api } from "@/api/client"
+import { useAuth } from "@/auth"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
+import { Label } from "@/components/ui/label"
+import { ThreaLogo } from "@/components/threa-logo"
+import { clearLastWorkspaceId } from "@/lib/last-workspace"
+
+type Step = "picker" | "email" | "verify"
+
+const MAGIC_CODE_LENGTH = 6
+
+export function AddAccountPage() {
+  const [search] = useSearchParams()
+  const navigate = useNavigate()
+  const { refetch } = useAuth()
+  const [step, setStep] = useState<Step>("picker")
+  const [email, setEmail] = useState("")
+  const [code, setCode] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const redirectTo = search.get("redirect_to") || undefined
+
+  const goSocial = useCallback(
+    (provider: "GoogleOAuth" | "MicrosoftOAuth") => {
+      // Same shape as the existing login flow: a full-page navigation to the
+      // backend so the OAuth callback's cookie writes land before the SPA
+      // boots. `intent=add` + a social provider together bypass AuthKit and
+      // the IdP shows its native account picker.
+      const qs = new URLSearchParams({ intent: "add", provider })
+      if (redirectTo) qs.set("redirect_to", redirectTo)
+      window.location.href = `${API_BASE}/api/auth/login?${qs.toString()}`
+    },
+    [redirectTo]
+  )
+
+  const sendCode = useCallback(async () => {
+    if (!email) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.post("/api/auth/magic/send", { email })
+      setStep("verify")
+    } catch {
+      // The endpoint deliberately replies 200 even when the email is unknown
+      // (no account-existence oracle), so the only way we land here is a
+      // network/server failure.
+      setError("Couldn't send the code right now. Please try again.")
+    } finally {
+      setBusy(false)
+    }
+  }, [email])
+
+  const verifyCode = useCallback(async () => {
+    if (code.length !== MAGIC_CODE_LENGTH) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await api.post<{ ok: boolean; redirectPath: string }>("/api/auth/magic/verify", {
+        email,
+        code,
+        intent: "add",
+      })
+      // A successful add makes the new account active; the stale last-workspace
+      // pointer would route us back into the *previous* account. Same dance
+      // the OAuth callback / AuthProvider mount-effect does on accountAdded=1.
+      clearLastWorkspaceId()
+      await refetch()
+      navigate(result.redirectPath, { replace: true })
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "MAX_ACCOUNTS_REACHED") {
+        toast.error("You're signed in to the maximum number of accounts. Remove one to add another.")
+        navigate(-1)
+        return
+      }
+      if (err instanceof ApiError && err.status === 401) {
+        setError("That code didn't match. Check your email and try again.")
+        setCode("")
+        return
+      }
+      setError("Couldn't verify the code right now. Please try again.")
+    } finally {
+      setBusy(false)
+    }
+  }, [code, email, navigate, refetch])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="flex w-full max-w-sm flex-col items-center gap-8">
+        <div className="flex flex-col items-center gap-3">
+          <ThreaLogo size="lg" />
+          <div className="text-center">
+            <h1 className="text-xl font-light tracking-[0.15em] uppercase text-primary">Add account</h1>
+            <p className="mt-1 text-muted-foreground text-sm">
+              {step === "picker" && "Choose how to add another account."}
+              {step === "email" && "We'll email you a one-time code."}
+              {step === "verify" && `Enter the 6-digit code we sent to ${email}.`}
+            </p>
+          </div>
+        </div>
+
+        {step === "picker" && (
+          <div className="flex w-full flex-col gap-3">
+            <Button onClick={() => goSocial("GoogleOAuth")} variant="outline" size="lg" className="justify-start gap-3">
+              <GoogleIcon />
+              <span>Continue with Google</span>
+            </Button>
+            <Button
+              onClick={() => goSocial("MicrosoftOAuth")}
+              variant="outline"
+              size="lg"
+              className="justify-start gap-3"
+            >
+              <MicrosoftIcon />
+              <span>Continue with Microsoft</span>
+            </Button>
+            <Button onClick={() => setStep("email")} variant="outline" size="lg" className="justify-start gap-3">
+              <MailIcon />
+              <span>Continue with email code</span>
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="mt-2">
+              Cancel
+            </Button>
+          </div>
+        )}
+
+        {step === "email" && (
+          <form
+            className="flex w-full flex-col gap-3"
+            onSubmit={(e) => {
+              e.preventDefault()
+              sendCode()
+            }}
+          >
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="add-account-email">Email</Label>
+              <Input
+                id="add-account-email"
+                type="email"
+                autoComplete="email"
+                required
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" size="lg" disabled={busy || !email}>
+              {busy ? "Sending..." : "Send code"}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setStep("picker")} disabled={busy}>
+              Back
+            </Button>
+          </form>
+        )}
+
+        {step === "verify" && (
+          <form
+            className="flex w-full flex-col items-center gap-4"
+            onSubmit={(e) => {
+              e.preventDefault()
+              verifyCode()
+            }}
+          >
+            <InputOTP
+              maxLength={MAGIC_CODE_LENGTH}
+              value={code}
+              onChange={setCode}
+              autoFocus
+              disabled={busy}
+              containerClassName="justify-center"
+            >
+              <InputOTPGroup>
+                {Array.from({ length: MAGIC_CODE_LENGTH }).map((_, i) => (
+                  <InputOTPSlot key={i} index={i} />
+                ))}
+              </InputOTPGroup>
+            </InputOTP>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" size="lg" disabled={busy || code.length !== MAGIC_CODE_LENGTH} className="w-full">
+              {busy ? "Verifying..." : "Verify"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setStep("email")
+                setCode("")
+                setError(null)
+              }}
+              disabled={busy}
+            >
+              Use a different email
+            </Button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.614z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
+      />
+    </svg>
+  )
+}
+
+function MicrosoftIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+      <path fill="#F25022" d="M0 0h8.5v8.5H0z" />
+      <path fill="#7FBA00" d="M9.5 0H18v8.5H9.5z" />
+      <path fill="#00A4EF" d="M0 9.5h8.5V18H0z" />
+      <path fill="#FFB900" d="M9.5 9.5H18V18H9.5z" />
+    </svg>
+  )
+}
+
+function MailIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect width="20" height="16" x="2" y="4" rx="2" />
+      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+    </svg>
+  )
+}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -28,6 +28,16 @@ export const router = createBrowserRouter([
     errorElement: <ErrorBoundary />,
   },
   {
+    // Custom add-account picker. Sits in front of `/api/auth/login?intent=add`
+    // because AuthKit's hosted UI silent-refreshes and can't reliably show an
+    // account picker. Buttons hit provider-direct social URLs or the magic
+    // auth endpoints — see apps/control-plane/src/features/auth/handlers.ts.
+    path: "/add-account",
+    HydrateFallback: FallbackLoader,
+    lazy: async () => ({ Component: (await import("@/pages/add-account")).AddAccountPage }),
+    errorElement: <ErrorBoundary />,
+  },
+  {
     path: "/share",
     HydrateFallback: FallbackLoader,
     lazy: async () => ({ Component: (await import("@/pages/share-target")).ShareTargetPage }),

--- a/packages/backend-common/src/auth/auth-service.stub.test.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.test.ts
@@ -1,28 +1,59 @@
 import { describe, expect, test } from "bun:test"
 import { StubAuthService } from "./auth-service.stub"
 
-describe("StubAuthService.getAuthorizationUrl prompt plumbing", () => {
-  test("omits prompt when no options are passed", () => {
+describe("StubAuthService.getAuthorizationUrl provider plumbing", () => {
+  test("omits provider when no options are passed", () => {
     const svc = new StubAuthService()
     const url = svc.getAuthorizationUrl("/redirect-here", "https://app.example.com/callback")
     const params = new URLSearchParams(url.split("?")[1])
 
-    expect(params.has("prompt")).toBe(false)
+    expect(params.has("provider")).toBe(false)
     expect(params.get("state")).toBe(Buffer.from("/redirect-here").toString("base64"))
     expect(params.get("redirect_uri")).toBe("https://app.example.com/callback")
   })
 
-  test("encodes a space-delimited multi-value prompt into the stub login URL", () => {
+  test("passes the social provider through to the stub login URL", () => {
     const svc = new StubAuthService()
     const url = svc.getAuthorizationUrl("/redirect-here", "https://app.example.com/callback", {
-      prompt: "login select_account",
+      provider: "GoogleOAuth",
     })
     const params = new URLSearchParams(url.split("?")[1])
 
-    // The add-account flow sends the OIDC space-delimited form; the space
-    // must survive URL encoding and decode back intact.
-    expect(params.get("prompt")).toBe("login select_account")
+    // The add-account picker emits `provider=GoogleOAuth` to bypass AuthKit.
+    // The stub echoes it back so tests can prove it survived plumbing.
+    expect(params.get("provider")).toBe("GoogleOAuth")
     expect(params.get("state")).toBe(Buffer.from("/redirect-here").toString("base64"))
     expect(params.get("redirect_uri")).toBe("https://app.example.com/callback")
+  })
+})
+
+describe("StubAuthService magic auth", () => {
+  test("sendMagicAuthCode + authenticateWithMagicAuth round-trips", async () => {
+    const svc = new StubAuthService()
+    const email = "magic-test@example.com"
+
+    const send = await svc.sendMagicAuthCode(email)
+    expect(send).toEqual({ ok: true })
+
+    // Wrong code rejects without consuming — the user can retry.
+    const wrong = await svc.authenticateWithMagicAuth(email, "000000")
+    expect(wrong.success).toBe(false)
+
+    const right = await svc.authenticateWithMagicAuth(email, "123456")
+    expect(right.success).toBe(true)
+    expect(right.sealedSession).toMatch(/^test_session_workos_test_/)
+    expect(right.user?.email).toBe(email)
+  })
+
+  test("authenticateWithMagicAuth consumes the code (single use)", async () => {
+    const svc = new StubAuthService()
+    const email = "once@example.com"
+
+    await svc.sendMagicAuthCode(email)
+    const first = await svc.authenticateWithMagicAuth(email, "123456")
+    expect(first.success).toBe(true)
+
+    const second = await svc.authenticateWithMagicAuth(email, "123456")
+    expect(second.success).toBe(false)
   })
 })

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -1,4 +1,5 @@
-import type { AuthResult, AuthService, SocialProvider } from "./auth-service"
+import type { SocialProvider } from "@threa/types"
+import type { AuthResult, AuthService } from "./auth-service"
 
 // Stub sessions deliberately surface no JWT permission claim
 // (`permissions: null`). Production OAuth-callback sessions also start with

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -177,13 +177,15 @@ export class StubAuthService implements AuthService {
     this.magicCodes.delete(normalized)
 
     // Auto-create the user the same way devLogin does so subsequent
-    // authenticateSession calls find them.
-    const fakeWorkosUserId = `workos_test_${Buffer.from(email).toString("base64url")}`
+    // authenticateSession calls find them. Key off the normalized address so a
+    // case-only variant resolves to the same in-memory user that the magic
+    // code was issued against, instead of forking a second record.
+    const fakeWorkosUserId = `workos_test_${Buffer.from(normalized).toString("base64url")}`
     const existing = this.users.get(fakeWorkosUserId)
     const user = existing ?? {
       id: fakeWorkosUserId,
-      email,
-      firstName: email.split("@")[0] ?? null,
+      email: normalized,
+      firstName: normalized.split("@")[0] ?? null,
       lastName: null,
     }
     this.users.set(fakeWorkosUserId, user)

--- a/packages/backend-common/src/auth/auth-service.stub.ts
+++ b/packages/backend-common/src/auth/auth-service.stub.ts
@@ -1,4 +1,4 @@
-import type { AuthResult, AuthService } from "./auth-service"
+import type { AuthResult, AuthService, SocialProvider } from "./auth-service"
 
 // Stub sessions deliberately surface no JWT permission claim
 // (`permissions: null`). Production OAuth-callback sessions also start with
@@ -23,6 +23,14 @@ export class StubAuthService implements AuthService {
   private users: Map<string, { id: string; email: string; firstName: string | null; lastName: string | null }> =
     new Map()
   private revoked = new Set<string>()
+  // Issued magic codes, keyed by lowercase email. One code per email at a time
+  // — a fresh send overwrites the previous one, mirroring real Magic Auth.
+  private magicCodes = new Map<string, string>()
+  /**
+   * Test seam: the fixed code the stub returns to every `sendMagicAuthCode` so
+   * e2e tests don't have to inspect emails. Defaults to "123456".
+   */
+  magicCodeForTests = "123456"
 
   /**
    * Dev login endpoint - creates/ensures in-memory auth user and registers session.
@@ -66,6 +74,7 @@ export class StubAuthService implements AuthService {
   clearUsers(): void {
     this.users.clear()
     this.revoked.clear()
+    this.magicCodes.clear()
   }
 
   async revokeSession(sealedSession: string): Promise<boolean> {
@@ -137,19 +146,53 @@ export class StubAuthService implements AuthService {
     }
   }
 
-  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { prompt?: string }): string {
-    // Encode state, optional redirect_uri, and optional prompt into the stub
+  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { provider?: SocialProvider }): string {
+    // Encode state, optional redirect_uri, and optional provider into the stub
     // login URL so tests can assert on any of them. The stub login page
-    // ignores redirect_uri and prompt.
+    // ignores redirect_uri and provider.
     const state = redirectTo ? Buffer.from(redirectTo).toString("base64") : ""
     const params = new URLSearchParams({ state })
     if (redirectUri) {
       params.set("redirect_uri", redirectUri)
     }
-    if (options?.prompt) {
-      params.set("prompt", options.prompt)
+    if (options?.provider) {
+      params.set("provider", options.provider)
     }
     return `/test-auth-login?${params.toString()}`
+  }
+
+  async sendMagicAuthCode(email: string): Promise<{ ok: true } | { ok: false; reason: string }> {
+    if (!email) return { ok: false, reason: "send_failed" }
+    this.magicCodes.set(email.toLowerCase(), this.magicCodeForTests)
+    return { ok: true }
+  }
+
+  async authenticateWithMagicAuth(email: string, code: string): Promise<AuthResult> {
+    const normalized = email.toLowerCase()
+    const expected = this.magicCodes.get(normalized)
+    if (!expected || expected !== code) {
+      return { success: false, refreshed: false, reason: "authentication_failed" }
+    }
+    this.magicCodes.delete(normalized)
+
+    // Auto-create the user the same way devLogin does so subsequent
+    // authenticateSession calls find them.
+    const fakeWorkosUserId = `workos_test_${Buffer.from(email).toString("base64url")}`
+    const existing = this.users.get(fakeWorkosUserId)
+    const user = existing ?? {
+      id: fakeWorkosUserId,
+      email,
+      firstName: email.split("@")[0] ?? null,
+      lastName: null,
+    }
+    this.users.set(fakeWorkosUserId, user)
+
+    return {
+      success: true,
+      user: { ...user, permissions: null },
+      sealedSession: `test_session_${fakeWorkosUserId}`,
+      refreshed: false,
+    }
   }
 
   async getLogoutUrl(_sealedSession: string, returnTo?: string): Promise<string | null> {

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -26,6 +26,21 @@ export interface AuthResult {
   reason?: string
 }
 
+/**
+ * Social IdPs that bypass AuthKit's hosted UI entirely.
+ *
+ * `provider=authkit` is AuthKit's hosted UI, which holds its own session cookie
+ * on `cheerful-refuge-87.authkit.app` and silent-refreshes whenever that cookie
+ * is live — silently re-authenticating the existing user regardless of the
+ * `prompt` claim on the authorize URL. That makes the add-account flow
+ * impossible through AuthKit.
+ *
+ * Passing one of these provider names routes WorkOS straight to the IdP, which
+ * natively honors `prompt=select_account` and lets the user pick a different
+ * account.
+ */
+export type SocialProvider = "GoogleOAuth" | "MicrosoftOAuth"
+
 export interface AuthService {
   authenticateSession(sealedSession: string): Promise<AuthResult>
   authenticateWithCode(code: string): Promise<AuthResult>
@@ -39,14 +54,30 @@ export interface AuthService {
    *                    control-plane to support multiple origins (e.g. the
    *                    backoffice on a different TLD) without cookie-domain
    *                    gymnastics.
-   * @param options.prompt Passed through to WorkOS as the OIDC `prompt`. The
-   *                    add-account flow passes `"login select_account"` (the
-   *                    space-delimited OIDC form) to force both a fresh
-   *                    credential prompt and the account picker, so the
-   *                    existing hosted session isn't silently reused for the
-   *                    second account.
+   * @param options.provider Bypass AuthKit and route directly to a social IdP.
+   *                    The add-account flow needs this because AuthKit's
+   *                    hosted UI silent-refreshes through its own session
+   *                    cookie regardless of `prompt`. When set, we also pass
+   *                    `prompt=select_account` to the IdP so the user can
+   *                    actually pick a different account.
    */
-  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { prompt?: string }): string
+  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { provider?: SocialProvider }): string
+  /**
+   * Send a 6-digit Magic Auth code to the given email.
+   *
+   * Used as the universal fallback for the custom add-account flow when the
+   * user didn't sign up via Google/Microsoft. WorkOS auto-creates a user if
+   * none exists for the email — that's intentional: the verify step proves
+   * email ownership, which is equivalent to a sign-up.
+   */
+  sendMagicAuthCode(email: string): Promise<{ ok: true } | { ok: false; reason: string }>
+  /**
+   * Verify a Magic Auth code and produce a sealed session for the user.
+   *
+   * Mirrors {@link authenticateWithCode} shape so the add-account path can
+   * funnel both OAuth and Magic Auth through the same park/coalesce logic.
+   */
+  authenticateWithMagicAuth(email: string, code: string): Promise<AuthResult>
   /**
    * Build a WorkOS single-logout URL.
    *
@@ -178,14 +209,72 @@ export class WorkosAuthService implements AuthService {
     }
   }
 
-  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { prompt?: string }): string {
+  getAuthorizationUrl(redirectTo?: string, redirectUri?: string, options?: { provider?: SocialProvider }): string {
+    // Social providers bypass AuthKit's hosted UI. We forward `prompt=select_account`
+    // via `providerQueryParams` so the IdP renders its native account picker —
+    // the only reliable way to add a *different* account when the user already
+    // has a live session at the IdP.
+    if (options?.provider) {
+      return this.workos.userManagement.getAuthorizationUrl({
+        provider: options.provider,
+        providerQueryParams: { prompt: "select_account" },
+        redirectUri: redirectUri ?? this.redirectUri,
+        clientId: this.clientId,
+        state: redirectTo ? Buffer.from(redirectTo).toString("base64") : undefined,
+      })
+    }
     return this.workos.userManagement.getAuthorizationUrl({
       provider: "authkit",
       redirectUri: redirectUri ?? this.redirectUri,
       clientId: this.clientId,
       state: redirectTo ? Buffer.from(redirectTo).toString("base64") : undefined,
-      ...(options?.prompt ? { prompt: options.prompt } : {}),
     })
+  }
+
+  async sendMagicAuthCode(email: string): Promise<{ ok: true } | { ok: false; reason: string }> {
+    try {
+      await this.workos.userManagement.sendMagicAuthCode({ email })
+      return { ok: true }
+    } catch (error) {
+      logger.error({ err: error }, "Failed to send magic auth code")
+      return { ok: false, reason: "send_failed" }
+    }
+  }
+
+  async authenticateWithMagicAuth(email: string, code: string): Promise<AuthResult> {
+    try {
+      const { user, sealedSession } = await this.workos.userManagement.authenticateWithMagicAuth({
+        email,
+        code,
+        clientId: this.clientId,
+        session: { sealSession: true, cookiePassword: this.cookiePassword },
+      })
+
+      logger.info({ email: user.email, sealedSession: !!sealedSession }, "User authenticated with magic auth")
+
+      return {
+        success: true,
+        user: {
+          id: user.id,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          // Same as the OAuth callback path: no JWT permission claim is in the
+          // initial authenticate response. The next authenticated request
+          // through authenticateSession will populate it.
+          permissions: null,
+        },
+        sealedSession: sealedSession!,
+        refreshed: false,
+      }
+    } catch (error) {
+      logger.error({ err: error }, "Authentication with magic auth failed")
+      return {
+        success: false,
+        refreshed: false,
+        reason: "authentication_failed",
+      }
+    }
   }
 
   async getLogoutUrl(sealedSession: string, returnTo?: string): Promise<string | null> {

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -1,4 +1,5 @@
 import { WorkOS } from "@workos-inc/node"
+import type { SocialProvider } from "@threa/types"
 import { logger } from "../logger"
 import type { WorkosConfig } from "./types"
 
@@ -25,21 +26,6 @@ export interface AuthResult {
   refreshed: boolean
   reason?: string
 }
-
-/**
- * Social IdPs that bypass AuthKit's hosted UI entirely.
- *
- * `provider=authkit` is AuthKit's hosted UI, which holds its own session cookie
- * on `cheerful-refuge-87.authkit.app` and silent-refreshes whenever that cookie
- * is live — silently re-authenticating the existing user regardless of the
- * `prompt` claim on the authorize URL. That makes the add-account flow
- * impossible through AuthKit.
- *
- * Passing one of these provider names routes WorkOS straight to the IdP, which
- * natively honors `prompt=select_account` and lets the user pick a different
- * account.
- */
-export type SocialProvider = "GoogleOAuth" | "MicrosoftOAuth"
 
 export interface AuthService {
   authenticateSession(sealedSession: string): Promise<AuthResult>

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -236,7 +236,7 @@ export class WorkosAuthService implements AuthService {
         session: { sealSession: true, cookiePassword: this.cookiePassword },
       })
 
-      logger.info({ email: user.email, sealedSession: !!sealedSession }, "User authenticated with magic auth")
+      logger.info({ userId: user.id, sealedSession: !!sealedSession }, "User authenticated with magic auth")
 
       return {
         success: true,

--- a/packages/backend-common/src/auth/middleware.test.ts
+++ b/packages/backend-common/src/auth/middleware.test.ts
@@ -19,6 +19,12 @@ class FakeAuthService implements AuthService {
   async revokeSession(): Promise<boolean> {
     return false
   }
+  async sendMagicAuthCode(): Promise<{ ok: true } | { ok: false; reason: string }> {
+    return { ok: true }
+  }
+  async authenticateWithMagicAuth(): Promise<AuthResult> {
+    return this.result
+  }
 }
 
 function makeRes(): Response {

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -1,6 +1,6 @@
 // Auth
 export { WorkosAuthService } from "./auth/auth-service"
-export type { AuthResult, AuthService } from "./auth/auth-service"
+export type { AuthResult, AuthService, SocialProvider } from "./auth/auth-service"
 export { StubAuthService } from "./auth/auth-service.stub"
 export type { DevLoginResult } from "./auth/auth-service.stub"
 export {

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -1,6 +1,6 @@
 // Auth
 export { WorkosAuthService } from "./auth/auth-service"
-export type { AuthResult, AuthService, SocialProvider } from "./auth/auth-service"
+export type { AuthResult, AuthService } from "./auth/auth-service"
 export { StubAuthService } from "./auth/auth-service.stub"
 export type { DevLoginResult } from "./auth/auth-service.stub"
 export {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -621,3 +621,14 @@ export type BotTrait = (typeof BOT_TRAITS)[number]
 export const BotTraits = {
   INTERACTIVE: "interactive",
 } as const satisfies Record<string, BotTrait>
+
+// Social IdPs that bypass AuthKit's hosted UI. Used by the add-account flow
+// where AuthKit silent-refreshes through its own session cookie regardless of
+// `prompt`, making provider-direct the only reliable way to route a different
+// account through the IdP's native account picker.
+export const SOCIAL_PROVIDERS = ["GoogleOAuth", "MicrosoftOAuth"] as const
+export type SocialProvider = (typeof SOCIAL_PROVIDERS)[number]
+
+// Length of the WorkOS Magic Auth code. Shared between the backend Zod schema
+// and the frontend OTP input so both sides accept the same shape.
+export const MAGIC_CODE_LENGTH = 6

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -172,6 +172,10 @@ export {
   BOT_TRAITS,
   type BotTrait,
   BotTraits,
+  // Auth (social providers + magic auth)
+  SOCIAL_PROVIDERS,
+  type SocialProvider,
+  MAGIC_CODE_LENGTH,
 } from "./constants"
 
 // Domain entities (wire format)


### PR DESCRIPTION
## Summary

WorkOS AuthKit's hosted UI silent-refreshes through its own session cookie regardless of the `prompt` claim on the authorize URL, which made the add-account flow impossible through AuthKit — the user always landed back as themselves. This PR replaces the AuthKit hand-off for `intent=add` with an in-app picker that uses provider-direct OAuth (Google/Microsoft, which honor `prompt=select_account` natively) or WorkOS Magic Auth as a universal email-code fallback.

- New `/add-account` route with a polished 3-step picker (provider → email → 6-digit OTP), visually consistent with the existing auth-landing pages (radial halo, tracked-uppercase kickers, HaloMailIcon mirroring `JoinPage`).
- Control-plane endpoints: `/api/auth/login?intent=add` hands off to the picker when no `provider` is set; `/api/auth/magic/send` and `/api/auth/magic/verify` drive the Magic Auth path through the same `addAndParkActive` service the OAuth callback uses.
- Shared `SocialProvider` + `MAGIC_CODE_LENGTH` extracted to `@threa/types` so frontend and backend stay in sync.

## Test plan

- [x] `bun test ./packages/backend-common/src/auth/auth-service.stub.test.ts ./packages/backend-common/src/auth/middleware.test.ts` — 7 pass
- [x] Typecheck across all workspaces
- [x] Lint across all apps
- [x] OpenAPI doc check
- [ ] CI: control-plane e2e `accounts.test.ts` covers Google bypass + magic-auth add + wrong-code 401
- [ ] Manual smoke: log in as account A, hit `/add-account`, verify Google flow lands B as active with A parked
- [ ] Manual smoke: same via "Continue with email code" → 6-digit OTP

## Pre-PR review notes

Self-review pass before pushing flagged and fixed:

1. **Magic-code Zod schema width** — `z.string().min(4).max(10)` let bad-length codes through to WorkOS where they'd deterministically 401 with a confusing message. Tightened to `z.string().length(MAGIC_CODE_LENGTH)`.
2. **Refetch error masking success** — a transient `refetch()` throw after a successful magic verify used to flip the UI to "Couldn't verify the code right now", but the code is single-use so a retry always 401s. The post-success side-effects (`clearLastWorkspaceId`, `refetch`, `navigate`) now live outside the catch block, and `refetch` is independently try/caught.
3. **Speculative plain-sign-in branch (INV-36)** — `magicVerify` had an `intent === "add"` branch with a plain-sign-in fallback that wasn't wired into any UI. Made `intent: "add"` required in the schema and dropped the dead branch.
4. **`SocialProvider` duplication (INV-33)** — the `"GoogleOAuth" | "MicrosoftOAuth"` union was inlined in the frontend and re-declared in backend-common. Both now import from `@threa/types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->