### PR TITLE
fix(timeline): stop unread-divider scroll hijacking an old-message deep-link

### DIFF
--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -58,4 +58,63 @@ describe("useUnreadDivider", () => {
     expect(result.current.firstUnreadEventId).toBeUndefined()
     expect(result.current.dividerEventId).toBeUndefined()
   })
+
+  it("latches off scroll-to-first-unread once a stream is deep-linked, even after the ?m= param clears", () => {
+    const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
+    const enabledCalls: (boolean | undefined)[] = []
+    vi.spyOn(useScrollToElementModule, "useScrollToElement").mockImplementation(((
+      options: { enabled?: boolean } = {}
+    ) => {
+      enabledCalls.push(options.enabled)
+      return undefined
+    }) as unknown as typeof useScrollToElementModule.useScrollToElement)
+
+    const lastEnabled = () => enabledCalls[enabledCalls.length - 1]
+
+    const { rerender } = renderHook(
+      ({ highlightMessageId, streamId }: { highlightMessageId: string | null; streamId: string }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId: null,
+          currentUserId: "me",
+          streamId,
+          highlightMessageId,
+        }),
+      { initialProps: { highlightMessageId: "msg_event_1" as string | null, streamId: "stream_1" } }
+    )
+
+    // Deep-link active: scroll-to-unread suppressed.
+    expect(lastEnabled()).toBe(false)
+
+    // ?m= auto-cleared ~3s later — must stay suppressed for this stream view.
+    rerender({ highlightMessageId: null, streamId: "stream_1" })
+    expect(lastEnabled()).toBe(false)
+
+    // Switching streams resets the latch: a non-deep-linked stream scrolls normally.
+    rerender({ highlightMessageId: null, streamId: "stream_2" })
+    expect(lastEnabled()).toBe(true)
+  })
+
+  it("enables scroll-to-first-unread when the stream was never deep-linked", () => {
+    const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
+    const enabledCalls: (boolean | undefined)[] = []
+    vi.spyOn(useScrollToElementModule, "useScrollToElement").mockImplementation(((
+      options: { enabled?: boolean } = {}
+    ) => {
+      enabledCalls.push(options.enabled)
+      return undefined
+    }) as unknown as typeof useScrollToElementModule.useScrollToElement)
+
+    renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadEventId: null,
+        currentUserId: "me",
+        streamId: "stream_1",
+        highlightMessageId: null,
+      })
+    )
+
+    expect(enabledCalls[enabledCalls.length - 1]).toBe(true)
+  })
 })

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -122,9 +122,24 @@ export function useUnreadDivider({
     setIsFading(false)
   }, [streamId])
 
+  // Latch deep-link mode per stream. The `?m=` param is auto-cleared from the
+  // URL ~3s after a deep-link lands, flipping highlightMessageId to null.
+  // Without this latch the scroll-to-first-unread gate below would re-arm at
+  // that moment and yank the user off the deep-linked message down to the
+  // first unread (≈ the live tail) — the "lands right, then jumps, then snaps
+  // to the bottom" deep-link bug. A stream the user deep-linked into should
+  // never auto-scroll to unread for that view. Resets only on stream change.
+  const deepLinkedRef = useRef<{ streamId: string; seen: boolean }>({ streamId, seen: false })
+  if (deepLinkedRef.current.streamId !== streamId) {
+    deepLinkedRef.current = { streamId, seen: false }
+  }
+  if (highlightMessageId) {
+    deepLinkedRef.current.seen = true
+  }
+
   // Scroll to first unread on initial load
   useScrollToElement({
-    enabled: scrollToUnread && !isLoading && !!firstUnreadEventId && !highlightMessageId,
+    enabled: scrollToUnread && !isLoading && !!firstUnreadEventId && !deepLinkedRef.current.seen,
     selector: firstUnreadEventId ? `[data-event-id="${firstUnreadEventId}"]` : undefined,
     resetKey: streamId,
   })


### PR DESCRIPTION
## Summary

Follow-up to #575. Deep-linking to an OLD message via `?m=<id>` still misbehaved: it lands on the correct message, then ~3s later jumps elsewhere and ends up at the most recent message. #575 (and the earlier timeline fixes) only addressed the `useVirtuosoScroll` reset path, which is why the symptom improved but never went away.

**Root cause — a separate scroll mechanism:** `useUnreadDivider` runs `useScrollToElement` to scroll to the first unread message, gated on `!highlightMessageId` (`use-unread-divider.ts`):

1. `?m=oldMsg` present → gate is `false` → the deep-link scroll wins → **lands correct.**
2. ~3s later the `?m=` param auto-clears from the URL (the URL-hygiene effect in `stream-content.tsx`) → `highlightMessageId` → `null` → the gate flips **false→true** → `useScrollToElement` fires `scrollIntoView` to `firstUnreadEventId`.
3. For someone deep-linking an *old* message, "first unread" is far down near the live tail → **jumps elsewhere, then ends up at the most recent message.**

Same root-cause class as #575 (the transient `?m=` auto-clear flipping derived scroll state mid-view) — just a second consumer the #575 latch didn't reach.

**Fix:** apply the same per-stream latch pattern in `useUnreadDivider`. Once a stream has been deep-linked, suppress the initial scroll-to-first-unread for the life of that stream view (correct UX — the user deliberately navigated to a specific old message). The latch resets only on stream change, so non-deep-linked streams scroll to first unread exactly as before. In-stream search is unaffected: the hook receives the raw `?m=` id, not the search-active id.

## Test plan

- [x] 2 new regression tests in `use-unread-divider.test.ts`:
  - gate stays suppressed after `?m=` clears within the same stream, and re-enables on stream change
  - non-deep-linked stream still enables scroll-to-first-unread (no regression)
- [x] `bun run typecheck` (full workspace, via pre-commit hook)
- [x] `bun run lint` (full workspace, via pre-commit hook)
- [x] Full frontend suite (1713 tests, all passing)
- [ ] On-device: deep-link to an OLD message, wait past the 3s mark — it should stay put, not jump to the latest
- [ ] On-device: open a normal stream with unread messages — scroll-to-first-unread still works
- [ ] On-device: in-stream search navigation unaffected

https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5HjbNJcQ7hLsnmMsGksXp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->