### PR TITLE
fix(pi-remote): sanitize instanceId and fail loud on bot:hello reject

### DIFF
--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -1,7 +1,7 @@
 import { CommandKinds, CommandScopes, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo } from "@threa/types"
 import type { CommandRegistry } from "./registry"
 
-export const PI_SESSION_CONTROL_COMMAND_NAMES = ["compact", "model", "thinking", "skill", "reload"] as const
+export const PI_SESSION_CONTROL_COMMAND_NAMES = ["compact", "model", "thinking", "skill", "reload", "shell"] as const
 export type PiSessionControlCommandName = (typeof PI_SESSION_CONTROL_COMMAND_NAMES)[number]
 
 export function listServerCommandInfos(commandRegistry: CommandRegistry): CommandInfo[] {
@@ -69,6 +69,13 @@ export function listPiSessionControlCommandInfos(): CommandInfo[] {
       description: "Reload Pi extensions, skills, prompts, and themes",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
+    },
+    {
+      name: "shell",
+      description: "Run a shell command in the linked Pi session's working directory",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+      args: [{ name: "command", required: true, description: "Shell command to run (passed to `$SHELL -c`)" }],
     },
   ]
 }

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -757,7 +757,7 @@ export function createPublicApiHandlers({
             rootStreamId: existingLink.rootStreamId,
             activeStreamId: existingLink.activeStreamId,
             runtimeSessionId: existingLink.runtimeSessionId,
-            streamUrlPath: `/streams/${existingLink.activeStreamId}`,
+            streamUrlPath: `/w/${req.workspaceId!}/s/${existingLink.activeStreamId}`,
           },
         })
       }
@@ -792,7 +792,7 @@ export function createPublicApiHandlers({
           rootStreamId: link.rootStreamId,
           activeStreamId: link.activeStreamId,
           runtimeSessionId: link.runtimeSessionId,
-          streamUrlPath: `/streams/${stream.id}`,
+          streamUrlPath: `/w/${req.workspaceId!}/s/${stream.id}`,
         },
       })
     },

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -383,3 +383,66 @@ describe("fetchWsHintFromConfig", () => {
     expect(__testing.WS_RESOLVE_RETRY_MS).toBe(60_000)
   })
 })
+
+describe("sanitizeInstanceIdSegment", () => {
+  test("replaces dots (macOS hostname `.lan` regression)", () => {
+    expect(__testing.sanitizeInstanceIdSegment("kristoffers-mbp.lan")).toBe("kristoffers-mbp-lan")
+  })
+
+  test("collapses runs of unsafe chars into a single dash", () => {
+    expect(__testing.sanitizeInstanceIdSegment("host..name....with.dots")).toBe("host-name-with-dots")
+  })
+
+  test("strips leading and trailing separators", () => {
+    expect(__testing.sanitizeInstanceIdSegment(".lan.")).toBe("lan")
+    expect(__testing.sanitizeInstanceIdSegment("---abc---")).toBe("abc")
+  })
+
+  test("passes through already-safe identifiers unchanged", () => {
+    expect(__testing.sanitizeInstanceIdSegment("pi-host-abc123")).toBe("pi-host-abc123")
+    expect(__testing.sanitizeInstanceIdSegment("UPPER_lower-09")).toBe("UPPER_lower-09")
+  })
+
+  test("collapses to empty when the input contains no safe characters at all", () => {
+    expect(__testing.sanitizeInstanceIdSegment("...")).toBe("")
+    expect(__testing.sanitizeInstanceIdSegment("")).toBe("")
+  })
+})
+
+describe("migrateInstanceId", () => {
+  test("rewrites a dotted macOS-hostname id without losing the random suffix", () => {
+    // Realistic shape of a macOS-derived id (`hostname()` returns `*.lan`).
+    // The server `bot:hello` schema (`^[A-Za-z0-9_-]+$`) rejects the dot, so
+    // the migration must preserve the suffix while normalising the host.
+    expect(__testing.migrateInstanceId("pi-kristoffers-mbp.lan-249fae79")).toBe("pi-kristoffers-mbp-lan-249fae79")
+  })
+
+  test("leaves an already-valid id untouched (no churn for healthy installs)", () => {
+    expect(__testing.migrateInstanceId("pi-host-abc12345")).toBe("pi-host-abc12345")
+  })
+
+  test("falls back to a fresh `pi-<random>` id when sanitization collapses to empty", () => {
+    const result = __testing.migrateInstanceId("...")
+    expect(result).toMatch(/^pi-[0-9a-f]{8}$/)
+  })
+})
+
+describe("formatHelloAckDetails", () => {
+  test("renders Zod fieldErrors as a parenthesized summary", () => {
+    expect(
+      __testing.formatHelloAckDetails({
+        instanceId: ["instanceId must be 1-64 chars of [A-Za-z0-9_-]"],
+      })
+    ).toBe(' (instanceId: ["instanceId must be 1-64 chars of [A-Za-z0-9_-]"])')
+  })
+
+  test("returns empty when details are missing or not an object", () => {
+    expect(__testing.formatHelloAckDetails(undefined)).toBe("")
+    expect(__testing.formatHelloAckDetails(null)).toBe("")
+    expect(__testing.formatHelloAckDetails("nope")).toBe("")
+  })
+
+  test("returns empty when details are an empty object (server sent the field but no entries)", () => {
+    expect(__testing.formatHelloAckDetails({})).toBe("")
+  })
+})

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -425,6 +425,20 @@ describe("migrateInstanceId", () => {
     const result = __testing.migrateInstanceId("...")
     expect(result).toMatch(/^pi-[0-9a-f]{8}$/)
   })
+
+  test("returns a fresh id when the stored value is not a string", () => {
+    // `config.instanceId` is loaded via `JSON.parse` from disk and only the
+    // three required string fields are validated. A hand-edited config could
+    // park anything here, so we must tolerate non-strings without crashing.
+    expect(__testing.migrateInstanceId(undefined)).toMatch(/^pi-[0-9a-f]{8}$/)
+    expect(__testing.migrateInstanceId(null)).toMatch(/^pi-[0-9a-f]{8}$/)
+    expect(__testing.migrateInstanceId(42)).toMatch(/^pi-[0-9a-f]{8}$/)
+    expect(__testing.migrateInstanceId({})).toMatch(/^pi-[0-9a-f]{8}$/)
+  })
+
+  test("returns a fresh id when the stored value is an empty string", () => {
+    expect(__testing.migrateInstanceId("")).toMatch(/^pi-[0-9a-f]{8}$/)
+  })
 })
 
 describe("formatHelloAckDetails", () => {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -96,7 +96,7 @@ describe("Pi remote trace safety", () => {
   test("advertises session-control command capabilities", () => {
     expect(__testing.buildRuntimeCapabilities()).toMatchObject({
       supportsSessionControlCommands: true,
-      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload"],
+      sessionControlCommands: ["compact", "model", "thinking", "skill", "reload", "shell"],
     })
   })
 
@@ -222,12 +222,15 @@ describe("Pi remote trace safety", () => {
     expect(__testing.formatDuration(139 * 60_000)).toBe("2h 19m")
   })
 
-  test("builds scratchpad URLs from configured base URL and stream path", () => {
-    expect(__testing.buildScratchpadUrl("https://app.threa.io", "/workspaces/ws_123/streams/stream_123")).toBe(
-      "https://app.threa.io/workspaces/ws_123/streams/stream_123"
+  test("builds scratchpad URLs from workspace and stream ids the client already owns", () => {
+    // The frontend route is `/w/:workspaceId/s/:streamId`. Composing locally
+    // means the URL is right even when `link.streamUrlPath` was persisted by a
+    // server version that returned the legacy `/streams/<id>` shape.
+    expect(__testing.buildScratchpadUrl("https://app.threa.io", "ws_123", "stream_123")).toBe(
+      "https://app.threa.io/w/ws_123/s/stream_123"
     )
-    expect(__testing.buildScratchpadUrl("https://app.threa.io/app/", "streams/stream_123")).toBe(
-      "https://app.threa.io/app/streams/stream_123"
+    expect(__testing.buildScratchpadUrl("https://app.threa.io/app/", "ws_123", "stream_123")).toBe(
+      "https://app.threa.io/w/ws_123/s/stream_123"
     )
   })
 
@@ -458,5 +461,165 @@ describe("formatHelloAckDetails", () => {
 
   test("returns empty when details are an empty object (server sent the field but no entries)", () => {
     expect(__testing.formatHelloAckDetails({})).toBe("")
+  })
+})
+
+describe("appendCapped", () => {
+  test("appends below the cap and reports no truncation", () => {
+    expect(__testing.appendCapped("abc", "def", 10)).toEqual({ text: "abcdef", truncated: false })
+  })
+
+  test("truncates at the cap and reports the overflow", () => {
+    expect(__testing.appendCapped("abcdef", "ghijklm", 8)).toEqual({ text: "abcdefgh", truncated: true })
+  })
+
+  test("returns the existing buffer untouched once the cap is already reached", () => {
+    expect(__testing.appendCapped("abcdefgh", "more", 8)).toEqual({ text: "abcdefgh", truncated: true })
+  })
+})
+
+describe("formatShellResult", () => {
+  const baseResult = {
+    stdout: "",
+    stderr: "",
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    elapsedMs: 142,
+    spawnError: null,
+  }
+
+  test("formats a successful run with stdout and exit 0", () => {
+    const body = __testing.formatShellResult("ls -la", { ...baseResult, stdout: "drwx 1\ndrwx 2\n" })
+    expect(body).toContain("```\n$ ls -la\ndrwx 1\ndrwx 2\n```")
+    expect(body).toContain("exit 0")
+    // Don't pin the duration formatter's wording — just verify the elapsed segment is there.
+    expect(body).toContain("·")
+  })
+
+  test("renders stderr in its own block only when present", () => {
+    const without = __testing.formatShellResult("true", baseResult)
+    expect(without).not.toContain("stderr")
+
+    const withErr = __testing.formatShellResult("missing-bin", {
+      ...baseResult,
+      stdout: "",
+      stderr: "command not found\n",
+      exitCode: 127,
+    })
+    expect(withErr).toContain("**stderr**")
+    expect(withErr).toContain("command not found")
+    expect(withErr).toContain("exit 127")
+  })
+
+  test("reports timeout instead of exit code when the command was killed by the watchdog", () => {
+    const body = __testing.formatShellResult("sleep 999", {
+      ...baseResult,
+      stdout: "",
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: true,
+      elapsedMs: __testing.SHELL_TIMEOUT_MS,
+    })
+    expect(body).toContain("timed out after")
+    expect(body).not.toContain("exit 0")
+  })
+
+  test("appends 'output truncated' when either stream hit the cap", () => {
+    const body = __testing.formatShellResult("yes | head", {
+      ...baseResult,
+      stdout: "y\n".repeat(10),
+      stdoutTruncated: true,
+    })
+    expect(body).toContain("output truncated")
+  })
+
+  test("surfaces spawn errors instead of swallowing them as exit code", () => {
+    // INV-11: a spawn failure (e.g. cwd doesn't exist) must be visible to the
+    // user, not silently presented as `exit ?`.
+    const body = __testing.formatShellResult("anything", {
+      ...baseResult,
+      stdout: "",
+      exitCode: null,
+      spawnError: "ENOENT: cwd missing",
+    })
+    expect(body).toContain("spawn failed: ENOENT: cwd missing")
+  })
+})
+
+describe("execShellCommand", () => {
+  test("runs a successful command and captures stdout with exit 0", async () => {
+    const result = await __testing.execShellCommand("printf 'hello\\nworld\\n'", process.cwd())
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe("hello\nworld\n")
+    expect(result.stderr).toBe("")
+    expect(result.timedOut).toBe(false)
+    expect(result.spawnError).toBeNull()
+  })
+
+  test("captures non-zero exit codes without throwing", async () => {
+    const result = await __testing.execShellCommand("exit 7", process.cwd())
+    expect(result.exitCode).toBe(7)
+    expect(result.spawnError).toBeNull()
+  })
+
+  test("reports a spawn error when the working directory does not exist", async () => {
+    const result = await __testing.execShellCommand("echo ok", "/definitely/does/not/exist-xyz-12345")
+    expect(result.spawnError).not.toBeNull()
+    expect(result.exitCode).toBeNull()
+  })
+
+  test("caps stdout at SHELL_MAX_OUTPUT_CHARS and flags truncation", async () => {
+    // Generate well over the cap to make sure we actually hit it.
+    const result = await __testing.execShellCommand(
+      `node -e 'process.stdout.write("a".repeat(${__testing.SHELL_MAX_OUTPUT_CHARS + 1000}))'`,
+      process.cwd()
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.length).toBe(__testing.SHELL_MAX_OUTPUT_CHARS)
+    expect(result.stdoutTruncated).toBe(true)
+  })
+
+  test("escalates SIGTERM to SIGKILL when the child traps and ignores SIGTERM", async () => {
+    // A bare `trap '' TERM` sh-builtin ignores SIGTERM. Without escalation
+    // the watchdog would sit forever. We've previously regressed this by
+    // gating the SIGKILL on `child.killed`, which flips to `true` the moment
+    // `kill()` is called and so blocked the escalation — pinned via the
+    // `settled` flag now. 150ms timeout + 250ms grace keeps the test fast.
+    const result = await __testing.execShellCommand("trap '' TERM; sleep 5", process.cwd(), {
+      timeoutMs: 150,
+      sigkillGraceMs: 250,
+    })
+    expect(result.timedOut).toBe(true)
+    expect(result.signal).toBe("SIGKILL")
+    expect(result.elapsedMs).toBeLessThan(2_000)
+  })
+})
+
+describe("formatShortDuration", () => {
+  test("renders sub-second durations as integer milliseconds", () => {
+    expect(__testing.formatShortDuration(0)).toBe("0ms")
+    expect(__testing.formatShortDuration(142)).toBe("142ms")
+    expect(__testing.formatShortDuration(999)).toBe("999ms")
+  })
+
+  test("renders sub-10s durations with two decimals", () => {
+    expect(__testing.formatShortDuration(1_000)).toBe("1.00s")
+    expect(__testing.formatShortDuration(2_345)).toBe("2.35s")
+    expect(__testing.formatShortDuration(9_999)).toBe("10.00s")
+  })
+
+  test("renders 10s–59s durations with one decimal", () => {
+    expect(__testing.formatShortDuration(10_000)).toBe("10.0s")
+    expect(__testing.formatShortDuration(59_949)).toBe("59.9s")
+  })
+
+  test("falls through to formatDuration at the minute boundary", () => {
+    // The shell timeout is 60_000ms exactly; the boundary lands on
+    // `formatDuration` so the longer-format wording stays consistent.
+    expect(__testing.formatShortDuration(60_000)).toBe("1 min")
+    expect(__testing.formatShortDuration(125_000)).toBe("2 min")
   })
 })

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process"
+import { execFile, spawn } from "node:child_process"
 import { promisify } from "node:util"
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
 import { homedir, hostname, platform } from "node:os"
@@ -34,7 +34,16 @@ const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000
 const MAX_RETRY_ATTEMPTS = 3
 const PI_TOOL_TRACE_FORMAT = "pi_tool_trace"
 const SESSION_CONTROL_CAPABILITY = "session-control"
-const SESSION_CONTROL_COMMANDS = ["compact", "model", "thinking", "skill", "reload"] as const
+const SESSION_CONTROL_COMMANDS = ["compact", "model", "thinking", "skill", "reload", "shell"] as const
+const SHELL_TIMEOUT_MS = 60_000
+// 32K chars per stream — large enough for typical output, small enough to avoid
+// dumping a CI log into the scratchpad if a curious user pipes `find /` in.
+const SHELL_MAX_OUTPUT_CHARS = 32 * 1024
+const SHELL_USAGE = [
+  "Usage: `/shell <command>`",
+  "Runs in the linked Pi session's working directory via `$SHELL -c`.",
+  "60s timeout; output capped at 32K chars per stream.",
+].join("\n")
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const
 type ThinkingLevel = (typeof THINKING_LEVELS)[number]
 const execFileAsync = promisify(execFile)
@@ -288,8 +297,14 @@ function setCurrentSessionEnabled(ctx: ExtensionContext, enabled: boolean): Runt
   return link
 }
 
-function buildScratchpadUrl(baseUrl: string, streamUrlPath: string): string {
-  return new URL(streamUrlPath, baseUrl).toString()
+function buildScratchpadUrl(baseUrl: string, workspaceId: string, streamId: string): string {
+  // The frontend route is `/w/:workspaceId/s/:streamId`. Older server versions
+  // returned `streamUrlPath: /streams/<id>` (no workspace prefix) and that
+  // value is persisted in `config.linkedSessions` for upgraded installs, so we
+  // can't trust the stored path. Compose locally from data the client owns —
+  // it's stable across server format changes and migrates existing links for
+  // free without touching disk.
+  return new URL(`/w/${workspaceId}/s/${streamId}`, baseUrl).toString()
 }
 
 async function openExternalUrl(url: string): Promise<void> {
@@ -1520,6 +1535,140 @@ async function runReloadCommand(invocation: ClaimedInvocation, ctx: ExtensionCon
   await ctx.reload()
 }
 
+type ShellExecResult = {
+  stdout: string
+  stderr: string
+  stdoutTruncated: boolean
+  stderrTruncated: boolean
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+  timedOut: boolean
+  elapsedMs: number
+  spawnError: string | null
+}
+
+function appendCapped(existing: string, chunk: string, max: number): { text: string; truncated: boolean } {
+  if (existing.length >= max) return { text: existing, truncated: true }
+  const remaining = max - existing.length
+  if (chunk.length <= remaining) return { text: existing + chunk, truncated: false }
+  return { text: existing + chunk.slice(0, remaining), truncated: true }
+}
+
+function formatShellResult(command: string, result: ShellExecResult): string {
+  // Single fenced block for stdout, separate block for stderr only when present
+  // — keeps the common "ran cleanly with stdout" case readable. Footer is one
+  // line of "exit N · 142ms · output truncated" so the human can scan it.
+  const lines: string[] = ["```", `$ ${command}`]
+  if (result.stdout.length > 0) lines.push(result.stdout.replace(/\n+$/, ""))
+  lines.push("```")
+  if (result.stderr.length > 0) {
+    lines.push("**stderr**", "```", result.stderr.replace(/\n+$/, ""), "```")
+  }
+  const footer: string[] = []
+  if (result.spawnError) {
+    footer.push(`spawn failed: ${result.spawnError}`)
+  } else if (result.timedOut) {
+    footer.push(`timed out after ${formatShortDuration(result.elapsedMs)}`)
+  } else if (result.signal) {
+    footer.push(`signal ${result.signal}`)
+    footer.push(formatShortDuration(result.elapsedMs))
+  } else {
+    footer.push(`exit ${result.exitCode ?? "?"}`)
+    footer.push(formatShortDuration(result.elapsedMs))
+  }
+  if (result.stdoutTruncated || result.stderrTruncated) footer.push("output truncated")
+  lines.push(footer.join(" · "))
+  return lines.join("\n")
+}
+
+async function execShellCommand(
+  command: string,
+  cwd: string,
+  options?: { timeoutMs?: number; sigkillGraceMs?: number }
+): Promise<ShellExecResult> {
+  // `$SHELL -c "<command>"` so pipes / redirects / globs / env-expansion all
+  // work the way Pi's `!` does. `/bin/sh` is the portable fallback when SHELL
+  // is unset (rare, but happens in stripped Docker images).
+  const shell = process.env.SHELL ?? "/bin/sh"
+  const timeoutMs = options?.timeoutMs ?? SHELL_TIMEOUT_MS
+  const sigkillGraceMs = options?.sigkillGraceMs ?? 1_000
+  const startedAt = Date.now()
+  return new Promise<ShellExecResult>((resolvePromise) => {
+    const child = spawn(shell, ["-c", command], { cwd, env: process.env })
+    let stdout = ""
+    let stderr = ""
+    let stdoutTruncated = false
+    let stderrTruncated = false
+    let timedOut = false
+    let settled = false
+    const settle = (result: Omit<ShellExecResult, "elapsedMs">) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolvePromise({ ...result, elapsedMs: Date.now() - startedAt })
+    }
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill("SIGTERM")
+      // Escalate to SIGKILL if the child ignores SIGTERM. `child.killed` is
+      // set the instant `kill()` is *called* — not when the process actually
+      // exits — so it would be `true` here regardless and SIGKILL would never
+      // fire. The `settled` flag, by contrast, only flips in the `exit`/
+      // `error` handlers, so it tells us whether the child has actually
+      // gone away. 1s is enough for a well-behaved process to flush; longer
+      // waits keep the scratchpad in a busy state for no benefit.
+      setTimeout(() => {
+        if (!settled) child.kill("SIGKILL")
+      }, sigkillGraceMs).unref()
+    }, timeoutMs)
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const { text, truncated } = appendCapped(stdout, chunk.toString("utf8"), SHELL_MAX_OUTPUT_CHARS)
+      stdout = text
+      if (truncated) stdoutTruncated = true
+    })
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const { text, truncated } = appendCapped(stderr, chunk.toString("utf8"), SHELL_MAX_OUTPUT_CHARS)
+      stderr = text
+      if (truncated) stderrTruncated = true
+    })
+    child.on("error", (err) => {
+      settle({
+        stdout,
+        stderr,
+        stdoutTruncated,
+        stderrTruncated,
+        exitCode: null,
+        signal: null,
+        timedOut,
+        spawnError: err instanceof Error ? err.message : String(err),
+      })
+    })
+    child.on("close", (exitCode, signal) => {
+      settle({
+        stdout,
+        stderr,
+        stdoutTruncated,
+        stderrTruncated,
+        exitCode,
+        signal,
+        timedOut,
+        spawnError: null,
+      })
+    })
+  })
+}
+
+async function runShellCommand(invocation: ClaimedInvocation, args: string, ctx: ExtensionContext): Promise<void> {
+  const command = args.trim()
+  if (command.length === 0) {
+    await completeInvocationWithMarkdown(invocation, SHELL_USAGE, ctx)
+    return
+  }
+  await recordInvocationTraceStep(invocation, "tool_call", `$ ${command}`, `Running shell…`)
+  const result = await execShellCommand(command, ctx.cwd)
+  await completeInvocationWithMarkdown(invocation, formatShellResult(command, result), ctx)
+}
+
 async function runSkillCommand(
   pi: ExtensionAPI,
   invocation: ClaimedInvocation,
@@ -1584,6 +1733,9 @@ async function handleSessionControlInvocation(
         return
       case "reload":
         await runReloadCommand(invocation, ctx)
+        return
+      case "shell":
+        await runShellCommand(invocation, command.args, ctx)
         return
       default:
         await failInvocation(invocation, `Unsupported session-control command: ${command.name}`)
@@ -1748,6 +1900,21 @@ function formatDuration(ms: number): string {
   const hours = Math.floor(totalMin / 60)
   const minutes = totalMin % 60
   return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
+}
+
+function formatShortDuration(ms: number): string {
+  // Used in surfaces where typical durations are sub-minute (shell footers,
+  // mostly). `formatDuration` rounds to whole minutes and collapses anything
+  // shorter into "<1 min", which is useless for commands that finish in tens
+  // of milliseconds. Fall through to `formatDuration` once we're past a
+  // minute so longer-format strings stay consistent across the file.
+  if (ms < 0) return formatDuration(ms)
+  if (ms < 1_000) return `${ms}ms`
+  if (ms < 60_000) {
+    const seconds = ms / 1_000
+    return `${seconds < 10 ? seconds.toFixed(2) : seconds.toFixed(1)}s`
+  }
+  return formatDuration(ms)
 }
 
 function describeProviderError(status: number, headers: unknown, now: number = Date.now()): string {
@@ -2034,6 +2201,7 @@ export const __testing = {
   describeProviderError,
   formatRetryNotice,
   formatDuration,
+  formatShortDuration,
   formatLocalTime,
   parseWsHint,
   buildBotSocketUrl,
@@ -2041,6 +2209,11 @@ export const __testing = {
   sanitizeInstanceIdSegment,
   migrateInstanceId,
   formatHelloAckDetails,
+  appendCapped,
+  formatShellResult,
+  execShellCommand,
+  SHELL_MAX_OUTPUT_CHARS,
+  SHELL_TIMEOUT_MS,
   MAX_AUTO_RETRY_MS,
   MAX_RETRY_ATTEMPTS,
   WS_BACKSTOP_POLL_MS,
@@ -2049,7 +2222,8 @@ export const __testing = {
 
 export default function (pi: ExtensionAPI): void {
   pi.registerCommand("remote-control", {
-    description: "Create or link a Threa scratchpad to this Pi session",
+    description:
+      "Link this Pi session to a Threa scratchpad: configure | status | open | on | off | debug | debug-polls [on|off]",
     handler: async (args, ctx) => {
       const trimmedArgs = args.trim()
       const commandMatch = trimmedArgs.match(/^(\S+)(?:\s+([\s\S]*))?$/)
@@ -2079,7 +2253,7 @@ export default function (pi: ExtensionAPI): void {
           ctx.ui.notify("No Threa remote session is linked here. Run /remote-control first.", "warning")
           return
         }
-        const url = buildScratchpadUrl(config.baseUrl, link.streamUrlPath)
+        const url = buildScratchpadUrl(config.baseUrl, config.workspaceId, link.activeStreamId)
         try {
           await openExternalUrl(url)
           ctx.ui.notify(`Opening Threa scratchpad: ${url}`, "info")
@@ -2127,6 +2301,23 @@ export default function (pi: ExtensionAPI): void {
           "info"
         )
         return
+      }
+      // Bare `/remote-control` with no args is idempotent: if this Pi session
+      // is already linked, report status instead of POSTing to /sessions, which
+      // would clobber the local link with a fresh scratchpad. An instanceId
+      // migration (or any change that makes the server's existing-link lookup
+      // miss) used to silently mint a new scratchpad here. Re-linking is a
+      // destructive action — the user has to ask for it explicitly by passing
+      // a display name (`/remote-control "Some name"`).
+      if (trimmedArgs === "") {
+        const link = getCurrentSessionLink(ctx)
+        if (link) {
+          ctx.ui.notify(
+            `Threa remote already linked for this Pi session (${link.enabled ? "on" : "off"}). Run \`/remote-control status\` for details or \`/remote-control open\` to open the scratchpad.`,
+            "info"
+          )
+          return
+        }
       }
       await createRemoteSession(ctx, trimmedArgs)
       await resolveBotWsHint(ctx, { force: true })

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -227,10 +227,37 @@ function saveConfig(): void {
   writeFileSync(CONFIG_PATH, `${JSON.stringify(persisted, null, 2)}\n`)
 }
 
+// Server `bot:hello` schema constrains `instanceId` to `^[A-Za-z0-9_-]+$`
+// (see backend `socket-handler.ts`). macOS `hostname()` returns values like
+// `kristoffers-mbp.lan` — the literal dot breaks the regex and the handshake
+// rejects every connect, silently degrading the plugin to a 30s WS backstop
+// poll. Sanitize at the boundary and migrate previously-persisted bad ids.
+const INSTANCE_ID_REGEX = /^[A-Za-z0-9_-]+$/
+const INSTANCE_ID_UNSAFE_CHARS = /[^A-Za-z0-9_-]+/g
+
+function sanitizeInstanceIdSegment(raw: string): string {
+  return raw.replace(INSTANCE_ID_UNSAFE_CHARS, "-").replace(/^-+|-+$/g, "")
+}
+
+function migrateInstanceId(stored: string): string {
+  if (INSTANCE_ID_REGEX.test(stored)) return stored
+  const cleaned = sanitizeInstanceIdSegment(stored)
+  return cleaned.length > 0 ? cleaned : `pi-${crypto.randomUUID().slice(0, 8)}`
+}
+
 function ensureInstanceId(): string {
   if (!config) throw new Error("Threa remote config not loaded")
-  if (config.instanceId) return config.instanceId
-  config.instanceId = `pi-${hostname()}-${crypto.randomUUID().slice(0, 8)}`
+  if (config.instanceId) {
+    const migrated = migrateInstanceId(config.instanceId)
+    if (migrated !== config.instanceId) {
+      config.instanceId = migrated
+      saveConfig()
+    }
+    return config.instanceId
+  }
+  const host = sanitizeInstanceIdSegment(hostname())
+  const prefix = host.length > 0 ? `pi-${host}` : "pi"
+  config.instanceId = `${prefix}-${crypto.randomUUID().slice(0, 8)}`
   saveConfig()
   return config.instanceId
 }
@@ -530,6 +557,12 @@ function attachBotWebSocket(pi: ExtensionAPI, ctx: ExtensionContext): void {
   })
 }
 
+function formatHelloAckDetails(details: unknown): string {
+  if (!isObject(details)) return ""
+  const parts = Object.entries(details).map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+  return parts.length > 0 ? ` (${parts.join("; ")})` : ""
+}
+
 function sendBotHello(pi: ExtensionAPI, ctx: ExtensionContext): void {
   if (!botSocket || !config) return
   const sessionLink = getCurrentSessionLink(ctx)
@@ -540,8 +573,22 @@ function sendBotHello(pi: ExtensionAPI, ctx: ExtensionContext): void {
       return
     }
     if (ack.ok !== true) {
+      // Fail loud: leaving the socket up with `botWsConnected = true` would
+      // keep us on the 30s WS backstop poll while no event will ever reach
+      // us (no room join happened). Drop the socket so polling resumes at
+      // the fast (3s) floor.
       const message = typeof ack.error === "string" ? ack.error : "unknown error"
-      noteWsDebug(ctx, `bot:hello rejected: ${message}`)
+      const details = formatHelloAckDetails((ack as { details?: unknown }).details)
+      noteWsDebug(ctx, `bot:hello rejected: ${message}${details}`)
+      setRemoteStatus(ctx, `Threa remote: WS handshake rejected — ${message}`, "error")
+      tearDownBotWebSocket()
+      // Gate re-resolve so a persistently-rejecting server doesn't get
+      // hammered every poll tick (~3s when WS is down). `tearDownBotWebSocket`
+      // resets the throttle so a `/configure` retries immediately; we set it
+      // here AFTER teardown to apply the 60s backoff specifically to the
+      // handshake-failure path. The next user-initiated path (`enableRemote`,
+      // `createRemoteSession`) passes `{ force: true }` and bypasses this.
+      lastWsResolveAttemptAt = Date.now()
       return
     }
     if (typeof ack.serverGeneratedAt === "string") {
@@ -1985,6 +2032,9 @@ export const __testing = {
   parseWsHint,
   buildBotSocketUrl,
   fetchWsHintFromConfig,
+  sanitizeInstanceIdSegment,
+  migrateInstanceId,
+  formatHelloAckDetails,
   MAX_AUTO_RETRY_MS,
   MAX_RETRY_ATTEMPTS,
   WS_BACKSTOP_POLL_MS,

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -239,7 +239,13 @@ function sanitizeInstanceIdSegment(raw: string): string {
   return raw.replace(INSTANCE_ID_UNSAFE_CHARS, "-").replace(/^-+|-+$/g, "")
 }
 
-function migrateInstanceId(stored: string): string {
+function migrateInstanceId(stored: unknown): string {
+  // `config.instanceId` is loaded via `JSON.parse` and `readConfig` only
+  // type-checks the three required fields. A hand-edited config could put
+  // anything here, so accept `unknown` and treat non-strings as missing.
+  if (typeof stored !== "string" || stored.length === 0) {
+    return `pi-${crypto.randomUUID().slice(0, 8)}`
+  }
   if (INSTANCE_ID_REGEX.test(stored)) return stored
   const cleaned = sanitizeInstanceIdSegment(stored)
   return cleaned.length > 0 ? cleaned : `pi-${crypto.randomUUID().slice(0, 8)}`
@@ -247,7 +253,7 @@ function migrateInstanceId(stored: string): string {
 
 function ensureInstanceId(): string {
   if (!config) throw new Error("Threa remote config not loaded")
-  if (config.instanceId) {
+  if (typeof config.instanceId === "string" && config.instanceId.length > 0) {
     const migrated = migrateInstanceId(config.instanceId)
     if (migrated !== config.instanceId) {
       config.instanceId = migrated


### PR DESCRIPTION
## Summary

- `hostname()` on macOS returns values like `kristoffers-mbp.lan`. The dot violates the server's `bot:hello` schema (`^[A-Za-z0-9_-]+$` at `apps/backend/src/features/bot-runtimes/socket-handler.ts:14`), so every WS handshake was rejected with `Invalid bot:hello payload` and the per-instance Socket.IO room never got joined. The push channel from PR #640 silently delivered zero events for affected hosts.
- Compounding bug: `sendBotHello`'s `ok: false` branch only logged `noteWsDebug` and returned. `botWsConnected` stayed `true`, so the safety-backstop poll ran at its WS-up cadence of **30s** instead of the WS-down floor of **3s**. Result: slash commands and mentions took 10–16s (mid-cycle of a 30s wait) instead of sub-second.
- Fix sanitizes `hostname()` before composing the id, migrates any persisted bad `config.instanceId` in place on next load (preserving the random suffix so presence/claim identity stays stable), and on hello rejection tears down the socket + surfaces an error-toned status so polling drops to the fast floor. A 60s `lastWsResolveAttemptAt` watermark is set after the rejected-teardown so a persistently-rejecting server isn't hammered every poll tick.

## Test plan

- [x] `cd extensions/pi-remote && bun test` — 50 pass, 0 fail (39 prior + 11 new covering sanitizer, migration including pinned dot-laptop case, and ack-details formatter)
- [ ] Local install per `extensions/pi-remote/README.md`, then `/remote-control` status no longer shows `bot:hello rejected: Invalid bot:hello payload`
- [ ] `/thinking` from a scratchpad responds sub-second (previously 10–16s)
- [ ] Force a schema failure (corrupt `instanceId` to contain `:` in config) and confirm the user-visible status surfaces `Threa remote: WS handshake rejected — Invalid bot:hello payload` and the plugin drops to the 3s polling floor instead of silently sitting on the 30s backstop

## Follow-up (not in this PR)

- Extend the `bot_invocation:available` outbox payload to carry the full serialized invocation (skip the HTTP claim round-trip for prompt content)
- Subscribe-then-bootstrap state machine + queue/dedupe per INV-53 (defense in depth against the room-join gap during `bot:hello` processing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782494268&installation_id=129946197&pr_number=641&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F641&signature=88636681d57b9f652ec81710574ba79f721249fadac48ab015c19d9ad3d3fc70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->