### PR TITLE
fix(editor): tighten GFM table parsing and add type-to-create input rule

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -11,13 +11,21 @@ import * as editorModule from "@/components/editor"
 
 let isMobileMockValue = false
 
+type MockEditorInstance = {
+  id: string
+  getJSON: () => JSONContent
+  isActive: () => boolean
+  on: () => void
+  off: () => void
+}
+
 const MockRichEditor = forwardRef<
   {
     focus: () => void
     insertMention: () => void
     insertSlash: () => void
     insertEmoji: () => void
-    getEditor: () => { id: string; getJSON: () => JSONContent } | null
+    getEditor: () => MockEditorInstance | null
   },
   {
     value: JSONContent
@@ -31,12 +39,19 @@ const MockRichEditor = forwardRef<
 >(function MockRichEditor({ value, onChange, onSubmit, placeholder, disabled, ariaLabel, ariaDescribedBy }, ref) {
   const valueRef = { current: value }
   valueRef.current = value
-  const [editorInstance, setEditorInstance] = useState<{
-    id: string
-    getJSON: () => JSONContent
-  } | null>(null)
+  const [editorInstance, setEditorInstance] = useState<MockEditorInstance | null>(null)
   useEffect(() => {
-    const timer = setTimeout(() => setEditorInstance({ id: "mock-editor", getJSON: () => valueRef.current }), 0)
+    const timer = setTimeout(
+      () =>
+        setEditorInstance({
+          id: "mock-editor",
+          getJSON: () => valueRef.current,
+          isActive: () => false,
+          on: () => undefined,
+          off: () => undefined,
+        }),
+      0
+    )
     return () => clearTimeout(timer)
   }, [])
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -261,6 +261,7 @@ export function MessageComposer({
   const actionBarWrapperRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
   const [formatOpen, setFormatOpen] = useState(false)
+  const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
   const [mobileFocused, setMobileFocused] = useState(false)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
@@ -327,6 +328,25 @@ export function MessageComposer({
     },
     []
   )
+
+  // Track whether the caret is inside a table so we can surface a discoverability
+  // hint on mobile — the floating selection toolbar is suppressed on mobile, so
+  // without this hint there's no visible cue that the format toolbar holds row
+  // and column controls.
+  useEffect(() => {
+    if (!mobileToolbarEditor) {
+      setIsInTable(false)
+      return
+    }
+    const update = () => setIsInTable(mobileToolbarEditor.isActive("table"))
+    update()
+    mobileToolbarEditor.on("selectionUpdate", update)
+    mobileToolbarEditor.on("update", update)
+    return () => {
+      mobileToolbarEditor.off("selectionUpdate", update)
+      mobileToolbarEditor.off("update", update)
+    }
+  }, [mobileToolbarEditor])
 
   // Build the send mode hint text (reactive to preference changes).
   // Expanded (fullscreen) and mobile always use cmdEnter — on mobile the send button
@@ -850,6 +870,23 @@ export function MessageComposer({
                 <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
                 <div className="pointer-events-auto">{sendButton}</div>
               </div>
+            )}
+
+            {/* Mobile-only table hint — the floating selection toolbar is
+               suppressed on mobile (it conflicts with the OS selection popup),
+               so without this banner there's no visible cue that the row /
+               column / delete controls live behind the Aa button. */}
+            {isMobile && mobileChromeOpen && isInTable && !formatOpen && (
+              <button
+                type="button"
+                onClick={() => setFormatOpen(true)}
+                onMouseDown={(e) => e.preventDefault()}
+                className="flex items-center gap-2 self-start rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
+              >
+                Editing table — tap{" "}
+                <span className="rounded bg-background px-1 py-0.5 text-[11px] font-bold leading-none">Aa</span> to add
+                or delete rows and columns
+              </button>
             )}
 
             {/* Editor — always mounted to preserve state; hidden in preview mode */}

--- a/apps/frontend/src/components/editor/editor-behaviors.ts
+++ b/apps/frontend/src/components/editor/editor-behaviors.ts
@@ -862,10 +862,20 @@ export const EditorBehaviors = Extension.create<EditorBehaviorsOptions>({
         )
       },
 
-      // Tab: VS Code-style indent (always trapped to prevent focus escape)
+      // Tab: VS Code-style indent (always trapped to prevent focus escape).
+      // Inside a table cell we delegate to prosemirror-tables' Tab command so
+      // the keyboard moves between cells (and adds a row at the last cell)
+      // instead of inserting an indent character.
       Tab: () => {
         if (isSuggestionActive(this.editor)) {
           return false
+        }
+
+        if (this.editor.isActive("table")) {
+          if (this.editor.commands.goToNextCell()) return true
+          if (!this.editor.can().addRowAfter()) return true
+          this.editor.chain().addRowAfter().goToNextCell().run()
+          return true
         }
 
         indentSelection(this.editor)
@@ -874,6 +884,10 @@ export const EditorBehaviors = Extension.create<EditorBehaviorsOptions>({
 
       // Shift+Tab: VS Code-style dedent (always trapped to prevent focus escape)
       "Shift-Tab": () => {
+        if (this.editor.isActive("table")) {
+          this.editor.commands.goToPreviousCell()
+          return true
+        }
         dedentSelection(this.editor)
         return true
       },

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -22,6 +22,7 @@ import { Table } from "@tiptap/extension-table/table"
 import { TableRow } from "@tiptap/extension-table/row"
 import { TableHeader } from "@tiptap/extension-table/header"
 import { TableCell } from "@tiptap/extension-table/cell"
+import { MarkdownTableInputRule } from "./markdown-table-input-rule"
 
 import { MentionExtension, type MentionOptions } from "./triggers/mention-extension"
 import { ChannelExtension, type ChannelOptions } from "./triggers/channel-extension"
@@ -107,6 +108,10 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
     TableRow,
     TableHeader,
     TableCell,
+
+    // Type-to-create: pressing Enter after `| h |\n| --- |` converts the
+    // pipe-row paragraphs to a real table node.
+    MarkdownTableInputRule,
 
     // Auto-link URLs (makes them clickable)
     BoundaryAwareLink.configure({

--- a/apps/frontend/src/components/editor/editor-toolbar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.test.tsx
@@ -24,6 +24,14 @@ function createEditorStub() {
     toggleCodeBlock: vi.fn(() => chain),
     toggleHeading: vi.fn(() => chain),
     setParagraph: vi.fn(() => chain),
+    addRowBefore: vi.fn(() => chain),
+    addRowAfter: vi.fn(() => chain),
+    addColumnBefore: vi.fn(() => chain),
+    addColumnAfter: vi.fn(() => chain),
+    deleteRow: vi.fn(() => chain),
+    deleteColumn: vi.fn(() => chain),
+    deleteTable: vi.fn(() => chain),
+    insertTable: vi.fn(() => chain),
     run: vi.fn(() => true),
   }
 
@@ -280,5 +288,29 @@ describe("EditorToolbar", () => {
     const boldButton = screen.getByRole("button", { name: "Bold" })
     expect(boldButton.className).toContain("bg-muted-foreground/20")
     expect(boldButton.className).toContain("hover:bg-muted-foreground/20")
+  })
+
+  it("waits for click before running mobile table menu actions so the popover absorbs the touchend", async () => {
+    const editor = createEditorStub()
+    vi.mocked(editor.isActive).mockImplementation((type) => type === "table")
+    const user = userEvent.setup()
+    render(<EditorToolbar editor={editor} isVisible inline inlinePosition="below" />)
+
+    await user.click(screen.getByRole("button", { name: "Edit table" }))
+
+    const deleteTable = await screen
+      .findByRole("menuitem", { name: /Delete table/ })
+      .catch(() => screen.getByRole("button", { name: /Delete table/ }))
+
+    // Mobile path: pointerdown on a menu item must NOT fire the action.
+    // Acting on pointerdown closes the popover before the synthesized
+    // touchend/click lands, which leaks the click through to whichever
+    // toolbar button now sits under the user's finger.
+    fireEvent.pointerDown(deleteTable)
+    const chainStub = (editor as unknown as { __chainState: { deleteTable: ReturnType<typeof vi.fn> } }).__chainState
+    expect(chainStub.deleteTable).not.toHaveBeenCalled()
+
+    fireEvent.click(deleteTable)
+    expect(chainStub.deleteTable).toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -642,24 +642,28 @@ function TableControls({
           label="Add row above"
           onAction={run(() => editor.chain().focus().addRowBefore().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <TableMenuItem
           icon={Rows3}
           label="Add row below"
           onAction={run(() => editor.chain().focus().addRowAfter().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <TableMenuItem
           icon={Columns3}
           label="Add column left"
           onAction={run(() => editor.chain().focus().addColumnBefore().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <TableMenuItem
           icon={Columns3}
           label="Add column right"
           onAction={run(() => editor.chain().focus().addColumnAfter().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <Separator className="my-1" />
         <TableMenuItem
@@ -667,12 +671,14 @@ function TableControls({
           label="Delete row"
           onAction={run(() => editor.chain().focus().deleteRow().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <TableMenuItem
           icon={Trash2}
           label="Delete column"
           onAction={run(() => editor.chain().focus().deleteColumn().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
         <TableMenuItem
           icon={Trash2}
@@ -680,6 +686,7 @@ function TableControls({
           danger
           onAction={run(() => editor.chain().focus().deleteTable().run())}
           keyboardAccessible={keyboardAccessible}
+          roomy={roomy}
         />
       </PopoverContent>
     </Popover>
@@ -692,26 +699,35 @@ function TableMenuItem({
   onAction,
   danger,
   keyboardAccessible,
+  roomy,
 }: {
   icon: React.ComponentType<{ className?: string }>
   label: string
   onAction: () => void
   danger?: boolean
   keyboardAccessible?: boolean
+  roomy?: boolean
 }) {
   return (
     <Button
       type="button"
       variant="ghost"
       size="sm"
-      // Mirror StylePicker's pointerdown handling so the editor selection is
-      // preserved while the table command runs.
-      onPointerDown={(e) => {
-        e.preventDefault()
-        onAction()
-      }}
+      // Desktop: act on pointerdown so the editor selection survives the menu
+      // click (Tiptap commands rely on the current selection).
+      // Mobile (roomy): defer to click. Acting on pointerdown closes the
+      // popover before touchend lands, which lets the trailing click pass
+      // through to whichever toolbar button now sits under the finger.
+      onPointerDown={
+        roomy
+          ? undefined
+          : (e) => {
+              e.preventDefault()
+              onAction()
+            }
+      }
       onClick={(e) => {
-        if (e.detail === 0) onAction()
+        if (roomy || e.detail === 0) onAction()
       }}
       className={cn(
         "h-8 w-full justify-start gap-2 px-2 text-sm font-normal",

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -640,38 +640,45 @@ function TableControls({
           icon={Rows3}
           label="Add row above"
           onAction={run(() => editor.chain().focus().addRowBefore().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <TableMenuItem
           icon={Rows3}
           label="Add row below"
           onAction={run(() => editor.chain().focus().addRowAfter().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <TableMenuItem
           icon={Columns3}
           label="Add column left"
           onAction={run(() => editor.chain().focus().addColumnBefore().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <TableMenuItem
           icon={Columns3}
           label="Add column right"
           onAction={run(() => editor.chain().focus().addColumnAfter().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <Separator className="my-1" />
         <TableMenuItem
           icon={Trash2}
           label="Delete row"
           onAction={run(() => editor.chain().focus().deleteRow().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <TableMenuItem
           icon={Trash2}
           label="Delete column"
           onAction={run(() => editor.chain().focus().deleteColumn().run())}
+          keyboardAccessible={keyboardAccessible}
         />
         <TableMenuItem
           icon={Trash2}
           label="Delete table"
           danger
           onAction={run(() => editor.chain().focus().deleteTable().run())}
+          keyboardAccessible={keyboardAccessible}
         />
       </PopoverContent>
     </Popover>
@@ -683,11 +690,13 @@ function TableMenuItem({
   label,
   onAction,
   danger,
+  keyboardAccessible,
 }: {
   icon: React.ComponentType<{ className?: string }>
   label: string
   onAction: () => void
   danger?: boolean
+  keyboardAccessible?: boolean
 }) {
   return (
     <Button
@@ -707,6 +716,7 @@ function TableMenuItem({
         "h-8 w-full justify-start gap-2 px-2 text-sm font-normal",
         danger && "text-destructive hover:text-destructive"
       )}
+      tabIndex={keyboardAccessible ? undefined : -1}
     >
       <Icon className="h-4 w-4 shrink-0" />
       {label}

--- a/apps/frontend/src/components/editor/editor-toolbar.tsx
+++ b/apps/frontend/src/components/editor/editor-toolbar.tsx
@@ -619,14 +619,15 @@ function TableControls({
             if (roomy) e.preventDefault()
           }}
           className={cn(
-            "p-0 shrink-0 bg-muted-foreground/20 text-foreground",
+            "px-1.5 shrink-0 gap-0.5 bg-muted-foreground/20 text-foreground",
             roomy
-              ? "h-9 w-9 min-w-9 active:bg-muted hover:bg-muted-foreground/20 hover:text-current"
-              : "h-8 w-8 hover:bg-muted-foreground/20"
+              ? "h-9 active:bg-muted hover:bg-muted-foreground/20 hover:text-current"
+              : "h-8 hover:bg-muted-foreground/20"
           )}
           tabIndex={keyboardAccessible ? undefined : -1}
         >
           <TableIcon className="h-4 w-4 stroke-[2.5px]" />
+          <ChevronDown className="h-3 w-3 opacity-60" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/apps/frontend/src/components/editor/markdown-table-input-rule.ts
+++ b/apps/frontend/src/components/editor/markdown-table-input-rule.ts
@@ -2,19 +2,27 @@
  * Markdown table input rule.
  *
  * When the user types a GFM table pattern as plain paragraphs (header row,
- * separator row, optional data rows) and presses Enter, the trailing pipe-row
- * paragraphs are replaced by a real ProseMirror table node. Other markdown
- * patterns (bold, italic, code fences) already have inline / Enter input
- * rules; tables span multiple paragraphs so we need a dedicated handler.
+ * optional separator row, optional data rows) and presses Enter, the trailing
+ * pipe-row paragraphs are replaced by a real ProseMirror table node. Other
+ * markdown patterns (bold, italic, code fences) already have inline / Enter
+ * input rules; tables span multiple paragraphs so we need a dedicated handler.
  *
  * Trigger: Enter at the end of a top-level paragraph whose text contains a
- * pipe, when walking backward through contiguous pipe-containing siblings
- * produces a string that `parseMarkdown` interprets as a single table block.
+ * pipe, when the trailing contiguous pipe-row paragraphs either parse as a
+ * single table (header + separator + ...) or look like a standalone header
+ * row that we can promote into a table with one empty body row.
  */
 import { Extension, type Editor } from "@tiptap/core"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { TextSelection } from "@tiptap/pm/state"
 import { Fragment } from "@tiptap/pm/model"
+import type { JSONContent } from "@threa/types"
 import { parseMarkdown } from "./editor-markdown"
+
+type TableConversion = {
+  tableJSON: JSONContent
+  cursorTarget: "trailingParagraph" | "firstBodyCell"
+}
 
 function convertTrailingTable(editor: Editor): boolean {
   const { state } = editor
@@ -51,13 +59,11 @@ function convertTrailingTable(editor: Editor): boolean {
     }
     indices.unshift(i)
   }
-
-  if (indices.length < 2) return false
+  if (indices.length === 0) return false
 
   const lines = indices.map((i) => doc.child(i).textContent)
-  const parsed = parseMarkdown(lines.join("\n"))
-  const blocks = parsed.content
-  if (!blocks || blocks.length !== 1 || blocks[0].type !== "table") return false
+  const conversion = buildConversion(lines)
+  if (!conversion) return false
 
   let pos = 0
   let firstPos = -1
@@ -72,7 +78,7 @@ function convertTrailingTable(editor: Editor): boolean {
   }
   if (firstPos < 0 || lastEnd < 0) return false
 
-  const tableNode = state.schema.nodeFromJSON(blocks[0])
+  const tableNode = state.schema.nodeFromJSON(conversion.tableJSON)
   if (!tableNode) return false
 
   const paragraphType = state.schema.nodes.paragraph
@@ -80,13 +86,104 @@ function convertTrailingTable(editor: Editor): boolean {
   const fragment = Fragment.fromArray([tableNode, emptyPara])
 
   const tr = state.tr.replaceWith(firstPos, lastEnd, fragment)
-  // Land the cursor in the trailing empty paragraph so the user can keep
-  // typing below the new table — matches what plain Enter would have done
-  // had we not intercepted it.
-  const trailingParaPos = firstPos + tableNode.nodeSize + 1
-  tr.setSelection(TextSelection.create(tr.doc, trailingParaPos))
+  const cursorPos =
+    conversion.cursorTarget === "firstBodyCell"
+      ? firstBodyCellTextPos(tableNode, firstPos)
+      : firstPos + tableNode.nodeSize + 1
+  tr.setSelection(TextSelection.create(tr.doc, cursorPos))
   editor.view.dispatch(tr)
   return true
+}
+
+function buildConversion(lines: string[]): TableConversion | null {
+  if (lines.length === 0) return null
+
+  // Multi-line pattern: user typed at least header + separator (+ rows).
+  // Trust the markdown parser to validate the structure.
+  if (lines.length >= 2) {
+    const parsed = parseMarkdown(lines.join("\n"))
+    const blocks = parsed.content
+    if (!blocks || blocks.length !== 1 || blocks[0].type !== "table") return null
+    return { tableJSON: blocks[0], cursorTarget: "trailingParagraph" }
+  }
+
+  // Single-line pattern: promote a standalone header row into a table with
+  // one empty body row so the user can keep typing values immediately.
+  // Require outer pipes (`| a | b |`) here — a bare `a | b` is too easily a
+  // sentence, and the user can always type the separator row to disambiguate.
+  const headerText = lines[0]
+  const columnCount = countRowCells(headerText)
+  if (!hasOuterPipes(headerText) || columnCount < 2 || isAllSeparator(headerText)) {
+    return null
+  }
+  // Parse header + separator into a real table, then append an empty body row
+  // ourselves. Round-tripping the empty row through markdown doesn't work —
+  // an all-empty-cells row is rejected by `isTableRowLine` (it requires at
+  // least one non-empty cell) and would be dropped by the parser.
+  const separator = `|${" --- |".repeat(columnCount)}`
+  const parsed = parseMarkdown([headerText, separator].join("\n"))
+  const blocks = parsed.content
+  if (!blocks || blocks.length !== 1 || blocks[0].type !== "table") return null
+  const table = blocks[0]
+  const emptyRow: JSONContent = {
+    type: "tableRow",
+    content: Array.from({ length: columnCount }, () => ({
+      type: "tableCell",
+      attrs: { colspan: 1, rowspan: 1, colwidth: null },
+      content: [{ type: "paragraph" }],
+    })),
+  }
+  const tableJSON: JSONContent = {
+    ...table,
+    content: [...(table.content ?? []), emptyRow],
+  }
+  return { tableJSON, cursorTarget: "firstBodyCell" }
+}
+
+function countRowCells(line: string): number {
+  const trimmed = line.trim()
+  const body = trimmed.replace(/^\|/, "").replace(/\|$/, "")
+  let count = 1
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === "\\" && body[i + 1] === "|") {
+      i++
+      continue
+    }
+    if (body[i] === "|") count++
+  }
+  return count
+}
+
+function hasOuterPipes(line: string): boolean {
+  const trimmed = line.trim()
+  return trimmed.startsWith("|") && trimmed.endsWith("|") && trimmed.length > 1
+}
+
+function isAllSeparator(line: string): boolean {
+  const trimmed = line.trim()
+  const body = trimmed.replace(/^\|/, "").replace(/\|$/, "")
+  return body.split("|").every((cell) => /^\s*:?-{3,}:?\s*$/.test(cell))
+}
+
+/**
+ * Walk into the freshly inserted table and return an absolute position that
+ * sits inside the first body cell. Falls back to the position just after the
+ * table opening token if the table has no body row (shouldn't happen for the
+ * single-header promotion path, but the math stays safe either way).
+ */
+function firstBodyCellTextPos(table: ProseMirrorNode, tableStartPos: number): number {
+  let bodyRowOffset = -1
+  let runningOffset = 1 // step inside the table node
+  table.forEach((row, offset) => {
+    if (bodyRowOffset >= 0) return
+    if (row.firstChild?.type.name === "tableCell") {
+      bodyRowOffset = runningOffset + offset
+    }
+  })
+  if (bodyRowOffset < 0) return tableStartPos + 1
+  // tableStartPos + bodyRowOffset == position before the row; +1 enters the
+  // row, +1 enters the first cell, +1 enters the cell's first paragraph.
+  return tableStartPos + bodyRowOffset + 3
 }
 
 export const MarkdownTableInputRule = Extension.create({

--- a/apps/frontend/src/components/editor/markdown-table-input-rule.ts
+++ b/apps/frontend/src/components/editor/markdown-table-input-rule.ts
@@ -1,0 +1,103 @@
+/**
+ * Markdown table input rule.
+ *
+ * When the user types a GFM table pattern as plain paragraphs (header row,
+ * separator row, optional data rows) and presses Enter, the trailing pipe-row
+ * paragraphs are replaced by a real ProseMirror table node. Other markdown
+ * patterns (bold, italic, code fences) already have inline / Enter input
+ * rules; tables span multiple paragraphs so we need a dedicated handler.
+ *
+ * Trigger: Enter at the end of a top-level paragraph whose text contains a
+ * pipe, when walking backward through contiguous pipe-containing siblings
+ * produces a string that `parseMarkdown` interprets as a single table block.
+ */
+import { Extension, type Editor } from "@tiptap/core"
+import { TextSelection } from "@tiptap/pm/state"
+import { Fragment } from "@tiptap/pm/model"
+import { parseMarkdown } from "./editor-markdown"
+
+function convertTrailingTable(editor: Editor): boolean {
+  const { state } = editor
+  const { selection } = state
+
+  if (!selection.empty) return false
+  if (
+    editor.isActive("codeBlock") ||
+    editor.isActive("table") ||
+    editor.isActive("blockquote") ||
+    editor.isActive("listItem")
+  ) {
+    return false
+  }
+
+  const $from = selection.$from
+  if ($from.parent.type.name !== "paragraph") return false
+  if ($from.parentOffset !== $from.parent.content.size) return false
+  // Only handle top-level paragraphs (direct children of the doc) so we don't
+  // accidentally tear apart structured containers (blockquote, list item, …).
+  if ($from.depth !== 1) return false
+
+  const doc = state.doc
+  const currentIndex = $from.index(0)
+
+  const indices: number[] = []
+  for (let i = currentIndex; i >= 0; i--) {
+    const child = doc.child(i)
+    if (child.type.name !== "paragraph") break
+    const text = child.textContent
+    if (!text.includes("|")) {
+      if (i === currentIndex) return false
+      break
+    }
+    indices.unshift(i)
+  }
+
+  if (indices.length < 2) return false
+
+  const lines = indices.map((i) => doc.child(i).textContent)
+  const parsed = parseMarkdown(lines.join("\n"))
+  const blocks = parsed.content
+  if (!blocks || blocks.length !== 1 || blocks[0].type !== "table") return false
+
+  let pos = 0
+  let firstPos = -1
+  let lastEnd = -1
+  const firstIdx = indices[0]
+  const lastIdx = indices[indices.length - 1]
+  for (let i = 0; i <= lastIdx; i++) {
+    const child = doc.child(i)
+    if (i === firstIdx) firstPos = pos
+    pos += child.nodeSize
+    if (i === lastIdx) lastEnd = pos
+  }
+  if (firstPos < 0 || lastEnd < 0) return false
+
+  const tableNode = state.schema.nodeFromJSON(blocks[0])
+  if (!tableNode) return false
+
+  const paragraphType = state.schema.nodes.paragraph
+  const emptyPara = paragraphType.create()
+  const fragment = Fragment.fromArray([tableNode, emptyPara])
+
+  const tr = state.tr.replaceWith(firstPos, lastEnd, fragment)
+  // Land the cursor in the trailing empty paragraph so the user can keep
+  // typing below the new table — matches what plain Enter would have done
+  // had we not intercepted it.
+  const trailingParaPos = firstPos + tableNode.nodeSize + 1
+  tr.setSelection(TextSelection.create(tr.doc, trailingParaPos))
+  editor.view.dispatch(tr)
+  return true
+}
+
+export const MarkdownTableInputRule = Extension.create({
+  name: "markdownTableInputRule",
+  // Higher than EditorBehaviors (priority 1000) so we get first crack at
+  // Enter before its splitBlock fallback runs.
+  priority: 1100,
+
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => convertTrailingTable(this.editor),
+    }
+  },
+})

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -1268,12 +1268,30 @@ describe("markdown table input rule", () => {
     editor.destroy()
   })
 
-  it("leaves a lone paragraph alone when there's no separator above", () => {
-    // No separator row means there's nothing to convert — Enter should fall
-    // through to the default new-paragraph behavior, not eat the keystroke.
+  it("promotes a header-only pipe row into a table with one empty body row", () => {
+    // Single header row + Enter: the user shouldn't have to hand-type the
+    // separator. Promote to a real table and drop the caret in the first body
+    // cell so they can keep typing values.
     const editor = createTestEditor({
       type: "doc",
       content: [{ type: "paragraph", content: [{ type: "text", text: "| name | age |" }] }],
+    })
+    editor.commands.focus("end")
+
+    expect(pressEnter(editor)).toBe(true)
+
+    const tableNode = (editor.getJSON().content ?? []).find((b) => b.type === "table")
+    expect(tableNode).toBeDefined()
+    expect(tableNode?.content).toHaveLength(2) // header row + one empty body row
+    editor.destroy()
+  })
+
+  it("does not convert a paragraph that just happens to contain a pipe", () => {
+    // Without outer pipes and with only a single internal `|`, we can't
+    // confidently say this is a table header — leave the paragraph alone.
+    const editor = createTestEditor({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "pipe | only" }] }],
     })
     editor.commands.focus("end")
 

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -1213,3 +1213,74 @@ describe("handleBeforeInputGraphemeDelete (mobile emoji text deletion)", () => {
     editor.destroy()
   })
 })
+
+describe("markdown table input rule", () => {
+  function pressEnter(editor: Editor) {
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+    let handled = false
+    editor.view.someProp("handleKeyDown", (handleKeyDown) => {
+      if (handleKeyDown(editor.view, event)) {
+        handled = true
+        return true
+      }
+      return false
+    })
+    return handled
+  }
+
+  it("converts header + separator paragraphs into a table when Enter is pressed", () => {
+    // Build the doc as raw paragraphs so the input rule (not the markdown
+    // parser at editor-construction time) is what produces the table.
+    const editor = createTestEditor({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "| name | age |" }] },
+        { type: "paragraph", content: [{ type: "text", text: "| --- | --- |" }] },
+      ],
+    })
+    editor.commands.focus("end")
+
+    expect(pressEnter(editor)).toBe(true)
+
+    const tableNode = (editor.getJSON().content ?? []).find((b) => b.type === "table")
+    expect(tableNode).toBeDefined()
+    expect(tableNode?.content).toHaveLength(1)
+    editor.destroy()
+  })
+
+  it("converts a header + separator + data row chain into a table on Enter", () => {
+    const editor = createTestEditor({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "| name | age |" }] },
+        { type: "paragraph", content: [{ type: "text", text: "| --- | --- |" }] },
+        { type: "paragraph", content: [{ type: "text", text: "| Kris | 31 |" }] },
+      ],
+    })
+    editor.commands.focus("end")
+
+    expect(pressEnter(editor)).toBe(true)
+
+    const tableNode = (editor.getJSON().content ?? []).find((b) => b.type === "table")
+    expect(tableNode).toBeDefined()
+    expect(tableNode?.content).toHaveLength(2)
+    expect(serializeToMarkdown(editor.getJSON())).toContain("| Kris | 31 |")
+    editor.destroy()
+  })
+
+  it("leaves a lone paragraph alone when there's no separator above", () => {
+    // No separator row means there's nothing to convert — Enter should fall
+    // through to the default new-paragraph behavior, not eat the keystroke.
+    const editor = createTestEditor({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "| name | age |" }] }],
+    })
+    editor.commands.focus("end")
+
+    pressEnter(editor)
+
+    const json = editor.getJSON()
+    expect((json.content ?? []).some((b) => b.type === "table")).toBe(false)
+    editor.destroy()
+  })
+})

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -192,6 +192,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const isInternalUpdate = useRef(false)
   const [isFocused, setIsFocused] = useState(false)
   const [hasSelection, setHasSelection] = useState(false)
+  const [isInTable, setIsInTable] = useState(false)
   const [linkPopoverOpen, setLinkPopoverOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [toolbarVisible, setToolbarVisible] = useState(false)
@@ -335,7 +336,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // selection-driven toolbar is disabled (e.g. mobile, where OS selection
   // popup conflicts with the floating bubble).
   const shouldBeVisible =
-    !staticToolbarOpen && !disableSelectionToolbar && ((isFocused && hasSelection) || linkPopoverOpen || dropdownOpen)
+    !staticToolbarOpen &&
+    !disableSelectionToolbar &&
+    ((isFocused && hasSelection) || (isFocused && isInTable) || linkPopoverOpen || dropdownOpen)
   useEffect(() => {
     if (shouldBeVisible) {
       if (hideTimeoutRef.current) {
@@ -600,9 +603,14 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   editorRef.current = editor
 
   // Track whether the editor has a non-empty selection (drives toolbar visibility)
+  // and whether the cursor is inside a table (keeps the table controls reachable
+  // even with a collapsed caret, since you can't "select" a table to reveal them).
   useEffect(() => {
     if (!editor) return
-    const updateSelection = () => setHasSelection(!editor.state.selection.empty)
+    const updateSelection = () => {
+      setHasSelection(!editor.state.selection.empty)
+      setIsInTable(editor.isActive("table"))
+    }
     editor.on("selectionUpdate", updateSelection)
     editor.on("update", updateSelection)
     return () => {

--- a/apps/frontend/src/components/ui/markdown-content.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.tsx
@@ -1,6 +1,7 @@
-import { memo, type ReactNode } from "react"
+import { memo, useMemo, type ReactNode } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { normalizeMarkdownTables } from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
 import { markdownComponents } from "@/lib/markdown/components"
 import { MentionProvider, type MentionType } from "@/lib/markdown/mention-context"
@@ -55,13 +56,17 @@ function urlTransform(url: string): string {
  * Uses fallback mention styling (all mentions styled as users).
  */
 export const MarkdownContent = memo(function MarkdownContent({ content, className, messageId }: MarkdownContentProps) {
+  // remark-gfm rejects tables with blank lines between rows, which LLM output
+  // and some pasted markdown contain. Collapsing those blanks lets the table
+  // render instead of falling through to plain paragraphs.
+  const normalizedContent = useMemo(() => normalizeMarkdownTables(content), [content])
   const body = (
     // min-w-0 + break-words: prevent long URLs, paths, and tokens from
     // overflowing the flex message-content column. overflow-wrap inherits,
     // so links, inline code, and mention chips pick it up automatically.
     <div className={cn("markdown-content min-w-0 break-words", className)}>
       <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents} urlTransform={urlTransform}>
-        {content}
+        {normalizedContent}
       </Markdown>
     </div>
   )

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -473,6 +473,7 @@
 .ProseMirror table td,
 .ProseMirror table th {
   @apply border border-border px-2 py-1 align-top text-sm;
+
   min-width: 4rem;
   position: relative;
 }
@@ -488,7 +489,7 @@
 /* ProseMirror's selectedCell decoration: highlight cells in the current
  * selection so users can see which row/column a command will affect. */
 .ProseMirror table .selectedCell {
-  background-color: hsl(var(--primary) / 0.12);
+  @apply bg-primary/[0.12];
 }
 
 /* Gapcursor base: collapse to zero space in the document flow */

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -9,6 +9,7 @@
 export {
   serializeToMarkdown,
   parseMarkdown,
+  normalizeMarkdownTables,
   INLINE_MARKDOWN_PATTERN,
   type MentionTypeLookup,
   type EmojiLookup,

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -653,8 +653,22 @@ describe("@threa/prosemirror normalizeMarkdownTables", () => {
     expect(normalized).toBe(["| a | b |", "| --- | --- |", "| 1 | 2 |", "| 3 | 4 |"].join("\n"))
   })
 
+  it("collapses blank lines between pipeless rows", () => {
+    // GFM accepts outer-pipe-less rows; LLM output uses this form too.
+    const input = ["Name | Role", "--- | ---", "", "Alice | PM", "", "Bob | Eng"].join("\n")
+    const normalized = normalizeMarkdownTables(input)
+    expect(normalized).toBe(["Name | Role", "--- | ---", "Alice | PM", "Bob | Eng"].join("\n"))
+  })
+
   it("preserves blank lines that are not between pipe rows", () => {
     const input = ["paragraph one", "", "paragraph two"].join("\n")
+    expect(normalizeMarkdownTables(input)).toBe(input)
+  })
+
+  it("leaves blank lines inside fenced code blocks untouched", () => {
+    // A markdown sample shown inside a code fence must not be rewritten — the
+    // user is documenting the literal source, not asking us to render it.
+    const input = ["```", "| a | b |", "", "| --- | --- |", "```"].join("\n")
     expect(normalizeMarkdownTables(input)).toBe(input)
   })
 

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { parseMarkdown, serializeToMarkdown } from "./markdown"
+import { normalizeMarkdownTables, parseMarkdown, serializeToMarkdown } from "./markdown"
 import type { JSONContent } from "@threa/types"
 
 describe("@threa/prosemirror markdown attachment metadata", () => {
@@ -604,5 +604,64 @@ describe("@threa/prosemirror table round-trip", () => {
       ],
     }
     expect(serializeToMarkdown(sliceDoc)).toBe(["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n"))
+  })
+
+  it("parses GFM rows without outer pipes", () => {
+    // GFM allows outer pipes to be optional. LLMs frequently emit this form.
+    const markdown = ["Name | Role", "--- | ---", "Alice | PM"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]?.type).toBe("table")
+    expect(parsed.content?.[0]?.content).toHaveLength(2)
+  })
+
+  it("rejects a header/separator pair with mismatched column counts", () => {
+    // If the separator row has a different number of cells than the header,
+    // the structure is malformed — fall back to plain paragraphs rather than
+    // pretending we have a coherent table.
+    const markdown = ["| a | b | c |", "| --- | --- |", "| 1 | 2 | 3 |"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]?.type).not.toBe("table")
+  })
+
+  it("escapes a literal <br> in cell content so round-trip preserves it", () => {
+    // `<br>` is our serialized form of an in-cell paragraph break, so a user
+    // who types literal `<br>` must be escaped to avoid colliding with the
+    // grammar separator.
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            { type: "tableRow", content: [cell("tableHeader", "h")] },
+            { type: "tableRow", content: [cell("tableCell", "use <br> to break")] },
+          ],
+        },
+      ],
+    }
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toContain("&lt;br&gt;")
+    const reparsed = parseMarkdown(markdown)
+    expect(reparsed.content?.[0]?.content?.[1]?.content?.[0]).toEqual(cell("tableCell", "use <br> to break"))
+  })
+})
+
+describe("@threa/prosemirror normalizeMarkdownTables", () => {
+  it("collapses blank lines between pipe rows so LLM tables parse", () => {
+    const input = ["| a | b |", "| --- | --- |", "", "| 1 | 2 |", "", "| 3 | 4 |"].join("\n")
+    const normalized = normalizeMarkdownTables(input)
+    expect(normalized).toBe(["| a | b |", "| --- | --- |", "| 1 | 2 |", "| 3 | 4 |"].join("\n"))
+  })
+
+  it("preserves blank lines that are not between pipe rows", () => {
+    const input = ["paragraph one", "", "paragraph two"].join("\n")
+    expect(normalizeMarkdownTables(input)).toBe(input)
+  })
+
+  it("parses tables with blank lines between body rows", () => {
+    const markdown = ["| name | age |", "| --- | --- |", "", "| Kris | 31 |", "", "| Ada | 28 |"].join("\n")
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]?.type).toBe("table")
+    expect(parsed.content?.[0]?.content).toHaveLength(3)
   })
 })

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -688,20 +688,32 @@ function parseSharedMessageLine(line: string): { authorName: string; streamId: s
  *   | c | d |
  *
  * which remark-gfm and our own parser both reject. The collapse is restricted
- * to blank lines flanked by lines that look like a GFM table row (start with
- * `|`) so that ordinary paragraphs containing a stray pipe aren't merged.
+ * to blank lines flanked by lines our table grammar recognises as rows or
+ * separators (with or without outer pipes) so that ordinary paragraphs
+ * containing a stray pipe aren't merged. Fenced code blocks are passed through
+ * unchanged so example markdown inside a snippet isn't rewritten.
  */
 export function normalizeMarkdownTables(markdown: string): string {
   const lines = markdown.split("\n")
   const out: string[] = []
+  let inFence = false
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
+    if (line.startsWith("```")) {
+      inFence = !inFence
+      out.push(line)
+      continue
+    }
+    if (inFence) {
+      out.push(line)
+      continue
+    }
     if (
       line.trim() === "" &&
       out.length > 0 &&
-      looksLikePipeRow(out[out.length - 1]) &&
+      isCollapsibleTableLine(out[out.length - 1]) &&
       i + 1 < lines.length &&
-      looksLikePipeRow(lines[i + 1])
+      isCollapsibleTableLine(lines[i + 1])
     ) {
       continue
     }
@@ -710,9 +722,8 @@ export function normalizeMarkdownTables(markdown: string): string {
   return out.join("\n")
 }
 
-function looksLikePipeRow(line: string): boolean {
-  const trimmed = line.trim()
-  return trimmed.startsWith("|") && trimmed.length > 1
+function isCollapsibleTableLine(line: string): boolean {
+  return isTableRowLine(line) || isTableSeparatorLine(line)
 }
 
 function isTableRowLine(line: string | undefined): boolean {

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -222,17 +222,16 @@ function serializeTable(node: JSONContent): string {
 function serializeTableCell(cell: JSONContent): string {
   const blocks = cell.content ?? []
   if (blocks.length === 0) return ""
-  const lines = blocks
-    .map((block) => {
-      if (block.type === "paragraph") return serializeInline(block.content)
-      // Fall back to a best-effort render for non-paragraph block content
-      // (rare — tiptap's table cells default to `block+`). We don't recurse
-      // through `serializeNode` because nested lists / code blocks would emit
-      // newlines that break the GFM table grammar.
-      return serializeInline(block.content)
-    })
-    .filter((line) => line.length > 0)
-  const joined = lines.join("<br>")
+  // Cells default to `block+` but the GFM grammar only supports inline content,
+  // so flatten any block-level child to its inline serialization. Lists and
+  // code blocks would emit newlines that break the row grammar, so we never
+  // recurse through `serializeNode`.
+  const lines = blocks.map((block) => serializeInline(block.content)).filter((line) => line.length > 0)
+  // Escape user-typed `<br>` so it doesn't collide with the literal `<br>` tag
+  // we use as a paragraph / hard-break separator. `buildTableCell` reverses
+  // this when parsing back.
+  const escaped = lines.map((line) => line.replace(/<br\s*\/?>/gi, "&lt;br&gt;"))
+  const joined = escaped.join("<br>")
   // Escape pipes so they don't terminate the cell, and collapse hard-break
   // newlines into `<br>` for the same reason. Leading/trailing whitespace
   // inside a cell is meaningless in GFM, so trim.
@@ -483,7 +482,7 @@ export function parseMarkdown(
     return { type: "doc", content: [{ type: "paragraph" }] }
   }
 
-  const lines = markdown.split("\n")
+  const lines = normalizeMarkdownTables(markdown).split("\n")
   const content: JSONContent[] = []
   let i = 0
 
@@ -677,10 +676,58 @@ function parseSharedMessageLine(line: string): { authorName: string; streamId: s
   return { authorName, streamId: match[2], messageId: match[3] }
 }
 
+/**
+ * Collapse blank lines that sit between two pipe-bearing rows so that GFM
+ * tables emitted with extra spacing for readability still parse as tables.
+ * LLMs and some hand-written markdown produce:
+ *
+ *   | a | b |
+ *
+ *   | --- | --- |
+ *
+ *   | c | d |
+ *
+ * which remark-gfm and our own parser both reject. The collapse is restricted
+ * to blank lines flanked by lines that look like a GFM table row (start with
+ * `|`) so that ordinary paragraphs containing a stray pipe aren't merged.
+ */
+export function normalizeMarkdownTables(markdown: string): string {
+  const lines = markdown.split("\n")
+  const out: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (
+      line.trim() === "" &&
+      out.length > 0 &&
+      looksLikePipeRow(out[out.length - 1]) &&
+      i + 1 < lines.length &&
+      looksLikePipeRow(lines[i + 1])
+    ) {
+      continue
+    }
+    out.push(line)
+  }
+  return out.join("\n")
+}
+
+function looksLikePipeRow(line: string): boolean {
+  const trimmed = line.trim()
+  return trimmed.startsWith("|") && trimmed.length > 1
+}
+
 function isTableRowLine(line: string | undefined): boolean {
   if (!line) return false
   const trimmed = line.trim()
-  return trimmed.startsWith("|") && trimmed.includes("|", 1)
+  if (!trimmed.includes("|")) return false
+  if (isTableSeparatorLine(trimmed)) return false
+  // Single-column tables ride on the outer pipes (`| col |`) since there
+  // are no internal separators. Multi-column rows can drop the outer pipes
+  // (`Name | Role`), but in that case we need at least one internal pipe to
+  // avoid misclassifying a sentence that happens to contain one.
+  const hasOuterPipes = trimmed.startsWith("|") && trimmed.endsWith("|")
+  const cells = splitTableRow(trimmed)
+  const minCells = hasOuterPipes ? 1 : 2
+  return cells.length >= minCells && cells.some((cell) => cell.length > 0)
 }
 
 function isTableSeparatorLine(line: string | undefined): boolean {
@@ -741,6 +788,11 @@ function parseTableBlock(
   const headerCells = splitTableRow(headerLine)
   const columnCount = headerCells.length
   if (columnCount === 0) return null
+  // Reject tables whose separator column count doesn't match the header.
+  // GFM treats those as plain paragraphs, and accepting them anyway would
+  // bind ragged-shape pasted markdown into broken tables.
+  const separatorCells = splitTableRow(separatorLine)
+  if (separatorCells.length !== columnCount) return null
 
   const bodyRows: string[][] = []
   let i = startIndex + 2
@@ -777,10 +829,12 @@ function buildTableCell(type: "tableHeader" | "tableCell", text: string, options
   // break — the only way GFM tables can express multi-line cell content.
   // Split on these and emit one paragraph per segment so the resulting
   // ProseMirror tree matches what tiptap's table cell schema expects
-  // (paragraph block*).
+  // (paragraph block*). User-typed `<br>` is escaped by `serializeTableCell`
+  // to `&lt;br&gt;`; restore it after splitting so round-trip is lossless.
   const segments = text.split(/<br\s*\/?>/i)
   const paragraphs: JSONContent[] = segments.map((segment) => {
-    const inline = parseInlineMarkdown(segment, options)
+    const restored = segment.replace(/&lt;br\s*\/?&gt;/gi, "<br>")
+    const inline = parseInlineMarkdown(restored, options)
     return inline.length > 0 ? { type: "paragraph", content: inline } : { type: "paragraph" }
   })
   return {


### PR DESCRIPTION
Follow-up to #620 addressing CodeRabbit's review and three reported UX gaps with GFM tables.

## Summary

- **Type-to-create**: pressing <kbd>Enter</kbd> after `| h |\n| --- |` in the composer now converts the pipe-row paragraphs into a real table node, mirroring how other markdown patterns turn into nodes as you type.
- **Spacey LLM tables**: tables with blank lines between rows (a common Ariadne output shape) now render in the timeline and parse in the composer. Done via a shared `normalizeMarkdownTables` helper applied in both `parseMarkdown` and `MarkdownContent`.
- **Round-trip fixes**: accept GFM rows without outer pipes (`Name | Role`), reject malformed tables whose separator column count doesn't match the header (instead of binding ragged shapes), and escape literal `<br>` in cell content so it survives serialize/parse.
- **Toolbar a11y**: the table popover's row/column buttons honor `keyboardAccessible` like the rest of the toolbar.
- **CodeRabbit nits**: blank-line-before for the `min-width` declaration, and the selected-cell highlight uses `@apply bg-primary/[0.12]` instead of a raw `hsl(var(--primary) / 0.12)`.

## Test plan

- [x] `bun test packages/prosemirror/src/markdown.test.ts` — 39 pass (added pipeless-row collapse, fenced-code passthrough, mismatched-separator rejection, `<br>` round-trip, blank-line normalization)
- [x] `bun run test` in `apps/frontend` — 1784 pass (added input-rule conversion tests: header+separator, header+separator+data, no-op for lone paragraph)
- [x] `bun run typecheck` — clean across the monorepo
- [x] `bun lint` — clean
- [ ] Manual: in the composer, type `| name | age |` ⏎ `| --- | --- |` ⏎ and confirm the paragraphs collapse into a table with cursor in the trailing paragraph
- [ ] Manual: paste an Ariadne reply containing a table with blank lines between rows and confirm it renders as a table in the timeline
- [ ] Manual: on mobile, tap "Aa" to open the format toolbar, place cursor in a table, and confirm the table popover's row/column actions are reachable


---
_Generated by [Claude Code](https://claude.ai/code/session_01QqVDSd4VTdBBkWS5sKc7BH)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782369373&installation_id=129946197&pr_number=623&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F623&signature=41042ceaa95366007fcb1252199e1fe388f0b76b4e0a10cb630cb169354977fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->