### PR TITLE
feat(voice): warn when the selected mic is producing pure silence

### DIFF
--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -87,6 +87,7 @@ describe("MicButton state surfaces", () => {
       hasUnlockedChunks: false,
       showOriginal: false,
       setShowOriginal: vi.fn(),
+      noAudioWarning: null,
       start: vi.fn(),
       stop: vi.fn(),
       ...overrides,

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -106,6 +106,7 @@ export function MicButton({
     hasUnlockedChunks,
     showOriginal,
     setShowOriginal,
+    noAudioWarning,
     start,
     stop,
   } = useVoiceDictation({
@@ -191,12 +192,34 @@ export function MicButton({
           or taps (mobile) a polished chunk in the editor. Lives at MicButton
           level so it has access to the live chunks map without lifting state. */}
       {hasUnlockedChunks && <DictationChunkInspector chunks={chunks} onToggle={() => setShowOriginal(!showOriginal)} />}
-      {recording && !polishPillVisible && (
+      {recording && noAudioWarning && (
+        // No-signal warning: the analyser has seen literal silence for the
+        // grace window, so the selected input is dead (Bluetooth headset that
+        // didn't switch to HFP/HSP, wired headphones with no mic wired in,
+        // muted at the OS layer). Replaces the clock pill — the user needs
+        // this far more than a m:ss readout right now. Absolute-positioned to
+        // keep the composer layout stable (INV-21). The pill is non-fatal,
+        // doesn't tear the take down; if the user fixes the input the warning
+        // clears automatically when signal returns.
+        <span
+          role="status"
+          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 flex max-w-[16rem] -translate-x-1/2 select-none items-center gap-1.5 rounded-lg bg-amber-600 px-2.5 py-1.5 text-[11px] font-medium leading-snug text-amber-50 shadow-lg ring-1 ring-inset ring-white/15 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span className="text-left">{noAudioWarning}</span>
+          <span
+            aria-hidden
+            className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-amber-600"
+          />
+        </span>
+      )}
+      {recording && !polishPillVisible && !noAudioWarning && (
         // Absolutely positioned so the running clock never shifts the composer
         // layout (INV-21). Switches to a remaining-time countdown with a
         // warning tint as the take nears the backend's hard cap. Hidden when
         // the polish pill is present — the pill occupies the same slot and the
-        // clock would overlap it.
+        // clock would overlap it. Also hidden when the no-audio warning is up;
+        // the warning takes the slot.
         <span
           className={cn(
             "pointer-events-none absolute bottom-full left-1/2 mb-1 -translate-x-1/2 select-none rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums leading-none whitespace-nowrap",

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -3,8 +3,8 @@ import {
   friendlyTranscriptionError,
   shouldWarnNoAudio,
   noAudioWarningMessage,
-  NO_AUDIO_WAIT_MS,
-  NO_AUDIO_PEAK_THRESHOLD,
+  NO_AUDIO_INITIAL_WAIT_MS,
+  NO_AUDIO_SILENCE_WAIT_MS,
 } from "./use-voice-dictation"
 
 describe("friendlyTranscriptionError", () => {
@@ -20,31 +20,65 @@ describe("friendlyTranscriptionError", () => {
   })
 })
 
-describe("shouldWarnNoAudio", () => {
-  it("waits out the grace window before warning — a take just starting is never silent enough to flag", () => {
-    expect(shouldWarnNoAudio(0, 0)).toBe(false)
-    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS - 1, 0)).toBe(false)
+describe("shouldWarnNoAudio — initial silence branch (peak still below floor)", () => {
+  it("waits out the grace window — a take just starting is never silent enough to flag", () => {
+    expect(shouldWarnNoAudio({ elapsedMs: 0, silenceMs: 0, peakLevel: 0 })).toBe(false)
+    expect(
+      shouldWarnNoAudio({
+        elapsedMs: NO_AUDIO_INITIAL_WAIT_MS - 1,
+        silenceMs: NO_AUDIO_INITIAL_WAIT_MS - 1,
+        peakLevel: 0,
+      })
+    ).toBe(false)
   })
 
   it("flags inputs that produced literal zero past the grace window", () => {
-    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, 0)).toBe(true)
-    expect(shouldWarnNoAudio(10_000, 0)).toBe(true)
+    expect(
+      shouldWarnNoAudio({ elapsedMs: NO_AUDIO_INITIAL_WAIT_MS, silenceMs: NO_AUDIO_INITIAL_WAIT_MS, peakLevel: 0 })
+    ).toBe(true)
+    expect(shouldWarnNoAudio({ elapsedMs: 10_000, silenceMs: 10_000, peakLevel: 0 })).toBe(true)
+  })
+})
+
+describe("shouldWarnNoAudio — lost-signal branch (peak above floor, was working)", () => {
+  it("does not flag short pauses — a user pausing mid-sentence shouldn't get nagged", () => {
+    expect(shouldWarnNoAudio({ elapsedMs: 8_000, silenceMs: 1_000, peakLevel: 0.3 })).toBe(false)
+    expect(shouldWarnNoAudio({ elapsedMs: 8_000, silenceMs: NO_AUDIO_SILENCE_WAIT_MS - 1, peakLevel: 0.3 })).toBe(false)
   })
 
-  it("does not flag inputs that crossed the ambient-noise floor — a working mic in a quiet room beats the threshold", () => {
-    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, NO_AUDIO_PEAK_THRESHOLD)).toBe(false)
-    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, NO_AUDIO_PEAK_THRESHOLD + 0.01)).toBe(false)
+  it("flags inputs that produced audio briefly and then went dead — the actual headphone-dropout case", () => {
+    // The reported bug: a single "yes" came through (peak crossed threshold),
+    // then headphones dropped HFP and the analyser went back to zeros. The
+    // initial-silence check above already passed, so we need the silence-since-last-signal
+    // check to catch the drop.
+    expect(shouldWarnNoAudio({ elapsedMs: 10_000, silenceMs: NO_AUDIO_SILENCE_WAIT_MS, peakLevel: 0.4 })).toBe(true)
+    expect(shouldWarnNoAudio({ elapsedMs: 12_000, silenceMs: 7_000, peakLevel: 0.4 })).toBe(true)
+  })
+
+  it("uses the silence window even early in the take — peak above floor switches to the lost-signal threshold immediately", () => {
+    // elapsed is small, but peak is high → we're in the lost-signal branch.
+    // Silence below 5s doesn't fire; at or above does.
+    expect(shouldWarnNoAudio({ elapsedMs: 3_000, silenceMs: 2_500, peakLevel: 0.4 })).toBe(false)
+    expect(shouldWarnNoAudio({ elapsedMs: 6_500, silenceMs: NO_AUDIO_SILENCE_WAIT_MS, peakLevel: 0.4 })).toBe(true)
   })
 })
 
 describe("noAudioWarningMessage", () => {
   it("names the offending device when the browser revealed its label", () => {
-    expect(noAudioWarningMessage("AirPods Pro")).toContain("AirPods Pro")
+    expect(noAudioWarningMessage({ deviceLabel: "AirPods Pro", everHadSignal: false })).toContain("AirPods Pro")
+    expect(noAudioWarningMessage({ deviceLabel: "AirPods Pro", everHadSignal: true })).toContain("AirPods Pro")
   })
 
   it("falls back to a generic phrase when the label is null or whitespace — labels are gated on permission and may be empty", () => {
-    expect(noAudioWarningMessage(null)).toContain("your microphone")
-    expect(noAudioWarningMessage("")).toContain("your microphone")
-    expect(noAudioWarningMessage("   ")).toContain("your microphone")
+    expect(noAudioWarningMessage({ deviceLabel: null, everHadSignal: false })).toContain("your microphone")
+    expect(noAudioWarningMessage({ deviceLabel: "", everHadSignal: false })).toContain("your microphone")
+    expect(noAudioWarningMessage({ deviceLabel: "   ", everHadSignal: false })).toContain("your microphone")
+  })
+
+  it("uses different phrasing for never-had-signal vs lost-signal — the remedy is different", () => {
+    // Initial silence → try a different input device (the current one is dead).
+    expect(noAudioWarningMessage({ deviceLabel: "AirPods Pro", everHadSignal: false })).toMatch(/not hearing/i)
+    // Lost signal → check the current input or switch (it WAS working).
+    expect(noAudioWarningMessage({ deviceLabel: "AirPods Pro", everHadSignal: true })).toMatch(/dropped/i)
   })
 })

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest"
-import { friendlyTranscriptionError } from "./use-voice-dictation"
+import {
+  friendlyTranscriptionError,
+  shouldWarnNoAudio,
+  noAudioWarningMessage,
+  NO_AUDIO_WAIT_MS,
+  NO_AUDIO_PEAK_THRESHOLD,
+} from "./use-voice-dictation"
 
 describe("friendlyTranscriptionError", () => {
   it("phrases known upstream codes as short human copy", () => {
@@ -11,5 +17,34 @@ describe("friendlyTranscriptionError", () => {
     expect(friendlyTranscriptionError(undefined)).toBe("Dictation hit a problem")
     // Even if a raw provider message arrives in `code`, we don't surface it.
     expect(friendlyTranscriptionError("ElevenLabs realtime closed (code 1000)")).toBe("Dictation hit a problem")
+  })
+})
+
+describe("shouldWarnNoAudio", () => {
+  it("waits out the grace window before warning — a take just starting is never silent enough to flag", () => {
+    expect(shouldWarnNoAudio(0, 0)).toBe(false)
+    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS - 1, 0)).toBe(false)
+  })
+
+  it("flags inputs that produced literal zero past the grace window", () => {
+    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, 0)).toBe(true)
+    expect(shouldWarnNoAudio(10_000, 0)).toBe(true)
+  })
+
+  it("does not flag inputs that crossed the ambient-noise floor — a working mic in a quiet room beats the threshold", () => {
+    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, NO_AUDIO_PEAK_THRESHOLD)).toBe(false)
+    expect(shouldWarnNoAudio(NO_AUDIO_WAIT_MS, NO_AUDIO_PEAK_THRESHOLD + 0.01)).toBe(false)
+  })
+})
+
+describe("noAudioWarningMessage", () => {
+  it("names the offending device when the browser revealed its label", () => {
+    expect(noAudioWarningMessage("AirPods Pro")).toContain("AirPods Pro")
+  })
+
+  it("falls back to a generic phrase when the label is null or whitespace — labels are gated on permission and may be empty", () => {
+    expect(noAudioWarningMessage(null)).toContain("your microphone")
+    expect(noAudioWarningMessage("")).toContain("your microphone")
+    expect(noAudioWarningMessage("   ")).toContain("your microphone")
   })
 })

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -480,15 +480,40 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         sessionIdRef.current = session.voiceSessionId
         setMaxDurationMs(session.maxDurationMs)
 
+        // Don't ask the browser to apply echo cancellation or noise suppression.
+        // On iOS Safari + Bluetooth headsets this is a known cause of silent
+        // audio: Apple's voice-processing path interprets the headset's
+        // already-cleaned signal as noise and zeros it out — the analyser keeps
+        // showing a faint level (from internal processing tail) while the
+        // worklet receives nothing real. ElevenLabs's STT does its own noise
+        // handling, so we just want the rawest mono signal the OS will give us.
         const stream = await navigator.mediaDevices.getUserMedia({
-          audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+          audio: { channelCount: 1, echoCancellation: false, noiseSuppression: false, autoGainControl: false },
         })
         streamRef.current = stream
+        const track = stream.getAudioTracks()[0]
         // Capture the device label so the silence-detection warning can name
         // the offending input ("AirPods Pro", "MacBook Pro Microphone"). The
         // label is populated post-permission; if the browser hides it we fall
         // back to a generic phrasing in the message builder.
-        deviceLabelRef.current = stream.getAudioTracks()[0]?.label || null
+        deviceLabelRef.current = track?.label || null
+        // Track-level mute fires when the OS revokes the input mid-take — most
+        // commonly a Bluetooth headset renegotiating profiles, or the user
+        // muting at the system level. The track stays alive but produces no
+        // frames; without this listener the take silently dies. Surface it
+        // through the same warning channel so the user knows the input
+        // dropped, and clear it on unmute so a recovered headset doesn't
+        // leave stale chrome.
+        if (track) {
+          track.onmute = () => {
+            warningShownRef.current = true
+            setNoAudioWarning(noAudioWarningMessage({ deviceLabel: deviceLabelRef.current, everHadSignal: true }))
+          }
+          track.onunmute = () => {
+            warningShownRef.current = false
+            setNoAudioWarning(null)
+          }
+        }
 
         const AudioCtx =
           window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
@@ -523,6 +548,18 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         // iOS Safari starts the context suspended; without this the worklet's
         // process() never runs and no audio frames are produced.
         if (audioContext.state === "suspended") await audioContext.resume()
+        // iOS Safari also suspends contexts MID-TAKE on various triggers (page
+        // backgrounding, silent-mode toggle, sometimes spontaneous power-save).
+        // When that happens, the worklet's process() stops running and no audio
+        // reaches the upstream — but no error fires either, so the take just
+        // goes silent. Auto-resume puts the graph back to work; if it can't
+        // resume (genuinely backgrounded), the next tick will fail and the
+        // existing teardown paths take over.
+        audioContext.onstatechange = () => {
+          if (audioContext.state === "suspended") {
+            audioContext.resume().catch(() => {})
+          }
+        }
 
         const socket = io(voiceUrl, { path: "/socket.io/", withCredentials: true, autoConnect: true })
         socketRef.current = socket

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -149,25 +149,39 @@ const SAMPLE_RATE_HZ = 16_000
 // through anyway so the button can't hang in the "stopping" state forever.
 const STOP_ACK_TIMEOUT_MS = 3000
 
-// Silence-detection thresholds. A working mic in even a very quiet room
-// produces ambient signal (breathing, faint motion, room tone) within a couple
-// of seconds and the smoothed level crosses this floor easily. A dead input —
-// e.g. a Bluetooth headset whose A2DP/HFP profile didn't switch, or wired
-// headphones whose mic isn't actually wired in — leaves the analyser at zero
-// because the audio graph is genuinely delivering zeros, so the smoothed level
-// stays at 0 forever. If we haven't seen ANY signal cross the floor within the
-// wait window, the input is dead and the user needs to know — otherwise they
-// stare at a recording mic that never produces a transcript.
-export const NO_AUDIO_WAIT_MS = 2500
+// Silence-detection thresholds. Two failure modes to catch:
+//
+// 1. Initial silence: the analyser was at zero from the moment the take began.
+//    The selected input is dead (Bluetooth headset stuck on A2DP, wired
+//    headphones with no working mic, OS-muted input). Fires fast (2.5s)
+//    because there's no ambiguity — a working mic shows ambient ADC dither
+//    within milliseconds.
+//
+// 2. Lost signal: the take WAS capturing audio and then went silent — e.g. a
+//    Bluetooth headset that briefly entered HFP and then dropped back, a USB
+//    glitch, a profile renegotiation. Fires slower (5s) to give legitimate
+//    pauses (taking a breath, thinking mid-sentence) room before nagging.
+//
+// `peakLevelInTakeRef >= NO_AUDIO_PEAK_THRESHOLD` separates the two cases:
+// peak only ever ratchets up, so if it's still below the floor we're in
+// case 1; otherwise we're in case 2 and the question becomes "how long since
+// the LAST signal crossing".
+export const NO_AUDIO_INITIAL_WAIT_MS = 2500
+export const NO_AUDIO_SILENCE_WAIT_MS = 5000
 export const NO_AUDIO_PEAK_THRESHOLD = 0.003
 
-export function shouldWarnNoAudio(elapsedMs: number, peakLevel: number): boolean {
-  return elapsedMs >= NO_AUDIO_WAIT_MS && peakLevel < NO_AUDIO_PEAK_THRESHOLD
+export function shouldWarnNoAudio(args: { elapsedMs: number; silenceMs: number; peakLevel: number }): boolean {
+  if (args.peakLevel >= NO_AUDIO_PEAK_THRESHOLD) {
+    return args.silenceMs >= NO_AUDIO_SILENCE_WAIT_MS
+  }
+  return args.elapsedMs >= NO_AUDIO_INITIAL_WAIT_MS
 }
 
-export function noAudioWarningMessage(deviceLabel: string | null): string {
-  const device = deviceLabel && deviceLabel.trim().length > 0 ? deviceLabel : "your microphone"
-  return `We're not hearing audio from ${device} — try a different input device`
+export function noAudioWarningMessage(args: { deviceLabel: string | null; everHadSignal: boolean }): string {
+  const device = args.deviceLabel && args.deviceLabel.trim().length > 0 ? args.deviceLabel : "your microphone"
+  return args.everHadSignal
+    ? `Audio from ${device} dropped — check it's still active or switch inputs`
+    : `We're not hearing audio from ${device} — try a different input device`
 }
 
 function detectSupport(): { supported: boolean; reason: string | null } {
@@ -251,11 +265,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const lastSetLevelRef = useRef(0)
   const lastElapsedTickRef = useRef(0)
   // Silence detection. Peak tracks the highest smoothed level seen in the
-  // current take; deviceLabel is the human-readable input name from the
-  // MediaStreamTrack so the warning can name the offending mic. `warningShownRef`
-  // mirrors the React state so the rAF tick can avoid setState churn when the
-  // condition hasn't flipped.
+  // current take (used as a "have we EVER had signal" proxy — it only ratchets
+  // up). `lastSignalAt` tracks the timestamp of the most recent tick that
+  // crossed the threshold, so the lost-signal warning can measure "time since
+  // we last heard anything". `deviceLabel` is the human-readable input name
+  // from the MediaStreamTrack so the warning can name the offending mic.
+  // `warningShownRef` mirrors the React state so the rAF tick can avoid
+  // setState churn when the condition hasn't flipped.
   const peakLevelInTakeRef = useRef(0)
+  const lastSignalAtRef = useRef(0)
   const deviceLabelRef = useRef<string | null>(null)
   const warningShownRef = useRef(false)
   const [noAudioWarning, setNoAudioWarning] = useState<string | null>(null)
@@ -319,6 +337,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     smoothedLevelRef.current = 0
     lastSetLevelRef.current = 0
     peakLevelInTakeRef.current = 0
+    lastSignalAtRef.current = 0
     deviceLabelRef.current = null
     if (warningShownRef.current) {
       warningShownRef.current = false
@@ -363,17 +382,26 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         setLevel(next)
       }
       const now = performance.now()
+      // Stamp the last-signal timestamp every tick the smoothed level crosses
+      // the floor. Used by the lost-signal branch of shouldWarnNoAudio so a
+      // take that briefly captured audio then went dead (e.g. headphone HFP
+      // dropping back to A2DP mid-take) is still surfaced to the user.
+      if (next >= NO_AUDIO_PEAK_THRESHOLD) lastSignalAtRef.current = now
       if (now - lastElapsedTickRef.current >= 250) {
         lastElapsedTickRef.current = now
         const elapsed = now - recordingStartRef.current
         setElapsedMs(elapsed)
-        // Once we've seen real signal we don't second-guess later quiet stretches —
-        // the user may simply have paused mid-take. The warning is only for inputs
-        // that have produced nothing at all since the take began.
-        const shouldWarn = shouldWarnNoAudio(elapsed, peakLevelInTakeRef.current)
+        const peak = peakLevelInTakeRef.current
+        const everHadSignal = peak >= NO_AUDIO_PEAK_THRESHOLD
+        // Time since last signal crossing. If we've never had signal,
+        // lastSignalAt is still 0 / take-start, so this reduces to elapsed —
+        // but the initial-silence branch in shouldWarnNoAudio ignores it
+        // anyway and gates on elapsed alone.
+        const silenceMs = everHadSignal ? now - lastSignalAtRef.current : elapsed
+        const shouldWarn = shouldWarnNoAudio({ elapsedMs: elapsed, silenceMs, peakLevel: peak })
         if (shouldWarn && !warningShownRef.current) {
           warningShownRef.current = true
-          setNoAudioWarning(noAudioWarningMessage(deviceLabelRef.current))
+          setNoAudioWarning(noAudioWarningMessage({ deviceLabel: deviceLabelRef.current, everHadSignal }))
         } else if (!shouldWarn && warningShownRef.current) {
           warningShownRef.current = false
           setNoAudioWarning(null)
@@ -600,6 +628,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             recordingStartRef.current = performance.now()
             lastElapsedTickRef.current = 0
             peakLevelInTakeRef.current = 0
+            lastSignalAtRef.current = recordingStartRef.current
             setElapsedMs(0)
             runMeter()
             setState("recording")

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -116,6 +116,14 @@ interface UseVoiceDictationResult {
   showOriginal: boolean
   /** Flip the session-wide toggle. Walks every unlocked chunk and swaps its text in the editor. */
   setShowOriginal: (target: boolean) => void
+  /**
+   * Non-fatal warning that the selected input device is producing silence —
+   * surfaced after a brief grace window when the analyser sees no signal at
+   * all. Null otherwise. Most common cause: a Bluetooth headset that didn't
+   * switch to its HFP/HSP profile, or a wired headphone selected as default
+   * input but with no working mic. Clears immediately when signal appears.
+   */
+  noAudioWarning: string | null
   start: () => void
   stop: () => void
 }
@@ -140,6 +148,27 @@ const SAMPLE_RATE_HZ = 16_000
 // If the server never acks voice:stop (dropped connection mid-stop), fall
 // through anyway so the button can't hang in the "stopping" state forever.
 const STOP_ACK_TIMEOUT_MS = 3000
+
+// Silence-detection thresholds. A working mic in even a very quiet room
+// produces ambient signal (breathing, faint motion, room tone) within a couple
+// of seconds and the smoothed level crosses this floor easily. A dead input —
+// e.g. a Bluetooth headset whose A2DP/HFP profile didn't switch, or wired
+// headphones whose mic isn't actually wired in — leaves the analyser at zero
+// because the audio graph is genuinely delivering zeros, so the smoothed level
+// stays at 0 forever. If we haven't seen ANY signal cross the floor within the
+// wait window, the input is dead and the user needs to know — otherwise they
+// stare at a recording mic that never produces a transcript.
+export const NO_AUDIO_WAIT_MS = 2500
+export const NO_AUDIO_PEAK_THRESHOLD = 0.003
+
+export function shouldWarnNoAudio(elapsedMs: number, peakLevel: number): boolean {
+  return elapsedMs >= NO_AUDIO_WAIT_MS && peakLevel < NO_AUDIO_PEAK_THRESHOLD
+}
+
+export function noAudioWarningMessage(deviceLabel: string | null): string {
+  const device = deviceLabel && deviceLabel.trim().length > 0 ? deviceLabel : "your microphone"
+  return `We're not hearing audio from ${device} — try a different input device`
+}
 
 function detectSupport(): { supported: boolean; reason: string | null } {
   if (typeof window === "undefined") return { supported: false, reason: "Voice input is unavailable here" }
@@ -221,6 +250,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const smoothedLevelRef = useRef(0)
   const lastSetLevelRef = useRef(0)
   const lastElapsedTickRef = useRef(0)
+  // Silence detection. Peak tracks the highest smoothed level seen in the
+  // current take; deviceLabel is the human-readable input name from the
+  // MediaStreamTrack so the warning can name the offending mic. `warningShownRef`
+  // mirrors the React state so the rAF tick can avoid setState churn when the
+  // condition hasn't flipped.
+  const peakLevelInTakeRef = useRef(0)
+  const deviceLabelRef = useRef<string | null>(null)
+  const warningShownRef = useRef(false)
+  const [noAudioWarning, setNoAudioWarning] = useState<string | null>(null)
   // Bumped on every start() and every teardown/stop so a `voice:start` ACK that
   // resolves after the user has already stopped (or torn down) can't flip the
   // state machine back to "recording" with nothing behind it.
@@ -280,6 +318,12 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     analyserRef.current = null
     smoothedLevelRef.current = 0
     lastSetLevelRef.current = 0
+    peakLevelInTakeRef.current = 0
+    deviceLabelRef.current = null
+    if (warningShownRef.current) {
+      warningShownRef.current = false
+      setNoAudioWarning(null)
+    }
     setLevel(0)
     setElapsedMs(0)
     workletRef.current?.port.close()
@@ -313,6 +357,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       const prev = smoothedLevelRef.current
       const next = prev + (target - prev) * (target > prev ? 0.5 : 0.12)
       smoothedLevelRef.current = next
+      if (next > peakLevelInTakeRef.current) peakLevelInTakeRef.current = next
       if (Math.abs(next - lastSetLevelRef.current) >= 0.02) {
         lastSetLevelRef.current = next
         setLevel(next)
@@ -320,7 +365,19 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       const now = performance.now()
       if (now - lastElapsedTickRef.current >= 250) {
         lastElapsedTickRef.current = now
-        setElapsedMs(now - recordingStartRef.current)
+        const elapsed = now - recordingStartRef.current
+        setElapsedMs(elapsed)
+        // Once we've seen real signal we don't second-guess later quiet stretches —
+        // the user may simply have paused mid-take. The warning is only for inputs
+        // that have produced nothing at all since the take began.
+        const shouldWarn = shouldWarnNoAudio(elapsed, peakLevelInTakeRef.current)
+        if (shouldWarn && !warningShownRef.current) {
+          warningShownRef.current = true
+          setNoAudioWarning(noAudioWarningMessage(deviceLabelRef.current))
+        } else if (!shouldWarn && warningShownRef.current) {
+          warningShownRef.current = false
+          setNoAudioWarning(null)
+        }
       }
       meterRafRef.current = requestAnimationFrame(tick)
     }
@@ -395,6 +452,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
         })
         streamRef.current = stream
+        // Capture the device label so the silence-detection warning can name
+        // the offending input ("AirPods Pro", "MacBook Pro Microphone"). The
+        // label is populated post-permission; if the browser hides it we fall
+        // back to a generic phrasing in the message builder.
+        deviceLabelRef.current = stream.getAudioTracks()[0]?.label || null
 
         const AudioCtx =
           window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
@@ -537,6 +599,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             }
             recordingStartRef.current = performance.now()
             lastElapsedTickRef.current = 0
+            peakLevelInTakeRef.current = 0
             setElapsedMs(0)
             runMeter()
             setState("recording")
@@ -707,6 +770,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     hasUnlockedChunks,
     showOriginal,
     setShowOriginal,
+    noAudioWarning,
     start,
     stop,
   }

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -117,11 +117,15 @@ interface UseVoiceDictationResult {
   /** Flip the session-wide toggle. Walks every unlocked chunk and swaps its text in the editor. */
   setShowOriginal: (target: boolean) => void
   /**
-   * Non-fatal warning that the selected input device is producing silence —
-   * surfaced after a brief grace window when the analyser sees no signal at
-   * all. Null otherwise. Most common cause: a Bluetooth headset that didn't
-   * switch to its HFP/HSP profile, or a wired headphone selected as default
-   * input but with no working mic. Clears immediately when signal appears.
+   * Non-fatal warning that the selected input device is producing silence.
+   * Fires in two cases:
+   *   - Initial silence: the analyser has been at zero since the take began
+   *     (Bluetooth headset stuck on A2DP, wired headphones with no working
+   *     mic, OS-muted input) — surfaces fast (~2.5s).
+   *   - Lost signal: the take was capturing audio and then went dead (HFP
+   *     dropped, USB glitch) — surfaces slower (~5s) so legitimate pauses
+   *     don't nag.
+   * Null otherwise. Clears automatically once signal returns.
    */
   noAudioWarning: string | null
   start: () => void

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -468,6 +468,38 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     setState("connecting")
     const generation = ++startGenerationRef.current
 
+    // iOS Safari only honors AudioContext creation and resume() inside a user
+    // gesture — and "inside" means the synchronous body of the gesture handler,
+    // not its async continuations. Awaiting `voiceApi.createSession()` or
+    // `getUserMedia()` first crosses the await boundary and the subsequent
+    // `new AudioContext()` / `.resume()` calls silently no-op: the context stays
+    // suspended, the worklet's process() never runs, and the upstream receives
+    // nothing while everything *looks* fine. So we construct + kick the context
+    // synchronously here, before any awaits, and let the async setup below
+    // attach nodes and the mic stream to it once they're ready.
+    const AudioCtx =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    // Don't pin the context to 16kHz. Firefox (incl. Android) throws from
+    // createMediaStreamSource when the context rate differs from the mic
+    // track's native rate instead of resampling like Chrome does. Run at the
+    // device's native rate and let the worklet downsample to the 16kHz the
+    // upstream STT expects (its targetSampleRate handles the conversion).
+    const audioContext = new AudioCtx()
+    audioContextRef.current = audioContext
+    void audioContext.resume().catch(() => {})
+    // iOS Safari also suspends contexts MID-TAKE on various triggers (page
+    // backgrounding, silent-mode toggle, sometimes spontaneous power-save).
+    // When that happens, the worklet's process() stops running and no audio
+    // reaches the upstream — but no error fires either, so the take just
+    // goes silent. Auto-resume puts the graph back to work; if it can't
+    // resume (genuinely backgrounded), the next tick will fail and the
+    // existing teardown paths take over.
+    audioContext.onstatechange = () => {
+      if (audioContext.state === "suspended") {
+        audioContext.resume().catch(() => {})
+      }
+    }
+
     void (async () => {
       try {
         const voiceUrl = resolveVoiceUrl(workspaceId)
@@ -515,15 +547,6 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           }
         }
 
-        const AudioCtx =
-          window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-        // Don't pin the context to 16kHz. Firefox (incl. Android) throws from
-        // createMediaStreamSource when the context rate differs from the mic
-        // track's native rate instead of resampling like Chrome does. Run at the
-        // device's native rate and let the worklet downsample to the 16kHz the
-        // upstream STT expects (its targetSampleRate handles the conversion).
-        const audioContext = new AudioCtx()
-        audioContextRef.current = audioContext
         await audioContext.audioWorklet.addModule("/worklets/pcm16-processor.js")
 
         const source = audioContext.createMediaStreamSource(stream)
@@ -545,21 +568,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         analyser.smoothingTimeConstant = 0.4
         source.connect(analyser)
         analyserRef.current = analyser
-        // iOS Safari starts the context suspended; without this the worklet's
-        // process() never runs and no audio frames are produced.
-        if (audioContext.state === "suspended") await audioContext.resume()
-        // iOS Safari also suspends contexts MID-TAKE on various triggers (page
-        // backgrounding, silent-mode toggle, sometimes spontaneous power-save).
-        // When that happens, the worklet's process() stops running and no audio
-        // reaches the upstream — but no error fires either, so the take just
-        // goes silent. Auto-resume puts the graph back to work; if it can't
-        // resume (genuinely backgrounded), the next tick will fail and the
-        // existing teardown paths take over.
-        audioContext.onstatechange = () => {
-          if (audioContext.state === "suspended") {
-            audioContext.resume().catch(() => {})
-          }
-        }
+        // The context was created and resume()'d synchronously at the top of
+        // start() (iOS Safari user-gesture requirement). By the time we get
+        // here it should be running; if it isn't, kick it once more in case
+        // the synchronous resume lost a race with this async setup.
+        if (audioContext.state === "suspended") await audioContext.resume().catch(() => {})
 
         const socket = io(voiceUrl, { path: "/socket.io/", withCredentials: true, autoConnect: true })
         socketRef.current = socket


### PR DESCRIPTION
## Problem

Voice dictation silently fails for users with headphones connected — most commonly Bluetooth headsets that stay on the A2DP (output-only) profile instead of switching to HFP/HSP (bidirectional), or wired headphones the OS selected as the default input even though they don't have a working mic.

In these cases the audio graph delivers literal zeros all the way through:

- `getUserMedia` resolves (the OS happily hands back a track on a dead device)
- The PCM16 worklet runs but only emits zeros
- ElevenLabs receives audio with no speech and never emits a `committed_transcript`
- The user stares at a red recording mic, says something, sees nothing happen, and assumes the feature is broken

There's no upstream error to surface and no obvious feedback that the input is the problem. The user reported: _"voice mode doesn't seem to work with headphones connected, no audio is picked up and sent to the provider. if I disconnect my headphones audio is streamed, so it very much seems like it's related to headphones somehow."_

## Solution

Watch the analyser's smoothed level during recording. If the peak level seen in the current take stays below an ambient-noise floor (`0.003`) past a grace window (`2.5s`), assume the input is dead and surface an amber warning pill above the mic naming the offending device:

> ⚠️ We're not hearing audio from AirPods Pro — try a different input device

The warning is non-fatal — it doesn't stop the take, doesn't disconnect the socket. If the user fixes the input mid-take (toggles their headset's microphone, switches back to internal mic at the OS layer), signal returns, peak crosses the floor, and the warning clears automatically.

This is a **band-aid that points at the problem** — a proper fix would let the user pick the input device from the composer itself. Filed as a follow-up; not in scope here.

### Why this threshold works

A working ADC with any input — even a quiet room — produces dither (~1 LSB of noise) which puts the smoothed level around `0.02`, comfortably above the `0.003` floor. A genuinely dead audio path delivers zeros, leaves the level at `0` forever, and gets correctly flagged. The threshold is chosen to separate these two regimes, not to detect "is the user speaking right now" (the take might have legitimate silence in the middle).

### Key design decisions

**1. Use peak-over-take, not current level**

The check is "have we seen ANY signal since the take started", not "is there signal right now". Once the peak crosses the floor, the warning won't fire later even if the user pauses mid-sentence — a user pausing is normal, a dead mic is the failure we're trying to flag.

**2. Helpers extracted as pure functions**

`shouldWarnNoAudio(elapsedMs, peakLevel)` and `noAudioWarningMessage(deviceLabel)` are exported so the threshold/wait-window and label-fallback behavior can be unit-tested without driving a real rAF loop. The hook itself stays untestable in jsdom (no `AudioWorkletNode`, no `getUserMedia`), but the decision logic doesn't need to.

**3. Warning copy is built in the frontend**

The decision is entirely client-side (analyser RMS on a local `AudioContext`), so there's no backend code to send. The message format lives in the hook, which is the layer that already owns the human copy for transcription errors (`friendlyTranscriptionError`).

**4. Pill replaces the clock, not the entire mic chrome**

The amber pill takes the slot above the mic that the clock pill normally occupies (the polish-toggle pill stacks differently and already has its own gating). The clock is hidden while the warning is up — the user needs to know the input is dead far more than they need a m:ss readout.

**5. `warningShownRef` mirrors React state to avoid setState churn**

The rAF loop ticks at ~4Hz for the elapsed-time check. Without a ref-backed `hasFlipped` guard, every tick where `shouldWarn` was true would call `setNoAudioWarning` with the same value and force a render. The ref lets us only `setState` on transitions.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-voice-dictation.ts` | Track per-take peak level, capture `MediaStreamTrack.label`, surface `noAudioWarning` in result; export `shouldWarnNoAudio` + `noAudioWarningMessage` |
| `apps/frontend/src/components/composer/mic-button.tsx` | Render amber warning pill above mic when `recording && noAudioWarning`; gate clock pill on `!noAudioWarning` |
| `apps/frontend/src/hooks/use-voice-dictation.test.ts` | Tests for `shouldWarnNoAudio` (threshold + wait window) and `noAudioWarningMessage` (device label fallback) |
| `apps/frontend/src/components/composer/mic-button.test.tsx` | Add `noAudioWarning: null` to the hook mock to satisfy the expanded result type |

## Test plan

- [x] `bun run typecheck` (frontend, clean)
- [x] `bun run test` (full frontend, 1782 passing)
- [x] Unit tests for `shouldWarnNoAudio` covering pre-grace-window, post-grace-window-with-zero, and post-grace-window-with-signal cases
- [x] Unit tests for `noAudioWarningMessage` covering labelled and unlabelled fallback
- [ ] Manual: connect Bluetooth headset stuck in A2DP, start dictation, verify amber pill appears after ~2.5s and names the headset
- [ ] Manual: start dictation on a working mic, hold breath / stay silent for 5s, verify warning does NOT fire (ambient noise crosses the floor)
- [ ] Manual: trigger warning, switch to a working input, verify warning clears once signal returns

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPtM427dDUsL1CXzdcEg7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782394497&installation_id=129946197&pr_number=628&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F628&signature=fd8f7034bd6c8cdcaabcd3158815558b1c9cf335231cc1619701be85d97069f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->