### PR TITLE
fix: show Pi commands immediately with traces

### DIFF
--- a/.claude/plans/pi-command-feedback.md
+++ b/.claude/plans/pi-command-feedback.md
@@ -1,0 +1,44 @@
+# Pi Command Feedback
+
+## Goal
+
+Make Pi runtime slash commands feel dispatched immediately in Threa, and expose trace rows for session-control outputs so long-running commands such as `/compact` show progress instead of only a final bot reply.
+
+## What Was Built
+
+### Offline-first command queueing
+
+When the composer dispatches a server/runtime slash command, it now writes an optimistic `command_dispatched` event into IndexedDB and enqueues a durable `dispatch_command` operation. The operation queue replays the dispatch when online, swaps the optimistic event for the authoritative server event, and socket delivery still dedupes by event ID. Bootstrap cleanup preserves command events while their queued operation is pending, preserves terminal failed optimistic command rows, and permanent dispatch failures create a local `command_failed` event instead of retrying forever. The stream view no longer has to wait for the realtime round trip before showing the command row, and offline commands survive retries like other queued writes.
+
+**Files:**
+- `apps/frontend/src/components/timeline/message-input.tsx`
+- `apps/frontend/src/hooks/use-command-dispatch-queue.ts`
+- `apps/frontend/src/db/database.ts`
+- `apps/frontend/src/sync/operation-queue.ts`
+
+### Session-control trace steps
+
+The Pi remote extension now records trace steps for session-control commands:
+
+- a `context_received` step when a runtime command starts
+- a `tool_call` step when `/compact` starts compaction
+- a `response` step containing the final command output before completing the invocation
+
+**Files:**
+- `docs/examples/pi-remote/threa-remote-v2.ts`
+
+## Schema Changes
+
+None.
+
+## Status
+
+- [x] Show dispatched slash commands immediately via an optimistic local event.
+- [x] Queue command dispatches through the offline operation queue for retry.
+- [x] Preserve optimistic command rows across bootstrap cleanup while queued.
+- [x] Preserve terminal failed command rows across bootstrap cleanup.
+- [x] Convert permanent dispatch errors into local failed command rows.
+- [x] Record traces for Pi session-control command outputs.
+- [x] Copy updated Pi remote extension to `~/.pi/agent/extensions/threa-remote.ts`.
+- [x] Move IndexedDB command queue writes behind a hook so timeline components do not import the database directly.
+- [x] Verify Pi remote focused tests.

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -22,13 +22,13 @@ import type { ComposerControlHandle } from "@/components/composer"
 import { useScheduleMessage } from "@/hooks"
 import { toast } from "sonner"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
-import { commandsApi } from "@/api"
 import { extractCommandNode } from "@/lib/commands"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
 import { consumeShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
+import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
 import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent } from "@threa/types"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 
@@ -201,6 +201,7 @@ function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason
   const { stream, sendMessage } = useStreamOrDraft(workspaceId, streamId)
   const startDiscussWithAriadne = useDiscussWithAriadne(workspaceId)
   const scheduleMessageMutation = useScheduleMessage(workspaceId)
+  const { queueCommand } = useCommandDispatchQueue(workspaceId, streamId)
   const draftKey = getDraftMessageKey({ type: "stream", streamId })
 
   // Broadcast/mention filtering, member/bot allow-lists, and the admin gate
@@ -475,16 +476,9 @@ function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason
 
         const commandMarkdown = serializeToMarkdown(normalizedContent).trim()
         try {
-          const result = await commandsApi.dispatch(workspaceId, {
-            command: commandMarkdown,
-            streamId,
-          })
-
-          if (!result.success) {
-            setError(result.error)
-          }
+          await queueCommand({ commandMarkdown, commandName: commandNode.name })
         } catch {
-          setError("Failed to dispatch command. Please try again.")
+          setError("Failed to queue command. Please try again.")
         } finally {
           composer.setIsSending(false)
         }
@@ -526,7 +520,7 @@ function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason
         composer.setIsSending(false)
       }
     },
-    [composer, sendMessage, navigate, workspaceId, streamId, startDiscussWithAriadne]
+    [composer, sendMessage, navigate, workspaceId, streamId, startDiscussWithAriadne, queueCommand]
   )
 
   /**

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -243,6 +243,7 @@ export interface PendingOperation {
     | "update_scheduled_message"
     | "cancel_scheduled_message"
     | "send_scheduled_now"
+    | "dispatch_command"
   payload: Record<string, unknown>
   createdAt: number
   retryCount: number

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -1,0 +1,72 @@
+import { useCallback, useMemo } from "react"
+import { useUser } from "@/auth"
+import { db, sequenceToNum } from "@/db"
+import { enqueueOperation } from "@/sync/operation-queue"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+import { AuthorTypes, CommandKinds, type StreamEvent } from "@threa/types"
+
+function parseCommandArgs(commandMarkdown: string): string {
+  const trimmed = commandMarkdown.trim()
+  const withoutSlash = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed
+  const firstSpace = withoutSlash.search(/\s/)
+  if (firstSpace === -1) return ""
+  return withoutSlash.slice(firstSpace).trim()
+}
+
+export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
+  const user = useUser()
+  const syncEngine = useOptionalSyncEngine()
+  const idbUsers = useWorkspaceUsers(workspaceId)
+  const currentUserId = useMemo(
+    () => idbUsers.find((u) => u.workosUserId === user?.id)?.id ?? null,
+    [idbUsers, user?.id]
+  )
+
+  const queueCommand = useCallback(
+    async (params: { commandMarkdown: string; commandName: string }) => {
+      if (!currentUserId) {
+        throw new Error("Cannot dispatch command: user identity not resolved yet")
+      }
+
+      const optimisticEventId = `temp_cmd_${Date.now()}_${Math.random().toString(36).slice(2)}`
+      const now = new Date().toISOString()
+      const optimisticEvent: StreamEvent = {
+        id: optimisticEventId,
+        streamId,
+        sequence: Date.now().toString(),
+        eventType: "command_dispatched",
+        payload: {
+          commandId: optimisticEventId,
+          name: params.commandName,
+          args: parseCommandArgs(params.commandMarkdown),
+          status: "dispatched",
+          executionKind: CommandKinds.BOT_RUNTIME,
+        },
+        actorId: currentUserId,
+        actorType: AuthorTypes.USER,
+        createdAt: now,
+      }
+
+      await db.transaction("rw", [db.events, db.pendingOperations], async () => {
+        await db.events.add({
+          ...optimisticEvent,
+          workspaceId,
+          _sequenceNum: sequenceToNum(optimisticEvent.sequence),
+          _status: "pending",
+          _cachedAt: Date.now(),
+        })
+        await enqueueOperation(workspaceId, "dispatch_command", {
+          streamId,
+          command: params.commandMarkdown,
+          optimisticEventId,
+        })
+      })
+
+      syncEngine?.kickOperationQueue()
+    },
+    [currentUserId, streamId, syncEngine, workspaceId]
+  )
+
+  return { queueCommand }
+}

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -1,6 +1,7 @@
-import { db } from "@/db"
-import type { PendingOperation } from "@/db/database"
-import type { ScheduleMessageInput, ScheduledMessageView } from "@threa/types"
+import { db, sequenceToNum } from "@/db"
+import type { CachedEvent, PendingOperation } from "@/db/database"
+import type { CommandFailedPayload, ScheduleMessageInput, ScheduledMessageView } from "@threa/types"
+import { ApiError, commandsApi } from "@/api"
 import { persistScheduledRows, replaceLocalScheduledRow } from "@/hooks/use-scheduled"
 
 function getRetryDelay(retryCount: number): number {
@@ -28,6 +29,40 @@ interface ScheduledServiceLike {
   create: (workspaceId: string, input: ScheduleMessageInput) => Promise<ScheduledMessageView>
   delete: (workspaceId: string, id: string) => Promise<void>
   sendNow: (workspaceId: string, id: string) => Promise<ScheduledMessageView>
+}
+
+function isPermanentCommandDispatchError(error: unknown): error is ApiError {
+  return ApiError.isApiError(error) && error.status >= 400 && error.status < 500 && error.status !== 408 && error.status !== 429
+}
+
+async function markCommandDispatchFailed(
+  workspaceId: string,
+  optimisticEventId: string,
+  error: Error
+): Promise<void> {
+  const dispatched = await db.events.get(optimisticEventId)
+  if (!dispatched) return
+  const failedEvent: CachedEvent = {
+    id: `${optimisticEventId}:failed`,
+    workspaceId,
+    streamId: dispatched.streamId,
+    sequence: (Number(dispatched.sequence) + 1).toString(),
+    eventType: "command_failed",
+    payload: {
+      commandId: optimisticEventId,
+      error: error.message,
+    } satisfies CommandFailedPayload,
+    actorId: dispatched.actorId,
+    actorType: dispatched.actorType,
+    createdAt: new Date().toISOString(),
+    _sequenceNum: sequenceToNum((Number(dispatched.sequence) + 1).toString()),
+    _status: "failed",
+    _cachedAt: Date.now(),
+  }
+  await db.transaction("rw", db.events, async () => {
+    await db.events.update(optimisticEventId, { _status: "failed" })
+    await db.events.put(failedEvent)
+  })
 }
 
 /**
@@ -154,5 +189,29 @@ async function executeOperation(
       // conflict synchronously and the user re-saves with the latest
       // version. This case is reserved for a future opt-in.
       throw new Error("update_scheduled_message replay is not implemented")
+
+    case "dispatch_command": {
+      const optimisticEventId = payload.optimisticEventId as string
+      try {
+        const result = await commandsApi.dispatch(workspaceId, {
+          streamId: payload.streamId as string,
+          command: payload.command as string,
+        })
+        if (!result.success) throw new ApiError(400, "COMMAND_DISPATCH_FAILED", result.error)
+        await db.transaction("rw", db.events, async () => {
+          await db.events.delete(optimisticEventId).catch(() => undefined)
+          await db.events.put({
+            ...result.event,
+            workspaceId,
+            _sequenceNum: sequenceToNum(result.event.sequence),
+            _cachedAt: Date.now(),
+          })
+        })
+      } catch (error) {
+        if (!isPermanentCommandDispatchError(error)) throw error
+        await markCommandDispatchFailed(workspaceId, optimisticEventId, error)
+      }
+      break
+    }
   }
 }

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -103,9 +103,16 @@ async function cleanupStaleOptimisticEvents(streamId: string): Promise<void> {
     .filter((e) => e.id.startsWith("temp_"))
     .toArray()
 
+  const pendingCommandEventIds = new Set(
+    (await db.pendingOperations.where("type").equals("dispatch_command").toArray())
+      .map((op) => op.payload.optimisticEventId)
+      .filter((id): id is string => typeof id === "string")
+  )
+
   for (const temp of tempEvents) {
+    if (temp._status === "failed") continue
     const stillPending = await db.pendingMessages.get(temp.id)
-    if (!stillPending) {
+    if (!stillPending && !pendingCommandEventIds.has(temp.id)) {
       await db.events.delete(temp.id)
     }
   }
@@ -264,7 +271,7 @@ export async function applyStreamBootstrap(
   bootstrap: StreamBootstrap
 ): Promise<void> {
   const now = Date.now()
-  await db.transaction("rw", [db.events, db.streams, db.pendingMessages], async () => {
+  await db.transaction("rw", [db.events, db.streams, db.pendingMessages, db.pendingOperations], async () => {
     await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
   })
 }

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -533,3 +533,7 @@ export function useSyncEngine(): SyncEngine {
   if (!engine) throw new Error("useSyncEngine must be used within a SyncEngineContext provider")
   return engine
 }
+
+export function useOptionalSyncEngine(): SyncEngine | null {
+  return useContext(SyncEngineContext)
+}

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -945,6 +945,7 @@ async function completeInvocationWithMarkdown(
   ctx?: ExtensionContext
 ): Promise<void> {
   if (!config) return
+  await recordInvocationTraceStep(invocation, "response", finalMessageMarkdown, "Composing response…")
   await request(`/api/v1/workspaces/${config.workspaceId}/bot-invocations/${invocation.id}/complete`, {
     method: "POST",
     body: JSON.stringify({
@@ -1149,6 +1150,7 @@ function resolveSkillCommand(pi: ExtensionAPI, query: string): { match?: PiComma
 }
 
 async function runCompactCommand(invocation: ClaimedInvocation, args: string, ctx: ExtensionContext): Promise<void> {
+  await recordInvocationTraceStep(invocation, "tool_call", "Compacting the linked Pi session…", "Compacting session…")
   await compactSession(ctx, args)
   await completeInvocationWithMarkdown(invocation, "Compacted the linked Pi session.", ctx)
 }
@@ -1249,6 +1251,7 @@ async function handleSessionControlInvocation(
 
   try {
     await heartbeat("busy", `Running /${command.name}…`, ctx)
+    await recordInvocationTraceStep(invocation, "context_received", `Running /${command.name}${command.args ? ` ${command.args}` : ""}`, `Running /${command.name}…`)
     switch (command.name) {
       case "compact":
         await runCompactCommand(invocation, command.args, ctx)


### PR DESCRIPTION
## Problem

Pi runtime slash commands currently feel invisible after send: the composer clears, but the command row may not appear until realtime delivery or the eventual bot output. Long-running session-control commands like `/compact` also lack a trace trail, so progress is opaque.

## Solution

- Queue server/runtime slash commands through the existing offline operation queue.
- Write an optimistic `command_dispatched` event to IndexedDB immediately, so the command row appears even before network/realtime confirmation.
- Keep component UI code out of direct IndexedDB access by routing command queue writes through a hook.
- Preserve optimistic command events across bootstrap cleanup while their `dispatch_command` operation is still pending.
- Preserve terminal failed command rows across bootstrap cleanup.
- Replay queued command dispatches when online; on success, swap the optimistic command event for the authoritative server event.
- Convert permanent dispatch errors into a local `command_failed` event instead of retrying forever.
- Record Pi session-control trace steps for command start, `/compact` progress, and final command output.
- Updated the local Pi extension install at `~/.pi/agent/extensions/threa-remote.ts` from the repo copy.

## Files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/timeline/message-input.tsx` | Uses the command queue hook for slash commands |
| `apps/frontend/src/hooks/use-command-dispatch-queue.ts` | Queues command dispatches, writes optimistic command events locally, keeps event/op creation synchronized, and kicks the operation queue when available |
| `apps/frontend/src/db/database.ts` | Adds `dispatch_command` as a queued operation type |
| `apps/frontend/src/sync/operation-queue.ts` | Replays queued command dispatches, swaps optimistic events for server events, and records permanent failures |
| `apps/frontend/src/sync/stream-sync.ts` | Preserves queued and failed optimistic command rows during bootstrap cleanup |
| `apps/frontend/src/sync/sync-engine.ts` | Adds optional sync-engine access for hooks that can run in test contexts without a provider |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Adds trace steps for session-control command start/output and compaction progress |
| `.claude/plans/pi-command-feedback.md` | Plan and verification notes |

## Test plan

- [x] `bun run --cwd apps/frontend lint`
- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts` — 24 pass, 0 fail
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run --cwd apps/frontend test src/components/timeline/message-input.test.tsx` — 0 failing tests
- [ ] `bun run --cwd apps/frontend typecheck` — fails on unrelated TipTap table extension/type errors from main; no errors in changed files