### PR TITLE
fix: keep pi remote traces secret-safe

### DIFF
--- a/.claude/plans/pi-remote-safe-traces.md
+++ b/.claude/plans/pi-remote-safe-traces.md
@@ -1,0 +1,59 @@
+# Pi Remote Secret-Safe Traces
+
+## Goal
+
+Prevent Pi remote trace/status telemetry from leaking credentials or sensitive local tool data into Threa while preserving useful progress signals for bot invocations.
+
+## What Was Built
+
+### Pi remote trace summarization
+
+The Pi remote extension now treats tool events as telemetry rather than logs. Tool calls are described with generated safe labels, and tool results report only output-size metadata instead of raw stdout/stderr contents.
+
+**Files:**
+- `docs/examples/pi-remote/threa-remote-v2.ts` — replaces raw tool input/output trace serialization with safe summaries; restricts status text to generated activity labels; avoids retaining raw tool arguments in `pendingToolCalls`.
+- `docs/examples/pi-remote/threa-remote-v2.test.ts` — verifies bash commands, tool outputs, and edit patch bodies are omitted from trace payloads.
+
+### Backend defense-in-depth sanitization
+
+The public API sanitizes unstructured bot-provided trace/status data before persistence and socket broadcast. This is not the primary defense — the extension should not send raw data — but protects against custom/older bot runtimes.
+
+**Files:**
+- `apps/backend/src/features/public-api/handlers.ts` — redacts common secret shapes, clamps presence `statusText` to safe labels, and strips structured Pi tool trace `Arguments`, `Output`, and `Error output` bodies before storing steps.
+
+## Design Decisions
+
+### Treat traces as telemetry, not logs
+
+**Chose:** Store what happened and approximate output size, not what the tool saw.
+**Why:** A tool can read `.env`, credentials, tokens, or local files that Threa should not ingest or retain.
+**Alternatives considered:** Regex-redacting raw outputs. This remains as backend defense-in-depth, but is insufficient as the primary protection because regexes miss novel secret formats.
+
+### Allow only generated status text
+
+**Chose:** Presence text is mapped to known safe phrases such as `Running shell command…`, `Searching files…`, and `Tool finished`.
+**Why:** Presence is broadcast widely and displayed inline; it should never contain user/tool-provided strings.
+**Alternatives considered:** Free-form redacted status text. This still risks leaking unusual credentials or sensitive filenames.
+
+### Keep backend sanitization conservative
+
+**Chose:** For structured Pi traces, backend replaces argument/output section bodies with omission messages regardless of whether the current extension already summarized them.
+**Why:** Public API callers are untrusted bot runtimes. The server must not assume all clients follow the latest extension behavior.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No opt-in raw debug trace mode.
+- No retention-policy changes for trace rows.
+- No frontend UI redesign; existing trace rendering continues to display structured trace sections.
+
+## Status
+
+- [x] Omit raw Pi tool call inputs from trace payloads.
+- [x] Omit raw Pi tool outputs from trace payloads.
+- [x] Restrict Pi remote status text to safe generated labels.
+- [x] Add backend defense-in-depth sanitization for trace steps and presence text.
+- [x] Add focused safety tests for the Pi remote example extension.

--- a/apps/backend/src/features/public-api/handlers.test.ts
+++ b/apps/backend/src/features/public-api/handlers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { PI_TOOL_TRACE_FORMAT, PiToolTraceSectionLabels } from "@threa/types"
+import { sanitizeInvocationStepContent } from "./handlers"
+
+function parse(content: string) {
+  return JSON.parse(content) as Record<string, unknown>
+}
+
+describe("sanitizeInvocationStepContent", () => {
+  test("drops unknown top-level fields", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Ran tool",
+      sections: [{ label: PiToolTraceSectionLabels.DETAILS, body: "ok", lang: null }],
+      leakedSecret: "AKIAABCDEFGHIJKLMNOP",
+      attackerMetadata: { token: "ghs_aaaaaaaaaaaaaaaaaaaaaa" },
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+
+    expect(Object.keys(result).sort()).toEqual(["format", "headline", "sections"])
+    expect(JSON.stringify(result)).not.toContain("AKIA")
+    expect(JSON.stringify(result)).not.toContain("ghs_")
+  })
+
+  test("drops unknown per-section fields", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Ran tool",
+      sections: [
+        {
+          label: PiToolTraceSectionLabels.DETAILS,
+          body: "ok",
+          lang: null,
+          rawOutput: "AKIAABCDEFGHIJKLMNOP",
+          customField: { nested: "ghs_aaaaaaaaaaaaaaaaaaaaaa" },
+        },
+      ],
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+    const sections = result.sections as Array<Record<string, unknown>>
+
+    expect(Object.keys(sections[0]!).sort()).toEqual(["body", "label", "lang"])
+    expect(JSON.stringify(result)).not.toContain("AKIA")
+    expect(JSON.stringify(result)).not.toContain("ghs_")
+  })
+
+  test("drops sections with unknown labels", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Ran tool",
+      sections: [
+        { label: PiToolTraceSectionLabels.DETAILS, body: "kept", lang: null },
+        { label: "Stack trace", body: "AKIAABCDEFGHIJKLMNOP", lang: null },
+        { label: "Raw stdout", body: "ghs_aaaaaaaaaaaaaaaaaaaaaa", lang: null },
+      ],
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+    const sections = result.sections as Array<Record<string, unknown>>
+
+    expect(sections).toHaveLength(1)
+    expect(sections[0]!.label).toBe(PiToolTraceSectionLabels.DETAILS)
+    expect(JSON.stringify(result)).not.toContain("AKIA")
+    expect(JSON.stringify(result)).not.toContain("ghs_")
+  })
+
+  test("replaces Arguments/Output/Error output bodies regardless of provided content", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "Ran tool",
+      sections: [
+        { label: PiToolTraceSectionLabels.ARGUMENTS, body: "AKIAABCDEFGHIJKLMNOP", lang: "json" },
+        { label: PiToolTraceSectionLabels.OUTPUT, body: "ghs_aaaaaaaaaaaaaaaaaaaaaa", lang: "text" },
+        { label: PiToolTraceSectionLabels.ERROR_OUTPUT, body: "DB_URL=postgres://u:secret@h/d", lang: "text" },
+      ],
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+    const sections = result.sections as Array<Record<string, unknown>>
+
+    expect(sections[0]!.body).toBe("Tool arguments omitted for safety.")
+    expect(sections[1]!.body).toBe("Tool output omitted for safety.")
+    expect(sections[2]!.body).toBe("Tool output omitted for safety.")
+    expect(JSON.stringify(result)).not.toContain("AKIA")
+    expect(JSON.stringify(result)).not.toContain("ghs_")
+    expect(JSON.stringify(result)).not.toContain("secret")
+  })
+
+  test("regex-redacts the Details body and the headline", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "AKIAABCDEFGHIJKLMNOP ran tool",
+      sections: [{ label: PiToolTraceSectionLabels.DETAILS, body: "Saw AKIAABCDEFGHIJKLMNOP in env", lang: null }],
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+    const sections = result.sections as Array<Record<string, unknown>>
+
+    expect(result.headline).toContain("[REDACTED]")
+    expect(sections[0]!.body).toContain("[REDACTED]")
+    expect(JSON.stringify(result)).not.toContain("AKIA")
+  })
+
+  test("caps headline, body, and lang lengths", () => {
+    const payload = JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline: "a".repeat(5_000),
+      sections: [{ label: PiToolTraceSectionLabels.DETAILS, body: "b".repeat(50_000), lang: "x".repeat(500) }],
+    })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+    const sections = result.sections as Array<Record<string, unknown>>
+
+    expect((result.headline as string).length).toBeLessThanOrEqual(200)
+    expect((sections[0]!.body as string).length).toBeLessThanOrEqual(10_000)
+    expect((sections[0]!.lang as string).length).toBeLessThanOrEqual(32)
+  })
+
+  test("caps the number of sections", () => {
+    const sections = Array.from({ length: 100 }, () => ({
+      label: PiToolTraceSectionLabels.DETAILS,
+      body: "ok",
+      lang: null,
+    }))
+    const payload = JSON.stringify({ format: PI_TOOL_TRACE_FORMAT, headline: "Ran tool", sections })
+
+    const result = parse(sanitizeInvocationStepContent(payload))
+
+    expect((result.sections as unknown[]).length).toBeLessThanOrEqual(16)
+  })
+
+  test("falls back to plain regex redaction for non-trace JSON", () => {
+    const result = sanitizeInvocationStepContent("token=AKIAABCDEFGHIJKLMNOP")
+    expect(result).not.toContain("AKIA")
+    expect(result).toContain("[REDACTED]")
+  })
+
+  test("falls back to plain regex redaction for invalid JSON", () => {
+    const result = sanitizeInvocationStepContent("not json AKIAABCDEFGHIJKLMNOP")
+    expect(result).not.toContain("AKIA")
+    expect(result).toContain("[REDACTED]")
+  })
+})

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -351,7 +351,8 @@ export interface PublicApiDeps {
 }
 
 const SENSITIVE_VALUE_PATTERNS = [
-  /\b(?:sk|rk|pk|lf|wos|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{10,}\b/g,
+  /\b(?:sk|rk|pk|lf|wos|gh[a-z]|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{10,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
   /\b(?:Authorization|X-Api-Key|api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;\"'}]+/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
 ]

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -423,6 +423,15 @@ function sanitizeTraceSection(section: unknown): SafeTraceSection | null {
   return { label, body, lang }
 }
 
+// Trace step content is stored as-received from the bot runtime, after
+// best-effort sanitization. The official Pi extension is the security
+// boundary — it is responsible for never forwarding raw tool stdout, file
+// contents, or credentials. Third-party runtimes inherit the trust level
+// of the API key holder; the allowlist + regex here is defense-in-depth,
+// not a guarantee. Do not loosen this (relax the allowlist, drop the
+// length caps, or pass arbitrary fields through) without revisiting the
+// threat model — see docs/examples/pi-remote/ for the trusted-runtime
+// contract.
 export function sanitizeInvocationStepContent(content: string): string {
   const redacted = redactSensitiveText(content)
   try {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -33,6 +33,8 @@ import {
   AttachmentSafetyStatuses,
   AuthorTypes,
   BotRuntimeKinds,
+  PI_TOOL_TRACE_FORMAT,
+  PiToolTraceSectionLabels,
   sentViaApiKey,
   type AuthorType,
 } from "@threa/types"
@@ -348,6 +350,69 @@ export interface PublicApiDeps {
   io?: Server
 }
 
+const SENSITIVE_VALUE_PATTERNS = [
+  /\b(?:sk|rk|pk|lf|wos|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{10,}\b/g,
+  /\b(?:Authorization|X-Api-Key|api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;\"'}]+/gi,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+]
+
+function redactSensitiveText(text: string): string {
+  let redacted = text
+  for (const pattern of SENSITIVE_VALUE_PATTERNS) redacted = redacted.replace(pattern, "[REDACTED]")
+  return redacted
+}
+
+function sanitizeStatusText(statusText?: string | null): string | null {
+  const trimmed = redactSensitiveText(statusText?.trim() ?? "")
+  if (!trimmed) return null
+  const allowed = new Set([
+    "Thinking…",
+    "Loaded context…",
+    "Running shell command…",
+    "Reading file…",
+    "Reading sensitive file…",
+    "Writing file…",
+    "Editing file…",
+    "Searching files…",
+    "Listing directory…",
+    "Using tool…",
+    "Tool finished",
+    "Tool failed",
+    "Working…",
+    "Composing response…",
+    "Sent response",
+  ])
+  if (allowed.has(trimmed)) return trimmed
+  return "Working…"
+}
+
+function sanitizeInvocationStepContent(content: string): string {
+  const redacted = redactSensitiveText(content)
+  try {
+    const parsed = JSON.parse(redacted) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return redacted
+    const trace = parsed as Record<string, unknown>
+    if (trace.format !== PI_TOOL_TRACE_FORMAT || !Array.isArray(trace.sections)) return redacted
+    return JSON.stringify({
+      ...trace,
+      sections: trace.sections.map((section) => {
+        if (!section || typeof section !== "object" || Array.isArray(section)) return section
+        const item = section as Record<string, unknown>
+        const label = typeof item.label === "string" ? item.label : ""
+        if (label === PiToolTraceSectionLabels.ARGUMENTS) {
+          return { ...item, body: "Tool arguments omitted for safety.", lang: null }
+        }
+        if (label === PiToolTraceSectionLabels.OUTPUT || label === PiToolTraceSectionLabels.ERROR_OUTPUT) {
+          return { ...item, body: "Tool output omitted for safety.", lang: null }
+        }
+        return { ...item, body: typeof item.body === "string" ? redactSensitiveText(item.body) : item.body }
+      }),
+    })
+  } catch {
+    return redacted
+  }
+}
+
 function serializeTraceStep(step: AgentSessionStep) {
   return {
     id: step.id,
@@ -512,7 +577,7 @@ export function createPublicApiHandlers({
         instanceId: params.instanceId,
         status: params.status,
         acceptingInvocations: params.acceptingInvocations,
-        statusText: params.statusText,
+        statusText: sanitizeStatusText(params.statusText),
       })
       await broadcastBotPresence(params.workspaceId, params.botId, presence)
     } catch (err) {
@@ -568,6 +633,7 @@ export function createPublicApiHandlers({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
         ...result.data,
+        statusText: sanitizeStatusText(result.data.statusText),
       })
       await broadcastBotPresence(req.workspaceId!, req.botApiKey.botId, presence)
       res.json({
@@ -787,7 +853,7 @@ export function createPublicApiHandlers({
           id: stepId(),
           sessionId: claim.id,
           stepType: result.data.stepType,
-          content: result.data.content,
+          content: sanitizeInvocationStepContent(result.data.content),
           startedAt: now,
           completedAt: now,
         })
@@ -819,7 +885,7 @@ export function createPublicApiHandlers({
         instanceId: result.data.instanceId,
         status: "busy",
         acceptingInvocations: false,
-        statusText: result.data.statusText?.trim() || null,
+        statusText: sanitizeStatusText(result.data.statusText),
       })
       res.json({ data: { invocationId: claim.id, sessionId: claim.id, stepId: step.id } })
     },

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -34,9 +34,11 @@ import {
   AuthorTypes,
   BotRuntimeKinds,
   PI_TOOL_TRACE_FORMAT,
+  PI_TOOL_TRACE_SECTION_LABELS,
   PiToolTraceSectionLabels,
   sentViaApiKey,
   type AuthorType,
+  type PiToolTraceSectionLabel,
 } from "@threa/types"
 import { BotRuntimeService, type BotRuntimeInstance } from "../bot-runtimes"
 import type { BotRuntimeKind, BotRuntimeStatus } from "@threa/types"
@@ -387,28 +389,56 @@ function sanitizeStatusText(statusText?: string | null): string | null {
   return "Working…"
 }
 
-function sanitizeInvocationStepContent(content: string): string {
+const TRACE_HEADLINE_MAX_CHARS = 200
+const TRACE_BODY_MAX_CHARS = 10_000
+const TRACE_LANG_MAX_CHARS = 32
+const TRACE_MAX_SECTIONS = 16
+
+const TRACE_SECTION_LABEL_SET: ReadonlySet<string> = new Set(PI_TOOL_TRACE_SECTION_LABELS)
+
+interface SafeTraceSection {
+  label: PiToolTraceSectionLabel
+  body: string
+  lang: string | null
+}
+
+function clampString(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value
+}
+
+function sanitizeTraceSection(section: unknown): SafeTraceSection | null {
+  if (!section || typeof section !== "object" || Array.isArray(section)) return null
+  const item = section as Record<string, unknown>
+  const rawLabel = typeof item.label === "string" ? item.label : ""
+  if (!TRACE_SECTION_LABEL_SET.has(rawLabel)) return null
+  const label = rawLabel as PiToolTraceSectionLabel
+  if (label === PiToolTraceSectionLabels.ARGUMENTS) {
+    return { label, body: "Tool arguments omitted for safety.", lang: null }
+  }
+  if (label === PiToolTraceSectionLabels.OUTPUT || label === PiToolTraceSectionLabels.ERROR_OUTPUT) {
+    return { label, body: "Tool output omitted for safety.", lang: null }
+  }
+  const body = typeof item.body === "string" ? clampString(redactSensitiveText(item.body), TRACE_BODY_MAX_CHARS) : ""
+  const lang = typeof item.lang === "string" ? clampString(item.lang, TRACE_LANG_MAX_CHARS) : null
+  return { label, body, lang }
+}
+
+export function sanitizeInvocationStepContent(content: string): string {
   const redacted = redactSensitiveText(content)
   try {
     const parsed = JSON.parse(redacted) as unknown
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return redacted
     const trace = parsed as Record<string, unknown>
     if (trace.format !== PI_TOOL_TRACE_FORMAT || !Array.isArray(trace.sections)) return redacted
-    return JSON.stringify({
-      ...trace,
-      sections: trace.sections.map((section) => {
-        if (!section || typeof section !== "object" || Array.isArray(section)) return section
-        const item = section as Record<string, unknown>
-        const label = typeof item.label === "string" ? item.label : ""
-        if (label === PiToolTraceSectionLabels.ARGUMENTS) {
-          return { ...item, body: "Tool arguments omitted for safety.", lang: null }
-        }
-        if (label === PiToolTraceSectionLabels.OUTPUT || label === PiToolTraceSectionLabels.ERROR_OUTPUT) {
-          return { ...item, body: "Tool output omitted for safety.", lang: null }
-        }
-        return { ...item, body: typeof item.body === "string" ? redactSensitiveText(item.body) : item.body }
-      }),
-    })
+    const headline =
+      typeof trace.headline === "string"
+        ? clampString(redactSensitiveText(trace.headline), TRACE_HEADLINE_MAX_CHARS)
+        : ""
+    const sections = trace.sections
+      .slice(0, TRACE_MAX_SECTIONS)
+      .map(sanitizeTraceSection)
+      .filter((section): section is SafeTraceSection => section !== null)
+    return JSON.stringify({ format: PI_TOOL_TRACE_FORMAT, headline, sections })
   } catch {
     return redacted
   }

--- a/docs/examples/pi-remote/threa-remote-v2.test.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { __testing } from "./threa-remote-v2"
+
+describe("Pi remote trace safety", () => {
+  test("omits sensitive bash command arguments from tool_call traces", () => {
+    const trace = __testing.formatToolCallTrace({
+      toolName: "bash",
+      toolCallId: "call_1",
+      input: { command: "cat .env && curl -H 'Authorization: Bearer sk-test-secret-token' https://example.com" },
+    } as never)
+
+    expect(trace).toContain("Shell command omitted for safety")
+    expect(trace).not.toContain("cat .env")
+    expect(trace).not.toContain("sk-test-secret-token")
+    expect(__testing.describeToolCall({ toolName: "bash", toolCallId: "call_1", input: {} } as never)).toBe(
+      "Running shell command…"
+    )
+  })
+
+  test("omits tool result bodies while preserving output size telemetry", () => {
+    const trace = __testing.formatToolResultTrace({
+      toolName: "bash",
+      toolCallId: "call_1",
+      isError: false,
+      content: "DATABASE_URL=postgres://user:password@example.test/db\nOPENAI_API_KEY=sk-test-secret-token",
+    } as never)
+
+    expect(trace).toContain("Tool output omitted for safety")
+    expect(trace).toContain("characters across 2 lines")
+    expect(trace).not.toContain("DATABASE_URL")
+    expect(trace).not.toContain("sk-test-secret-token")
+  })
+
+  test("omits write/edit patch bodies from argument summaries", () => {
+    const trace = __testing.formatToolCallTrace({
+      toolName: "edit",
+      toolCallId: "call_1",
+      input: { path: "src/config.ts", oldText: "password = 'secret'", newText: "password = 'new-secret'" },
+    } as never)
+
+    expect(trace).toContain("Edit target:")
+    expect(trace).toContain("File contents and patches omitted for safety")
+    expect(trace).not.toContain("oldText")
+    expect(trace).not.toContain("secret")
+  })
+})

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -84,7 +84,7 @@ let pollInFlightRunId: number | undefined
 let pending: ClaimedInvocation | undefined
 let pendingContextCursor: string | undefined
 let pendingAssistantTexts: string[] = []
-let pendingToolCalls = new Map<string, { headline: string; args: unknown }>()
+let pendingToolCalls = new Map<string, { headline: string }>()
 let lastTraceHeartbeat: { text: string; at: number } | undefined
 let consecutivePollFailures = 0
 let lastPollFailureSummary: string | undefined
@@ -217,7 +217,7 @@ async function recordTraceStep(stepType: string, content: string, statusText?: s
 
 async function traceHeartbeat(text: string, stepType?: string): Promise<void> {
   if (!pending) return
-  const trimmed = text.trim().slice(0, 160)
+  const trimmed = safeStatusText(text)
   if (!trimmed) return
   const now = Date.now()
   if (lastTraceHeartbeat?.text === trimmed && now - lastTraceHeartbeat.at < 5000) return
@@ -229,34 +229,69 @@ async function traceHeartbeat(text: string, stepType?: string): Promise<void> {
   await heartbeat("busy", trimmed).catch(() => undefined)
 }
 
+function safeStatusText(text: string): string {
+  const trimmed = text.trim()
+  const allowed = new Set([
+    "Thinking…",
+    "Loaded context…",
+    "Running shell command…",
+    "Reading file…",
+    "Reading sensitive file…",
+    "Writing file…",
+    "Editing file…",
+    "Searching files…",
+    "Listing directory…",
+    "Using tool…",
+    "Tool finished",
+    "Tool failed",
+    "Composing response…",
+    "Sent response",
+  ])
+  if (allowed.has(trimmed)) return trimmed
+  if (/^Finished [A-Za-z0-9_-]+$/.test(trimmed)) return "Tool finished"
+  if (/^[A-Za-z0-9_-]+ failed$/.test(trimmed)) return "Tool failed"
+  return "Working…"
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function basenameFromInputPath(path: unknown): string | undefined {
+  if (typeof path !== "string") return undefined
+  const parts = path.split(/[\\/]+/).filter(Boolean)
+  return parts.at(-1)
+}
+
+function isSensitivePath(path: unknown): boolean {
+  if (typeof path !== "string") return false
+  return /(^|[\\/.])(?:env|npmrc|netrc|pypirc|pgpass|aws|credentials|config|secrets?|tokens?|keys?)(?:$|[.\\/-])/i.test(
+    path
+  )
+}
+
+function safeFileSummary(path: unknown): string {
+  if (isSensitivePath(path)) return "sensitive file"
+  const name = basenameFromInputPath(path)
+  return name ? `file ${name}` : "file"
+}
+
+function safeToolName(toolName: string): string {
+  return /^[A-Za-z0-9_-]{1,64}$/.test(toolName) ? toolName : "tool"
+}
+
 function describeToolCall(event: ToolCallEvent): string {
   const input = "input" in event ? event.input : undefined
-  if (event.toolName === "bash" && input && typeof input === "object" && "command" in input) {
-    return `Running ${String(input.command).split("\n")[0].slice(0, 80)}…`
+  const toolName = safeToolName(event.toolName)
+  if (event.toolName === "bash") return "Running shell command…"
+  if ((event.toolName === "read" || event.toolName === "write") && isObject(input) && "path" in input) {
+    if (event.toolName === "read" && isSensitivePath(input.path)) return "Reading sensitive file…"
+    return `${event.toolName === "read" ? "Reading" : "Writing"} ${safeFileSummary(input.path)}…`
   }
-  if (
-    (event.toolName === "read" || event.toolName === "write") &&
-    input &&
-    typeof input === "object" &&
-    "path" in input
-  ) {
-    return `${event.toolName === "read" ? "Reading" : "Writing"} ${String(input.path).slice(0, 80)}…`
-  }
-  if (event.toolName === "edit" && input && typeof input === "object" && "path" in input) {
-    return `Editing ${String(input.path).slice(0, 80)}…`
-  }
-  if (
-    (event.toolName === "grep" || event.toolName === "find") &&
-    input &&
-    typeof input === "object" &&
-    "pattern" in input
-  ) {
-    return `Searching for ${String(input.pattern).slice(0, 80)}…`
-  }
-  if (event.toolName === "ls" && input && typeof input === "object" && "path" in input) {
-    return `Listing ${String(input.path).slice(0, 80)}…`
-  }
-  return `Using ${event.toolName}…`
+  if (event.toolName === "edit" && isObject(input) && "path" in input) return `Editing ${safeFileSummary(input.path)}…`
+  if (event.toolName === "grep" || event.toolName === "find") return "Searching files…"
+  if (event.toolName === "ls") return "Listing directory…"
+  return `Using ${toolName}…`
 }
 
 function textFromToolContent(content: unknown): string {
@@ -272,14 +307,6 @@ function textFromToolContent(content: unknown): string {
     })
     .filter(Boolean)
     .join("\n")
-}
-
-function formatJsonForTrace(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2)
-  } catch {
-    return String(value)
-  }
 }
 
 function formatStructuredToolTrace(params: {
@@ -325,32 +352,51 @@ function formatStructuredToolTrace(params: {
   })
 }
 
+function safeToolArgumentSummary(event: ToolCallEvent): string {
+  const input = "input" in event ? event.input : undefined
+  const toolName = safeToolName(event.toolName)
+  if (event.toolName === "bash") return "Shell command omitted for safety."
+  if ((event.toolName === "read" || event.toolName === "write" || event.toolName === "edit") && isObject(input)) {
+    const action = event.toolName === "read" ? "Read" : event.toolName === "write" ? "Write" : "Edit"
+    return `${action} target: ${"path" in input ? safeFileSummary(input.path) : "file"}. File contents and patches omitted for safety.`
+  }
+  if (event.toolName === "grep" || event.toolName === "find") return "Search arguments omitted for safety."
+  if (event.toolName === "ls") return "Directory listing arguments omitted for safety."
+  return `Arguments for ${toolName} omitted for safety.`
+}
+
 function formatToolCallTrace(event: ToolCallEvent): string {
   return formatStructuredToolTrace({
     headline: describeToolCall(event).replace(/…$/, ""),
-    sections: [{ label: PI_TOOL_TRACE_SECTION_LABELS.ARGUMENTS, body: formatJsonForTrace(event.input), lang: "json" }],
+    sections: [
+      {
+        label: PI_TOOL_TRACE_SECTION_LABELS.DETAILS,
+        body: safeToolArgumentSummary(event),
+        lang: null,
+      },
+    ],
   })
+}
+
+function summarizeToolOutput(output: string): string {
+  const text = output.trim()
+  if (!text) return "Tool produced no textual output."
+  const lines = text.split("\n").length
+  return `Tool output omitted for safety. Captured locally: ${text.length} characters across ${lines} ${lines === 1 ? "line" : "lines"}.`
 }
 
 function formatToolResultTrace(event: ToolResultEvent): string {
   const call = pendingToolCalls.get(event.toolCallId)
   const output = textFromToolContent(event.content)
   const sections: Array<{ label: PiToolTraceSectionLabel; body: string; lang: string | null }> = []
-  if (call)
-    sections.push({ label: PI_TOOL_TRACE_SECTION_LABELS.ARGUMENTS, body: formatJsonForTrace(call.args), lang: "json" })
   sections.push({
     label: event.isError ? PI_TOOL_TRACE_SECTION_LABELS.ERROR_OUTPUT : PI_TOOL_TRACE_SECTION_LABELS.OUTPUT,
-    body: output.trim() || (event.isError ? "(tool failed without textual output)" : "(no textual output)"),
+    body: event.isError
+      ? `${summarizeToolOutput(output)} Error details omitted for safety.`
+      : summarizeToolOutput(output),
     lang: null,
   })
-  if (event.details !== undefined) {
-    sections.push({
-      label: PI_TOOL_TRACE_SECTION_LABELS.DETAILS,
-      body: formatJsonForTrace(event.details),
-      lang: "json",
-    })
-  }
-  return formatStructuredToolTrace({ headline: call?.headline ?? `Used ${event.toolName}`, sections })
+  return formatStructuredToolTrace({ headline: call?.headline ?? `Used ${safeToolName(event.toolName)}`, sections })
 }
 
 function sanitizeTraceText(text: string): string {
@@ -805,6 +851,13 @@ async function failPending(error: unknown): Promise<void> {
   await heartbeat("available").catch(() => undefined)
 }
 
+export const __testing = {
+  describeToolCall,
+  formatToolCallTrace,
+  formatToolResultTrace,
+  safeStatusText,
+}
+
 export default function (pi: ExtensionAPI): void {
   pi.registerCommand("remote-control", {
     description: "Create or link a Threa scratchpad to this Pi session",
@@ -851,7 +904,7 @@ export default function (pi: ExtensionAPI): void {
   pi.on("tool_call", async (event) => {
     if (!pending) return
     const description = describeToolCall(event)
-    pendingToolCalls.set(event.toolCallId, { headline: description.replace(/…$/, ""), args: event.input })
+    pendingToolCalls.set(event.toolCallId, { headline: description.replace(/…$/, "") })
     await recordTraceStep("tool_call", formatToolCallTrace(event), description)
   })
 


### PR DESCRIPTION
## Problem

Pi remote trace/status updates from #606 can include unstructured bot-provided data. Tool inputs and outputs are especially risky: a runtime could execute something like `cat .env` and accidentally persist/broadcast credentials through Threa trace steps or presence text.

This PR is stacked on #606 (`pi-remote-thinking-traces`) as a follow-up to keep that scope smaller.

## Solution

Treat Pi trace data as telemetry, not logs:

- Pi remote tool-call traces now use generated safe summaries instead of raw `event.input`.
- Pi remote tool-result traces omit stdout/stderr bodies and preserve only output-size telemetry.
- Runtime status text is constrained to safe generated activity labels.
- Backend public API sanitizes trace step content and presence text before persistence/broadcast as defense-in-depth.

### Key design decisions

**1. Do not store raw tool I/O**

Raw tool output is omitted at the source. Regex redaction exists on the backend only as a backup because it cannot reliably catch every secret format.

**2. Status text is allowlisted**

Presence text is user-visible and socket-broadcast, so it is mapped to known safe labels like `Running shell command…`, `Searching files…`, and `Tool finished`.

**3. Backend sanitization is conservative**

For structured Pi traces, the server strips `Arguments`, `Output`, and `Error output` bodies even if a custom/older runtime sends them.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/pi-remote-safe-traces.md` | Greptile/reviewer plan for this follow-up |
| `docs/examples/pi-remote/threa-remote-v2.test.ts` | Focused tests for secret-safe trace formatting |

## Modified files

| File | Change |
| --- | --- |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Replaces raw trace serialization with safe summaries and allowlisted status text |
| `apps/backend/src/features/public-api/handlers.ts` | Sanitizes bot trace step content and runtime presence text before persistence/broadcast |

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts`
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run typecheck`
- [x] Pre-commit: lint, typecheck, OpenAPI check

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782211973&installation_id=129946197&pr_number=608&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F608&signature=8ef9267a95571dd81d4468fe789ad7da5806e85002b40ee8f58589fe5308f8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->