### PR TITLE
feat(pi-remote): adopt /bot WebSocket with HTTP-poll backstop (Phase 2)

### DIFF
--- a/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
+++ b/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
@@ -221,8 +221,11 @@ describe("bot-runtime /bot WebSocket transport (e2e)", () => {
       first.disconnect()
     }
 
-    // Socket is closed. Dispatch a command — push has nowhere to land,
-    // so the only way the next connection learns about it is the hello replay.
+    // Dispatch after the captured cursor. `first.disconnect()` is best-effort
+    // (the server-side close may not have landed yet), but the assertion below
+    // depends only on cursor monotonicity: the dispatched invocation's
+    // created_at > cursor, so the replay on `second` must surface it
+    // regardless of whether `first` was fully torn down before dispatch.
     const dispatched = await dispatchCommand(client, workspace.id, linked.streamId, "/thinking high")
     expect(dispatched.success).toBe(true)
 

--- a/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
+++ b/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
@@ -104,7 +104,7 @@ interface HelloAck {
   error?: string
   serverGeneratedAt?: string
   availableInvocations?: Array<{ id: string; requiredCapability?: string }>
-  ownedClaims?: Array<{ id: string }>
+  ownedClaims?: Array<{ id: string; requiredCapability?: string }>
 }
 
 function sendHello(
@@ -125,6 +125,20 @@ function sendHello(
           BotInvocationCapabilities.MENTIONABLE,
           BotInvocationCapabilities.SESSION_CONTROL,
         ],
+        // Mirror what the real Pi runtime (`buildBotHelloPayload`) sends. The
+        // hello handler unconditionally re-upserts presence, so without these
+        // fields the prior `/bot-runtime/presence` capability advertisement
+        // (sessionControlCommands etc.) gets wiped and `/thinking` disappears
+        // from the command surface — making `dispatchCommand` fail with
+        // "Unknown command: thinking".
+        capabilities: {
+          runtimeSessionId: params.runtimeSessionId,
+          supportsActiveScratchpad: true,
+          supportsPersistentSessions: true,
+          supportsSessionControlCommands: true,
+          sessionControlCommands: ["compact", "model", "thinking", "skill", "reload"],
+          thinkingLevels: ["off", "minimal", "low", "medium", "high"],
+        },
         ...(params.sinceCursor ? { sinceCursor: params.sinceCursor } : {}),
       },
       (ack: HelloAck) => {
@@ -212,8 +226,9 @@ describe("bot-runtime /bot WebSocket transport (e2e)", () => {
     const dispatched = await dispatchCommand(client, workspace.id, linked.streamId, "/thinking high")
     expect(dispatched.success).toBe(true)
 
-    // Reconnect with the captured cursor. Replay must surface the invocation
-    // in availableInvocations (or ownedClaims if it got claimed in between).
+    // Reconnect with the captured cursor. The dispatched invocation must
+    // surface in availableInvocations (nothing else holds a claim, so
+    // ownedClaims is the wrong bucket — assert on the specific one).
     const second = openBotSocket(linked.apiKey)
     try {
       await connect(second)
@@ -223,8 +238,13 @@ describe("bot-runtime /bot WebSocket transport (e2e)", () => {
         sinceCursor: cursor,
       })
       expect(ack.ok).toBe(true)
-      const surfaced = (ack.availableInvocations?.length ?? 0) > 0 || (ack.ownedClaims?.length ?? 0) > 0
-      expect(surfaced).toBe(true)
+      const replayed = ack.availableInvocations ?? []
+      const sessionControl = replayed.filter(
+        (inv) => inv.requiredCapability === BotInvocationCapabilities.SESSION_CONTROL
+      )
+      expect(sessionControl.length).toBe(1)
+      expect(typeof sessionControl[0].id).toBe("string")
+      expect(sessionControl[0].id.length).toBeGreaterThan(0)
     } finally {
       second.removeAllListeners()
       second.disconnect()

--- a/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
+++ b/apps/backend/tests/e2e/bot-runtime-websocket.test.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E test for the bot-runtime `/bot` Socket.IO namespace.
+ *
+ * Boots a real Socket.IO connection against the running backend, exercises the
+ * hello handshake, asserts a live push lands on the wire, and verifies that
+ * reconnecting with a `sinceCursor` replays invocations that were dispatched
+ * while the socket was down. This is the transport-level coverage the
+ * unit-level handler tests can't give us — they all mock the namespace.
+ */
+
+import { describe, test, expect, setDefaultTimeout } from "bun:test"
+import { BotInvocationCapabilities, BotTraits, WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { io, type Socket } from "socket.io-client"
+import { TestClient, loginAs, createWorkspace, createBot, createBotKey, botApiPost, dispatchCommand } from "../client"
+
+setDefaultTimeout(60_000)
+
+const testRunId = Math.random().toString(36).substring(7)
+const testEmail = (name: string) => `${name}-${testRunId}@test.com`
+
+function getBaseUrl(): string {
+  return process.env.TEST_BASE_URL || "http://localhost:3001"
+}
+
+interface LinkedPi {
+  apiKey: string
+  streamId: string
+  instanceId: string
+  runtimeSessionId: string
+}
+
+async function createLinkedPi(client: TestClient, workspaceId: string, suffix: string): Promise<LinkedPi> {
+  const bot = await createBot(client, workspaceId, {
+    type: "personal",
+    name: `Pi ${suffix}`,
+    slug: `pi-${suffix}`,
+    traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+  })
+  const apiKey = await createBotKey(client, workspaceId, bot.id, [
+    WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+    WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+  ])
+  const instanceId = `inst-${suffix}`
+  const runtimeSessionId = `sess-${suffix}`
+
+  const session = await botApiPost<{
+    data: { activeStreamId: string; runtimeSessionId: string }
+  }>(client, workspaceId, "/bot-runtime/sessions", apiKey, {
+    runtimeKind: "pi-local",
+    instanceId,
+    runtimeSessionId,
+    displayName: `Pi ${suffix}`,
+    localCwd: "/tmp/threa-test",
+  })
+  if (session.status !== 200) throw new Error(`Session create failed: ${JSON.stringify(session.data)}`)
+
+  const presence = await botApiPost(client, workspaceId, "/bot-runtime/presence", apiKey, {
+    runtimeKind: "pi-local",
+    instanceId,
+    runtimeSessionId,
+    displayName: `Pi ${suffix}`,
+    status: "available",
+    acceptingInvocations: true,
+    capabilities: {
+      runtimeSessionId,
+      supportsActiveScratchpad: true,
+      supportsPersistentSessions: true,
+      supportsSessionControlCommands: true,
+      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload"],
+      thinkingLevels: ["off", "minimal", "low", "medium", "high"],
+    },
+  })
+  if (presence.status !== 200) throw new Error(`Presence failed: ${JSON.stringify(presence.data)}`)
+
+  return { apiKey, streamId: session.data.data.activeStreamId, instanceId, runtimeSessionId }
+}
+
+function openBotSocket(apiKey: string): Socket {
+  return io(`${getBaseUrl()}/bot`, {
+    auth: { token: apiKey },
+    transports: ["websocket"],
+    autoConnect: false,
+    reconnection: false,
+  })
+}
+
+function connect(socket: Socket, timeoutMs = 5_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("connect timeout")), timeoutMs)
+    socket.once("connect", () => {
+      clearTimeout(t)
+      resolve()
+    })
+    socket.once("connect_error", (err) => {
+      clearTimeout(t)
+      reject(err)
+    })
+    socket.connect()
+  })
+}
+
+interface HelloAck {
+  ok: boolean
+  error?: string
+  serverGeneratedAt?: string
+  availableInvocations?: Array<{ id: string; requiredCapability?: string }>
+  ownedClaims?: Array<{ id: string }>
+}
+
+function sendHello(
+  socket: Socket,
+  params: { instanceId: string; runtimeSessionId: string; sinceCursor?: string },
+  timeoutMs = 10_000
+): Promise<HelloAck> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("hello ack timeout")), timeoutMs)
+    socket.emit(
+      "bot:hello",
+      {
+        instanceId: params.instanceId,
+        runtimeKind: "pi-local",
+        runtimeSessionId: params.runtimeSessionId,
+        supportedCapabilities: [
+          BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
+          BotInvocationCapabilities.MENTIONABLE,
+          BotInvocationCapabilities.SESSION_CONTROL,
+        ],
+        ...(params.sinceCursor ? { sinceCursor: params.sinceCursor } : {}),
+      },
+      (ack: HelloAck) => {
+        clearTimeout(t)
+        if (!ack) reject(new Error("missing ack"))
+        else resolve(ack)
+      }
+    )
+  })
+}
+
+interface AvailablePayload {
+  invocationId: string
+  targetRuntimeSessionId: string | null
+  createdAt: string
+}
+
+function waitForAvailable(socket: Socket, runtimeSessionId: string, timeoutMs = 15_000): Promise<AvailablePayload> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => {
+      socket.off("bot_invocation:available", handler)
+      reject(new Error("bot_invocation:available timeout"))
+    }, timeoutMs)
+    const handler = (payload: AvailablePayload) => {
+      if (payload?.targetRuntimeSessionId === runtimeSessionId) {
+        clearTimeout(t)
+        socket.off("bot_invocation:available", handler)
+        resolve(payload)
+      }
+    }
+    socket.on("bot_invocation:available", handler)
+  })
+}
+
+describe("bot-runtime /bot WebSocket transport (e2e)", () => {
+  test("hello → live push: dispatch after hello surfaces via bot_invocation:available", async () => {
+    const client = new TestClient()
+    await loginAs(client, testEmail("ws-push"), "WS Push User")
+    const workspace = await createWorkspace(client, `WS Push WS ${testRunId}`)
+    const linked = await createLinkedPi(client, workspace.id, `push-${testRunId}`)
+
+    const socket = openBotSocket(linked.apiKey)
+    try {
+      await connect(socket)
+      const ack = await sendHello(socket, { instanceId: linked.instanceId, runtimeSessionId: linked.runtimeSessionId })
+      expect(ack.ok).toBe(true)
+      expect(typeof ack.serverGeneratedAt).toBe("string")
+
+      const pushPromise = waitForAvailable(socket, linked.runtimeSessionId)
+      const dispatched = await dispatchCommand(client, workspace.id, linked.streamId, "/thinking high")
+      expect(dispatched.success).toBe(true)
+
+      const push = await pushPromise
+      expect(push.targetRuntimeSessionId).toBe(linked.runtimeSessionId)
+      expect(typeof push.invocationId).toBe("string")
+      expect(push.invocationId.length).toBeGreaterThan(0)
+    } finally {
+      socket.removeAllListeners()
+      socket.disconnect()
+    }
+  })
+
+  test("reconnect with sinceCursor replays invocations dispatched while the socket was down", async () => {
+    const client = new TestClient()
+    await loginAs(client, testEmail("ws-replay"), "WS Replay User")
+    const workspace = await createWorkspace(client, `WS Replay WS ${testRunId}`)
+    const linked = await createLinkedPi(client, workspace.id, `replay-${testRunId}`)
+
+    // First connection: hello, capture cursor, disconnect.
+    const first = openBotSocket(linked.apiKey)
+    let cursor: string
+    try {
+      await connect(first)
+      const ack = await sendHello(first, { instanceId: linked.instanceId, runtimeSessionId: linked.runtimeSessionId })
+      expect(ack.ok).toBe(true)
+      expect(typeof ack.serverGeneratedAt).toBe("string")
+      cursor = ack.serverGeneratedAt!
+    } finally {
+      first.removeAllListeners()
+      first.disconnect()
+    }
+
+    // Socket is closed. Dispatch a command — push has nowhere to land,
+    // so the only way the next connection learns about it is the hello replay.
+    const dispatched = await dispatchCommand(client, workspace.id, linked.streamId, "/thinking high")
+    expect(dispatched.success).toBe(true)
+
+    // Reconnect with the captured cursor. Replay must surface the invocation
+    // in availableInvocations (or ownedClaims if it got claimed in between).
+    const second = openBotSocket(linked.apiKey)
+    try {
+      await connect(second)
+      const ack = await sendHello(second, {
+        instanceId: linked.instanceId,
+        runtimeSessionId: linked.runtimeSessionId,
+        sinceCursor: cursor,
+      })
+      expect(ack.ok).toBe(true)
+      const surfaced = (ack.availableInvocations?.length ?? 0) > 0 || (ack.ownedClaims?.length ?? 0) > 0
+      expect(surfaced).toBe(true)
+    } finally {
+      second.removeAllListeners()
+      second.disconnect()
+    }
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
         "shadcn": "^3.6.3",
+        "socket.io-client": "^4.8.1",
         "typescript": "^5.9.3",
       },
     },

--- a/docs/examples/pi-remote/threa-remote-v2.test.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.test.ts
@@ -248,4 +248,51 @@ describe("Pi remote trace safety", () => {
       defaultDisplayName: "Local Pi",
     })
   })
+
+  test("parseWsHint accepts the shape returned by POST /bot-runtime/presence", () => {
+    expect(__testing.parseWsHint({ url: "wss://eu.threa.io", path: "/socket.io/", namespace: "/bot" })).toEqual({
+      url: "wss://eu.threa.io",
+      path: "/socket.io/",
+      namespace: "/bot",
+    })
+  })
+
+  test("parseWsHint defaults the Socket.IO path and namespace when the server omits them", () => {
+    expect(__testing.parseWsHint({ url: "wss://eu.threa.io" })).toEqual({
+      url: "wss://eu.threa.io",
+      path: "/socket.io/",
+      namespace: "/bot",
+    })
+  })
+
+  test("parseWsHint rejects payloads without a url so we do not dial blank origins", () => {
+    expect(__testing.parseWsHint({ path: "/socket.io/", namespace: "/bot" })).toBeUndefined()
+    expect(__testing.parseWsHint(null)).toBeUndefined()
+    expect(__testing.parseWsHint("wss://eu.threa.io")).toBeUndefined()
+    expect(__testing.parseWsHint({ url: "   " })).toBeUndefined()
+  })
+
+  test("preserves an existing wsCursor when migrating session state", () => {
+    const migrated = __testing.migrateSessionState({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        session_1: {
+          linkId: "brsl_123",
+          rootStreamId: "stream_a",
+          activeStreamId: "stream_a",
+          runtimeSessionId: "session_1",
+          streamUrlPath: "/streams/stream_a",
+          wsCursor: "2026-05-27T12:34:56.000Z",
+        },
+      },
+    })
+
+    expect(migrated.linkedSessions?.session_1.wsCursor).toBe("2026-05-27T12:34:56.000Z")
+  })
+
+  test("WS_BACKSTOP_POLL_MS is the 30s safety cadence described in the plan", () => {
+    expect(__testing.WS_BACKSTOP_POLL_MS).toBe(30_000)
+  })
 })

--- a/docs/examples/pi-remote/threa-remote-v2.ts
+++ b/docs/examples/pi-remote/threa-remote-v2.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util"
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
 import { homedir, hostname, platform } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
+import { io as openSocket, type Socket } from "socket.io-client"
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
@@ -17,6 +18,11 @@ const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 const FETCH_TIMEOUT_MS = 30_000
 const MAX_FAILURE_POLL_MS = 60_000
 const BUSY_HEARTBEAT_MS = 15_000
+// Cadence the safety-backstop poll runs at while a `/bot` WebSocket is up.
+// Pushes deliver new invocations within a frame; the poll is only there to
+// catch the rare missed-emit / mid-flight-disconnect case (plan §5).
+const WS_BACKSTOP_POLL_MS = 30_000
+const WS_RECONNECTION_DELAY_MAX_MS = 30_000
 const TRACE_CONTENT_MAX_CHARS = 9_500
 const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000
 const MAX_RETRY_ATTEMPTS = 3
@@ -62,6 +68,18 @@ type RuntimeSessionLink = {
   enabled?: boolean
   debugPolling?: boolean
   streamCursors?: Record<string, string>
+  /**
+   * Server-stamped ISO timestamp from the last `bot:hello` bootstrap.
+   * Sent back as `sinceCursor` on reconnect so the server can scope the
+   * pending-invocation replay to rows we haven't already seen.
+   */
+  wsCursor?: string
+}
+
+type WsHint = {
+  url: string
+  path: string
+  namespace: string
 }
 
 type ConfigPatch = Pick<
@@ -135,6 +153,10 @@ let lastBusyHeartbeatAt = 0
 let lastPollDebugSummary: string | undefined
 let pollingRunId = 0
 let fallbackRuntimeSessionId: string | undefined
+let botSocket: Socket | undefined
+let botWsConnected = false
+let botWsHint: WsHint | undefined
+let lastBotWsSummary: string | undefined
 
 function validateConfig(value: unknown): Config | undefined {
   if (!value || typeof value !== "object") {
@@ -344,19 +366,23 @@ async function heartbeat(
 ): Promise<void> {
   if (!config) return
   const runtimeSessionId = ctx ? getRuntimeSessionId(ctx) : undefined
-  await request(`/api/v1/workspaces/${config.workspaceId}/bot-runtime/presence`, {
-    method: "POST",
-    body: JSON.stringify({
-      runtimeKind: "pi-local",
-      instanceId: ensureInstanceId(),
-      runtimeSessionId,
-      displayName: config.defaultDisplayName,
-      status,
-      acceptingInvocations: status === "available",
-      capabilities: buildRuntimeCapabilities(ctx),
-      statusText,
-    }),
-  })
+  const body = await request<{ data?: { ws?: unknown } }>(
+    `/api/v1/workspaces/${config.workspaceId}/bot-runtime/presence`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        runtimeKind: "pi-local",
+        instanceId: ensureInstanceId(),
+        runtimeSessionId,
+        displayName: config.defaultDisplayName,
+        status,
+        acceptingInvocations: status === "available",
+        capabilities: buildRuntimeCapabilities(ctx),
+        statusText,
+      }),
+    }
+  )
+  captureWsHint(body?.data?.ws)
 }
 
 async function heartbeatBusyIfStale(statusText = "Working…", ctx?: ExtensionContext): Promise<boolean> {
@@ -365,6 +391,145 @@ async function heartbeatBusyIfStale(statusText = "Working…", ctx?: ExtensionCo
   lastBusyHeartbeatAt = now
   await heartbeat("busy", statusText, ctx)
   return true
+}
+
+function captureWsHint(value: unknown): void {
+  const parsed = parseWsHint(value)
+  if (parsed) botWsHint = parsed
+}
+
+function parseWsHint(value: unknown): WsHint | undefined {
+  if (!isObject(value)) return undefined
+  const url = typeof value.url === "string" ? value.url.trim() : ""
+  if (!url) return undefined
+  const path = typeof value.path === "string" && value.path.trim() ? value.path : "/socket.io/"
+  const namespace = typeof value.namespace === "string" && value.namespace.trim() ? value.namespace : "/bot"
+  return { url, path, namespace }
+}
+
+function buildBotHelloPayload(ctx: ExtensionContext, sinceCursor: string | undefined): Record<string, unknown> {
+  return {
+    instanceId: ensureInstanceId(),
+    runtimeKind: "pi-local",
+    runtimeSessionId: getRuntimeSessionId(ctx),
+    displayName: config?.defaultDisplayName,
+    supportedCapabilities: ["active-scratchpad", "mentionable", SESSION_CONTROL_CAPABILITY],
+    capabilities: buildRuntimeCapabilities(ctx),
+    ...(sinceCursor ? { sinceCursor } : {}),
+  }
+}
+
+function noteWsDebug(ctx: ExtensionContext, summary: string): void {
+  lastBotWsSummary = `${new Date().toISOString()} ${summary}`
+  emitPollDebug(ctx, `ws ${summary}`)
+}
+
+function attachBotWebSocket(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  if (!config || !botWsHint || botSocket) return
+  if (!isEnabled(ctx)) return
+
+  const hint = botWsHint
+  const token = config.apiKey
+  let socket: Socket
+  try {
+    socket = openSocket(`${hint.url.replace(/\/$/, "")}${hint.namespace}`, {
+      path: hint.path,
+      auth: { token },
+      transports: ["websocket"],
+      reconnection: true,
+      reconnectionDelayMax: WS_RECONNECTION_DELAY_MAX_MS,
+    })
+  } catch (error) {
+    // Connection construction itself failed (malformed URL etc.). Fall back to
+    // polling silently; the next heartbeat refreshes the hint.
+    noteWsDebug(ctx, `attach failed: ${summarizeError(error)}`)
+    return
+  }
+  botSocket = socket
+
+  socket.on("connect", () => {
+    botWsConnected = true
+    noteWsDebug(ctx, `connect ${socket.id ?? ""}`)
+    sendBotHello(pi, ctx)
+  })
+
+  socket.on("disconnect", (reason) => {
+    botWsConnected = false
+    noteWsDebug(ctx, `disconnect ${String(reason)}`)
+  })
+
+  socket.on("connect_error", (error) => {
+    botWsConnected = false
+    noteWsDebug(ctx, `connect_error ${summarizeError(error)}`)
+  })
+
+  socket.on("bot_invocation:available", (payload: unknown) => {
+    const invocationId = isObject(payload) && typeof payload.invocationId === "string" ? payload.invocationId : ""
+    noteWsDebug(ctx, `available ${invocationId}`)
+    void claimIfIdle(pi, ctx).catch(() => undefined)
+  })
+
+  socket.on("bot_invocation:claimed", (payload: unknown) => {
+    const invocationId = isObject(payload) && typeof payload.invocationId === "string" ? payload.invocationId : ""
+    noteWsDebug(ctx, `claimed ${invocationId}`)
+  })
+
+  socket.on("bot:active_actor_changed", () => {
+    noteWsDebug(ctx, "active_actor_changed")
+  })
+
+  socket.on("bot:resync", (payload: unknown) => {
+    const reason = isObject(payload) && typeof payload.reason === "string" ? payload.reason : ""
+    noteWsDebug(ctx, `resync ${reason}`)
+    sendBotHello(pi, ctx)
+  })
+}
+
+function sendBotHello(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  if (!botSocket || !config) return
+  const sessionLink = getCurrentSessionLink(ctx)
+  const payload = buildBotHelloPayload(ctx, sessionLink?.wsCursor)
+  botSocket.emit("bot:hello", payload, (ack: unknown) => {
+    if (!isObject(ack)) {
+      noteWsDebug(ctx, "bot:hello ack missing")
+      return
+    }
+    if (ack.ok !== true) {
+      const message = typeof ack.error === "string" ? ack.error : "unknown error"
+      noteWsDebug(ctx, `bot:hello rejected: ${message}`)
+      return
+    }
+    if (typeof ack.serverGeneratedAt === "string") {
+      const link = getCurrentSessionLink(ctx)
+      if (link) {
+        link.wsCursor = ack.serverGeneratedAt
+        saveConfig()
+      }
+    }
+    const hasAvailable = Array.isArray(ack.availableInvocations) && ack.availableInvocations.length > 0
+    const hasOwned = Array.isArray(ack.ownedClaims) && ack.ownedClaims.length > 0
+    noteWsDebug(
+      ctx,
+      `bot:hello ack pending=${hasAvailable ? (ack.availableInvocations as unknown[]).length : 0} owned=${
+        hasOwned ? (ack.ownedClaims as unknown[]).length : 0
+      }`
+    )
+    if (hasAvailable || hasOwned) {
+      void claimIfIdle(pi, ctx).catch(() => undefined)
+    }
+  })
+}
+
+function tearDownBotWebSocket(): void {
+  if (!botSocket) return
+  try {
+    botSocket.removeAllListeners()
+    botSocket.disconnect()
+  } catch {
+    // ignore — socket may already be closed
+  }
+  botSocket = undefined
+  botWsConnected = false
 }
 
 function truncateForTrace(text: string, max = TRACE_CONTENT_MAX_CHARS): string {
@@ -674,6 +839,10 @@ function stopPolling(): void {
 }
 
 function basePollMs(): number {
+  // When the `/bot` socket is up the server pushes new work within a frame,
+  // so the poll is just a safety net for the rare missed-emit case (plan §5).
+  // Drop to a 30s backstop instead of the 3s spin we run without WS.
+  if (botWsConnected) return Math.max(WS_BACKSTOP_POLL_MS, config?.pollMs ?? WS_BACKSTOP_POLL_MS)
   return Math.max(1000, config?.pollMs ?? 3000)
 }
 
@@ -781,6 +950,7 @@ async function disableRemote(ctx: ExtensionContext): Promise<void> {
   if (!config) return
   const link = setCurrentSessionEnabled(ctx, false)
   stopPolling()
+  tearDownBotWebSocket()
   await failPending("Threa remote disabled", ctx)
   await heartbeat("offline", undefined, ctx).catch(() => undefined)
   setRemoteStatus(ctx, "Threa remote: off")
@@ -796,6 +966,7 @@ async function enableRemote(pi: ExtensionAPI, ctx: ExtensionContext): Promise<vo
   }
   lastBusyHeartbeatAt = 0
   await heartbeat("available", undefined, ctx)
+  attachBotWebSocket(pi, ctx)
   startPolling(pi, ctx)
   ctx.ui.notify("Threa remote enabled for this Pi session", "info")
 }
@@ -1741,8 +1912,10 @@ export const __testing = {
   formatRetryNotice,
   formatDuration,
   formatLocalTime,
+  parseWsHint,
   MAX_AUTO_RETRY_MS,
   MAX_RETRY_ATTEMPTS,
+  WS_BACKSTOP_POLL_MS,
 }
 
 export default function (pi: ExtensionAPI): void {
@@ -1813,6 +1986,9 @@ export default function (pi: ExtensionAPI): void {
                 `steered=${steeredInvocations.length}`,
                 `lastPoll=${lastPollDebugSummary ?? "<none>"}`,
                 `lastFailure=${lastPollFailureSummary ?? "<none>"}`,
+                `ws=${botWsConnected ? "connected" : botWsHint ? "disconnected" : "<no hint>"}`,
+                `wsCursor=${link?.wsCursor ?? "<none>"}`,
+                `lastWs=${lastBotWsSummary ?? "<none>"}`,
               ].join("\n")
             : ""
         ctx.ui.notify(
@@ -1824,6 +2000,7 @@ export default function (pi: ExtensionAPI): void {
         return
       }
       await createRemoteSession(ctx, trimmedArgs)
+      attachBotWebSocket(pi, ctx)
       startPolling(pi, ctx)
     },
   })
@@ -1837,6 +2014,7 @@ export default function (pi: ExtensionAPI): void {
     }
     lastBusyHeartbeatAt = 0
     await heartbeat("available", undefined, ctx)
+    attachBotWebSocket(pi, ctx)
     startPolling(pi, ctx)
     if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")
   })
@@ -1927,6 +2105,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (event, ctx) => {
     stopPolling()
+    tearDownBotWebSocket()
     if (event.reason === "reload" && config && isEnabled(ctx)) {
       setRemoteStatus(ctx, "Threa remote: reloading…")
       return

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
-    "shadcn": "^3.6.3"
+    "shadcn": "^3.6.3",
+    "socket.io-client": "^4.8.1"
   },
   "lint-staged": {
     "!(.agents|.claude)/**/*.{js,jsx,ts,tsx,json,css,md,html}": "prettier --write"


### PR DESCRIPTION
## Problem

Phase 1 (#622) shipped the additive backend pieces for the bot-runtime `/bot` WebSocket namespace: the `/bot-runtime/presence` endpoint now echoes a `ws: { url, path, namespace }` hint, the Socket.IO server accepts a `bot:hello` handshake with `sinceCursor`, and outbox dispatch fans `bot_invocation:*`, `bot:active_actor_changed`, and `bot:resync` to bot-scoped rooms. Nothing on the Pi side opens the socket yet, so the Pi remote keeps the 3 s HTTP poll for every invocation — which is wasteful when the server can push.

`docs/bot-runtime-websocket-plan.md` §7 calls this Phase 2: "Pi runtime / bot SDK opens WS by default with HTTP-poll fallback. Polling cadence drops to 30 s."

## Solution

The Pi remote (`docs/examples/pi-remote/threa-remote-v2.ts`) now opens the `/bot` namespace whenever the most recent `POST /bot-runtime/presence` response includes a `ws` hint. HTTP polling stays in place as a safety backstop, but the cadence drops to 30 s once the socket is connected.

### How it works

1. `heartbeat()` captures `body.data.ws` into module-level `botWsHint` on every successful presence call.
2. `enableRemote` / `session_start` / `/remote-control` (no-arg) call `attachBotWebSocket(pi, ctx)` after the first heartbeat — opens one Socket.IO client per Pi process against `${hint.url}${hint.namespace}` with `path: hint.path`, `auth: { token: apiKey }`, `transports: ["websocket"]`, and reconnection enabled.
3. `connect` fires `sendBotHello(pi, ctx)`, which emits `bot:hello` with `instanceId`, `runtimeKind: "pi-local"`, `runtimeSessionId`, capabilities, and (when known) the per-link `sinceCursor`. On a successful ack the cursor is anchored to `serverGeneratedAt` and persisted via `saveConfig()`. If the ack reports pending `availableInvocations` or `ownedClaims`, the runtime drives a single `claimIfIdle(pi, ctx)` so anything that piled up while the socket was down gets picked up immediately.
4. Live pushes — `bot_invocation:available`, `bot_invocation:claimed`, `bot:active_actor_changed`, `bot:resync` — log to the debug ring and (for `available`) trigger `claimIfIdle`. `bot:resync` re-sends `bot:hello` so the server can replay anything we missed.
5. `basePollMs()` returns the larger of `WS_BACKSTOP_POLL_MS` (30 s) and any user-configured `pollMs` when `botWsConnected` is true; otherwise it keeps the existing 1 s floor / 3 s default.
6. `disableRemote` / `session_shutdown` call `tearDownBotWebSocket()` which calls `removeAllListeners()` + `disconnect()` and clears the module socket so the next enable/start cycle gets a fresh socket.

### Key design decisions

**1. socket.io-client as a runtime dependency.** The Pi remote has historically used only Node built-ins, but the backend speaks Socket.IO (not raw WebSocket), so a hand-rolled Engine.IO framer would duplicate a battle-tested library for no gain. Pi extensions can resolve npm deps, so the cost is small.

**2. Per-link cursor, not global.** Each `linkedSessions[sessionId]` now carries its own `wsCursor` (alongside the existing `streamCursors`). A Pi process can have multiple linked sessions for different workspaces / scratchpads; replay state has to follow the link, not the process.

**3. Backstop kept at 30 s, not removed.** Even with WS connected, the poll loop continues every 30 s. This catches the case where the socket appears connected but is silently broken (NAT timeout, intermediate proxy dropping frames), and matches the cadence the plan called out.

**4. Single socket per Pi process.** One bot API key + one `instanceId` per Pi process means there's no value in fan-out per session; the `/bot` namespace already routes events to the right runtime via the hello-reported `runtimeSessionId`. Idempotent attach (`if (botSocket) return`) and idempotent teardown keep this safe across reload cycles.

**5. Tear down on reload too.** `session_shutdown` now always tears down the socket before the early-return for reload — leaving sockets dangling across `ctx.reload()` would pile up zombie connections on the server.

## Modified files

| File                                              | Change                                                                                                     |
| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| `docs/examples/pi-remote/threa-remote-v2.ts`      | Opens `/bot` Socket.IO namespace, sends `bot:hello` with per-link `sinceCursor`, drops poll cadence to 30 s when connected, tears down socket on disable/shutdown |
| `docs/examples/pi-remote/threa-remote-v2.test.ts` | Adds 5 tests covering `parseWsHint` (3 cases), `wsCursor` preservation through `migrateSessionState`, and the `WS_BACKSTOP_POLL_MS` constant |
| `package.json`, `bun.lock`                        | Adds `socket.io-client@^4.8.1` as a root devDependency so the docs/examples test can resolve the import (the workspace is outside `apps/*` / `packages/*` and doesn't get hoisted deps) |

## Test plan

- [x] `bun test ./docs/examples/pi-remote/threa-remote-v2.test.ts` — 30 pass, 0 fail
- [x] `bun run typecheck` — clean (via pre-commit hook)
- [x] `bun run lint` — clean (via pre-commit hook)
- [ ] Manual: install the updated extension on a Pi runtime, watch the `/bot` socket open after `POST /bot-runtime/presence`, kick an invocation from the server side, verify it lands without waiting for the 30 s backstop poll
- [ ] Manual: kill the WS at the network layer, verify the runtime falls back to the 30 s backstop poll and that the socket reconnects with a fresh `bot:hello` once the network recovers

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782460481&installation_id=129946197&pr_number=636&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F636&signature=24d5575ebac3eaae268c0931c30797488c7b48c49b6e56219ab5ee2da0e7626f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->