### PR TITLE
feat(attachment-explorer): use thumbnails + crossfade to full-res in preview

### DIFF
--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -5,6 +5,7 @@ import { categoryFromMime } from "@threa/types"
 import { Check, ChevronDown, ChevronUp, Copy, Download, ExternalLink, Hash } from "lucide-react"
 import { attachmentsApi, type AttachmentExtractionContent, type AttachmentSearchItem } from "@/api/attachments"
 import { Button } from "@/components/ui/button"
+import { ProgressiveImage } from "@/components/ui/progressive-image"
 import { useFormattedDate } from "@/hooks"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { formatFileSize } from "@/lib/file-size"
@@ -19,6 +20,9 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const { formatFull } = useFormattedDate()
   const [rawUrl, setRawUrl] = useState<string | null>(null)
   const [processedUrl, setProcessedUrl] = useState<string | null>(null)
+  // Image-only: fetched in parallel with the raw URL so the preview pane has
+  // something painted while the full-resolution variant streams in.
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
   const [previewError, setPreviewError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -102,9 +106,21 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   useEffect(() => {
     setRawUrl(null)
     setProcessedUrl(null)
+    setThumbnailUrl(null)
     setPreviewError(null)
     if (!item) return
     let cancelled = false
+    if (category === "image") {
+      attachmentsApi
+        .getDownloadUrl(workspaceId, item.id, { variant: "thumbnail" })
+        .then((url) => {
+          if (!cancelled) setThumbnailUrl(url)
+        })
+        .catch(() => {
+          // Thumbnail is best-effort — the raw fetch below still drives the
+          // real preview, and ProgressiveImage degrades to raw-only gracefully.
+        })
+    }
     attachmentsApi
       .getDownloadUrl(workspaceId, item.id, { variant: "raw" })
       .then((url) => {
@@ -152,16 +168,24 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
     if (previewError) {
       return <div className="px-6 py-4 text-xs text-muted-foreground">{previewError}</div>
     }
+    // Images bypass the "no rawUrl yet" fallback so the thumbnail can paint as
+    // soon as it lands — ProgressiveImage will then crossfade to the raw
+    // variant when it arrives.
+    if (category === "image" && (rawUrl || thumbnailUrl)) {
+      return (
+        <ProgressiveImage
+          src={rawUrl}
+          posterSrc={thumbnailUrl}
+          alt={selected.filename}
+          imgClassName="block max-h-[50vh] min-w-0 max-w-full"
+        />
+      )
+    }
     if (!rawUrl) {
       return (
         <div className={`flex h-16 w-16 items-center justify-center rounded-card ${meta.accent}`}>
           <Icon className="h-8 w-8" />
         </div>
-      )
-    }
-    if (category === "image") {
-      return (
-        <img src={rawUrl} alt={selected.filename} className="block max-h-[50vh] min-w-0 max-w-full object-contain" />
       )
     }
     if (category === "video") {

--- a/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-preview.tsx
@@ -2,11 +2,14 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { Link } from "react-router-dom"
 import { useQuery, type UseQueryResult } from "@tanstack/react-query"
 import { categoryFromMime } from "@threa/types"
-import { Check, ChevronDown, ChevronUp, Copy, Download, ExternalLink, Hash } from "lucide-react"
+import { Check, ChevronDown, ChevronUp, Code2, Copy, Download, ExternalLink, Eye, Hash } from "lucide-react"
 import { attachmentsApi, type AttachmentExtractionContent, type AttachmentSearchItem } from "@/api/attachments"
 import { Button } from "@/components/ui/button"
+import { HtmlViewer } from "@/components/gallery/html-viewer"
+import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
 import { ProgressiveImage } from "@/components/ui/progressive-image"
 import { useFormattedDate } from "@/hooks"
+import { isHtmlAttachment, isMarkdownAttachment } from "@/lib/attachment-kind"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { formatFileSize } from "@/lib/file-size"
 import { CATEGORY_META } from "./category"
@@ -27,6 +30,9 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
   const [expanded, setExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
   const [isTruncated, setIsTruncated] = useState(false)
+  // Source vs. rendered toggle for markdown/html. Resets per item so a fresh
+  // selection always lands on the rendered view.
+  const [rawMode, setRawMode] = useState(false)
   const previewRef = useRef<HTMLPreElement | null>(null)
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Tracks which attachment is currently selected so handleCopy can drop
@@ -41,6 +47,7 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
     setExpanded(false)
     setCopied(false)
     setIsTruncated(false)
+    setRawMode(false)
     if (copyResetTimerRef.current) {
       clearTimeout(copyResetTimerRef.current)
       copyResetTimerRef.current = null
@@ -163,6 +170,9 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
     selected.streamId && selected.messageId ? `/w/${workspaceId}/s/${selected.streamId}?m=${selected.messageId}` : null
   // Browsers handle iPhone .mov source poorly; prefer the transcoded mp4 when ready.
   const playbackUrl = category === "video" ? (processedUrl ?? rawUrl) : rawUrl
+  const isMarkdown = isMarkdownAttachment(selected)
+  const isHtml = isHtmlAttachment(selected)
+  const canToggleRaw = isMarkdown || isHtml
 
   function renderMedia() {
     if (previewError) {
@@ -180,6 +190,12 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
           imgClassName="block max-h-[50vh] min-w-0 max-w-full"
         />
       )
+    }
+    if (isMarkdown && rawUrl) {
+      return <MarkdownViewer url={rawUrl} filename={selected.filename} rawMode={rawMode} variant="inline" />
+    }
+    if (isHtml && rawUrl) {
+      return <HtmlViewer url={rawUrl} filename={selected.filename} rawMode={rawMode} variant="inline" />
     }
     if (!rawUrl) {
       return (
@@ -300,6 +316,19 @@ export function ExplorerPreview({ workspaceId, item }: ExplorerPreviewProps) {
                   <ExternalLink className="h-3.5 w-3.5" />
                   Show message
                 </Link>
+              </Button>
+            ) : null}
+            {canToggleRaw ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setRawMode((v) => !v)}
+                aria-pressed={rawMode}
+                aria-label={rawMode ? "Show rendered preview" : "Show raw source"}
+                className="gap-1"
+              >
+                {rawMode ? <Eye className="h-3.5 w-3.5" /> : <Code2 className="h-3.5 w-3.5" />}
+                {rawMode ? "Rendered" : "Source"}
               </Button>
             ) : null}
             {rawUrl ? (

--- a/apps/frontend/src/components/attachment-explorer/explorer-row.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-row.tsx
@@ -26,7 +26,7 @@ export function ExplorerRow({ workspaceId, item, isSelected, onSelect }: Explore
     if (category !== "image") return
     let cancelled = false
     attachmentsApi
-      .getDownloadUrl(workspaceId, item.id, { variant: "raw" })
+      .getDownloadUrl(workspaceId, item.id, { variant: "thumbnail" })
       .then((url) => {
         if (!cancelled) setThumbnailUrl(url)
       })

--- a/apps/frontend/src/components/gallery/html-viewer.tsx
+++ b/apps/frontend/src/components/gallery/html-viewer.tsx
@@ -5,6 +5,11 @@ interface HtmlViewerProps {
   url: string
   filename: string
   rawMode?: boolean
+  /** Layout chrome. `gallery` (default) is absolute-positioned with dark-chrome
+   *  loading states sized for the gallery dialog. `inline` is block-flow with a
+   *  height cap and muted chrome — used by surfaces like the attachment
+   *  explorer preview pane. */
+  variant?: "gallery" | "inline"
 }
 
 /**
@@ -22,11 +27,16 @@ interface HtmlViewerProps {
  * In rawMode the same source is shown as a `<pre>` block, sharing the panel
  * surface with the markdown viewer.
  */
-export function HtmlViewer({ url, filename, rawMode = false }: HtmlViewerProps) {
+export function HtmlViewer({ url, filename, rawMode = false, variant = "gallery" }: HtmlViewerProps) {
   const { content, error } = useTextContent(url || null)
+  const isInline = variant === "inline"
 
   if (!url || (content === null && !error)) {
-    return (
+    return isInline ? (
+      <div className="flex h-32 w-full items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    ) : (
       <div className="absolute inset-0 flex items-center justify-center">
         <Loader2 className="h-6 w-6 animate-spin text-white/50" />
       </div>
@@ -34,9 +44,36 @@ export function HtmlViewer({ url, filename, rawMode = false }: HtmlViewerProps) 
   }
 
   if (error) {
-    return (
+    return isInline ? (
+      <p className="px-4 py-4 text-xs text-muted-foreground">Couldn't load {filename}.</p>
+    ) : (
       <div className="absolute inset-0 flex items-center justify-center">
         <p className="text-sm text-white/70">Couldn't load {filename}.</p>
+      </div>
+    )
+  }
+
+  if (isInline) {
+    if (rawMode) {
+      return (
+        <div className="w-full">
+          <div className="mx-auto w-full max-w-[800px] max-h-[60vh] overflow-auto overscroll-contain rounded-lg border border-border bg-card text-foreground">
+            <pre className="whitespace-pre-wrap px-4 py-4 font-mono text-xs leading-relaxed text-foreground">
+              {content ?? ""}
+            </pre>
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="w-full">
+        <iframe
+          srcDoc={content ?? ""}
+          title={filename}
+          sandbox=""
+          referrerPolicy="no-referrer"
+          className="mx-auto block h-[60vh] w-full max-w-[800px] rounded-lg border border-border bg-white"
+        />
       </div>
     )
   }

--- a/apps/frontend/src/components/gallery/markdown-viewer.tsx
+++ b/apps/frontend/src/components/gallery/markdown-viewer.tsx
@@ -6,6 +6,11 @@ interface MarkdownViewerProps {
   url: string
   filename: string
   rawMode?: boolean
+  /** Layout chrome. `gallery` (default) is absolute-positioned with dark-chrome
+   *  loading states sized for the gallery dialog. `inline` is block-flow with a
+   *  height cap and muted chrome — used by surfaces like the attachment
+   *  explorer preview pane. */
+  variant?: "gallery" | "inline"
 }
 
 // Native `overflow-auto` instead of Radix ScrollArea: ScrollArea's viewport
@@ -14,11 +19,16 @@ interface MarkdownViewerProps {
 // through to the underlying message gesture). The browser's own scrolling
 // handles both axes and respects the surrounding gallery carousel via
 // `overscroll-behavior: contain`.
-export function MarkdownViewer({ url, filename, rawMode = false }: MarkdownViewerProps) {
+export function MarkdownViewer({ url, filename, rawMode = false, variant = "gallery" }: MarkdownViewerProps) {
   const { content, error } = useTextContent(url || null)
+  const isInline = variant === "inline"
 
   if (!url || (content === null && !error)) {
-    return (
+    return isInline ? (
+      <div className="flex h-32 w-full items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    ) : (
       <div className="absolute inset-0 flex items-center justify-center">
         <Loader2 className="h-6 w-6 animate-spin text-white/50" />
       </div>
@@ -26,9 +36,29 @@ export function MarkdownViewer({ url, filename, rawMode = false }: MarkdownViewe
   }
 
   if (error) {
-    return (
+    return isInline ? (
+      <p className="px-4 py-4 text-xs text-muted-foreground">Couldn't load {filename}.</p>
+    ) : (
       <div className="absolute inset-0 flex items-center justify-center">
         <p className="text-sm text-white/70">Couldn't load {filename}.</p>
+      </div>
+    )
+  }
+
+  if (isInline) {
+    return (
+      <div className="w-full">
+        <div className="mx-auto w-full max-w-[800px] max-h-[60vh] overflow-auto overscroll-contain rounded-lg border border-border bg-card text-foreground">
+          {rawMode ? (
+            <pre className="whitespace-pre-wrap px-4 py-4 font-mono text-xs leading-relaxed text-foreground">
+              {content ?? ""}
+            </pre>
+          ) : (
+            <div className="px-4 py-4">
+              <MarkdownContent content={content ?? ""} />
+            </div>
+          )}
+        </div>
       </div>
     )
   }

--- a/apps/frontend/src/components/ui/progressive-image.tsx
+++ b/apps/frontend/src/components/ui/progressive-image.tsx
@@ -3,22 +3,16 @@ import { cn } from "@/lib/utils"
 
 export interface ProgressiveImageProps {
   /** Full-resolution image URL. Pass null while the URL is still being
-   *  fetched; the poster (if any) will be shown alone until `src` arrives. */
+   *  fetched; the poster (if any) is shown alone until `src` arrives. */
   src: string | null
   /** Low-resolution poster shown until the full-resolution image decodes.
    *  Must share `src`'s aspect ratio — the crossfade depends on both layers
    *  rendering at the same pixel bounds. */
   posterSrc?: string | null
   alt: string
-  /** object-fit policy applied to both layers. */
-  fit?: "contain" | "cover"
-  /** Class applied to the `relative inline-block` wrapper that hosts the two
-   *  image layers (only used when both poster and full-res are present). */
-  className?: string
-  /** Class applied to both `<img>` elements. Set sizing constraints here
-   *  (`max-h-[50vh] max-w-full`, fixed dimensions, etc.) — the poster uses
-   *  them to establish the wrapper's natural size and the full-res layer
-   *  inherits the same box via `absolute inset-0`. */
+  /** Class applied to the size-determining `<img>` — the poster when one is
+   *  present, otherwise the full-res. Use this for sizing constraints
+   *  (`max-h-[50vh] max-w-full`, fixed dimensions, etc.). */
   imgClassName?: string
 }
 
@@ -26,31 +20,29 @@ export interface ProgressiveImageProps {
  * Crossfades from a low-resolution poster to a full-resolution image so heavy
  * originals don't show a blank box during decode.
  *
- * Layering: the poster `<img>` is inline (block) and establishes the wrapper's
- * dimensions; the full-res `<img>` is absolutely positioned to fill the same
- * box. Because both share the same aspect ratio and `object-fit`, they paint
- * at identical pixel bounds — the crossfade is a true overlap, never a resize.
+ * The poster `<img>` is inline (block) and establishes the wrapper's
+ * dimensions. The full-res `<img>` is absolutely positioned over it. Because
+ * both share the source's aspect ratio and `object-contain`, they paint at
+ * identical pixel bounds — the crossfade is a true overlap, never a resize.
+ * If a caller needs `object-cover`, pass it via `imgClassName` — `twMerge`
+ * lets it win over the default.
  *
- * Tracks `loadedSrc === src` instead of a boolean so a `src` change auto-resets
- * the decoded state without a separate effect — the moment a new src is set,
- * `decoded` flips false until the new image's onLoad fires.
+ * The wrapper renders whenever `posterSrc` is set, even before `src` arrives,
+ * so the poster `<img>` keeps the same DOM identity across the
+ * `src: null → string` transition. Without that, React would unmount a bare
+ * poster `<img>` and mount the two-layer subtree when the full-res URL lands —
+ * destroying the already-loaded poster and flashing blank exactly when the
+ * crossfade should begin.
  *
- * Originally lifted from the gallery's `ZoomableImage` poster pattern
- * (PR #612). Use anywhere you have a small variant ready while a larger one
- * is still in flight.
+ * `loadedSrc === src` (instead of a boolean) auto-resets the decoded state
+ * when `src` changes — no separate effect needed. A stale `onLoad` from a
+ * previous src writes the previous URL into `loadedSrc`, which still compares
+ * unequal to the new `src`, so `decoded` stays false until the new image's
+ * own `onLoad` fires.
  */
-export function ProgressiveImage({
-  src,
-  posterSrc,
-  alt,
-  fit = "contain",
-  className,
-  imgClassName,
-}: ProgressiveImageProps) {
+export function ProgressiveImage({ src, posterSrc, alt, imgClassName }: ProgressiveImageProps) {
   const [loadedSrc, setLoadedSrc] = useState<string | null>(null)
   const decoded = !!src && loadedSrc === src
-
-  const fitClass = fit === "contain" ? "object-contain" : "object-cover"
 
   if (!posterSrc) {
     if (!src) return null
@@ -59,42 +51,37 @@ export function ProgressiveImage({
         src={src}
         alt={alt}
         onLoad={() => setLoadedSrc(src)}
-        className={cn(fitClass, imgClassName)}
+        className={cn("object-contain", imgClassName)}
         draggable={false}
       />
     )
   }
 
-  if (!src) {
-    return <img src={posterSrc} alt={alt} className={cn(fitClass, imgClassName)} draggable={false} />
-  }
-
   return (
-    <div className={cn("relative inline-block", className)}>
+    <div className="relative inline-block">
       <img
         src={posterSrc}
-        alt=""
-        aria-hidden
+        alt={src ? "" : alt}
+        aria-hidden={src ? true : undefined}
         className={cn(
-          "block transition-opacity duration-200",
-          fitClass,
+          "block object-contain transition-opacity duration-200",
           decoded ? "opacity-0" : "opacity-100",
           imgClassName
         )}
         draggable={false}
       />
-      <img
-        src={src}
-        alt={alt}
-        onLoad={() => setLoadedSrc(src)}
-        className={cn(
-          "absolute inset-0 h-full w-full transition-opacity duration-200",
-          fitClass,
-          decoded ? "opacity-100" : "opacity-0",
-          imgClassName
-        )}
-        draggable={false}
-      />
+      {src && (
+        <img
+          src={src}
+          alt={alt}
+          onLoad={() => setLoadedSrc(src)}
+          className={cn(
+            "absolute inset-0 h-full w-full object-contain transition-opacity duration-200",
+            decoded ? "opacity-100" : "opacity-0"
+          )}
+          draggable={false}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/ui/progressive-image.tsx
+++ b/apps/frontend/src/components/ui/progressive-image.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+
+export interface ProgressiveImageProps {
+  /** Full-resolution image URL. Pass null while the URL is still being
+   *  fetched; the poster (if any) will be shown alone until `src` arrives. */
+  src: string | null
+  /** Low-resolution poster shown until the full-resolution image decodes.
+   *  Must share `src`'s aspect ratio — the crossfade depends on both layers
+   *  rendering at the same pixel bounds. */
+  posterSrc?: string | null
+  alt: string
+  /** object-fit policy applied to both layers. */
+  fit?: "contain" | "cover"
+  /** Class applied to the `relative inline-block` wrapper that hosts the two
+   *  image layers (only used when both poster and full-res are present). */
+  className?: string
+  /** Class applied to both `<img>` elements. Set sizing constraints here
+   *  (`max-h-[50vh] max-w-full`, fixed dimensions, etc.) — the poster uses
+   *  them to establish the wrapper's natural size and the full-res layer
+   *  inherits the same box via `absolute inset-0`. */
+  imgClassName?: string
+}
+
+/**
+ * Crossfades from a low-resolution poster to a full-resolution image so heavy
+ * originals don't show a blank box during decode.
+ *
+ * Layering: the poster `<img>` is inline (block) and establishes the wrapper's
+ * dimensions; the full-res `<img>` is absolutely positioned to fill the same
+ * box. Because both share the same aspect ratio and `object-fit`, they paint
+ * at identical pixel bounds — the crossfade is a true overlap, never a resize.
+ *
+ * Tracks `loadedSrc === src` instead of a boolean so a `src` change auto-resets
+ * the decoded state without a separate effect — the moment a new src is set,
+ * `decoded` flips false until the new image's onLoad fires.
+ *
+ * Originally lifted from the gallery's `ZoomableImage` poster pattern
+ * (PR #612). Use anywhere you have a small variant ready while a larger one
+ * is still in flight.
+ */
+export function ProgressiveImage({
+  src,
+  posterSrc,
+  alt,
+  fit = "contain",
+  className,
+  imgClassName,
+}: ProgressiveImageProps) {
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null)
+  const decoded = !!src && loadedSrc === src
+
+  const fitClass = fit === "contain" ? "object-contain" : "object-cover"
+
+  if (!posterSrc) {
+    if (!src) return null
+    return (
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoadedSrc(src)}
+        className={cn(fitClass, imgClassName)}
+        draggable={false}
+      />
+    )
+  }
+
+  if (!src) {
+    return <img src={posterSrc} alt={alt} className={cn(fitClass, imgClassName)} draggable={false} />
+  }
+
+  return (
+    <div className={cn("relative inline-block", className)}>
+      <img
+        src={posterSrc}
+        alt=""
+        aria-hidden
+        className={cn(
+          "block transition-opacity duration-200",
+          fitClass,
+          decoded ? "opacity-0" : "opacity-100",
+          imgClassName
+        )}
+        draggable={false}
+      />
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoadedSrc(src)}
+        className={cn(
+          "absolute inset-0 h-full w-full transition-opacity duration-200",
+          fitClass,
+          decoded ? "opacity-100" : "opacity-0",
+          imgClassName
+        )}
+        draggable={false}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a reusable `ProgressiveImage` primitive in `components/ui/` that crossfades a low-res poster to a full-res source. Inspired by the poster-pattern in #612's `ZoomableImage` but designed standalone so any surface can use it. Single layer when there's no poster; two-layer wrapper kept stable across the `src: null → string` transition so the poster `<img>` keeps its DOM identity and isn't destroyed when the full-res arrives. `loadedSrc === src` (rather than a boolean) auto-resets the decoded state when `src` changes, so a stale `onLoad` from a previous src can't incorrectly flip the new one.
- Switches `explorer-row.tsx` from `variant: "raw"` → `variant: "thumbnail"`. The 32px row was previously loading the full original for every image in the file list.
- Updates `explorer-preview.tsx` to fetch the thumbnail variant in parallel with raw for image attachments and render the image branch through `ProgressiveImage`. The preview pane now paints the thumbnail the moment it arrives, then crossfades to full-res when the original decodes — no more multi-second blank box on heavy images.

`ZoomableImage` itself is unchanged for now — its own poster implementation is coupled to the zoom-transform `imgRef` and shimmer positioning, so unifying it with `ProgressiveImage` is a clean follow-up rather than scope creep here.

## Test plan

- [ ] Open the attachment explorer (`?explorer=`) in a workspace with image attachments. Rows show thumbnails (not the full original) — confirm via DevTools Network that requests are the `?variant=thumbnail` URL.
- [ ] Select an image. The preview pane shows the thumbnail almost immediately, then smoothly crossfades to the full-resolution variant without any blank frame between them.
- [ ] Click rapidly between several image attachments — no flash of the previous image, no stale `decoded` state, no double-render.
- [ ] Select a non-image (PDF, doc, video) — preview behaviour unchanged (icon fallback / raw / processed video flow all still work).
- [ ] Select an image whose thumbnail variant 404s — preview still loads raw and renders it; no broken-image icon between fetches.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113RpneAgVes1WQkYqqhAB4)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782252230&installation_id=129946197&pr_number=615&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F615&signature=7435f52e6de05664f748ef46a844f8871d805c111c2cc404e19b9e2838cf1ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->