### PR TITLE
fix: require matching Pi runtime session for targeted claims

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -392,6 +392,28 @@ export const BotRuntimeSessionLinkRepository = {
     )
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
+
+  async findActiveByStreams(
+    db: Querier,
+    params: { workspaceId: string; botId: string; activeStreamIds: string[] }
+  ): Promise<Map<string, BotRuntimeSessionLink>> {
+    if (params.activeStreamIds.length === 0) return new Map()
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`SELECT DISTINCT ON (active_stream_id) * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND active_stream_id = ANY(${params.activeStreamIds}) AND status = 'active' ORDER BY active_stream_id, updated_at DESC`
+    )
+    return new Map(result.rows.map((row) => [row.active_stream_id, mapSessionLink(row)]))
+  },
+
+  async findActiveByBotsAndStream(
+    db: Querier,
+    params: { workspaceId: string; botIds: string[]; activeStreamId: string }
+  ): Promise<Map<string, BotRuntimeSessionLink>> {
+    if (params.botIds.length === 0) return new Map()
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`SELECT DISTINCT ON (bot_id) * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ANY(${params.botIds}) AND active_stream_id = ${params.activeStreamId} AND status = 'active' ORDER BY bot_id, updated_at DESC`
+    )
+    return new Map(result.rows.map((row) => [row.bot_id, mapSessionLink(row)]))
+  },
 }
 
 export const BotInvocationRepository = {
@@ -424,6 +446,7 @@ export const BotInvocationRepository = {
       workspaceId: string
       botId: string
       instanceId: string
+      runtimeSessionId?: string
       runtimeKind: BotRuntimeKind
       claimToken: string
       supportedCapabilities: BotInvocationCapability[]
@@ -444,6 +467,7 @@ export const BotInvocationRepository = {
               AND r.runtime_kind = ${params.runtimeKind}
           )
           AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
+          AND (target_runtime_session_id IS NULL OR target_runtime_session_id = ${params.runtimeSessionId ?? null})
           AND (status = 'pending' OR (status = 'claimed' AND claim_expires_at < NOW()))
         ORDER BY created_at ASC, id ASC
         FOR UPDATE SKIP LOCKED

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -114,6 +114,30 @@ export class BotRuntimeService {
     })
   }
 
+  async findActivePiRemoteSessionsForStreams(params: {
+    workspaceId: string
+    botId: string
+    streamIds: string[]
+  }): Promise<Map<string, BotRuntimeSessionLink>> {
+    return BotRuntimeSessionLinkRepository.findActiveByStreams(this.pool, {
+      workspaceId: params.workspaceId,
+      botId: params.botId,
+      activeStreamIds: params.streamIds,
+    })
+  }
+
+  async findActivePiRemoteSessionsForBotsInStream(params: {
+    workspaceId: string
+    botIds: string[]
+    streamId: string
+  }): Promise<Map<string, BotRuntimeSessionLink>> {
+    return BotRuntimeSessionLinkRepository.findActiveByBotsAndStream(this.pool, {
+      workspaceId: params.workspaceId,
+      botIds: params.botIds,
+      activeStreamId: params.streamId,
+    })
+  }
+
   async repairBotTraitsInTransaction(
     db: Querier,
     params: { workspaceId: string; botId: string; traits: readonly BotTrait[] }
@@ -224,6 +248,7 @@ export class BotRuntimeService {
     workspaceId: string
     botId: string
     instanceId: string
+    runtimeSessionId?: string
     runtimeKind: BotRuntimeKind
     claimToken: string
     supportedCapabilities: BotInvocationCapability[]

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -574,7 +574,12 @@ export function createPublicApiHandlers({
     if (!io) return
     const streamIds = await BotChannelAccessRepository.getGrantedStreamIds(pool, workspaceId, botId)
     if (streamIds.length === 0) return
-    const links = await botRuntimeService.findActivePiRemoteSessionsForStreams({ workspaceId, botId, streamIds })
+    // Only pi-local runtimes create scratchpad session links; skip the lookup
+    // when there's no presence or the runtime kind can't have linked sessions.
+    const links =
+      presence?.runtimeKind === BotRuntimeKinds.PI_LOCAL
+        ? await botRuntimeService.findActivePiRemoteSessionsForStreams({ workspaceId, botId, streamIds })
+        : new Map<string, { instanceId: string; runtimeSessionId: string }>()
     const payload = {
       workspaceId,
       botId,
@@ -959,12 +964,20 @@ export function createPublicApiHandlers({
       // Step recording also serves as a busy heartbeat — keeps the runtime's
       // presence statusText in sync with the most recent trace step so Pi
       // does not need to send a separate /presence call alongside each step.
+      // Capabilities is fully overwritten on upsert, so we have to re-supply
+      // the runtime's session id for untargeted invocations; otherwise the
+      // scratchpad's session-link filter would treat the runtime as stale and
+      // hide its presence mid-run.
+      const persistedRuntimeSessionId =
+        typeof runtimePresence?.capabilities.runtimeSessionId === "string"
+          ? runtimePresence.capabilities.runtimeSessionId
+          : undefined
       await touchAndBroadcastPresence({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
         runtimeKind: runtimePresence?.runtimeKind ?? BotRuntimeKinds.PI_LOCAL,
         instanceId: result.data.instanceId,
-        runtimeSessionId: claim.targetRuntimeSessionId ?? undefined,
+        runtimeSessionId: claim.targetRuntimeSessionId ?? persistedRuntimeSessionId,
         status: "busy",
         acceptingInvocations: false,
         statusText: sanitizeStatusText(result.data.statusText),

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -574,6 +574,7 @@ export function createPublicApiHandlers({
     if (!io) return
     const streamIds = await BotChannelAccessRepository.getGrantedStreamIds(pool, workspaceId, botId)
     if (streamIds.length === 0) return
+    const links = await botRuntimeService.findActivePiRemoteSessionsForStreams({ workspaceId, botId, streamIds })
     const payload = {
       workspaceId,
       botId,
@@ -590,8 +591,19 @@ export function createPublicApiHandlers({
           }
         : null,
     }
+    const runtimeSessionId =
+      typeof presence?.capabilities.runtimeSessionId === "string" ? presence.capabilities.runtimeSessionId : null
     for (const streamId of streamIds) {
-      io.to(`ws:${workspaceId}:stream:${streamId}`).emit("bot_runtime:presence", { ...payload, streamId })
+      const link = links.get(streamId)
+      const streamPresence =
+        link && (!presence || presence.instanceId !== link.instanceId || runtimeSessionId !== link.runtimeSessionId)
+          ? null
+          : payload.presence
+      io.to(`ws:${workspaceId}:stream:${streamId}`).emit("bot_runtime:presence", {
+        ...payload,
+        presence: streamPresence,
+        streamId,
+      })
     }
   }
 
@@ -605,6 +617,7 @@ export function createPublicApiHandlers({
     botId: string
     runtimeKind: BotRuntimeKind
     instanceId: string
+    runtimeSessionId?: string
     status: BotRuntimeStatus
     acceptingInvocations: boolean
     statusText?: string | null
@@ -617,6 +630,7 @@ export function createPublicApiHandlers({
         instanceId: params.instanceId,
         status: params.status,
         acceptingInvocations: params.acceptingInvocations,
+        capabilities: params.runtimeSessionId ? { runtimeSessionId: params.runtimeSessionId } : undefined,
         statusText: sanitizeStatusText(params.statusText),
       })
       await broadcastBotPresence(params.workspaceId, params.botId, presence)
@@ -672,7 +686,15 @@ export function createPublicApiHandlers({
       const presence = await botRuntimeService.upsertPresenceFromBotKey({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        ...result.data,
+        runtimeKind: result.data.runtimeKind,
+        instanceId: result.data.instanceId,
+        displayName: result.data.displayName,
+        status: result.data.status,
+        acceptingInvocations: result.data.acceptingInvocations,
+        capabilities: {
+          ...result.data.capabilities,
+          ...(result.data.runtimeSessionId && { runtimeSessionId: result.data.runtimeSessionId }),
+        },
         statusText: sanitizeStatusText(result.data.statusText),
       })
       await broadcastBotPresence(req.workspaceId!, req.botApiKey.botId, presence)
@@ -777,6 +799,7 @@ export function createPublicApiHandlers({
         botId: req.botApiKey.botId,
         runtimeKind: result.data.runtimeKind,
         instanceId: result.data.instanceId,
+        runtimeSessionId: result.data.runtimeSessionId,
         status: "available",
         acceptingInvocations: true,
       })
@@ -785,6 +808,7 @@ export function createPublicApiHandlers({
         botId: req.botApiKey.botId,
         runtimeKind: result.data.runtimeKind,
         instanceId: result.data.instanceId,
+        runtimeSessionId: result.data.runtimeSessionId,
         supportedCapabilities: result.data.supportedCapabilities,
         claimTtlSeconds: result.data.claimTtlSeconds,
         claimToken: randomUUID(),
@@ -795,6 +819,7 @@ export function createPublicApiHandlers({
         botId: req.botApiKey.botId,
         runtimeKind: result.data.runtimeKind,
         instanceId: result.data.instanceId,
+        runtimeSessionId: invocation.targetRuntimeSessionId ?? result.data.runtimeSessionId,
         status: "busy",
         acceptingInvocations: false,
       })
@@ -939,6 +964,7 @@ export function createPublicApiHandlers({
         botId: req.botApiKey.botId,
         runtimeKind: runtimePresence?.runtimeKind ?? BotRuntimeKinds.PI_LOCAL,
         instanceId: result.data.instanceId,
+        runtimeSessionId: claim.targetRuntimeSessionId ?? undefined,
         status: "busy",
         acceptingInvocations: false,
         statusText: sanitizeStatusText(result.data.statusText),

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -67,6 +67,7 @@ export const listStreamsSchema = z.object({
 export const upsertPresenceSchema = z.object({
   runtimeKind: z.enum(BOT_RUNTIME_KINDS),
   instanceId: z.string().min(1).max(128),
+  runtimeSessionId: z.string().min(1).max(256).optional(),
   displayName: z.string().max(100).optional(),
   status: z.enum(BOT_RUNTIME_STATUSES),
   acceptingInvocations: z.boolean(),
@@ -85,6 +86,7 @@ export const createRuntimeSessionSchema = z.object({
 export const claimInvocationSchema = z.object({
   runtimeKind: z.enum(BOT_RUNTIME_KINDS),
   instanceId: z.string().min(1).max(128),
+  runtimeSessionId: z.string().min(1).max(256).optional(),
   supportedCapabilities: z.array(z.enum(BOT_INVOCATION_CAPABILITIES)).min(1),
   claimTtlSeconds: z.number().int().min(15).max(300).optional().default(60),
 })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -301,6 +301,15 @@ function serializeBotRuntimePresence(presence: Awaited<ReturnType<BotRuntimeServ
     : null
 }
 
+function presenceMatchesRuntimeSessionLink(
+  presence: Awaited<ReturnType<BotRuntimeService["findLatestPresence"]>>,
+  link: { instanceId: string; runtimeSessionId: string } | null | undefined
+): boolean {
+  if (!link) return true
+  if (!presence || presence.instanceId !== link.instanceId) return false
+  return presence.capabilities.runtimeSessionId === link.runtimeSessionId
+}
+
 export function createStreamHandlers({
   pool,
   streamService,
@@ -689,8 +698,23 @@ export function createStreamHandlers({
           activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
         ])
       const botRuntimePresences = await botRuntimeService.findLatestPresences({ workspaceId, botIds: botMemberIds })
+      const botRuntimeLinkByBotId =
+        stream.type === StreamTypes.SCRATCHPAD
+          ? await botRuntimeService.findActivePiRemoteSessionsForBotsInStream({
+              workspaceId,
+              botIds: botMemberIds,
+              streamId: stream.id,
+            })
+          : new Map<string, { instanceId: string; runtimeSessionId: string }>()
       const botRuntimePresence = Object.fromEntries(
-        botMemberIds.map((botId) => [botId, serializeBotRuntimePresence(botRuntimePresences.get(botId) ?? null)])
+        botMemberIds.map((botId) => {
+          const presence = botRuntimePresences.get(botId) ?? null
+          const link = botRuntimeLinkByBotId.get(botId)
+          return [
+            botId,
+            serializeBotRuntimePresence(presenceMatchesRuntimeSessionLink(presence, link) ? presence : null),
+          ]
+        })
       )
 
       const unreadCount = membership ? await streamService.getUnreadCount(streamId, membership.lastReadEventId) : 0

--- a/docs/examples/pi-remote/threa-remote-v2.test.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.test.ts
@@ -78,6 +78,16 @@ describe("Pi remote trace safety", () => {
     expect(migrated.linkedSessions).toEqual({})
   })
 
+  test("includes the Pi session id when claiming invocations", () => {
+    expect(__testing.buildClaimInvocationPayload("pi-host-123", "pi-session-abc")).toMatchObject({
+      runtimeKind: "pi-local",
+      instanceId: "pi-host-123",
+      runtimeSessionId: "pi-session-abc",
+      supportedCapabilities: ["active-scratchpad", "mentionable"],
+      claimTtlSeconds: 120,
+    })
+  })
+
   test("parses pasted self-configuration JSON", () => {
     expect(
       __testing.parseConfigPatch(`{

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -261,13 +261,19 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return (await response.json()) as T
 }
 
-async function heartbeat(status: "available" | "busy" | "offline" | "error", statusText?: string): Promise<void> {
+async function heartbeat(
+  status: "available" | "busy" | "offline" | "error",
+  statusText?: string,
+  ctx?: ExtensionContext
+): Promise<void> {
   if (!config) return
+  const runtimeSessionId = ctx ? getRuntimeSessionId(ctx) : undefined
   await request(`/api/v1/workspaces/${config.workspaceId}/bot-runtime/presence`, {
     method: "POST",
     body: JSON.stringify({
       runtimeKind: "pi-local",
       instanceId: ensureInstanceId(),
+      runtimeSessionId,
       displayName: config.defaultDisplayName,
       status,
       acceptingInvocations: status === "available",
@@ -281,11 +287,11 @@ async function heartbeat(status: "available" | "busy" | "offline" | "error", sta
   })
 }
 
-async function heartbeatBusyIfStale(statusText = "Working…"): Promise<boolean> {
+async function heartbeatBusyIfStale(statusText = "Working…", ctx?: ExtensionContext): Promise<boolean> {
   const now = Date.now()
   if (now - lastBusyHeartbeatAt < BUSY_HEARTBEAT_MS) return false
   lastBusyHeartbeatAt = now
-  await heartbeat("busy", statusText)
+  await heartbeat("busy", statusText, ctx)
   return true
 }
 
@@ -560,7 +566,7 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
 
   ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
   setRemoteStatus(ctx, `Threa remote: ${displayName}`)
-  await heartbeat("available")
+  await heartbeat("available", undefined, ctx)
 }
 
 async function renewPendingClaim(): Promise<void> {
@@ -689,8 +695,8 @@ async function disableRemote(ctx: ExtensionContext): Promise<void> {
   if (!config) return
   const link = setCurrentSessionEnabled(ctx, false)
   stopPolling()
-  await failPending("Threa remote disabled")
-  await heartbeat("offline").catch(() => undefined)
+  await failPending("Threa remote disabled", ctx)
+  await heartbeat("offline", undefined, ctx).catch(() => undefined)
   setRemoteStatus(ctx, "Threa remote: off")
   ctx.ui.notify(link ? "Threa remote disabled for this Pi session" : "No Threa remote session is linked here", "info")
 }
@@ -703,7 +709,7 @@ async function enableRemote(pi: ExtensionAPI, ctx: ExtensionContext): Promise<vo
     return
   }
   lastBusyHeartbeatAt = 0
-  await heartbeat("available")
+  await heartbeat("available", undefined, ctx)
   startPolling(pi, ctx)
   ctx.ui.notify("Threa remote enabled for this Pi session", "info")
 }
@@ -803,6 +809,20 @@ async function fetchInvocationContext(
   }
 }
 
+function buildClaimInvocationPayload(instanceId: string, runtimeSessionId: string): Record<string, unknown> {
+  return {
+    runtimeKind: "pi-local",
+    instanceId,
+    runtimeSessionId,
+    supportedCapabilities: ["active-scratchpad", "mentionable"],
+    claimTtlSeconds: 120,
+  }
+}
+
+function buildClaimInvocationBody(ctx: ExtensionContext): Record<string, unknown> {
+  return buildClaimInvocationPayload(ensureInstanceId(), getRuntimeSessionId(ctx))
+}
+
 async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvocation | null> {
   if (!config) return null
   const startedAt = Date.now()
@@ -811,12 +831,7 @@ async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvoca
       `/api/v1/workspaces/${config.workspaceId}/bot-invocations/claim`,
       {
         method: "POST",
-        body: JSON.stringify({
-          runtimeKind: "pi-local",
-          instanceId: ensureInstanceId(),
-          supportedCapabilities: ["active-scratchpad", "mentionable"],
-          claimTtlSeconds: 120,
-        }),
+        body: JSON.stringify(buildClaimInvocationBody(ctx)),
       }
     )
     emitPollDebug(
@@ -889,7 +904,7 @@ async function claimIfIdle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<boo
   if (pending) await renewPendingClaim()
 
   const steer = pending !== undefined || !ctx.isIdle()
-  if (steer) await heartbeatBusyIfStale(pending ? "Working on Threa invocation…" : "Busy in Pi…")
+  if (steer) await heartbeatBusyIfStale(pending ? "Working on Threa invocation…" : "Busy in Pi…", ctx)
 
   const invocation = await claimNextInvocation(ctx)
   if (!invocation) return true
@@ -1097,10 +1112,10 @@ async function completePending(markdown: string, ctx: ExtensionContext): Promise
   pendingToolCalls = new Map()
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
-  await heartbeat("available")
+  await heartbeat("available", undefined, ctx)
 }
 
-async function failPending(error: unknown): Promise<void> {
+async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void> {
   if (!config || !pending) return
   const invocation = pending
   const steered = steeredInvocations
@@ -1113,13 +1128,14 @@ async function failPending(error: unknown): Promise<void> {
   pendingToolCalls = new Map()
   lastTraceHeartbeat = undefined
   lastBusyHeartbeatAt = 0
-  await heartbeat("available").catch(() => undefined)
+  await heartbeat("available", undefined, ctx).catch(() => undefined)
 }
 
 export const __testing = {
   describeToolCall,
   formatToolCallTrace,
   formatToolResultTrace,
+  buildClaimInvocationPayload,
   migrateSessionState,
   parseConfigPatch,
   safeStatusText,
@@ -1201,12 +1217,12 @@ export default function (pi: ExtensionAPI): void {
       return
     }
     lastBusyHeartbeatAt = 0
-    await heartbeat("available")
+    await heartbeat("available", undefined, ctx)
     startPolling(pi, ctx)
   })
 
   pi.on("agent_start", async (_event, ctx) => {
-    if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…").catch(() => undefined)
+    if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…", ctx).catch(() => undefined)
     await traceHeartbeat("Thinking…", "thinking")
   })
 
@@ -1249,7 +1265,7 @@ export default function (pi: ExtensionAPI): void {
     if (!pending) {
       if (config && isEnabled(ctx)) {
         lastBusyHeartbeatAt = 0
-        await heartbeat("available").catch(() => undefined)
+        await heartbeat("available", undefined, ctx).catch(() => undefined)
       }
       return
     }
@@ -1262,14 +1278,14 @@ export default function (pi: ExtensionAPI): void {
       setRemoteStatus(ctx, "Threa remote: linked")
     } catch (error) {
       ctx.ui.notify(`Failed to complete Threa invocation: ${String(error)}`, "warning")
-      await failPending(error)
+      await failPending(error, ctx)
     }
   })
 
   pi.on("session_shutdown", async (_event, ctx) => {
     stopPolling()
-    await failPending("Pi session shut down")
-    await heartbeat("offline").catch(() => undefined)
+    await failPending("Pi session shut down", ctx)
+    await heartbeat("offline", undefined, ctx).catch(() => undefined)
     ctx.ui.setStatus(STATUS_KEY, undefined)
   })
 }

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -907,6 +907,7 @@
                     "enum": ["pi-local", "hermes", "openclaw", "claude-code-channel", "custom"]
                   },
                   "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "displayName": { "type": "string", "maxLength": 100 },
                   "status": { "type": "string", "enum": ["available", "busy", "offline", "error"] },
                   "acceptingInvocations": { "type": "boolean" },
@@ -1124,6 +1125,7 @@
                     "enum": ["pi-local", "hermes", "openclaw", "claude-code-channel", "custom"]
                   },
                   "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "supportedCapabilities": {
                     "minItems": 1,
                     "type": "array",


### PR DESCRIPTION
## Problem

Pi remote active-scratchpad invocations were targeted only by `instanceId`. A Pi process can keep the same instance id across Pi sessions, so a newly-opened session on the same machine could claim an invocation intended for an older scratchpad/session link. That makes the old scratchpad appear available when it should be unavailable until its linked session is open.

## Solution

Thread the Pi runtime session id through the bot invocation claim and presence paths. Targeted invocations now require both the runtime instance and runtime session to match, and scratchpad presence is filtered to the linked runtime session so stale scratchpads no longer appear available because a different Pi session on the same machine is online.

### How it works

1. The Pi remote adapter includes `runtimeSessionId` in `/bot-invocations/claim` and `/bot-runtime/presence` requests.
2. The public API validates and forwards that optional field.
3. `BotInvocationRepository.claimOne` still allows untargeted invocations, but targeted active-scratchpad invocations now require `target_runtime_session_id = runtimeSessionId`.
4. Presence broadcasts/bootstrap compare the latest runtime presence session against the scratchpad session link and emit `null` presence for mismatched stale scratchpads.

### Key design decisions

**1. Keep presence advisory, claims authoritative**

Presence can say whether a runtime is online, but the claim query is the atomic gate. Enforcing the session match there prevents a different session from consuming work even if presence is stale.

**2. Make `runtimeSessionId` optional for compatibility**

Untargeted/legacy claims can still flow. The stricter match only applies to invocations that carry a `target_runtime_session_id`.

## New files

None.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/public-api/schemas.ts` | Accept optional `runtimeSessionId` on claim requests. |
| `apps/backend/src/features/public-api/handlers.ts` | Forward `runtimeSessionId` into the runtime service and filter presence broadcasts per linked scratchpad session. |
| `apps/backend/src/features/streams/handlers.ts` | Filter bootstrap scratchpad presence to the linked runtime session. |
| `apps/backend/src/features/bot-runtimes/service.ts` | Carry `runtimeSessionId` through claim params. |
| `apps/backend/src/features/bot-runtimes/repository.ts` | Require targeted claims to match `target_runtime_session_id`. |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Include current Pi session id in claim and presence payloads. |
| `docs/examples/pi-remote/threa-remote-v2.test.ts` | Cover the claim payload shape. |
| `docs/public-api/openapi.json` | Regenerate public API docs. |

## Deleted files

None.

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts`
- [x] `bun test ./apps/backend/src/features/public-api/handlers.test.ts`
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run generate:api-docs:check`
- [x] pre-commit lint/typecheck/API docs checks

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782286299&installation_id=129946197&pr_number=617&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F617&signature=ed73129c476b22f6a311753df09342d8c66d60c39a7af1a0da2b510bcd68bd3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
