### PR TITLE
fix: preserve Pi session-control presence capabilities

### DIFF
--- a/.claude/plans/pi-session-control-presence.md
+++ b/.claude/plans/pi-session-control-presence.md
@@ -1,0 +1,46 @@
+# Pi Session-Control Presence Preservation
+
+## Goal
+
+Keep Pi runtime session-control slash commands (`/model`, `/thinking`, `/compact`, `/skill`, `/reload`) visible after the Pi remote begins polling for invocations. Claim polling sends a lightweight presence heartbeat; it must not erase the richer capability advertisement from the explicit `/bot-runtime/presence` heartbeat.
+
+## What Was Built
+
+### Preserve runtime capabilities across lightweight heartbeats
+
+Changed the bot runtime presence upsert to support explicit merge mode for lightweight heartbeats. Claim/step heartbeats merge incoming capabilities with the existing JSONB capabilities, while full `/bot-runtime/presence` heartbeats remain authoritative replacements. This lets claim polling update `runtimeSessionId` and status without deleting fields such as `supportsSessionControlCommands`, `sessionControlCommands`, `thinkingLevels`, and `modelSuggestions`, while still allowing runtimes to remove stale capabilities.
+
+**Files:**
+- `apps/backend/src/features/bot-runtimes/repository.ts` — adds optional merge-mode capability upserts for lightweight heartbeat callers.
+
+### Regression coverage for command availability after claim polling
+
+Extended the stream-scoped Pi command e2e test to claim an invocation after advertising session-control support and then re-fetch stream bootstrap commands. The test asserts `/model` remains available after the lightweight claim heartbeat, and also verifies an explicit downgraded presence heartbeat can remove `/model` again.
+
+**Files:**
+- `apps/backend/tests/e2e/commands.test.ts` — adds regression coverage for claim heartbeat preserving Pi slash-command availability.
+
+## Design Decisions
+
+### Merge capabilities in the repository upsert
+
+**Chose:** JSONB merge at the persistence boundary, gated by an explicit `mergeCapabilities` flag.
+**Why:** All presence writers converge on `BotRuntimeInstanceRepository.upsertPresence`, including explicit presence heartbeats and claim/step lightweight heartbeats. A caller-controlled merge mode protects lightweight heartbeats without changing the authoritative replacement semantics of full presence heartbeats.
+**Alternatives considered:** Always merge in the repository. That fixed claim polling but would keep stale capabilities forever when a runtime intentionally stops advertising them. Only sending full capabilities from claim polling would require runtime callers to know and resend capability state on every lightweight heartbeat, increasing API coupling.
+
+## Schema Changes
+
+None.
+
+## What's NOT Included
+
+- No bot reconfiguration or new bot traits.
+- No frontend command-list changes.
+- No migration/backfill; a fresh explicit Pi heartbeat (`/remote-control on`) repopulates rich capabilities after deploy.
+
+## Status
+
+- [x] Preserve rich Pi runtime capabilities during lightweight presence upserts.
+- [x] Keep explicit presence heartbeats authoritative so stale capabilities can be removed.
+- [x] Add e2e regression coverage for `/model` remaining available after claim polling and disappearing after downgraded presence.
+- [x] Verify focused e2e locally against a running test backend.

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -332,10 +332,15 @@ export const BotRuntimeInstanceRepository = {
       acceptingInvocations: boolean
       capabilities: Record<string, unknown>
       statusText?: string | null
+      mergeCapabilities?: boolean
     }
   ): Promise<BotRuntimeInstance> {
-    const result =
-      await db.query<BotRuntimeInstanceRow>(sql`INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, runtime_kind, instance_id, display_name, status, accepting_invocations, capabilities, status_text)
+    const result = params.mergeCapabilities
+      ? await db.query<BotRuntimeInstanceRow>(sql`INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, runtime_kind, instance_id, display_name, status, accepting_invocations, capabilities, status_text)
+      VALUES (${params.id}, ${params.workspaceId}, ${params.botId}, ${params.runtimeKind}, ${params.instanceId}, ${params.displayName ?? null}, ${params.status}, ${params.acceptingInvocations}, ${params.capabilities}, ${params.statusText ?? null})
+      ON CONFLICT (workspace_id, bot_id, instance_id) DO UPDATE SET runtime_kind = EXCLUDED.runtime_kind, display_name = EXCLUDED.display_name, status = EXCLUDED.status, accepting_invocations = EXCLUDED.accepting_invocations, capabilities = bot_runtime_instances.capabilities || EXCLUDED.capabilities, status_text = EXCLUDED.status_text, last_seen_at = NOW(), updated_at = NOW()
+      RETURNING *`)
+      : await db.query<BotRuntimeInstanceRow>(sql`INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, runtime_kind, instance_id, display_name, status, accepting_invocations, capabilities, status_text)
       VALUES (${params.id}, ${params.workspaceId}, ${params.botId}, ${params.runtimeKind}, ${params.instanceId}, ${params.displayName ?? null}, ${params.status}, ${params.acceptingInvocations}, ${params.capabilities}, ${params.statusText ?? null})
       ON CONFLICT (workspace_id, bot_id, instance_id) DO UPDATE SET runtime_kind = EXCLUDED.runtime_kind, display_name = EXCLUDED.display_name, status = EXCLUDED.status, accepting_invocations = EXCLUDED.accepting_invocations, capabilities = EXCLUDED.capabilities, status_text = EXCLUDED.status_text, last_seen_at = NOW(), updated_at = NOW()
       RETURNING *`)

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -80,6 +80,7 @@ export class BotRuntimeService {
     acceptingInvocations: boolean
     capabilities?: Record<string, unknown>
     statusText?: string | null
+    mergeCapabilities?: boolean
   }): Promise<BotRuntimeInstance> {
     return BotRuntimeInstanceRepository.upsertPresence(this.pool, {
       id: botRuntimeInstanceId(),
@@ -92,6 +93,7 @@ export class BotRuntimeService {
       acceptingInvocations: params.acceptingInvocations,
       capabilities: params.capabilities ?? {},
       statusText: params.statusText,
+      mergeCapabilities: params.mergeCapabilities,
     })
   }
 

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -643,6 +643,7 @@ export function createPublicApiHandlers({
         acceptingInvocations: params.acceptingInvocations,
         capabilities: params.runtimeSessionId ? { runtimeSessionId: params.runtimeSessionId } : undefined,
         statusText: sanitizeStatusText(params.statusText),
+        mergeCapabilities: true,
       })
       await broadcastBotPresence(params.workspaceId, params.botId, presence)
     } catch (err) {

--- a/apps/backend/tests/e2e/commands.test.ts
+++ b/apps/backend/tests/e2e/commands.test.ts
@@ -236,6 +236,38 @@ describe("Stream-scoped Pi session-control commands", () => {
     const modelSuggestions = modelCommand?.args?.find((a) => a.name === "model")?.suggestions
     expect(modelSuggestions?.map((s) => s.value)).toEqual(["anthropic/claude-sonnet-4-6", "openai/gpt-5-high"])
 
+    // Claim polling doubles as a lightweight heartbeat with only runtimeSessionId.
+    // It must not erase the richer session-control capability advertisement from
+    // the explicit presence heartbeat, or slash commands disappear between polls.
+    const claim = await botApiPost(client, workspace.id, "/bot-invocations/claim", linked.apiKey, {
+      runtimeKind: "pi-local",
+      instanceId: linked.instanceId,
+      runtimeSessionId: linked.runtimeSessionId,
+      supportedCapabilities: [BotInvocationCapabilities.ACTIVE_SCRATCHPAD, BotInvocationCapabilities.SESSION_CONTROL],
+      claimTtlSeconds: 120,
+    })
+    expect(claim.status).toBe(200)
+    const afterClaimBootstrap = await getBootstrap(client, workspace.id, linked.streamId)
+    const afterClaimNames = afterClaimBootstrap.commands?.map((c) => c.name) ?? []
+    expect(afterClaimNames).toContain("model")
+
+    const downgradedPresence = await botApiPost(client, workspace.id, "/bot-runtime/presence", linked.apiKey, {
+      runtimeKind: "pi-local",
+      instanceId: linked.instanceId,
+      runtimeSessionId: linked.runtimeSessionId,
+      displayName: `Pi list-${testRunId}`,
+      status: "available",
+      acceptingInvocations: true,
+      capabilities: {
+        runtimeSessionId: linked.runtimeSessionId,
+        supportsActiveScratchpad: true,
+      },
+    })
+    expect(downgradedPresence.status).toBe(200)
+    const afterDowngradeBootstrap = await getBootstrap(client, workspace.id, linked.streamId)
+    const afterDowngradeNames = afterDowngradeBootstrap.commands?.map((c) => c.name) ?? []
+    expect(afterDowngradeNames).not.toContain("model")
+
     // A separate scratchpad with no active Pi runtime should not expose
     // session-control commands.
     const scratchpad = await createScratchpad(client, workspace.id, "off")


### PR DESCRIPTION
## Problem

Pi session-control slash commands (`/model`, `/thinking`, `/compact`, `/skill`, `/reload`) disappeared from linked scratchpads after the Pi remote started polling. The runtime initially advertised rich capabilities through `/bot-runtime/presence`, but claim polling also updates presence with a lightweight payload containing only `runtimeSessionId`. That lightweight heartbeat replaced the full capabilities JSON, removing `supportsSessionControlCommands` and `sessionControlCommands`, so command availability stopped surfacing Pi commands.

## Solution

Preserve existing runtime capabilities only for lightweight presence updates. Claim/step heartbeats now opt into capability merging, while explicit `/bot-runtime/presence` heartbeats remain authoritative replacements so stale capabilities can still be removed.

### How it works

1. Pi sends full presence with session-control support.
2. Pi polls `/bot-invocations/claim`, which touches presence with lightweight capabilities.
3. The lightweight touch path sets `mergeCapabilities: true`, so the repository merges those fields into existing capabilities.
4. Direct `/bot-runtime/presence` calls do not set merge mode, so they replace capabilities and can intentionally downgrade/remove command support.
5. Command availability continues to see `supportsSessionControlCommands: true` after claim polling and lists stream-scoped Pi commands.

### Key design decisions

**1. Explicit merge mode**

Merging is caller-selected instead of global. This fixes the claim heartbeat bug without making stale capability flags sticky forever.

**2. No bot reconfiguration**

This is runtime presence state, not bot trait configuration. Existing `active-scratchpad` bots should continue to work once Pi sends a fresh full heartbeat after deploy.

## New files

| File | Purpose |
| --- | --- |
| `.claude/plans/pi-session-control-presence.md` | Review plan describing the bug, fix, and verification |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/repository.ts` | Add optional merge-mode capability upserts |
| `apps/backend/src/features/bot-runtimes/service.ts` | Thread `mergeCapabilities` through service presence upserts |
| `apps/backend/src/features/public-api/handlers.ts` | Use merge mode for lightweight touch-and-broadcast presence updates |
| `apps/backend/tests/e2e/commands.test.ts` | Add regression coverage that `/model` remains listed after claim polling and disappears after explicit downgraded presence |

## Test plan

- [x] `bun test --preload ./apps/backend/tests/setup.ts ./apps/backend/tests/e2e/commands.test.ts` — 6 pass, 0 fail
- [x] `bun run --cwd apps/backend typecheck`
- [x] Pre-commit lint completed successfully
- [ ] Full root pre-commit typecheck currently fails on unrelated frontend table-extension errors from `main` (`@tiptap/extension-table/*` imports / chained command typings)
- [ ] After deploy, run `/remote-control on` in Pi to repopulate rich presence capabilities, then verify stream commands include `/model`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_