### PR TITLE
feat: add remote-control open command

### DIFF
--- a/docs/examples/pi-remote/threa-remote-v2.test.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.test.ts
@@ -222,6 +222,15 @@ describe("Pi remote trace safety", () => {
     expect(__testing.formatDuration(139 * 60_000)).toBe("2h 19m")
   })
 
+  test("builds scratchpad URLs from configured base URL and stream path", () => {
+    expect(__testing.buildScratchpadUrl("https://app.threa.io", "/workspaces/ws_123/streams/stream_123")).toBe(
+      "https://app.threa.io/workspaces/ws_123/streams/stream_123"
+    )
+    expect(__testing.buildScratchpadUrl("https://app.threa.io/app/", "streams/stream_123")).toBe(
+      "https://app.threa.io/app/streams/stream_123"
+    )
+  })
+
   test("parses pasted self-configuration JSON", () => {
     expect(
       __testing.parseConfigPatch(`{

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { homedir, hostname } from "node:os"
+import { homedir, hostname, platform } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import type {
   ExtensionAPI,
@@ -23,6 +25,9 @@ const SESSION_CONTROL_CAPABILITY = "session-control"
 const SESSION_CONTROL_COMMANDS = ["compact", "model", "thinking", "skill", "reload"] as const
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const
 type ThinkingLevel = (typeof THINKING_LEVELS)[number]
+const execFileAsync = promisify(execFile)
+const OPEN_URL_TIMEOUT_MS = 10_000
+
 const PI_TOOL_TRACE_SECTION_LABELS = {
   ARGUMENTS: "Arguments",
   OUTPUT: "Output",
@@ -215,6 +220,28 @@ function setCurrentSessionEnabled(ctx: ExtensionContext, enabled: boolean): Runt
   link.enabled = enabled
   saveConfig()
   return link
+}
+
+function buildScratchpadUrl(baseUrl: string, streamUrlPath: string): string {
+  return new URL(streamUrlPath, baseUrl).toString()
+}
+
+async function openExternalUrl(url: string): Promise<void> {
+  const os = platform()
+  if (os === "darwin") {
+    try {
+      await execFileAsync("open", ["-a", "Threa", url], { timeout: OPEN_URL_TIMEOUT_MS })
+      return
+    } catch {
+      await execFileAsync("open", [url], { timeout: OPEN_URL_TIMEOUT_MS })
+      return
+    }
+  }
+  if (os === "win32") {
+    await execFileAsync("cmd", ["/c", "start", "", url], { timeout: OPEN_URL_TIMEOUT_MS })
+    return
+  }
+  await execFileAsync("xdg-open", [url], { timeout: OPEN_URL_TIMEOUT_MS })
 }
 
 function isCurrentSessionEnabled(ctx: ExtensionContext): boolean {
@@ -1251,7 +1278,12 @@ async function handleSessionControlInvocation(
 
   try {
     await heartbeat("busy", `Running /${command.name}…`, ctx)
-    await recordInvocationTraceStep(invocation, "context_received", `Running /${command.name}${command.args ? ` ${command.args}` : ""}`, `Running /${command.name}…`)
+    await recordInvocationTraceStep(
+      invocation,
+      "context_received",
+      `Running /${command.name}${command.args ? ` ${command.args}` : ""}`,
+      `Running /${command.name}…`
+    )
     switch (command.name) {
       case "compact":
         await runCompactCommand(invocation, command.args, ctx)
@@ -1697,6 +1729,7 @@ export const __testing = {
   getRuntimeCommand,
   normalizeThinkingLevel,
   migrateSessionState,
+  buildScratchpadUrl,
   parseConfigPatch,
   safeStatusText,
   captureMessageText,
@@ -1736,6 +1769,21 @@ export default function (pi: ExtensionAPI): void {
       }
       if (command === "on" || command === "enable") {
         await enableRemote(pi, ctx)
+        return
+      }
+      if (command === "open") {
+        const link = getCurrentSessionLink(ctx)
+        if (!link) {
+          ctx.ui.notify("No Threa remote session is linked here. Run /remote-control first.", "warning")
+          return
+        }
+        const url = buildScratchpadUrl(config.baseUrl, link.streamUrlPath)
+        try {
+          await openExternalUrl(url)
+          ctx.ui.notify(`Opening Threa scratchpad: ${url}`, "info")
+        } catch (error) {
+          ctx.ui.notify(`Could not open Threa scratchpad: ${String(error)}\n${url}`, "error")
+        }
         return
       }
       if (command === "debug-polls") {


### PR DESCRIPTION
## Problem

Pi remote sessions are linked to Threa scratchpads, but there is no quick command to open the current session's scratchpad from Pi. Users have to find/copy the URL manually.

## Solution

Add `/remote-control open` to the Pi remote extension.

### How it works

- Reads the current Pi session's stored `RuntimeSessionLink`.
- Builds the scratchpad URL from `config.baseUrl` + `link.streamUrlPath`.
- Opens it through the OS URL opener:
  - macOS first tries `open -a Threa <url>` so the installed PWA opens when available.
  - macOS falls back to plain `open <url>` when the Threa app is not installed or cannot be opened.
  - Windows uses `cmd /c start`.
  - Linux uses `xdg-open`.

### Key design decisions

**1. Best-effort PWA support on macOS**

There is no reliable cross-platform API for detecting installed browser PWAs from a Pi extension. Since `open -a "Threa"` works locally, the command tries that first on macOS and gracefully falls back to the default browser.

**2. Keep it local to the existing remote-control config**

The command uses the already persisted session link instead of adding a new backend API or config field.

## New files

None.

## Modified files

| File | Change |
| --- | --- |
| `docs/examples/pi-remote/threa-remote-v2.ts` | Adds `/remote-control open`, URL construction, and OS opener helper. |
| `docs/examples/pi-remote/threa-remote-v2.test.ts` | Adds coverage for scratchpad URL construction. |

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts`
- [x] `bun --check docs/examples/pi-remote/threa-remote-v2.ts`
- [x] `bun run --cwd apps/frontend lint`
- [ ] Manual smoke: copy extension locally, `/reload`, then `/remote-control open`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421034&installation_id=129946197&pr_number=632&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F632&signature=cdd47c5951dda872cc58a04ce1a95faeed3c485cc510332398e1e3da4802b2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->