### PR TITLE
fix: anchor mobile gallery strip on the opened image

### DIFF
--- a/apps/frontend/src/components/image-gallery.reopen.test.tsx
+++ b/apps/frontend/src/components/image-gallery.reopen.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { MediaGalleryProvider } from "@/contexts"
+import { attachmentsApi } from "@/api"
+import { AttachmentList } from "@/components/timeline/attachment-list"
+import * as useMobileModule from "@/hooks/use-mobile"
+import type { AttachmentSummary } from "@threa/types"
+
+const WIDTH = 400
+const mockGetDownloadUrl = vi.fn()
+let offsetWidthSpy: PropertyDescriptor | undefined
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockGetDownloadUrl.mockReset()
+  mockGetDownloadUrl.mockResolvedValue("https://example.com/img")
+  vi.spyOn(attachmentsApi, "getDownloadUrl").mockImplementation(
+    (...args: Parameters<typeof attachmentsApi.getDownloadUrl>) => mockGetDownloadUrl(...args)
+  )
+  // The gallery's mobile strip carousel only runs when mobile + a real width.
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+  offsetWidthSpy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth")
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", { configurable: true, get: () => WIDTH })
+})
+
+afterEach(() => {
+  if (offsetWidthSpy) Object.defineProperty(HTMLElement.prototype, "offsetWidth", offsetWidthSpy)
+})
+
+const img = (id: string, filename: string): AttachmentSummary => ({
+  id,
+  filename,
+  mimeType: "image/png",
+  sizeBytes: 1024,
+})
+
+function renderGallery() {
+  const attachments = [img("img_1", "photo1.png"), img("img_2", "photo2.png"), img("img_3", "photo3.png")]
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/s",
+        element: (
+          <MediaGalleryProvider>
+            <AttachmentList attachments={attachments} workspaceId="ws_1" />
+          </MediaGalleryProvider>
+        ),
+      },
+    ],
+    { initialEntries: ["/s"] }
+  )
+  render(<RouterProvider router={router} />)
+}
+
+function stripTransform(): string {
+  const dialog = screen.getByRole("dialog")
+  const strip = dialog.querySelector<HTMLElement>('div[style*="will-change"]')
+  if (!strip) throw new Error("mobile strip not found")
+  return strip.style.transform
+}
+
+describe("MediaGallery mobile strip positioning across reopen", () => {
+  it("positions the strip on the clicked image on first open", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    await user.click(await screen.findByRole("button", { name: /photo3\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+
+    // Image 3 is index 2 -> strip shifted by -2 * width.
+    await waitFor(() => expect(stripTransform()).toBe(`translateX(${-2 * WIDTH}px)`))
+  })
+
+  it("positions the strip on the newly clicked image after a close+reopen", async () => {
+    const user = userEvent.setup()
+    renderGallery()
+
+    // Open image 3, then close it (closeMedia -> navigate(-1)).
+    await user.click(await screen.findByRole("button", { name: /photo3\.png/i }))
+    await waitFor(() => expect(stripTransform()).toBe(`translateX(${-2 * WIDTH}px)`))
+    await user.click(screen.getAllByRole("button", { name: /close/i })[0])
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+
+    // Reopen a different image. containerWidth is already known (component
+    // never unmounts), so this is the path that previously left the strip
+    // stuck on the first/previous slide.
+    await user.click(await screen.findByRole("button", { name: /photo2\.png/i }))
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+
+    // Image 2 is index 1 -> strip must shift to -1 * width, not stay at -2*width.
+    await waitFor(() => expect(stripTransform()).toBe(`translateX(${-1 * WIDTH}px)`))
+    expect(screen.getByText("2 / 3")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -192,8 +192,8 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const [containerWidth, setContainerWidth] = useState(0)
 
   // Mobile strip refs — all DOM manipulation goes through these to avoid re-render jank
-  const containerRef = useRef<HTMLDivElement>(null)
-  const stripRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const stripRef = useRef<HTMLDivElement | null>(null)
   const dismissWrapperRef = useRef<HTMLDivElement>(null)
 
   // Zoom/pan state for the current slide. Only reflects the active image.
@@ -240,9 +240,13 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   // Only sync currentIndex when the gallery opens — not on every initialIndex
   // change, which can shift due to late-loading images growing galleryImages.
+  // A layout effect (not passive) so currentIndex is corrected synchronously
+  // when isOpen flips, before Radix Presence's own layout effect mounts the
+  // dialog content — that ordering guarantees the strip callback ref (below)
+  // sees the opened item's index, not the previous one, on reopen.
   const prevOpen = useRef(false)
   const justOpened = useRef(false)
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isOpen && !prevOpen.current) {
       setCurrentIndex(initialIndex)
       justOpened.current = true
@@ -271,15 +275,19 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     el?.scrollIntoView({ block: "nearest", behavior: "smooth" })
   }, [currentIndex])
 
-  // Measure container width synchronously before first paint so slides size correctly
-  useLayoutEffect(() => {
-    if (!isOpen || !isMobile || !containerRef.current) return
-    setContainerWidth(containerRef.current.offsetWidth)
-  }, [isOpen, isMobile])
-
-  // Re-anchor the strip on resize (e.g. screen rotation)
-  useEffect(() => {
-    if (!isMobile || !containerRef.current) return
+  // Measure the container and watch it for resize via a callback ref. Radix
+  // Presence mounts the dialog content one render *after* `open` flips, so an
+  // effect keyed on [isOpen] runs before the node exists and never re-fires to
+  // pick up the late mount — leaving containerWidth at 0 and the strip stuck on
+  // slide 0. A callback ref fires exactly on (re)mount, which is precisely when
+  // the width becomes measurable.
+  const roRef = useRef<ResizeObserver | null>(null)
+  const setContainerNode = useCallback((node: HTMLDivElement | null) => {
+    roRef.current?.disconnect()
+    roRef.current = null
+    containerRef.current = node
+    if (!node) return
+    if (node.offsetWidth > 0) setContainerWidth(node.offsetWidth)
     const ro = new ResizeObserver(([entry]) => {
       const w = entry.contentRect.width
       if (w <= 0) return
@@ -289,18 +297,34 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
         stripRef.current.style.transform = `translateX(${-currentIndexRef.current * w}px)`
       }
     })
-    ro.observe(containerRef.current)
-    return () => ro.disconnect()
-  }, [isMobile])
+    ro.observe(node)
+    roRef.current = ro
+  }, [])
 
-  // Position the strip at the current index whenever the gallery opens or the
-  // container dimensions first become known. currentIndex is intentionally
-  // excluded so that in-progress swipe animations aren't interrupted by state updates.
+  // Anchor the strip on the opened item the instant it mounts. currentIndex is
+  // already synced to the opened item by the open-sync layout effect above
+  // (which runs before Presence mounts this node), so currentIndexRef is fresh
+  // here even on reopen. Width is read from the parent (the container) directly:
+  // its DOM node exists in this commit even though setContainerNode's state
+  // update hasn't been applied yet.
+  const setStripNode = useCallback((node: HTMLDivElement | null) => {
+    stripRef.current = node
+    if (!node) return
+    const w = node.parentElement?.offsetWidth ?? 0
+    if (w <= 0) return
+    setContainerWidth(w)
+    node.style.transition = "none"
+    node.style.transform = `translateX(${-currentIndexRef.current * w}px)`
+  }, [])
+
+  // Re-anchor when the gallery reopens without the content remounting (a close
+  // interrupted by a fast reopen keeps the Presence node alive, so the callback
+  // ref above doesn't re-fire) and when the width changes (rotation). Reads
+  // currentIndexRef so an in-progress swipe animation isn't interrupted.
   useLayoutEffect(() => {
-    if (!isOpen || !isMobile || containerWidth === 0 || !stripRef.current) return
+    if (!isMobile || containerWidth === 0 || !stripRef.current) return
     stripRef.current.style.transition = "none"
-    stripRef.current.style.transform = `translateX(${-currentIndex * containerWidth}px)`
-    // currentIndex intentionally excluded — position only on open/resize, not on every nav
+    stripRef.current.style.transform = `translateX(${-currentIndexRef.current * containerWidth}px)`
   }, [isOpen, isMobile, containerWidth])
 
   const current = items[currentIndex] ?? null
@@ -639,7 +663,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                 {actionBar}
 
                 <div
-                  ref={containerRef}
+                  ref={setContainerNode}
                   className="absolute inset-0 overflow-hidden"
                   onTouchStart={handleTouchStart}
                   onTouchMove={handleTouchMove}
@@ -647,7 +671,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                   onClick={handleMobileTap}
                 >
                   {/* Strip: all slides laid out horizontally; transform moves them as one */}
-                  <div ref={stripRef} className="flex h-full" style={{ willChange: "transform" }}>
+                  <div ref={setStripNode} className="flex h-full" style={{ willChange: "transform" }}>
                     {items.map((item, i) => (
                       <div
                         key={item.attachmentId}


### PR DESCRIPTION
## Problem

On mobile, opening the image gallery always showed the **first** image regardless of which thumbnail was clicked. This became consistently reproducible after #564 (push history on gallery open), which made open → close → reopen the common navigation path.

Root cause: Radix `Presence` mounts the dialog content **one render after** `open` flips to `true`. The container-measuring `useLayoutEffect` was keyed on `[isOpen, isMobile]`, so it ran during the render where `isOpen` became `true` — *before* the container DOM node existed — measured nothing, and never re-fired (its deps don't change when `Presence` later mounts the content). As a result `containerWidth` stayed `0`, the mobile strip's `translateX` was never set, and the strip sat on slide 0. The desktop counter was correct (it's driven by `currentIndex`, which synced fine), but the visible mobile slide was wrong — masking the bug in counter-based tests.

## Solution

Move container measurement and strip anchoring off `[isOpen]`-keyed effects and onto **callback refs**, which fire exactly on (re)mount — precisely when the node exists and width becomes measurable.

### How it works

- **`setContainerNode` (callback ref on the container):** stores the node, measures `offsetWidth`, and (re)attaches the `ResizeObserver`. Disconnects the previous observer on every (re)mount/unmount, so there is no leak and no stale observer.
- **`setStripNode` (callback ref on the strip):** anchors the strip to the opened item the instant it mounts. Width is read from `node.parentElement` (the container) directly, because the parent ref fires *after* the child ref, so `containerRef.current` isn't populated yet at this point but the parent DOM node already exists in the committed tree.
- **Open-sync effect promoted to `useLayoutEffect`:** `currentIndex` is now synced to `initialIndex` synchronously when `isOpen` flips, *before* `Presence`'s own layout effect mounts the content. This ordering guarantees `currentIndexRef` is fresh when `setStripNode` fires — so reopening a *different* image lands on it, not the previous one.
- **Layout-effect backstop (`[isOpen, isMobile, containerWidth]`):** covers reopen-without-remount (a close interrupted by a fast reopen keeps the `Presence` node alive, so the callback ref doesn't re-fire) and width changes (rotation). Reads `currentIndexRef` so in-progress swipe animations aren't interrupted.

### Key design decisions

**1. Callback refs over `[isOpen]`-keyed effects**

A callback ref is the correct primitive for "do X when this node mounts." Effects keyed on `[isOpen]` are structurally wrong here because Radix defers the content mount by one render and nothing in the dependency array changes on that later mount.

**2. Read width from `node.parentElement`, not `containerRef.current`**

React attaches refs child-first, so at strip-callback time the container's callback ref hasn't run yet and `containerRef.current` is still null. The container DOM node *does* exist in the committed tree, so `node.parentElement.offsetWidth` is the reliable source.

**3. Imperative `transform` retained**

The strip's `transform` stays imperative (`node.style.transform`), consistent with the existing 60fps-gesture architecture; React only owns `willChange` and per-slide width, so re-renders never clobber the strip position.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/image-gallery.tsx` | Replace `[isOpen,isMobile]` measure effect + `[isMobile]` ResizeObserver effect with `setContainerNode`/`setStripNode` callback refs; promote open-sync to `useLayoutEffect`; backstop effect now uses `currentIndexRef` |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/image-gallery.reopen.test.tsx` | Regression test: mounts real `AttachmentList` + `MediaGalleryProvider` under a data router with mocked mobile width; asserts the strip `translateX` lands on the clicked image on first open and on a different image after close + reopen |

## Test plan

- [x] New regression test fails on the old code (2/2) and passes with the fix (verified by stashing the fix and re-running)
- [x] 49 gallery-related tests green (`attachment-list`, `attachment-list.data-router`, `message-event`, `media-gallery-context`, `image-gallery.reopen`)
- [x] Full-monorepo lint + typecheck green (via pre-commit hook)
- [ ] Manual: on a mobile viewport, open several images from a multi-image message — each opens on the clicked image; close + reopen a different one lands correctly; swipe and rotation still work

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tnb8PkBU4a3SXMaFCbrbXx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->