### PR TITLE
fix(timeline): land deep-link navigation on the linked message

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -887,7 +887,8 @@ export function StreamContent({
   useEffect(() => {
     if (!highlightMessageId || isLoading || isDraft) return
     if (jumpTriggeredKeyRef.current === location.key) return
-    jumpTriggeredKeyRef.current = location.key
+    const navigationKey = location.key
+    jumpTriggeredKeyRef.current = navigationKey
     // Fresh navigation: re-arm the mount hold for this target.
     setDeepLinkGaveUp(false)
 
@@ -909,12 +910,17 @@ export function StreamContent({
       pendingScrollTarget.current = highlightMessageId
       jumpToEvent(highlightMessageId)
         .then((success) => {
+          // A newer navigation may have superseded this request while it was
+          // in flight; its stale completion must not clear the new target or
+          // release the new mount hold.
+          if (jumpTriggeredKeyRef.current !== navigationKey) return
           if (!success) {
             pendingScrollTarget.current = null
             setDeepLinkGaveUp(true)
           }
         })
         .catch(() => {
+          if (jumpTriggeredKeyRef.current !== navigationKey) return
           pendingScrollTarget.current = null
           setDeepLinkGaveUp(true)
         })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1353,6 +1353,24 @@ function VirtuosoMessageList({
   // would never get `isFirstMessage=true` and the badge would silently drop.
   const firstMessageId = useMemo(() => findFirstMessageId(visibleItems), [visibleItems])
 
+  // On a deep-link (?m=) jump the scroll hook returns `initialTopMostItemIndex:
+  // undefined` so it can drive the jump imperatively via scrollToMessage. But
+  // an absent prop leaves react-virtuoso's internal index stream at its `0`
+  // default, so the listState anchors the freshly-remounted (per-stream key)
+  // window at index 0 — the *top* of the loaded window — and the scroller
+  // lands far above the target, fighting scrollToMessage until it gives up.
+  // When the linked message is already in the loaded window, anchor the
+  // initial window on it so the cold-boot mount renders centered on the
+  // target; scrollToMessage then only has to refine. Falls back to the hook's
+  // value when the target isn't loaded yet (the jumpToEvent fetch path).
+  const effectiveInitialTopMostItemIndex = useMemo(() => {
+    if (highlightMessageId) {
+      const idx = findMessageItemIndex(visibleItems, highlightMessageId)
+      if (idx >= 0) return { index: idx, align: "center" } as const
+    }
+    return initialTopMostItemIndex
+  }, [highlightMessageId, visibleItems, initialTopMostItemIndex])
+
   const renderCtx = useMemo<TimelineItemRenderContext>(
     () => ({
       workspaceId,
@@ -1568,10 +1586,13 @@ function VirtuosoMessageList({
       // safe numeric default), and a later reactive listState recompute runs
       // its index normalizer on that `undefined` -> "Cannot read properties
       // of undefined (reading 'index')", which crashes the whole route via
-      // the error boundary. During deep-link (?m=) jumps the hook
-      // intentionally returns `undefined` here, so spread the prop only when
-      // it has a value and let react-virtuoso keep its default otherwise.
-      {...(initialTopMostItemIndex !== undefined ? { initialTopMostItemIndex } : {})}
+      // the error boundary. The hook returns `undefined` on deep-link jumps;
+      // effectiveInitialTopMostItemIndex substitutes the linked message's
+      // index when it is loaded. Spread the prop only when it has a value and
+      // let react-virtuoso keep its default otherwise.
+      {...(effectiveInitialTopMostItemIndex !== undefined
+        ? { initialTopMostItemIndex: effectiveInitialTopMostItemIndex }
+        : {})}
       data={visibleItems}
       // Intentionally no defaultItemHeight: it makes Virtuoso skip the probe
       // measure and reveal the list using the estimate, so a tall code block

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -107,6 +107,10 @@ export function StreamContent({
   // re-trigger the scroll — react-router generates a fresh key on every
   // navigation even when the URL is identical, which it auto-replaces.
   const jumpTriggeredKeyRef = useRef<string | null>(null)
+  // Set when a deep-link (?m=) jump can never resolve (target deleted / no
+  // access / fetch failed). Releases the deep-link mount hold so the timeline
+  // falls back to the loaded window instead of holding the skeleton forever.
+  const [deepLinkGaveUp, setDeepLinkGaveUp] = useState(false)
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [batchMode, setBatchMode] = useState(false)
@@ -884,6 +888,8 @@ export function StreamContent({
     if (!highlightMessageId || isLoading || isDraft) return
     if (jumpTriggeredKeyRef.current === location.key) return
     jumpTriggeredKeyRef.current = location.key
+    // Fresh navigation: re-arm the mount hold for this target.
+    setDeepLinkGaveUp(false)
 
     // Disable auto-scroll so highlight scroll-into-view isn't overridden
     disableAutoScroll()
@@ -905,10 +911,12 @@ export function StreamContent({
         .then((success) => {
           if (!success) {
             pendingScrollTarget.current = null
+            setDeepLinkGaveUp(true)
           }
         })
         .catch(() => {
           pendingScrollTarget.current = null
+          setDeepLinkGaveUp(true)
         })
     }
   }, [highlightMessageId, location.key, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
@@ -921,6 +929,7 @@ export function StreamContent({
     jumpTriggeredKeyRef.current = null
     scrollAbortRef.current?.()
     pendingScrollTarget.current = null
+    setDeepLinkGaveUp(false)
     exitJumpMode()
     setIsSearchOpen(false)
     clearSearch()
@@ -1006,6 +1015,30 @@ export function StreamContent({
     [editLastMessageCtx, scrollToMessage]
   )
 
+  // Deep-link (?m=) mount hold. On a push-notification / Activities deep link
+  // the latest window loads first; the jump effect then fetches the window
+  // around the target and swaps `events` wholesale. react-virtuoso only
+  // honors initialTopMostItemIndex at mount, so a Virtuoso instance mounted
+  // on the latest window can't re-anchor onto the jump window — scrollToMessage
+  // fights the stale anchor and the user lands far from the target ("scrolled
+  // to hell"). Holding the skeleton until the target is actually in the loaded
+  // window makes the single keyed mount land already-anchored on it. Uses the
+  // raw ?m= id (not the search-active id) so in-stream search is unaffected,
+  // and releases via deepLinkGaveUp / the 3s ?m= clear so it never hangs.
+  const deepLinkTargetLoaded = useMemo(
+    () =>
+      !highlightMessageId ||
+      events.some((e) => (e.payload as { messageId?: string })?.messageId === highlightMessageId),
+    [events, highlightMessageId]
+  )
+  const holdForDeepLink =
+    !!highlightMessageId &&
+    !deepLinkTargetLoaded &&
+    !deepLinkGaveUp &&
+    !isLoading &&
+    !isConfirmedEmpty &&
+    events.length > 0
+
   return (
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
       <QuoteReplyProvider>
@@ -1048,6 +1081,7 @@ export function StreamContent({
                   <VirtuosoMessageList
                     visibleItems={visibleItems}
                     isLoading={isLoading}
+                    holdForDeepLink={holdForDeepLink}
                     isConfirmedEmpty={isConfirmedEmpty}
                     virtuosoRef={virtuosoRef}
                     virtuosoScrollerRef={virtuosoScrollerRef}
@@ -1261,6 +1295,7 @@ export function StreamContent({
 function VirtuosoMessageList({
   visibleItems,
   isLoading,
+  holdForDeepLink,
   isConfirmedEmpty,
   virtuosoRef,
   virtuosoScrollerRef,
@@ -1290,6 +1325,9 @@ function VirtuosoMessageList({
 }: {
   visibleItems: TimelineItem[]
   isLoading: boolean
+  /** Hold the skeleton until a deep-link (?m=) target is in the loaded window
+   *  so the keyed Virtuoso instance mounts already anchored on it. */
+  holdForDeepLink: boolean
   /** True only when we've fully resolved IDB and bootstrap and the stream is
    *  actually empty. During mid-switch transitions this is false, so we avoid
    *  flashing the "No messages yet" state before useLiveQuery catches up. */
@@ -1521,7 +1559,7 @@ function VirtuosoMessageList({
     [reservedTopSpacer]
   )
 
-  if (isLoading) {
+  if (isLoading || holdForDeepLink) {
     return (
       <div className="flex flex-col gap-4 px-4 py-6 sm:px-6">
         <div className="flex gap-3">


### PR DESCRIPTION
## Problem

PR #571 fixed the route-crashing `TypeError: Cannot read properties of undefined (reading 'index')` on deep-link (`?m=`) navigation by **omitting** the `initialTopMostItemIndex` prop whenever the scroll hook returned `undefined`. That stopped the crash but broke deep-link scrolling in two ways:

1. **Recent-message deep link (cached stream).** An absent prop leaves react-virtuoso's internal index stream at its `0` default, so the per-stream-remounted (`<Virtuoso key={streamId}>`) listState anchors the window at **index 0 — the top of the loaded range**. The scroller lands far above the linked message and `scrollToMessage` can't win, so the user is stranded at the top. _("If I click a recent message… it scrolls faaaaaaaaaaaar away up from the actual message I clicked.")_

2. **Cold push-notification / Activities deep link (uncached stream).** The latest window loads first and Virtuoso mounts on it; the jump effect then fetches the window around the target and swaps `events` wholesale. react-virtuoso only honors `initialTopMostItemIndex` **at mount**, so the already-mounted instance can't re-anchor onto the jump window and `scrollToMessage` fights the stale anchor. _("I opened a push notification and it scrolled to hell.")_

## Solution

Make the scroll target stay in sync with what's actually loaded — two coordinated changes in `stream-content.tsx`:

**1. Anchor the mount on the linked message (`effectiveInitialTopMostItemIndex`).** `VirtuosoMessageList` derives an effective initial index: when the linked message is in the loaded window, the cold-boot mount is anchored on it (`{ index, align: "center" }`) so the list renders on-target and `scrollToMessage` only refines. Falls back to the hook's value (and the #571 prop-omission + react-virtuoso patch backstop) when the target isn't loaded — the crash fix is fully preserved (no `undefined` is ever published into the index stream).

**2. Hold the mount until the target is loaded (`holdForDeepLink`).** While a `?m=` target isn't in the loaded window yet, the skeleton is held instead of mounting Virtuoso on the latest window. The single keyed mount therefore happens already-anchored on the jump window. The gate keys off the raw `?m=` id (in-stream search is unaffected) and releases on jump failure (`deepLinkGaveUp`) or the existing 3s `?m=` param clear, so it can never hang.

Together: the deep-link target window resolves first, Virtuoso mounts once with the target present, and the mount anchors on it — no stale-anchor fight, no "load the latest window then scramble".

### Key design decisions

**Compute the index in the component, not the hook.** `useVirtuosoScroll` intentionally returns `undefined` on deep-link so it can drive the jump imperatively. The component is where `visibleItems` + `highlightMessageId` are both in scope to resolve message → index.

**Reactive `useMemo`, mirroring the existing `firstMessageId` pattern.** react-virtuoso only honors `initialTopMostItemIndex` at mount, so post-mount recomputes are harmless; this just maximizes the chance the value is correct at mount.

**Gate on the raw `?m=` id, with explicit release conditions.** Using the `?m=` id (not the search-active id) keeps in-stream search unaffected. `deepLinkGaveUp` (set on `jumpToEvent` failure / throw, reset per navigation and per stream) plus the pre-existing 3s `?m=` clear guarantee the skeleton hold is always terminal.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Add `effectiveInitialTopMostItemIndex` (anchor mount on target) and `holdForDeepLink` gate (hold skeleton until target window resolves, with `deepLinkGaveUp` release) |

## Test plan

- [x] Frontend typecheck clean (`tsc --noEmit`)
- [x] ESLint clean on the modified file
- [x] Full pre-commit gate (prettier + lint + typecheck across all workspaces) passed
- [x] Full frontend test suite green — **1711 passing, 0 failing** (includes the react-virtuoso patch, `use-virtuoso-scroll`, and `use-events` suites)
- [ ] Manual: click a recent message from the Activities tab → lands centered on that message
- [ ] Manual: open a push-notification deep link on mobile PWA (uncached stream, older message) → skeleton holds, then lands on the linked message
- [ ] Manual: in-stream search navigation still works (gate keys off `?m=` only, not search-active id)
- [ ] Manual: deep link to a deleted/inaccessible message → skeleton releases (no infinite hold), falls back to loaded window

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_