### PR TITLE
fix: reconnect remote control after reload

### DIFF
--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -1828,7 +1828,7 @@ export default function (pi: ExtensionAPI): void {
     },
   })
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
     config = readConfig()
     if (!config) return
     if (!isEnabled(ctx)) {
@@ -1838,6 +1838,7 @@ export default function (pi: ExtensionAPI): void {
     lastBusyHeartbeatAt = 0
     await heartbeat("available", undefined, ctx)
     startPolling(pi, ctx)
+    if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")
   })
 
   pi.on("agent_start", async (_event, ctx) => {
@@ -1924,8 +1925,12 @@ export default function (pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("session_shutdown", async (_event, ctx) => {
+  pi.on("session_shutdown", async (event, ctx) => {
     stopPolling()
+    if (event.reason === "reload" && config && isEnabled(ctx)) {
+      setRemoteStatus(ctx, "Threa remote: reloading…")
+      return
+    }
     await failPending("Pi session shut down", ctx)
     await heartbeat("offline", undefined, ctx).catch(() => undefined)
     ctx.ui.setStatus(STATUS_KEY, undefined)


### PR DESCRIPTION
## Problem

Running Pi `/reload` disconnects the Threa remote-control extension even when the current Pi session was linked/enabled before reload. The old extension instance handles `session_shutdown` by marking the runtime offline, and the user has to reconnect manually.

## Solution

Treat reload shutdowns as a transient extension-runtime restart when the current session is already enabled:

- stop the old polling timer
- keep the Threa runtime presence/link alive instead of heartbeating `offline`
- show a temporary `Threa remote: reloading…` status
- on `session_start` with `reason === "reload"`, heartbeat `available`, restart polling, and notify that remote control reconnected

Normal shutdown/session switch behavior is unchanged and still marks the runtime offline.

## Self-review

- Accepted: reload is documented to emit `session_shutdown` followed by `session_start(reason: "reload")`, so preserving presence during that narrow path is appropriate.
- Accepted: the change is gated on `config && isEnabled(ctx)`, so disabled/unlinked sessions do not get auto-reconnected.
- Accepted: non-reload shutdown still fails pending work and marks presence offline.
- Caveat: if Pi crashes mid-reload before `session_start`, presence may remain available until the backend considers it stale. That is preferable to a guaranteed disconnect on every successful reload.

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts`
- [x] `bun --check docs/examples/pi-remote/threa-remote-v2.ts`
- [ ] Manual smoke: copy extension locally, `/reload`, confirm status says reconnected and remote polling continues

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421486&installation_id=129946197&pr_number=634&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F634&signature=3716d58b2c0170c555626ff42e46aaf937a23d7d7b3bf952afa56e0c131cb345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->