### PR TITLE
refactor(frontend): consolidate stream-name resolution on shared helpers

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -27,22 +27,30 @@ Pick the entry point by what you're holding:
   In a non-hook context (list mappers, tests) call the pure
   `resolveStreamName(streamId, { streams, users, dmPeers }, context?)` directly.
 
-- **You already have a stream object** → `getStreamName(stream)` (channel → `#slug`,
-  otherwise `displayName`), falling back to `streamFallbackLabel(stream.type, context)`
-  when it returns `null`:
+- **You already have a stream object** → `streamLabel(stream, context?)`. It
+  returns a guaranteed non-null string: the resolved name (channel `#slug` /
+  `displayName`) when there is one, otherwise the context-appropriate
+  placeholder. This is the single call — do **not** append your own
+  `?? streamFallbackLabel(...)` tail; the fallback lives inside `streamLabel`:
 
   ```ts
-  const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "sidebar")
+  const label = streamLabel(stream, "sidebar")
   ```
 
   When the object can be a DM whose `displayName` may be stale/null (raw socket
   rows carry `displayName: null`), resolve the peer first with
-  `resolveDmDisplayName(streamId, users, dmPeers)` before falling back to the
-  object's own name — or just go through `resolveStreamName`/`useStreamName` by id.
+  `resolveDmDisplayName(streamId, users, dmPeers)` before `streamLabel` — or just
+  go through `resolveStreamName`/`useStreamName` by id.
+
+  Reach for the nullable `getStreamName(stream)` primitive **only** when you
+  genuinely need `null` rather than a placeholder — sort/search keys
+  (`getStreamName(s) ?? ""`) or a caller-specific fallback phrase
+  (``getStreamName(s) ?? `this ${noun}` ``). If you want a displayable label,
+  use `streamLabel`, not `getStreamName`.
 
 `FallbackContext` (`"sidebar" | "activity" | "breadcrumb" | "generic" | "noun"`)
 selects context-appropriate placeholder wording for unnamed streams; pass the
-one that matches the surface.
+one that matches the surface. `streamLabel` defaults to `"generic"`.
 
 ### Why this exists
 

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -1,0 +1,53 @@
+# Frontend Agent Notes
+
+Scoped guidance for `apps/frontend`. The repo-root `CLAUDE.md` invariants still
+apply; this file adds frontend conventions that are easy to reinvent badly.
+
+## Resolving a stream's display name
+
+There is **one** place that knows how to turn a stream into a label:
+`apps/frontend/src/lib/streams.ts`. Use it. Do not hand-roll the
+slug-vs-`displayName` ternary, do not call `dmPeers.find(...)` and look up the
+user yourself, and do not gate DM resolution behind "is the stream object in the
+cache" — DM names are viewer-specific and a DM you can open may not be in the
+streams cache at all.
+
+Pick the entry point by what you're holding:
+
+- **You have a stream id** (and want the label) → `useStreamName(workspaceId, streamId, context?)`
+  from `@/hooks/use-stream-name`. It reads the workspace caches and resolves DM
+  peer names, channel slugs, and placeholder fallbacks for you. Returns `null`
+  only when the id matches no DM peer and no cached stream — layer your own
+  last-resort fallback after it (e.g. a persisted snapshot name):
+
+  ```ts
+  const label = useStreamName(workspaceId, streamId) ?? snapshotName ?? "Unknown"
+  ```
+
+  In a non-hook context (list mappers, tests) call the pure
+  `resolveStreamName(streamId, { streams, users, dmPeers }, context?)` directly.
+
+- **You already have a stream object** → `getStreamName(stream)` (channel → `#slug`,
+  otherwise `displayName`), falling back to `streamFallbackLabel(stream.type, context)`
+  when it returns `null`:
+
+  ```ts
+  const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "sidebar")
+  ```
+
+  When the object can be a DM whose `displayName` may be stale/null (raw socket
+  rows carry `displayName: null`), resolve the peer first with
+  `resolveDmDisplayName(streamId, users, dmPeers)` before falling back to the
+  object's own name — or just go through `resolveStreamName`/`useStreamName` by id.
+
+`FallbackContext` (`"sidebar" | "activity" | "breadcrumb" | "generic" | "noun"`)
+selects context-appropriate placeholder wording for unnamed streams; pass the
+one that matches the surface.
+
+### Why this exists
+
+DM display names are computed per-viewer on the backend at bootstrap and are
+**not** persisted on the stream row (`displayName` is `null` for DMs on the
+wire). Every surface that re-derived this by hand drifted: the Saved view showed
+"Unknown", scheduled rows skipped peer resolution, etc. Routing through the
+shared resolver is the fix — reach for it instead of writing the lookup again.

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/frontend/src/components/attachment-explorer/explorer-filters.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-filters.tsx
@@ -19,7 +19,7 @@ import { useWorkspaceStreams, useWorkspaceUnreadState, useWorkspaceUsers } from 
 import { useActivityCounts, useUnreadCounts } from "@/hooks"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
 import { compareStreamEntries, scoreStreamMatch } from "@/lib/stream-sort"
-import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
+import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { CATEGORY_OPTIONS } from "./category"
 import type { ExplorerFilters } from "./use-explorer-url-state"
 
@@ -119,7 +119,7 @@ export function ExplorerFilters({ workspaceId, filters, parentStreamId, onUpdate
   }, [streams, streamSearch, filters.streamIds, getUnreadCount, getMentionCount, mutedStreamIds])
 
   const labelForStream = (stream: { type: string; displayName?: string | null; slug?: string | null }) =>
-    getStreamName(stream) ?? streamFallbackLabel(stream.type as Parameters<typeof streamFallbackLabel>[0], "generic")
+    streamLabel(stream)
 
   const toggleCategory = (cat: AttachmentCategory) => {
     const set = new Set(filters.categories)

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -10,7 +10,7 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { cn } from "@/lib/utils"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import { BADGE_CONFIG, URGENCY_COLORS } from "./config"
 import {
   SidebarActionDrawer,
@@ -203,7 +203,7 @@ export function StreamItem({
   }
 
   const avatar = getAvatar()
-  const name = getStreamName(stream) ?? streamFallbackLabel(stream.type, "sidebar")
+  const name = streamLabel(stream, "sidebar")
   const threadRootStream =
     stream.type === StreamTypes.THREAD && stream.rootStreamId
       ? (allStreams.find((s) => s.id === stream.rootStreamId) ?? null)

--- a/apps/frontend/src/components/quick-switcher/filter-select.tsx
+++ b/apps/frontend/src/components/quick-switcher/filter-select.tsx
@@ -4,7 +4,7 @@ import { Calendar } from "@/components/ui/calendar"
 import { formatISODate } from "@/lib/dates"
 import { useFormattedDate } from "@/hooks"
 import type { StreamType, User, Stream } from "@threa/types"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamLabel } from "@/lib/streams"
 
 interface StreamTypeOption {
   value: StreamType
@@ -176,7 +176,7 @@ function StreamSelect({ streams, onSelect }: StreamSelectProps) {
     return name.toLowerCase().includes(search.toLowerCase())
   })
 
-  const resolvedName = (stream: Stream) => getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+  const resolvedName = (stream: Stream) => streamLabel(stream)
 
   return (
     <div className="w-48">

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Hash, Plus, X, Archive } from "lucide-react"
 import { StreamTypes, getAvatarUrl } from "@threa/types"
 import type { Stream, StreamType } from "@threa/types"
-import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
+import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { streamsApi } from "@/api"
 import { createDmDraftId, useUnreadCounts, useActivityCounts } from "@/hooks"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
@@ -199,7 +199,7 @@ export function useStreamItems(context: ModeContext): ModeResult {
 
         return {
           id: stream.id,
-          label: getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic"),
+          label: streamLabel(stream),
           description,
           icon: STREAM_ICONS[stream.type],
           avatarUrl,

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -12,7 +12,7 @@ import {
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceUnreadState } from "@/stores/workspace-store"
-import { getStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
+import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { compareStreamEntries, scoreStreamMatch, useStoredStreamSortMode } from "@/lib/stream-sort"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
@@ -178,7 +178,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
                 <CommandGroup key={group.id} heading={group.heading}>
                   {list.map(({ stream }) => {
                     const Icon = STREAM_ICONS[stream.type]
-                    const label = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+                    const label = streamLabel(stream)
                     return (
                       <CommandItem key={stream.id} value={stream.id} onSelect={() => handleSelect(stream.id)}>
                         <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -17,6 +17,7 @@ import {
   ResponsiveAlertDialogTitle,
 } from "@/components/ui/responsive-alert-dialog"
 import { ChannelSlugInput } from "./channel-slug-input"
+import { getStreamName } from "@/lib/streams"
 import { useUpdateStream, useArchiveStream, useUnarchiveStream, useSetNotificationLevel } from "@/hooks"
 import {
   StreamTypes,
@@ -78,7 +79,7 @@ export function GeneralTab({
       <ThreadVisibilityDisplay
         key="visibility"
         inheritedVisibility={rootStream.visibility}
-        rootStreamName={rootStream.slug ? `#${rootStream.slug}` : (rootStream.displayName ?? "parent stream")}
+        rootStreamName={getStreamName(rootStream) ?? "parent stream"}
       />
     )
   } else if (isThread) {
@@ -473,7 +474,7 @@ function ArchiveSection({
     setConfirmOpen(false)
   }
 
-  const streamName = stream.slug ? `#${stream.slug}` : (stream.displayName ?? `this ${streamTypeLabel}`)
+  const streamName = getStreamName(stream) ?? `this ${streamTypeLabel}`
 
   return (
     <div className="space-y-3">

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.test.tsx
@@ -133,4 +133,38 @@ describe("StreamSettingsDialog", () => {
     expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
     expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
   })
+
+  it("titles a DM with the resolved peer name when the stream row has no displayName", async () => {
+    // Raw DM rows arrive with displayName: null (viewer-specific names aren't
+    // persisted), so the title must resolve through the shared resolver via the
+    // peer user rather than falling back to a generic label.
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_dm"), {
+      stream: makeStream({ displayName: null }),
+      events: [],
+      members: [],
+      botMemberIds: [],
+      membership: null,
+      latestSequence: "0",
+      hasOlderEvents: false,
+      syncMode: "replace",
+      unreadCount: 0,
+      mentionCount: 0,
+      activityCount: 0,
+    } satisfies StreamBootstrap)
+
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([
+      { id: "user_peer", name: "Ada Lovelace" },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([
+      { streamId: "stream_dm", userId: "user_peer" },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceDmPeers>)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <StreamSettingsDialog workspaceId="ws_1" />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText("Ada Lovelace Settings")).toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -21,7 +21,7 @@ import {
   useWorkspaceDmPeers,
 } from "@/stores/workspace-store"
 import { StreamTypes, type Stream, type StreamBootstrap, type NotificationLevel } from "@threa/types"
-import { getStreamName, resolveDmDisplayName, streamFallbackLabel } from "@/lib/streams"
+import { resolveDmDisplayName, streamLabel } from "@/lib/streams"
 
 const TAB_CONFIG: Record<StreamSettingsTab, { label: string; description: string }> = {
   general: { label: "General", description: "Notifications and stream details" },
@@ -96,7 +96,7 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
   // resolves through the shared helper so the title matches every other surface.
   let streamName = "Stream"
   if (resolvedStream) {
-    streamName = dmDisplayName ?? getStreamName(resolvedStream) ?? streamFallbackLabel(resolvedStream.type, "generic")
+    streamName = dmDisplayName ?? streamLabel(resolvedStream)
   }
 
   return (

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -21,7 +21,7 @@ import {
   useWorkspaceDmPeers,
 } from "@/stores/workspace-store"
 import { StreamTypes, type Stream, type StreamBootstrap, type NotificationLevel } from "@threa/types"
-import { resolveDmDisplayName } from "@/lib/streams"
+import { getStreamName, resolveDmDisplayName, streamFallbackLabel } from "@/lib/streams"
 
 const TAB_CONFIG: Record<StreamSettingsTab, { label: string; description: string }> = {
   general: { label: "General", description: "Notifications and stream details" },
@@ -92,9 +92,11 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
   // If active tab isn't available for this stream type, fall back
   const effectiveTab = (availableTabs as readonly string[]).includes(activeTab) ? activeTab : availableTabs[0]
 
+  // DMs carry the viewer-specific peer name in `dmDisplayName`; everything else
+  // resolves through the shared helper so the title matches every other surface.
   let streamName = "Stream"
   if (resolvedStream) {
-    streamName = resolvedStream.slug ? `#${resolvedStream.slug}` : (resolvedStream.displayName ?? "Stream")
+    streamName = dmDisplayName ?? getStreamName(resolvedStream) ?? streamFallbackLabel(resolvedStream.type, "generic")
   }
 
   return (

--- a/apps/frontend/src/components/thread/breadcrumb-ellipsis-dropdown.tsx
+++ b/apps/frontend/src/components/thread/breadcrumb-ellipsis-dropdown.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom"
 import { BreadcrumbItem, BreadcrumbEllipsis, BreadcrumbSeparator } from "@/components/ui/breadcrumb"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import type { StreamType } from "@threa/types"
 
 interface StreamInfo {
@@ -35,7 +35,7 @@ export function BreadcrumbEllipsisDropdown({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
             {items.map((item) => {
-              const displayName = getStreamName(item) ?? streamFallbackLabel(item.type, "breadcrumb")
+              const displayName = streamLabel(item, "breadcrumb")
 
               if (isMainViewStream(item.id)) {
                 return (

--- a/apps/frontend/src/components/thread/breadcrumb-helpers.tsx
+++ b/apps/frontend/src/components/thread/breadcrumb-helpers.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom"
 import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "@/components/ui/breadcrumb"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import type { StreamType } from "@threa/types"
 
 interface StreamInfo {
@@ -33,7 +33,7 @@ export function getThreadRootContext(
   const rootStream = allStreams.find((s) => s.id === thread.rootStreamId)
   if (!rootStream) return null
 
-  return getStreamName(rootStream) ?? streamFallbackLabel(rootStream.type, "sidebar")
+  return streamLabel(rootStream, "sidebar")
 }
 
 interface AncestorBreadcrumbItemProps {
@@ -58,7 +58,7 @@ export function AncestorBreadcrumbItem({
   getNavigationUrl,
   maxWidth = 120,
 }: AncestorBreadcrumbItemProps) {
-  const displayName = getStreamName(stream) ?? streamFallbackLabel(stream.type, "breadcrumb")
+  const displayName = streamLabel(stream, "breadcrumb")
 
   if (isMainViewStream) {
     return (

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -48,9 +48,9 @@ import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { ThreadParentMessage } from "./thread-parent-message"
 import { ThreadHeader } from "./thread-header"
 import { ResponsiveBreadcrumbs } from "./responsive-breadcrumbs"
-import { StreamTypes, type StreamType } from "@threa/types"
+import { StreamTypes } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 
 interface StreamPanelProps {
   workspaceId: string
@@ -378,11 +378,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   } else if (isThread && stream) {
     headerContent = <ThreadHeader workspaceId={workspaceId} stream={stream} inPanel />
   } else {
-    headerContent = (
-      <SidePanelTitle className="flex-1">
-        {stream ? (getStreamName(stream) ?? streamFallbackLabel(stream.type as StreamType, "generic")) : "Stream"}
-      </SidePanelTitle>
-    )
+    headerContent = <SidePanelTitle className="flex-1">{stream ? streamLabel(stream) : "Stream"}</SidePanelTitle>
   }
 
   return (
@@ -422,9 +418,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 description="Choose an action for this stream."
                 header={
                   <div className="px-4 pt-2 pb-3">
-                    <p className="truncate text-base font-semibold text-foreground">
-                      {getStreamName(stream) ?? streamFallbackLabel(stream.type as StreamType, "generic")}
-                    </p>
+                    <p className="truncate text-base font-semibold text-foreground">{streamLabel(stream)}</p>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                       {stream.type === StreamTypes.THREAD ? "Thread" : "Stream"} actions
                     </p>

--- a/apps/frontend/src/components/thread/thread-header.tsx
+++ b/apps/frontend/src/components/thread/thread-header.tsx
@@ -4,7 +4,7 @@ import { useThreadAncestors } from "@/hooks"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { usePanel } from "@/contexts"
 import { ResponsiveBreadcrumbs } from "./responsive-breadcrumbs"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import type { StreamType } from "@threa/types"
 
 interface ThreadHeaderStream {
@@ -70,7 +70,7 @@ export function ThreadHeader({ workspaceId, stream, inPanel = false }: ThreadHea
     <div className={`min-w-0 flex-1 overflow-hidden ${inPanel ? "pr-2" : ""}`}>
       <ResponsiveBreadcrumbs
         ancestors={ancestors}
-        currentLabel={getStreamName(stream) ?? streamFallbackLabel("thread", "breadcrumb")}
+        currentLabel={streamLabel(stream, "breadcrumb")}
         isMainViewStream={isMainViewStream}
         onClosePanel={closePanel}
         getNavigationUrl={getNavigationUrl}

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -11,10 +11,10 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { isDraftId } from "./use-draft-scratchpads"
 import { deleteStashedDraftById } from "./use-stashed-drafts"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import type { JSONContent, StreamType } from "@threa/types"
+import type { JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
 
 /**
  * Defensive ceiling on the workspace-wide stash scan that powers the /drafts
@@ -133,7 +133,7 @@ function resolveDraftLocation(
     const messageInfo = messageToStreamMap.get(parsed.id)
     const parentStream = messageInfo ? streamMap.get(messageInfo.streamId) : null
     if (parentStream) {
-      const streamName = getStreamName(parentStream) ?? streamFallbackLabel(parentStream.type as StreamType, "sidebar")
+      const streamName = streamLabel(parentStream, "sidebar")
       const displayName = `Thread in ${streamName}`
       return {
         draftType: "thread",

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react"
 import type { Stream } from "@threa/types"
 import type { UrgencyLevel } from "@/components/layout/sidebar/types"
 import { getActivityTime } from "@/components/layout/sidebar/utils"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 
 /** Sort modes used by stream pickers (quick switcher, share modal, share picker). */
 export type StreamSortMode = "recency" | "alphabetical"
@@ -27,7 +27,7 @@ export function scoreStreamMatch(
   lowerQuery: string
 ): number {
   if (!lowerQuery) return 0
-  const name = (getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")).toLowerCase()
+  const name = streamLabel(stream).toLowerCase()
   if (name === lowerQuery) return 0
   if (name.startsWith(lowerQuery)) return 1
   if (name.includes(lowerQuery)) return 2
@@ -36,8 +36,8 @@ export function scoreStreamMatch(
 }
 
 function compareNames(a: SortableStream, b: SortableStream): number {
-  const aName = getStreamName(a) ?? streamFallbackLabel(a.type, "generic")
-  const bName = getStreamName(b) ?? streamFallbackLabel(b.type, "generic")
+  const aName = streamLabel(a)
+  const bName = streamLabel(b)
   return aName.localeCompare(bName)
 }
 

--- a/apps/frontend/src/lib/streams.test.ts
+++ b/apps/frontend/src/lib/streams.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest"
-import { resolveDmDisplayName, resolveStreamName } from "./streams"
+import { resolveDmDisplayName, resolveStreamName, streamLabel } from "./streams"
+
+describe("streamLabel", () => {
+  it("prefixes a channel with its slug", () => {
+    expect(streamLabel({ type: "channel", slug: "general", displayName: null })).toBe("#general")
+  })
+
+  it("uses the displayName for a named non-channel stream", () => {
+    expect(streamLabel({ type: "thread", slug: null, displayName: "Launch plan" })).toBe("Launch plan")
+  })
+
+  it("falls through to a context-appropriate placeholder when the stream has no name", () => {
+    expect(streamLabel({ type: "scratchpad", slug: null, displayName: null }, "sidebar")).toBe("New scratchpad")
+  })
+
+  it("defaults the fallback context to generic", () => {
+    expect(streamLabel({ type: "thread", slug: null, displayName: null })).toBe("Thread")
+  })
+})
 
 describe("resolveStreamName", () => {
   const users = [{ id: "user_peer", name: "Pierre Boberg" }]

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -77,6 +77,24 @@ export function streamFallbackLabel(type: StreamType, context: FallbackContext):
   return FALLBACK_LABELS[type]?.[context] ?? "Untitled"
 }
 
+/**
+ * The display label for a stream object — always a non-null string. Resolves
+ * the name (channel slug / displayName) and falls through to a context-
+ * appropriate placeholder when the stream has no name yet.
+ *
+ * This is the entry point for any surface that renders a stream's name and
+ * needs a guaranteed string. Use the nullable `getStreamName` only when you
+ * genuinely need null (sort/search keys, or a bespoke caller-specific
+ * fallback). For DM objects whose `displayName` may be stale, resolve the peer
+ * first (or go through `resolveStreamName`/`useStreamName` by id).
+ */
+export function streamLabel(
+  stream: { type: string; slug?: string | null; displayName?: string | null },
+  context: FallbackContext = "generic"
+): string {
+  return getStreamName(stream) ?? streamFallbackLabel(stream.type as StreamType, context)
+}
+
 interface StreamNameCaches {
   streams: Array<{ id: string; type: StreamType; slug?: string | null; displayName?: string | null }>
   users: Array<{ id: string; name: string }>
@@ -105,6 +123,6 @@ export function resolveStreamName(
   const peerName = resolveDmDisplayName(streamId, caches.users, caches.dmPeers)
   if (peerName) return peerName
   const stream = caches.streams.find((s) => s.id === streamId)
-  if (stream) return getStreamName(stream) ?? streamFallbackLabel(stream.type, context)
+  if (stream) return streamLabel(stream, context)
   return null
 }

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -32,7 +32,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { RelativeTime } from "@/components/relative-time"
 import { SidebarToggle } from "@/components/layout"
 import { cn } from "@/lib/utils"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import type { MemoExplorerDetail, MemoExplorerResult, MemoExplorerStreamRef } from "@/api"
 
 const ALL_MEMO_TYPES = "all-memo-types"
@@ -557,7 +557,7 @@ export function MemoryPage() {
     .filter((stream) => !stream.archivedAt)
     .map((stream) => ({
       id: stream.id,
-      label: getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic"),
+      label: streamLabel(stream),
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -28,7 +28,7 @@ import {
   type ShareData,
   type ShareMeta,
 } from "@/hooks/use-share-target"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import { Input } from "@/components/ui/input"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { ItemList } from "@/components/quick-switcher/item-list"
@@ -215,7 +215,7 @@ export function SharePickerPage() {
 
         return {
           id: stream.id,
-          label: getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic"),
+          label: streamLabel(stream),
           description: typeLabel,
           icon: STREAM_ICONS[stream.type],
           avatarUrl,

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -33,7 +33,7 @@ import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
 import { StreamTypes, type StreamType } from "@threa/types"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { setPageStreamName } from "@/lib/page-title"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
 
@@ -131,7 +131,7 @@ export function StreamPage() {
   const isDmDraft = isDraft && isDmDraftId(streamId)
   let streamName = "Stream"
   if (stream) {
-    streamName = getStreamName(stream) ?? streamFallbackLabel(stream.type, "generic")
+    streamName = streamLabel(stream)
   } else if (isDraft) {
     streamName = streamFallbackLabel(isDmDraft ? "dm" : "scratchpad", "sidebar")
   }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -33,9 +33,8 @@ import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
 import { StreamTypes, type StreamType } from "@threa/types"
-import { getStreamName, resolveDmDisplayName, streamFallbackLabel } from "@/lib/streams"
+import { getStreamName, streamFallbackLabel } from "@/lib/streams"
 import { setPageStreamName } from "@/lib/page-title"
-import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
 
 function getStreamTypeLabel(type: StreamType): string {
@@ -96,7 +95,6 @@ export function StreamPage() {
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
   const dmPeers = useWorkspaceDmPeers(workspaceId ?? "")
-  const workspaceUsers = useWorkspaceUsers(workspaceId)
 
   const isThread = stream?.type === StreamTypes.THREAD
   const isChannel = stream?.type === StreamTypes.CHANNEL
@@ -108,20 +106,16 @@ export function StreamPage() {
   const [isMenuDrawerOpen, setIsMenuDrawerOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  // Set document title to include stream name (matching sidebar DM resolution logic)
+  // `stream.displayName` is already viewer-resolved by useStreamOrDraft (DM peer
+  // names included), so the page title just reads the shared name off it.
   useEffect(() => {
     if (!stream) {
       setPageStreamName(null)
       return () => setPageStreamName(null)
     }
-    const resolvedName =
-      stream.type === StreamTypes.DM
-        ? (resolveDmDisplayName(stream.id, workspaceUsers, dmPeers) ?? stream.displayName)
-        : null
-    const name = resolvedName ?? getStreamName(stream)
-    setPageStreamName(name)
+    setPageStreamName(getStreamName(stream))
     return () => setPageStreamName(null)
-  }, [stream, workspaceUsers, dmPeers])
+  }, [stream])
 
   if (!workspaceId || !streamId) {
     return null

--- a/apps/frontend/src/pages/threads.tsx
+++ b/apps/frontend/src/pages/threads.tsx
@@ -8,7 +8,7 @@ import { StreamTypes } from "@threa/types"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { useActors } from "@/hooks"
 import { getThreadRootContext } from "@/components/thread/breadcrumb-helpers"
-import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 
 export function ThreadsPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
@@ -25,7 +25,7 @@ export function ThreadsPage() {
   // Convert threads to QuickSwitcherItem format
   const items: QuickSwitcherItem[] = useMemo(() => {
     return threads.map((thread) => {
-      const displayName = getStreamName(thread) ?? streamFallbackLabel("thread", "sidebar")
+      const displayName = streamLabel(thread, "sidebar")
       // CachedStream doesn't have lastMessagePreview
       const preview = (thread as any).lastMessagePreview
       const authorName = preview ? getActorName(preview.authorId, preview.authorType) : null


### PR DESCRIPTION
## Summary
- Route the remaining bespoke stream-name composition through the shared resolvers in `apps/frontend/src/lib/streams.ts`, so DM peer names, channel slugs, and placeholder fallbacks resolve consistently everywhere:
  - **Stream page title** (`pages/stream.tsx`): dropped the manual DM peer dance — `stream.displayName` is already viewer-resolved by `useStreamOrDraft`, so the title just reads `getStreamName(stream)`.
  - **Stream-settings dialog title** (`stream-settings-dialog.tsx`): now resolves via the shared helpers; a DM whose row `displayName` is `null` titles to the resolved **peer name** instead of a generic "Stream".
  - **General tab** (`general-tab.tsx`): two inline `#${slug}` ternaries collapsed to `getStreamName(...)`.
- Add `apps/frontend/AGENTS.md` (with `CLAUDE.md` symlinked to it) documenting the single-resolver convention and *why* it exists (DM names are viewer-specific and not persisted on the stream row), so this lookup isn't reinvented per surface and drifts into "Unknown"/missing-name bugs again.
- Add a regression test pinning the DM settings title to the resolved peer name when the stream row carries no `displayName`.

Intentionally left alone (these aren't haphazard duplication): the sidebar's hot map-pipeline already uses the shared `resolveDmDisplayName`; `buildShareToStreamLabel` and `JoinChannelBar`'s bare-slug prop are deliberately type-specific; `use-stream-or-draft`'s fallback chain has behavior we don't want to silently change.

## Test plan
- [x] `vitest run` — stream-settings-dialog (2), streams (4), saved-item (4) suites pass
- [x] `tsc --noEmit` across all workspaces (via pre-commit)
- [x] `eslint` clean (via pre-commit)
- [ ] Manual: open a DM's settings dialog and confirm the title shows the peer's name (not "Stream"); confirm the browser tab title still reflects DM/channel/scratchpad names

https://claude.ai/code/session_01RwokxjYQ5bQhAoN2qLYnyn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwokxjYQ5bQhAoN2qLYnyn)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782038881&installation_id=129946197&pr_number=591&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F591&signature=9e26019baeef2aba621d2f2883a29d90a052fc061c3eb7dabde4a6fe505e3e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->