### PR TITLE
fix(timeline): latch deep-link mode against the 3s ?m= param clear

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -654,6 +654,22 @@ export function StreamContent({
     [visibleItems]
   )
 
+  // Latch deep-link mode per stream. `?m=` is auto-cleared from the URL after
+  // 3s (see effect above), which would otherwise flip skipInitialScroll
+  // true->false mid-view and re-run useVirtuosoScroll's destructive reset
+  // (firstItemIndex + follow-output), yanking the user off the deep-linked
+  // message and snapping to the bottom. The latch only resets on streamId
+  // change, so a fresh deep-link into the same stream still re-arms (false
+  // is never written back within a stream once highlightMessageId was seen).
+  const deepLinkLatchRef = useRef<{ streamId: string; latched: boolean }>({ streamId, latched: false })
+  if (deepLinkLatchRef.current.streamId !== streamId) {
+    deepLinkLatchRef.current = { streamId, latched: false }
+  }
+  if (highlightMessageId) {
+    deepLinkLatchRef.current.latched = true
+  }
+  const skipInitialScroll = deepLinkLatchRef.current.latched
+
   // --- Virtuoso scroll (main streams, channels, scratchpads) ---
   const {
     virtuosoRef,
@@ -671,7 +687,7 @@ export function StreamContent({
     itemCount: useVirtualized ? visibleItems.length : 0,
     getItemKey: useVirtualized ? getItemKey : () => "0",
     resetKey: streamId,
-    skipInitialScroll: !!highlightMessageId,
+    skipInitialScroll,
   })
 
   // Virtuoso ref for scroll container access (search highlight, etc.)


### PR DESCRIPTION
## Summary

Deep-linking to an OLD message via `?m=<id>` lands on the correct message, then ~3s later the viewport jumps off it and snaps to the bottom. This is the remaining breakage after #574 (which removed the smooth-scroll thrash).

**Root cause:** the effect at `stream-content.tsx:148` auto-deletes the `m` URL param 3 seconds after a deep-link lands. That flips `highlightMessageId` to `undefined`, which flipped `skipInitialScroll: !!highlightMessageId` from `true` to `false` **mid-view**. `skipInitialScroll` is a dependency of `useVirtuosoScroll`'s reset `useLayoutEffect` (`use-virtuoso-scroll.ts:92-100`); re-running it destructively resets `firstItemIndexRef` (viewport jumps) and re-arms `isAtBottomRef` / `setShouldFollowOutput(true)` (snaps to bottom). This bypassed #574's guards because the hook sets follow-state directly, not via the user-scroll observer path those guards covered.

**Fix:** latch deep-link mode per stream with a render-time ref reconciliation (consistent with the existing `visibleItemsRef` pattern in the same file). Once `highlightMessageId` is seen for a stream, `skipInitialScroll` stays `true` for that stream view; the latch resets only on `streamId` change, so a fresh deep-link into the same stream still re-arms and stream switching gets normal scroll-to-bottom-at-mount. `initialTopMostItemIndex` is honored only at mount and `<Virtuoso key={streamId}>` remounts per stream, so latching for the life of a stream view is safe. Follow-output is still re-armed independently via the scroll observer (`handleAtBottomChange`), so autoscroll after the user scrolls to the bottom is unaffected.

## Self-review

Three independent review passes:

- **Correctness / edge-cases — 94/100.** Render ordering, stream-switch reset, same-stream re-deep-link, StrictMode double-render all verified safe. Confirmed no path legitimately needs `skipInitialScroll` to revert to `false` within a stream view.
- **Invariant / architecture — 97/100.** No violations. INV-15 (matches existing render-time ref pattern), INV-36 (minimal; the `streamId` field is load-bearing), INV-59 (`?m=` is a one-shot signal, not a persistent view — no violation), INV-25 (comment explains the constraint).
- **Regression hunt — 72/100.** Jump-to-latest, in-stream search nav, follow-output re-arm, stream switching all verified safe. One pre-existing issue surfaced (see below).

## Known pre-existing limitation (not introduced here)

`StreamPanel` (`stream-panel.tsx:64,559`) forwards the raw `?m=` param to whatever thread the panel shows, regardless of whether that thread owns the message. `?panel=` and `?m=` are independent URL params and can coexist.

- **Legitimate case** (deep-link a thread reply → panel opens to that thread → `?m=` highlights the reply within the panel): the message *is* in the panel thread; the latch is correct and beneficial, same as the main view.
- **Irrelevant case** (panel already open to thread-A while `?m=` points to a message in another stream): the panel thread was already broken for 3s pre-fix; the latch extends that to the panel's lifetime instead of self-healing after the param clears.

The correct fix is architectural — relevance-gate `?m=` forwarding in `StreamPanel` — which is a different component and out of scope for this timeline scroll fix. Every minimal mitigation attempted (unlatch on `deepLinkGaveUp`, gate on `isHighlightInEvents`) reintroduces the exact destructive-reset bug class this change exists to kill, or breaks the OLD-message main-view fix. Flagged here for a follow-up rather than expanding scope.

## Test plan

- [x] `bun run typecheck` (full workspace, via pre-commit hook)
- [x] `bun run lint` (full workspace, via pre-commit hook)
- [x] Scroll-specific suites: `use-virtuoso-scroll`, `use-scroll-behavior`, `react-virtuoso-patch` (12 tests)
- [x] Full frontend suite (1711 tests, all passing)
- [ ] On-device: deep-link to an OLD message, wait past the 3s mark, confirm it stays put instead of jumping/snapping
- [ ] On-device: deep-link into a thread reply (panel opens), confirm the reply is highlighted and stays put
- [ ] On-device: "Jump to latest" and in-stream search navigation after a deep-link

https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->