### PR TITLE
fix(timeline): re-anchor to bottom when composer height settles

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -39,6 +39,12 @@ interface MessageInputProps {
   disabled?: boolean
   disabledReason?: string
   autoFocus?: boolean
+  /**
+   * Notified when the composer's measured height changes (after the initial
+   * measure). The virtualized timeline uses this to re-anchor to the bottom so
+   * the last message isn't left covered by a composer that settled taller.
+   */
+  onComposerHeightChange?: (px: number) => void
 }
 
 function attachmentMatchKey(attachment: Pick<PendingAttachment, "filename" | "mimeType">): string {
@@ -193,7 +199,14 @@ export function materializePendingAttachmentReferences(
 // across `StreamContent` renders, so the default shallow comparison is enough.
 export const MessageInput = memo(MessageInputComponent)
 
-function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason, autoFocus }: MessageInputProps) {
+function MessageInputComponent({
+  workspaceId,
+  streamId,
+  disabled,
+  disabledReason,
+  autoFocus,
+  onComposerHeightChange,
+}: MessageInputProps) {
   const editLastCtx = useEditLastMessage()
   const triggerEditLast = editLastCtx?.triggerEditLast
   const scrollToMessage = editLastCtx?.scrollToMessage
@@ -409,8 +422,9 @@ function MessageInputComponent({ workspaceId, streamId, disabled, disabledReason
   // Publish the floating composer's measured height so the scroll area can
   // reserve matching space (Virtuoso Footer, plain-scroll padding-bottom).
   // Disabled while the expanded overlay is open so the scroll area can use its
-  // full height behind the overlay.
-  useComposerHeightPublish(selfRef, { active: !expanded })
+  // full height behind the overlay. `onHeightChange` lets the virtualized
+  // timeline re-anchor to the bottom when the composer settles to a new height.
+  useComposerHeightPublish(selfRef, { active: !expanded, onHeightChange: onComposerHeightChange })
 
   // Escape to close — only when focus is inside this expanded editor
   useEffect(() => {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -780,6 +780,29 @@ export function StreamContent({
   const scrollToBottom = useVirtualized ? virtualScrollToBottom : plainScrollToBottom
   const disableAutoScroll = useVirtualized ? virtualDisableAutoScroll : plainDisableAutoScroll
 
+  // Re-anchor the virtualized list to the bottom when the floating composer
+  // settles to a new height. The footer spacer that keeps the last message
+  // above the composer is sized from `--composer-height`, but Virtuoso freezes
+  // its scrollTop when that spacer grows (followOutput only reacts to new
+  // items; the resize safety-net only watches the scroller's own height). So a
+  // composer that lands taller a few frames after a message arrives (its 200ms
+  // height transition, async encryption notice / attachment chips) covers the
+  // bottom of the last message until the next reload. virtualScrollToBottom
+  // self-guards on isAtBottomRef, so this is a no-op unless the user is parked
+  // at the live tail (never fires during a deep-link jump or while scrolled up
+  // reading). Debounced so the snap lands once after the transition settles
+  // rather than fighting Virtuoso's reflow on every intermediate frame. The
+  // plain-scroll (thread/draft) path needs none of this: its `padding-bottom`
+  // reflows the content so the bottom row is never frozen behind the composer.
+  const composerResizeTimerRef = useRef<number | undefined>(undefined)
+  const handleComposerHeightChange = useCallback(() => {
+    window.clearTimeout(composerResizeTimerRef.current)
+    composerResizeTimerRef.current = window.setTimeout(() => {
+      virtualScrollToBottom()
+    }, 120)
+  }, [virtualScrollToBottom])
+  useEffect(() => () => window.clearTimeout(composerResizeTimerRef.current), [])
+
   // Scroll to a specific message and keep re-scrolling until the target
   // element is actually visible in the scroller viewport. Items rendered
   // with estimated heights cause the target to drift after the first scroll
@@ -1504,6 +1527,7 @@ export function StreamContent({
                 disabled={isArchived || isSystem}
                 disabledReason={disabledReason}
                 autoFocus={autoFocus}
+                onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
               />
             )}
           </div>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -794,13 +794,20 @@ export function StreamContent({
   // rather than fighting Virtuoso's reflow on every intermediate frame. The
   // plain-scroll (thread/draft) path needs none of this: its `padding-bottom`
   // reflows the content so the bottom row is never frozen behind the composer.
+  //
+  // Called through a ref so the handler identity stays stable: virtualScrollToBottom
+  // is rebuilt on every itemCount change, and a changing prop would re-render
+  // the memoized MessageInput on every new message (the exact churn that memo
+  // exists to prevent).
+  const virtualScrollToBottomRef = useRef(virtualScrollToBottom)
+  virtualScrollToBottomRef.current = virtualScrollToBottom
   const composerResizeTimerRef = useRef<number | undefined>(undefined)
   const handleComposerHeightChange = useCallback(() => {
     window.clearTimeout(composerResizeTimerRef.current)
     composerResizeTimerRef.current = window.setTimeout(() => {
-      virtualScrollToBottom()
+      virtualScrollToBottomRef.current()
     }, 120)
-  }, [virtualScrollToBottom])
+  }, [])
   useEffect(() => () => window.clearTimeout(composerResizeTimerRef.current), [])
 
   // Scroll to a specific message and keep re-scrolling until the target

--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { useRef } from "react"
+import { render } from "@testing-library/react"
+import { useComposerHeightPublish } from "./use-composer-height-publish"
+
+type ResizeCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
+
+function installManualResizeObserver(): {
+  fire: (blockSize: number) => void
+  restore: () => void
+} {
+  let lastCallback: ResizeCallback | null = null
+  const original = global.ResizeObserver
+  class ManualResizeObserver {
+    constructor(cb: ResizeCallback) {
+      lastCallback = cb
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  global.ResizeObserver = ManualResizeObserver as unknown as typeof ResizeObserver
+  return {
+    fire: (blockSize: number) =>
+      lastCallback?.(
+        [{ borderBoxSize: [{ blockSize, inlineSize: 0 }] }] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver
+      ),
+    restore: () => {
+      global.ResizeObserver = original
+    },
+  }
+}
+
+// The hook seeds its baseline from getBoundingClientRect on mount; pin it so
+// the initial measure is a known, stable height (jsdom returns 0 otherwise).
+function pinInitialHeight(px: number): () => void {
+  const original = HTMLElement.prototype.getBoundingClientRect
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return { height: px, width: 0, top: 0, left: 0, right: 0, bottom: px, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+  }
+  return () => {
+    HTMLElement.prototype.getBoundingClientRect = original
+  }
+}
+
+function Harness({ onHeightChange, active = true }: { onHeightChange: (px: number) => void; active?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useComposerHeightPublish(ref, { active, onHeightChange })
+  return (
+    <div data-editor-zone="main">
+      <div ref={ref}>composer</div>
+    </div>
+  )
+}
+
+describe("useComposerHeightPublish", () => {
+  let restoreRect: () => void
+
+  beforeEach(() => {
+    restoreRect = pinInitialHeight(80)
+  })
+
+  afterEach(() => {
+    restoreRect()
+  })
+
+  it("publishes the measured height as --composer-height on the editor zone", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const { container } = render(<Harness onHeightChange={() => {}} />)
+      const zone = container.querySelector<HTMLElement>("[data-editor-zone]")!
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("80px")
+
+      ro.fire(132)
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("132px")
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("does NOT fire onHeightChange for the initial measurement", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      render(<Harness onHeightChange={onHeightChange} />)
+      // Mount seeded the baseline at 80px; no change has happened yet.
+      expect(onHeightChange).not.toHaveBeenCalled()
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("fires onHeightChange only when the height actually changes", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      render(<Harness onHeightChange={onHeightChange} />)
+
+      // Same height as the seeded baseline — no notification.
+      ro.fire(80)
+      expect(onHeightChange).not.toHaveBeenCalled()
+
+      // Composer grows (e.g. multi-line draft / attachments settle).
+      ro.fire(160)
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+      expect(onHeightChange).toHaveBeenLastCalledWith(160)
+
+      // A redundant fire at the same height must not re-notify.
+      ro.fire(160)
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+
+      // Composer shrinks back (message sent, draft cleared).
+      ro.fire(80)
+      expect(onHeightChange).toHaveBeenCalledTimes(2)
+      expect(onHeightChange).toHaveBeenLastCalledWith(80)
+    } finally {
+      ro.restore()
+    }
+  })
+})

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -1,5 +1,22 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { persistComposerHeight } from "@/lib/composer-height-storage"
+
+interface UseComposerHeightPublishOptions {
+  active?: boolean
+  /**
+   * Fired whenever the published height *changes* from a previously-measured
+   * value (never on the initial measurement). The timeline uses this to
+   * re-anchor a virtualized list to the bottom: the footer spacer that keeps
+   * the last message above the composer is sized from `--composer-height`, but
+   * Virtuoso's scroll position is frozen when that spacer grows (its
+   * `followOutput` only reacts to new items, and its resize safety-net only
+   * watches the scroller's own height — not footer growth). Without this
+   * notification a composer that settles taller a few frames after a message
+   * lands (the 200ms height transition, async encryption notice / attachment
+   * chips) covers the bottom of the last message until the next reload.
+   */
+  onHeightChange?: (px: number) => void
+}
 
 /**
  * Measures the element referenced by `ref` and publishes its height (in px) as
@@ -19,8 +36,13 @@ import { persistComposerHeight } from "@/lib/composer-height-storage"
  */
 export function useComposerHeightPublish(
   ref: React.RefObject<HTMLElement | null>,
-  { active = true }: { active?: boolean } = {}
+  { active = true, onHeightChange }: UseComposerHeightPublishOptions = {}
 ): void {
+  // Held in a ref so a new callback identity each render doesn't tear down and
+  // re-create the ResizeObserver (which would re-fire the initial measure).
+  const onHeightChangeRef = useRef(onHeightChange)
+  onHeightChangeRef.current = onHeightChange
+
   useEffect(() => {
     const el = ref.current
     if (!el || !active) return
@@ -28,10 +50,17 @@ export function useComposerHeightPublish(
     const zone = el.closest<HTMLElement>("[data-editor-zone]")
     if (!zone) return
 
+    let lastPublished: number | null = null
+
     const write = (h: number) => {
       const px = Math.ceil(h)
       zone.style.setProperty("--composer-height", `${px}px`)
       persistComposerHeight(px)
+      // Only notify on an actual change from an already-established height —
+      // the initial measure just seeds the baseline (the footer spacer is
+      // already sized for it via the persisted `:root` fallback).
+      if (lastPublished !== null && px !== lastPublished) onHeightChangeRef.current?.(px)
+      lastPublished = px
     }
 
     write(el.getBoundingClientRect().height)


### PR DESCRIPTION
## Problem

When parked at the live tail of a stream, the **last message sometimes ends up covered by the floating composer** — the "padding after the last message" appears to be missing, and a reload is needed to see it.

## Root cause

The last message is kept above the floating composer by a footer spacer sized from `--composer-height` (`ComposerFooterSpacer` in `stream-content.tsx`). But Virtuoso **freezes its `scrollTop` when that spacer grows**:

- `followOutput="auto"` only reacts to **new items**, not to footer growth.
- The existing resize safety-net in `use-virtuoso-scroll.ts` only watches the **scroller's own `clientHeight`** (the viewport) — which does not change when the footer (content) grows.

So when the composer settles to a taller height a few frames after a message lands — its 200ms height transition (`message-composer.tsx`), or async relayout (encryption notice, attachment chips) — its top edge creeps up and covers the bottom of the last message. It's **intermittent** because it's a timing race against that settle; a **reload fixes it** only because the initial mount re-runs scroll-to-LAST against the final footer height.

## Fix

- `useComposerHeightPublish` now accepts an `onHeightChange` callback, fired only when the published height **changes** from an already-established value (never on the initial measure — the persisted `:root` fallback already sizes the spacer for that).
- `StreamContent` debounces that into a guarded `virtualScrollToBottom()`. It **self-guards on `isAtBottomRef`**, so it's a no-op unless the user is parked at the live tail — it never fires during a deep-link jump or while scrolled up reading. The debounce (120ms) lets the snap land once after the transition settles instead of fighting Virtuoso's reflow each frame.
- Wired **only** for the virtualized path. The plain-scroll thread/draft path needs nothing: its `padding-bottom` reflows the content so the bottom row is never frozen.
- The resize handler is called through a ref so its identity stays stable — otherwise it would re-render the memoized `MessageInput` on every new message.

## Tests

New `use-composer-height-publish.test.tsx` verifies the publish contract: the CSS var is set on the editor zone, `onHeightChange` does **not** fire on the initial measure or on redundant same-height fires, and **does** fire on real grow/shrink changes. Existing `use-virtuoso-scroll` / `use-scroll-behavior` suites still pass; full typecheck + lint gate green.

## Note for review

The 120ms debounce is tuned to land just after the composer's 200ms height transition. If the last message still flashes briefly behind the composer on a real device before snapping, that constant is the knob to turn (or switch to a continuous snap).

https://claude.ai/code/session_01Lfwxa9krSrb7yd32ste3pL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lfwxa9krSrb7yd32ste3pL)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593184&installation_id=129946197&pr_number=668&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F668&signature=f290b5d122846bee9c1f2fbedece66b71d44a81be37cb914f9ce2134d6c7ebf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->