### PR TITLE
perf: stop composer re-renders during pi trace activity

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react"
+import { memo, useState, useCallback, useEffect, useRef } from "react"
 import { createPortal } from "react-dom"
 import { useNavigate } from "react-router-dom"
 import {
@@ -186,7 +186,13 @@ export function materializePendingAttachmentReferences(
   }
 }
 
-export function MessageInput({ workspaceId, streamId, disabled, disabledReason, autoFocus }: MessageInputProps) {
+// Memoized so trace/presence-driven re-renders of `StreamContent` (which fire
+// on every Pi step + heartbeat while a bot is active) don't tear through the
+// composer subtree. All props here are primitives that stay reference-stable
+// across `StreamContent` renders, so the default shallow comparison is enough.
+export const MessageInput = memo(MessageInputComponent)
+
+function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason, autoFocus }: MessageInputProps) {
   const editLastCtx = useEditLastMessage()
   const triggerEditLast = editLastCtx?.triggerEditLast
   const scrollToMessage = editLastCtx?.scrollToMessage

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import type { Socket } from "socket.io-client"
 import { db } from "@/db"
 import {
   applyStreamBootstrap,
   getLatestPersistedSequence,
+  registerStreamSocketHandlers,
   toCachedStreamBootstrap,
   updateMessageEvent,
+  type CachedStreamBootstrap,
 } from "./stream-sync"
-import type { StreamBootstrap, StreamEvent } from "@threa/types"
+import { streamKeys } from "@/hooks/use-streams"
+import type { BotRuntimePresenceSummary, StreamBootstrap, StreamEvent } from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
 // in-memory IndexedDB. No mocks needed — tests exercise actual queries.
@@ -756,5 +761,165 @@ describe("event display filtering", () => {
     ]
     const displayed = filterEventsForDisplay(idbEvents, 100n)
     expect(displayed.map((e) => e.sequence)).toEqual(["100", "120", "150", "200"])
+  })
+})
+
+describe("registerStreamSocketHandlers — bot_runtime:presence cache patching", () => {
+  // Active Pi runtimes touch presence on every poll/step (multiple times per
+  // second). The bootstrap cache must not be patched when only `lastSeenAt`
+  // advanced, or every active session bursts cascade re-renders through
+  // StreamContent and the composer subtree — that's what was making mobile
+  // typing feel laggy.
+
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+
+    return {
+      socket,
+      emit(event: string, payload: unknown) {
+        handlers.get(event)?.forEach((handler) => handler(payload))
+      },
+    }
+  }
+
+  function seedBootstrap(
+    queryClient: QueryClient,
+    streamId: string,
+    presence: Record<string, BotRuntimePresenceSummary | null>
+  ): CachedStreamBootstrap {
+    const base = makeBootstrap([], streamId)
+    const cached: CachedStreamBootstrap = {
+      ...base,
+      botRuntimePresence: presence,
+      windowVersion: 0,
+    }
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", streamId), cached)
+    return cached
+  }
+
+  function makePresence(overrides: Partial<BotRuntimePresenceSummary> = {}): BotRuntimePresenceSummary {
+    return {
+      botId: "bot_1",
+      runtimeKind: "pi-local",
+      instanceId: "inst_1",
+      displayName: "Pi-on-laptop",
+      status: "busy",
+      acceptingInvocations: false,
+      statusText: "Searching the workspace…",
+      lastSeenAt: new Date(1700000000000).toISOString(),
+      ...overrides,
+    }
+  }
+
+  it("does not patch the bootstrap cache when only lastSeenAt advances", () => {
+    const queryClient = new QueryClient()
+    const streamId = "stream_presence_skip"
+    const initial = seedBootstrap(queryClient, streamId, { bot_1: makePresence() })
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    emit("bot_runtime:presence", {
+      workspaceId: "ws_1",
+      streamId,
+      botId: "bot_1",
+      presence: makePresence({ lastSeenAt: new Date(1700000001000).toISOString() }),
+    })
+
+    // Same reference both ways — the cache value must stay identical so
+    // downstream `useStreamBootstrap` consumers don't re-render.
+    const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(after).toBe(before)
+    expect(after).toBe(initial)
+
+    cleanup()
+  })
+
+  it("patches the cache when statusText changes", () => {
+    const queryClient = new QueryClient()
+    const streamId = "stream_presence_text"
+    seedBootstrap(queryClient, streamId, { bot_1: makePresence({ statusText: "Searching the workspace…" }) })
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    emit("bot_runtime:presence", {
+      workspaceId: "ws_1",
+      streamId,
+      botId: "bot_1",
+      presence: makePresence({
+        statusText: "Composing reply…",
+        lastSeenAt: new Date(1700000001000).toISOString(),
+      }),
+    })
+
+    const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(after).not.toBe(before)
+    expect(after?.botRuntimePresence?.bot_1?.statusText).toBe("Composing reply…")
+
+    cleanup()
+  })
+
+  it("patches the cache when status flips even if statusText is unchanged", () => {
+    const queryClient = new QueryClient()
+    const streamId = "stream_presence_status"
+    seedBootstrap(queryClient, streamId, { bot_1: makePresence({ status: "busy" }) })
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    emit("bot_runtime:presence", {
+      workspaceId: "ws_1",
+      streamId,
+      botId: "bot_1",
+      presence: makePresence({
+        status: "available",
+        acceptingInvocations: true,
+        lastSeenAt: new Date(1700000002000).toISOString(),
+      }),
+    })
+
+    const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(after).not.toBe(before)
+    expect(after?.botRuntimePresence?.bot_1?.status).toBe("available")
+
+    cleanup()
+  })
+
+  it("ignores presence events for a different stream", () => {
+    const queryClient = new QueryClient()
+    const streamId = "stream_presence_other"
+    seedBootstrap(queryClient, streamId, { bot_1: makePresence() })
+    const before = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    emit("bot_runtime:presence", {
+      workspaceId: "ws_1",
+      streamId: "stream_other",
+      botId: "bot_1",
+      presence: makePresence({ statusText: "Different stream, ignore me" }),
+    })
+
+    const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+    expect(after).toBe(before)
+
+    cleanup()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -758,6 +758,14 @@ export function registerStreamSocketHandlers(
   // Bot runtime presence updates fan out to every stream room the bot is a
   // member of. Patch the cached bootstrap so any open scratchpad showing the
   // status strip re-renders without a refetch.
+  //
+  // `lastSeenAt` is intentionally excluded from the equality check — Pi runtimes
+  // touch presence on every poll/step (multiple times per second during active
+  // sessions), but the UI only renders `status`, `statusText`, and
+  // `displayName`. Including `lastSeenAt` here forced the bootstrap cache to
+  // patch on every heartbeat, which cascaded into a full StreamContent
+  // re-render (and the heavy composer subtree with it) and made typing on
+  // mobile feel laggy whenever a bot was active.
   const handleBotRuntimePresence = (payload: {
     workspaceId: string
     streamId: string
@@ -768,17 +776,21 @@ export function registerStreamSocketHandlers(
     queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (old) => {
       if (!old) return old
       const current = old.botRuntimePresence ?? {}
+      const previous = current[payload.botId] ?? null
+      const next = payload.presence
       if (
-        current[payload.botId]?.lastSeenAt === payload.presence?.lastSeenAt &&
-        current[payload.botId]?.status === payload.presence?.status &&
-        current[payload.botId]?.statusText === payload.presence?.statusText &&
-        current[payload.botId]?.displayName === payload.presence?.displayName
+        previous?.status === next?.status &&
+        previous?.statusText === next?.statusText &&
+        previous?.displayName === next?.displayName &&
+        previous?.acceptingInvocations === next?.acceptingInvocations &&
+        previous?.runtimeKind === next?.runtimeKind &&
+        previous?.instanceId === next?.instanceId
       ) {
         return old
       }
       return {
         ...old,
-        botRuntimePresence: { ...current, [payload.botId]: payload.presence },
+        botRuntimePresence: { ...current, [payload.botId]: next },
       }
     })
   }


### PR DESCRIPTION
Follow-up to #606. While Pi bots stream traces, typing on mobile became laggy because every heartbeat tore through the composer subtree. Two narrow fixes restore responsiveness.

## Summary

- **Drop `lastSeenAt` from the `handleBotRuntimePresence` equality short-circuit.** Pi runtimes touch presence on every poll/step (multiple times per second), so `lastSeenAt` always advanced and forced a `setQueryData` patch on the bootstrap cache for every heartbeat. That patch cascaded into a full `StreamContent` re-render and dragged the heavy TipTap composer subtree with it. The UI only renders `status`, `statusText`, and `displayName`, so the comparison now covers those plus the other stable identity fields.
- **Memoize `MessageInput`.** Its props (`workspaceId`, `streamId`, `disabled`, `disabledReason`, `autoFocus`) are reference-stable across `StreamContent` renders, so a shallow-equality `React.memo` isolates the composer from upstream trace/presence churn.

## Test plan

- [x] `bunx vitest run src/sync/stream-sync.test.ts` — 27 passed (4 new tests cover the presence equality contract: cache stays reference-identical when only `lastSeenAt` advances, patches when `status`/`statusText` change, ignores events for other streams).
- [ ] Manual: open a stream with an active Pi bot on mobile, watch a trace stream, type in the composer — keystrokes stay responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782199692&installation_id=129946197&pr_number=607&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F607&signature=6012509f613a6464784358bb4d4b34878ea8432d5acb1081f10cf0e2fee528ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->