### PR TITLE
feat(memos): hybrid memo retrieval — RRF, intent, structural boost, fail-open rerank

### DIFF
--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -60,7 +60,7 @@ import {
 import { AttachmentService, createMalwareScanner } from "../../../src/features/attachments"
 import { SearchService } from "../../../src/features/search"
 import { UserPreferencesService } from "../../../src/features/user-preferences"
-import { EmbeddingService, MemoExplorerService } from "../../../src/features/memos"
+import { EmbeddingService, MemoExplorerService, MemoReranker } from "../../../src/features/memos"
 import { StreamRepository, StreamMemberRepository } from "../../../src/features/streams"
 import { MessageRepository } from "../../../src/features/messaging"
 import { createModelRegistry } from "../../../src/lib/ai/model-registry"
@@ -297,7 +297,11 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       pool: ctx.pool,
       embeddingService,
     })
-    const memoExplorerService = new MemoExplorerService({ pool: ctx.pool, embeddingService })
+    const memoExplorerService = new MemoExplorerService({
+      pool: ctx.pool,
+      embeddingService,
+      reranker: new MemoReranker({ ai: ctx.ai }),
+    })
 
     // Stub Socket.io server for tracing - evals don't need real-time updates
     const stubIo = { to: () => ({ to: () => ({ emit: () => {} }), emit: () => {} }) } as unknown as Server

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -52,7 +52,7 @@ import {
 } from "../../../src/features/agents"
 import { SearchService } from "../../../src/features/search"
 import { UserPreferencesService } from "../../../src/features/user-preferences"
-import { EmbeddingService, MemoExplorerService } from "../../../src/features/memos"
+import { EmbeddingService, MemoExplorerService, MemoReranker } from "../../../src/features/memos"
 import { StreamRepository, StreamMemberRepository } from "../../../src/features/streams"
 import { MessageRepository, EventService } from "../../../src/features/messaging"
 import {
@@ -287,7 +287,11 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
       pool: ctx.pool,
       embeddingService,
     })
-    const memoExplorerService = new MemoExplorerService({ pool: ctx.pool, embeddingService })
+    const memoExplorerService = new MemoExplorerService({
+      pool: ctx.pool,
+      embeddingService,
+      reranker: new MemoReranker({ ai: ctx.ai }),
+    })
 
     // Mock storage provider that returns our test images
     const mockStorage = createMockStorage(mockImages)

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -1070,10 +1070,13 @@ Each query must have:
           functionId: "ws-memo-embed",
         })
         // Hybrid keyword + vector with RRF fusion (B1); the intent
-        // classifier (B4) bends the per-list weights. The accessible-stream
+        // classifier (B4) bends the per-list weights and the B2 structural
+        // boost (bypassed for temporal intent). The accessible-stream
         // predicate is the agent-invocation scope resolved upstream and is
         // pushed into both inner CTEs before fusion (§3.1). Single query
-        // (INV-30).
+        // (INV-30). The B3 reranker is intentionally not run on this
+        // latency-budgeted multi-search loop — the plan cost-gates rerank
+        // to the user-facing surface.
         const intent = classifyMemoQueryIntent(query.query)
         const hybridResults = await MemoRepository.hybridSearch(pool, {
           workspaceId,
@@ -1083,6 +1086,7 @@ Each query must have:
           limit: WORKSPACE_AGENT_MAX_RESULTS_PER_SEARCH,
           keywordWeight: intent.keywordWeight,
           semanticWeight: intent.semanticWeight,
+          applyStructuralBoost: intent.intent !== "temporal",
           semanticDistanceThreshold: SEMANTIC_DISTANCE_THRESHOLD,
         })
         const results =

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -7,7 +7,7 @@ import { COMPONENT_PATHS } from "../../../lib/ai/config-resolver"
 import type { TraceSource } from "@threa/types"
 import type { EmbeddingServiceLike } from "../../memos"
 import { MessageRepository, type Message } from "../../messaging"
-import { MemoRepository } from "../../memos"
+import { MemoRepository, classifyMemoQueryIntent } from "../../memos"
 import { SearchRepository } from "../../search"
 import { StreamRepository } from "../../streams"
 import { AttachmentRepository } from "../../attachments"
@@ -1069,17 +1069,25 @@ Each query must have:
           workspaceId,
           functionId: "ws-memo-embed",
         })
-        // DB search (single query, INV-30)
-        const semanticResults = await MemoRepository.semanticSearch(pool, {
+        // Hybrid keyword + vector with RRF fusion (B1); the intent
+        // classifier (B4) bends the per-list weights. The accessible-stream
+        // predicate is the agent-invocation scope resolved upstream and is
+        // pushed into both inner CTEs before fusion (§3.1). Single query
+        // (INV-30).
+        const intent = classifyMemoQueryIntent(query.query)
+        const hybridResults = await MemoRepository.hybridSearch(pool, {
           workspaceId,
+          query: query.query,
           embedding,
           filters: { streamIds: accessibleStreamIds },
           limit: WORKSPACE_AGENT_MAX_RESULTS_PER_SEARCH,
+          keywordWeight: intent.keywordWeight,
+          semanticWeight: intent.semanticWeight,
           semanticDistanceThreshold: SEMANTIC_DISTANCE_THRESHOLD,
         })
         const results =
-          semanticResults.length > 0
-            ? semanticResults
+          hybridResults.length > 0
+            ? hybridResults
             : await MemoRepository.fullTextSearch(pool, {
                 workspaceId,
                 query: query.query,
@@ -1093,7 +1101,7 @@ Each query must have:
           sourceStream: r.sourceStream,
         }))
       } catch (error) {
-        logger.warn({ error, query: query.query }, "Memo semantic search failed")
+        logger.warn({ error, query: query.query }, "Memo hybrid search failed")
         return []
       }
     }

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -1105,8 +1105,23 @@ Each query must have:
           sourceStream: r.sourceStream,
         }))
       } catch (error) {
-        logger.warn({ error, query: query.query }, "Memo hybrid search failed")
-        return []
+        logger.warn({ error, query: query.query }, "Memo hybrid search failed; falling back to full-text")
+        try {
+          const fallback = await MemoRepository.fullTextSearch(pool, {
+            workspaceId,
+            query: query.query,
+            filters: { streamIds: accessibleStreamIds },
+            limit: WORKSPACE_AGENT_MAX_RESULTS_PER_SEARCH,
+          })
+          return fallback.map((r) => ({
+            memo: r.memo,
+            distance: r.distance,
+            sourceStream: r.sourceStream,
+          }))
+        } catch (fallbackError) {
+          logger.warn({ fallbackError, query: query.query }, "Memo full-text fallback failed")
+          return []
+        }
       }
     }
 

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod"
-import { KNOWLEDGE_TYPES } from "@threa/types"
+import { KNOWLEDGE_TYPES, type KnowledgeType, type StreamType } from "@threa/types"
 import { formatDate } from "../../lib/temporal"
 
 // ============================================================================
@@ -53,6 +53,90 @@ export const MEMO_GEM_CONFIDENCE_FLOOR = 0.7
  * Deferred items are retried on the next batch cycle (5-minute cap interval).
  */
 export const MEMO_SINGLE_MESSAGE_AGE_GATE_MS = 10 * 60 * 1000
+
+// ============================================================================
+// Retrieval Configuration (gbrain B2 / B3 / B7)
+// ============================================================================
+
+/**
+ * B2 structural boost. A multiplicative factor on the fused RRF score,
+ * applied in the *outer* stage of hybrid search (after the inner
+ * access-scoped scan — never before it, §3.1). The factor is structural
+ * (knowledge/stream type), not editorial, and is the single source of
+ * truth for the SQL `CASE` (INV-33). Temporal-intent queries bypass the
+ * boost so recency still surfaces recent chatter (B4 escape hatch).
+ *
+ * Decisions/procedures are durable knowledge and rank above incidental
+ * context; system streams are de-emphasised vs. human channels.
+ */
+export const MEMO_KNOWLEDGE_TYPE_BOOST: Record<KnowledgeType, number> = {
+  decision: 1.3,
+  procedure: 1.2,
+  reference: 1.1,
+  learning: 1.05,
+  context: 1.0,
+}
+
+export const MEMO_STREAM_TYPE_BOOST: Record<StreamType, number> = {
+  channel: 1.1,
+  scratchpad: 1.05,
+  dm: 1.0,
+  thread: 1.0,
+  system: 0.9,
+}
+
+/** Neutral factor for any type not present in the maps above. */
+export const MEMO_BOOST_DEFAULT = 1.0
+
+/**
+ * B3 reranker. GPT-5.4 Nano is the model-reference primary target for
+ * ranking (INV-16); rerank is a best-effort enhancer only — fixed
+ * timeout, fail-open on every failure reason, never a dependency.
+ */
+export const MEMO_RERANKER_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
+export const MEMO_RERANKER_TEMPERATURE = 0
+export const MEMO_RERANKER_TIMEOUT_MS = 4000
+/** Top-K window handed to the reranker; the un-reranked tail is appended (recall protection). */
+export const MEMO_RERANKER_CANDIDATE_LIMIT = 20
+
+export const memoRerankSchema = z.object({
+  /** Candidate indices (0-based, into the input list) in descending relevance. */
+  order: z.array(z.number().int().nonnegative()),
+})
+
+export type MemoRerankResult = z.infer<typeof memoRerankSchema>
+
+/**
+ * B7 search-mode bundles: correlated retrieval knobs behind one key.
+ *
+ * NOTE: gbrain ties these to a billing plan (free/pro/max) and adds a
+ * scope-keyed shared query cache. Threa has neither a billing-plan model
+ * nor a cache layer today, so this ships the prerequisite-free part — the
+ * knob bundle with a single default mode — structured so a plan→mode map
+ * and a §3.5 scope-keyed cache can be layered on without reshaping callers.
+ */
+export interface MemoSearchModeConfig {
+  /** Final result count returned to the caller. */
+  limit: number
+  /** Candidate pool size pulled from hybrid search before rerank/trim. */
+  candidatePoolSize: number
+  /** Whether the fail-open reranker runs for this mode. */
+  rerank: boolean
+}
+
+export const MEMO_SEARCH_MODES = {
+  fast: { limit: 30, candidatePoolSize: 30, rerank: false },
+  balanced: { limit: 30, candidatePoolSize: 50, rerank: true },
+  thorough: { limit: 50, candidatePoolSize: 80, rerank: true },
+} as const satisfies Record<string, MemoSearchModeConfig>
+
+export type MemoSearchMode = keyof typeof MEMO_SEARCH_MODES
+
+export const DEFAULT_MEMO_SEARCH_MODE: MemoSearchMode = "balanced"
+
+export function resolveMemoSearchMode(mode: MemoSearchMode = DEFAULT_MEMO_SEARCH_MODE): MemoSearchModeConfig {
+  return MEMO_SEARCH_MODES[mode]
+}
 
 // ============================================================================
 // Schemas

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -4,6 +4,7 @@ import { logger } from "../../lib/logger"
 import { ConversationRepository } from "../conversations"
 import { MessageRepository, type Message } from "../messaging"
 import { MemoRepository, type Memo, type MemoSearchFilters } from "./repository"
+import { classifyMemoQueryIntent } from "./query-intent"
 import type { EmbeddingServiceLike } from "./embedding-service"
 import { StreamRepository, type Stream } from "../streams"
 import { PersonaRepository } from "../agents"
@@ -116,18 +117,22 @@ export class MemoExplorerService {
         functionId: "memo-explorer-query",
       })
 
-      const semanticResults = await MemoRepository.semanticSearch(this.pool, {
+      const intent = classifyMemoQueryIntent(query)
+      const hybridResults = await MemoRepository.hybridSearch(this.pool, {
         workspaceId,
+        query,
         embedding,
         filters: repoFilters,
         limit,
+        keywordWeight: intent.keywordWeight,
+        semanticWeight: intent.semanticWeight,
       })
 
-      if (semanticResults.length > 0) {
-        return semanticResults
+      if (hybridResults.length > 0) {
+        return hybridResults
       }
     } catch (error) {
-      logger.warn({ error, workspaceId, query }, "Memo explorer semantic search failed, falling back to text search")
+      logger.warn({ error, workspaceId, query }, "Memo explorer hybrid search failed, falling back to text search")
     }
 
     return MemoRepository.fullTextSearch(this.pool, {

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -5,6 +5,8 @@ import { ConversationRepository } from "../conversations"
 import { MessageRepository, type Message } from "../messaging"
 import { MemoRepository, type Memo, type MemoSearchFilters } from "./repository"
 import { classifyMemoQueryIntent } from "./query-intent"
+import { resolveMemoSearchMode, DEFAULT_MEMO_SEARCH_MODE, MEMO_RERANKER_CANDIDATE_LIMIT } from "./config"
+import type { RerankerLike } from "./reranker"
 import type { EmbeddingServiceLike } from "./embedding-service"
 import { StreamRepository, type Stream } from "../streams"
 import { PersonaRepository } from "../agents"
@@ -65,15 +67,18 @@ export interface MemoExplorerDetail extends MemoExplorerResult {
 export interface MemoExplorerServiceDeps {
   pool: Pool
   embeddingService: EmbeddingServiceLike
+  reranker: RerankerLike
 }
 
 export class MemoExplorerService {
   private readonly pool: Pool
   private readonly embeddingService: EmbeddingServiceLike
+  private readonly reranker: RerankerLike
 
   constructor(deps: MemoExplorerServiceDeps) {
     this.pool = deps.pool
     this.embeddingService = deps.embeddingService
+    this.reranker = deps.reranker
   }
 
   async search(params: MemoExplorerSearchParams): Promise<MemoExplorerResult[]> {
@@ -118,18 +123,22 @@ export class MemoExplorerService {
       })
 
       const intent = classifyMemoQueryIntent(query)
+      const mode = resolveMemoSearchMode(DEFAULT_MEMO_SEARCH_MODE)
+
       const hybridResults = await MemoRepository.hybridSearch(this.pool, {
         workspaceId,
         query,
         embedding,
         filters: repoFilters,
-        limit,
+        limit: Math.max(limit, mode.candidatePoolSize),
         keywordWeight: intent.keywordWeight,
         semanticWeight: intent.semanticWeight,
+        applyStructuralBoost: intent.intent !== "temporal",
       })
 
       if (hybridResults.length > 0) {
-        return hybridResults
+        const ranked = mode.rerank ? await this.applyRerank(workspaceId, query, hybridResults) : hybridResults
+        return ranked.slice(0, limit)
       }
     } catch (error) {
       logger.warn({ error, workspaceId, query }, "Memo explorer hybrid search failed, falling back to text search")
@@ -141,6 +150,31 @@ export class MemoExplorerService {
       filters: repoFilters,
       limit,
     })
+  }
+
+  /**
+   * B3: reorder the top window with the fail-open reranker and append the
+   * un-reranked tail unchanged (recall protection). The reranker only sees
+   * rows that already passed the §3.1 access-scoped scan, so it can
+   * reorder but never widen visibility; on any failure it returns identity
+   * order and results are unchanged.
+   */
+  private async applyRerank(
+    workspaceId: string,
+    query: string,
+    results: MemoExplorerResult[]
+  ): Promise<MemoExplorerResult[]> {
+    const window = Math.min(MEMO_RERANKER_CANDIDATE_LIMIT, results.length)
+    if (window <= 1) return results
+
+    const head = results.slice(0, window)
+    const tail = results.slice(window)
+    const order = await this.reranker.rerank(
+      query,
+      head.map((r) => ({ title: r.memo.title, abstract: r.memo.abstract })),
+      { workspaceId }
+    )
+    return [...order.map((i) => head[i]), ...tail]
   }
 
   async getById(

--- a/apps/backend/src/features/memos/index.ts
+++ b/apps/backend/src/features/memos/index.ts
@@ -8,7 +8,11 @@ export type {
   MemoSearchResult,
   SemanticSearchParams,
   FullTextSearchParams,
+  HybridSearchParams,
 } from "./repository"
+
+export { classifyMemoQueryIntent } from "./query-intent"
+export type { MemoQueryIntent, MemoQueryIntentResult } from "./query-intent"
 
 export { PendingItemRepository } from "./pending-item-repository"
 export type { PendingMemoItem, QueuePendingItemParams } from "./pending-item-repository"

--- a/apps/backend/src/features/memos/index.ts
+++ b/apps/backend/src/features/memos/index.ts
@@ -56,6 +56,11 @@ export type {
   MemoStreamRef,
 } from "./explorer-service"
 
+export { MemoReranker } from "./reranker"
+export type { RerankerLike, RerankCandidate, RerankContext, RerankerServiceConfig } from "./reranker"
+
+export { StubReranker } from "./reranker.stub"
+
 export { EmbeddingService } from "./embedding-service"
 export type { EmbeddingServiceLike, EmbeddingServiceConfig, EmbeddingContext } from "./embedding-service"
 

--- a/apps/backend/src/features/memos/query-intent.test.ts
+++ b/apps/backend/src/features/memos/query-intent.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test"
+import { classifyMemoQueryIntent } from "./query-intent"
+
+describe("classifyMemoQueryIntent", () => {
+  it("treats a short query with no digits as an entity lookup (vector-leaning)", () => {
+    const result = classifyMemoQueryIntent("billing migration")
+    expect(result.intent).toBe("entity")
+    expect(result.semanticWeight).toBeGreaterThan(result.keywordWeight)
+  })
+
+  it("treats a single token as an entity lookup", () => {
+    const result = classifyMemoQueryIntent("Stripe")
+    expect(result.intent).toBe("entity")
+    expect(result.semanticWeight).toBeGreaterThan(result.keywordWeight)
+  })
+
+  it("treats a query with a year as temporal (keyword-leaning)", () => {
+    const result = classifyMemoQueryIntent("what did we decide in 2024")
+    expect(result.intent).toBe("temporal")
+    expect(result.keywordWeight).toBeGreaterThan(result.semanticWeight)
+  })
+
+  it("treats an ISO date query as temporal", () => {
+    const result = classifyMemoQueryIntent("incident on 2025-01-15")
+    expect(result.intent).toBe("temporal")
+    expect(result.keywordWeight).toBeGreaterThan(result.semanticWeight)
+  })
+
+  it("treats a longer conceptual query as general (balanced)", () => {
+    const result = classifyMemoQueryIntent("how do we handle workspace access derivation")
+    expect(result.intent).toBe("general")
+    expect(result.keywordWeight).toBe(result.semanticWeight)
+  })
+
+  it("always returns positive weights that sum to 1", () => {
+    for (const q of ["", "x", "a b c d e f", "release 2023-09 rollback plan", "auth"]) {
+      const { keywordWeight, semanticWeight } = classifyMemoQueryIntent(q)
+      expect(keywordWeight).toBeGreaterThan(0)
+      expect(semanticWeight).toBeGreaterThan(0)
+      expect(keywordWeight + semanticWeight).toBeCloseTo(1, 5)
+    }
+  })
+
+  it("is deterministic and language-neutral (no natural-language keyword lists)", () => {
+    // Same structural shape in a non-English script must classify identically
+    // to its ASCII analogue: two short tokens, no digits -> entity.
+    const ascii = classifyMemoQueryIntent("project roadmap")
+    const cjk = classifyMemoQueryIntent("プロジェクト 計画")
+    expect(cjk.intent).toBe(ascii.intent)
+    expect(classifyMemoQueryIntent("project roadmap")).toEqual(ascii)
+  })
+})

--- a/apps/backend/src/features/memos/query-intent.test.ts
+++ b/apps/backend/src/features/memos/query-intent.test.ts
@@ -26,6 +26,15 @@ describe("classifyMemoQueryIntent", () => {
     expect(result.keywordWeight).toBeGreaterThan(result.semanticWeight)
   })
 
+  it("detects non-ASCII numerals as temporal (script-neutral digits, INV-54)", () => {
+    // Arabic-Indic 2024 and Devanagari 2025 must classify like ASCII digits.
+    for (const q of ["مذكرة ٢٠٢٤", "निर्णय २०२५"]) {
+      const result = classifyMemoQueryIntent(q)
+      expect(result.intent).toBe("temporal")
+      expect(result.keywordWeight).toBeGreaterThan(result.semanticWeight)
+    }
+  })
+
   it("treats a longer conceptual query as general (balanced)", () => {
     const result = classifyMemoQueryIntent("how do we handle workspace access derivation")
     expect(result.intent).toBe("general")

--- a/apps/backend/src/features/memos/query-intent.ts
+++ b/apps/backend/src/features/memos/query-intent.ts
@@ -19,9 +19,9 @@ export interface MemoQueryIntentResult {
   semanticWeight: number
 }
 
-// Year (1900-2099), ISO-ish date, or any standalone digit run. All
-// language-neutral — digits are not script-specific.
-const HAS_DIGITS = /\d/
+// Any Unicode decimal digit (dates, version numbers, ids). `\p{Nd}` keeps
+// this script-neutral so non-ASCII numerals also count as temporal (INV-54).
+const HAS_DIGITS = /\p{Nd}/u
 
 export function classifyMemoQueryIntent(query: string): MemoQueryIntentResult {
   const trimmed = query.trim()

--- a/apps/backend/src/features/memos/query-intent.ts
+++ b/apps/backend/src/features/memos/query-intent.ts
@@ -1,0 +1,43 @@
+/**
+ * B4 query-intent classification (gbrain concept B4, reframed for Threa).
+ *
+ * Deterministic and language-neutral: the only signals are query *structure*
+ * (token count, presence of digit/date tokens), never natural-language word
+ * lists, so it does not encode an English-only semantic heuristic (INV-54).
+ * Its sole effect is to bend the keyword-vs-vector weights of the hybrid
+ * search RRF fusion (B1) — a soft ranking nudge that never changes recall or
+ * the access-scoped candidate set, so a crude classification can only reorder,
+ * never leak.
+ */
+export type MemoQueryIntent = "entity" | "temporal" | "general"
+
+export interface MemoQueryIntentResult {
+  intent: MemoQueryIntent
+  /** RRF weight for the keyword (full-text) list. */
+  keywordWeight: number
+  /** RRF weight for the semantic (vector) list. */
+  semanticWeight: number
+}
+
+// Year (1900-2099), ISO-ish date, or any standalone digit run. All
+// language-neutral — digits are not script-specific.
+const HAS_DIGITS = /\d/
+
+export function classifyMemoQueryIntent(query: string): MemoQueryIntentResult {
+  const trimmed = query.trim()
+  const tokens = trimmed.length === 0 ? [] : trimmed.split(/\s+/)
+
+  if (HAS_DIGITS.test(trimmed)) {
+    // Temporal / literal queries (dates, version numbers, ids) reward exact
+    // keyword recall over fuzzy vector similarity.
+    return { intent: "temporal", keywordWeight: 0.7, semanticWeight: 0.3 }
+  }
+
+  if (tokens.length > 0 && tokens.length <= 2) {
+    // Short entity/topic lookups ("Stripe", "billing migration") reward
+    // vector recall — the few keywords rarely full-text-match the abstract.
+    return { intent: "entity", keywordWeight: 0.35, semanticWeight: 0.65 }
+  }
+
+  return { intent: "general", keywordWeight: 0.5, semanticWeight: 0.5 }
+}

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -1,5 +1,29 @@
 import { sql, type Querier } from "../../db"
 import type { MemoType, KnowledgeType, MemoStatus } from "@threa/types"
+import { MEMO_KNOWLEDGE_TYPE_BOOST, MEMO_STREAM_TYPE_BOOST, MEMO_BOOST_DEFAULT } from "./config"
+
+/**
+ * B2 structural boost expression, generated from the config maps (single
+ * source of truth, INV-33). Emitted into the *outer* stage of hybrid
+ * search only — the inner access-scoped CTEs are untouched, so the boost
+ * can reorder but never widen visibility (§3.1). `m.knowledge_type` and
+ * the resolved stream type are plain columns/expressions here; the values
+ * are numeric literals from a typed constant, so raw interpolation is safe.
+ */
+function buildBoostExpression(apply: boolean): ReturnType<typeof sql.raw> {
+  if (!apply) return sql.raw("1.0")
+
+  const caseFor = (column: string, map: Record<string, number>): string => {
+    const arms = Object.entries(map)
+      .map(([key, factor]) => `WHEN '${key.replace(/'/g, "''")}' THEN ${Number(factor)}`)
+      .join(" ")
+    return `CASE ${column} ${arms} ELSE ${Number(MEMO_BOOST_DEFAULT)} END`
+  }
+
+  const knowledge = caseFor("m.knowledge_type", MEMO_KNOWLEDGE_TYPE_BOOST)
+  const stream = caseFor("COALESCE(msg_stream.type, conv_stream.type)", MEMO_STREAM_TYPE_BOOST)
+  return sql.raw(`(${knowledge}) * (${stream})`)
+}
 
 interface MemoRow {
   id: string
@@ -129,6 +153,8 @@ export interface HybridSearchParams {
   semanticWeight?: number
   k?: number
   semanticDistanceThreshold?: number
+  /** B2: apply the structural knowledge/stream-type boost (default true; bypassed for temporal intent). */
+  applyStructuralBoost?: boolean
 }
 
 function mapRowToMemo(row: MemoRow): Memo {
@@ -621,6 +647,7 @@ export const MemoRepository = {
       semanticWeight = 0.5,
       k = 60,
       semanticDistanceThreshold = 0.8,
+      applyStructuralBoost = true,
     } = params
 
     if (!query.trim()) return []
@@ -646,6 +673,9 @@ export const MemoRepository = {
 
     // Per-list candidate cap before fusion (matches the message hybrid path).
     const internalLimit = 50
+
+    // B2: structural boost, applied only in the outer hydrate stage.
+    const boost = buildBoostExpression(applyStructuralBoost)
 
     const result = await db.query<MemoSearchRow & { score: number }>(sql`
       WITH keyword_ranked AS (
@@ -703,7 +733,7 @@ export const MemoRepository = {
       )
       SELECT
         ${sql.raw(SELECT_FIELDS_PREFIXED)},
-        f.score,
+        (f.score * ${boost}) as score,
         COALESCE(msg_stream.id, conv_stream.id) as stream_id,
         COALESCE(msg_stream.type, conv_stream.type) as stream_type,
         COALESCE(msg_stream.display_name, msg_stream.slug, conv_stream.display_name, conv_stream.slug) as stream_name,
@@ -713,7 +743,7 @@ export const MemoRepository = {
       FROM fused f
       JOIN memos m ON m.id = f.id
       ${streamJoins}
-      ORDER BY f.score DESC
+      ORDER BY (f.score * ${boost}) DESC
       LIMIT ${limit}
     `)
 

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -670,8 +670,10 @@ export const MemoRepository = {
       LEFT JOIN streams root_stream ON root_stream.id = COALESCE(msg_stream.root_stream_id, conv_stream.root_stream_id)
     `)
 
-    // Per-list candidate cap before fusion (matches the message hybrid path).
-    const internalLimit = 50
+    // Per-list candidate cap before fusion. The 50 floor matches the
+    // message hybrid path; widen to the requested pool so a larger
+    // configured candidate pool is actually filled before rerank/trim.
+    const internalLimit = Math.max(limit, 50)
 
     // B2: structural boost, applied only in the outer hydrate stage.
     const boost = buildBoostExpression(applyStructuralBoost)

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -654,7 +654,6 @@ export const MemoRepository = {
 
     const streamIds = filters?.streamIds
     const hasStreamFilter = streamIds && streamIds.length > 0
-    if (hasStreamFilter && streamIds.length === 0) return []
     const hasMemoTypeFilter = Boolean(filters?.memoTypes?.length)
     const hasKnowledgeTypeFilter = Boolean(filters?.knowledgeTypes?.length)
     const hasTagFilter = Boolean(filters?.tags?.length)

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -119,6 +119,18 @@ export interface FullTextSearchParams {
   limit?: number
 }
 
+export interface HybridSearchParams {
+  workspaceId: string
+  query: string
+  embedding: number[]
+  filters?: MemoSearchFilters
+  limit?: number
+  keywordWeight?: number
+  semanticWeight?: number
+  k?: number
+  semanticDistanceThreshold?: number
+}
+
 function mapRowToMemo(row: MemoRow): Memo {
   return {
     id: row.id,
@@ -581,6 +593,131 @@ export const MemoRepository = {
     `)
 
     return result.rows.map((row) => mapMemoSearchResult(row, 1 - row.rank))
+  },
+
+  /**
+   * Hybrid memo search: keyword (full-text) + semantic (vector) candidate
+   * lists fused with Reciprocal Rank Fusion (gbrain concept B1).
+   *
+   * Access discipline (§3.1): the accessible-stream predicate is pushed into
+   * **both** inner candidate CTEs *before* RRF, never as a post-filter — a
+   * private high-scorer must not displace a public result the viewer should
+   * have seen, and the internal per-list LIMIT must be filled from
+   * accessible rows only. Thread memos inherit access from their root stream,
+   * same as the other memo search paths.
+   *
+   * RRF score(d) = Σ(weight / (k + rank(d))); higher score = better. The
+   * returned `distance` is `1 / (1 + score)` so the existing "lower is
+   * better" contract holds, though rows are already SQL-ordered.
+   */
+  async hybridSearch(db: Querier, params: HybridSearchParams): Promise<MemoSearchResult[]> {
+    const {
+      workspaceId,
+      query,
+      embedding,
+      filters,
+      limit = 10,
+      keywordWeight = 0.5,
+      semanticWeight = 0.5,
+      k = 60,
+      semanticDistanceThreshold = 0.8,
+    } = params
+
+    if (!query.trim()) return []
+
+    const streamIds = filters?.streamIds
+    const hasStreamFilter = streamIds && streamIds.length > 0
+    if (hasStreamFilter && streamIds.length === 0) return []
+    const hasMemoTypeFilter = Boolean(filters?.memoTypes?.length)
+    const hasKnowledgeTypeFilter = Boolean(filters?.knowledgeTypes?.length)
+    const hasTagFilter = Boolean(filters?.tags?.length)
+
+    const embeddingLiteral = `[${embedding.join(",")}]`
+    const tsvector = sql.raw(
+      "to_tsvector('english', m.title || ' ' || m.abstract || ' ' || array_to_string(m.key_points, ' '))"
+    )
+    const streamJoins = sql.raw(`
+      LEFT JOIN messages msg ON m.source_message_id = msg.id
+      LEFT JOIN streams msg_stream ON msg.stream_id = msg_stream.id
+      LEFT JOIN conversations conv ON m.source_conversation_id = conv.id
+      LEFT JOIN streams conv_stream ON conv.stream_id = conv_stream.id
+      LEFT JOIN streams root_stream ON root_stream.id = COALESCE(msg_stream.root_stream_id, conv_stream.root_stream_id)
+    `)
+
+    // Per-list candidate cap before fusion (matches the message hybrid path).
+    const internalLimit = 50
+
+    const result = await db.query<MemoSearchRow & { score: number }>(sql`
+      WITH keyword_ranked AS (
+        SELECT
+          m.id,
+          ROW_NUMBER() OVER (
+            ORDER BY ts_rank(${tsvector}, websearch_to_tsquery('english', ${query})) DESC
+          ) as rank
+        FROM memos m
+        ${streamJoins}
+        WHERE m.workspace_id = ${workspaceId}
+          AND m.status = 'active'
+          AND (
+            ${!hasStreamFilter}
+            OR COALESCE(msg_stream.id, conv_stream.id) = ANY(${streamIds ?? []})
+            OR root_stream.id = ANY(${streamIds ?? []})
+          )
+          AND (${!hasMemoTypeFilter} OR m.memo_type = ANY(${filters?.memoTypes ?? []}))
+          AND (${!hasKnowledgeTypeFilter} OR m.knowledge_type = ANY(${filters?.knowledgeTypes ?? []}))
+          AND (${!hasTagFilter} OR m.tags && ${filters?.tags ?? []})
+          AND (${filters?.before === undefined} OR m.created_at < ${filters?.before ?? new Date()})
+          AND (${filters?.after === undefined} OR m.created_at >= ${filters?.after ?? new Date(0)})
+          AND ${tsvector} @@ websearch_to_tsquery('english', ${query})
+        LIMIT ${internalLimit}
+      ),
+      semantic_ranked AS (
+        SELECT
+          m.id,
+          ROW_NUMBER() OVER (ORDER BY m.embedding <=> ${embeddingLiteral}::vector) as rank
+        FROM memos m
+        ${streamJoins}
+        WHERE m.workspace_id = ${workspaceId}
+          AND m.status = 'active'
+          AND m.embedding IS NOT NULL
+          AND m.embedding <=> ${embeddingLiteral}::vector < ${semanticDistanceThreshold}
+          AND (
+            ${!hasStreamFilter}
+            OR COALESCE(msg_stream.id, conv_stream.id) = ANY(${streamIds ?? []})
+            OR root_stream.id = ANY(${streamIds ?? []})
+          )
+          AND (${!hasMemoTypeFilter} OR m.memo_type = ANY(${filters?.memoTypes ?? []}))
+          AND (${!hasKnowledgeTypeFilter} OR m.knowledge_type = ANY(${filters?.knowledgeTypes ?? []}))
+          AND (${!hasTagFilter} OR m.tags && ${filters?.tags ?? []})
+          AND (${filters?.before === undefined} OR m.created_at < ${filters?.before ?? new Date()})
+          AND (${filters?.after === undefined} OR m.created_at >= ${filters?.after ?? new Date(0)})
+        LIMIT ${internalLimit}
+      ),
+      fused AS (
+        SELECT
+          COALESCE(kr.id, sr.id) as id,
+          COALESCE(${keywordWeight}::float / (${k}::float + kr.rank), 0) +
+          COALESCE(${semanticWeight}::float / (${k}::float + sr.rank), 0) as score
+        FROM keyword_ranked kr
+        FULL OUTER JOIN semantic_ranked sr ON kr.id = sr.id
+      )
+      SELECT
+        ${sql.raw(SELECT_FIELDS_PREFIXED)},
+        f.score,
+        COALESCE(msg_stream.id, conv_stream.id) as stream_id,
+        COALESCE(msg_stream.type, conv_stream.type) as stream_type,
+        COALESCE(msg_stream.display_name, msg_stream.slug, conv_stream.display_name, conv_stream.slug) as stream_name,
+        root_stream.id as root_stream_id,
+        root_stream.type as root_stream_type,
+        COALESCE(root_stream.display_name, root_stream.slug) as root_stream_name
+      FROM fused f
+      JOIN memos m ON m.id = f.id
+      ${streamJoins}
+      ORDER BY f.score DESC
+      LIMIT ${limit}
+    `)
+
+    return result.rows.map((row) => mapMemoSearchResult(row, 1 / (1 + row.score)))
   },
 
   async exactSearch(db: Querier, params: FullTextSearchParams): Promise<MemoSearchResult[]> {

--- a/apps/backend/src/features/memos/reranker.stub.ts
+++ b/apps/backend/src/features/memos/reranker.stub.ts
@@ -1,0 +1,11 @@
+import type { RerankerLike, RerankCandidate, RerankContext } from "./reranker"
+
+/**
+ * Stub reranker for tests / `useStubAI`: identity order (no model call),
+ * which is exactly the production fail-open behaviour.
+ */
+export class StubReranker implements RerankerLike {
+  async rerank(_query: string, candidates: RerankCandidate[], _context: RerankContext): Promise<number[]> {
+    return Array.from({ length: candidates.length }, (_, i) => i)
+  }
+}

--- a/apps/backend/src/features/memos/reranker.test.ts
+++ b/apps/backend/src/features/memos/reranker.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test"
+import { sanitizeOrder } from "./reranker"
+import { StubReranker } from "./reranker.stub"
+
+describe("sanitizeOrder", () => {
+  it("passes a valid full permutation through unchanged", () => {
+    expect(sanitizeOrder([2, 0, 1], 3)).toEqual([2, 0, 1])
+  })
+
+  it("appends omitted indices in original order (recall protection)", () => {
+    // Model only ranked 2 of 4 candidates; the rest must survive at the tail.
+    expect(sanitizeOrder([3, 1], 4)).toEqual([3, 1, 0, 2])
+  })
+
+  it("drops duplicates, keeping the first occurrence", () => {
+    expect(sanitizeOrder([1, 1, 0], 3)).toEqual([1, 0, 2])
+  })
+
+  it("ignores out-of-range and non-integer indices", () => {
+    expect(sanitizeOrder([5, -1, 1.5, 2, 0], 3)).toEqual([2, 0, 1])
+  })
+
+  it("returns identity order for an empty proposal", () => {
+    expect(sanitizeOrder([], 3)).toEqual([0, 1, 2])
+  })
+
+  it("never drops or adds candidates: output is always a full permutation", () => {
+    const n = 6
+    const result = sanitizeOrder([4, 4, 99, -3, 1], n)
+    expect([...result].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5])
+  })
+})
+
+describe("StubReranker", () => {
+  it("returns identity order (production fail-open behaviour)", async () => {
+    const reranker = new StubReranker()
+    const order = await reranker.rerank(
+      "q",
+      [
+        { title: "a", abstract: "" },
+        { title: "b", abstract: "" },
+        { title: "c", abstract: "" },
+      ],
+      { workspaceId: "ws_1" }
+    )
+    expect(order).toEqual([0, 1, 2])
+  })
+
+  it("handles the empty candidate list", async () => {
+    const reranker = new StubReranker()
+    expect(await reranker.rerank("q", [], { workspaceId: "ws_1" })).toEqual([])
+  })
+})

--- a/apps/backend/src/features/memos/reranker.ts
+++ b/apps/backend/src/features/memos/reranker.ts
@@ -1,0 +1,128 @@
+import type { AI, CostContext } from "../../lib/ai/ai"
+import { isAbortError } from "../../lib/ai/ai"
+import { logger } from "../../lib/logger"
+import { MEMO_RERANKER_MODEL_ID, MEMO_RERANKER_TEMPERATURE, MEMO_RERANKER_TIMEOUT_MS, memoRerankSchema } from "./config"
+
+export interface RerankCandidate {
+  title: string
+  abstract: string
+}
+
+export interface RerankContext {
+  workspaceId: string
+  userId?: string
+}
+
+/**
+ * B3 reranker. A pure enhancer over candidates that have *already* passed
+ * the §3.1 access-scoped scan — it can only reorder, never widen
+ * visibility. Fail-open on every failure reason (timeout, abort, model
+ * error, malformed output): returns the input order unchanged so a
+ * reranker problem can never block or shrink results.
+ */
+export interface RerankerLike {
+  /** Returns a full permutation of `0..candidates.length-1` in descending relevance. */
+  rerank(query: string, candidates: RerankCandidate[], context: RerankContext): Promise<number[]>
+}
+
+export interface RerankerServiceConfig {
+  ai: AI
+  model?: string
+  timeoutMs?: number
+}
+
+function identityOrder(n: number): number[] {
+  return Array.from({ length: n }, (_, i) => i)
+}
+
+/**
+ * Coerce a model-proposed order into a valid full permutation: keep the
+ * first occurrence of each in-range index, then append any candidates the
+ * model omitted in their original order. This protects recall — a
+ * candidate the model forgot is never dropped, only pushed to the tail.
+ */
+export function sanitizeOrder(proposed: number[], n: number): number[] {
+  const seen = new Set<number>()
+  const ordered: number[] = []
+  for (const idx of proposed) {
+    if (Number.isInteger(idx) && idx >= 0 && idx < n && !seen.has(idx)) {
+      seen.add(idx)
+      ordered.push(idx)
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    if (!seen.has(i)) ordered.push(i)
+  }
+  return ordered
+}
+
+export class MemoReranker implements RerankerLike {
+  private readonly ai: AI
+  private readonly model: string
+  private readonly timeoutMs: number
+
+  constructor(config: RerankerServiceConfig) {
+    this.ai = config.ai
+    this.model = config.model ?? MEMO_RERANKER_MODEL_ID
+    this.timeoutMs = config.timeoutMs ?? MEMO_RERANKER_TIMEOUT_MS
+  }
+
+  async rerank(query: string, candidates: RerankCandidate[], context: RerankContext): Promise<number[]> {
+    if (candidates.length <= 1) return identityOrder(candidates.length)
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => {
+      try {
+        controller.abort(new DOMException("memo rerank timeout", "TimeoutError"))
+      } catch {
+        controller.abort(new Error("memo rerank timeout"))
+      }
+    }, this.timeoutMs)
+
+    try {
+      const list = candidates.map((c, i) => `[${i}] ${c.title}\n${c.abstract}`).join("\n\n")
+
+      const costContext: CostContext = {
+        workspaceId: context.workspaceId,
+        userId: context.userId,
+        origin: "system",
+      }
+
+      const { value } = await this.ai.generateObject({
+        model: this.model,
+        schema: memoRerankSchema,
+        temperature: MEMO_RERANKER_TEMPERATURE,
+        abortSignal: controller.signal,
+        telemetry: {
+          functionId: "memo-rerank",
+          metadata: { candidateCount: candidates.length },
+        },
+        context: costContext,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You re-rank candidate knowledge memos by relevance to a search query. " +
+              "Return only an `order` array of the candidate indices, most relevant first. " +
+              "Include every index exactly once.",
+          },
+          {
+            role: "user",
+            content: `Query: ${query}\n\nCandidates:\n${list}`,
+          },
+        ],
+      })
+
+      return sanitizeOrder(value.order, candidates.length)
+    } catch (error) {
+      if (isAbortError(error)) {
+        logger.debug({ workspaceId: context.workspaceId }, "Memo rerank timed out; using pre-rerank order")
+      } else {
+        logger.warn({ error, workspaceId: context.workspaceId }, "Memo rerank failed; using pre-rerank order")
+      }
+      return identityOrder(candidates.length)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/apps/backend/src/features/memos/search-mode.test.ts
+++ b/apps/backend/src/features/memos/search-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test"
+import { KNOWLEDGE_TYPES, STREAM_TYPES } from "@threa/types"
+import {
+  DEFAULT_MEMO_SEARCH_MODE,
+  MEMO_BOOST_DEFAULT,
+  MEMO_KNOWLEDGE_TYPE_BOOST,
+  MEMO_SEARCH_MODES,
+  MEMO_STREAM_TYPE_BOOST,
+  resolveMemoSearchMode,
+} from "./config"
+
+describe("resolveMemoSearchMode", () => {
+  it("defaults to the balanced mode", () => {
+    expect(resolveMemoSearchMode()).toEqual(MEMO_SEARCH_MODES[DEFAULT_MEMO_SEARCH_MODE])
+    expect(DEFAULT_MEMO_SEARCH_MODE).toBe("balanced")
+  })
+
+  it("resolves each named mode to its bundle", () => {
+    expect(resolveMemoSearchMode("fast")).toEqual({ limit: 30, candidatePoolSize: 30, rerank: false })
+    expect(resolveMemoSearchMode("balanced")).toEqual({ limit: 30, candidatePoolSize: 50, rerank: true })
+    expect(resolveMemoSearchMode("thorough")).toEqual({ limit: 50, candidatePoolSize: 80, rerank: true })
+  })
+
+  it("keeps candidate pool >= final limit so trim never starves results", () => {
+    for (const mode of Object.values(MEMO_SEARCH_MODES)) {
+      expect(mode.candidatePoolSize).toBeGreaterThanOrEqual(mode.limit)
+    }
+  })
+})
+
+describe("structural boost maps", () => {
+  it("covers every knowledge type with a positive factor", () => {
+    for (const type of KNOWLEDGE_TYPES) {
+      expect(MEMO_KNOWLEDGE_TYPE_BOOST[type]).toBeGreaterThan(0)
+    }
+  })
+
+  it("covers every stream type with a positive factor", () => {
+    for (const type of STREAM_TYPES) {
+      expect(MEMO_STREAM_TYPE_BOOST[type]).toBeGreaterThan(0)
+    }
+  })
+
+  it("favours decisions over plain context and de-emphasises system streams", () => {
+    expect(MEMO_KNOWLEDGE_TYPE_BOOST.decision).toBeGreaterThan(MEMO_KNOWLEDGE_TYPE_BOOST.context)
+    expect(MEMO_STREAM_TYPE_BOOST.system).toBeLessThan(MEMO_BOOST_DEFAULT)
+  })
+})

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -39,6 +39,8 @@ import { SearchService } from "./features/search"
 import {
   MemoService,
   MemoExplorerService,
+  MemoReranker,
+  StubReranker,
   StubMemoService,
   MemoClassifier,
   Memorizer,
@@ -241,8 +243,9 @@ export async function startServer(): Promise<ServerInstance> {
 
   // Search and embedding services
   const embeddingService = config.useStubAI ? new StubEmbeddingService() : new EmbeddingService({ ai })
+  const memoReranker = config.useStubAI ? new StubReranker() : new MemoReranker({ ai })
   const searchService = new SearchService({ pool, embeddingService })
-  const memoExplorerService = new MemoExplorerService({ pool, embeddingService })
+  const memoExplorerService = new MemoExplorerService({ pool, embeddingService, reranker: memoReranker })
 
   // Job queue for durable background work (companion responses, etc.).
   //


### PR DESCRIPTION
## Problem

Memo retrieval (the workspace research page **and** the workspace agent's
`searchMemos`) used a hard semantic-else-fulltext split: it ran a vector
search and *only* fell back to full-text if the vector path returned
nothing. A query that is strong on exact keywords but weak on embedding
similarity (dates, version numbers, ids, proper nouns) got the worse of
the two paths, never a blend. There was also no notion of which memos are
structurally more valuable (a decision vs. incidental context) and no
second-pass relevance refinement.

This implements **Tier 1** of `docs/plans/gbrain-concepts-for-threa-memory.md`
(B1, B4, B2, B3, B7) on both retrieval surfaces. The G1 eval harness was
intentionally **out of scope** for this PR.

## Solution

A single hybrid query with Reciprocal Rank Fusion, an intent-aware weight
nudge, a structural boost, and an optional fail-open rerank — all behind
the existing access-control spine.

### How it works

```
query ─▶ B4 classify intent (structural signals only)
         │
         ├─ keyword weight / semantic weight
         ▼
   B1 hybridSearch (one SQL):
     keyword_ranked CTE  ─┐  each inner CTE carries the §3.1
     semantic_ranked CTE ─┤  accessible-stream predicate
                          ▼  *before* its per-list LIMIT
     fused (RRF: Σ weight/(k+rank), k=60)
                          ▼
     outer hydrate × B2 structural boost (knowledge/stream type)
                          ▼
   B3 fail-open rerank (explorer only) ─▶ trim to caller limit
```

- **B1 — Hybrid + RRF.** `MemoRepository.hybridSearch` fuses a full-text
  list and a vector list with RRF (`k=60`), reusing the proven message
  hybrid pattern. The §3.1 accessible-stream predicate lives inside *both*
  inner CTEs, before the per-list `LIMIT`, so fusion can only reorder
  rows the caller may already see — never widen visibility.
- **B4 — Intent classifier.** Deterministic and language-neutral: signals
  are query *structure* (digit presence, token count), never NL word
  lists, so it is not an English-only heuristic (INV-54). It only bends
  the RRF weights — a soft ranking nudge that never changes recall or the
  access-scoped candidate set.
- **B2 — Structural boost.** A multiplicative knowledge/stream-type factor
  built from typed config maps (single source of truth, INV-33), applied
  only in the *outer* hydrate stage. Temporal-intent queries bypass it so
  recency still surfaces recent chatter.
- **B3 — Fail-open reranker.** Best-effort `gpt-5.4-nano` reorder of the
  top window via `createAI` with telemetry (INV-19/28), fixed timeout,
  full-permutation sanitisation, identity-order fail-open on every failure
  reason. Runs on the explorer (user-facing, viewer scope); deliberately
  **not** on the latency-budgeted agent multi-search loop. Stub mirrors
  the fail-open identity order for `useStubAI`/evals.
- **B7 — Search-mode bundles.** Correlated retrieval knobs behind one key.

### Key design decisions

**1. Access predicate stays in the inner CTEs (§3.1, §3.2).** Post-filtering
the fused set would let a private high-scorer displace a public result the
viewer should have seen and starve the per-list LIMIT. The explorer passes
the *viewer* scope; the researcher passes the *agent-invocation* scope
resolved upstream. Both callers also return early on an empty access scope,
matching the existing `semanticSearch/fullTextSearch/exactSearch` contract.

**2. B7 shipped scope-reduced.** gbrain ties modes to a billing plan
(free/pro/max) and adds a §3.5 scope-keyed shared query cache. Threa has
**neither a billing-plan model nor a cache/Redis layer**, so building those
would mean inventing large speculative infra (INV-36). This ships the
prerequisite-free part — the knob bundle with a single default mode —
structured so a `plan→mode` map and the scope-keyed cache can layer on
later without reshaping callers. Documented in `config.ts` and the commit.

**3. Rerank is explorer-only.** The plan cost-gates rerank to the
user-facing surface; the agent runs a multi-query loop under a latency
budget where an extra model round-trip per query is not worth it.

**4. Distance contract preserved.** RRF/boost yields "higher = better";
results map to `distance = 1/(1+score)` so the existing "lower is better"
ordering contract is unchanged (rows are already SQL-ordered).

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/features/memos/query-intent.ts` | B4 deterministic, language-neutral intent → RRF weights |
| `apps/backend/src/features/memos/reranker.ts` | B3 `MemoReranker` (fail-open, timeout, sanitisation) |
| `apps/backend/src/features/memos/reranker.stub.ts` | Identity-order stub (matches production fail-open) |
| `apps/backend/src/features/memos/query-intent.test.ts` | Classifier unit tests |
| `apps/backend/src/features/memos/reranker.test.ts` | `sanitizeOrder` recall-protection + stub tests |
| `apps/backend/src/features/memos/search-mode.test.ts` | Mode-resolution + structural-boost-map tests |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/memos/repository.ts` | `hybridSearch` (RRF, inner-CTE access predicate, B2 boost) |
| `apps/backend/src/features/memos/config.ts` | B2 boost maps, B3 reranker config + schema, B7 mode bundles (INV-44) |
| `apps/backend/src/features/memos/explorer-service.ts` | Hybrid + intent + mode + `applyRerank` (viewer scope) |
| `apps/backend/src/features/agents/researcher/researcher.ts` | `searchMemos` → hybrid + intent + boost (agent scope, no rerank) |
| `apps/backend/src/features/memos/index.ts` | Barrel exports for reranker + intent (INV-52) |
| `apps/backend/src/server.ts` | Construct/inject `MemoReranker`/`StubReranker` (INV-12/13) |
| `apps/backend/evals/suites/{companion,multimodal-vision}/suite.ts` | Inject reranker into eval `MemoExplorerService` (INV-45) |

## Test plan

- [x] `bun run typecheck` (both `tsconfig` + `tsconfig.tests.json`) green
- [x] `eslint` clean on changed src + eval suites
- [x] 44 tests pass across memos + researcher suites (incl. new classifier, `sanitizeOrder` recall-protection, mode-resolution, boost-map tests)
- [x] `describe-memo-tool` suite green
- [ ] Manual: workspace research page returns blended results for keyword-heavy and entity queries
- [ ] Manual: agent retrieval respects agent-invocation scope; no cross-stream leakage

## Follow-ups (not in this PR)

- G1 eval harness (intentionally deferred per request)
- B7 full scope: billing-plan model + `plan→mode` map + §3.5 scope-keyed query cache (blocked on billing + cache infra that does not exist yet)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015VbH4WGZ4ueh2t5SHpRpqC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->