### PR TITLE
Refine stream naming to focus on topic and follow conversation language

### DIFF
--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -355,4 +355,74 @@ Any ideas what's causing this?`,
       minConfidence: 0.7,
     },
   },
+
+  // Topic naming: lead with the subject, no framing preamble
+  {
+    id: "topic-naming-no-preamble-001",
+    name: "Topic naming: English topic without 'Discussion about' preamble",
+    input: {
+      newMessage: {
+        authorId: "user_abc123",
+        authorType: "user",
+        contentMarkdown:
+          "Let's lock down the seating chart for the wedding — 120 guests across 12 tables, and we need to keep the two families apart.",
+      },
+      activeConversations: [],
+      streamType: "channel",
+      category: "new-topic",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["seating", "wedding", "table"],
+      topicNotContains: ["discussion about", "chat about", "conversation about", "thoughts on"],
+      minConfidence: 0.7,
+    },
+  },
+
+  // Topic naming: follow the conversation's language, don't label it
+  {
+    id: "topic-naming-swedish-001",
+    name: "Topic naming: Swedish conversation stays in Swedish",
+    input: {
+      newMessage: {
+        authorId: "user_abc123",
+        authorType: "user",
+        contentMarkdown:
+          "Jag funderar på att börja odla tomater på balkongen i sommar. Vilken sort passar bäst för ett soligt läge, och hur ofta måste man vattna?",
+      },
+      activeConversations: [],
+      streamType: "channel",
+      category: "new-topic",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      // Must not label the language or fall back to English framing
+      topicNotContains: ["swedish", "svenska", "discussion", "chat about", "conversation about"],
+      minConfidence: 0.7,
+    },
+  },
+
+  // Topic naming: keep proper nouns verbatim, don't translate them
+  {
+    id: "topic-naming-proper-noun-001",
+    name: "Topic naming: product names preserved verbatim in Swedish chat",
+    input: {
+      newMessage: {
+        authorId: "user_abc123",
+        authorType: "user",
+        contentMarkdown:
+          "Har du testat Lightroom för att redigera bilderna? Jag tycker färgerna blir bättre där än i Photoshop, men exporten känns långsam.",
+      },
+      activeConversations: [],
+      streamType: "channel",
+      category: "new-topic",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      // Proper nouns survive untranslated (evaluator passes on any one match)
+      topicContains: ["lightroom", "photoshop"],
+      topicNotContains: ["swedish", "svenska"],
+      minConfidence: 0.7,
+    },
+  },
 ]

--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -396,6 +396,8 @@ Any ideas what's causing this?`,
     },
     expectedOutput: {
       expectNewConversation: true,
+      // Require Swedish wording from the source conversation (evaluator passes on any one match)
+      topicContains: ["tomat", "balkong"],
       // Must not label the language or fall back to English framing
       topicNotContains: ["swedish", "svenska", "discussion", "chat about", "conversation about"],
       minConfidence: 0.7,

--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -396,7 +396,7 @@ Any ideas what's causing this?`,
     },
     expectedOutput: {
       expectNewConversation: true,
-      // Require Swedish wording from the source conversation (evaluator passes on any one match)
+      // Topic must reuse the source conversation's Swedish wording, not translate to English
       topicContains: ["tomat", "balkong"],
       // Must not label the language or fall back to English framing
       topicNotContains: ["swedish", "svenska", "discussion", "chat about", "conversation about"],

--- a/apps/backend/evals/suites/boundary-extraction/evaluators.ts
+++ b/apps/backend/evals/suites/boundary-extraction/evaluators.ts
@@ -80,6 +80,36 @@ export const topicContainsEvaluator: Evaluator<BoundaryExtractionOutput, Boundar
 }
 
 /**
+ * Evaluator that checks the new conversation topic avoids unwanted phrases
+ * (framing preamble like "discussion about", language labels like "in swedish").
+ */
+export const topicNotContainsEvaluator: Evaluator<BoundaryExtractionOutput, BoundaryExtractionExpected> = {
+  name: "topic-not-contains",
+  evaluate: (output: BoundaryExtractionOutput, expected: BoundaryExtractionExpected): EvaluatorResult => {
+    if (!expected.topicNotContains || expected.topicNotContains.length === 0) {
+      return { name: "topic-not-contains", score: 1, passed: true, details: "No exclusion requirements" }
+    }
+
+    // Skip if not a new conversation
+    if (output.conversationId !== null) {
+      return { name: "topic-not-contains", score: 1, passed: true, details: "Not a new conversation" }
+    }
+
+    const topic = (output.newConversationTopic || "").toLowerCase()
+    const found = expected.topicNotContains.filter((word) => topic.includes(word.toLowerCase()))
+
+    const passed = found.length === 0
+    return {
+      name: "topic-not-contains",
+      score: passed ? 1 : 0,
+      passed,
+      details:
+        found.length > 0 ? `Topic "${output.newConversationTopic}" contains unwanted: ${found.join(", ")}` : undefined,
+    }
+  },
+}
+
+/**
  * Evaluator that checks confidence is above threshold.
  */
 export const confidenceEvaluator: Evaluator<BoundaryExtractionOutput, BoundaryExtractionExpected> = {

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -34,6 +34,7 @@ import type {
 import {
   conversationDecisionEvaluator,
   topicContainsEvaluator,
+  topicNotContainsEvaluator,
   confidenceEvaluator,
   completenessUpdateEvaluator,
   accuracyEvaluator,
@@ -143,7 +144,13 @@ export const boundaryExtractionSuite: EvalSuite<
 
   task: runBoundaryExtractionTask,
 
-  evaluators: [conversationDecisionEvaluator, topicContainsEvaluator, confidenceEvaluator, completenessUpdateEvaluator],
+  evaluators: [
+    conversationDecisionEvaluator,
+    topicContainsEvaluator,
+    topicNotContainsEvaluator,
+    confidenceEvaluator,
+    completenessUpdateEvaluator,
+  ],
 
   runEvaluators: [accuracyEvaluator, decisionAccuracyEvaluator, averageConfidenceEvaluator],
 

--- a/apps/backend/evals/suites/boundary-extraction/types.ts
+++ b/apps/backend/evals/suites/boundary-extraction/types.ts
@@ -73,6 +73,8 @@ export interface BoundaryExtractionExpected {
   expectConversationId?: string
   /** New topic should contain these words (if new conversation) */
   topicContains?: string[]
+  /** New topic should NOT contain these words (e.g. framing preamble, language labels) */
+  topicNotContains?: string[]
   /** Minimum confidence threshold */
   minConfidence?: number
   /** Should update completeness for these conversations */

--- a/apps/backend/evals/suites/stream-naming/cases.ts
+++ b/apps/backend/evals/suites/stream-naming/cases.ts
@@ -222,7 +222,7 @@ User: Och hur ofta måste man vattna?`,
       category: "language",
     },
     expectedOutput: {
-      // Require Swedish wording from the source conversation (evaluator passes on any one match)
+      // Title must reuse the source conversation's Swedish wording, not translate to English
       nameContains: ["tomat", "balkong"],
       // Should not label the language or use English framing words
       nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation", "about"],
@@ -241,7 +241,7 @@ User: Men exporten känns långsam`,
     expectedOutput: {
       // Proper nouns must survive untranslated
       nameContains: ["lightroom", "photoshop"],
-      nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation"],
+      nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation", "about"],
       wordCountRange: { min: 2, max: 5 },
     },
   },

--- a/apps/backend/evals/suites/stream-naming/cases.ts
+++ b/apps/backend/evals/suites/stream-naming/cases.ts
@@ -222,6 +222,8 @@ User: Och hur ofta måste man vattna?`,
       category: "language",
     },
     expectedOutput: {
+      // Require Swedish wording from the source conversation (evaluator passes on any one match)
+      nameContains: ["tomat", "balkong"],
       // Should not label the language or use English framing words
       nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation", "about"],
       wordCountRange: { min: 2, max: 5 },

--- a/apps/backend/evals/suites/stream-naming/cases.ts
+++ b/apps/backend/evals/suites/stream-naming/cases.ts
@@ -211,6 +211,53 @@ User: Can we hire a freelancer for this?`,
       wordCountRange: { min: 2, max: 5 },
     },
   },
+  // Language: title follows the conversation's language and drops preamble
+  {
+    id: "language-swedish-topic-001",
+    name: "Language: Swedish conversation stays in Swedish",
+    input: {
+      conversationText: `User: Jag funderar på att börja odla tomater på balkongen i sommar
+User: Vilken sort tror du passar bäst för ett soligt läge?
+User: Och hur ofta måste man vattna?`,
+      category: "language",
+    },
+    expectedOutput: {
+      // Should not label the language or use English framing words
+      nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation", "about"],
+      wordCountRange: { min: 2, max: 5 },
+    },
+  },
+  {
+    id: "language-proper-noun-001",
+    name: "Language: Product name preserved verbatim in Swedish chat",
+    input: {
+      conversationText: `User: Har du testat Lightroom för att redigera bilderna?
+User: Jag tycker färgerna blir bättre där än i Photoshop
+User: Men exporten känns långsam`,
+      category: "language",
+    },
+    expectedOutput: {
+      // Proper nouns must survive untranslated
+      nameContains: ["lightroom", "photoshop"],
+      nameNotContains: ["swedish", "svenska", "discussion", "chat", "conversation"],
+      wordCountRange: { min: 2, max: 5 },
+    },
+  },
+  {
+    id: "language-no-preamble-001",
+    name: "Language: English topic without 'Discussion about' preamble",
+    input: {
+      conversationText: `User: Let's figure out the seating chart for the wedding
+User: We have 120 guests and 12 tables
+User: The tricky part is keeping the two families apart`,
+      category: "casual",
+    },
+    expectedOutput: {
+      nameContains: ["seating", "wedding", "table"],
+      nameNotContains: ["discussion about", "chat about", "conversation about"],
+      wordCountRange: { min: 2, max: 5 },
+    },
+  },
   {
     id: "edge-code-heavy-001",
     name: "Edge: Heavy code content",

--- a/apps/backend/evals/suites/stream-naming/types.ts
+++ b/apps/backend/evals/suites/stream-naming/types.ts
@@ -13,7 +13,7 @@ export interface StreamNamingInput {
   /** Whether a name is required (true for agent messages) */
   requireName?: boolean
   /** Category for organizing test cases */
-  category?: "technical" | "casual" | "question" | "minimal" | "duplicate-avoidance"
+  category?: "technical" | "casual" | "question" | "minimal" | "duplicate-avoidance" | "language"
 }
 
 /**

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -43,11 +43,18 @@ Reassignment is *the* mechanism for fixing classification mistakes. Use it whene
 
 ## Output Requirements
 - assignments: Array of {conversationId, isPrimary}. At least one entry with isPrimary=true. conversationId=null means "create a new conversation" (set newConversationTopic).
-- newConversationTopic: Topic summary if any assignment has conversationId=null. Required in that case.
+- newConversationTopic: Topic summary if any assignment has conversationId=null. Required in that case. See "Naming new conversations" below.
 - reassignments: Array of {messageId, toConversationId, reason, confidence}. messageId must be from this prompt. toConversationId=null means "move into the new conversation being created this turn" (only valid if assignments includes a conversationId=null primary).
 - completenessUpdates: Array of {conversationId, score (1-7), status} for conversations whose completeness changed.
   - status must be one of: "active", "stalled", "resolved"
 - confidence: 0.0 to 1.0 confidence in this classification overall.
+
+## Naming new conversations
+When you set newConversationTopic, write a short title of 2-5 words that names the topic itself:
+- Lead with the subject. Do NOT add framing like "Discussion about", "Chat about", "Conversation regarding", "Thoughts on", "Questions about", and do NOT describe the tone ("Casual chat", "Quick question"). That a conversation discusses something is already implied — name the thing, not the act of discussing it.
+- Do NOT state which language the conversation is in (never write "in Swedish", "auf Deutsch", etc.); that label is noise next to the conversation.
+- Write the title in the dominant language of the conversation, not English by default. If the participants are talking in Swedish, the title is in Swedish; if in Japanese, in Japanese. When the messages mix languages, follow the language the topic is actually discussed in and reuse the participants' own phrasing.
+- Keep names, products, technical terms, and other proper nouns exactly as they appear in the conversation. Never translate, localize, or re-spell them — carry the participants' own words into the title verbatim.
 
 Respond with ONLY the JSON object. No explanation, no markdown code blocks.`
 
@@ -78,7 +85,9 @@ export const extractionResponseSchema = z.object({
   newConversationTopic: z
     .string()
     .nullable()
-    .describe("Topic summary; required when any assignment has conversationId=null"),
+    .describe(
+      "2-5 word topic title; required when any assignment has conversationId=null. Name the topic directly with no framing ('Discussion about'), no language label ('in Swedish'), in the conversation's own language, keeping proper nouns verbatim"
+    ),
   reassignments: z.array(reassignmentSchema).nullable().describe("Prior messages to move, or null"),
   completenessUpdates: z
     .array(

--- a/apps/backend/src/features/streams/naming-config.ts
+++ b/apps/backend/src/features/streams/naming-config.ts
@@ -25,12 +25,16 @@ export function buildNamingSystemPrompt(existingNames: string[], requireName: bo
   1. Analyze the conversation and identify the main topic or purpose
   2. Pay attention to any attached files - if a user uploads an image or document and asks about it, the title should reflect what's in the attachment
   3. Consider any other streams provided in the list of existing names, these should be avoided as much as possible as recent conversations with similar names confuse users
-  4. Generate a title that is descriptive and concise
+  4. Name the topic directly, in the language and wording the participants used
   5. Evaluate the title against the evaluation criteria
 
 Evaluation criteria:
 - Return ONLY the title, no quotes or explanation.
-- The title should be descriptive and concise, try avoiding generic names like "Quick Question" or "New Discussion"
+- Lead with the subject itself. Do NOT add framing like "Discussion about", "Chat about", "Conversation regarding", "Thoughts on", "Questions about", and do NOT describe the tone (e.g. "Casual chat", "Quick question"). That a conversation discusses something is already implied — name the thing, not the act of discussing it.
+- Do NOT state which language the conversation is in (never write "in Swedish", "auf Deutsch", etc.). The title sits next to the conversation, so labeling its language is noise.
+- Write the title in the dominant language of the conversation, not English by default. If the participants are talking in Swedish, the title is in Swedish; if in Japanese, in Japanese. When a conversation mixes languages, follow the language the topic is actually discussed in and reuse the participants' own phrasing.
+- Keep names, products, technical terms, and other proper nouns exactly as they appear in the conversation. Never translate, localize, or re-spell them — carry the participants' own words into the title verbatim.
+- The title should be specific and concrete, try avoiding generic names like "Quick Question" or "New Discussion"
 - If the conversation involves attached files (images, documents, etc.), incorporate what they contain into the title
 ${existingNames.length > 0 ? `- Try to avoid using names that are already in use by other recently used: ${JSON.stringify(existingNames)}` : ""}
 ${

--- a/apps/backend/src/features/streams/naming-service.test.ts
+++ b/apps/backend/src/features/streams/naming-service.test.ts
@@ -214,6 +214,21 @@ describe("StreamNamingService", () => {
 
       expect(systemMessage).toContain("You MUST generate a title")
     })
+
+    test("should instruct the model to follow the conversation language and drop preamble", async () => {
+      mockGenerateText.mockResolvedValue({ value: "Title", response: {} })
+
+      await service.attemptAutoNaming("stream_123", false)
+
+      const calls = mockGenerateText.mock.calls
+      const lastCall = calls[calls.length - 1]?.[0] as { messages: Array<{ role: string; content: string }> }
+      const systemMessage = lastCall.messages.find((m) => m.role === "system")?.content ?? ""
+
+      expect(systemMessage).toContain("dominant language of the conversation")
+      expect(systemMessage).toContain("Do NOT state which language")
+      expect(systemMessage).toContain("Do NOT add framing")
+      expect(systemMessage).toContain("verbatim")
+    })
   })
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Summary

Conversation titles were dominated by useless framing — "Discussion in Swedish about…", "Casual Swedish banter about…", "General chat about…" — so the actual topic got truncated away. This reworks the naming system prompt to lead with the subject and follow the conversation's own language.

Changes to `buildNamingSystemPrompt` (`apps/backend/src/features/streams/naming-config.ts`):

- **No framing preamble** — titles name the subject directly; banned "Discussion about" / "Chat about" / "Conversation regarding" and tone descriptors like "Casual chat" / "Quick question". That a conversation discusses something is implied.
- **Never label the language** — explicitly forbids "in Swedish", "auf Deutsch", etc.
- **Follow the conversation's language** — write the title in the dominant language of the chat, not English by default; mixed-language conversations follow the language the topic is discussed in and reuse the participants' phrasing.
- **Proper nouns stay verbatim** — product names and technical terms are carried over exactly, never translated, localized, or re-spelled.

This keeps language decisions in the model rather than English-only heuristics (aligns with INV-54).

## Tests

- Added eval cases in `evals/suites/stream-naming/cases.ts`: a Swedish conversation (title must stay Swedish, no language label/preamble), a Swedish conversation mentioning product names (preserved untranslated), and an English no-preamble case. Added a `"language"` category to the input type.
- Added a unit assertion in `naming-service.test.ts` that the assembled prompt carries the new guidance.

## Test plan

- [x] `bun test src/features/streams/naming-service.test.ts` — 17/17 pass
- [x] Backend typecheck clean; pre-commit lint + monorepo typecheck + API-doc check green
- [ ] Run the model-backed eval suite (`bun run eval -- -s stream-naming`) — needs DB + OpenRouter access, not run in this environment

https://claude.ai/code/session_01SFDPBDVDRs7WoBQDNKJK1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFDPBDVDRs7WoBQDNKJK1V)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782039833&installation_id=129946197&pr_number=592&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F592&signature=c64079066ed88e04e21823898bdd802f98ea64c409c9ce5d57a3604b82e34abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->