### PR TITLE
fix(pi-remote): stop presence flicker and fix Local Pi default

### DIFF
--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -709,6 +709,14 @@ export function createPublicApiHandlers({
           ...(result.data.runtimeSessionId && { runtimeSessionId: result.data.runtimeSessionId }),
         },
         statusText: sanitizeStatusText(result.data.statusText),
+        // Merge instead of replace: any heartbeat that arrives without a
+        // `runtimeSessionId` (e.g. an older client, or a code path that
+        // forgets to thread the runtime ctx through) would otherwise wipe the
+        // id from the row, and `broadcastBotPresence` would then emit
+        // `presence: null` to the linked scratchpad stream — flickering the
+        // status strip to "Not connected" mid-turn. The trace-step path
+        // (`recordBotInvocationStep`) already merges for the same reason.
+        mergeCapabilities: true,
       })
       await broadcastBotPresence(req.workspaceId!, req.botApiKey.botId, presence)
       res.json({

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -709,14 +709,6 @@ export function createPublicApiHandlers({
           ...(result.data.runtimeSessionId && { runtimeSessionId: result.data.runtimeSessionId }),
         },
         statusText: sanitizeStatusText(result.data.statusText),
-        // Merge instead of replace: any heartbeat that arrives without a
-        // `runtimeSessionId` (e.g. an older client, or a code path that
-        // forgets to thread the runtime ctx through) would otherwise wipe the
-        // id from the row, and `broadcastBotPresence` would then emit
-        // `presence: null` to the linked scratchpad stream — flickering the
-        // status strip to "Not connected" mid-turn. The trace-step path
-        // (`recordBotInvocationStep`) already merges for the same reason.
-        mergeCapabilities: true,
       })
       await broadcastBotPresence(req.workspaceId!, req.botApiKey.botId, presence)
       res.json({

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -625,25 +625,37 @@ describe("formatShortDuration", () => {
 })
 
 describe("defaultDisplayNameFor", () => {
-  test("derives `Pi remote: <dirname>` from the working directory tail", () => {
-    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa")).toBe("Pi remote: threa")
+  test("derives `Pi remote - <dirname>` from the working directory tail", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa")).toBe("Pi remote - threa")
   })
 
   test("ignores a trailing slash on the working directory", () => {
-    // `cwd` is conventionally unsuffixed, but defensively we should not produce
-    // `Pi remote: ` with an empty dirname when the path ends in `/`.
-    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa/")).toBe("Pi remote: threa")
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa/")).toBe("Pi remote - threa")
   })
 
   test("falls back to `session` when the working directory is the filesystem root", () => {
-    expect(__testing.defaultDisplayNameFor("/")).toBe("Pi remote: session")
+    expect(__testing.defaultDisplayNameFor("/")).toBe("Pi remote - session")
   })
 
-  test("respects an explicit configured override", () => {
-    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "Local Pi")).toBe("Local Pi")
+  test("uses a configured override as a prefix and still appends the dirname", () => {
+    // The override no longer wins outright — every scratchpad needs the dirname
+    // to be distinguishable in the sidebar.
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "Work Pi")).toBe("Work Pi - threa")
   })
 
-  test("treats an empty configured override as unset (avoids `Pi remote: ` shape collapse)", () => {
-    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "")).toBe("Pi remote: threa")
+  test("treats an empty configured override as unset", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "")).toBe("Pi remote - threa")
+  })
+
+  test("treats the legacy `Local Pi` default as unset so old configs stop colliding", () => {
+    // `configTemplate` used to bake `"Local Pi"` into the JSON the user pasted
+    // during /configure, and that override beat the dirname — every scratchpad
+    // across every repo ended up named "Local Pi". Stop honoring it.
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "Local Pi")).toBe("Pi remote - threa")
+  })
+
+  test("ignores surrounding whitespace on the override", () => {
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "   ")).toBe("Pi remote - threa")
+    expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "  Work Pi  ")).toBe("Work Pi - threa")
   })
 })

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -696,7 +696,7 @@ async function recordTraceStep(stepType: string, content: string, statusText?: s
   await recordInvocationTraceStep(pending, stepType, content, statusText)
 }
 
-async function traceHeartbeat(text: string, stepType?: string): Promise<void> {
+async function traceHeartbeat(text: string, ctx?: ExtensionContext, stepType?: string): Promise<void> {
   if (!pending) return
   const trimmed = safeStatusText(text)
   if (!trimmed) return
@@ -707,7 +707,12 @@ async function traceHeartbeat(text: string, stepType?: string): Promise<void> {
     await recordTraceStep(stepType, trimmed, trimmed)
     return
   }
-  await heartbeat("busy", trimmed).catch(() => undefined)
+  // `ctx` carries the cwd-derived displayName and runtimeSessionId into the
+  // heartbeat body. Dropping it makes the server's upsert wipe runtimeSessionId
+  // out of `capabilities`, and `broadcastBotPresence` then emits `presence:
+  // null` for the linked scratchpad — the strip flickers to "Not connected"
+  // mid-turn.
+  await heartbeat("busy", trimmed, ctx).catch(() => undefined)
 }
 
 function safeStatusText(text: string): string {
@@ -903,14 +908,25 @@ function formatInvocationTrace(invocation: ClaimedInvocation, context: string): 
   )
 }
 
+// Legacy default that older configTemplate versions baked into the JSON the
+// user pasted during /configure. Treated as "unset" so it no longer collapses
+// every scratchpad onto a single name across repos.
+const LEGACY_DEFAULT_DISPLAY_NAME = "Local Pi"
+
 function defaultDisplayNameFor(cwd: string, configuredOverride?: string): string {
-  // `configuredOverride` (set during /configure) wins over the dirname shape so
-  // power users can pin a name across workspaces. The dirname suffix is what
-  // most users actually want — it makes the scratchpad searchable in Threa as
-  // "Pi remote: <project>" without needing to type a label every time.
-  if (configuredOverride) return configuredOverride
+  // The dirname tail is what makes the scratchpad distinguishable across
+  // repos — without it, every Pi runtime on the same workspace produces a
+  // scratchpad named "Pi remote" (or, worse, "Local Pi") and they're
+  // impossible to tell apart in the sidebar. So always append it.
+  //
+  // `configuredOverride` (set during /configure) is treated as a *prefix*
+  // when present, not a full replacement. Empty/whitespace and the legacy
+  // "Local Pi" default fall back to "Pi remote" so existing configs do not
+  // keep producing the bad name.
+  const trimmed = configuredOverride?.trim() ?? ""
+  const prefix = trimmed.length === 0 || trimmed === LEGACY_DEFAULT_DISPLAY_NAME ? "Pi remote" : trimmed
   const dir = cwd.split("/").filter(Boolean).pop() ?? "session"
-  return `Pi remote: ${dir}`
+  return `${prefix} - ${dir}`
 }
 
 async function createRemoteSession(ctx: ExtensionCommandContext, args: string): Promise<void> {
@@ -1037,7 +1053,11 @@ function configTemplate(existing: Partial<Config> | undefined): string {
       workspaceId: existing?.workspaceId ?? "",
       apiKey: existing?.apiKey ?? "",
       pollMs: existing?.pollMs ?? 3000,
-      defaultDisplayName: existing?.defaultDisplayName ?? "Local Pi",
+      // Empty default: `defaultDisplayNameFor` now always appends the dirname,
+      // so leaving this blank produces "Pi remote - <project>". Users who want
+      // a custom prefix (e.g. "Work Pi") can set it here and the dirname will
+      // still be appended.
+      defaultDisplayName: existing?.defaultDisplayName ?? "",
       preferredModels: existing?.preferredModels ?? [],
     },
     null,
@@ -2403,7 +2423,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("agent_start", async (_event, ctx) => {
     if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…", ctx).catch(() => undefined)
-    await traceHeartbeat("Thinking…", "thinking")
+    await traceHeartbeat("Thinking…", ctx, "thinking")
   })
 
   pi.on("tool_call", async (event) => {
@@ -2423,15 +2443,15 @@ export default function (pi: ExtensionAPI): void {
     pendingToolCalls.delete(event.toolCallId)
   })
 
-  pi.on("tool_execution_end", async (event) => {
+  pi.on("tool_execution_end", async (event, ctx) => {
     if (!event.isError || !pendingToolCalls.has(event.toolCallId)) return
-    await traceHeartbeat(`${event.toolName} failed`, "tool_error")
+    await traceHeartbeat(`${event.toolName} failed`, ctx, "tool_error")
     pendingToolCalls.delete(event.toolCallId)
   })
 
-  pi.on("message_start", async (event) => {
+  pi.on("message_start", async (event, ctx) => {
     if (!pending || event.message.role !== "assistant") return
-    await traceHeartbeat("Composing response…")
+    await traceHeartbeat("Composing response…", ctx)
   })
 
   pi.on("message_end", async (event) => {


### PR DESCRIPTION
## Summary

The Pi remote status strip flickered to "Not connected" mid-turn and named every scratchpad "Local Pi" across every repo. Two unrelated causes, both in the Pi extension.

### Cause A & B — "Not connected" + missing cwd mid-turn

`traceHeartbeat` called `heartbeat("busy", text)` with no `ctx`. The body's top-level `runtimeSessionId` (the field `handlers.ts` injects into `capabilities`) was undefined, so the server's upsert *replaced* `capabilities` and the id got wiped from the row. `broadcastBotPresence`'s per-stream filter then saw `null !== link.runtime_session_id` and emitted `presence: null` to the linked scratchpad — strip rendered "Not connected" until the next ctx-bearing heartbeat. Without `ctx`, `displayName` also fell back to `config.defaultDisplayName`, alternating the cwd detail on/off.

**Fix:** every `pi.on` handler that calls `traceHeartbeat` (`message_start`, `tool_execution_end`, `agent_start`) now threads `ctx` through, so the heartbeat body always carries `runtimeSessionId` and the cwd-derived `displayName`.

### Cause C — "Local Pi" name collision across repos

`configTemplate` baked `defaultDisplayName: "Local Pi"` into the JSON every user pasted during `/configure`, and `defaultDisplayNameFor` returned the override verbatim — so every scratchpad across every repo ended up named "Local Pi".

**Fix:** `defaultDisplayNameFor` always appends the dirname now and treats `configuredOverride` as a *prefix* rather than a replacement. Empty/whitespace overrides and the legacy `"Local Pi"` literal are treated as unset (→ `Pi remote - <dirname>`). `configTemplate` now ships an empty `defaultDisplayName`.

| input | output |
|---|---|
| `defaultDisplayNameFor("/Users/kris/dev/threa")` | `Pi remote - threa` |
| `defaultDisplayNameFor("/Users/kris/dev/threa", "Work Pi")` | `Work Pi - threa` |
| `defaultDisplayNameFor("/Users/kris/dev/threa", "Local Pi")` | `Pi remote - threa` |

### One thing I tried and reverted

The first push added `mergeCapabilities: true` to the bare-heartbeat upsert in `handlers.ts` as a backend-side safety net. CI caught it: `tests/e2e/commands.test.ts:269` exercises an *explicit* capability downgrade through this same endpoint (the runtime intentionally trims `sessionControlCommands` to drop `/model`) and the merge made the downgrade a no-op. Reverted in the second commit — the Pi-side `ctx` threading is the actual fix, and the presence endpoint must keep replace-semantics so downgrades work.

## Test plan

- [x] `bun test ./extensions/pi-remote/src/threa-remote.test.ts` — 76 pass / 0 fail
- [x] `bun run --cwd apps/backend typecheck` — clean
- [ ] CI green (re-running after the revert)
- [ ] Verify on Pi: install the extension build, link a scratchpad, trigger a bot invocation, watch the status strip stays "Working in <project>" through the whole turn (no "Not connected" flicker, no missing cwd frames)
- [ ] Verify default name: fresh `/configure` produces `Pi remote - <project>`; existing config with `defaultDisplayName: "Local Pi"` also produces `Pi remote - <project>`; custom prefix `"Work Pi"` produces `Work Pi - <project>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
