### PR TITLE
fix: allow mobile suggestion list scrolling

### DIFF
--- a/apps/frontend/src/components/editor/triggers/suggestion-list.tsx
+++ b/apps/frontend/src/components/editor/triggers/suggestion-list.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type ReactNode } from "react"
 import { useFloating, offset, flip, shift, autoUpdate, type Placement } from "@floating-ui/react"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 
 /**
@@ -116,7 +115,7 @@ function SuggestionListInner<T>(
       role="listbox"
       aria-label={ariaLabel}
     >
-      <ScrollArea className="max-h-[280px]">
+      <div className="max-h-[min(280px,50dvh)] overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch]">
         <div className="p-1">
           {isEmpty ? (
             <div className="px-2.5 py-2 text-sm text-muted-foreground">{emptyState}</div>
@@ -143,7 +142,7 @@ function SuggestionListInner<T>(
             ))
           )}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

On mobile, long slash-command suggestion lists could not be scrolled, making commands near the bottom impossible to select.

## Solution

Use native touch scrolling for the shared suggestion list popup instead of the Radix scroll area wrapper. The popup keeps the same visual max height, adds a viewport-aware cap, and explicitly enables vertical touch panning / momentum scrolling.

This affects slash commands plus the shared mention/channel/emoji suggestion popup path.

## Test plan

- [x] `bun run --cwd apps/frontend lint`
- [ ] `bun run --cwd apps/frontend typecheck` — blocked by existing TipTap table type errors on `main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782405699&installation_id=129946197&pr_number=630&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F630&signature=416565bcdcc7f82de3e2811ce6925d98c93a2a42f5e09c3d8bc352bf5eb93a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->