### PR TITLE
docs(e2e): sync scratchpads plan with shipped multi-actor model

### DIFF
--- a/docs/plans/e2e-encrypted-scratchpads.md
+++ b/docs/plans/e2e-encrypted-scratchpads.md
@@ -25,8 +25,8 @@ This is what makes the product safe enough for Kris's wife (private journaling a
 ## Non-goals (be loud about these)
 
 - **Defending against the LLM provider.** The provider that runs the inference necessarily sees the prompt. We narrow trust to that one party and prefer zero-retention enterprise tiers, but we do not pretend the LLM provider is blind.
-- **Hiding metadata.** Threa still sees: which user owns the scratchpad, when messages were sent, how big they are, who the invited agent is, whether an invocation succeeded. Reducing this is a v2+ problem (padding, cover traffic).
-- **Group / multi-user E2E.** Scratchpads are 1-to-1 (user ↔ agent). Channels and DMs are out of scope for v1.
+- **Hiding metadata.** Threa still sees: which user owns the scratchpad, when messages were sent, how big they are, which actors are invited, whether an invocation succeeded. Reducing this is a v2+ problem (padding, cover traffic).
+- **Group / multi-_human_ E2E.** A scratchpad has exactly one human owner; the invited agents are a set (0..N actors, e.g. a bot and the enclave together). Multi-_human_ E2E — channels and DMs shared across people — is out of scope for v1.
 - **Post-compromise security.** v1 uses per-message random keys wrapped to long-lived identity keys (good forward secrecy, no PCS). A Signal-style ratchet is a later phase.
 - **Recovery without the user's passphrase.** Lose the passphrase, lose the scratchpad. v1 accepts that. (Social / hardware recovery is a future addition.)
 
@@ -102,7 +102,7 @@ EncryptedMessage {
 }
 ```
 
-`recipients` is the list of everyone who can read this message — for a scratchpad that is normally `[UIK, agent-key]`. The same envelope shape covers user-to-user E2E if we ever ship it.
+`recipients` is the list of everyone who can read this message — for a scratchpad that is `[UIK, ...one key per invited actor]` (normally just the owner plus a single agent, but the set generalizes to several actors). The same envelope shape covers user-to-user E2E if we ever ship it.
 
 ### Storage
 
@@ -116,7 +116,7 @@ ALTER TABLE messages
   ADD COLUMN e2e_version SMALLINT;     -- protocol version for forward compat
 ```
 
-For E2E messages, `content_json` and `content_markdown` are `NULL`. Server enforces "if `e2e_scratchpads.stream_id = streamId`, then content columns must be NULL and ciphertext must be present", and vice versa.
+For E2E messages, `content_json` and `content_markdown` are `NULL`. Server enforces "if `e2e_streams.stream_id = streamId`, then content columns must be NULL and ciphertext must be present", and vice versa.
 
 New tables:
 
@@ -150,14 +150,29 @@ ALTER TABLE agent_session_steps
   ADD COLUMN e2e_version SMALLINT;
 -- For E2E sessions, `content` and `sources` are NULL and the encrypted blob carries both.
 
-CREATE TABLE e2e_scratchpads (
+-- The E2E flag lives on its own table (named `e2e_streams` in the code).
+-- A row here means "this stream is end-to-end encrypted"; its absence means
+-- plaintext. No agent columns — invited agents live in `e2e_stream_actors`.
+CREATE TABLE e2e_streams (
   stream_id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL,
   enabled_at TIMESTAMPTZ NOT NULL,
+  owner_user_id TEXT NOT NULL,
   -- denormalized for fast checks in outbox handlers
-  owner_user_key_id TEXT NOT NULL,
-  invited_agent_kind TEXT NOT NULL,    -- 'bot' | 'enclave' | 'none'
-  invited_agent_key_id TEXT
+  owner_user_key_id TEXT NOT NULL
+);
+
+-- Invited non-human actors as a SET, not a scalar. Empty set = owner-only
+-- stream. Composite PK (no synthetic ULID) mirrors `stream_members`, the
+-- documented INV-2 exception for link tables. `kind` is TEXT validated in
+-- code (INV-3); `key_id` is NULL until that actor registers its public key.
+CREATE TABLE e2e_stream_actors (
+  workspace_id TEXT NOT NULL,
+  stream_id TEXT NOT NULL,
+  kind TEXT NOT NULL,                  -- 'bot' | 'enclave'
+  key_id TEXT,                         -- the actor's pubkey id, set once registered
+  added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (workspace_id, stream_id, kind)
 );
 ```
 
@@ -165,7 +180,7 @@ CREATE TABLE e2e_scratchpads (
 
 ### Server invariants
 
-- **INV-E1**: For any stream in `e2e_scratchpads`, every persisted `messages` row has `ciphertext IS NOT NULL` and `content_json IS NULL` and `content_markdown IS NULL`. Enforced at the repository layer + a check constraint.
+- **INV-E1**: For any stream in `e2e_streams`, every persisted `messages` row has `ciphertext IS NOT NULL` and `content_json IS NULL` and `content_markdown IS NULL`. Enforced at the repository layer + a check constraint.
 - **INV-E2**: Outbox handlers (companion, boundary, memo, naming, search-indexer, mention extractor) short-circuit when the stream is E2E. We add a single helper `isE2eStream(streamId)` they all consult.
 - **INV-E3**: The Pi remote / bot runtime endpoints never decrypt. They forward the envelope verbatim. **This includes `/bot-invocations/:id/steps`** — the server-side `pi_tool_trace` sanitizer (`apps/backend/src/features/public-api/handlers.ts:415-420`) does not run for E2E sessions because there is no plaintext to scrub.
 - **INV-E4**: Sidebar previews and push payloads carry no content for E2E streams. Server returns `"hasContent": true` only; client renders the preview by decrypting locally if it has the key cached.
@@ -475,7 +490,7 @@ Deliverable: a user can set up keys. Nothing else changes yet.
 
 ### Phase 1 — E2E flag + envelope plumbing on a scratchpad (no agent yet)
 
-- `e2e_scratchpads` table, `messages.ciphertext` + `messages.envelope` columns (additive, INV-17).
+- `e2e_streams` table, `messages.ciphertext` + `messages.envelope` columns (additive, INV-17).
 - New endpoint or extension: `POST /api/v1/streams/:id/messages` accepts `{ ciphertext, envelope, e2eVersion }` when the stream is E2E. Server rejects content fields on E2E streams.
 - **Opt-in UI**: `New encrypted scratchpad` command in the Quickswitcher (primary entry point); "Make this end-to-end encrypted" link on empty scratchpads as a secondary path; first-time-per-account onboarding modal; one-click confirm dialog thereafter on the header-link path.
 - **Visual treatment**: padlock chip in stream header, padlock + tooltip in sidebar, subtle background tint on the message list area, "Encrypted message…" placeholder in composer, recipients popover (will show just the user's UIK fingerprint until Phase 2).
@@ -551,6 +566,6 @@ Deliverable: Ariadne works inside an E2E scratchpad. The "private journaling aga
 
 The big architectural forks are decided above ("Decisions taken"). These remain:
 
-1. **E2E representation in the schema.** Per-scratchpad flag in `e2e_scratchpads` + additive message columns (current default), versus a separate stream type `e2e_scratchpad`. Flag is easier to roll out and lets us share UI surfaces; separate type makes it impossible for a server-side code path to accidentally treat E2E content as plaintext. Decide before Phase 1 lands.
+1. ~~**E2E representation in the schema.**~~ **Resolved (shipped Phase 1):** flag table (`e2e_streams`) + additive message columns, sharing the normal stream UI surfaces — not a separate stream type. INV-E1 (repository-layer + check-constraint enforcement) carries the "never treat E2E content as plaintext" guarantee that a separate type would have given structurally.
 2. **LLM provider for Ariadne E2E.** Keep OpenRouter (default) but restrict to providers offering zero-retention enterprise tiers, versus go direct to Anthropic (simpler attestation story, narrower model selection). Decide at Phase 5 kickoff alongside enclave platform.
 3. **Forward secrecy posture.** v1 plan uses per-message random keys wrapped to long-lived identity keys (good FS for content, no PCS). A Signal-style double-ratchet adds PCS but is multiple-PR work and isn't on the Phase 0–5 critical path. Revisit at Phase 6 unless an early adopter explicitly asks for it.


### PR DESCRIPTION
## Summary

Updates `docs/plans/e2e-encrypted-scratchpads.md` to reflect what actually shipped in the E2E enclave work (#657, #660). The plan still described the original single-agent scalar model; this brings it in line with the multi-actor set we built.

- **Storage schema**: replaced the `e2e_scratchpads` table (with `invited_agent_kind`/`invited_agent_key_id`) with the real `e2e_streams` row (no agent columns) **plus** the new `e2e_stream_actors` link table (composite PK `(workspace_id, stream_id, kind)`, `key_id` nullable until the actor registers a key).
- **Non-goal reworded**: "1-to-1 user ↔ agent" → one human owner with a **set** of 0..N agent actors; multi-_human_ E2E (shared channels/DMs) stays the explicit non-goal.
- **Recipients prose**: `[UIK, agent-key]` → `[UIK, ...one key per invited actor]`.
- **Open question #1** marked resolved (flag table shipped, not a separate stream type).
- **Table-name drift** fixed throughout: `e2e_scratchpads` → `e2e_streams` (matches the code).

Docs-only — no code, crypto design, phased delivery, or flows changed.

## Test plan

- [ ] N/A — documentation only; pre-commit lint + full monorepo typecheck passed locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Y13m77DPXHhA1diyVWs4G)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782585615&installation_id=129946197&pr_number=664&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F664&signature=61c9c77fe701808232e2a5158470d24b5d22b70fe5d3e190df60d04434666782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->