### PR TITLE
fix: harden pi remote session linking

### DIFF
--- a/.agents/skills/update-pi-remote-plugin/SKILL.md
+++ b/.agents/skills/update-pi-remote-plugin/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: update-pi-remote-plugin
+description: Keep the Threa Pi remote-control extension in `docs/examples/pi-remote/` aligned with the current Pi extension API and Threa bot-runtime public API. Use when asked to update, verify, sync, or troubleshoot the Pi remote plugin, `/remote-control`, or `threa-remote-v2.ts`.
+---
+
+# Update Pi remote plugin
+
+The canonical Threa Pi remote adapter currently lives at:
+
+- `docs/examples/pi-remote/threa-remote-v2.ts`
+- tests: `docs/examples/pi-remote/threa-remote-v2.test.ts`
+
+The local install target for real use is typically:
+
+- `~/.pi/agent/extensions/threa-remote.ts`
+
+Do not edit the installed copy first. Update the repo copy, verify it, then tell Kris how to copy/reload it.
+
+## Required context
+
+1. Read repo guidance before changing code:
+   - `CLAUDE.md`
+   - `~/.claude/CLAUDE.md` if present
+2. Read current Pi extension docs/API because Pi changes independently of Threa:
+   - `/Users/kristofferremback/.bun/install/global/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md`
+   - Focus on extension locations, `pi.registerCommand(name, options)`, lifecycle events, `ctx.isIdle()`, `ctx.sessionManager`, and `pi.sendUserMessage()`.
+3. Check the Threa protocol/API surfaces the plugin depends on:
+   - `apps/backend/src/features/public-api/schemas.ts`
+   - `apps/backend/src/features/public-api/handlers.ts`
+   - `apps/backend/src/routes.ts` around `/bot-runtime/*` and `/bot-invocations/*`
+   - `apps/backend/src/features/bot-runtimes/`
+   - `packages/types/src/constants.ts` around bot runtime/invocation constants
+4. Compare against product intent:
+   - `docs/plans/pi-remote-protocol-implementation.md`
+   - `docs/plans/interactive-bot-scratchpads.md` only if behavior is unclear
+
+## Update checklist
+
+Verify the adapter still:
+
+- Registers `/remote-control` using the current Pi API: `pi.registerCommand("remote-control", { ... })`.
+- Reads config from `~/.pi/agent/threa-remote.json` with required `baseUrl`, `workspaceId`, and `apiKey`.
+- Supports `/remote-control configure` so Kris can paste/edit `baseUrl`, `workspaceId`, `apiKey`, `pollMs`, and `defaultDisplayName` from inside Pi.
+- Uses a bot API key only; do not add user-key fallback behavior.
+- Creates/links sessions through `POST /api/v1/workspaces/:workspaceId/bot-runtime/sessions`.
+- Heartbeats through `POST /api/v1/workspaces/:workspaceId/bot-runtime/presence`.
+- Claims through `POST /api/v1/workspaces/:workspaceId/bot-invocations/claim` with current `supportedCapabilities`.
+- Renews long-running claims before expiry.
+- Advertises `busy` presence while Pi is working locally or on a Threa invocation, not just while claims are being processed.
+- Claims messages that arrive while Pi is busy and injects them with Pi steering (`deliverAs: "steer"`) instead of waiting until idle.
+- Records trace steps through `/steps` without leaking raw tool args, file contents, shell output, or secrets.
+- Completes/fails through `/complete` and `/fail` with `instanceId` + `claimToken`.
+- Stores enabled/disabled state per Pi session link, not as a global config flag.
+- Stores stream cursors per Pi session link, not as a global cursor map.
+- Stops polling and marks presence offline on `session_shutdown`.
+- Does not poll arbitrary stream messages as the work trigger. Threa-owned invocation rows are the trigger.
+
+## Verification
+
+Run the focused test:
+
+```bash
+bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts
+```
+
+If you changed backend API contracts, also run the relevant backend tests and/or typecheck. At minimum, inspect the route schemas and explain why the plugin request/response shapes still match.
+
+Optional local smoke check when Pi is available:
+
+```bash
+cp docs/examples/pi-remote/threa-remote-v2.ts ~/.pi/agent/extensions/threa-remote.ts
+# In Pi: /reload, then /remote-control status or /remote-control
+```
+
+## Placement note
+
+`docs/examples/pi-remote/` is acceptable while the adapter is example/distribution material rather than shipped app code. If it gains packaging, dependencies, or release automation, move it to a dedicated package or scripts directory and keep this skill updated with the new canonical path.

--- a/.claude/plans/update-pi-remote-plugin.md
+++ b/.claude/plans/update-pi-remote-plugin.md
@@ -1,0 +1,89 @@
+# Pi Remote Session State and Runtime Readiness
+
+## Goal
+
+Make the Threa Pi remote adapter reliable enough for main Threa usage by removing global runtime state, adding self-configuration and diagnostics, advertising accurate busy presence, supporting steering while Pi is already working, and ensuring Pi runtime bots are eligible for invocation creation.
+
+## What Was Built
+
+### Pi remote adapter
+
+`docs/examples/pi-remote/threa-remote-v2.ts` now keeps runtime state scoped to the active Pi session link instead of global config fields.
+
+**Files:**
+
+- `docs/examples/pi-remote/threa-remote-v2.ts` — session-scoped enablement/cursors, `/remote-control configure`, `/remote-control debug`, busy heartbeats, steering injection, legacy config migration.
+- `docs/examples/pi-remote/threa-remote-v2.test.ts` — regression coverage for config migration and pasted configuration parsing, alongside existing trace-safety tests.
+- `.agents/skills/update-pi-remote-plugin/SKILL.md` — repeatable maintenance workflow for keeping the plugin aligned with Pi and Threa APIs.
+
+### Backend runtime bot readiness
+
+`apps/backend/src/features/public-api/handlers.ts` now ensures a personal bot linked as a Pi runtime has the runtime traits required by the invocation producer.
+
+**Files:**
+
+- `apps/backend/src/features/public-api/handlers.ts` — `POST /bot-runtime/sessions` ensures the personal bot has the `active-scratchpad` trait before linking the session.
+- `apps/backend/src/features/bot-runtimes/service.ts` — owns transactional runtime trait repair and session-link creation helpers.
+- `apps/backend/src/features/public-api/bot-repository.ts` — atomically adds missing bot traits without clobbering concurrent updates.
+
+### Bot trait controls
+
+The workspace bot settings UI now exposes bot capability tags on create/edit so admins and bot owners can explicitly configure whether a bot is mentionable or can act as an active scratchpad runtime.
+
+**Files:**
+
+- `apps/frontend/src/api/bots.ts` — includes `traits` in create/update bot payload types.
+- `apps/frontend/src/components/workspace-settings/bot-traits-picker.tsx` — shared capability picker.
+- `apps/frontend/src/components/workspace-settings/bots-tab.tsx` — includes capabilities when creating shared or personal bots.
+- `apps/frontend/src/components/workspace-settings/bot-detail.tsx` — displays and edits bot capabilities.
+
+## Design Decisions
+
+### Session-local runtime state
+
+**Chose:** store `enabled` and `streamCursors` on each `linkedSessions[runtimeSessionId]` entry.
+**Why:** a global on/off flag caused one Pi session to disable or enable every linked session, and global cursors could skip messages across unrelated scratchpads.
+**Alternatives considered:** separate config files per session. That would avoid mixing state but make setup and migration harder.
+
+### In-plugin configuration
+
+**Chose:** add `/remote-control configure` with an editor-backed JSON template.
+**Why:** users should not need to manually find and edit `~/.pi/agent/threa-remote.json` to paste API URL, workspace ID, or bot key.
+
+### Busy presence and steering
+
+**Chose:** heartbeat `busy` when Pi is already working, and claim/inject new invocations as Pi steering messages via `deliverAs: "steer"`.
+**Why:** Threa should not show an available green dot while Pi cannot pick up a fresh request, and follow-up messages in the scratchpad should steer the active local run instead of waiting silently.
+
+### Backend trait repair on session link
+
+**Chose:** session linking ensures the personal bot has the `active-scratchpad` trait only.
+**Why:** the invocation outbox handler checks `active-scratchpad` before creating scratchpad invocation rows. `mentionable` expands who can invoke a bot by `@mention`, so it remains an explicit UI capability choice.
+
+### Explicit bot capability UI
+
+**Chose:** expose the existing `BOT_TRAITS` vocabulary in bot create/edit flows.
+**Why:** users need a supported way to repair or intentionally configure bot scheduling behavior without hand-written API calls or database edits.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No packaged npm/git distribution for the Pi plugin; `docs/examples/pi-remote/` remains the canonical repo copy for now.
+- No dedicated public debug endpoint for bot invocations.
+- No production data mutation outside normal runtime session linking behavior.
+
+## Status
+
+- [x] Session-scoped plugin state
+- [x] Self-configuration command
+- [x] Debug status command
+- [x] Busy presence while Pi is occupied
+- [x] Steering support for messages received mid-run
+- [x] Backend trait repair for linked runtime bots
+- [x] Bot trait controls in settings UI
+- [x] Focused plugin tests
+- [x] Backend typecheck
+- [x] Frontend typecheck

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -1,7 +1,9 @@
 import type { Pool } from "pg"
 import type { Querier } from "../../db"
-import type { BotInvocationCapability, BotRuntimeKind, BotRuntimeStatus } from "@threa/types"
+import type { BotInvocationCapability, BotRuntimeKind, BotRuntimeStatus, BotTrait } from "@threa/types"
 import { withTransaction } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
+import { BotRepository, type Bot } from "../public-api/bot-repository"
 import { botInvocationId, botRuntimeInstanceId, botRuntimeSessionLinkId, streamActiveActorId } from "../../lib/id"
 import {
   BotInvocationRepository,
@@ -16,6 +18,24 @@ import {
 
 interface BotRuntimeServiceDeps {
   pool: Pool
+}
+
+function serializeBotForOutbox(bot: Bot) {
+  const common = {
+    id: bot.id,
+    workspaceId: bot.workspaceId,
+    traits: bot.traits,
+    slug: bot.slug,
+    name: bot.name,
+    description: bot.description,
+    avatarEmoji: bot.avatarEmoji,
+    avatarUrl: bot.avatarUrl,
+    archivedAt: bot.archivedAt?.toISOString() ?? null,
+    createdAt: bot.createdAt.toISOString(),
+    updatedAt: bot.updatedAt.toISOString(),
+  }
+  if (bot.type === "personal") return { ...common, type: "personal" as const, ownerUserId: bot.ownerUserId }
+  return { ...common, type: "shared" as const, ownerUserId: null }
 }
 
 export class BotRuntimeService {
@@ -94,6 +114,18 @@ export class BotRuntimeService {
     })
   }
 
+  async repairBotTraitsInTransaction(
+    db: Querier,
+    params: { workspaceId: string; botId: string; traits: readonly BotTrait[] }
+  ): Promise<void> {
+    const updated = await BotRepository.addTraitsIfMissing(db, params.botId, params.workspaceId, params.traits)
+    if (!updated) return
+    await OutboxRepository.insert(db, "bot:updated", {
+      workspaceId: params.workspaceId,
+      bot: serializeBotForOutbox(updated),
+    })
+  }
+
   async createOrLinkPiRemoteSession(params: {
     workspaceId: string
     botId: string
@@ -104,37 +136,51 @@ export class BotRuntimeService {
     linkedBy: string
     metadata?: Record<string, unknown>
   }): Promise<BotRuntimeSessionLink> {
-    return withTransaction(this.pool, async (client) => {
-      await BotRuntimeInstanceRepository.upsertPresence(client, {
-        id: botRuntimeInstanceId(),
-        workspaceId: params.workspaceId,
-        botId: params.botId,
-        runtimeKind: "pi-local",
-        instanceId: params.instanceId,
-        status: "available",
-        acceptingInvocations: true,
-        capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
-      })
-      await StreamActiveActorRepository.upsert(client, {
-        id: streamActiveActorId(),
-        workspaceId: params.workspaceId,
-        rootStreamId: params.rootStreamId,
-        actorType: "bot",
-        actorId: params.botId,
-        createdBy: params.linkedBy,
-      })
-      return BotRuntimeSessionLinkRepository.upsert(client, {
-        id: botRuntimeSessionLinkId(),
-        workspaceId: params.workspaceId,
-        botId: params.botId,
-        runtimeKind: "pi-local",
-        instanceId: params.instanceId,
-        runtimeSessionId: params.runtimeSessionId,
-        rootStreamId: params.rootStreamId,
-        activeStreamId: params.activeStreamId,
-        linkedBy: params.linkedBy,
-        metadata: params.metadata,
-      })
+    return withTransaction(this.pool, (client) => this.createOrLinkPiRemoteSessionInTransaction(client, params))
+  }
+
+  async createOrLinkPiRemoteSessionInTransaction(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      instanceId: string
+      runtimeSessionId: string
+      rootStreamId: string
+      activeStreamId: string
+      linkedBy: string
+      metadata?: Record<string, unknown>
+    }
+  ): Promise<BotRuntimeSessionLink> {
+    await BotRuntimeInstanceRepository.upsertPresence(db, {
+      id: botRuntimeInstanceId(),
+      workspaceId: params.workspaceId,
+      botId: params.botId,
+      runtimeKind: "pi-local",
+      instanceId: params.instanceId,
+      status: "available",
+      acceptingInvocations: true,
+      capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
+    })
+    await StreamActiveActorRepository.upsert(db, {
+      id: streamActiveActorId(),
+      workspaceId: params.workspaceId,
+      rootStreamId: params.rootStreamId,
+      actorType: "bot",
+      actorId: params.botId,
+      createdBy: params.linkedBy,
+    })
+    return BotRuntimeSessionLinkRepository.upsert(db, {
+      id: botRuntimeSessionLinkId(),
+      workspaceId: params.workspaceId,
+      botId: params.botId,
+      runtimeKind: "pi-local",
+      instanceId: params.instanceId,
+      runtimeSessionId: params.runtimeSessionId,
+      rootStreamId: params.rootStreamId,
+      activeStreamId: params.activeStreamId,
+      linkedBy: params.linkedBy,
+      metadata: params.metadata,
     })
   }
 

--- a/apps/backend/src/features/public-api/bot-repository.ts
+++ b/apps/backend/src/features/public-api/bot-repository.ts
@@ -316,6 +316,31 @@ export const BotRepository = {
     return mapRowToBot(result.rows[0])
   },
 
+  async addTraitsIfMissing(
+    db: Querier,
+    id: string,
+    workspaceId: string,
+    traits: readonly BotTrait[]
+  ): Promise<Bot | null> {
+    if (traits.length === 0) return null
+    for (const trait of traits) {
+      if (!KNOWN_BOT_TRAITS.has(trait)) {
+        throw new Error(`Bot addTraitsIfMissing: unknown trait "${trait}"`)
+      }
+    }
+    const result = await db.query<BotRow>(sql`
+      UPDATE bots
+      SET traits = ARRAY(SELECT DISTINCT trait FROM unnest(traits || ${traits}::text[]) AS trait ORDER BY trait),
+          updated_at = NOW()
+      WHERE id = ${id}
+        AND workspace_id = ${workspaceId}
+        AND archived_at IS NULL
+        AND NOT (traits @> ${traits}::text[])
+      RETURNING ${sql.raw(BOT_COLUMNS)}
+    `)
+    return result.rows[0] ? mapRowToBot(result.rows[0]) : null
+  },
+
   async updateAvatarUrl(db: Querier, id: string, workspaceId: string, avatarUrl: string | null): Promise<Bot | null> {
     const result = await db.query<BotRow>(sql`
       UPDATE bots

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -701,6 +701,8 @@ export function createPublicApiHandlers({
         })
       }
 
+      const requiredRuntimeTraits = ["active-scratchpad"] as const
+
       const existingLink = await botRuntimeService.findActivePiRemoteSession({
         workspaceId: req.workspaceId!,
         botId: bot.id,
@@ -708,6 +710,13 @@ export function createPublicApiHandlers({
         runtimeSessionId: result.data.runtimeSessionId,
       })
       if (existingLink) {
+        await withTransaction(pool, (client) =>
+          botRuntimeService.repairBotTraitsInTransaction(client, {
+            workspaceId: req.workspaceId!,
+            botId: bot.id,
+            traits: requiredRuntimeTraits,
+          })
+        )
         return res.json({
           data: {
             linkId: existingLink.id,
@@ -725,15 +734,22 @@ export function createPublicApiHandlers({
         createdBy: bot.ownerUserId,
       })
       await streamService.addBotToStream(stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
-      const link = await botRuntimeService.createOrLinkPiRemoteSession({
-        workspaceId: req.workspaceId!,
-        botId: bot.id,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: result.data.runtimeSessionId,
-        rootStreamId: stream.id,
-        activeStreamId: stream.id,
-        linkedBy: bot.ownerUserId,
-        metadata: { displayName: result.data.displayName, localCwd: result.data.localCwd ?? null },
+      const link = await withTransaction(pool, async (client) => {
+        await botRuntimeService.repairBotTraitsInTransaction(client, {
+          workspaceId: req.workspaceId!,
+          botId: bot.id,
+          traits: requiredRuntimeTraits,
+        })
+        return botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
+          workspaceId: req.workspaceId!,
+          botId: bot.id,
+          instanceId: result.data.instanceId,
+          runtimeSessionId: result.data.runtimeSessionId,
+          rootStreamId: stream.id,
+          activeStreamId: stream.id,
+          linkedBy: bot.ownerUserId,
+          metadata: { displayName: result.data.displayName, localCwd: result.data.localCwd ?? null },
+        })
       })
 
       res.json({

--- a/apps/frontend/src/api/bots.ts
+++ b/apps/frontend/src/api/bots.ts
@@ -1,5 +1,5 @@
 import { api, API_BASE, parseApiError } from "./client"
-import type { Bot, BotApiKey, CreateBotApiKeyResponse, WorkspacePermissionSlug } from "@threa/types"
+import type { Bot, BotApiKey, BotTrait, CreateBotApiKeyResponse, WorkspacePermissionSlug } from "@threa/types"
 
 export interface CreateBotInput {
   type?: "shared" | "personal"
@@ -7,6 +7,7 @@ export interface CreateBotInput {
   slug: string
   description?: string | null
   avatarEmoji?: string | null
+  traits?: BotTrait[]
 }
 
 export interface UpdateBotInput {
@@ -14,6 +15,7 @@ export interface UpdateBotInput {
   slug?: string
   description?: string | null
   avatarEmoji?: string | null
+  traits?: BotTrait[]
 }
 
 export interface CreateBotKeyInput {

--- a/apps/frontend/src/components/workspace-settings/bot-detail.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-detail.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { botsApi } from "@/api/bots"
+import type { BotTrait } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -22,6 +23,7 @@ import { ArrowLeft, Archive, ArchiveRestore, Upload, X } from "lucide-react"
 import { BotAvatar } from "./bot-avatar"
 import { BotKeysSection } from "./bot-keys-section"
 import { BotChannelsSection } from "./bot-channels-section"
+import { BotTraitsPicker } from "./bot-traits-picker"
 
 interface BotDetailProps {
   workspaceId: string
@@ -43,10 +45,11 @@ export function BotDetail({ workspaceId, botId, onBack }: BotDetailProps) {
   const [editName, setEditName] = useState("")
   const [editSlug, setEditSlug] = useState("")
   const [editDescription, setEditDescription] = useState("")
+  const [editTraits, setEditTraits] = useState<Set<BotTrait>>(() => new Set())
   const [archiveTarget, setArchiveTarget] = useState(false)
 
   const updateMutation = useMutation({
-    mutationFn: (data: { name?: string; slug?: string; description?: string | null }) =>
+    mutationFn: (data: { name?: string; slug?: string; description?: string | null; traits?: BotTrait[] }) =>
       botsApi.update(workspaceId, botId, data),
     onSuccess: () => {
       setEditing(false)
@@ -93,7 +96,17 @@ export function BotDetail({ workspaceId, botId, onBack }: BotDetailProps) {
     setEditName(bot.name)
     setEditSlug(bot.slug ?? "")
     setEditDescription(bot.description ?? "")
+    setEditTraits(new Set(bot.traits))
     setEditing(true)
+  }
+
+  const toggleEditTrait = (trait: BotTrait) => {
+    setEditTraits((current) => {
+      const next = new Set(current)
+      if (next.has(trait)) next.delete(trait)
+      else next.add(trait)
+      return next
+    })
   }
 
   const handleSave = () => {
@@ -102,6 +115,7 @@ export function BotDetail({ workspaceId, botId, onBack }: BotDetailProps) {
       name: editName.trim(),
       slug: editSlug.trim(),
       description: editDescription.trim() || null,
+      traits: Array.from(editTraits),
     })
   }
 
@@ -224,6 +238,7 @@ export function BotDetail({ workspaceId, botId, onBack }: BotDetailProps) {
               <Label className="text-xs text-muted-foreground">Description</Label>
               <Textarea value={editDescription} onChange={(e) => setEditDescription(e.target.value)} rows={2} />
             </div>
+            <BotTraitsPicker traits={editTraits} onToggle={toggleEditTrait} />
             <div className="flex items-center justify-between pt-1">
               <Button variant="ghost" size="sm" onClick={() => setEditing(false)}>
                 Cancel
@@ -250,6 +265,19 @@ export function BotDetail({ workspaceId, botId, onBack }: BotDetailProps) {
             </div>
             {bot.description && <p className="text-xs text-muted-foreground">{bot.description}</p>}
             {!bot.description && <p className="text-xs text-muted-foreground italic">No description</p>}
+            <div className="flex flex-wrap gap-1 pt-1">
+              {bot.traits.length > 0 ? (
+                bot.traits.map((trait) => (
+                  <Badge key={trait} variant="secondary" className="text-[11px] font-normal">
+                    {trait}
+                  </Badge>
+                ))
+              ) : (
+                <Badge variant="outline" className="text-[11px] font-normal text-muted-foreground">
+                  no capabilities
+                </Badge>
+              )}
+            </div>
           </div>
         )}
       </section>

--- a/apps/frontend/src/components/workspace-settings/bot-traits-picker.tsx
+++ b/apps/frontend/src/components/workspace-settings/bot-traits-picker.tsx
@@ -1,0 +1,38 @@
+import { BOT_TRAITS, type BotTrait } from "@threa/types"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+
+interface BotTraitsPickerProps {
+  traits: ReadonlySet<BotTrait>
+  onToggle: (trait: BotTrait) => void
+}
+
+export function BotTraitsPicker({ traits, onToggle }: BotTraitsPickerProps) {
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <div>
+        <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Capabilities</Label>
+        <p className="text-xs text-muted-foreground mt-1">
+          Enable how Threa can route work to this bot. Pi remote needs Active scratchpad.
+        </p>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {BOT_TRAITS.map((trait) => (
+          <label key={trait} className="flex items-start gap-2 rounded-md border px-2.5 py-2 text-sm">
+            <Checkbox checked={traits.has(trait)} onCheckedChange={() => onToggle(trait)} />
+            <span>
+              <span className="block font-medium">
+                {trait === "active-scratchpad" ? "Active scratchpad" : "Mentionable"}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {trait === "active-scratchpad"
+                  ? "Receives messages from scratchpads where this bot is the active actor."
+                  : "Can be invoked by @mention where it has access."}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/bots-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/bots-tab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { WORKSPACE_PERMISSION_SCOPES, type BotTrait } from "@threa/types"
 import { botsApi, type CreateBotInput } from "@/api/bots"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Plus, BotIcon, ChevronRight, Globe, User } from "lucide-react"
 import { BotAvatar } from "./bot-avatar"
 import { BotDetail } from "./bot-detail"
+import { BotTraitsPicker } from "./bot-traits-picker"
 import { useCachedWorkspaceBootstrap, workspaceKeys } from "@/hooks/use-workspaces"
 import { hasPermission } from "@/lib/permissions"
 import { useWorkspaceBots } from "@/stores/workspace-store"
@@ -205,6 +206,7 @@ function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: Cr
   const [name, setName] = useState("")
   const [slug, setSlug] = useState("")
   const [description, setDescription] = useState("")
+  const [traits, setTraits] = useState<Set<BotTrait>>(() => new Set())
   const [slugTouched, setSlugTouched] = useState(false)
 
   const handleNameChange = (value: string) => {
@@ -221,9 +223,23 @@ function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: Cr
 
   const canSubmit = name.trim().length > 0 && slug.trim().length > 0 && !isPending
 
+  const toggleTrait = (trait: BotTrait) => {
+    setTraits((current) => {
+      const next = new Set(current)
+      if (next.has(trait)) next.delete(trait)
+      else next.add(trait)
+      return next
+    })
+  }
+
   const handleCreate = () => {
     if (!canSubmit) return
-    onCreate({ name: name.trim(), slug: slug.trim(), description: description.trim() || null })
+    onCreate({
+      name: name.trim(),
+      slug: slug.trim(),
+      description: description.trim() || null,
+      traits: Array.from(traits),
+    })
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -276,6 +292,8 @@ function CreateBotForm({ placeholder, isPending, error, onCancel, onCreate }: Cr
           rows={2}
         />
       </div>
+
+      <BotTraitsPicker traits={traits} onToggle={toggleTrait} />
 
       <div className="flex items-center justify-between pt-1">
         <Button variant="ghost" size="sm" onClick={onCancel} disabled={isPending}>

--- a/docs/examples/pi-remote/threa-remote-v2.test.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.test.ts
@@ -43,4 +43,56 @@ describe("Pi remote trace safety", () => {
     expect(trace).not.toContain("oldText")
     expect(trace).not.toContain("secret")
   })
+
+  test("migrates legacy global enabled and stream cursors into session links", () => {
+    const migrated = __testing.migrateSessionState({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      streamCursors: { stream_a: "42" },
+      linkedSessions: {
+        session_1: {
+          linkId: "brsl_123",
+          rootStreamId: "stream_a",
+          activeStreamId: "stream_a",
+          runtimeSessionId: "session_1",
+          streamUrlPath: "/streams/stream_a",
+        },
+      },
+    })
+
+    expect(migrated.linkedSessions?.session_1.enabled).toBe(true)
+    expect(migrated.linkedSessions?.session_1.streamCursors).toEqual({ stream_a: "42" })
+  })
+
+  test("drops malformed linked session entries during migration", () => {
+    const migrated = __testing.migrateSessionState({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        session_1: null,
+      } as never,
+    })
+
+    expect(migrated.linkedSessions).toEqual({})
+  })
+
+  test("parses pasted self-configuration JSON", () => {
+    expect(
+      __testing.parseConfigPatch(`{
+        "baseUrl": " https://app.threa.io/ ",
+        "workspaceId": " ws_123 ",
+        "apiKey": " threa_bk_test ",
+        "pollMs": 1500,
+        "defaultDisplayName": " Local Pi "
+      }`)
+    ).toEqual({
+      baseUrl: "https://app.threa.io/",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      pollMs: 1500,
+      defaultDisplayName: "Local Pi",
+    })
+  })
 })

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -14,6 +14,7 @@ const STATUS_KEY = "threa-remote"
 const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 const FETCH_TIMEOUT_MS = 30_000
 const MAX_FAILURE_POLL_MS = 60_000
+const BUSY_HEARTBEAT_MS = 15_000
 const TRACE_CONTENT_MAX_CHARS = 9_500
 const PI_TOOL_TRACE_FORMAT = "pi_tool_trace"
 const PI_TOOL_TRACE_SECTION_LABELS = {
@@ -32,8 +33,10 @@ type Config = {
   pollMs?: number
   instanceId?: string
   defaultDisplayName?: string
+  /** Legacy global flag; migrated to per-session link state on write. */
   enabled?: boolean
   linkedSessions?: Record<string, RuntimeSessionLink>
+  /** Legacy global cursors; migrated to per-session link state on write. */
   streamCursors?: Record<string, string>
 }
 
@@ -43,7 +46,12 @@ type RuntimeSessionLink = {
   activeStreamId: string
   runtimeSessionId: string
   streamUrlPath: string
+  enabled?: boolean
+  debugPolling?: boolean
+  streamCursors?: Record<string, string>
 }
+
+type ConfigPatch = Pick<Config, "baseUrl" | "workspaceId" | "apiKey" | "pollMs" | "defaultDisplayName">
 
 type ClaimedInvocation = {
   id: string
@@ -78,17 +86,30 @@ interface UploadedAttachment {
   sizeBytes: number
 }
 
+interface BotPrincipal {
+  kind: "bot"
+  workspaceId: string
+  botId: string
+  botType: string
+  traits: string[]
+  ownerUserId: string
+}
+
 let config: Config | undefined
 let timer: ReturnType<typeof setTimeout> | undefined
 let pollInFlightRunId: number | undefined
 let pending: ClaimedInvocation | undefined
+let steeredInvocations: Array<{ invocation: ClaimedInvocation; cursor?: string }> = []
 let pendingContextCursor: string | undefined
 let pendingAssistantTexts: string[] = []
 let pendingToolCalls = new Map<string, { headline: string }>()
 let lastTraceHeartbeat: { text: string; at: number } | undefined
 let consecutivePollFailures = 0
 let lastPollFailureSummary: string | undefined
+let lastBusyHeartbeatAt = 0
+let lastPollDebugSummary: string | undefined
 let pollingRunId = 0
+let fallbackRuntimeSessionId: string | undefined
 
 function validateConfig(value: unknown): Config | undefined {
   if (!value || typeof value !== "object") {
@@ -104,23 +125,48 @@ function validateConfig(value: unknown): Config | undefined {
     console.error(`Invalid ${CONFIG_PATH}: missing or invalid ${invalidFields.join(", ")}`)
     return undefined
   }
-  return candidate as Config
+  return migrateSessionState(candidate as Config)
 }
 
-function readConfig(): Config | undefined {
+function readStoredConfig(): Partial<Config> | undefined {
   if (!existsSync(CONFIG_PATH)) return undefined
   try {
-    return validateConfig(JSON.parse(readFileSync(CONFIG_PATH, "utf8")))
+    const parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as unknown
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Partial<Config>) : undefined
   } catch (error) {
     console.error(`Failed to parse ${CONFIG_PATH}: ${String(error)}`)
     return undefined
   }
 }
 
+function migrateSessionState(candidate: Config): Config {
+  if (!candidate.linkedSessions || typeof candidate.linkedSessions !== "object") return candidate
+  for (const [sessionId, link] of Object.entries(candidate.linkedSessions)) {
+    if (!link || typeof link !== "object") {
+      delete candidate.linkedSessions[sessionId]
+      continue
+    }
+    link.enabled ??= candidate.enabled ?? true
+    if (!link.streamCursors && candidate.streamCursors) {
+      const cursor = candidate.streamCursors[link.activeStreamId] ?? candidate.streamCursors[link.rootStreamId]
+      if (cursor) link.streamCursors = { [link.activeStreamId]: cursor }
+    }
+  }
+  return candidate
+}
+
+function readConfig(): Config | undefined {
+  const stored = readStoredConfig()
+  return stored ? validateConfig(stored) : undefined
+}
+
 function saveConfig(): void {
   if (!config) return
+  const persisted: Config = { ...config }
+  delete persisted.enabled
+  delete persisted.streamCursors
   mkdirSync(dirname(CONFIG_PATH), { recursive: true })
-  writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+  writeFileSync(CONFIG_PATH, `${JSON.stringify(persisted, null, 2)}\n`)
 }
 
 function ensureInstanceId(): string {
@@ -129,6 +175,48 @@ function ensureInstanceId(): string {
   config.instanceId = `pi-${hostname()}-${crypto.randomUUID().slice(0, 8)}`
   saveConfig()
   return config.instanceId
+}
+
+function getRuntimeSessionId(ctx: ExtensionContext): string {
+  const sessionId = ctx.sessionManager.getSessionId()
+  if (sessionId) return sessionId
+  fallbackRuntimeSessionId ??= `pi-session-${Date.now()}`
+  return fallbackRuntimeSessionId
+}
+
+function getCurrentSessionLink(ctx: ExtensionContext): RuntimeSessionLink | undefined {
+  if (!config?.linkedSessions) return undefined
+  return config.linkedSessions[getRuntimeSessionId(ctx)]
+}
+
+function setCurrentSessionEnabled(ctx: ExtensionContext, enabled: boolean): RuntimeSessionLink | undefined {
+  const link = getCurrentSessionLink(ctx)
+  if (!link) return undefined
+  link.enabled = enabled
+  saveConfig()
+  return link
+}
+
+function isCurrentSessionEnabled(ctx: ExtensionContext): boolean {
+  return getCurrentSessionLink(ctx)?.enabled === true
+}
+
+function isPollDebugEnabled(ctx: ExtensionContext): boolean {
+  return getCurrentSessionLink(ctx)?.debugPolling === true
+}
+
+function setPollDebug(ctx: ExtensionContext, enabled: boolean): boolean {
+  const link = getCurrentSessionLink(ctx)
+  if (!link) return false
+  link.debugPolling = enabled
+  saveConfig()
+  return true
+}
+
+function emitPollDebug(ctx: ExtensionContext, summary: string): void {
+  lastPollDebugSummary = `${new Date().toISOString()} ${summary}`
+  if (!isPollDebugEnabled(ctx)) return
+  ctx.ui.notify(`Threa remote poll: ${summary}`, "info")
 }
 
 function setRemoteStatus(ctx: ExtensionContext, text: string, tone: "muted" | "error" = "muted"): void {
@@ -193,26 +281,44 @@ async function heartbeat(status: "available" | "busy" | "offline" | "error", sta
   })
 }
 
+async function heartbeatBusyIfStale(statusText = "Working…"): Promise<boolean> {
+  const now = Date.now()
+  if (now - lastBusyHeartbeatAt < BUSY_HEARTBEAT_MS) return false
+  lastBusyHeartbeatAt = now
+  await heartbeat("busy", statusText)
+  return true
+}
+
 function truncateForTrace(text: string, max = TRACE_CONTENT_MAX_CHARS): string {
   const trimmed = text.trim()
   if (trimmed.length <= max) return trimmed
   return `${trimmed.slice(0, max)}\n\n…[trace content truncated; ${trimmed.length - max} more characters]`
 }
 
-async function recordTraceStep(stepType: string, content: string, statusText?: string): Promise<void> {
-  if (!config || !pending) return
+async function recordInvocationTraceStep(
+  invocation: ClaimedInvocation,
+  stepType: string,
+  content: string,
+  statusText?: string
+): Promise<void> {
+  if (!config) return
   const trimmed = truncateForTrace(content)
   if (!trimmed) return
-  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${pending.id}/steps`, {
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/steps`, {
     method: "POST",
     body: JSON.stringify({
       instanceId: ensureInstanceId(),
-      claimToken: pending.claimToken,
+      claimToken: invocation.claimToken,
       stepType,
       content: trimmed,
       statusText: statusText?.trim().slice(0, 160),
     }),
   }).catch(() => undefined)
+}
+
+async function recordTraceStep(stepType: string, content: string, statusText?: string): Promise<void> {
+  if (!pending) return
+  await recordInvocationTraceStep(pending, stepType, content, statusText)
 }
 
 async function traceHeartbeat(text: string, stepType?: string): Promise<void> {
@@ -424,7 +530,7 @@ function formatInvocationTrace(invocation: ClaimedInvocation, context: string): 
 
 async function createRemoteSession(ctx: ExtensionCommandContext, args: string): Promise<void> {
   if (!config) throw new Error("Threa remote config not loaded")
-  const runtimeSessionId = ctx.sessionManager.getSessionId() ?? `pi-session-${Date.now()}`
+  const runtimeSessionId = getRuntimeSessionId(ctx)
   const displayName = args.trim() || config.defaultDisplayName || ctx.cwd.split("/").pop() || "Pi"
 
   const body = await request<{ data: RuntimeSessionLink }>(
@@ -441,8 +547,15 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
     }
   )
 
+  const existing = config.linkedSessions?.[runtimeSessionId]
+  const legacyCursor =
+    config.streamCursors?.[body.data.activeStreamId] ?? config.streamCursors?.[body.data.rootStreamId]
   config.linkedSessions ??= {}
-  config.linkedSessions[runtimeSessionId] = body.data
+  config.linkedSessions[runtimeSessionId] = {
+    ...body.data,
+    enabled: true,
+    streamCursors: existing?.streamCursors ?? (legacyCursor ? { [body.data.activeStreamId]: legacyCursor } : undefined),
+  }
   saveConfig()
 
   ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
@@ -466,8 +579,8 @@ async function renewPendingClaim(): Promise<void> {
   pending.claimExpiresAt = body.data.claimExpiresAt
 }
 
-function isEnabled(): boolean {
-  return config?.enabled !== false
+function isEnabled(ctx: ExtensionContext): boolean {
+  return isCurrentSessionEnabled(ctx)
 }
 
 function stopPolling(): void {
@@ -503,24 +616,96 @@ function notePollFailure(ctx: ExtensionContext, error: unknown): void {
   }
 }
 
+function configTemplate(existing: Partial<Config> | undefined): string {
+  return JSON.stringify(
+    {
+      baseUrl: existing?.baseUrl ?? "https://app.threa.io",
+      workspaceId: existing?.workspaceId ?? "",
+      apiKey: existing?.apiKey ?? "",
+      pollMs: existing?.pollMs ?? 3000,
+      defaultDisplayName: existing?.defaultDisplayName ?? "Local Pi",
+    },
+    null,
+    2
+  )
+}
+
+function parseConfigPatch(text: string): ConfigPatch {
+  const parsed = JSON.parse(text) as unknown
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Expected a JSON object")
+  }
+  const candidate = parsed as Partial<ConfigPatch>
+  for (const field of ["baseUrl", "workspaceId", "apiKey"] as const) {
+    if (typeof candidate[field] !== "string" || candidate[field].trim().length === 0) {
+      throw new Error(`Missing required config field: ${field}`)
+    }
+  }
+  if (candidate.pollMs !== undefined && (typeof candidate.pollMs !== "number" || !Number.isFinite(candidate.pollMs))) {
+    throw new Error("pollMs must be a number")
+  }
+  if (candidate.defaultDisplayName !== undefined && typeof candidate.defaultDisplayName !== "string") {
+    throw new Error("defaultDisplayName must be a string")
+  }
+  const { baseUrl, workspaceId, apiKey } = candidate as ConfigPatch
+  return {
+    baseUrl: baseUrl.trim(),
+    workspaceId: workspaceId.trim(),
+    apiKey: apiKey.trim(),
+    pollMs: candidate.pollMs,
+    defaultDisplayName: candidate.defaultDisplayName?.trim() || undefined,
+  }
+}
+
+async function configureRemote(ctx: ExtensionCommandContext, args: string): Promise<void> {
+  const existing = readStoredConfig()
+  const input = args.trim() || (await ctx.ui.editor("Threa remote config", configTemplate(existing)))
+  if (!input) return
+  const patch = parseConfigPatch(input)
+  const next = validateConfig({ ...existing, ...patch })
+  if (!next) throw new Error(`Invalid ${CONFIG_PATH}`)
+  config = next
+  saveConfig()
+  ctx.ui.notify(`Saved Threa remote config to ${CONFIG_PATH}`, "info")
+}
+
+async function fetchBotPrincipal(): Promise<BotPrincipal | null> {
+  if (!config) return null
+  const body = await request<{ data: BotPrincipal | { kind: string } }>(`/api/v1/workspaces/${config.workspaceId}/me`)
+  return body.data.kind === "bot" ? (body.data as BotPrincipal) : null
+}
+
+function botTraitDiagnostics(principal: BotPrincipal | null): string[] {
+  if (!principal) return ["bot=<not a bot key>"]
+  const missing = ["active-scratchpad", "mentionable"].filter((trait) => !principal.traits.includes(trait))
+  return [
+    `bot=${principal.botId}`,
+    `botTraits=${principal.traits.length > 0 ? principal.traits.join(",") : "<none>"}`,
+    ...(missing.length > 0 ? [`missingTraits=${missing.join(",")}`] : []),
+  ]
+}
+
 async function disableRemote(ctx: ExtensionContext): Promise<void> {
   if (!config) return
-  config.enabled = false
-  saveConfig()
+  const link = setCurrentSessionEnabled(ctx, false)
   stopPolling()
   await failPending("Threa remote disabled")
   await heartbeat("offline").catch(() => undefined)
   setRemoteStatus(ctx, "Threa remote: off")
-  ctx.ui.notify("Threa remote disabled", "info")
+  ctx.ui.notify(link ? "Threa remote disabled for this Pi session" : "No Threa remote session is linked here", "info")
 }
 
 async function enableRemote(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
   if (!config) return
-  config.enabled = true
-  saveConfig()
+  const link = setCurrentSessionEnabled(ctx, true)
+  if (!link) {
+    ctx.ui.notify("No Threa remote session is linked here. Run /remote-control first.", "warning")
+    return
+  }
+  lastBusyHeartbeatAt = 0
   await heartbeat("available")
   startPolling(pi, ctx)
-  ctx.ui.notify("Threa remote enabled", "info")
+  ctx.ui.notify("Threa remote enabled for this Pi session", "info")
 }
 
 function formatInvocationContext(
@@ -590,10 +775,11 @@ async function downloadContextAttachments(
 
 async function fetchInvocationContext(
   invocation: ClaimedInvocation,
-  cwd: string
+  cwd: string,
+  sessionLink: RuntimeSessionLink | undefined
 ): Promise<{ context: string; cursor?: string }> {
   if (!config) return { context: "" }
-  const cursor = config.streamCursors?.[invocation.activeStreamId]
+  const cursor = sessionLink?.streamCursors?.[invocation.activeStreamId]
   const query = cursor ? `after=${encodeURIComponent(cursor)}&limit=50` : "limit=12"
   const body = await request<{ data: StreamMessage[] }>(
     `/api/v1/workspaces/${config.workspaceId}/streams/${invocation.activeStreamId}/messages?${query}`
@@ -617,52 +803,97 @@ async function fetchInvocationContext(
   }
 }
 
-async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boolean> {
-  if (!config || !isEnabled()) return false
-  if (pending) {
-    await renewPendingClaim()
-    return true
+async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvocation | null> {
+  if (!config) return null
+  const startedAt = Date.now()
+  try {
+    const body = await request<{ data: ClaimedInvocation | null }>(
+      `/api/v1/workspaces/${config.workspaceId}/bot-invocations/claim`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          runtimeKind: "pi-local",
+          instanceId: ensureInstanceId(),
+          supportedCapabilities: ["active-scratchpad", "mentionable"],
+          claimTtlSeconds: 120,
+        }),
+      }
+    )
+    emitPollDebug(
+      ctx,
+      body.data
+        ? `claimed ${body.data.id} in ${Date.now() - startedAt}ms`
+        : `no invocation in ${Date.now() - startedAt}ms`
+    )
+    return body.data
+  } catch (error) {
+    emitPollDebug(ctx, `failed after ${Date.now() - startedAt}ms: ${summarizeError(error)}`)
+    throw error
   }
-  if (!ctx.isIdle()) return false
-  // /claim doubles as the per-tick heartbeat on the server: it refreshes
-  // presence as "available" before looking for work and as "busy" if a claim
-  // lands. Saves a round trip per poll versus calling /presence separately.
-  const body = await request<{ data: ClaimedInvocation | null }>(
-    `/api/v1/workspaces/${config.workspaceId}/bot-invocations/claim`,
-    {
-      method: "POST",
-      body: JSON.stringify({
-        runtimeKind: "pi-local",
-        instanceId: ensureInstanceId(),
-        supportedCapabilities: ["active-scratchpad", "mentionable"],
-        claimTtlSeconds: 120,
-      }),
+}
+
+async function buildInvocationPrompt(
+  invocation: ClaimedInvocation,
+  ctx: ExtensionContext
+): Promise<{ prompt: string; cursor?: string; context: string }> {
+  const { context, cursor } = await fetchInvocationContext(invocation, ctx.cwd, getCurrentSessionLink(ctx)).catch(
+    (error): { context: string; cursor?: string } => {
+      ctx.ui.notify(`Threa remote context fetch failed: ${summarizeError(error)}`, "warning")
+      return { context: "" }
     }
   )
-
-  if (!body.data) return true
-  pending = body.data
-  pendingAssistantTexts = []
-  pendingToolCalls = new Map()
-  lastTraceHeartbeat = undefined
-  const { context, cursor } = await fetchInvocationContext(body.data, ctx.cwd).catch((error) => {
-    ctx.ui.notify(`Threa remote context fetch failed: ${summarizeError(error)}`, "warning")
-    return { context: "" }
-  })
-  pendingContextCursor = cursor
-  await recordTraceStep("context_received", formatInvocationTrace(body.data, context), "Loaded context…")
-  setRemoteStatus(ctx, `Threa remote: running ${body.data.id}`)
-  pi.sendUserMessage(
-    [
-      `Remote Threa invocation ${body.data.id}.`,
-      `Source message: ${body.data.sourceMessageId}`,
+  return {
+    context,
+    cursor,
+    prompt: [
+      `Remote Threa invocation ${invocation.id}.`,
+      `Source message: ${invocation.sourceMessageId}`,
       "Respond normally; the extension will post your final answer back to Threa.",
       "To attach a local file to your reply, add a line exactly like `THREA_ATTACH: path/to/file`; the extension will upload it and replace it with an attachment link.",
       context ? `\n${context}` : "",
       "\nSource message prompt:",
-      body.data.promptMarkdown,
-    ].join("\n")
-  )
+      invocation.promptMarkdown,
+    ].join("\n"),
+  }
+}
+
+async function injectInvocation(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  invocation: ClaimedInvocation,
+  steer: boolean
+): Promise<void> {
+  const { prompt, cursor, context } = await buildInvocationPrompt(invocation, ctx)
+  if (!pending) {
+    pending = invocation
+    pendingContextCursor = cursor
+    pendingAssistantTexts = []
+    pendingToolCalls = new Map()
+    lastTraceHeartbeat = undefined
+    await recordTraceStep("context_received", formatInvocationTrace(invocation, context), "Loaded context…")
+  } else {
+    steeredInvocations.push({ invocation, cursor })
+    await recordInvocationTraceStep(
+      invocation,
+      "context_received",
+      formatInvocationTrace(invocation, context),
+      "Loaded context…"
+    )
+  }
+  setRemoteStatus(ctx, `Threa remote: running ${pending.id}`)
+  pi.sendUserMessage(prompt, steer ? { deliverAs: "steer" } : undefined)
+}
+
+async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boolean> {
+  if (!config || !isEnabled(ctx)) return false
+  if (pending) await renewPendingClaim()
+
+  const steer = pending !== undefined || !ctx.isIdle()
+  if (steer) await heartbeatBusyIfStale(pending ? "Working on Threa invocation…" : "Busy in Pi…")
+
+  const invocation = await claimNextInvocation(ctx)
+  if (!invocation) return true
+  await injectInvocation(pi, ctx, invocation, steer)
   return true
 }
 
@@ -694,7 +925,7 @@ function textFromAgentMessages(messages: unknown): string {
 }
 
 function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
-  if (!isEnabled()) return
+  if (!isEnabled(ctx)) return
   stopPolling()
   const runId = ++pollingRunId
   const poll = async () => {
@@ -719,10 +950,12 @@ function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
   void poll()
 }
 
-function advanceStreamCursor(invocation: ClaimedInvocation): void {
-  if (!config || !pendingContextCursor) return
-  config.streamCursors ??= {}
-  config.streamCursors[invocation.activeStreamId] = pendingContextCursor
+function advanceStreamCursor(invocation: ClaimedInvocation, ctx: ExtensionContext, cursor?: string): void {
+  if (!config || !cursor) return
+  const link = getCurrentSessionLink(ctx)
+  if (!link) return
+  link.streamCursors ??= {}
+  link.streamCursors[invocation.activeStreamId] = cursor
   saveConfig()
 }
 
@@ -802,10 +1035,41 @@ async function prepareFinalMarkdown(
   }
 }
 
-async function completePending(markdown: string, cwd: string): Promise<void> {
+async function completeInvocationNoResponse(invocation: ClaimedInvocation): Promise<void> {
+  if (!config) return
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      claimToken: invocation.claimToken,
+      noResponse: true,
+      metadata: {
+        "pi.remote.invocationId": invocation.id,
+        "pi.remote.instanceId": ensureInstanceId(),
+        "pi.remote.noResponse": "true",
+        "pi.remote.steered": "true",
+      },
+    }),
+  }).catch(() => undefined)
+}
+
+async function failInvocation(invocation: ClaimedInvocation, error: unknown): Promise<void> {
+  if (!config) return
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/fail`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      claimToken: invocation.claimToken,
+      errorMessage: String(error).slice(0, 1000),
+    }),
+  }).catch(() => undefined)
+}
+
+async function completePending(markdown: string, ctx: ExtensionContext): Promise<void> {
   if (!config || !pending) return
   const invocation = pending
-  const { finalMarkdown, uploadedAttachments } = await prepareFinalMarkdown(markdown, cwd)
+  const steered = steeredInvocations
+  const { finalMarkdown, uploadedAttachments } = await prepareFinalMarkdown(markdown, ctx.cwd)
   const noResponse = finalMarkdown === NO_RESPONSE_MARKER
   await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
     method: "POST",
@@ -823,31 +1087,32 @@ async function completePending(markdown: string, cwd: string): Promise<void> {
       },
     }),
   })
-  advanceStreamCursor(invocation)
+  await Promise.all(steered.map((item) => completeInvocationNoResponse(item.invocation)))
+  advanceStreamCursor(invocation, ctx, pendingContextCursor)
+  for (const item of steered) advanceStreamCursor(item.invocation, ctx, item.cursor)
   pending = undefined
+  steeredInvocations = []
   pendingContextCursor = undefined
   pendingAssistantTexts = []
   pendingToolCalls = new Map()
   lastTraceHeartbeat = undefined
+  lastBusyHeartbeatAt = 0
   await heartbeat("available")
 }
 
 async function failPending(error: unknown): Promise<void> {
   if (!config || !pending) return
   const invocation = pending
+  const steered = steeredInvocations
+  await failInvocation(invocation, error)
+  await Promise.all(steered.map((item) => failInvocation(item.invocation, error)))
   pending = undefined
+  steeredInvocations = []
   pendingContextCursor = undefined
   pendingAssistantTexts = []
   pendingToolCalls = new Map()
   lastTraceHeartbeat = undefined
-  await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/fail`, {
-    method: "POST",
-    body: JSON.stringify({
-      instanceId: ensureInstanceId(),
-      claimToken: invocation.claimToken,
-      errorMessage: String(error).slice(0, 1000),
-    }),
-  }).catch(() => undefined)
+  lastBusyHeartbeatAt = 0
   await heartbeat("available").catch(() => undefined)
 }
 
@@ -855,6 +1120,8 @@ export const __testing = {
   describeToolCall,
   formatToolCallTrace,
   formatToolResultTrace,
+  migrateSessionState,
+  parseConfigPatch,
   safeStatusText,
 }
 
@@ -862,12 +1129,20 @@ export default function (pi: ExtensionAPI): void {
   pi.registerCommand("remote-control", {
     description: "Create or link a Threa scratchpad to this Pi session",
     handler: async (args, ctx) => {
-      config = readConfig()
-      if (!config) {
-        ctx.ui.notify(`Missing ${CONFIG_PATH}`, "warning")
+      const trimmedArgs = args.trim()
+      const commandMatch = trimmedArgs.match(/^(\S+)(?:\s+([\s\S]*))?$/)
+      const command = commandMatch?.[1]?.toLowerCase() ?? ""
+      const commandArgs = commandMatch?.[2] ?? ""
+      if (command === "configure" || command === "config") {
+        await configureRemote(ctx, commandArgs)
         return
       }
-      const command = args.trim().toLowerCase()
+
+      config = readConfig()
+      if (!config) {
+        ctx.ui.notify(`Missing ${CONFIG_PATH}. Run /remote-control configure to paste setup JSON.`, "warning")
+        return
+      }
       if (command === "off" || command === "disable") {
         await disableRemote(ctx)
         return
@@ -876,12 +1151,44 @@ export default function (pi: ExtensionAPI): void {
         await enableRemote(pi, ctx)
         return
       }
-      if (command === "status") {
-        ctx.ui.notify(`Threa remote is ${isEnabled() ? "on" : "off"}${pending ? ` (${pending.id})` : ""}`, "info")
+      if (command === "debug-polls") {
+        const enabled = commandArgs.trim().toLowerCase() !== "off"
+        if (!setPollDebug(ctx, enabled)) {
+          ctx.ui.notify("No Threa remote session is linked here. Run /remote-control first.", "warning")
+          return
+        }
+        ctx.ui.notify(`Threa remote poll debug ${enabled ? "enabled" : "disabled"} for this Pi session`, "info")
         return
       }
-      config.enabled = true
-      await createRemoteSession(ctx, args)
+      if (command === "status" || command === "debug") {
+        const link = getCurrentSessionLink(ctx)
+        const state = link?.enabled === true ? "on" : "off"
+        const linked = link ? `linked to ${link.streamUrlPath}` : "not linked"
+        const principal = command === "debug" ? await fetchBotPrincipal().catch(() => null) : null
+        const details =
+          command === "debug" && config
+            ? [
+                `session=${getRuntimeSessionId(ctx)}`,
+                `instance=${config.instanceId ?? "<unset>"}`,
+                `workspace=${config.workspaceId}`,
+                `stream=${link?.activeStreamId ?? "<none>"}`,
+                ...botTraitDiagnostics(principal),
+                `debugPolling=${link?.debugPolling === true ? "on" : "off"}`,
+                `pending=${pending?.id ?? "<none>"}`,
+                `steered=${steeredInvocations.length}`,
+                `lastPoll=${lastPollDebugSummary ?? "<none>"}`,
+                `lastFailure=${lastPollFailureSummary ?? "<none>"}`,
+              ].join("\n")
+            : ""
+        ctx.ui.notify(
+          `Threa remote is ${state} for this Pi session (${linked})${pending ? `; running ${pending.id}` : ""}${
+            details ? `\n${details}` : ""
+          }`,
+          "info"
+        )
+        return
+      }
+      await createRemoteSession(ctx, trimmedArgs)
       startPolling(pi, ctx)
     },
   })
@@ -889,15 +1196,17 @@ export default function (pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     config = readConfig()
     if (!config) return
-    if (!isEnabled()) {
-      setRemoteStatus(ctx, "Threa remote: off")
+    if (!isEnabled(ctx)) {
+      setRemoteStatus(ctx, getCurrentSessionLink(ctx) ? "Threa remote: off" : "Threa remote: not linked")
       return
     }
+    lastBusyHeartbeatAt = 0
     await heartbeat("available")
     startPolling(pi, ctx)
   })
 
-  pi.on("agent_start", async () => {
+  pi.on("agent_start", async (_event, ctx) => {
+    if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…").catch(() => undefined)
     await traceHeartbeat("Thinking…", "thinking")
   })
 
@@ -937,13 +1246,19 @@ export default function (pi: ExtensionAPI): void {
   })
 
   pi.on("agent_end", async (event, ctx) => {
-    if (!pending) return
+    if (!pending) {
+      if (config && isEnabled(ctx)) {
+        lastBusyHeartbeatAt = 0
+        await heartbeat("available").catch(() => undefined)
+      }
+      return
+    }
     try {
       const finalText =
         pendingAssistantTexts.length > 0 ? pendingAssistantTexts.join("\n\n") : textFromAgentMessages(event.messages)
       const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
       await recordTraceStep("message_sent", `Final response:\n\n${sanitizeTraceText(traceFinalText)}`, "Sent response")
-      await completePending(finalText, ctx.cwd)
+      await completePending(finalText, ctx)
       setRemoteStatus(ctx, "Threa remote: linked")
     } catch (error) {
       ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")


### PR DESCRIPTION
## Problem

The Pi remote-control adapter could appear linked and available in Threa while never picking up messages. The debugging session found two root causes / gaps:

1. The plugin stored `enabled` and stream cursor state globally in `~/.pi/agent/threa-remote.json`, so one Pi session could affect another and cursors could be shared across unrelated linked scratchpads.
2. Personal runtime bots could be linked through `/bot-runtime/sessions` without the `active-scratchpad` / `mentionable` traits that the invocation outbox handler requires before creating `bot_invocations` rows. That makes the UI look connected while no work is scheduled.

The adapter also lacked in-Pi configuration and diagnostics, and Threa presence could show the bot as available while Pi was busy with local work.

## Solution

Harden the Pi remote adapter and session-link backend path:

- Move plugin enabled state and stream cursors onto each linked runtime session.
- Migrate legacy top-level `enabled` / `streamCursors` into session links on next save.
- Add `/remote-control configure` for pasting/editing base URL, workspace ID, API key, poll interval, and display name from inside Pi.
- Add `/remote-control debug` with current session/link/pending/failure details.
- Advertise `busy` presence while Pi is occupied locally or handling Threa work.
- Claim Threa messages that arrive while Pi is busy and inject them via Pi steering (`deliverAs: "steer"`).
- Ensure Pi-linked personal bots have the `active-scratchpad` trait needed for scratchpad invocation creation.

### How it works

1. Pi runs `/remote-control` and calls `POST /bot-runtime/sessions`.
2. Backend verifies the personal bot and ensures it has the `active-scratchpad` trait required for scratchpad invocation routing; `mentionable` remains an explicit capability picker choice.
3. The adapter stores the returned stream link under `linkedSessions[ctx.sessionManager.getSessionId()]` with per-session `enabled` and `streamCursors`.
4. Polling claims invocation rows. If Pi is idle, the invocation is sent as a normal user message. If Pi is busy, the invocation is sent as a steering message.
5. The primary invocation posts the final response. Steered invocation rows are completed with `noResponse` to avoid duplicate final bot messages.

### Key design decisions

**1. Session-local state in one config file**

This keeps setup simple while avoiding global runtime state. Separate config files per Pi session would be cleaner isolation but more painful to configure and migrate.

**2. Trait repair during runtime session linking**

The outbox invocation producer already treats bot traits as the scheduling gate. Adding only `active-scratchpad` when a personal bot links as a runtime keeps that invariant intact, while leaving `mentionable` as an explicit user-controlled capability.

**3. Steering rather than queue-only behavior**

If Threa messages arrive while Pi is already working, the expected behavior is to steer the active run. The adapter now claims those invocations and calls `pi.sendUserMessage(..., { deliverAs: "steer" })`.

## New files

| File | Purpose |
| --- | --- |
| `.agents/skills/update-pi-remote-plugin/SKILL.md` | Repeatable maintenance workflow for this plugin. |
| `.claude/plans/update-pi-remote-plugin.md` | Review plan/context for this PR. |

## Modified files

| File | Change |
| --- | --- |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Session-scoped state, configuration/debug commands, busy presence, steering support, migration from legacy config. |
| `docs/examples/pi-remote/threa-remote-v2.test.ts` | Adds config migration and pasted config parsing coverage. |
| `apps/backend/src/features/public-api/handlers.ts` | Ensures Pi-linked personal bots have runtime invocation traits. |

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts`
- [x] Standalone TypeScript check for the Pi plugin against installed Pi package types
- [x] `bun run --cwd apps/backend typecheck`
- [x] Pre-commit hooks: repo lint, repo typecheck, generated API docs check

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782251738&installation_id=129946197&pr_number=614&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F614&signature=3e7aee17318b585d396e0dd5232ff93a12adec2bda6f1024ab6e0d0c40f0f065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
