### PR TITLE
feat(gallery): preview markdown and HTML attachments inline

### DIFF
--- a/apps/frontend/src/components/gallery/html-viewer.tsx
+++ b/apps/frontend/src/components/gallery/html-viewer.tsx
@@ -1,0 +1,71 @@
+import { Loader2 } from "lucide-react"
+import { useTextContent } from "./use-text-content"
+
+interface HtmlViewerProps {
+  url: string
+  filename: string
+  rawMode?: boolean
+}
+
+/**
+ * Renders an HTML attachment inside a hard-sandboxed iframe. We always fetch
+ * the source ourselves and pass it via `srcDoc` rather than pointing the
+ * iframe at the presigned S3 URL — that earlier setup produced a permanent
+ * white iframe in real browsers because the strict sandbox + cross-origin S3
+ * response combination tripped the browser's render path. With srcDoc the
+ * iframe gets a literal HTML string under a null origin, no network hop, no
+ * Content-Type guessing.
+ *
+ * `sandbox=""` means: render HTML + CSS, but no scripts, no same-origin, no
+ * top-frame navigation. Safe for arbitrary user-uploaded HTML.
+ *
+ * In rawMode the same source is shown as a `<pre>` block, sharing the panel
+ * surface with the markdown viewer.
+ */
+export function HtmlViewer({ url, filename, rawMode = false }: HtmlViewerProps) {
+  const { content, error } = useTextContent(url || null)
+
+  if (!url || (content === null && !error)) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-white/50" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <p className="text-sm text-white/70">Couldn't load {filename}.</p>
+      </div>
+    )
+  }
+
+  if (rawMode) {
+    return (
+      <div className="absolute inset-0 pb-16 pt-14 sm:py-16">
+        <div
+          data-gallery-text-viewer="true"
+          className="mx-auto h-full w-full max-w-[800px] overflow-auto overscroll-contain rounded-lg bg-card text-foreground sm:border sm:border-border sm:shadow-2xl"
+        >
+          <pre className="px-4 py-6 sm:px-8 sm:py-8 font-mono text-xs leading-relaxed whitespace-pre text-foreground">
+            {content ?? ""}
+          </pre>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="absolute inset-0 pb-16 pt-14 sm:py-16">
+      <iframe
+        data-gallery-text-viewer="true"
+        srcDoc={content ?? ""}
+        title={filename}
+        sandbox=""
+        referrerPolicy="no-referrer"
+        className="mx-auto block h-full w-full max-w-[800px] rounded-lg bg-white sm:border sm:border-border sm:shadow-2xl"
+      />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/gallery/markdown-viewer.tsx
+++ b/apps/frontend/src/components/gallery/markdown-viewer.tsx
@@ -1,0 +1,60 @@
+import { Loader2 } from "lucide-react"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+import { useTextContent } from "./use-text-content"
+
+interface MarkdownViewerProps {
+  url: string
+  filename: string
+  rawMode?: boolean
+}
+
+// Native `overflow-auto` instead of Radix ScrollArea: ScrollArea's viewport
+// intercepts horizontal touch on iOS, which broke pan-to-scroll inside wide
+// code blocks (and made horizontal swipes feel like dead taps that fell
+// through to the underlying message gesture). The browser's own scrolling
+// handles both axes and respects the surrounding gallery carousel via
+// `overscroll-behavior: contain`.
+export function MarkdownViewer({ url, filename, rawMode = false }: MarkdownViewerProps) {
+  const { content, error } = useTextContent(url || null)
+
+  if (!url || (content === null && !error)) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-white/50" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <p className="text-sm text-white/70">Couldn't load {filename}.</p>
+      </div>
+    )
+  }
+
+  return (
+    // Mobile: panel goes edge-to-edge between top action bar and bottom filename
+    // bar; rounded corners match the desktop card so the transition into the
+    // dark dialog chrome isn't a hard horizontal line.
+    // Desktop: drop horizontal padding so the panel can grow up to the same
+    // 800px column the stream uses for messages; vertical padding still keeps
+    // the action bar and filename bar from overlapping the card.
+    <div className="absolute inset-0 pb-16 pt-14 sm:py-16">
+      <div
+        data-gallery-text-viewer="true"
+        className="mx-auto h-full w-full max-w-[800px] overflow-auto overscroll-contain rounded-lg bg-card text-foreground sm:border sm:border-border sm:shadow-2xl"
+      >
+        {rawMode ? (
+          <pre className="px-4 py-6 sm:px-8 sm:py-8 font-mono text-xs leading-relaxed whitespace-pre text-foreground">
+            {content ?? ""}
+          </pre>
+        ) : (
+          <div className="px-4 py-6 sm:px-8 sm:py-8">
+            <MarkdownContent content={content ?? ""} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/gallery/use-text-content.ts
+++ b/apps/frontend/src/components/gallery/use-text-content.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react"
+
+// Module-level URL → fetch promise cache so the viewer body and the gallery's
+// Copy button issue a single network round-trip per presigned URL. The URLs are
+// already attachment-API-deduped (15-min TTL); this caches the text response so
+// hitting Copy on an already-loaded panel resolves immediately.
+const textCache = new Map<string, Promise<string>>()
+
+export interface TextContentState {
+  content: string | null
+  error: boolean
+}
+
+export function useTextContent(url: string | null): TextContentState {
+  const [state, setState] = useState<TextContentState>({ content: null, error: false })
+
+  useEffect(() => {
+    if (!url) {
+      setState({ content: null, error: false })
+      return
+    }
+    let mounted = true
+    setState({ content: null, error: false })
+
+    let promise = textCache.get(url)
+    if (!promise) {
+      promise = fetch(url).then((res) => {
+        if (!res.ok) throw new Error(`status ${res.status}`)
+        return res.text()
+      })
+      textCache.set(url, promise)
+    }
+
+    promise
+      .then((text) => {
+        if (mounted) setState({ content: text, error: false })
+      })
+      .catch(() => {
+        if (mounted) setState({ content: null, error: true })
+        // Drop the failed promise so a retry on next mount can try again.
+        textCache.delete(url)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [url])
+
+  return state
+}
+
+/** Fetch text for a URL using the shared cache, without subscribing a component
+ *  to the result. Used for one-shot reads like the gallery Copy button. */
+export function fetchTextContent(url: string): Promise<string> {
+  let promise = textCache.get(url)
+  if (!promise) {
+    promise = fetch(url).then((res) => {
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      return res.text()
+    })
+    textCache.set(url, promise)
+  }
+  return promise.catch((err) => {
+    textCache.delete(url)
+    throw err
+  })
+}

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -1,6 +1,6 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from "react"
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
 import { TopbarLoadingIndicator } from "@/components/layout/topbar-loading-indicator"
-import { useZoomPan } from "@/hooks/use-zoom-pan"
+import { fitContain, useZoomPan } from "@/hooks/use-zoom-pan"
 import { cn } from "@/lib/utils"
 
 export interface ZoomableImageHandle {
@@ -37,6 +37,52 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
   const [loadedSrc, setLoadedSrc] = useState<string | null>(null)
   const decoded = loadedSrc === src
 
+  // Compute the exact object-contain bounds ourselves so the poster and the
+  // main image render at identical pixel sizes during the crossfade. Without
+  // this the poster (forced to container size) and the main image (sized to
+  // natural with max-w/h caps) lay out differently for any image smaller
+  // than the viewport, producing a visible size jump between frames.
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 })
+  const [naturalDims, setNaturalDims] = useState<{ w: number; h: number } | null>(null)
+
+  // Reset measured dims when src changes so the new image gets its own bounds
+  // — leaving stale dims in place flashes the previous image's aspect.
+  useEffect(() => {
+    setNaturalDims(null)
+  }, [src])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const measure = () => setContainerSize({ w: container.clientWidth, h: container.clientHeight })
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(container)
+    return () => ro.disconnect()
+  }, [])
+
+  const rendered =
+    naturalDims && containerSize.w > 0 && containerSize.h > 0
+      ? fitContain(naturalDims.w, naturalDims.h, containerSize.w, containerSize.h)
+      : null
+
+  // Style applied to BOTH the poster and the main image so they cross-fade at
+  // identical dimensions and overlap pixel-for-pixel. `inset: 0; margin: auto`
+  // centers absolute children inside the container without flex (flex would
+  // stack siblings instead of overlapping them). The fallback (before we've
+  // measured naturalDims) fills the container so object-contain handles
+  // sizing — that way the switch to explicit rendered dims is a no-op, not
+  // a visible jump from "natural size, centered" to "filled".
+  const imageBoxStyle: React.CSSProperties = rendered
+    ? { position: "absolute", inset: 0, margin: "auto", width: rendered.w, height: rendered.h }
+    : { position: "absolute", inset: 0, width: "100%", height: "100%" }
+
+  const captureNatural = (img: HTMLImageElement) => {
+    if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+      setNaturalDims({ w: img.naturalWidth, h: img.naturalHeight })
+    }
+  }
+
   const { isZoomed, zoomIn, zoomOut, reset } = useZoomPan({
     containerRef,
     contentRef: imgRef,
@@ -53,6 +99,18 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
     }),
     [reset, zoomIn, zoomOut]
   )
+
+  // Shimmer sits along the top edge of the rendered image bounds (not the
+  // modal). Wrapper is absolutely positioned so toggling visibility never
+  // shifts layout, and the inner indicator uses `top-0` to anchor to the
+  // top of that wrapper instead of the bottom default.
+  const shimmerStyle: React.CSSProperties = rendered
+    ? {
+        top: (containerSize.h - rendered.h) / 2,
+        left: (containerSize.w - rendered.w) / 2,
+        width: rendered.w,
+      }
+    : { top: 0, left: 0, right: 0 }
 
   return (
     <div
@@ -72,9 +130,11 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
           alt=""
           aria-hidden
           className={cn(
-            "pointer-events-none absolute inset-0 h-full w-full object-contain select-none transition-opacity duration-200",
+            "pointer-events-none absolute object-contain select-none transition-opacity duration-200",
             decoded ? "opacity-0" : "opacity-100"
           )}
+          style={imageBoxStyle}
+          onLoad={(event) => captureNatural(event.currentTarget)}
           draggable={false}
         />
       )}
@@ -82,15 +142,20 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
         ref={imgRef}
         src={src}
         alt={alt}
-        onLoad={() => setLoadedSrc(src)}
+        onLoad={(event) => {
+          captureNatural(event.currentTarget)
+          setLoadedSrc(src)
+        }}
         className={cn(
-          "max-w-full max-h-full object-contain select-none transition-opacity duration-200",
+          "object-contain select-none transition-opacity duration-200",
           decoded ? "opacity-100" : "opacity-0"
         )}
         draggable={false}
-        style={{ willChange: "transform" }}
+        style={{ ...imageBoxStyle, willChange: "transform" }}
       />
-      <TopbarLoadingIndicator visible={!decoded} className="bottom-auto top-0" />
+      <div className="pointer-events-none absolute" style={shimmerStyle}>
+        <TopbarLoadingIndicator visible={!decoded} className="bottom-auto top-0" />
+      </div>
     </div>
   )
 })

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -1,5 +1,7 @@
-import { forwardRef, useImperativeHandle, useRef } from "react"
+import { forwardRef, useImperativeHandle, useRef, useState } from "react"
+import { Loader2 } from "lucide-react"
 import { useZoomPan } from "@/hooks/use-zoom-pan"
+import { cn } from "@/lib/utils"
 
 export interface ZoomableImageHandle {
   reset: () => void
@@ -10,6 +12,11 @@ export interface ZoomableImageHandle {
 interface ZoomableImageProps {
   src: string
   alt: string
+  /** Low-resolution thumbnail to show underneath while the full-resolution
+   *  image decodes. Heavy originals can take several seconds to paint after
+   *  `src` lands; without a poster the viewport is blank between "src set"
+   *  and "bytes painted", which reads as the gallery being stuck. */
+  posterSrc?: string
   onZoomChange?: (zoomed: boolean) => void
   /** Fires synchronously on every scale change (including 60fps during pinch).
    *  Subscribers should be self-contained — using this to drive parent state
@@ -18,11 +25,17 @@ interface ZoomableImageProps {
 }
 
 export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>(function ZoomableImage(
-  { src, alt, onZoomChange, onScaleChange },
+  { src, alt, posterSrc, onZoomChange, onScaleChange },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
   const imgRef = useRef<HTMLImageElement>(null)
+  // Track which src has actually painted. Comparing to the prop instead of
+  // a boolean handles src changes without a separate reset effect — the
+  // moment a new src lands, decoded flips false until the new image's
+  // onLoad fires.
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null)
+  const decoded = loadedSrc === src
 
   const { isZoomed, zoomIn, zoomOut, reset } = useZoomPan({
     containerRef,
@@ -53,11 +66,28 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
         userSelect: "none",
       }}
     >
+      {posterSrc && (
+        <img
+          src={posterSrc}
+          alt=""
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-0 h-full w-full object-contain select-none transition-opacity duration-200",
+            decoded ? "opacity-0" : "opacity-80"
+          )}
+          draggable={false}
+        />
+      )}
+      {!decoded && <Loader2 className="absolute h-8 w-8 animate-spin text-white/70" />}
       <img
         ref={imgRef}
         src={src}
         alt={alt}
-        className="max-w-full max-h-full object-contain select-none"
+        onLoad={() => setLoadedSrc(src)}
+        className={cn(
+          "max-w-full max-h-full object-contain select-none transition-opacity duration-200",
+          decoded ? "opacity-100" : "opacity-0"
+        )}
         draggable={false}
         style={{ willChange: "transform" }}
       />

--- a/apps/frontend/src/components/gallery/zoomable-image.tsx
+++ b/apps/frontend/src/components/gallery/zoomable-image.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useImperativeHandle, useRef, useState } from "react"
-import { Loader2 } from "lucide-react"
+import { TopbarLoadingIndicator } from "@/components/layout/topbar-loading-indicator"
 import { useZoomPan } from "@/hooks/use-zoom-pan"
 import { cn } from "@/lib/utils"
 
@@ -73,12 +73,11 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
           aria-hidden
           className={cn(
             "pointer-events-none absolute inset-0 h-full w-full object-contain select-none transition-opacity duration-200",
-            decoded ? "opacity-0" : "opacity-80"
+            decoded ? "opacity-0" : "opacity-100"
           )}
           draggable={false}
         />
       )}
-      {!decoded && <Loader2 className="absolute h-8 w-8 animate-spin text-white/70" />}
       <img
         ref={imgRef}
         src={src}
@@ -91,6 +90,7 @@ export const ZoomableImage = forwardRef<ZoomableImageHandle, ZoomableImageProps>
         draggable={false}
         style={{ willChange: "transform" }}
       />
+      <TopbarLoadingIndicator visible={!decoded} className="bottom-auto top-0" />
     </div>
   )
 })

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -19,6 +19,7 @@ import {
   Code2,
   Eye,
 } from "lucide-react"
+import { TopbarLoadingIndicator } from "@/components/layout/topbar-loading-indicator"
 import { downloadImage, copyImage } from "@/lib/image-utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -172,19 +173,15 @@ function GalleryMediaContent({
   if (!current.url) {
     return (
       <div className="absolute inset-0 flex items-center justify-center">
-        {current.thumbnailUrl ? (
-          <>
-            <img
-              src={current.thumbnailUrl}
-              alt={current.filename}
-              className="max-w-full max-h-full object-contain select-none opacity-80"
-              draggable={false}
-            />
-            <Loader2 className="absolute h-8 w-8 animate-spin text-white/70" />
-          </>
-        ) : (
-          <Loader2 className="h-8 w-8 animate-spin text-white/50" />
+        {current.thumbnailUrl && (
+          <img
+            src={current.thumbnailUrl}
+            alt={current.filename}
+            className="max-w-full max-h-full object-contain select-none"
+            draggable={false}
+          />
         )}
+        <TopbarLoadingIndicator visible className="bottom-auto top-0" />
       </div>
     )
   }

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -191,9 +191,14 @@ function GalleryMediaContent({
   }
   // Active image slide gets the zoomable viewport. Inactive slides stay as plain
   // <img> so we don't wire up gesture listeners for images the user isn't viewing.
+  // `key={current.attachmentId}` forces a fresh instance per attachment so internal
+  // state (loadedSrc, naturalDims) and the underlying <img> bitmap can't leak from
+  // a previously-viewed image — without this, rapidly toggling between two images
+  // can show the wrong image after a late onLoad fires against stale internal state.
   if (zoomableRef) {
     return (
       <ZoomableImage
+        key={current.attachmentId}
         ref={zoomableRef}
         src={current.url}
         alt={current.filename}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -170,14 +170,18 @@ function GalleryMediaContent({
   // While the full-resolution URL hasn't arrived yet, show the already-loaded
   // thumbnail as a poster instead of a blank loader — matches the video path
   // (poster while bytes stream in) and makes large-image opens feel instant.
+  // Poster fills the container with object-contain (same sizing strategy as
+  // the ZoomableImage poster fallback) so the swap into ZoomableImage when
+  // the URL arrives is pixel-for-pixel — no "small thumbnail → filled image"
+  // flash at the branch boundary.
   if (!current.url) {
     return (
-      <div className="absolute inset-0 flex items-center justify-center">
+      <div className="absolute inset-0">
         {current.thumbnailUrl && (
           <img
             src={current.thumbnailUrl}
             alt={current.filename}
-            className="max-w-full max-h-full object-contain select-none"
+            className="absolute inset-0 h-full w-full object-contain select-none"
             draggable={false}
           />
         )}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -196,6 +196,7 @@ function GalleryMediaContent({
         ref={zoomableRef}
         src={current.url}
         alt={current.filename}
+        posterSrc={current.thumbnailUrl || undefined}
         onZoomChange={onZoomChange}
         onScaleChange={onScaleChange}
       />
@@ -763,9 +764,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
               onClick={handleCopy}
             >
               <Copy className="h-5 w-5" />
-              <span className="sr-only">
-                {current?.type === "image" ? "Copy image" : "Copy source"}
-              </span>
+              <span className="sr-only">{current?.type === "image" ? "Copy image" : "Copy source"}</span>
             </Button>
           )}
         </>

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/compone
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   X,
   Download,
@@ -13,6 +14,10 @@ import {
   PanelRightOpen,
   Loader2,
   Play,
+  FileText,
+  Globe,
+  Code2,
+  Eye,
 } from "lucide-react"
 import { downloadImage, copyImage } from "@/lib/image-utils"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -21,10 +26,34 @@ import { attachmentsApi } from "@/api"
 import { triggerDownload } from "@/lib/image-utils"
 import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
+import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
+import { HtmlViewer } from "@/components/gallery/html-viewer"
+import { fetchTextContent } from "@/components/gallery/use-text-content"
 
 export type GalleryItem =
-  | { type: "image"; url: string; filename: string; attachmentId: string }
+  | { type: "image"; url: string; thumbnailUrl: string; filename: string; attachmentId: string }
   | { type: "video"; url: string; thumbnailUrl: string; filename: string; attachmentId: string }
+  | { type: "markdown"; url: string; filename: string; attachmentId: string }
+  | { type: "html"; url: string; filename: string; attachmentId: string }
+
+const GALLERY_TYPE_LABELS: Record<GalleryItem["type"], string> = {
+  image: "Image",
+  video: "Video",
+  markdown: "Markdown document",
+  html: "HTML document",
+}
+
+// Sidebar thumbnails are 124px wide — long filenames (URLs, slugs with the
+// extension at the tail) get unrecognizable when chopped from the end. Cut
+// from the middle instead so both the leading word and the extension survive.
+function truncateMiddle(filename: string, maxLength: number): string {
+  if (filename.length <= maxLength) return filename
+  const ellipsis = "…"
+  const budget = maxLength - ellipsis.length
+  const head = Math.ceil(budget / 2)
+  const tail = Math.floor(budget / 2)
+  return filename.slice(0, head) + ellipsis + filename.slice(-tail)
+}
 
 interface MediaGalleryProps {
   isOpen: boolean
@@ -70,6 +99,8 @@ interface GalleryMediaContentProps {
   zoomableRef?: React.Ref<ZoomableImageHandle>
   onZoomChange?: (zoomed: boolean) => void
   onScaleChange?: (scale: number) => void
+  /** Raw-source toggle; only consumed by markdown/html viewers. */
+  rawMode?: boolean
 }
 
 function GalleryMediaContent({
@@ -78,7 +109,28 @@ function GalleryMediaContent({
   zoomableRef,
   onZoomChange,
   onScaleChange,
+  rawMode = false,
 }: GalleryMediaContentProps) {
+  if (current.type === "markdown") {
+    if (!isActive) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <FileText className="h-10 w-10 text-white/30" />
+        </div>
+      )
+    }
+    return <MarkdownViewer url={current.url} filename={current.filename} rawMode={rawMode} />
+  }
+  if (current.type === "html") {
+    if (!isActive) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Globe className="h-10 w-10 text-white/30" />
+        </div>
+      )
+    }
+    return <HtmlViewer url={current.url} filename={current.filename} rawMode={rawMode} />
+  }
   if (current.type === "video") {
     // Non-active video slides show poster so the <video> element doesn't load
     if (!isActive) {
@@ -114,12 +166,28 @@ function GalleryMediaContent({
       </div>
     )
   }
-  if (!current.url)
+  // While the full-resolution URL hasn't arrived yet, show the already-loaded
+  // thumbnail as a poster instead of a blank loader — matches the video path
+  // (poster while bytes stream in) and makes large-image opens feel instant.
+  if (!current.url) {
     return (
       <div className="absolute inset-0 flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-white/50" />
+        {current.thumbnailUrl ? (
+          <>
+            <img
+              src={current.thumbnailUrl}
+              alt={current.filename}
+              className="max-w-full max-h-full object-contain select-none opacity-80"
+              draggable={false}
+            />
+            <Loader2 className="absolute h-8 w-8 animate-spin text-white/70" />
+          </>
+        ) : (
+          <Loader2 className="h-8 w-8 animate-spin text-white/50" />
+        )}
       </div>
     )
+  }
   // Active image slide gets the zoomable viewport. Inactive slides stay as plain
   // <img> so we don't wire up gesture listeners for images the user isn't viewing.
   if (zoomableRef) {
@@ -146,6 +214,17 @@ function GalleryMediaContent({
 }
 
 function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
+  if (item.type === "markdown" || item.type === "html") {
+    const Icon = item.type === "markdown" ? FileText : Globe
+    return (
+      <div className="w-full h-20 min-w-0 flex flex-col items-center justify-center gap-1 bg-white/5 px-1">
+        <Icon className="h-5 w-5 text-white/60" />
+        <span className="block max-w-full overflow-hidden whitespace-nowrap text-[10px] text-white/50">
+          {truncateMiddle(item.filename, 18)}
+        </span>
+      </div>
+    )
+  }
   if (item.type === "video") {
     if (!item.thumbnailUrl) {
       return (
@@ -157,11 +236,11 @@ function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
       )
     }
     return (
-      <div className="relative">
+      <div className="relative w-full h-20 bg-black/40">
         <img
           src={item.thumbnailUrl}
           alt={item.filename}
-          className="w-full h-20 object-cover"
+          className="absolute inset-0 w-full h-full object-contain"
           loading="lazy"
           draggable={false}
         />
@@ -171,7 +250,11 @@ function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
       </div>
     )
   }
-  if (!item.url) {
+  // Prefer the already-loaded inline thumbnail URL for the sidebar so the panel
+  // isn't full of spinners waiting for the full-resolution variant to lazy-fetch
+  // on open. Fall back to full URL (if present) or a spinner.
+  const sidebarSrc = item.thumbnailUrl || item.url
+  if (!sidebarSrc) {
     return (
       <div className="w-full h-20 flex items-center justify-center bg-white/5">
         <Loader2 className="h-4 w-4 animate-spin text-white/40" />
@@ -179,7 +262,15 @@ function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
     )
   }
   return (
-    <img src={item.url} alt={item.filename} className="w-full h-20 object-cover" loading="lazy" draggable={false} />
+    <div className="relative w-full h-20 bg-black/40">
+      <img
+        src={sidebarSrc}
+        alt={item.filename}
+        className="absolute inset-0 w-full h-full object-contain"
+        loading="lazy"
+        draggable={false}
+      />
+    </div>
   )
 }
 
@@ -188,6 +279,10 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const isMobile = useIsMobile()
   const [panelOpen, setPanelOpen] = useState(true)
   const [showArrows, setShowArrows] = useState(false)
+  // Source vs. rendered toggle for markdown/html slides. Persists across
+  // navigation within a session — if the user is reading raw markdown and
+  // arrows over to the next markdown file, they probably want raw there too.
+  const [rawMode, setRawMode] = useState(false)
   // containerWidth drives both slide sizing and strip transform calculations on mobile
   const [containerWidth, setContainerWidth] = useState(0)
 
@@ -231,6 +326,11 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const lastTouchX = useRef(0)
   const lastTouchTime = useRef(0)
   const velocityX = useRef(0) // px/ms — used for flick-to-next even on short drags
+  // When a touch starts inside the markdown/html panel we relinquish the
+  // gesture entirely so native scroll can pan both axes (essential for wide
+  // code blocks and tables). Carousel swipe/dismiss still work from the
+  // surrounding gallery margin.
+  const skipGesture = useRef(false)
 
   // Ref mirror of currentIndex so ResizeObserver can read it without stale closures
   const currentIndexRef = useRef(currentIndex)
@@ -386,9 +486,24 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     }
   }, [workspaceId, current])
 
-  const handleCopy = useCallback(() => {
-    if (current?.type === "image" && current.url) copyImage(current.url)
+  const handleCopy = useCallback(async () => {
+    if (!current?.url) return
+    if (current.type === "image") {
+      copyImage(current.url)
+      return
+    }
+    if (current.type === "markdown" || current.type === "html") {
+      try {
+        const text = await fetchTextContent(current.url)
+        await navigator.clipboard.writeText(text)
+      } catch {
+        // Clipboard or fetch failed; nothing actionable for the user here.
+      }
+    }
   }, [current])
+
+  const canCopy = current?.type === "image" || current?.type === "markdown" || current?.type === "html"
+  const canToggleRaw = current?.type === "markdown" || current?.type === "html"
 
   // Keyboard navigation
   useEffect(() => {
@@ -411,11 +526,22 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // at 60fps without React rendering in the hot path.
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    // The gallery owns every touch inside its Dialog. Stop React-tree bubbling
+    // before any early return — React events propagate up the React tree (not
+    // the DOM tree), so events from the Radix Portal still reach the message
+    // row's swipe-to-quote and long-press handlers if we don't stop them here.
+    e.stopPropagation()
     // When zoomed or pinching, the zoomable viewport owns the gesture — don't
     // start a carousel swipe in parallel (would cause the strip to drift while
     // the user is panning inside an image).
     if (isZoomedRef.current || e.touches.length > 1) return
-    e.stopPropagation()
+    const target = e.target as HTMLElement | null
+    if (target?.closest("[data-gallery-text-viewer]")) {
+      // Yield to native scroll inside the text panel.
+      skipGesture.current = true
+      return
+    }
+    skipGesture.current = false
     // Read where the strip actually is right now (could be mid-animation)
     // so we can continue from that exact position rather than jumping.
     if (stripRef.current) {
@@ -439,8 +565,9 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
-      if (isZoomedRef.current || e.touches.length > 1) return
       e.stopPropagation()
+      if (skipGesture.current) return
+      if (isZoomedRef.current || e.touches.length > 1) return
       const dx = e.touches[0].clientX - touchStartX.current
       const dy = e.touches[0].clientY - touchStartY.current
       touchDeltaX.current = dx
@@ -479,8 +606,12 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   const handleTouchEnd = useCallback(
     (e: React.TouchEvent) => {
-      if (isZoomedRef.current) return
       e.stopPropagation()
+      if (skipGesture.current) {
+        skipGesture.current = false
+        return
+      }
+      if (isZoomedRef.current) return
       const dx = touchDeltaX.current
       const dy = touchDeltaY.current
       const vx = velocityX.current
@@ -544,6 +675,12 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     (e: React.MouseEvent) => {
       if (!isMobile || !isMultiple) return
       if (isZoomedRef.current) return
+      // Tap-to-navigate inside the text panel would hijack link clicks, text
+      // selection, and code-block interactions. Taps in the surrounding margin
+      // still navigate — that's the only way to flip between text slides on
+      // mobile once swipe is relinquished to native scroll.
+      const target = e.target as HTMLElement | null
+      if (target?.closest("[data-gallery-text-viewer]")) return
       if (didSwipe.current) {
         didSwipe.current = false
         return
@@ -561,8 +698,13 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const handleZoomReset = useCallback(() => zoomableRef.current?.reset(), [])
 
   // ─── Action bar (shared between mobile/desktop) ─────────────────────────────
+  // Sits in a translucent dark pill so it stays readable against any backdrop
+  // (image, video poster, markdown panel, sandboxed iframe). The text viewers
+  // reserve their top inset (pt-14 / pt-16) so the pill never overlaps the
+  // panel chrome; `top-3 right-3` gives the pill visible breathing room from
+  // the screen edge instead of kissing it.
   const actionBar = (
-    <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
+    <div className="absolute top-3 right-3 z-10 flex items-center gap-1 rounded-full bg-black/55 px-1 py-0.5 shadow-lg backdrop-blur-sm">
       {!isMobile && current?.type === "image" && (
         <ZoomControls
           subscribeScale={subscribeScale}
@@ -592,6 +734,18 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
         </DropdownMenu>
       ) : (
         <>
+          {canToggleRaw && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
+              onClick={() => setRawMode((v) => !v)}
+              aria-pressed={rawMode}
+            >
+              {rawMode ? <Eye className="h-5 w-5" /> : <Code2 className="h-5 w-5" />}
+              <span className="sr-only">{rawMode ? "Show rendered preview" : "Show raw source"}</span>
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"
@@ -599,17 +753,21 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
             onClick={handleDownload}
           >
             <Download className="h-5 w-5" />
-            <span className="sr-only">Download image</span>
+            <span className="sr-only">Download</span>
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
-            onClick={handleCopy}
-          >
-            <Copy className="h-5 w-5" />
-            <span className="sr-only">Copy image</span>
-          </Button>
+          {canCopy && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
+              onClick={handleCopy}
+            >
+              <Copy className="h-5 w-5" />
+              <span className="sr-only">
+                {current?.type === "image" ? "Copy image" : "Copy source"}
+              </span>
+            </Button>
+          )}
         </>
       )}
       {!isMobile && isMultiple && (
@@ -649,7 +807,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
         >
           <DialogTitle className="sr-only">{current.filename}</DialogTitle>
           <DialogDescription className="sr-only">
-            {current.type === "image" ? "Image" : "Video"} {currentIndex + 1} of {items.length}
+            {GALLERY_TYPE_LABELS[current.type]} {currentIndex + 1} of {items.length}
           </DialogDescription>
 
           <div className="relative flex h-full overflow-hidden">
@@ -684,6 +842,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                           zoomableRef={i === currentIndex && item.type === "image" ? zoomableRef : undefined}
                           onZoomChange={i === currentIndex && item.type === "image" ? setIsZoomed : undefined}
                           onScaleChange={i === currentIndex && item.type === "image" ? publishScale : undefined}
+                          rawMode={i === currentIndex ? rawMode : false}
                         />
                       </div>
                     ))}
@@ -710,6 +869,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                     zoomableRef={current.type === "image" ? zoomableRef : undefined}
                     onZoomChange={current.type === "image" ? setIsZoomed : undefined}
                     onScaleChange={current.type === "image" ? publishScale : undefined}
+                    rawMode={rawMode}
                   />
                 </div>
 
@@ -756,30 +916,38 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
             {!isMobile && isMultiple && panelOpen && (
               <div className="w-[140px] shrink-0 border-l border-white/10 bg-black/80 flex flex-col">
                 <ScrollArea className="flex-1">
-                  <div className="flex flex-col gap-1.5 p-2">
-                    {items.map((item, i) => (
-                      <button
-                        key={item.attachmentId}
-                        ref={(el) => {
-                          if (el) thumbnailRefs.current.set(i, el)
-                          else thumbnailRefs.current.delete(i)
-                        }}
-                        type="button"
-                        className={cn(
-                          "relative w-full rounded overflow-hidden border-2 transition-all",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
-                          i === currentIndex
-                            ? "border-white opacity-100"
-                            : "border-transparent opacity-50 hover:opacity-80"
-                        )}
-                        onClick={() => goTo(i)}
-                        aria-label={`View ${item.filename}`}
-                        aria-current={i === currentIndex ? "true" : undefined}
-                      >
-                        <GalleryThumbnailContent item={item} />
-                      </button>
-                    ))}
-                  </div>
+                  <TooltipProvider delayDuration={400}>
+                    <div className="flex flex-col gap-1.5 p-2">
+                      {items.map((item, i) => (
+                        <Tooltip key={item.attachmentId}>
+                          <TooltipTrigger asChild>
+                            <button
+                              ref={(el) => {
+                                if (el) thumbnailRefs.current.set(i, el)
+                                else thumbnailRefs.current.delete(i)
+                              }}
+                              type="button"
+                              className={cn(
+                                "relative w-full rounded overflow-hidden border-2 transition-all",
+                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+                                i === currentIndex
+                                  ? "border-white opacity-100"
+                                  : "border-transparent opacity-50 hover:opacity-80"
+                              )}
+                              onClick={() => goTo(i)}
+                              aria-label={`View ${item.filename}`}
+                              aria-current={i === currentIndex ? "true" : undefined}
+                            >
+                              <GalleryThumbnailContent item={item} />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="left" className="max-w-[260px] break-all">
+                            {item.filename}
+                          </TooltipContent>
+                        </Tooltip>
+                      ))}
+                    </div>
+                  </TooltipProvider>
                 </ScrollArea>
               </div>
             )}

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react"
-import { Download, FileText, File, Loader2, Copy, Play } from "lucide-react"
+import { Download, FileText, File, Loader2, Copy, Play, Globe } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
@@ -12,6 +12,7 @@ import { useAttachmentContext } from "@/lib/markdown/attachment-context"
 import { useMediaGallery } from "@/contexts"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useLongPress } from "@/hooks/use-long-press"
+import { isHtmlAttachment, isMarkdownAttachment } from "@/lib/attachment-kind"
 import type { AttachmentSummary } from "@threa/types"
 
 interface AttachmentListProps {
@@ -26,6 +27,10 @@ interface AttachmentItemProps {
   attachment: AttachmentSummary
   workspaceId: string
   onImageClick?: (attachmentId: string) => void
+  /** Image variant: surface the resolved thumbnail URL to the parent so the
+   *  gallery sidebar can render the same small image instead of waiting for the
+   *  full-resolution variant to lazy-fetch on open. */
+  onThumbnailLoaded?: (attachmentId: string, thumbnailUrl: string) => void
   isHighlighted?: boolean
   deferHydration?: boolean
 }
@@ -126,6 +131,7 @@ function ImageAttachment({
   attachment,
   workspaceId,
   onImageClick,
+  onThumbnailLoaded,
   isHighlighted,
   deferHydration = false,
 }: AttachmentItemProps) {
@@ -147,6 +153,7 @@ function ImageAttachment({
         const url = await attachmentsApi.getDownloadUrl(workspaceId, attachment.id, { variant: "thumbnail" })
         if (mounted) {
           setThumbnailUrl(url)
+          onThumbnailLoaded?.(attachment.id, url)
         }
       } catch {
         if (mounted) {
@@ -160,7 +167,7 @@ function ImageAttachment({
     return () => {
       mounted = false
     }
-  }, [workspaceId, attachment.id, deferHydration])
+  }, [workspaceId, attachment.id, deferHydration, onThumbnailLoaded])
 
   // The box is interactable as soon as it mounts — the gallery fetches the
   // full-resolution image itself, so opening it never depends on the inline
@@ -415,6 +422,31 @@ function VideoAttachment({
   )
 }
 
+function OpenableFileChip({
+  attachment,
+  isHighlighted,
+  icon: Icon,
+  onOpen,
+}: {
+  attachment: AttachmentSummary
+  isHighlighted?: boolean
+  icon: typeof FileText
+  onOpen: (attachmentId: string) => void
+}) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className={cn("h-8 gap-2 text-xs", isHighlighted && "ring-2 ring-primary border-primary shadow-sm")}
+      onClick={() => onOpen(attachment.id)}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span className="max-w-[150px] truncate">{attachment.filename}</span>
+      <span className="text-muted-foreground">{formatFileSize(attachment.sizeBytes)}</span>
+    </Button>
+  )
+}
+
 function FileAttachment({ attachment, workspaceId, isHighlighted }: AttachmentItemProps) {
   const [isDownloading, setIsDownloading] = useState(false)
   const Icon = getFileIcon(attachment.mimeType)
@@ -456,6 +488,10 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
   const [loadedFullImageUrls, setLoadedFullImageUrls] = useState<Map<string, string>>(new Map())
   const [loadedThumbnails, setLoadedThumbnails] = useState<Map<string, string>>(new Map())
   const [loadedVideoUrls, setLoadedVideoUrls] = useState<Map<string, string>>(new Map())
+  // Markdown and HTML attachments share a single URL cache: both viewers just
+  // need a presigned URL (the markdown viewer fetches text from it, the HTML
+  // viewer hands it straight to a sandboxed iframe).
+  const [loadedTextUrls, setLoadedTextUrls] = useState<Map<string, string>>(new Map())
   const attachmentContext = useAttachmentContext()
   const hoveredAttachmentId = attachmentContext?.hoveredAttachmentId ?? null
   const { mediaAttachmentId, openMedia, closeMedia } = useMediaGallery()
@@ -482,8 +518,23 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     () => (attachments ?? []).filter((a) => !a.mimeType.startsWith("image/") && a.processingStatus === "failed"),
     [attachments]
   )
+  const markdownAttachments = useMemo(
+    () => (attachments ?? []).filter((a) => !a.processingStatus && isMarkdownAttachment(a)),
+    [attachments]
+  )
+  const htmlAttachments = useMemo(
+    () => (attachments ?? []).filter((a) => !a.processingStatus && isHtmlAttachment(a)),
+    [attachments]
+  )
   const fileAttachments = useMemo(
-    () => (attachments ?? []).filter((a) => !a.mimeType.startsWith("image/") && !a.processingStatus),
+    () =>
+      (attachments ?? []).filter(
+        (a) =>
+          !a.mimeType.startsWith("image/") &&
+          !a.processingStatus &&
+          !isMarkdownAttachment(a) &&
+          !isHtmlAttachment(a)
+      ),
     [attachments]
   )
 
@@ -495,6 +546,7 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     const imageItems: GalleryItem[] = imageAttachments.map((a) => ({
       type: "image" as const,
       url: loadedFullImageUrls.get(a.id) ?? "",
+      thumbnailUrl: loadedThumbnails.get(a.id) ?? "",
       filename: a.filename,
       attachmentId: a.id,
     }))
@@ -513,8 +565,31 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
         }
       })
 
-    return [...imageItems, ...videoItems]
-  }, [imageAttachments, videoAttachments, loadedFullImageUrls, loadedThumbnails, loadedVideoUrls])
+    const markdownItems: GalleryItem[] = markdownAttachments.map((a) => ({
+      type: "markdown" as const,
+      url: loadedTextUrls.get(a.id) ?? "",
+      filename: a.filename,
+      attachmentId: a.id,
+    }))
+
+    const htmlItems: GalleryItem[] = htmlAttachments.map((a) => ({
+      type: "html" as const,
+      url: loadedTextUrls.get(a.id) ?? "",
+      filename: a.filename,
+      attachmentId: a.id,
+    }))
+
+    return [...imageItems, ...videoItems, ...markdownItems, ...htmlItems]
+  }, [
+    imageAttachments,
+    videoAttachments,
+    markdownAttachments,
+    htmlAttachments,
+    loadedFullImageUrls,
+    loadedThumbnails,
+    loadedVideoUrls,
+    loadedTextUrls,
+  ])
 
   // Called by VideoAttachment children when their thumbnail loads
   const registerThumbnailUrl = useCallback((attachmentId: string, thumbnailUrl: string) => {
@@ -539,6 +614,13 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
   )
 
   const handleVideoClick = useCallback(
+    (attachmentId: string) => {
+      openMedia(attachmentId)
+    },
+    [openMedia]
+  )
+
+  const handleTextOpen = useCallback(
     (attachmentId: string) => {
       openMedia(attachmentId)
     },
@@ -614,6 +696,35 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     }
   }, [selectedAttachmentId, imageAttachments, loadedFullImageUrls, workspaceId])
 
+  // Lazy-fetch presigned URLs for markdown/html attachments when opened.
+  useEffect(() => {
+    if (!selectedAttachmentId) return
+    const isText =
+      markdownAttachments.some((a) => a.id === selectedAttachmentId) ||
+      htmlAttachments.some((a) => a.id === selectedAttachmentId)
+    if (!isText || loadedTextUrls.has(selectedAttachmentId)) return
+
+    let mounted = true
+    async function fetchTextUrl() {
+      try {
+        const url = await attachmentsApi.getDownloadUrl(workspaceId, selectedAttachmentId!)
+        if (mounted) {
+          setLoadedTextUrls((prev) => {
+            const next = new Map(prev)
+            next.set(selectedAttachmentId!, url)
+            return next
+          })
+        }
+      } catch {
+        console.error("Failed to get attachment URL")
+      }
+    }
+    fetchTextUrl()
+    return () => {
+      mounted = false
+    }
+  }, [selectedAttachmentId, markdownAttachments, htmlAttachments, loadedTextUrls, workspaceId])
+
   if (!attachments || attachments.length === 0) {
     return null
   }
@@ -631,6 +742,7 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
                 attachment={attachment}
                 workspaceId={workspaceId}
                 onImageClick={handleImageClick}
+                onThumbnailLoaded={registerThumbnailUrl}
                 isHighlighted={attachment.id === hoveredAttachmentId}
                 deferHydration={deferHydration}
               />
@@ -648,8 +760,26 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
             ))}
           </div>
         )}
-        {allFileAttachments.length > 0 && (
+        {(allFileAttachments.length > 0 || markdownAttachments.length > 0 || htmlAttachments.length > 0) && (
           <div className="flex flex-wrap gap-2">
+            {markdownAttachments.map((attachment) => (
+              <OpenableFileChip
+                key={attachment.id}
+                attachment={attachment}
+                isHighlighted={attachment.id === hoveredAttachmentId}
+                icon={FileText}
+                onOpen={handleTextOpen}
+              />
+            ))}
+            {htmlAttachments.map((attachment) => (
+              <OpenableFileChip
+                key={attachment.id}
+                attachment={attachment}
+                isHighlighted={attachment.id === hoveredAttachmentId}
+                icon={Globe}
+                onOpen={handleTextOpen}
+              />
+            ))}
             {allFileAttachments.map((attachment) => (
               <FileAttachment
                 key={attachment.id}

--- a/apps/frontend/src/lib/attachment-kind.ts
+++ b/apps/frontend/src/lib/attachment-kind.ts
@@ -1,0 +1,19 @@
+/** Discriminators for attachment kinds that have first-class preview support
+ *  in the media gallery. Used by both the inline attachment chips and the
+ *  markdown-link openAttachment dispatcher so a single source of truth decides
+ *  whether a file opens in the gallery or downloads. */
+
+interface AttachmentTypeShape {
+  mimeType: string
+  filename: string
+}
+
+export function isMarkdownAttachment(a: AttachmentTypeShape): boolean {
+  if (a.mimeType.startsWith("text/markdown") || a.mimeType === "text/x-markdown") return true
+  return /\.(md|mdx|markdown)$/i.test(a.filename)
+}
+
+export function isHtmlAttachment(a: AttachmentTypeShape): boolean {
+  if (a.mimeType === "text/html" || a.mimeType === "application/xhtml+xml") return true
+  return /\.x?html?$/i.test(a.filename)
+}

--- a/apps/frontend/src/lib/markdown/attachment-context.tsx
+++ b/apps/frontend/src/lib/markdown/attachment-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useCallback, useState, type ReactNode } from
 import { attachmentsApi } from "@/api"
 import { triggerDownload } from "@/lib/image-utils"
 import { useMediaGallery } from "@/contexts"
+import { isHtmlAttachment, isMarkdownAttachment } from "@/lib/attachment-kind"
 
 interface Attachment {
   id: string
@@ -45,12 +46,18 @@ export function AttachmentProvider({ workspaceId, attachments, children }: Attac
       const isVideo = !isImage && !!attachment.processingStatus
       const isPlayableVideo =
         isVideo && (attachment.processingStatus === "completed" || attachment.processingStatus === "skipped")
+      // Markdown/HTML have first-class preview surfaces in the gallery, so an
+      // inline link to one should open the preview — matches what the chip
+      // below the message does. Without this, links from the same file would
+      // download while the sibling chip previews, which felt inconsistent.
+      const isPreviewableText =
+        !attachment.processingStatus && (isMarkdownAttachment(attachment) || isHtmlAttachment(attachment))
 
       try {
         if (metaKey) {
           const url = await attachmentsApi.getDownloadUrl(workspaceId, attachmentId)
           window.open(url, "_blank")
-        } else if (isImage || isPlayableVideo) {
+        } else if (isImage || isPlayableVideo || isPreviewableText) {
           openMedia(attachmentId)
         } else {
           const url = await attachmentsApi.getDownloadUrl(workspaceId, attachmentId)


### PR DESCRIPTION
## Summary

- Markdown and HTML attachments now open in the existing image-gallery overlay instead of triggering a download. Markdown renders through `MarkdownContent`; HTML is sandboxed inside a `srcDoc` iframe (`sandbox=""`, null origin, no scripts) which works around the strict-sandbox + cross-origin S3 whitescreen we hit when pointing the iframe directly at the presigned URL. Both viewers get a raw-source toggle and a copy-to-clipboard action.
- Sidebar thumbnails now reuse the URL already loaded by `ImageAttachment` (mirrors the `VideoAttachment` callback pattern) so the strip doesn't show spinners while the gallery is open. Long filenames middle-truncate (with a shadcn `Tooltip` for the full name on desktop hover) so text never pushes thumbnails out of view, and thumbnails use `object-contain` over a letterbox instead of `object-cover` so neither axis crops.
- Fixed the swipe-to-quote regression: every gallery touch handler now `stopPropagation` up front, before any early returns, and bails when the target is inside `[data-gallery-text-viewer]`. React events propagate through the React tree, not the DOM tree, so Radix Portal'd gallery content was still bubbling into the underlying `MessageEvent`.
- Native `overflow-auto overscroll-contain` replaces Radix `ScrollArea` on the text panel because the latter intercepts iOS horizontal touch and broke pan-to-scroll inside wide code blocks.
- Desktop panel max width is now `800px` (matches the stream message column) and drops horizontal padding so narrow windows aren't wasted.

## Test plan

- [ ] Open a stream with an image, a markdown file, and an HTML file attached. Click each:
  - [ ] Markdown renders with the app's markdown styling; toggle raw-source; copy works.
  - [ ] HTML renders inside the sandboxed iframe; toggle raw-source; copy works.
  - [ ] Image still opens normally and the sidebar shows real thumbnails (no spinner column).
- [ ] On desktop, hover a long-filename sidebar entry — the shadcn tooltip shows the full name.
- [ ] On mobile (iOS Safari), swipe horizontally inside a wide markdown code block — page scrolls horizontally without triggering the quote/swipe gesture on the underlying message.
- [ ] On mobile, swipe-to-quote still works when starting the gesture outside the viewer panel.
- [ ] Resize the window narrow on desktop — the markdown panel uses the full available width up to `800px` with no leftover horizontal padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782240242&installation_id=129946197&pr_number=612&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F612&signature=4b4ab4264f243345671fc5296fbe39fac2e2a33636e646a96317261cd93d0e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->