### PR TITLE
feat(voice): end dictation on send/clear and let users dismiss warnings

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -20,10 +20,11 @@ import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
-import { MicButton } from "./mic-button"
+import { MicButton, type MicButtonHandle } from "./mic-button"
 import { ContextRefStrip } from "./context-ref-strip"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import { cn } from "@/lib/utils"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
 import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
 import type { MessageSendMode, JSONContent } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
@@ -273,6 +274,25 @@ export function MessageComposer({
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const instructionsId = useId()
 
+  // Imperative handle to the live mic button so the composer can end the
+  // dictation take when it sends or clears the draft (drops the polish toggle
+  // and any warning chrome rather than letting them ride out a timer).
+  const micRef = useRef<MicButtonHandle | null>(null)
+  // Mirror so the content-empty effect can read it without re-subscribing.
+  const voiceActiveRef = useRef(voiceActive)
+  voiceActiveRef.current = voiceActive
+  // Edge-detect the composer emptying (send-clear, manual delete, stash) so we
+  // tear down the dictation session exactly once on the non-empty → empty
+  // transition. Skipped while a take is live — clearing text mid-dictation
+  // shouldn't stop the recording.
+  const wasEmptyRef = useRef(isEmptyContent(content))
+  useEffect(() => {
+    const empty = isEmptyContent(content)
+    const wasEmpty = wasEmptyRef.current
+    wasEmptyRef.current = empty
+    if (empty && !wasEmpty && !voiceActiveRef.current) micRef.current?.endSession()
+  }, [content])
+
   // Close inline format toolbar and collapse expansion when navigating to a different stream/scope.
   // Clearing voiceActive collapses the mobile chrome; combined with the scopeId-keyed mic below,
   // an in-flight dictation take ends on navigation rather than carrying over into the next stream.
@@ -384,6 +404,10 @@ export function MessageComposer({
     setFormatOpen(false)
     setMobileExpanded(false)
     setMobileLinkPopoverOpen(false)
+    // End any in-flight take first: this flushes the live hypothesis into the
+    // editor (so the tail lands in the message) and drops the polish toggle +
+    // warnings before we snapshot the content below.
+    micRef.current?.endSession()
     onSubmit(richEditorRef.current?.getEditor()?.getJSON() as JSONContent | undefined)
   }, [onSubmit])
 
@@ -538,6 +562,7 @@ export function MessageComposer({
   const micButton = workspaceId ? (
     <MicButton
       key={`mic-${scopeId ?? ""}`}
+      ref={micRef}
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}
@@ -552,6 +577,7 @@ export function MessageComposer({
   const micButtonFab = workspaceId ? (
     <MicButton
       key={`mic-fab-${scopeId ?? ""}`}
+      ref={micRef}
       workspaceId={workspaceId}
       onInsertText={insertTranscribedText}
       onInterimText={setDictationInterim}

--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -1,9 +1,10 @@
+import { createRef } from "react"
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import * as voiceDictation from "@/hooks/use-voice-dictation"
-import { MicButton, formatClock, recordingRingShadow } from "./mic-button"
+import { MicButton, formatClock, recordingRingShadow, type MicButtonHandle } from "./mic-button"
 
 describe("formatClock", () => {
   it("renders m:ss with zero-padded seconds", () => {
@@ -88,8 +89,11 @@ describe("MicButton state surfaces", () => {
       showOriginal: false,
       setShowOriginal: vi.fn(),
       noAudioWarning: null,
+      dismissNoAudioWarning: vi.fn(),
+      dismissError: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
+      endSession: vi.fn(),
       ...overrides,
     })
   }
@@ -110,6 +114,31 @@ describe("MicButton state surfaces", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Dictation connection lost")
     // The button itself is the tap-to-resume target.
     expect(screen.getByRole("button", { name: "Retry dictation" })).toBeEnabled()
+  })
+
+  it("lets the user tap the inline error away instead of waiting it out", async () => {
+    const dismissError = vi.fn()
+    mockDictation({ state: "error", error: "Dictation connection lost", dismissError })
+    const user = userEvent.setup()
+    renderButton()
+
+    await user.click(screen.getByRole("button", { name: "Dismiss dictation error" }))
+    expect(dismissError).toHaveBeenCalledOnce()
+  })
+
+  it("lets the user tap the no-audio warning away instead of waiting it out", async () => {
+    const dismissNoAudioWarning = vi.fn()
+    mockDictation({
+      state: "recording",
+      noAudioWarning: "We're not hearing your mic — check your input device.",
+      dismissNoAudioWarning,
+    })
+    const user = userEvent.setup()
+    renderButton()
+
+    expect(screen.getByRole("status")).toHaveTextContent("We're not hearing your mic")
+    await user.click(screen.getByRole("button", { name: "Dismiss audio warning" }))
+    expect(dismissNoAudioWarning).toHaveBeenCalledOnce()
   })
 
   it("shows a live elapsed clock while recording", () => {
@@ -150,5 +179,46 @@ describe("MicButton state surfaces", () => {
     renderButton()
 
     expect(screen.getByRole("button", { name: "Switch to polished transcript" })).toHaveTextContent("Showing original")
+  })
+})
+
+// The composer drives this imperatively: it ends the take on send/clear so the
+// polish toggle and warning chrome don't outlive the message (rather than
+// waiting out the post-session grace timer).
+describe("MicButton imperative handle", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("exposes endSession through the forwarded ref so the composer can end a take on send", () => {
+    const endSession = vi.fn()
+    vi.spyOn(voiceDictation, "useVoiceDictation").mockReturnValue({
+      state: "recording",
+      supported: true,
+      unsupportedReason: null,
+      error: null,
+      interimText: "",
+      level: 0,
+      elapsedMs: 0,
+      maxDurationMs: null,
+      chunks: new Map(),
+      hasUnlockedChunks: false,
+      showOriginal: false,
+      setShowOriginal: vi.fn(),
+      noAudioWarning: null,
+      dismissNoAudioWarning: vi.fn(),
+      dismissError: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      endSession,
+    })
+
+    const ref = createRef<MicButtonHandle>()
+    render(
+      <TooltipProvider>
+        <MicButton ref={ref} workspaceId="ws_1" onInsertText={vi.fn()} />
+      </TooltipProvider>
+    )
+
+    ref.current?.endSession()
+    expect(endSession).toHaveBeenCalledOnce()
   })
 })

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react"
-import { Mic, Loader2, AlertTriangle, Sparkles } from "lucide-react"
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
+import { Mic, Loader2, AlertTriangle, Sparkles, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -49,6 +49,15 @@ function tooltipFor(args: {
   return "Dictate a message"
 }
 
+export interface MicButtonHandle {
+  /**
+   * End any in-flight take and immediately drop the polished-chunk toggle and
+   * any transient warning/error chrome. The composer calls this when it sends
+   * or clears the draft so the dictation surfaces don't outlive the message.
+   */
+  endSession: () => void
+}
+
 interface MicButtonProps {
   workspaceId: string
   /** Insert a committed transcript span into the editor at the caret. */
@@ -80,19 +89,22 @@ interface MicButtonProps {
   language?: string
 }
 
-export function MicButton({
-  workspaceId,
-  onInsertText,
-  onInterimText,
-  onActiveChange,
-  onInsertPolishedChunk,
-  onChunkSwap,
-  onLockAllChunks,
-  onGetChunkText,
-  disabled,
-  className,
-  language,
-}: MicButtonProps) {
+export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function MicButton(
+  {
+    workspaceId,
+    onInsertText,
+    onInterimText,
+    onActiveChange,
+    onInsertPolishedChunk,
+    onChunkSwap,
+    onLockAllChunks,
+    onGetChunkText,
+    disabled,
+    className,
+    language,
+  },
+  ref
+) {
   const {
     state,
     supported,
@@ -107,8 +119,11 @@ export function MicButton({
     showOriginal,
     setShowOriginal,
     noAudioWarning,
+    dismissNoAudioWarning,
+    dismissError,
     start,
     stop,
+    endSession,
   } = useVoiceDictation({
     workspaceId,
     onCommittedText: onInsertText,
@@ -118,6 +133,8 @@ export function MicButton({
     onGetChunkText,
     language,
   })
+
+  useImperativeHandle(ref, () => ({ endSession }), [endSession])
 
   // Tell the host when a take is in flight. The mobile composer collapses its
   // action bar (and this button) on blur; without this signal a tap-outside
@@ -203,14 +220,25 @@ export function MicButton({
         // clears automatically when signal returns.
         <span
           role="status"
-          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 flex max-w-[16rem] -translate-x-1/2 select-none items-center gap-1.5 rounded-lg bg-amber-600 px-2.5 py-1.5 text-[11px] font-medium leading-snug text-amber-50 shadow-lg ring-1 ring-inset ring-white/15 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 flex max-w-[16rem] -translate-x-1/2 justify-center"
         >
-          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span className="text-left">{noAudioWarning}</span>
-          <span
-            aria-hidden
-            className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-amber-600"
-          />
+          <button
+            type="button"
+            aria-label="Dismiss audio warning"
+            onClick={(e) => {
+              e.stopPropagation()
+              dismissNoAudioWarning()
+            }}
+            className="pointer-events-auto relative flex select-none items-center gap-1.5 rounded-lg bg-amber-600 px-2.5 py-1.5 text-left text-[11px] font-medium leading-snug text-amber-50 shadow-lg ring-1 ring-inset ring-white/15 transition-colors hover:bg-amber-500 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span>{noAudioWarning}</span>
+            <X className="h-3 w-3 shrink-0 opacity-70" aria-hidden />
+            <span
+              aria-hidden
+              className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-amber-600"
+            />
+          </button>
         </span>
       )}
       {recording && !polishPillVisible && !noAudioWarning && (
@@ -271,19 +299,31 @@ export function MicButton({
       {state === "error" && error && (
         // The tooltip alone is invisible on touch (no hover), so a dropped
         // take would look like it just stopped. Surface the reason inline as
-        // a compact toast with a caret pointing at the mic, which stays the
-        // tap-to-retry target. Absolute positioning keeps it from shifting
-        // the composer layout (INV-21).
+        // a compact toast with a caret pointing at the mic (which stays the
+        // tap-to-retry target), and let the toast itself be tapped to dismiss
+        // so it doesn't sit over the composer once the user has read it.
+        // Absolute positioning keeps it from shifting the composer layout (INV-21).
         <span
           role="status"
-          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 flex max-w-[15rem] -translate-x-1/2 select-none items-center gap-1.5 rounded-lg bg-destructive px-2.5 py-1.5 text-[11px] font-medium leading-snug text-destructive-foreground shadow-lg ring-1 ring-inset ring-white/15 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 flex max-w-[15rem] -translate-x-1/2 justify-center"
         >
-          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span className="text-left">{error}</span>
-          <span
-            aria-hidden
-            className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-destructive"
-          />
+          <button
+            type="button"
+            aria-label="Dismiss dictation error"
+            onClick={(e) => {
+              e.stopPropagation()
+              dismissError()
+            }}
+            className="pointer-events-auto relative flex select-none items-center gap-1.5 rounded-lg bg-destructive px-2.5 py-1.5 text-left text-[11px] font-medium leading-snug text-destructive-foreground shadow-lg ring-1 ring-inset ring-white/15 transition-opacity hover:opacity-90 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+            <X className="h-3 w-3 shrink-0 opacity-70" aria-hidden />
+            <span
+              aria-hidden
+              className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-destructive"
+            />
+          </button>
         </span>
       )}
       <Tooltip>
@@ -319,4 +359,4 @@ export function MicButton({
       </Tooltip>
     </span>
   )
-}
+})

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -125,11 +125,30 @@ interface UseVoiceDictationResult {
    *   - Lost signal: the take was capturing audio and then went dead (HFP
    *     dropped, USB glitch) — surfaces slower (~5s) so legitimate pauses
    *     don't nag.
-   * Null otherwise. Clears automatically once signal returns.
+   * Null otherwise. Clears automatically once signal returns, or when the user
+   * dismisses it via `dismissNoAudioWarning`.
    */
   noAudioWarning: string | null
+  /**
+   * Dismiss the no-audio warning by hand. Stays dismissed for the rest of the
+   * take (so it doesn't immediately re-show while the input is still silent)
+   * and re-arms only once signal returns or a new take begins. The warning is
+   * non-fatal, so dismissing it doesn't touch the take.
+   */
+  dismissNoAudioWarning: () => void
+  /** Clear the error surface and return to idle (the mic itself is the retry target). */
+  dismissError: () => void
   start: () => void
   stop: () => void
+  /**
+   * End the take for good: stop an in-flight recording (flushing its tail into
+   * the editor), then immediately drop polished-chunk tracking, reset the
+   * toggle, and clear any transient warning/error chrome — without waiting out
+   * the post-session grace window. Called when the composer sends or clears the
+   * draft: the message is gone, so the toggle pill and warnings have nothing
+   * left to act on and shouldn't linger on a timer. Idempotent.
+   */
+  endSession: () => void
 }
 
 // Phrase structured upstream error codes as short, human copy. The raw provider
@@ -280,6 +299,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const lastSignalAtRef = useRef(0)
   const deviceLabelRef = useRef<string | null>(null)
   const warningShownRef = useRef(false)
+  // Set when the user dismisses the no-audio warning by hand. While set, the
+  // meter loop and the track-mute handler suppress the warning so it doesn't
+  // pop right back up over silent audio; it re-arms once signal returns (meter
+  // sees level) or a new take begins.
+  const noAudioDismissedRef = useRef(false)
   const [noAudioWarning, setNoAudioWarning] = useState<string | null>(null)
   // Bumped on every start() and every teardown/stop so a `voice:start` ACK that
   // resolves after the user has already stopped (or torn down) can't flip the
@@ -302,6 +326,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // mode the toggle currently shows (the toggle can be flipped mid-session).
   const showOriginalRef = useRef(showOriginal)
   showOriginalRef.current = showOriginal
+  // Mirror the chunks map so endSession can cheaply tell whether there's any
+  // tracking to drop without depending on render state.
+  const chunksRef = useRef(chunks)
+  chunksRef.current = chunks
   // Post-session lock window: a single timer expires the whole session at once,
   // dropping editor-side tracking and clearing chunks state so the toggle hides.
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -347,6 +375,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       warningShownRef.current = false
       setNoAudioWarning(null)
     }
+    noAudioDismissedRef.current = false
     setLevel(0)
     setElapsedMs(0)
     workletRef.current?.port.close()
@@ -403,11 +432,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         // anyway and gates on elapsed alone.
         const silenceMs = everHadSignal ? now - lastSignalAtRef.current : elapsed
         const shouldWarn = shouldWarnNoAudio({ elapsedMs: elapsed, silenceMs, peakLevel: peak })
-        if (shouldWarn && !warningShownRef.current) {
+        if (shouldWarn && !warningShownRef.current && !noAudioDismissedRef.current) {
           warningShownRef.current = true
           setNoAudioWarning(noAudioWarningMessage({ deviceLabel: deviceLabelRef.current, everHadSignal }))
-        } else if (!shouldWarn && warningShownRef.current) {
+        } else if (!shouldWarn && (warningShownRef.current || noAudioDismissedRef.current)) {
+          // Signal came back: clear the banner and re-arm so a later drop can
+          // surface it again (a manual dismiss only silences the current spell
+          // of silence, not the rest of the take).
           warningShownRef.current = false
+          noAudioDismissedRef.current = false
           setNoAudioWarning(null)
         }
       }
@@ -460,6 +493,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     // Take the single active slot, flushing+stopping any other composer's take.
     coordinator.activate(coordinatedStop)
     setError(null)
+    noAudioDismissedRef.current = false
     updateInterim("")
     // Starting a new take supersedes any polished chunks from the previous
     // session — drop their tracking and reset the toggle so the new take begins
@@ -538,11 +572,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         // leave stale chrome.
         if (track) {
           track.onmute = () => {
+            // Respect a manual dismiss — if the user waved the warning away,
+            // don't resurrect it on the next mute blip until audio recovers.
+            if (noAudioDismissedRef.current) return
             warningShownRef.current = true
             setNoAudioWarning(noAudioWarningMessage({ deviceLabel: deviceLabelRef.current, everHadSignal: true }))
           }
           track.onunmute = () => {
             warningShownRef.current = false
+            noAudioDismissedRef.current = false
             setNoAudioWarning(null)
           }
         }
@@ -800,6 +838,40 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     [chunks, showOriginal]
   )
 
+  const dismissNoAudioWarning = useCallback(() => {
+    noAudioDismissedRef.current = true
+    warningShownRef.current = false
+    setNoAudioWarning(null)
+  }, [])
+
+  const dismissError = useCallback(() => {
+    setError(null)
+    setState("idle")
+  }, [])
+
+  const endSession = useCallback(() => {
+    // Stop a live take first so its tail flushes into the editor before we drop
+    // tracking (the user's words on a manual send should still land).
+    if (state === "recording" || state === "connecting") stop()
+    // Drop polished-chunk tracking + reset the toggle right now instead of
+    // waiting out the post-session grace window. Guarded so a speculative call
+    // (e.g. on every composer clear) doesn't dispatch a no-op editor transaction
+    // when there was nothing tracked. stop() above sets the lock timer, so the
+    // timer-ref check also covers the just-stopped case.
+    if (chunksRef.current.size > 0 || sessionChunkIdRef.current !== null || lockTimerRef.current !== null) {
+      lockAllChunks()
+    }
+    if (state === "error") {
+      setError(null)
+      setState("idle")
+    }
+    if (warningShownRef.current) {
+      warningShownRef.current = false
+      setNoAudioWarning(null)
+    }
+    noAudioDismissedRef.current = false
+  }, [state, stop, lockAllChunks])
+
   // Backgrounding the tab throttles the rAF meter and (on mobile) suspends audio
   // capture, so a take left "recording" would silently record nothing while the
   // UI still says it's live. End it cleanly on hide instead: stop() flushes the
@@ -854,7 +926,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     showOriginal,
     setShowOriginal,
     noAudioWarning,
+    dismissNoAudioWarning,
+    dismissError,
     start,
     stop,
+    endSession,
   }
 }


### PR DESCRIPTION
Stop a take and drop the polish toggle + warning chrome the moment the
composer sends or clears the draft, instead of letting them ride out the
post-session grace timer. Surface tap-to-dismiss on both the no-audio
warning and the error toast so a touch user isn't stuck waiting for them
to time out; a dismissed no-audio warning re-arms only once signal
returns or a new take begins.

https://claude.ai/code/session_01NqjagwH8kDU6WiKAfjfPut

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782577480&installation_id=129946197&pr_number=662&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F662&signature=349b2f36b0d3776b5699cde3893ed88703bb9d4b4de47827fbc0f0384ec84a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->