### PR TITLE
fix(timeline): re-anchor firstItemIndex on window slides to stop cold-load jump

### DIFF
--- a/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
@@ -51,6 +51,31 @@ function makeScrollableDiv(initial: { clientHeight: number; scrollTop?: number }
 
 type HookApi = ReturnType<typeof useVirtuosoScroll>
 
+type ScrollOptions = Parameters<typeof useVirtuosoScroll>[0]
+
+function renderScrollHook(initialOptions: ScrollOptions): {
+  current: HookApi
+  rerender: (options: ScrollOptions) => void
+} {
+  const ref: { current: HookApi | undefined } = { current: undefined }
+  function Probe({ options }: { options: ScrollOptions }) {
+    ref.current = useVirtuosoScroll(options)
+    return null
+  }
+  const utils = render(<Probe options={initialOptions} />)
+  return {
+    get current(): HookApi {
+      if (!ref.current) throw new Error("Probe did not capture the hook return value")
+      return ref.current
+    },
+    rerender: (options: ScrollOptions) => act(() => utils.rerender(<Probe options={options} />)),
+  }
+}
+
+function makeKeys(prefixes: number[]): string[] {
+  return prefixes.map((n) => `e${n}`)
+}
+
 function renderHookWithScroller(
   options: Parameters<typeof useVirtuosoScroll>[0],
   scrollerEl: HTMLDivElement,
@@ -73,6 +98,51 @@ function renderHookWithScroller(
 }
 
 describe("useVirtuosoScroll", () => {
+  it("re-anchors firstItemIndex when the window slides forward on cold first visit", () => {
+    // Cold first visit: the list mounts off stale IDB data, then the bootstrap
+    // response slides the window forward — the oldest rows drop as the floor
+    // moves up and newer rows append, so the item count is unchanged. A
+    // count-growth heuristic does nothing here, leaving firstItemIndex stale so
+    // the surviving rows shift virtual index and Virtuoso jumps the viewport.
+    // The anchor-based compensation must shift firstItemIndex by the same
+    // amount the surviving rows moved.
+    const stale: ScrollOptions = {
+      itemCount: 50,
+      getItemKey: (i) => makeKeys(Array.from({ length: 50 }, (_, n) => n))[i],
+      resetKey: "stream_1",
+    }
+    const harness = renderScrollHook({ itemCount: 0, getItemKey: () => "", resetKey: "stream_1" })
+
+    // IDB live query resolves with the stale window e0..e49.
+    harness.rerender(stale)
+    const base = harness.current.firstItemIndex
+
+    // Bootstrap resolves: drop the 10 oldest (e0..e9), append 10 newer
+    // (e50..e59). e10 was at index 10 and is now at index 0.
+    const slidKeys = makeKeys(Array.from({ length: 50 }, (_, n) => n + 10))
+    harness.rerender({ itemCount: 50, getItemKey: (i) => slidKeys[i], resetKey: "stream_1" })
+
+    // To keep the surviving anchor (e10) at the same virtual index
+    // (firstItemIndex + index) after it moved from index 10 to index 0,
+    // firstItemIndex must increase by 10.
+    expect(harness.current.firstItemIndex).toBe(base + 10)
+  })
+
+  it("decrements firstItemIndex when older messages are prepended", () => {
+    const initialKeys = makeKeys(Array.from({ length: 50 }, (_, n) => n + 10))
+    const harness = renderScrollHook({ itemCount: 0, getItemKey: () => "", resetKey: "stream_1" })
+
+    harness.rerender({ itemCount: 50, getItemKey: (i) => initialKeys[i], resetKey: "stream_1" })
+    const base = harness.current.firstItemIndex
+
+    // Prepend 10 older messages (e0..e9). The anchor e10 moves from index 0 to
+    // index 10, so firstItemIndex must decrease by 10 to hold its position.
+    const prependedKeys = makeKeys(Array.from({ length: 60 }, (_, n) => n))
+    harness.rerender({ itemCount: 60, getItemKey: (i) => prependedKeys[i], resetKey: "stream_1" })
+
+    expect(harness.current.firstItemIndex).toBe(base - 10)
+  })
+
   it("does NOT keep snapping to LAST on every measurement fire during a deep-link jump", async () => {
     // Regression: deep-link to an old message. skipInitialScroll=true keeps
     // the user away from the bottom on initial render, but Virtuoso emits a

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -79,31 +79,77 @@ export function useVirtuosoScroll({
   // with the old firstItemIndex for one frame.
   const firstItemIndexRef = useRef(FIRST_ITEM_INDEX)
   const prevItemCountRef = useRef(0)
-  const prevFirstKeyRef = useRef<string | null>(null)
+  // Map of item key -> index from the previous render. Comparing the index of
+  // a surviving (anchor) row across renders is what lets us compensate
+  // firstItemIndex for any window shift — prepend, leading removal, or a window
+  // that slides forward (drops leading rows AND appends, count ~unchanged).
+  const prevKeyIndexMapRef = useRef<Map<string, number>>(new Map())
+  const lastResetKeyRef = useRef(resetKey)
 
   // Scroller element stored in state (not a ref) so the ResizeObserver effect
   // re-runs when Virtuoso mounts its scroller asynchronously (e.g. after an
   // isLoading skeleton is replaced).
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null)
 
-  // Reset all state when stream changes. Honor skipInitialScroll so deep-link
-  // navigation to a cached stream does not briefly scroll to bottom before
-  // the scrollToMessage retry loop kicks in.
-  useLayoutEffect(() => {
+  // Reset the ref-backed virtual-index state synchronously when the stream
+  // changes, BEFORE the re-anchor block below runs. This must not live in a
+  // layout effect: that runs after the render that already recorded the new
+  // stream's baseline, so it would clobber that baseline (skipping the first
+  // window-slide compensation) and hand the freshly-keyed Virtuoso the previous
+  // stream's index base for one frame before correcting it — a visible jump.
+  // resetKey is unchanged on the initial mount (the ref is seeded with it), so
+  // this only fires on actual stream switches.
+  const resetKeyChanged = lastResetKeyRef.current !== resetKey
+  if (resetKeyChanged) {
+    lastResetKeyRef.current = resetKey
     firstItemIndexRef.current = FIRST_ITEM_INDEX
+    prevItemCountRef.current = 0
+    prevKeyIndexMapRef.current = new Map()
+    hasSettledRef.current = false
+    isAtBottomRef.current = !skipInitialScroll
+  }
+
+  // Reset React-visible state when the stream changes. The ref-backed state
+  // resets synchronously above so Virtuoso already gets the right
+  // firstItemIndex on the first render for the new stream; this effect only
+  // catches up the state that drives re-renders. Honor skipInitialScroll so
+  // deep-link navigation to a cached stream does not briefly scroll to bottom
+  // before the scrollToMessage retry loop kicks in.
+  useLayoutEffect(() => {
     setIsScrolledFarFromBottom(false)
     isAtBottomRef.current = !skipInitialScroll
     setShouldFollowOutput(!skipInitialScroll)
-    prevItemCountRef.current = 0
-    prevFirstKeyRef.current = null
-    hasSettledRef.current = false
   }, [resetKey, skipInitialScroll])
 
-  // Detect prepends synchronously during render. This runs in the same
-  // render pass where data changes, so Virtuoso receives the updated
+  // Re-anchor firstItemIndex synchronously during render. This runs in the
+  // same render pass where data changes, so Virtuoso receives the updated
   // firstItemIndex and data array together — no one-frame-late jump.
+  //
+  // We can't infer the shift from count alone: on a cold first visit the
+  // window mounts off stale IDB data, then the bootstrap response slides the
+  // window forward — leading rows drop while newer ones append, so the count
+  // barely moves even though every row shifted index. A count-growth heuristic
+  // misses that and leaves firstItemIndex stale, jumping the viewport.
+  //
+  // Instead, find the first row that survived from the previous render (the
+  // anchor) and compare its old vs new index. Virtuoso keeps a row visually
+  // fixed when `firstItemIndex + index` is constant, so to preserve position
+  // across a shift of `currentIndex - previousIndex` we move firstItemIndex by
+  // the negation of that delta. This handles prepend, leading removal, and a
+  // sliding window uniformly.
   if (itemCount > 0) {
-    const currentFirstKey = getItemKey(0)
+    const currentKeyIndexMap = new Map<string, number>()
+    let preservedAnchor: { previousIndex: number; currentIndex: number } | null = null
+    for (let index = 0; index < itemCount; index++) {
+      const key = getItemKey(index)
+      currentKeyIndexMap.set(key, index)
+      if (preservedAnchor === null) {
+        const previousIndex = prevKeyIndexMapRef.current.get(key)
+        if (previousIndex !== undefined) {
+          preservedAnchor = { previousIndex, currentIndex: index }
+        }
+      }
+    }
     // When the list goes from empty to populated (e.g. mid stream-switch
     // where the previous stream's empty result was stamped as settled),
     // Virtuoso needs to run its initial scroll again. Re-arm hasSettledRef
@@ -112,17 +158,21 @@ export function useVirtuosoScroll({
     if (prevItemCountRef.current === 0) {
       hasSettledRef.current = false
     }
-    if (
-      prevItemCountRef.current > 0 &&
-      itemCount > prevItemCountRef.current &&
-      currentFirstKey !== prevFirstKeyRef.current &&
-      prevFirstKeyRef.current !== null
-    ) {
-      const prependedCount = itemCount - prevItemCountRef.current
-      firstItemIndexRef.current -= prependedCount
+    if (prevItemCountRef.current > 0 && preservedAnchor !== null) {
+      const indexDelta = preservedAnchor.currentIndex - preservedAnchor.previousIndex
+      if (indexDelta !== 0) {
+        firstItemIndexRef.current -= indexDelta
+      }
     }
     prevItemCountRef.current = itemCount
-    prevFirstKeyRef.current = currentFirstKey
+    prevKeyIndexMapRef.current = currentKeyIndexMap
+  } else if (prevItemCountRef.current !== 0) {
+    // List emptied (e.g. mid stream-switch). Drop the stale baseline so the
+    // next populated render is treated as a fresh start and re-arms the
+    // settle gate rather than matching keys against the old window.
+    prevItemCountRef.current = 0
+    prevKeyIndexMapRef.current = new Map()
+    hasSettledRef.current = false
   }
 
   const scrollToBottom = useCallback(
@@ -254,7 +304,7 @@ export function useVirtuosoScroll({
 
   const resetPrependState = useCallback(() => {
     prevItemCountRef.current = 0
-    prevFirstKeyRef.current = null
+    prevKeyIndexMapRef.current = new Map()
   }, [])
 
   const initialTopMostItemIndex =
@@ -264,8 +314,11 @@ export function useVirtuosoScroll({
     virtuosoRef,
     firstItemIndex: firstItemIndexRef.current,
     initialTopMostItemIndex,
-    isScrolledFarFromBottom,
-    shouldFollowOutput,
+    // On the stream-switch render the state resets above are still queued in
+    // the layout effect, so surface the fresh values directly for that frame
+    // to avoid carrying the previous stream's scroll affordances over.
+    isScrolledFarFromBottom: resetKeyChanged ? false : isScrolledFarFromBottom,
+    shouldFollowOutput: resetKeyChanged ? !skipInitialScroll : shouldFollowOutput,
     scrollToBottom,
     disableAutoScroll,
     handleAtBottomChange,


### PR DESCRIPTION
## Summary

Fixes the regression where the timeline jumps ~half a screen a frame after load, **only on the first visit to a long stream** (not when navigating back).

On a cold first visit the list mounts off stale IndexedDB data, then the bootstrap response **slides the window forward** — leading rows drop as the floor ratchets up, newer rows append, so the item count is roughly unchanged. The post-#582 `firstItemIndex` compensation used a count-growth heuristic that did nothing in that case, leaving `firstItemIndex` stale so every surviving row shifted virtual index and Virtuoso yanked the viewport. Navigating back had bootstrap cached at mount, so no slide and no jump — which is exactly the reported asymmetry.

## Changes (`apps/frontend/src/hooks/use-virtuoso-scroll.ts`)

- **Anchor-based delta instead of count.** Find the first row that survived from the previous render and shift `firstItemIndex` by the negation of its index delta. This handles prepend, leading removal, and a forward-sliding window uniformly (live bottom-append yields delta 0, so it's a no-op there).
- **Synchronous baseline reset on stream change.** Moved the ref-backed virtual-index reset out of the `useLayoutEffect` (which ran *after* the render that already recorded the new stream's baseline, clobbering it and skipping the first slide) into a render-time `resetKeyChanged` guard. The layout effect now only catches up the React state that drives re-renders.

This restores the anchor logic from #579 for this hook only — it does **not** reintroduce #579's cold-boot blank-gap behavior (the #582 fix in `stream-content.tsx`/`event-list.tsx` is untouched), nor its physical-distance jump detection or scroll listener.

Bottom-landing is preserved; unread handling is intentionally left alone (to be revisited separately).

## Test plan

- [x] `bunx vitest run src/hooks/use-virtuoso-scroll.test.tsx` — added 2 tests: forward window-slide (`firstItemIndex` +10) and prepend guard (−10)
- [x] `use-unread-divider` + `use-events` (25) and timeline components (219) green
- [x] frontend typecheck + lint clean (also ran via pre-commit hook across the monorepo)
- [ ] Manual browser check on a long stream's first cold visit (not runnable in the remote container — needs a live backend + primed IndexedDB)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ch9gUWKsmBqomdTEUiPYN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782581107&installation_id=129946197&pr_number=663&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F663&signature=349ad5280a370c0ce9a3f73e1b562d9f36e5139b3fd7ebd376f81158031c4533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->