### PR TITLE
feat(voice): live interim dictation transcript + mobile hover-state fix

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,11 @@
 import { RouterProvider } from "react-router-dom"
 import { AuthProvider, AccountScopeProvider } from "./auth"
-import { AccountQueryClientProvider, ServicesProvider, PendingMessagesProvider } from "./contexts"
+import {
+  AccountQueryClientProvider,
+  ServicesProvider,
+  PendingMessagesProvider,
+  DictationCoordinatorProvider,
+} from "./contexts"
 import { router } from "./routes"
 import { TooltipProvider } from "./components/ui/tooltip"
 
@@ -11,9 +16,11 @@ export function App() {
         <AccountQueryClientProvider>
           <ServicesProvider>
             <PendingMessagesProvider>
-              <TooltipProvider delayDuration={300}>
-                <RouterProvider router={router} />
-              </TooltipProvider>
+              <DictationCoordinatorProvider>
+                <TooltipProvider delayDuration={300}>
+                  <RouterProvider router={router} />
+                </TooltipProvider>
+              </DictationCoordinatorProvider>
             </PendingMessagesProvider>
           </ServicesProvider>
         </AccountQueryClientProvider>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -21,7 +21,6 @@ import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
 import { MicButton } from "./mic-button"
-import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { ContextRefStrip } from "./context-ref-strip"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import { cn } from "@/lib/utils"
@@ -265,9 +264,6 @@ export function MessageComposer({
   const [mobileExpanded, setMobileExpanded] = useState(false)
   const [mobileFocused, setMobileFocused] = useState(false)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
-  // Dictation stays mounted while live even after it inserts text, so the
-  // typing-detection that otherwise hides the mic can't tear it down mid-take.
-  const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobile()
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const instructionsId = useId()
@@ -485,32 +481,27 @@ export function MessageComposer({
   )
 
   // ── Mic / dictation button ────────────────────────────────────────────────
-  // Shown only on workspace surfaces, and only while the composer is empty
-  // (so it doesn't crowd typed text) or dictation is already live.
+  // Always available on workspace surfaces so dictation can be resumed after the
+  // composer already has text — appended at the caret like committed speech.
   const insertTranscribedText = useCallback((text: string) => richEditorRef.current?.insertTranscribedText(text), [])
   const setDictationInterim = useCallback((text: string) => richEditorRef.current?.setDictationInterim(text), [])
-  const showMic = !!workspaceId && (voiceActive || isEmptyContent(content))
-  const micButton =
-    showMic && workspaceId ? (
-      <MicButton
-        workspaceId={workspaceId}
-        onInsertText={insertTranscribedText}
-        onInterimText={setDictationInterim}
-        onActiveChange={setVoiceActive}
-        disabled={controlsDisabled}
-      />
-    ) : null
-  const micButtonFab =
-    showMic && workspaceId ? (
-      <MicButton
-        workspaceId={workspaceId}
-        onInsertText={insertTranscribedText}
-        onInterimText={setDictationInterim}
-        onActiveChange={setVoiceActive}
-        disabled={controlsDisabled}
-        className="h-[30px] w-[30px] rounded-md border bg-background shadow-md"
-      />
-    ) : null
+  const micButton = workspaceId ? (
+    <MicButton
+      workspaceId={workspaceId}
+      onInsertText={insertTranscribedText}
+      onInterimText={setDictationInterim}
+      disabled={controlsDisabled}
+    />
+  ) : null
+  const micButtonFab = workspaceId ? (
+    <MicButton
+      workspaceId={workspaceId}
+      onInsertText={insertTranscribedText}
+      onInterimText={setDictationInterim}
+      disabled={controlsDisabled}
+      className="h-[30px] w-[30px] rounded-md border bg-background shadow-md"
+    />
+  ) : null
 
   // ── Expanded (fullscreen) layout ──────────────────────────────────────────
   // Trailing content for the inline toolbar: just the close X

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -264,6 +264,10 @@ export function MessageComposer({
   const [mobileExpanded, setMobileExpanded] = useState(false)
   const [mobileFocused, setMobileFocused] = useState(false)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
+  // True while a dictation take is in flight. Keeps the mobile chrome (and the
+  // mic button it lives in) mounted across a tap-outside blur so the session
+  // isn't torn down mid-take.
+  const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobile()
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const instructionsId = useId()
@@ -288,6 +292,11 @@ export function MessageComposer({
       setMobileLinkPopoverOpen(false)
     }
   }, [isMobile])
+
+  // Mobile chrome (action bar + full editor padding) stays open while focused
+  // OR while a dictation take is in flight, so a tap-outside doesn't unmount the
+  // mic mid-take and abort the session.
+  const mobileChromeOpen = mobileFocused || voiceActive
 
   // Track focus state for mobile progressive disclosure.
   // Uses a small delay on blur to avoid flicker when focus moves between editor and action bar buttons.
@@ -490,6 +499,7 @@ export function MessageComposer({
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}
+      onActiveChange={setVoiceActive}
       disabled={controlsDisabled}
     />
   ) : null
@@ -498,6 +508,7 @@ export function MessageComposer({
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}
+      onActiveChange={setVoiceActive}
       disabled={controlsDisabled}
       className="h-[30px] w-[30px] rounded-md border bg-background shadow-md"
     />
@@ -787,14 +798,14 @@ export function MessageComposer({
             className={cn(
               "rounded-[16px] border border-input bg-card flex flex-col flex-1 min-h-0",
               // Compact padding when mobile-unfocused (single line), normal otherwise
-              isMobile && !mobileFocused ? "px-3 py-2" : "p-3 gap-2",
+              isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
               // When mobile-expanded, let the editor grow and override its internal max-height
               mobileExpanded && "[&_.tiptap]:max-h-none"
             )}
             onClick={(e) => {
               if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']")) return
               // On mobile unfocused, reveal the editor first then focus on next frame
-              if (isMobile && !mobileFocused) {
+              if (isMobile && !mobileChromeOpen) {
                 setMobileFocused(true)
                 requestAnimationFrame(() => richEditorRef.current?.focus())
                 return
@@ -803,7 +814,7 @@ export function MessageComposer({
             }}
           >
             {/* Mobile preview bar — plain text first line + send button */}
-            {isMobile && !mobileFocused && (
+            {isMobile && !mobileChromeOpen && (
               <div className="flex items-center gap-2 min-h-[30px] text-sm select-none pointer-events-none">
                 <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
                 <div className="pointer-events-auto">{sendButton}</div>
@@ -813,14 +824,14 @@ export function MessageComposer({
             {/* Editor — always mounted to preserve state; hidden in preview mode */}
             <div
               className={cn(
-                isMobile && !mobileFocused ? "h-0 overflow-hidden" : "flex-1 min-h-0",
+                isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
                 mobileExpanded && "overflow-y-auto"
               )}
             >
               <div className="h-full">{sharedEditor}</div>
             </div>
 
-            {/* Bottom action bar — visible on desktop always, on mobile only when focused.
+            {/* Bottom action bar — visible on desktop always, on mobile when focused or dictating.
                onMouseDown preventDefault keeps editor focus on mobile so the virtual keyboard
                stays open when tapping any button in this bar.
 
@@ -833,7 +844,7 @@ export function MessageComposer({
                DOM-subtree guard below limits the suppression to elements actually
                living under this wrapper — buttons in our own action bar — and
                leaves portaled content untouched. */}
-            {(!isMobile || mobileFocused) && (
+            {(!isMobile || mobileChromeOpen) && (
               <div
                 ref={actionBarWrapperRef}
                 onMouseDown={(e) => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -272,7 +272,9 @@ export function MessageComposer({
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const instructionsId = useId()
 
-  // Close inline format toolbar and collapse expansion when navigating to a different stream/scope
+  // Close inline format toolbar and collapse expansion when navigating to a different stream/scope.
+  // Clearing voiceActive collapses the mobile chrome; combined with the scopeId-keyed mic below,
+  // an in-flight dictation take ends on navigation rather than carrying over into the next stream.
   useEffect(() => {
     if (blurTimeoutRef.current) {
       clearTimeout(blurTimeoutRef.current)
@@ -282,6 +284,7 @@ export function MessageComposer({
     setMobileExpanded(false)
     setMobileFocused(false)
     setMobileLinkPopoverOpen(false)
+    setVoiceActive(false)
   }, [scopeId])
 
   // Reset mobile-only state when viewport crosses the mobile/desktop threshold
@@ -494,8 +497,11 @@ export function MessageComposer({
   // composer already has text — appended at the caret like committed speech.
   const insertTranscribedText = useCallback((text: string) => richEditorRef.current?.insertTranscribedText(text), [])
   const setDictationInterim = useCallback((text: string) => richEditorRef.current?.setDictationInterim(text), [])
+  // Keyed by scopeId so navigating to a different stream remounts the button, tearing down any
+  // in-flight dictation session (the unmount cleanup aborts the take) instead of carrying it over.
   const micButton = workspaceId ? (
     <MicButton
+      key={`mic-${scopeId ?? ""}`}
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}
@@ -505,6 +511,7 @@ export function MessageComposer({
   ) : null
   const micButtonFab = workspaceId ? (
     <MicButton
+      key={`mic-fab-${scopeId ?? ""}`}
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -488,12 +488,14 @@ export function MessageComposer({
   // Shown only on workspace surfaces, and only while the composer is empty
   // (so it doesn't crowd typed text) or dictation is already live.
   const insertTranscribedText = useCallback((text: string) => richEditorRef.current?.insertTranscribedText(text), [])
+  const setDictationInterim = useCallback((text: string) => richEditorRef.current?.setDictationInterim(text), [])
   const showMic = !!workspaceId && (voiceActive || isEmptyContent(content))
   const micButton =
     showMic && workspaceId ? (
       <MicButton
         workspaceId={workspaceId}
         onInsertText={insertTranscribedText}
+        onInterimText={setDictationInterim}
         onActiveChange={setVoiceActive}
         disabled={controlsDisabled}
       />
@@ -503,6 +505,7 @@ export function MessageComposer({
       <MicButton
         workspaceId={workspaceId}
         onInsertText={insertTranscribedText}
+        onInterimText={setDictationInterim}
         onActiveChange={setVoiceActive}
         disabled={controlsDisabled}
         className="h-[30px] w-[30px] rounded-md border bg-background shadow-md"

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { Mic, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -22,6 +22,8 @@ interface MicButtonProps {
   workspaceId: string
   /** Insert a committed transcript span into the editor at the caret. */
   onInsertText: (text: string) => void
+  /** Live (uncommitted) transcript hypothesis, pushed as it grows and cleared ("") when a segment commits or the take ends. */
+  onInterimText?: (text: string) => void
   disabled?: boolean
   /** Notifies the composer when dictation is live so it can keep the button visible while typing-detection would otherwise hide it. */
   onActiveChange?: (active: boolean) => void
@@ -32,12 +34,13 @@ interface MicButtonProps {
 export function MicButton({
   workspaceId,
   onInsertText,
+  onInterimText,
   disabled,
   onActiveChange,
   className,
   language,
 }: MicButtonProps) {
-  const { state, supported, unsupportedReason, error, start, stop } = useVoiceDictation({
+  const { state, supported, unsupportedReason, error, interimText, start, stop } = useVoiceDictation({
     workspaceId,
     onCommittedText: onInsertText,
     language,
@@ -48,6 +51,18 @@ export function MicButton({
   useEffect(() => {
     onActiveChange?.(isActive)
   }, [isActive, onActiveChange])
+
+  // Mirror the live hypothesis into the editor. Keep the callback in a ref so a
+  // new function identity each render doesn't re-fire this on every keystroke,
+  // and clear the ghost on unmount so a hidden mic can't strand preview text.
+  const onInterimTextRef = useRef(onInterimText)
+  onInterimTextRef.current = onInterimText
+  useEffect(() => {
+    onInterimTextRef.current?.(interimText)
+  }, [interimText])
+  useEffect(() => {
+    return () => onInterimTextRef.current?.("")
+  }, [])
 
   const tooltip = tooltipFor({ supported, unsupportedReason, state, error })
 

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -25,32 +25,16 @@ interface MicButtonProps {
   /** Live (uncommitted) transcript hypothesis, pushed as it grows and cleared ("") when a segment commits or the take ends. */
   onInterimText?: (text: string) => void
   disabled?: boolean
-  /** Notifies the composer when dictation is live so it can keep the button visible while typing-detection would otherwise hide it. */
-  onActiveChange?: (active: boolean) => void
   className?: string
   language?: string
 }
 
-export function MicButton({
-  workspaceId,
-  onInsertText,
-  onInterimText,
-  disabled,
-  onActiveChange,
-  className,
-  language,
-}: MicButtonProps) {
+export function MicButton({ workspaceId, onInsertText, onInterimText, disabled, className, language }: MicButtonProps) {
   const { state, supported, unsupportedReason, error, interimText, start, stop } = useVoiceDictation({
     workspaceId,
     onCommittedText: onInsertText,
     language,
   })
-
-  const isActive = state === "connecting" || state === "recording" || state === "stopping"
-
-  useEffect(() => {
-    onActiveChange?.(isActive)
-  }, [isActive, onActiveChange])
 
   // Mirror the live hypothesis into the editor. Keep the callback in a ref so a
   // new function identity each render doesn't re-fire this on every keystroke,

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -24,17 +24,40 @@ interface MicButtonProps {
   onInsertText: (text: string) => void
   /** Live (uncommitted) transcript hypothesis, pushed as it grows and cleared ("") when a segment commits or the take ends. */
   onInterimText?: (text: string) => void
+  /** Reports whether a take is in flight, so the host can keep its chrome (and this button) mounted while dictating. */
+  onActiveChange?: (active: boolean) => void
   disabled?: boolean
   className?: string
   language?: string
 }
 
-export function MicButton({ workspaceId, onInsertText, onInterimText, disabled, className, language }: MicButtonProps) {
+export function MicButton({
+  workspaceId,
+  onInsertText,
+  onInterimText,
+  onActiveChange,
+  disabled,
+  className,
+  language,
+}: MicButtonProps) {
   const { state, supported, unsupportedReason, error, interimText, start, stop } = useVoiceDictation({
     workspaceId,
     onCommittedText: onInsertText,
     language,
   })
+
+  // Tell the host when a take is in flight. The mobile composer collapses its
+  // action bar (and this button) on blur; without this signal a tap-outside
+  // mid-take would unmount the hook and abort the session, losing the take.
+  const isActive = state === "connecting" || state === "recording" || state === "stopping"
+  const onActiveChangeRef = useRef(onActiveChange)
+  onActiveChangeRef.current = onActiveChange
+  useEffect(() => {
+    onActiveChangeRef.current?.(isActive)
+  }, [isActive])
+  useEffect(() => {
+    return () => onActiveChangeRef.current?.(false)
+  }, [])
 
   // Mirror the live hypothesis into the editor. Keep the callback in a ref so a
   // new function identity each render doesn't re-fire this on every keystroke,

--- a/apps/frontend/src/components/editor/dictation-preview-extension.test.ts
+++ b/apps/frontend/src/components/editor/dictation-preview-extension.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@tiptap/react"
+import { createEditorExtensions } from "./editor-extensions"
+
+function createEditor(content?: JSONContent) {
+  const element = document.createElement("div")
+  document.body.append(element)
+  const editor = new Editor({
+    element,
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content: content ?? { type: "doc", content: [{ type: "paragraph" }] },
+  })
+  editor.view.hasFocus = () => true
+  editor.on("destroy", () => element.remove())
+  return editor
+}
+
+let editor: Editor
+
+afterEach(() => {
+  editor?.destroy()
+})
+
+describe("dictation preview", () => {
+  it("renders the live hypothesis as a ghost and clears it", () => {
+    editor = createEditor()
+
+    expect(editor.view.dom.querySelector(".dictation-preview-ghost")).toBeNull()
+
+    editor.commands.setDictationPreview("hello there")
+    const ghost = editor.view.dom.querySelector(".dictation-preview-ghost")
+    expect(ghost?.textContent).toBe("hello there")
+
+    editor.commands.setDictationPreview("")
+    expect(editor.view.dom.querySelector(".dictation-preview-ghost")).toBeNull()
+  })
+
+  it("never writes the preview into the document", () => {
+    editor = createEditor()
+    editor.commands.setDictationPreview("not committed")
+
+    expect(editor.getText()).toBe("")
+  })
+})

--- a/apps/frontend/src/components/editor/dictation-preview-extension.ts
+++ b/apps/frontend/src/components/editor/dictation-preview-extension.ts
@@ -1,0 +1,72 @@
+import { Extension } from "@tiptap/core"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
+import { Decoration, DecorationSet } from "@tiptap/pm/view"
+
+export const DictationPreviewPluginKey = new PluginKey<string>("dictationPreview")
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    dictationPreview: {
+      /** Show live (uncommitted) dictation text as a caret-anchored ghost; empty string clears it. */
+      setDictationPreview: (text: string) => ReturnType
+    }
+  }
+}
+
+/**
+ * Renders the in-flight dictation hypothesis as a non-editable ghost span at the
+ * caret while the user is speaking, so words appear immediately instead of only
+ * after the upstream VAD commits a segment. It is a view-only decoration: it
+ * never touches the document, so it adds nothing to undo history and is inert
+ * (decorations() returns null) whenever no preview text is set — i.e. for every
+ * editor surface that isn't actively dictating.
+ */
+export const DictationPreview = Extension.create({
+  name: "dictationPreview",
+
+  addCommands() {
+    return {
+      setDictationPreview:
+        (text: string) =>
+        ({ tr, dispatch }) => {
+          dispatch?.(tr.setMeta(DictationPreviewPluginKey, text))
+          return true
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<string>({
+        key: DictationPreviewPluginKey,
+        state: {
+          init: () => "",
+          apply(tr, value) {
+            const meta = tr.getMeta(DictationPreviewPluginKey)
+            return typeof meta === "string" ? meta : value
+          },
+        },
+        props: {
+          decorations(state) {
+            const text = DictationPreviewPluginKey.getState(state)
+            if (!text) return null
+            const widget = Decoration.widget(
+              state.selection.to,
+              () => {
+                const span = document.createElement("span")
+                span.className = "dictation-preview-ghost"
+                span.textContent = text
+                return span
+              },
+              // side:1 keeps the ghost after the caret; ignoreSelection stops it
+              // from being treated as a selectable boundary. The text in the key
+              // forces a fresh node when the hypothesis grows.
+              { side: 1, ignoreSelection: true, key: `dictation-${text}` }
+            )
+            return DecorationSet.create(state.doc, [widget])
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/apps/frontend/src/components/editor/editor-action-bar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.test.tsx
@@ -12,6 +12,7 @@ function renderBar(props: Partial<React.ComponentProps<typeof EditorActionBar>> 
     insertSlash: vi.fn(),
     insertEmoji: vi.fn(),
     insertTranscribedText: vi.fn(),
+    setDictationInterim: vi.fn(),
     getEditor: vi.fn(() => null),
   }
 

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -27,6 +27,7 @@ import { AttachmentReferenceExtension } from "./attachment-reference-extension"
 import HorizontalRule from "@tiptap/extension-horizontal-rule"
 import { QuoteReplyExtension } from "./quote-reply-extension"
 import { SharedMessageExtension } from "./shared-message-extension"
+import { DictationPreview } from "./dictation-preview-extension"
 
 // Create lowlight instance with common languages
 const lowlight = createLowlight(common)
@@ -106,6 +107,9 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
 
     // Shared message pointer blocks (cross-stream shares)
     SharedMessageExtension,
+
+    // Live dictation hypothesis ghost (inert unless actively dictating)
+    DictationPreview,
   ]
 
   // Add mention extension if suggestion config provided

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -36,8 +36,10 @@ export interface RichEditorHandle {
   insertMention(): void
   insertSlash(): void
   insertEmoji(): void
-  /** Append a committed dictation span at the caret (PR1: naive insert, no interim replacement). */
+  /** Append a committed dictation span at the caret. */
   insertTranscribedText(text: string): void
+  /** Show the live (uncommitted) dictation hypothesis as a caret ghost; empty string clears it. */
+  setDictationInterim(text: string): void
   /** Access the TipTap editor instance for external toolbar rendering */
   getEditor(): import("@tiptap/react").Editor | null
 }
@@ -806,6 +808,14 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     [editor]
   )
 
+  const setDictationInterim = useCallback(
+    (text: string) => {
+      if (!editor || editor.isDestroyed) return
+      editor.commands.setDictationPreview(text)
+    },
+    [editor]
+  )
+
   // Expose imperative handle for parent to trigger insert actions
   useImperativeHandle(
     ref,
@@ -816,9 +826,19 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       insertSlash: handleSlashClick,
       insertEmoji: handleEmojiClick,
       insertTranscribedText,
+      setDictationInterim,
       getEditor: () => editor,
     }),
-    [focus, focusAfterQuoteReply, handleMentionClick, handleSlashClick, handleEmojiClick, insertTranscribedText, editor]
+    [
+      focus,
+      focusAfterQuoteReply,
+      handleMentionClick,
+      handleSlashClick,
+      handleEmojiClick,
+      insertTranscribedText,
+      setDictationInterim,
+      editor,
+    ]
   )
 
   return (

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -466,6 +466,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                     submitLabel="Reply"
                     submittingLabel="Creating..."
                     placeholder="Write your reply..."
+                    workspaceId={workspaceId}
                     scopeId={panelId}
                     expanded
                     onCollapse={handleDraftCollapse}
@@ -534,6 +535,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                   submittingLabel="Creating..."
                   placeholder="Write your reply..."
                   autoFocus={!isMobile}
+                  workspaceId={workspaceId}
                   scopeId={panelId}
                   onExpandClick={handleDraftExpand}
                   streamContext={draftStreamContext}

--- a/apps/frontend/src/contexts/dictation-coordinator-context.test.tsx
+++ b/apps/frontend/src/contexts/dictation-coordinator-context.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest"
+import { render } from "@testing-library/react"
+import { useEffect } from "react"
+import { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"
+
+function Activator({
+  stop,
+  onReady,
+}: {
+  stop: () => void
+  onReady: (activate: () => void, deactivate: () => void) => void
+}) {
+  const coordinator = useDictationCoordinator()
+  useEffect(() => {
+    onReady(
+      () => coordinator.activate(stop),
+      () => coordinator.deactivate(stop)
+    )
+  }, [coordinator, stop, onReady])
+  return null
+}
+
+describe("DictationCoordinatorProvider", () => {
+  it("stops the previously-active take when a new take activates", () => {
+    const stopA = vi.fn()
+    const stopB = vi.fn()
+    let activateA = () => {}
+    let activateB = () => {}
+
+    render(
+      <DictationCoordinatorProvider>
+        <Activator stop={stopA} onReady={(a) => (activateA = a)} />
+        <Activator stop={stopB} onReady={(a) => (activateB = a)} />
+      </DictationCoordinatorProvider>
+    )
+
+    activateA()
+    expect(stopA).not.toHaveBeenCalled()
+
+    activateB()
+    expect(stopA).toHaveBeenCalledTimes(1)
+    expect(stopB).not.toHaveBeenCalled()
+  })
+
+  it("does not stop a take that re-activates itself", () => {
+    const stopA = vi.fn()
+    let activateA = () => {}
+
+    render(
+      <DictationCoordinatorProvider>
+        <Activator stop={stopA} onReady={(a) => (activateA = a)} />
+      </DictationCoordinatorProvider>
+    )
+
+    activateA()
+    activateA()
+    expect(stopA).not.toHaveBeenCalled()
+  })
+
+  it("releases the slot only when the deactivating identity still holds it", () => {
+    const stopA = vi.fn()
+    const stopB = vi.fn()
+    let activateA = () => {}
+    let deactivateA = () => {}
+    let activateB = () => {}
+
+    render(
+      <DictationCoordinatorProvider>
+        <Activator
+          stop={stopA}
+          onReady={(a, d) => {
+            activateA = a
+            deactivateA = d
+          }}
+        />
+        <Activator stop={stopB} onReady={(a) => (activateB = a)} />
+      </DictationCoordinatorProvider>
+    )
+
+    // A activates, then B takes over (stopping A). A's late deactivate must not
+    // release B's slot.
+    activateA()
+    activateB()
+    expect(stopA).toHaveBeenCalledTimes(1)
+
+    deactivateA()
+    // A new activation should still stop B, proving B kept the slot.
+    activateA()
+    expect(stopB).toHaveBeenCalledTimes(1)
+  })
+
+  it("activation is inert without a provider mounted", () => {
+    const stop = vi.fn()
+    let activate = () => {}
+
+    render(<Activator stop={stop} onReady={(a) => (activate = a)} />)
+
+    activate()
+    expect(stop).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/contexts/dictation-coordinator-context.tsx
+++ b/apps/frontend/src/contexts/dictation-coordinator-context.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from "react"
+
+interface DictationCoordinatorContextValue {
+  /**
+   * Register this take as the single active dictation, stopping whichever take
+   * was active before. `stop` is the registering take's own stop callback; it is
+   * invoked on the previously-active take so it flushes its in-flight hypothesis
+   * and tears down before the new take begins.
+   */
+  activate: (stop: () => void) => void
+  /** Release the active slot if `stop` still holds it (no-op otherwise). */
+  deactivate: (stop: () => void) => void
+}
+
+const DictationCoordinatorContext = createContext<DictationCoordinatorContextValue | null>(null)
+
+// Standalone fallback so the dictation hook works without a provider mounted
+// (tests, isolated stories). With no shared slot there is nothing to stop, so
+// activation/deactivation are inert.
+const NOOP_COORDINATOR: DictationCoordinatorContextValue = {
+  activate: () => {},
+  deactivate: () => {},
+}
+
+export function DictationCoordinatorProvider({ children }: { children: ReactNode }) {
+  // Holds the active take's stop callback. Only one take dictates at a time;
+  // starting another flushes and stops this one first.
+  const activeStopRef = useRef<(() => void) | null>(null)
+
+  const activate = useCallback((stop: () => void) => {
+    const previous = activeStopRef.current
+    activeStopRef.current = stop
+    if (previous && previous !== stop) previous()
+  }, [])
+
+  const deactivate = useCallback((stop: () => void) => {
+    if (activeStopRef.current === stop) activeStopRef.current = null
+  }, [])
+
+  const value = useMemo<DictationCoordinatorContextValue>(() => ({ activate, deactivate }), [activate, deactivate])
+
+  return <DictationCoordinatorContext.Provider value={value}>{children}</DictationCoordinatorContext.Provider>
+}
+
+export function useDictationCoordinator(): DictationCoordinatorContextValue {
+  return useContext(DictationCoordinatorContext) ?? NOOP_COORDINATOR
+}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -44,3 +44,4 @@ export {
 export { SidebarProvider, useSidebar, type ViewMode, type UrgencyBlock, type CollapseState } from "./sidebar-context"
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
+export { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { io, type Socket } from "socket.io-client"
 import { voiceApi } from "@/api/voice"
 import { getCachedWsConfig } from "@/lib/cached-ws-config"
+import { useDictationCoordinator } from "@/contexts"
 
 export type VoiceDictationState = "idle" | "connecting" | "recording" | "stopping" | "error"
 
@@ -95,6 +96,13 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const onCommittedTextRef = useRef(onCommittedText)
   onCommittedTextRef.current = onCommittedText
 
+  // Only one take dictates at a time across all composers. Starting a take stops
+  // whichever was active first (flushing its tail). `coordinatedStop` is a stable
+  // identity the coordinator can compare and invoke; it always calls the latest stop().
+  const coordinator = useDictationCoordinator()
+  const stopRef = useRef<() => void>(() => {})
+  const coordinatedStop = useCallback(() => stopRef.current(), [])
+
   // Mirror the interim hypothesis into a ref so teardown/stop/fail can read and
   // flush it synchronously, without those callbacks depending on render state.
   const interimRef = useRef("")
@@ -129,7 +137,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     socketRef.current = null
     sessionIdRef.current = null
     updateInterim("")
-  }, [teardownAudio, updateInterim])
+    coordinator.deactivate(coordinatedStop)
+  }, [teardownAudio, updateInterim, coordinator, coordinatedStop])
 
   const fail = useCallback(
     (message: string) => {
@@ -147,6 +156,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     if (!supportRef.current.supported) return
     if (state !== "idle" && state !== "error") return
 
+    // Take the single active slot, flushing+stopping any other composer's take.
+    coordinator.activate(coordinatedStop)
     setError(null)
     updateInterim("")
     setState("connecting")
@@ -258,10 +269,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         fail(message)
       }
     })()
-  }, [state, workspaceId, language, fail, teardown, flushInterim])
+  }, [state, workspaceId, language, fail, teardown, flushInterim, coordinator, coordinatedStop])
 
   const stop = useCallback(() => {
     if (state !== "recording" && state !== "connecting") return
+    coordinator.deactivate(coordinatedStop)
     setState("stopping")
     // Keep the in-flight hypothesis: the backend commits buffered audio on stop,
     // but we've already advanced past this session id (below), so its final delta
@@ -285,7 +297,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     } else {
       setState("idle")
     }
-  }, [state, teardownAudio, flushInterim])
+  }, [state, teardownAudio, flushInterim, coordinator, coordinatedStop])
+  // Keep the stable coordinator handle pointed at the latest stop().
+  stopRef.current = stop
 
   // Abort a still-open session on unmount: disconnecting the socket makes the
   // gateway finalize it as aborted; if the socket never opened, abort over HTTP

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -95,6 +95,23 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const onCommittedTextRef = useRef(onCommittedText)
   onCommittedTextRef.current = onCommittedText
 
+  // Mirror the interim hypothesis into a ref so teardown/stop/fail can read and
+  // flush it synchronously, without those callbacks depending on render state.
+  const interimRef = useRef("")
+  const updateInterim = useCallback((text: string) => {
+    interimRef.current = text
+    setInterimText(text)
+  }, [])
+  // Commit whatever uncommitted hypothesis is in flight, then clear it. Used when
+  // a take ends before the upstream emits a final delta (manual stop, error, or a
+  // dropped connection) so the words the user already saw are kept rather than
+  // silently discarded.
+  const flushInterim = useCallback(() => {
+    const pending = interimRef.current
+    if (pending) onCommittedTextRef.current(pending)
+    updateInterim("")
+  }, [updateInterim])
+
   const teardownAudio = useCallback(() => {
     workletRef.current?.port.close()
     workletRef.current?.disconnect()
@@ -111,16 +128,19 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     socketRef.current?.disconnect()
     socketRef.current = null
     sessionIdRef.current = null
-    setInterimText("")
-  }, [teardownAudio])
+    updateInterim("")
+  }, [teardownAudio, updateInterim])
 
   const fail = useCallback(
     (message: string) => {
+      // Don't throw away words the user already saw mid-segment — commit the
+      // pending hypothesis before tearing the failed take down.
+      flushInterim()
       setError(message)
       setState("error")
       teardown()
     },
-    [teardown]
+    [teardown, flushInterim]
   )
 
   const start = useCallback(() => {
@@ -128,7 +148,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     if (state !== "idle" && state !== "error") return
 
     setError(null)
-    setInterimText("")
+    updateInterim("")
     setState("connecting")
     const generation = ++startGenerationRef.current
 
@@ -186,17 +206,18 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             // The segment endpointed: commit it for real and drop the live
             // hypothesis so the next segment starts from a clean preview.
             if (delta.text) onCommittedTextRef.current(delta.text)
-            setInterimText("")
+            updateInterim("")
           } else {
             // Running hypothesis for the current segment — each partial replaces
             // the prior one rather than appending.
-            setInterimText(delta.text)
+            updateInterim(delta.text)
           }
         })
         socket.on("voice:transcription:error", (e: { message?: string }) => fail(e?.message || "Transcription failed"))
         socket.on("voice:stopped", () => {
-          // Server-initiated stop (e.g. the max-duration guard). Leave the
-          // recording state, not just tear down the audio graph.
+          // Server-initiated stop (e.g. the max-duration guard). Keep any pending
+          // hypothesis and leave the recording state, not just tear down audio.
+          flushInterim()
           teardown()
           setState("idle")
         })
@@ -237,12 +258,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         fail(message)
       }
     })()
-  }, [state, workspaceId, language, fail, teardown])
+  }, [state, workspaceId, language, fail, teardown, flushInterim])
 
   const stop = useCallback(() => {
     if (state !== "recording" && state !== "connecting") return
     setState("stopping")
-    setInterimText("")
+    // Keep the in-flight hypothesis: the backend commits buffered audio on stop,
+    // but we've already advanced past this session id (below), so its final delta
+    // would be dropped — flush the local hypothesis so the tail isn't lost.
+    flushInterim()
     // Invalidate any in-flight `voice:start` ACK so a late accept can't flip us
     // back to "recording" after we've decided to stop.
     startGenerationRef.current++
@@ -261,7 +285,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     } else {
       setState("idle")
     }
-  }, [state, teardownAudio])
+  }, [state, teardownAudio, flushInterim])
 
   // Abort a still-open session on unmount: disconnecting the socket makes the
   // gateway finalize it as aborted; if the socket never opened, abort over HTTP

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -13,7 +13,7 @@ interface VoiceDelta {
 
 interface UseVoiceDictationOptions {
   workspaceId: string
-  /** Called with each committed (final) transcript span. PR1 ignores interim deltas. */
+  /** Called with each committed (final) transcript span. */
   onCommittedText: (text: string) => void
   language?: string
 }
@@ -24,6 +24,13 @@ interface UseVoiceDictationResult {
   supported: boolean
   unsupportedReason: string | null
   error: string | null
+  /**
+   * The live (uncommitted) transcript hypothesis for the current segment. It
+   * grows as the user speaks and clears to "" once the segment commits (or the
+   * take ends). Surfaced so the UI can show words immediately instead of only
+   * after the upstream VAD endpoints a segment.
+   */
+  interimText: string
   start: () => void
   stop: () => void
 }
@@ -64,14 +71,15 @@ function resolveVoiceUrl(workspaceId: string): string | null {
 /**
  * Drives one voice-dictation session: create the session over HTTP, capture
  * mic audio as PCM16 frames via an AudioWorklet, stream them up the dedicated
- * `/voice` socket namespace, and surface committed transcript spans. PR1 is a
- * naive caret insert — only final deltas are forwarded, interim replacement
- * lands in a later PR.
+ * `/voice` socket namespace, and surface transcript spans. Committed (final)
+ * spans are forwarded to `onCommittedText`; the in-flight hypothesis is exposed
+ * live via `interimText` so callers can show words as they're spoken.
  */
 export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDictationResult {
   const { workspaceId, onCommittedText, language } = options
   const [state, setState] = useState<VoiceDictationState>("idle")
   const [error, setError] = useState<string | null>(null)
+  const [interimText, setInterimText] = useState("")
   const supportRef = useRef(detectSupport())
 
   const socketRef = useRef<Socket | null>(null)
@@ -103,6 +111,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     socketRef.current?.disconnect()
     socketRef.current = null
     sessionIdRef.current = null
+    setInterimText("")
   }, [teardownAudio])
 
   const fail = useCallback(
@@ -119,6 +128,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     if (state !== "idle" && state !== "error") return
 
     setError(null)
+    setInterimText("")
     setState("connecting")
     const generation = ++startGenerationRef.current
 
@@ -172,7 +182,16 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           // Ignore deltas from a session we've already moved past so a stale
           // socket can't leak text into a new take (plan §3).
           if (delta.voiceSessionId !== sessionIdRef.current) return
-          if (delta.isFinal && delta.text) onCommittedTextRef.current(delta.text)
+          if (delta.isFinal) {
+            // The segment endpointed: commit it for real and drop the live
+            // hypothesis so the next segment starts from a clean preview.
+            if (delta.text) onCommittedTextRef.current(delta.text)
+            setInterimText("")
+          } else {
+            // Running hypothesis for the current segment — each partial replaces
+            // the prior one rather than appending.
+            setInterimText(delta.text)
+          }
         })
         socket.on("voice:transcription:error", (e: { message?: string }) => fail(e?.message || "Transcription failed"))
         socket.on("voice:stopped", () => {
@@ -223,6 +242,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const stop = useCallback(() => {
     if (state !== "recording" && state !== "connecting") return
     setState("stopping")
+    setInterimText("")
     // Invalidate any in-flight `voice:start` ACK so a late accept can't flip us
     // back to "recording" after we've decided to stop.
     startGenerationRef.current++
@@ -262,6 +282,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     supported: supportRef.current.supported,
     unsupportedReason: supportRef.current.reason,
     error,
+    interimText,
     start,
     stop,
   }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -327,6 +327,15 @@
   content: attr(data-placeholder);
 }
 
+/* Live dictation hypothesis shown at the caret while speaking. Muted and
+   non-selectable so it reads as provisional and never participates in editing. */
+.dictation-preview-ghost {
+  @apply text-muted-foreground/70 italic pointer-events-none select-none;
+}
+.dictation-preview-ghost::before {
+  content: " ";
+}
+
 .ProseMirror > *:not(.ProseMirror-gapcursor) + *:not(.ProseMirror-gapcursor) {
   @apply mt-2;
 }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -335,6 +335,11 @@
 .dictation-preview-ghost::before {
   content: " ";
 }
+/* While a dictation preview occupies the line, suppress the empty-state
+   placeholder so it doesn't render on top of the ghost text. */
+.ProseMirror p.is-editor-empty:first-child:has(.dictation-preview-ghost)::before {
+  content: "";
+}
 
 .ProseMirror > *:not(.ProseMirror-gapcursor) + *:not(.ProseMirror-gapcursor) {
   @apply mt-2;

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,6 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ["class"],
+  // Gate hover: utilities behind @media (hover: hover) so touch taps don't leave
+  // a stuck hover state until the next tap elsewhere.
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Problem

Two frontend UX papercuts on top of the already-merged voice-dictation walking skeleton (#595):

1. **Dictation felt dead.** The frontend only consumed *committed* (`isFinal`) transcript deltas and dropped the running hypothesis the backend already streams. So nothing appeared on screen until the upstream VAD endpointed a whole segment — a noticeable lag where it looked like the mic wasn't doing anything.
2. **Sticky hover on touch.** Every button (the composer chips especially) used `hover:` styling. On touch devices the browser emulates `:hover` on tap and leaves it stuck until you tap elsewhere, so buttons looked half-pressed after every tap.

## Solution

### 1. Live interim transcript while dictating

The backend already emits both `partial_transcript` (interim, `isFinal: false`) and `committed_transcript` (`isFinal: true`) deltas. The hook now surfaces the in-flight hypothesis as `interimText`:

- **`use-voice-dictation.ts`** — final deltas commit via `onCommittedText` and clear the hypothesis; partials replace the current `interimText` (ElevenLabs partials are a running hypothesis, not an append). Cleared on `start`/`stop`/`teardown` so a stale take can't strand text.
- **`mic-button.tsx`** — mirrors `interimText` into the editor through a ref-held callback (so a new callback identity per render doesn't refire on every keystroke), and clears the ghost on unmount.
- **`dictation-preview-extension.ts`** (new TipTap extension) — renders the hypothesis as a caret-anchored **view-only widget decoration**. It never enters the document (no undo-history pollution, respects INV-58: `contentJson` stays canonical) and is completely inert (`decorations()` returns `null`) for every editor that isn't actively dictating.

### 2. Mobile hover-state fix

Enabled Tailwind's `future.hoverOnlyWhenSupported`, which compiles every `hover:` utility under `@media (hover: hover) and (pointer: fine)`. On touch devices the hover rule simply never matches, so a tap is just a tap. Genuine toggle/active states (format toggle's `bg-accent`, mic recording pulse) are not hover-driven and are unaffected.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/components/editor/dictation-preview-extension.ts` | View-only TipTap decoration that renders the live dictation hypothesis at the caret |
| `apps/frontend/src/components/editor/dictation-preview-extension.test.ts` | Verifies the ghost renders/clears and never writes into the document |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/hooks/use-voice-dictation.ts` | Surface `interimText`; handle partial vs final deltas |
| `apps/frontend/src/components/composer/mic-button.tsx` | `onInterimText` prop; mirror hypothesis to editor, clear on unmount |
| `apps/frontend/src/components/composer/message-composer.tsx` | Wire `setDictationInterim` into both mic-button instances |
| `apps/frontend/src/components/editor/rich-editor.tsx` | `setDictationInterim` on the imperative handle |
| `apps/frontend/src/components/editor/editor-extensions.ts` | Register `DictationPreview` |
| `apps/frontend/src/components/editor/editor-action-bar.test.tsx` | Add `setDictationInterim` to the mock handle |
| `apps/frontend/src/index.css` | `.dictation-preview-ghost` styling |
| `apps/frontend/tailwind.config.js` | Enable `hoverOnlyWhenSupported` |

## Test plan

- [x] `bun run test` — editor/composer suites + the 2 new decoration tests green
- [x] `tsc --noEmit` clean across the monorepo (pre-commit hook)
- [x] `bun run build` — frontend builds; confirmed compiled CSS gates `hover:` utilities behind `@media (hover: hover) and (pointer: fine)`
- [ ] Manual: dictate on desktop and confirm interim words appear immediately and resolve into committed text
- [ ] Manual: on a real touch device, tap composer buttons and confirm no stuck hover state

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPtM427dDUsL1CXzdcEg7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782054972&installation_id=129946197&pr_number=597&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F597&signature=1b1889249975c4a8dae82d553149322f7e968e00c4b9f440bfe10a6eb42fe22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->