### PR TITLE
feat(frontend): voice-reactive mic ring + recording timer with cap hint

### DIFF
--- a/apps/backend/src/features/voice-transcription/handlers.test.ts
+++ b/apps/backend/src/features/voice-transcription/handlers.test.ts
@@ -64,6 +64,7 @@ describe("createVoiceTranscriptionHandlers.createSession", () => {
       provider: "elevenlabs",
       region: "us",
       expiresAt: expiresAt.toISOString(),
+      maxDurationMs: 10 * 60 * 1_000,
     })
   })
 })

--- a/apps/backend/src/features/voice-transcription/handlers.ts
+++ b/apps/backend/src/features/voice-transcription/handlers.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import { HttpError } from "../../lib/errors"
+import { voiceConfig } from "./config"
 import type { VoiceTranscriptionService } from "./service"
 
 const createSessionSchema = z.object({
@@ -36,6 +37,9 @@ export function createVoiceTranscriptionHandlers({ voiceTranscriptionService }: 
         provider: row.provider,
         region: row.region,
         expiresAt: row.expiresAt.toISOString(),
+        // The gateway force-stops a take at this duration; surface it so the
+        // client can show a countdown and the auto-stop isn't a surprise.
+        maxDurationMs: voiceConfig.maxSessionMs,
       })
     },
 

--- a/apps/frontend/src/api/voice.ts
+++ b/apps/frontend/src/api/voice.ts
@@ -6,6 +6,8 @@ export interface VoiceSession {
   provider: string
   region: string
   expiresAt: string
+  /** Hard cap after which the backend force-stops the take, in ms. */
+  maxDurationMs: number
 }
 
 export interface CreateVoiceSessionInput {

--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import { MicButton, formatClock } from "./mic-button"
+import { MicButton, formatClock, recordingRingShadow } from "./mic-button"
 
 describe("formatClock", () => {
   it("renders m:ss with zero-padded seconds", () => {
@@ -14,6 +14,30 @@ describe("formatClock", () => {
   it("floors sub-second remainders and clamps negatives to 0:00", () => {
     expect(formatClock(1_999)).toBe("0:01")
     expect(formatClock(-500)).toBe("0:00")
+  })
+})
+
+describe("recordingRingShadow", () => {
+  it("layers three concentric destructive rings", () => {
+    const shadow = recordingRingShadow(0)
+    expect(shadow.split(", ")).toEqual([
+      "0 0 0 1.00px hsl(var(--destructive) / 0.280)",
+      "0 0 0 3.00px hsl(var(--destructive) / 0.100)",
+      "0 0 0 6.00px hsl(var(--destructive) / 0.030)",
+    ])
+  })
+
+  it("grows spread and opacity with the input level", () => {
+    expect(recordingRingShadow(1).split(", ")).toEqual([
+      "0 0 0 2.50px hsl(var(--destructive) / 0.600)",
+      "0 0 0 9.00px hsl(var(--destructive) / 0.260)",
+      "0 0 0 16.00px hsl(var(--destructive) / 0.120)",
+    ])
+  })
+
+  it("clamps out-of-range levels", () => {
+    expect(recordingRingShadow(-1)).toBe(recordingRingShadow(0))
+    expect(recordingRingShadow(5)).toBe(recordingRingShadow(1))
   })
 })
 

--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -18,20 +18,18 @@ describe("formatClock", () => {
 })
 
 describe("recordingRingShadow", () => {
-  it("layers three concentric destructive rings", () => {
+  it("layers a crisp inner ring and a soft outer ring", () => {
     const shadow = recordingRingShadow(0)
     expect(shadow.split(", ")).toEqual([
-      "0 0 0 1.00px hsl(var(--destructive) / 0.280)",
-      "0 0 0 3.00px hsl(var(--destructive) / 0.100)",
-      "0 0 0 6.00px hsl(var(--destructive) / 0.030)",
+      "0 0 0 1.00px hsl(var(--destructive) / 0.300)",
+      "0 0 0 2.50px hsl(var(--destructive) / 0.080)",
     ])
   })
 
   it("grows spread and opacity with the input level", () => {
     expect(recordingRingShadow(1).split(", ")).toEqual([
-      "0 0 0 2.50px hsl(var(--destructive) / 0.600)",
-      "0 0 0 9.00px hsl(var(--destructive) / 0.260)",
-      "0 0 0 16.00px hsl(var(--destructive) / 0.120)",
+      "0 0 0 2.00px hsl(var(--destructive) / 0.550)",
+      "0 0 0 6.50px hsl(var(--destructive) / 0.180)",
     ])
   })
 

--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -1,7 +1,21 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import { MicButton } from "./mic-button"
+import { MicButton, formatClock } from "./mic-button"
+
+describe("formatClock", () => {
+  it("renders m:ss with zero-padded seconds", () => {
+    expect(formatClock(0)).toBe("0:00")
+    expect(formatClock(5_000)).toBe("0:05")
+    expect(formatClock(65_000)).toBe("1:05")
+    expect(formatClock(600_000)).toBe("10:00")
+  })
+
+  it("floors sub-second remainders and clamps negatives to 0:00", () => {
+    expect(formatClock(1_999)).toBe("0:01")
+    expect(formatClock(-500)).toBe("0:00")
+  })
+})
 
 // jsdom provides neither AudioWorkletNode nor navigator.mediaDevices.getUserMedia,
 // so the capability check fails closed — exactly the unsupported-browser path we

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -5,6 +5,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils"
 import { useVoiceDictation, type VoiceDictationState } from "@/hooks/use-voice-dictation"
 
+// Surface the cap warning in the final stretch so the auto-stop isn't a surprise.
+const NEAR_CAP_MS = 60_000
+
+export function formatClock(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
 function tooltipFor(args: {
   supported: boolean
   unsupportedReason: string | null
@@ -40,11 +50,12 @@ export function MicButton({
   className,
   language,
 }: MicButtonProps) {
-  const { state, supported, unsupportedReason, error, interimText, start, stop } = useVoiceDictation({
-    workspaceId,
-    onCommittedText: onInsertText,
-    language,
-  })
+  const { state, supported, unsupportedReason, error, interimText, level, elapsedMs, maxDurationMs, start, stop } =
+    useVoiceDictation({
+      workspaceId,
+      onCommittedText: onInsertText,
+      language,
+    })
 
   // Tell the host when a take is in flight. The mobile composer collapses its
   // action bar (and this button) on blur; without this signal a tap-outside
@@ -73,6 +84,24 @@ export function MicButton({
 
   const tooltip = tooltipFor({ supported, unsupportedReason, state, error })
 
+  // Detected once: under reduced-motion the recording ring stays static (the
+  // bg tint alone signals the live state) rather than pulsing with the voice.
+  const prefersReducedMotion = useRef(
+    typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+  ).current
+
+  const recording = state === "recording"
+  const remainingMs = maxDurationMs !== null ? maxDurationMs - elapsedMs : null
+  const nearCap = remainingMs !== null && remainingMs <= NEAR_CAP_MS
+  // A voice-reactive ring while recording: spread + opacity track the live input
+  // level so the button visibly responds to speech instead of a fixed pulse.
+  const recordingRing =
+    recording && !prefersReducedMotion
+      ? {
+          boxShadow: `0 0 0 ${(1 + level * 5).toFixed(2)}px hsl(var(--destructive) / ${(0.12 + level * 0.28).toFixed(3)})`,
+        }
+      : undefined
+
   const handleClick = () => {
     if (state === "recording" || state === "connecting") {
       stop()
@@ -87,7 +116,20 @@ export function MicButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span>
+        <span className="relative inline-flex">
+          {recording && (
+            // Absolutely positioned so the running clock never shifts the
+            // composer layout (INV-21). Switches to a remaining-time countdown
+            // with a warning tint as the take nears the backend's hard cap.
+            <span
+              className={cn(
+                "pointer-events-none absolute bottom-full left-1/2 mb-1 -translate-x-1/2 select-none rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums leading-none whitespace-nowrap",
+                nearCap ? "bg-destructive text-destructive-foreground" : "bg-muted text-muted-foreground"
+              )}
+            >
+              {nearCap && remainingMs !== null ? `${formatClock(remainingMs)} left` : formatClock(elapsedMs)}
+            </span>
+          )}
           <Button
             type="button"
             variant="ghost"
@@ -95,10 +137,12 @@ export function MicButton({
             aria-label={state === "recording" ? "Stop dictation" : "Dictate a message"}
             aria-pressed={state === "recording"}
             className={cn(
-              "h-7 w-7 shrink-0",
-              state === "recording" && "bg-destructive/15 text-destructive animate-pulse",
+              "h-7 w-7 shrink-0 transition-shadow duration-100",
+              recording && "bg-destructive/15 text-destructive",
+              recording && prefersReducedMotion && "animate-pulse",
               className
             )}
+            style={recordingRing}
             onClick={handleClick}
             disabled={disabled || !supported || state === "stopping"}
           >

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -138,8 +138,10 @@ export function MicButton({
             aria-pressed={state === "recording"}
             className={cn(
               "h-7 w-7 shrink-0 transition-shadow duration-100",
+              // The persistent destructive tint signals the live state on its
+              // own; the voice-reactive ring (below) adds motion only when the
+              // user hasn't opted out via prefers-reduced-motion.
               recording && "bg-destructive/15 text-destructive",
-              recording && prefersReducedMotion && "animate-pulse",
               className
             )}
             style={recordingRing}

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -9,16 +9,16 @@ import { useVoiceDictation, type VoiceDictationState } from "@/hooks/use-voice-d
 const NEAR_CAP_MS = 60_000
 
 // Voice-reactive halo for the recording state: a crisp inner ring gives the live
-// state a defined edge, while two softer rings bloom outward as the input level
-// rises so the button visibly "breathes" with the speaker's voice. Built purely
-// from layered box-shadows so it never reflows neighbors (INV-21) and reads the
-// same at both the 28px inline and 30px FAB sizes the button renders at.
+// state a defined edge, and a single soft ring breathes outward as the input
+// level rises so the button responds to the speaker's voice without bleeding
+// into neighboring controls. Built purely from layered box-shadows so it never
+// reflows neighbors (INV-21) and reads the same at both the 28px inline and 30px
+// FAB sizes the button renders at.
 export function recordingRingShadow(level: number): string {
   const l = Math.max(0, Math.min(1, level))
   return [
-    `0 0 0 ${(1 + l * 1.5).toFixed(2)}px hsl(var(--destructive) / ${(0.28 + l * 0.32).toFixed(3)})`,
-    `0 0 0 ${(3 + l * 6).toFixed(2)}px hsl(var(--destructive) / ${(0.1 + l * 0.16).toFixed(3)})`,
-    `0 0 0 ${(6 + l * 10).toFixed(2)}px hsl(var(--destructive) / ${(0.03 + l * 0.09).toFixed(3)})`,
+    `0 0 0 ${(1 + l * 1).toFixed(2)}px hsl(var(--destructive) / ${(0.3 + l * 0.25).toFixed(3)})`,
+    `0 0 0 ${(2.5 + l * 4).toFixed(2)}px hsl(var(--destructive) / ${(0.08 + l * 0.1).toFixed(3)})`,
   ].join(", ")
 }
 
@@ -107,18 +107,11 @@ export function MicButton({
   const recording = state === "recording"
   const remainingMs = maxDurationMs !== null ? maxDurationMs - elapsedMs : null
   const nearCap = remainingMs !== null && remainingMs <= NEAR_CAP_MS
-  // While recording (and motion is allowed), drive both the halo rings and the
-  // fill tint from the live input level so the whole button responds to speech
-  // instead of pulsing on a fixed timer. The fill deepens as the inner ring
-  // tightens, reinforcing the center; reduced-motion falls back to the static
-  // `bg-destructive/15` tint below (no level reactivity).
-  const recordingStyle =
-    recording && !prefersReducedMotion
-      ? {
-          boxShadow: recordingRingShadow(level),
-          backgroundColor: `hsl(var(--destructive) / ${(0.12 + level * 0.12).toFixed(3)})`,
-        }
-      : undefined
+  // While recording (and motion is allowed), drive the halo rings from the live
+  // input level so the button responds to speech instead of pulsing on a fixed
+  // timer. The fill stays the static `bg-destructive/15` tint (below) so only
+  // the ring moves; reduced-motion drops the ring and keeps the tint alone.
+  const recordingStyle = recording && !prefersReducedMotion ? { boxShadow: recordingRingShadow(level) } : undefined
 
   const handleClick = () => {
     if (state === "recording" || state === "connecting") {
@@ -155,10 +148,10 @@ export function MicButton({
             aria-label={state === "recording" ? "Stop dictation" : "Dictate a message"}
             aria-pressed={state === "recording"}
             className={cn(
-              "h-7 w-7 shrink-0 transition-[box-shadow,background-color] duration-100",
+              "h-7 w-7 shrink-0 transition-shadow duration-100",
               // The persistent destructive tint signals the live state on its
-              // own; the voice-reactive halo + fill (below) add motion only when
-              // the user hasn't opted out via prefers-reduced-motion.
+              // own; the voice-reactive halo (below) adds motion only when the
+              // user hasn't opted out via prefers-reduced-motion.
               recording && "bg-destructive/15 text-destructive",
               className
             )}

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -8,6 +8,20 @@ import { useVoiceDictation, type VoiceDictationState } from "@/hooks/use-voice-d
 // Surface the cap warning in the final stretch so the auto-stop isn't a surprise.
 const NEAR_CAP_MS = 60_000
 
+// Voice-reactive halo for the recording state: a crisp inner ring gives the live
+// state a defined edge, while two softer rings bloom outward as the input level
+// rises so the button visibly "breathes" with the speaker's voice. Built purely
+// from layered box-shadows so it never reflows neighbors (INV-21) and reads the
+// same at both the 28px inline and 30px FAB sizes the button renders at.
+export function recordingRingShadow(level: number): string {
+  const l = Math.max(0, Math.min(1, level))
+  return [
+    `0 0 0 ${(1 + l * 1.5).toFixed(2)}px hsl(var(--destructive) / ${(0.28 + l * 0.32).toFixed(3)})`,
+    `0 0 0 ${(3 + l * 6).toFixed(2)}px hsl(var(--destructive) / ${(0.1 + l * 0.16).toFixed(3)})`,
+    `0 0 0 ${(6 + l * 10).toFixed(2)}px hsl(var(--destructive) / ${(0.03 + l * 0.09).toFixed(3)})`,
+  ].join(", ")
+}
+
 export function formatClock(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000))
   const minutes = Math.floor(totalSeconds / 60)
@@ -93,12 +107,16 @@ export function MicButton({
   const recording = state === "recording"
   const remainingMs = maxDurationMs !== null ? maxDurationMs - elapsedMs : null
   const nearCap = remainingMs !== null && remainingMs <= NEAR_CAP_MS
-  // A voice-reactive ring while recording: spread + opacity track the live input
-  // level so the button visibly responds to speech instead of a fixed pulse.
-  const recordingRing =
+  // While recording (and motion is allowed), drive both the halo rings and the
+  // fill tint from the live input level so the whole button responds to speech
+  // instead of pulsing on a fixed timer. The fill deepens as the inner ring
+  // tightens, reinforcing the center; reduced-motion falls back to the static
+  // `bg-destructive/15` tint below (no level reactivity).
+  const recordingStyle =
     recording && !prefersReducedMotion
       ? {
-          boxShadow: `0 0 0 ${(1 + level * 5).toFixed(2)}px hsl(var(--destructive) / ${(0.12 + level * 0.28).toFixed(3)})`,
+          boxShadow: recordingRingShadow(level),
+          backgroundColor: `hsl(var(--destructive) / ${(0.12 + level * 0.12).toFixed(3)})`,
         }
       : undefined
 
@@ -137,14 +155,14 @@ export function MicButton({
             aria-label={state === "recording" ? "Stop dictation" : "Dictate a message"}
             aria-pressed={state === "recording"}
             className={cn(
-              "h-7 w-7 shrink-0 transition-shadow duration-100",
+              "h-7 w-7 shrink-0 transition-[box-shadow,background-color] duration-100",
               // The persistent destructive tint signals the live state on its
-              // own; the voice-reactive ring (below) adds motion only when the
-              // user hasn't opted out via prefers-reduced-motion.
+              // own; the voice-reactive halo + fill (below) add motion only when
+              // the user hasn't opted out via prefers-reduced-motion.
               recording && "bg-destructive/15 text-destructive",
               className
             )}
-            style={recordingRing}
+            style={recordingStyle}
             onClick={handleClick}
             disabled={disabled || !supported || state === "stopping"}
           >

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -32,6 +32,19 @@ interface UseVoiceDictationResult {
    * after the upstream VAD endpoints a segment.
    */
   interimText: string
+  /**
+   * Smoothed live input level (0–1) derived from the mic signal while recording,
+   * so the UI can react to the user's voice instead of pulsing on a fixed timer.
+   * 0 whenever not recording.
+   */
+  level: number
+  /** Elapsed recording time for the current take, in ms (0 when not recording). */
+  elapsedMs: number
+  /**
+   * Hard cap after which the backend force-stops the take, in ms — null until a
+   * session is created. Pair with `elapsedMs` to show a countdown near the cap.
+   */
+  maxDurationMs: number | null
   start: () => void
   stop: () => void
 }
@@ -81,6 +94,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const [state, setState] = useState<VoiceDictationState>("idle")
   const [error, setError] = useState<string | null>(null)
   const [interimText, setInterimText] = useState("")
+  const [level, setLevel] = useState(0)
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const [maxDurationMs, setMaxDurationMs] = useState<number | null>(null)
   const supportRef = useRef(detectSupport())
 
   const socketRef = useRef<Socket | null>(null)
@@ -88,6 +104,14 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const audioContextRef = useRef<AudioContext | null>(null)
   const workletRef = useRef<AudioWorkletNode | null>(null)
   const sessionIdRef = useRef<string | null>(null)
+  // Live input-level metering: an AnalyserNode taps the mic source and a rAF
+  // loop computes a smoothed RMS level + elapsed time while recording.
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const meterRafRef = useRef<number | null>(null)
+  const recordingStartRef = useRef(0)
+  const smoothedLevelRef = useRef(0)
+  const lastSetLevelRef = useRef(0)
+  const lastElapsedTickRef = useRef(0)
   // Bumped on every start() and every teardown/stop so a `voice:start` ACK that
   // resolves after the user has already stopped (or torn down) can't flip the
   // state machine back to "recording" with nothing behind it.
@@ -121,6 +145,14 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   }, [updateInterim])
 
   const teardownAudio = useCallback(() => {
+    if (meterRafRef.current !== null) cancelAnimationFrame(meterRafRef.current)
+    meterRafRef.current = null
+    analyserRef.current?.disconnect()
+    analyserRef.current = null
+    smoothedLevelRef.current = 0
+    lastSetLevelRef.current = 0
+    setLevel(0)
+    setElapsedMs(0)
     workletRef.current?.port.close()
     workletRef.current?.disconnect()
     workletRef.current = null
@@ -130,12 +162,49 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     audioContextRef.current = null
   }, [])
 
+  // rAF loop: sample the analyser, surface a smoothed input level and the
+  // elapsed recording time. Fast attack / slow decay reads as responsive; the
+  // level setState is gated to meaningful changes so a 60fps loop doesn't churn
+  // renders, and elapsed ticks at ~4Hz (enough for an m:ss readout + cap hint).
+  const runMeter = useCallback(() => {
+    const analyser = analyserRef.current
+    if (!analyser) return
+    const buf = new Uint8Array(analyser.fftSize)
+    const tick = () => {
+      const node = analyserRef.current
+      if (!node) return
+      node.getByteTimeDomainData(buf)
+      let sumSquares = 0
+      for (let i = 0; i < buf.length; i++) {
+        const sample = (buf[i] - 128) / 128
+        sumSquares += sample * sample
+      }
+      const rms = Math.sqrt(sumSquares / buf.length)
+      const target = Math.min(1, rms * 3)
+      const prev = smoothedLevelRef.current
+      const next = prev + (target - prev) * (target > prev ? 0.5 : 0.12)
+      smoothedLevelRef.current = next
+      if (Math.abs(next - lastSetLevelRef.current) >= 0.02) {
+        lastSetLevelRef.current = next
+        setLevel(next)
+      }
+      const now = performance.now()
+      if (now - lastElapsedTickRef.current >= 250) {
+        lastElapsedTickRef.current = now
+        setElapsedMs(now - recordingStartRef.current)
+      }
+      meterRafRef.current = requestAnimationFrame(tick)
+    }
+    meterRafRef.current = requestAnimationFrame(tick)
+  }, [])
+
   const teardown = useCallback(() => {
     startGenerationRef.current++
     teardownAudio()
     socketRef.current?.disconnect()
     socketRef.current = null
     sessionIdRef.current = null
+    setMaxDurationMs(null)
     updateInterim("")
     coordinator.deactivate(coordinatedStop)
   }, [teardownAudio, updateInterim, coordinator, coordinatedStop])
@@ -173,6 +242,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
 
         const session = await voiceApi.createSession(workspaceId, { language })
         sessionIdRef.current = session.voiceSessionId
+        setMaxDurationMs(session.maxDurationMs)
 
         const stream = await navigator.mediaDevices.getUserMedia({
           audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
@@ -202,6 +272,13 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         source.connect(worklet)
         worklet.connect(muted)
         muted.connect(audioContext.destination)
+        // Tap the source for level metering. The analyser is a pure sink (no
+        // onward connection), so it never feeds audio back into the graph.
+        const analyser = audioContext.createAnalyser()
+        analyser.fftSize = 1024
+        analyser.smoothingTimeConstant = 0.4
+        source.connect(analyser)
+        analyserRef.current = analyser
         // iOS Safari starts the context suspended; without this the worklet's
         // process() never runs and no audio frames are produced.
         if (audioContext.state === "suspended") await audioContext.resume()
@@ -255,6 +332,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             worklet.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
               socketRef.current?.emit("voice:audio", event.data)
             }
+            recordingStartRef.current = performance.now()
+            lastElapsedTickRef.current = 0
+            setElapsedMs(0)
+            runMeter()
             setState("recording")
           }
         )
@@ -269,7 +350,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         fail(message)
       }
     })()
-  }, [state, workspaceId, language, fail, teardown, flushInterim, coordinator, coordinatedStop])
+  }, [state, workspaceId, language, fail, teardown, flushInterim, runMeter, coordinator, coordinatedStop])
 
   const stop = useCallback(() => {
     if (state !== "recording" && state !== "connecting") return
@@ -321,6 +402,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     unsupportedReason: supportRef.current.reason,
     error,
     interimText,
+    level,
+    elapsedMs,
+    maxDurationMs,
     start,
     stop,
   }


### PR DESCRIPTION
## Problem

Two gaps in the dictation UX:

1. **No feedback that the mic is actually hearing you.** While recording, the button only pulsed on a fixed CSS timer — it looked identical whether you were speaking, silent, or the mic was dead.
2. **The take auto-stops without warning.** The backend force-stops a session at a hard cap (`voiceConfig.maxSessionMs`, currently 10 min) and emits `voice:stopped`, but the client gave no indication of elapsed time or how close you were to the cap — so a long dictation just vanished mid-sentence.

## Solution

**Voice-reactive ring.** An `AnalyserNode` taps the existing mic `source` node (a pure sink — no onward connection, so it never feeds audio back into the graph). A `requestAnimationFrame` loop computes a smoothed RMS level (fast attack / slow decay) and the dictation hook exposes it as `level` (0–1). The button's recording ring scales its spread + opacity with `level`, so it visibly responds to speech.

**Recording timer + cap hint.** The hook tracks `elapsedMs` and surfaces the backend's `maxDurationMs`. The button shows a running `m:ss` clock that flips to a remaining-time countdown with a warning tint in the final minute, so the auto-stop isn't a surprise.

### How it works

- Hook (`use-voice-dictation.ts`) gains `level`, `elapsedMs`, `maxDurationMs`. The rAF loop gates `level` setState to changes ≥0.02 and ticks `elapsedMs` at ~4 Hz so a 60 fps loop doesn't churn renders. Metering tears down with the audio graph (rAF cancelled, analyser disconnected, values reset).
- Button (`mic-button.tsx`) renders an absolutely-positioned timer pill (no layout shift, INV-21) and the level-driven ring.

### Key design decisions

**1. Surface the cap from the backend, don't mirror it.** `createSession` now returns `maxDurationMs` from `voiceConfig.maxSessionMs`. config.ts explicitly documents this guard as a PR1-skeleton value that changes in PR2, so a hardcoded frontend constant would drift (INV-33 — single source of truth).

**2. AnalyserNode tap over piggybacking the worklet port.** The worklet port is dedicated to real-time PCM frame transfer; a main-thread analyser is orthogonal and doesn't contend with streaming.

**3. Respect `prefers-reduced-motion`.** The reactive ring is disabled under reduced-motion — the static destructive tint signals the recording state without any animation (the prior `animate-pulse` was itself motion those users opt out of).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/voice-transcription/handlers.ts` | `createSession` response includes `maxDurationMs` |
| `apps/backend/src/features/voice-transcription/handlers.test.ts` | Assert the new response field |
| `apps/frontend/src/api/voice.ts` | `VoiceSession.maxDurationMs` |
| `apps/frontend/src/hooks/use-voice-dictation.ts` | AnalyserNode + rAF metering; expose `level`, `elapsedMs`, `maxDurationMs` |
| `apps/frontend/src/components/composer/mic-button.tsx` | Voice-reactive ring + timer pill / cap countdown; `formatClock` |
| `apps/frontend/src/components/composer/mic-button.test.tsx` | `formatClock` edge cases |

## Test plan

- [x] `bun run --cwd apps/frontend test` — composer/voice/editor suites pass
- [x] `bun test apps/backend/.../handlers.test.ts` pass
- [x] Frontend + backend typecheck, lint, OpenAPI check clean (commit hooks)
- [x] Production `vite build` clean
- [ ] Manual on staging: speak and confirm the ring tracks your voice; let a take run toward the cap and confirm the countdown + warning tint; verify reduced-motion shows a static tint

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPtM427dDUsL1CXzdcEg7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782065374&installation_id=129946197&pr_number=600&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F600&signature=26cfd4580be47a3796f0acd77a0d97f47de922652bf481da9b4ebd4be7e387a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->