### PR TITLE
fix: show current user's command events

### DIFF
--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -23,9 +23,9 @@ import {
   useQueueDraftMessage,
   useComposerHeightPublish,
   useStashComposer,
+  useWorkspaceUserId,
 } from "@/hooks"
 import { useCoordinatedLoading, usePanel, isDraftPanel, parseDraftPanel, useSidebar } from "@/contexts"
-import { useUser } from "@/auth"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { onDraftPromoted } from "@/lib/draft-promotions"
@@ -63,7 +63,6 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const [searchParams] = useSearchParams()
   const highlightMessageId = searchParams.get("m")
   const { panelId, openPanel, getPanelUrl, closePanel } = usePanel()
-  const user = useUser()
   const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
@@ -88,6 +87,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   })
   const stream = idbPanelStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
+  const currentWorkspaceUserId = useWorkspaceUserId(workspaceId)
 
   // Show loading indicator only for real streams (not drafts) and only when actively loading after initial data
   const showLoadingIndicator = !isDraft && !!panelId && getStreamState(panelId) === "loading"
@@ -102,8 +102,8 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const draftThreadPendingEvents = useStreamEvents(isDraft ? (panelId ?? undefined) : undefined)
   const hasDraftThreadPendingEvents = isDraft && draftThreadPendingEvents && draftThreadPendingEvents.length > 0
   const draftThreadTimelineItems = useMemo(
-    () => (hasDraftThreadPendingEvents ? groupTimelineItems(draftThreadPendingEvents!, user?.id) : []),
-    [hasDraftThreadPendingEvents, draftThreadPendingEvents, user?.id]
+    () => (hasDraftThreadPendingEvents ? groupTimelineItems(draftThreadPendingEvents!, currentWorkspaceUserId ?? undefined) : []),
+    [hasDraftThreadPendingEvents, draftThreadPendingEvents, currentWorkspaceUserId]
   )
   const cachedParentMessage = useMemo(() => {
     if (!draftInfo || !parentCachedEvents) return null

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -399,8 +399,8 @@ export function StreamContent({
   }, [events, isThread])
 
   const timelineItems = useMemo(
-    () => annotateAuthorGroups(groupTimelineItems(displayEvents, user?.id)),
-    [displayEvents, user?.id]
+    () => annotateAuthorGroups(groupTimelineItems(displayEvents, currentWorkspaceUserId ?? undefined)),
+    [displayEvents, currentWorkspaceUserId]
   )
 
   // `order` is the position in the rendered timeline. Non-thread streams


### PR DESCRIPTION
## Problem

Production still did not show the slash-command row after PR #627. The optimistic/server `command_dispatched` events were being grouped only when `event.actorId === currentUserId`, but `StreamContent` passed `user?.id` from auth (WorkOS account id). Command events use workspace-scoped user ids as `actorId`, so the current user's command events were filtered out before rendering.

## Solution

Pass the workspace-scoped current user id into `groupTimelineItems` in the main stream timeline and draft thread panel paths.

## Test plan

- [x] `bun run --cwd apps/frontend lint`
- [x] `bun run --cwd apps/frontend test src/components/timeline/event-list.test.ts` — 0 failing tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782403915&installation_id=129946197&pr_number=629&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F629&signature=d6d7e73e18ab94cda1973483933f7d5008b52ea98584d8f7118175c48d648f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->