### PR TITLE
fix(timeline): stabilize virtualized stream scrolling

### DIFF
--- a/.claude/plans/custom-infinite-scroller.md
+++ b/.claude/plans/custom-infinite-scroller.md
@@ -1,0 +1,95 @@
+# Custom Infinite Scroller Stability
+
+## Goal
+
+Make the stream timeline pixel-stable under virtualization while preserving the existing IndexedDB/offline-first data path. The timeline should not visibly jump when history is prepended, when live events append, when jump/deep-link windows replace the current event window, or when Virtuoso overscans beyond the viewport.
+
+## What Was Built
+
+### Virtual index anchoring
+
+`useVirtuosoScroll` now tracks a map of stable item keys to indexes and adjusts `firstItemIndex` synchronously during render based on the first preserved item. This handles prepends, appends, mixed prepend+append updates, and leading removals without a one-frame mismatch between the data array and Virtuoso's virtual index base.
+
+**Files:**
+- `apps/frontend/src/hooks/use-virtuoso-scroll.ts` — synchronous key-preserving `firstItemIndex` updates, reset handling, bottom-distance tracking.
+- `apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx` — regression coverage for prepend/append anchoring, stream reset behavior, skip-initial-scroll behavior, and overscanned bottom-button visibility.
+
+### Guarded edge pagination
+
+Direct Virtuoso `startReached` / `endReached` callbacks were removed from the stream list. Pagination now runs through the existing guarded `rangeChanged` path, which can suppress transient edge ranges during initial mount, deep-link scroll convergence, and jump-mode windows.
+
+**Files:**
+- `apps/frontend/src/components/timeline/stream-content.tsx` — removes direct edge callbacks, resets range/prepend state around jump-window replacements, and keys range-settlement state by stream/jump mode.
+
+### Overscan and pre-rendering
+
+The timeline now pre-renders at least one viewport of content above and below the visible range, plus a minimum item-count overscan. The overscan distance tracks the actual scroller height via `ResizeObserver` so larger viewports get enough measured content without requiring a patched Virtuoso bundle change.
+
+**Files:**
+- `apps/frontend/src/components/timeline/stream-content.tsx` — dynamic `increaseViewportBy` and `minOverscanItemCount` configuration.
+
+### Jump-to-latest correctness under overscan
+
+The jump-to-latest affordance no longer relies solely on Virtuoso's rendered range, because overscan can render bottom rows while they are still physically offscreen. The hook now computes distance from bottom using actual scroll pixels when a scroller element is available.
+
+**Files:**
+- `apps/frontend/src/hooks/use-virtuoso-scroll.ts` — scroll listener and pixel-distance threshold.
+- `apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx` — regression for overscanned ranges not hiding the button.
+
+### Zero-height row filtering
+
+Timeline items that render as no visible row are filtered before virtualization count/key calculation. This prevents Virtuoso from measuring zero-height rows that can overlap subsequent content.
+
+**Files:**
+- `apps/frontend/src/components/timeline/event-list.tsx` — filters destination-side `messages:moved` rows and invalid command groups lacking `command_dispatched`.
+- `apps/frontend/src/components/timeline/event-list.test.ts` — regression coverage for the new filters.
+
+## Design Decisions
+
+### Key-preserving index adjustment
+
+**Chose:** Compare stable item keys across renders and adjust `firstItemIndex` by the preserved anchor delta.
+
+**Why:** Count-only prepend detection fails when prepends and appends happen together or when leading rows are removed. A key-preserving anchor matches how the user perceives continuity: the same row should stay at the same pixel position.
+
+**Alternatives considered:** Only comparing the first key and item count. That misses mixed update shapes and can misclassify window replacement.
+
+### RangeChanged-only pagination
+
+**Chose:** Route pagination through `rangeChanged` instead of Virtuoso's direct edge callbacks.
+
+**Why:** The direct callbacks can fire during programmatic/deep-link scrolling and bypass existing guards. `rangeChanged` lets the component gate pagination on settled range state and scroll-abort state.
+
+**Alternatives considered:** Keep `startReached` / `endReached` and add local guards around each. That leaves multiple edge-trigger paths to keep in sync.
+
+### Pixel-distance bottom detection
+
+**Chose:** Use physical scroll distance from the scroller element for `isScrolledFarFromBottom` when available.
+
+**Why:** Overscan intentionally renders rows outside the viewport, so rendered range is no longer a reliable proxy for whether the user can see the bottom.
+
+**Alternatives considered:** Increasing the rendered-range threshold. That still couples UI state to overscan configuration instead of actual scroll position.
+
+## Design Evolution
+
+- **Overscan regression:** Increasing pre-render/overscan improved row pop-in but made the rendered range include bottom rows too early. The bottom-button logic was updated to use physical scroll distance so overscan and UI affordance visibility do not conflict.
+- **Jump-window replacement:** Jump/deep-link event windows are wholesale replacements, not incremental history prepends. The stream now resets prepend/range state before jump loads so the anchoring logic does not treat replacement as pagination.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No IndexedDB/query/cache changes are included in this PR.
+- No coordinated-loading changes are included; initial-load blank/skeleton behavior remains a separate follow-up.
+- No patched `react-virtuoso` bundle changes are included; the fix uses public Virtuoso props and hook-level state.
+
+## Status
+
+- [x] Stabilize `firstItemIndex` across prepend/append/removal/reset cases.
+- [x] Guard pagination through `rangeChanged` and reset jump/deep-link range state.
+- [x] Increase dynamic pre-render/overscan without bundle changes.
+- [x] Restore Jump to latest visibility under overscan via physical scroll distance.
+- [x] Filter zero-height virtual rows before virtualization.
+- [x] Add regression tests for scroll anchoring and row filtering.

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import type { StreamEvent } from "@threa/types"
 import {
   annotateAuthorGroups,
+  filterVisibleItems,
   findFirstMessageId,
   findMessageItemIndex,
   groupTimelineItems,
@@ -279,6 +280,51 @@ describe("annotateAuthorGroups", () => {
       { type: "session_group", sessionId: "sess_1", sessionVersion: 1, events: [] },
     ]
     expect(annotateAuthorGroups(input)).toEqual(input)
+  })
+})
+
+describe("filterVisibleItems", () => {
+  it("filters destination-side move tombstones before they reach Virtuoso", () => {
+    const items: TimelineItem[] = [
+      {
+        type: "event",
+        event: createEvent({
+          id: "evt_move_dest",
+          sequence: "1",
+          eventType: "messages:moved",
+          payload: { destinationStreamId: "stream_123", messages: [] },
+        }),
+      },
+      toEventItem(createMessageEvent({ id: "2", actorId: "user_a", createdAt: "2026-04-19T10:00:00Z" })),
+    ]
+
+    const visibleEventIds = filterVisibleItems(items, false, "stream_123").map((item) =>
+      item.type === "event" ? item.event.id : null
+    )
+
+    expect(visibleEventIds).toEqual(["2"])
+  })
+
+  it("keeps source-side move tombstones visible", () => {
+    const event = createEvent({
+      id: "evt_move_source",
+      sequence: "1",
+      eventType: "messages:moved",
+      payload: { destinationStreamId: "stream_other", messages: [] },
+    })
+
+    expect(filterVisibleItems([{ type: "event", event }], false, "stream_123")).toEqual([{ type: "event", event }])
+  })
+
+  it("filters command groups that cannot render without a dispatched event", () => {
+    const completedOnly = createEvent({
+      id: "evt_command_completed",
+      sequence: "1",
+      eventType: "command_completed",
+      payload: { commandId: "cmd_1" },
+    })
+
+    expect(filterVisibleItems([{ type: "command_group", commandId: "cmd_1", events: [completedOnly] }])).toEqual([])
   })
 })
 

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -170,10 +170,21 @@ const ZERO_HEIGHT_EVENT_TYPES = new Set([
  * Filters out timeline items that would render as zero-height elements.
  * Must be applied before computing virtualizer count/keys to prevent overlap.
  */
-export function filterVisibleItems(items: TimelineItem[], hideSessionCards?: boolean): TimelineItem[] {
+export function filterVisibleItems(
+  items: TimelineItem[],
+  hideSessionCards?: boolean,
+  streamId?: string
+): TimelineItem[] {
   return items.filter((item) => {
     if (item.type === "session_group" && hideSessionCards) return false
+    if (item.type === "command_group" && !item.events.some((event) => event.eventType === "command_dispatched")) {
+      return false
+    }
     if (item.type === "event" && ZERO_HEIGHT_EVENT_TYPES.has(item.event.eventType)) return false
+    if (item.type === "event" && item.event.eventType === "messages:moved" && streamId) {
+      const payload = item.event.payload as { destinationStreamId?: string }
+      if (payload.destinationStreamId === streamId) return false
+    }
     return true
   })
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -80,6 +80,14 @@ import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
 const THREAD_HIDDEN_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["member_joined", "member_added", "member_left"])
 
 /**
+ * Render at least one full viewport ahead and behind the visible range. The
+ * scroller measures rows as they mount; Firefox in particular can otherwise
+ * show rows popping in only after their leading edge crosses the viewport.
+ */
+const TIMELINE_MIN_PRE_RENDER_PX = 1000
+const TIMELINE_MIN_OVERSCAN_ITEM_COUNT = { top: 8, bottom: 8 }
+
+/**
  * Opt-in deep-link scroll tracing. Off by default (zero console noise in
  * production). Enable from the browser console with
  * `window.__threaDeepLinkDebug = true`, then reproduce a deep-link (`?m=`)
@@ -685,8 +693,8 @@ export function StreamContent({
   // Without this, items that render as empty wrappers get measured as 0px, causing
   // subsequent items to overlap at the same Y position.
   const visibleItems = useMemo(
-    () => (useVirtualized ? filterVisibleItems(timelineItems, isChannel) : timelineItems),
-    [timelineItems, useVirtualized, isChannel]
+    () => (useVirtualized ? filterVisibleItems(timelineItems, isChannel, streamId) : timelineItems),
+    [timelineItems, useVirtualized, isChannel, streamId]
   )
 
   // Mirror of `visibleItems` for the long-lived scrollToMessage retry loop:
@@ -958,12 +966,15 @@ export function StreamContent({
         return
       }
 
-      // Message not in current window — load events around it, then scroll after load
+      // Message not in current window — load events around it, then scroll after load.
+      // The jump result replaces the timeline window; clear prepend anchors so
+      // that wholesale swap is not interpreted as incremental history loading.
       disableAutoScroll()
+      resetPrependState()
       pendingScrollTarget.current = messageId
       jumpToEvent(messageId)
     },
-    [events, jumpToEvent, disableAutoScroll, scrollToMessage]
+    [events, jumpToEvent, disableAutoScroll, resetPrependState, scrollToMessage]
   )
 
   // Highlight search matches in the DOM via CSS Custom Highlight API
@@ -1083,6 +1094,7 @@ export function StreamContent({
 
     if (events.length > 0) {
       deepLinkDebug("highlight: target out of window, jumping", highlightMessageId)
+      resetPrependState()
       pendingScrollTarget.current = highlightMessageId
       jumpToEvent(highlightMessageId)
         .then((success) => {
@@ -1103,7 +1115,17 @@ export function StreamContent({
           setDeepLinkGaveUp(true)
         })
     }
-  }, [highlightMessageId, location.key, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
+  }, [
+    highlightMessageId,
+    location.key,
+    isLoading,
+    isDraft,
+    events,
+    jumpToEvent,
+    disableAutoScroll,
+    resetPrependState,
+    scrollToMessage,
+  ])
 
   // Reset jump and search state when switching streams (component stays mounted).
   // Also abort any in-flight scrollToMessage retry loop so its stale closure
@@ -1703,12 +1725,23 @@ function VirtuosoMessageList({
   // across messages and leak per-message state (e.g. link previews).
   const computeItemKey = useCallback((_index: number, item: TimelineItem) => getTimelineItemKey(item), [])
 
+  const [viewportOverscanPx, setViewportOverscanPx] = useState(TIMELINE_MIN_PRE_RENDER_PX)
+  const updateViewportOverscan = useCallback((el: HTMLElement) => {
+    const next = Math.max(TIMELINE_MIN_PRE_RENDER_PX, Math.ceil(el.clientHeight))
+    setViewportOverscanPx((prev) => (prev === next ? prev : next))
+  }, [])
+  const increaseViewportBy = useMemo(
+    () => ({ top: viewportOverscanPx, bottom: viewportOverscanPx }),
+    [viewportOverscanPx]
+  )
+
   // Stable scroller ref callback — wrapping in useCallback avoids Virtuoso
   // calling the old callback with null and the new one with the element
   // on every render, which would disconnect/reconnect the ResizeObserver.
-  // Detaches the long-lived user-interaction listeners when the scroller is
-  // swapped (per-stream remount) or the component unmounts.
+  // Detaches the long-lived user-interaction + overscan observers when the
+  // scroller is swapped (per-stream remount) or the component unmounts.
   const userInteractionCleanupRef = useRef<(() => void) | null>(null)
+  const viewportOverscanCleanupRef = useRef<(() => void) | null>(null)
   const handleVirtuosoScrollerRef = useCallback(
     (ref: HTMLElement | Window | null) => {
       virtuosoScrollerRef.current = ref as HTMLDivElement | null
@@ -1716,8 +1749,17 @@ function VirtuosoMessageList({
 
       userInteractionCleanupRef.current?.()
       userInteractionCleanupRef.current = null
+      viewportOverscanCleanupRef.current?.()
+      viewportOverscanCleanupRef.current = null
       const el = ref as HTMLElement | null
       if (el) {
+        updateViewportOverscan(el)
+        if (typeof ResizeObserver !== "undefined") {
+          const observer = new ResizeObserver(() => updateViewportOverscan(el))
+          observer.observe(el)
+          viewportOverscanCleanupRef.current = () => observer.disconnect()
+        }
+
         // Long-lived genuine-input stamp. Deliberately listens to
         // wheel/touch/keydown (real user gestures) and NOT `scroll`, so
         // Virtuoso's own programmatic scroll-into-view never trips it. This
@@ -1738,10 +1780,16 @@ function VirtuosoMessageList({
         }
       }
     },
-    [virtuosoScrollerRef, handleScrollerRef]
+    [virtuosoScrollerRef, handleScrollerRef, updateViewportOverscan]
   )
 
-  useEffect(() => () => userInteractionCleanupRef.current?.(), [])
+  useEffect(
+    () => () => {
+      userInteractionCleanupRef.current?.()
+      viewportOverscanCleanupRef.current?.()
+    },
+    []
+  )
 
   // Virtuoso's `startReached` / `endReached` observables throttle via
   // `zt(200)` and use `distinctUntilChanged` on the emitted index, which
@@ -1753,9 +1801,12 @@ function VirtuosoMessageList({
   // items of either edge. Gated on `hasSettledRef` so transient ranges
   // during the initial scroll-to-LAST don't kick off an unwanted fetch.
   const hasRangeSettledRef = useRef(false)
-  useEffect(() => {
+  const rangeSettlementKey = `${streamId}:${isJumpMode ? "jump" : "live"}`
+  const rangeSettlementKeyRef = useRef(rangeSettlementKey)
+  if (rangeSettlementKeyRef.current !== rangeSettlementKey) {
+    rangeSettlementKeyRef.current = rangeSettlementKey
     hasRangeSettledRef.current = false
-  }, [streamId])
+  }
 
   const wrappedHandleAtBottomChange = useCallback(
     (atBottom: boolean) => {
@@ -1897,10 +1948,9 @@ function VirtuosoMessageList({
       followOutput={followOutput}
       atBottomStateChange={wrappedHandleAtBottomChange}
       rangeChanged={wrappedHandleRangeChanged}
-      startReached={handleStartReached}
-      endReached={handleEndReached}
       atBottomThreshold={30}
-      increaseViewportBy={{ top: 600, bottom: 600 }}
+      increaseViewportBy={increaseViewportBy}
+      minOverscanItemCount={TIMELINE_MIN_OVERSCAN_ITEM_COUNT}
       components={components}
       {...batchPointerHandlers}
     />

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
@@ -26,11 +26,13 @@ function installManualResizeObserver(): { trigger: () => void; restore: () => vo
   }
 }
 
-function makeScrollableDiv(initial: { clientHeight: number; scrollTop?: number }) {
+function makeScrollableDiv(initial: { clientHeight: number; scrollHeight?: number; scrollTop?: number }) {
   const el = document.createElement("div")
   let scrollTop = initial.scrollTop ?? 0
   let clientHeight = initial.clientHeight
+  let scrollHeight = initial.scrollHeight ?? initial.clientHeight
   Object.defineProperty(el, "clientHeight", { configurable: true, get: () => clientHeight })
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight })
   Object.defineProperty(el, "scrollTop", {
     configurable: true,
     get: () => scrollTop,
@@ -45,6 +47,12 @@ function makeScrollableDiv(initial: { clientHeight: number; scrollTop?: number }
     },
     setClientHeight: (h: number) => {
       clientHeight = h
+    },
+    setScrollHeight: (h: number) => {
+      scrollHeight = h
+    },
+    setScrollTop: (v: number) => {
+      scrollTop = v
     },
   }
 }
@@ -72,7 +80,71 @@ function renderHookWithScroller(
   return ref as { current: HookApi }
 }
 
+function renderDynamicHook(initial: { keys: string[]; resetKey: string; skipInitialScroll?: boolean }) {
+  const ref: { current: HookApi | undefined } = { current: undefined }
+  function Probe(props: { keys: string[]; resetKey: string; skipInitialScroll?: boolean }) {
+    const api = useVirtuosoScroll({
+      itemCount: props.keys.length,
+      getItemKey: (index) => props.keys[index] ?? `missing-${index}`,
+      resetKey: props.resetKey,
+      skipInitialScroll: props.skipInitialScroll ?? false,
+    })
+    ref.current = api
+    return null
+  }
+  const view = render(<Probe {...initial} />)
+  if (!ref.current) throw new Error("Probe did not capture the hook return value")
+  return {
+    apiRef: ref as { current: HookApi },
+    rerender: (next: { keys: string[]; resetKey: string; skipInitialScroll?: boolean }) => {
+      view.rerender(<Probe {...next} />)
+      if (!ref.current) throw new Error("Probe did not capture the hook return value")
+    },
+  }
+}
+
 describe("useVirtuosoScroll", () => {
+  it("adjusts firstItemIndex by the actual leading insert count when prepend and append arrive together", () => {
+    const api = renderDynamicHook({ keys: ["a", "b"], resetKey: "stream_1" })
+    const initialFirstItemIndex = api.apiRef.current.firstItemIndex
+
+    api.rerender({ keys: ["older_1", "older_2", "a", "b", "newer_1"], resetKey: "stream_1" })
+
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex - 2)
+  })
+
+  it("adjusts firstItemIndex upward when leading items are removed", () => {
+    const api = renderDynamicHook({ keys: ["a", "b", "c", "d"], resetKey: "stream_1" })
+    const initialFirstItemIndex = api.apiRef.current.firstItemIndex
+
+    api.rerender({ keys: ["c", "d"], resetKey: "stream_1" })
+
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex + 2)
+  })
+
+  it("resets firstItemIndex synchronously when the stream key changes", () => {
+    const api = renderDynamicHook({ keys: ["a", "b"], resetKey: "stream_1" })
+    const initialFirstItemIndex = api.apiRef.current.firstItemIndex
+    api.rerender({ keys: ["older", "a", "b"], resetKey: "stream_1" })
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex - 1)
+
+    api.rerender({ keys: ["x", "y"], resetKey: "stream_2" })
+
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex)
+  })
+
+  it("does not reset firstItemIndex when skipInitialScroll changes within the same stream", () => {
+    const api = renderDynamicHook({ keys: ["a", "b"], resetKey: "stream_1" })
+    const initialFirstItemIndex = api.apiRef.current.firstItemIndex
+    api.rerender({ keys: ["older", "a", "b"], resetKey: "stream_1" })
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex - 1)
+
+    api.rerender({ keys: ["older", "a", "b"], resetKey: "stream_1", skipInitialScroll: true })
+
+    expect(api.apiRef.current.firstItemIndex).toBe(initialFirstItemIndex - 1)
+    expect(api.apiRef.current.shouldFollowOutput).toBe(false)
+  })
+
   it("does NOT keep snapping to LAST on every measurement fire during a deep-link jump", async () => {
     // Regression: deep-link to an old message. skipInitialScroll=true keeps
     // the user away from the bottom on initial render, but Virtuoso emits a
@@ -137,6 +209,50 @@ describe("useVirtuosoScroll", () => {
       await new Promise((r) => setTimeout(r, 150))
 
       expect(scrollToIndex).toHaveBeenCalledWith({ index: "LAST", align: "end", behavior: "auto" })
+    } finally {
+      restore()
+    }
+  })
+
+  it("uses actual scroll distance for the jump button instead of the overscanned rendered range", () => {
+    const { restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800, scrollHeight: 4000, scrollTop: 0 })
+      const virtuosoHandle = { scrollToIndex: vi.fn() } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 100, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      act(() => apiRef.current.handleAtBottomChange(false))
+      act(() => apiRef.current.handleRangeChanged({ startIndex: 1_000_000, endIndex: 1_000_099 }))
+
+      expect(apiRef.current.isScrolledFarFromBottom).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  it("does not run a delayed LAST snap after the user scrolls away from bottom", async () => {
+    const { trigger, restore } = installManualResizeObserver()
+    try {
+      const scrollable = makeScrollableDiv({ clientHeight: 800 })
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        scrollable.el,
+        virtuosoHandle
+      )
+
+      act(() => trigger())
+      act(() => apiRef.current.handleAtBottomChange(false))
+      await new Promise((r) => setTimeout(r, 150))
+
+      expect(scrollToIndex).not.toHaveBeenCalled()
     } finally {
       restore()
     }

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -79,31 +79,65 @@ export function useVirtuosoScroll({
   // with the old firstItemIndex for one frame.
   const firstItemIndexRef = useRef(FIRST_ITEM_INDEX)
   const prevItemCountRef = useRef(0)
-  const prevFirstKeyRef = useRef<string | null>(null)
+  const prevKeyIndexMapRef = useRef<Map<string, number>>(new Map())
+  const lastResetKeyRef = useRef(resetKey)
+  const stateResetKeyRef = useRef(resetKey)
+
+  const scrollerElRef = useRef<HTMLElement | null>(null)
 
   // Scroller element stored in state (not a ref) so the ResizeObserver effect
   // re-runs when Virtuoso mounts its scroller asynchronously (e.g. after an
   // isLoading skeleton is replaced).
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null)
 
-  // Reset all state when stream changes. Honor skipInitialScroll so deep-link
-  // navigation to a cached stream does not briefly scroll to bottom before
-  // the scrollToMessage retry loop kicks in.
-  useLayoutEffect(() => {
+  const resetKeyChanged = lastResetKeyRef.current !== resetKey
+  if (resetKeyChanged) {
+    lastResetKeyRef.current = resetKey
     firstItemIndexRef.current = FIRST_ITEM_INDEX
+    prevItemCountRef.current = 0
+    prevKeyIndexMapRef.current = new Map()
+    hasSettledRef.current = false
+    isAtBottomRef.current = !skipInitialScroll
+  }
+
+  // Reset React-visible state when the stream changes. The ref-backed virtual
+  // index state resets synchronously above so the first render for the new
+  // stream already gives Virtuoso the right firstItemIndex; doing that work in
+  // this layout effect would be one render too late and can leave the new
+  // keyed Virtuoso instance mounted with the previous stream's index base.
+  useLayoutEffect(() => {
+    if (stateResetKeyRef.current === resetKey) return
+    stateResetKeyRef.current = resetKey
     setIsScrolledFarFromBottom(false)
     isAtBottomRef.current = !skipInitialScroll
     setShouldFollowOutput(!skipInitialScroll)
-    prevItemCountRef.current = 0
-    prevFirstKeyRef.current = null
-    hasSettledRef.current = false
   }, [resetKey, skipInitialScroll])
 
-  // Detect prepends synchronously during render. This runs in the same
-  // render pass where data changes, so Virtuoso receives the updated
-  // firstItemIndex and data array together — no one-frame-late jump.
+  useLayoutEffect(() => {
+    if (!skipInitialScroll) return
+    isAtBottomRef.current = false
+    setShouldFollowOutput(false)
+  }, [skipInitialScroll])
+
+  // Detect leading insertions/removals synchronously during render. This runs
+  // in the same render pass where data changes, so Virtuoso receives the
+  // updated firstItemIndex and data array together — no one-frame-late jump.
   if (itemCount > 0) {
-    const currentFirstKey = getItemKey(0)
+    const currentKeyIndexMap = new Map<string, number>()
+    let preservedAnchor: { previousIndex: number; currentIndex: number } | null = null
+
+    for (let index = 0; index < itemCount; index++) {
+      const key = getItemKey(index)
+      currentKeyIndexMap.set(key, index)
+
+      if (preservedAnchor === null) {
+        const previousIndex = prevKeyIndexMapRef.current.get(key)
+        if (previousIndex !== undefined) {
+          preservedAnchor = { previousIndex, currentIndex: index }
+        }
+      }
+    }
+
     // When the list goes from empty to populated (e.g. mid stream-switch
     // where the previous stream's empty result was stamped as settled),
     // Virtuoso needs to run its initial scroll again. Re-arm hasSettledRef
@@ -112,17 +146,20 @@ export function useVirtuosoScroll({
     if (prevItemCountRef.current === 0) {
       hasSettledRef.current = false
     }
-    if (
-      prevItemCountRef.current > 0 &&
-      itemCount > prevItemCountRef.current &&
-      currentFirstKey !== prevFirstKeyRef.current &&
-      prevFirstKeyRef.current !== null
-    ) {
-      const prependedCount = itemCount - prevItemCountRef.current
-      firstItemIndexRef.current -= prependedCount
+
+    if (prevItemCountRef.current > 0 && preservedAnchor !== null) {
+      const indexDelta = preservedAnchor.currentIndex - preservedAnchor.previousIndex
+      if (indexDelta !== 0) {
+        firstItemIndexRef.current -= indexDelta
+      }
     }
+
     prevItemCountRef.current = itemCount
-    prevFirstKeyRef.current = currentFirstKey
+    prevKeyIndexMapRef.current = currentKeyIndexMap
+  } else if (prevItemCountRef.current !== 0) {
+    prevItemCountRef.current = 0
+    prevKeyIndexMapRef.current = new Map()
+    hasSettledRef.current = false
   }
 
   const scrollToBottom = useCallback(
@@ -165,6 +202,17 @@ export function useVirtuosoScroll({
     [itemCount]
   )
 
+  const updateScrolledFarFromBottom = useCallback(() => {
+    const el = scrollerElRef.current
+    if (!el || itemCount === 0 || !hasSettledRef.current) return false
+
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    const avgItemHeight = el.scrollHeight / itemCount
+    const thresholdPx = JUMP_TO_LATEST_ITEM_THRESHOLD * avgItemHeight
+    setIsScrolledFarFromBottom(distanceFromBottom > thresholdPx)
+    return true
+  }, [itemCount])
+
   const handleRangeChanged = useCallback(
     (range: { startIndex: number; endIndex: number }) => {
       if (itemCount === 0) return
@@ -172,11 +220,13 @@ export function useVirtuosoScroll({
       // The transient ranges that fire during the initial scroll to LAST would
       // otherwise flash the "Jump to latest" button on long streams.
       if (!hasSettledRef.current) return
+      if (updateScrolledFarFromBottom()) return
+
       const lastVirtualIndex = firstItemIndexRef.current + itemCount - 1
       const distFromEnd = lastVirtualIndex - range.endIndex
       setIsScrolledFarFromBottom(distFromEnd > JUMP_TO_LATEST_ITEM_THRESHOLD)
     },
-    [itemCount]
+    [itemCount, updateScrolledFarFromBottom]
   )
 
   // Re-anchor scroll position when the scroll container resizes (e.g. mobile
@@ -197,6 +247,7 @@ export function useVirtuosoScroll({
 
   const handleScrollerRef = useCallback((ref: HTMLElement | Window | null) => {
     const el = ref as HTMLElement | null
+    scrollerElRef.current = el
     setScrollerEl(el)
     // Apply scroll-related CSS to Virtuoso's actual scroller element (not the outer wrapper)
     if (el) {
@@ -205,6 +256,17 @@ export function useVirtuosoScroll({
       el.style.overflowAnchor = "none"
     }
   }, [])
+
+  useEffect(() => {
+    if (!scrollerEl) return
+
+    const onScroll = () => {
+      updateScrolledFarFromBottom()
+    }
+
+    scrollerEl.addEventListener("scroll", onScroll, { passive: true })
+    return () => scrollerEl.removeEventListener("scroll", onScroll)
+  }, [scrollerEl, updateScrolledFarFromBottom])
 
   useEffect(() => {
     if (!scrollerEl) return
@@ -237,6 +299,7 @@ export function useVirtuosoScroll({
 
       window.clearTimeout(resizeTimerRef.current)
       resizeTimerRef.current = window.setTimeout(() => {
+        if (!isAtBottomRef.current) return
         virtuosoRef.current?.scrollToIndex({
           index: "LAST",
           align: "end",
@@ -254,7 +317,7 @@ export function useVirtuosoScroll({
 
   const resetPrependState = useCallback(() => {
     prevItemCountRef.current = 0
-    prevFirstKeyRef.current = null
+    prevKeyIndexMapRef.current = new Map()
   }, [])
 
   const initialTopMostItemIndex =
@@ -264,8 +327,8 @@ export function useVirtuosoScroll({
     virtuosoRef,
     firstItemIndex: firstItemIndexRef.current,
     initialTopMostItemIndex,
-    isScrolledFarFromBottom,
-    shouldFollowOutput,
+    isScrolledFarFromBottom: resetKeyChanged ? false : isScrolledFarFromBottom,
+    shouldFollowOutput: resetKeyChanged ? !skipInitialScroll : shouldFollowOutput,
     scrollToBottom,
     disableAutoScroll,
     handleAtBottomChange,


### PR DESCRIPTION
## Problem

The stream timeline has accumulated several virtualization jank issues:

1. **Jump-to-latest button disappears or behaves incorrectly** when overscan renders bottom rows while they are still physically offscreen — the old rendered-range heuristic gives a false "at bottom" signal.
2. **Direct `startReached`/`endReached` callbacks** fire during programmatic/deep-link scroll and bypass existing guards, triggering unwanted pagination during jump convergence.
3. **Jump-window replacement vs. incremental prepend**: When a deep-link or search jump swaps the entire event window, the prepend-anchoring logic can misclassify the replacement as history pagination, causing a one-frame anchor jump.
4. **Zero-height virtual rows** (destination-side `messages:moved`, invalid `command_group` without `command_dispatched`) get measured at 0px, causing subsequent items to overlap at the same Y position.
5. **Insufficient pre-render/overscan** on Firefox makes rows pop in only after their leading edge crosses the viewport.

## Solution

### Key-preserving `firstItemIndex` anchoring

`useVirtuosoScroll` now tracks a key-to-index map across renders and adjusts `firstItemIndex` based on the first preserved item. Handles prepend, append, prepend+append, and leading removals without a one-frame mismatch.

### Guarded edge pagination

Removed direct `startReached`/`endReached` props; pagination runs through the existing guarded `rangeChanged` path. Range settlement state re-keys on stream+mode changes so jump windows get a clean state.

### Dynamic overscan with viewport tracking

Pre-renders at least one viewport of content above/below the visible range, tracked via `ResizeObserver`. Replaces the previous static 600px overscan.

### Pixel-distance bottom detection

Jump-to-latest computes distance from actual scroll pixels (`scrollHeight - scrollTop - clientHeight`) instead of Virtuoso's rendered range, so overscan never tricks it into hiding the button.

### Zero-height row filtering

Filters invalid command groups and destination-side `messages:moved` rows before computing virtualizer count/keys, preventing zero-height overlap.

## Key design decisions

**1. Key-preserving index adjustment over count-only delta**

Count-only prepend detection fails when prepends and appends happen together or when leading rows are removed. A key-preserving anchor matches how the user perceives continuity: the same row should stay at the same pixel position.

**2. RangeChanged-only pagination over direct edge callbacks**

Direct callbacks can fire during programmatic/deep-link scrolling and bypass existing guards. `rangeChanged` lets the component gate pagination on settled range state and scroll-abort state.

**3. Pixel-distance bottom detection over rendered-range heuristics**

Overscan intentionally renders rows outside the viewport, so rendered range is no longer a reliable proxy for whether the user can see the bottom.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-virtuoso-scroll.ts` | Key-preserving anchor, pixel-distance bottom detection, reset handling |
| `apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx` | 118 lines of regression tests |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Guarded edge pagination, dynamic overscan, jump-window reset |
| `apps/frontend/src/components/timeline/event-list.tsx` | Zero-height row filtering |
| `apps/frontend/src/components/timeline/event-list.test.ts` | Filter regression tests |

## Test plan

- [x] Virtual index anchoring across prepend/append/removal/reset
- [x] Bottom-button visibility under overscan
- [x] Jump-to-latest with skip-initial-scroll
- [x] Zero-height row filtering
- [x] Stream-content scroll/deep-link behavior
- [x] Full frontend typecheck and lint pass
- [x] Monorepo-wide typecheck and lint pass (via commit hooks)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->