### PR TITLE
feat(scratchpad): support companion-off scratchpads ("quiet mode")

### DIFF
--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -10,6 +10,7 @@ import type {
   UpdateStreamInput,
   NotificationLevel,
   SharedMessageHydration,
+  CompanionMode,
 } from "@threa/types"
 
 /**
@@ -62,6 +63,18 @@ export const streamsApi = {
 
   async update(workspaceId: string, streamId: string, data: UpdateStreamInput): Promise<Stream> {
     const res = await api.patch<{ stream: Stream }>(`/api/workspaces/${workspaceId}/streams/${streamId}`, data)
+    return res.stream
+  },
+
+  async updateCompanionMode(
+    workspaceId: string,
+    streamId: string,
+    data: { companionMode: CompanionMode; companionPersonaId?: string | null }
+  ): Promise<Stream> {
+    const res = await api.patch<{ stream: Stream }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/companion`,
+      data
+    )
     return res.stream
   },
 

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -162,6 +162,34 @@ describe("ScratchpadItem", () => {
     expect(screen.getByTestId("location").textContent).toBe(initialPath)
   })
 
+  it("shows the AI companion badge on companion-on scratchpads", () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({ companionMode: "on" })}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    expect(screen.getByLabelText("AI companion attached")).toBeInTheDocument()
+  })
+
+  it("hides the AI companion badge on companion-off scratchpads", () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({ companionMode: "off" })}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    expect(screen.queryByLabelText("AI companion attached")).not.toBeInTheDocument()
+  })
+
   it("deletes draft scratchpads directly and navigates away when the active draft is removed", async () => {
     renderWithRouter(
       <ScratchpadItem

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -188,6 +188,24 @@ describe("ScratchpadItem", () => {
     )
 
     expect(screen.queryByLabelText("AI companion attached")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Encrypted scratchpad")).not.toBeInTheDocument()
+  })
+
+  it("shows the lock badge on encrypted scratchpads instead of the companion badge", () => {
+    // INV-E1 forces companion off for E2E streams server-side, so we only ever
+    // see this combination in the wild.
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({ companionMode: "off", e2eEnabled: true })}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    expect(screen.getByLabelText("Encrypted scratchpad")).toBeInTheDocument()
+    expect(screen.queryByLabelText("AI companion attached")).not.toBeInTheDocument()
   })
 
   it("deletes draft scratchpads directly and navigates away when the active draft is removed", async () => {

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, type RefObject } from "react"
-import { Archive, FileEdit, Settings } from "lucide-react"
+import { Archive, FileEdit, Settings, Sparkles } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/hooks"
@@ -8,6 +8,7 @@ import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { cn } from "@/lib/utils"
 import { streamFallbackLabel } from "@/lib/streams"
+import { CompanionModes } from "@threa/types"
 import { useUrgencyTracking } from "./use-urgency-tracking"
 import {
   SidebarActionDrawer,
@@ -114,6 +115,11 @@ export function ScratchpadItem({
 
   const showHoverPreview = compact && showPreviewOnHover && !isMobile && !!preview?.content
 
+  const companionDecoration =
+    streamWithPreview.companionMode === CompanionModes.ON
+      ? { icon: Sparkles, color: "text-primary", ariaLabel: "AI companion attached" }
+      : null
+
   return (
     <>
       <div className="group relative">
@@ -136,7 +142,11 @@ export function ScratchpadItem({
           {showUrgencyStrip && <UrgencyStrip urgency={streamWithPreview.urgency} />}
 
           <div className="flex items-center gap-2.5 flex-1 min-w-0 px-2 py-2">
-            <StreamItemAvatar icon={<FileEdit className="h-3.5 w-3.5" />} className="bg-primary/10 text-primary" />
+            <StreamItemAvatar
+              icon={<FileEdit className="h-3.5 w-3.5" />}
+              className="bg-primary/10 text-primary"
+              decoration={companionDecoration}
+            />
 
             <div
               className={cn(

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, type RefObject } from "react"
-import { Archive, FileEdit, Settings, Sparkles } from "lucide-react"
+import { Archive, FileEdit, Lock, Settings, Sparkles } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/hooks"
@@ -115,10 +115,15 @@ export function ScratchpadItem({
 
   const showHoverPreview = compact && showPreviewOnHover && !isMobile && !!preview?.content
 
-  const companionDecoration =
-    streamWithPreview.companionMode === CompanionModes.ON
-      ? { icon: Sparkles, color: "text-primary", ariaLabel: "AI companion attached" }
-      : null
+  // E2E and companion-on are mutually exclusive (INV-E1 forces companion off
+  // server-side for encrypted streams), so a single decoration slot is enough
+  // — lock takes priority when both shapes could theoretically apply.
+  let decoration: { icon: typeof Lock; color: string; ariaLabel: string } | null = null
+  if (streamWithPreview.e2eEnabled) {
+    decoration = { icon: Lock, color: "text-muted-foreground", ariaLabel: "Encrypted scratchpad" }
+  } else if (streamWithPreview.companionMode === CompanionModes.ON) {
+    decoration = { icon: Sparkles, color: "text-primary", ariaLabel: "AI companion attached" }
+  }
 
   return (
     <>
@@ -145,7 +150,7 @@ export function ScratchpadItem({
             <StreamItemAvatar
               icon={<FileEdit className="h-3.5 w-3.5" />}
               className="bg-primary/10 text-primary"
-              decoration={companionDecoration}
+              decoration={decoration}
             />
 
             <div

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -64,7 +64,11 @@ export function SectionHeader({
         e.stopPropagation()
         if (!hasMenu) onAdd?.()
       }}
-      className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded opacity-0 group-hover/section:opacity-100 max-sm:opacity-100 hover:bg-muted transition-all"
+      // Mobile is the implicit base case (no opacity rule → always visible);
+      // desktop hides until the section is hovered. Inverting the cascade
+      // this way avoids the previous `opacity-0 max-sm:opacity-100` ordering
+      // which left mobile users without a "+" on collapsed sections.
+      className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded sm:opacity-0 sm:group-hover/section:opacity-100 hover:bg-muted transition-all"
       title={addTooltip}
       aria-label={addTooltip}
     >

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -3,6 +3,7 @@ import type { ReactNode, RefObject } from "react"
 import type { CollapseState } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { UnreadBadge } from "@/components/unread-badge"
+import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
 import { SMART_SECTIONS } from "./config"
 import { StreamItem } from "./stream-item"
 import type { SectionKey, StreamItemData } from "./types"
@@ -19,10 +20,16 @@ interface SectionHeaderProps {
   unreadAggregate?: number
   /** Aggregate mention count across items in the section (colors the badge on collapsed header). */
   mentionAggregate?: number
-  /** Add button callback - shows plus icon on hover */
+  /** Add button callback - shows plus icon on hover. Ignored if `addMenuActions` is set. */
   onAdd?: () => void
   /** Tooltip for add button */
   addTooltip?: string
+  /**
+   * When provided, the "+" button opens a dropdown menu of these actions instead
+   * of invoking `onAdd` directly. Used by Scratchpads to expose Quick Note /
+   * Encrypted Scratchpad alongside the default Scratchpad creator.
+   */
+  addMenuActions?: SidebarActionItem[] | null
   /** Smaller header style used for nested subsections (e.g. "With activity" / "Rest"). */
   nested?: boolean
 }
@@ -37,6 +44,7 @@ export function SectionHeader({
   mentionAggregate = 0,
   onAdd,
   addTooltip,
+  addMenuActions,
   nested = false,
 }: SectionHeaderProps) {
   const isInteractive = !!onToggle && !!state
@@ -45,8 +53,24 @@ export function SectionHeader({
   if (state) headerTitle = isCollapsed ? "Expand section" : "Collapse section"
   const hasAggregate = isCollapsed && unreadAggregate > 0
   const hasMentions = mentionAggregate > 0
+  const hasMenu = !!addMenuActions && addMenuActions.length > 0
 
   const Chevron = isCollapsed ? ChevronRight : ChevronDown
+
+  const addButton = (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        if (!hasMenu) onAdd?.()
+      }}
+      className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded opacity-0 group-hover/section:opacity-100 max-sm:opacity-100 hover:bg-muted transition-all"
+      title={addTooltip}
+      aria-label={addTooltip}
+    >
+      <Plus className="h-3.5 w-3.5" />
+    </button>
+  )
 
   const headingContent = (
     <div className="flex items-center gap-1.5 min-w-0">
@@ -75,18 +99,18 @@ export function SectionHeader({
           )}
         />
       )}
-      {onAdd && !isCollapsed && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onAdd()
-          }}
-          className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded opacity-0 group-hover/section:opacity-100 max-sm:opacity-100 hover:bg-muted transition-all"
-          title={addTooltip}
-        >
-          <Plus className="h-3.5 w-3.5" />
-        </button>
-      )}
+      {!isCollapsed &&
+        (addMenuActions && addMenuActions.length > 0 ? (
+          <SidebarActionMenu
+            actions={addMenuActions}
+            trigger={addButton}
+            ariaLabel={addTooltip ?? "Create"}
+            align="end"
+            contentClassName="w-56"
+          />
+        ) : (
+          onAdd && addButton
+        ))}
     </div>
   )
 
@@ -179,6 +203,8 @@ interface StreamSectionProps {
   onAdd?: () => void
   /** Tooltip for add button */
   addTooltip?: string
+  /** Dropdown actions for the "+" button. Overrides `onAdd` when provided. */
+  addMenuActions?: SidebarActionItem[] | null
 }
 
 /** Simple binary collapsible section used for Important / Recent / Pinned. */
@@ -199,6 +225,7 @@ export function StreamSection({
   scrollContainerRef,
   onAdd,
   addTooltip,
+  addMenuActions,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -215,6 +242,7 @@ export function StreamSection({
         mentionAggregate={mentionAggregate}
         onAdd={onAdd}
         addTooltip={addTooltip}
+        addMenuActions={addMenuActions}
       />
 
       {!isCollapsed && items.length > 0 && (
@@ -291,6 +319,7 @@ export function TieredStreamSection({
   scrollContainerRef,
   onAdd,
   addTooltip,
+  addMenuActions,
 }: TieredStreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -335,6 +364,7 @@ export function TieredStreamSection({
         mentionAggregate={mentionAggregate}
         onAdd={onAdd}
         addTooltip={addTooltip}
+        addMenuActions={addMenuActions}
       />
 
       {!isCollapsed && visibleItems.length > 0 && (

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -88,8 +88,17 @@ export function SectionHeader({
     </div>
   )
 
+  // Stop event propagation on the rightContent: the DropdownMenuContent
+  // renders in a React portal, but React still propagates synthetic events
+  // through the React tree — without this guard, clicking (or pressing
+  // Enter/Space on) a menu item bubbles up to the header's `onToggle` and
+  // collapses the section as a side effect.
   const rightContent = (
-    <div className="flex items-center gap-1">
+    <div
+      className="flex items-center gap-1"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
       {hasAggregate && (
         <UnreadBadge
           count={unreadAggregate}
@@ -99,18 +108,17 @@ export function SectionHeader({
           )}
         />
       )}
-      {!isCollapsed &&
-        (addMenuActions && addMenuActions.length > 0 ? (
-          <SidebarActionMenu
-            actions={addMenuActions}
-            trigger={addButton}
-            ariaLabel={addTooltip ?? "Create"}
-            align="end"
-            contentClassName="w-56"
-          />
-        ) : (
-          onAdd && addButton
-        ))}
+      {addMenuActions && addMenuActions.length > 0 ? (
+        <SidebarActionMenu
+          actions={addMenuActions}
+          trigger={addButton}
+          ariaLabel={addTooltip ?? "Create"}
+          align="end"
+          contentClassName="w-56"
+        />
+      ) : (
+        onAdd && addButton
+      )}
     </div>
   )
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -3,6 +3,7 @@ import type { CollapseState } from "@/contexts"
 import { Button } from "@/components/ui/button"
 import { SMART_SECTIONS } from "./config"
 import { SmartSection, TieredStreamSection } from "./sections"
+import type { SidebarActionItem } from "./sidebar-actions"
 import type { StreamItemData } from "./types"
 
 /** Default state of the "more" expander: collapsed so quiet tails stay hidden. */
@@ -38,6 +39,12 @@ interface SidebarStreamListProps {
   toggleSectionState: (section: string, defaultState?: CollapseState) => void
   onCreateScratchpad: () => void | Promise<void>
   onCreateChannel: () => void | Promise<void>
+  /**
+   * Dropdown actions for the Scratchpads "+" button. When provided, the button
+   * opens this menu (Scratchpad / Quick Note / Encrypted Scratchpad) instead of
+   * invoking `onCreateScratchpad` directly.
+   */
+  scratchpadAddMenuActions?: SidebarActionItem[]
   scrollContainerRef: RefObject<HTMLDivElement | null>
 }
 
@@ -57,6 +64,7 @@ export function SidebarStreamList({
   toggleSectionState,
   onCreateScratchpad,
   onCreateChannel,
+  scratchpadAddMenuActions,
   scrollContainerRef,
 }: SidebarStreamListProps) {
   if (hasError) {
@@ -157,7 +165,8 @@ export function SidebarStreamList({
         onToggleMore={() => toggleSectionState(moreKey("scratchpads"), MORE_DEFAULT)}
         scrollContainerRef={scrollContainerRef}
         onAdd={() => void onCreateScratchpad()}
-        addTooltip="+ New Scratchpad"
+        addTooltip={scratchpadAddMenuActions ? "New scratchpad…" : "+ New Scratchpad"}
+        addMenuActions={scratchpadAddMenuActions}
         compact
         showPreviewOnHover
       />

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
-import { RefreshCw } from "lucide-react"
+import { FileText, Lock, RefreshCw, StickyNote } from "lucide-react"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { useAuth } from "@/auth"
+import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
 import {
   useActivityCounts,
   useAllDrafts,
@@ -32,6 +33,7 @@ import { SidebarStreamList } from "./sidebar-stream-list"
 import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skeletons"
 import { SidebarFooter } from "./sidebar-footer"
 import { ALL_SECTIONS, SMART_SECTIONS } from "./config"
+import type { SidebarActionItem } from "./sidebar-actions"
 import { calculateUrgency, categorizeStream, sortStreams } from "./utils"
 import type { StreamItemData } from "./types"
 import { resolveDmDisplayName } from "@/lib/streams"
@@ -72,6 +74,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const { user } = useAuth()
   const navigate = useNavigate()
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
+  const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
 
   const draftCount = allDrafts.length
   const savedCount = useLiveSavedCount(workspaceId)
@@ -346,6 +349,43 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     }
   }
 
+  const handleCreateQuickNote = async () => {
+    const draftId = await createDraft("off")
+    collapseOnMobile()
+    navigate(`/w/${workspaceId}/s/${draftId}`)
+  }
+
+  // `runSidebarAction` toasts on throw, so let the encrypted creator's session
+  // checks propagate ("Unlock encrypted scratchpads first…") rather than
+  // swallowing them here.
+  const handleCreateEncryptedScratchpad = async () => {
+    const streamId = await createEncryptedScratchpad()
+    collapseOnMobile()
+    navigate(`/w/${workspaceId}/s/${streamId}`)
+  }
+
+  const scratchpadAddMenuActions: SidebarActionItem[] = [
+    {
+      id: "new-scratchpad",
+      label: "New Scratchpad",
+      icon: FileText,
+      onSelect: handleCreateScratchpad,
+    },
+    {
+      id: "new-quick-note",
+      label: "New Quick Note",
+      icon: StickyNote,
+      onSelect: handleCreateQuickNote,
+    },
+    {
+      id: "new-encrypted-scratchpad",
+      label: "New Encrypted Scratchpad",
+      icon: Lock,
+      onSelect: handleCreateEncryptedScratchpad,
+      separatorBefore: true,
+    },
+  ]
+
   const handleCreateChannel = () => {
     collapseOnMobile()
     openCreateChannel()
@@ -396,6 +436,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             toggleSectionState={toggleSectionState}
             onCreateScratchpad={handleCreateScratchpad}
             onCreateChannel={handleCreateChannel}
+            scratchpadAddMenuActions={scratchpadAddMenuActions}
             scrollContainerRef={scrollContainerRef}
           />
         </>

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -40,9 +40,15 @@ interface StreamItemAvatarProps {
   avatarUrl?: string
   avatarAlt?: string
   badge?: { icon: typeof Hash; color: string } | null
+  /**
+   * Optional top-right overlay used to surface stream metadata that isn't tied
+   * to the thread-root signal — e.g. the AI companion indicator on scratchpads.
+   * Renders as a small bordered circle, independent of `badge` (top-left).
+   */
+  decoration?: { icon: typeof Hash; color: string; ariaLabel?: string } | null
 }
 
-export function StreamItemAvatar({ icon, className, avatarUrl, avatarAlt, badge }: StreamItemAvatarProps) {
+export function StreamItemAvatar({ icon, className, avatarUrl, avatarAlt, badge, decoration }: StreamItemAvatarProps) {
   // Thread-of-DM: thread icon as main content, avatar as small badge overlay
   if (badge && avatarUrl) {
     return (
@@ -54,6 +60,7 @@ export function StreamItemAvatar({ icon, className, avatarUrl, avatarAlt, badge 
             <badge.icon className="h-2 w-2" />
           </AvatarFallback>
         </Avatar>
+        {decoration && <AvatarDecoration {...decoration} />}
       </div>
     )
   }
@@ -88,6 +95,22 @@ export function StreamItemAvatar({ icon, className, avatarUrl, avatarAlt, badge 
           <badge.icon className="h-2 w-2" />
         </div>
       )}
+      {decoration && <AvatarDecoration {...decoration} />}
+    </div>
+  )
+}
+
+function AvatarDecoration({ icon: Icon, color, ariaLabel }: { icon: typeof Hash; color: string; ariaLabel?: string }) {
+  return (
+    <div
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+      className={cn(
+        "absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-background border border-border flex items-center justify-center",
+        color
+      )}
+    >
+      <Icon className="h-2 w-2" />
     </div>
   )
 }

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -1,5 +1,5 @@
 import type { NavigateFunction } from "react-router-dom"
-import { Brain, FileText, Hash, Paperclip, Search, FileEdit, Lock, Settings } from "lucide-react"
+import { Brain, FileText, Hash, Paperclip, Search, FileEdit, Lock, Settings, StickyNote } from "lucide-react"
 import { toast } from "sonner"
 import type { SettingsTab } from "@threa/types"
 import type { ExplorerFilters } from "@/components/attachment-explorer"
@@ -57,6 +57,22 @@ export const commands: Command[] = [
       } catch (error) {
         console.error("Failed to create scratchpad:", error)
         toast.error("Failed to create scratchpad")
+      }
+    },
+  },
+  {
+    id: "new-quick-note",
+    label: "New Quick Note",
+    icon: StickyNote,
+    keywords: ["scratchpad", "plain", "dump", "link", "links", "no companion", "no ai", "silent", "note"],
+    action: async ({ workspaceId, navigate, closeDialog, createDraftScratchpad }) => {
+      try {
+        const draftId = await createDraftScratchpad("off")
+        closeDialog()
+        navigate(`/w/${workspaceId}/s/${draftId}`)
+      } catch (error) {
+        console.error("Failed to create quick note:", error)
+        toast.error("Failed to create quick note")
       }
     },
   },

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -38,6 +38,7 @@ export interface CommandContext {
 export interface Command {
   id: string
   label: string
+  description?: string
   icon: React.ComponentType<{ className?: string }>
   keywords?: string[]
   action: (context: CommandContext) => void | Promise<void>
@@ -63,8 +64,23 @@ export const commands: Command[] = [
   {
     id: "new-quick-note",
     label: "New Quick Note",
+    description: "Scratchpad without the AI companion — links, ideas, quick captures",
     icon: StickyNote,
-    keywords: ["scratchpad", "plain", "dump", "link", "links", "no companion", "no ai", "silent", "note"],
+    keywords: [
+      "scratchpad",
+      "plain",
+      "pure",
+      "dump",
+      "link",
+      "links",
+      "bookmark",
+      "no companion",
+      "no ai",
+      "silent",
+      "quiet",
+      "note",
+      "capture",
+    ],
     action: async ({ workspaceId, navigate, closeDialog, createDraftScratchpad }) => {
       try {
         const draftId = await createDraftScratchpad("off")

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -22,6 +22,7 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
       (command): QuickSwitcherItem => ({
         id: command.id,
         label: command.label,
+        description: command.description,
         icon: command.icon,
         group: "Commands",
         onSelect: () => {

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -1,33 +1,56 @@
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { CompanionModes, type Stream } from "@threa/types"
+import { useUpdateCompanionMode } from "@/hooks/use-streams"
+import { CompanionModes, type CompanionMode, type Stream } from "@threa/types"
+import { toast } from "sonner"
 
 interface CompanionTabProps {
+  workspaceId: string
   stream: Stream
 }
 
-export function CompanionTab({ stream }: CompanionTabProps) {
+export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
+  const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
+
+  // E2E streams force companion off server-side (INV-E1); reflect that constraint in the UI.
+  const isE2e = stream.e2eEnabled === true
+
+  const handleChange = async (next: string) => {
+    if (next !== CompanionModes.ON && next !== CompanionModes.OFF) return
+    if (next === stream.companionMode) return
+    try {
+      await updateCompanionMode(next as CompanionMode)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update companion mode"
+      toast.error(message)
+    }
+  }
+
   return (
     <div className="space-y-6 p-1">
       <div className="space-y-3">
         <Label className="text-sm font-medium">Companion mode</Label>
-        <RadioGroup value={stream.companionMode} disabled>
+        <RadioGroup value={stream.companionMode} onValueChange={handleChange} disabled={isPending || isE2e}>
           <div className="flex items-center space-x-2">
             <RadioGroupItem value={CompanionModes.ON} id="companion-on" />
-            <Label htmlFor="companion-on" className="font-normal text-muted-foreground">
-              On
+            <Label htmlFor="companion-on" className="font-normal">
+              On — the companion responds to new messages
             </Label>
           </div>
           <div className="flex items-center space-x-2">
             <RadioGroupItem value={CompanionModes.OFF} id="companion-off" />
-            <Label htmlFor="companion-off" className="font-normal text-muted-foreground">
-              Off
+            <Label htmlFor="companion-off" className="font-normal">
+              Off — messages are stored without any AI response
             </Label>
           </div>
         </RadioGroup>
       </div>
 
-      <p className="text-sm text-muted-foreground">Companion settings will be configurable in a future update.</p>
+      {isE2e && (
+        <p className="text-sm text-muted-foreground">
+          End-to-end encrypted streams can&apos;t use the companion — responses would be plaintext.
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -1,8 +1,9 @@
+import { Moon, Sparkles } from "lucide-react"
+import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
 import { CompanionModes, type CompanionMode, type Stream } from "@threa/types"
-import { toast } from "sonner"
 
 interface CompanionTabProps {
   workspaceId: string
@@ -12,14 +13,15 @@ interface CompanionTabProps {
 export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
   const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
 
-  // E2E streams force companion off server-side (INV-E1); reflect that constraint in the UI.
+  // INV-E1: E2E streams can't speak plaintext through the companion, so this
+  // surface is purely informational for them.
   const isE2e = stream.e2eEnabled === true
+  const disabled = isPending || isE2e
 
-  const handleChange = async (next: string) => {
-    if (next !== CompanionModes.ON && next !== CompanionModes.OFF) return
+  const handleChange = async (next: CompanionMode) => {
     if (next === stream.companionMode) return
     try {
-      await updateCompanionMode(next as CompanionMode)
+      await updateCompanionMode(next)
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to update companion mode"
       toast.error(message)
@@ -29,28 +31,78 @@ export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
   return (
     <div className="space-y-6 p-1">
       <div className="space-y-3">
-        <Label className="text-sm font-medium">Companion mode</Label>
-        <RadioGroup value={stream.companionMode} onValueChange={handleChange} disabled={isPending || isE2e}>
-          <div className="flex items-center space-x-2">
-            <RadioGroupItem value={CompanionModes.ON} id="companion-on" />
-            <Label htmlFor="companion-on" className="font-normal">
-              On — the companion responds to new messages
-            </Label>
-          </div>
-          <div className="flex items-center space-x-2">
-            <RadioGroupItem value={CompanionModes.OFF} id="companion-off" />
-            <Label htmlFor="companion-off" className="font-normal">
-              Off — messages are stored without any AI response
-            </Label>
-          </div>
-        </RadioGroup>
+        <div className="space-y-1">
+          <Label className="text-sm font-medium">Companion mode</Label>
+          <p className="text-xs text-muted-foreground">
+            Decide whether Ariadne reads new messages and replies, or whether this scratchpad stays a silent dump.
+          </p>
+        </div>
+        <div
+          role="radiogroup"
+          aria-label="Companion mode"
+          aria-disabled={disabled || undefined}
+          className="grid gap-2 sm:grid-cols-2"
+        >
+          <CompanionOption
+            selected={stream.companionMode === CompanionModes.ON}
+            onSelect={() => handleChange(CompanionModes.ON)}
+            icon={Sparkles}
+            label="Companion"
+            hint="Ariadne reads new messages and replies in the thread"
+            disabled={disabled}
+          />
+          <CompanionOption
+            selected={stream.companionMode === CompanionModes.OFF}
+            onSelect={() => handleChange(CompanionModes.OFF)}
+            icon={Moon}
+            label="Quiet"
+            hint="Just storage — no AI replies, no inference cost"
+            disabled={disabled}
+          />
+        </div>
       </div>
 
       {isE2e && (
-        <p className="text-sm text-muted-foreground">
-          End-to-end encrypted streams can&apos;t use the companion — responses would be plaintext.
+        <p className="text-xs text-muted-foreground">
+          End-to-end encrypted streams keep the companion off — responses would be plaintext.
         </p>
       )}
     </div>
+  )
+}
+
+interface CompanionOptionProps {
+  selected: boolean
+  onSelect: () => void
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  hint: string
+  disabled?: boolean
+}
+
+function CompanionOption({ selected, onSelect, icon: Icon, label, hint, disabled }: CompanionOptionProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      role="radio"
+      aria-checked={selected}
+      className={cn(
+        "flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-all",
+        disabled && "opacity-50 cursor-not-allowed",
+        selected
+          ? "border-primary bg-primary/5 ring-1 ring-primary/20"
+          : "border-border hover:border-muted-foreground/30 hover:bg-accent/50"
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Icon className={cn("h-3.5 w-3.5", selected ? "text-primary" : "text-muted-foreground")} />
+        <span className={cn("text-sm font-medium", selected ? "text-foreground" : "text-muted-foreground")}>
+          {label}
+        </span>
+      </div>
+      <span className="text-[11px] leading-snug text-muted-foreground">{hint}</span>
+    </button>
   )
 }

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -140,7 +140,7 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
                   />
                 </TabsContent>
                 <TabsContent value="companion" className="mt-0">
-                  <CompanionTab stream={resolvedStream} />
+                  <CompanionTab workspaceId={workspaceId} stream={resolvedStream} />
                 </TabsContent>
                 <TabsContent value="members" className="mt-0">
                   <MembersTab workspaceId={workspaceId} streamId={streamId} currentUserId={currentUserId} />

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -21,6 +21,7 @@ export interface StreamService {
   bootstrap: typeof streamsApi.bootstrap
   create: typeof streamsApi.create
   update: typeof streamsApi.update
+  updateCompanionMode: typeof streamsApi.updateCompanionMode
   archive: typeof streamsApi.archive
   unarchive: typeof streamsApi.unarchive
   getEvents: typeof streamsApi.getEvents

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -11,7 +11,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { isDraftId } from "./use-draft-scratchpads"
 import { deleteStashedDraftById } from "./use-stashed-drafts"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import type { JSONContent } from "@threa/types"
+import type { CompanionMode, JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
@@ -68,6 +68,12 @@ export interface UnifiedDraft {
    * slightly differently (e.g. an "Editing" hint vs. a saved indicator).
    */
   isStashed: boolean
+  /**
+   * Scratchpad-only: the companion mode the draft was created with (locked at
+   * Quick Switcher choice). Lets the drafts explorer distinguish "Quick Note"
+   * (off) from "Scratchpad" (on) at a glance.
+   */
+  companionMode?: CompanionMode
 }
 
 /**
@@ -306,6 +312,7 @@ export function useAllDrafts(workspaceId: string) {
           href: `/w/${workspaceId}/s/${draft.id}`,
           groupLabel: displayName,
           isStashed: false,
+          companionMode: draft.companionMode,
         })
       }
     }

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -97,6 +97,13 @@ export interface VirtualStream {
   parentMessageId: string | null
   rootStreamId: string | null
   archivedAt: string | null
+  /**
+   * Server-persisted streams may be end-to-end encrypted. Drafts can't be
+   * encrypted (encrypted scratchpads bypass the draft system and are
+   * created server-side immediately), so this is always undefined/false on
+   * draft virtual streams.
+   */
+  e2eEnabled?: boolean
 }
 
 export interface SendMessageInput {
@@ -449,6 +456,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         parentMessageId: baseStream.parentMessageId,
         rootStreamId: baseStream.rootStreamId,
         archivedAt: baseStream.archivedAt,
+        e2eEnabled: baseStream.e2eEnabled,
       }
     : undefined
 

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -13,6 +13,7 @@ import type {
   StreamBootstrap,
   WorkspaceBootstrap,
   NotificationLevel,
+  CompanionMode,
 } from "@threa/types"
 import type { CreateStreamInput, UpdateStreamInput } from "@/api"
 import { workspaceKeys } from "./use-workspaces"
@@ -218,6 +219,36 @@ export function useUpdateStream(workspaceId: string, streamId: string) {
       queryClient.invalidateQueries({ queryKey: streamKeys.lists() })
 
       // Cache to IndexedDB
+      db.streams.put({ ...updatedStream, _cachedAt: Date.now() })
+    },
+  })
+}
+
+export function useUpdateCompanionMode(workspaceId: string, streamId: string) {
+  const streamService = useStreamService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (companionMode: CompanionMode) =>
+      streamService.updateCompanionMode(workspaceId, streamId, { companionMode }),
+    onSuccess: (updatedStream) => {
+      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), updatedStream)
+
+      queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
+        if (!old || typeof old !== "object") return old
+        return { ...old, stream: updatedStream }
+      })
+
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+        if (!old) return old
+        return {
+          ...old,
+          streams: old.streams.map((s) =>
+            s.id === streamId ? { ...s, ...updatedStream, lastMessagePreview: s.lastMessagePreview } : s
+          ),
+        }
+      })
+
       db.streams.put({ ...updatedStream, _cachedAt: Date.now() })
     },
   })

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from "react"
 import { useParams, useNavigate, Link } from "react-router-dom"
-import { FileText, Hash, MessageSquare, Trash2, FileEdit, ArrowLeft, Bookmark } from "lucide-react"
+import { FileText, Hash, MessageSquare, Trash2, FileEdit, ArrowLeft, Bookmark, StickyNote } from "lucide-react"
+import { CompanionModes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveAlertDialog,
@@ -70,7 +71,14 @@ export function DraftsPage() {
       }
 
       const label = draft.isStashed ? draft.preview || "Empty draft" : draft.displayName
-      const icon = draft.isStashed ? Bookmark : TYPE_ICONS[draft.type]
+      let icon: React.ComponentType<{ className?: string }>
+      if (draft.isStashed) {
+        icon = Bookmark
+      } else if (draft.type === "scratchpad" && draft.companionMode === CompanionModes.OFF) {
+        icon = StickyNote
+      } else {
+        icon = TYPE_ICONS[draft.type]
+      }
 
       return {
         id: draft.id,

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -13,6 +13,7 @@ import {
   Settings,
   Sparkles,
   Moon,
+  Lock,
 } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
@@ -228,23 +229,64 @@ export function StreamPage() {
     }
   }
 
-  // Scratchpad companion-mode indicator. Drafts get an inert badge because
-  // the settings dialog reads from caches that don't have draft entries yet —
-  // the pill becomes interactive once the scratchpad is persisted.
+  // Scratchpad mode indicator. Three shapes share one pill slot:
+  //   - Encrypted (E2E): Lock + "Encrypted" — companion mode is locked off
+  //     server-side (INV-E1), so the lock is the more meaningful signal.
+  //   - Companion: Sparkles + "Companion" — Ariadne replies to new messages.
+  //   - Quiet: Moon + "Quiet" — silent capture, no AI replies.
+  // Drafts get an inert variant because the settings dialog reads from caches
+  // that don't have draft entries yet; the pill becomes interactive once the
+  // scratchpad is persisted. (E2E scratchpads are never drafts — they're
+  // server-persisted on creation.)
   let companionModeIndicator: React.ReactNode = null
   if (stream && isScratchpad && (isDraft || !isUnnamedScratchpad)) {
-    const isOn = stream.companionMode === CompanionModes.ON
-    const Icon = isOn ? Sparkles : Moon
-    const modeLabel = isOn ? "Companion" : "Quiet"
+    const isEncrypted = !!stream.e2eEnabled
+    const isOn = !isEncrypted && stream.companionMode === CompanionModes.ON
+
+    let Icon: typeof Sparkles
+    let modeLabel: string
+    let pillVariant: string
+    let hoverVariant: string
+    let iconTint: string
+    let interactiveAria: string
+    let inertAria: string
+    let tooltipBody: string
+
+    if (isEncrypted) {
+      Icon = Lock
+      modeLabel = "Encrypted"
+      pillVariant = "border-border bg-secondary text-foreground"
+      hoverVariant = "hover:bg-accent"
+      iconTint = "text-muted-foreground"
+      interactiveAria = "End-to-end encrypted. Open companion settings."
+      inertAria = "End-to-end encrypted"
+      tooltipBody = "End-to-end encrypted — Companion is disabled. Click for details."
+    } else if (isOn) {
+      Icon = Sparkles
+      modeLabel = "Companion"
+      pillVariant = "border-primary/30 bg-primary/5 text-foreground"
+      hoverVariant = "hover:bg-primary/10"
+      iconTint = "text-primary"
+      interactiveAria = "Companion is on. Click to change."
+      inertAria = "Companion on"
+      tooltipBody = "Ariadne replies to new messages. Click to change."
+    } else {
+      Icon = Moon
+      modeLabel = "Quiet"
+      pillVariant = "border-border bg-secondary text-muted-foreground"
+      hoverVariant = "hover:bg-accent hover:text-foreground"
+      iconTint = ""
+      interactiveAria = "Quiet mode. Click to change."
+      inertAria = "Quiet mode"
+      tooltipBody = "Silent capture — no AI replies. Click to change."
+    }
+
     const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
-    const pillVariant = isOn
-      ? "border-primary/30 bg-primary/5 text-foreground"
-      : "border-border bg-secondary text-muted-foreground"
 
     if (isDraft) {
       companionModeIndicator = (
-        <span className={cn(pillBase, pillVariant)} aria-label={isOn ? "Companion on" : "Quiet mode"}>
-          <Icon className={cn("h-3 w-3", isOn && "text-primary")} aria-hidden="true" />
+        <span className={cn(pillBase, pillVariant)} aria-label={inertAria}>
+          <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
           <span>{modeLabel}</span>
         </span>
       )
@@ -255,23 +297,19 @@ export function StreamPage() {
             <button
               type="button"
               onClick={() => openStreamSettings(streamId, "companion")}
-              aria-label={isOn ? "Companion is on. Click to change." : "Quiet mode. Click to change."}
+              aria-label={interactiveAria}
               className={cn(
                 pillBase,
                 pillVariant,
                 "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                isOn ? "hover:bg-primary/10" : "hover:bg-accent hover:text-foreground"
+                hoverVariant
               )}
             >
-              <Icon className={cn("h-3 w-3", isOn && "text-primary")} aria-hidden="true" />
+              <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
               <span>{modeLabel}</span>
             </button>
           </TooltipTrigger>
-          <TooltipContent>
-            {isOn
-              ? "Ariadne replies to new messages. Click to change."
-              : "Silent capture — no AI replies. Click to change."}
-          </TooltipContent>
+          <TooltipContent>{tooltipBody}</TooltipContent>
         </Tooltip>
       )
     }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -11,7 +11,10 @@ import {
   CornerDownRight,
   Paperclip,
   Settings,
+  Sparkles,
+  StickyNote,
 } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -32,7 +35,7 @@ import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
-import { StreamTypes, type StreamType } from "@threa/types"
+import { CompanionModes, StreamTypes, type StreamType } from "@threa/types"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { setPageStreamName } from "@/lib/page-title"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
@@ -276,6 +279,27 @@ export function StreamPage() {
           {headerTitle}
           {stream && !isThread && !isDraft && !isChannel && !isUnnamedScratchpad && (
             <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
+          )}
+          {stream && isScratchpad && !isDraft && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="inline-flex items-center text-muted-foreground"
+                  aria-label={stream.companionMode === CompanionModes.ON ? "Companion is on" : "Companion is off"}
+                >
+                  {stream.companionMode === CompanionModes.ON ? (
+                    <Sparkles className="h-3.5 w-3.5" />
+                  ) : (
+                    <StickyNote className="h-3.5 w-3.5" />
+                  )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {stream.companionMode === CompanionModes.ON
+                  ? "Companion is on — Ariadne replies to new messages"
+                  : "Companion is off — messages are stored silently"}
+              </TooltipContent>
+            </Tooltip>
           )}
           {isArchived && (
             <Badge variant="secondary" className="gap-1">

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -139,7 +139,6 @@ export function StreamPage() {
   } else if (isDraft) {
     streamName = streamFallbackLabel(isDmDraft ? "dm" : "scratchpad", "sidebar")
   }
-  const isUnnamedScratchpad = isScratchpad && !stream?.displayName
 
   const handleStartRename = () => {
     setEditValue(stream?.displayName ?? "")
@@ -237,9 +236,11 @@ export function StreamPage() {
   // Drafts get an inert variant because the settings dialog reads from caches
   // that don't have draft entries yet; the pill becomes interactive once the
   // scratchpad is persisted. (E2E scratchpads are never drafts — they're
-  // server-persisted on creation.)
+  // server-persisted on creation, with no displayName until the user names
+  // them, which is exactly why we render the pill on unnamed scratchpads too:
+  // for encrypted ones the lock IS the only signal of their nature.)
   let companionModeIndicator: React.ReactNode = null
-  if (stream && isScratchpad && (isDraft || !isUnnamedScratchpad)) {
+  if (stream && isScratchpad) {
     const isEncrypted = !!stream.e2eEnabled
     const isOn = !isEncrypted && stream.companionMode === CompanionModes.ON
 

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -12,7 +12,7 @@ import {
   Paperclip,
   Settings,
   Sparkles,
-  StickyNote,
+  Moon,
 } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
@@ -277,30 +277,45 @@ export function StreamPage() {
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <SidebarToggle location="page" />
           {headerTitle}
-          {stream && !isThread && !isDraft && !isChannel && !isUnnamedScratchpad && (
-            <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
-          )}
-          {stream && isScratchpad && !isDraft && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="inline-flex items-center text-muted-foreground"
-                  aria-label={stream.companionMode === CompanionModes.ON ? "Companion is on" : "Companion is off"}
-                >
-                  {stream.companionMode === CompanionModes.ON ? (
-                    <Sparkles className="h-3.5 w-3.5" />
-                  ) : (
-                    <StickyNote className="h-3.5 w-3.5" />
-                  )}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                {stream.companionMode === CompanionModes.ON
-                  ? "Companion is on — Ariadne replies to new messages"
-                  : "Companion is off — messages are stored silently"}
-              </TooltipContent>
-            </Tooltip>
-          )}
+          {stream &&
+            !isThread &&
+            !isDraft &&
+            !isUnnamedScratchpad &&
+            (isScratchpad ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => openStreamSettings(streamId, "companion")}
+                    aria-label={
+                      stream.companionMode === CompanionModes.ON
+                        ? "Companion is on. Click to change."
+                        : "Quiet mode. Click to change."
+                    }
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                      stream.companionMode === CompanionModes.ON
+                        ? "border-primary/30 bg-primary/5 text-foreground hover:bg-primary/10"
+                        : "border-border bg-secondary text-muted-foreground hover:bg-accent hover:text-foreground"
+                    )}
+                  >
+                    {stream.companionMode === CompanionModes.ON ? (
+                      <Sparkles className="h-3 w-3 text-primary" aria-hidden="true" />
+                    ) : (
+                      <Moon className="h-3 w-3" aria-hidden="true" />
+                    )}
+                    <span>{stream.companionMode === CompanionModes.ON ? "Companion" : "Quiet"}</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {stream.companionMode === CompanionModes.ON
+                    ? "Ariadne replies to new messages. Click to change."
+                    : "Silent capture — no AI replies. Click to change."}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              !isChannel && <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
+            ))}
           {isArchived && (
             <Badge variant="secondary" className="gap-1">
               <ArchiveX className="h-3 w-3" />

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -228,6 +228,55 @@ export function StreamPage() {
     }
   }
 
+  // Scratchpad companion-mode indicator. Drafts get an inert badge because
+  // the settings dialog reads from caches that don't have draft entries yet —
+  // the pill becomes interactive once the scratchpad is persisted.
+  let companionModeIndicator: React.ReactNode = null
+  if (stream && isScratchpad && (isDraft || !isUnnamedScratchpad)) {
+    const isOn = stream.companionMode === CompanionModes.ON
+    const Icon = isOn ? Sparkles : Moon
+    const modeLabel = isOn ? "Companion" : "Quiet"
+    const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+    const pillVariant = isOn
+      ? "border-primary/30 bg-primary/5 text-foreground"
+      : "border-border bg-secondary text-muted-foreground"
+
+    if (isDraft) {
+      companionModeIndicator = (
+        <span className={cn(pillBase, pillVariant)} aria-label={isOn ? "Companion on" : "Quiet mode"}>
+          <Icon className={cn("h-3 w-3", isOn && "text-primary")} aria-hidden="true" />
+          <span>{modeLabel}</span>
+        </span>
+      )
+    } else {
+      companionModeIndicator = (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => openStreamSettings(streamId, "companion")}
+              aria-label={isOn ? "Companion is on. Click to change." : "Quiet mode. Click to change."}
+              className={cn(
+                pillBase,
+                pillVariant,
+                "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                isOn ? "hover:bg-primary/10" : "hover:bg-accent hover:text-foreground"
+              )}
+            >
+              <Icon className={cn("h-3 w-3", isOn && "text-primary")} aria-hidden="true" />
+              <span>{modeLabel}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isOn
+              ? "Ariadne replies to new messages. Click to change."
+              : "Silent capture — no AI replies. Click to change."}
+          </TooltipContent>
+        </Tooltip>
+      )
+    }
+  }
+
   let headerTitle: React.ReactNode
   if (isEditing) {
     headerTitle = (
@@ -277,45 +326,10 @@ export function StreamPage() {
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <SidebarToggle location="page" />
           {headerTitle}
-          {stream &&
-            !isThread &&
-            !isDraft &&
-            !isUnnamedScratchpad &&
-            (isScratchpad ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => openStreamSettings(streamId, "companion")}
-                    aria-label={
-                      stream.companionMode === CompanionModes.ON
-                        ? "Companion is on. Click to change."
-                        : "Quiet mode. Click to change."
-                    }
-                    className={cn(
-                      "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                      stream.companionMode === CompanionModes.ON
-                        ? "border-primary/30 bg-primary/5 text-foreground hover:bg-primary/10"
-                        : "border-border bg-secondary text-muted-foreground hover:bg-accent hover:text-foreground"
-                    )}
-                  >
-                    {stream.companionMode === CompanionModes.ON ? (
-                      <Sparkles className="h-3 w-3 text-primary" aria-hidden="true" />
-                    ) : (
-                      <Moon className="h-3 w-3" aria-hidden="true" />
-                    )}
-                    <span>{stream.companionMode === CompanionModes.ON ? "Companion" : "Quiet"}</span>
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {stream.companionMode === CompanionModes.ON
-                    ? "Ariadne replies to new messages. Click to change."
-                    : "Silent capture — no AI replies. Click to change."}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              !isChannel && <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
-            ))}
+          {companionModeIndicator}
+          {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
+            <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
+          )}
           {isArchived && (
             <Badge variant="secondary" className="gap-1">
               <ArchiveX className="h-3 w-3" />


### PR DESCRIPTION
## Problem

Scratchpads have always come with the AI companion attached — every message you send triggers Ariadne to read, infer, and reply. That's perfect for thinking-out-loud sessions, but it's the wrong shape for the kind of scratchpad most of us reach for ten times a day: a place to dump a link, a half-formed thought, a phone number, a quote. For that use case the companion reply is noise ("Got it!") and the inference cost is wasted.

The infrastructure to opt out already existed — `companionMode: "off"` is a valid value on the wire, the backend handler accepts it on create, the `CompanionHandler` skips inference when it's off, and `PATCH /streams/:id/companion` already exists. There was simply no UI surface to set or change it. The placeholder Companion tab in stream settings explicitly admitted as much: _"Companion settings will be configurable in a future update."_

While wiring the mode picker through, we also confronted the broader visibility gap: with three flavors of scratchpad in play (companion, quiet, encrypted) and no consistent indicator across surfaces, users had no way to tell at a glance which kind of stream they were looking at — either in the sidebar list, in the stream header, or on the Drafts page.

## Solution

Wire the existing backend through the frontend and turn the companion-mode choice into a first-class part of the scratchpad experience. Then propagate visual indicators of that mode (and of E2E encryption) consistently to every surface that shows a scratchpad.

### How it works

**Creating a scratchpad in a specific mode**

1. **Quick Switcher → "New Quick Note"** — sibling to "New Scratchpad", calls `createDraftScratchpad("off")`. Renders with a description subtext ("Scratchpad without the AI companion — links, ideas, quick captures") so its purpose is obvious before you select it.
2. **Sidebar `+` create-menu** — the `+` button on the Scratchpads section header opens a dropdown of all three creation modes (Scratchpad, Quick Note, Encrypted) instead of jumping straight to the default. Same `+` button is also always visible on mobile (regardless of section collapse state), and the click is properly isolated from the section's collapse toggle.

**Knowing which mode a scratchpad is in**

3. **Stream header pill** — for any scratchpad, the generic `Scratchpad` type badge is replaced with a clickable mode pill:
   - `✨ Companion` (Sparkles in primary tint) when companion is on
   - `🌙 Quiet` (Moon in muted tone) when companion is off
   - `🔒 Encrypted` (Lock in muted tone) for E2E scratchpads
   - Clicking deep-links to `Settings → Companion`. On drafts it renders as an inert label (settings dialog reads from caches that don't yet have draft entries).
4. **Sidebar avatar decoration** — each scratchpad's avatar gets a top-right overlay:
   - Sparkles when companion is on
   - Lock when E2E (takes priority — INV-E1 forces companion off for E2E anyway, so they're mutually exclusive)
   - Nothing when quiet (the absence is its own signal)
5. **Drafts page icon** — companion-off drafts render with the `StickyNote` icon instead of the generic scratchpad icon, so the Drafts list reads consistently with the Quick Switcher entry that created them.

**Changing the mode**

6. **Settings → Companion tab** — replaces the disabled placeholder `RadioGroup` with a card-style picker that mirrors `VisibilityPicker` exactly. Each option pairs an icon with use-case framing — "Ariadne reads new messages and replies" vs. "Just storage — no AI replies, no inference cost". E2E scratchpads see both cards disabled with a one-line explainer of why the mode is locked.

The mode change flows through a new `useUpdateCompanionMode` hook that calls `PATCH /api/workspaces/:workspaceId/streams/:streamId/companion` and updates the detail / stream-bootstrap / workspace-bootstrap React Query caches plus IndexedDB so every surface flips instantly.

### Key design decisions

**1. Reuse the `VisibilityPicker` pattern verbatim for the Companion picker**

The settings dialog already has a card-style picker for stream visibility. Cloning its structure (grid, border-primary/bg-primary-5 selected state, hint typography) makes the new picker read as native rather than as a one-off. INV-37: reuse existing helpers and abstractions instead of parallel implementations.

**2. Replace the generic type badge for scratchpads instead of adding a sibling**

Two adjacent chips (`[Scratchpad] [Companion]`) read as redundant — if you're in the scratchpad route, you know it's a scratchpad. The mode pill carries the actionable information; the type was decorative. DMs and system streams still get the generic type badge.

**3. Two distinct icons (Sparkles / Moon / Lock) rather than one icon with state treatment**

`Sparkles` is the established "AI / companion" iconography across the product. `Moon` evokes silence and rest. `Lock` is the universal encryption signal. Three icons make the three modes legible at a glance — a single icon with subtle tint differences would have hidden the distinction.

**4. Make the header pill a button that opens the relevant settings tab**

A status indicator that is also the affordance for changing the status keeps the surface area honest — there's no separate "where do I change this?" question to answer. Drafts render as inert because the settings dialog reads from caches that don't have draft entries yet.

**5. Keep E2E scratchpads locked to companion-off in the UI, mirroring INV-E1 on the backend**

The server already forces `companionMode = "off"` on E2E stream creation because plaintext companion responses would break end-to-end encryption. The Companion tab reflects that constraint with disabled cards and explainer rather than letting the user toggle and then having the server reject it.

**6. Drop the `!isUnnamedScratchpad` gate on the header pill**

Encrypted scratchpads are created without a `displayName` (the user names them after the fact), and the original "hide pill until named" rule hid the lock indicator exactly when it mattered most. Render the pill on any scratchpad — for unnamed encrypted ones the lock is the only header signal of what kind of stream this is.

**7. Single avatar decoration slot, not two**

INV-E1 makes E2E and companion-on mutually exclusive server-side, so the avatar overlay only ever needs one icon at a time. Lock wins on the rare case where both shapes could theoretically apply.

**8. Invert the mobile `+` visibility cascade**

The original `opacity-0 group-hover/section:opacity-100 max-sm:opacity-100` lost on collapsed sections because mobile users have no hover state — the `+` was effectively hidden. Inverted to `sm:opacity-0 sm:group-hover/section:opacity-100` so mobile is the implicit default-visible base case and the hover gating is desktop-only.

**9. Stop event propagation on the section header's right-content wrapper**

Radix `DropdownMenuContent` renders in a portal, but React synthetic events still propagate through the React tree — so clicking a menu item bubbled up to the section header's `onToggle` and collapsed the section. Adding `onClick`/`onKeyDown` `stopPropagation` on the wrapper keeps menu interactions and section collapse cleanly separated.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/api/streams.ts` | New `streamsApi.updateCompanionMode(workspaceId, streamId, { companionMode })` wrapping the existing PATCH endpoint |
| `apps/frontend/src/contexts/services-context.tsx` | Expose `updateCompanionMode` on the `StreamService` interface |
| `apps/frontend/src/hooks/use-streams.ts` | New `useUpdateCompanionMode` mutation that updates detail / stream-bootstrap / workspace-bootstrap caches and IndexedDB |
| `apps/frontend/src/hooks/use-stream-or-draft.ts` | Propagate `e2eEnabled` through the `VirtualStream` view so the stream header can see it on the non-draft path |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Carry `companionMode` through to `UnifiedDraft` so the Drafts page can choose its icon |
| `apps/frontend/src/components/quick-switcher/commands.ts` | New `new-quick-note` command (StickyNote icon, descriptive subtext, "pure / dump / bookmark / quiet / capture" keywords) calling `createDraftScratchpad("off")`. Adds optional `description` to the `Command` type. |
| `apps/frontend/src/components/quick-switcher/use-command-items.ts` | Threads `description` through into `QuickSwitcherItem` |
| `apps/frontend/src/components/stream-settings/companion-tab.tsx` | Replaces the disabled placeholder with a card-style picker (mirrors `VisibilityPicker`). Accepts `workspaceId`. E2E streams remain disabled with explainer. |
| `apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx` | Pass `workspaceId` through to `CompanionTab` |
| `apps/frontend/src/components/layout/sidebar/sections.tsx` | `SectionHeader` accepts `addMenuActions` for dropdown-style `+` buttons; right-content wrapper stops event propagation so menu clicks don't collapse the section; `+` is always visible on mobile regardless of section state |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | Wire the Scratchpads `+` to a three-option create menu (Scratchpad / Quick Note / Encrypted) |
| `apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx` | Pass the new create-menu actions through to the section |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Avatar overlay infrastructure (`decoration` prop) for sidebar items |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx` | Pick the right avatar decoration (Lock for E2E, Sparkles for companion-on, none for quiet) |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx` | Tests for the decoration priority (Sparkles when companion-on, Lock when E2E, nothing when quiet) |
| `apps/frontend/src/pages/drafts.tsx` | StickyNote icon for companion-off scratchpad drafts |
| `apps/frontend/src/pages/stream.tsx` | Replace floating mode icon with a clickable header pill that opens Settings → Companion; three-shape pill (Companion / Quiet / Encrypted); renders on any scratchpad including unnamed encrypted ones; inert variant for drafts |

No new dependencies, no schema changes, no migrations — the backend already supported every code path the UI exercises here.

## Test plan

- [x] `bun run typecheck` clean across all workspaces
- [x] `bun run --cwd apps/frontend lint` clean
- [x] `scratchpad-item.test.tsx` covers the avatar decoration priority (Sparkles / Lock / none) and the archive vs delete-draft branches
- [ ] **Quick Switcher** — open `Cmd/Ctrl+K`, type `quick`, confirm "New Quick Note" appears with subtext. Select it, send a message — no Ariadne reply
- [ ] **Sidebar `+` menu** — click the `+` next to Scratchpads, confirm all three options appear; selecting an option does NOT collapse the section
- [ ] **Mobile `+`** — on a narrow viewport, confirm the `+` is visible whether the Scratchpads section is open or collapsed
- [ ] **Default path unchanged** — "New Scratchpad" still defaults companion on, Ariadne still replies
- [ ] **Header pill (Quiet)** — open a companion-off scratchpad, confirm `🌙 Quiet` pill renders next to the title; click it, settings opens on the Companion tab
- [ ] **Header pill (Companion)** — same on a companion-on scratchpad, `✨ Companion` pill with primary-tinted background
- [ ] **Header pill (Encrypted)** — open an E2E scratchpad (named OR unnamed), confirm `🔒 Encrypted` pill renders
- [ ] **Mode toggle** — flip the picker in Settings → Companion, confirm the header pill updates and the next message respects the new mode
- [ ] **E2E scratchpad** — open Companion tab, confirm both cards are disabled and the explainer is visible
- [ ] **Sidebar avatar overlays** — verify Sparkles overlay on companion-on, Lock overlay on E2E, nothing on quiet
- [ ] **Drafts page** — confirm companion-off scratchpad drafts render with the StickyNote icon and companion-on with the standard scratchpad icon

## Verification limits

The remote container this branch was developed in has no Docker daemon, no chromium, and no local Postgres/Redis — so visual verification with a real browser session wasn't possible. Static checks (typecheck, lint, tests) are clean, and the visual treatment intentionally mirrors `VisibilityPicker` and the existing `Badge`/avatar-overlay chips so it has shipped precedent in-app. Local screenshot verification is the missing leg of the test plan above.