### PR TITLE
fix(accounts): propagate WorkOS-rotated sealed sessions in account switcher

### DIFF
--- a/apps/control-plane/src/features/accounts/handlers.ts
+++ b/apps/control-plane/src/features/accounts/handlers.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express"
 import { z } from "zod/v4"
-import { HttpError, SESSION_COOKIE_NAME } from "@threa/backend-common"
+import { HttpError } from "@threa/backend-common"
 import type { AccountsService } from "./service"
 
 interface Dependencies {
@@ -24,7 +24,7 @@ export function createAccountsHandlers({ accountsService }: Dependencies) {
       if (!req.workosUserId || !req.authUser) {
         throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
       }
-      res.json(await accountsService.list(req.cookies, req.authUser))
+      res.json(await accountsService.list(res, req.cookies, req.authUser))
     },
 
     async resolve(req: Request, res: Response) {
@@ -35,31 +35,33 @@ export function createAccountsHandlers({ accountsService }: Dependencies) {
       if (!parsed.success) {
         throw new HttpError("Invalid query", { status: 400, code: "VALIDATION_ERROR" })
       }
-      res.json(await accountsService.resolve(req.cookies, req.authUser, parsed.data))
+      res.json(await accountsService.resolve(res, req.cookies, req.authUser, parsed.data))
     },
 
     async switch(req: Request, res: Response) {
-      if (!req.workosUserId || !req.authUser) {
+      if (!req.workosUserId || !req.authUser || !req.sealedSession) {
         throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
       }
       const parsed = targetSchema.safeParse(req.body)
       if (!parsed.success) {
         throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
       }
-      const activeSealed = req.cookies[SESSION_COOKIE_NAME]
-      res.json(await accountsService.switch(res, req.cookies, activeSealed, req.authUser, parsed.data.targetUserId))
+      res.json(
+        await accountsService.switch(res, req.cookies, req.sealedSession, req.authUser, parsed.data.targetUserId)
+      )
     },
 
     async remove(req: Request, res: Response) {
-      if (!req.workosUserId || !req.authUser) {
+      if (!req.workosUserId || !req.authUser || !req.sealedSession) {
         throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
       }
       const parsed = targetSchema.safeParse(req.body)
       if (!parsed.success) {
         throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
       }
-      const activeSealed = req.cookies[SESSION_COOKIE_NAME]
-      res.json(await accountsService.remove(res, req.cookies, activeSealed, req.authUser, parsed.data.targetUserId))
+      res.json(
+        await accountsService.remove(res, req.cookies, req.sealedSession, req.authUser, parsed.data.targetUserId)
+      )
     },
   }
 }

--- a/apps/control-plane/src/features/accounts/service.test.ts
+++ b/apps/control-plane/src/features/accounts/service.test.ts
@@ -45,6 +45,7 @@ type AuthReply = AuthResult | ((sealed: string) => AuthResult)
 
 class ProgrammableAuthService implements AuthService {
   private replies = new Map<string, AuthReply>()
+  readonly revoked: string[] = []
 
   on(sealed: string, reply: AuthReply): void {
     this.replies.set(sealed, reply)
@@ -71,8 +72,9 @@ class ProgrammableAuthService implements AuthService {
   async getLogoutUrl(): Promise<string | null> {
     return null
   }
-  async revokeSession(): Promise<boolean> {
-    return false
+  async revokeSession(sealed: string): Promise<boolean> {
+    this.revoked.push(sealed)
+    return true
   }
 }
 
@@ -165,5 +167,65 @@ describe("AccountsService — refreshed sealed propagation", () => {
     expect(result).toEqual({ ok: true })
     expect(res.__cookies.get(SESSION_COOKIE_NAME)).toBe("sealed_b_new")
     expect(res.__cookies.get(altCookieName(0))).toBe("sealed_a_rotated")
+  })
+
+  test("removeCurrentAndPromote revokes the rotated sealed and promotes the alt", async () => {
+    // The "sign out of just this account" path: WorkOS may rotate the active
+    // session's refresh token during the authenticate() pre-check. If we then
+    // pass the pre-refresh sealed to revokeSession, WorkOS's session.refresh
+    // fails on a stale token and revoke silently returns false — the live
+    // WorkOS session stays alive. The rotated value must reach revoke.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_active", {
+      success: true,
+      refreshed: true,
+      sealedSession: "sealed_a_rotated",
+      user: makeUser("user_a"),
+    })
+    auth.on("sealed_b_parked", { success: true, refreshed: false, user: makeUser("user_b") })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+    const cookies = { [altCookieName(0)]: "sealed_b_parked" }
+
+    const promoted = await service.removeCurrentAndPromote(res, cookies, "sealed_a_active")
+
+    expect(promoted).toBe(true)
+    // Active cookie now holds the promoted parked sealed; the parked slot was
+    // cleared on promotion.
+    expect(res.__cookies.get(SESSION_COOKIE_NAME)).toBe("sealed_b_parked")
+    expect(res.__cookies.get(altCookieName(0))).toBeNull()
+    // The rotated sealed is what reached revokeSession — without the fix this
+    // would be "sealed_a_active" and the active WorkOS session would survive.
+    expect(auth.revoked).toEqual(["sealed_a_rotated"])
+  })
+
+  test("removeCurrentAndPromote returns false when there is no parked alt to promote", async () => {
+    // No alts means a "sign out current" would empty the cookie jar — that's
+    // indistinguishable from a full logout, so the caller falls through to
+    // the WorkOS SSO logout flow instead of going through revoke + promote.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_active", { success: true, refreshed: false, user: makeUser("user_a") })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+
+    const promoted = await service.removeCurrentAndPromote(res, {}, "sealed_a_active")
+
+    expect(promoted).toBe(false)
+    // No cookie writes, no revoke calls — caller is responsible for full logout.
+    expect(res.__cookies.size).toBe(0)
+    expect(auth.revoked).toEqual([])
+  })
+
+  test("removeCurrentAndPromote returns false when there is no active sealed", async () => {
+    const auth = new ProgrammableAuthService()
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+
+    const promoted = await service.removeCurrentAndPromote(res, {}, undefined)
+
+    expect(promoted).toBe(false)
+    expect(res.__cookies.size).toBe(0)
   })
 })

--- a/apps/control-plane/src/features/accounts/service.test.ts
+++ b/apps/control-plane/src/features/accounts/service.test.ts
@@ -218,6 +218,45 @@ describe("AccountsService — refreshed sealed propagation", () => {
     expect(auth.revoked).toEqual([])
   })
 
+  test("removeCurrentAndPromote returns false when the only parked alt is stale", async () => {
+    // Stale-alt-only: the alt cookie exists but its sealed session fails
+    // validation. Treating "any alt cookie" as "promotable account" would
+    // make `remove` revoke the active session and clear cookies without
+    // hitting SSO logout — the live WorkOS session would survive. The
+    // caller must take the full-logout path instead.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_active", { success: true, refreshed: false, user: makeUser("user_a") })
+    // "stale_alt" deliberately unset — authenticateSession returns not_found.
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+    const cookies = { [altCookieName(0)]: "stale_alt" }
+
+    const promoted = await service.removeCurrentAndPromote(res, cookies, "sealed_a_active")
+
+    expect(promoted).toBe(false)
+    expect(res.__cookies.size).toBe(0)
+    expect(auth.revoked).toEqual([])
+  })
+
+  test("removeCurrentAndPromote returns false when the only parked alt is a duplicate of the active account", async () => {
+    // A duplicate-of-active alt isn't a *different* signed-in account to
+    // promote to, so the same "no promotable" rule applies.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_active", { success: true, refreshed: false, user: makeUser("user_a") })
+    auth.on("sealed_a_dup", { success: true, refreshed: false, user: makeUser("user_a") })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+    const cookies = { [altCookieName(0)]: "sealed_a_dup" }
+
+    const promoted = await service.removeCurrentAndPromote(res, cookies, "sealed_a_active")
+
+    expect(promoted).toBe(false)
+    expect(res.__cookies.size).toBe(0)
+    expect(auth.revoked).toEqual([])
+  })
+
   test("removeCurrentAndPromote returns false when there is no active sealed", async () => {
     const auth = new ProgrammableAuthService()
     const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })

--- a/apps/control-plane/src/features/accounts/service.test.ts
+++ b/apps/control-plane/src/features/accounts/service.test.ts
@@ -1,0 +1,169 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import type { Response } from "express"
+import type { AuthResult, AuthService } from "@threa/backend-common"
+import { AccountsService } from "./service"
+
+// Capture the env-scoped cookie names this test process will use. Mirrors
+// middleware.test.ts so this file works in isolation and alongside others.
+let SESSION_COOKIE_NAME: string
+let altCookieName: (slot: number) => string
+
+beforeAll(async () => {
+  process.env.SESSION_COOKIE_NAME ??= "wos_session_test_accounts"
+  const cookies = await import("@threa/backend-common")
+  SESSION_COOKIE_NAME = cookies.SESSION_COOKIE_NAME
+  altCookieName = cookies.altSessionCookieName
+})
+
+// In-memory `Response` stub that records `cookie()` / `clearCookie()` calls.
+// We assert only the resulting cookie state after a method finishes, so the
+// implementation just plays the calls forward into a Map.
+interface RecordingResponse extends Response {
+  __cookies: Map<string, string | null>
+}
+
+function makeRes(): RecordingResponse {
+  const cookies = new Map<string, string | null>()
+  const res = {
+    __cookies: cookies,
+    cookie(name: string, value: string) {
+      cookies.set(name, value)
+      return this
+    },
+    clearCookie(name: string) {
+      cookies.set(name, null)
+      return this
+    },
+  }
+  return res as unknown as RecordingResponse
+}
+
+// Programmable auth stub. The bug-fix test needs `refreshed: true` (with a
+// rotated `sealedSession`), which `StubAuthService` never returns — that's
+// exactly why this bug slipped past the e2e suite.
+type AuthReply = AuthResult | ((sealed: string) => AuthResult)
+
+class ProgrammableAuthService implements AuthService {
+  private replies = new Map<string, AuthReply>()
+
+  on(sealed: string, reply: AuthReply): void {
+    this.replies.set(sealed, reply)
+  }
+
+  async authenticateSession(sealed: string): Promise<AuthResult> {
+    const reply = this.replies.get(sealed)
+    if (!reply) return { success: false, refreshed: false, reason: "not_found" }
+    return typeof reply === "function" ? reply(sealed) : reply
+  }
+
+  async authenticateWithCode(): Promise<AuthResult> {
+    return { success: false, refreshed: false, reason: "unused" }
+  }
+  getAuthorizationUrl(): string {
+    return "/unused"
+  }
+  async sendMagicAuthCode(): Promise<{ ok: true } | { ok: false; reason: string }> {
+    return { ok: true }
+  }
+  async authenticateWithMagicAuth(): Promise<AuthResult> {
+    return { success: false, refreshed: false, reason: "unused" }
+  }
+  async getLogoutUrl(): Promise<string | null> {
+    return null
+  }
+  async revokeSession(): Promise<boolean> {
+    return false
+  }
+}
+
+const NEVER_MEMBER = {
+  async isMember(): Promise<boolean> {
+    return false
+  },
+}
+
+function makeUser(id: string): NonNullable<AuthResult["user"]> {
+  return { id, email: `${id}@example.com`, firstName: id, lastName: null, permissions: null }
+}
+
+describe("AccountsService — refreshed sealed propagation", () => {
+  test("switch uses the rotated sealed when WorkOS refreshes the parked session", async () => {
+    // Setup: A is parked in alt slot 0 with a sealed that's about to be
+    // rotated by `authenticate` -> `refresh`. B is active.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_b_active", { success: true, refreshed: false, user: makeUser("user_b") })
+    auth.on("sealed_a_stale", {
+      success: true,
+      refreshed: true,
+      sealedSession: "sealed_a_rotated",
+      user: makeUser("user_a"),
+    })
+    // After rotation the pre-refresh value is dead at WorkOS, so any caller
+    // who re-uses it for a follow-up `authenticate` would 401. We model that
+    // by leaving "sealed_a_stale" unset for the rotated reply (a fresh call
+    // returns not_found from the map). The rotated value is what must be
+    // promoted to the active cookie.
+    auth.on("sealed_a_rotated", { success: true, refreshed: false, user: makeUser("user_a") })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+    const cookies = { [altCookieName(0)]: "sealed_a_stale" }
+
+    const result = await service.switch(res, cookies, "sealed_b_active", makeUser("user_b"), "user_a")
+
+    expect(result).toEqual({ activeUserId: "user_a" })
+    // The active cookie now holds the *rotated* sealed, not the dead one the
+    // browser sent. Without the fix this would be "sealed_a_stale" and the
+    // very next /api/auth/me would 401.
+    expect(res.__cookies.get(SESSION_COOKIE_NAME)).toBe("sealed_a_rotated")
+    // The previously-active session was parked into the slot the target
+    // vacated.
+    expect(res.__cookies.get(altCookieName(0))).toBe("sealed_b_active")
+  })
+
+  test("list writes the rotated sealed back to the alt cookie when refresh happens", async () => {
+    // Just viewing the switcher must not destroy a parked session: if the
+    // alt's access token has expired, `authenticate` rotates the refresh
+    // token, and the pre-refresh sealed is dead. The cookie has to be
+    // rewritten or the next view 401s the parked account.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_stale", {
+      success: true,
+      refreshed: true,
+      sealedSession: "sealed_a_rotated",
+      user: makeUser("user_a"),
+    })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+    const cookies = { [altCookieName(0)]: "sealed_a_stale" }
+    const activeUser = makeUser("user_b")
+
+    const { accounts } = await service.list(res, cookies, activeUser)
+    expect(accounts.map((a) => a.id)).toEqual(["user_b", "user_a"])
+    expect(res.__cookies.get(altCookieName(0))).toBe("sealed_a_rotated")
+  })
+
+  test("addAndParkActive parks the rotated sealed when WorkOS refreshes the previous active", async () => {
+    // Mid-OAuth-callback we re-authenticate the previous active session to
+    // decide whether to park it. WorkOS rotating the refresh token there
+    // means the pre-refresh sealed (what the browser sent) is now dead — we
+    // must park the rotated value, not the original.
+    const auth = new ProgrammableAuthService()
+    auth.on("sealed_a_stale", {
+      success: true,
+      refreshed: true,
+      sealedSession: "sealed_a_rotated",
+      user: makeUser("user_a"),
+    })
+
+    const service = new AccountsService({ authService: auth, membership: NEVER_MEMBER })
+    const res = makeRes()
+
+    const result = await service.addAndParkActive(res, {}, "sealed_a_stale", "sealed_b_new", "user_b")
+
+    expect(result).toEqual({ ok: true })
+    expect(res.__cookies.get(SESSION_COOKIE_NAME)).toBe("sealed_b_new")
+    expect(res.__cookies.get(altCookieName(0))).toBe("sealed_a_rotated")
+  })
+})

--- a/apps/control-plane/src/features/accounts/service.ts
+++ b/apps/control-plane/src/features/accounts/service.ts
@@ -72,14 +72,26 @@ export class AccountsService {
   // Validate every parked alt cookie in parallel (never a serial loop). A
   // slot whose sealed session fails validation comes back `ok:false` and is
   // reclaimable on the next write (self-heals corrupt/expired alts).
-  private async resolveAlts(cookies: Record<string, string>): Promise<ResolvedAlt[]> {
+  //
+  // WorkOS access tokens are short-lived and `session.refresh()` rotates the
+  // refresh token — the pre-refresh sealed value is dead the moment refresh
+  // runs. We MUST write the rotated sealed back to the alt cookie and surface
+  // it to callers; otherwise a switcher view (or any GET that calls this) kills
+  // the parked session for good. Mirrors what `createAuthMiddleware` already
+  // does for the active cookie.
+  private async resolveAlts(res: Response, cookies: Record<string, string>): Promise<ResolvedAlt[]> {
     const alts = readAltSessionCookies(cookies)
     const auths = await Promise.all(alts.map((a) => this.authService.authenticateSession(a.sealed)))
     return alts.map((a, i) => {
       const r = auths[i]
-      return r.success && r.user
-        ? { slot: a.slot, sealed: a.sealed, ok: true, user: r.user }
-        : { slot: a.slot, sealed: a.sealed, ok: false }
+      if (!r.success || !r.user) {
+        return { slot: a.slot, sealed: a.sealed, ok: false }
+      }
+      const sealed = r.refreshed && r.sealedSession ? r.sealedSession : a.sealed
+      if (sealed !== a.sealed) {
+        setAltSessionCookie(res, a.slot, sealed)
+      }
+      return { slot: a.slot, sealed, ok: true, user: r.user }
     })
   }
 
@@ -113,7 +125,12 @@ export class AccountsService {
       return { ok: true }
     }
 
-    const alts = await this.resolveAlts(cookies)
+    // If WorkOS rotated the prev session while we were validating it, the
+    // pre-refresh sealed is now revoked. Park the rotated value so the slot
+    // doesn't hold a dead token.
+    const prevSealedToPark = prevAuth.refreshed && prevAuth.sealedSession ? prevAuth.sealedSession : prevActiveSealed
+
+    const alts = await this.resolveAlts(res, cookies)
     const validAlts = alts.filter((a) => a.ok && a.user)
 
     // The new account is already parked: promote it, park the previous active
@@ -121,7 +138,7 @@ export class AccountsService {
     const existing = validAlts.find((a) => a.user?.id === newUserId)
     if (existing) {
       setSessionCookie(res, newSealed)
-      setAltSessionCookie(res, existing.slot, prevActiveSealed)
+      setAltSessionCookie(res, existing.slot, prevSealedToPark)
       for (const a of validAlts) {
         if (a.slot !== existing.slot && a.user?.id === newUserId) {
           clearAltSessionCookie(res, a.slot)
@@ -146,12 +163,13 @@ export class AccountsService {
       return { ok: false, code: "MAX_ACCOUNTS_REACHED" }
     }
 
-    setAltSessionCookie(res, freeSlot, prevActiveSealed)
+    setAltSessionCookie(res, freeSlot, prevSealedToPark)
     setSessionCookie(res, newSealed)
     return { ok: true }
   }
 
   async list(
+    res: Response,
     cookies: Record<string, string>,
     activeUser: ActiveUser
   ): Promise<{ accounts: AccountSummary[]; maxAccounts: number }> {
@@ -165,10 +183,13 @@ export class AccountsService {
     ]
 
     // Coalesce on read: hide any alt that resolves to the active account or to
-    // an account already surfaced by an earlier (lower) slot. GET stays
-    // Set-Cookie-free; slot reconciliation is deferred to the next write.
+    // an account already surfaced by an earlier (lower) slot. Slot
+    // reconciliation (clearing coalesced duplicates) is still deferred to the
+    // next write, but `resolveAlts` does write rotated sealed values back when
+    // WorkOS refreshes during validation — without that the parked session
+    // would be revoked the instant the switcher view triggered a refresh.
     const seen = new Set<string>([activeUser.id])
-    for (const alt of await this.resolveAlts(cookies)) {
+    for (const alt of await this.resolveAlts(res, cookies)) {
       if (alt.ok && alt.user) {
         if (seen.has(alt.user.id)) continue
         seen.add(alt.user.id)
@@ -207,11 +228,12 @@ export class AccountsService {
    * already-seen id are de-duped; stale alts (failed validation) skipped.
    */
   async resolve(
+    res: Response,
     cookies: Record<string, string>,
     activeUser: ActiveUser,
     q: { userId?: string; workspaceId?: string }
   ): Promise<{ ownerUserId: string }> {
-    const alts = await this.resolveAlts(cookies)
+    const alts = await this.resolveAlts(res, cookies)
     const seen = new Set<string>()
     const signedInIds: string[] = []
     for (const id of [activeUser.id, ...alts.flatMap((a) => (a.ok && a.user ? [a.user.id] : []))]) {
@@ -260,15 +282,18 @@ export class AccountsService {
       throw new HttpError("Account is already active", { status: 409, code: "ALREADY_ACTIVE" })
     }
 
-    const alts = await this.resolveAlts(cookies)
+    const alts = await this.resolveAlts(res, cookies)
     const target = alts.find((a) => a.ok && a.user?.id === targetUserId)
     if (!target || !target.user) {
       throw new HttpError("Account not found", { status: 404, code: "ACCOUNT_NOT_FOUND" })
     }
 
     // Deterministic Set-Cookie order so a mid-flight failure never strands a
-    // session: promote target, park the old active into the slot the target
-    // just vacated (always free), then drop any duplicate slots.
+    // session: promote target (using the latest sealed `resolveAlts` returned,
+    // not the pre-refresh value the browser sent), park the old active into
+    // the slot the target just vacated (always free), then drop any duplicate
+    // slots. `activeSealed` is whatever the auth middleware surfaced — that's
+    // the rotated value when this request triggered a refresh.
     setSessionCookie(res, target.sealed)
     setAltSessionCookie(res, target.slot, activeSealed)
     for (const alt of alts) {
@@ -299,7 +324,7 @@ export class AccountsService {
       return { removedId: targetUserId }
     }
 
-    const alts = await this.resolveAlts(cookies)
+    const alts = await this.resolveAlts(res, cookies)
 
     if (targetUserId === activeUser.id) {
       // Removing the active account: kill its WorkOS session for real, plus

--- a/apps/control-plane/src/features/accounts/service.ts
+++ b/apps/control-plane/src/features/accounts/service.ts
@@ -6,6 +6,7 @@ import {
   clearAltSessionCookie,
   clearSessionCookie,
   displayNameFromWorkos,
+  pickSealed,
   readAltSessionCookies,
   setAltSessionCookie,
   setSessionCookie,
@@ -87,7 +88,7 @@ export class AccountsService {
       if (!r.success || !r.user) {
         return { slot: a.slot, sealed: a.sealed, ok: false }
       }
-      const sealed = r.refreshed && r.sealedSession ? r.sealedSession : a.sealed
+      const sealed = pickSealed(r, a.sealed)
       if (sealed !== a.sealed) {
         setAltSessionCookie(res, a.slot, sealed)
       }
@@ -128,7 +129,7 @@ export class AccountsService {
     // If WorkOS rotated the prev session while we were validating it, the
     // pre-refresh sealed is now revoked. Park the rotated value so the slot
     // doesn't hold a dead token.
-    const prevSealedToPark = prevAuth.refreshed && prevAuth.sealedSession ? prevAuth.sealedSession : prevActiveSealed
+    const prevSealedToPark = pickSealed(prevAuth, prevActiveSealed)
 
     const alts = await this.resolveAlts(res, cookies)
     const validAlts = alts.filter((a) => a.ok && a.user)
@@ -360,5 +361,32 @@ export class AccountsService {
     for (const m of matches) clearAltSessionCookie(res, m.slot)
 
     return { removedId: targetUserId }
+  }
+
+  /**
+   * "Sign out of just the current account, stay signed in to others" — revokes
+   * the active WorkOS session and promotes the lowest parked alt to active.
+   * Reuses the existing `remove(active)` orchestration (revoke + cookie writes)
+   * and adds the rotation-aware sealed pick the handler can't do alone.
+   *
+   * Returns `false` without touching cookies when the call is a no-op (no
+   * session, no parked alt to promote, or the session can't be authenticated)
+   * so the caller can fall through to a normal full-logout flow that hits
+   * `getLogoutUrl` for the SSO round-trip.
+   */
+  async removeCurrentAndPromote(
+    res: Response,
+    cookies: Record<string, string>,
+    activeSealed: string | undefined
+  ): Promise<boolean> {
+    if (!activeSealed) return false
+    const auth = await this.authService.authenticateSession(activeSealed)
+    if (!auth.success || !auth.user) return false
+    if (readAltSessionCookies(cookies).length === 0) return false
+    // WorkOS may have rotated the refresh token during authenticate; pass the
+    // post-refresh sealed into `remove` so `revokeSession` kills the live
+    // session, not the already-dead pre-refresh value the browser sent.
+    await this.remove(res, cookies, pickSealed(auth, activeSealed), auth.user, auth.user.id)
+    return true
   }
 }

--- a/apps/control-plane/src/features/accounts/service.ts
+++ b/apps/control-plane/src/features/accounts/service.ts
@@ -382,11 +382,18 @@ export class AccountsService {
     if (!activeSealed) return false
     const auth = await this.authService.authenticateSession(activeSealed)
     if (!auth.success || !auth.user) return false
-    if (readAltSessionCookies(cookies).length === 0) return false
+    const activeUser = auth.user
+    // Stale or duplicate-of-active alts can't be promoted. If we proceeded
+    // anyway, `remove` would revoke the active session and clear cookies
+    // without ever hitting the SSO logout round-trip — the live WorkOS
+    // session would survive. Bail so the caller takes the full-logout path.
+    const alts = await this.resolveAlts(res, cookies)
+    const promotable = alts.some((a) => a.ok && a.user && a.user.id !== activeUser.id)
+    if (!promotable) return false
     // WorkOS may have rotated the refresh token during authenticate; pass the
     // post-refresh sealed into `remove` so `revokeSession` kills the live
     // session, not the already-dead pre-refresh value the browser sent.
-    await this.remove(res, cookies, pickSealed(auth, activeSealed), auth.user, auth.user.id)
+    await this.remove(res, cookies, pickSealed(auth, activeSealed), activeUser, activeUser.id)
     return true
   }
 }

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -206,27 +206,18 @@ export function createControlPlaneAuthHandlers({
           : frontendUrl || "/"
 
       // scope=current: revoke just the active session and promote a parked
-      // alt, keeping the user signed in as the next account. Reuses the
-      // existing remove(active) path so revoke + promote stay in one place.
-      // Falls through to full logout when there's no parked alt to promote
-      // (or the active session is no longer authenticatable).
-      if (scope === "current" && session) {
-        const auth = await authService.authenticateSession(session)
-        if (auth.success && auth.user) {
-          const alts = readAltSessionCookies(req.cookies)
-          if (alts.length > 0) {
-            // WorkOS may have rotated the refresh token during authenticate;
-            // the pre-refresh `session` is dead at WorkOS, so revoke must use
-            // the post-refresh sealed (parallels addAndParkActive).
-            const sealedToRevoke = auth.refreshed && auth.sealedSession ? auth.sealedSession : session
-            try {
-              await accountsService.remove(res, req.cookies, sealedToRevoke, auth.user, auth.user.id)
-              return res.redirect(sameAppOrigin)
-            } catch {
-              // Fall through to full logout if the promote path fails — the
-              // user still gets logged out, just everywhere at once.
-            }
+      // alt, keeping the user signed in as the next account. The service
+      // owns the auth → alt-check → revoke + promote sequence; here we just
+      // act on the outcome. A `false` return (no session, no parked alt, or
+      // auth failed) falls through to the full-logout path below.
+      if (scope === "current") {
+        try {
+          if (await accountsService.removeCurrentAndPromote(res, req.cookies, session)) {
+            return res.redirect(sameAppOrigin)
           }
+        } catch {
+          // Promote raised — full logout still gets the user out, just
+          // everywhere at once. Fall through.
         }
       }
 

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -31,6 +31,10 @@ const magicVerifySchema = z.object({
   intent: z.literal("add"),
 })
 
+const logoutQuerySchema = z.object({
+  scope: z.enum(["current"]).optional(),
+})
+
 /**
  * Validate that a forwarded host is an allowed staging subdomain.
  * Prevents open redirect via X-Forwarded-Host spoofing.
@@ -190,7 +194,8 @@ export function createControlPlaneAuthHandlers({
     async logout(req: Request, res: Response) {
       const session = req.cookies[SESSION_COOKIE_NAME]
       const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
-      const scope = typeof req.query.scope === "string" ? req.query.scope : undefined
+      const queryParse = logoutQuerySchema.safeParse(req.query)
+      const scope = queryParse.success ? queryParse.data.scope : undefined
 
       // Where we land on a same-app redirect (no WorkOS round-trip). Falls
       // back to the configured frontend origin, then "/" — same precedence the
@@ -210,8 +215,12 @@ export function createControlPlaneAuthHandlers({
         if (auth.success && auth.user) {
           const alts = readAltSessionCookies(req.cookies)
           if (alts.length > 0) {
+            // WorkOS may have rotated the refresh token during authenticate;
+            // the pre-refresh `session` is dead at WorkOS, so revoke must use
+            // the post-refresh sealed (parallels addAndParkActive).
+            const sealedToRevoke = auth.refreshed && auth.sealedSession ? auth.sealedSession : session
             try {
-              await accountsService.remove(res, req.cookies, session, auth.user, auth.user.id)
+              await accountsService.remove(res, req.cookies, sealedToRevoke, auth.user, auth.user.id)
               return res.redirect(sameAppOrigin)
             } catch {
               // Fall through to full logout if the promote path fails — the

--- a/apps/control-plane/src/features/auth/handlers.ts
+++ b/apps/control-plane/src/features/auth/handlers.ts
@@ -189,6 +189,37 @@ export function createControlPlaneAuthHandlers({
 
     async logout(req: Request, res: Response) {
       const session = req.cookies[SESSION_COOKIE_NAME]
+      const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
+      const scope = typeof req.query.scope === "string" ? req.query.scope : undefined
+
+      // Where we land on a same-app redirect (no WorkOS round-trip). Falls
+      // back to the configured frontend origin, then "/" — same precedence the
+      // full-logout path uses below.
+      const sameAppOrigin =
+        forwardedHost && isTrustedHost(forwardedHost, allowedRedirectDomain, dedicatedRedirectHosts)
+          ? `https://${forwardedHost}`
+          : frontendUrl || "/"
+
+      // scope=current: revoke just the active session and promote a parked
+      // alt, keeping the user signed in as the next account. Reuses the
+      // existing remove(active) path so revoke + promote stay in one place.
+      // Falls through to full logout when there's no parked alt to promote
+      // (or the active session is no longer authenticatable).
+      if (scope === "current" && session) {
+        const auth = await authService.authenticateSession(session)
+        if (auth.success && auth.user) {
+          const alts = readAltSessionCookies(req.cookies)
+          if (alts.length > 0) {
+            try {
+              await accountsService.remove(res, req.cookies, session, auth.user, auth.user.id)
+              return res.redirect(sameAppOrigin)
+            } catch {
+              // Fall through to full logout if the promote path fails — the
+              // user still gets logged out, just everywhere at once.
+            }
+          }
+        }
+      }
 
       clearSessionCookie(res)
 
@@ -198,8 +229,6 @@ export function createControlPlaneAuthHandlers({
       for (const { slot } of readAltSessionCookies(req.cookies)) {
         clearAltSessionCookie(res, slot)
       }
-
-      const forwardedHost = req.headers["x-forwarded-host"] as string | undefined
 
       if (session) {
         // For dedicated-redirect-host sessions, tell WorkOS to single-logout
@@ -216,10 +245,7 @@ export function createControlPlaneAuthHandlers({
       }
 
       // Fallback when there's no session or getLogoutUrl returned null.
-      if (forwardedHost && isTrustedHost(forwardedHost, allowedRedirectDomain, dedicatedRedirectHosts)) {
-        return res.redirect(`https://${forwardedHost}`)
-      }
-      res.redirect(frontendUrl || "/")
+      res.redirect(sameAppOrigin)
     },
 
     async me(req: Request, res: Response) {

--- a/apps/frontend/src/api/accounts.ts
+++ b/apps/frontend/src/api/accounts.ts
@@ -14,6 +14,12 @@ export interface AccountSummary {
   state: "active" | "parked" | "stale"
 }
 
+// Shared TanStack Query key for the accounts switcher list. Several surfaces
+// (sidebar logout pre-check, switcher dialog, logout-scope dialog) read the
+// same query — keeping the key in one place stops a cache-miss bug from
+// sneaking in when one consumer drifts.
+export const ACCOUNTS_LIST_KEY = ["accounts", "list"] as const
+
 export const accountsApi = {
   // Bare-workspace form: "which signed-in account owns this workspace?" — used
   // by the cross-account deep-link guard. 404s on ambiguity (a workspace more

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -1,5 +1,5 @@
 export { api, ApiError } from "./client"
-export { accountsApi, type AccountSummary } from "./accounts"
+export { accountsApi, ACCOUNTS_LIST_KEY, type AccountSummary } from "./accounts"
 export { workspacesApi, type WorkspaceBootstrap } from "./workspaces"
 export { streamsApi, type StreamBootstrap, type CreateStreamInput, type UpdateStreamInput } from "./streams"
 export { messagesApi, type CreateMessageInput, type UpdateMessageInput } from "./messages"

--- a/apps/frontend/src/auth/context.tsx
+++ b/apps/frontend/src/auth/context.tsx
@@ -14,7 +14,14 @@ declare global {
 
 interface AuthContextValue extends AuthState {
   login: (redirectTo?: string, opts?: { intent?: "add" }) => void
-  logout: () => void
+  /**
+   * Log out of one or all accounts on this browser. `scope: "current"` revokes
+   * just the active session and promotes a parked alt (the user stays signed
+   * in to the next account). Default `"all"` empties the local cookie jar of
+   * every signed-in account on this browser (parked WorkOS sessions stay
+   * intact server-side — explicit revoke is the `/api/accounts/remove` path).
+   */
+  logout: (opts?: { scope?: "current" | "all" }) => void
   refetch: () => Promise<void>
 }
 
@@ -179,7 +186,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     window.location.href = `${API_BASE}/api/auth/login${qs ? `?${qs}` : ""}`
   }, [])
 
-  const logout = useCallback(async () => {
+  const logout = useCallback(async (opts?: { scope?: "current" | "all" }) => {
+    const scope = opts?.scope ?? "all"
     // Clean up push subscriptions on logout:
     // 1. Tell backend to remove all records for this browser's endpoint (cross-workspace)
     // 2. Unsubscribe from the browser push service to prevent post-logout notifications
@@ -188,6 +196,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // never rejects, so a worker stranded in "installing" (common with the dev
     // injectManifest module SW) would hang this step — and the redirect below —
     // forever. Cap the whole best-effort block so logout always proceeds.
+    //
+    // The push subscription is a per-browser endpoint shared across accounts,
+    // so cleaning it up belongs to both scopes — we don't want post-logout
+    // notifications for an account the user just signed out of either way.
     const pushCleanup = (async () => {
       const registration = await navigator.serviceWorker?.ready
       const subscription = await registration?.pushManager.getSubscription()
@@ -207,8 +219,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
     ]).catch(() => {})
     clearCachedUser()
     clearLastWorkspaceId()
+    // `clearAllCachedData` uses the active-account `db` proxy, so it drops
+    // exactly the current account's IDB. Promoted-account IDB (a separate
+    // named handle) is untouched, which is what scope=current wants.
     await clearAllCachedData().catch(() => {})
-    window.location.href = `${API_BASE}/api/auth/logout`
+    window.location.href =
+      scope === "current" ? `${API_BASE}/api/auth/logout?scope=current` : `${API_BASE}/api/auth/logout`
   }, [])
 
   const value: AuthContextValue = {

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.test.tsx
@@ -76,7 +76,7 @@ describe("AccountSwitcherDialog", () => {
     expect(screen.getByText("Ben Parked")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Remove Ben Parked" })).toBeInTheDocument()
     expect(screen.getByText("Signed-out account")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Sign in again" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Add an account" })).toBeInTheDocument()
   })
 
   it("flips a parked account in place via switchAccount (no navigation)", async () => {

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { Check, LogIn, Trash2, UserPlus } from "lucide-react"
+import { Check, Trash2, UserPlus } from "lucide-react"
 import { toast } from "sonner"
 import { ACCOUNTS_LIST_KEY, accountsApi, type AccountSummary } from "@/api"
 import { useAccountScope, useAuth } from "@/auth"
@@ -40,8 +40,8 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
           <p className="truncate text-xs text-muted-foreground">Session expired — sign in again</p>
         </div>
         <Button variant="ghost" size="sm" onClick={onReauth}>
-          <LogIn className="mr-1.5 h-4 w-4" />
-          Sign in again
+          <UserPlus className="mr-1.5 h-4 w-4" />
+          Add an account
         </Button>
         <Button
           variant="ghost"
@@ -77,7 +77,7 @@ function AccountRow({ account, onSwitch, onRemove, onReauth }: AccountRowProps) 
       <button
         type="button"
         onClick={() => onSwitch(account.id)}
-        className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/60"
+        className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left ring-offset-background transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       >
         <Avatar className="h-9 w-9">
           <AvatarFallback>{initials}</AvatarFallback>

--- a/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/account-switcher-dialog.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Check, LogIn, Trash2, UserPlus } from "lucide-react"
 import { toast } from "sonner"
-import { accountsApi, type AccountSummary } from "@/api"
+import { ACCOUNTS_LIST_KEY, accountsApi, type AccountSummary } from "@/api"
 import { useAccountScope, useAuth } from "@/auth"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
@@ -19,7 +19,6 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { getInitials } from "@/lib/initials"
 
-const ACCOUNTS_LIST_KEY = ["accounts", "list"]
 const SEARCH_PARAM = "account-switcher"
 
 interface AccountRowProps {

--- a/apps/frontend/src/components/account-switcher/index.ts
+++ b/apps/frontend/src/components/account-switcher/index.ts
@@ -1,1 +1,2 @@
 export { AccountSwitcherDialog } from "./account-switcher-dialog"
+export { LogoutScopeDialog } from "./logout-scope-dialog"

--- a/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import { LogOut, Users } from "lucide-react"
+import { accountsApi } from "@/api"
+import { useAuth } from "@/auth"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+
+const ACCOUNTS_LIST_KEY = ["accounts", "list"]
+const SEARCH_PARAM = "logout-confirm"
+
+/**
+ * Confirm dialog shown when the user clicks "Log out" with more than one
+ * account signed in on this browser. Lets them pick between signing out of
+ * just the active account (the parked alt is promoted in its place, no full
+ * logout) or every account on this browser (the existing scope=all behavior).
+ *
+ * Mounted globally alongside `AccountSwitcherDialog`. Opens via the
+ * `?logout-confirm` search param so the sidebar menu can defer the decision
+ * to the dialog without owning any state itself.
+ */
+export function LogoutScopeDialog() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [mounted, setMounted] = useState(false)
+  const isOpen = searchParams.get(SEARCH_PARAM) !== null
+  const { logout, user } = useAuth()
+
+  // Mirror AccountSwitcherDialog: defer until after hydration so the
+  // ResponsiveDialog doesn't briefly mount on the server-shaped tree.
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const { data, isLoading } = useQuery({
+    queryKey: ACCOUNTS_LIST_KEY,
+    queryFn: () => accountsApi.list(),
+    enabled: isOpen,
+  })
+
+  if (!mounted) return null
+
+  const close = () => {
+    const next = new URLSearchParams(searchParams)
+    next.delete(SEARCH_PARAM)
+    setSearchParams(next, { replace: true })
+  }
+
+  const liveAccounts = data?.accounts.filter((a) => a.state !== "stale") ?? []
+  const otherCount = Math.max(0, liveAccounts.length - 1)
+  const activeLabel = user?.email || user?.name || "this account"
+
+  return (
+    <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && close()}>
+      <ResponsiveDialogContent desktopClassName="sm:max-w-md p-0 gap-0" drawerClassName="flex flex-col gap-0">
+        <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
+          <ResponsiveDialogTitle>Log out</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            You&apos;re signed in to more than one account on this browser. What would you like to do?
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <ResponsiveDialogBody className="flex flex-col gap-2 px-4 py-4 sm:px-6">
+          {isLoading ? (
+            <>
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => logout({ scope: "current" })}
+                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/60"
+              >
+                <LogOut className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-foreground">Sign out of {activeLabel}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {otherCount > 0
+                      ? `You'll stay signed in to the other ${otherCount === 1 ? "account" : `${otherCount} accounts`} on this browser.`
+                      : "You'll stay signed in to your other account on this browser."}
+                  </p>
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => logout({ scope: "all" })}
+                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/60"
+              >
+                <Users className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-foreground">Sign out of all accounts</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    Empties the cookie jar for every signed-in account on this browser.
+                  </p>
+                </div>
+              </button>
+
+              <Button variant="ghost" className="mt-1 w-full" onClick={close}>
+                Cancel
+              </Button>
+            </>
+          )}
+        </ResponsiveDialogBody>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { LogOut, Users } from "lucide-react"
-import { accountsApi } from "@/api"
+import { ACCOUNTS_LIST_KEY, accountsApi } from "@/api"
 import { useAuth } from "@/auth"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -15,8 +15,10 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 
-const ACCOUNTS_LIST_KEY = ["accounts", "list"]
-const SEARCH_PARAM = "logout-confirm"
+// Search-param sentinel that opens the dialog. Exported so the sidebar (and
+// any other "log out" surface) sets the same key — drifting strings would
+// silently leave the confirm dialog closed and skip the multi-account check.
+export const LOGOUT_CONFIRM_PARAM = "logout-confirm"
 
 /**
  * Confirm dialog shown when the user clicks "Log out" with more than one
@@ -31,7 +33,7 @@ const SEARCH_PARAM = "logout-confirm"
 export function LogoutScopeDialog() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [mounted, setMounted] = useState(false)
-  const isOpen = searchParams.get(SEARCH_PARAM) !== null
+  const isOpen = searchParams.get(LOGOUT_CONFIRM_PARAM) !== null
   const { logout, user } = useAuth()
 
   // Mirror AccountSwitcherDialog: defer until after hydration so the
@@ -50,7 +52,7 @@ export function LogoutScopeDialog() {
 
   const close = () => {
     const next = new URLSearchParams(searchParams)
-    next.delete(SEARCH_PARAM)
+    next.delete(LOGOUT_CONFIRM_PARAM)
     setSearchParams(next, { replace: true })
   }
 

--- a/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
+++ b/apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx
@@ -58,7 +58,10 @@ export function LogoutScopeDialog() {
 
   const liveAccounts = data?.accounts.filter((a) => a.state !== "stale") ?? []
   const otherCount = Math.max(0, liveAccounts.length - 1)
-  const activeLabel = user?.email || user?.name || "this account"
+  // Name first then email mirrors AccountRow (name as title, email as
+  // subtitle). Showing an email as the primary label is identifying but
+  // less friendly, and long emails overflow narrow drawers.
+  const activeLabel = user?.name || user?.email || "this account"
 
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={(open) => !open && close()}>
@@ -81,11 +84,11 @@ export function LogoutScopeDialog() {
               <button
                 type="button"
                 onClick={() => logout({ scope: "current" })}
-                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/60"
+                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left ring-offset-background transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 <LogOut className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-foreground">Sign out of {activeLabel}</p>
+                  <p className="truncate text-sm font-medium text-foreground">Sign out of {activeLabel}</p>
                   <p className="mt-0.5 text-xs text-muted-foreground">
                     {otherCount > 0
                       ? `You'll stay signed in to the other ${otherCount === 1 ? "account" : `${otherCount} accounts`} on this browser.`
@@ -97,14 +100,12 @@ export function LogoutScopeDialog() {
               <button
                 type="button"
                 onClick={() => logout({ scope: "all" })}
-                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/60"
+                className="flex w-full items-start gap-3 rounded-lg border bg-card px-4 py-3 text-left ring-offset-background transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 <Users className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium text-foreground">Sign out of all accounts</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Empties the cookie jar for every signed-in account on this browser.
-                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">Signs out of every account on this browser.</p>
                 </div>
               </button>
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react"
 import { describe, expect, it, beforeEach, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, userEvent, spyOnExport } from "@/test"
 import { SidebarFooter } from "./sidebar-footer"
 import * as authModule from "@/auth"
@@ -14,7 +15,12 @@ const collapseOnMobile = vi.fn()
 const isMobile = { value: true }
 
 function renderWithRouter(ui: React.ReactElement) {
-  return render(<MemoryRouter>{ui}</MemoryRouter>)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  )
 }
 
 describe("SidebarFooter", () => {

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, useCallback, useMemo, useState, type ComponentPropsWithoutRef } from "react"
 import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon, Users } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
+import { useQueryClient } from "@tanstack/react-query"
+import { accountsApi } from "@/api"
 import { useAuth } from "@/auth"
 import { useSettings, useSidebar } from "@/contexts"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -72,6 +74,7 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
   const { collapseOnMobile } = useSidebar()
   const isMobile = useIsMobile()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const queryClient = useQueryClient()
 
   const handleOpenSettings = useCallback(
     (tab: "profile" | "appearance") => {
@@ -104,6 +107,37 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
       { replace: true }
     )
   }, [collapseOnMobile, setSearchParams])
+
+  // Single-account: full logout is unambiguous. Multi-account: defer to the
+  // confirm dialog so the user picks current-only vs all. The accounts query
+  // is the same one the switcher uses, so a cached value usually answers
+  // instantly; a cold call still costs one request before the menu reacts.
+  // Network failure falls back to the all-accounts path — refusing to log out
+  // because we couldn't count accounts is the worse failure mode.
+  const handleLogout = useCallback(async () => {
+    try {
+      const data = await queryClient.fetchQuery({
+        queryKey: ["accounts", "list"],
+        queryFn: () => accountsApi.list(),
+        staleTime: 10_000,
+      })
+      const liveCount = data.accounts.filter((a) => a.state !== "stale").length
+      if (liveCount > 1) {
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev)
+            next.set("logout-confirm", "")
+            return next
+          },
+          { replace: true }
+        )
+        return
+      }
+    } catch {
+      // Fall through to all-accounts logout.
+    }
+    logout()
+  }, [queryClient, setSearchParams, logout])
 
   const avatarSrc = currentUser ? getAvatarUrl(workspaceId, currentUser.avatarUrl, 64) : null
   const menuActions = useMemo<SidebarActionItem[]>(
@@ -145,10 +179,10 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
         id: "logout",
         label: "Log out",
         icon: LogOut,
-        onSelect: () => logout(),
+        onSelect: handleLogout,
       },
     ],
-    [handleOpenSettings, openWorkspaceSettings, openAccountSwitcher, collapseOnMobile, logout, workspaceId]
+    [handleOpenSettings, openWorkspaceSettings, openAccountSwitcher, collapseOnMobile, handleLogout, workspaceId]
   )
 
   if (!currentUser) return null

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useMemo, useState, type ComponentPropsWithoutRef } from "react"
-import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon, Users } from "lucide-react"
+import { ArrowLeftRight, ChevronUp, DollarSign, LogOut, Settings, User as UserIcon } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
 import { useQueryClient } from "@tanstack/react-query"
 import { ACCOUNTS_LIST_KEY, accountsApi } from "@/api"
@@ -172,7 +172,7 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
       {
         id: "switch-account",
         label: "Switch account",
-        icon: Users,
+        icon: ArrowLeftRight,
         onSelect: openAccountSwitcher,
         separatorBefore: true,
       },

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -2,8 +2,9 @@ import { forwardRef, useCallback, useMemo, useState, type ComponentPropsWithoutR
 import { ChevronUp, DollarSign, LogOut, Settings, User as UserIcon, Users } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
 import { useQueryClient } from "@tanstack/react-query"
-import { accountsApi } from "@/api"
+import { ACCOUNTS_LIST_KEY, accountsApi } from "@/api"
 import { useAuth } from "@/auth"
+import { LOGOUT_CONFIRM_PARAM } from "@/components/account-switcher/logout-scope-dialog"
 import { useSettings, useSidebar } from "@/contexts"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -117,7 +118,7 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
   const handleLogout = useCallback(async () => {
     try {
       const data = await queryClient.fetchQuery({
-        queryKey: ["accounts", "list"],
+        queryKey: ACCOUNTS_LIST_KEY,
         queryFn: () => accountsApi.list(),
         staleTime: 10_000,
       })
@@ -126,7 +127,7 @@ export function SidebarFooter({ workspaceId, currentUser }: SidebarFooterProps) 
         setSearchParams(
           (prev) => {
             const next = new URLSearchParams(prev)
-            next.set("logout-confirm", "")
+            next.set(LOGOUT_CONFIRM_PARAM, "")
             return next
           },
           { replace: true }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -60,7 +60,7 @@ import { messagesApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { SettingsDialog } from "@/components/settings"
 import { WorkspaceSettingsDialog } from "@/components/workspace-settings/workspace-settings-dialog"
-import { AccountSwitcherDialog } from "@/components/account-switcher"
+import { AccountSwitcherDialog, LogoutScopeDialog } from "@/components/account-switcher"
 import { StreamSettingsDialog } from "@/components/stream-settings/stream-settings-dialog"
 import { CreateChannelDialog } from "@/components/create-channel"
 import { AttachmentExplorer, useExplorerUrlState } from "@/components/attachment-explorer"
@@ -390,6 +390,7 @@ export function WorkspaceLayout() {
                                     <SettingsDialog />
                                     <WorkspaceSettingsDialog workspaceId={workspaceId} />
                                     <AccountSwitcherDialog />
+                                    <LogoutScopeDialog />
                                     <StreamSettingsDialog workspaceId={workspaceId} />
                                     <CreateChannelDialog workspaceId={workspaceId} />
                                     <AttachmentExplorer workspaceId={workspaceId} />

--- a/packages/backend-common/src/auth/auth-service.ts
+++ b/packages/backend-common/src/auth/auth-service.ts
@@ -27,6 +27,21 @@ export interface AuthResult {
   reason?: string
 }
 
+/**
+ * Pick the sealed session value to commit/use after `authenticateSession`.
+ *
+ * WorkOS rotates the refresh token transparently when the access token has
+ * expired and returns the rotated sealed in `result.sealedSession` together
+ * with `refreshed: true`. The pre-refresh `original` value is revoked at
+ * WorkOS the moment rotation runs, so any caller that wants to keep the
+ * session alive (write the cookie, re-park, revoke) MUST use the rotated
+ * value when one was issued. Centralized here so middleware, the accounts
+ * service, and any future caller share one source of truth.
+ */
+export function pickSealed(result: AuthResult, original: string): string {
+  return result.refreshed && result.sealedSession ? result.sealedSession : original
+}
+
 export interface AuthService {
   authenticateSession(sealedSession: string): Promise<AuthResult>
   authenticateWithCode(code: string): Promise<AuthResult>

--- a/packages/backend-common/src/auth/middleware.ts
+++ b/packages/backend-common/src/auth/middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express"
 import type { AuthService } from "./auth-service"
+import { pickSealed } from "./auth-service"
 import { SESSION_COOKIE_NAME, clearSessionCookie, setSessionCookie } from "../cookies"
 
 interface AuthenticatedUser {
@@ -59,7 +60,7 @@ export function createAuthMiddleware({ authService }: Dependencies) {
 
     req.workosUserId = result.user.id
     req.authUser = result.user
-    req.sealedSession = result.refreshed && result.sealedSession ? result.sealedSession : session
+    req.sealedSession = pickSealed(result, session)
     next()
   }
 }

--- a/packages/backend-common/src/auth/middleware.ts
+++ b/packages/backend-common/src/auth/middleware.ts
@@ -22,6 +22,14 @@ declare global {
       workosUserId?: string
       /** Full WorkOS identity from authenticated session */
       authUser?: AuthenticatedUser
+      /**
+       * Latest valid sealed session for the active account. Equals the rotated
+       * sealed when this request triggered a refresh, otherwise the original
+       * cookie value. Handlers that re-park or re-set the active cookie MUST
+       * read this — `req.cookies[SESSION_COOKIE_NAME]` is the pre-refresh
+       * value, which WorkOS has already revoked after refresh-token rotation.
+       */
+      sealedSession?: string
     }
   }
 }
@@ -51,6 +59,7 @@ export function createAuthMiddleware({ authService }: Dependencies) {
 
     req.workosUserId = result.user.id
     req.authUser = result.user
+    req.sealedSession = result.refreshed && result.sealedSession ? result.sealedSession : session
     next()
   }
 }

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -1,5 +1,5 @@
 // Auth
-export { WorkosAuthService } from "./auth/auth-service"
+export { WorkosAuthService, pickSealed } from "./auth/auth-service"
 export type { AuthResult, AuthService } from "./auth/auth-service"
 export { StubAuthService } from "./auth/auth-service.stub"
 export type { DevLoginResult } from "./auth/auth-service.stub"


### PR DESCRIPTION
## Summary

Switching back to a parked account 401'd, and logging out always took every signed-in account on the browser with it. Two related fixes:

### 1. The switcher bug: `resolveAlts` discarded WorkOS-rotated sealed sessions

WorkOS access tokens are short-lived. `authService.authenticateSession()` transparently calls `session.refresh()` when the access token expires and returns `{ refreshed: true, sealedSession: <rotated> }` — at which point the pre-refresh sealed value is **revoked** at WorkOS. The control-plane `resolveAlts` ignored this and kept handing the dead pre-refresh sealed back to callers. So:

- `switch` promoted the dead sealed to the active cookie — the next `/api/auth/me` 401'd, browser saw "no session" and looked logged out.
- `list` left dead sealeds in the alt cookies — parked sessions died silently the moment the switcher view triggered a refresh.
- `addAndParkActive` parked the dead pre-refresh sealed of the previous active mid-OAuth-callback.

Fix: `resolveAlts` now writes the rotated sealed back to the alt cookie via `setAltSessionCookie` and returns it; the callers use the returned (post-refresh) sealed instead of the cookie the browser sent. `addAndParkActive` does the same for the previous-active sealed. `createAuthMiddleware` stamps `req.sealedSession` with the post-refresh value so the switch/remove handlers re-park the live token.

The e2e suite missed this because `StubAuthService.authenticateSession` always returns `refreshed: false`. Added focused unit tests with a `ProgrammableAuthService` that can return `refreshed: true` — three tests lock in the refreshed-sealed propagation through `switch`, `list`, and `addAndParkActive`.

### 2. Logout scope choice for multi-account browsers

When more than one account is signed in, clicking "Log out" now opens a confirm dialog with two options:

- **Sign out of \<active email\>** — revokes just the active WorkOS session and promotes a parked alt (the user stays signed in to the next account).
- **Sign out of all accounts** — the existing scope=all behavior.

Mechanics:
- Sidebar's logout action fetches `accountsApi.list()` (cached, reused by the switcher); if `liveCount > 1` it opens the dialog via a `?logout-confirm` search param, otherwise it calls `logout()` directly. Cold-call failure falls through to all-accounts so the user is never trapped.
- New `LogoutScopeDialog` mounted globally alongside `AccountSwitcherDialog`. `useAuth().logout` now takes `{ scope?: "current" | "all" }` and hits `/api/auth/logout?scope=current` or the default endpoint.
- Backend `logout` handler intercepts `scope=current`: re-uses `accountsService.remove(activeUser.id)` (which revokes the active session and promotes the lowest parked alt), then redirects to the same-app origin. Falls through to the full-logout path if there's no parked alt or the promote step throws.

## Files

- `packages/backend-common/src/auth/middleware.ts` — adds `req.sealedSession` with the post-refresh value
- `apps/control-plane/src/features/accounts/service.ts` — `resolveAlts` writes/returns rotated sealed; `addAndParkActive` parks rotated previous-active
- `apps/control-plane/src/features/accounts/handlers.ts` — switch/remove read `req.sealedSession`; list/resolve pass `res` through
- `apps/control-plane/src/features/auth/handlers.ts` — `scope=current` branch
- `apps/control-plane/src/features/accounts/service.test.ts` — new unit tests with refresh-aware stub
- `apps/frontend/src/auth/context.tsx` — `logout({ scope })` signature
- `apps/frontend/src/components/account-switcher/logout-scope-dialog.tsx` — new dialog
- `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` — fetch-count + branch
- `apps/frontend/src/pages/workspace-layout.tsx` — mount `LogoutScopeDialog`

## Test plan

- [x] `bun test apps/control-plane/src/features/accounts/service.test.ts` — 3 pass (new refresh-propagation cases)
- [x] `bun run --cwd apps/backend test:unit` — 1423 pass, 0 fail
- [x] `bun run --cwd apps/frontend test` — 1824 pass, 0 fail
- [x] `bun run --cwd packages/backend-common typecheck`
- [x] `bun run --cwd apps/control-plane typecheck`
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run --cwd apps/frontend typecheck`
- [ ] Manual: sign in to account A, add account B, switch back to A — A stays signed in (was 401'ing before).
- [ ] Manual: signed in to A and B, click "Log out" — dialog appears; "Sign out of A" lands you signed in as B; "Sign out of all accounts" empties the jar.
- [ ] Manual: signed in to A only, click "Log out" — no dialog, direct full logout.
- [ ] Backend e2e (`apps/control-plane/tests/e2e/accounts.test.ts`) — needs Postgres on :5454, not available in remote env; re-run locally before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vVdzv2dAEVK9hUHce6HcQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421126&installation_id=129946197&pr_number=633&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F633&signature=e0f5960dbf4aa79b9124b02f21197ab39f9db9f4d93607150f5602b6b4daa3d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->