### PR TITLE
feat: show bot runtime presence in streams

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -290,6 +290,13 @@ export const StreamActiveActorRepository = {
 }
 
 export const BotRuntimeInstanceRepository = {
+  async findLatestForBot(db: Querier, workspaceId: string, botId: string): Promise<BotRuntimeInstance | null> {
+    const result = await db.query<BotRuntimeInstanceRow>(
+      sql`SELECT * FROM bot_runtime_instances WHERE workspace_id = ${workspaceId} AND bot_id = ${botId} ORDER BY last_seen_at DESC LIMIT 1`
+    )
+    return result.rows[0] ? mapRuntimeInstance(result.rows[0]) : null
+  },
+
   async upsertPresence(
     db: Querier,
     params: {

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -297,6 +297,18 @@ export const BotRuntimeInstanceRepository = {
     return result.rows[0] ? mapRuntimeInstance(result.rows[0]) : null
   },
 
+  async findLatestForBots(
+    db: Querier,
+    workspaceId: string,
+    botIds: string[]
+  ): Promise<Map<string, BotRuntimeInstance>> {
+    if (botIds.length === 0) return new Map()
+    const result = await db.query<BotRuntimeInstanceRow>(
+      sql`SELECT DISTINCT ON (bot_id) * FROM bot_runtime_instances WHERE workspace_id = ${workspaceId} AND bot_id = ANY(${botIds}) ORDER BY bot_id, last_seen_at DESC`
+    )
+    return new Map(result.rows.map((row) => [row.bot_id, mapRuntimeInstance(row)]))
+  },
+
   async upsertPresence(
     db: Querier,
     params: {

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -29,6 +29,13 @@ export class BotRuntimeService {
     return BotRuntimeInstanceRepository.findLatestForBot(this.pool, params.workspaceId, params.botId)
   }
 
+  async findLatestPresences(params: {
+    workspaceId: string
+    botIds: string[]
+  }): Promise<Map<string, BotRuntimeInstance>> {
+    return BotRuntimeInstanceRepository.findLatestForBots(this.pool, params.workspaceId, params.botIds)
+  }
+
   async upsertPresenceFromBotKey(params: {
     workspaceId: string
     botId: string

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -25,6 +25,10 @@ export class BotRuntimeService {
     this.pool = deps.pool
   }
 
+  async findLatestPresence(params: { workspaceId: string; botId: string }): Promise<BotRuntimeInstance | null> {
+    return BotRuntimeInstanceRepository.findLatestForBot(this.pool, params.workspaceId, params.botId)
+  }
+
   async upsertPresenceFromBotKey(params: {
     workspaceId: string
     botId: string

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -688,13 +688,9 @@ export function createStreamHandlers({
           eventService.getLatestSequence(streamId),
           activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
         ])
+      const botRuntimePresences = await botRuntimeService.findLatestPresences({ workspaceId, botIds: botMemberIds })
       const botRuntimePresence = Object.fromEntries(
-        await Promise.all(
-          botMemberIds.map(async (botId) => {
-            const presence = await botRuntimeService.findLatestPresence({ workspaceId, botId })
-            return [botId, serializeBotRuntimePresence(presence ?? null)] as const
-          })
-        )
+        botMemberIds.map((botId) => [botId, serializeBotRuntimePresence(botRuntimePresences.get(botId) ?? null)])
       )
 
       const unreadCount = membership ? await streamService.getUnreadCount(streamId, membership.lastReadEventId) : 0
@@ -759,13 +755,9 @@ export function createStreamHandlers({
       const { streamId } = req.params
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
       const botMemberIds = await streamService.getBotMemberIds(workspaceId, streamId)
+      const botRuntimePresences = await botRuntimeService.findLatestPresences({ workspaceId, botIds: botMemberIds })
       const data = Object.fromEntries(
-        await Promise.all(
-          botMemberIds.map(async (botId) => {
-            const presence = await botRuntimeService.findLatestPresence({ workspaceId, botId })
-            return [botId, serializeBotRuntimePresence(presence ?? null)] as const
-          })
-        )
+        botMemberIds.map((botId) => [botId, serializeBotRuntimePresence(botRuntimePresences.get(botId) ?? null)])
       )
       res.json({ data })
     },

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -5,6 +5,7 @@ import type { EventService } from "../messaging"
 import { collectSharedMessageIds, hydrateSharedMessageIds, type HydratedSharedMessage } from "../messaging"
 import type { ActivityService } from "../activity"
 import type { LinkPreviewService } from "../link-previews"
+import type { BotRuntimeService } from "../bot-runtimes"
 import type { StreamEvent } from "./event-repository"
 import type { EventType, JSONContent, LinkPreviewSummary, StreamType } from "@threa/types"
 import { ARIADNE_PERSONA_SLUG, StreamTypes, SLUG_PATTERN, CompanionModes } from "@threa/types"
@@ -179,6 +180,7 @@ interface Dependencies {
   eventService: EventService
   activityService?: ActivityService
   linkPreviewService: LinkPreviewService
+  botRuntimeService?: BotRuntimeService
 }
 
 /**
@@ -284,12 +286,28 @@ async function enrichEventsWithLinkPreviews(
   return applyLinkPreviewStateToEvents(events, previewMap, dismissals)
 }
 
+function serializeBotRuntimePresence(presence: Awaited<ReturnType<BotRuntimeService["findLatestPresence"]>>) {
+  return presence
+    ? {
+        botId: presence.botId,
+        runtimeKind: presence.runtimeKind,
+        instanceId: presence.instanceId,
+        displayName: presence.displayName,
+        status: presence.status,
+        acceptingInvocations: presence.acceptingInvocations,
+        statusText: presence.statusText,
+        lastSeenAt: presence.lastSeenAt.toISOString(),
+      }
+    : null
+}
+
 export function createStreamHandlers({
   pool,
   streamService,
   eventService,
   activityService,
   linkPreviewService,
+  botRuntimeService,
 }: Dependencies) {
   return {
     async list(req: Request, res: Response) {
@@ -670,6 +688,14 @@ export function createStreamHandlers({
           eventService.getLatestSequence(streamId),
           activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
         ])
+      const botRuntimePresence = Object.fromEntries(
+        await Promise.all(
+          botMemberIds.map(async (botId) => {
+            const presence = await botRuntimeService?.findLatestPresence({ workspaceId, botId })
+            return [botId, serializeBotRuntimePresence(presence ?? null)] as const
+          })
+        )
+      )
 
       const unreadCount = membership ? await streamService.getUnreadCount(streamId, membership.lastReadEventId) : 0
 
@@ -713,6 +739,7 @@ export function createStreamHandlers({
           sharedMessages,
           members,
           botMemberIds,
+          botRuntimePresence,
           membership,
           latestSequence: (latestSequence ?? 0n).toString(),
           snapshotAt,
@@ -724,6 +751,23 @@ export function createStreamHandlers({
           contextBag,
         },
       })
+    },
+
+    async botRuntimePresence(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { streamId } = req.params
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
+      const botMemberIds = await streamService.getBotMemberIds(workspaceId, streamId)
+      const data = Object.fromEntries(
+        await Promise.all(
+          botMemberIds.map(async (botId) => {
+            const presence = await botRuntimeService?.findLatestPresence({ workspaceId, botId })
+            return [botId, serializeBotRuntimePresence(presence ?? null)] as const
+          })
+        )
+      )
+      res.json({ data })
     },
 
     async checkSlugAvailable(req: Request, res: Response) {

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -180,7 +180,7 @@ interface Dependencies {
   eventService: EventService
   activityService?: ActivityService
   linkPreviewService: LinkPreviewService
-  botRuntimeService?: BotRuntimeService
+  botRuntimeService: BotRuntimeService
 }
 
 /**
@@ -691,7 +691,7 @@ export function createStreamHandlers({
       const botRuntimePresence = Object.fromEntries(
         await Promise.all(
           botMemberIds.map(async (botId) => {
-            const presence = await botRuntimeService?.findLatestPresence({ workspaceId, botId })
+            const presence = await botRuntimeService.findLatestPresence({ workspaceId, botId })
             return [botId, serializeBotRuntimePresence(presence ?? null)] as const
           })
         )
@@ -762,7 +762,7 @@ export function createStreamHandlers({
       const data = Object.fromEntries(
         await Promise.all(
           botMemberIds.map(async (botId) => {
-            const presence = await botRuntimeService?.findLatestPresence({ workspaceId, botId })
+            const presence = await botRuntimeService.findLatestPresence({ workspaceId, botId })
             return [botId, serializeBotRuntimePresence(presence ?? null)] as const
           })
         )

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -174,7 +174,15 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workosOrgService,
     pool,
   })
-  const stream = createStreamHandlers({ pool, streamService, eventService, activityService, linkPreviewService })
+  const botRuntimeService = new BotRuntimeService({ pool })
+  const stream = createStreamHandlers({
+    pool,
+    streamService,
+    eventService,
+    activityService,
+    linkPreviewService,
+    botRuntimeService,
+  })
   const message = createMessageHandlers({ pool, eventService, streamService, commandRegistry })
   const attachment = createAttachmentHandlers({ attachmentService, streamService, storage, pool })
   const search = createSearchHandlers({ pool, searchService })
@@ -260,6 +268,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.get)
   app.patch("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.update)
   app.get("/api/workspaces/:workspaceId/streams/:streamId/bootstrap", ...authed, stream.bootstrap)
+  app.get("/api/workspaces/:workspaceId/streams/:streamId/bot-runtime-presence", ...authed, stream.botRuntimePresence)
   app.patch("/api/workspaces/:workspaceId/streams/:streamId/companion", ...authed, stream.updateCompanionMode)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/pin", ...authed, stream.pin)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/notification-level", ...authed, stream.setNotificationLevel)
@@ -550,7 +559,6 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
   // Public API v1 — API key auth (workspace-scoped or user-scoped)
   const publicAuth = createPublicApiAuthMiddleware({ userApiKeyService, botApiKeyService, workspaceAuthzService, pool })
-  const botRuntimeService = new BotRuntimeService({ pool })
   const publicApi = createPublicApiHandlers({
     searchService,
     memoExplorerService,

--- a/apps/frontend/src/api/bot-runtime.ts
+++ b/apps/frontend/src/api/bot-runtime.ts
@@ -1,0 +1,22 @@
+import { api } from "./client"
+import type { BotRuntimeStatus } from "@threa/types"
+
+export interface BotRuntimePresence {
+  botId: string
+  runtimeKind: string
+  instanceId: string
+  displayName: string | null
+  status: BotRuntimeStatus
+  acceptingInvocations: boolean
+  statusText: string | null
+  lastSeenAt: string
+}
+
+export const botRuntimeApi = {
+  async getPresence(workspaceId: string, streamId: string): Promise<Record<string, BotRuntimePresence | null>> {
+    const res = await api.get<{ data: Record<string, BotRuntimePresence | null> }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/bot-runtime-presence`
+    )
+    return res.data
+  },
+}

--- a/apps/frontend/src/api/bot-runtime.ts
+++ b/apps/frontend/src/api/bot-runtime.ts
@@ -1,20 +1,9 @@
 import { api } from "./client"
-import type { BotRuntimeStatus } from "@threa/types"
-
-export interface BotRuntimePresence {
-  botId: string
-  runtimeKind: string
-  instanceId: string
-  displayName: string | null
-  status: BotRuntimeStatus
-  acceptingInvocations: boolean
-  statusText: string | null
-  lastSeenAt: string
-}
+import type { BotRuntimePresenceSummary } from "@threa/types"
 
 export const botRuntimeApi = {
-  async getPresence(workspaceId: string, streamId: string): Promise<Record<string, BotRuntimePresence | null>> {
-    const res = await api.get<{ data: Record<string, BotRuntimePresence | null> }>(
+  async getPresence(workspaceId: string, streamId: string): Promise<Record<string, BotRuntimePresenceSummary | null>> {
+    const res = await api.get<{ data: Record<string, BotRuntimePresenceSummary | null> }>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/bot-runtime-presence`
     )
     return res.data

--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -5,27 +5,27 @@ interface ActiveBotStatusStripProps {
   botName: string
   runtimeDisplayName: string | null
   status: BotRuntimeStatus | "unknown"
-  statusText?: string | null
   className?: string
 }
 
 const STATUS_COPY: Record<BotRuntimeStatus | "unknown", string> = {
-  available: "available",
-  busy: "busy",
-  offline: "offline",
-  error: "error",
-  unknown: "not linked",
+  available: "Available",
+  busy: "Working",
+  offline: "Offline",
+  error: "Error",
+  unknown: "Not linked",
 }
 
-export function ActiveBotStatusStrip({
-  botName,
-  runtimeDisplayName,
-  status,
-  statusText,
-  className,
-}: ActiveBotStatusStripProps) {
-  const detail =
-    statusText ?? (runtimeDisplayName ? `linked to ${runtimeDisplayName}` : "run /remote-control in Pi to connect")
+const STATUS_DOT_CLASS: Record<BotRuntimeStatus | "unknown", string> = {
+  available: "bg-emerald-500",
+  busy: "animate-pulse bg-amber-500",
+  offline: "bg-muted-foreground/40",
+  error: "animate-pulse bg-destructive",
+  unknown: "bg-muted-foreground/40",
+}
+
+export function ActiveBotStatusStrip({ botName, runtimeDisplayName, status, className }: ActiveBotStatusStripProps) {
+  const detail = runtimeDisplayName ? runtimeDisplayName : "run /remote-control in Pi to connect"
 
   return (
     <div
@@ -35,7 +35,8 @@ export function ActiveBotStatusStrip({
       )}
       aria-live="polite"
     >
-      <span className="font-medium text-foreground">{botName}</span>
+      <span className={cn("inline-block size-2 rounded-full", STATUS_DOT_CLASS[status])} aria-hidden="true" />
+      <span className="ml-2 font-medium text-foreground">{botName}</span>
       <span aria-hidden="true"> · </span>
       <span>{STATUS_COPY[status]}</span>
       <span aria-hidden="true"> · </span>

--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -5,6 +5,7 @@ interface ActiveBotStatusStripProps {
   botName: string
   runtimeDisplayName: string | null
   status: BotRuntimeStatus | "unknown"
+  statusText?: string | null
   className?: string
 }
 
@@ -16,8 +17,15 @@ const STATUS_COPY: Record<BotRuntimeStatus | "unknown", string> = {
   unknown: "not linked",
 }
 
-export function ActiveBotStatusStrip({ botName, runtimeDisplayName, status, className }: ActiveBotStatusStripProps) {
-  const detail = runtimeDisplayName ? `linked to ${runtimeDisplayName}` : "run /remote-control in Pi to connect"
+export function ActiveBotStatusStrip({
+  botName,
+  runtimeDisplayName,
+  status,
+  statusText,
+  className,
+}: ActiveBotStatusStripProps) {
+  const detail =
+    statusText ?? (runtimeDisplayName ? `linked to ${runtimeDisplayName}` : "run /remote-control in Pi to connect")
 
   return (
     <div

--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -30,7 +30,7 @@ export function ActiveBotStatusStrip({
   return (
     <div
       className={cn(
-        "rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-sm text-muted-foreground",
+        "relative z-30 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground shadow-lg ring-1 ring-background/80",
         className
       )}
       aria-live="polite"

--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -30,13 +30,13 @@ export function ActiveBotStatusStrip({ botName, runtimeDisplayName, status, clas
   return (
     <div
       className={cn(
-        "relative z-30 rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground shadow-lg ring-1 ring-background/80",
+        "relative z-30 inline-flex max-w-[min(26rem,calc(100vw-2rem))] items-center gap-1.5 rounded-full bg-background px-3 py-1 text-[11px] font-medium tracking-wide text-muted-foreground shadow-sm ring-1 ring-border",
         className
       )}
       aria-live="polite"
     >
       <span className={cn("inline-block size-2 rounded-full", STATUS_DOT_CLASS[status])} aria-hidden="true" />
-      <span className="ml-2 font-medium text-foreground">{botName}</span>
+      <span className="text-foreground">{botName}</span>
       <span aria-hidden="true"> · </span>
       <span>{STATUS_COPY[status]}</span>
       <span aria-hidden="true"> · </span>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1497,7 +1497,7 @@ export function StreamContent({
                 runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
                 status={activeBotPresence.presence?.status ?? "unknown"}
                 statusText={activeBotPresence.presence?.statusText ?? null}
-                className="mx-4 mb-2"
+                className="mx-4 mb-3"
               />
             )}
             {(isMember || !isPublicChannel || !membershipResolved) && (

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1496,7 +1496,6 @@ export function StreamContent({
                 botName={activeBotPresence.bot.name}
                 runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
                 status={activeBotPresence.presence?.status ?? "unknown"}
-                statusText={activeBotPresence.presence?.statusText ?? null}
                 className="mx-4 mb-3"
               />
             )}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -3,7 +3,7 @@ import { useLocation, useSearchParams } from "react-router-dom"
 import { Virtuoso } from "react-virtuoso"
 import { MessageSquare, ArrowDown, X, Move, Loader2, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   useEvents,
   useStreamSocket,
@@ -24,7 +24,7 @@ import {
 import { useSocket, useCoordinatedLoading } from "@/contexts"
 import { useMessageService } from "@/contexts"
 import { useStreamEvents } from "@/stores/stream-store"
-import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
+import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceBots } from "@/stores/workspace-store"
 import { useUser } from "@/auth"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
@@ -64,6 +64,7 @@ import {
   type BatchTimelineState,
 } from "./event-list"
 import { MessageInput } from "./message-input"
+import { ActiveBotStatusStrip } from "./active-bot-status-strip"
 import { JoinChannelBar } from "./join-channel-bar"
 import { ThreadParentMessage } from "../thread/thread-parent-message"
 import { EditLastMessageContext } from "./edit-last-message-context"
@@ -75,6 +76,7 @@ import { useStreamSearch } from "@/hooks/use-stream-search"
 import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
+import { botRuntimeApi } from "@/api/bot-runtime"
 
 /** Membership events; suppressed in threads (see displayEvents memo). */
 const THREAD_HIDDEN_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["member_joined", "member_added", "member_left"])
@@ -212,6 +214,7 @@ export function StreamContent({
 
   const idbStreams = useWorkspaceStreams(workspaceId)
   const idbMemberships = useWorkspaceStreamMemberships(workspaceId)
+  const workspaceBots = useWorkspaceBots(workspaceId)
   const idbStream = useMemo(() => idbStreams.find((candidate) => candidate.id === streamId), [idbStreams, streamId])
 
   // Resolve current workspace-scoped user ID. The hook deduplicates with SentMessageEvent instances.
@@ -233,6 +236,21 @@ export function StreamContent({
 
   const stream = streamFromProps ?? idbStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
+  const botRuntimePresenceQuery = useQuery({
+    queryKey: ["bot-runtime-presence", workspaceId, streamId],
+    queryFn: () => botRuntimeApi.getPresence(workspaceId, streamId),
+    enabled: !isDraft && !!workspaceId && !!streamId,
+    refetchInterval: 10_000,
+  })
+  const botRuntimePresence = botRuntimePresenceQuery.data ?? bootstrap?.botRuntimePresence ?? {}
+  const activeBotPresence = useMemo(() => {
+    const botIds = bootstrap?.botMemberIds ?? Object.keys(botRuntimePresence)
+    const botId = botIds.find((candidate) => botRuntimePresence[candidate]) ?? botIds[0]
+    if (!botId) return null
+    const bot = workspaceBots.find((candidate) => candidate.id === botId)
+    if (!bot) return null
+    return { bot, presence: botRuntimePresence[botId] ?? null }
+  }, [bootstrap?.botMemberIds, botRuntimePresence, workspaceBots])
   const isArchived = stream?.archivedAt != null
   const isSystem = stream?.type === StreamTypes.SYSTEM
   const parentStreamId = stream?.parentStreamId
@@ -1472,6 +1490,15 @@ export function StreamContent({
                   onJoined={handleJoined}
                 />
               </div>
+            )}
+            {activeBotPresence && (
+              <ActiveBotStatusStrip
+                botName={activeBotPresence.bot.name}
+                runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
+                status={activeBotPresence.presence?.status ?? "unknown"}
+                statusText={activeBotPresence.presence?.statusText ?? null}
+                className="mx-4 mb-2"
+              />
             )}
             {(isMember || !isPublicChannel || !membershipResolved) && (
               <MessageInput

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1493,7 +1493,7 @@ export function StreamContent({
               </div>
             )}
             {showBotRuntimePresence && activeBotPresence && (
-              <div className="pointer-events-none mx-4 mb-2 flex justify-center">
+              <div className="pointer-events-none mx-4 mb-2 mt-2 flex justify-center">
                 <ActiveBotStatusStrip
                   botName={activeBotPresence.bot.name}
                   runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1493,12 +1493,14 @@ export function StreamContent({
               </div>
             )}
             {showBotRuntimePresence && activeBotPresence && (
-              <ActiveBotStatusStrip
-                botName={activeBotPresence.bot.name}
-                runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
-                status={activeBotPresence.presence?.status ?? "unknown"}
-                className="mx-4 mb-3"
-              />
+              <div className="pointer-events-none mx-4 mb-2 flex justify-center">
+                <ActiveBotStatusStrip
+                  botName={activeBotPresence.bot.name}
+                  runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
+                  status={activeBotPresence.presence?.status ?? "unknown"}
+                  className="pointer-events-auto"
+                />
+              </div>
             )}
             {(isMember || !isPublicChannel || !membershipResolved) && (
               <MessageInput

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -236,10 +236,11 @@ export function StreamContent({
 
   const stream = streamFromProps ?? idbStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
+  const showBotRuntimePresence = stream?.type === StreamTypes.SCRATCHPAD
   const botRuntimePresenceQuery = useQuery({
     queryKey: ["bot-runtime-presence", workspaceId, streamId],
     queryFn: () => botRuntimeApi.getPresence(workspaceId, streamId),
-    enabled: !isDraft && !!workspaceId && !!streamId,
+    enabled: !isDraft && showBotRuntimePresence && !!workspaceId && !!streamId,
     refetchInterval: 10_000,
   })
   const botRuntimePresence = botRuntimePresenceQuery.data ?? bootstrap?.botRuntimePresence ?? {}
@@ -1491,7 +1492,7 @@ export function StreamContent({
                 />
               </div>
             )}
-            {activeBotPresence && (
+            {showBotRuntimePresence && activeBotPresence && (
               <ActiveBotStatusStrip
                 botName={activeBotPresence.bot.name}
                 runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -276,7 +276,7 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<voi
     return { context: "" }
   })
   pendingContextCursor = cursor
-  await heartbeat("busy", `Working on ${body.data.id}`)
+  await heartbeat("busy", "Working…")
   setRemoteStatus(ctx, `Threa remote: running ${body.data.id}`)
   pi.sendUserMessage(
     [

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -96,12 +96,24 @@ export interface StreamContextBagPayload {
   refs: StreamContextRef[]
 }
 
+export interface BotRuntimePresenceSummary {
+  botId: string
+  runtimeKind: string
+  instanceId: string
+  displayName: string | null
+  status: "available" | "busy" | "offline" | "error"
+  acceptingInvocations: boolean
+  statusText: string | null
+  lastSeenAt: string
+}
+
 export interface StreamBootstrap {
   stream: Stream
   events: StreamEvent[]
   members: StreamMember[]
   /** Bot IDs that have been granted access to this stream. */
   botMemberIds: string[]
+  botRuntimePresence?: Record<string, BotRuntimePresenceSummary | null>
   membership: StreamMember | null
   latestSequence: string
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -311,6 +311,7 @@ export type {
   UpdateStreamInput,
   UpdateCompanionModeInput,
   StreamBootstrap,
+  BotRuntimePresenceSummary,
   StreamContextBagPayload,
   StreamContextRef,
   StreamContextRefSource,


### PR DESCRIPTION
## Problem

Pi remote adapters already heartbeat runtime presence (`available`, `busy`, `offline`) but the app did not surface that state. During dogfood this made remote work feel silent: users could not tell whether Pi was linked, idle, or currently processing.

## Solution

Expose bot runtime presence to stream views and render a compact scratchpad-only presence pill near the composer.

### How it works

1. Backend resolves the latest runtime presence row for each bot granted to a stream.
2. Stream bootstrap includes `botRuntimePresence` so the first render has presence data when available.
3. A lightweight authenticated endpoint returns fresh runtime presence for a stream.
4. The frontend polls that endpoint every 10s, but only in scratchpads.
5. Scratchpads render a small centered pill with a state dot:
   - green = available
   - amber pulsing = working/busy
   - muted = offline/not linked
   - red pulsing = error

### Key design decisions

**1. Use existing heartbeat data**

No new persistence model: this surfaces `bot_runtime_instances`, which the Pi adapter already updates.

**2. Scratchpad-only UI**

Presence in normal channels felt intrusive and conceptually odd. The pill is scoped to scratchpads where the bot is acting as the active remote runtime.

**3. Compact pill, not a full status bar**

The UI follows the connection-pill feel: small, opaque, centered, high enough z-index to sit above content, with a subtle ring/shadow and a little top spacing.

**4. Avoid leaking invocation IDs**

The local Pi adapter now heartbeats busy as `Working…`; the visible UI communicates state via the dot and label rather than raw invocation IDs.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/api/bot-runtime.ts` | Frontend client for stream bot runtime presence |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/repository.ts` | Add latest-presence lookup by bot |
| `apps/backend/src/features/bot-runtimes/service.ts` | Expose latest-presence service method |
| `apps/backend/src/features/streams/handlers.ts` | Include runtime presence in bootstrap and expose fresh stream presence endpoint |
| `apps/backend/src/routes.ts` | Wire stream presence endpoint and share bot runtime service |
| `apps/frontend/src/components/timeline/active-bot-status-strip.tsx` | Render compact presence pill with state dot |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Poll and render scratchpad-only bot presence |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Heartbeat busy as `Working…` instead of exposing invocation IDs |
| `packages/types/src/api.ts` | Add shared stream bootstrap presence type |
| `packages/types/src/index.ts` | Export shared presence type |

## Test plan

- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun --check ~/.pi/agent/extensions/threa-remote.ts`
- [x] `git diff --check origin/main...HEAD`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782077074&installation_id=129946197&pr_number=603&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F603&signature=10a765f377c9aae1dfac30c9274ace363772f15d47a80efd37e345aee9ea39aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->