### PR TITLE
fix: align pi remote mention behavior

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -9,6 +9,7 @@ import { BotRepository } from "../public-api/bot-repository"
 import { BotRuntimeService } from "./service"
 import { BotRuntimeSessionLinkRepository, StreamActiveActorRepository } from "./repository"
 import { EventService } from "../messaging"
+import { PersonaRepository } from "../agents"
 
 const DEFAULT_CONFIG = {
   batchSize: 100,
@@ -90,11 +91,17 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
     const invocationRootStreamId = rootStream?.id ?? stream.id
     const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
-    const mentionableBots = (
+    const [mentionedBots, mentionedPersonas] =
       mentionedSlugs.length > 0
-        ? await BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs)
-        : []
-    ).filter((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
+        ? await Promise.all([
+            BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs),
+            Promise.all(
+              mentionedSlugs.map((slug) => PersonaRepository.findBySlug(this.pool, slug, message.workspaceId))
+            ),
+          ])
+        : [[], []]
+    const mentionableBots = mentionedBots.filter((mentionedBot) => botHasCapability(mentionedBot, "mentionable"))
+    const hasMentionedPersona = mentionedPersonas.some(Boolean)
 
     for (const mentionedBot of mentionableBots) {
       await this.service.createInvocation({
@@ -121,7 +128,7 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const bot = await BotRepository.findById(this.pool, message.workspaceId, active.actorId)
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
     const activeExplicitlyMentioned = bot.slug != null && mentionedSlugs.includes(bot.slug)
-    if (mentionableBots.length > 0 && !activeExplicitlyMentioned) return
+    if ((mentionableBots.length > 0 || hasMentionedPersona) && !activeExplicitlyMentioned) return
 
     let link = await BotRuntimeSessionLinkRepository.findActiveByStream(this.pool, {
       workspaceId: message.workspaceId,

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -91,12 +91,18 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
     const invocationRootStreamId = rootStream?.id ?? stream.id
     const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
+    const uniqueMentionedSlugs = Array.from(new Set(mentionedSlugs))
     const [mentionedBots, mentionedPersonas] =
-      mentionedSlugs.length > 0
+      uniqueMentionedSlugs.length > 0
         ? await Promise.all([
-            BotRepository.findVisibleBySlugs(this.pool, message.workspaceId, message.event.actorId, mentionedSlugs),
+            BotRepository.findVisibleBySlugs(
+              this.pool,
+              message.workspaceId,
+              message.event.actorId,
+              uniqueMentionedSlugs
+            ),
             Promise.all(
-              mentionedSlugs.map((slug) => PersonaRepository.findBySlug(this.pool, slug, message.workspaceId))
+              uniqueMentionedSlugs.map((slug) => PersonaRepository.findBySlug(this.pool, slug, message.workspaceId))
             ),
           ])
         : [[], []]

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -114,7 +114,7 @@ async function heartbeat(status: "available" | "busy" | "offline" | "error", sta
       capabilities: {
         supportsActiveScratchpad: true,
         supportsPersistentSessions: true,
-        supportsMentionInvocations: false,
+        supportsMentionInvocations: true,
       },
       statusText,
     }),
@@ -211,7 +211,7 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<voi
       body: JSON.stringify({
         runtimeKind: "pi-local",
         instanceId: ensureInstanceId(),
-        supportedCapabilities: ["active-scratchpad"],
+        supportedCapabilities: ["active-scratchpad", "mentionable"],
         claimTtlSeconds: 120,
       }),
     }


### PR DESCRIPTION
## Problem

Dogfooding the remote-control stack exposed two follow-up gaps after the stacked PRs landed:

- `@pi-remote` mention invocations could be created by the backend, but the Pi reference adapter only advertised/claimed `active-scratchpad`, so those mention invocations stayed unclaimed.
- Active Pi scratchpads suppressed auto-replies for explicit mentionable bot mentions, but not for persona mentions such as `@ariadne`, causing both Ariadne and the active Pi bot to reply to the same explicit persona invocation.

## Solution

Align the backend suppression rules and the Pi reference adapter capabilities with the intended mention behavior.

### Key design decisions

**1. Pi adapter now opts into mentionable invocations**

The reference adapter advertises `supportsMentionInvocations: true` and claims both `active-scratchpad` and `mentionable` invocation capabilities.

**2. Persona mentions suppress active auto-replies**

The bot invocation outbox handler now resolves mentioned persona slugs in addition to mentionable bots. If a message mentions any persona or mentionable bot, the active bot auto-invocation is suppressed unless the active bot itself was explicitly mentioned.

**3. Non-user context remains deferred**

The richer behavior where Pi can observe Ariadne/bot replies as context without automatically responding remains a separate orchestration follow-up. This PR keeps the safe user-authored trigger boundary.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | Resolve persona mentions and include them in active-bot suppression |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Advertise and claim `mentionable` invocations in the Pi reference adapter |

## Test plan

- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun --check docs/examples/pi-remote/threa-remote-v2.ts`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782045429&installation_id=129946197&pr_number=596&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F596&signature=245fb596bb57b1b868592065dd87be8d9f674a24155222e791119414984cfc6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->