### PR TITLE
feat(crypto): add per-stream symmetric key (SSK) primitives

### DIFF
--- a/.claude/plans/e2e-enclave-ssk.md
+++ b/.claude/plans/e2e-enclave-ssk.md
@@ -1,0 +1,381 @@
+# Phase 5a (redesign) — Ariadne enclave on a per-stream symmetric key (SSK)
+
+> Supersedes the keying design in `.claude/plans/shiny-weaving-lovelace.md`.
+> That plan's product context, threat model, and service-shell shape are still
+> correct; its **keying design (one EIK + per-user UIK + per-message recipient
+> fan-out, no per-stream key) is WRONG and is replaced wholesale here.** PR #646
+> (`claude/e2e-5a-2-enclave-service`) implemented the old design and is being
+> closed; keep its branch as read-only reference only.
+
+## 0. Why we are redoing this
+
+The shipped-and-closed design sealed each message to a per-message recipient
+list `[UIK, ...liveEIKs]` with no per-stream key. Two fatal flaws:
+
+1. **Cross-user leakage is not prevented cryptographically.** A bug in
+   recipient-list construction could place another user's UIK on the list and
+   nothing stops it.
+2. **Message loss on enclave rotation.** EIKs are generated in-memory at boot
+   and never persisted; when the enclave redeploys, history sealed to the old
+   EIK is undecryptable by the new instance. The old orchestrator
+   (`apps/enclave/src/orchestrator.ts` `decryptHistory`) **silently skipped**
+   undecryptable history (catch + continue) → Ariadne gets amnesia after every
+   deploy.
+
+Confirmed in the closed code, all four target bugs are present:
+`decryptHistory` catch-and-continue (silent skip); a single `capturedReply`
+string (overwrite, not append); per-message `[UIK, ...EIKs]` recipients (no
+SSK); and `replyMessageId`/`invocationId` minted fresh per `runJob` (not
+idempotent on retry).
+
+## 1. The design: per-stream symmetric key (SSK)
+
+Every E2E scratchpad ("stream") owns its own AES-256 key — the **SSK** — scoped
+to a **key generation** (integer, starts at 1). Messages are AEAD-sealed
+directly under the current-generation SSK. The SSK itself is never stored in
+plaintext on the server; it exists only **HPKE-wrapped** to each authorized
+recipient's long-term public key — the active UIKs of stream members plus the
+currently-live EIKs. Wraps live in a new `stream_e2e_key_wraps` table. Each
+message references the SSK by `(stream_id, key_generation)`.
+
+This single primitive fixes everything:
+
+- **Cross-user isolation is cryptographic.** A non-member's UIK is never wrapped
+  to the stream's SSK, so a recipient-list bug cannot expose the stream.
+- **Enclave rotation is lossless.** When a new EIK appears, the client wraps the
+  *existing* SSK to the new EIK and uploads it. The SSK never changes — only its
+  wrappers — so all history stays readable. No silent skip.
+- **Edits** re-seal one ciphertext under the same SSK; everyone authorized reads.
+- **Member removal (Signal model):** bump `key_generation`, generate a new SSK,
+  wrap to remaining members only. The removed member keeps wraps for old
+  generations (reads history they already had) but gets no wrap for the new one.
+- **Member add with inviter-chosen history visibility (required):**
+  - *See history* → wrap the **existing** current-generation SSK to the new
+    member's UIK (one row). No re-encryption.
+  - *Start fresh* → bump generation; new SSK wrapped to old members + the new
+    member; the new member has no wrap for older generations.
+  This is a single bit chosen at invite time and surfaced in the invite UI.
+- **Bonus:** closes operator-spoofing of Ariadne replies — a backend operator
+  cannot seal new content under the SSK without an EIK or UIK private key.
+
+EIKs stay ephemeral (privacy posture). Wraps to dead EIKs remain in the table
+forever — harmless, since those private keys are gone.
+
+### 1.1 Cryptographic operations (all client-side / enclave-side; server sees ciphertext only)
+
+- **Generate SSK:** 32 random bytes (AES-256). Generation starts at 1.
+- **Wrap SSK to a recipient:** `wrapStreamKey({ key, recipientPublicKey, aad })`
+  → `{ enc, ct }`, where `aad = buildWrapAad({ streamId, keyGeneration,
+  recipientKeyId })` binds the wrap to its `stream_e2e_key_wraps` slot so a
+  malicious server can't relocate a wrap row to a different
+  stream/generation/recipient. Thin wrapper over the existing HPKE `seal()`.
+- **Unwrap SSK:** `unwrapStreamKey({ enc, ct, recipientPrivateKey, aad })` →
+  `sskBytes` (validates recovered length === 32).
+- **Seal a message:** `AES-256-GCM(ssk, iv, payload, aad)` →
+  `{ iv, ciphertext }`. New thin helper `sealMessage` in `@threa/crypto`.
+- **Open a message:** `AES-256-GCM-open(ssk, iv, ciphertext, aad)`. New helper
+  `openMessage`.
+- **AAD** continues to bind `streamId | messageId | senderId` via the existing
+  `buildMessageAad`, so the server still can't shuffle envelopes between rows.
+
+### 1.2 New message envelope shape
+
+The current `Envelope` (`@threa/crypto/envelope.ts`) carries an inline
+`recipients[]` (per-message HPKE fan-out). The SSK design moves recipient
+wrapping out of the message and into `stream_e2e_key_wraps`, so the
+message-level envelope becomes:
+
+```ts
+interface StreamEnvelope {
+  v: number            // STREAM_ENVELOPE_VERSION = 2 (distinct from the v1 recipient-fan-out shape)
+  keyGeneration: number
+  iv: string           // base64 AES-GCM IV
+  aad: string          // base64 AAD bytes
+  // ciphertext stays in messages.ciphertext (BYTEA); also mirrored here is unnecessary
+}
+```
+
+`messages.ciphertext BYTEA` holds the AES-GCM ciphertext (incl. tag);
+`messages.envelope JSONB` holds `StreamEnvelope`; `messages.e2e_version` is the
+new envelope version. A reader resolves the SSK from the wrap table by
+`(stream_id, keyGeneration, theirKeyId)`, HPKE-opens it, then AES-opens the
+message. **No new `messages` column is required** — `keyGeneration` rides inside
+the envelope JSON.
+
+## 2. Schema (new tables — global infra tables fall under the INV-8 exception; product tables are workspace-scoped)
+
+### 2.1 `stream_e2e_keys` — generation metadata (no SSK plaintext)
+
+```sql
+CREATE TABLE stream_e2e_keys (
+  id TEXT PRIMARY KEY,                       -- sek_<ulid>  (INV-2)
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  key_generation INTEGER NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (stream_id, key_generation)
+);
+CREATE INDEX idx_stream_e2e_keys_stream ON stream_e2e_keys (workspace_id, stream_id, key_generation DESC);
+```
+
+The active generation for sealing is tracked on `e2e_streams`
+(`current_key_generation INTEGER NOT NULL DEFAULT 1`, added by migration). The
+SSK bytes live *only* in `stream_e2e_key_wraps`.
+
+### 2.2 `stream_e2e_key_wraps` — one wrap per (stream, generation, recipient key)
+
+```sql
+CREATE TABLE stream_e2e_key_wraps (
+  id TEXT PRIMARY KEY,                       -- sekw_<ulid>
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  key_generation INTEGER NOT NULL,
+  recipient_kind TEXT NOT NULL,              -- 'user' | 'enclave'  (TEXT, validated in code — INV-3)
+  recipient_key_id TEXT NOT NULL,            -- UIK key_id or EIK key_id
+  wrap_enc BYTEA NOT NULL,                   -- HPKE encapsulation
+  wrap_ct BYTEA NOT NULL,                    -- HPKE-wrapped SSK bytes
+  created_by_user_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (stream_id, key_generation, recipient_key_id)
+);
+CREATE INDEX idx_stream_e2e_key_wraps_gen ON stream_e2e_key_wraps (workspace_id, stream_id, key_generation);
+CREATE INDEX idx_stream_e2e_key_wraps_recipient ON stream_e2e_key_wraps (recipient_key_id);
+```
+
+Wrap upload is race-safe: `INSERT ... ON CONFLICT (stream_id, key_generation,
+recipient_key_id) DO NOTHING` (INV-20). Re-uploading an identical wrap is a
+no-op.
+
+### 2.3 `enclave_runtimes` — EIK registry (reuse closed PR's design verbatim)
+
+```sql
+CREATE TABLE enclave_runtimes (
+  id TEXT PRIMARY KEY,                       -- elr_<ulid>
+  instance_id TEXT NOT NULL,
+  key_id TEXT NOT NULL,
+  public_key BYTEA NOT NULL,
+  instance_url TEXT NOT NULL,
+  registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_enclave_runtimes_key_id ON enclave_runtimes (key_id);
+CREATE INDEX idx_enclave_runtimes_live ON enclave_runtimes (last_seen_at DESC) WHERE revoked_at IS NULL;
+```
+
+Liveness derived: `revoked_at IS NULL AND last_seen_at > NOW() - 2 min`.
+Multi-instance from day one; never a single-active-key assumption.
+
+### 2.4 `enclave_invocations` — idempotent job identity + revive linkage (HR #6, HR #1)
+
+```sql
+CREATE TABLE enclave_invocations (
+  id TEXT PRIMARY KEY,                       -- einv_<ulid>  (this IS the invocationId)
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  queue_message_id TEXT NOT NULL,            -- links to queue_messages.id for revive
+  trigger_message_id TEXT NOT NULL,
+  base_reply_message_id TEXT NOT NULL,       -- minted ONCE; per-output id = base-<index>
+  session_id TEXT NOT NULL,                  -- agent_session id for the trace
+  status TEXT NOT NULL,                      -- 'pending' | 'awaiting_wrap' | 'completed' | 'failed'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (queue_message_id)
+);
+CREATE INDEX idx_enclave_invocations_stream_status ON enclave_invocations (workspace_id, stream_id, status);
+```
+
+On the **first** job attempt the dispatcher `INSERT ... ON CONFLICT
+(queue_message_id) DO NOTHING` then `SELECT` to read back, minting
+`invocationId` / `base_reply_message_id` / `session_id` exactly once. On retry,
+it reuses the existing row. Per-output ids = `${base_reply_message_id}-${index}`.
+Because `MessageRepository.insert` uses `ON CONFLICT (stream_id,
+client_message_id) DO NOTHING` and returns the existing row, re-writing the same
+ids on retry is a no-op (verified: `messaging/repository.ts:385-423`).
+
+### 2.5 `agent_session_steps` E2E columns (PR 5)
+
+Additive (INV-17): `ciphertext BYTEA`, `envelope JSONB`, `e2e_version SMALLINT`.
+For E2E sessions `content` and `sources` are `NULL`.
+
+## 3. How the six hard requirements are met
+
+### HR #1 — No message loss on enclave rotation (needs-wrap → soft-dead-letter → revive)
+
+The dispatcher, **before** calling any enclave instance, resolves the set of
+key generations spanned by the dispatched history window + the current
+generation (for sealing the reply). It then needs a live EIK that has a wrap for
+**every** generation in that set.
+
+- If at least one live EIK is fully covered → dispatch to an instance whose EIK
+  is covered. The enclave can decrypt all history and seal the reply.
+- If **no** live EIK is fully covered → do not dispatch, do not process partial
+  history. Instead:
+  1. Throw `SoftDeadLetterError` (new sentinel). `QueueManager.processMessage`
+     gains a small branch: a `SoftDeadLetterError` skips the retry/backoff path
+     and goes straight to `moveMessageToDlq` (manager.ts:837-858). This avoids
+     burning five backoff retries while the client catches up.
+  2. The `ENCLAVE_PERSONA_AGENT` handler is registered with an `onDLQ` hook
+     (existing seam, job-queue.ts:298-311; runs in the DLQ transaction with a
+     `Querier`). The hook writes an `enclave:needs-wrap` outbox event carrying
+     `{ streamId, invocationId, missing: [{ keyGeneration, eikKeyId, eikPublicKey }...] }`
+     and flips `enclave_invocations.status = 'awaiting_wrap'` — atomically with
+     the DLQ move.
+- The frontend receives `enclave:needs-wrap` (it already holds the unlocked
+  UIK, so it can unwrap the SSK for any generation it has a wrap for), re-wraps
+  those SSK generations to the named live EIKs, and uploads via the wrap
+  endpoint.
+- **Uploading a wrap revives the job.** The wrap-upload handler, after
+  persisting wraps, finds `enclave_invocations WHERE stream_id = ? AND status =
+  'awaiting_wrap'` and calls `QueueRepository.unDlq(queue_message_id)`
+  (repository.ts:393-414 — clears `dlq_at`, resets `failed_count`, sets
+  `process_after = NOW()` for immediate retry) + sets status back to `'pending'`.
+  The retried job re-checks coverage; now covered, it dispatches and processes
+  in full.
+
+Net: either the message is processed in full, or the user sees an "enclave is
+updating, reply coming shortly" affordance (driven by the `enclave:needs-wrap`
+event) — never silent loss.
+
+### HR #2 — An invocation may produce MULTIPLE messages (append, not overwrite)
+
+The enclave→backend response is `{ messages: [{ keyGeneration, iv, ciphertext,
+envelope, e2eVersion }...], sidecar }`. The enclave orchestrator's `sendMessage`
+callback **appends** each produced message to an array (replacing the closed
+code's single `capturedReply`). The dispatcher iterates `messages` and writes
+each via `MessageRepository.insert` with `clientMessageId =
+${base_reply_message_id}-${index}`.
+
+### HR #3 — Same trigger semantics as plaintext persona-agent
+
+Per-message trigger, history fan-in via `MessageRepository.list`. The companion
+outbox handler currently *skips* E2E streams (`companion-outbox-handler.ts:116`).
+The new branch: if the stream is E2E **and** `invitedAgentKind === "enclave"`,
+dispatch `JobQueues.ENCLAVE_PERSONA_AGENT` instead of skipping; otherwise keep
+the skip. The mention handler keeps its E2E skip (ciphertext `@`-mentions are
+invisible — always-on companion mode for enclave-invited E2E). No new trigger
+model.
+
+### HR #4 — Edits
+
+Re-seal one ciphertext under the same SSK (same generation). `MessageRepository`
+edit path is extended to update `ciphertext`/`envelope`/`e2e_version` (today
+`updateContent` only touches `content_json`/`content_markdown`). Outbox
+`message:edited` propagates; the frontend re-decrypts on render.
+
+### HR #5 — Deletes
+
+Soft-delete + tombstone (existing `softDelete` sets `deleted_at`; `list` already
+filters `deleted_at IS NULL`). The enclave history fetch therefore never sees
+tombstoned messages and always uses the latest ciphertext per message (edits
+update in place). Accepted: the model may have seen pre-delete content in a
+prior invocation — not engineered around.
+
+### HR #6 — Idempotent job retries
+
+Custom Postgres queue (`lib/queue/manager.ts`, `maxRetries` default 5 +
+exponential backoff — NOT BullMQ). `invocationId` + `base_reply_message_id` are
+minted **once per job** (persisted to `enclave_invocations` on first attempt,
+reused on retry — §2.4), and per-output ids are `${base}-${index}`. Combined
+with `MessageRepository.insert`'s `ON CONFLICT DO NOTHING`-returns-existing,
+duplicate writes on retry are no-ops.
+
+## 4. Accepted trade-offs (already signed off)
+
+- Enclave-lifetime compromise window: a compromised running enclave exposes the
+  SSKs wrapped to its EIK during its lifetime. Real fix = attested TEE (Nitro),
+  future phase.
+- No streaming replies in E2E (request/response, full sealed reply per
+  invocation).
+- Delete removes from storage + future context, not from an LLM's already-seen
+  prior context.
+
+## 5. PR stack (strict dependency chain, each independently mergeable)
+
+> **PR 1 — the `@threa/crypto` + `@threa/agent-runtime` extraction — is ALREADY
+> MERGED on `main`** (commit `da02c7e`, #642). The multi-recipient envelope, the
+> AI wrapper, `AgentRuntime`, and the web/send tools are already shared
+> packages. PR 2 below re-verifies that extraction and lands the genuinely-new
+> SSK primitives as a small, standalone, self-testing package change so the
+> service/protocol PRs that follow can import them without bundling crypto into a
+> larger diff.
+
+- **PR 1 (DONE, #642):** extract `packages/crypto/` + `packages/agent-runtime/`.
+  Load-bearing; everything else imports from these.
+
+- **PR 2 (THIS PR) — Audit extraction + SSK crypto primitives.** Re-verify #642's
+  extraction is sound (crypto typechecks, envelope tests green, backend barrels
+  re-export correctly). Add `packages/crypto/src/stream-key.ts`: the symmetric
+  SSK layer that `envelope.ts` (recipient-fan-out, v1) deliberately can't
+  express — `generateStreamKey`, `sealMessage`/`openMessage`/`openMessageAsString`
+  (AES-256-GCM directly under the SSK, `STREAM_ENVELOPE_VERSION = 2`),
+  `wrapStreamKey`/`unwrapStreamKey` (HPKE-wrap the SSK to a recipient UIK/EIK),
+  `buildWrapAad` (binds a wrap to its `(streamId, keyGeneration, recipientKeyId)`
+  slot), and the `StreamEnvelope`/`StreamKeyWrap` types. Export from the barrel;
+  cover with vitest (round-trips, wrong-key/forged-AAD/bad-version rejections,
+  the cross-recipient "two recipients open one SSK-sealed message" property,
+  `buildWrapAad` determinism, 32-byte validation). Deliverable: `@threa/crypto`
+  exposes the SSK API the protocol PR depends on, fully tested in isolation.
+
+- **PR 3 — Enclave SERVICE SHELL.** `apps/enclave/` (Bun + Express):
+  `/healthz`, `/pubkey`, `/attestation`; EIK generation + keystore;
+  register/heartbeat/revoke against the backend; `enclave_runtimes` table +
+  `enclave-runtimes/` feature folder (repo/service/handlers/barrel);
+  internal shared-secret auth; SSRF guards on `instanceUrl`; invite flow setting
+  `e2eInvitedAgentKind = "enclave"`; `active-keys` endpoint; invite UI.
+  **No AgentRuntime yet** (`e2eCapable: false` on Ariadne). Deliverable: enclave
+  deployable, visible in active-keys, invite works, **no replies yet.** Most of
+  this is portable from the closed PR's scaffolding (high quality, reusable).
+
+- **PR 4 — Enclave dispatcher + AgentRuntime in the enclave + the SSK protocol.**
+  Tables `stream_e2e_keys` + `stream_e2e_key_wraps` + `enclave_invocations`;
+  `e2e_streams.current_key_generation`; wrap repo + endpoints; frontend SSK
+  gen/wrap/seal/open (using the PR 2 primitives) + member-add history-visibility
+  bit; the `SoftDeadLetterError` queue enhancement + `enclave:needs-wrap` outbox
+  event + revive-on-wrap-upload; `tools: []` hard-wired; multi-message output;
+  idempotent job ids; edit/delete propagation; Ariadne `e2eCapable: true`.
+  Deliverable: rotation-safe, multi-message E2E Ariadne replies with edits/deletes.
+
+- **PR 5 — Encrypted trace.** `agent_session_steps.ciphertext/envelope/e2e_version`;
+  step endpoint (invocationId-scoped); `EncryptedTraceObserver` in the enclave
+  (seals each step under the SSK); frontend per-step decrypt renderer.
+  Deliverable: trace UI works for E2E sessions; server sees only ciphertext.
+
+- **PR 6 — Web tools.** `web_search` + `read_url` wired in the enclave (both call
+  external services directly, no backend callback). Deliverable: Ariadne can
+  search/read URLs inside an E2E scratchpad.
+
+Each PR starts from a fresh branch off latest `origin/main` (e.g.
+`claude/e2e-enclave-ssk-pr3`). No PR opened unless asked.
+
+## 6. Out of scope (tracked separately)
+
+The E2E **unlock UX** (passphrase re-entry on app open) is a separate track with
+its own plan. This stack touches it only as far as the SSK protocol strictly
+requires (the frontend must hold the unlocked UIK to wrap/unwrap SSKs).
+
+## 7. Invariants to actively respect
+
+INV-2 (`elr_`, `sek_`, `sekw_`, `einv_` prefixes), INV-3 (no DB enums —
+`recipient_kind`/`status` are TEXT validated in code), INV-8 (workspace-scoped
+product tables), INV-17 (append-only migrations), INV-20 (race-safe wrap upload
++ invocation insert), INV-28 (AI only via `createAI`), INV-19 (telemetry/usage
+on every invocation via the sidecar), INV-13 (`EnclaveClient` + services
+constructed once at boot), INV-30/41 (release DB connection across the enclave
+HTTP call), INV-48 (spy on the `EnclaveClient` namespace; no `vi.mock` of shared
+runtime), INV-51/52 (feature-folder colocation + barrels for `enclave-runtimes`,
+the wrap feature, and `enclave-invocations`), INV-55 (Zod at boundaries),
+INV-33 (centralize constants — generation start, staleness window, history
+limit).
+
+## 8. Reference (closed PR #646, read-only)
+
+Reusable near-verbatim for PR 3: `apps/enclave/src/{config,keystore,register,
+heartbeat,index,access-log}.ts`, `apps/enclave/package.json`,
+`apps/backend/src/features/enclave-runtimes/{repository,service,handlers,index}.ts`,
+the SSRF `isPermittedInstanceUrl` guard, the `createBearerAuth` timing-safe
+check. **Discard and rewrite** for PR 4: `orchestrator.ts` (single
+`capturedReply` + silent `decryptHistory` skip), `enclave-dispatcher.ts`
+(per-message `[UIK, ...EIKs]` recipients, fresh ids per run, no SSK), and the
+`/invoke` wire shape (must become SSK-based + multi-message).

--- a/packages/crypto/src/__tests__/stream-key.test.ts
+++ b/packages/crypto/src/__tests__/stream-key.test.ts
@@ -99,6 +99,13 @@ describe("sealMessage / openMessage rejection paths", () => {
 
     await expect(openMessage({ key: new Uint8Array(16), envelope, ciphertext })).rejects.toThrow(/must be 32 bytes/)
   })
+
+  it("rejects sealing with empty AAD", async () => {
+    const key = generateStreamKey()
+    await expect(sealMessage({ key, keyGeneration: 1, payload: "x", aad: new Uint8Array(0) })).rejects.toThrow(
+      /aad must be non-empty/
+    )
+  })
 })
 
 describe("wrapStreamKey / unwrapStreamKey", () => {
@@ -179,6 +186,23 @@ describe("wrapStreamKey / unwrapStreamKey", () => {
     await expect(
       wrapStreamKey({ key: new Uint8Array(16), recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
     ).rejects.toThrow(/must be 32 bytes/)
+  })
+
+  it("rejects wrapping with empty AAD", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    await expect(wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: new Uint8Array(0) })).rejects.toThrow(
+      /aad must be non-empty/
+    )
+  })
+
+  it("rejects unwrapping with empty AAD", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
+    await expect(
+      unwrapStreamKey({ enc: wrap.enc, ct: wrap.ct, recipientPrivateKey: alice.privateKey, aad: new Uint8Array(0) })
+    ).rejects.toThrow(/aad must be non-empty/)
   })
 })
 

--- a/packages/crypto/src/__tests__/stream-key.test.ts
+++ b/packages/crypto/src/__tests__/stream-key.test.ts
@@ -13,6 +13,9 @@ import {
   wrapStreamKey,
 } from "../stream-key"
 
+const MSG_AAD = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_1" })
+const WRAP_AAD = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
+
 async function makeRecipient() {
   const pair = await generateKeyPair()
   const publicKey = await exportPublicKey(pair.publicKey)
@@ -32,13 +35,12 @@ describe("generateStreamKey", () => {
 describe("sealMessage / openMessage round-trip", () => {
   it("seals and opens a UTF-8 string payload under the SSK", async () => {
     const key = generateStreamKey()
-    const aad = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_1" })
 
     const { envelope, ciphertext } = await sealMessage({
       key,
       keyGeneration: 3,
       payload: "hello stream world",
-      aad,
+      aad: MSG_AAD,
     })
 
     expect(envelope.v).toBe(STREAM_ENVELOPE_VERSION)
@@ -52,17 +54,10 @@ describe("sealMessage / openMessage round-trip", () => {
     const key = generateStreamKey()
     const payload = utf8Encode('{"contentMarkdown":"hi"}')
 
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload, aad: MSG_AAD })
 
     const opened = await openMessage({ key, envelope, ciphertext })
     expect(utf8Decode(opened)).toBe('{"contentMarkdown":"hi"}')
-  })
-
-  it("round-trips when no AAD is supplied", async () => {
-    const key = generateStreamKey()
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "no aad" })
-    const decoded = await openMessageAsString({ key, envelope, ciphertext })
-    expect(decoded).toBe("no aad")
   })
 })
 
@@ -70,15 +65,14 @@ describe("sealMessage / openMessage rejection paths", () => {
   it("rejects opening with the wrong SSK", async () => {
     const key = generateStreamKey()
     const wrongKey = generateStreamKey()
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "secret" })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "secret", aad: MSG_AAD })
 
     await expect(openMessage({ key: wrongKey, envelope, ciphertext })).rejects.toThrow()
   })
 
   it("rejects opening when the bound AAD is forged", async () => {
     const key = generateStreamKey()
-    const aad = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_1" })
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "tamper", aad })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "tamper", aad: MSG_AAD })
 
     const tampered = { ...envelope, aad: btoa("stream_evil|msg_evil|usr_evil") }
     await expect(openMessage({ key, envelope: tampered, ciphertext })).rejects.toThrow()
@@ -86,7 +80,7 @@ describe("sealMessage / openMessage rejection paths", () => {
 
   it("rejects an envelope with an unknown protocol version", async () => {
     const key = generateStreamKey()
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "v" })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "v", aad: MSG_AAD })
 
     await expect(openMessage({ key, envelope: { ...envelope, v: 99 }, ciphertext })).rejects.toThrow(
       /Unsupported stream envelope version/
@@ -94,14 +88,14 @@ describe("sealMessage / openMessage rejection paths", () => {
   })
 
   it("rejects sealing with a non-32-byte key", async () => {
-    await expect(sealMessage({ key: new Uint8Array(16), keyGeneration: 1, payload: "x" })).rejects.toThrow(
-      /must be 32 bytes/
-    )
+    await expect(
+      sealMessage({ key: new Uint8Array(16), keyGeneration: 1, payload: "x", aad: MSG_AAD })
+    ).rejects.toThrow(/must be 32 bytes/)
   })
 
   it("rejects opening with a non-32-byte key", async () => {
     const key = generateStreamKey()
-    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "x" })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "x", aad: MSG_AAD })
 
     await expect(openMessage({ key: new Uint8Array(16), envelope, ciphertext })).rejects.toThrow(/must be 32 bytes/)
   })
@@ -111,14 +105,13 @@ describe("wrapStreamKey / unwrapStreamKey", () => {
   it("wraps the SSK to a recipient and unwraps it back", async () => {
     const key = generateStreamKey()
     const alice = await makeRecipient()
-    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
 
-    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
     const recovered = await unwrapStreamKey({
       enc: wrap.enc,
       ct: wrap.ct,
       recipientPrivateKey: alice.privateKey,
-      aad,
+      aad: WRAP_AAD,
     })
 
     expect(recovered).toEqual(key)
@@ -162,20 +155,18 @@ describe("wrapStreamKey / unwrapStreamKey", () => {
     const key = generateStreamKey()
     const alice = await makeRecipient()
     const mallory = await makeRecipient()
-    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
 
-    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
     await expect(
-      unwrapStreamKey({ enc: wrap.enc, ct: wrap.ct, recipientPrivateKey: mallory.privateKey, aad })
+      unwrapStreamKey({ enc: wrap.enc, ct: wrap.ct, recipientPrivateKey: mallory.privateKey, aad: WRAP_AAD })
     ).rejects.toThrow()
   })
 
   it("rejects unwrapping when the wrap AAD is repointed to a different slot", async () => {
     const key = generateStreamKey()
     const alice = await makeRecipient()
-    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
 
-    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
 
     const relocated = buildWrapAad({ streamId: "stream_2", keyGeneration: 1, recipientKeyId: "uik_alice" })
     await expect(
@@ -185,9 +176,9 @@ describe("wrapStreamKey / unwrapStreamKey", () => {
 
   it("rejects wrapping a non-32-byte key", async () => {
     const alice = await makeRecipient()
-    await expect(wrapStreamKey({ key: new Uint8Array(16), recipientPublicKey: alice.publicKey })).rejects.toThrow(
-      /must be 32 bytes/
-    )
+    await expect(
+      wrapStreamKey({ key: new Uint8Array(16), recipientPublicKey: alice.publicKey, aad: WRAP_AAD })
+    ).rejects.toThrow(/must be 32 bytes/)
   })
 })
 

--- a/packages/crypto/src/__tests__/stream-key.test.ts
+++ b/packages/crypto/src/__tests__/stream-key.test.ts
@@ -222,4 +222,27 @@ describe("buildWrapAad", () => {
     expect(diffGen).not.toEqual(base)
     expect(diffRecipient).not.toEqual(base)
   })
+
+  it("rejects ids containing the '|' delimiter", () => {
+    expect(() => buildWrapAad({ streamId: "s|1", keyGeneration: 1, recipientKeyId: "uik_1" })).toThrow(
+      /must not contain/
+    )
+    expect(() => buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "uik|1" })).toThrow(
+      /must not contain/
+    )
+  })
+
+  it("rejects empty ids", () => {
+    expect(() => buildWrapAad({ streamId: "", keyGeneration: 1, recipientKeyId: "uik_1" })).toThrow(/non-empty/)
+    expect(() => buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "" })).toThrow(/non-empty/)
+  })
+
+  it("rejects a non-integer or negative generation", () => {
+    expect(() => buildWrapAad({ streamId: "s1", keyGeneration: -1, recipientKeyId: "uik_1" })).toThrow(
+      /non-negative integer/
+    )
+    expect(() => buildWrapAad({ streamId: "s1", keyGeneration: 1.5, recipientKeyId: "uik_1" })).toThrow(
+      /non-negative integer/
+    )
+  })
 })

--- a/packages/crypto/src/__tests__/stream-key.test.ts
+++ b/packages/crypto/src/__tests__/stream-key.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest"
+import { utf8Decode, utf8Encode } from "../encoding"
+import { buildMessageAad } from "../envelope"
+import { exportPublicKey, generateKeyPair } from "../hpke"
+import {
+  buildWrapAad,
+  generateStreamKey,
+  openMessage,
+  openMessageAsString,
+  sealMessage,
+  STREAM_ENVELOPE_VERSION,
+  unwrapStreamKey,
+  wrapStreamKey,
+} from "../stream-key"
+
+async function makeRecipient() {
+  const pair = await generateKeyPair()
+  const publicKey = await exportPublicKey(pair.publicKey)
+  return { publicKey, privateKey: pair.privateKey }
+}
+
+describe("generateStreamKey", () => {
+  it("returns a fresh 32-byte key each call", () => {
+    const a = generateStreamKey()
+    const b = generateStreamKey()
+    expect(a).toHaveLength(32)
+    expect(b).toHaveLength(32)
+    expect(a).not.toEqual(b)
+  })
+})
+
+describe("sealMessage / openMessage round-trip", () => {
+  it("seals and opens a UTF-8 string payload under the SSK", async () => {
+    const key = generateStreamKey()
+    const aad = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_1" })
+
+    const { envelope, ciphertext } = await sealMessage({
+      key,
+      keyGeneration: 3,
+      payload: "hello stream world",
+      aad,
+    })
+
+    expect(envelope.v).toBe(STREAM_ENVELOPE_VERSION)
+    expect(envelope.keyGeneration).toBe(3)
+
+    const decoded = await openMessageAsString({ key, envelope, ciphertext })
+    expect(decoded).toBe("hello stream world")
+  })
+
+  it("seals and opens a raw byte payload", async () => {
+    const key = generateStreamKey()
+    const payload = utf8Encode('{"contentMarkdown":"hi"}')
+
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload })
+
+    const opened = await openMessage({ key, envelope, ciphertext })
+    expect(utf8Decode(opened)).toBe('{"contentMarkdown":"hi"}')
+  })
+
+  it("round-trips when no AAD is supplied", async () => {
+    const key = generateStreamKey()
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "no aad" })
+    const decoded = await openMessageAsString({ key, envelope, ciphertext })
+    expect(decoded).toBe("no aad")
+  })
+})
+
+describe("sealMessage / openMessage rejection paths", () => {
+  it("rejects opening with the wrong SSK", async () => {
+    const key = generateStreamKey()
+    const wrongKey = generateStreamKey()
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "secret" })
+
+    await expect(openMessage({ key: wrongKey, envelope, ciphertext })).rejects.toThrow()
+  })
+
+  it("rejects opening when the bound AAD is forged", async () => {
+    const key = generateStreamKey()
+    const aad = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_1" })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "tamper", aad })
+
+    const tampered = { ...envelope, aad: btoa("stream_evil|msg_evil|usr_evil") }
+    await expect(openMessage({ key, envelope: tampered, ciphertext })).rejects.toThrow()
+  })
+
+  it("rejects an envelope with an unknown protocol version", async () => {
+    const key = generateStreamKey()
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "v" })
+
+    await expect(openMessage({ key, envelope: { ...envelope, v: 99 }, ciphertext })).rejects.toThrow(
+      /Unsupported stream envelope version/
+    )
+  })
+
+  it("rejects sealing with a non-32-byte key", async () => {
+    await expect(sealMessage({ key: new Uint8Array(16), keyGeneration: 1, payload: "x" })).rejects.toThrow(
+      /must be 32 bytes/
+    )
+  })
+
+  it("rejects opening with a non-32-byte key", async () => {
+    const key = generateStreamKey()
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 1, payload: "x" })
+
+    await expect(openMessage({ key: new Uint8Array(16), envelope, ciphertext })).rejects.toThrow(/must be 32 bytes/)
+  })
+})
+
+describe("wrapStreamKey / unwrapStreamKey", () => {
+  it("wraps the SSK to a recipient and unwraps it back", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
+
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+    const recovered = await unwrapStreamKey({
+      enc: wrap.enc,
+      ct: wrap.ct,
+      recipientPrivateKey: alice.privateKey,
+      aad,
+    })
+
+    expect(recovered).toEqual(key)
+  })
+
+  it("lets two distinct recipients each recover the same SSK and open a message", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    const enclave = await makeRecipient()
+
+    const aliceAad = buildWrapAad({ streamId: "stream_1", keyGeneration: 2, recipientKeyId: "uik_alice" })
+    const enclaveAad = buildWrapAad({ streamId: "stream_1", keyGeneration: 2, recipientKeyId: "eik_live" })
+
+    const aliceWrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad: aliceAad })
+    const enclaveWrap = await wrapStreamKey({ key, recipientPublicKey: enclave.publicKey, aad: enclaveAad })
+
+    const aliceKey = await unwrapStreamKey({
+      enc: aliceWrap.enc,
+      ct: aliceWrap.ct,
+      recipientPrivateKey: alice.privateKey,
+      aad: aliceAad,
+    })
+    const enclaveKey = await unwrapStreamKey({
+      enc: enclaveWrap.enc,
+      ct: enclaveWrap.ct,
+      recipientPrivateKey: enclave.privateKey,
+      aad: enclaveAad,
+    })
+
+    expect(aliceKey).toEqual(key)
+    expect(enclaveKey).toEqual(key)
+
+    const msgAad = buildMessageAad({ streamId: "stream_1", messageId: "msg_1", senderId: "usr_alice" })
+    const { envelope, ciphertext } = await sealMessage({ key, keyGeneration: 2, payload: "shared secret", aad: msgAad })
+
+    expect(await openMessageAsString({ key: aliceKey, envelope, ciphertext })).toBe("shared secret")
+    expect(await openMessageAsString({ key: enclaveKey, envelope, ciphertext })).toBe("shared secret")
+  })
+
+  it("rejects unwrapping with the wrong recipient private key", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    const mallory = await makeRecipient()
+    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
+
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+    await expect(
+      unwrapStreamKey({ enc: wrap.enc, ct: wrap.ct, recipientPrivateKey: mallory.privateKey, aad })
+    ).rejects.toThrow()
+  })
+
+  it("rejects unwrapping when the wrap AAD is repointed to a different slot", async () => {
+    const key = generateStreamKey()
+    const alice = await makeRecipient()
+    const aad = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
+
+    const wrap = await wrapStreamKey({ key, recipientPublicKey: alice.publicKey, aad })
+
+    const relocated = buildWrapAad({ streamId: "stream_2", keyGeneration: 1, recipientKeyId: "uik_alice" })
+    await expect(
+      unwrapStreamKey({ enc: wrap.enc, ct: wrap.ct, recipientPrivateKey: alice.privateKey, aad: relocated })
+    ).rejects.toThrow()
+  })
+
+  it("rejects wrapping a non-32-byte key", async () => {
+    const alice = await makeRecipient()
+    await expect(wrapStreamKey({ key: new Uint8Array(16), recipientPublicKey: alice.publicKey })).rejects.toThrow(
+      /must be 32 bytes/
+    )
+  })
+})
+
+describe("buildWrapAad", () => {
+  it("is deterministic for the same inputs", () => {
+    const a = buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "uik_1" })
+    const b = buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "uik_1" })
+    expect(a).toEqual(b)
+  })
+
+  it("differs when any component differs", () => {
+    const base = buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "uik_1" })
+    const diffStream = buildWrapAad({ streamId: "s2", keyGeneration: 1, recipientKeyId: "uik_1" })
+    const diffGen = buildWrapAad({ streamId: "s1", keyGeneration: 2, recipientKeyId: "uik_1" })
+    const diffRecipient = buildWrapAad({ streamId: "s1", keyGeneration: 1, recipientKeyId: "uik_2" })
+    expect(diffStream).not.toEqual(base)
+    expect(diffGen).not.toEqual(base)
+    expect(diffRecipient).not.toEqual(base)
+  })
+})

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -25,3 +25,21 @@ export {
   type EncryptResult,
   type DecryptInput,
 } from "./envelope"
+
+export {
+  STREAM_ENVELOPE_VERSION,
+  generateStreamKey,
+  sealMessage,
+  openMessage,
+  openMessageAsString,
+  wrapStreamKey,
+  unwrapStreamKey,
+  buildWrapAad,
+  type StreamEnvelope,
+  type SealMessageInput,
+  type SealMessageResult,
+  type OpenMessageInput,
+  type StreamKeyWrap,
+  type WrapStreamKeyInput,
+  type UnwrapStreamKeyInput,
+} from "./stream-key"

--- a/packages/crypto/src/stream-key.ts
+++ b/packages/crypto/src/stream-key.ts
@@ -56,8 +56,11 @@ export interface SealMessageInput {
   /**
    * Bytes bound into AEAD as additional-authenticated-data — use
    * `buildMessageAad` so the same bytes can be reconstructed at open time.
+   * Required: the SSK design treats slot-binding as a security invariant
+   * (cross-user isolation, no envelope relocation), so every seal must bind
+   * its message identity rather than silently producing unbound ciphertext.
    */
-  aad?: Uint8Array
+  aad: Uint8Array
 }
 
 export interface SealMessageResult {
@@ -77,7 +80,7 @@ export async function sealMessage(input: SealMessageInput): Promise<SealMessageR
 
   const plaintext: Uint8Array<ArrayBuffer> =
     typeof input.payload === "string" ? utf8Encode(input.payload) : new Uint8Array(input.payload)
-  const aad: Uint8Array<ArrayBuffer> = input.aad ? new Uint8Array(input.aad) : new Uint8Array(0)
+  const aad: Uint8Array<ArrayBuffer> = new Uint8Array(input.aad)
 
   const sskKey = await crypto.subtle.importKey("raw", new Uint8Array(input.key), { name: "AES-GCM" }, false, [
     "encrypt",
@@ -144,8 +147,12 @@ export interface WrapStreamKeyInput {
   key: Uint8Array
   /** Raw X25519 public key of the recipient (a member's UIK or a live EIK). */
   recipientPublicKey: Uint8Array
-  /** Binding bytes — use `buildWrapAad` so a wrap can't be relocated between rows. */
-  aad?: Uint8Array
+  /**
+   * Binding bytes — use `buildWrapAad` so a wrap can't be relocated between rows.
+   * Required for the same reason as `SealMessageInput.aad`: a wrap that isn't
+   * bound to its `(stream, generation, recipient)` slot could be replayed.
+   */
+  aad: Uint8Array
 }
 
 /** HPKE-wrap the SSK so only the holder of the recipient's private key recovers it. */
@@ -164,7 +171,7 @@ export interface UnwrapStreamKeyInput {
   /** The recipient's HPKE private key (UIK or EIK). */
   recipientPrivateKey: CryptoKey
   /** Must match the `aad` used at wrap time (see `buildWrapAad`). */
-  aad?: Uint8Array
+  aad: Uint8Array
 }
 
 /** Recover the SSK from a wrap. Throws if the key doesn't match or AAD is forged. */

--- a/packages/crypto/src/stream-key.ts
+++ b/packages/crypto/src/stream-key.ts
@@ -1,0 +1,202 @@
+import { base64ToBytes, bytesToBase64, concatBytes, utf8Decode, utf8Encode } from "./encoding"
+import { importRecipientPublicKey, open as hpkeOpen, seal as hpkeSeal } from "./hpke"
+
+/**
+ * Per-stream symmetric key (SSK) primitives.
+ *
+ * Every end-to-end-encrypted stream owns an AES-256 key (the SSK) scoped to a
+ * `keyGeneration`. Messages are AEAD-sealed directly under the SSK; the SSK
+ * itself is never stored in plaintext — it exists only HPKE-wrapped to each
+ * authorized recipient's long-term key (a member's UIK or a live enclave EIK).
+ *
+ * This differs from `envelope.ts` (the per-message recipient-fan-out shape used
+ * by the user↔bot E2E path): there the message carries its own recipient list
+ * and a fresh random key each time. Here the recipient wrapping lives out of
+ * band (one `wrapStreamKey` per recipient per generation) so authorization is
+ * cryptographic — a non-recipient is never wrapped the SSK — and so an enclave
+ * redeploy only re-wraps the existing SSK to the new EIK rather than losing
+ * history sealed under a dead key.
+ */
+
+/** Stream-envelope version. Distinct namespace from `ENVELOPE_VERSION` (the
+ * recipient-fan-out shape); a reader switches on `e2e_version` / `envelope.v`. */
+export const STREAM_ENVELOPE_VERSION = 2
+const SSK_LENGTH = 32 // AES-256
+const IV_LENGTH = 12
+
+/** Generate a fresh 32-byte SSK for a new stream or key generation. */
+export function generateStreamKey(): Uint8Array<ArrayBuffer> {
+  const key = new Uint8Array(SSK_LENGTH)
+  crypto.getRandomValues(key)
+  return key
+}
+
+/**
+ * The message-level envelope for SSK-sealed content. Unlike `Envelope` it
+ * carries no recipient list — recipients are resolved out of band via the
+ * stream's key wraps for `keyGeneration`. The AES-GCM ciphertext is returned
+ * separately (stored in `messages.ciphertext`); only the framing lives here.
+ */
+export interface StreamEnvelope {
+  /** Always `STREAM_ENVELOPE_VERSION`; old clients reject an unknown version loudly. */
+  v: number
+  /** Which generation of the stream's SSK sealed this message. */
+  keyGeneration: number
+  /** Base64-encoded AES-GCM IV. */
+  iv: string
+  /** Base64-encoded AAD (caller-supplied binding bytes — see `buildMessageAad`). */
+  aad: string
+}
+
+export interface SealMessageInput {
+  /** 32-byte SSK for `keyGeneration`. */
+  key: Uint8Array
+  keyGeneration: number
+  payload: Uint8Array | string
+  /**
+   * Bytes bound into AEAD as additional-authenticated-data — use
+   * `buildMessageAad` so the same bytes can be reconstructed at open time.
+   */
+  aad?: Uint8Array
+}
+
+export interface SealMessageResult {
+  envelope: StreamEnvelope
+  /** AES-256-GCM ciphertext (tag included). Store in `messages.ciphertext`. */
+  ciphertext: Uint8Array<ArrayBuffer>
+}
+
+/** AEAD-seal a message payload under the stream's SSK for `keyGeneration`. */
+export async function sealMessage(input: SealMessageInput): Promise<SealMessageResult> {
+  if (input.key.length !== SSK_LENGTH) {
+    throw new Error(`sealMessage: SSK must be ${SSK_LENGTH} bytes, got ${input.key.length}`)
+  }
+
+  const iv = new Uint8Array(IV_LENGTH)
+  crypto.getRandomValues(iv)
+
+  const plaintext: Uint8Array<ArrayBuffer> =
+    typeof input.payload === "string" ? utf8Encode(input.payload) : new Uint8Array(input.payload)
+  const aad: Uint8Array<ArrayBuffer> = input.aad ? new Uint8Array(input.aad) : new Uint8Array(0)
+
+  const sskKey = await crypto.subtle.importKey("raw", new Uint8Array(input.key), { name: "AES-GCM" }, false, [
+    "encrypt",
+  ])
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv, additionalData: aad }, sskKey, plaintext)
+  )
+
+  return {
+    envelope: {
+      v: STREAM_ENVELOPE_VERSION,
+      keyGeneration: input.keyGeneration,
+      iv: bytesToBase64(iv),
+      aad: bytesToBase64(aad),
+    },
+    ciphertext,
+  }
+}
+
+export interface OpenMessageInput {
+  /** 32-byte SSK for `envelope.keyGeneration`. */
+  key: Uint8Array
+  envelope: StreamEnvelope
+  /** AES-256-GCM ciphertext (tag included) — as stored in `messages.ciphertext`. */
+  ciphertext: Uint8Array
+}
+
+/** Open an SSK-sealed message. Throws on version mismatch, wrong key, or forged AAD. */
+export async function openMessage(input: OpenMessageInput): Promise<Uint8Array<ArrayBuffer>> {
+  if (input.envelope.v !== STREAM_ENVELOPE_VERSION) {
+    throw new Error(`Unsupported stream envelope version: ${input.envelope.v}`)
+  }
+  if (input.key.length !== SSK_LENGTH) {
+    throw new Error(`openMessage: SSK must be ${SSK_LENGTH} bytes, got ${input.key.length}`)
+  }
+
+  const aad = base64ToBytes(input.envelope.aad)
+  const sskKey = await crypto.subtle.importKey("raw", new Uint8Array(input.key), { name: "AES-GCM" }, false, [
+    "decrypt",
+  ])
+  const plaintext = new Uint8Array(
+    await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: base64ToBytes(input.envelope.iv), additionalData: aad },
+      sskKey,
+      new Uint8Array(input.ciphertext)
+    )
+  )
+  return plaintext
+}
+
+export async function openMessageAsString(input: OpenMessageInput): Promise<string> {
+  return utf8Decode(await openMessage(input))
+}
+
+export interface StreamKeyWrap {
+  /** Base-layer HPKE encapsulation. Store in `stream_e2e_key_wraps.wrap_enc`. */
+  enc: Uint8Array<ArrayBuffer>
+  /** HPKE-wrapped SSK bytes. Store in `stream_e2e_key_wraps.wrap_ct`. */
+  ct: Uint8Array<ArrayBuffer>
+}
+
+export interface WrapStreamKeyInput {
+  /** 32-byte SSK to wrap. */
+  key: Uint8Array
+  /** Raw X25519 public key of the recipient (a member's UIK or a live EIK). */
+  recipientPublicKey: Uint8Array
+  /** Binding bytes — use `buildWrapAad` so a wrap can't be relocated between rows. */
+  aad?: Uint8Array
+}
+
+/** HPKE-wrap the SSK so only the holder of the recipient's private key recovers it. */
+export async function wrapStreamKey(input: WrapStreamKeyInput): Promise<StreamKeyWrap> {
+  if (input.key.length !== SSK_LENGTH) {
+    throw new Error(`wrapStreamKey: SSK must be ${SSK_LENGTH} bytes, got ${input.key.length}`)
+  }
+  const recipient = await importRecipientPublicKey(input.recipientPublicKey)
+  const sealed = await hpkeSeal({ recipientPublicKey: recipient, plaintext: new Uint8Array(input.key), aad: input.aad })
+  return { enc: sealed.enc, ct: sealed.ct }
+}
+
+export interface UnwrapStreamKeyInput {
+  enc: Uint8Array
+  ct: Uint8Array
+  /** The recipient's HPKE private key (UIK or EIK). */
+  recipientPrivateKey: CryptoKey
+  /** Must match the `aad` used at wrap time (see `buildWrapAad`). */
+  aad?: Uint8Array
+}
+
+/** Recover the SSK from a wrap. Throws if the key doesn't match or AAD is forged. */
+export async function unwrapStreamKey(input: UnwrapStreamKeyInput): Promise<Uint8Array<ArrayBuffer>> {
+  const key = await hpkeOpen({
+    recipientPrivateKey: input.recipientPrivateKey,
+    enc: input.enc,
+    ct: input.ct,
+    aad: input.aad,
+  })
+  if (key.length !== SSK_LENGTH) {
+    throw new Error(`unwrapStreamKey: recovered key is ${key.length} bytes, expected ${SSK_LENGTH}`)
+  }
+  return key
+}
+
+/**
+ * Canonical AAD for an SSK wrap. Binds a wrap to its `(streamId, keyGeneration,
+ * recipientKeyId)` slot so a malicious server can't relocate a wrap row to a
+ * different stream/generation/recipient. Keep stable — changing the layout
+ * breaks unwrapping of every existing wrap.
+ */
+export function buildWrapAad(parts: {
+  streamId: string
+  keyGeneration: number
+  recipientKeyId: string
+}): Uint8Array<ArrayBuffer> {
+  return concatBytes(
+    utf8Encode(parts.streamId),
+    utf8Encode("|"),
+    utf8Encode(String(parts.keyGeneration)),
+    utf8Encode("|"),
+    utf8Encode(parts.recipientKeyId)
+  )
+}

--- a/packages/crypto/src/stream-key.ts
+++ b/packages/crypto/src/stream-key.ts
@@ -24,6 +24,18 @@ export const STREAM_ENVELOPE_VERSION = 2
 const SSK_LENGTH = 32 // AES-256
 const IV_LENGTH = 12
 
+/**
+ * Reject empty AAD at the boundary. Slot-binding is a security invariant of the
+ * SSK design, so an empty `aad` is always a caller bug (a missing/zero-length
+ * `buildMessageAad`/`buildWrapAad` result) rather than a valid "unbound" mode —
+ * fail loud instead of producing ciphertext that binds to nothing.
+ */
+function assertBoundAad(fn: string, aad: Uint8Array): void {
+  if (aad.length === 0) {
+    throw new Error(`${fn}: aad must be non-empty (see buildMessageAad/buildWrapAad)`)
+  }
+}
+
 /** Generate a fresh 32-byte SSK for a new stream or key generation. */
 export function generateStreamKey(): Uint8Array<ArrayBuffer> {
   const key = new Uint8Array(SSK_LENGTH)
@@ -74,6 +86,7 @@ export async function sealMessage(input: SealMessageInput): Promise<SealMessageR
   if (input.key.length !== SSK_LENGTH) {
     throw new Error(`sealMessage: SSK must be ${SSK_LENGTH} bytes, got ${input.key.length}`)
   }
+  assertBoundAad("sealMessage", input.aad)
 
   const iv = new Uint8Array(IV_LENGTH)
   crypto.getRandomValues(iv)
@@ -160,6 +173,7 @@ export async function wrapStreamKey(input: WrapStreamKeyInput): Promise<StreamKe
   if (input.key.length !== SSK_LENGTH) {
     throw new Error(`wrapStreamKey: SSK must be ${SSK_LENGTH} bytes, got ${input.key.length}`)
   }
+  assertBoundAad("wrapStreamKey", input.aad)
   const recipient = await importRecipientPublicKey(input.recipientPublicKey)
   const sealed = await hpkeSeal({ recipientPublicKey: recipient, plaintext: new Uint8Array(input.key), aad: input.aad })
   return { enc: sealed.enc, ct: sealed.ct }
@@ -176,6 +190,7 @@ export interface UnwrapStreamKeyInput {
 
 /** Recover the SSK from a wrap. Throws if the key doesn't match or AAD is forged. */
 export async function unwrapStreamKey(input: UnwrapStreamKeyInput): Promise<Uint8Array<ArrayBuffer>> {
+  assertBoundAad("unwrapStreamKey", input.aad)
   const key = await hpkeOpen({
     recipientPrivateKey: input.recipientPrivateKey,
     enc: input.enc,

--- a/packages/crypto/src/stream-key.ts
+++ b/packages/crypto/src/stream-key.ts
@@ -208,12 +208,26 @@ export async function unwrapStreamKey(input: UnwrapStreamKeyInput): Promise<Uint
  * recipientKeyId)` slot so a malicious server can't relocate a wrap row to a
  * different stream/generation/recipient. Keep stable — changing the layout
  * breaks unwrapping of every existing wrap.
+ *
+ * The `|` delimiter is only unambiguous if the ids can't themselves contain it
+ * (otherwise distinct slots could collide into identical AAD and defeat the
+ * binding), so reject ids carrying the delimiter or empty and require a
+ * non-negative integer generation rather than trusting the slot inputs.
  */
 export function buildWrapAad(parts: {
   streamId: string
   keyGeneration: number
   recipientKeyId: string
 }): Uint8Array<ArrayBuffer> {
+  if (parts.streamId.length === 0 || parts.recipientKeyId.length === 0) {
+    throw new Error("buildWrapAad: streamId and recipientKeyId must be non-empty")
+  }
+  if (parts.streamId.includes("|") || parts.recipientKeyId.includes("|")) {
+    throw new Error("buildWrapAad: streamId and recipientKeyId must not contain '|'")
+  }
+  if (!Number.isInteger(parts.keyGeneration) || parts.keyGeneration < 0) {
+    throw new Error("buildWrapAad: keyGeneration must be a non-negative integer")
+  }
   return concatBytes(
     utf8Encode(parts.streamId),
     utf8Encode("|"),


### PR DESCRIPTION
## Summary

First code PR of the rebuilt **E2E "Ariadne enclave"** stack, rebased onto a **per-stream symmetric key (SSK)** foundation. This PR is deliberately small and self-contained: it re-verifies the already-merged `@threa/crypto` + `@threa/agent-runtime` extraction (#642) is sound, and lands the genuinely-new symmetric crypto layer that the protocol PRs depend on.

`packages/crypto/src/stream-key.ts` adds the SSK layer that the existing `envelope.ts` (per-message recipient fan-out, `v1`) deliberately can't express:

- `generateStreamKey()` — fresh 32-byte AES-256 SSK.
- `sealMessage` / `openMessage` / `openMessageAsString` — AEAD-seal a message directly under the stream's SSK (`STREAM_ENVELOPE_VERSION = 2`); recipients are resolved out of band rather than carried inline.
- `wrapStreamKey` / `unwrapStreamKey` — HPKE-wrap the SSK to a recipient's long-term key (a member's UIK or a live enclave EIK). Thin wrappers over the existing HPKE `seal`/`open`.
- `buildWrapAad({ streamId, keyGeneration, recipientKeyId })` — binds a wrap to its `stream_e2e_key_wraps` slot so a malicious server can't relocate a wrap row to a different stream/generation/recipient.

The design plan lives at `.claude/plans/e2e-enclave-ssk.md` (PR-stack numbering, schema, and how the six hard requirements are met).

Why a separate `STREAM_ENVELOPE_VERSION = 2`: a reader switches on `e2e_version` to tell the SSK-sealed shape apart from the v1 recipient-fan-out shape. Wrapping moves out of the message and into the (forthcoming) `stream_e2e_key_wraps` table, so an enclave redeploy re-wraps the existing SSK to the new EIK rather than losing history sealed under a dead key.

No callers yet — the protocol/service PRs (PR 3+) consume these.

## Test plan

- [x] `bun run --cwd packages/crypto typecheck` — clean
- [x] `bun run --cwd packages/crypto test` — 24/24 pass (16 new SSK cases + 8 existing envelope)
- [x] Pre-commit hook: full-monorepo typecheck + lint + api-docs check — green
- New `stream-key.test.ts` covers: seal/open round-trips (string + bytes + no-AAD), wrong-key / forged-AAD / unknown-version rejections, 32-byte key validation, wrap/unwrap round-trip, wrong-recipient + relocated-wrap-AAD failures, the cross-recipient property (one SSK wrapped to two recipients → both open one sealed message), and `buildWrapAad` determinism.

https://claude.ai/code/session_015Y13m77DPXHhA1diyVWs4G

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y13m77DPXHhA1diyVWs4G)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782542804&installation_id=129946197&pr_number=654&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F654&signature=04f26e3d09e3791e3bb37d0fd69a20bf0635bfac5e6577a4c66d535f00688e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->