### PR TITLE
feat(frontend): fade in only newly-arrived dictation ghost text

### DIFF
--- a/apps/frontend/src/components/editor/dictation-preview-extension.test.ts
+++ b/apps/frontend/src/components/editor/dictation-preview-extension.test.ts
@@ -42,4 +42,27 @@ describe("dictation preview", () => {
 
     expect(editor.getText()).toBe("")
   })
+
+  it("fades only the newly-arrived tail when a partial grows", () => {
+    editor = createEditor()
+
+    editor.commands.setDictationPreview("hello")
+    editor.commands.setDictationPreview("hello there")
+
+    const ghost = editor.view.dom.querySelector(".dictation-preview-ghost")
+    expect(ghost?.textContent).toBe("hello there")
+    // Only the appended tail carries the fade class; the carry-over prefix
+    // paints instantly so the line grows word-by-word.
+    expect(ghost?.querySelector(".dictation-preview-ghost__fresh")?.textContent).toBe(" there")
+  })
+
+  it("fades the whole hypothesis when a partial is revised without a shared prefix", () => {
+    editor = createEditor()
+
+    editor.commands.setDictationPreview("umm")
+    editor.commands.setDictationPreview("the cat")
+
+    const fresh = editor.view.dom.querySelector(".dictation-preview-ghost__fresh")
+    expect(fresh?.textContent).toBe("the cat")
+  })
 })

--- a/apps/frontend/src/components/editor/dictation-preview-extension.ts
+++ b/apps/frontend/src/components/editor/dictation-preview-extension.ts
@@ -2,7 +2,26 @@ import { Extension } from "@tiptap/core"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { Decoration, DecorationSet } from "@tiptap/pm/view"
 
-export const DictationPreviewPluginKey = new PluginKey<string>("dictationPreview")
+interface DictationPreviewState {
+  /** Full in-flight hypothesis for the current segment. */
+  text: string
+  /**
+   * Character offset where the latest partial diverges from the previous one.
+   * Text before this is unchanged from the prior frame (rendered instantly);
+   * text from here on is freshly arrived (faded in) so growing partials read as
+   * words materializing rather than the whole line repainting each update.
+   */
+  freshFrom: number
+}
+
+export const DictationPreviewPluginKey = new PluginKey<DictationPreviewState>("dictationPreview")
+
+function commonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length)
+  let i = 0
+  while (i < max && a[i] === b[i]) i++
+  return i
+}
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -37,30 +56,44 @@ export const DictationPreview = Extension.create({
 
   addProseMirrorPlugins() {
     return [
-      new Plugin<string>({
+      new Plugin<DictationPreviewState>({
         key: DictationPreviewPluginKey,
         state: {
-          init: () => "",
+          init: () => ({ text: "", freshFrom: 0 }),
           apply(tr, value) {
             const meta = tr.getMeta(DictationPreviewPluginKey)
-            return typeof meta === "string" ? meta : value
+            if (typeof meta !== "string" || meta === value.text) return value
+            return { text: meta, freshFrom: commonPrefixLength(value.text, meta) }
           },
         },
         props: {
           decorations(state) {
-            const text = DictationPreviewPluginKey.getState(state)
-            if (!text) return null
+            const preview = DictationPreviewPluginKey.getState(state)
+            if (!preview?.text) return null
+            const { text, freshFrom } = preview
             const widget = Decoration.widget(
               state.selection.to,
               () => {
                 const span = document.createElement("span")
                 span.className = "dictation-preview-ghost"
-                span.textContent = text
+                // Carry-over text from the previous partial paints instantly; the
+                // newly-arrived tail fades in (see .dictation-preview-ghost__fresh)
+                // so the line grows word-by-word instead of repainting wholesale.
+                const settled = text.slice(0, freshFrom)
+                const fresh = text.slice(freshFrom)
+                if (settled) span.append(settled)
+                if (fresh) {
+                  const freshSpan = document.createElement("span")
+                  freshSpan.className = "dictation-preview-ghost__fresh"
+                  freshSpan.textContent = fresh
+                  span.appendChild(freshSpan)
+                }
                 return span
               },
               // side:1 keeps the ghost after the caret; ignoreSelection stops it
               // from being treated as a selectable boundary. The text in the key
-              // forces a fresh node when the hypothesis grows.
+              // forces a fresh node when the hypothesis grows, replaying the
+              // fade on the new tail.
               { side: 1, ignoreSelection: true, key: `dictation-${text}` }
             )
             return DecorationSet.create(state.doc, [widget])

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -335,6 +335,24 @@
 .dictation-preview-ghost::before {
   content: " ";
 }
+/* The freshly-arrived tail of the hypothesis fades in so growing partials read
+   as words materializing rather than the whole line repainting each update. */
+.dictation-preview-ghost__fresh {
+  animation: dictation-ghost-fade 0.18s ease-out;
+}
+@keyframes dictation-ghost-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dictation-preview-ghost__fresh {
+    animation: none;
+  }
+}
 /* While a dictation preview occupies the line, suppress the empty-state
    placeholder so it doesn't render on top of the ghost text. */
 .ProseMirror p.is-editor-empty:first-child:has(.dictation-preview-ghost)::before {


### PR DESCRIPTION
## Problem

The live dictation hypothesis ("ghost" text shown at the caret while you speak) rebuilt its **entire** decoration widget on every partial transcript update — the widget is keyed by the full hypothesis string, so each STT partial recreated the whole span from scratch. The result: the complete line repaints on every update, so words pop/flash in abruptly rather than appearing gracefully as you speak.

## Solution

Track the **common prefix** between successive partials in the ProseMirror plugin state and split the ghost into two parts:

- **Carry-over prefix** — the portion unchanged from the previous partial, rendered as a plain text node that paints instantly (no animation).
- **Fresh tail** — the newly-arrived suffix, wrapped in a `.dictation-preview-ghost__fresh` span that fades in over 180ms.

So a growing partial like `"hello"` → `"hello there"` only fades in `" there"`; the `"hello"` stays put. The line now grows word-by-word instead of repainting wholesale. A revision with no shared prefix (e.g. `"umm"` → `"the cat"`) fades the whole new hypothesis, which reads naturally as a correction.

### Key design decisions

**1. Keep the full-text widget key.** The widget is still keyed by the full hypothesis, so ProseMirror rebuilds it each partial — that's what re-triggers the CSS fade on the new tail. The smoothness comes from *which span* carries the animation, not from avoiding the rebuild.

**2. Respect `prefers-reduced-motion`.** The fade is disabled under reduced-motion, so the feature degrades to instant text for users who opt out of animation.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/dictation-preview-extension.ts` | Plugin state now tracks `{ text, freshFrom }` (common-prefix offset); decoration splits into instant carry-over + faded fresh tail |
| `apps/frontend/src/index.css` | Add `dictation-ghost-fade` keyframe + `.dictation-preview-ghost__fresh` animation, gated by `prefers-reduced-motion` |
| `apps/frontend/src/components/editor/dictation-preview-extension.test.ts` | Add coverage: only the appended tail carries the fade class on growth; full hypothesis fades on a no-shared-prefix revision |

## Test plan

- [x] `bun run --cwd apps/frontend test` — editor/composer/voice suites pass (316 tests), incl. 4 dictation-preview tests
- [x] `bun run --cwd apps/frontend typecheck` clean
- [x] Production `vite build` clean
- [ ] Manual: dictate a multi-word sentence and confirm new words fade in while earlier words stay stable (deploy to staging)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPtM427dDUsL1CXzdcEg7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782063568&installation_id=129946197&pr_number=599&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F599&signature=bd54e3f841202a47da70de428c2f0344d287e3a989f986700d12a1c152163dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->