### PR TITLE
feat(conversations): include attachment transcripts in boundary extraction

### DIFF
--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -4,7 +4,9 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
+import { AttachmentRepository, awaitAttachmentProcessing, type AttachmentWithExtraction } from "../attachments"
 import type {
+  AttachmentExtractContext,
   BoundaryExtractor,
   ExtractionContext,
   ConversationSummary,
@@ -54,6 +56,40 @@ export class BoundaryExtractionService {
    * conversation and decides.
    */
   async processMessage(messageId: string, streamId: string, workspaceId: string): Promise<Conversation | null> {
+    // Phase 0: For channels/threads (which call the LLM), wait for the new
+    // message's attachments to finish processing so the classifier sees the
+    // transcript/OCR/parsed text alongside the written content. We deliberately
+    // only await the *new* message's attachments — surrounding context
+    // attachments were almost always processed by their own earlier
+    // boundary-extract runs, and waiting for them too would multiply latency
+    // for the common case.
+    //
+    // INV-41: awaitAttachmentProcessing releases its connection between polls.
+    // Do not wrap this in withClient.
+    const streamForAwait = await StreamRepository.findById(this.pool, streamId)
+    if (streamForAwait && streamForAwait.type !== StreamTypes.SCRATCHPAD) {
+      const newMessageAttachments = await AttachmentRepository.findByMessageId(this.pool, messageId)
+      const attachmentIds = newMessageAttachments.map((a) => a.id)
+      if (attachmentIds.length > 0) {
+        logger.debug(
+          { messageId, attachmentCount: attachmentIds.length },
+          "Boundary extraction awaiting attachment processing for new message"
+        )
+        const awaitResult = await awaitAttachmentProcessing(this.pool, attachmentIds)
+        if (!awaitResult.allCompleted) {
+          // Classify with whatever extractions exist; don't block forever.
+          logger.warn(
+            {
+              messageId,
+              completedCount: awaitResult.completedIds.length,
+              failedCount: awaitResult.failedOrTimedOutIds.length,
+            },
+            "Boundary extraction proceeding without all attachments processed"
+          )
+        }
+      }
+    }
+
     // Phase 1: Fetch all data with withClient (no transaction, fast reads ~100-200ms)
     const fetchedData = await withClient(this.pool, async (client) => {
       const message = await MessageRepository.findById(client, messageId)
@@ -119,12 +155,24 @@ export class BoundaryExtractionService {
           ? this.buildConversationSummaries(parentMessageConversations, [], contextMessageIdSet)
           : undefined
 
+      // Pull attachments + extractions for the new message AND every context
+      // message in one batched query. We render fullText (transcript / OCR /
+      // parse) only for the new message in the prompt; for context messages we
+      // fall back to the short summary so the prompt stays bounded.
+      const attachmentTargetIds = [message.id, ...allContextMessageIds]
+      const attachmentsByMessage = await AttachmentRepository.findByMessageIdsWithExtractions(
+        client,
+        attachmentTargetIds
+      )
+      const attachmentsByMessageId = buildAttachmentContextMap(attachmentsByMessage, message.id)
+
       const extractionContext: ExtractionContext = {
         newMessage: message,
         recentMessages: allContextMessages,
         activeConversations,
         streamType: stream.type,
         parentMessageConversations: parentConversations,
+        attachmentsByMessageId,
         workspaceId: stream.workspaceId,
       }
 
@@ -497,6 +545,40 @@ export class BoundaryExtractionService {
       }
     })
   }
+}
+
+/**
+ * Build the per-message attachment-context map used by the LLM prompt. Only
+ * the new message keeps its full extracted text; context messages drop
+ * `fullText` (the prompt renderer falls back to `summary`, keeping the prompt
+ * bounded). Attachments with neither a summary nor fullText are dropped so the
+ * prompt does not get cluttered with empty entries.
+ */
+function buildAttachmentContextMap(
+  attachmentsByMessage: Map<string, AttachmentWithExtraction[]>,
+  newMessageId: string
+): Map<string, AttachmentExtractContext[]> {
+  const result = new Map<string, AttachmentExtractContext[]>()
+  for (const [msgId, attachments] of attachmentsByMessage) {
+    const contexts: AttachmentExtractContext[] = []
+    for (const a of attachments) {
+      const isNewMessage = msgId === newMessageId
+      const summary = a.extraction?.summary ?? null
+      const fullText = isNewMessage ? (a.extraction?.fullText ?? null) : null
+      // Drop attachments with no extracted text at all (e.g. still pending or
+      // a type that produces no extraction) — there is nothing useful to add.
+      if (!summary && !fullText) continue
+      contexts.push({
+        filename: a.filename,
+        mimeType: a.mimeType,
+        contentType: a.extraction?.contentType ?? null,
+        summary,
+        fullText,
+      })
+    }
+    if (contexts.length > 0) result.set(msgId, contexts)
+  }
+  return result
 }
 
 // Re-export type for service consumers

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -56,50 +56,20 @@ export class BoundaryExtractionService {
    * conversation and decides.
    */
   async processMessage(messageId: string, streamId: string, workspaceId: string): Promise<Conversation | null> {
-    // Phase 0: For channels/threads (which call the LLM), wait for the new
-    // message's attachments to finish processing so the classifier sees the
-    // transcript/OCR/parsed text alongside the written content. We deliberately
-    // only await the *new* message's attachments — surrounding context
-    // attachments were almost always processed by their own earlier
-    // boundary-extract runs, and waiting for them too would multiply latency
-    // for the common case.
-    //
-    // INV-41: awaitAttachmentProcessing releases its connection between polls.
-    // Do not wrap this in withClient.
-    const streamForAwait = await StreamRepository.findById(this.pool, streamId)
-    if (streamForAwait && streamForAwait.type !== StreamTypes.SCRATCHPAD) {
-      const newMessageAttachments = await AttachmentRepository.findByMessageId(this.pool, messageId)
-      const attachmentIds = newMessageAttachments.map((a) => a.id)
-      if (attachmentIds.length > 0) {
-        logger.debug(
-          { messageId, attachmentCount: attachmentIds.length },
-          "Boundary extraction awaiting attachment processing for new message"
-        )
-        const awaitResult = await awaitAttachmentProcessing(this.pool, attachmentIds)
-        if (!awaitResult.allCompleted) {
-          // Classify with whatever extractions exist; don't block forever.
-          logger.warn(
-            {
-              messageId,
-              completedCount: awaitResult.completedIds.length,
-              failedCount: awaitResult.failedOrTimedOutIds.length,
-            },
-            "Boundary extraction proceeding without all attachments processed"
-          )
-        }
-      }
-    }
-
-    // Phase 1: Fetch all data with withClient (no transaction, fast reads ~100-200ms)
+    // Phase 1: Fetch all data with withClient (no transaction, fast reads ~100-200ms).
+    // Includes the new message's attachment IDs so we can await their processing
+    // once the connection is released (INV-41) — extractions for the full
+    // new+context set are fetched on the pool after the await, mirroring the
+    // pattern in streams/naming-service.ts.
     const fetchedData = await withClient(this.pool, async (client) => {
       const message = await MessageRepository.findById(client, messageId)
       if (!message) {
-        return { message: null, stream: null, extractionContext: null }
+        return { message: null, stream: null, extractionContextBase: null }
       }
 
       const stream = await StreamRepository.findById(client, streamId)
       if (!stream) {
-        return { message: null, stream: null, extractionContext: null }
+        return { message: null, stream: null, extractionContextBase: null }
       }
 
       // For scratchpads: just fetch existing conversations (no AI needed)
@@ -108,7 +78,7 @@ export class BoundaryExtractionService {
         return {
           message,
           stream,
-          extractionContext: null,
+          extractionContextBase: null,
           scratchpadConversations: existingConversations,
           validUpdateTargets: new Set<string>(),
         }
@@ -155,24 +125,19 @@ export class BoundaryExtractionService {
           ? this.buildConversationSummaries(parentMessageConversations, [], contextMessageIdSet)
           : undefined
 
-      // Pull attachments + extractions for the new message AND every context
-      // message in one batched query. We render fullText (transcript / OCR /
-      // parse) only for the new message in the prompt; for context messages we
-      // fall back to the short summary so the prompt stays bounded.
-      const attachmentTargetIds = [message.id, ...allContextMessageIds]
-      const attachmentsByMessage = await AttachmentRepository.findByMessageIdsWithExtractions(
-        client,
-        attachmentTargetIds
-      )
-      const attachmentsByMessageId = buildAttachmentContextMap(attachmentsByMessage, message.id)
+      // New-message attachment IDs only — we await *just* these because they
+      // are the payload most likely to change the classification decision.
+      // Surrounding-context attachments were almost always processed by their
+      // own earlier boundary-extract runs.
+      const newMessageAttachments = await AttachmentRepository.findByMessageId(client, message.id)
+      const newMessageAttachmentIds = newMessageAttachments.map((a) => a.id)
 
-      const extractionContext: ExtractionContext = {
+      const extractionContextBase: Omit<ExtractionContext, "attachmentsByMessageId"> = {
         newMessage: message,
         recentMessages: allContextMessages,
         activeConversations,
         streamType: stream.type,
         parentMessageConversations: parentConversations,
-        attachmentsByMessageId,
         workspaceId: stream.workspaceId,
       }
 
@@ -184,7 +149,9 @@ export class BoundaryExtractionService {
       return {
         message,
         stream,
-        extractionContext,
+        extractionContextBase,
+        newMessageAttachmentIds,
+        attachmentTargetIds: [message.id, ...allContextMessageIds],
         validUpdateTargets,
         validReassignmentMessageIds: new Set(allContextMessageIds),
       }
@@ -198,11 +165,46 @@ export class BoundaryExtractionService {
     const {
       message,
       stream,
-      extractionContext,
+      extractionContextBase,
+      newMessageAttachmentIds,
+      attachmentTargetIds,
       scratchpadConversations,
       validUpdateTargets,
       validReassignmentMessageIds,
     } = fetchedData
+
+    // Phase 1.5 (channels/threads only): await new-message attachment processing
+    // with no DB connection held (INV-41), then fetch extractions for new +
+    // context messages on the pool (INV-30).
+    let extractionContext: ExtractionContext | null = null
+    if (extractionContextBase && attachmentTargetIds) {
+      if (newMessageAttachmentIds && newMessageAttachmentIds.length > 0) {
+        logger.debug(
+          { messageId, attachmentCount: newMessageAttachmentIds.length },
+          "Boundary extraction awaiting attachment processing for new message"
+        )
+        const awaitResult = await awaitAttachmentProcessing(this.pool, newMessageAttachmentIds)
+        if (!awaitResult.allCompleted) {
+          // Classify with whatever extractions exist; don't block forever.
+          logger.warn(
+            {
+              messageId,
+              completedCount: awaitResult.completedIds.length,
+              failedCount: awaitResult.failedOrTimedOutIds.length,
+            },
+            "Boundary extraction proceeding without all attachments processed"
+          )
+        }
+      }
+
+      const attachmentsByMessage = await AttachmentRepository.findByMessageIdsWithExtractions(
+        this.pool,
+        attachmentTargetIds
+      )
+      const attachmentsByMessageId = buildAttachmentContextMap(attachmentsByMessage, message.id)
+
+      extractionContext = { ...extractionContextBase, attachmentsByMessageId }
+    }
 
     // Phase 2: Determine conversation (AI call only for channels/threads, 1-5+ seconds!)
     let decision: ConversationDecision

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -30,9 +30,12 @@ export const BOUNDARY_EXTRACTION_PROMPT = `Analyze this new message and decide w
 From: {{AUTHOR}}
 Content: {{CONTENT}}
 
+## Attachments
+Some messages above may include an indented \`[attachment <filename> (<kind>)]:\` block beneath them. That block is the extracted text of the attachment — the transcript for audio/video, OCR text for an image, the parsed body for a PDF/Word/Excel, etc. Treat that extracted text as **part of the message's content** when judging topic continuity: a voice memo whose transcript is about onboarding is an onboarding message even if its written content is empty. Pay particular attention to the new message's attachments, since a short or empty written body is often a wrapper around the real payload that lives in the attachment.
+
 ## Choosing a conversation
 First decide whether this message continues an existing conversation or starts a new one. Assign it to an existing conversation (as primary) only when it genuinely continues that topic — judge by:
-- Topic continuity: does it advance the same subject the conversation is about?
+- Topic continuity: does it advance the same subject the conversation is about? Use the attachment-extracted text as content here too.
 - Explicit references: does it reply to, quote, or build on something in that conversation?
 - Recency and flow: does it read as the next turn of an active back-and-forth?
 

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -14,6 +14,15 @@ export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.4-nano"
 /** Temperature for classification - low for consistency */
 export const BOUNDARY_EXTRACTION_TEMPERATURE = 0.2
 
+/**
+ * Per-attachment character budget when rendering extracted text in the prompt.
+ * The new message's attachments get a bigger window because they are the
+ * payload most likely to change the classification decision; context messages
+ * use a smaller window (closer to a summary) to keep the prompt bounded.
+ */
+export const NEW_MESSAGE_ATTACHMENT_CHARS = 2000
+export const RECENT_ATTACHMENT_CHARS = 400
+
 /** System prompt for boundary extraction */
 export const BOUNDARY_EXTRACTION_SYSTEM_PROMPT = `You are a conversation boundary classifier. You analyze messages and output ONLY valid JSON matching the required schema. No explanations, no markdown, no prose - just the JSON object.`
 

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -539,4 +539,179 @@ describe("LLMBoundaryExtractor", () => {
       expect(result.newConversationTopic?.length).toBe(100)
     })
   })
+
+  describe("attachment context", () => {
+    test("includes new-message attachment fullText in the prompt", async () => {
+      const newMessage = createMockMessage({ id: "msg_with_attachment", contentMarkdown: "voice memo" })
+      const existingConv = createMockConversation({ id: "conv_existing" })
+      const context = createMockContext({
+        streamType: "channel",
+        newMessage,
+        recentMessages: [newMessage],
+        activeConversations: [existingConv],
+        attachmentsByMessageId: new Map([
+          [
+            "msg_with_attachment",
+            [
+              {
+                filename: "onboarding.m4a",
+                mimeType: "audio/mp4",
+                contentType: "audio",
+                summary: "Short audio about onboarding",
+                fullText: "Hey team, today I want to talk about how we onboard new engineers.",
+              },
+            ],
+          ],
+        ]),
+      })
+
+      mockGenerateObject.mockResolvedValueOnce({
+        value: {
+          assignments: [{ conversationId: "conv_existing", isPrimary: true }],
+          confidence: 0.9,
+        },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      expect(mockGenerateObject).toHaveBeenCalledTimes(1)
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const call = calls[0]?.[0] ?? { messages: [] }
+      const userPrompt = call.messages.find((m) => m.role === "user")?.content ?? ""
+      expect(userPrompt).toContain("onboarding.m4a")
+      expect(userPrompt).toContain("Hey team, today I want to talk about how we onboard new engineers.")
+    })
+
+    test("uses summary (not fullText) for context messages even when fullText is provided", async () => {
+      const newMessage = createMockMessage({ id: "msg_new", contentMarkdown: "follow up" })
+      const contextMessage = createMockMessage({ id: "msg_ctx", contentMarkdown: "" })
+      const existingConv = createMockConversation({ id: "conv_existing" })
+      const context = createMockContext({
+        streamType: "channel",
+        newMessage,
+        recentMessages: [contextMessage, newMessage],
+        activeConversations: [existingConv],
+        attachmentsByMessageId: new Map([
+          [
+            "msg_ctx",
+            [
+              {
+                filename: "old.pdf",
+                mimeType: "application/pdf",
+                contentType: "pdf",
+                summary: "Quarterly results overview",
+                // Service strips fullText for non-new messages before passing
+                // it to the extractor, so simulate that here.
+                fullText: null,
+              },
+            ],
+          ],
+        ]),
+      })
+
+      mockGenerateObject.mockResolvedValueOnce({
+        value: {
+          assignments: [{ conversationId: "conv_existing", isPrimary: true }],
+          confidence: 0.85,
+        },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const call = calls[0]?.[0] ?? { messages: [] }
+      const userPrompt = call.messages.find((m) => m.role === "user")?.content ?? ""
+      expect(userPrompt).toContain("old.pdf")
+      expect(userPrompt).toContain("Quarterly results overview")
+    })
+
+    test("truncates very long attachment text in the new-message block", async () => {
+      const longTranscript = "x".repeat(5000)
+      const newMessage = createMockMessage({ id: "msg_long", contentMarkdown: "see attached" })
+      const existingConv = createMockConversation({ id: "conv_existing" })
+      const context = createMockContext({
+        streamType: "channel",
+        newMessage,
+        recentMessages: [newMessage],
+        activeConversations: [existingConv],
+        attachmentsByMessageId: new Map([
+          [
+            "msg_long",
+            [
+              {
+                filename: "long.m4a",
+                mimeType: "audio/mp4",
+                contentType: "audio",
+                summary: null,
+                fullText: longTranscript,
+              },
+            ],
+          ],
+        ]),
+      })
+
+      mockGenerateObject.mockResolvedValueOnce({
+        value: {
+          assignments: [{ conversationId: "conv_existing", isPrimary: true }],
+          confidence: 0.9,
+        },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const call = calls[0]?.[0] ?? { messages: [] }
+      const userPrompt = call.messages.find((m) => m.role === "user")?.content ?? ""
+      expect(userPrompt).toContain("long.m4a")
+      // Long transcript must be capped; we should not see the entire 5000-char body inline.
+      const xCount = (userPrompt.match(/x/g) ?? []).length
+      expect(xCount).toBeLessThan(longTranscript.length)
+      expect(userPrompt).toContain("…")
+    })
+
+    test("omits attachment block when extraction has neither summary nor fullText", async () => {
+      const newMessage = createMockMessage({ id: "msg_empty", contentMarkdown: "ping" })
+      const existingConv = createMockConversation({ id: "conv_existing" })
+      const context = createMockContext({
+        streamType: "channel",
+        newMessage,
+        recentMessages: [newMessage],
+        activeConversations: [existingConv],
+        attachmentsByMessageId: new Map(),
+      })
+
+      mockGenerateObject.mockResolvedValueOnce({
+        value: {
+          assignments: [{ conversationId: "conv_existing", isPrimary: true }],
+          confidence: 0.9,
+        },
+        response: { usage: {} },
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      })
+
+      await extractor.extract(context)
+
+      const calls = mockGenerateObject.mock.calls as unknown as Array<
+        [{ messages: { role: string; content: string }[] }]
+      >
+      const call = calls[0]?.[0] ?? { messages: [] }
+      const userPrompt = call.messages.find((m) => m.role === "user")?.content ?? ""
+      // The rendered (not instructional) attachment line lives directly under
+      // the message line with a 2-space indent. No rendered block here means
+      // no `  [attachment ` anywhere in the prompt.
+      expect(userPrompt).not.toContain("  [attachment ")
+    })
+  })
 })

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -17,17 +17,10 @@ import {
   extractionResponseSchema,
   BOUNDARY_EXTRACTION_SYSTEM_PROMPT,
   BOUNDARY_EXTRACTION_PROMPT,
+  NEW_MESSAGE_ATTACHMENT_CHARS,
+  RECENT_ATTACHMENT_CHARS,
   type ExtractionResponse,
 } from "./config"
-
-/**
- * Per-attachment character budget when rendering extracted text in the prompt.
- * The new message's attachments get a bigger window because they are the
- * payload most likely to change the classification decision; context messages
- * use a smaller window (closer to a summary) to keep the prompt bounded.
- */
-const NEW_MESSAGE_ATTACHMENT_CHARS = 2000
-const RECENT_ATTACHMENT_CHARS = 400
 
 function indent(text: string, prefix: string): string {
   return text

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -2,7 +2,14 @@ import { NoObjectGeneratedError } from "ai"
 import type { AI } from "../../../lib/ai/ai"
 import type { ConfigResolver } from "../../../lib/ai/config-resolver"
 import { COMPONENT_PATHS } from "../../../lib/ai/config-resolver"
-import type { BoundaryExtractor, ExtractionContext, ExtractionResult, MessageAssignment, Reassignment } from "./types"
+import type {
+  AttachmentExtractContext,
+  BoundaryExtractor,
+  ExtractionContext,
+  ExtractionResult,
+  MessageAssignment,
+  Reassignment,
+} from "./types"
 import type { Message } from "../../messaging"
 import { logger } from "../../../lib/logger"
 import { StreamTypes } from "@threa/types"
@@ -12,6 +19,22 @@ import {
   BOUNDARY_EXTRACTION_PROMPT,
   type ExtractionResponse,
 } from "./config"
+
+/**
+ * Per-attachment character budget when rendering extracted text in the prompt.
+ * The new message's attachments get a bigger window because they are the
+ * payload most likely to change the classification decision; context messages
+ * use a smaller window (closer to a summary) to keep the prompt bounded.
+ */
+const NEW_MESSAGE_ATTACHMENT_CHARS = 2000
+const RECENT_ATTACHMENT_CHARS = 400
+
+function indent(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => prefix + line)
+    .join("\n")
+}
 
 export class LLMBoundaryExtractor implements BoundaryExtractor {
   constructor(
@@ -96,17 +119,39 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
             .join("\n")
         : "No active conversations in this stream yet."
 
+    const attachmentsByMessageId = context.attachmentsByMessageId ?? new Map()
+
     const recentSection = context.recentMessages
-      .map(
-        (m) =>
-          `[${m.id}] ${m.authorType}:${m.authorId.slice(-8)}: ${m.contentMarkdown.slice(0, 200)}${m.contentMarkdown.length > 200 ? "..." : ""}`
-      )
+      .map((m) => {
+        const head = `[${m.id}] ${m.authorType}:${m.authorId.slice(-8)}: ${m.contentMarkdown.slice(0, 200)}${m.contentMarkdown.length > 200 ? "..." : ""}`
+        const atts = attachmentsByMessageId.get(m.id)
+        const attBlock = atts && atts.length > 0 ? `\n${this.renderAttachments(atts, RECENT_ATTACHMENT_CHARS)}` : ""
+        return head + attBlock
+      })
       .join("\n")
+
+    const newMessageAtts = attachmentsByMessageId.get(context.newMessage.id) ?? []
+    const newMessageAttachmentSection =
+      newMessageAtts.length > 0 ? `\n${this.renderAttachments(newMessageAtts, NEW_MESSAGE_ATTACHMENT_CHARS)}` : ""
 
     return BOUNDARY_EXTRACTION_PROMPT.replace("{{CONVERSATIONS}}", convSection)
       .replace("{{RECENT_MESSAGES}}", recentSection || "No recent messages.")
       .replace("{{AUTHOR}}", `${context.newMessage.authorType}:${context.newMessage.authorId.slice(-8)}`)
-      .replace("{{CONTENT}}", context.newMessage.contentMarkdown)
+      .replace("{{CONTENT}}", context.newMessage.contentMarkdown + newMessageAttachmentSection)
+  }
+
+  private renderAttachments(attachments: AttachmentExtractContext[], maxChars: number): string {
+    const lines = attachments.map((a) => {
+      const kind = a.contentType ?? a.mimeType
+      // Prefer fullText (transcript / OCR / parse). Fall back to summary so the
+      // model at least sees what the attachment is about when extraction is
+      // still summary-only (or has no fullText, e.g. image captions).
+      const body = (a.fullText ?? a.summary ?? "").trim()
+      if (!body) return `  [attachment ${a.filename} (${kind}): no extracted content]`
+      const truncated = body.length > maxChars ? body.slice(0, maxChars) + "…" : body
+      return `  [attachment ${a.filename} (${kind})]:\n${indent(truncated, "    ")}`
+    })
+    return lines.join("\n")
   }
 
   private validateResult(parsed: ExtractionResponse, context: ExtractionContext): ExtractionResult {

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -88,6 +88,24 @@ export interface ConversationSummary {
   contextMessageIds: string[]
 }
 
+/**
+ * Compact extraction summary for one attachment, shaped for the boundary
+ * extractor's prompt. `fullText` is the complete transcript / OCR / parse,
+ * `summary` is the AI-generated short description that is always present.
+ *
+ * The service decides per-message whether to populate `fullText` (typically
+ * only for the new message, where extracted content is most likely to change
+ * the classification decision) or leave it null and rely on `summary`.
+ */
+export interface AttachmentExtractContext {
+  filename: string
+  mimeType: string
+  /** "text" | "image" | "pdf" | "word" | "excel" | "video" | "audio" or whatever extractor recorded. */
+  contentType: string | null
+  summary: string | null
+  fullText: string | null
+}
+
 export interface ExtractionContext {
   newMessage: Message
   recentMessages: Message[]
@@ -95,6 +113,13 @@ export interface ExtractionContext {
   streamType: string
   /** For threads: conversations containing the parent message (in the parent channel) */
   parentMessageConversations?: ConversationSummary[]
+  /**
+   * Extracted text from attachments, keyed by message id. Includes the new
+   * message and any recent/context messages whose attachments produced a
+   * transcript, OCR text, or other extracted content. Empty/absent when no
+   * relevant attachments exist.
+   */
+  attachmentsByMessageId?: Map<string, AttachmentExtractContext[]>
   /** Workspace ID for cost tracking - required for cost attribution */
   workspaceId: string
 }

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1271,6 +1271,7 @@
                   "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
                   "claimToken": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "finalMessageMarkdown": { "type": "string", "minLength": 1, "maxLength": 50000 },
+                  "noResponse": { "type": "boolean" },
                   "metadata": {
                     "type": "object",
                     "propertyNames": {
@@ -1282,7 +1283,7 @@
                     "additionalProperties": { "type": "string", "maxLength": 256 }
                   }
                 },
-                "required": ["instanceId", "claimToken", "finalMessageMarkdown"],
+                "required": ["instanceId", "claimToken"],
                 "additionalProperties": false
               }
             }
@@ -1302,47 +1303,52 @@
                       "properties": {
                         "invocationId": { "type": "string" },
                         "message": {
-                          "type": "object",
-                          "properties": {
-                            "id": { "type": "string" },
-                            "streamId": { "type": "string" },
-                            "sequence": { "type": "string", "description": "Numeric sequence as string" },
-                            "authorId": { "type": "string" },
-                            "authorType": { "type": "string", "enum": ["user", "persona", "system", "bot"] },
-                            "authorDisplayName": { "type": "string" },
-                            "content": { "type": "string" },
-                            "replyCount": {
-                              "type": "integer",
-                              "minimum": -9007199254740991,
-                              "maximum": 9007199254740991
-                            },
-                            "threadStreamId": { "type": "string" },
-                            "clientMessageId": { "type": "string" },
-                            "sentVia": {
-                              "description": "Present when message was sent via API on behalf of a user",
-                              "type": "string"
-                            },
-                            "metadata": {
+                          "anyOf": [
+                            {
                               "type": "object",
-                              "propertyNames": { "type": "string" },
-                              "additionalProperties": { "type": "string" },
-                              "description": "External references attached by the sender. Always present; empty when unset."
+                              "properties": {
+                                "id": { "type": "string" },
+                                "streamId": { "type": "string" },
+                                "sequence": { "type": "string", "description": "Numeric sequence as string" },
+                                "authorId": { "type": "string" },
+                                "authorType": { "type": "string", "enum": ["user", "persona", "system", "bot"] },
+                                "authorDisplayName": { "type": "string" },
+                                "content": { "type": "string" },
+                                "replyCount": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                "threadStreamId": { "type": "string" },
+                                "clientMessageId": { "type": "string" },
+                                "sentVia": {
+                                  "description": "Present when message was sent via API on behalf of a user",
+                                  "type": "string"
+                                },
+                                "metadata": {
+                                  "type": "object",
+                                  "propertyNames": { "type": "string" },
+                                  "additionalProperties": { "type": "string" },
+                                  "description": "External references attached by the sender. Always present; empty when unset."
+                                },
+                                "editedAt": { "type": "string", "format": "date-time" },
+                                "createdAt": { "type": "string", "format": "date-time" }
+                              },
+                              "required": [
+                                "id",
+                                "streamId",
+                                "sequence",
+                                "authorId",
+                                "authorType",
+                                "content",
+                                "replyCount",
+                                "metadata",
+                                "createdAt"
+                              ],
+                              "additionalProperties": false
                             },
-                            "editedAt": { "type": "string", "format": "date-time" },
-                            "createdAt": { "type": "string", "format": "date-time" }
-                          },
-                          "required": [
-                            "id",
-                            "streamId",
-                            "sequence",
-                            "authorId",
-                            "authorType",
-                            "content",
-                            "replyCount",
-                            "metadata",
-                            "createdAt"
-                          ],
-                          "additionalProperties": false
+                            { "type": "null" }
+                          ]
                         }
                       },
                       "required": ["invocationId", "message"],


### PR DESCRIPTION
## Problem

Conversation classification (`BoundaryExtractionService`) is blind to attachment content. When a user drops a voice memo, screenshot, or PDF into a channel/thread, the classifier sees only `contentMarkdown` — often empty or a one-line wrapper like "see attached". A short or empty body collapses to "ambiguous → likely a new conversation", even when the attached transcript clearly continues an existing thread.

Meanwhile, our agents already solved this problem: personas and the companion agent block on `awaitAttachmentProcessing` before invoking their LLMs so the model sees the transcript/OCR/parsed text alongside the written content. The boundary extractor was the missing piece.

## Solution

Mirror the agent pattern in boundary extraction:

1. For channels/threads only (scratchpads skip the LLM), wait for the new message's attachments to finish processing before the LLM call.
2. Fetch attachments + extractions for the new message **and** every surrounding context message in a single batched query.
3. Render an indented `[attachment <filename> (<kind>)]` block per message in the prompt — `fullText` (transcript / OCR / parse) for the new message, `summary` only for context messages, with character caps.
4. Teach the system prompt that attachment-extracted text counts as message content for topic continuity.

### How it works

```
processMessage(messageId, streamId, workspaceId)
  ├─ Phase 0 (NEW): if channel/thread, awaitAttachmentProcessing(newMessageAttachments)
  │                 60s ceiling, releases connection between polls (INV-41)
  │                 timeouts log a warn and continue — classifier proceeds with
  │                 whatever extractions exist
  ├─ Phase 1: withClient — fetch message, stream, surrounding messages, conversations,
  │           AND findByMessageIdsWithExtractions(newMsg + context msgs)
  ├─ Phase 2: extractor.extract(context) — LLM sees attachment blocks inline
  └─ Phase 3: withTransaction — persist assignments / reassignments / completeness
```

### Key design decisions

**1. Only await the new message's attachments**

Awaiting surrounding-context attachments too would multiply the worst-case latency on every classification. In practice, prior messages' attachments were processed by their own earlier boundary-extract runs (or by other awaiters like the agent), so they're already in a terminal state by the time we read them. The new message is the one whose payload is most likely to change the classification decision.

**2. `fullText` for new message, `summary` for context**

Full transcripts can be long (audio/video). Putting `fullText` everywhere would balloon the prompt for no decision benefit — context messages mostly need topical hints, not verbatim content. Caps: 2000 chars for the new message, 400 chars per context attachment.

**3. Don't block forever on attachment failures**

If `awaitAttachmentProcessing` returns `allCompleted: false` (timeout / FAILED / SKIPPED), we log a warn and proceed. Same posture as the agent path. The renderer simply omits attachments with no extracted text. Better to classify with degraded signal than to wedge the queue.

**4. System-prompt change, not a new section**

Added a `## Attachments` instruction block that teaches the model how to read the indented `[attachment …]` lines and treat them as message content. Avoids a separate top-level data section — keeps the per-message rendering local to where each message appears.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/boundary-extraction-service.ts` | Phase 0 await for new message attachments; Phase 1 fetches extractions for new message + context via `findByMessageIdsWithExtractions`; new `buildAttachmentContextMap` helper strips `fullText` from non-new messages. |
| `apps/backend/src/features/conversations/boundary-extraction/types.ts` | New `AttachmentExtractContext` type; `attachmentsByMessageId?: Map<…>` on `ExtractionContext`. |
| `apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts` | `buildPrompt` renders indented `[attachment …]` block per message; new `renderAttachments` helper with per-message character caps. |
| `apps/backend/src/features/conversations/boundary-extraction/config.ts` | New `## Attachments` instructions in the user prompt template. |
| `apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts` | +4 unit tests: fullText shown for new message, summary used for context, truncation, empty-attachments case. |
| `docs/public-api/openapi.json` | Pre-existing drift on main flagged by pre-commit hook (Pi instance endpoints). Committed separately as a `chore`. |

## Latency note

Channel/thread messages with attached payloads now wait up to 60s for processing before classification runs. The `conversation:message_assigned` outbox event for those messages is delayed accordingly. Empty-attachment messages are unaffected (the await short-circuits). This mirrors what agents/companion-agent already accept.

## Test plan

- [x] `bun test src/features/conversations/boundary-extraction/llm-extractor.test.ts` — 25/25 pass, including 4 new attachment-rendering cases
- [x] `bun test src/features/conversations src/features/attachments` — 189/189 pass
- [x] Full monorepo `tsc --noEmit` clean
- [x] Full monorepo `eslint` clean
- [x] `bun apps/backend/scripts/generate-api-docs.ts --check` — clean
- [ ] Manual: upload an audio attachment to a channel with an existing conversation about that topic; verify the new message lands on the existing conversation (not a new one) once transcription completes
- [ ] Manual: upload a PDF; verify classification picks up content from the parsed body
- [ ] Manual: upload a slow-to-process attachment and confirm classification waits, then proceeds

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XokDyouUGf8urpXFtNdkd3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782131186&installation_id=129946197&pr_number=605&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F605&signature=9d5b125156bdfe8ff99015a770741708fde5fd2fa7394f3f3d12af491dd16d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->