### PR TITLE
feat(e2e): Phase 3.5 — keep ciphertext at rest, decrypt on render

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -158,6 +158,7 @@ export function ScratchpadItem({
                 compact={compact}
                 showPreviewOnHover={showPreviewOnHover}
                 isMobile={isMobile}
+                e2eEnabled={streamWithPreview.e2eEnabled}
               />
             </div>
           </div>

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -99,6 +99,13 @@ interface StreamItemPreviewProps {
   compact: boolean
   showPreviewOnHover: boolean
   isMobile: boolean
+  /**
+   * E2E streams: sidebar previews are public surfaces, so we never decrypt
+   * here. Phase 3.5 keeps ciphertext at rest and routes decryption through
+   * the per-message render hook — show a sentinel in the sidebar so the
+   * placeholder zero-width-space wire content never leaks.
+   */
+  e2eEnabled?: boolean
 }
 
 export function StreamItemPreview({
@@ -108,6 +115,7 @@ export function StreamItemPreview({
   compact,
   showPreviewOnHover,
   isMobile,
+  e2eEnabled,
 }: StreamItemPreviewProps) {
   if (!preview?.content) return null
 
@@ -123,7 +131,9 @@ export function StreamItemPreview({
       aria-hidden={hoverPreview ? "true" : undefined}
     >
       <span className="truncate flex-1">
-        {getActorName(preview.authorId, preview.authorType)}: {truncateContent(preview.content, 50, toEmoji)}
+        {e2eEnabled
+          ? `${getActorName(preview.authorId, preview.authorType)}: 🔒 Encrypted message`
+          : `${getActorName(preview.authorId, preview.authorType)}: ${truncateContent(preview.content, 50, toEmoji)}`}
       </span>
       <RelativeTime date={preview.createdAt} className="flex-shrink-0" />
     </div>
@@ -330,6 +340,7 @@ export function StreamItem({
                 compact={compact}
                 showPreviewOnHover={showPreviewOnHover}
                 isMobile={isMobile}
+                e2eEnabled={stream.e2eEnabled}
               />
             </div>
           </div>

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -20,6 +20,7 @@ import { usePendingMessages, usePanel, createDraftPanelId, useTrace, useMessageS
 import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useMessageMarkdownCopy } from "@/hooks/use-message-markdown-copy"
+import { useDecryptedMessageContent, type DecryptedMessageContent } from "@/hooks/use-decrypted-message-content"
 import { useEditLastMessage } from "./edit-last-message-context"
 import {
   useActors,
@@ -1535,6 +1536,31 @@ function EditingMessageEvent({
   )
 }
 
+function makePlaceholderJson(text: string): JSONContent {
+  return { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] }
+}
+
+function applyDecryptedContent(payload: MessagePayload, decrypted: DecryptedMessageContent): MessagePayload {
+  switch (decrypted.status) {
+    case "plaintext":
+      return payload
+    case "decrypted":
+      return { ...payload, contentMarkdown: decrypted.contentMarkdown, contentJson: decrypted.contentJson }
+    case "locked": {
+      const text = "🔒 Locked — unlock to view"
+      return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
+    }
+    case "pending": {
+      const text = "🔒 Decrypting…"
+      return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
+    }
+    case "failed": {
+      const text = "🔒 Decryption failed"
+      return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
+    }
+  }
+}
+
 export function MessageEvent({
   event,
   workspaceId,
@@ -1548,7 +1574,10 @@ export function MessageEvent({
   isFirstMessage = false,
   batch,
 }: MessageEventProps) {
-  const payload = event.payload as MessagePayload
+  const rawPayload = event.payload as MessagePayload
+  const currentUserId = useWorkspaceUserId(workspaceId)
+  const decrypted = useDecryptedMessageContent(event, workspaceId, currentUserId)
+  const payload = useMemo(() => applyDecryptedContent(rawPayload, decrypted), [rawPayload, decrypted])
   const { getStatus } = usePendingMessages()
   const { getActorName } = useActors(workspaceId)
   const status = getStatus(event.id)

--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -1,0 +1,102 @@
+import { useEffect, useSyncExternalStore } from "react"
+import type { JSONContent, StreamEvent } from "@threa/types"
+import {
+  getCachedDecryption,
+  requestDecryption,
+  subscribeToDecryption,
+  type DecryptCacheEntry,
+} from "@/lib/crypto/decrypt-cache"
+import { useE2eSession } from "@/stores/e2e-session-store"
+
+/**
+ * Render-time decryption hook for E2E `message_created` events.
+ *
+ * Phase 3.5 keeps ciphertext + envelope on `db.events.payload` and decrypts
+ * only in memory. This hook is the single read path: callers get back the
+ * effective content to render, plus a status discriminator so locked /
+ * decrypting / failed states can show distinct UI.
+ *
+ *  - `plaintext`  — event has no envelope; payload is plaintext on the wire.
+ *  - `locked`     — payload has an envelope but the session isn't unlocked.
+ *  - `pending`    — unlocked, decrypt in flight (cache miss on first paint).
+ *  - `decrypted`  — unlocked, decrypt succeeded; render the returned content.
+ *  - `failed`     — decrypt threw (wrong recipient, tampered AAD, etc.).
+ *
+ * Subscribes to both the per-event cache entry and the workspace-scoped
+ * session state, so the component re-renders when a decrypt resolves or the
+ * user unlocks.
+ */
+
+export type DecryptedMessageContent =
+  | { status: "plaintext"; contentMarkdown: string; contentJson: JSONContent | undefined }
+  | { status: "locked" }
+  | { status: "pending" }
+  | { status: "decrypted"; contentMarkdown: string; contentJson: JSONContent }
+  | { status: "failed" }
+
+interface EnvelopePayload {
+  ciphertext: string
+  envelope: unknown
+  contentMarkdown?: string
+  contentJson?: JSONContent
+}
+
+function readEnvelopePayload(event: StreamEvent): EnvelopePayload | null {
+  if (event.eventType !== "message_created") return null
+  const payload = event.payload as Record<string, unknown> | undefined
+  if (!payload || typeof payload.ciphertext !== "string" || !payload.envelope) return null
+  return {
+    ciphertext: payload.ciphertext,
+    envelope: payload.envelope,
+    contentMarkdown: typeof payload.contentMarkdown === "string" ? payload.contentMarkdown : undefined,
+    contentJson: payload.contentJson as JSONContent | undefined,
+  }
+}
+
+export function useDecryptedMessageContent(
+  event: StreamEvent,
+  workspaceId: string,
+  userId: string | null
+): DecryptedMessageContent {
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const eventId = event.id
+
+  const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
+    (listener) => subscribeToDecryption(eventId, listener),
+    () => getCachedDecryption(eventId),
+    () => undefined
+  )
+
+  const envelopePayload = readEnvelopePayload(event)
+  const canDecrypt = !!envelopePayload && session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
+
+  useEffect(() => {
+    if (!needsDecrypt || !envelopePayload || !session.privateKey || !session.keyId) return
+    void requestDecryption(
+      eventId,
+      { contentMarkdown: envelopePayload.contentMarkdown ?? "", envelope: envelopePayload.envelope },
+      { privateKey: session.privateKey, recipientKeyId: session.keyId }
+    )
+  }, [needsDecrypt, envelopePayload, session.privateKey, session.keyId, eventId])
+
+  if (!envelopePayload) {
+    const payload = event.payload as { contentMarkdown?: unknown; contentJson?: unknown } | undefined
+    return {
+      status: "plaintext",
+      contentMarkdown: typeof payload?.contentMarkdown === "string" ? payload.contentMarkdown : "",
+      contentJson: payload?.contentJson as JSONContent | undefined,
+    }
+  }
+
+  if (!canDecrypt) return { status: "locked" }
+  if (cached?.status === "decrypted" && cached.content) {
+    return {
+      status: "decrypted",
+      contentMarkdown: cached.content.contentMarkdown,
+      contentJson: cached.content.contentJson,
+    }
+  }
+  if (cached?.status === "failed") return { status: "failed" }
+  return { status: "pending" }
+}

--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from "react"
+import { useEffect, useMemo, useSyncExternalStore } from "react"
 import type { JSONContent, StreamEvent } from "@threa/types"
 import {
   getCachedDecryption,
@@ -67,7 +67,9 @@ export function useDecryptedMessageContent(
     () => undefined
   )
 
-  const envelopePayload = readEnvelopePayload(event)
+  // Memoize so useEffect deps don't churn on every render — a fresh wrapper
+  // object every render would re-fire the effect even though nothing changed.
+  const envelopePayload = useMemo(() => readEnvelopePayload(event), [event])
   const canDecrypt = !!envelopePayload && session.status === "unlocked" && !!session.privateKey && !!session.keyId
   const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
 

--- a/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
@@ -77,6 +77,28 @@ describe("decrypt-cache", () => {
     expect(listenerB).toHaveBeenCalledTimes(1)
   })
 
+  it("drops in-flight decrypt results that resolve after clearDecryptCache (no plaintext leak past lock)", async () => {
+    // Hold the decrypt open so we can simulate clear() landing while it's in flight.
+    let resolveDecrypt: (value: messageEnvelope.DecryptedMessageContent | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockImplementation(
+      () =>
+        new Promise<messageEnvelope.DecryptedMessageContent | null>((r) => {
+          resolveDecrypt = r
+        })
+    )
+    const pending = requestDecryption("evt_race", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    expect(getCachedDecryption("evt_race")?.status).toBe("pending")
+
+    // Session locks (or account switches) while decrypt is still in flight.
+    clearDecryptCache()
+    expect(getCachedDecryption("evt_race")).toBeUndefined()
+
+    // Decrypt now resolves — its plaintext must NOT be written back to the cache.
+    resolveDecrypt({ contentMarkdown: "secret", contentJson: { type: "doc", content: [] } })
+    await pending
+    expect(getCachedDecryption("evt_race")).toBeUndefined()
+  })
+
   it("evicts the least recently used entry when the cache exceeds its cap", async () => {
     // Sanity-check eviction without filling the production cap (500); we
     // ensure ordering is least-recently-touched by re-touching an early entry

--- a/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { clearDecryptCache, getCachedDecryption, requestDecryption, subscribeToDecryption } from "../decrypt-cache"
+import * as messageEnvelope from "../message-envelope"
+
+const STUB_OPTS = { privateKey: {} as CryptoKey, recipientKeyId: "e2ek_alice" }
+
+function stubDecrypt(returnValue: messageEnvelope.DecryptedMessageContent | null) {
+  return vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockResolvedValue(returnValue)
+}
+
+beforeEach(() => {
+  clearDecryptCache()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("decrypt-cache", () => {
+  it("returns the decrypted content from cache after the first request", async () => {
+    const decrypt = stubDecrypt({ contentMarkdown: "hello", contentJson: { type: "doc", content: [] } })
+    await requestDecryption("evt_1", { contentMarkdown: "ph", envelope: { fake: true } }, STUB_OPTS)
+    const cached = getCachedDecryption("evt_1")
+    expect(cached?.status).toBe("decrypted")
+    expect(cached?.content?.contentMarkdown).toBe("hello")
+    expect(decrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent requests for the same event into a single decrypt", async () => {
+    const decrypt = stubDecrypt({ contentMarkdown: "hi", contentJson: { type: "doc", content: [] } })
+    await Promise.all([
+      requestDecryption("evt_dup", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS),
+      requestDecryption("evt_dup", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS),
+      requestDecryption("evt_dup", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS),
+    ])
+    expect(decrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it("records a failed entry without retrying on subsequent requests", async () => {
+    const decrypt = stubDecrypt(null)
+    await requestDecryption("evt_fail", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    await requestDecryption("evt_fail", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    expect(getCachedDecryption("evt_fail")?.status).toBe("failed")
+    expect(decrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it("notifies subscribers exactly once when a decrypt completes", async () => {
+    stubDecrypt({ contentMarkdown: "x", contentJson: { type: "doc", content: [] } })
+    const listener = vi.fn()
+    const unsubscribe = subscribeToDecryption("evt_sub", listener)
+    await requestDecryption("evt_sub", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("drops listeners on unsubscribe", async () => {
+    stubDecrypt({ contentMarkdown: "x", contentJson: { type: "doc", content: [] } })
+    const listener = vi.fn()
+    const unsubscribe = subscribeToDecryption("evt_unsub", listener)
+    unsubscribe()
+    await requestDecryption("evt_unsub", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it("clears all cached entries and notifies subscribers on clearDecryptCache", async () => {
+    stubDecrypt({ contentMarkdown: "x", contentJson: { type: "doc", content: [] } })
+    await requestDecryption("evt_a", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    await requestDecryption("evt_b", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    const listenerA = vi.fn()
+    const listenerB = vi.fn()
+    subscribeToDecryption("evt_a", listenerA)
+    subscribeToDecryption("evt_b", listenerB)
+    clearDecryptCache()
+    expect(getCachedDecryption("evt_a")).toBeUndefined()
+    expect(getCachedDecryption("evt_b")).toBeUndefined()
+    expect(listenerA).toHaveBeenCalledTimes(1)
+    expect(listenerB).toHaveBeenCalledTimes(1)
+  })
+
+  it("evicts the least recently used entry when the cache exceeds its cap", async () => {
+    // Sanity-check eviction without filling the production cap (500); we
+    // ensure ordering is least-recently-touched by re-touching an early entry
+    // and checking it survives while a different one drops.
+    let counter = 0
+    vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockImplementation(async () => ({
+      contentMarkdown: `m${counter++}`,
+      contentJson: { type: "doc", content: [] },
+    }))
+    // Fill cache to cap + 1 to trigger one eviction; cap is 500, so write 501
+    // entries with distinct ids and confirm the very first one is gone.
+    for (let i = 0; i < 501; i++) {
+      await requestDecryption(`evt_${i}`, { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    }
+    expect(getCachedDecryption("evt_0")).toBeUndefined()
+    expect(getCachedDecryption("evt_500")?.status).toBe("decrypted")
+  })
+})

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -28,6 +28,10 @@ const entries = new Map<string, DecryptCacheEntry>()
 const inflight = new Map<string, Promise<DecryptCacheEntry>>()
 const listeners = new Map<string, Set<() => void>>()
 
+// Bumped by clearDecryptCache so in-flight decrypts that resolve after a lock
+// can detect they're stale and refuse to write plaintext back into the cache.
+let generation = 0
+
 function emit(eventId: string): void {
   const set = listeners.get(eventId)
   if (!set) return
@@ -81,11 +85,16 @@ export function requestDecryption(
 
   touch(eventId, { status: "pending", content: null })
 
+  const startGeneration = generation
   const promise = (async (): Promise<DecryptCacheEntry> => {
     const decrypted = await tryDecryptMessagePayload(payload, opts)
     const entry: DecryptCacheEntry = decrypted
       ? { status: "decrypted", content: decrypted }
       : { status: "failed", content: null }
+    // If the cache was cleared (lock / account switch) while this decrypt was
+    // in flight, drop the result — writing it back would leak plaintext past
+    // the lock boundary.
+    if (startGeneration !== generation) return entry
     touch(eventId, entry)
     inflight.delete(eventId)
     emit(eventId)
@@ -97,6 +106,7 @@ export function requestDecryption(
 }
 
 export function clearDecryptCache(): void {
+  generation++
   const ids = Array.from(entries.keys())
   entries.clear()
   inflight.clear()

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -1,0 +1,104 @@
+import { tryDecryptMessagePayload, type DecryptedMessageContent } from "./message-envelope"
+
+/**
+ * In-memory cache for decrypted E2E message payloads.
+ *
+ * Phase 3.5 keeps ciphertext + envelope at rest in `db.events.payload` and
+ * decrypts only on demand at render time. Each rendered message hits this
+ * cache; on miss, the caller kicks off a decrypt and the cache notifies
+ * subscribers when it lands.
+ *
+ * Lifecycle:
+ *  - Entries are inserted on successful (or failed) decrypt.
+ *  - LRU eviction caps memory regardless of how many messages the user scrolls.
+ *  - `clearDecryptCache()` drops everything; call it on session lock and on
+ *    account switch so plaintext never outlives the unlocked session.
+ */
+
+export type DecryptStatus = "pending" | "decrypted" | "failed"
+
+export interface DecryptCacheEntry {
+  status: DecryptStatus
+  content: DecryptedMessageContent | null
+}
+
+const MAX_ENTRIES = 500
+
+const entries = new Map<string, DecryptCacheEntry>()
+const inflight = new Map<string, Promise<DecryptCacheEntry>>()
+const listeners = new Map<string, Set<() => void>>()
+
+function emit(eventId: string): void {
+  const set = listeners.get(eventId)
+  if (!set) return
+  for (const listener of set) listener()
+}
+
+function touch(eventId: string, entry: DecryptCacheEntry): void {
+  // Map iteration order is insertion order; re-inserting bumps it to MRU.
+  entries.delete(eventId)
+  entries.set(eventId, entry)
+  if (entries.size > MAX_ENTRIES) {
+    const oldest = entries.keys().next().value
+    if (oldest !== undefined) entries.delete(oldest)
+  }
+}
+
+export function getCachedDecryption(eventId: string): DecryptCacheEntry | undefined {
+  return entries.get(eventId)
+}
+
+export function subscribeToDecryption(eventId: string, listener: () => void): () => void {
+  let set = listeners.get(eventId)
+  if (!set) {
+    set = new Set()
+    listeners.set(eventId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = listeners.get(eventId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) listeners.delete(eventId)
+  }
+}
+
+export interface RequestDecryptionInput {
+  contentMarkdown: string
+  envelope: unknown
+}
+
+export function requestDecryption(
+  eventId: string,
+  payload: RequestDecryptionInput,
+  opts: { privateKey: CryptoKey; recipientKeyId: string }
+): Promise<DecryptCacheEntry> {
+  const existing = entries.get(eventId)
+  if (existing && existing.status !== "pending") return Promise.resolve(existing)
+
+  const pending = inflight.get(eventId)
+  if (pending) return pending
+
+  touch(eventId, { status: "pending", content: null })
+
+  const promise = (async (): Promise<DecryptCacheEntry> => {
+    const decrypted = await tryDecryptMessagePayload(payload, opts)
+    const entry: DecryptCacheEntry = decrypted
+      ? { status: "decrypted", content: decrypted }
+      : { status: "failed", content: null }
+    touch(eventId, entry)
+    inflight.delete(eventId)
+    emit(eventId)
+    return entry
+  })()
+
+  inflight.set(eventId, promise)
+  return promise
+}
+
+export function clearDecryptCache(): void {
+  const ids = Array.from(entries.keys())
+  entries.clear()
+  inflight.clear()
+  for (const id of ids) emit(id)
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -54,7 +54,7 @@ import {
 import { usePageResume } from "@/hooks/use-page-resume"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
-import { useWorkspaceStreams, useWorkspaceUsers } from "@/stores/workspace-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext } from "@/sync/sync-engine"
 import { messagesApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
@@ -150,9 +150,6 @@ function WorkspaceSyncHandler({
   const isOnline = useOnlineStatus()
   const { streamId: currentStreamId } = useParams<{ streamId: string }>()
   const wasOfflineRef = useRef(!navigator.onLine)
-  const workspaceUsers = useWorkspaceUsers(workspaceId)
-  const currentWorkspaceUserId = user ? (workspaceUsers.find((u) => u.workosUserId === user.id)?.id ?? null) : null
-
   // Construct SyncEngine once per workspace. Use ref to survive StrictMode
   // double-render — useMemo + destroy effect breaks because the cleanup
   // destroys the engine before the socket connect effect fires.
@@ -195,10 +192,6 @@ function WorkspaceSyncHandler({
   useEffect(() => {
     syncEngine.setCurrentUser(user)
   }, [syncEngine, user])
-
-  useEffect(() => {
-    syncEngine.setCurrentWorkspaceUserId(currentWorkspaceUserId)
-  }, [syncEngine, currentWorkspaceUserId])
 
   // Wire SyncEngine to socket connect/disconnect/reconnect based on actual socket status.
   useEffect(() => {

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react"
 import { e2eKeysApi } from "@/api/e2e-keys"
+import { clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import { base64ToBytes, bytesToBase64 } from "@/lib/crypto/encoding"
 import { generateUIK, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
 import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "@/lib/crypto/passphrase"
@@ -359,6 +360,10 @@ export async function revokeKeyForUser(workspaceId: string, userId: string): Pro
  */
 export function lock(workspaceId: string, userId: string): void {
   const scope = getOrCreateScope(workspaceId, userId)
+  // Drop every decrypted payload from memory — Phase 3.5 keeps ciphertext at
+  // rest in IDB and decrypts at render time, so the in-memory cache is the
+  // only surface holding plaintext for this session.
+  clearDecryptCache()
   if (!scope.cachedKey) {
     setState(workspaceId, userId, INITIAL_STATE)
     return
@@ -430,4 +435,5 @@ export function useE2eSession(workspaceId: string, userId: string): E2eSessionSt
 export function resetE2eSessionStoreCache(): void {
   scopes.clear()
   listeners.clear()
+  clearDecryptCache()
 }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -608,6 +608,37 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
     expect(append.events.map((event) => event.id)).toEqual(["evt_B", "evt_C"])
   })
 
+  it("keeps E2E ciphertext + envelope at rest in IDB (no sync-time decrypt)", async () => {
+    // Phase 3.5: bootstrap no longer decrypts E2E payloads at write time. The
+    // wire shape (placeholder + ciphertext + envelope) must round-trip into
+    // db.events unchanged so the render-time cache is the only surface that
+    // ever holds plaintext.
+    const streamId = "stream_e2e_atrest"
+    const e2eEvent = makeEvent({
+      id: "evt_e2e",
+      streamId,
+      sequence: "100",
+      payload: {
+        messageId: "msg_e2e",
+        contentMarkdown: "​",
+        ciphertext: "base64-ciphertext",
+        envelope: { kdfParams: { alg: "argon2id" } },
+      },
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([e2eEvent], streamId))
+
+    const persisted = await db.events.get(e2eEvent.id)
+    const payload = persisted?.payload as {
+      contentMarkdown: string
+      ciphertext?: string
+      envelope?: unknown
+    }
+    expect(payload.contentMarkdown).toBe("​")
+    expect(payload.ciphertext).toBe("base64-ciphertext")
+    expect(payload.envelope).toEqual({ kdfParams: { alg: "argon2id" } })
+  })
+
   it("derives the reconnect cursor from the latest persisted non-optimistic event", async () => {
     const streamId = "stream_cursor"
     await db.events.bulkPut([

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -14,50 +14,6 @@ import type { Socket } from "socket.io-client"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import type { QueryClient } from "@tanstack/react-query"
-import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
-
-/**
- * Decrypt the wire payload of a `message_created` event in-place when:
- *   - the payload carries an envelope
- *   - the active workspace user has an unlocked UIK
- *
- * Failure modes (locked session, wrong recipient, malformed envelope) are
- * swallowed: the placeholder `contentMarkdown` already stored on the wire
- * survives so the UI still has something to render. The placeholder will
- * be replaced on the next decrypt attempt (e.g. after the user unlocks).
- */
-async function decryptEventPayloadIfNeeded(
-  event: StreamEvent,
-  workspaceId: string,
-  userId: string | null
-): Promise<StreamEvent> {
-  if (event.eventType !== "message_created") return event
-  const payload = event.payload as Record<string, unknown> | undefined
-  if (!payload || typeof payload.ciphertext !== "string" || !payload.envelope) return event
-  if (!userId) return event
-
-  const session = getE2eSessionState(workspaceId, userId)
-  if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return event
-
-  const decrypted = await tryDecryptMessagePayload(
-    {
-      contentMarkdown: typeof payload.contentMarkdown === "string" ? payload.contentMarkdown : "",
-      envelope: payload.envelope,
-    },
-    { privateKey: session.privateKey, recipientKeyId: session.keyId }
-  )
-  if (!decrypted) return event
-
-  return {
-    ...event,
-    payload: {
-      ...payload,
-      contentMarkdown: decrypted.contentMarkdown,
-      contentJson: decrypted.contentJson,
-    },
-  }
-}
 
 // ============================================================================
 // Bootstrap application — writes stream bootstrap data to IndexedDB
@@ -190,27 +146,6 @@ async function pruneBootstrapReplaceWindow(streamId: string, bootstrap: StreamBo
   }
 }
 
-/**
- * Decrypt any E2E `message_created` events the backend stamped with placeholder
- * content. Plaintext events pass through untouched. If the user is locked, the
- * placeholder survives — a later subscribe/bootstrap pass after unlock will
- * refill the plaintext. Called BEFORE opening the IDB transaction in the apply
- * paths so the (asynchronous, non-Dexie) decrypt work doesn't hold the
- * transaction open — awaiting non-Dexie promises inside `db.transaction` can
- * tear the transaction down on some browsers.
- */
-export async function decryptBootstrapEventsIfNeeded(
-  bootstrap: StreamBootstrap,
-  workspaceId: string,
-  userId: string | null
-): Promise<StreamBootstrap> {
-  if (!bootstrap.stream.e2eEnabled || bootstrap.events.length === 0) return bootstrap
-  return {
-    ...bootstrap,
-    events: await Promise.all(bootstrap.events.map((event) => decryptEventPayloadIfNeeded(event, workspaceId, userId))),
-  }
-}
-
 async function writeBootstrapEventsAndStream(
   workspaceId: string,
   streamId: string,
@@ -333,30 +268,17 @@ async function writeBootstrapEventsAndStream(
 export async function applyStreamBootstrap(
   workspaceId: string,
   streamId: string,
-  bootstrap: StreamBootstrap,
-  userId: string | null = null
+  bootstrap: StreamBootstrap
 ): Promise<void> {
-  // Decrypt outside the Dexie transaction so HPKE/AES-GCM work doesn't hold
-  // the IDB transaction open (Dexie tears down transactions that await
-  // unrelated promises).
-  const decrypted = await decryptBootstrapEventsIfNeeded(bootstrap, workspaceId, userId)
   const now = Date.now()
   await db.transaction("rw", [db.events, db.streams, db.pendingMessages, db.pendingOperations], async () => {
-    await writeBootstrapEventsAndStream(workspaceId, streamId, decrypted, now)
+    await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now)
   })
 }
 
 /**
  * Same as `applyStreamBootstrap` but written for callers that have already
- * opened a `db.transaction` — it just delegates to `writeBootstrapEventsAndStream`
- * without wrapping or running E2E decryption.
- *
- * The caller MUST pass a `bootstrap` whose events have already been routed
- * through `decryptBootstrapEventsIfNeeded`. Awaiting the decrypt promise
- * inside a Dexie transaction tears the transaction down on browsers where
- * the microtask queue drains before the awaited promise resolves, so the
- * decrypt step is deliberately hoisted to the caller (see
- * `applyReconnectBootstrapBatch` in `workspace-sync.ts`).
+ * opened a `db.transaction` — it just delegates to `writeBootstrapEventsAndStream`.
  */
 export async function applyStreamBootstrapInCurrentTransaction(
   workspaceId: string,
@@ -559,21 +481,17 @@ export function registerStreamSocketHandlers(
   socket: Socket,
   workspaceId: string,
   streamId: string,
-  queryClient: QueryClient,
-  opts: { getCurrentUserId?: () => string | null } = {}
+  queryClient: QueryClient
 ): () => void {
   const handleMessageCreated = async (payload: MessageEventPayload) => {
     if (payload.streamId !== streamId) return
 
-    // Decrypt before any of the downstream branches touch the payload —
-    // optimistic-swap dedup, sidebar preview and sharedMessage detection
-    // all assume `contentMarkdown` / `contentJson` are plaintext.
-    const decryptedEvent = await decryptEventPayloadIfNeeded(
-      payload.event,
-      workspaceId,
-      opts.getCurrentUserId?.() ?? null
-    )
-    const newEvent = decryptedEvent
+    // E2E payloads stay as ciphertext + envelope at rest; decryption runs on
+    // demand in the render path. The wire `contentMarkdown` / `contentJson`
+    // for E2E messages is the backend placeholder, so the sidebar preview
+    // write below is a placeholder-by-placeholder substitution — the sidebar
+    // surfaces it as the sentinel via `stream.e2eEnabled`.
+    const newEvent = payload.event
     const newPayload = newEvent.payload as {
       contentJson: unknown
       contentMarkdown: string

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -80,14 +80,6 @@ export class SyncEngine {
   private currentStreamId: string | undefined = undefined
   private visibleStreamIds: string[] = []
   private currentUser: { id: string } | null = null
-  /**
-   * Workspace-scoped user id (`UserId`) for the active session — distinct
-   * from `currentUser.id`, which is the WorkOS auth id. The E2E session
-   * store keys by workspace user id (the same id stored in `e2e_keys` and
-   * on `e2e_streams`), so the message decrypt path needs this one.
-   * Resolved by the React layer once `useWorkspaceUsers` has the row.
-   */
-  private currentWorkspaceUserId: string | null = null
   /** Last workspace bootstrap error, if any. Consumers can check this for 404/403 handling. */
   lastWorkspaceError: unknown = null
 
@@ -113,23 +105,6 @@ export class SyncEngine {
   /** Update the current auth user (called from React when auth state settles). */
   setCurrentUser(user: { id: string } | null): void {
     this.currentUser = user
-  }
-
-  /** Update the workspace-scoped user id (called from React once `useWorkspaceUsers` resolves it). */
-  setCurrentWorkspaceUserId(id: string | null): void {
-    if (this.currentWorkspaceUserId === id) return
-    const justBecameAvailable = this.currentWorkspaceUserId === null && id !== null
-    this.currentWorkspaceUserId = id
-    if (justBecameAvailable) {
-      // The decrypt-on-arrival path keys off this id; any stream bootstrap
-      // that landed before it resolved cached placeholders into IDB. Replay
-      // the visible-stream refreshes so those rows pick up plaintext now
-      // that the viewer is identified — the current stream + the sidebar's
-      // visible window covers what the user can actually see.
-      for (const streamId of this.getVisibleServerStreamIds()) {
-        void this.refreshStreamAfterNavigation(streamId)
-      }
-    }
   }
 
   /**
@@ -345,25 +320,22 @@ export class SyncEngine {
           }
         }
 
-        const { workspaceBootstrap: appliedWorkspaceBootstrap, decryptedStreamBootstraps } =
+        const { workspaceBootstrap: appliedWorkspaceBootstrap, streamBootstraps: appliedStreamBootstraps } =
           await applyReconnectBootstrapBatch(
             workspaceId,
             workspaceBootstrap,
             successfulStreamBootstraps,
             staleStreamIds,
             terminalStreamIds,
-            fetchStartedAt,
-            this.currentWorkspaceUserId
+            fetchStartedAt
           )
         bootstrap = appliedWorkspaceBootstrap
 
         queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), bootstrap)
-        // Seed the per-stream TanStack cache from the *decrypted* bootstraps —
-        // `successfulStreamBootstraps` still carries the placeholder text for
-        // E2E messages, and IDB already holds the decrypted rows from
-        // `applyReconnectBootstrapBatch`. Using the encrypted map here would
-        // leave visible E2E streams stuck on the placeholder until refresh.
-        for (const [streamId, streamBootstrap] of decryptedStreamBootstraps) {
+        // Seed the per-stream TanStack cache from the bootstraps we just
+        // applied. E2E payloads stay as ciphertext + envelope here — the
+        // render layer decrypts in memory via `useDecryptedMessageContent`.
+        for (const [streamId, streamBootstrap] of appliedStreamBootstraps) {
           queryClient.setQueryData(
             streamKeys.bootstrap(workspaceId, streamId),
             toCachedStreamBootstrap(
@@ -464,15 +436,7 @@ export class SyncEngine {
 
     if (!this.subscribedStreams.has(streamId)) {
       this.subscribedStreams.add(streamId)
-      const cleanup = registerStreamSocketHandlers(
-        this.socket,
-        this.deps.workspaceId,
-        streamId,
-        this.deps.queryClient,
-        {
-          getCurrentUserId: () => this.currentWorkspaceUserId,
-        }
-      )
+      const cleanup = registerStreamSocketHandlers(this.socket, this.deps.workspaceId, streamId, this.deps.queryClient)
       this.streamHandlerCleanups.set(streamId, cleanup)
     }
 
@@ -523,7 +487,7 @@ export class SyncEngine {
       const previousBootstrap = queryClient.getQueryData<CachedStreamBootstrap>(queryKey)
       const after = previousBootstrap ? await getLatestPersistedSequence(streamId) : null
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
-      await applyStreamBootstrap(workspaceId, streamId, bootstrap, this.currentWorkspaceUserId)
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
 
       queryClient.setQueryData<CachedStreamBootstrap>(queryKey, (currentBootstrap) =>
         toCachedStreamBootstrap(bootstrap, currentBootstrap ?? previousBootstrap, {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -26,7 +26,7 @@ import type {
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
 import { persistScheduledRows, removeScheduledRow, scheduledKeys } from "@/hooks/use-scheduled"
 import { NOTIFICATION_CONFIG, NotificationLevels, StreamTypes, Visibilities } from "@threa/types"
-import { applyStreamBootstrapInCurrentTransaction, decryptBootstrapEventsIfNeeded } from "./stream-sync"
+import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 
 // ============================================================================
 // Workspace socket handler payload types
@@ -1646,23 +1646,10 @@ export async function applyReconnectBootstrapBatch(
   streamBootstraps: Map<string, StreamBootstrap>,
   staleStreamIds: Set<string>,
   terminalStreamIds: Set<string>,
-  fetchStartedAt?: number,
-  /**
-   * Workspace-scoped viewer id used by the per-stream bootstrap apply to
-   * decrypt E2E message payloads. Optional so callers without that context
-   * (tests, older paths) keep compiling — decryption is best-effort and
-   * silently skipped when omitted.
-   */
-  userId: string | null = null
+  fetchStartedAt?: number
 ): Promise<{
   workspaceBootstrap: WorkspaceBootstrap
-  /**
-   * Per-stream bootstraps with E2E payloads already decrypted. The caller
-   * uses this to seed the TanStack `streamKeys.bootstrap(...)` cache —
-   * writing the pre-decryption map there would leave visible E2E streams
-   * stuck on the placeholder until the next refresh.
-   */
-  decryptedStreamBootstraps: Map<string, StreamBootstrap>
+  streamBootstraps: Map<string, StreamBootstrap>
 }> {
   const now = Date.now()
 
@@ -1682,22 +1669,6 @@ export async function applyReconnectBootstrapBatch(
     localUnreadState: localUnreadState ?? undefined,
     fetchStartedAt,
   })
-
-  // Decrypt E2E payloads BEFORE opening the IDB transaction so HPKE/AES-GCM
-  // work doesn't keep `db.transaction` alive across an unrelated await (Dexie
-  // tears the transaction down on browsers where the microtask queue drains
-  // before the awaited promise resolves).
-  const decryptedStreamBootstraps = new Map(
-    await Promise.all(
-      Array.from(
-        streamBootstraps,
-        async ([streamId, bootstrap]): Promise<[string, StreamBootstrap]> => [
-          streamId,
-          await decryptBootstrapEventsIfNeeded(bootstrap, workspaceId, userId),
-        ]
-      )
-    )
-  )
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 
@@ -1786,7 +1757,7 @@ export async function applyReconnectBootstrapBatch(
         })
       }
 
-      for (const [streamId, bootstrap] of decryptedStreamBootstraps) {
+      for (const [streamId, bootstrap] of streamBootstraps) {
         await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now)
       }
 
@@ -1854,7 +1825,7 @@ export async function applyReconnectBootstrapBatch(
     },
   })
 
-  return { workspaceBootstrap: finalBootstrap, decryptedStreamBootstraps }
+  return { workspaceBootstrap: finalBootstrap, streamBootstraps }
 }
 
 async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBootstrap, now: number): Promise<void> {


### PR DESCRIPTION
## Summary

Phase 3.5 of E2E-encrypted scratchpads. Up to now we decrypted on sync (when an event arrived), which meant plaintext landed in IDB alongside ciphertext. That trades the lock guarantee for convenience: if the user locks the session, the plaintext is still sitting in IndexedDB on disk.

This change moves decryption out of the sync layer entirely. Events arrive ciphertext-only and stay that way in IDB (`db.events.payload` keeps the wire `{ciphertext, envelope}` shape). Decryption happens only in memory at render time, on demand, behind an LRU-bounded in-memory cache. When the user locks (or switches accounts) the cache is dropped — plaintext never outlives the unlocked session.

### What changed

**New: render-time decryption layer**
- `lib/crypto/decrypt-cache.ts` — module-level cache with insertion-order LRU (cap 500), per-event listener pattern, coalesces concurrent decrypts via an inflight Promise map. `clearDecryptCache()` drops everything and notifies subscribers.
- `hooks/use-decrypted-message-content.ts` — `useSyncExternalStore` reads the cache, kicks off decrypts on miss when unlocked, returns a discriminated union (`plaintext | locked | pending | decrypted | failed`) so the UI can render distinct states.

**Removed: sync-time decryption**
- `sync/stream-sync.ts` no longer decrypts in `applyStreamBootstrap` or `handleMessageCreated` (deleted `decryptEventPayloadIfNeeded`, `decryptBootstrapEventsIfNeeded`, the `_userId` param).
- `sync/workspace-sync.ts` no longer takes a `userId` param or runs `decryptBootstrapEventsIfNeeded`. Field renamed to `streamBootstraps`.
- `sync/sync-engine.ts`, `pages/workspace-layout.tsx` — dead `currentWorkspaceUserId` plumbing removed (its only consumer was the sync-time decrypt path).

**UI integration**
- `components/timeline/message-event.tsx` — runs each E2E message through `useDecryptedMessageContent` and shows `🔒 Locked — unlock to view` / `🔒 Decrypting…` / `🔒 Decryption failed` placeholders during non-decrypted states.
- `components/layout/sidebar/{stream-item,scratchpad-item}.tsx` — sidebar previews show `🔒 Encrypted message` rather than leaking a wire placeholder.

**Lock-time invalidation**
- `stores/e2e-session-store.ts` — `lock()` and `resetE2eSessionStoreCache()` now call `clearDecryptCache()` so locking really does drop plaintext.

### Self-review fix (second commit)

A race surfaced during self-review: a `requestDecryption` that was in flight when `clearDecryptCache()` ran would still write its plaintext back into the cleared cache on resolve, defeating the lock guarantee. Fixed by snapshotting a module-level `generation` counter before the decrypt's `await`; if the generation has changed (cache was cleared) by the time the decrypt resolves, the result is dropped rather than touched into the cache. Test added.

## Test plan

- [x] `bun run test` — 1838/1838 passing (added one new test for the lock-race fix)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Manual: lock session mid-decrypt; verify cached plaintext is dropped and no leak in DevTools after relock
- [ ] Manual: scroll through a long E2E scratchpad; verify per-message decrypt latency is unnoticeable on repeat visits (cache hits)
- [ ] Manual: hard-refresh while locked; verify `🔒 Locked` placeholder shows and unlocking populates content without a re-fetch


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtinEwrFfpJEdkENwAKCj8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782468127&installation_id=129946197&pr_number=637&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F637&signature=4a8f21e96429f2f706ba69c0d9e5375bcaa83d4f196942870c8b1cc41cc42c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->