### PR TITLE
fix(frontend): stop a hung SW update() from stranding the reload button

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest"
-import { shouldNotifyUpdate } from "./use-app-update"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { reloadForUpdate, shouldNotifyUpdate, UPDATE_RELOAD_FALLBACK_MS } from "./use-app-update"
 
 const RUNNING = "abc1234"
 
@@ -24,5 +24,88 @@ describe("shouldNotifyUpdate", () => {
 
   it("stays silent on an empty/missing server version", () => {
     expect(shouldNotifyUpdate("", RUNNING, null)).toBe(false)
+  })
+})
+
+describe("reloadForUpdate", () => {
+  const originalLocation = window.location
+  const swDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  const setRegistration = (registration: unknown): void => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        addEventListener: vi.fn(),
+        getRegistration: () => Promise.resolve(registration),
+      },
+    })
+  }
+
+  beforeEach(() => {
+    reloadSpy = vi.fn()
+    // jsdom's location.reload() throws "Not implemented" — replace it with a spy.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+    if (swDescriptor) {
+      Object.defineProperty(navigator, "serviceWorker", swDescriptor)
+    } else {
+      // jsdom has no serviceWorker by default — drop the stub we added.
+      delete (navigator as { serviceWorker?: unknown }).serviceWorker
+    }
+  })
+
+  it("still reloads within the fallback window when registration.update() never settles", async () => {
+    // The regression: every guaranteed-reload path used to sit behind
+    // `await registration.update()`. A hung update() (stalled SW-script fetch,
+    // throttled/offline tab) dismissed the toast and then left Reload doing
+    // nothing. The time-bounded fallback must fire regardless.
+    vi.useFakeTimers()
+    setRegistration({
+      installing: null,
+      waiting: null,
+      update: () => new Promise<void>(() => {}), // never settles
+    })
+
+    await reloadForUpdate()
+    expect(reloadSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(UPDATE_RELOAD_FALLBACK_MS)
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  it("reloads immediately when there is no service worker registration", async () => {
+    setRegistration(undefined)
+    await reloadForUpdate()
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  it("falls back to a plain reload when registration.update() rejects", async () => {
+    setRegistration({
+      installing: null,
+      waiting: null,
+      update: () => Promise.reject(new Error("update failed")),
+    })
+
+    await reloadForUpdate()
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
+  })
+
+  it("reloads as soon as the update resolves with no pending worker, without waiting the fallback out", async () => {
+    setRegistration({
+      installing: null,
+      waiting: null,
+      update: () => Promise.resolve(),
+    })
+
+    await reloadForUpdate()
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
   })
 })

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -29,12 +29,14 @@ async function triggerSwUpdate(): Promise<void> {
  * plain reload returns whatever build the *currently controlling* SW precached.
  * If the new SW hasn't installed and claimed this page yet, that is still the
  * old build and the version toast just reappears — which is why an
- * unconditional reload needed "a bunch of refreshes". So force the update now
- * and reload exactly once when the new SW takes control: it self-activates via
- * skipWaiting + clients.claim, firing `controllerchange`. Fall back to a plain
- * reload when there is no registration, no pending worker (the new SW already
- * claimed in the background), or the update stalls — never worse than a bare
- * reload, and time-bounded.
+ * unconditional reload needed "a bunch of refreshes".
+ *
+ * So the guaranteed behaviour is a single time-bounded reload, armed up front
+ * and never gated on the SW update settling. On top of that, as a best-effort
+ * optimization, force the SW update and reload the moment the new worker takes
+ * control (it self-activates via skipWaiting + clients.claim, firing
+ * `controllerchange`) so the reload lands on the new build instead of waiting
+ * the fallback out. Reloads exactly once; never worse than a bare reload.
  */
 export async function reloadForUpdate(): Promise<void> {
   let reloaded = false

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -9,7 +9,7 @@ const TOAST_ID = "app-update"
 const IS_DEV = import.meta.env.DEV
 
 /** Cap how long the Reload action waits for the new SW before reloading anyway. */
-const UPDATE_RELOAD_FALLBACK_MS = 10_000
+export const UPDATE_RELOAD_FALLBACK_MS = 10_000
 
 /**
  * Tell the browser to check for a new service worker. The SW's install handler
@@ -36,7 +36,7 @@ async function triggerSwUpdate(): Promise<void> {
  * claimed in the background), or the update stalls — never worse than a bare
  * reload, and time-bounded.
  */
-async function reloadForUpdate(): Promise<void> {
+export async function reloadForUpdate(): Promise<void> {
   let reloaded = false
   const reloadOnce = (): void => {
     if (reloaded) return
@@ -57,24 +57,34 @@ async function reloadForUpdate(): Promise<void> {
     // before we are listening.
     navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
 
-    await registration.update()
-
-    const pending = registration.installing ?? registration.waiting
-    if (!pending) {
-      // The new SW already installed and took control in the background — a
-      // plain reload now serves its precached shell.
-      reloadOnce()
-      return
-    }
-
-    // Backstop for controllerchange in case it does not fire for this client:
-    // reload as soon as the new SW reaches `activated`.
-    pending.addEventListener("statechange", () => {
-      if (pending.state === "activated") reloadOnce()
-    })
-
-    // Last resort so a stuck install can't strand the toast indefinitely.
+    // Arm the time-bounded reload BEFORE awaiting update(). registration.update()
+    // can hang indefinitely (stalled SW-script fetch, throttled or offline tab),
+    // and every other guarantee here used to sit behind that await — so a hung
+    // update() dismissed the toast and then stranded the user on the old build
+    // with Reload doing nothing. The reload now always happens within
+    // UPDATE_RELOAD_FALLBACK_MS regardless of how update() behaves.
     setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
+
+    // Best effort on top of that fallback: reload the moment the new SW takes
+    // control so the reload lands on its precached build instead of waiting the
+    // fallback out. Not awaited, so a hung update() can't block the timeout.
+    void registration
+      .update()
+      .then(() => {
+        const pending = registration.installing ?? registration.waiting
+        if (!pending) {
+          // The new SW already installed and took control in the background — a
+          // plain reload now serves its precached shell.
+          reloadOnce()
+          return
+        }
+        // Backstop for controllerchange in case it does not fire for this
+        // client: reload as soon as the new SW reaches `activated`.
+        pending.addEventListener("statechange", () => {
+          if (pending.state === "activated") reloadOnce()
+        })
+      })
+      .catch(reloadOnce)
   } catch {
     reloadOnce()
   }

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -59,12 +59,11 @@ export async function reloadForUpdate(): Promise<void> {
     // before we are listening.
     navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
 
-    // Arm the time-bounded reload BEFORE awaiting update(). registration.update()
-    // can hang indefinitely (stalled SW-script fetch, throttled or offline tab),
-    // and every other guarantee here used to sit behind that await — so a hung
-    // update() dismissed the toast and then stranded the user on the old build
-    // with Reload doing nothing. The reload now always happens within
-    // UPDATE_RELOAD_FALLBACK_MS regardless of how update() behaves.
+    // registration.update() can hang indefinitely (stalled SW-script fetch,
+    // throttled or offline tab), so it must not gate the reload. Arming the
+    // fallback here, independent of the update() promise below, guarantees
+    // reloadOnce runs within UPDATE_RELOAD_FALLBACK_MS no matter how update()
+    // behaves.
     setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
 
     // Best effort on top of that fallback: reload the moment the new SW takes


### PR DESCRIPTION
The "reload onto the new build in one click" change moved every
guaranteed-reload path behind `await registration.update()`: the
no-pending immediate reload, the statechange backstop, and the 10s
last-resort timeout were all armed only after that await resolved.
registration.update() can hang indefinitely in real browsers (stalled
SW-script fetch, throttled or offline tab), so a click dismissed the
toast (sonner default on action click) and then parked on the await
forever — the Reload button did nothing.

Arm the time-bounded fallback (and the controllerchange subscription)
before/independent of awaiting update(), and run the SW-coordination as
a non-awaited best-effort optimization on top. The reload now always
happens within UPDATE_RELOAD_FALLBACK_MS regardless of how update()
behaves, while still reloading promptly the moment the new SW takes
control. Adds regression coverage for the hung-update() path.

https://claude.ai/code/session_01KtgmTGydayAUefyZsuvGUk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->