### PR TITLE
feat: let active pi observe non-user replies

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -82,7 +82,7 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
   private async processMessageCreated(payload: unknown): Promise<void> {
     const message = parseMessagePayload(payload)
     if (!message) return
-    if (message.event.actorType !== AuthorTypes.USER || !message.event.actorId) return
+    if (!message.event.actorId) return
 
     const stream = await StreamRepository.findById(this.pool, message.streamId)
     if (!stream || stream.workspaceId !== message.workspaceId || stream.archivedAt) return
@@ -90,7 +90,8 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const rootStreamId = stream.rootStreamId ?? stream.id
     const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
     const invocationRootStreamId = rootStream?.id ?? stream.id
-    const mentionedSlugs = extractMentionSlugs(message.event.payload.contentMarkdown)
+    const isUserAuthored = message.event.actorType === AuthorTypes.USER
+    const mentionedSlugs = isUserAuthored ? extractMentionSlugs(message.event.payload.contentMarkdown) : []
     const uniqueMentionedSlugs = Array.from(new Set(mentionedSlugs))
     const [mentionedBots, mentionedPersonas] =
       uniqueMentionedSlugs.length > 0
@@ -133,6 +134,7 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
 
     const bot = await BotRepository.findById(this.pool, message.workspaceId, active.actorId)
     if (!bot || bot.archivedAt || !botHasCapability(bot, "active-scratchpad")) return
+    if (message.event.actorType === AuthorTypes.BOT && message.event.actorId === bot.id) return
     if (mentionableBots.some((mentionedBot) => mentionedBot.id === bot.id)) return
     const activeExplicitlyMentioned = bot.slug != null && mentionedSlugs.includes(bot.slug)
     if ((mentionableBots.length > 0 || hasMentionedPersona) && !activeExplicitlyMentioned) return
@@ -171,7 +173,14 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
       actorId: bot.id,
       trigger: "active-scratchpad",
       requiredCapability: "active-scratchpad",
-      promptMarkdown: message.event.payload.contentMarkdown,
+      promptMarkdown: isUserAuthored
+        ? message.event.payload.contentMarkdown
+        : [
+            "A non-user message was posted in your active Threa scratchpad.",
+            "Use the stream context to decide whether a reply is useful. If no reply is needed, respond exactly: THREA_NO_RESPONSE",
+            "",
+            message.event.payload.contentMarkdown,
+          ].join("\n"),
       authorUserId: message.event.actorId,
       mentionedActorSlugs: mentionedSlugs,
       targetInstanceId: link.instanceId,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -564,9 +564,10 @@ export function createPublicApiHandlers({
       }
       const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
       if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
-      const contentMarkdown = result.data.finalMessageMarkdown
-        ? normalizeMessage(result.data.finalMessageMarkdown)
-        : null
+      const contentMarkdown =
+        result.data.noResponse === true || !result.data.finalMessageMarkdown
+          ? null
+          : normalizeMessage(result.data.finalMessageMarkdown)
       const contentJson = contentMarkdown ? parseMarkdown(contentMarkdown, undefined, toEmoji) : null
       const attachmentIds = contentJson ? collectAttachmentReferenceIds(contentJson) : []
       const { completed, message } = await withTransaction(pool, async (client) => {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -564,9 +564,11 @@ export function createPublicApiHandlers({
       }
       const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
       if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
-      const contentMarkdown = normalizeMessage(result.data.finalMessageMarkdown)
-      const contentJson = parseMarkdown(contentMarkdown, undefined, toEmoji)
-      const attachmentIds = collectAttachmentReferenceIds(contentJson)
+      const contentMarkdown = result.data.finalMessageMarkdown
+        ? normalizeMessage(result.data.finalMessageMarkdown)
+        : null
+      const contentJson = contentMarkdown ? parseMarkdown(contentMarkdown, undefined, toEmoji) : null
+      const attachmentIds = contentJson ? collectAttachmentReferenceIds(contentJson) : []
       const { completed, message } = await withTransaction(pool, async (client) => {
         const claim = await botRuntimeService.findActiveClaimForUpdate(client, {
           workspaceId: req.workspaceId!,
@@ -577,17 +579,19 @@ export function createPublicApiHandlers({
         })
         if (!claim) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
         await assertStreamAccessible(req, claim.responseStreamId)
-        const message = await eventService.createMessageInTransaction(client, {
-          workspaceId: req.workspaceId!,
-          streamId: claim.responseStreamId,
-          authorId: bot.id,
-          authorType: AuthorTypes.BOT,
-          contentJson,
-          contentMarkdown,
-          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-          clientMessageId: `bot-invocation:${claim.id}`,
-          metadata: result.data.metadata,
-        })
+        const message = contentMarkdown
+          ? await eventService.createMessageInTransaction(client, {
+              workspaceId: req.workspaceId!,
+              streamId: claim.responseStreamId,
+              authorId: bot.id,
+              authorType: AuthorTypes.BOT,
+              contentJson: contentJson!,
+              contentMarkdown,
+              attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+              clientMessageId: `bot-invocation:${claim.id}`,
+              metadata: result.data.metadata,
+            })
+          : null
         const completed = await botRuntimeService.completeInvocationInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: req.botApiKey!.botId,
@@ -599,7 +603,10 @@ export function createPublicApiHandlers({
         return { completed, message }
       })
       res.json({
-        data: { invocationId: completed.id, message: serializeMessage(message, { authorDisplayName: bot.name }) },
+        data: {
+          invocationId: completed.id,
+          message: message ? serializeMessage(message, { authorDisplayName: bot.name }) : null,
+        },
       })
     },
 

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -304,7 +304,7 @@ const runtimeSessionLinkSchema = z.object({
 
 const invocationStatusSchema = z.object({ invocationId: z.string(), status: z.string() })
 const renewedInvocationSchema = invocationStatusSchema.extend({ claimExpiresAt: z.string().datetime().nullable() })
-const completedInvocationSchema = z.object({ invocationId: z.string(), message: messageSchema })
+const completedInvocationSchema = z.object({ invocationId: z.string(), message: messageSchema.nullable() })
 
 const errorSchema = z.object({
   error: z.string(),

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -94,12 +94,18 @@ export const renewInvocationClaimSchema = z.object({
   claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
 })
 
-export const completeInvocationSchema = z.object({
-  instanceId: z.string().min(1).max(128),
-  claimToken: z.string().min(1).max(256),
-  finalMessageMarkdown: z.string().min(1).max(50_000),
-  metadata: messageMetadataSchema.optional(),
-})
+export const completeInvocationSchema = z
+  .object({
+    instanceId: z.string().min(1).max(128),
+    claimToken: z.string().min(1).max(256),
+    finalMessageMarkdown: z.string().min(1).max(50_000).optional(),
+    noResponse: z.boolean().optional(),
+    metadata: messageMetadataSchema.optional(),
+  })
+  .refine((value) => value.noResponse === true || value.finalMessageMarkdown != null, {
+    message: "Either finalMessageMarkdown or noResponse is required",
+    path: ["finalMessageMarkdown"],
+  })
 
 export const failInvocationSchema = z.object({
   instanceId: z.string().min(1).max(128),

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -5,6 +5,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 
 const CONFIG_PATH = join(homedir(), ".pi", "agent", "threa-remote.json")
 const STATUS_KEY = "threa-remote"
+const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 
 type Config = {
   baseUrl: string
@@ -344,15 +345,18 @@ function advanceStreamCursor(invocation: ClaimedInvocation): void {
 async function completePending(markdown: string): Promise<void> {
   if (!config || !pending) return
   const invocation = pending
+  const finalMarkdown = markdown.trim() || "Done."
+  const noResponse = finalMarkdown === NO_RESPONSE_MARKER
   await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
     method: "POST",
     body: JSON.stringify({
       instanceId: ensureInstanceId(),
       claimToken: invocation.claimToken,
-      finalMessageMarkdown: markdown || "Done.",
+      ...(noResponse ? { noResponse: true } : { finalMessageMarkdown: finalMarkdown }),
       metadata: {
         "pi.remote.invocationId": invocation.id,
         "pi.remote.instanceId": ensureInstanceId(),
+        ...(noResponse && { "pi.remote.noResponse": "true" }),
       },
     }),
   })


### PR DESCRIPTION
## Problem

After adding stream context, Pi can see nearby Ariadne/persona replies when directly invoked, but the active scratchpad path still only created invocations for user-authored messages. That means Pi cannot observe a persona/bot reply and decide whether a response is warranted.

## Solution

Allow active Pi scratchpads to receive non-user message invocations while adding an explicit no-response escape hatch.

### How it works

1. The bot invocation outbox handler now processes non-user messages for active scratchpads.
2. It still skips Pi's own bot messages to avoid self-reply loops.
3. Non-user invocations get a prompt prefix instructing Pi to answer exactly `THREA_NO_RESPONSE` when no reply is useful.
4. The Pi adapter maps that marker to `noResponse: true` on completion.
5. The public complete endpoint can now complete an invocation without creating a stream message when `noResponse` is set.

### Key design decisions

**1. Keep mention behavior user-scoped**

Mention extraction/invocations remain user-authored only. Non-user messages only enter through the active scratchpad observer path.

**2. Complete without posting instead of failing**

No-response decisions are successful completions, not failures. This keeps invocation state accurate and avoids noisy failed rows.

**3. Preserve explicit self-loop guard**

Pi's own bot messages are ignored by the observer path, preventing immediate feedback loops.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | Create active scratchpad invocations for non-user messages with no-response instruction; skip Pi self messages |
| `apps/backend/src/features/public-api/schemas.ts` | Allow `noResponse` completion payloads |
| `apps/backend/src/features/public-api/handlers.ts` | Complete invocations without posting a message when no response is requested |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Map `THREA_NO_RESPONSE` final output to no-response completion |

## Test plan

- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun --check docs/examples/pi-remote/threa-remote-v2.ts`
- [x] `bun --check ~/.pi/agent/extensions/threa-remote.ts`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782074232&installation_id=129946197&pr_number=602&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F602&signature=ee9e626bb27805c61d6be40bd14aa4bb2bd5d167b88362b787c0ec84443a42ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->