### PR TITLE
feat(voice): add Deepgram Nova-3 as a second realtime STT provider

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -41,6 +41,9 @@ const updatePreferencesSchema = z.object({
     .min(BLOCKQUOTE_COLLAPSE_THRESHOLD_MIN)
     .max(BLOCKQUOTE_COLLAPSE_THRESHOLD_MAX)
     .optional(),
+  // Model id like "elevenlabs:scribe-v2-realtime". Validated against the model
+  // registry server-side when a session opens; this layer only bounds length.
+  voiceTranscriptionModel: z.string().max(100).nullable().optional(),
   keyboardShortcuts: z.record(z.string(), z.string()).optional(),
   accessibility: z
     .object({

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -85,6 +85,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "scratchpadCustomPrompt",
     "codeBlockCollapseThreshold",
     "blockquoteCollapseThreshold",
+    "voiceTranscriptionModel",
   ] as const
 
   for (const key of simpleKeys) {

--- a/apps/backend/src/features/voice-transcription/config.ts
+++ b/apps/backend/src/features/voice-transcription/config.ts
@@ -5,7 +5,9 @@
 
 import { parseModelId } from "../../lib/ai/ai"
 
-export const VOICE_DEFAULT_MODEL = "elevenlabs:scribe-v2-realtime"
+// TEMPORARY: flipped to Deepgram for a mobile staging A/B. Revert to
+// `elevenlabs:scribe-v2-realtime` once we're happy.
+export const VOICE_DEFAULT_MODEL = "deepgram:nova-3"
 
 /** Status values for voice_sessions.status (validated in code, no DB enum — INV-3). */
 export const VOICE_SESSION_STATUSES = ["active", "finished", "aborted", "expired"] as const

--- a/apps/backend/src/features/voice-transcription/config.ts
+++ b/apps/backend/src/features/voice-transcription/config.ts
@@ -5,9 +5,7 @@
 
 import { parseModelId } from "../../lib/ai/ai"
 
-// TEMPORARY: flipped to Deepgram for a mobile staging A/B. Revert to
-// `elevenlabs:scribe-v2-realtime` once we're happy.
-export const VOICE_DEFAULT_MODEL = "deepgram:nova-3"
+export const VOICE_DEFAULT_MODEL = "elevenlabs:scribe-v2-realtime"
 
 /** Status values for voice_sessions.status (validated in code, no DB enum — INV-3). */
 export const VOICE_SESSION_STATUSES = ["active", "finished", "aborted", "expired"] as const

--- a/apps/backend/src/features/voice-transcription/service.test.ts
+++ b/apps/backend/src/features/voice-transcription/service.test.ts
@@ -2,11 +2,26 @@ import { describe, expect, test, spyOn, afterEach } from "bun:test"
 import type { Pool } from "pg"
 import { HttpError } from "../../lib/errors"
 import { UserRepository } from "../workspaces"
+import { UserPreferencesService } from "../user-preferences"
 import { VoiceTranscriptionService } from "./service"
 import { VoiceSessionRepository, type VoiceSessionRow } from "./repository"
 import { voiceConfig } from "./config"
+import { DEFAULT_USER_PREFERENCES, type UserPreferences } from "@threa/types"
 
 const pool = {} as Pool
+
+const userPreferencesService = new UserPreferencesService(pool)
+
+function makePrefs(overrides: Partial<UserPreferences> = {}): UserPreferences {
+  return {
+    workspaceId: "ws_1",
+    userId: "user_1",
+    ...DEFAULT_USER_PREFERENCES,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
 
 function makeRow(overrides: Partial<VoiceSessionRow> = {}): VoiceSessionRow {
   return {
@@ -34,12 +49,14 @@ afterEach(() => {
   ;(VoiceSessionRepository.finalizeOwned as ReturnType<typeof spyOn>)?.mockRestore?.()
   ;(VoiceSessionRepository.expireStale as ReturnType<typeof spyOn>)?.mockRestore?.()
   ;(UserRepository.findByWorkosUserIdInWorkspace as ReturnType<typeof spyOn>)?.mockRestore?.()
+  ;(userPreferencesService.getPreferences as ReturnType<typeof spyOn>)?.mockRestore?.()
 })
 
 describe("VoiceTranscriptionService.createSession", () => {
-  test("defaults the model, derives provider and region, sets a future expiry", async () => {
+  test("falls back to the configured default when neither the caller nor the user pref names a model", async () => {
     const insert = spyOn(VoiceSessionRepository, "insert").mockResolvedValue(makeRow())
-    const service = new VoiceTranscriptionService(pool)
+    spyOn(userPreferencesService, "getPreferences").mockResolvedValue(makePrefs())
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
 
     const before = Date.now()
     await service.createSession({ workspaceId: "ws_1", userId: "user_1" })
@@ -53,9 +70,24 @@ describe("VoiceTranscriptionService.createSession", () => {
     expect(arg.expiresAt.getTime()).toBeGreaterThanOrEqual(before + voiceConfig.maxSessionMs)
   })
 
-  test("parses the provider from an explicit model id", async () => {
+  test("uses the user's voiceTranscriptionModel preference when the caller does not pass one", async () => {
+    const insert = spyOn(VoiceSessionRepository, "insert").mockResolvedValue(makeRow({ model: "deepgram:nova-3" }))
+    spyOn(userPreferencesService, "getPreferences").mockResolvedValue(
+      makePrefs({ voiceTranscriptionModel: "deepgram:nova-3" })
+    )
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
+
+    await service.createSession({ workspaceId: "ws_1", userId: "user_1" })
+
+    const arg = insert.mock.calls[0][1]
+    expect(arg.model).toBe("deepgram:nova-3")
+    expect(arg.provider).toBe("deepgram")
+  })
+
+  test("an explicit model wins over the user preference and skips the prefs lookup", async () => {
     const insert = spyOn(VoiceSessionRepository, "insert").mockResolvedValue(makeRow())
-    const service = new VoiceTranscriptionService(pool)
+    const getPrefs = spyOn(userPreferencesService, "getPreferences")
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
 
     await service.createSession({ workspaceId: "ws_1", userId: "user_1", model: "deepgram:nova-3", language: "en" })
 
@@ -63,11 +95,12 @@ describe("VoiceTranscriptionService.createSession", () => {
     expect(arg.model).toBe("deepgram:nova-3")
     expect(arg.provider).toBe("deepgram")
     expect(arg.language).toBe("en")
+    expect(getPrefs).not.toHaveBeenCalled()
   })
 
   test("rejects a model without a provider prefix", async () => {
     spyOn(VoiceSessionRepository, "insert").mockResolvedValue(makeRow())
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
 
     const promise = service.createSession({ workspaceId: "ws_1", userId: "user_1", model: "no-colon" })
     await expect(promise).rejects.toMatchObject({ status: 400, code: "INVALID_VOICE_MODEL" })
@@ -86,7 +119,7 @@ describe("VoiceTranscriptionService.getRelaySession", () => {
     mockUser()
     const row = makeRow()
     const findOwned = spyOn(VoiceSessionRepository, "findOwned").mockResolvedValue(row)
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     expect(await service.getRelaySession(params)).toBe(row)
     // The session lookup is scoped to the resolved workspace user id, not the
     // raw WorkOS id from the socket.
@@ -96,7 +129,7 @@ describe("VoiceTranscriptionService.getRelaySession", () => {
   test("throws 403 when the WorkOS user is not a member of the workspace", async () => {
     spyOn(UserRepository, "findByWorkosUserIdInWorkspace").mockResolvedValue(null)
     const findOwned = spyOn(VoiceSessionRepository, "findOwned")
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.getRelaySession(params)).rejects.toMatchObject({
       status: 403,
       code: "VOICE_NOT_AUTHORIZED",
@@ -107,7 +140,7 @@ describe("VoiceTranscriptionService.getRelaySession", () => {
   test("throws 404 when not found", async () => {
     mockUser()
     spyOn(VoiceSessionRepository, "findOwned").mockResolvedValue(null)
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.getRelaySession(params)).rejects.toMatchObject({
       status: 404,
       code: "VOICE_SESSION_NOT_FOUND",
@@ -117,7 +150,7 @@ describe("VoiceTranscriptionService.getRelaySession", () => {
   test("throws 409 when not active", async () => {
     mockUser()
     spyOn(VoiceSessionRepository, "findOwned").mockResolvedValue(makeRow({ status: "finished" }))
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.getRelaySession(params)).rejects.toMatchObject({
       status: 409,
       code: "VOICE_SESSION_NOT_ACTIVE",
@@ -127,7 +160,7 @@ describe("VoiceTranscriptionService.getRelaySession", () => {
   test("throws 409 when expired", async () => {
     mockUser()
     spyOn(VoiceSessionRepository, "findOwned").mockResolvedValue(makeRow({ expiresAt: new Date(Date.now() - 1) }))
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.getRelaySession(params)).rejects.toMatchObject({
       status: 409,
       code: "VOICE_SESSION_EXPIRED",
@@ -140,21 +173,21 @@ describe("VoiceTranscriptionService finalize paths", () => {
 
   test("finishSession transitions with status finished", async () => {
     const finalize = spyOn(VoiceSessionRepository, "finalizeOwned").mockResolvedValue("ok")
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await service.finishSession(params)
     expect(finalize.mock.calls[0][1]).toMatchObject({ status: "finished", totalAudioMs: 1234, id: "voicesess_1" })
   })
 
   test("abortSession defaults totalAudioMs to 0 and uses status aborted", async () => {
     const finalize = spyOn(VoiceSessionRepository, "finalizeOwned").mockResolvedValue("ok")
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await service.abortSession({ workspaceId: "ws_1", userId: "user_1", sessionId: "voicesess_1" })
     expect(finalize.mock.calls[0][1]).toMatchObject({ status: "aborted", totalAudioMs: 0 })
   })
 
   test("throws 404 when the session does not exist", async () => {
     spyOn(VoiceSessionRepository, "finalizeOwned").mockResolvedValue("not_found")
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.finishSession(params)).rejects.toMatchObject({
       status: 404,
       code: "VOICE_SESSION_NOT_FOUND",
@@ -163,7 +196,7 @@ describe("VoiceTranscriptionService finalize paths", () => {
 
   test("treats already_final as an idempotent no-op", async () => {
     spyOn(VoiceSessionRepository, "finalizeOwned").mockResolvedValue("already_final")
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
     await expect(service.finishSession(params)).resolves.toBeUndefined()
   })
 })
@@ -171,7 +204,7 @@ describe("VoiceTranscriptionService finalize paths", () => {
 describe("VoiceTranscriptionService.expireStaleSessions", () => {
   test("sweeps with the current time and returns the swept count", async () => {
     const expireStale = spyOn(VoiceSessionRepository, "expireStale").mockResolvedValue(3)
-    const service = new VoiceTranscriptionService(pool)
+    const service = new VoiceTranscriptionService(pool, userPreferencesService)
 
     const before = Date.now()
     expect(await service.expireStaleSessions()).toBe(3)

--- a/apps/backend/src/features/voice-transcription/service.test.ts
+++ b/apps/backend/src/features/voice-transcription/service.test.ts
@@ -64,7 +64,7 @@ describe("VoiceTranscriptionService.createSession", () => {
     expect(insert).toHaveBeenCalledTimes(1)
     const arg = insert.mock.calls[0][1]
     expect(arg.model).toBe(voiceConfig.defaultModel)
-    expect(arg.provider).toBe("elevenlabs")
+    expect(arg.provider).toBe(voiceConfig.defaultModel.split(":")[0])
     expect(arg.region).toBe("us")
     expect(arg.language).toBeNull()
     expect(arg.expiresAt.getTime()).toBeGreaterThanOrEqual(before + voiceConfig.maxSessionMs)

--- a/apps/backend/src/features/voice-transcription/service.ts
+++ b/apps/backend/src/features/voice-transcription/service.ts
@@ -2,20 +2,25 @@ import type { Pool } from "pg"
 import { HttpError } from "../../lib/errors"
 import { voiceSessionId } from "../../lib/id"
 import { UserRepository } from "../workspaces"
+import { UserPreferencesService } from "../user-preferences"
 import { VoiceSessionRepository, type VoiceSessionRow } from "./repository"
 import { voiceConfig, parseModelProvider, type VoiceSessionStatus } from "./config"
 
 export class VoiceTranscriptionService {
-  private pool: Pool
-
-  constructor(pool: Pool) {
-    this.pool = pool
-  }
+  constructor(
+    private pool: Pool,
+    private userPreferencesService: UserPreferencesService
+  ) {}
 
   /**
    * Create an active dictation session. Provider is derived from the model
    * prefix; region is fixed to `us` for the PR1 skeleton — the residency
    * resolver that may route elsewhere (e.g. Deepgram-EU) lands in PR5.
+   *
+   * Model resolution order: explicit `params.model` (one-off override from the
+   * client) → the user's `voiceTranscriptionModel` preference → the configured
+   * default. This is what lets a user opt into Deepgram without UI: set the
+   * preference once and every session inherits it.
    */
   async createSession(params: {
     workspaceId: string
@@ -23,7 +28,11 @@ export class VoiceTranscriptionService {
     model?: string
     language?: string
   }): Promise<VoiceSessionRow> {
-    const model = params.model ?? voiceConfig.defaultModel
+    let model = params.model
+    if (!model) {
+      const prefs = await this.userPreferencesService.getPreferences(params.workspaceId, params.userId)
+      model = prefs.voiceTranscriptionModel ?? voiceConfig.defaultModel
+    }
     const provider = parseModelProvider(model)
     if (!provider) {
       throw new HttpError(`Invalid voice model: ${model}`, { status: 400, code: "INVALID_VOICE_MODEL" })

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { RealtimeDeepgramStrategy } from "./realtime-deepgram"
+import type { TranscriptionDelta, TranscriptionError } from "./strategy"
+
+type Listener = (event: unknown) => void
+
+let lastSocket: FakeWebSocket | null = null
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readyState = FakeWebSocket.CONNECTING
+  readonly sent: Array<string | Buffer> = []
+  readonly url: string
+  readonly options: unknown
+  private readonly listeners = new Map<string, Listener[]>()
+
+  constructor(url: string, options?: unknown) {
+    this.url = url
+    this.options = options
+    lastSocket = this
+  }
+
+  addEventListener(type: string, cb: Listener): void {
+    const list = this.listeners.get(type) ?? []
+    list.push(cb)
+    this.listeners.set(type, list)
+  }
+
+  send(data: string | Buffer): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED
+  }
+
+  dispatch(type: string, event: unknown): void {
+    for (const cb of this.listeners.get(type) ?? []) cb(event)
+  }
+
+  simulateOpen(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.dispatch("open", {})
+  }
+}
+
+const realWebSocket = globalThis.WebSocket
+
+beforeEach(() => {
+  lastSocket = null
+  ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
+})
+
+afterEach(() => {
+  ;(globalThis as { WebSocket: unknown }).WebSocket = realWebSocket
+})
+
+async function openSession() {
+  const strategy = new RealtimeDeepgramStrategy({ apiKey: "secret-key" })
+  const openPromise = strategy.open({ model: "deepgram:nova-3" })
+  await Promise.resolve()
+  lastSocket!.simulateOpen()
+  return { session: await openPromise, socket: lastSocket! }
+}
+
+describe("RealtimeDeepgramStrategy connect", () => {
+  test("connects with the model and PCM16 params and a Token Authorization header", async () => {
+    const { socket } = await openSession()
+    expect(socket.url).toContain("model=nova-3")
+    expect(socket.url).toContain("encoding=linear16")
+    expect(socket.url).toContain("sample_rate=16000")
+    expect(socket.url).toContain("channels=1")
+    expect(socket.url).toContain("interim_results=true")
+    expect(socket.options).toMatchObject({ headers: { Authorization: "Token secret-key" } })
+  })
+
+  test("requests endpointing so utterances finalize on silence, not only on stop", async () => {
+    const { socket } = await openSession()
+    expect(socket.url).toContain("endpointing=300")
+  })
+
+  test("passes language when one is provided", async () => {
+    const strategy = new RealtimeDeepgramStrategy({ apiKey: "k" })
+    const p = strategy.open({ model: "deepgram:nova-3", language: "sv" })
+    await Promise.resolve()
+    lastSocket!.simulateOpen()
+    await p
+    expect(lastSocket!.url).toContain("language=sv")
+  })
+
+  test("rejects if the socket closes before opening", async () => {
+    const strategy = new RealtimeDeepgramStrategy({ apiKey: "k" })
+    const p = strategy.open({ model: "deepgram:nova-3" })
+    await Promise.resolve()
+    lastSocket!.dispatch("close", { code: 1006 })
+    await expect(p).rejects.toThrow(/closed before open/)
+  })
+})
+
+describe("RealtimeDeepgramStrategy audio + transcripts", () => {
+  test("pushAudio sends raw binary PCM and accumulates audio ms", async () => {
+    const { session, socket } = await openSession()
+    // 32000 bytes of PCM16 mono @ 16kHz == 1000ms of audio.
+    const frame = Buffer.alloc(32_000)
+    session.pushAudio(frame)
+    expect(socket.sent[0]).toBe(frame)
+
+    const result = await session.close()
+    expect(result.totalAudioMs).toBe(1000)
+  })
+
+  test("flush sends a CloseStream control message", async () => {
+    const { session, socket } = await openSession()
+    await session.flush()
+    const msg = JSON.parse(socket.sent.at(-1) as string)
+    expect(msg).toEqual({ type: "CloseStream" })
+  })
+
+  test("Results with is_final=false emits an interim delta, is_final=true a final one", async () => {
+    const { session, socket } = await openSession()
+    const deltas: TranscriptionDelta[] = []
+    session.onDelta((d) => deltas.push(d))
+
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: false,
+        channel: { alternatives: [{ transcript: "hel" }] },
+      }),
+    })
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: true,
+        channel: { alternatives: [{ transcript: "hello" }] },
+      }),
+    })
+
+    expect(deltas).toEqual([
+      { text: "hel", isFinal: false },
+      { text: "hello", isFinal: true },
+    ])
+  })
+
+  test("Results with empty transcript are ignored (keepalive frames)", async () => {
+    const { session, socket } = await openSession()
+    const deltas: TranscriptionDelta[] = []
+    session.onDelta((d) => deltas.push(d))
+
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: false,
+        channel: { alternatives: [{ transcript: "" }] },
+      }),
+    })
+
+    expect(deltas).toEqual([])
+  })
+
+  test("Error is surfaced via onError", async () => {
+    const { session, socket } = await openSession()
+    const errors: TranscriptionError[] = []
+    session.onError((e) => errors.push(e))
+
+    socket.dispatch("message", { data: JSON.stringify({ type: "Error", error: "bad audio" }) })
+
+    expect(errors).toEqual([{ code: "INPUT_ERROR", message: "bad audio" }])
+  })
+
+  test("close tears down the socket", async () => {
+    const { session, socket } = await openSession()
+    await session.close()
+    expect(socket.readyState).toBe(FakeWebSocket.CLOSED)
+  })
+
+  test("an unsolicited close after open surfaces an UPSTREAM_CLOSED error", async () => {
+    const { session, socket } = await openSession()
+    const errors: TranscriptionError[] = []
+    session.onError((e) => errors.push(e))
+
+    socket.dispatch("close", { code: 1006 })
+
+    expect(errors).toEqual([{ code: "UPSTREAM_CLOSED", message: "Deepgram realtime closed (code 1006)" }])
+  })
+
+  test("a close we initiated via close() does not surface an error", async () => {
+    const { session, socket } = await openSession()
+    const errors: TranscriptionError[] = []
+    session.onError((e) => errors.push(e))
+
+    await session.close()
+    socket.dispatch("close", { code: 1000 })
+
+    expect(errors).toEqual([])
+  })
+})

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
@@ -113,11 +113,59 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
     expect(result.totalAudioMs).toBe(1000)
   })
 
-  test("flush sends a CloseStream control message", async () => {
+  test("flush sends CloseStream and resolves when the final Results frame arrives", async () => {
     const { session, socket } = await openSession()
-    await session.flush()
+    const deltas: TranscriptionDelta[] = []
+    session.onDelta((d) => deltas.push(d))
+
+    const flushed = session.flush()
+    // CloseStream has been sent, but flush is still awaiting the final frame.
     const msg = JSON.parse(socket.sent.at(-1) as string)
     expect(msg).toEqual({ type: "CloseStream" })
+
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: true,
+        channel: { alternatives: [{ transcript: "last word" }] },
+      }),
+    })
+
+    await flushed
+    expect(deltas).toEqual([{ text: "last word", isFinal: true }])
+  })
+
+  test("flush resolves on its safety timeout when no final frame ever lands", async () => {
+    const { session } = await openSession()
+    // The 1500ms guard timer is real; advance it explicitly so the test stays fast.
+    // Using fake timers would cross-pollute the test file, so settle for a real
+    // wait scoped to one short case.
+    const flushed = session.flush()
+    const start = Date.now()
+    await flushed
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeGreaterThanOrEqual(1400)
+  }, 5000)
+
+  test("a server-initiated close after a successful flush does NOT surface an error", async () => {
+    const { session, socket } = await openSession()
+    const errors: TranscriptionError[] = []
+    session.onError((e) => errors.push(e))
+
+    const flushed = session.flush()
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: true,
+        channel: { alternatives: [{ transcript: "ok" }] },
+      }),
+    })
+    await flushed
+    // Deepgram closes the socket itself right after the final frame. That
+    // socket teardown must not look like an unsolicited upstream drop.
+    socket.dispatch("close", { code: 1000 })
+
+    expect(errors).toEqual([])
   })
 
   test("Results with is_final=false emits an interim delta, is_final=true a final one", async () => {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
@@ -83,6 +83,11 @@ describe("RealtimeDeepgramStrategy connect", () => {
     expect(socket.url).toContain("endpointing=300")
   })
 
+  test("defaults to multilingual auto-detect when no language is provided", async () => {
+    const { socket } = await openSession()
+    expect(socket.url).toContain("language=multi")
+  })
+
   test("passes language when one is provided", async () => {
     const strategy = new RealtimeDeepgramStrategy({ apiKey: "k" })
     const p = strategy.open({ model: "deepgram:nova-3", language: "sv" })
@@ -90,6 +95,8 @@ describe("RealtimeDeepgramStrategy connect", () => {
     lastSocket!.simulateOpen()
     await p
     expect(lastSocket!.url).toContain("language=sv")
+    // The explicit language wins over the multilingual default.
+    expect(lastSocket!.url).not.toContain("language=multi")
   })
 
   test("rejects if the socket closes before opening", async () => {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
@@ -88,7 +88,14 @@ class DeepgramSession implements TranscriptionSession {
       // same role VAD plays for ElevenLabs.
       endpointing: "300",
     })
-    if (this.opts.language) params.set("language", this.opts.language)
+    if (this.opts.language) {
+      params.set("language", this.opts.language)
+    } else {
+      // Nova-3 defaults to English-only when `language` is omitted, so Swedish
+      // (or any non-English) dictation comes back as garbled English. Enable
+      // multilingual auto-detect across Nova-3's supported set instead.
+      params.set("language", "multi")
+    }
     const url = `${REALTIME_URL}?${params.toString()}`
 
     // Bun's WebSocket accepts a non-standard options arg for request headers.

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
@@ -52,6 +52,14 @@ export class RealtimeDeepgramStrategy implements TranscriptionStrategy {
   }
 }
 
+/**
+ * Upper bound on how long {@link DeepgramSession.flush} will wait for the
+ * post-CloseStream final transcript before giving up. Deepgram is normally
+ * sub-second; the cap is just a safety net so the gateway doesn't hang on a
+ * dead upstream.
+ */
+const FLUSH_FINAL_WAIT_MS = 1500
+
 class DeepgramSession implements TranscriptionSession {
   private readonly deltaCallbacks: Array<(delta: TranscriptionDelta) => void> = []
   private readonly errorCallbacks: Array<(e: TranscriptionError) => void> = []
@@ -60,6 +68,8 @@ class DeepgramSession implements TranscriptionSession {
   private chunksSent = 0
   private openedAt = 0
   private closed = false
+  /** Resolves when the post-flush final transcript lands (or the timeout fires). */
+  private pendingFlush: (() => void) | null = null
 
   constructor(
     private readonly apiKey: string,
@@ -151,8 +161,10 @@ class DeepgramSession implements TranscriptionSession {
     switch (data.type) {
       case "Results": {
         const text = data.channel?.alternatives?.[0]?.transcript ?? ""
+        const isFinal = data.is_final === true
+        if (isFinal) this.resolvePendingFlush()
         if (!text) return
-        this.emitDelta({ text, isFinal: data.is_final === true })
+        this.emitDelta({ text, isFinal })
         return
       }
       case "Metadata":
@@ -177,9 +189,34 @@ class DeepgramSession implements TranscriptionSession {
 
   async flush(): Promise<void> {
     if (this.closed || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
-    // Tells Deepgram to finalize any buffered audio and emit a final transcript
-    // segment without tearing down the socket.
+    // Deepgram's CloseStream is request-response: it asks the server to commit
+    // any buffered audio and reply with one last `is_final=true` Results frame.
+    // The gateway immediately calls close() after flush(), so if we returned
+    // here right away the socket teardown would race the final frame and the
+    // user's last utterance would silently disappear. Wait for the final
+    // Results (resolved from handleMessage) or the safety timeout.
     this.ws.send(JSON.stringify({ type: "CloseStream" }))
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingFlush = null
+        resolve()
+      }, FLUSH_FINAL_WAIT_MS)
+      this.pendingFlush = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+  }
+
+  private resolvePendingFlush(): void {
+    if (!this.pendingFlush) return
+    const cb = this.pendingFlush
+    this.pendingFlush = null
+    // The server initiates a clean socket close right after the final Results
+    // frame. Mark closed so the upcoming close event isn't surfaced as a
+    // spurious UPSTREAM_CLOSED to the user.
+    this.closed = true
+    cb()
   }
 
   onDelta(cb: (delta: TranscriptionDelta) => void): void {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
@@ -1,0 +1,209 @@
+import { logger } from "../../../lib/logger"
+import { voiceConfig } from "../config"
+import type {
+  TranscriptionStrategy,
+  TranscriptionSession,
+  TranscriptionOpenOptions,
+  TranscriptionDelta,
+  TranscriptionError,
+  TranscriptionResult,
+} from "./strategy"
+
+export interface DeepgramStrategyConfig {
+  apiKey: string
+}
+
+const REALTIME_URL = "wss://api.deepgram.com/v1/listen"
+const SAMPLE_RATE_HZ = voiceConfig.sampleRateHz
+/** PCM16 mono: 2 bytes/sample, so ms = bytes / (2 * 16000 / 1000) = bytes / 32. */
+const BYTES_PER_MS = (SAMPLE_RATE_HZ * 2) / 1000
+
+/**
+ * Map our registry model id (`deepgram:nova-3`) to Deepgram's `model` query
+ * param (`nova-3`). Only the suffix is provider-facing.
+ */
+function toUpstreamModelId(model: string): string {
+  const colon = model.indexOf(":")
+  return colon === -1 ? model : model.slice(colon + 1)
+}
+
+/**
+ * Deepgram Nova-3 realtime strategy — opens an STT WebSocket, streams binary
+ * PCM16 (16kHz mono) frames up, and surfaces transcript deltas.
+ *
+ * Wire protocol: connect with `Authorization: Token <key>` and `encoding`,
+ * `sample_rate`, `channels`, `model`, `interim_results`, `endpointing` as
+ * query params. Audio frames are sent as raw binary (not JSON). Transcript
+ * messages come back as JSON with `type: "Results"`, with `is_final` marking
+ * the commit point for a segment.
+ */
+export class RealtimeDeepgramStrategy implements TranscriptionStrategy {
+  readonly provider = "deepgram"
+  private readonly apiKey: string
+
+  constructor(config: DeepgramStrategyConfig) {
+    this.apiKey = config.apiKey
+  }
+
+  async open(opts: TranscriptionOpenOptions): Promise<TranscriptionSession> {
+    const session = new DeepgramSession(this.apiKey, opts)
+    await session.connect()
+    return session
+  }
+}
+
+class DeepgramSession implements TranscriptionSession {
+  private readonly deltaCallbacks: Array<(delta: TranscriptionDelta) => void> = []
+  private readonly errorCallbacks: Array<(e: TranscriptionError) => void> = []
+  private ws: WebSocket | null = null
+  private totalAudioMs = 0
+  private chunksSent = 0
+  private openedAt = 0
+  private closed = false
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly opts: TranscriptionOpenOptions
+  ) {}
+
+  connect(): Promise<void> {
+    const params = new URLSearchParams({
+      encoding: "linear16",
+      sample_rate: String(SAMPLE_RATE_HZ),
+      channels: "1",
+      model: toUpstreamModelId(this.opts.model),
+      interim_results: "true",
+      // Endpointing (ms of silence to mark utterance end) is what makes Deepgram
+      // emit speech_final/is_final segments without us sending CloseStream — the
+      // same role VAD plays for ElevenLabs.
+      endpointing: "300",
+    })
+    if (this.opts.language) params.set("language", this.opts.language)
+    const url = `${REALTIME_URL}?${params.toString()}`
+
+    // Bun's WebSocket accepts a non-standard options arg for request headers.
+    const ws = new WebSocket(url, { headers: { Authorization: `Token ${this.apiKey}` } } as never)
+    this.ws = ws
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false
+
+      ws.addEventListener("open", () => {
+        if (settled) return
+        settled = true
+        this.openedAt = Date.now()
+        resolve()
+      })
+
+      ws.addEventListener("error", () => {
+        if (!settled) {
+          settled = true
+          reject(new Error("Deepgram realtime connection failed"))
+          return
+        }
+        this.emitError({ code: "UPSTREAM_ERROR", message: "Deepgram realtime socket error" })
+      })
+
+      ws.addEventListener("close", (event) => {
+        if (!settled) {
+          settled = true
+          reject(new Error(`Deepgram realtime closed before open (code ${event.code})`))
+          return
+        }
+        logger.info(
+          {
+            provider: "deepgram",
+            code: event.code,
+            reason: event.reason || null,
+            wasClean: event.wasClean,
+            initiatedByUs: this.closed,
+            chunksSent: this.chunksSent,
+            totalAudioMs: Math.round(this.totalAudioMs),
+            connectedMs: this.openedAt ? Date.now() - this.openedAt : null,
+          },
+          "Deepgram realtime socket closed"
+        )
+        if (!this.closed) {
+          this.emitError({ code: "UPSTREAM_CLOSED", message: `Deepgram realtime closed (code ${event.code})` })
+        }
+      })
+
+      ws.addEventListener("message", (event) => this.handleMessage(event.data))
+    })
+  }
+
+  private handleMessage(raw: unknown): void {
+    if (typeof raw !== "string") return
+    let data: {
+      type?: string
+      is_final?: boolean
+      channel?: { alternatives?: Array<{ transcript?: string }> }
+      error?: string
+      message?: string
+    }
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      logger.warn({ provider: "deepgram" }, "Failed to parse realtime transcript message")
+      return
+    }
+
+    switch (data.type) {
+      case "Results": {
+        const text = data.channel?.alternatives?.[0]?.transcript ?? ""
+        if (!text) return
+        this.emitDelta({ text, isFinal: data.is_final === true })
+        return
+      }
+      case "Metadata":
+      case "SpeechStarted":
+      case "UtteranceEnd":
+        return
+      case "Error":
+        this.emitError({ code: "INPUT_ERROR", message: data.error ?? data.message ?? "Upstream input error" })
+        return
+      default:
+        return
+    }
+  }
+
+  pushAudio(frame: Buffer): void {
+    if (this.closed || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    this.totalAudioMs += frame.length / BYTES_PER_MS
+    this.chunksSent++
+    // Deepgram takes raw PCM bytes, not a JSON envelope.
+    this.ws.send(frame)
+  }
+
+  async flush(): Promise<void> {
+    if (this.closed || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    // Tells Deepgram to finalize any buffered audio and emit a final transcript
+    // segment without tearing down the socket.
+    this.ws.send(JSON.stringify({ type: "CloseStream" }))
+  }
+
+  onDelta(cb: (delta: TranscriptionDelta) => void): void {
+    this.deltaCallbacks.push(cb)
+  }
+
+  onError(cb: (e: TranscriptionError) => void): void {
+    this.errorCallbacks.push(cb)
+  }
+
+  private emitDelta(delta: TranscriptionDelta): void {
+    for (const cb of this.deltaCallbacks) cb(delta)
+  }
+
+  private emitError(e: TranscriptionError): void {
+    for (const cb of this.errorCallbacks) cb(e)
+  }
+
+  async close(): Promise<TranscriptionResult> {
+    this.closed = true
+    if (this.ws && this.ws.readyState <= WebSocket.OPEN) {
+      this.ws.close()
+    }
+    this.ws = null
+    return { totalAudioMs: Math.round(this.totalAudioMs) }
+  }
+}

--- a/apps/backend/src/features/voice-transcription/transcription/strategy.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/strategy.test.ts
@@ -35,4 +35,11 @@ describe("createTranscription", () => {
       /No transcription strategy/
     )
   })
+
+  test("rejects deepgram when no key is configured (provider disabled)", async () => {
+    const transcription = createTranscription({
+      modelRegistry: fakeRegistry(new Set(["deepgram:nova-3"])),
+    })
+    await expect(transcription.open({ model: "deepgram:nova-3" })).rejects.toThrow(/No transcription strategy/)
+  })
 })

--- a/apps/backend/src/features/voice-transcription/transcription/strategy.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/strategy.ts
@@ -1,6 +1,7 @@
 import type { ModelRegistry } from "../../../lib/ai/model-registry"
 import { logger } from "../../../lib/logger"
 import { parseModelProvider } from "../config"
+import { RealtimeDeepgramStrategy } from "./realtime-deepgram"
 import { RealtimeElevenLabsStrategy } from "./realtime-elevenlabs"
 
 /**
@@ -61,6 +62,8 @@ export interface TranscriptionStrategy {
 export interface TranscriptionFactoryConfig {
   /** Present when ELEVENLABS_API_KEY is configured; absent disables the provider. */
   elevenlabs?: { apiKey: string }
+  /** Present when DEEPGRAM_API_KEY is configured; absent disables the provider. */
+  deepgram?: { apiKey: string }
   modelRegistry: ModelRegistry
 }
 
@@ -80,6 +83,9 @@ export function createTranscription(config: TranscriptionFactoryConfig): Transcr
   const strategies = new Map<string, TranscriptionStrategy>()
   if (config.elevenlabs) {
     strategies.set("elevenlabs", new RealtimeElevenLabsStrategy({ apiKey: config.elevenlabs.apiKey }))
+  }
+  if (config.deepgram) {
+    strategies.set("deepgram", new RealtimeDeepgramStrategy({ apiKey: config.deepgram.apiKey }))
   }
 
   return {

--- a/apps/backend/src/lib/ai/models.yaml
+++ b/apps/backend/src/lib/ai/models.yaml
@@ -84,3 +84,10 @@ models:
     outputModalities: [text]
     streaming: realtime
     audioPricePerHour: 0.39
+
+  deepgram:nova-3:
+    name: Deepgram Nova-3
+    inputModalities: [audio]
+    outputModalities: [text]
+    streaming: realtime
+    audioPricePerHour: 0.46

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -9,6 +9,8 @@ export interface AIConfig {
   tavilyApiKey: string
   /** ElevenLabs API key for realtime speech-to-text (voice dictation). Empty string disables voice. */
   elevenLabsApiKey: string
+  /** Deepgram API key for realtime speech-to-text. Empty string disables Deepgram as a voice provider. */
+  deepgramApiKey: string
   /** Model for stream auto-naming, in provider:model format (e.g., "openrouter:anthropic/claude-haiku-4.5") */
   namingModel: string
   /** Model for conversational boundary extraction, in provider:model format */
@@ -154,6 +156,7 @@ export function loadConfig(): Config {
       openRouterApiKey: process.env.OPENROUTER_API_KEY || "",
       tavilyApiKey: process.env.TAVILY_API_KEY || "",
       elevenLabsApiKey: process.env.ELEVENLABS_API_KEY || "",
+      deepgramApiKey: process.env.DEEPGRAM_API_KEY || "",
       namingModel: process.env.AI_NAMING_MODEL || "openrouter:openai/gpt-5-mini",
       extractionModel: process.env.AI_EXTRACTION_MODEL || "openrouter:openai/gpt-5-mini",
     },

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -474,12 +474,13 @@ export async function startServer(): Promise<ServerInstance> {
   const userApiKeyService = new UserApiKeyServiceImpl(pool)
 
   // Voice dictation — session lifecycle service + the realtime STT factory.
-  // The factory only registers the ElevenLabs strategy when a key is present
-  // (empty string disables voice); fail loudly later if a session is opened
-  // without a configured provider (INV-11).
-  const voiceTranscriptionService = new VoiceTranscriptionService(pool)
+  // The factory only registers a provider strategy when its key is present
+  // (empty string disables that provider); fail loudly later if a session is
+  // opened with a model whose provider isn't configured (INV-11).
+  const voiceTranscriptionService = new VoiceTranscriptionService(pool, userPreferencesService)
   const transcription = createTranscription({
     elevenlabs: config.ai.elevenLabsApiKey ? { apiKey: config.ai.elevenLabsApiKey } : undefined,
+    deepgram: config.ai.deepgramApiKey ? { apiKey: config.ai.deepgramApiKey } : undefined,
     modelRegistry,
   })
 

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -71,6 +71,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,
+      voiceTranscriptionModel: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -79,6 +79,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,
+      voiceTranscriptionModel: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -213,6 +213,49 @@ All models use `provider:modelPath` format:
 
 ---
 
+## Speech-to-Text Models
+
+Realtime WebSocket speech-to-text providers used by voice dictation. The
+`TranscriptionStrategy` interface (in `apps/backend/src/features/voice-transcription/transcription/strategy.ts`)
+abstracts the per-provider wire protocol. A provider is only registered if its
+API key env var is set; with no key, sessions for that provider fail loudly at
+relay open time (INV-11).
+
+Users pick which provider to use via the `voiceTranscriptionModel` preference;
+omitted → server-configured default (`voiceConfig.defaultModel`).
+
+### elevenlabs:scribe-v2-realtime
+
+**Name:** ElevenLabs Scribe v2 Realtime
+
+**Description:** Multilingual realtime STT. Audio is sent as base64-wrapped JSON chunks; auto-commits on VAD silence.
+
+**Typical cost:** ~$0.39/hour of audio
+
+**Env var:** `ELEVENLABS_API_KEY`
+
+**When to use:**
+
+- Default voice dictation provider
+- Multilingual workspaces (auto-detects language by default)
+
+### deepgram:nova-3
+
+**Name:** Deepgram Nova-3
+
+**Description:** Realtime STT. Audio is sent as raw binary PCM16; auto-finalizes utterances on 300ms silence (`endpointing=300`).
+
+**Typical cost:** ~$0.46/hour of audio
+
+**Env var:** `DEEPGRAM_API_KEY`
+
+**When to use:**
+
+- Alternative when ElevenLabs is unavailable or a workspace prefers Deepgram for accuracy/latency on specific languages
+- Opt in per user via `voiceTranscriptionModel: "deepgram:nova-3"` preference
+
+---
+
 ## Deprecated Models (Do Not Use)
 
 **Claude 3 Series:**

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -169,6 +169,12 @@ export interface UserPreferences {
   scratchpadCustomPrompt: string | null
   codeBlockCollapseThreshold: number
   blockquoteCollapseThreshold: number
+  /**
+   * Preferred voice dictation model id (e.g. "elevenlabs:scribe-v2-realtime",
+   * "deepgram:nova-3"). When null, the backend falls back to the configured
+   * default. The string is validated server-side against the model registry.
+   */
+  voiceTranscriptionModel: string | null
   keyboardShortcuts: KeyboardShortcuts
   accessibility: AccessibilityPreferences
   createdAt: string
@@ -192,6 +198,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   scratchpadCustomPrompt: null,
   codeBlockCollapseThreshold: DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
+  voiceTranscriptionModel: null,
   keyboardShortcuts: {},
   accessibility: DEFAULT_ACCESSIBILITY,
 }
@@ -217,6 +224,7 @@ export interface UpdateUserPreferencesInput {
   scratchpadCustomPrompt?: string | null
   codeBlockCollapseThreshold?: number
   blockquoteCollapseThreshold?: number
+  voiceTranscriptionModel?: string | null
   keyboardShortcuts?: KeyboardShortcuts
   accessibility?: Partial<AccessibilityPreferences>
 }


### PR DESCRIPTION
## Summary

Adds Deepgram Nova-3 as a second realtime STT provider alongside the existing ElevenLabs strategy, plus a per-user `voiceTranscriptionModel` preference to pick which one to use. No UI yet — backend-only A/B path. Empty `DEEPGRAM_API_KEY` simply disables the provider (INV-11).

- New `RealtimeDeepgramStrategy` (raw binary PCM, `Authorization: Token`, `endpointing=300`), registered next to ElevenLabs in `createTranscription`.
- `voiceTranscriptionModel: string | null` added to `UserPreferences` (sparse override). `createSession` resolves model as: explicit caller → user pref → `voiceConfig.defaultModel`. Explicit caller skips the prefs lookup.
- `deepgram:nova-3` registered in `models.yaml`; `DEEPGRAM_API_KEY` added to `env.ts`.
- Both providers documented in `docs/model-reference.md`.

## Self-review (3 parallel sonnet reviewers, threshold ≥80/100)

**Fixed:**

- **Bug (correctness, 82):** Deepgram's `flush()` sends `CloseStream`, which is request-response — the server commits, replies one final `is_final=true` frame, then closes the socket. Returning from `flush()` synchronously raced the gateway's immediate `close()` and dropped the user's last utterance; the server-initiated close also surfaced as a spurious `UPSTREAM_CLOSED` toast. `flush()` now awaits the final frame (or a 1500ms safety timer) and marks the session closed.
- **Plan (82):** Added a "Speech-to-Text Models" section to `docs/model-reference.md` covering both providers — the plan called for it and the doc had no STT entries.

**Deferred (with reasoning):**

- **Design (82):** ~90 LOC of session-lifecycle plumbing (connect-promise, close handler, telemetry fields, callback management, `close()`) is duplicated between `realtime-deepgram.ts` and `realtime-elevenlabs.ts`. CLAUDE.md says "three similar lines is better than a premature abstraction"; with only two providers I'm holding off on extracting a shared base. A third provider tips the scales.
- **Design (80):** `voiceTranscriptionModel` is validated against the model registry at relay-open time, not at preference-save time. A typoed pref persists silently until the next session attempt fails. Tightening this would mean threading the model registry into the user-preferences handler — invasive for a single field; deferred.

## Activating Deepgram on staging

`DEEPGRAM_API_KEY` is set on staging. Switch a user via:

```
PATCH /preferences  { "voiceTranscriptionModel": "deepgram:nova-3" }
```

Setting it back to `null` (or omitting it) falls back to the configured default.

## Test plan

- [x] `bun test apps/backend/src/features/voice-transcription/` — 57 pass (3 new tests cover the flush/final-frame race)
- [x] Typecheck across all workspaces — clean
- [ ] On staging: switch a user to `deepgram:nova-3`, dictate, confirm interim + final transcripts appear and the last utterance isn't dropped
- [ ] On staging: switch back to default, confirm ElevenLabs still works unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPtM427dDUsL1CXzdcEg7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782215218&installation_id=129946197&pr_number=609&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F609&signature=e46f9a6cae8264f8529f550d95e3318201cb33c91345f16c83eca62ae285d869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->