### PR TITLE
fix(conversations): restore new-topic detection in boundary prompt

### DIFF
--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -65,6 +65,43 @@ export const boundaryExtractionCases: EvalCase<BoundaryExtractionInput, Boundary
     },
   },
 
+  {
+    id: "new-topic-after-resolved-001",
+    name: "New topic: Unrelated message after a resolved conversation",
+    input: {
+      newMessage: {
+        authorId: "user_abc123",
+        authorType: "user",
+        contentMarkdown: "Switching gears — can someone review my PR for the new billing export?",
+      },
+      activeConversations: [
+        {
+          id: "conv_deploy_done001",
+          topicSummary: "Deployment pipeline issues",
+          messageCount: 8,
+          lastMessagePreview: "Perfect, that fixed it! Thanks everyone.",
+          participantIds: ["user_abc123", "user_def456"],
+          completenessScore: 7,
+          status: "resolved",
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_def456",
+          authorType: "user",
+          contentMarkdown: "Perfect, that fixed it! Thanks everyone.",
+        },
+      ],
+      streamType: "channel",
+      category: "new-topic",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["billing", "export", "PR", "review"],
+      minConfidence: 0.7,
+    },
+  },
+
   // Continue existing conversation cases
   {
     id: "continue-direct-reply-001",

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -84,7 +84,11 @@ function buildExtractionContext(input: BoundaryExtractionInput, workspaceId: str
   return {
     newMessage: toMessage(input.newMessage, streamId, 1),
     recentMessages: (input.recentMessages || []).map((m, i) => toMessage(m, streamId, i + 2)),
-    activeConversations: (input.activeConversations || []).map((c) => ({ ...c, contextMessageIds: [] })),
+    activeConversations: (input.activeConversations || []).map((c) => ({
+      ...c,
+      status: c.status ?? "active",
+      contextMessageIds: [],
+    })),
     streamType: input.streamType || "scratchpad",
     workspaceId,
   }

--- a/apps/backend/evals/suites/boundary-extraction/types.ts
+++ b/apps/backend/evals/suites/boundary-extraction/types.ts
@@ -14,6 +14,8 @@ export interface EvalConversationSummary {
   lastMessagePreview: string
   participantIds: string[]
   completenessScore: number
+  /** Lifecycle status; defaults to "active" when omitted. */
+  status?: ConversationStatus
 }
 
 /**

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -492,6 +492,7 @@ export class BoundaryExtractionService {
         lastMessagePreview: lastMessage?.contentMarkdown.slice(0, 100) ?? "",
         participantIds: c.participantIds,
         completenessScore: c.completenessScore,
+        status: c.status,
         contextMessageIds: contextIds,
       }
     })

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -30,6 +30,14 @@ export const BOUNDARY_EXTRACTION_PROMPT = `Analyze this new message and decide w
 From: {{AUTHOR}}
 Content: {{CONTENT}}
 
+## Choosing a conversation
+First decide whether this message continues an existing conversation or starts a new one. Assign it to an existing conversation (as primary) only when it genuinely continues that topic — judge by:
+- Topic continuity: does it advance the same subject the conversation is about?
+- Explicit references: does it reply to, quote, or build on something in that conversation?
+- Recency and flow: does it read as the next turn of an active back-and-forth?
+
+Start a NEW conversation (primary assignment with conversationId=null) when the message opens a topic that no active conversation covers — a new question, a new subject, or an unrelated aside. A short or ambiguous message that doesn't clearly continue any listed conversation is a new conversation, not a default into the most recent one. Do not attach a message to a conversation whose status is "resolved" unless it directly reopens that exact topic; a new topic after a resolved conversation is a new conversation. When in doubt between extending a stale/resolved conversation and starting fresh, start fresh.
+
 ## Multi-membership
 A message can belong to more than one conversation. If this new message clearly continues two different ongoing threads (e.g. a single ping that references two topics), assign it to both. Pick the conversation it MOST continues as primary; the others are secondaries. Most messages have only a primary assignment — only return secondaries when the message genuinely advances two distinct conversations.
 

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -71,6 +71,7 @@ function createMockConversation(overrides: Partial<ConversationSummary> = {}): C
     lastMessagePreview: "Last message preview",
     participantIds: ["usr_test"],
     completenessScore: 3,
+    status: "active",
     contextMessageIds: [],
     ...overrides,
   }

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -91,7 +91,7 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
               const tag = c.isParent ? " [parent-thread]" : ""
               const contextIds =
                 c.contextMessageIds.length > 0 ? `, in-context messages: [${c.contextMessageIds.join(", ")}]` : ""
-              return `- ${c.id}${tag}: "${c.topicSummary ?? "No topic yet"}" (${c.messageCount} messages, completeness: ${c.completenessScore}/7, participants: ${c.participantIds.length}${contextIds})`
+              return `- ${c.id}${tag}: "${c.topicSummary ?? "No topic yet"}" (status: ${c.status}, ${c.messageCount} messages, completeness: ${c.completenessScore}/7, participants: ${c.participantIds.length}${contextIds})`
             })
             .join("\n")
         : "No active conversations in this stream yet."

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -79,6 +79,8 @@ export interface ConversationSummary {
   lastMessagePreview: string
   participantIds: string[]
   completenessScore: number
+  /** Lifecycle status so the model treats "resolved" conversations as closed. */
+  status: string
   /**
    * Message IDs from this conversation that appear in the current extraction
    * context. The LLM may reassign these to a different conversation.

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -80,7 +80,7 @@ export interface ConversationSummary {
   participantIds: string[]
   completenessScore: number
   /** Lifecycle status so the model treats "resolved" conversations as closed. */
-  status: string
+  status: (typeof CONVERSATION_STATUSES)[number]
   /**
    * Message IDs from this conversation that appear in the current extraction
    * context. The LLM may reassign these to a different conversation.


### PR DESCRIPTION
## Summary

Since PR #586 (multi-membership + reassignment) deployed, production stopped creating new conversations entirely — the last `conversations` row was created `2026-05-20T16:20:32Z`, while messages and `conversation:message_assigned`/`conversation:updated` events kept flowing.

**Root cause:** the #586 prompt rewrite dropped the criteria that told the model *when a message starts a new conversation*. The replacement only covered attaching/reassigning to existing conversations ("do not be conservative…"), so the extractor stopped emitting new-conversation (`conversationId: null`) assignments and funneled every message into the most recent existing conversation. One DM's conversation grew to 44 primary messages despite being marked `resolved`.

**Diagnosis confirmed against prod (read-only DB + Railway logs):**
- `boundary.extract` queue healthy: 3221 enqueued / 3221 done, 0 DLQ, no errors or warnings.
- Recent extractions all resolve their primary to one existing `resolved` conversation; zero `conversation:created` events after the deploy.
- Running deploy is commit `a35985d` = "feat(conversations): multi-membership and reassignment (#586)".

## Fix

- Add a `## Choosing a conversation` section to the boundary prompt restoring topic-continuity / explicit-reference / recency criteria, with an explicit rule to start a new conversation on a new topic — including after a `resolved` conversation, and to start fresh when in doubt.
- Surface each candidate conversation's `status` in the prompt (`ConversationSummary.status` → `buildConversationSummaries` → prompt line) so the model treats `resolved` conversations as closed instead of silently extending them.
- Add a regression eval case: a new, unrelated message after a `resolved` conversation must start a new conversation.

The multi-membership and reassignment behavior from #586 is preserved — this only re-adds the boundary-detection guidance that was lost.

## Test plan

- [x] `bun test` for `boundary-extraction/` unit tests (21/21 pass)
- [x] Full-monorepo typecheck + lint (pre-commit hook)
- [ ] CI: backend integration tests (need Postgres)
- [ ] Run the boundary-extraction eval suite to confirm `new-topic-after-resolved-001` passes and existing cases don't regress
- [ ] Observe prod after deploy: new `conversation:created` events resume for topic shifts

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZqdYwwVfTCvjaeQMw2ePc)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782040315&installation_id=129946197&pr_number=593&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F593&signature=3bfd5eabda9be55e7fc9bab3831ffa64bf98e95fdc9511a948038078262cd4eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->