### PR TITLE
fix(frontend): refresh stream on desktop window focus, not just tab visibility

### DIFF
--- a/apps/frontend/src/hooks/use-page-resume-refresh.test.tsx
+++ b/apps/frontend/src/hooks/use-page-resume-refresh.test.tsx
@@ -15,6 +15,14 @@ function setVisibility(state: DocumentVisibilityState) {
   document.dispatchEvent(new Event("visibilitychange"))
 }
 
+function blurWindow() {
+  window.dispatchEvent(new Event("blur"))
+}
+
+function focusWindow() {
+  window.dispatchEvent(new Event("focus"))
+}
+
 function makeWrapper(queryClient: QueryClient, route: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return createElement(
@@ -124,6 +132,25 @@ describe("usePageResumeRefresh", () => {
     })
 
     expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it("invalidates active stream bootstrap when the window regains focus (desktop app-switch)", () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+    renderHook(() => usePageResumeRefresh(), {
+      wrapper: makeWrapper(queryClient, "/w/ws_1/s/stream_1"),
+    })
+
+    act(() => {
+      blurWindow()
+      vi.advanceTimersByTime(6_000)
+      focusWindow()
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceKeys.bootstrap("ws_1") })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: streamKeys.bootstrap("ws_1", "stream_1") })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
   })
 
   it("invalidates panel stream bootstraps in addition to the route stream", () => {

--- a/apps/frontend/src/hooks/use-page-resume-refresh.test.tsx
+++ b/apps/frontend/src/hooks/use-page-resume-refresh.test.tsx
@@ -23,6 +23,16 @@ function focusWindow() {
   window.dispatchEvent(new Event("focus"))
 }
 
+function pageHide() {
+  window.dispatchEvent(new Event("pagehide"))
+}
+
+function pageShow(persisted: boolean) {
+  const event = new Event("pageshow")
+  Object.defineProperty(event, "persisted", { value: persisted, configurable: true })
+  window.dispatchEvent(event)
+}
+
 function makeWrapper(queryClient: QueryClient, route: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return createElement(
@@ -146,6 +156,25 @@ describe("usePageResumeRefresh", () => {
       blurWindow()
       vi.advanceTimersByTime(6_000)
       focusWindow()
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceKeys.bootstrap("ws_1") })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: streamKeys.bootstrap("ws_1", "stream_1") })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it("invalidates workspace + active stream bootstrap when the app is restored from bfcache", () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+    renderHook(() => usePageResumeRefresh(), {
+      wrapper: makeWrapper(queryClient, "/w/ws_1/s/stream_1"),
+    })
+
+    act(() => {
+      pageHide()
+      vi.advanceTimersByTime(6_000)
+      pageShow(true)
     })
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceKeys.bootstrap("ws_1") })

--- a/apps/frontend/src/hooks/use-page-resume.test.ts
+++ b/apps/frontend/src/hooks/use-page-resume.test.ts
@@ -10,6 +10,14 @@ function setVisibility(state: DocumentVisibilityState) {
   document.dispatchEvent(new Event("visibilitychange"))
 }
 
+function blurWindow() {
+  window.dispatchEvent(new Event("blur"))
+}
+
+function focusWindow() {
+  window.dispatchEvent(new Event("focus"))
+}
+
 describe("usePageResume", () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -123,6 +131,92 @@ describe("usePageResume", () => {
       setVisibility("hidden")
       vi.advanceTimersByTime(12_000)
       setVisibility("visible")
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("fires when the window regains focus after a long blur (desktop app-switch)", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      blurWindow()
+      vi.advanceTimersByTime(12_000)
+      focusWindow()
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire for a brief focus loss under the threshold", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      blurWindow()
+      vi.advanceTimersByTime(2_000)
+      focusWindow()
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("does not fire on focus without a prior blur", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      focusWindow()
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("resumes exactly once when a tab switch fires both visibility and focus events", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      blurWindow()
+      vi.advanceTimersByTime(12_000)
+      setVisibility("visible")
+      focusWindow()
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not resume on focus while the tab is still hidden", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(12_000)
+      focusWindow()
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+
+    act(() => {
+      setVisibility("visible")
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("removes the focus and blur listeners on unmount", () => {
+    const onResume = vi.fn()
+    const { unmount } = renderHook(() => usePageResume(onResume, 10_000))
+
+    unmount()
+
+    act(() => {
+      blurWindow()
+      vi.advanceTimersByTime(12_000)
+      focusWindow()
     })
 
     expect(onResume).not.toHaveBeenCalled()

--- a/apps/frontend/src/hooks/use-page-resume.test.ts
+++ b/apps/frontend/src/hooks/use-page-resume.test.ts
@@ -18,6 +18,16 @@ function focusWindow() {
   window.dispatchEvent(new Event("focus"))
 }
 
+function pageHide() {
+  window.dispatchEvent(new Event("pagehide"))
+}
+
+function pageShow(persisted: boolean) {
+  const event = new Event("pageshow")
+  Object.defineProperty(event, "persisted", { value: persisted, configurable: true })
+  window.dispatchEvent(event)
+}
+
 describe("usePageResume", () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -217,6 +227,75 @@ describe("usePageResume", () => {
       blurWindow()
       vi.advanceTimersByTime(12_000)
       focusWindow()
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("fires when the page is restored from bfcache after a long freeze (app reopen)", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      pageHide()
+      vi.advanceTimersByTime(12_000)
+      pageShow(true)
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire for a brief bfcache round-trip under the threshold", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      pageHide()
+      vi.advanceTimersByTime(2_000)
+      pageShow(true)
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("does not fire on a non-persisted pageshow (fresh load, not a bfcache restore)", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      pageHide()
+      vi.advanceTimersByTime(12_000)
+      pageShow(false)
+    })
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it("resumes exactly once when a bfcache round-trip also fires visibility events", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 10_000))
+
+    act(() => {
+      setVisibility("hidden")
+      pageHide()
+      vi.advanceTimersByTime(12_000)
+      pageShow(true)
+      setVisibility("visible")
+    })
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it("removes the pageshow and pagehide listeners on unmount", () => {
+    const onResume = vi.fn()
+    const { unmount } = renderHook(() => usePageResume(onResume, 10_000))
+
+    unmount()
+
+    act(() => {
+      pageHide()
+      vi.advanceTimersByTime(12_000)
+      pageShow(true)
     })
 
     expect(onResume).not.toHaveBeenCalled()

--- a/apps/frontend/src/hooks/use-page-resume.ts
+++ b/apps/frontend/src/hooks/use-page-resume.ts
@@ -1,41 +1,65 @@
 import { useEffect, useRef } from "react"
 
-const DEFAULT_HIDDEN_THRESHOLD_MS = 10_000
+const DEFAULT_AWAY_THRESHOLD_MS = 10_000
 
 /**
- * Fires `onResume` when the page transitions from hidden → visible after
- * being hidden for at least `hiddenThresholdMs` (default 10s).
+ * Fires `onResume` when the page becomes active again after being "away" for at
+ * least `awayThresholdMs` (default 10s).
  *
- * The threshold filters out quick app-switcher previews and notification-shade
- * glances, so the callback only runs when the page was genuinely backgrounded
- * long enough that socket events may have been missed.
+ * "Away" covers two distinct cases so the callback fires whether the user left
+ * to another tab/app or just clicked into a different window:
+ *   - the tab was hidden (`visibilitychange` → "hidden"); and
+ *   - the window lost focus (`blur`) while the tab itself stayed visible — the
+ *     desktop app-switch case, where `visibilitychange` never fires.
+ *
+ * The focus path matters because the message bootstrap queries opt out of
+ * React Query's window-focus refetch, so without it, switching from another
+ * desktop app back to an already-visible Threa window triggered no refresh at
+ * all: messages that arrived while the socket sat idle (or had silently
+ * zombied) only appeared after a hard reload.
+ *
+ * The threshold filters out quick app-switcher previews and momentary focus
+ * loss (e.g. a file dialog), so the callback only runs when the page was away
+ * long enough that socket events may have been missed. A single `awaySince`
+ * timestamp is shared across both event sources, so a tab switch — which fires
+ * both `visibilitychange` and a window `blur`/`focus` pair — still resumes
+ * exactly once.
  *
  * `onResume` is stored in a ref so consumers don't need to memoize.
  */
-export function usePageResume(onResume: () => void, hiddenThresholdMs: number = DEFAULT_HIDDEN_THRESHOLD_MS): void {
+export function usePageResume(onResume: () => void, awayThresholdMs: number = DEFAULT_AWAY_THRESHOLD_MS): void {
   const onResumeRef = useRef(onResume)
   onResumeRef.current = onResume
 
   useEffect(() => {
-    let hiddenSince: number | null = null
+    let awaySince: number | null = null
+
+    const markAway = () => {
+      if (awaySince === null) awaySince = Date.now()
+    }
+
+    const markBack = () => {
+      // Only resume once the page is genuinely active again — a stray focus
+      // event while the tab is still hidden must not consume the away window.
+      if (document.visibilityState !== "visible") return
+      if (awaySince !== null && Date.now() - awaySince >= awayThresholdMs) {
+        onResumeRef.current()
+      }
+      awaySince = null
+    }
 
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        hiddenSince = Date.now()
-        return
-      }
-
-      if (document.visibilityState === "visible") {
-        if (hiddenSince !== null && Date.now() - hiddenSince >= hiddenThresholdMs) {
-          onResumeRef.current()
-        }
-        hiddenSince = null
-      }
+      if (document.visibilityState === "hidden") markAway()
+      else markBack()
     }
 
     document.addEventListener("visibilitychange", handleVisibilityChange)
+    window.addEventListener("blur", markAway)
+    window.addEventListener("focus", markBack)
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange)
+      window.removeEventListener("blur", markAway)
+      window.removeEventListener("focus", markBack)
     }
-  }, [hiddenThresholdMs])
+  }, [awayThresholdMs])
 }

--- a/apps/frontend/src/hooks/use-page-resume.ts
+++ b/apps/frontend/src/hooks/use-page-resume.ts
@@ -18,12 +18,19 @@ const DEFAULT_AWAY_THRESHOLD_MS = 10_000
  * all: messages that arrived while the socket sat idle (or had silently
  * zombied) only appeared after a hard reload.
  *
+ * A third "away" source is the back/forward cache: when a backgrounded page is
+ * frozen into bfcache and later restored, it resumes with a stale in-memory
+ * cache. On iOS standalone PWAs (the "I just reopened the app" case) neither
+ * `visibilitychange` nor `focus` reliably fires on that restore, so `pageshow`
+ * with `event.persisted` is the only dependable resume signal — without it the
+ * reopened app keeps showing pre-background state until a hard reload.
+ *
  * The threshold filters out quick app-switcher previews and momentary focus
  * loss (e.g. a file dialog), so the callback only runs when the page was away
  * long enough that socket events may have been missed. A single `awaySince`
- * timestamp is shared across both event sources, so a tab switch — which fires
- * both `visibilitychange` and a window `blur`/`focus` pair — still resumes
- * exactly once.
+ * timestamp is shared across all event sources, so a tab switch — which fires
+ * both `visibilitychange` and a window `blur`/`focus` pair (and, on a bfcache
+ * round-trip, `pagehide`/`pageshow` too) — still resumes exactly once.
  *
  * `onResume` is stored in a ref so consumers don't need to memoize.
  */
@@ -53,13 +60,23 @@ export function usePageResume(onResume: () => void, awayThresholdMs: number = DE
       else markBack()
     }
 
+    // Only a bfcache restore (`persisted`) is a resume; a normal `pageshow`
+    // fires on every fresh load, where `awaySince` is null and markBack no-ops.
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) markBack()
+    }
+
     document.addEventListener("visibilitychange", handleVisibilityChange)
     window.addEventListener("blur", markAway)
     window.addEventListener("focus", markBack)
+    window.addEventListener("pagehide", markAway)
+    window.addEventListener("pageshow", handlePageShow)
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange)
       window.removeEventListener("blur", markAway)
       window.removeEventListener("focus", markBack)
+      window.removeEventListener("pagehide", markAway)
+      window.removeEventListener("pageshow", handlePageShow)
     }
   }, [awayThresholdMs])
 }


### PR DESCRIPTION
Resume-driven stream refresh only listened to `visibilitychange`, but the
message bootstrap queries opt out of React Query's window-focus refetch. On
desktop, switching from another app back to an already-visible Threa window
fires window focus/blur (not visibilitychange), so nothing refetched and
recently-arrived messages only appeared after a hard reload.

Broaden usePageResume to treat a window blur -> focus cycle as an away ->
back resume (deduped with tab hide/show via a shared awaySince timestamp).
This drives the existing cursor-based refresh, which fetches events newer
than the latest persisted sequence.

https://claude.ai/code/session_016bFHk3x8RZFWTVPcKneUzT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782577365&installation_id=129946197&pr_number=661&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F661&signature=df25ba835a250a6271b1daff94c3360d264c11ea94a51182ec19aa8be10a83c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->