### PR TITLE
fix: enable scroll in emoji picker inside dialogs

### DIFF
--- a/apps/frontend/src/components/ui/alert-dialog.tsx
+++ b/apps/frontend/src/components/ui/alert-dialog.tsx
@@ -30,15 +30,19 @@ const AlertDialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    />
+    {/* Content is nested inside Overlay so react-remove-scroll tracks the full
+        React tree including portalled children like Popover.
+        See: https://github.com/radix-ui/primitives/issues/1159 */}
+    <AlertDialogOverlay>
+      <AlertDialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogOverlay>
   </AlertDialogPortal>
 ))
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -27,30 +27,36 @@ interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof Dialo
 const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
   ({ className, children, hideCloseButton, ...props }, ref) => (
     <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        ref={ref}
-        className={cn(
-          "fixed z-50 w-full max-w-lg gap-4 border bg-background p-6 shadow-lg",
-          // Mobile: full-screen, flex layout for proper overflow/scroll
-          // NOTE: twMerge does not merge across breakpoint prefixes. Callers that
-          // pass `p-0` or `gap-0` must also pass `max-sm:p-0` / `max-sm:gap-0`
-          // to cancel these mobile defaults.
-          "max-sm:inset-0 max-sm:flex max-sm:flex-col max-sm:gap-4 max-sm:max-w-none max-sm:max-h-none max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-none max-sm:border-0 max-sm:overflow-y-auto max-sm:p-4",
-          // Desktop: centered grid modal
-          "sm:grid sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-modal",
-          className
-        )}
-        {...props}
-      >
-        {children}
-        {!hideCloseButton && (
-          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
+      {/* Content is nested inside Overlay so react-remove-scroll (used by Radix
+          Dialog to prevent body scroll) tracks the full React tree including
+          portalled children like Popover. Without this nesting, scrollable
+          content inside a Popover within a Dialog would not work.
+          See: https://github.com/radix-ui/primitives/issues/1159 */}
+      <DialogOverlay>
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(
+            "fixed z-50 w-full max-w-lg gap-4 border bg-background p-6 shadow-lg",
+            // Mobile: full-screen, flex layout for proper overflow/scroll
+            // NOTE: twMerge does not merge across breakpoint prefixes. Callers that
+            // pass `p-0` or `gap-0` must also pass `max-sm:p-0` / `max-sm:gap-0`
+            // to cancel these mobile defaults.
+            "max-sm:inset-0 max-sm:flex max-sm:flex-col max-sm:gap-4 max-sm:max-w-none max-sm:max-h-none max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-none max-sm:border-0 max-sm:overflow-y-auto max-sm:p-4",
+            // Desktop: centered grid modal
+            "sm:grid sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-modal",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          {!hideCloseButton && (
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogOverlay>
     </DialogPortal>
   )
 )


### PR DESCRIPTION
## Problem

The emoji picker (ReactionEmojiPicker) on desktop in the label view does not support scrolling. Typing into the search input filters correctly, but mouse-wheel scrolling over the emoji grid does nothing — the grid stays frozen at its initial position.

**Reproduction:** Open "Add label" dialog → click the emoji picker trigger → try to scroll the emoji grid with the mouse wheel.

## Root Cause

This is a known Radix UI issue ([#1159](https://github.com/radix-ui/primitives/issues/1159), [#2028](https://github.com/radix-ui/primitives/issues/2028)): Radix Dialog uses `react-remove-scroll` to prevent body scroll when a dialog is open. This library blocks scroll/wheel events on portalled elements (like `Popover.Content`) that are **not part of the Dialogs React component tree**.

In our code, `DialogContent` rendered `DialogOverlay` and `DialogPrimitive.Content` as **siblings** inside the portal:

```tsx
<DialogPortal>
  <DialogOverlay />           {/* sibling */}
  <DialogPrimitive.Content>  {/* sibling */}
    {/* ... children including EmojiField → ReactionEmojiPicker → Popover */}
  </DialogPrimitive.Content>
</DialogPortal>
```

When the Popover opened, it portalled to `document.body` — outside the Dialog s React tree. `react-remove-scroll` couldn not see it and blocked all wheel events inside the Virtuoso emoji grid.

## Solution

Nest `DialogPrimitive.Content` **inside** `DialogOverlay`. This makes the full React component tree — including portalled Popover children — visible to `react-remove-scroll`, which correctly allows scroll events within them.

## Changed files

| File | Change |
|------|--------|
| `apps/frontend/src/components/ui/dialog.tsx` | Nest `DialogPrimitive.Content` inside `DialogOverlay` |
| `apps/frontend/src/components/ui/alert-dialog.tsx` | Same nesting fix for consistency |

## Test plan

- [x] TypeScript compiles across all packages
- [x] ESLint passes
- [x] Prettier passes
- [ ] Manual: Open label dialog on desktop, open emoji picker, scroll via mouse wheel
- [ ] Manual: Verify click-outside-close still works for all dialogs
- [ ] Manual: Verify dialogs still look correct (overlay + centered content)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782589824&installation_id=129946197&pr_number=666&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F666&signature=8e623951e9afbcbdbe4d0a84ffe2c2f3271b792b432b8e0865e46536295db191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->