### PR TITLE
fix(memory): clip horizontal overflow on the mobile page wrapper

### DIFF
--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -586,7 +586,7 @@ export function MemoryPage() {
   }
 
   return (
-    <div className="flex h-full flex-col bg-background">
+    <div className="flex h-full min-w-0 flex-col overflow-x-hidden bg-background">
       {/* Header */}
       <header className="border-b bg-card/50">
         <div className="flex h-12 items-center gap-2 px-4">
@@ -706,13 +706,10 @@ export function MemoryPage() {
       <div className="relative flex min-h-0 flex-1 flex-col lg:flex-row">
         {/* Delayed loading bar — covers the header/content divider */}
         <LoadingBar visible={isRefreshing} />
-        {/* Results list — full width on mobile, fixed sidebar on desktop */}
-        {/* `[&>div>div]:!block [&>div>div]:!w-full` overrides Radix ScrollArea's
-            internal `display:table` Viewport wrapper to a block sized to the
-            parent. Without this the wrapper sizes to min-content, and any
-            descendant whose intrinsic width exceeds the column (line-clamp's
-            `-webkit-box` h3, long unbreakable tokens, etc.) pushes the cards
-            past the viewport. Matches the pattern in saved/activity/scheduled. */}
+        {/* Results list — full width on mobile, fixed sidebar on desktop.
+            `[&>div>div]:!block [&>div>div]:!w-full` overrides Radix ScrollArea's
+            internal `display:table` wrapper so the cards can't be pushed past
+            the column by descendant min-content (matches saved/activity/scheduled). */}
         <ScrollArea className="min-w-0 flex-1 lg:w-[22rem] lg:flex-none lg:border-r border-border/50 [&>div>div]:!block [&>div>div]:!w-full">
           <div className="min-w-0 space-y-1.5 p-2 [overflow-wrap:anywhere]">
             {searchResponse.isLoading && (


### PR DESCRIPTION
## Summary

Follow-up to #583. That PR fixed the desktop memory list by overriding Radix ScrollArea's internal `display:table` viewport wrapper, which works there because `lg:w-[22rem]` pins the column to an explicit width. On mobile the column has no explicit width, so a long unbreakable token in a card title could still push the whole results column past the screen edge.

This change adds `min-w-0 overflow-x-hidden` to the page-level wrapper so the column chain has a definitive horizontal clip and shrink boundary regardless of descendant intrinsic widths.

- Adds `min-w-0 overflow-x-hidden` to the memory page root wrapper
- Trims the now-redundant comment on the ScrollArea fix

## Test plan

- [x] `bunx vitest run src/pages/memory.test.tsx` — 6/6 passing
- [ ] Verify on mobile viewport that cards with long titles no longer push past the screen edge
- [ ] Verify desktop list view still renders correctly (regression check on #583)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9xFgmywUrYxgDGYnu3PSV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781886241&installation_id=129946197&pr_number=584&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F584&signature=87fc50cfc33801aeaaf20372e67b2c997a1ff7b4bb74ce9589260f14800d14f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->