### PR TITLE
fix: make bot invocation session creation idempotent

### DIFF
--- a/apps/backend/src/features/agents/session-repository.test.ts
+++ b/apps/backend/src/features/agents/session-repository.test.ts
@@ -37,6 +37,29 @@ function createQuerierCapture(captured: { text: string | null; values: unknown[]
   }
 }
 
+describe("AgentSessionRepository.insertRunningOrSkip", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("skips conflicts from both the running-session index and session primary key", async () => {
+    const captured = { text: null as string | null, values: null as unknown[] | null }
+    const db = createQuerierCapture(captured)
+
+    await AgentSessionRepository.insertRunningOrSkip(db, {
+      id: "binv_1",
+      streamId: "stream_1",
+      personaId: "bot_1",
+      triggerMessageId: "msg_1",
+      initialSequence: 5n,
+    })
+
+    expect(captured.text).not.toBeNull()
+    expect(captured.text).toContain("ON CONFLICT DO NOTHING")
+    expect(captured.text).not.toContain("ON CONFLICT (stream_id)")
+  })
+})
+
 describe("AgentSessionRepository.updateStatus SQL guards", () => {
   afterEach(() => {
     mock.restore()

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -198,10 +198,12 @@ export const AgentSessionRepository = {
   },
 
   /**
-   * Atomically insert a RUNNING session, failing if one already exists for the stream.
-   * Uses ON CONFLICT with the partial unique index to prevent race conditions.
+   * Atomically insert a RUNNING session, failing if one already exists for the stream
+   * or if this invocation already created its session on an earlier claim attempt.
+   * Uses ON CONFLICT DO NOTHING to cover both the partial running-session index
+   * and the primary key without surfacing a duplicate-key error.
    *
-   * @returns The created session, or null if a running session already exists
+   * @returns The created session, or null if a conflicting session already exists
    */
   async insertRunningOrSkip(
     db: Querier,
@@ -225,7 +227,7 @@ export const AgentSessionRepository = {
           ${params.serverId ? new Date() : null},
           ${params.initialSequence.toString()}
         )
-        ON CONFLICT (stream_id) WHERE status = 'running' DO NOTHING
+        ON CONFLICT DO NOTHING
         RETURNING ${sql.raw(SESSION_SELECT_FIELDS)}
       `
     )


### PR DESCRIPTION
## Problem

Claiming an expired remote bot invocation can fail with a 500 when the invocation already created its `agent_sessions` row during an earlier claim attempt:

```text
duplicate key value violates unique constraint "agent_sessions_pkey"
Key (id)=(binv_...) already exists.
```

The claim path intentionally reuses the bot invocation id as the agent session id. `AgentSessionRepository.insertRunningOrSkip` already handled the "one running session per stream" conflict, but it did not handle the primary-key conflict from retrying/reclaiming the same invocation.

## Solution

Make running session creation idempotent across all insert conflicts by changing the insert to `ON CONFLICT DO NOTHING`.

### How it works

1. `/bot-invocations/claim` claims or reclaims a `bot_invocations` row.
2. The handler attempts to insert the corresponding running `agent_sessions` row using the invocation id.
3. If either a running session already exists for the stream or the same invocation/session id already exists, the insert returns no row.
4. The caller already treats `null` as "session start event not needed" and still returns the claimed invocation to the runtime.

### Key design decisions

**1. Handle the conflict in the repository insert**

This keeps the race/idempotency guarantee at the write boundary and preserves existing caller behavior.

**2. Use untargeted `ON CONFLICT DO NOTHING`**

The insert must tolerate two unique constraints:

- `agent_sessions_pkey` on `id`
- `idx_agent_sessions_one_running_per_stream` partial unique index on running sessions per stream

Targeting only one constraint leaves the other capable of surfacing a 500.

## New files

None.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/session-repository.ts` | Make `insertRunningOrSkip` skip all insert conflicts instead of only the running-session partial index. |
| `apps/backend/src/features/agents/session-repository.test.ts` | Add coverage that the generated SQL handles both primary-key and running-session conflicts. |

## Deleted files

None.

## Self-review

- Verified the failing constraint is covered by the new conflict clause.
- Checked that existing caller behavior already handles a `null` session by skipping duplicate `agent_session:started` event creation.
- No schema changes required.
- No API contract changes.

## Test plan

- [x] `git diff --check`
- [x] `bun test apps/backend/src/features/agents/session-repository.test.ts`
- [x] Pre-commit lint/typecheck/OpenAPI checks run by git hook

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782241967&installation_id=129946197&pr_number=613&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F613&signature=5a5ec6cf3f38670f86d8da9cde88c13f370af850d3bf62a2c7599831596a61f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->