### PR TITLE
Collapse markdown blocks by measured line height, not newline count

### DIFF
--- a/apps/frontend/src/lib/markdown/blockquote-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/blockquote-block.test.tsx
@@ -7,11 +7,16 @@ import { BlockquoteBlock } from "./blockquote-block"
 import { MarkdownBlockProvider, composeBlockCollapseKey, hashMarkdownBlock } from "./markdown-block-context"
 import { hydrateCollapseCache } from "./collapse-cache"
 import * as preferencesModule from "@/contexts/preferences-context"
+import * as lineMeasureModule from "./use-measured-line-count"
 
 // Stubbable preferences mock — each test can override via `currentPrefs`.
 let currentPrefs: { blockquoteCollapseThreshold?: number } | null = {
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
 }
+
+// JSDOM can't lay out text, so the rendered-height measurement is driven from
+// a mutable the test controls (short vs long → chrome / no chrome).
+let measure: lineMeasureModule.MeasuredLines = { lineCount: 1, lineHeightPx: 22 }
 
 function buildPreferencesContext() {
   if (!currentPrefs) return null
@@ -35,6 +40,12 @@ function renderBlockquote(children: React.ReactNode, messageId = "msg_quote") {
   )
 }
 
+/** Inline `max-height` clamp the collapsed body carries, if any. */
+function clampStyle(): string | undefined {
+  const el = document.querySelector<HTMLElement>('[style*="max-height"]')
+  return el?.style.maxHeight || undefined
+}
+
 describe("BlockquoteBlock collapse behavior", () => {
   beforeEach(async () => {
     vi.restoreAllMocks()
@@ -44,7 +55,9 @@ describe("BlockquoteBlock collapse behavior", () => {
       return value
     })
     vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(() => buildPreferencesContext())
+    vi.spyOn(lineMeasureModule, "useMeasuredLineCount").mockImplementation(() => measure)
     currentPrefs = { blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD }
+    measure = { lineCount: 1, lineHeightPx: 22 }
     await db.markdownBlockCollapse.clear()
   })
 
@@ -52,14 +65,18 @@ describe("BlockquoteBlock collapse behavior", () => {
     await db.markdownBlockCollapse.clear()
   })
 
-  it("renders short quotes expanded by default", () => {
+  it("renders short quotes with no collapse chrome", () => {
+    measure = { lineCount: 1, lineHeightPx: 22 }
     renderBlockquote(<p>A short quote.</p>)
     expect(screen.getByText("A short quote.")).toBeInTheDocument()
     expect(screen.queryByText(/click to expand/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    expect(clampStyle()).toBeUndefined()
   })
 
-  it("collapses long quotes by default and shows a line-count affordance", () => {
+  it("collapses long quotes by default and clamps to threshold + half a line", () => {
     currentPrefs = { blockquoteCollapseThreshold: 2 }
+    measure = { lineCount: 3, lineHeightPx: 22 }
     renderBlockquote(
       <>
         <p>Paragraph one of the quote.</p>
@@ -68,38 +85,44 @@ describe("BlockquoteBlock collapse behavior", () => {
       </>
     )
     expect(screen.getByText(/3 lines, click to expand/i)).toBeInTheDocument()
+    expect(clampStyle()).toBe(`${(2 + 0.5) * 22}px`)
   })
 
-  it("a short block quote also honors an explicit low threshold", () => {
+  it("a block quote also honors an explicit low threshold", () => {
     currentPrefs = { blockquoteCollapseThreshold: 0 }
+    measure = { lineCount: 1, lineHeightPx: 20 }
     renderBlockquote(<p>Just one line.</p>)
     expect(screen.getByText(/1 line, click to expand/i)).toBeInTheDocument()
   })
 
-  it("expanding a collapsed quote reveals the full content", async () => {
+  it("expanding a collapsed quote drops the clamp; full content stays mounted", async () => {
     const user = userEvent.setup()
     currentPrefs = { blockquoteCollapseThreshold: 1 }
+    measure = { lineCount: 3, lineHeightPx: 22 }
     renderBlockquote(
       <>
         <p>First paragraph.</p>
         <p>Second paragraph.</p>
-        <p>Third paragraph revealed only after expanding.</p>
+        <p>Third paragraph stays mounted, clamped by CSS.</p>
       </>
     )
 
-    // Initially collapsed — third paragraph is not in the DOM.
-    expect(screen.queryByText("Third paragraph revealed only after expanding.")).not.toBeInTheDocument()
+    // Full content is always in the DOM; collapse is a visual clamp.
+    expect(screen.getByText("Third paragraph stays mounted, clamped by CSS.")).toBeInTheDocument()
+    expect(clampStyle()).toBe(`${(1 + 0.5) * 22}px`)
 
     await user.click(screen.getByRole("button", { name: /expand 3 lines/i }))
 
     await waitFor(() => {
-      expect(screen.getByText("Third paragraph revealed only after expanding.")).toBeInTheDocument()
+      expect(clampStyle()).toBeUndefined()
+      expect(screen.getByRole("button", { name: /collapse block quote/i })).toHaveAttribute("aria-expanded", "true")
     })
   })
 
   it("persists a user's toggle choice keyed by message + kind + content hash", async () => {
     const user = userEvent.setup()
     currentPrefs = { blockquoteCollapseThreshold: 1 }
+    measure = { lineCount: 2, lineHeightPx: 22 }
     const messageId = "msg_persist_quote"
     renderBlockquote(
       <>
@@ -119,9 +142,11 @@ describe("BlockquoteBlock collapse behavior", () => {
     })
   })
 
-  it("restores collapsed state from IDB on subsequent renders", async () => {
+  it("restores a persisted expand override on subsequent renders", async () => {
+    currentPrefs = { blockquoteCollapseThreshold: 1 }
+    measure = { lineCount: 5, lineHeightPx: 22 }
     const messageId = "msg_restore_quote"
-    const text = "Preserved quote."
+    const text = "Preserved quote that is long enough to collapse."
     const hash = hashMarkdownBlock(text, "blockquote")
     const key = composeBlockCollapseKey(messageId, "blockquote", hash)
 
@@ -130,24 +155,26 @@ describe("BlockquoteBlock collapse behavior", () => {
         id: key,
         messageId,
         kind: "blockquote",
-        collapsed: true,
+        collapsed: false,
         updatedAt: Date.now(),
       })
-      // Bulk-load the seeded row into the synchronous in-memory cache so
-      // `useBlockCollapse`'s first paint already reflects the persisted state.
       await hydrateCollapseCache()
     })
 
     renderBlockquote(<p>{text}</p>, messageId)
 
+    // Without the override a collapsible quote defaults collapsed; the override
+    // keeps it expanded (no clamp, no affordance).
     await waitFor(() => {
-      expect(screen.getByText(/click to expand/i)).toBeInTheDocument()
+      expect(screen.queryByText(/click to expand/i)).not.toBeInTheDocument()
+      expect(clampStyle()).toBeUndefined()
     })
   })
 
   it("scopes collapse state per messageId", async () => {
     const user = userEvent.setup()
     currentPrefs = { blockquoteCollapseThreshold: 1 }
+    measure = { lineCount: 4, lineHeightPx: 22 }
     const body = (
       <>
         <p>Shared quote content A.</p>
@@ -157,6 +184,7 @@ describe("BlockquoteBlock collapse behavior", () => {
 
     const { unmount } = renderBlockquote(body, "msg_quote_A")
     await user.click(screen.getByRole("button", { name: /expand/i }))
+    await waitFor(() => expect(clampStyle()).toBeUndefined())
     unmount()
 
     // Second message with the same content should still collapse by default.
@@ -167,6 +195,7 @@ describe("BlockquoteBlock collapse behavior", () => {
   it("does not collide with code-block collapse entries for the same text", async () => {
     const user = userEvent.setup()
     currentPrefs = { blockquoteCollapseThreshold: 1 }
+    measure = { lineCount: 3, lineHeightPx: 22 }
     const messageId = "msg_mixed"
 
     renderBlockquote(
@@ -179,15 +208,18 @@ describe("BlockquoteBlock collapse behavior", () => {
 
     await user.click(screen.getByRole("button", { name: /expand/i }))
 
-    const rows = await db.markdownBlockCollapse.where("messageId").equals(messageId).toArray()
-    expect(rows.every((row) => row.kind === "blockquote")).toBe(true)
+    await waitFor(async () => {
+      const rows = await db.markdownBlockCollapse.where("messageId").equals(messageId).toArray()
+      expect(rows.length).toBeGreaterThan(0)
+      expect(rows.every((row) => row.kind === "blockquote")).toBe(true)
+    })
   })
 
   it("only the outermost blockquote folds when blockquotes are nested", () => {
-    // Threshold high enough that neither block defaults to collapsed —
-    // we want to verify the inner block renders without fold chrome at all,
-    // not just that it happens to be expanded.
-    currentPrefs = { blockquoteCollapseThreshold: 100 }
+    // Outer is long enough to be collapsible, so it provides the
+    // inside-collapsible context that suppresses the inner block's chrome.
+    currentPrefs = { blockquoteCollapseThreshold: 6 }
+    measure = { lineCount: 25, lineHeightPx: 22 }
     render(
       <MarkdownBlockProvider messageId="msg_nested">
         <BlockquoteBlock>
@@ -199,8 +231,11 @@ describe("BlockquoteBlock collapse behavior", () => {
       </MarkdownBlockProvider>
     )
 
-    // Exactly one fold toggle exists — the outer one's "Collapse block quote".
-    expect(screen.getAllByRole("button", { name: /collapse block quote/i })).toHaveLength(1)
+    // Exactly one fold toggle exists — the outer one (collapsed by default).
+    const buttons = screen.getAllByRole("button")
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toHaveAccessibleName(/expand 25 lines/i)
+    // Both bodies stay mounted (the outer is clamped, not sliced).
     expect(screen.getByText("Outer quote line.")).toBeInTheDocument()
     expect(screen.getByText("Inner quote line.")).toBeInTheDocument()
   })

--- a/apps/frontend/src/lib/markdown/blockquote-block.tsx
+++ b/apps/frontend/src/lib/markdown/blockquote-block.tsx
@@ -1,11 +1,16 @@
-import { useMemo, type ReactNode } from "react"
+import { useMemo, useRef, type ReactNode } from "react"
 import { ChevronDown, ChevronRight } from "lucide-react"
 import { DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
-import { InsideCollapsibleBlockProvider } from "./markdown-block-context"
-import { extractBlockText, estimateBlockLines, takeQuotePreview, QUOTE_PREVIEW_LINE_COUNT } from "./extract-block-text"
+import { useMeasuredLineCount } from "./use-measured-line-count"
+import {
+  InsideCollapsibleBlockProvider,
+  useIsInsideCollapsibleBlock,
+  useMarkdownBlockContext,
+} from "./markdown-block-context"
+import { extractBlockText } from "./extract-block-text"
 
 interface BlockquoteBlockProps {
   children: ReactNode
@@ -13,24 +18,40 @@ interface BlockquoteBlockProps {
 
 export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
   const text = useMemo(() => extractBlockText(children), [children])
-  const lineCount = useMemo(() => estimateBlockLines(text), [text])
 
   const preferencesContext = usePreferencesOptional()
   const threshold =
     preferencesContext?.preferences?.blockquoteCollapseThreshold ?? DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD
-  const defaultCollapsed = lineCount > threshold
-  const hasTruncatedPreview = lineCount > QUOTE_PREVIEW_LINE_COUNT
+
+  const messageContext = useMarkdownBlockContext()
+  const nested = useIsInsideCollapsibleBlock()
+  // Whether folding is even possible here is a synchronous fact (is there a
+  // message to persist against, and are we the outermost block?). Branching
+  // the DOM on this — not on the async measurement — keeps the measured node
+  // at a stable position so it isn't remounted when it flips to collapsible.
+  const foldable = Boolean(messageContext) && !nested
+
+  const bodyRef = useRef<HTMLDivElement | null>(null)
+  const measured = useMeasuredLineCount(bodyRef, [text])
+  const lineCount = measured.lineCount
+  // Same "more than threshold" semantic as before, but measured by rendered
+  // line-height (handles soft wrapping) instead of paragraph/char estimates.
+  // The extra half line is exactly what the collapsed view reveals as the
+  // "there's more" hint, so a barely-over quote never gets a useless toggle.
+  const collapsible = foldable && lineCount !== null && lineCount > threshold + 0.5
+  const displayLineCount = lineCount !== null ? Math.max(1, Math.round(lineCount)) : 0
 
   const { collapsed, canToggle, toggle } = useBlockCollapse({
     kind: "blockquote",
     content: text,
-    defaultCollapsed,
+    collapsible,
   })
 
-  // Rendered outside a message context (standalone previews, tests with no
-  // provider): fall back to the plain bordered blockquote. Nothing to persist
-  // to, and the collapse chrome would be dead UI.
-  if (!canToggle) {
+  // Rendered without a message context or nested inside another foldable
+  // block: a plain bordered quote. Nothing to persist to, and the fold chrome
+  // would be dead UI. This branch is measurement-independent so it never
+  // swaps with the foldable structure mid-life.
+  if (!foldable) {
     return (
       <blockquote className="my-2 border-l-2 border-primary/50 pl-4 text-muted-foreground italic">
         {children}
@@ -38,43 +59,59 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
     )
   }
 
-  const previewText = collapsed && hasTruncatedPreview ? takeQuotePreview(text) : ""
-  const toggleLabel = collapsed ? `Expand ${lineCount} line${lineCount === 1 ? "" : "s"}` : "Collapse block quote"
-  const bodyTogglesExpand = collapsed && hasTruncatedPreview
+  const collapsedMaxHeight =
+    collapsed && measured.lineHeightPx !== null ? (threshold + 0.5) * measured.lineHeightPx : undefined
+  const toggleLabel = collapsed
+    ? `Expand ${displayLineCount} line${displayLineCount === 1 ? "" : "s"}`
+    : "Collapse block quote"
+  const bodyExpandable = collapsed && canToggle
 
   return (
-    <InsideCollapsibleBlockProvider>
-      <blockquote className="my-2 rounded-r-md border-l-2 border-primary/50 bg-muted/20">
-        <button
-          type="button"
-          onClick={toggle}
-          aria-expanded={!collapsed}
-          aria-label={toggleLabel}
-          title={toggleLabel}
-          className="flex w-full cursor-pointer items-center gap-1 px-3 py-1 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground"
-        >
-          {collapsed ? (
-            <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
-          ) : (
-            <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
-          )}
-          <span className="shrink-0">Quote</span>
-          {collapsed && (
-            <span className="text-muted-foreground/80 font-normal shrink-0">
-              — {lineCount} line{lineCount === 1 ? "" : "s"}, click to expand
-            </span>
-          )}
-        </button>
-        {collapsed ? (
-          <div
-            className={cn("px-4 pb-2 text-sm text-muted-foreground italic", bodyTogglesExpand && "cursor-pointer")}
-            onClick={bodyTogglesExpand ? toggle : undefined}
-          >
-            {hasTruncatedPreview ? <p className="mb-0 truncate">{previewText}</p> : children}
-          </div>
-        ) : (
-          <div className="px-4 pb-2 text-muted-foreground italic">{children}</div>
+    <InsideCollapsibleBlockProvider active={canToggle}>
+      <blockquote
+        className={cn(
+          "my-2 border-l-2 border-primary/50",
+          canToggle ? "rounded-r-md bg-muted/20" : "pl-4 text-muted-foreground italic"
         )}
+      >
+        {canToggle ? (
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={!collapsed}
+            aria-label={toggleLabel}
+            title={toggleLabel}
+            className="flex w-full cursor-pointer items-center gap-1 px-3 py-1 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            {collapsed ? (
+              <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
+            )}
+            <span className="shrink-0">Quote</span>
+            {collapsed && (
+              <span className="text-muted-foreground/80 font-normal shrink-0">
+                — {displayLineCount} line{displayLineCount === 1 ? "" : "s"}, click to expand
+              </span>
+            )}
+          </button>
+        ) : null}
+        <div className={cn("relative", canToggle && "px-4 pb-2 text-muted-foreground italic")}>
+          <div
+            ref={bodyRef}
+            className={cn(collapsed && "overflow-hidden", bodyExpandable && "cursor-pointer")}
+            style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
+            onClick={bodyExpandable ? toggle : undefined}
+          >
+            {children}
+          </div>
+          {collapsed && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-muted/20"
+            />
+          )}
+        </div>
       </blockquote>
     </InsideCollapsibleBlockProvider>
   )

--- a/apps/frontend/src/lib/markdown/code-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.test.tsx
@@ -7,11 +7,17 @@ import CodeBlock from "./code-block"
 import { MarkdownBlockProvider, hashMarkdownBlock, composeBlockCollapseKey } from "./markdown-block-context"
 import { hydrateCollapseCache } from "./collapse-cache"
 import * as preferencesModule from "@/contexts/preferences-context"
+import * as lineMeasureModule from "./use-measured-line-count"
 
 // Stubbable preferences mock: each test can override via `currentPrefs`.
 let currentPrefs: { codeBlockCollapseThreshold?: number } | null = {
   codeBlockCollapseThreshold: DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
 }
+
+// JSDOM has no layout engine, so `useMeasuredLineCount` can never observe a
+// real rendered height. Drive it from a mutable value the test controls so we
+// can exercise "short → no chrome" and "long → collapsed clamp" deterministically.
+let measure: lineMeasureModule.MeasuredLines = { lineCount: 2, lineHeightPx: 20 }
 
 function buildPreferencesContext() {
   if (!currentPrefs) return null
@@ -35,6 +41,12 @@ function renderCodeBlock(code: string, messageId = "msg_test", language = "types
   )
 }
 
+/** Inline `max-height` clamp the collapsed body carries, if any. */
+function clampStyle(): string | undefined {
+  const el = document.querySelector<HTMLElement>('[style*="max-height"]')
+  return el?.style.maxHeight || undefined
+}
+
 describe("CodeBlock collapse behavior", () => {
   beforeEach(async () => {
     vi.restoreAllMocks()
@@ -44,8 +56,10 @@ describe("CodeBlock collapse behavior", () => {
       return value
     })
     vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(() => buildPreferencesContext())
+    vi.spyOn(lineMeasureModule, "useMeasuredLineCount").mockImplementation(() => measure)
 
     currentPrefs = { codeBlockCollapseThreshold: DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD }
+    measure = { lineCount: 2, lineHeightPx: 20 }
     await db.markdownBlockCollapse.clear()
   })
 
@@ -53,88 +67,81 @@ describe("CodeBlock collapse behavior", () => {
     await db.markdownBlockCollapse.clear()
   })
 
-  it("renders short code blocks (≤ threshold) expanded by default", async () => {
-    const code = "const x = 1\nconst y = 2"
-    renderCodeBlock(code)
+  it("renders short code blocks (≤ threshold) with no collapse chrome", async () => {
+    measure = { lineCount: 2, lineHeightPx: 20 }
+    renderCodeBlock("const x = 1\nconst y = 2")
 
-    // Highlighted HTML eventually appears (expanded state invokes shiki).
-    await waitFor(() => {
-      expect(document.querySelector("pre.shiki")).toBeInTheDocument()
-    })
-    // No "click to expand" affordance shown.
     expect(screen.queryByText(/click to expand/i)).not.toBeInTheDocument()
+    expect(clampStyle()).toBeUndefined()
+    // Flush the async highlight so the trailing setState doesn't escape act().
+    await waitFor(() => expect(document.querySelector("pre")).toBeInTheDocument())
   })
 
-  it("renders long code blocks (> threshold) collapsed by default with a 3-line preview and total line count", async () => {
+  it("collapses long code blocks (> threshold) by default and clamps to threshold + half a line", async () => {
+    measure = { lineCount: 25, lineHeightPx: 20 }
     const code = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`).join("\n")
     renderCodeBlock(code)
 
-    // Header advertises the total count + expand affordance.
+    // Header advertises the measured total + the expand affordance.
     expect(screen.getByText(/25 lines, click to expand/i)).toBeInTheDocument()
 
-    // Preview shows the first 3 lines — not the full block.
-    const highlighted = await waitFor(() => {
-      const el = document.querySelector("pre.shiki")
-      expect(el).toBeInTheDocument()
-      return el!
-    })
-    expect(highlighted.textContent).toContain("line 1")
-    expect(highlighted.textContent).toContain("line 2")
-    expect(highlighted.textContent).toContain("line 3")
-    expect(highlighted.textContent).not.toContain("line 4")
-    expect(highlighted.textContent).not.toContain("line 25")
+    // The half-line peek: clamp = (threshold + 0.5) × line-height.
+    const expected = `${(DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD + 0.5) * 20}px`
+    await waitFor(() => expect(clampStyle()).toBe(expected))
+
+    // Full code stays mounted (clamped by CSS, never sliced).
+    const pre = document.querySelector("pre")
+    expect(pre?.textContent).toContain("line 1")
+    expect(pre?.textContent).toContain("line 25")
   })
 
-  it("expanding a collapsed block reveals the full content", async () => {
+  it("expanding a collapsed block drops the clamp and keeps the full content", async () => {
     const user = userEvent.setup()
-    const code = Array.from({ length: 8 }, (_, i) => `line ${i + 1}`).join("\n")
-    currentPrefs = { codeBlockCollapseThreshold: 3 }
+    measure = { lineCount: 25, lineHeightPx: 20 }
+    const code = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`).join("\n")
     renderCodeBlock(code, "msg_expand_full")
 
-    // Initially collapsed with preview.
-    await waitFor(() => {
-      const el = document.querySelector("pre.shiki")
-      expect(el?.textContent).not.toContain("line 8")
-    })
+    await waitFor(() => expect(clampStyle()).toBeDefined())
 
-    await user.click(screen.getByRole("button", { name: /expand 8 lines/i }))
+    await user.click(screen.getByRole("button", { name: /expand 25 lines/i }))
 
     await waitFor(() => {
-      const el = document.querySelector("pre.shiki")
-      expect(el?.textContent).toContain("line 8")
+      expect(clampStyle()).toBeUndefined()
+      expect(screen.getByRole("button", { name: /collapse code block/i })).toHaveAttribute("aria-expanded", "true")
     })
+    expect(document.querySelector("pre")?.textContent).toContain("line 25")
   })
 
-  it("uses the user's threshold override when one is set", () => {
+  it("uses the user's threshold override when one is set", async () => {
     currentPrefs = { codeBlockCollapseThreshold: 3 }
-    const code = "line 1\nline 2\nline 3\nline 4\nline 5"
-    renderCodeBlock(code)
+    measure = { lineCount: 5, lineHeightPx: 18 }
+    renderCodeBlock("line 1\nline 2\nline 3\nline 4\nline 5")
 
-    // 5 lines > threshold 3 → collapsed by default
+    // 5 measured lines > threshold 3 → collapsed by default.
     expect(screen.getByText(/5 lines, click to expand/i)).toBeInTheDocument()
+    await waitFor(() => expect(clampStyle()).toBe(`${(3 + 0.5) * 18}px`))
   })
 
-  it("treats a threshold of 0 as 'collapse all non-empty blocks'", () => {
+  it("treats a threshold of 0 as 'collapse all non-empty blocks'", async () => {
     currentPrefs = { codeBlockCollapseThreshold: 0 }
+    measure = { lineCount: 1, lineHeightPx: 20 }
     renderCodeBlock("const x = 1")
 
     expect(screen.getByText(/1 line, click to expand/i)).toBeInTheDocument()
+    await waitFor(() => expect(document.querySelector("pre")).toBeInTheDocument())
   })
 
   it("toggles collapsed → expanded on click and persists the choice to IDB", async () => {
     const user = userEvent.setup()
+    measure = { lineCount: 20, lineHeightPx: 20 }
     const code = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n")
     const messageId = "msg_toggle_expand"
     renderCodeBlock(code, messageId)
 
-    const toggle = screen.getByRole("button", { name: /expand 20 lines/i })
-    await user.click(toggle)
+    await user.click(screen.getByRole("button", { name: /expand 20 lines/i }))
 
-    await waitFor(() => {
-      expect(document.querySelector("pre.shiki")).toBeInTheDocument()
-    })
+    await waitFor(() => expect(clampStyle()).toBeUndefined())
 
-    // Persisted row reflects the expanded override.
     const key = composeBlockCollapseKey(messageId, "code", hashMarkdownBlock(code.trim(), "typescript"))
     const row = await db.markdownBlockCollapse.get(key)
     expect(row?.collapsed).toBe(false)
@@ -143,65 +150,76 @@ describe("CodeBlock collapse behavior", () => {
 
   it("toggles expanded → collapsed on click and persists the choice", async () => {
     const user = userEvent.setup()
-    const code = "const a = 1\nconst b = 2"
+    measure = { lineCount: 20, lineHeightPx: 20 }
+    const code = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n")
     const messageId = "msg_toggle_collapse"
-    renderCodeBlock(code, messageId)
-
-    await waitFor(() => {
-      expect(document.querySelector("pre.shiki")).toBeInTheDocument()
-    })
-
-    const toggle = screen.getByRole("button", { name: /collapse code block/i })
-    await user.click(toggle)
-
-    await waitFor(() => {
-      expect(screen.getByText(/2 lines, click to expand/i)).toBeInTheDocument()
-    })
-
-    const key = composeBlockCollapseKey(messageId, "code", hashMarkdownBlock(code.trim(), "typescript"))
-    const row = await db.markdownBlockCollapse.get(key)
-    expect(row?.collapsed).toBe(true)
-  })
-
-  it("restores collapsed state from IDB on subsequent renders", async () => {
-    const code = "short block\ntwo lines"
-    const messageId = "msg_persisted"
     const key = composeBlockCollapseKey(messageId, "code", hashMarkdownBlock(code.trim(), "typescript"))
 
-    // Pre-seed IDB with a user override (collapsed even though it's short).
+    // Seed an expanded override so the block starts open.
     await act(async () => {
       await db.markdownBlockCollapse.put({
         id: key,
         messageId,
         kind: "code",
-        collapsed: true,
+        collapsed: false,
         updatedAt: Date.now(),
       })
-      // Bulk-load the seeded row into the synchronous in-memory cache so
-      // `useBlockCollapse`'s first paint already reflects the persisted state.
       await hydrateCollapseCache()
     })
 
     renderCodeBlock(code, messageId)
 
+    await user.click(screen.getByRole("button", { name: /collapse code block/i }))
+
     await waitFor(() => {
-      expect(screen.getByText(/2 lines, click to expand/i)).toBeInTheDocument()
+      expect(screen.getByText(/20 lines, click to expand/i)).toBeInTheDocument()
+    })
+
+    const row = await db.markdownBlockCollapse.get(key)
+    expect(row?.collapsed).toBe(true)
+  })
+
+  it("restores a persisted expand override on subsequent renders", async () => {
+    measure = { lineCount: 30, lineHeightPx: 20 }
+    const code = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join("\n")
+    const messageId = "msg_persisted"
+    const key = composeBlockCollapseKey(messageId, "code", hashMarkdownBlock(code.trim(), "typescript"))
+
+    await act(async () => {
+      await db.markdownBlockCollapse.put({
+        id: key,
+        messageId,
+        kind: "code",
+        collapsed: false,
+        updatedAt: Date.now(),
+      })
+      await hydrateCollapseCache()
+    })
+
+    renderCodeBlock(code, messageId)
+
+    // A collapsible block would default collapsed; the persisted override keeps
+    // it expanded (no clamp, no "click to expand" affordance).
+    await waitFor(() => {
+      expect(screen.queryByText(/click to expand/i)).not.toBeInTheDocument()
+      expect(clampStyle()).toBeUndefined()
     })
   })
 
-  it('marks the wrapper with data-native-context="true" so mobile long-press defers to native text selection', () => {
+  it('marks the wrapper with data-native-context="true" so mobile long-press defers to native text selection', async () => {
     renderCodeBlock("const x = 1\nconst y = 2")
     expect(document.querySelector('[data-native-context="true"]')).toBeInTheDocument()
+    await waitFor(() => expect(document.querySelector("pre")).toBeInTheDocument())
   })
 
   it("scopes collapse state per messageId", async () => {
     const user = userEvent.setup()
+    measure = { lineCount: 15, lineHeightPx: 20 }
     const code = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`).join("\n")
 
     const { unmount } = renderCodeBlock(code, "msg_A")
-    const toggleA = screen.getByRole("button", { name: /expand 15 lines/i })
-    await user.click(toggleA)
-    await waitFor(() => expect(document.querySelector("pre.shiki")).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /expand 15 lines/i }))
+    await waitFor(() => expect(clampStyle()).toBeUndefined())
     unmount()
 
     // Second message with the exact same content should not inherit the expand.

--- a/apps/frontend/src/lib/markdown/code-block.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 import { DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD } from "@threa/types"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
+import { useMeasuredLineCount } from "./use-measured-line-count"
 import { ensureHighlight, tryHighlightSync } from "./highlighter"
 
 interface CodeBlockProps {
@@ -43,19 +44,6 @@ function formatLanguage(lang: string): string {
   return displayNames[lang] || lang
 }
 
-function countLines(text: string): number {
-  const trimmed = text.replace(/\n+$/, "")
-  if (trimmed.length === 0) return 0
-  let count = 1
-  for (let i = 0; i < trimmed.length; i++) {
-    if (trimmed.charCodeAt(i) === 10) count++
-  }
-  return count
-}
-
-/** Number of leading lines shown as a preview when a block is collapsed. */
-const PREVIEW_LINE_COUNT = 3
-
 export default function CodeBlock({ language, children }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
 
@@ -64,25 +52,40 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
   const threshold = preferencesContext?.preferences?.codeBlockCollapseThreshold ?? DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD
 
   const trimmedCode = useMemo(() => children.trim(), [children])
-  const lineCount = useMemo(() => countLines(trimmedCode), [trimmedCode])
-  const defaultCollapsed = lineCount > threshold
-  const hasTruncatedPreview = lineCount > PREVIEW_LINE_COUNT
+
+  // Always render the full code (highlighted) and clamp it with CSS when
+  // collapsed — that lets us measure the real rendered height and keeps
+  // expanding instant (no re-highlight on toggle).
+  const bodyRef = useRef<HTMLDivElement | null>(null)
+
+  // Sync-first: warmed highlighter returns HTML on first render, skipping the
+  // placeholder → highlighted swap that caused row remeasure jumps. Cold path
+  // (still booting or unknown language) falls through to the effect below.
+  const syncHtml = useMemo(() => tryHighlightSync(trimmedCode, language), [trimmedCode, language])
+  const [html, setHtml] = useState<string | null>(syncHtml)
+  // Captured once on mount: did we hit the cold path? If yes, we'll fade the
+  // highlighted output in when it eventually arrives. Hot path renders chrome
+  // and code together with no animation.
+  const renderedColdRef = useRef(syncHtml === null)
+
+  const measured = useMeasuredLineCount(bodyRef, [trimmedCode, html])
+  const lineCount = measured.lineCount
+  // Same "more than threshold" semantic as before, but measured by rendered
+  // line-height (not "\n" count). The extra half line keeps a barely-over
+  // block from sprouting a toggle that would only hide a sliver — and it is
+  // exactly the half line the collapsed view shows as the "there's more" hint.
+  const collapsible = lineCount !== null && lineCount > threshold + 0.5
+  const displayLineCount = lineCount !== null ? Math.max(1, Math.round(lineCount)) : 0
 
   const { collapsed, canToggle, toggle } = useBlockCollapse({
     kind: "code",
     hashNamespace: language,
     content: trimmedCode,
-    defaultCollapsed,
+    collapsible,
   })
 
-  // Collapsed view shows the first PREVIEW_LINE_COUNT lines so readers get a
-  // taste of the block without the full bulk. If the block is already short,
-  // previewing "all" lines is just showing the block.
-  const displayCode = useMemo(() => {
-    if (!collapsed || !hasTruncatedPreview) return trimmedCode
-    const lines = trimmedCode.split("\n")
-    return lines.slice(0, PREVIEW_LINE_COUNT).join("\n")
-  }, [collapsed, hasTruncatedPreview, trimmedCode])
+  const collapsedMaxHeight =
+    collapsed && measured.lineHeightPx !== null ? (threshold + 0.5) * measured.lineHeightPx : undefined
 
   const handleCopy = useCallback(
     async (event: React.MouseEvent) => {
@@ -98,29 +101,16 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
     [trimmedCode]
   )
 
-  // Sync-first: warmed highlighter returns HTML on first render, skipping the
-  // placeholder → highlighted swap that caused row remeasure jumps. Cold path
-  // (still booting or unknown language) falls through to the effect below.
-  const syncHtml = useMemo(() => tryHighlightSync(displayCode, language), [displayCode, language])
-  const [html, setHtml] = useState<string | null>(syncHtml)
-  // Captured once on mount: did we hit the cold path? If yes, we'll fade the
-  // highlighted output in when it eventually arrives. Hot path renders chrome
-  // and code together with no animation.
-  const renderedColdRef = useRef(syncHtml === null)
-
   useEffect(() => {
     if (syncHtml !== null) {
       setHtml(syncHtml)
       return
     }
 
-    // Re-entering the cold path (e.g. collapse toggle before shiki finishes
-    // warming) keeps showing the previous highlighted HTML until the new
-    // promise resolves; clear it so the chrome paints empty rather than stale.
     setHtml(null)
 
     let cancelled = false
-    ensureHighlight(displayCode, language).then((result) => {
+    ensureHighlight(trimmedCode, language).then((result) => {
       if (cancelled) return
       if (result !== null) {
         setHtml(result)
@@ -130,16 +120,18 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
       // singleton init failed and even the plaintext fallback threw. Render
       // escaped raw text inside the chrome so the block stays readable and
       // accessible instead of collapsing to the invisible placeholder.
-      const escaped = displayCode.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+      const escaped = trimmedCode.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
       setHtml(`<pre><code>${escaped}</code></pre>`)
     })
 
     return () => {
       cancelled = true
     }
-  }, [syncHtml, displayCode, language])
+  }, [syncHtml, trimmedCode, language])
 
-  const toggleLabel = collapsed ? `Expand ${lineCount} line${lineCount === 1 ? "" : "s"}` : "Collapse code block"
+  const toggleLabel = collapsed
+    ? `Expand ${displayLineCount} line${displayLineCount === 1 ? "" : "s"}`
+    : "Collapse code block"
 
   const header = (
     <div className="flex items-center gap-1.5 px-2.5 py-1 bg-muted/50 border-b border-border">
@@ -166,7 +158,7 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
         <span className="truncate">{formatLanguage(language)}</span>
         {collapsed && (
           <span className="text-muted-foreground/80 font-normal shrink-0">
-            — {lineCount} line{lineCount === 1 ? "" : "s"}, click to expand
+            — {displayLineCount} line{displayLineCount === 1 ? "" : "s"}, click to expand
           </span>
         )}
       </button>
@@ -188,37 +180,10 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
     </div>
   )
 
-  // When collapsed + truncated, clicking anywhere in the preview body also
-  // expands the block. Non-truncated collapsed blocks (lineCount ≤ 3) show
-  // the same content as expanded, so the body click target is unnecessary.
-  const bodyTogglesExpand = collapsed && canToggle && hasTruncatedPreview
-  const bodyClickHandler = bodyTogglesExpand ? toggle : undefined
-
-  if (!html) {
-    return (
-      <div
-        className="group my-2 rounded-md overflow-hidden border border-border bg-muted/50 select-text [-webkit-touch-callout:default]"
-        data-native-context="true"
-      >
-        {header}
-        {/* Pre matches the font sizing/line-height shiki applies to its own <pre>
-         * so the row keeps the right height while we're waiting for highlight.
-         * Text is `invisible` (kept in layout, hidden visually) so the user
-         * doesn't see unstyled raw code flash before the highlighted version
-         * fades in. */}
-        <pre
-          className={cn(
-            "px-2.5 py-2 overflow-x-auto text-xs font-mono leading-snug invisible",
-            bodyTogglesExpand && "cursor-pointer"
-          )}
-          onClick={bodyClickHandler}
-          aria-hidden="true"
-        >
-          <code>{displayCode}</code>
-        </pre>
-      </div>
-    )
-  }
+  // A collapsed block always has a toggle (collapsible ⇒ canToggle), so the
+  // clamped body is also a click target for expanding.
+  const bodyExpandable = collapsed && canToggle
+  const bodyClickHandler = bodyExpandable ? toggle : undefined
 
   return (
     <div
@@ -226,19 +191,46 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
       data-native-context="true"
     >
       {header}
-      <div
-        className={cn(
-          "[&>pre]:px-2.5 [&>pre]:py-2 [&>pre]:text-xs [&>pre]:leading-snug [&>pre]:overflow-x-auto [&>pre]:bg-transparent [&>pre]:m-0",
-          bodyTogglesExpand && "cursor-pointer",
-          // Fade in only when we previously rendered the invisible placeholder
-          // (cold path). Hot-path first render skips animation so chrome and
-          // code appear together.
-          renderedColdRef.current && "animate-in fade-in duration-200"
+      {/* py-2 lives on this non-measured wrapper so bodyRef.scrollHeight is
+       * exactly lines × line-height — see useMeasuredLineCount. */}
+      <div className="relative py-2">
+        <div
+          ref={bodyRef}
+          className={cn("text-xs leading-snug", collapsed && "overflow-hidden", bodyExpandable && "cursor-pointer")}
+          style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
+          onClick={bodyClickHandler}
+        >
+          {html ? (
+            <div
+              className={cn(
+                "[&>pre]:m-0 [&>pre]:px-2.5 [&>pre]:py-0 [&>pre]:text-xs [&>pre]:leading-snug [&>pre]:overflow-x-auto [&>pre]:bg-transparent",
+                // Fade in only when we previously rendered the invisible
+                // placeholder (cold path). Hot-path first render skips
+                // animation so chrome and code appear together.
+                renderedColdRef.current && "animate-in fade-in duration-200"
+              )}
+              // Safe: Shiki generates this HTML internally from the code string - no user HTML passthrough
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          ) : (
+            /* Matches shiki's font sizing/line-height so the row keeps the
+             * right height (and measures correctly) while highlight loads.
+             * `invisible` keeps it in layout without flashing raw code. */
+            <pre
+              className="m-0 px-2.5 py-0 overflow-x-auto text-xs font-mono leading-snug invisible"
+              aria-hidden="true"
+            >
+              <code>{trimmedCode}</code>
+            </pre>
+          )}
+        </div>
+        {collapsed && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-muted/50"
+          />
         )}
-        onClick={bodyClickHandler}
-        // Safe: Shiki generates this HTML internally from the code string - no user HTML passthrough
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/lib/markdown/collapse-cache.ts
+++ b/apps/frontend/src/lib/markdown/collapse-cache.ts
@@ -11,11 +11,11 @@ import type { MarkdownBlockKind } from "./markdown-block-context"
  * IDB reads are async, so on cold boot the in-memory cache was empty until
  * `hydrateCollapseCache()` resolved. `main.tsx` capped the wait at 500ms; on
  * users with large collapse tables or slow `db.open()` paths, React mounted
- * with an empty cache. Long code blocks render `defaultCollapsed=true`
- * (3-line preview) until the persisted override (`false` for an expanded
- * block) lands, then flip to expanded post-mount — Virtuoso compensates by
- * shifting sibling rows, which the user sees as a "down jump then back" in
- * mega threads where many tall items are above the viewport.
+ * with an empty cache. A collapsible long block renders collapsed (clamped to
+ * threshold + half a line) until the persisted override expanding it lands,
+ * then flips to fully expanded post-mount — Virtuoso compensates by shifting
+ * sibling rows, which the user sees as a "down jump then back" in mega threads
+ * where many tall items are above the viewport.
  *
  * Reading localStorage at module-import time eliminates the race entirely:
  * the in-memory cache is populated before any React component can mount, so
@@ -145,7 +145,8 @@ export function hydrateCollapseCache(): Promise<void> {
       if (blockChanged) writePersistedMap(BLOCK_COLLAPSE_LS_KEY, blockCollapse)
       if (previewChanged) writePersistedMap(LINK_PREVIEW_LS_KEY, linkPreviewExpand)
     } catch {
-      // Empty cache → consumers fall back to their `defaultCollapsed` / `false`.
+      // Empty cache → consumers fall back to their default (collapsed when
+      // collapsible, otherwise expanded).
     } finally {
       blockHydrated = true
       linkPreviewHydrated = true

--- a/apps/frontend/src/lib/markdown/extract-block-text.ts
+++ b/apps/frontend/src/lib/markdown/extract-block-text.ts
@@ -13,9 +13,9 @@ function flattenInline(children: ReactNode): string {
 }
 
 /**
- * Join top-level block children with newlines so each contributes at least
- * one "line" to line-count estimates. Fragments are transparently unwrapped
- * so fragment-wrapped inputs and react-markdown arrays both work.
+ * Flatten block children to a stable plain-text string used as the content
+ * key for per-message collapse persistence. Fragments are transparently
+ * unwrapped so fragment-wrapped inputs and react-markdown arrays both work.
  */
 export function extractBlockText(children: ReactNode): string {
   const parts: string[] = []
@@ -47,33 +47,4 @@ export function extractBlockText(children: ReactNode): string {
     .map((part) => part.trim())
     .filter((part) => part.length > 0)
     .join("\n")
-}
-
-/** Approximate visual characters per wrapped line for line-count estimation. */
-const APPROX_CHARS_PER_LINE = 80
-
-/**
- * Counts explicit paragraph breaks plus a wrap estimate for long single lines.
- * Not pixel-perfect — good enough to decide whether a quote is "long".
- */
-export function estimateBlockLines(text: string): number {
-  if (text.length === 0) return 0
-  const segments = text.split("\n")
-  let total = 0
-  for (const segment of segments) {
-    const trimmed = segment.trim()
-    if (trimmed.length === 0) continue
-    total += Math.max(1, Math.ceil(trimmed.length / APPROX_CHARS_PER_LINE))
-  }
-  return Math.max(1, total)
-}
-
-export const QUOTE_PREVIEW_LINE_COUNT = 2
-
-export function takeQuotePreview(text: string): string {
-  const segments = text.split("\n").filter((segment) => segment.trim().length > 0)
-  const picked = segments.slice(0, QUOTE_PREVIEW_LINE_COUNT).join(" ")
-  const charCap = APPROX_CHARS_PER_LINE * QUOTE_PREVIEW_LINE_COUNT
-  if (picked.length <= charCap) return picked
-  return `${picked.slice(0, charCap).trimEnd()}…`
 }

--- a/apps/frontend/src/lib/markdown/markdown-block-context.tsx
+++ b/apps/frontend/src/lib/markdown/markdown-block-context.tsx
@@ -36,11 +36,24 @@ export function useMarkdownBlockContext(): MarkdownBlockContextValue | null {
 const InsideCollapsibleBlockContext = createContext<boolean>(false)
 
 interface InsideCollapsibleBlockProviderProps {
+  /**
+   * Whether *this* block is currently an active fold. Kept mounted with a
+   * dynamic value (rather than conditionally rendered) so a block that only
+   * becomes collapsible after its size is measured doesn't remount — and lose
+   * the measurement ref — when it flips. OR-ed with the parent so a short,
+   * non-folding quote doesn't suppress a long foldable nested inside it.
+   */
+  active?: boolean
   children: ReactNode
 }
 
-export function InsideCollapsibleBlockProvider({ children }: InsideCollapsibleBlockProviderProps) {
-  return <InsideCollapsibleBlockContext.Provider value={true}>{children}</InsideCollapsibleBlockContext.Provider>
+export function InsideCollapsibleBlockProvider({ active = true, children }: InsideCollapsibleBlockProviderProps) {
+  const parentInside = useContext(InsideCollapsibleBlockContext)
+  return (
+    <InsideCollapsibleBlockContext.Provider value={parentInside || active}>
+      {children}
+    </InsideCollapsibleBlockContext.Provider>
+  )
 }
 
 export function useIsInsideCollapsibleBlock(): boolean {

--- a/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD } from "@threa/types"
 import { db } from "@/db"
 import { QuoteReplyBlock } from "./quote-reply-block"
 import { BlockquoteBlock } from "./blockquote-block"
-import { MarkdownBlockProvider } from "./markdown-block-context"
+import { MarkdownBlockProvider, composeBlockCollapseKey, hashMarkdownBlock } from "./markdown-block-context"
 import * as preferencesModule from "@/contexts/preferences-context"
 import * as hooksModule from "@/hooks"
 import * as userProfileModule from "@/components/user-profile"
+import * as lineMeasureModule from "./use-measured-line-count"
 
 let currentPrefs: { blockquoteCollapseThreshold?: number } | null = {
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
 }
+
+// JSDOM has no layout, so the rendered-height measurement is supplied here.
+let measure: lineMeasureModule.MeasuredLines = { lineCount: 1, lineHeightPx: 20 }
 
 function buildPreferencesContext() {
   if (!currentPrefs) return null
@@ -28,17 +33,28 @@ function buildPreferencesContext() {
   } as unknown as ReturnType<typeof preferencesModule.usePreferences>
 }
 
-function renderInWorkspace(ui: React.ReactElement, workspaceId = "ws_test") {
+function renderQuoteReply(ui: React.ReactElement, messageId = "msg_container", workspaceId = "ws_test") {
   return render(
     <MemoryRouter initialEntries={[`/w/${workspaceId}`]}>
       <Routes>
-        <Route path="/w/:workspaceId" element={ui} />
+        <Route
+          path="/w/:workspaceId"
+          element={<MarkdownBlockProvider messageId={messageId}>{ui}</MarkdownBlockProvider>}
+        />
       </Routes>
     </MemoryRouter>
   )
 }
 
-describe("QuoteReplyBlock nesting behavior", () => {
+/** Inline `max-height` clamp the collapsed body carries, if any. */
+function clampStyle(): string | undefined {
+  const el = document.querySelector<HTMLElement>('[style*="max-height"]')
+  return el?.style.maxHeight || undefined
+}
+
+const toggleName = /expand \d+ lines|collapse quote reply/i
+
+describe("QuoteReplyBlock collapse behavior", () => {
   beforeEach(async () => {
     vi.restoreAllMocks()
     vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(() => buildPreferencesContext())
@@ -53,7 +69,9 @@ describe("QuoteReplyBlock nesting behavior", () => {
     vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({
       openUserProfile: vi.fn(),
     } as unknown as ReturnType<typeof userProfileModule.useUserProfile>)
-    currentPrefs = { blockquoteCollapseThreshold: 100 }
+    vi.spyOn(lineMeasureModule, "useMeasuredLineCount").mockImplementation(() => measure)
+    currentPrefs = { blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD }
+    measure = { lineCount: 1, lineHeightPx: 20 }
     await db.markdownBlockCollapse.clear()
   })
 
@@ -61,27 +79,104 @@ describe("QuoteReplyBlock nesting behavior", () => {
     await db.markdownBlockCollapse.clear()
   })
 
-  it("only the outer quote-reply folds when a blockquote is nested inside it", () => {
-    renderInWorkspace(
-      <MarkdownBlockProvider messageId="msg_nested_qr">
-        <QuoteReplyBlock
-          authorName="Alex"
-          authorId="user_alex"
-          actorType="user"
-          streamId="stream_src"
-          messageId="msg_src"
-        >
-          <BlockquoteBlock>
-            <p>Inner quote line.</p>
-          </BlockquoteBlock>
-        </QuoteReplyBlock>
-      </MarkdownBlockProvider>
+  it("renders short quote replies with no fold chrome", () => {
+    measure = { lineCount: 1, lineHeightPx: 20 }
+    renderQuoteReply(
+      <QuoteReplyBlock
+        authorName="Alex"
+        authorId="user_alex"
+        actorType="user"
+        streamId="stream_src"
+        messageId="msg_src"
+      >
+        <p>Short quoted line.</p>
+      </QuoteReplyBlock>
     )
 
-    // Quote-reply renders its own toggle (the outermost foldable block).
-    expect(screen.getAllByRole("button", { name: /collapse quote reply/i })).toHaveLength(1)
+    expect(screen.getByText("Short quoted line.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: toggleName })).not.toBeInTheDocument()
+    expect(clampStyle()).toBeUndefined()
+  })
+
+  it("collapses long quote replies by default and clamps to threshold + half a line", () => {
+    currentPrefs = { blockquoteCollapseThreshold: 4 }
+    measure = { lineCount: 12, lineHeightPx: 20 }
+    renderQuoteReply(
+      <QuoteReplyBlock
+        authorName="Alex"
+        authorId="user_alex"
+        actorType="user"
+        streamId="stream_src"
+        messageId="msg_src"
+      >
+        <p>A quoted reply long enough to fold.</p>
+      </QuoteReplyBlock>
+    )
+
+    const toggle = screen.getByRole("button", { name: /expand 12 lines/i })
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+    expect(clampStyle()).toBe(`${(4 + 0.5) * 20}px`)
+  })
+
+  it("expanding drops the clamp and persists the choice under the source-message namespace", async () => {
+    const user = userEvent.setup()
+    currentPrefs = { blockquoteCollapseThreshold: 2 }
+    measure = { lineCount: 9, lineHeightPx: 20 }
+    const containerId = "msg_container_qr"
+    renderQuoteReply(
+      <QuoteReplyBlock
+        authorName="Alex"
+        authorId="user_alex"
+        actorType="user"
+        streamId="stream_src"
+        messageId="msg_src"
+      >
+        <p>Quoted content that folds.</p>
+      </QuoteReplyBlock>,
+      containerId
+    )
+
+    await user.click(screen.getByRole("button", { name: /expand 9 lines/i }))
+
+    await waitFor(() => {
+      expect(clampStyle()).toBeUndefined()
+      expect(screen.getByRole("button", { name: /collapse quote reply/i })).toHaveAttribute("aria-expanded", "true")
+    })
+
+    const key = composeBlockCollapseKey(
+      containerId,
+      "quote-reply",
+      hashMarkdownBlock("Quoted content that folds.", "stream_src/msg_src")
+    )
+    const row = await db.markdownBlockCollapse.get(key)
+    expect(row?.collapsed).toBe(false)
+    expect(row?.kind).toBe("quote-reply")
+  })
+
+  it("only the outer quote-reply folds when a blockquote is nested inside it", () => {
+    // Outer is long enough to be collapsible, so it owns the only fold toggle
+    // and suppresses the nested blockquote's chrome.
+    currentPrefs = { blockquoteCollapseThreshold: 6 }
+    measure = { lineCount: 25, lineHeightPx: 20 }
+    renderQuoteReply(
+      <QuoteReplyBlock
+        authorName="Alex"
+        authorId="user_alex"
+        actorType="user"
+        streamId="stream_src"
+        messageId="msg_src"
+      >
+        <BlockquoteBlock>
+          <p>Inner quote line.</p>
+        </BlockquoteBlock>
+      </QuoteReplyBlock>,
+      "msg_nested_qr"
+    )
+
+    // Quote-reply renders its own toggle (collapsed by default).
+    expect(screen.getAllByRole("button", { name: /expand 25 lines/i })).toHaveLength(1)
     // The nested blockquote does NOT render a fold toggle of its own.
-    expect(screen.queryByRole("button", { name: /collapse block quote/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /block quote/i })).not.toBeInTheDocument()
     expect(screen.getByText("Inner quote line.")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react"
+import { useMemo, useRef, type ReactNode } from "react"
 import { Quote, ChevronDown, ChevronRight } from "lucide-react"
 import { Link, useParams } from "react-router-dom"
 import { DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD, type AuthorType } from "@threa/types"
@@ -9,8 +9,9 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
+import { useMeasuredLineCount } from "./use-measured-line-count"
 import { InsideCollapsibleBlockProvider } from "./markdown-block-context"
-import { extractBlockText, estimateBlockLines } from "./extract-block-text"
+import { extractBlockText } from "./extract-block-text"
 
 interface QuoteReplyBlockProps {
   authorName: string
@@ -38,12 +39,19 @@ export function QuoteReplyBlock({
   const { workspaceId } = useParams<{ workspaceId: string }>()
 
   const quotedText = useMemo(() => extractBlockText(children), [children])
-  const lineCount = useMemo(() => estimateBlockLines(quotedText), [quotedText])
 
   const preferencesContext = usePreferencesOptional()
   const threshold =
     preferencesContext?.preferences?.blockquoteCollapseThreshold ?? DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD
-  const defaultCollapsed = lineCount > threshold
+
+  const bodyRef = useRef<HTMLDivElement | null>(null)
+  const measured = useMeasuredLineCount(bodyRef, [quotedText])
+  const lineCount = measured.lineCount
+  // Measured by rendered line-height (handles soft wrapping) with the same
+  // "more than threshold" semantic. The +0.5 keeps barely-over quotes from
+  // sprouting a toggle that would only hide the half line we already show.
+  const collapsible = lineCount !== null && lineCount > threshold + 0.5
+  const displayLineCount = lineCount !== null ? Math.max(1, Math.round(lineCount)) : 0
 
   const { collapsed, canToggle, toggle } = useBlockCollapse({
     // Quote replies are anchored by the quoted (streamId, messageId) pair, so
@@ -52,17 +60,21 @@ export function QuoteReplyBlock({
     kind: "quote-reply",
     hashNamespace: `${streamId}/${messageId}`,
     content: quotedText,
-    defaultCollapsed,
+    collapsible,
   })
 
   if (!workspaceId) return null
 
   const url = `/w/${workspaceId}/s/${streamId}?m=${messageId}`
 
-  const collapseLabel = collapsed ? `Expand ${lineCount} line${lineCount === 1 ? "" : "s"}` : "Collapse quote reply"
+  const collapseLabel = collapsed
+    ? `Expand ${displayLineCount} line${displayLineCount === 1 ? "" : "s"}`
+    : "Collapse quote reply"
+  const collapsedMaxHeight =
+    collapsed && measured.lineHeightPx !== null ? (threshold + 0.5) * measured.lineHeightPx : undefined
 
   return (
-    <InsideCollapsibleBlockProvider>
+    <InsideCollapsibleBlockProvider active={canToggle}>
       <div className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm">
         <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">
@@ -92,16 +104,20 @@ export function QuoteReplyBlock({
           </div>
           <Link
             to={url}
-            className="mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
+            className="relative mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
           >
-            {collapsed ? (
-              <div className="truncate text-xs italic text-muted-foreground/80">
-                {lineCount > 0
-                  ? `${lineCount} line${lineCount === 1 ? "" : "s"} — click chevron to expand`
-                  : "Quoted message"}
-              </div>
-            ) : (
-              <div className="[&_p]:mb-0">{children}</div>
+            <div
+              ref={bodyRef}
+              className={cn("[&_p]:mb-0", collapsed && "overflow-hidden")}
+              style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
+            >
+              {children}
+            </div>
+            {collapsed && (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-muted/30"
+              />
             )}
           </Link>
         </div>

--- a/apps/frontend/src/lib/markdown/use-block-collapse.ts
+++ b/apps/frontend/src/lib/markdown/use-block-collapse.ts
@@ -24,8 +24,13 @@ interface UseBlockCollapseOptions {
    */
   hashNamespace?: string
   content: string
-  /** Starting collapse state when no persisted user override exists. */
-  defaultCollapsed: boolean
+  /**
+   * Whether the block is long enough to be worth collapsing at all. Short
+   * blocks (≤ threshold) render plain with no fold chrome — there is nothing
+   * worth hiding. When true the block also starts collapsed unless the user
+   * has a persisted override expanding it.
+   */
+  collapsible: boolean
 }
 
 /**
@@ -39,21 +44,27 @@ export function useBlockCollapse({
   kind,
   hashNamespace = kind,
   content,
-  defaultCollapsed,
+  collapsible,
 }: UseBlockCollapseOptions): BlockCollapseState {
   const messageContext = useMarkdownBlockContext()
   const nested = useIsInsideCollapsibleBlock()
 
   const collapseKey = useMemo(() => {
-    if (!messageContext || nested) return null
+    // No key — and therefore no fold chrome — when there is nothing to persist
+    // to (standalone preview), when nested inside another foldable block, or
+    // when the block is too short to be worth collapsing.
+    if (!messageContext || nested || !collapsible) return null
     return composeBlockCollapseKey(messageContext.messageId, kind, hashMarkdownBlock(content, hashNamespace))
-  }, [messageContext, nested, kind, hashNamespace, content])
+  }, [messageContext, nested, collapsible, kind, hashNamespace, content])
 
   const persistedOverride = useBlockCollapseStore(collapseKey)
 
-  // Nested blocks render plain (always expanded, no toggle) so only the
-  // outermost foldable block folds.
-  const collapsed = nested ? false : (persistedOverride ?? defaultCollapsed)
+  // Render plain (expanded, no toggle) whenever there is nothing to fold
+  // against: nested inside another foldable block, too short to collapse, or
+  // no persistence key (standalone preview) — collapsing with no way to
+  // toggle would strand the content clamped. Otherwise start collapsed unless
+  // the user persisted an expand.
+  const collapsed = !collapseKey ? false : (persistedOverride ?? true)
 
   const toggle = useCallback(() => {
     if (!collapseKey || !messageContext) return

--- a/apps/frontend/src/lib/markdown/use-measured-line-count.ts
+++ b/apps/frontend/src/lib/markdown/use-measured-line-count.ts
@@ -1,0 +1,78 @@
+import { useLayoutEffect, useState, type RefObject } from "react"
+
+export interface MeasuredLines {
+  /**
+   * Visual line count = rendered content height ÷ computed line-height.
+   * `null` until a real layout exists (first paint, JSDOM with no layout
+   * engine, detached node). Consumers treat `null` as "not measured yet" and
+   * render the block expanded with no collapse chrome.
+   */
+  lineCount: number | null
+  /** Computed line-height in CSS px, used to build the collapsed clamp. */
+  lineHeightPx: number | null
+}
+
+const UNMEASURED: MeasuredLines = { lineCount: null, lineHeightPx: null }
+
+function resolveLineHeightPx(el: HTMLElement): number {
+  const cs = getComputedStyle(el)
+  const lh = Number.parseFloat(cs.lineHeight)
+  if (Number.isFinite(lh) && lh > 0) return lh
+  // `line-height: normal` doesn't expose a px value; browsers render it at
+  // roughly 1.2× the font size, which is close enough to decide "long vs not".
+  const fs = Number.parseFloat(cs.fontSize)
+  return Number.isFinite(fs) && fs > 0 ? fs * 1.2 : 0
+}
+
+/**
+ * Measures how many *visual* lines an element occupies after wrapping, by
+ * dividing its rendered content height by the computed line-height. Unlike
+ * counting "\n" in the source, this reflects soft-wrapped lines, which depend
+ * on the viewport / message-column width — the number that actually decides
+ * whether a block reads as "long".
+ *
+ * Measurement runs in a layout effect (before paint, so a block that resolves
+ * to collapsed never flashes its full height) and re-runs when the element
+ * resizes (column resize, font-size preference change) or when `deps` change
+ * (content changed). `scrollHeight` reports full content height even while a
+ * max-height clamp is applied, so the collapsed state never hides lines from
+ * the measurement.
+ *
+ * Constraint: the ref'd element and its subtree must carry no vertical
+ * padding/border/margin, so `scrollHeight` equals the text block height
+ * exactly. Put visual spacing on a non-ref'd ancestor.
+ */
+export function useMeasuredLineCount(ref: RefObject<HTMLElement | null>, deps: ReadonlyArray<unknown>): MeasuredLines {
+  const [measured, setMeasured] = useState<MeasuredLines>(UNMEASURED)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      const node = ref.current
+      if (!node) return
+      const lineHeightPx = resolveLineHeightPx(node)
+      const height = node.scrollHeight
+      if (lineHeightPx <= 0 || height <= 0) {
+        // No layout engine (JSDOM) or not yet attached — stay unmeasured so
+        // consumers fall back to "expanded, no chrome".
+        return
+      }
+      const lineCount = height / lineHeightPx
+      setMeasured((prev) =>
+        prev.lineCount !== null && Math.abs(prev.lineCount - lineCount) < 0.01 && prev.lineHeightPx === lineHeightPx
+          ? prev
+          : { lineCount, lineHeightPx }
+      )
+    }
+
+    measure()
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [ref, ...deps])
+
+  return measured
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -61,8 +61,8 @@ if ("serviceWorker" in navigator) {
 // we need to clear those cases without bailing too early; the previous 100ms
 // cap was tight enough that returning users with large collapse tables would
 // mount with an empty cache and then flip a previously-expanded long code
-// block from `defaultCollapsed=true` (small preview) to `persistedOverride=
-// false` (full block) on the next render — the "mega jump" reported in prod.
+// block from its default collapsed clamp to fully expanded once the persisted
+// override landed on the next render — the "mega jump" reported in prod.
 // At the deadline we mount with whatever the cache holds; `hydrateCollapseCache`
 // keeps running and `notify()` still wakes subscribers, so the cache heals
 // even if the deadline fired.


### PR DESCRIPTION
## Summary

Reworks the collapse behavior of code, blockquote, and quote-reply markdown blocks so the "how long is this?" decision matches what the user actually sees on screen.

- **Measured, not counted.** New `useMeasuredLineCount` hook (`useLayoutEffect` + `ResizeObserver`) derives the visual line count from `scrollHeight ÷ computed line-height`. Soft-wrapped lines, viewport width, and user font-size preferences are all reflected — counting `\n` in the source isn't.
- **No chrome on short blocks.** Blocks at or under the user's configurable threshold (defaults: code `10`, blockquote `6`) render plain with no fold toggle. There is nothing worth hiding.
- **Half-line peek when collapsed.** Long blocks default collapsed and clamp via CSS `max-height` to `(threshold + 0.5) × lineHeight`. The visible half line is the "there's more" hint, and the `+ 0.5` buffer keeps a barely-over block from sprouting a toggle that would only hide the sliver it's already showing. Full content stays mounted (clamped, never sliced), so expanding is instant.
- **Stable DOM across the async measurement flip.** The `InsideCollapsibleBlockProvider` stays mounted with a dynamic `active` value, and `BlockquoteBlock` branches on the *synchronous* `foldable` (has provider, not nested) rather than the async `collapsible` — so the measured node isn't remounted (and the ResizeObserver isn't lost) when collapsibility flips post-measurement.

Cleanup: removed the dead newline-estimate helpers (`estimateBlockLines`, `takeQuotePreview`, `APPROX_CHARS_PER_LINE`, `QUOTE_PREVIEW_LINE_COUNT`) and refreshed two stale "3-line preview / `defaultCollapsed=true`" comments in `main.tsx` and `collapse-cache.ts` to describe the clamp model.

Preferences (`codeBlockCollapseThreshold`, `blockquoteCollapseThreshold`) are unchanged — same shape, same range, same defaults.

## Test plan

- [x] `bun run --cwd apps/frontend test -- --run src/lib/markdown` — 103/103 pass (the three rewritten suites mock `useMeasuredLineCount` via a scoped `vi.spyOn` against a namespace import, per INV-48, since JSDOM has no layout engine)
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] `bun run lint` (frontend + cross-app + dockerfile checks via pre-commit hook) — clean
- [ ] Manual check in browser: paste a long code block at narrow column width, confirm the toggle still appears when soft-wrapping pushes line count over threshold (not just hard newlines)
- [ ] Manual check: shrink the message column with a borderline-length block and confirm the toggle appears/disappears as `ResizeObserver` re-measures

https://claude.ai/code/session_01M87qoML2L7sMk1nrrsRtoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01M87qoML2L7sMk1nrrsRtoD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->