### PR TITLE
feat(sidebar): drive rendering from a config object (PR1 of configurable sidebar)

### DIFF
--- a/.claude/plans/configurable-sidebar-and-visible-labels.md
+++ b/.claude/plans/configurable-sidebar-and-visible-labels.md
@@ -1,0 +1,133 @@
+# Configurable sidebar + visible stream labels
+
+Branch: `claude/stoic-cori-PnIXF`. Delivered as a **stack of small PRs**, not one
+god PR. This doc is the source of truth for the whole initiative.
+
+## Goal
+
+Labels (color + title + emoji) exist as a complete data layer but have no visual
+surface. Make them visible:
+
+1. **Sidebar** — labels become grouping sections, via a newly **configurable
+   sidebar** (the two presets become editable default configs).
+2. **Stream top bar** — a compact stack of label chips.
+
+## Locked product/architecture decisions
+
+- **Sidebar model:** a per-user, per-workspace **sidebar config** = an ordered
+  list of typed **sections**. **Every section is an independent filter** (each
+  smart bucket, each stream type, each label is its own reorderable section).
+- **Overlap:** each section carries a **`hideAboveShown`** flag (ON by default).
+  With it on, a stream renders only in the first matching section (reproduces
+  today). Turn it off to make a section an **additive lens** (e.g. a label
+  section that shows streams even if shown above). A **`remainder`** section
+  kind renders "everything not shown above" (today's "Everything Else").
+- **Presets → default seed configs:** `Smart = [important, recent, pinned,
+  remainder]`, `All = [type:scratchpads, type:channels, type:dms]`. New users
+  seed from Smart; existing users seed from their current `viewMode`. "Reset to
+  preset" restores a seed.
+- **Editor:** both — inline quick add/remove (label picker, section-header menu,
+  labels page) **plus** a roomy "Sidebar" settings panel for drag-reorder/reset.
+- **Label model:** **unify membership** — creator gets a `label_members` row on
+  every label (private + public); backfill existing private labels.
+  `creator_user_id` still owns edit/delete. **Lifecycle:** `leave()` removes
+  only the caller's row; the label is archived only when the **last** member
+  leaves (race-safe, single transaction) or someone explicitly archives it.
+- **Top bar:** stack shows the **full public pool on the stream + the viewer's
+  private labels** (already delivered by `listForViewer` → bootstrap; stays live
+  via stream-room `label:assigned/unassigned` events). Deduped by label, cap ~3
+  then `+N`, **desktop hover fans out** to name-pills (absolute overlay, no
+  reflow — INV-21), **mobile tap → vaul drawer**. **Display-only**; editing
+  stays in `LabelPicker`.
+- **Visual language (shared `LabelChip`):** **tinted** — `hexToRgba(color,0.12)`
+  bg, ~30% border, emoji leads, name in ink; collapsed = emoji on a tinted disc,
+  **solid color dot fallback** when a label has no emoji. Shadcn + lucide only,
+  no new global accent tokens (per-label authored color only, like trace hues).
+  See `DESIGN.md`.
+
+## Data shapes
+
+```ts
+// Sidebar config (per user, per workspace)
+type SidebarSectionKind =
+  | { kind: "smart"; bucket: "important" | "recent" | "pinned" }
+  | { kind: "remainder" }
+  | { kind: "type"; streamType: "scratchpad" | "channel" | "dm" }
+  | { kind: "label"; labelId: string }
+
+interface SidebarSection {
+  id: string            // stable ulid, e.g. sbsec_xxx
+  spec: SidebarSectionKind
+  hideAboveShown: boolean
+  // label-display name/emoji/color resolved from the labels cache at render
+}
+interface SidebarConfig {
+  workspaceId: string
+  userId: string
+  sections: SidebarSection[]
+  basePreset: "smart" | "all" | "custom"
+  updatedAt: string
+}
+```
+
+## The PR stack
+
+### PR1 — Config-driven sidebar rendering (no behavior change, no editor) ✅ implemented
+Frontend only. Introduce the config types + a pure resolver and route the
+existing sidebar through it, seeded from today's `viewMode` (no persistence yet
+— configs can't diverge from presets until the editor lands).
+- `sidebar/sidebar-config.ts` — `SidebarSectionSpec` (`smart` bucket | `type`),
+  `SidebarConfig`, `SMART_PRESET` / `ALL_PRESET` seeds, `presetForViewMode`, and
+  `sectionPresentation(spec)` (label/icon/tiered/compact/hideWhenEmpty/default
+  collapse derived purely from the spec).
+- `sidebar/resolve-sections.ts` — pure
+  `resolveSections(config, { processedStreams, virtualDmStreams, getUnreadCount })`
+  → `Array<{ section, items }>`. Reuses existing `sortStreams` and Recent's 5-cap
+  / Important's 10-cap as per-section params; DM section composed as
+  realDMs(activity) ++ system(alpha) ++ virtual.
+- Refactor `sidebar.tsx` to build the active config + call the resolver; refactor
+  `sidebar-stream-list.tsx` to render the resolved list generically (dropped the
+  `viewMode` if/else branch and the dead `SmartSection`). Collapse state keyed by
+  `section.id`, which equals the prior keys so persisted collapse prefs survive.
+- Tests: resolver reproduces today's Smart and All buckets, caps, Recent logic,
+  and DM composition (object-compare, INV-24). `bun run typecheck` + `lint` clean.
+
+**Deviations from the model below (deferred, not dropped):** `hideAboveShown`
+and the `remainder` kind are **not** in PR1. Today's buckets are mutually
+exclusive (a stream is in exactly one `categorizeStream` bucket and is exactly
+one type), so dedup is a no-op and a `remainder` kind would be unused — adding
+either now would be speculative (INV-36). Smart's "Everything Else" is modeled as
+`{ kind: "smart", bucket: "other" }` (faithful: streams capped out of Important/
+Recent vanish today, they do not fall through). `hideAboveShown` + `remainder`
+land in **PR4**, where additive label lenses are the first thing to exercise them.
+
+### PR2 — Sidebar editor + config persistence
+Backend per-user config (table + types + bootstrap field + sync events + API),
+plus the editor: inline add/remove and a "Sidebar" settings panel
+(drag-reorder, add/remove kinds, reset-to-preset). Existing users' configs
+seeded server-side from their last preset on first read.
+
+### PR3 — Label model: unified membership + lifecycle
+Backend + tests only, no UI. `create()` inserts creator membership for every
+label; backfill migration for existing private labels; `leave()` →
+last-member-archive (race-safe). `listVisibleTo`/membership reads simplified to
+the uniform set; `creator_user_id` retained for permissions.
+
+### PR4 — Sidebar label sections + shared chip
+Shared tinted `LabelChip` (`components/labels/label-chip.tsx`). Add the `label`
+section kind end-to-end (resolver filter by assignment, tinted section header,
+add/remove entry points: label picker, labels page, section-header menu).
+
+### PR5 — Stream top-bar label stack
+`components/labels/stream-label-stack.tsx` in the `stream.tsx` header. Reuses
+`LabelChip`. Hover fan-out (desktop) / vaul drawer (mobile), cap 3 + `+N`,
+display-only.
+
+## Cross-cutting invariants
+INV-51/52 (colocate label backend, import via barrels), INV-20 (race-safe
+last-member-archive + idempotent membership upsert), INV-17 (append-only
+migrations), INV-21 (no layout shift on hover), INV-59 (URL-driven where
+relevant), INV-60 (strip markdown in any preview), INV-24 (object-compare in
+tests), INV-23 (assert event presence not counts). Tests run with
+`bun run test` / `bun run test:e2e`; never ship unexecuted.
+```

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest"
+import { StreamTypes, Visibilities } from "@threa/types"
+import { resolveSections, type ResolveSectionsInput } from "./resolve-sections"
+import { ALL_PRESET, SMART_PRESET } from "./sidebar-config"
+import type { SectionKey, StreamItemData, UrgencyLevel } from "./types"
+
+interface ItemOverrides {
+  id: string
+  section?: SectionKey
+  urgency?: UrgencyLevel
+  type?: StreamItemData["type"]
+  displayName?: string | null
+  slug?: string | null
+  /** Minutes since epoch for the last message — controls activity ordering. */
+  activity?: number
+}
+
+function makeItem(overrides: ItemOverrides): StreamItemData {
+  const { id, section = "other", urgency = "quiet", type = StreamTypes.SCRATCHPAD, activity = 0 } = overrides
+  const createdAt = new Date(activity * 60_000).toISOString()
+  return {
+    id,
+    workspaceId: "ws_1",
+    type,
+    displayName: overrides.displayName ?? id,
+    slug: overrides.slug ?? null,
+    description: null,
+    visibility: Visibilities.PRIVATE,
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt,
+    updatedAt: createdAt,
+    archivedAt: null,
+    lastMessagePreview: { authorId: "user_2", authorType: "user", content: "x", createdAt },
+    urgency,
+    section,
+  }
+}
+
+/** Collapse the resolver output to a comparable shape: section id → item ids. */
+function shape(input: ResolveSectionsInput, preset = SMART_PRESET) {
+  return resolveSections(preset, input).map((resolved) => ({
+    id: resolved.section.id,
+    items: resolved.items.map((item) => item.id),
+  }))
+}
+
+function unreadFrom(unreadIds: Set<string>) {
+  return (streamId: string) => (unreadIds.has(streamId) ? 1 : 0)
+}
+
+describe("resolveSections — Smart preset", () => {
+  it("partitions streams into important / recent / pinned / other buckets", () => {
+    const processedStreams = [
+      makeItem({ id: "imp_1", section: "important", urgency: "mentions" }),
+      makeItem({ id: "rec_1", section: "recent", activity: 10 }),
+      makeItem({ id: "pin_1", section: "pinned", activity: 5 }),
+      makeItem({ id: "oth_1", section: "other", activity: 1 }),
+    ]
+    const virtualDmStreams = [makeItem({ id: "vdm_1", section: "other", type: StreamTypes.DM, activity: 2 })]
+
+    expect(shape({ processedStreams, virtualDmStreams, getUnreadCount: () => 0 })).toEqual([
+      { id: "important", items: ["imp_1"] },
+      { id: "recent", items: ["rec_1"] },
+      { id: "pinned", items: ["pin_1"] },
+      // virtual DMs carry section "other", so they join the Everything Else bucket,
+      // sorted by activity (vdm_1 @2 before oth_1 @1).
+      { id: "other", items: ["vdm_1", "oth_1"] },
+    ])
+  })
+
+  it("caps Important at 10 items", () => {
+    const processedStreams = Array.from({ length: 13 }, (_, i) =>
+      makeItem({ id: `imp_${i}`, section: "important", urgency: "mentions", activity: i })
+    )
+    const resolved = resolveSections(SMART_PRESET, {
+      processedStreams,
+      virtualDmStreams: [],
+      getUnreadCount: () => 1,
+    })
+    expect(resolved.find((r) => r.section.id === "important")?.items).toHaveLength(10)
+  })
+
+  it("Recent fills unreads then reads up to 5 total", () => {
+    const processedStreams = [
+      makeItem({ id: "u1", section: "recent", activity: 100 }),
+      makeItem({ id: "u2", section: "recent", activity: 90 }),
+      makeItem({ id: "r1", section: "recent", activity: 80 }),
+      makeItem({ id: "r2", section: "recent", activity: 70 }),
+      makeItem({ id: "r3", section: "recent", activity: 60 }),
+      makeItem({ id: "r4", section: "recent", activity: 50 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["u1", "u2"]))
+    const recent = resolveSections(SMART_PRESET, { processedStreams, virtualDmStreams: [], getUnreadCount }).find(
+      (r) => r.section.id === "recent"
+    )
+    // 2 unreads + 3 reads = 5, dropping r4.
+    expect(recent?.items.map((i) => i.id)).toEqual(["u1", "u2", "r1", "r2", "r3"])
+  })
+
+  it("Recent shows all unreads when there are 5 or more", () => {
+    const processedStreams = Array.from({ length: 7 }, (_, i) =>
+      makeItem({ id: `u${i}`, section: "recent", activity: 100 - i })
+    )
+    const getUnreadCount = () => 1
+    const recent = resolveSections(SMART_PRESET, { processedStreams, virtualDmStreams: [], getUnreadCount }).find(
+      (r) => r.section.id === "recent"
+    )
+    expect(recent?.items).toHaveLength(7)
+  })
+})
+
+describe("resolveSections — All preset", () => {
+  it("partitions by stream type with DMs composed of real, system, then virtual", () => {
+    const processedStreams = [
+      makeItem({ id: "sp_2", type: StreamTypes.SCRATCHPAD, activity: 5 }),
+      makeItem({ id: "sp_1", type: StreamTypes.SCRATCHPAD, activity: 10 }),
+      makeItem({ id: "ch_b", type: StreamTypes.CHANNEL, slug: "beta" }),
+      makeItem({ id: "ch_a", type: StreamTypes.CHANNEL, slug: "alpha" }),
+      makeItem({ id: "dm_old", type: StreamTypes.DM, activity: 1 }),
+      makeItem({ id: "dm_new", type: StreamTypes.DM, activity: 9 }),
+      makeItem({ id: "sys_1", type: StreamTypes.SYSTEM, displayName: "System" }),
+    ]
+    const virtualDmStreams = [makeItem({ id: "vdm_1", type: StreamTypes.DM, activity: 0 })]
+
+    expect(shape({ processedStreams, virtualDmStreams, getUnreadCount: () => 0 }, ALL_PRESET)).toEqual([
+      // Scratchpads by activity (most recent first).
+      { id: "scratchpads", items: ["sp_1", "sp_2"] },
+      // Channels alphabetically (no unreads to float).
+      { id: "channels", items: ["ch_a", "ch_b"] },
+      // Real DMs (activity), then system streams, then synthetic drafts.
+      { id: "dms", items: ["dm_new", "dm_old", "sys_1", "vdm_1"] },
+    ])
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -1,0 +1,100 @@
+import { type StreamType, StreamTypes } from "@threa/types"
+import { ALL_SECTIONS, SMART_SECTIONS } from "./config"
+import type { SidebarConfig, SidebarSection, SidebarSectionSpec } from "./sidebar-config"
+import type { SectionKey, StreamItemData } from "./types"
+import { sortStreams } from "./utils"
+
+type TypeSectionStream = Extract<StreamType, "scratchpad" | "channel" | "dm">
+
+/** Important is capped so a noisy day can't bury the rest of the sidebar. */
+const IMPORTANT_LIMIT = 10
+/** Recent shows at most this many reads; unreads beyond it still surface (see below). */
+const RECENT_LIMIT = 5
+
+export interface ResolveSectionsInput {
+  /** Real streams, already filtered + enriched with urgency/section. */
+  processedStreams: StreamItemData[]
+  /** Synthetic DM drafts for members the user hasn't messaged yet. */
+  virtualDmStreams: StreamItemData[]
+  getUnreadCount: (streamId: string) => number
+}
+
+export interface ResolvedSection {
+  section: SidebarSection
+  items: StreamItemData[]
+}
+
+/**
+ * Turn a {@link SidebarConfig} into the ordered, capped, sorted stream lists the
+ * sidebar renders. Pure — no React, no IO — so it is exercised directly in tests
+ * and reused by every view. Each spec is mutually exclusive today (a stream
+ * lands in exactly one smart bucket and is exactly one type), so sections are
+ * resolved independently against the shared pool.
+ */
+export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
+  return config.sections.map((section) => ({
+    section,
+    items: resolveItems(section.spec, input),
+  }))
+}
+
+function resolveItems(spec: SidebarSectionSpec, input: ResolveSectionsInput): StreamItemData[] {
+  if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input)
+  return resolveTypeSection(spec.streamType, input)
+}
+
+function resolveSmartBucket(
+  bucket: SectionKey,
+  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput
+): StreamItemData[] {
+  const pool = [...processedStreams, ...virtualDmStreams]
+  const items = pool.filter((stream) => stream.section === bucket)
+
+  switch (bucket) {
+    case "important":
+      sortStreams(items, SMART_SECTIONS.important.sortType, getUnreadCount)
+      return items.slice(0, IMPORTANT_LIMIT)
+
+    case "recent": {
+      // Show unreads, OR up to RECENT_LIMIT most recent:
+      // - no unreads → at most RECENT_LIMIT reads
+      // - <RECENT_LIMIT unreads → unreads + reads filling the remaining slots
+      // - ≥RECENT_LIMIT unreads → all unreads (cap is lifted so nothing unread hides)
+      sortStreams(items, SMART_SECTIONS.recent.sortType, getUnreadCount)
+      const unreads = items.filter((stream) => getUnreadCount(stream.id) > 0)
+      const reads = items.filter((stream) => getUnreadCount(stream.id) === 0)
+      if (unreads.length >= RECENT_LIMIT) return unreads
+      return [...unreads, ...reads.slice(0, RECENT_LIMIT - unreads.length)]
+    }
+
+    case "pinned":
+      sortStreams(items, SMART_SECTIONS.pinned.sortType, getUnreadCount)
+      return items
+
+    case "other":
+      sortStreams(items, SMART_SECTIONS.other.sortType, getUnreadCount)
+      return items
+  }
+}
+
+function resolveTypeSection(
+  streamType: TypeSectionStream,
+  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput
+): StreamItemData[] {
+  if (streamType === "scratchpad") {
+    const items = processedStreams.filter((stream) => stream.type === StreamTypes.SCRATCHPAD)
+    return sortStreams(items, ALL_SECTIONS.scratchpads.sortType, getUnreadCount)
+  }
+
+  if (streamType === "channel") {
+    const items = processedStreams.filter((stream) => stream.type === StreamTypes.CHANNEL)
+    return sortStreams(items, ALL_SECTIONS.channels.sortType, getUnreadCount)
+  }
+
+  // DMs: real DMs by activity, then system streams, then synthetic DM drafts.
+  const realDms = processedStreams.filter((stream) => stream.type === StreamTypes.DM)
+  const systemStreams = processedStreams.filter((stream) => stream.type === StreamTypes.SYSTEM)
+  sortStreams(realDms, "activity", getUnreadCount)
+  sortStreams(systemStreams, ALL_SECTIONS.dms.sortType, getUnreadCount)
+  return [...realDms, ...systemStreams, ...virtualDmStreams]
+}

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -4,9 +4,8 @@ import type { CollapseState } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { UnreadBadge } from "@/components/unread-badge"
 import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
-import { SMART_SECTIONS } from "./config"
 import { StreamItem } from "./stream-item"
-import type { SectionKey, StreamItemData } from "./types"
+import type { StreamItemData } from "./types"
 import { getActivityTime } from "./utils"
 
 interface SectionHeaderProps {
@@ -420,55 +419,5 @@ function MoreDivider({ isOpen, hiddenCount, onToggle }: MoreDividerProps) {
       </span>
       <span className="h-px flex-1 bg-border/70" aria-hidden />
     </button>
-  )
-}
-
-interface SmartSectionProps {
-  section: SectionKey
-  items: StreamItemData[]
-  allStreams: StreamItemData[]
-  workspaceId: string
-  activeStreamId?: string
-  getUnreadCount: (streamId: string) => number
-  getMentionCount: (streamId: string) => number
-  state?: CollapseState
-  onToggle?: () => void
-  /** Reference to scroll container for position tracking */
-  scrollContainerRef?: RefObject<HTMLDivElement | null>
-}
-
-/** Smart view section wrapper - uses StreamSection with config-driven settings */
-export function SmartSection({
-  section,
-  items,
-  allStreams,
-  workspaceId,
-  activeStreamId,
-  getUnreadCount,
-  getMentionCount,
-  state = "open",
-  onToggle,
-  scrollContainerRef,
-}: SmartSectionProps) {
-  const config = SMART_SECTIONS[section]
-
-  if (items.length === 0) return null
-
-  return (
-    <StreamSection
-      label={config.label}
-      icon={config.icon}
-      items={items}
-      allStreams={allStreams}
-      workspaceId={workspaceId}
-      activeStreamId={activeStreamId}
-      getUnreadCount={getUnreadCount}
-      getMentionCount={getMentionCount}
-      state={state}
-      onToggle={onToggle}
-      compact={config.compact}
-      showPreviewOnHover={config.showPreviewOnHover}
-      scrollContainerRef={scrollContainerRef}
-    />
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -1,0 +1,115 @@
+import type { StreamType } from "@threa/types"
+import type { CollapseState, ViewMode } from "@/contexts"
+import { SMART_SECTIONS } from "./config"
+import type { SectionKey } from "./types"
+
+/**
+ * The sidebar is an ordered list of typed **sections**. Each section's `spec`
+ * declares which streams it draws from; presentation (label, collapse style,
+ * preview behavior) is derived from the spec at render time.
+ *
+ * Today the two view-mode presets (Smart / All) are the only shapes a config
+ * can take. Persistence and a user-editable order land in a later step — this
+ * module exists so rendering is already driven by a config object rather than a
+ * `viewMode` branch.
+ */
+export type SidebarSectionSpec =
+  | { kind: "smart"; bucket: SectionKey }
+  | { kind: "type"; streamType: Extract<StreamType, "scratchpad" | "channel" | "dm"> }
+
+export interface SidebarSection {
+  /** Stable key — also the collapse-state persistence key (see SidebarProvider). */
+  id: string
+  spec: SidebarSectionSpec
+}
+
+export type SidebarBasePreset = "smart" | "all"
+
+export interface SidebarConfig {
+  basePreset: SidebarBasePreset
+  sections: SidebarSection[]
+}
+
+/** How a resolved section renders. Derived purely from its spec. */
+export interface SectionPresentation {
+  label: string
+  icon?: string
+  /** Tiered sections show a "N more" expander; binary sections are open/collapsed only. */
+  tiered: boolean
+  compact: boolean
+  showPreviewOnHover: boolean
+  /** Sections that vanish entirely when they hold no streams. */
+  hideWhenEmpty: boolean
+  /** Collapse state before the user has toggled this section. */
+  defaultCollapse: CollapseState
+}
+
+/** Presentation for the "All" view's stream-type sections. */
+const TYPE_PRESENTATION: Record<Extract<StreamType, "scratchpad" | "channel" | "dm">, SectionPresentation> = {
+  scratchpad: {
+    label: "Scratchpads",
+    tiered: true,
+    compact: true,
+    showPreviewOnHover: true,
+    hideWhenEmpty: false,
+    defaultCollapse: "open",
+  },
+  channel: {
+    label: "Channels",
+    tiered: true,
+    compact: true,
+    showPreviewOnHover: true,
+    hideWhenEmpty: false,
+    defaultCollapse: "open",
+  },
+  dm: {
+    label: "Direct Messages",
+    tiered: true,
+    compact: true,
+    showPreviewOnHover: true,
+    hideWhenEmpty: true,
+    defaultCollapse: "open",
+  },
+}
+
+/** Resolve how a section should render from its spec. */
+export function sectionPresentation(spec: SidebarSectionSpec): SectionPresentation {
+  if (spec.kind === "type") return TYPE_PRESENTATION[spec.streamType]
+
+  const config = SMART_SECTIONS[spec.bucket]
+  return {
+    label: config.label,
+    icon: config.icon,
+    // Important / Recent / Pinned are simple binary sections; "Everything Else"
+    // gets the tiered "N more" reveal for its long quiet tail.
+    tiered: spec.bucket === "other",
+    compact: config.compact,
+    showPreviewOnHover: config.showPreviewOnHover,
+    hideWhenEmpty: true,
+    defaultCollapse: spec.bucket === "other" ? "collapsed" : "open",
+  }
+}
+
+/** Section ids double as collapse-state keys, so they must match prior keys. */
+export const SMART_PRESET: SidebarConfig = {
+  basePreset: "smart",
+  sections: [
+    { id: "important", spec: { kind: "smart", bucket: "important" } },
+    { id: "recent", spec: { kind: "smart", bucket: "recent" } },
+    { id: "pinned", spec: { kind: "smart", bucket: "pinned" } },
+    { id: "other", spec: { kind: "smart", bucket: "other" } },
+  ],
+}
+
+export const ALL_PRESET: SidebarConfig = {
+  basePreset: "all",
+  sections: [
+    { id: "scratchpads", spec: { kind: "type", streamType: "scratchpad" } },
+    { id: "channels", spec: { kind: "type", streamType: "channel" } },
+    { id: "dms", spec: { kind: "type", streamType: "dm" } },
+  ],
+}
+
+export function presetForViewMode(viewMode: ViewMode): SidebarConfig {
+  return viewMode === "all" ? ALL_PRESET : SMART_PRESET
+}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -1,8 +1,9 @@
 import type { RefObject } from "react"
 import type { CollapseState } from "@/contexts"
 import { Button } from "@/components/ui/button"
-import { SMART_SECTIONS } from "./config"
-import { SmartSection, TieredStreamSection } from "./sections"
+import { StreamSection, TieredStreamSection } from "./sections"
+import { sectionPresentation, type SidebarSectionSpec } from "./sidebar-config"
+import type { ResolvedSection } from "./resolve-sections"
 import type { SidebarActionItem } from "./sidebar-actions"
 import type { StreamItemData } from "./types"
 
@@ -14,25 +15,21 @@ function moreKey(parent: string): string {
   return `${parent}:more`
 }
 
+interface AddWiring {
+  onAdd: () => void
+  addTooltip: string
+  addMenuActions?: SidebarActionItem[]
+}
+
 interface SidebarStreamListProps {
   workspaceId: string
-  viewMode: "smart" | "all"
-  isLoading: boolean
   hasError: boolean
   hasUserStreams: boolean
   activeStreamId?: string
+  /** All real streams — passed to each item for thread/preview lookups. */
   processedStreams: StreamItemData[]
-  streamsBySection: {
-    important: StreamItemData[]
-    recent: StreamItemData[]
-    pinned: StreamItemData[]
-    other: StreamItemData[]
-  }
-  streamsByType: {
-    scratchpads: StreamItemData[]
-    channels: StreamItemData[]
-    dms: StreamItemData[]
-  }
+  /** Ordered sections with their resolved, sorted, capped stream lists. */
+  resolvedSections: ResolvedSection[]
   getUnreadCount: (streamId: string) => number
   getMentionCount: (streamId: string) => number
   getSectionState: (section: string, defaultState?: CollapseState) => CollapseState
@@ -50,14 +47,11 @@ interface SidebarStreamListProps {
 
 export function SidebarStreamList({
   workspaceId,
-  viewMode,
-  isLoading: _isLoading,
   hasError,
   hasUserStreams,
   activeStreamId,
   processedStreams,
-  streamsBySection,
-  streamsByType,
+  resolvedSections,
   getUnreadCount,
   getMentionCount,
   getSectionState,
@@ -85,131 +79,78 @@ export function SidebarStreamList({
     )
   }
 
-  if (viewMode === "smart") {
-    return (
-      <>
-        <SmartSection
-          section="important"
-          items={streamsBySection.important}
-          allStreams={processedStreams}
-          workspaceId={workspaceId}
-          activeStreamId={activeStreamId}
-          getUnreadCount={getUnreadCount}
-          getMentionCount={getMentionCount}
-          state={getSectionState("important")}
-          onToggle={() => toggleSectionState("important")}
-          scrollContainerRef={scrollContainerRef}
-        />
-        <SmartSection
-          section="recent"
-          items={streamsBySection.recent}
-          allStreams={processedStreams}
-          workspaceId={workspaceId}
-          activeStreamId={activeStreamId}
-          getUnreadCount={getUnreadCount}
-          getMentionCount={getMentionCount}
-          state={getSectionState("recent")}
-          onToggle={() => toggleSectionState("recent")}
-          scrollContainerRef={scrollContainerRef}
-        />
-        <SmartSection
-          section="pinned"
-          items={streamsBySection.pinned}
-          allStreams={processedStreams}
-          workspaceId={workspaceId}
-          activeStreamId={activeStreamId}
-          getUnreadCount={getUnreadCount}
-          getMentionCount={getMentionCount}
-          state={getSectionState("pinned")}
-          onToggle={() => toggleSectionState("pinned")}
-          scrollContainerRef={scrollContainerRef}
-        />
-        {streamsBySection.other.length > 0 && (
-          <TieredStreamSection
-            sectionKey="other"
-            label={SMART_SECTIONS.other.label}
-            icon={SMART_SECTIONS.other.icon}
-            items={streamsBySection.other}
+  // Add-button wiring is per stream type (Scratchpads / Channels expose creators).
+  const addWiringFor = (spec: SidebarSectionSpec): AddWiring | undefined => {
+    if (spec.kind !== "type") return undefined
+    if (spec.streamType === "scratchpad") {
+      return {
+        onAdd: () => void onCreateScratchpad(),
+        addTooltip: scratchpadAddMenuActions ? "New scratchpad…" : "+ New Scratchpad",
+        addMenuActions: scratchpadAddMenuActions,
+      }
+    }
+    if (spec.streamType === "channel") {
+      return { onAdd: () => void onCreateChannel(), addTooltip: "+ New Channel" }
+    }
+    return undefined
+  }
+
+  return (
+    <>
+      {resolvedSections.map(({ section, items }) => {
+        const presentation = sectionPresentation(section.spec)
+        if (presentation.hideWhenEmpty && items.length === 0) return null
+
+        const state = getSectionState(section.id, presentation.defaultCollapse)
+        const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
+        const add = addWiringFor(section.spec)
+
+        if (presentation.tiered) {
+          return (
+            <TieredStreamSection
+              key={section.id}
+              sectionKey={section.id}
+              label={presentation.label}
+              icon={presentation.icon}
+              items={items}
+              allStreams={processedStreams}
+              workspaceId={workspaceId}
+              activeStreamId={activeStreamId}
+              getUnreadCount={getUnreadCount}
+              getMentionCount={getMentionCount}
+              state={state}
+              onToggle={onToggle}
+              moreState={getSectionState(moreKey(section.id), MORE_DEFAULT)}
+              onToggleMore={() => toggleSectionState(moreKey(section.id), MORE_DEFAULT)}
+              compact={presentation.compact}
+              showPreviewOnHover={presentation.showPreviewOnHover}
+              scrollContainerRef={scrollContainerRef}
+              onAdd={add?.onAdd}
+              addTooltip={add?.addTooltip}
+              addMenuActions={add?.addMenuActions}
+            />
+          )
+        }
+
+        return (
+          <StreamSection
+            key={section.id}
+            label={presentation.label}
+            icon={presentation.icon}
+            items={items}
             allStreams={processedStreams}
             workspaceId={workspaceId}
             activeStreamId={activeStreamId}
             getUnreadCount={getUnreadCount}
             getMentionCount={getMentionCount}
-            state={getSectionState("other", "collapsed")}
-            onToggle={() => toggleSectionState("other", "collapsed")}
-            moreState={getSectionState(moreKey("other"), MORE_DEFAULT)}
-            onToggleMore={() => toggleSectionState(moreKey("other"), MORE_DEFAULT)}
-            compact={SMART_SECTIONS.other.compact}
-            showPreviewOnHover={SMART_SECTIONS.other.showPreviewOnHover}
+            state={state}
+            onToggle={onToggle}
+            compact={presentation.compact}
+            showPreviewOnHover={presentation.showPreviewOnHover}
             scrollContainerRef={scrollContainerRef}
           />
-        )}
-      </>
-    )
-  }
-
-  return (
-    <>
-      <TieredStreamSection
-        sectionKey="scratchpads"
-        label="Scratchpads"
-        items={streamsByType.scratchpads}
-        allStreams={processedStreams}
-        workspaceId={workspaceId}
-        activeStreamId={activeStreamId}
-        getUnreadCount={getUnreadCount}
-        getMentionCount={getMentionCount}
-        state={getSectionState("scratchpads")}
-        onToggle={() => toggleSectionState("scratchpads")}
-        moreState={getSectionState(moreKey("scratchpads"), MORE_DEFAULT)}
-        onToggleMore={() => toggleSectionState(moreKey("scratchpads"), MORE_DEFAULT)}
-        scrollContainerRef={scrollContainerRef}
-        onAdd={() => void onCreateScratchpad()}
-        addTooltip={scratchpadAddMenuActions ? "New scratchpad…" : "+ New Scratchpad"}
-        addMenuActions={scratchpadAddMenuActions}
-        compact
-        showPreviewOnHover
-      />
-
-      <TieredStreamSection
-        sectionKey="channels"
-        label="Channels"
-        items={streamsByType.channels}
-        allStreams={processedStreams}
-        workspaceId={workspaceId}
-        activeStreamId={activeStreamId}
-        getUnreadCount={getUnreadCount}
-        getMentionCount={getMentionCount}
-        state={getSectionState("channels")}
-        onToggle={() => toggleSectionState("channels")}
-        moreState={getSectionState(moreKey("channels"), MORE_DEFAULT)}
-        onToggleMore={() => toggleSectionState(moreKey("channels"), MORE_DEFAULT)}
-        scrollContainerRef={scrollContainerRef}
-        onAdd={() => void onCreateChannel()}
-        addTooltip="+ New Channel"
-        compact
-        showPreviewOnHover
-      />
-
-      {streamsByType.dms.length > 0 && (
-        <TieredStreamSection
-          sectionKey="dms"
-          label="Direct Messages"
-          items={streamsByType.dms}
-          allStreams={processedStreams}
-          workspaceId={workspaceId}
-          activeStreamId={activeStreamId}
-          getUnreadCount={getUnreadCount}
-          getMentionCount={getMentionCount}
-          state={getSectionState("dms")}
-          onToggle={() => toggleSectionState("dms")}
-          moreState={getSectionState(moreKey("dms"), MORE_DEFAULT)}
-          onToggleMore={() => toggleSectionState(moreKey("dms"), MORE_DEFAULT)}
-          scrollContainerRef={scrollContainerRef}
-          compact
-          showPreviewOnHover
-        />
-      )}
+        )
+      })}
     </>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -32,9 +32,10 @@ import { SidebarQuickLinks } from "./quick-links"
 import { SidebarStreamList } from "./sidebar-stream-list"
 import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skeletons"
 import { SidebarFooter } from "./sidebar-footer"
-import { ALL_SECTIONS, SMART_SECTIONS } from "./config"
+import { presetForViewMode } from "./sidebar-config"
+import { resolveSections } from "./resolve-sections"
 import type { SidebarActionItem } from "./sidebar-actions"
-import { calculateUrgency, categorizeStream, sortStreams } from "./utils"
+import { calculateUrgency, categorizeStream } from "./utils"
 import type { StreamItemData } from "./types"
 import { resolveDmDisplayName } from "@/lib/streams"
 import { StreamTypes, Visibilities } from "@threa/types"
@@ -58,7 +59,6 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const location = useLocation()
   const syncStatus = useSyncStatus(`workspace:${workspaceId}`)
   const syncEngine = useSyncEngine()
-  const isLoading = syncStatus === "syncing" || syncStatus === "idle"
   const error = syncStatus === "error"
   const workspace = useWorkspaceFromStore(workspaceId)
   const unreadState = useWorkspaceUnreadState(workspaceId)
@@ -188,93 +188,11 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   const hasUserStreams = hasUserStreamsFromStreams || virtualDmStreams.length > 0
 
-  // Organize streams by section
-  const streamsBySection = useMemo(() => {
-    const important: StreamItemData[] = []
-    const recentCandidates: StreamItemData[] = [] // All streams that could go in Recent
-    const pinned: StreamItemData[] = []
-    const other: StreamItemData[] = []
-    const smartStreams = [...processedStreams, ...virtualDmStreams]
-
-    for (const stream of smartStreams) {
-      switch (stream.section) {
-        case "important":
-          important.push(stream)
-          break
-        case "recent":
-          recentCandidates.push(stream)
-          break
-        case "pinned":
-          pinned.push(stream)
-          break
-        case "other":
-          other.push(stream)
-          break
-      }
-    }
-
-    // Sort each section using configured sort types
-    sortStreams(important, SMART_SECTIONS.important.sortType, getUnreadCount)
-    sortStreams(pinned, SMART_SECTIONS.pinned.sortType, getUnreadCount)
-    sortStreams(other, SMART_SECTIONS.other.sortType, getUnreadCount)
-
-    // Recent section: special filtering logic
-    // Show unreads OR up to 5 most recent (excluding items already in Important)
-    // - If no unreads: show at most 5 recent streams
-    // - If <5 unreads: show unreads + remaining reads up to 5 total
-    // - If ≥5 unreads: show all unreads
-    sortStreams(recentCandidates, SMART_SECTIONS.recent.sortType, getUnreadCount)
-
-    const recentUnreads = recentCandidates.filter((s) => getUnreadCount(s.id) > 0)
-    const recentReads = recentCandidates.filter((s) => getUnreadCount(s.id) === 0)
-
-    let recent: StreamItemData[]
-    if (recentUnreads.length >= 5) {
-      // Show all unreads when there are 5 or more
-      recent = recentUnreads
-    } else {
-      // Show unreads + fill remaining slots with reads (up to 5 total)
-      const remainingSlots = 5 - recentUnreads.length
-      recent = [...recentUnreads, ...recentReads.slice(0, remainingSlots)]
-    }
-
-    // Limit Important to 10
-    return {
-      important: important.slice(0, 10),
-      recent,
-      pinned,
-      other,
-    }
-  }, [processedStreams, virtualDmStreams, getUnreadCount])
-
-  // Organize streams by type for "All" view
-  const streamsByType = useMemo(() => {
-    const scratchpads: StreamItemData[] = []
-    const channels: StreamItemData[] = []
-    const dms: StreamItemData[] = []
-
-    for (const stream of processedStreams) {
-      if (stream.type === StreamTypes.SCRATCHPAD) {
-        scratchpads.push(stream)
-      } else if (stream.type === StreamTypes.CHANNEL) {
-        channels.push(stream)
-      } else if (stream.type === StreamTypes.DM || stream.type === StreamTypes.SYSTEM) {
-        dms.push(stream)
-      }
-      // Note: threads are not shown in All view
-    }
-
-    // Sort each section using configured sort types
-    sortStreams(scratchpads, ALL_SECTIONS.scratchpads.sortType, getUnreadCount)
-    sortStreams(channels, ALL_SECTIONS.channels.sortType, getUnreadCount)
-    const realDms = dms.filter((stream) => stream.type === StreamTypes.DM)
-    const systemStreams = dms.filter((stream) => stream.type === StreamTypes.SYSTEM)
-
-    sortStreams(realDms, "activity", getUnreadCount)
-    sortStreams(systemStreams, ALL_SECTIONS.dms.sortType, getUnreadCount)
-
-    return { scratchpads, channels, dms: [...realDms, ...systemStreams, ...virtualDmStreams] }
-  }, [processedStreams, getUnreadCount, virtualDmStreams])
+  // Resolve the active view's preset config into ordered, sorted, capped lists.
+  const resolvedSections = useMemo(
+    () => resolveSections(presetForViewMode(viewMode), { processedStreams, virtualDmStreams, getUnreadCount }),
+    [viewMode, processedStreams, virtualDmStreams, getUnreadCount]
+  )
 
   // Track sidebar and scroll container dimensions for position calculations
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -424,14 +342,11 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           </div>
           <SidebarStreamList
             workspaceId={workspaceId}
-            viewMode={viewMode}
-            isLoading={isLoading}
             hasError={Boolean(error)}
             hasUserStreams={hasUserStreams}
             activeStreamId={activeStreamId}
             processedStreams={processedStreams}
-            streamsBySection={streamsBySection}
-            streamsByType={streamsByType}
+            resolvedSections={resolvedSections}
             getUnreadCount={getUnreadCount}
             getMentionCount={getMentionCount}
             getSectionState={getSectionState}

--- a/docs/plans/configurable-sidebar-and-visible-labels.md
+++ b/docs/plans/configurable-sidebar-and-visible-labels.md
@@ -23,7 +23,7 @@ surface. Make them visible:
   section that shows streams even if shown above). A **`remainder`** section
   kind renders "everything not shown above" (today's "Everything Else").
 - **Presets → default seed configs:** `Smart = [important, recent, pinned,
-  remainder]`, `All = [type:scratchpads, type:channels, type:dms]`. New users
+remainder]`, `All = [type:scratchpads, type:channels, type:dms]`. New users
   seed from Smart; existing users seed from their current `viewMode`. "Reset to
   preset" restores a seed.
 - **Editor:** both — inline quick add/remove (label picker, section-header menu,
@@ -56,7 +56,7 @@ type SidebarSectionKind =
   | { kind: "label"; labelId: string }
 
 interface SidebarSection {
-  id: string            // stable ulid, e.g. sbsec_xxx
+  id: string // stable ulid, e.g. sbsec_xxx
   spec: SidebarSectionKind
   hideAboveShown: boolean
   // label-display name/emoji/color resolved from the labels cache at render
@@ -73,9 +73,11 @@ interface SidebarConfig {
 ## The PR stack
 
 ### PR1 — Config-driven sidebar rendering (no behavior change, no editor) ✅ implemented
+
 Frontend only. Introduce the config types + a pure resolver and route the
 existing sidebar through it, seeded from today's `viewMode` (no persistence yet
 — configs can't diverge from presets until the editor lands).
+
 - `sidebar/sidebar-config.ts` — `SidebarSectionSpec` (`smart` bucket | `type`),
   `SidebarConfig`, `SMART_PRESET` / `ALL_PRESET` seeds, `presetForViewMode`, and
   `sectionPresentation(spec)` (label/icon/tiered/compact/hideWhenEmpty/default
@@ -102,32 +104,40 @@ Recent vanish today, they do not fall through). `hideAboveShown` + `remainder`
 land in **PR4**, where additive label lenses are the first thing to exercise them.
 
 ### PR2 — Sidebar editor + config persistence
+
 Backend per-user config (table + types + bootstrap field + sync events + API),
 plus the editor: inline add/remove and a "Sidebar" settings panel
 (drag-reorder, add/remove kinds, reset-to-preset). Existing users' configs
 seeded server-side from their last preset on first read.
 
 ### PR3 — Label model: unified membership + lifecycle
+
 Backend + tests only, no UI. `create()` inserts creator membership for every
 label; backfill migration for existing private labels; `leave()` →
 last-member-archive (race-safe). `listVisibleTo`/membership reads simplified to
 the uniform set; `creator_user_id` retained for permissions.
 
 ### PR4 — Sidebar label sections + shared chip
+
 Shared tinted `LabelChip` (`components/labels/label-chip.tsx`). Add the `label`
 section kind end-to-end (resolver filter by assignment, tinted section header,
 add/remove entry points: label picker, labels page, section-header menu).
 
 ### PR5 — Stream top-bar label stack
+
 `components/labels/stream-label-stack.tsx` in the `stream.tsx` header. Reuses
 `LabelChip`. Hover fan-out (desktop) / vaul drawer (mobile), cap 3 + `+N`,
 display-only.
 
 ## Cross-cutting invariants
+
 INV-51/52 (colocate label backend, import via barrels), INV-20 (race-safe
 last-member-archive + idempotent membership upsert), INV-17 (append-only
 migrations), INV-21 (no layout shift on hover), INV-59 (URL-driven where
 relevant), INV-60 (strip markdown in any preview), INV-24 (object-compare in
 tests), INV-23 (assert event presence not counts). Tests run with
 `bun run test` / `bun run test:e2e`; never ship unexecuted.
+
+```
+
 ```


### PR DESCRIPTION
## What & why

First step of the **configurable sidebar + visible labels** initiative (full plan in `docs/plans/configurable-sidebar-and-visible-labels.md`). Labels have a complete data layer but no visual surface; before adding label-driven sections we need the sidebar to render from a **config object** instead of a hardcoded `viewMode` branch.

This PR is **pure refactor — no behavior change.** The two view modes (Smart / All) become preset configs, and a pure resolver reproduces today's output exactly.

## Changes

- **`sidebar-config.ts`** (new) — `SidebarSectionSpec` (`smart` bucket | stream `type`), `SidebarConfig`, `SMART_PRESET`/`ALL_PRESET` seeds, `presetForViewMode()`, and a spec-derived `sectionPresentation()` (label / icon / tiered / compact / hideWhenEmpty / default-collapse).
- **`resolve-sections.ts`** (new) — pure `resolveSections(config, { processedStreams, virtualDmStreams, getUnreadCount })`. Reuses the existing `sortStreams` and keeps Important's 10-cap, Recent's 5-cap-with-unread-priority, and the DM composition (real DMs by activity → system → synthetic drafts).
- **`sidebar.tsx`** — builds the active preset and calls the resolver once; the two `streamsBySection`/`streamsByType` `useMemo`s are gone.
- **`sidebar-stream-list.tsx`** — renders the resolved list generically; the `viewMode` if/else branch is removed.
- Dead `SmartSection` deleted (INV-38); unused imports cleaned.

## Behavior parity notes

- Section ids equal the prior collapse-state keys, so users' persisted collapse/“more” prefs survive the refactor.
- `hideWhenEmpty`, default-collapse, and add-button wiring reproduce the old per-section guards exactly.

## Deferred (intentionally, to avoid speculative config — INV-36)

`hideAboveShown` and a `remainder` section kind are **not** here. Today's buckets are mutually exclusive (a stream is in exactly one `categorizeStream` bucket and is exactly one type), so dedup is a no-op and a remainder kind would be unused. They land in **PR4**, where additive label lenses first exercise them. "Everything Else" is modeled as `{ kind: "smart", bucket: "other" }`, which is faithful (streams capped out of Important/Recent vanish today rather than falling through).

## Tests

- New `resolve-sections.test.ts`: 5 object-compare tests (INV-24) covering both presets, caps, Recent logic, and DM composition.
- 40/40 sidebar tests pass; frontend typecheck + lint clean (pre-commit hook ran the full-repo lint/typecheck/api-doc checks too).

## Next in the stack

PR2 — sidebar editor + config persistence.

https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782592418&installation_id=129946197&pr_number=667&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F667&signature=6e023139a1fc86c17c1bde73bcf86d2644361aef8c1d702113656359d14d8c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->