### PR TITLE
Remove subtitle from Quick Note in Quick Switcher

### DIFF
--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -38,7 +38,6 @@ export interface CommandContext {
 export interface Command {
   id: string
   label: string
-  description?: string
   icon: React.ComponentType<{ className?: string }>
   keywords?: string[]
   action: (context: CommandContext) => void | Promise<void>
@@ -64,7 +63,6 @@ export const commands: Command[] = [
   {
     id: "new-quick-note",
     label: "New Quick Note",
-    description: "Scratchpad without the AI companion — links, ideas, quick captures",
     icon: StickyNote,
     keywords: [
       "scratchpad",

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -22,7 +22,6 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
       (command): QuickSwitcherItem => ({
         id: command.id,
         label: command.label,
-        description: command.description,
         icon: command.icon,
         group: "Commands",
         onSelect: () => {


### PR DESCRIPTION
The New Quick Note command was the only command with a description
subtitle, making it inconsistent with every other command item.

https://claude.ai/code/session_01St2ytKS8mqDWiBtvpPumCH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782541366&installation_id=129946197&pr_number=653&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F653&signature=19ad8ce1c7d1678679951a72b4fe039f65c4c7a8c45445c23e545077343a6289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->