### PR TITLE
fix: coordinate offline stream initial load

### DIFF
--- a/.claude/plans/speed-up-loading.md
+++ b/.claude/plans/speed-up-loading.md
@@ -1,0 +1,85 @@
+# Offline-First Coordinated Stream Loading
+
+## Goal
+
+Restore the initial stream-view loading contract after the virtual scroller changes: when IndexedDB already has stream messages, the app shell and stream timeline should stay hidden during the short coordinated blank phase, then reveal together from local data without waiting for a remote stream bootstrap. The stream should not show an intermediate blank viewport or a premature "Jump to latest" control before timeline rows are renderable.
+
+## What Was Built
+
+### Local stream event readiness for the coordinated gate
+
+The coordinated loading provider now observes the visible stream IDs' IndexedDB event rows directly. A resolved local event read with cached events is enough to bypass pending remote bootstrap; an unresolved read is treated as "not done", not as "no data".
+
+**Files:**
+- `apps/frontend/src/contexts/use-visible-stream-events-snapshot.ts` — `useLiveQuery` helper that reads event counts for visible stream IDs from IndexedDB via the existing `loadStreamEvents` path.
+- `apps/frontend/src/contexts/coordinated-loading-context.tsx` — folds local event readiness into the initial gate and debug state.
+
+### Mounted-but-hidden shell/content coordination
+
+The app shell and main content now remain mounted while hidden during the initial blank/skeleton phases. This lets the stream view's own IndexedDB reads and virtualizer setup run in parallel with workspace/sidebar reads, instead of starting only after the provider declares ready.
+
+**Files:**
+- `apps/frontend/src/contexts/coordinated-loading-context.tsx` — `CoordinatedLoadingGate` uses hidden/inert wrapping instead of unmounting; `MainContentGate` overlays the skeleton while keeping children mounted.
+
+### Stream-content readiness reporting
+
+The stream content reports when its own timeline data path has resolved and, for virtualized timelines, when Virtuoso has produced an item range. The provider waits for this signal before leaving the initial coordinated phase, so the shell does not reveal while the stream's separate `useLiveQuery` or virtualizer is still blank.
+
+**Files:**
+- `apps/frontend/src/contexts/coordinated-loading-context.tsx` — adds `reportStreamContentReady` and waits for visible server stream IDs.
+- `apps/frontend/src/components/timeline/stream-content.tsx` — reports readiness after IDB/events resolve and the virtualized range has rendered.
+
+### Premature Jump-to-latest suppression
+
+The Jump-to-latest affordance is hidden until there are renderable timeline items and the virtualized list has produced a range. This prevents the button from appearing over a blank stream during the virtualizer's initial mount/reveal window.
+
+**Files:**
+- `apps/frontend/src/components/timeline/stream-content.tsx` — gates the button on renderable items and virtualizer readiness.
+
+## Design Decisions
+
+### Keep IndexedDB as the source of truth
+
+**Chose:** Read local stream readiness from IndexedDB and reuse the existing `loadStreamEvents` path.
+
+**Why:** The bug is a coordination/order issue, not an IDB performance issue. Adding an in-memory event cache would hide the underlying race and duplicate the local read model.
+
+**Alternatives considered:** Reintroducing a stream event memory cache. Rejected because the requirement is offline-first IndexedDB, and the repo had already removed that cache.
+
+### Coordinate on the stream's actual render path
+
+**Chose:** Add a readiness report from mounted `StreamContent` back to the provider.
+
+**Why:** A provider-level IDB query can prove messages exist, but the timeline's own `useLiveQuery` and Virtuoso mount can still be unresolved for a frame. Waiting for the child render path prevents the second blank phase.
+
+**Alternatives considered:** Trust only the provider's local event count. Rejected after retesting showed the stream could still reveal before its own query/virtualizer was ready.
+
+### Hide rather than unmount during the blank phase
+
+**Chose:** Keep children mounted with `visibility: hidden`, `aria-hidden`, and `inert` during the initial blank phase.
+
+**Why:** Unmounting prevents nested IDB live queries from starting. Hidden-but-mounted preserves the desired blank UI while allowing local reads and virtualizer measurement to complete.
+
+## Design Evolution
+
+- **Provider-only readiness was insufficient:** The first fix let the provider bypass remote bootstrap when it saw local event rows. Manual retesting showed the stream could still reveal before `StreamContent`'s own live query and virtualizer finished. The final approach additionally waits for stream-content readiness.
+- **Jump button needed render readiness:** Hiding the Jump-to-latest button only when `visibleItems.length === 0` was not enough; it can be non-empty while Virtuoso is still mounting. The final guard waits for the virtualizer's range callback.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No in-memory stream event cache.
+- No changes to server bootstrap APIs.
+- No react-virtuoso package or patch changes.
+- No broad refactor of the timeline data model.
+
+## Status
+
+- [x] Treat unresolved local stream event reads as not done.
+- [x] Let app shell and stream content mount hidden so local reads run together.
+- [x] Wait for stream content/virtualizer readiness before coordinated reveal.
+- [x] Hide Jump-to-latest until timeline rows are renderable.
+- [x] Add regression tests for coordinated loading readiness.

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -159,6 +159,7 @@ export function StreamContent({
   const [, setSearchParams] = useSearchParams()
   const location = useLocation()
   const socket = useSocket()
+  const { reportStreamContentReady } = useCoordinatedLoading()
   const messageService = useMessageService()
   // Tracks the location key we've already handled for a highlight jump. Using
   // the key (not the message id) lets re-clicking the same message link
@@ -696,6 +697,13 @@ export function StreamContent({
     () => (useVirtualized ? filterVisibleItems(timelineItems, isChannel, streamId) : timelineItems),
     [timelineItems, useVirtualized, isChannel, streamId]
   )
+  const [virtualizedTimelineReady, setVirtualizedTimelineReady] = useState(false)
+  useEffect(() => {
+    setVirtualizedTimelineReady(false)
+  }, [streamId])
+  const handleVirtualizedItemsRendered = useCallback(() => {
+    setVirtualizedTimelineReady(true)
+  }, [])
 
   // Mirror of `visibleItems` for the long-lived scrollToMessage retry loop:
   // its closure is created once per scroll but runs for up to ~1.2s, during
@@ -773,6 +781,8 @@ export function StreamContent({
   const isScrolledFarFromBottom = useVirtualized ? virtualIsScrolledFar : plainIsScrolledFar
   const scrollToBottom = useVirtualized ? virtualScrollToBottom : plainScrollToBottom
   const disableAutoScroll = useVirtualized ? virtualDisableAutoScroll : plainDisableAutoScroll
+  const hasRenderableTimelineItems = visibleItems.length > 0
+  const jumpControlsReady = !useVirtualized || virtualizedTimelineReady
 
   // Scroll to a specific message and keep re-scrolling until the target
   // element is actually visible in the scroller viewport. Items rendered
@@ -1211,21 +1221,6 @@ export function StreamContent({
     }
   }, [isJumpMode, exitJumpMode, resetPrependState, scrollToBottom])
 
-  if (error && !isDraft && events.length === 0 && !idbStream) {
-    return (
-      <ErrorView
-        className="h-full border-0"
-        title="Failed to Load Messages"
-        description="We couldn't load the messages for this stream. Please refresh the page or try again later."
-      />
-    )
-  }
-
-  const editLastMessageCtxWithScroll = useMemo(
-    () => ({ ...editLastMessageCtx, scrollToMessage }),
-    [editLastMessageCtx, scrollToMessage]
-  )
-
   // Deep-link (?m=) mount hold. On a push-notification / Activities deep link
   // the latest window loads first; the jump effect then fetches the window
   // around the target and swaps `events` wholesale. react-virtuoso only
@@ -1255,6 +1250,32 @@ export function StreamContent({
     prevHoldForDeepLinkRef.current = holdForDeepLink
     deepLinkDebug("holdForDeepLink ->", holdForDeepLink, "for", highlightMessageId)
   }
+
+  const hasResolvedDraftEvents = !isDraft || draftPendingEvents !== undefined
+  const hasResolvedTimeline = isConfirmedEmpty || events.length > 0
+  const virtualizedRenderReady = !useVirtualized || visibleItems.length === 0 || virtualizedTimelineReady
+  const streamContentReadyForCoordination = isDraft
+    ? hasResolvedDraftEvents
+    : !isLoading && !holdForDeepLink && hasResolvedTimeline && virtualizedRenderReady
+
+  useEffect(() => {
+    reportStreamContentReady(streamId, streamContentReadyForCoordination)
+  }, [reportStreamContentReady, streamId, streamContentReadyForCoordination])
+
+  if (error && !isDraft && events.length === 0 && !idbStream) {
+    return (
+      <ErrorView
+        className="h-full border-0"
+        title="Failed to Load Messages"
+        description="We couldn't load the messages for this stream. Please refresh the page or try again later."
+      />
+    )
+  }
+
+  const editLastMessageCtxWithScroll = useMemo(
+    () => ({ ...editLastMessageCtx, scrollToMessage }),
+    [editLastMessageCtx, scrollToMessage]
+  )
 
   return (
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
@@ -1328,6 +1349,7 @@ export function StreamContent({
                     isSearchOpen={isSearchOpen}
                     batch={batchState}
                     batchPointerHandlers={batchPointerHandlers}
+                    onItemsRendered={handleVirtualizedItemsRendered}
                   />
                   {/* Overlay loading indicators — absolutely positioned so they
                     don't cause layout shift when prepending older messages. */}
@@ -1408,7 +1430,7 @@ export function StreamContent({
             </div>
             {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
               Positioned above the floating composer pill. */}
-            {(isJumpMode || isScrolledFarFromBottom) && (
+            {hasRenderableTimelineItems && jumpControlsReady && (isJumpMode || isScrolledFarFromBottom) && (
               <div
                 className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
                 style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
@@ -1545,6 +1567,7 @@ function VirtuosoMessageList({
   isSearchOpen,
   batch,
   batchPointerHandlers,
+  onItemsRendered,
 }: {
   visibleItems: TimelineItem[]
   isLoading: boolean
@@ -1589,6 +1612,7 @@ function VirtuosoMessageList({
   isSearchOpen: boolean
   batch?: BatchTimelineState
   batchPointerHandlers?: React.HTMLAttributes<HTMLElement>
+  onItemsRendered: () => void
 }) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
@@ -1826,6 +1850,7 @@ function VirtuosoMessageList({
   const wrappedHandleRangeChanged = useCallback(
     (range: { startIndex: number; endIndex: number }) => {
       handleRangeChanged(range)
+      if (visibleItems.length > 0) onItemsRendered()
       if (!hasRangeSettledRef.current || visibleItems.length === 0) return
       // A scrollToMessage refine loop is in flight: its programmatic
       // scroll-into-view sweeps the (viewport-inflated) range across the
@@ -1841,7 +1866,7 @@ function VirtuosoMessageList({
       const distFromEnd = lastVirtualIndex - range.endIndex
       if (distFromEnd <= 3) handleEndReached()
     },
-    [handleRangeChanged, firstItemIndex, visibleItems.length, handleStartReached, handleEndReached]
+    [handleRangeChanged, firstItemIndex, visibleItems.length, handleStartReached, handleEndReached, onItemsRendered]
   )
 
   // Virtuoso positions items absolutely inside its scroller, so plain CSS

--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, act } from "@testing-library/react"
 import {
@@ -14,6 +15,7 @@ import * as usePreloadImagesModule from "@/hooks/use-preload-images"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as draftStoreModule from "@/stores/draft-store"
 import * as loadingComponentsModule from "@/components/loading"
+import * as visibleStreamEventsModule from "./use-visible-stream-events-snapshot"
 
 type MockQueryResult = {
   status: "pending" | "success" | "error"
@@ -39,6 +41,9 @@ let mockBots: Array<{ id: string }> = []
 let mockUnreadState: { id: string } | undefined
 let mockMetadata: { id: string } | undefined
 let mockHasSeededDraftCache = false
+let mockLocalStreamEventsResolved = true
+let mockLocalStreamEventCounts: Record<string, number> = { stream_1: 1 }
+let mockStreamContentReady = true
 let mockSyncStatuses = new Map<string, string>()
 let mockSyncErrors = new Map<string, { status: number | null; error: Error }>()
 
@@ -98,10 +103,27 @@ function installSpies() {
   vi.spyOn(loadingComponentsModule, "StreamContentSkeleton").mockImplementation(() => (
     <div data-testid="stream-content-skeleton">Stream Content Skeleton</div>
   ))
+  vi.spyOn(visibleStreamEventsModule, "useVisibleStreamEventsSnapshot").mockImplementation((workspaceId, streamIds) => {
+    if (!mockLocalStreamEventsResolved) return undefined
+    return {
+      key: `${workspaceId}\u0000${streamIds.join("\u0000")}`,
+      eventCounts: mockLocalStreamEventCounts,
+    }
+  })
+}
+
+function useMockStreamContentReady() {
+  const { reportStreamContentReady } = useCoordinatedLoading()
+
+  useEffect(() => {
+    reportStreamContentReady("stream_1", mockStreamContentReady)
+  }, [reportStreamContentReady])
 }
 
 function TestConsumer() {
   const { phase, getStreamState, hasErrors, showLoadingIndicator } = useCoordinatedLoading()
+  useMockStreamContentReady()
+
   return (
     <div>
       <span data-testid="phase">{phase}</span>
@@ -110,6 +132,11 @@ function TestConsumer() {
       <span data-testid="show-loading-indicator">{String(showLoadingIndicator)}</span>
     </div>
   )
+}
+
+function ReadyContent() {
+  useMockStreamContentReady()
+  return <div data-testid="content">Actual Content</div>
 }
 
 async function flushEffects() {
@@ -150,6 +177,9 @@ describe("CoordinatedLoadingProvider", () => {
     mockUnreadState = undefined
     mockMetadata = undefined
     mockHasSeededDraftCache = false
+    mockLocalStreamEventsResolved = true
+    mockLocalStreamEventCounts = { stream_1: 1 }
+    mockStreamContentReady = true
     mockSyncStatuses = new Map()
     mockSyncErrors = new Map()
     installSpies()
@@ -193,7 +223,7 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("phase").textContent).toBe("skeleton")
   })
 
-  it("is ready when IDB is primed and stream record exists (no per-stream cache needed)", async () => {
+  it("is ready when IDB is primed and visible stream events are locally resolved", async () => {
     mockSeedCacheFromIdbResult = true
     mockHasSeededWorkspaceCache = true
     mockHasSeededDraftCache = true
@@ -211,8 +241,56 @@ describe("CoordinatedLoadingProvider", () => {
 
     await flushEffects()
 
-    // IDB primed + stream record exists = ready (useLiveQuery serves events from IDB)
+    // IDB primed + local stream events = ready (useLiveQuery serves events from IDB)
     expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("bypasses pending stream bootstrap when local stream events are available", async () => {
+    makeReadyWorkspaceState()
+    mockStreamsLoadState = QUERY_LOAD_STATE.FETCHING
+    mockStreamResults = [{ status: "pending", fetchStatus: "fetching", isLoading: true, isError: false, error: null }]
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("keeps the initial gate loading while the local stream event read is unresolved", async () => {
+    makeReadyWorkspaceState()
+    mockStreamsLoadState = QUERY_LOAD_STATE.FETCHING
+    mockStreamResults = [{ status: "pending", fetchStatus: "fetching", isLoading: true, isError: false, error: null }]
+    mockLocalStreamEventsResolved = false
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("loading")
+  })
+
+  it("waits for mounted stream content readiness before becoming ready", async () => {
+    makeReadyWorkspaceState()
+    mockStreamContentReady = false
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("loading")
   })
 
   it("waits for workspace metadata before becoming ready", async () => {
@@ -439,6 +517,9 @@ describe("CoordinatedLoadingGate", () => {
     mockStreams = []
     mockUnreadState = undefined
     mockMetadata = undefined
+    mockLocalStreamEventsResolved = true
+    mockLocalStreamEventCounts = { stream_1: 1 }
+    mockStreamContentReady = true
     installSpies()
   })
 
@@ -447,7 +528,7 @@ describe("CoordinatedLoadingGate", () => {
     vi.clearAllMocks()
   })
 
-  it("shows nothing during the blank loading phase", async () => {
+  it("keeps children mounted but hidden during the blank loading phase", async () => {
     render(
       <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
         <CoordinatedLoadingGate>
@@ -458,7 +539,7 @@ describe("CoordinatedLoadingGate", () => {
 
     await flushEffects()
 
-    expect(screen.queryByTestId("content")).not.toBeInTheDocument()
+    expect(screen.getByTestId("content").closest('[aria-hidden="true"]')).not.toBeNull()
   })
 
   it("renders children during the skeleton phase", async () => {
@@ -509,6 +590,9 @@ describe("MainContentGate", () => {
     mockStreams = []
     mockUnreadState = undefined
     mockMetadata = undefined
+    mockLocalStreamEventsResolved = true
+    mockLocalStreamEventCounts = { stream_1: 1 }
+    mockStreamContentReady = true
     installSpies()
   })
 
@@ -529,7 +613,7 @@ describe("MainContentGate", () => {
     await flushEffects()
 
     expect(screen.getByTestId("stream-content-skeleton")).toBeInTheDocument()
-    expect(screen.queryByTestId("content")).not.toBeInTheDocument()
+    expect(screen.getByTestId("content").closest('[aria-hidden="true"]')).not.toBeNull()
   })
 
   it("shows children once the coordinated load is ready", async () => {
@@ -538,7 +622,7 @@ describe("MainContentGate", () => {
     render(
       <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
         <MainContentGate>
-          <div data-testid="content">Actual Content</div>
+          <ReadyContent />
         </MainContentGate>
       </CoordinatedLoadingProvider>
     )

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useMemo, useRef, type ReactNode } from "react"
+import { createContext, useContext, useState, useEffect, useMemo, useRef, useCallback, type ReactNode } from "react"
 import { usePreloadImages } from "@/hooks/use-preload-images"
 import { useCoordinatedStreamQueries } from "@/hooks/use-coordinated-stream-queries"
 import {
@@ -15,6 +15,7 @@ import {
   useWorkspaceUsers,
 } from "@/stores/workspace-store"
 import { hasSeededDraftCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { useVisibleStreamEventsSnapshot } from "./use-visible-stream-events-snapshot"
 import { useSyncSnapshot, useSyncStatus } from "@/sync/sync-status"
 import { debugBootstrap, isBootstrapDebugEnabled } from "@/lib/bootstrap-debug"
 import {
@@ -65,6 +66,9 @@ interface CoordinatedLoadingContextValue {
 
   /** True when loading indicator should be visible (after delay, same as skeleton) */
   showLoadingIndicator: boolean
+
+  /** Report when the mounted stream content has resolved its own local read/render path. */
+  reportStreamContentReady: (streamId: string, ready: boolean) => void
 }
 
 const CoordinatedLoadingContext = createContext<CoordinatedLoadingContextValue | null>(null)
@@ -97,11 +101,19 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   const loadingIndicatorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hideIndicatorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loggedSuppressedStreamErrorsRef = useRef(new Set<string>())
+  const [streamContentReady, setStreamContentReady] = useState<Record<string, boolean>>({})
 
-  // Prime the in-memory cache from IndexedDB on mount. If IDB has workspace
-  // data from a previous session, this populates the cache so store hooks
-  // return real data on their first synchronous render. When successful, the
-  // gate bypasses network wait — IDB IS the source of truth.
+  const reportStreamContentReady = useCallback((streamId: string, ready: boolean) => {
+    setStreamContentReady((current) => {
+      if (current[streamId] === ready) return current
+      return { ...current, [streamId]: ready }
+    })
+  }, [])
+
+  // Prime the existing workspace store seed from IndexedDB on mount. If IDB
+  // has workspace data from a previous session, store hooks can return it on
+  // their first render. When successful, the gate can bypass network wait —
+  // IDB IS the source of truth.
   useEffect(() => {
     let cancelled = false
     seedCacheFromIdb(workspaceId).then((hasData) => {
@@ -133,6 +145,8 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
     () => streamIds.filter((id) => !id.startsWith("draft_") && !id.startsWith("draft:")),
     [streamIds]
   )
+  const localEventStreamIds = useMemo(() => Array.from(new Set(serverStreamIds)), [serverStreamIds])
+  const localStreamEvents = useVisibleStreamEventsSnapshot(workspaceId, localEventStreamIds)
 
   // When bypassing via IDB cache, verify the data is actually populated —
   // don't just trust the loading flags. usePreloadImages resolves immediately
@@ -157,24 +171,34 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
         const result = results[index]
         const cachedStream = streamById.get(streamId)
         const hasStreamRecord = !!cachedStream || result?.data?.stream?.id === streamId
-        // IDB is the source of truth — if the workspace was primed from IDB,
-        // stream events are there and useLiveQuery will serve them. Otherwise
-        // wait for the bootstrap query to resolve.
-        const hasUsableLocalData = hasStreamRecord && (idbCachePrimed || result?.data !== undefined)
+        const localEventCount = localStreamEvents?.eventCounts[streamId]
+        const localEventsResolved = localEventCount !== undefined
+        const hasLocalEvents = (localEventCount ?? 0) > 0
+        // IDB is the source of truth: cached stream events are enough to show
+        // the timeline without waiting for a remote bootstrap. An unresolved
+        // local event read is still "not done" (not "no data"), so the gate
+        // stays in its coordinated blank/skeleton phase instead of revealing a
+        // second blank stream area.
+        const hasUsableLocalData = hasStreamRecord && (result?.data !== undefined || hasLocalEvents)
         return {
           streamId,
           result,
           hasStreamRecord,
+          localEventsResolved,
+          localEventCount,
           hasUsableLocalData,
           suppressError: shouldSuppressBootstrapError(result?.error, hasUsableLocalData),
         }
       }),
-    [results, serverStreamIds, streamById, idbCachePrimed]
+    [results, serverStreamIds, streamById, localStreamEvents]
   )
   const visibleStreamIdsReady = streamQueryStates.every((state) => state.hasUsableLocalData)
-  const canBypassVisibleStreamNetwork = idbCachePrimed && visibleStreamIdsReady
+  const visibleStreamEventsResolved = localStreamEvents !== undefined
+  const visibleStreamContentReady = serverStreamIds.every((streamId) => streamContentReady[streamId] === true)
+  const canBypassVisibleStreamNetwork = idbCachePrimed && visibleStreamEventsResolved && visibleStreamIdsReady
   const workspaceLoading = !workspaceDataReady && workspaceSyncStatus !== "error"
   const streamsLoading = !canBypassVisibleStreamNetwork && isQueryLoadStateLoading(streamsLoadState)
+  const streamContentLoading = !visibleStreamContentReady
   const draftsLoading = !draftDataReady
   const suppressedStreamErrors = useMemo(
     () => streamQueryStates.filter((state) => state.suppressError && state.result?.error),
@@ -192,7 +216,11 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   // (triggered by navigating to a new stream) should not re-trigger the
   // top-bar loading indicator. Individual stream loading is handled by
   // EventList's skeleton/loading state within the stream content area.
-  const isLoading = workspaceLoading || (!isReady && streamsLoading) || draftsLoading || (isReady && isAnySyncing)
+  const isLoading =
+    workspaceLoading ||
+    (!isReady && (streamsLoading || streamContentLoading)) ||
+    draftsLoading ||
+    (isReady && isAnySyncing)
 
   if (isBootstrapDebugEnabled()) {
     debugBootstrap("Coordinated loading state", {
@@ -207,6 +235,14 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       workspaceDataReady,
       draftDataReady,
       visibleStreamIdsReady,
+      visibleStreamEventsResolved,
+      visibleStreamContentReady,
+      streamContentReady,
+      localStreamEventCounts: streamQueryStates.map((state) => ({
+        streamId: state.streamId,
+        resolved: state.localEventsResolved,
+        count: state.localEventCount ?? null,
+      })),
       suppressedStreamErrors: suppressedStreamErrors.map((state) => ({
         streamId: state.streamId,
         message: state.result?.error?.message ?? "unknown error",
@@ -222,6 +258,7 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       hasMetadata: idbMetadata !== undefined,
       workspaceLoading,
       streamsLoading,
+      streamContentLoading,
       draftsLoading,
       isAnySyncing,
       isLoading,
@@ -388,8 +425,16 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   const hasErrors = streamErrors.length > 0
 
   const value = useMemo<CoordinatedLoadingContextValue>(
-    () => ({ phase, hasErrors, getStreamState, getStreamError, isLoading, showLoadingIndicator }),
-    [phase, hasErrors, getStreamState, getStreamError, isLoading, showLoadingIndicator]
+    () => ({
+      phase,
+      hasErrors,
+      getStreamState,
+      getStreamError,
+      isLoading,
+      showLoadingIndicator,
+      reportStreamContentReady,
+    }),
+    [phase, hasErrors, getStreamState, getStreamError, isLoading, showLoadingIndicator, reportStreamContentReady]
   )
 
   return <CoordinatedLoadingContext.Provider value={value}>{children}</CoordinatedLoadingContext.Provider>
@@ -408,32 +453,45 @@ interface CoordinatedLoadingGateProps {
 }
 
 /**
- * Gate component that shows nothing during the "loading" phase (first ~300ms),
- * then renders children. Only applies during initial load.
+ * Gate component that shows nothing during the "loading" phase (first ~300ms).
+ * Children stay mounted while hidden so their IndexedDB live queries can resolve
+ * before the coordinated gate reveals the app shell.
  */
 export function CoordinatedLoadingGate({ children }: CoordinatedLoadingGateProps) {
   const { phase } = useCoordinatedLoading()
+  const hidden = phase === "loading"
 
-  if (phase === "loading") {
-    return null
-  }
-
-  return <>{children}</>
+  return (
+    <div className={hidden ? "invisible" : undefined} aria-hidden={hidden || undefined} inert={hidden || undefined}>
+      {children}
+    </div>
+  )
 }
 
 /**
  * Gate for the main content area (Outlet).
- * Shows skeleton during initial load, then renders children.
+ * Shows skeleton during initial load while keeping children mounted but hidden,
+ * so stream-level IndexedDB reads run in parallel with the app shell reads.
  * Individual stream components handle their own loading states after that.
  */
 export function MainContentGate({ children }: CoordinatedLoadingGateProps) {
   const { phase, hasErrors } = useCoordinatedLoading()
+  const gated = phase !== "ready" && !hasErrors
 
-  // During initial load, show skeleton
-  // Exception: if there are errors, render children so error pages can display
-  if (phase !== "ready" && !hasErrors) {
-    return <StreamContentSkeleton />
-  }
-
-  return <>{children}</>
+  return (
+    <div className="relative flex-1 overflow-hidden">
+      <div
+        className={gated ? "invisible h-full" : "h-full"}
+        aria-hidden={gated || undefined}
+        inert={gated || undefined}
+      >
+        {children}
+      </div>
+      {gated && (
+        <div className="absolute inset-0">
+          <StreamContentSkeleton />
+        </div>
+      )}
+    </div>
+  )
 }

--- a/apps/frontend/src/contexts/use-visible-stream-events-snapshot.ts
+++ b/apps/frontend/src/contexts/use-visible-stream-events-snapshot.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react"
+import { useLiveQuery } from "dexie-react-hooks"
+import { loadStreamEvents } from "@/stores/stream-store"
+
+export interface VisibleStreamEventsSnapshot {
+  key: string
+  eventCounts: Record<string, number>
+}
+
+function makeVisibleStreamEventsKey(workspaceId: string, streamIds: string[]): string {
+  return `${workspaceId}\u0000${streamIds.join("\u0000")}`
+}
+
+export function useVisibleStreamEventsSnapshot(
+  workspaceId: string,
+  streamIds: string[]
+): VisibleStreamEventsSnapshot | undefined {
+  const snapshotKey = useMemo(() => makeVisibleStreamEventsKey(workspaceId, streamIds), [workspaceId, streamIds])
+  const initialValue = useMemo<VisibleStreamEventsSnapshot | undefined>(
+    () => (streamIds.length === 0 ? { key: snapshotKey, eventCounts: {} } : undefined),
+    [snapshotKey, streamIds.length]
+  )
+
+  const snapshot = useLiveQuery(
+    async () => {
+      const entries = await Promise.all(
+        streamIds.map(async (streamId) => {
+          const events = await loadStreamEvents(streamId, null)
+          return [streamId, events.length] as const
+        })
+      )
+
+      return { key: snapshotKey, eventCounts: Object.fromEntries(entries) }
+    },
+    [snapshotKey],
+    initialValue
+  )
+
+  return snapshot?.key === snapshotKey ? snapshot : undefined
+}


### PR DESCRIPTION
## Problem

Initial stream loads regressed after the virtual scroller work. When IndexedDB already has messages, the app shell can become visible before the stream timeline's own IndexedDB read and Virtuoso mount have resolved. That causes a visible sequence of blank/skeleton/blank states, and the Jump to latest button can appear over an otherwise blank stream.

The intended behavior is offline-first coordinated loading: if local IndexedDB has stream messages, the shell and stream content should reveal together without waiting on remote bootstrap. An unresolved `useLiveQuery` result must mean "not done yet", not "no local data".

## Solution

Coordinate the initial gate on both local event availability and the stream content's actual render readiness:

### How it works

1. `CoordinatedLoadingProvider` observes visible stream IDs through an IndexedDB-backed local event snapshot.
2. A stream bootstrap can be bypassed only when local stream events have resolved with cached events.
3. The app shell and outlet remain mounted but hidden during the blank/skeleton phases so nested stream `useLiveQuery` calls and Virtuoso setup can start immediately.
4. `StreamContent` reports readiness once its own timeline data path has resolved and, for virtualized streams, Virtuoso has produced an item range.
5. Jump to latest is suppressed until timeline items are renderable and the virtualizer is ready.

### Key design decisions

**1. Keep IndexedDB as the source of truth**

No in-memory event cache was added. The new local readiness hook reuses the existing `loadStreamEvents` IndexedDB path and treats unresolved reads as still loading.

**2. Wait for the child render path, not just provider-local data**

A provider-level IDB query can prove messages exist, but the timeline's own `useLiveQuery` and virtualizer can still be unresolved. The provider now waits for `StreamContent` to report that its actual render path is ready before revealing.

**3. Hide instead of unmount during coordinated loading**

The gates use hidden/inert wrappers during initial loading so local reads and Virtuoso measurement happen in parallel while preserving the blank first phase.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/speed-up-loading.md` | Review plan describing the coordinated loading fix and constraints. |
| `apps/frontend/src/contexts/use-visible-stream-events-snapshot.ts` | IndexedDB-backed visible stream event readiness hook. |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/contexts/coordinated-loading-context.tsx` | Waits on local stream events plus mounted stream content readiness; keeps gates mounted but hidden. |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Reports timeline/virtualizer readiness and suppresses premature Jump to latest. |
| `apps/frontend/src/contexts/coordinated-loading-context.test.tsx` | Adds regression coverage for local event readiness, unresolved reads, mounted content readiness, and hidden-but-mounted gates. |

## Deleted files

None.

## Test plan

- [x] `bun run --cwd apps/frontend test -- contexts/coordinated-loading-context.test.tsx hooks/use-events.test.ts hooks/use-coordinated-stream-queries.test.ts hooks/use-virtuoso-scroll.test.tsx components/timeline/stream-content.test.ts`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun run --cwd apps/frontend lint -- src/contexts/coordinated-loading-context.tsx src/contexts/coordinated-loading-context.test.tsx src/contexts/use-visible-stream-events-snapshot.ts src/components/timeline/stream-content.tsx`
- [x] Pre-commit hook: full lint, full monorepo typecheck, OpenAPI check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->