### PR TITLE
fix(frontend): resolve saved DM names without the streams cache

### DIFF
--- a/apps/frontend/src/components/saved/saved-item.test.tsx
+++ b/apps/frontend/src/components/saved/saved-item.test.tsx
@@ -104,7 +104,17 @@ describe("SavedItem stream label", () => {
     expect(getByText("#general")).toBeTruthy()
   })
 
-  it("falls back to the snapshot stream name, then Unknown, when nothing resolves", () => {
+  it("falls back to the snapshot stream name when the cache lookup misses", () => {
+    mockStore({ streams: [], users: [], dmPeers: [] })
+
+    const { getByText } = mount(
+      makeView({ streamId: "stream_gone", message: { ...makeView().message!, streamName: "Legacy Stream" } })
+    )
+
+    expect(getByText("Legacy Stream")).toBeTruthy()
+  })
+
+  it("falls back to Unknown when neither cache nor snapshot resolves", () => {
     mockStore({ streams: [], users: [], dmPeers: [] })
 
     const { getByText } = mount(

--- a/apps/frontend/src/components/saved/saved-item.test.tsx
+++ b/apps/frontend/src/components/saved/saved-item.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type { SavedMessageView } from "@threa/types"
+import { SavedItem } from "./saved-item"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as contextsModule from "@/contexts"
+
+const WORKSPACE_ID = "ws_1"
+
+function makeView(overrides: Partial<SavedMessageView> = {}): SavedMessageView {
+  const now = "2026-01-01T00:00:00.000Z"
+  return {
+    id: "saved_1",
+    workspaceId: WORKSPACE_ID,
+    userId: "usr_me",
+    messageId: "msg_1",
+    streamId: "stream_dm",
+    status: "saved",
+    remindAt: null,
+    reminderSentAt: null,
+    savedAt: now,
+    statusChangedAt: now,
+    unavailableReason: null,
+    message: {
+      authorId: "usr_peer",
+      authorType: "user",
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "hello there",
+      createdAt: now,
+      editedAt: null,
+      // Backend snapshot stores the raw stream.displayName, which is null for DMs.
+      streamName: null,
+    },
+    ...overrides,
+  }
+}
+
+function mockStore({
+  streams = [],
+  users = [],
+  dmPeers = [],
+}: {
+  streams?: unknown[]
+  users?: unknown[]
+  dmPeers?: unknown[]
+} = {}) {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(
+    streams as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue(
+    users as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue(
+    dmPeers as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceDmPeers>
+  )
+}
+
+function mount(saved: SavedMessageView) {
+  return render(
+    <MemoryRouter>
+      <SavedItem saved={saved} workspaceId={WORKSPACE_ID} />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  // RelativeTime (rendered in the row footer) reads the timezone/locale from
+  // the preferences context.
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("SavedItem stream label", () => {
+  it("resolves a DM peer name even when the DM stream is absent from the streams cache", () => {
+    // The regression: the streams cache has no entry for this DM, but dmPeers +
+    // users do. The label must still resolve to the peer's name, not "Unknown".
+    mockStore({
+      streams: [],
+      users: [{ id: "usr_peer", name: "Ada Lovelace" }],
+      dmPeers: [{ streamId: "stream_dm", userId: "usr_peer" }],
+    })
+
+    const { getByText, queryByText } = mount(makeView({ streamId: "stream_dm" }))
+
+    expect(getByText("Ada Lovelace")).toBeTruthy()
+    expect(queryByText("Unknown")).toBeNull()
+  })
+
+  it("renders a channel with its # slug from the streams cache", () => {
+    mockStore({
+      streams: [{ id: "stream_ch", type: "channel", slug: "general", displayName: null }],
+    })
+
+    const { getByText } = mount(makeView({ streamId: "stream_ch" }))
+
+    expect(getByText("#general")).toBeTruthy()
+  })
+
+  it("falls back to the snapshot stream name, then Unknown, when nothing resolves", () => {
+    mockStore({ streams: [], users: [], dmPeers: [] })
+
+    const { getByText } = mount(
+      makeView({ streamId: "stream_gone", message: { ...makeView().message!, streamName: null } })
+    )
+
+    expect(getByText("Unknown")).toBeTruthy()
+  })
+})

--- a/apps/frontend/src/components/saved/saved-item.tsx
+++ b/apps/frontend/src/components/saved/saved-item.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Archive, Bell, Check, CircleAlert, Trash2, Undo2 } from "lucide-react"
-import { StreamTypes } from "@threa/types"
 import type { SavedMessageView, SavedStatus, StreamType } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -208,14 +207,16 @@ function resolveStreamLabel(
   users: Array<{ id: string; name: string }>,
   dmPeers: Array<{ streamId: string; userId: string }>
 ): string {
-  if (!stream) {
-    // No cached stream (lost access, archived membership). Fall back to the
-    // backend snapshot, then to a generic placeholder.
-    return saved.message?.streamName ?? "Unknown"
-  }
-  if (stream.type === StreamTypes.DM) {
-    const peerName = resolveDmDisplayName(stream.id, users, dmPeers)
-    if (peerName) return peerName
-  }
-  return getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+  // DM names are viewer-specific and resolved from the peer user. `dmPeers`
+  // covers every DM the viewer belongs to (streamId -> peer), so this resolves
+  // even when the DM's stream object isn't in the streams cache — which is the
+  // common case here, since the saved list can reference DMs the sidebar never
+  // loaded. Try it first off the saved row's streamId; non-DM streamIds have
+  // no peer entry and fall through.
+  const peerName = resolveDmDisplayName(saved.streamId, users, dmPeers)
+  if (peerName) return peerName
+  if (stream) return getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+  // No peer match and no cached stream (lost access, cold cache). Fall back to
+  // the backend snapshot, then to a generic placeholder.
+  return saved.message?.streamName ?? "Unknown"
 }

--- a/apps/frontend/src/components/saved/saved-item.tsx
+++ b/apps/frontend/src/components/saved/saved-item.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Archive, Bell, Check, CircleAlert, Trash2, Undo2 } from "lucide-react"
-import type { SavedMessageView, SavedStatus, StreamType } from "@threa/types"
+import type { SavedMessageView, SavedStatus } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
-import { getStreamName, resolveDmDisplayName, streamFallbackLabel } from "@/lib/streams"
-import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
+import { useStreamName } from "@/hooks/use-stream-name"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { RelativeTime } from "@/components/relative-time"
 import { ReminderPopoverContent } from "@/components/timeline/reminder-popover-content"
@@ -28,16 +27,11 @@ export function SavedItem({ saved, workspaceId, onMarkDone, onArchive, onRestore
   const linkable = !isUnavailable && saved.message !== null
   const href = `/w/${workspaceId}/s/${saved.streamId}?m=${saved.messageId}`
   const previewText = resolvePreview(saved)
-  // Stream label routes through the canonical resolvers so DMs render the
-  // peer's name (the snapshot's `streamName` is null for DMs since DM names
-  // are viewer-specific and not persisted on the stream row). When the stream
-  // isn't in local cache (access lost, snapshot pre-dates membership churn)
-  // we fall back to the snapshot, then to a context-appropriate label.
-  const streams = useWorkspaceStreams(workspaceId)
-  const users = useWorkspaceUsers(workspaceId)
-  const dmPeers = useWorkspaceDmPeers(workspaceId)
-  const stream = streams.find((s) => s.id === saved.streamId)
-  const streamLabel = resolveStreamLabel(stream, saved, users, dmPeers)
+  // The backend snapshot's `streamName` is null for DMs (viewer-specific names
+  // aren't persisted on the stream row), so resolve from the workspace caches.
+  // The persisted snapshot is the last-resort fallback for rows whose stream
+  // is no longer cached (lost access).
+  const streamLabel = useStreamName(workspaceId, saved.streamId) ?? saved.message?.streamName ?? "Unknown"
 
   // Row-as-link: the content area navigates to the message when clicked.
   // Action buttons are siblings (not nested inside the Link) so their clicks
@@ -199,24 +193,4 @@ function resolvePreview(saved: SavedMessageView): string {
   if (saved.message) return stripMarkdownToInline(saved.message.contentMarkdown)
   if (saved.unavailableReason === "deleted") return "Original message was deleted"
   return "You no longer have access to this message"
-}
-
-function resolveStreamLabel(
-  stream: { id: string; type: StreamType; slug?: string | null; displayName?: string | null } | undefined,
-  saved: SavedMessageView,
-  users: Array<{ id: string; name: string }>,
-  dmPeers: Array<{ streamId: string; userId: string }>
-): string {
-  // DM names are viewer-specific and resolved from the peer user. `dmPeers`
-  // covers every DM the viewer belongs to (streamId -> peer), so this resolves
-  // even when the DM's stream object isn't in the streams cache — which is the
-  // common case here, since the saved list can reference DMs the sidebar never
-  // loaded. Try it first off the saved row's streamId; non-DM streamIds have
-  // no peer entry and fall through.
-  const peerName = resolveDmDisplayName(saved.streamId, users, dmPeers)
-  if (peerName) return peerName
-  if (stream) return getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
-  // No peer match and no cached stream (lost access, cold cache). Fall back to
-  // the backend snapshot, then to a generic placeholder.
-  return saved.message?.streamName ?? "Unknown"
 }

--- a/apps/frontend/src/components/scheduled/scheduled-item.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-item.tsx
@@ -5,8 +5,7 @@ import type { ScheduledMessageView } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { formatSendCountdown } from "@/lib/dates"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
-import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useStreamName } from "@/hooks/use-stream-name"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useLongPress } from "@/hooks/use-long-press"
 import { RelativeTime } from "@/components/relative-time"
@@ -41,13 +40,9 @@ export function ScheduledItem({ scheduled, workspaceId, onEdit, onCancel, onSend
   // everywhere keeps display and input consistent.
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
-  // Stream name resolution must go through the canonical helpers so #channels
-  // pick up their slug prefix and untitled streams get a context-appropriate
-  // fallback. The row may briefly outlive a membership the user no longer has;
-  // the empty-find branch covers that until the failure path catches it.
-  const streams = useWorkspaceStreams(workspaceId)
-  const stream = streams.find((s) => s.id === scheduled.streamId)
-  const streamName = stream ? (getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")) : "stream"
+  // The row may briefly outlive a membership the user no longer has; the
+  // "stream" fallback covers that until the failure path catches it.
+  const streamName = useStreamName(workspaceId, scheduled.streamId) ?? "stream"
 
   const preview = useMemo(
     () => stripMarkdownToInline(scheduled.contentMarkdown).trim() || "(empty)",

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -188,3 +188,5 @@ export {
   isLocalScheduledId,
   scheduledKeys,
 } from "./use-scheduled"
+
+export { useStreamName } from "./use-stream-name"

--- a/apps/frontend/src/hooks/use-stream-name.ts
+++ b/apps/frontend/src/hooks/use-stream-name.ts
@@ -1,0 +1,18 @@
+import { resolveStreamName, type FallbackContext } from "@/lib/streams"
+import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
+
+/**
+ * Resolve a stream's display name from the workspace caches by id. Handles
+ * every stream type (DM peer names, channel slugs, generated/placeholder names)
+ * so callers never reimplement the cache lookup + DM resolution dance.
+ *
+ * Returns null when the id resolves to neither a DM peer nor a cached stream;
+ * callers layer their own last-resort fallback (a persisted snapshot name, a
+ * generic placeholder, etc.).
+ */
+export function useStreamName(workspaceId: string, streamId: string, context?: FallbackContext): string | null {
+  const streams = useWorkspaceStreams(workspaceId)
+  const users = useWorkspaceUsers(workspaceId)
+  const dmPeers = useWorkspaceDmPeers(workspaceId)
+  return resolveStreamName(streamId, { streams, users, dmPeers }, context)
+}

--- a/apps/frontend/src/lib/streams.test.ts
+++ b/apps/frontend/src/lib/streams.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from "vitest"
-import { resolveDmDisplayName } from "./streams"
+import { resolveDmDisplayName, resolveStreamName } from "./streams"
+
+describe("resolveStreamName", () => {
+  const users = [{ id: "user_peer", name: "Pierre Boberg" }]
+  const dmPeers = [{ streamId: "stream_dm", userId: "user_peer" }]
+
+  it("resolves a DM peer name even when the DM stream object isn't cached", () => {
+    expect(resolveStreamName("stream_dm", { streams: [], users, dmPeers })).toBe("Pierre Boberg")
+  })
+
+  it("prefixes channels with their slug from the cached stream", () => {
+    const streams = [{ id: "stream_ch", type: "channel" as const, slug: "general", displayName: null }]
+    expect(resolveStreamName("stream_ch", { streams, users: [], dmPeers: [] })).toBe("#general")
+  })
+
+  it("uses a context-appropriate fallback for a cached stream with no name", () => {
+    const streams = [{ id: "stream_sp", type: "scratchpad" as const, slug: null, displayName: null }]
+    expect(resolveStreamName("stream_sp", { streams, users: [], dmPeers: [] }, "sidebar")).toBe("New scratchpad")
+  })
+
+  it("returns null when the id matches no DM peer and no cached stream", () => {
+    expect(resolveStreamName("stream_gone", { streams: [], users: [], dmPeers: [] })).toBeNull()
+  })
+})
 
 describe("resolveDmDisplayName", () => {
   const workspaceUsers = [

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -56,7 +56,7 @@ export function resolveDmDisplayName(
   return workspaceUsers.find((u) => u.id === peerUserId)?.name ?? null
 }
 
-type FallbackContext = "sidebar" | "activity" | "breadcrumb" | "generic" | "noun"
+export type FallbackContext = "sidebar" | "activity" | "breadcrumb" | "generic" | "noun"
 
 const FALLBACK_LABELS: Record<string, Record<FallbackContext, string>> = {
   scratchpad: {
@@ -75,4 +75,36 @@ const FALLBACK_LABELS: Record<string, Record<FallbackContext, string>> = {
 /** Context-appropriate fallback text for streams that truly have no name yet. */
 export function streamFallbackLabel(type: StreamType, context: FallbackContext): string {
   return FALLBACK_LABELS[type]?.[context] ?? "Untitled"
+}
+
+interface StreamNameCaches {
+  streams: Array<{ id: string; type: StreamType; slug?: string | null; displayName?: string | null }>
+  users: Array<{ id: string; name: string }>
+  dmPeers: Array<{ streamId: string; userId: string }>
+}
+
+/**
+ * Resolve a stream's display name from the workspace caches by id — the single
+ * entry point any surface should use when it has a stream id and wants a label.
+ *
+ * DMs resolve from the peer user first, which works even when the DM's stream
+ * object isn't in the streams cache (`dmPeers` covers every DM the viewer
+ * belongs to). Other types use the cached stream's name with a context
+ * fallback. Returns null only when the id matches no DM peer and no cached
+ * stream, so the caller can layer its own last-resort fallback (e.g. a
+ * persisted snapshot name).
+ *
+ * Prefer the `useStreamName` hook in components; this pure function exists for
+ * non-hook contexts (list mappers, tests) and as the hook's implementation.
+ */
+export function resolveStreamName(
+  streamId: string,
+  caches: StreamNameCaches,
+  context: FallbackContext = "generic"
+): string | null {
+  const peerName = resolveDmDisplayName(streamId, caches.users, caches.dmPeers)
+  if (peerName) return peerName
+  const stream = caches.streams.find((s) => s.id === streamId)
+  if (stream) return getStreamName(stream) ?? streamFallbackLabel(stream.type, context)
+  return null
 }


### PR DESCRIPTION
The Saved list still showed "Saved from Unknown" for DMs: the previous
fix gated DM name resolution behind a `useWorkspaceStreams` lookup, so a
DM whose stream object wasn't in the streams cache (the common case —
the saved list can reference DMs the sidebar never loaded) short-circuited
to "Unknown" without ever attempting the peer lookup.

`resolveDmDisplayName` only needs the saved row's `streamId` plus the
`dmPeers` + `users` caches, and `dmPeers` covers every DM the viewer
belongs to. Resolve from that first, independent of whether the stream
object is cached; fall through to the cached stream (channels/threads/
scratchpads) and finally the backend snapshot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782035810&installation_id=129946197&pr_number=589&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F589&signature=bbb791ece88df820f9b8e20c9f3dde0c1fca478b42c455c197775335aceb54f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->