### PR TITLE
fix: hydrate agent session progress on bootstrap

### DIFF
--- a/.claude/plans/agent-session-bootstrap-progress.md
+++ b/.claude/plans/agent-session-bootstrap-progress.md
@@ -1,0 +1,67 @@
+# Agent Session Bootstrap Progress
+
+## Goal
+
+Fix timeline agent-session cards after a refresh during an active Pi/bot invocation. Running sessions already persist trace steps, but stream bootstrap only returned the original `agent_session:started` event, so the timeline could render a running card with `0 steps` until another live progress socket event arrived.
+
+## What Was Built
+
+### Backend bootstrap enrichment
+
+Running `agent_session:started` events are enriched during stream bootstrap with a persisted progress snapshot: current step type, step count, and sent-message count. This makes the bootstrap response self-sufficient for mid-run refreshes while preserving existing socket progress events for live updates.
+
+**Files:**
+- `apps/backend/src/features/agents/session-repository.ts` — adds `findProgressSnapshotsByIds()` to fetch running session step/message counts in a set-based query.
+- `apps/backend/src/features/messaging/event-service.ts` — enriches bootstrapped `agent_session:started` events with persisted progress snapshot fields for still-running sessions.
+- `packages/types/src/agent-trace.ts` — documents optional bootstrap-only fields on `AgentSessionStartedPayload`.
+
+### Frontend activity hydration
+
+The timeline activity hook now seeds running-session state from optional snapshot fields on bootstrapped `agent_session:started` events, then lets live `agent_session:progress` socket updates override those values as before.
+
+**Files:**
+- `apps/frontend/src/hooks/use-agent-activity.ts` — carries bootstrapped `stepCount`, `messageCount`, and `currentStepType` into `MessageAgentActivity`.
+- `apps/frontend/src/hooks/use-agent-activity.test.tsx` — covers the refresh-mid-run bootstrap path.
+
+## Design Decisions
+
+### Enrich the existing started event instead of adding another bootstrap endpoint
+
+**Chose:** Add optional progress snapshot fields to `AgentSessionStartedPayload` when stream events are bootstrapped.
+
+**Why:** The timeline already derives running sessions from stream events. Enriching that existing event keeps the subscribe-then-bootstrap model intact and avoids another client fetch per running session.
+
+**Alternatives considered:** Fetch full trace details from the timeline or add a separate activity snapshot endpoint. Those would duplicate the trace modal path or introduce extra network round trips for every stream load.
+
+### Keep live progress socket events authoritative after bootstrap
+
+**Chose:** Use bootstrapped counts only as the initial state; existing `agent_session:progress` events still update counts and current step live.
+
+**Why:** The bug is only the refresh gap. Socket events remain the correct low-latency live-update mechanism.
+
+### Snapshot only running sessions
+
+**Chose:** Repository snapshots filter to `agent_sessions.status = 'running'`.
+
+**Why:** Completed/failed/deleted lifecycle stream events already carry terminal counts and should remain the source of truth for non-running cards.
+
+## Design Evolution
+
+- **Problem narrowed:** Initial suspicion was that trace events might not be persisted. Inspection showed the trace modal reads persisted `agent_session_steps` correctly; the missing data was only in timeline bootstrap state.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No changes to trace modal loading; it already reads persisted steps correctly.
+- No new socket event types.
+- No persistence changes for `agent_session:progress`; it remains an ephemeral live event.
+
+## Status
+
+- [x] Backend stream bootstrap enriches running session progress snapshots.
+- [x] Frontend timeline activity hook hydrates counts from bootstrap.
+- [x] Focused frontend hook test covers the refresh-mid-run behavior.
+- [x] Typechecks pass for affected packages/apps.

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -44,6 +44,13 @@ interface StepRow {
   completed_at: Date | null
 }
 
+interface SessionProgressSnapshotRow {
+  id: string
+  current_step_type: string | null
+  step_count: string
+  message_count: number
+}
+
 // Domain types (camelCase)
 export interface AgentSession {
   id: string
@@ -77,6 +84,13 @@ export interface AgentSessionStep {
   tokensUsed: number | null
   startedAt: Date
   completedAt: Date | null
+}
+
+export interface AgentSessionProgressSnapshot {
+  sessionId: string
+  currentStepType: StepType | null
+  stepCount: number
+  messageCount: number
 }
 
 // Insert params
@@ -268,6 +282,38 @@ export const AgentSessionRepository = {
       `
     )
     return result.rows.map(mapRowToSession)
+  },
+
+  async findProgressSnapshotsByIds(
+    db: Querier,
+    sessionIds: string[]
+  ): Promise<Map<string, AgentSessionProgressSnapshot>> {
+    if (sessionIds.length === 0) return new Map()
+    const result = await db.query<SessionProgressSnapshotRow>(
+      sql`
+        SELECT
+          s.id,
+          s.current_step_type,
+          COUNT(st.id) AS step_count,
+          COALESCE(array_length(s.sent_message_ids, 1), 0) AS message_count
+        FROM agent_sessions s
+        LEFT JOIN agent_session_steps st ON st.session_id = s.id
+        WHERE s.id = ANY(${sessionIds})
+          AND s.status = ${SessionStatuses.RUNNING}
+        GROUP BY s.id, s.current_step_type, s.sent_message_ids
+      `
+    )
+    return new Map(
+      result.rows.map((row) => [
+        row.id,
+        {
+          sessionId: row.id,
+          currentStepType: row.current_step_type as StepType | null,
+          stepCount: Number(row.step_count),
+          messageCount: row.message_count,
+        },
+      ])
+    )
   },
 
   async findLatestBySupersedesSession(db: Querier, supersedesSessionId: string): Promise<AgentSession | null> {

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -13,7 +13,7 @@ import {
   toAttachmentSummary,
 } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
-import { StreamPersonaParticipantRepository } from "../agents"
+import { AgentSessionRepository, StreamPersonaParticipantRepository } from "../agents"
 import { attachmentReferenceId, eventId, messageId, messageVersionId, streamId as generateStreamId } from "../../lib/id"
 import { MessageVersionRepository, type MessageVersion } from "./version-repository"
 import { serializeBigInt } from "@threa/backend-common"
@@ -1457,9 +1457,33 @@ export class EventService {
           })
         : new Map<string, string>()
 
+    const startedSessionIds = events
+      .filter((e) => e.eventType === "agent_session:started")
+      .map((e) => (e.payload as { sessionId?: unknown }).sessionId)
+      .filter((id): id is string => typeof id === "string")
+    const runningSessionProgress =
+      startedSessionIds.length > 0
+        ? await AgentSessionRepository.findProgressSnapshotsByIds(this.pool, startedSessionIds)
+        : new Map()
+
     return events
       .filter((e) => e.eventType !== "message_edited" && e.eventType !== "message_deleted")
       .map((event) => {
+        if (event.eventType === "agent_session:started") {
+          const payload = event.payload as { sessionId?: string }
+          const progress = payload.sessionId ? runningSessionProgress.get(payload.sessionId) : undefined
+          return progress
+            ? {
+                ...event,
+                payload: {
+                  ...payload,
+                  stepCount: progress.stepCount,
+                  messageCount: progress.messageCount,
+                  currentStepType: progress.currentStepType,
+                },
+              }
+            : event
+        }
         if (event.eventType !== "message_created") return event
         const payload = event.payload as MessageCreatedPayload
         const threadData = threadDataMap.get(payload.messageId)

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest"
-import { renderHook } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
+import type { Socket } from "socket.io-client"
 import { AuthorTypes, type StreamEvent } from "@threa/types"
 import { useAgentActivity } from "./use-agent-activity"
 
@@ -14,6 +15,21 @@ function streamEvent(payload: unknown): StreamEvent {
     actorType: AuthorTypes.BOT,
     createdAt: "2026-05-25T00:00:00.000Z",
   }
+}
+
+function fakeSocket() {
+  const handlers = new Map<string, (payload: unknown) => void>()
+  const socket = {
+    on: (event: string, handler: (payload: unknown) => void) => {
+      handlers.set(event, handler)
+      return socket
+    },
+    off: (event: string) => {
+      handlers.delete(event)
+      return socket
+    },
+  } as unknown as Socket
+  return { socket, handlers }
 }
 
 describe("useAgentActivity", () => {
@@ -42,6 +58,44 @@ describe("useAgentActivity", () => {
       stepCount: 3,
       messageCount: 1,
       currentStepType: "tool_call",
+    })
+  })
+
+  test("live activity_started clears bootstrapped currentStepType", () => {
+    const { socket, handlers } = fakeSocket()
+    const { result } = renderHook(() =>
+      useAgentActivity(
+        [
+          streamEvent({
+            sessionId: "asess_1",
+            personaId: "bot_1",
+            personaName: "Pi Remote",
+            triggerMessageId: "msg_1",
+            stepCount: 3,
+            messageCount: 1,
+            currentStepType: "tool_call",
+            startedAt: "2026-05-25T00:00:00.000Z",
+          }),
+        ],
+        socket
+      )
+    )
+
+    expect(result.current.get("msg_1")?.currentStepType).toBe("tool_call")
+
+    act(() => {
+      handlers.get("agent_session:activity_started")?.({
+        sessionId: "asess_1",
+        triggerMessageId: "msg_1",
+        personaName: "Pi Remote",
+      })
+    })
+
+    expect(result.current.get("msg_1")).toMatchObject({
+      sessionId: "asess_1",
+      currentStepType: null,
+      stepCount: 0,
+      messageCount: 0,
     })
   })
 })

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { AuthorTypes, type StreamEvent } from "@threa/types"
+import { useAgentActivity } from "./use-agent-activity"
+
+function streamEvent(payload: unknown): StreamEvent {
+  return {
+    id: "event_1",
+    streamId: "stream_1",
+    sequence: "1",
+    eventType: "agent_session:started",
+    payload,
+    actorId: "bot_1",
+    actorType: AuthorTypes.BOT,
+    createdAt: "2026-05-25T00:00:00.000Z",
+  }
+}
+
+describe("useAgentActivity", () => {
+  test("hydrates running session counts from bootstrapped started events", () => {
+    const { result } = renderHook(() =>
+      useAgentActivity(
+        [
+          streamEvent({
+            sessionId: "asess_1",
+            personaId: "bot_1",
+            personaName: "Pi Remote",
+            triggerMessageId: "msg_1",
+            stepCount: 3,
+            messageCount: 1,
+            currentStepType: "tool_call",
+            startedAt: "2026-05-25T00:00:00.000Z",
+          }),
+        ],
+        null
+      )
+    )
+
+    expect(result.current.get("msg_1")).toMatchObject({
+      sessionId: "asess_1",
+      personaName: "Pi Remote",
+      stepCount: 3,
+      messageCount: 1,
+      currentStepType: "tool_call",
+    })
+  })
+})

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -61,7 +61,16 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
   // Derive running sessions from events array (bootstrap source of truth for streams
   // that contain session lifecycle events, e.g. threads and scratchpads)
   const runningSessions = useMemo(() => {
-    const started = new Map<string, { triggerMessageId: string; personaName: string }>()
+    const started = new Map<
+      string,
+      {
+        triggerMessageId: string
+        personaName: string
+        currentStepType: AgentStepType | null
+        stepCount: number
+        messageCount: number
+      }
+    >()
     const terminated = new Set<string>()
 
     for (const event of events) {
@@ -71,6 +80,9 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
           started.set(payload.sessionId, {
             triggerMessageId: payload.triggerMessageId,
             personaName: payload.personaName,
+            currentStepType: payload.currentStepType ?? null,
+            stepCount: payload.stepCount ?? 0,
+            messageCount: payload.messageCount ?? 0,
           })
           break
         }
@@ -207,9 +219,9 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
       result.set(session.triggerMessageId, {
         sessionId,
         personaName: progress?.personaName ?? session.personaName,
-        currentStepType: progress?.currentStepType ?? null,
-        stepCount: progress?.stepCount ?? 0,
-        messageCount: progress?.messageCount ?? 0,
+        currentStepType: progress?.currentStepType ?? session.currentStepType,
+        stepCount: progress?.stepCount ?? session.stepCount,
+        messageCount: progress?.messageCount ?? session.messageCount,
         substep: progress?.substep ?? null,
         threadStreamId: progress?.threadStreamId,
       })

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -219,9 +219,9 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
       result.set(session.triggerMessageId, {
         sessionId,
         personaName: progress?.personaName ?? session.personaName,
-        currentStepType: progress?.currentStepType ?? session.currentStepType,
-        stepCount: progress?.stepCount ?? session.stepCount,
-        messageCount: progress?.messageCount ?? session.messageCount,
+        currentStepType: progress ? progress.currentStepType : session.currentStepType,
+        stepCount: progress ? progress.stepCount : session.stepCount,
+        messageCount: progress ? progress.messageCount : session.messageCount,
         substep: progress?.substep ?? null,
         threadStreamId: progress?.threadStreamId,
       })

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -101,6 +101,10 @@ export interface AgentSessionStartedPayload {
   personaName: string
   triggerMessageId: string
   rerunContext?: AgentSessionRerunContext | null
+  /** Bootstrap-only snapshot for running sessions; live updates still use agent_session:progress. */
+  stepCount?: number
+  messageCount?: number
+  currentStepType?: AgentStepType | null
   startedAt: string
 }
 


### PR DESCRIPTION
## Problem

Refreshing a stream while a Pi/bot invocation is still running can leave the timeline session card showing a running trace with `0 steps`, even though opening the trace dialog shows the fully populated persisted steps.

The persisted trace data is correct; the stale path is timeline bootstrap. `useAgentActivity()` reconstructs running sessions from bootstrapped `agent_session:started` events, but live step counts only arrive through socket-only `agent_session:progress` events. After a mid-run refresh, the card starts at zero and only fixes itself if another progress event arrives.

## Solution

Hydrate running agent-session progress during stream bootstrap and use that snapshot to seed the frontend timeline activity state.

### How it works

1. Stream bootstrap loads recent stream events.
2. `EventService.enrichBootstrapEvents()` finds bootstrapped `agent_session:started` events.
3. For still-running sessions, the backend queries persisted session/step state and adds snapshot fields to the started payload:
   - `stepCount`
   - `messageCount`
   - `currentStepType`
4. `useAgentActivity()` seeds timeline cards from those optional fields.
5. Live `agent_session:progress` socket events continue to override the snapshot as the run proceeds.

### Key design decisions

**1. Enrich existing started events**

The timeline already derives running sessions from stream events, so enriching `agent_session:started` keeps the existing subscribe/bootstrap flow intact and avoids adding a second activity endpoint or fetching full traces for every running card.

**2. Only snapshot running sessions**

Completed/failed/deleted events already carry terminal counts. The new query intentionally filters to running sessions so terminal lifecycle payloads remain authoritative.

**3. Keep progress events ephemeral**

`agent_session:progress` remains socket-only for live updates. The persisted snapshot is only used to close the refresh gap.

## New files

| File | Purpose |
| ---- | ------- |
| `.claude/plans/agent-session-bootstrap-progress.md` | Plan context for review. |
| `apps/frontend/src/hooks/use-agent-activity.test.tsx` | Covers bootstrap hydration of running activity counts. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/session-repository.ts` | Adds a set-based running progress snapshot query. |
| `apps/backend/src/features/messaging/event-service.ts` | Enriches bootstrapped started events with persisted progress snapshots. |
| `apps/frontend/src/hooks/use-agent-activity.ts` | Seeds running session counts/current step from bootstrap fields. |
| `packages/types/src/agent-trace.ts` | Documents optional bootstrap-only fields on `AgentSessionStartedPayload`. |

## Deleted files

None.

## Test plan

- [x] `bun run --cwd apps/frontend test -- use-agent-activity.test.tsx`
- [x] `bun run --cwd packages/types typecheck`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun run --cwd apps/backend typecheck`
- [x] Pre-commit lint/typecheck/OpenAPI checks passed during commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782318895&installation_id=129946197&pr_number=618&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F618&signature=76885f7860a89d2a21cb291f195a65271cefd102c2f0a144f5e18d8797cbf4a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->