### PR TITLE
feat(editor): GFM table support in composer and timeline

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -64,6 +64,7 @@
     "@tiptap/extension-paragraph": "^3.22.3",
     "@tiptap/extension-placeholder": "^3.22.3",
     "@tiptap/extension-strike": "^3.22.3",
+    "@tiptap/extension-table": "^3.22.3",
     "@tiptap/extension-text": "^3.22.3",
     "@tiptap/pm": "^3.22.3",
     "@tiptap/react": "^3.22.3",

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -18,6 +18,10 @@ import ListItem from "@tiptap/extension-list-item"
 import Heading from "@tiptap/extension-heading"
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight"
 import { common, createLowlight } from "lowlight"
+import { Table } from "@tiptap/extension-table/table"
+import { TableRow } from "@tiptap/extension-table/row"
+import { TableHeader } from "@tiptap/extension-table/header"
+import { TableCell } from "@tiptap/extension-table/cell"
 
 import { MentionExtension, type MentionOptions } from "./triggers/mention-extension"
 import { ChannelExtension, type ChannelOptions } from "./triggers/channel-extension"
@@ -89,6 +93,20 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
       lowlight,
       defaultLanguage: "plaintext",
     }),
+
+    // GFM tables. Default cell content (`block+`) is intentionally kept so
+    // pasting a table whose cells contain inline marks or hard breaks works
+    // — the markdown serializer flattens those to a single line of pipes.
+    // `renderWrapper: true` emits the standard `<div class="tableWrapper">`
+    // around the table so the composer can scroll wide tables horizontally
+    // on narrow viewports, matching how the timeline displays them.
+    Table.configure({
+      resizable: false,
+      renderWrapper: true,
+    }),
+    TableRow,
+    TableHeader,
+    TableCell,
 
     // Auto-link URLs (makes them clickable)
     BoundaryAwareLink.configure({

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -14,6 +14,10 @@ import {
   ChevronDown,
   ListIndentIncrease,
   ListIndentDecrease,
+  Table as TableIcon,
+  Rows3,
+  Columns3,
+  Trash2,
 } from "lucide-react"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
@@ -280,6 +284,7 @@ export function EditorToolbar({
         showTooltip={!isMobileInlineToolbar}
         keyboardAccessible={inline}
       />
+      <TableControls editor={editor} roomy={isMobileInlineToolbar} keyboardAccessible={inline} />
       {showSpecialInputControls && (
         <>
           <Separator orientation="vertical" className={separatorClassName} />
@@ -557,6 +562,155 @@ function StylePicker({
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+function TableControls({
+  editor,
+  roomy,
+  keyboardAccessible,
+}: {
+  editor: Editor
+  roomy: boolean
+  keyboardAccessible: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const inTable = editor.isActive("table")
+
+  // When the cursor leaves the table, close the popover so the trigger reverts
+  // to the plain "Insert table" button. Without this the popover would stay
+  // open with disabled-looking controls.
+  useEffect(() => {
+    if (!inTable && open) setOpen(false)
+  }, [inTable, open])
+
+  if (!inTable) {
+    return (
+      <ToolbarButton
+        onAction={() => editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()}
+        icon={TableIcon}
+        label="Insert table"
+        roomy={roomy}
+        showTooltip={!roomy}
+        keyboardAccessible={keyboardAccessible}
+      />
+    )
+  }
+
+  const close = () => setOpen(false)
+  const run = (action: () => void) => () => {
+    action()
+    close()
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Edit table"
+          onPointerDown={(e) => {
+            // Match ToolbarButton's pointerdown-on-desktop pattern so focus
+            // doesn't leave the editor while the popover opens.
+            if (!roomy) e.preventDefault()
+          }}
+          onMouseDown={(e) => {
+            if (roomy) e.preventDefault()
+          }}
+          className={cn(
+            "p-0 shrink-0 bg-muted-foreground/20 text-foreground",
+            roomy
+              ? "h-9 w-9 min-w-9 active:bg-muted hover:bg-muted-foreground/20 hover:text-current"
+              : "h-8 w-8 hover:bg-muted-foreground/20"
+          )}
+          tabIndex={keyboardAccessible ? undefined : -1}
+        >
+          <TableIcon className="h-4 w-4 stroke-[2.5px]" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="top"
+        className="w-48 p-1"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <TableMenuItem
+          icon={Rows3}
+          label="Add row above"
+          onAction={run(() => editor.chain().focus().addRowBefore().run())}
+        />
+        <TableMenuItem
+          icon={Rows3}
+          label="Add row below"
+          onAction={run(() => editor.chain().focus().addRowAfter().run())}
+        />
+        <TableMenuItem
+          icon={Columns3}
+          label="Add column left"
+          onAction={run(() => editor.chain().focus().addColumnBefore().run())}
+        />
+        <TableMenuItem
+          icon={Columns3}
+          label="Add column right"
+          onAction={run(() => editor.chain().focus().addColumnAfter().run())}
+        />
+        <Separator className="my-1" />
+        <TableMenuItem
+          icon={Trash2}
+          label="Delete row"
+          onAction={run(() => editor.chain().focus().deleteRow().run())}
+        />
+        <TableMenuItem
+          icon={Trash2}
+          label="Delete column"
+          onAction={run(() => editor.chain().focus().deleteColumn().run())}
+        />
+        <TableMenuItem
+          icon={Trash2}
+          label="Delete table"
+          danger
+          onAction={run(() => editor.chain().focus().deleteTable().run())}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function TableMenuItem({
+  icon: Icon,
+  label,
+  onAction,
+  danger,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  onAction: () => void
+  danger?: boolean
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      // Mirror StylePicker's pointerdown handling so the editor selection is
+      // preserved while the table command runs.
+      onPointerDown={(e) => {
+        e.preventDefault()
+        onAction()
+      }}
+      onClick={(e) => {
+        if (e.detail === 0) onAction()
+      }}
+      className={cn(
+        "h-8 w-full justify-start gap-2 px-2 text-sm font-normal",
+        danger && "text-destructive hover:text-destructive"
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      {label}
+    </Button>
   )
 }
 

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -371,6 +371,85 @@ describe("multiline block paste handling", () => {
     editor.destroy()
   })
 
+  it("reconstructs a GFM table from a markdown paste", () => {
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    const tableMarkdown = ["| Name | Role |", "| --- | --- |", "| Alice | PM |", "| Bob | Eng |"].join("\n")
+    insertPastedText(
+      editor,
+      tableMarkdown,
+      () => "user",
+      () => null
+    )
+
+    const tableNode = (editor.getJSON().content ?? []).find((b) => b.type === "table")
+    expect(tableNode).toBeDefined()
+    expect(tableNode?.content).toHaveLength(3)
+    expect(serializeToMarkdown(editor.getJSON())).toContain("| Alice | PM |")
+    editor.destroy()
+  })
+
+  it("round-trips a copied table back through paste", () => {
+    // Build a table doc, serialize it (the cut/copy path), then paste it back
+    // into a fresh editor. This is the in-app copy/paste scenario: the
+    // clipboard carries our own markdown, so the destination must rebuild the
+    // exact same structure.
+    const tableDoc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "h1" }] }],
+                },
+                {
+                  type: "tableHeader",
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "h2" }] }],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "a" }] }],
+                },
+                {
+                  type: "tableCell",
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "b" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const copied = serializeToMarkdown(tableDoc)
+
+    const editor = createTestEditor("")
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    insertPastedText(
+      editor,
+      copied,
+      () => "user",
+      () => null
+    )
+
+    // The re-serialized output must match the original markdown.
+    expect(serializeToMarkdown(editor.getJSON())).toBe(copied)
+    editor.destroy()
+  })
+
   it("reconstructs a sharedMessage when pasted into a non-empty paragraph", () => {
     const editor = createTestEditor("Hello ")
     editor.commands.setTextSelection(editor.state.doc.content.size)

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -455,6 +455,42 @@
   @apply my-4 border-border;
 }
 
+/* GFM tables — composer styling mirrors how the timeline renders the same
+ * markdown so the user gets WYSIWYG parity. The `tableWrapper` div is emitted
+ * by @tiptap/extension-table with `renderWrapper: true`, and gives us a
+ * scrolling container so wide tables don't push the composer past the viewport
+ * on narrow chat columns / mobile. */
+.ProseMirror .tableWrapper {
+  @apply my-2 w-full overflow-x-auto;
+}
+
+.ProseMirror table {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.ProseMirror table td,
+.ProseMirror table th {
+  @apply border border-border px-2 py-1 align-top text-sm;
+  min-width: 4rem;
+  position: relative;
+}
+
+.ProseMirror table th {
+  @apply bg-muted text-left font-semibold;
+}
+
+.ProseMirror table p {
+  margin: 0;
+}
+
+/* ProseMirror's selectedCell decoration: highlight cells in the current
+ * selection so users can see which row/column a command will affect. */
+.ProseMirror table .selectedCell {
+  background-color: hsl(var(--primary) / 0.12);
+}
+
 /* Gapcursor base: collapse to zero space in the document flow */
 .ProseMirror .ProseMirror-gapcursor {
   pointer-events: none;

--- a/bun.lock
+++ b/bun.lock
@@ -238,6 +238,7 @@
         "@tiptap/extension-paragraph": "^3.22.3",
         "@tiptap/extension-placeholder": "^3.22.3",
         "@tiptap/extension-strike": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
         "@tiptap/extension-text": "^3.22.3",
         "@tiptap/pm": "^3.22.3",
         "@tiptap/react": "^3.22.3",
@@ -1499,6 +1500,8 @@
     "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@3.22.3", "", { "peerDependencies": { "@tiptap/extensions": "^3.22.3" } }, "sha512-7vbtlDVO00odqCnsMSmA4b6wjL5PFdfExFsdsDO0K0VemqHZ/doIRx/tosNUD1VYSOyKQd8U7efUjkFyVoIPlg=="],
 
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.22.3", "", { "peerDependencies": { "@tiptap/core": "^3.22.3" } }, "sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g=="],
+
+    "@tiptap/extension-table": ["@tiptap/extension-table@3.23.6", "", { "peerDependencies": { "@tiptap/core": "3.23.6", "@tiptap/pm": "3.23.6" } }, "sha512-XbhZXjhsS6AP7ThoZxjAnNs+NiR81YRori25l6E+ORqB7quiPkIXOAi5h4AIpkn/CYIqze6ere11lWsYpDjtaQ=="],
 
     "@tiptap/extension-text": ["@tiptap/extension-text@3.22.3", "", { "peerDependencies": { "@tiptap/core": "^3.22.3" } }, "sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw=="],
 

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -488,3 +488,121 @@ describe("mention/channel whitespace boundary", () => {
     expect(content?.[0]?.type).toBe("mention")
   })
 })
+
+describe("@threa/prosemirror table round-trip", () => {
+  function cell(type: "tableHeader" | "tableCell", text: string): JSONContent {
+    return {
+      type,
+      attrs: { colspan: 1, rowspan: 1, colwidth: null },
+      content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
+    }
+  }
+
+  it("serializes a table to GFM markdown", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("tableHeader", "Name"), cell("tableHeader", "Role")] },
+            { type: "tableRow", content: [cell("tableCell", "Alice"), cell("tableCell", "PM")] },
+            { type: "tableRow", content: [cell("tableCell", "Bob"), cell("tableCell", "Eng")] },
+          ],
+        },
+      ],
+    }
+
+    expect(serializeToMarkdown(doc)).toBe(
+      ["| Name | Role |", "| --- | --- |", "| Alice | PM |", "| Bob | Eng |"].join("\n")
+    )
+  })
+
+  it("parses a GFM markdown table into table/tableRow/cell nodes", () => {
+    const markdown = ["| Name | Role |", "| --- | --- |", "| Alice | PM |", "| Bob | Eng |"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]?.type).toBe("table")
+    expect(parsed.content?.[0]?.content).toHaveLength(3)
+    expect(parsed.content?.[0]?.content?.[0]?.content?.[0]).toEqual(cell("tableHeader", "Name"))
+    expect(parsed.content?.[0]?.content?.[1]?.content?.[0]).toEqual(cell("tableCell", "Alice"))
+  })
+
+  it("round-trips a table losslessly through markdown", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("tableHeader", "h1"), cell("tableHeader", "h2")] },
+            { type: "tableRow", content: [cell("tableCell", "a"), cell("tableCell", "b")] },
+          ],
+        },
+      ],
+    }
+    const reparsed = parseMarkdown(serializeToMarkdown(doc))
+    expect(reparsed.content?.[0]).toEqual(doc.content![0])
+  })
+
+  it("escapes pipes in cell content and round-trips them back", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("tableHeader", "code"), cell("tableHeader", "desc")] },
+            { type: "tableRow", content: [cell("tableCell", "a | b"), cell("tableCell", "or")] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toContain("a \\| b")
+    const reparsed = parseMarkdown(markdown)
+    expect(reparsed.content?.[0]?.content?.[1]?.content?.[0]).toEqual(cell("tableCell", "a | b"))
+  })
+
+  it("preserves inline marks inside table cells", () => {
+    const markdown = ["| heading |", "| --- |", "| **bold** and *italic* |"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    const bodyCellContent = parsed.content?.[0]?.content?.[1]?.content?.[0]?.content?.[0]?.content
+    expect(bodyCellContent?.[0]).toEqual({ type: "text", text: "bold", marks: [{ type: "bold" }] })
+    expect(bodyCellContent?.[1]).toEqual({ type: "text", text: " and " })
+    expect(bodyCellContent?.[2]).toEqual({ type: "text", text: "italic", marks: [{ type: "italic" }] })
+  })
+
+  it("pads ragged body rows to the header width", () => {
+    const markdown = ["| a | b | c |", "| --- | --- | --- |", "| 1 | 2 |"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    const rowCells = parsed.content?.[0]?.content?.[1]?.content
+    expect(rowCells).toHaveLength(3)
+    expect(rowCells?.[2]).toEqual({
+      type: "tableCell",
+      attrs: { colspan: 1, rowspan: 1, colwidth: null },
+      content: [{ type: "paragraph" }],
+    })
+  })
+
+  it("treats a paragraph that just contains pipes as plain text, not a table", () => {
+    // No separator row → not a table; previously this was a regression risk
+    // because the table detector saw a pipe-laden line and tried to parse it.
+    const parsed = parseMarkdown("foo | bar")
+    expect(parsed.content?.[0]?.type).toBe("paragraph")
+  })
+
+  it("serializes a CellSelection-style slice of bare tableRows as a single table", () => {
+    // ProseMirror's CellSelection produces a slice whose top-level children
+    // are bare `tableRow` nodes (no enclosing `table`). The copy handler
+    // wraps that in a doc and feeds it to `serializeToMarkdown`, so we need
+    // to recognize this shape.
+    const sliceDoc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "tableRow", content: [cell("tableHeader", "a"), cell("tableHeader", "b")] },
+        { type: "tableRow", content: [cell("tableCell", "1"), cell("tableCell", "2")] },
+      ],
+    }
+    expect(serializeToMarkdown(sliceDoc)).toBe(["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n"))
+  })
+})

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -49,7 +49,28 @@ export const INLINE_MARKDOWN_PATTERN =
  */
 export function serializeToMarkdown(content: JSONContent): string {
   if (!content.content) return ""
-  return content.content.map((node) => serializeNode(node)).join("\n\n")
+  // Group consecutive top-level `tableRow` nodes into a synthetic table.
+  // ProseMirror's CellSelection serializes to a slice whose top-level children
+  // are bare table rows (no enclosing `table`); without this grouping a copy
+  // of "two cells across two rows" would round-trip through a non-table fallback.
+  const nodes = content.content
+  const out: string[] = []
+  let i = 0
+  while (i < nodes.length) {
+    const node = nodes[i]
+    if (node.type === "tableRow") {
+      const rows: JSONContent[] = []
+      while (i < nodes.length && nodes[i].type === "tableRow") {
+        rows.push(nodes[i])
+        i++
+      }
+      out.push(serializeTable({ type: "table", content: rows }))
+      continue
+    }
+    out.push(serializeNode(node))
+    i++
+  }
+  return out.join("\n\n")
 }
 
 function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): string {
@@ -148,9 +169,74 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
     case "hardBreak":
       return "\n"
 
+    case "table":
+      return serializeTable(node)
+
     default:
       return serializeInline(node.content)
   }
+}
+
+/**
+ * Serialize a `table` node to GFM-flavoured markdown.
+ *
+ * Cells are flattened to a single line of inline markdown — pipes are escaped
+ * as `\|` and any hard breaks / extra paragraphs are joined with `<br>` so
+ * remark-gfm can round-trip them back into multi-line cells. The first row
+ * of every table is emitted as a header even when the source row contains
+ * `tableCell` nodes; GFM does not have a header-less table form, and the
+ * downstream renderer (react-markdown + remark-gfm) treats any table without
+ * a header as invalid and drops it. Forcing a header row keeps the table
+ * visible.
+ */
+function serializeTable(node: JSONContent): string {
+  const rows = node.content ?? []
+  if (rows.length === 0) return ""
+
+  const grid: string[][] = rows.map((row) => {
+    const cells = row.content ?? []
+    return cells.map((cell) => serializeTableCell(cell))
+  })
+
+  const columnCount = grid.reduce((max, row) => Math.max(max, row.length), 0)
+  if (columnCount === 0) return ""
+
+  // Pad short rows so the resulting markdown is rectangular.
+  for (const row of grid) {
+    while (row.length < columnCount) row.push("")
+  }
+
+  const headerCells = grid[0]
+  const separator = Array.from({ length: columnCount }, () => "---")
+  const bodyRows = grid.slice(1)
+
+  const lines: string[] = []
+  lines.push(`| ${headerCells.join(" | ")} |`)
+  lines.push(`| ${separator.join(" | ")} |`)
+  for (const row of bodyRows) {
+    lines.push(`| ${row.join(" | ")} |`)
+  }
+  return lines.join("\n")
+}
+
+function serializeTableCell(cell: JSONContent): string {
+  const blocks = cell.content ?? []
+  if (blocks.length === 0) return ""
+  const lines = blocks
+    .map((block) => {
+      if (block.type === "paragraph") return serializeInline(block.content)
+      // Fall back to a best-effort render for non-paragraph block content
+      // (rare — tiptap's table cells default to `block+`). We don't recurse
+      // through `serializeNode` because nested lists / code blocks would emit
+      // newlines that break the GFM table grammar.
+      return serializeInline(block.content)
+    })
+    .filter((line) => line.length > 0)
+  const joined = lines.join("<br>")
+  // Escape pipes so they don't terminate the cell, and collapse hard-break
+  // newlines into `<br>` for the same reason. Leading/trailing whitespace
+  // inside a cell is meaningless in GFM, so trim.
+  return joined.replace(/\|/g, "\\|").replace(/\n/g, "<br>").trim()
 }
 
 /**
@@ -519,6 +605,19 @@ export function parseMarkdown(
       continue
     }
 
+    // GFM table — header row + separator row + zero or more body rows.
+    // Detected by peeking at the next line for the dashes-and-pipes
+    // separator; without that peek a normal paragraph that happens to
+    // contain pipes (`foo | bar`) would be misclassified as a table.
+    if (isTableSeparatorLine(lines[i + 1]) && isTableRowLine(line)) {
+      const table = parseTableBlock(lines, i, options)
+      if (table) {
+        content.push(table.node)
+        i = table.nextIndex
+        continue
+      }
+    }
+
     // Horizontal rule
     if (line.match(/^---+$/) || line.match(/^\*\*\*+$/)) {
       content.push({ type: "horizontalRule" })
@@ -576,6 +675,119 @@ function parseSharedMessageLine(line: string): { authorName: string; streamId: s
   if (!match) return null
   const authorName = match[1].replace(/\\([\]\\])/g, "$1")
   return { authorName, streamId: match[2], messageId: match[3] }
+}
+
+function isTableRowLine(line: string | undefined): boolean {
+  if (!line) return false
+  const trimmed = line.trim()
+  return trimmed.startsWith("|") && trimmed.includes("|", 1)
+}
+
+function isTableSeparatorLine(line: string | undefined): boolean {
+  if (!line) return false
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("|") && !trimmed.startsWith("-") && !trimmed.startsWith(":")) return false
+  // Strip optional leading/trailing pipes, then verify every column is just
+  // dashes (with optional `:` alignment markers and surrounding whitespace).
+  const body = trimmed.replace(/^\|/, "").replace(/\|$/, "")
+  const cells = body.split("|")
+  if (cells.length < 1) return false
+  return cells.every((cell) => /^\s*:?-{3,}:?\s*$/.test(cell))
+}
+
+/**
+ * Split a GFM table row into its cells. Handles escaped pipes (`\|`).
+ * Leading and trailing pipes are optional.
+ */
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim()
+  const body = trimmed.replace(/^\|/, "").replace(/\|$/, "")
+  const cells: string[] = []
+  let current = ""
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i]
+    if (ch === "\\" && body[i + 1] === "|") {
+      current += "|"
+      i++
+      continue
+    }
+    if (ch === "|") {
+      cells.push(current.trim())
+      current = ""
+      continue
+    }
+    current += ch
+  }
+  cells.push(current.trim())
+  return cells
+}
+
+/**
+ * Parse a GFM table starting at `lines[startIndex]`. The caller is responsible
+ * for verifying the header + separator look like a table — we re-check here
+ * and bail (returning `null`) if the structure breaks, which lets the
+ * surrounding loop fall back to treating the line as a regular paragraph.
+ */
+function parseTableBlock(
+  lines: string[],
+  startIndex: number,
+  options: ParseOptions
+): { node: JSONContent; nextIndex: number } | null {
+  const headerLine = lines[startIndex]
+  const separatorLine = lines[startIndex + 1]
+  if (!isTableRowLine(headerLine) || !isTableSeparatorLine(separatorLine)) {
+    return null
+  }
+  const headerCells = splitTableRow(headerLine)
+  const columnCount = headerCells.length
+  if (columnCount === 0) return null
+
+  const bodyRows: string[][] = []
+  let i = startIndex + 2
+  while (i < lines.length && isTableRowLine(lines[i])) {
+    const cells = splitTableRow(lines[i])
+    // Normalize ragged rows to the header width so the resulting table is
+    // rectangular — extra cells are dropped, missing cells become empty.
+    while (cells.length < columnCount) cells.push("")
+    if (cells.length > columnCount) cells.length = columnCount
+    bodyRows.push(cells)
+    i++
+  }
+
+  const tableRows: JSONContent[] = []
+  tableRows.push({
+    type: "tableRow",
+    content: headerCells.map((cellText) => buildTableCell("tableHeader", cellText, options)),
+  })
+  for (const row of bodyRows) {
+    tableRows.push({
+      type: "tableRow",
+      content: row.map((cellText) => buildTableCell("tableCell", cellText, options)),
+    })
+  }
+
+  return {
+    node: { type: "table", content: tableRows },
+    nextIndex: i,
+  }
+}
+
+function buildTableCell(type: "tableHeader" | "tableCell", text: string, options: ParseOptions): JSONContent {
+  // `<br>` (and the self-closing variants) inside a cell encode a hard line
+  // break — the only way GFM tables can express multi-line cell content.
+  // Split on these and emit one paragraph per segment so the resulting
+  // ProseMirror tree matches what tiptap's table cell schema expects
+  // (paragraph block*).
+  const segments = text.split(/<br\s*\/?>/i)
+  const paragraphs: JSONContent[] = segments.map((segment) => {
+    const inline = parseInlineMarkdown(segment, options)
+    return inline.length > 0 ? { type: "paragraph", content: inline } : { type: "paragraph" }
+  })
+  return {
+    type,
+    attrs: { colspan: 1, rowspan: 1, colwidth: null },
+    content: paragraphs.length > 0 ? paragraphs : [{ type: "paragraph" }],
+  }
 }
 
 function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONContent[] {


### PR DESCRIPTION
## Summary

The timeline already rendered GFM tables via `remark-gfm`, but the composer had no way to insert or edit them. This wires up Tiptap's table extension, extends the shared markdown serializer/parser to round-trip tables, and surfaces toolbar controls on both the floating bubble (desktop) and inline toolbar (mobile / thread panel).

## How to trigger it

- **Insert** — click the table icon in the formatting toolbar (floating bubble on desktop, inline toolbar on mobile and in pinned mode). Inserts a 3×3 table with a header row.
- **Edit** — once the cursor is inside a table, the same icon flips into a popover with add/remove row/column and delete table.
- **Tab / Shift-Tab** — navigate cells. Tab on the last cell adds a new row.
- **Paste GFM markdown** — pasting `| h | h |\n| --- | --- |\n| c | c |` lands as a real table (existing paste handler routes plain text through `parseMarkdown`).
- **Copy & paste within Threa** — copies serialize to GFM via the existing copy handler; pasting back rebuilds the table. CellSelection (multi-cell) copies are wrapped in a synthetic table so partial selections round-trip too.

## Mobile vs desktop vs thread panel

- The inline toolbar (mobile + pinned mode) and the floating bubble (desktop) both use the same button set, so the table button shows everywhere.
- Main stream view and thread panel share the same `RichEditor`, so this works in both with no per-surface code.
- Composer and timeline use the same scrolling wrapper (`<div class="tableWrapper">` from Tiptap, mirrored by the timeline's `overflow-x-auto`) so wide tables scroll horizontally on narrow viewports.

## Markdown round-trip

- **Serializer** emits standard GFM with `\|` escaping and `<br>` for hard breaks / multi-paragraph cells so cells stay on one line.
- **Parser** detects tables by peeking at the separator row so pipe-laden paragraphs (`foo | bar`) aren't misclassified. Ragged rows are padded to the header width.
- **CellSelection slice** (top-level bare `tableRow` nodes from a partial copy) is grouped into a synthetic table before serialization.

## Test plan

- [x] `bun test` in `packages/prosemirror` — 8 new tests covering serialize, parse, round-trip, pipe escaping, inline marks in cells, ragged rows, plain-text protection, and CellSelection slice grouping.
- [x] `vitest run src/components/editor/` in `apps/frontend` — 2 new paste tests including a full copy-then-paste round trip through a live editor instance.
- [x] Full monorepo `bun run typecheck` and `bun run build` pass.
- [ ] Manual: insert table from desktop bubble toolbar, edit cells, add row/column via popover, paste GFM markdown from outside, copy and paste within the editor, view rendered table in timeline on mobile width.

## Known gap

No markdown-as-you-type input rule yet — you can't type `| h |\n| --- |` and have it auto-convert mid-document. Toolbar button + paste cover the primary entry points; an input rule could be added later if there's demand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqVDSd4VTdBBkWS5sKc7BH)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782335626&installation_id=129946197&pr_number=620&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F620&signature=4ebf1858d46ab562f5ffefa22cfd0aa2d508a352cddc6a0d222d7d485d229bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->