### PR TITLE
feat(pi-remote): /remote-control rename + dirname-aware default name

### DIFF
--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -87,6 +87,7 @@ import {
   findMessagesByMetadataSchema,
   upsertPresenceSchema,
   createRuntimeSessionSchema,
+  renameRuntimeSessionSchema,
   claimInvocationSchema,
   renewInvocationClaimSchema,
   completeInvocationSchema,
@@ -793,6 +794,37 @@ export function createPublicApiHandlers({
           activeStreamId: link.activeStreamId,
           runtimeSessionId: link.runtimeSessionId,
           streamUrlPath: `/w/${req.workspaceId!}/s/${stream.id}`,
+        },
+      })
+    },
+
+    async renameBotRuntimeSession(req: Request, res: Response) {
+      if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
+      const result = renameRuntimeSessionSchema.safeParse(req.body)
+      if (!result.success) {
+        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
+      }
+      const link = await botRuntimeService.findActivePiRemoteSession({
+        workspaceId: req.workspaceId!,
+        botId: req.botApiKey.botId,
+        instanceId: result.data.instanceId,
+        runtimeSessionId: result.data.runtimeSessionId,
+      })
+      if (!link) {
+        throw new HttpError("No active runtime session link found", { status: 404, code: "NOT_FOUND" })
+      }
+      const updated = await streamService.updateStream(link.activeStreamId, { displayName: result.data.displayName })
+      if (!updated) {
+        throw new HttpError("Linked stream not found", { status: 404, code: "NOT_FOUND" })
+      }
+      res.json({
+        data: {
+          linkId: link.id,
+          rootStreamId: link.rootStreamId,
+          activeStreamId: link.activeStreamId,
+          runtimeSessionId: link.runtimeSessionId,
+          streamUrlPath: `/w/${req.workspaceId!}/s/${link.activeStreamId}`,
+          displayName: updated.displayName ?? result.data.displayName,
         },
       })
     },

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -35,6 +35,7 @@ import {
   findMessagesByMetadataSchema,
   upsertPresenceSchema,
   createRuntimeSessionSchema,
+  renameRuntimeSessionSchema,
   claimInvocationSchema,
   renewInvocationClaimSchema,
   completeInvocationSchema,
@@ -324,6 +325,8 @@ const runtimeSessionLinkSchema = z.object({
   streamUrlPath: z.string(),
 })
 
+const renamedRuntimeSessionLinkSchema = runtimeSessionLinkSchema.extend({ displayName: z.string() })
+
 const invocationStatusSchema = z.object({ invocationId: z.string(), status: z.string() })
 const invocationStepSchema = z.object({ invocationId: z.string(), sessionId: z.string(), stepId: z.string() })
 const renewedInvocationSchema = invocationStatusSchema.extend({ claimExpiresAt: z.string().datetime().nullable() })
@@ -541,6 +544,19 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     requestSchema: createRuntimeSessionSchema,
     requestIn: "body",
     responseSchema: dataEnvelope(runtimeSessionLinkSchema),
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-runtime/sessions/rename",
+    operationId: "renameBotRuntimeSession",
+    summary: "Rename the scratchpad linked to a bot runtime session",
+    tags: ["Bot runtimes"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE],
+    parameters: [workspaceIdParam],
+    requestSchema: renameRuntimeSessionSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(renamedRuntimeSessionLinkSchema),
+    canReturn404: true,
   },
   {
     method: "post",

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -83,6 +83,12 @@ export const createRuntimeSessionSchema = z.object({
   localCwd: z.string().max(1000).optional(),
 })
 
+export const renameRuntimeSessionSchema = z.object({
+  instanceId: z.string().min(1).max(128),
+  runtimeSessionId: z.string().min(1).max(256),
+  displayName: z.string().min(1).max(100),
+})
+
 export const claimInvocationSchema = z.object({
   runtimeKind: z.enum(BOT_RUNTIME_KINDS),
   instanceId: z.string().min(1).max(128),

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -660,6 +660,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     publicApi.createBotRuntimeSession
   )
   app.post(
+    "/api/v1/workspaces/:workspaceId/bot-runtime/sessions/rename",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE),
+    publicApi.renameBotRuntimeSession
+  )
+  app.post(
     "/api/v1/workspaces/:workspaceId/bot-invocations/claim",
     ...publicMiddleware,
     requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1097,6 +1097,102 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/bot-runtime/sessions/rename": {
+      "post": {
+        "operationId": "renameBotRuntimeSession",
+        "summary": "Rename the scratchpad linked to a bot runtime session",
+        "tags": ["Bot runtimes"],
+        "security": [{ "apiKey": ["bot-runtime:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
+                  "displayName": { "type": "string", "minLength": 1, "maxLength": 100 }
+                },
+                "required": ["instanceId", "runtimeSessionId", "displayName"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "linkId": { "type": "string" },
+                        "rootStreamId": { "type": "string" },
+                        "activeStreamId": { "type": "string" },
+                        "runtimeSessionId": { "type": "string" },
+                        "streamUrlPath": { "type": "string" },
+                        "displayName": { "type": "string" }
+                      },
+                      "required": [
+                        "linkId",
+                        "rootStreamId",
+                        "activeStreamId",
+                        "runtimeSessionId",
+                        "streamUrlPath",
+                        "displayName"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/bot-invocations/claim": {
       "post": {
         "operationId": "claimBotInvocation",

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -623,3 +623,27 @@ describe("formatShortDuration", () => {
     expect(__testing.formatShortDuration(125_000)).toBe("2 min")
   })
 })
+
+describe("defaultDisplayNameFor", () => {
+  test("derives `Pi remote: <dirname>` from the working directory tail", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa")).toBe("Pi remote: threa")
+  })
+
+  test("ignores a trailing slash on the working directory", () => {
+    // `cwd` is conventionally unsuffixed, but defensively we should not produce
+    // `Pi remote: ` with an empty dirname when the path ends in `/`.
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa/")).toBe("Pi remote: threa")
+  })
+
+  test("falls back to `session` when the working directory is the filesystem root", () => {
+    expect(__testing.defaultDisplayNameFor("/")).toBe("Pi remote: session")
+  })
+
+  test("respects an explicit configured override", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "Local Pi")).toBe("Local Pi")
+  })
+
+  test("treats an empty configured override as unset (avoids `Pi remote: ` shape collapse)", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "")).toBe("Pi remote: threa")
+  })
+})

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -890,10 +890,20 @@ function formatInvocationTrace(invocation: ClaimedInvocation, context: string): 
   )
 }
 
+function defaultDisplayNameFor(cwd: string, configuredOverride?: string): string {
+  // `configuredOverride` (set during /configure) wins over the dirname shape so
+  // power users can pin a name across workspaces. The dirname suffix is what
+  // most users actually want — it makes the scratchpad searchable in Threa as
+  // "Pi remote: <project>" without needing to type a label every time.
+  if (configuredOverride) return configuredOverride
+  const dir = cwd.split("/").filter(Boolean).pop() ?? "session"
+  return `Pi remote: ${dir}`
+}
+
 async function createRemoteSession(ctx: ExtensionCommandContext, args: string): Promise<void> {
   if (!config) throw new Error("Threa remote config not loaded")
   const runtimeSessionId = getRuntimeSessionId(ctx)
-  const displayName = args.trim() || config.defaultDisplayName || ctx.cwd.split("/").pop() || "Pi"
+  const displayName = args.trim() || defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName)
 
   const body = await request<{ data: RuntimeSessionLink }>(
     `/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions`,
@@ -923,6 +933,25 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
   ctx.ui.notify(`Threa remote linked: ${body.data.streamUrlPath}`, "info")
   setRemoteStatus(ctx, `Threa remote: ${displayName}`)
   await heartbeat("available", undefined, ctx)
+}
+
+async function renameRemoteSession(ctx: ExtensionCommandContext, displayName: string): Promise<void> {
+  if (!config) throw new Error("Threa remote config not loaded")
+  const link = getCurrentSessionLink(ctx)
+  if (!link) {
+    ctx.ui.notify("No Threa remote session is linked here. Run /remote-control first.", "warning")
+    return
+  }
+  await request(`/api/v1/workspaces/${config.workspaceId}/bot-runtime/sessions/rename`, {
+    method: "POST",
+    body: JSON.stringify({
+      instanceId: ensureInstanceId(),
+      runtimeSessionId: getRuntimeSessionId(ctx),
+      displayName,
+    }),
+  })
+  ctx.ui.notify(`Threa remote renamed to "${displayName}"`, "info")
+  setRemoteStatus(ctx, `Threa remote: ${displayName}`)
 }
 
 async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<void> {
@@ -2202,6 +2231,7 @@ export const __testing = {
   formatRetryNotice,
   formatDuration,
   formatShortDuration,
+  defaultDisplayNameFor,
   formatLocalTime,
   parseWsHint,
   buildBotSocketUrl,
@@ -2223,7 +2253,7 @@ export const __testing = {
 export default function (pi: ExtensionAPI): void {
   pi.registerCommand("remote-control", {
     description:
-      "Link this Pi session to a Threa scratchpad: configure | status | open | on | off | debug | debug-polls [on|off]",
+      "Link this Pi session to a Threa scratchpad: configure | status | open | rename <name> | on | off | debug | debug-polls [on|off]",
     handler: async (args, ctx) => {
       const trimmedArgs = args.trim()
       const commandMatch = trimmedArgs.match(/^(\S+)(?:\s+([\s\S]*))?$/)
@@ -2302,22 +2332,39 @@ export default function (pi: ExtensionAPI): void {
         )
         return
       }
-      // Bare `/remote-control` with no args is idempotent: if this Pi session
-      // is already linked, report status instead of POSTing to /sessions, which
-      // would clobber the local link with a fresh scratchpad. An instanceId
-      // migration (or any change that makes the server's existing-link lookup
-      // miss) used to silently mint a new scratchpad here. Re-linking is a
-      // destructive action — the user has to ask for it explicitly by passing
-      // a display name (`/remote-control "Some name"`).
-      if (trimmedArgs === "") {
-        const link = getCurrentSessionLink(ctx)
-        if (link) {
+      if (command === "rename") {
+        const newName = commandArgs.trim()
+        if (!newName) {
+          ctx.ui.notify("Usage: `/remote-control rename <new name>`", "warning")
+          return
+        }
+        await renameRemoteSession(ctx, newName)
+        return
+      }
+      // Once a session is linked, a bare display-name argument is ambiguous —
+      // it could mean "re-link to a fresh scratchpad" or "rename the existing
+      // one". Force the user to be explicit: `rename` mutates the current
+      // scratchpad, `off` first then `/remote-control "Name"` creates a new one.
+      const existingLink = getCurrentSessionLink(ctx)
+      if (existingLink) {
+        if (trimmedArgs === "") {
+          // Bare `/remote-control` with no args is idempotent: if this Pi
+          // session is already linked, report status instead of POSTing to
+          // /sessions, which would clobber the local link with a fresh
+          // scratchpad. An instanceId migration (or any change that makes the
+          // server's existing-link lookup miss) used to silently mint a new
+          // scratchpad here.
           ctx.ui.notify(
-            `Threa remote already linked for this Pi session (${link.enabled ? "on" : "off"}). Run \`/remote-control status\` for details or \`/remote-control open\` to open the scratchpad.`,
+            `Threa remote already linked for this Pi session (${existingLink.enabled ? "on" : "off"}). Run \`/remote-control status\` for details or \`/remote-control open\` to open the scratchpad.`,
             "info"
           )
           return
         }
+        ctx.ui.notify(
+          "Threa remote is already linked for this Pi session. Use `/remote-control rename <name>` to rename the scratchpad, or `/remote-control off` first to relink.",
+          "warning"
+        )
+        return
       }
       await createRemoteSession(ctx, trimmedArgs)
       await resolveBotWsHint(ctx, { force: true })


### PR DESCRIPTION
## Summary

- **`/remote-control rename <new name>`** retitles the scratchpad linked to the current Pi session without re-linking. Passing a name to an already-linked session (`/remote-control \"Some name\"`) now prints a hint pointing at `rename` or `off`, instead of one or the other ambiguously happening silently.
- **Default display name on first link** is now `Pi remote: <dirname>` — `Pi remote: threa` for this project. Explicit name arg still wins; `config.defaultDisplayName` (set via `/configure`) still wins over the dirname shape for power users who want to pin a name.
- **Backend:** new bot-scoped `POST /api/v1/workspaces/:wsId/bot-runtime/sessions/rename` (BOT_RUNTIME_WRITE). Looks up the active link by `(botId, instanceId, runtimeSessionId)`, calls `streamService.updateStream`, which emits the existing `stream:updated` outbox event so the frontend picks up the new name on its normal channel — no special-case bot path needed.

The user-facing PATCH `/streams/:streamId` endpoint is `authed`-only (cookie session), so a bot can't reuse it. The new endpoint is a thin wrapper over the same service call, but gated on the runtime-session link (404 if the bot doesn't actually own a session there) — so a bot key can't rename arbitrary scratchpads, only its own.

## Test plan

- [x] `bun test` in `extensions/pi-remote` (74 pass — 5 new tests for `defaultDisplayNameFor`)
- [x] `bun test src/features/public-api` + `bun test src/features/bot-runtimes` in backend (clean)
- [x] `bun run typecheck` (workspace-wide)
- [x] `bun run generate:api-docs:check` (spec regenerated, new endpoint included)
- [ ] Manual: `/remote-control` in a fresh Pi session creates a scratchpad named `Pi remote: <project>`
- [ ] Manual: `/remote-control rename Better Name` updates the title in real time in the Threa UI
- [ ] Manual: `/remote-control \"Some name\"` with an existing link prints the hint instead of clobbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782503764&installation_id=129946197&pr_number=645&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F645&signature=f8bf7ab8c9c3c9a5e1c2ccb50fdfb3bbbb40dc7cdf14e2f8e566e21e932f8ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->