### PR TITLE
fix(pi-remote): accept response/rate-limit step types in trace enum

### DIFF
--- a/apps/frontend/src/lib/step-config.ts
+++ b/apps/frontend/src/lib/step-config.ts
@@ -16,6 +16,7 @@ import {
   MessageSquare,
   Wrench,
   AlertTriangle,
+  Hourglass,
   type LucideIcon,
 } from "lucide-react"
 
@@ -115,6 +116,14 @@ export const STEP_DISPLAY_CONFIG: Record<AgentStepType, StepDisplayConfig> = {
     saturation: 76,
     lightness: 36,
   },
+  response: {
+    label: "Response",
+    inlineLabel: "Composing response...",
+    icon: MessageSquare,
+    hue: 142,
+    saturation: 76,
+    lightness: 36,
+  },
   tool_call: {
     label: "Tool Call",
     inlineLabel: "Using tools...",
@@ -130,6 +139,22 @@ export const STEP_DISPLAY_CONFIG: Record<AgentStepType, StepDisplayConfig> = {
     hue: 0,
     saturation: 72,
     lightness: 51,
+  },
+  rate_limited: {
+    label: "Rate Limited",
+    inlineLabel: "Rate limited, waiting...",
+    icon: Hourglass,
+    hue: 38,
+    saturation: 92,
+    lightness: 50,
+  },
+  rate_limit_retry: {
+    label: "Retrying",
+    inlineLabel: "Retrying...",
+    icon: RotateCcw,
+    hue: 38,
+    saturation: 92,
+    lightness: 50,
   },
 }
 

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1479,8 +1479,11 @@
                       "linear_access",
                       "message_sent",
                       "message_edited",
+                      "response",
                       "tool_call",
-                      "tool_error"
+                      "tool_error",
+                      "rate_limited",
+                      "rate_limit_retry"
                     ]
                   },
                   "content": { "type": "string", "minLength": 1, "maxLength": 10000 },

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -375,8 +375,11 @@ export const AGENT_STEP_TYPES = [
   "linear_access",
   "message_sent",
   "message_edited",
+  "response",
   "tool_call",
   "tool_error",
+  "rate_limited",
+  "rate_limit_retry",
 ] as const
 export type AgentStepType = (typeof AGENT_STEP_TYPES)[number]
 
@@ -391,8 +394,11 @@ export const AgentStepTypes = {
   LINEAR_ACCESS: "linear_access",
   MESSAGE_SENT: "message_sent",
   MESSAGE_EDITED: "message_edited",
+  RESPONSE: "response",
   TOOL_CALL: "tool_call",
   TOOL_ERROR: "tool_error",
+  RATE_LIMITED: "rate_limited",
+  RATE_LIMIT_RETRY: "rate_limit_retry",
 } as const satisfies Record<string, AgentStepType>
 
 // Agent reconsideration decision values


### PR DESCRIPTION
## Summary

The Pi remote extension already emits three `stepType` values the server doesn't accept: `"response"`, `"rate_limited"`, and `"rate_limit_retry"`. Every call site wraps the request in `.catch(() => undefined)`, so the `/steps` POST silently 400s and these events never reach the trace timeline. Diagnosed during the Pi remote plugin audit; deliberately split from #652 because it's an independent fix in different files.

| stepType | Plugin site | What it records |
|---|---|---|
| `"response"` | `completeInvocationWithMarkdown` (threa-remote.ts:1337) | Final markdown at the `/complete` boundary. Separate from `after_provider_response`'s `message_sent` (line 2499) because `/skill` and other paths that bypass `after_provider_response` still need to record the answer. |
| `"rate_limited"` | `scheduleProviderRetry` (threa-remote.ts:1821) | Provider returned a rate-limit; waiting for retry slot. |
| `"rate_limit_retry"` | `executeProviderRetry` (threa-remote.ts:1853) | Re-issuing the prompt after the rate-limit window. |

## Why option (a) — extend the enum

Considered collapsing the three values onto existing step types instead. Rejected because:

1. **`response` mapping to `message_sent` duplicates** — `after_provider_response` already records `message_sent` for the same content; we'd get two identical entries in the trace timeline whenever both paths fire.
2. **Rate-limit pair has no semantic counterpart** — mapping to `reconsidering` gives a misleading inline label ("Reconsidering...") for what is actually an infrastructure pause/retry. The operational signal is genuinely useful for "why is the agent slow?" debugging.

Extending the enum is purely additive: no DB migration (`step_type` is `TEXT NOT NULL`, no check constraint per INV-3), the only enforcement point is the Zod enum on `recordInvocationStepSchema`, and the frontend's `renderStepContent` switch has a `default: return <span>{content}</span>` fallthrough so the trace renders without intervention.

## What changed

- `packages/types/src/constants.ts` — added `"response"`, `"rate_limited"`, `"rate_limit_retry"` to `AGENT_STEP_TYPES` and the `AgentStepTypes` record.
- `apps/frontend/src/lib/step-config.ts` — added `STEP_DISPLAY_CONFIG` entries (required: it's typed `Record<AgentStepType, StepDisplayConfig>`). `response` shares the message-sent green + MessageSquare; `rate_limited` and `rate_limit_retry` get an amber Hourglass / RotateCcw pair.
- `docs/public-api/openapi.json` — regenerated; only the `stepType` enum on `/bot-invocations/{invocationId}/steps` changed.

## Test plan

- [x] `bun run --cwd packages/types typecheck` — clean
- [x] `bun run --cwd apps/backend typecheck` — clean
- [x] `bun run --cwd apps/frontend typecheck` — clean (no exhaustive switches break; `renderStepContent` has a `default` arm)
- [x] `bun test apps/backend/src/features/agents/session-repository.test.ts` — 3 pass / 0 fail
- [x] `bun run --cwd apps/frontend test -- src/components/trace` — 14 pass / 0 fail
- [x] `bun run --cwd apps/frontend test -- src/components/timeline` — 219 pass / 0 fail (`currentStepType` consumer in `thread-slot`)
- [x] `bun test ./extensions/pi-remote/src/threa-remote.test.ts` — 76 pass / 0 fail (no regression)
- [ ] CI green
- [ ] Verify on Pi: link a scratchpad, trigger an invocation that completes normally — `Response` step appears in trace dialog with the final markdown.
- [ ] Verify on Pi: trigger an invocation while the provider is rate-limited — `Rate Limited` and `Retrying` steps appear in the trace timeline rather than silently disappearing.

## Pre-existing failing tests (not introduced here)

`apps/backend/src/lib/env.test.ts` has 11 failures on `main` unrelated to this change. Reproduced against `main` before making any edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782557445&installation_id=129946197&pr_number=656&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F656&signature=e9a39f42b1ab8e6e2993163ff63acd76d520f6486d677b9d72aa8336a7115fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->