### PR TITLE
fix(frontend): make the "new version" reload actually load the new client

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { reloadForUpdate, shouldNotifyUpdate, UPDATE_RELOAD_FALLBACK_MS } from "./use-app-update"
+import { reloadForUpdate, shouldNotifyUpdate, RELOAD_FRESH_ACK_TIMEOUT_MS } from "./use-app-update"
+import { SW_MSG_RELOAD_FRESH } from "@/lib/sw-messages"
 
 const RUNNING = "abc1234"
 
@@ -32,13 +33,10 @@ describe("reloadForUpdate", () => {
   const swDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
   let reloadSpy: ReturnType<typeof vi.fn>
 
-  const setRegistration = (registration: unknown): void => {
+  const setController = (controller: unknown): void => {
     Object.defineProperty(navigator, "serviceWorker", {
       configurable: true,
-      value: {
-        addEventListener: vi.fn(),
-        getRegistration: () => Promise.resolve(registration),
-      },
+      value: { controller, addEventListener: vi.fn() },
     })
   }
 
@@ -62,50 +60,41 @@ describe("reloadForUpdate", () => {
     }
   })
 
-  it("still reloads within the fallback window when registration.update() never settles", async () => {
-    // The regression: every guaranteed-reload path used to sit behind
-    // `await registration.update()`. A hung update() (stalled SW-script fetch,
-    // throttled/offline tab) dismissed the toast and then left Reload doing
-    // nothing. The time-bounded fallback must fire regardless.
-    vi.useFakeTimers()
-    setRegistration({
-      installing: null,
-      waiting: null,
-      update: () => new Promise<void>(() => {}), // never settles
-    })
+  it("reloads immediately when no SW controls the page (navigation already hits network)", async () => {
+    setController(null)
+    await reloadForUpdate()
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  it("asks the controlling SW for a fresh navigation, then reloads once it acks", async () => {
+    let received: { type: string } | undefined
+    const controller = {
+      postMessage: vi.fn((message: { type: string }, transfer?: Transferable[]) => {
+        received = message
+        // Mimic the SW: ack on the transferred port so the reload proceeds.
+        const port = transfer?.[0] as MessagePort | undefined
+        port?.postMessage({ ok: true })
+      }),
+    }
+    setController(controller)
 
     await reloadForUpdate()
+
+    expect(controller.postMessage).toHaveBeenCalledOnce()
+    expect(received).toEqual({ type: SW_MSG_RELOAD_FRESH })
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
+  })
+
+  it("reloads anyway when the SW never acks (wedged worker can't strand Reload)", async () => {
+    vi.useFakeTimers()
+    // Controller that swallows the message without acking.
+    setController({ postMessage: vi.fn() })
+
+    const promise = reloadForUpdate()
     expect(reloadSpy).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(UPDATE_RELOAD_FALLBACK_MS)
+    await vi.advanceTimersByTimeAsync(RELOAD_FRESH_ACK_TIMEOUT_MS)
+    await promise
     expect(reloadSpy).toHaveBeenCalledOnce()
-  })
-
-  it("reloads immediately when there is no service worker registration", async () => {
-    setRegistration(undefined)
-    await reloadForUpdate()
-    expect(reloadSpy).toHaveBeenCalledOnce()
-  })
-
-  it("falls back to a plain reload when registration.update() rejects", async () => {
-    setRegistration({
-      installing: null,
-      waiting: null,
-      update: () => Promise.reject(new Error("update failed")),
-    })
-
-    await reloadForUpdate()
-    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
-  })
-
-  it("reloads as soon as the update resolves with no pending worker, without waiting the fallback out", async () => {
-    setRegistration({
-      installing: null,
-      waiting: null,
-      update: () => Promise.resolve(),
-    })
-
-    await reloadForUpdate()
-    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
   })
 })

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -3,13 +3,18 @@ import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
 import { getNotifiedVersion, setNotifiedVersion } from "@/lib/app-update-version"
+import { SW_MSG_RELOAD_FRESH } from "@/lib/sw-messages"
 
 const POLL_INTERVAL = 300_000 // 5 minutes
 const TOAST_ID = "app-update"
 const IS_DEV = import.meta.env.DEV
 
-/** Cap how long the Reload action waits for the new SW before reloading anyway. */
-export const UPDATE_RELOAD_FALLBACK_MS = 10_000
+/**
+ * Cap how long the Reload action waits for the SW to acknowledge the
+ * network-fresh request before reloading anyway. The ack is near-instant; this
+ * only guards against a wedged SW so Reload can never hang.
+ */
+export const RELOAD_FRESH_ACK_TIMEOUT_MS = 1500
 
 /**
  * Tell the browser to check for a new service worker. The SW's install handler
@@ -23,72 +28,50 @@ async function triggerSwUpdate(): Promise<void> {
 }
 
 /**
+ * Ask the controlling SW to serve the next navigation from the network, then
+ * resolve once it acks (or the timeout elapses). The ack guarantees the SW has
+ * set its one-shot flag before we trigger the navigation, so the reload that
+ * follows is the one served fresh.
+ */
+function requestFreshNav(controller: ServiceWorker): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel()
+    const timer = setTimeout(resolve, RELOAD_FRESH_ACK_TIMEOUT_MS)
+    channel.port1.onmessage = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    try {
+      controller.postMessage({ type: SW_MSG_RELOAD_FRESH }, [channel.port2])
+    } catch {
+      clearTimeout(timer)
+      resolve()
+    }
+  })
+}
+
+/**
  * Reload onto the new build.
  *
  * The SW serves navigations cache-first from the build-atomic precache, so a
- * plain reload returns whatever build the *currently controlling* SW precached.
- * If the new SW hasn't installed and claimed this page yet, that is still the
- * old build and the version toast just reappears — which is why an
- * unconditional reload needed "a bunch of refreshes".
+ * plain reload returns whatever build the *currently controlling* SW precached
+ * — and right after a deploy that is still the old build, so the version toast
+ * just reappears. Waiting for the new SW to install and claim before reloading
+ * is racy (a slow/throttled install reloads onto the old shell anyway), so
+ * instead we ask the controlling SW to serve this one navigation from the
+ * network. The reload then fetches the freshly-deployed index.html (and its new
+ * hashed assets) directly, landing on the new build in one click regardless of
+ * SW-update timing. The new SW installs in the background as usual.
  *
- * So the guaranteed behaviour is a single time-bounded reload, armed up front
- * and never gated on the SW update settling. On top of that, as a best-effort
- * optimization, force the SW update and reload the moment the new worker takes
- * control (it self-activates via skipWaiting + clients.claim, firing
- * `controllerchange`) so the reload lands on the new build instead of waiting
- * the fallback out. Reloads exactly once; never worse than a bare reload.
+ * No controller (first load before the SW claims) means the navigation already
+ * hits the network, so a plain reload is correct.
  */
 export async function reloadForUpdate(): Promise<void> {
-  let reloaded = false
-  const reloadOnce = (): void => {
-    if (reloaded) return
-    reloaded = true
-    window.location.reload()
+  const controller = navigator.serviceWorker?.controller
+  if (controller) {
+    await requestFreshNav(controller)
   }
-
-  // Any unexpected failure must still reload — this is the user's escape hatch
-  // onto the new build, so it can never silently do nothing.
-  try {
-    const registration = await navigator.serviceWorker?.getRegistration()
-    if (!registration) {
-      reloadOnce()
-      return
-    }
-
-    // Subscribe before update() so a fast activate→claim can't fire the event
-    // before we are listening.
-    navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
-
-    // registration.update() can hang indefinitely (stalled SW-script fetch,
-    // throttled or offline tab), so it must not gate the reload. Arming the
-    // fallback here, independent of the update() promise below, guarantees
-    // reloadOnce runs within UPDATE_RELOAD_FALLBACK_MS no matter how update()
-    // behaves.
-    setTimeout(reloadOnce, UPDATE_RELOAD_FALLBACK_MS)
-
-    // Best effort on top of that fallback: reload the moment the new SW takes
-    // control so the reload lands on its precached build instead of waiting the
-    // fallback out. Not awaited, so a hung update() can't block the timeout.
-    void registration
-      .update()
-      .then(() => {
-        const pending = registration.installing ?? registration.waiting
-        if (!pending) {
-          // The new SW already installed and took control in the background — a
-          // plain reload now serves its precached shell.
-          reloadOnce()
-          return
-        }
-        // Backstop for controllerchange in case it does not fire for this
-        // client: reload as soon as the new SW reaches `activated`.
-        pending.addEventListener("statechange", () => {
-          if (pending.state === "activated") reloadOnce()
-        })
-      })
-      .catch(reloadOnce)
-  } catch {
-    reloadOnce()
-  }
+  window.location.reload()
 }
 
 /**

--- a/apps/frontend/src/lib/sw-messages.ts
+++ b/apps/frontend/src/lib/sw-messages.ts
@@ -18,5 +18,13 @@ export const SW_MSG_CLEAR_NOTIFICATIONS = "CLEAR_NOTIFICATIONS"
  */
 export const SW_MSG_QUEUE_BOOTSTRAP_SYNC = "QUEUE_BOOTSTRAP_SYNC"
 
+/**
+ * Posted from the app to the SW (the controlling worker) to serve the *next*
+ * navigation from the network instead of the cache-first precache shell. Used by
+ * the "new version" reload so the reload lands on the freshly-deployed build
+ * rather than the old build the current SW precached.
+ */
+export const SW_MSG_RELOAD_FRESH = "RELOAD_FRESH"
+
 /** Cache name used by the SW to stash share-target POST data (files + text) for the app to read. */
 export const SHARE_TARGET_CACHE = "share-target"

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -7,10 +7,31 @@ import {
   SW_MSG_SUBSCRIPTION_CHANGED,
   SW_MSG_CLEAR_NOTIFICATIONS,
   SW_MSG_QUEUE_BOOTSTRAP_SYNC,
+  SW_MSG_RELOAD_FRESH,
   SHARE_TARGET_CACHE,
 } from "./lib/sw-messages"
 
 declare const self: ServiceWorkerGlobalScope
+
+/**
+ * One-shot: serve the next app-shell navigation from the network instead of the
+ * cache-first precache. Set by the "new version" reload (SW_MSG_RELOAD_FRESH)
+ * so the reload fetches the freshly-deployed index.html — the precache here is
+ * still the *old* build until the new SW installs and claims, so a plain
+ * cache-first reload would just re-serve the old client. In-memory is fine: the
+ * page reloads within milliseconds of the ack, so the flag never needs to
+ * survive an SW restart, and if it somehow does reset we fall back to the safe
+ * cache-first path (no worse than before).
+ */
+let serveNextNavFromNetwork = false
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type !== SW_MSG_RELOAD_FRESH) return
+  serveNextNavFromNetwork = true
+  // Ack so the page reloads only once the flag is set, guaranteeing the
+  // navigation that follows is the one served from the network.
+  event.ports[0]?.postMessage({ ok: true })
+})
 
 /** Extend NotificationOptions with properties supported by browsers but missing from TS lib types. */
 interface ExtendedNotificationOptions extends NotificationOptions {
@@ -80,6 +101,19 @@ self.addEventListener("fetch", (event) => {
 
   event.respondWith(
     (async () => {
+      // One-shot network-first: the user clicked "Reload" on the new-version
+      // toast. Fetch the freshly-deployed shell so the reload lands on the new
+      // build instead of this (old) SW's precached shell. Falls through to the
+      // precache if the network fails (offline) so the reload still yields a
+      // working app.
+      if (serveNextNavFromNetwork) {
+        serveNextNavFromNetwork = false
+        try {
+          return await fetch(event.request)
+        } catch {
+          // Offline — fall through to the precached shell below.
+        }
+      }
       // matchPrecache resolves workbox's revisioned cache key, so this is the
       // exact index.html that ships with the precached asset bundle.
       const precached = await matchPrecache("/index.html")


### PR DESCRIPTION
## Problem

The "A new version of Threa is available" toast has a **Reload** button that's supposed to update the client to the latest build. In practice it didn't: clicking it appeared to only re-fetch the open stream's data, leaving the client on the old version (and the toast reappearing).

Root cause is the service worker, not the button. `reloadForUpdate()` already called `window.location.reload()`, but the SW serves **all navigations cache-first** from its precache (`sw.ts`). A plain reload therefore re-serves whatever build the *currently controlling* SW precached — and right after a deploy that is still the **old** build until the new SW installs and claims control. So the page remounted and the stream bootstrap refetched (the "data reloaded" flicker), but `__APP_VERSION__` never changed.

The previous implementation tried to wait for the new SW to install and `clients.claim()` before reloading, but that's racy: a slow/throttled install, the 10s fallback, or a CDN serving a stale `sw.js` while `version.json` is already fresh all reload onto the old shell anyway.

## Solution

Make the reload fetch the freshly-deployed app shell from the **network** for that one navigation, instead of relying on the new SW having claimed control first.

### How it works

1. On Reload, the page posts `SW_MSG_RELOAD_FRESH` to the controlling SW over a `MessageChannel` and awaits the ack (with a 1.5s timeout so a wedged SW can never strand the button).
2. The SW sets a one-shot `serveNextNavFromNetwork` flag and acks.
3. The page calls `window.location.reload()`.
4. The SW's navigation handler sees the flag, consumes it, and serves that one navigation from the network — fetching the freshly-deployed `index.html` and its new hashed assets directly, landing on the new build in one click.
5. The new SW installs in the background as usual and takes over subsequent loads.

This drops the racy `registration.update()` / `controllerchange` / `statechange` / 10s-fallback dance entirely.

### Key design decisions

**1. One-shot network nav over network-first-for-all-navigations**

The cache-first navigation handler exists deliberately to prevent a post-deploy "unstyled page" (the SPA `/* /index.html 200` fallback serving HTML for now-deleted asset URLs) and to keep zero network on the boot critical path. Making *all* navigations network-first would regress offline boot and add latency to every launch. The one-shot flag only changes behavior for the explicit update reload and leaves normal launches untouched.

**2. Ack before reload**

The page waits for the SW to ack before navigating, guaranteeing the flag is set before the navigation arrives (the two are otherwise unordered tasks on the SW thread). The 1.5s timeout means a non-responsive SW still reloads (degrading to today's cache-first behavior — never worse).

**3. Offline fallback preserved**

If the network fetch fails (offline), the handler falls through to the precached shell, so the reload still yields a working app.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-app-update.ts` | Replace the SW-update-and-wait reload with `requestFreshNav()` (postMessage + ack over MessageChannel) followed by `window.location.reload()`. Swap `UPDATE_RELOAD_FALLBACK_MS` for `RELOAD_FRESH_ACK_TIMEOUT_MS`. |
| `apps/frontend/src/sw.ts` | Add `serveNextNavFromNetwork` one-shot flag, a `SW_MSG_RELOAD_FRESH` message handler that sets it and acks, and a network-first branch (with precache fallback) at the top of the navigation handler. |
| `apps/frontend/src/lib/sw-messages.ts` | Add the `SW_MSG_RELOAD_FRESH` message constant. |
| `apps/frontend/src/hooks/use-app-update.test.ts` | Rewrite the `reloadForUpdate` tests for the message-based flow: no-controller plain reload, post-message + ack + reload, and wedged-SW timeout. |

## Test plan

- [x] `bun run test src/hooks/use-app-update.test.ts` — 8 passing (shouldNotifyUpdate + reloadForUpdate paths)
- [x] Monorepo typecheck + lint (pre-commit hooks)
- [ ] **Manual on staging** (requires two different build hashes — can't be reproduced locally): trigger the version toast, click Reload, confirm `__APP_VERSION__` changes and the toast does not reappear
- [ ] Verify offline reload still loads the precached shell
- [ ] Verify the new SW installs/takes over on subsequent loads

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015XzgHNWLzzenXkfATseFRi)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782036923&installation_id=129946197&pr_number=590&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F590&signature=d5c3e17700897419e5f420186da9dc73bd726b3fd5d5c8841452cb2e222d38ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->