### PR TITLE
fix(pi-remote): simplify bot presence strip and show cwd as detail

### DIFF
--- a/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
+++ b/apps/frontend/src/components/timeline/active-bot-status-strip.tsx
@@ -5,35 +5,21 @@ interface ActiveBotStatusStripProps {
   botName: string
   runtimeDisplayName: string | null
   status: BotRuntimeStatus | "unknown"
-  statusText?: string | null
   className?: string
 }
 
 const STATUS_COPY: Record<BotRuntimeStatus | "unknown", string> = {
   available: "Available",
   busy: "Working",
-  offline: "Offline",
-  error: "Error",
-  unknown: "Not linked",
+  offline: "Not connected",
+  error: "Not connected",
+  unknown: "Not connected",
 }
 
-const STATUS_DOT_CLASS: Record<BotRuntimeStatus | "unknown", string> = {
-  available: "bg-emerald-500",
-  busy: "animate-pulse bg-amber-500",
-  offline: "bg-muted-foreground/40",
-  error: "animate-pulse bg-destructive",
-  unknown: "bg-muted-foreground/40",
-}
-
-export function ActiveBotStatusStrip({
-  botName,
-  runtimeDisplayName,
-  status,
-  statusText,
-  className,
-}: ActiveBotStatusStripProps) {
-  const statusCopy = statusText?.trim() || STATUS_COPY[status]
-  const detail = runtimeDisplayName ? runtimeDisplayName : "run /remote-control in Pi to connect"
+export function ActiveBotStatusStrip({ botName, runtimeDisplayName, status, className }: ActiveBotStatusStripProps) {
+  const isConnected = status === "available" || status === "busy"
+  const statusCopy = STATUS_COPY[status]
+  const detail = isConnected ? runtimeDisplayName?.trim() || null : null
 
   return (
     <div
@@ -43,12 +29,33 @@ export function ActiveBotStatusStrip({
       )}
       aria-live="polite"
     >
-      <span className={cn("inline-block size-2 rounded-full", STATUS_DOT_CLASS[status])} aria-hidden="true" />
-      <span className="text-foreground">{botName}</span>
-      <span aria-hidden="true"> · </span>
-      <span className="max-w-48 truncate">{statusCopy}</span>
-      <span aria-hidden="true"> · </span>
-      <span>{detail}</span>
+      <span
+        className={cn(
+          "inline-block size-2 shrink-0 rounded-full",
+          isConnected ? "bg-emerald-500" : "bg-muted-foreground/40"
+        )}
+        aria-hidden="true"
+      />
+      <span className="shrink-0 text-foreground">{botName}</span>
+      <span className="shrink-0" aria-hidden="true">
+        {" "}
+        ·{" "}
+      </span>
+      <span className="shrink-0">{statusCopy}</span>
+      {detail && (
+        <>
+          <span className="shrink-0" aria-hidden="true">
+            {" "}
+            ·{" "}
+          </span>
+          {/* RTL truncation so the tail of the path (e.g. the project folder)
+              stays visible while a long prefix is replaced by an ellipsis. The
+              leading LRM keeps neutral characters like `/` rendering LTR. */}
+          <span className="min-w-0 truncate" style={{ direction: "rtl", textAlign: "left" }}>
+            {`‎${detail}`}
+          </span>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1493,7 +1493,6 @@ export function StreamContent({
                   botName={activeBotPresence.bot.name}
                   runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
                   status={activeBotPresence.presence?.status ?? "unknown"}
-                  statusText={activeBotPresence.presence?.statusText ?? null}
                   className="pointer-events-auto"
                 />
               </div>

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -277,6 +277,18 @@ function ensureInstanceId(): string {
   return config.instanceId
 }
 
+// Tildified cwd for the bot presence pill. The scratchpad UI shows this as
+// the "where Pi is running" hint, so a shell-style `~/dev/foo` reads better
+// than the static "Local Pi" we used to send.
+function presenceDisplayNameFromCwd(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined
+  const home = homedir()
+  const labeled = cwd === home ? "~" : cwd.startsWith(`${home}/`) ? `~${cwd.slice(home.length)}` : cwd
+  // `upsertPresenceSchema` caps `displayName` at 100 chars; the strip CSS-truncates
+  // anything longer, but keep the wire payload inside the validator's limit.
+  return labeled.length > 100 ? labeled.slice(-100) : labeled
+}
+
 function getRuntimeSessionId(ctx: ExtensionContext): string {
   const sessionId = ctx.sessionManager.getSessionId()
   if (sessionId) return sessionId
@@ -431,7 +443,7 @@ async function heartbeat(
       runtimeKind: "pi-local",
       instanceId: ensureInstanceId(),
       runtimeSessionId,
-      displayName: config.defaultDisplayName,
+      displayName: presenceDisplayNameFromCwd(ctx?.cwd) ?? config.defaultDisplayName,
       status,
       acceptingInvocations: status === "available",
       capabilities: buildRuntimeCapabilities(ctx),
@@ -505,7 +517,7 @@ function buildBotHelloPayload(ctx: ExtensionContext, sinceCursor: string | undef
     instanceId: ensureInstanceId(),
     runtimeKind: "pi-local",
     runtimeSessionId: getRuntimeSessionId(ctx),
-    displayName: config?.defaultDisplayName,
+    displayName: presenceDisplayNameFromCwd(ctx.cwd) ?? config?.defaultDisplayName,
     supportedCapabilities: ["active-scratchpad", "mentionable", SESSION_CONTROL_CAPABILITY],
     capabilities: buildRuntimeCapabilities(ctx),
     ...(sinceCursor ? { sinceCursor } : {}),

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -283,7 +283,8 @@ function ensureInstanceId(): string {
 function presenceDisplayNameFromCwd(cwd: string | undefined): string | undefined {
   if (!cwd) return undefined
   const home = homedir()
-  const labeled = cwd === home ? "~" : cwd.startsWith(`${home}/`) ? `~${cwd.slice(home.length)}` : cwd
+  const isUnderHome = cwd === home || cwd.startsWith(`${home}/`)
+  const labeled = isUnderHome ? `~${cwd.slice(home.length)}` : cwd
   // `upsertPresenceSchema` caps `displayName` at 100 chars; the strip CSS-truncates
   // anything longer, but keep the wire payload inside the validator's limit.
   return labeled.length > 100 ? labeled.slice(-100) : labeled


### PR DESCRIPTION
## Summary

The scratchpad's bot presence strip flickered through five different status copies (Available / Working / Loading context / Thinking… / Sent response) because it surfaced every transient `statusText` Pi sent on a heartbeat, and it always carried the "run /remote-control in Pi to connect" hint even when already connected.

- **Three labels, two colors.** Collapse the strip to `Available` / `Working` / `Not connected`, with a green dot when connected (status `available` or `busy`) and grey otherwise. `statusText` is no longer surfaced in the pill — it still lives on the wire for the per-message trace, just not as the status copy.
- **Drop the "run /remote-control" hint.** It was nonsense once already connected. The detail slot now shows the Pi cwd instead (e.g. `~/dev/personal/threa`), via free-form `displayName` set by the Pi extension on heartbeat and `bot:hello`. Backend schema unchanged — `displayName` was already a `z.string().max(100)`.
- **RTL truncation for long paths.** The detail span uses `direction: rtl; text-align: left` with a leading LRM so an overflowing path like `~/dev/personal/threa.some-long-workspace-name` truncates as `…workspace-name`, preserving the tail (project folder) instead of the prefix.

## Test plan

- [ ] Open a scratchpad with Pi linked → pill reads `Pi · Available · ~/dev/<cwd>` with a green dot
- [ ] Trigger an invocation → pill reads `Pi · Working · ~/dev/<cwd>` with a still-green dot; no flicker through "Loading context…", "Thinking…", "Sent response"
- [ ] Disable Pi (`/remote-control off`) → pill reads `Pi · Not connected` with a grey dot, no detail
- [ ] Resize the window so the pill hits its max width → ellipsis appears on the **left** of the path, the tail stays visible

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xn9vKH4UzEoER8u6NsjPo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782505769&installation_id=129946197&pr_number=648&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F648&signature=e8c8140c91d7733572572d2fa288f7ea053031f4a021d60c8e4323553e11c7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->