### PR TITLE
fix(memory): stop card list overflowing the viewport on narrow screens

### DIFF
--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -707,7 +707,13 @@ export function MemoryPage() {
         {/* Delayed loading bar — covers the header/content divider */}
         <LoadingBar visible={isRefreshing} />
         {/* Results list — full width on mobile, fixed sidebar on desktop */}
-        <ScrollArea className="min-w-0 flex-1 lg:w-[22rem] lg:flex-none lg:border-r border-border/50">
+        {/* `[&>div>div]:!block [&>div>div]:!w-full` overrides Radix ScrollArea's
+            internal `display:table` Viewport wrapper to a block sized to the
+            parent. Without this the wrapper sizes to min-content, and any
+            descendant whose intrinsic width exceeds the column (line-clamp's
+            `-webkit-box` h3, long unbreakable tokens, etc.) pushes the cards
+            past the viewport. Matches the pattern in saved/activity/scheduled. */}
+        <ScrollArea className="min-w-0 flex-1 lg:w-[22rem] lg:flex-none lg:border-r border-border/50 [&>div>div]:!block [&>div>div]:!w-full">
           <div className="min-w-0 space-y-1.5 p-2 [overflow-wrap:anywhere]">
             {searchResponse.isLoading && (
               <>


### PR DESCRIPTION
Radix ScrollArea wraps its Viewport content in a `display: table` div
that sizes to min-content. On narrow viewports any descendant whose
intrinsic width exceeds the column (line-clamp's `-webkit-box` h3, long
unbreakable tokens) pushed the table wider than the column, so memo
cards spilled off the right edge on mobile and inside the desktop list
sidebar.

The `[overflow-wrap:anywhere]` workaround in place only collapsed long
unbreakable strings; it didn't address the `-webkit-box` line-clamp on
the title, which still drove the wrapper's min-content past the column.

Override the Viewport wrapper to `display: block` + `width: 100%` so it
follows the column width regardless of content, matching the pattern
already used in saved/activity/scheduled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->