### PR TITLE
fix: reliably re-alert repeat push notifications in the same stream

### DIFF
--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -563,6 +563,16 @@ self.addEventListener("push", (event) => {
           vibrate: THREA_VIBRATION_PATTERN,
         }
 
+        // Re-alerting a replaced same-tag notification depends on `renotify`,
+        // which Firefox, iOS/Safari, and some Chromium builds ignore — they
+        // swap the tray entry silently, so every message after the first in a
+        // stream arrives with no sound/vibration/banner. Closing the
+        // predecessor (its message history is already lifted into `messages`
+        // above, so the grouped body/count survives) means showNotification has
+        // no same-tag entry to silently replace and reliably re-alerts on every
+        // platform.
+        for (const n of existing) n.close()
+
         await self.registration.showNotification(title, options)
 
         // Queue a Background Sync to prefetch stream + workspace bootstrap so


### PR DESCRIPTION
## Problem

Push notifications were flaky: the **first** message from a stream alerted normally, but every follow-up message from that **same** stream arrived silently — no sound, no vibration, no banner — even though the notification text updated in the tray.

The service worker `push` handler groups per-stream notifications under a stable `tag` (`streamId`, or `${streamId}:mention` for mentions) so a burst of messages collapses into one rolling entry instead of spamming the tray. To re-alert the user when it replaces that same-tag entry, it relied **solely** on `renotify: true`.

`renotify` is not reliable cross-platform. Firefox, iOS/Safari (including installed PWAs), and some Chromium builds ignore it: they swap the existing same-tag tray entry **silently** in place. Result: only the very first notification per stream ever produced an alert — exactly the reported symptom ("received one, then nothing further from the same stream").

## Solution

Before calling `showNotification`, explicitly close any existing same-tag notification. The accumulated message history is already lifted into the new payload's `messages` array *before* the close, so the grouped body and count survive intact — the user still sees "N new messages" with the rolling history. With no same-tag entry left for the browser to silently replace, `showNotification` is treated as a brand-new notification and reliably re-alerts on every platform.

### Key design decisions

**1. Close-then-show instead of trusting `renotify`**

`renotify` is kept as defense-in-depth (it's correct on platforms that honor it and harmless where they don't), but correctness no longer depends on it. Closing the predecessor is the cross-platform-reliable primitive.

**2. Ordering preserves the grouped notification**

The close happens *after* the existing notifications' message history is read and merged into the new `messages` array, and *after* the title/body/options are built — so closing the old entry loses no information. The new notification carries the full rolling history and updated count.

**3. Tag-scoped close**

Only notifications matching the computed `tag` are closed (`getNotifications({ tag })`), so a new message in stream A never dismisses an unrelated notification for stream B, and a mention notification (`:mention` tag) stays visually separate from the plain-message entry for the same stream.

## Modified files

| File                       | Change                                                                                  |
| -------------------------- | --------------------------------------------------------------------------------------- |
| `apps/frontend/src/sw.ts`  | Close existing same-tag notification before `showNotification` so repeat alerts in a stream reliably re-notify across Firefox / iOS-Safari / Chromium |

## Test plan

- [x] `bunx tsc --noEmit` (frontend) — clean
- [x] `sw-notification-format` unit suite — 20/20 pass (grouping/tag/title/body helpers unaffected)
- [x] Monorepo pre-commit gate (prettier, eslint ×4 workspaces, full typecheck, API-docs check) — pass
- [ ] Manual real-device verification: send 3+ messages to one stream while backgrounded on **iOS Safari + installed PWA** and **Firefox** — every message must alert (sound/vibration/banner), and the tray entry must still show the grouped rolling history + correct count
- [ ] Verify a mention and a plain message in the same stream remain two separate tray entries

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeD6gEQQ9ecPVKKFvVcsdk)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->