### PR TITLE
feat(sidebar): persist sidebar config per user with cross-device sync (PR2 of configurable sidebar)

### DIFF
--- a/apps/backend/src/db/migrations/20260529120000_sidebar_configs.sql
+++ b/apps/backend/src/db/migrations/20260529120000_sidebar_configs.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Sidebar Configs
+-- One row per (workspace, user) holding the viewer's sidebar layout as a single
+-- JSON document (basePreset + ordered sections). Absent row = code-defined
+-- default (the Smart preset), so changing the default is a code deploy, not a
+-- migration. No FKs (INV-1), no enums (INV-3), workspace-scoped (INV-8).
+-- =============================================================================
+
+CREATE TABLE sidebar_configs (
+    workspace_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    config JSONB NOT NULL,          -- Full SidebarConfig document
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (workspace_id, user_id)
+);

--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import type { SidebarConfigService } from "./service"
+import { HttpError } from "../../lib/errors"
 import { SIDEBAR_SECTION_KEYS, SIDEBAR_TYPE_SECTIONS, SIDEBAR_BASE_PRESETS } from "@threa/types"
 
 const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
@@ -41,10 +42,7 @@ export function createSidebarConfigHandlers({ sidebarConfigService }: Dependenci
 
       const result = updateSidebarConfigSchema.safeParse(req.body)
       if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
+        throw new HttpError("Invalid sidebar config", { status: 400, code: "VALIDATION_ERROR" })
       }
 
       const sidebarConfig = await sidebarConfigService.updateConfig(workspaceId, userId, result.data)

--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -1,0 +1,54 @@
+import { z } from "zod"
+import type { Request, Response } from "express"
+import type { SidebarConfigService } from "./service"
+import { SIDEBAR_SECTION_KEYS, SIDEBAR_TYPE_SECTIONS, SIDEBAR_BASE_PRESETS } from "@threa/types"
+
+const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("smart"), bucket: z.enum(SIDEBAR_SECTION_KEYS) }),
+  z.object({ kind: z.literal("type"), streamType: z.enum(SIDEBAR_TYPE_SECTIONS) }),
+])
+
+const sidebarSectionSchema = z.object({
+  id: z.string().min(1).max(64),
+  spec: sidebarSectionSpecSchema,
+})
+
+// The PATCH body is the full config document — it replaces the stored layout.
+const updateSidebarConfigSchema = z.object({
+  basePreset: z.enum(SIDEBAR_BASE_PRESETS),
+  sections: z.array(sidebarSectionSchema).max(50),
+})
+
+export { updateSidebarConfigSchema }
+
+interface Dependencies {
+  sidebarConfigService: SidebarConfigService
+}
+
+export function createSidebarConfigHandlers({ sidebarConfigService }: Dependencies) {
+  return {
+    async get(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const sidebarConfig = await sidebarConfigService.getConfig(workspaceId, userId)
+      res.json({ sidebarConfig })
+    },
+
+    async update(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const result = updateSidebarConfigSchema.safeParse(req.body)
+      if (!result.success) {
+        return res.status(400).json({
+          error: "Validation failed",
+          details: z.flattenError(result.error).fieldErrors,
+        })
+      }
+
+      const sidebarConfig = await sidebarConfigService.updateConfig(workspaceId, userId, result.data)
+      res.json({ sidebarConfig })
+    },
+  }
+}

--- a/apps/backend/src/features/sidebar-config/index.ts
+++ b/apps/backend/src/features/sidebar-config/index.ts
@@ -1,0 +1,3 @@
+export { createSidebarConfigHandlers, updateSidebarConfigSchema } from "./handlers"
+export { SidebarConfigService } from "./service"
+export { SidebarConfigRepository } from "./repository"

--- a/apps/backend/src/features/sidebar-config/repository.ts
+++ b/apps/backend/src/features/sidebar-config/repository.ts
@@ -1,0 +1,37 @@
+import { sql, type Querier } from "../../db"
+import type { SidebarConfig } from "@threa/types"
+
+interface SidebarConfigRow {
+  config: SidebarConfig
+}
+
+export const SidebarConfigRepository = {
+  /**
+   * Fetch the stored sidebar config for a user in a workspace.
+   * Returns null when the user has never customized it — the service layer
+   * falls back to the code-defined default.
+   */
+  async find(db: Querier, workspaceId: string, userId: string): Promise<SidebarConfig | null> {
+    const result = await db.query<SidebarConfigRow>(sql`
+      SELECT config
+      FROM sidebar_configs
+      WHERE workspace_id = ${workspaceId}
+        AND user_id = ${userId}
+    `)
+    return result.rows[0]?.config ?? null
+  },
+
+  /**
+   * Persist the full sidebar config document. Race-safe upsert (INV-20) so
+   * concurrent writes from a user's devices converge rather than collide.
+   */
+  async upsert(db: Querier, workspaceId: string, userId: string, config: SidebarConfig): Promise<void> {
+    await db.query(sql`
+      INSERT INTO sidebar_configs (workspace_id, user_id, config)
+      VALUES (${workspaceId}, ${userId}, ${JSON.stringify(config)}::jsonb)
+      ON CONFLICT (workspace_id, user_id) DO UPDATE SET
+        config = EXCLUDED.config,
+        updated_at = NOW()
+    `)
+  },
+}

--- a/apps/backend/src/features/sidebar-config/service.test.ts
+++ b/apps/backend/src/features/sidebar-config/service.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { PoolClient } from "pg"
+import { ALL_SIDEBAR_CONFIG, DEFAULT_SIDEBAR_CONFIG, type SidebarConfig } from "@threa/types"
+import { SidebarConfigService } from "./service"
+import { SidebarConfigRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const USER_ID = "usr_1"
+
+function setupService() {
+  // withTransaction invokes the callback with a fake client.
+  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+  return new SidebarConfigService({} as any)
+}
+
+describe("SidebarConfigService.getConfig", () => {
+  afterEach(() => mock.restore())
+
+  it("returns the stored config when the user has customized it", async () => {
+    const service = setupService()
+    spyOn(SidebarConfigRepository, "find").mockResolvedValue(ALL_SIDEBAR_CONFIG)
+
+    const config = await service.getConfig(WORKSPACE_ID, USER_ID)
+
+    expect(config).toEqual(ALL_SIDEBAR_CONFIG)
+  })
+
+  it("falls back to the default config when none is stored", async () => {
+    const service = setupService()
+    spyOn(SidebarConfigRepository, "find").mockResolvedValue(null)
+
+    const config = await service.getConfig(WORKSPACE_ID, USER_ID)
+
+    expect(config).toEqual(DEFAULT_SIDEBAR_CONFIG)
+  })
+})
+
+describe("SidebarConfigService.updateConfig", () => {
+  afterEach(() => mock.restore())
+
+  it("persists the config and emits an author-scoped sidebar_config:updated event", async () => {
+    const service = setupService()
+
+    const upsert = spyOn(SidebarConfigRepository, "upsert").mockResolvedValue(undefined)
+    const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const next: SidebarConfig = {
+      basePreset: "all",
+      sections: [{ id: "channels", spec: { kind: "type", streamType: "channel" } }],
+    }
+    const result = await service.updateConfig(WORKSPACE_ID, USER_ID, next)
+
+    expect(result).toEqual(next)
+    expect(upsert).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, USER_ID, next)
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "sidebar_config:updated", {
+      workspaceId: WORKSPACE_ID,
+      authorId: USER_ID,
+      sidebarConfig: next,
+    })
+  })
+})

--- a/apps/backend/src/features/sidebar-config/service.ts
+++ b/apps/backend/src/features/sidebar-config/service.ts
@@ -1,0 +1,37 @@
+import { Pool } from "pg"
+import { withTransaction } from "../../db"
+import { SidebarConfigRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
+import { type SidebarConfig, DEFAULT_SIDEBAR_CONFIG } from "@threa/types"
+
+export class SidebarConfigService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Get a user's sidebar config, falling back to the code-defined default
+   * when they have never customized it.
+   */
+  async getConfig(workspaceId: string, userId: string): Promise<SidebarConfig> {
+    // Single query, INV-30.
+    const stored = await SidebarConfigRepository.find(this.pool, workspaceId, userId)
+    return stored ?? DEFAULT_SIDEBAR_CONFIG
+  }
+
+  /**
+   * Replace a user's sidebar config and broadcast to their other devices via
+   * the outbox (author-scoped event).
+   */
+  async updateConfig(workspaceId: string, userId: string, config: SidebarConfig): Promise<SidebarConfig> {
+    return withTransaction(this.pool, async (client) => {
+      await SidebarConfigRepository.upsert(client, workspaceId, userId, config)
+
+      await OutboxRepository.insert(client, "sidebar_config:updated", {
+        workspaceId,
+        authorId: userId,
+        sidebarConfig: config,
+      })
+
+      return config
+    })
+  }
+}

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express"
 import type { WorkspaceService } from "./service"
 import type { StreamService } from "../streams"
 import type { UserPreferencesService } from "../user-preferences"
+import type { SidebarConfigService } from "../sidebar-config"
 import type { InvitationService } from "../invitations"
 import type { ActivityService } from "../activity"
 import type { CommandAvailabilityService } from "../commands"
@@ -49,6 +50,7 @@ interface Dependencies {
   workspaceService: WorkspaceService
   streamService: StreamService
   userPreferencesService: UserPreferencesService
+  sidebarConfigService: SidebarConfigService
   invitationService: InvitationService
   activityService?: ActivityService
   commandAvailabilityService: CommandAvailabilityService
@@ -63,6 +65,7 @@ export function createWorkspaceHandlers({
   workspaceService,
   streamService,
   userPreferencesService,
+  sidebarConfigService,
   invitationService,
   activityService,
   commandAvailabilityService,
@@ -137,6 +140,7 @@ export function createWorkspaceHandlers({
         bots,
         emojiWeights,
         userPreferences,
+        sidebarConfig,
         dmPeers,
         labels,
         labelMemberships,
@@ -149,6 +153,7 @@ export function createWorkspaceHandlers({
         BotRepository.listVisibleTo(pool, workspaceId, userId),
         workspaceService.getEmojiWeights(workspaceId, userId),
         userPreferencesService.getPreferences(workspaceId, userId),
+        sidebarConfigService.getConfig(workspaceId, userId),
         streamService.listDmPeers(workspaceId, userId),
         labelService.listVisibleTo(workspaceId, userId),
         labelService.listMembershipsForUser(workspaceId, userId),
@@ -235,6 +240,7 @@ export function createWorkspaceHandlers({
           mutedStreamIds,
           dmPeers,
           userPreferences,
+          sidebarConfig,
           labels,
           labelMemberships,
           labelAssignments,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -7,6 +7,7 @@ import type {
   Memo as WireMemo,
   StreamEvent as WireStreamEvent,
   UserPreferences,
+  SidebarConfig,
   LastMessagePreview,
   Bot as WireBot,
   BotInvocationCapability,
@@ -58,6 +59,7 @@ export type OutboxEventType =
   | "agent_session:failed"
   | "agent_session:deleted"
   | "user_preferences:updated"
+  | "sidebar_config:updated"
   | "budget:alert"
   | "stream:member_joined"
   | "stream:member_added"
@@ -429,6 +431,12 @@ export interface UserPreferencesUpdatedOutboxPayload extends WorkspaceScopedPayl
   preferences: UserPreferences
 }
 
+// Sidebar config event payload (author-scoped - only visible to the user who updated)
+export interface SidebarConfigUpdatedOutboxPayload extends WorkspaceScopedPayload {
+  authorId: string
+  sidebarConfig: SidebarConfig
+}
+
 // Invitation event payloads
 export interface InvitationSentOutboxPayload extends WorkspaceScopedPayload {
   invitationId: string
@@ -682,6 +690,7 @@ export interface OutboxEventPayloadMap {
   "agent_session:failed": AgentSessionFailedOutboxPayload
   "agent_session:deleted": AgentSessionDeletedOutboxPayload
   "user_preferences:updated": UserPreferencesUpdatedOutboxPayload
+  "sidebar_config:updated": SidebarConfigUpdatedOutboxPayload
   "budget:alert": BudgetAlertOutboxPayload
   "invitation:sent": InvitationSentOutboxPayload
   "invitation:link-created": InvitationLinkCreatedOutboxPayload
@@ -783,6 +792,7 @@ export type AuthorScopedEventType =
   | "stream:read"
   | "stream:read_all"
   | "user_preferences:updated"
+  | "sidebar_config:updated"
   | "link_preview:dismissed"
 
 const AUTHOR_SCOPED_EVENTS: AuthorScopedEventType[] = [
@@ -790,6 +800,7 @@ const AUTHOR_SCOPED_EVENTS: AuthorScopedEventType[] = [
   "stream:read_all",
   "link_preview:dismissed",
   "user_preferences:updated",
+  "sidebar_config:updated",
 ]
 
 /**

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -22,6 +22,7 @@ import { createEmojiHandlers } from "./features/emoji"
 import { createConversationHandlers } from "./features/conversations"
 import { CommandAvailabilityService, createCommandHandlers } from "./features/commands"
 import { createUserPreferencesHandlers } from "./features/user-preferences"
+import { createSidebarConfigHandlers } from "./features/sidebar-config"
 import { createUserE2eKeysHandlers } from "./features/user-e2e-keys"
 import { createAIUsageHandlers } from "./features/ai-usage"
 import type { AI } from "@threa/agent-runtime"
@@ -68,6 +69,7 @@ import type { S3Config } from "./lib/env"
 import type { StorageProvider } from "./lib/storage/s3-client"
 import type { CommandRegistry } from "./features/commands"
 import type { UserPreferencesService } from "./features/user-preferences"
+import type { SidebarConfigService } from "./features/sidebar-config"
 import type { UserE2eKeysService } from "./features/user-e2e-keys"
 import type { AvatarService } from "./features/workspaces"
 import type { BotChannelService } from "./features/api-keys"
@@ -91,6 +93,7 @@ interface Dependencies {
   memoExplorerService: MemoExplorerService
   conversationService: ConversationService
   userPreferencesService: UserPreferencesService
+  sidebarConfigService: SidebarConfigService
   userE2eKeysService: UserE2eKeysService
   invitationService: InvitationService
   activityService: ActivityService
@@ -136,6 +139,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     memoExplorerService,
     conversationService,
     userPreferencesService,
+    sidebarConfigService,
     userE2eKeysService,
     invitationService,
     activityService,
@@ -187,6 +191,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workspaceService,
     streamService,
     userPreferencesService,
+    sidebarConfigService,
     invitationService,
     activityService,
     commandAvailabilityService,
@@ -218,6 +223,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const conversation = createConversationHandlers({ conversationService, streamService })
   const command = createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService })
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
+  const sidebarConfig = createSidebarConfigHandlers({ sidebarConfigService })
   const userE2eKeys = createUserE2eKeysHandlers({ userE2eKeysService })
   const aiUsage = createAIUsageHandlers({ pool })
   const debug = createDebugHandlers({ pool, poolMonitor })
@@ -300,6 +306,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // User preferences
   app.get("/api/workspaces/:workspaceId/preferences", ...authed, preferences.get)
   app.patch("/api/workspaces/:workspaceId/preferences", ...authed, preferences.update)
+
+  // Sidebar config (per-user, per-workspace layout)
+  app.get("/api/workspaces/:workspaceId/sidebar-config", ...authed, sidebarConfig.get)
+  app.patch("/api/workspaces/:workspaceId/sidebar-config", ...authed, sidebarConfig.update)
 
   // End-to-end encryption keys (Phase 0)
   // Server stores only ciphertext + public key. Body is the encrypted private

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -69,6 +69,7 @@ import {
   StubBoundaryExtractor,
 } from "./features/conversations"
 import { UserPreferencesService } from "./features/user-preferences"
+import { SidebarConfigService } from "./features/sidebar-config"
 import { UserE2eKeysService } from "./features/user-e2e-keys"
 import { createS3Storage } from "./lib/storage/s3-client"
 import {
@@ -257,6 +258,7 @@ export async function startServer(): Promise<ServerInstance> {
     : new StreamNamingService(pool, ai, configResolver, messageFormatter)
   const conversationService = new ConversationService(pool)
   const userPreferencesService = new UserPreferencesService(pool)
+  const sidebarConfigService = new SidebarConfigService(pool)
   const userE2eKeysService = new UserE2eKeysService(pool)
 
   // Search and embedding services
@@ -548,6 +550,7 @@ export async function startServer(): Promise<ServerInstance> {
     memoExplorerService,
     conversationService,
     userPreferencesService,
+    sidebarConfigService,
     userE2eKeysService,
     invitationService,
     activityService,

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./memos"
 export { conversationsApi, type ListConversationsParams } from "./conversations"
 export { preferencesApi } from "./preferences"
+export { sidebarConfigApi } from "./sidebar-config"
 export { aiUsageApi } from "./ai-usage"
 export { agentSessionsApi } from "./agent-sessions"
 export {

--- a/apps/frontend/src/api/sidebar-config.ts
+++ b/apps/frontend/src/api/sidebar-config.ts
@@ -1,0 +1,17 @@
+import { api } from "./client"
+import type { SidebarConfig } from "@threa/types"
+
+export const sidebarConfigApi = {
+  async get(workspaceId: string): Promise<SidebarConfig> {
+    const res = await api.get<{ sidebarConfig: SidebarConfig }>(`/api/workspaces/${workspaceId}/sidebar-config`)
+    return res.sidebarConfig
+  },
+
+  async update(workspaceId: string, config: SidebarConfig): Promise<SidebarConfig> {
+    const res = await api.patch<{ sidebarConfig: SidebarConfig }>(
+      `/api/workspaces/${workspaceId}/sidebar-config`,
+      config
+    )
+    return res.sidebarConfig
+  },
+}

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest"
-import { StreamTypes, Visibilities } from "@threa/types"
+import { StreamTypes, Visibilities, ALL_SIDEBAR_CONFIG, SMART_SIDEBAR_CONFIG } from "@threa/types"
 import { resolveSections, type ResolveSectionsInput } from "./resolve-sections"
-import { ALL_PRESET, SMART_PRESET } from "./sidebar-config"
 import type { SectionKey, StreamItemData, UrgencyLevel } from "./types"
 
 interface ItemOverrides {
@@ -42,7 +41,7 @@ function makeItem(overrides: ItemOverrides): StreamItemData {
 }
 
 /** Collapse the resolver output to a comparable shape: section id → item ids. */
-function shape(input: ResolveSectionsInput, preset = SMART_PRESET) {
+function shape(input: ResolveSectionsInput, preset = SMART_SIDEBAR_CONFIG) {
   return resolveSections(preset, input).map((resolved) => ({
     id: resolved.section.id,
     items: resolved.items.map((item) => item.id),
@@ -77,7 +76,7 @@ describe("resolveSections — Smart preset", () => {
     const processedStreams = Array.from({ length: 13 }, (_, i) =>
       makeItem({ id: `imp_${i}`, section: "important", urgency: "mentions", activity: i })
     )
-    const resolved = resolveSections(SMART_PRESET, {
+    const resolved = resolveSections(SMART_SIDEBAR_CONFIG, {
       processedStreams,
       virtualDmStreams: [],
       getUnreadCount: () => 1,
@@ -95,9 +94,11 @@ describe("resolveSections — Smart preset", () => {
       makeItem({ id: "r4", section: "recent", activity: 50 }),
     ]
     const getUnreadCount = unreadFrom(new Set(["u1", "u2"]))
-    const recent = resolveSections(SMART_PRESET, { processedStreams, virtualDmStreams: [], getUnreadCount }).find(
-      (r) => r.section.id === "recent"
-    )
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, {
+      processedStreams,
+      virtualDmStreams: [],
+      getUnreadCount,
+    }).find((r) => r.section.id === "recent")
     // 2 unreads + 3 reads = 5, dropping r4.
     expect(recent?.items.map((i) => i.id)).toEqual(["u1", "u2", "r1", "r2", "r3"])
   })
@@ -107,9 +108,11 @@ describe("resolveSections — Smart preset", () => {
       makeItem({ id: `u${i}`, section: "recent", activity: 100 - i })
     )
     const getUnreadCount = () => 1
-    const recent = resolveSections(SMART_PRESET, { processedStreams, virtualDmStreams: [], getUnreadCount }).find(
-      (r) => r.section.id === "recent"
-    )
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, {
+      processedStreams,
+      virtualDmStreams: [],
+      getUnreadCount,
+    }).find((r) => r.section.id === "recent")
     expect(recent?.items).toHaveLength(7)
   })
 })
@@ -127,7 +130,7 @@ describe("resolveSections — All preset", () => {
     ]
     const virtualDmStreams = [makeItem({ id: "vdm_1", type: StreamTypes.DM, activity: 0 })]
 
-    expect(shape({ processedStreams, virtualDmStreams, getUnreadCount: () => 0 }, ALL_PRESET)).toEqual([
+    expect(shape({ processedStreams, virtualDmStreams, getUnreadCount: () => 0 }, ALL_SIDEBAR_CONFIG)).toEqual([
       // Scratchpads by activity (most recent first).
       { id: "scratchpads", items: ["sp_1", "sp_2"] },
       // Channels alphabetically (no unreads to float).

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -1,34 +1,15 @@
 import type { StreamType } from "@threa/types"
-import type { CollapseState, ViewMode } from "@/contexts"
+import type { SidebarConfig, SidebarSection, SidebarSectionSpec, SidebarBasePreset } from "@threa/types"
+import type { CollapseState } from "@/contexts"
 import { SMART_SECTIONS } from "./config"
-import type { SectionKey } from "./types"
 
 /**
- * The sidebar is an ordered list of typed **sections**. Each section's `spec`
- * declares which streams it draws from; presentation (label, collapse style,
- * preview behavior) is derived from the spec at render time.
- *
- * Today the two view-mode presets (Smart / All) are the only shapes a config
- * can take. Persistence and a user-editable order land in a later step — this
- * module exists so rendering is already driven by a config object rather than a
- * `viewMode` branch.
+ * The sidebar renders an ordered list of typed **sections** described by a
+ * {@link SidebarConfig} (the persisted wire contract lives in `@threa/types`).
+ * This module adds the purely-presentational layer on top: how each section's
+ * `spec` maps to a label, icon, and collapse behavior at render time.
  */
-export type SidebarSectionSpec =
-  | { kind: "smart"; bucket: SectionKey }
-  | { kind: "type"; streamType: Extract<StreamType, "scratchpad" | "channel" | "dm"> }
-
-export interface SidebarSection {
-  /** Stable key — also the collapse-state persistence key (see SidebarProvider). */
-  id: string
-  spec: SidebarSectionSpec
-}
-
-export type SidebarBasePreset = "smart" | "all"
-
-export interface SidebarConfig {
-  basePreset: SidebarBasePreset
-  sections: SidebarSection[]
-}
+export type { SidebarConfig, SidebarSection, SidebarSectionSpec, SidebarBasePreset }
 
 /** How a resolved section renders. Derived purely from its spec. */
 export interface SectionPresentation {
@@ -88,28 +69,4 @@ export function sectionPresentation(spec: SidebarSectionSpec): SectionPresentati
     hideWhenEmpty: true,
     defaultCollapse: spec.bucket === "other" ? "collapsed" : "open",
   }
-}
-
-/** Section ids double as collapse-state keys, so they must match prior keys. */
-export const SMART_PRESET: SidebarConfig = {
-  basePreset: "smart",
-  sections: [
-    { id: "important", spec: { kind: "smart", bucket: "important" } },
-    { id: "recent", spec: { kind: "smart", bucket: "recent" } },
-    { id: "pinned", spec: { kind: "smart", bucket: "pinned" } },
-    { id: "other", spec: { kind: "smart", bucket: "other" } },
-  ],
-}
-
-export const ALL_PRESET: SidebarConfig = {
-  basePreset: "all",
-  sections: [
-    { id: "scratchpads", spec: { kind: "type", streamType: "scratchpad" } },
-    { id: "channels", spec: { kind: "type", streamType: "channel" } },
-    { id: "dms", spec: { kind: "type", streamType: "dm" } },
-  ],
-}
-
-export function presetForViewMode(viewMode: ViewMode): SidebarConfig {
-  return viewMode === "all" ? ALL_PRESET : SMART_PRESET
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
@@ -1,6 +1,7 @@
 import { Search as SearchIcon, Terminal, FileText } from "lucide-react"
 import { Link } from "react-router-dom"
-import { useQuickSwitcher, usePreferences, type ViewMode } from "@/contexts"
+import type { SidebarBasePreset } from "@threa/types"
+import { useQuickSwitcher, usePreferences } from "@/contexts"
 import { useSidebar } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { ThemeDropdown } from "@/components/theme-dropdown"
@@ -11,13 +12,13 @@ import { getEffectiveKeyBinding, formatKeyBinding, formatKeyBindingText } from "
 
 interface SidebarHeaderProps {
   workspaceName: string
-  viewMode: ViewMode
-  onViewModeChange: (mode: ViewMode) => void
+  basePreset: SidebarBasePreset
+  onBasePresetChange: (preset: SidebarBasePreset) => void
   /** Hide the view toggle (e.g., when no streams exist) */
   hideViewToggle?: boolean
 }
 
-export function SidebarHeader({ workspaceName, viewMode, onViewModeChange, hideViewToggle }: SidebarHeaderProps) {
+export function SidebarHeader({ workspaceName, basePreset, onBasePresetChange, hideViewToggle }: SidebarHeaderProps) {
   const { openSwitcher } = useQuickSwitcher()
   const { collapseOnMobile } = useSidebar()
   const { preferences } = usePreferences()
@@ -79,19 +80,19 @@ export function SidebarHeader({ workspaceName, viewMode, onViewModeChange, hideV
         <div className="flex items-center gap-2 px-3 pb-3 pt-2">
           <div className="flex gap-1 rounded-md bg-muted p-0.5">
             <button
-              onClick={() => onViewModeChange("smart")}
+              onClick={() => onBasePresetChange("smart")}
               className={cn(
                 "rounded px-2 py-1 text-xs font-medium transition-all",
-                viewMode === "smart" ? "bg-card text-primary" : "text-muted-foreground hover:text-foreground"
+                basePreset === "smart" ? "bg-card text-primary" : "text-muted-foreground hover:text-foreground"
               )}
             >
               Smart
             </button>
             <button
-              onClick={() => onViewModeChange("all")}
+              onClick={() => onBasePresetChange("all")}
               className={cn(
                 "rounded px-2 py-1 text-xs font-medium transition-all",
-                viewMode === "all" ? "bg-card text-primary" : "text-muted-foreground hover:text-foreground"
+                basePreset === "all" ? "bg-card text-primary" : "text-muted-foreground hover:text-foreground"
               )}
             >
               All

--- a/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
@@ -80,6 +80,8 @@ export function SidebarHeader({ workspaceName, basePreset, onBasePresetChange, h
         <div className="flex items-center gap-2 px-3 pb-3 pt-2">
           <div className="flex gap-1 rounded-md bg-muted p-0.5">
             <button
+              type="button"
+              aria-pressed={basePreset === "smart"}
               onClick={() => onBasePresetChange("smart")}
               className={cn(
                 "rounded px-2 py-1 text-xs font-medium transition-all",
@@ -89,6 +91,8 @@ export function SidebarHeader({ workspaceName, basePreset, onBasePresetChange, h
               Smart
             </button>
             <button
+              type="button"
+              aria-pressed={basePreset === "all"}
               onClick={() => onBasePresetChange("all")}
               className={cn(
                 "rounded px-2 py-1 text-xs font-medium transition-all",

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   useDraftScratchpads,
   useLiveSavedCount,
   useLiveScheduledCount,
+  useSidebarConfig,
   useUnreadCounts,
 } from "@/hooks"
 import { useSyncStatus } from "@/sync/sync-status"
@@ -32,7 +33,6 @@ import { SidebarQuickLinks } from "./quick-links"
 import { SidebarStreamList } from "./sidebar-stream-list"
 import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skeletons"
 import { SidebarFooter } from "./sidebar-footer"
-import { presetForViewMode } from "./sidebar-config"
 import { resolveSections } from "./resolve-sections"
 import type { SidebarActionItem } from "./sidebar-actions"
 import { calculateUrgency, categorizeStream } from "./utils"
@@ -46,15 +46,9 @@ interface SidebarProps {
 
 export function Sidebar({ workspaceId }: SidebarProps) {
   const { phase } = useCoordinatedLoading()
-  const {
-    viewMode,
-    setViewMode,
-    getSectionState,
-    toggleSectionState,
-    setSidebarHeight,
-    setScrollContainerOffset,
-    collapseOnMobile,
-  } = useSidebar()
+  const { getSectionState, toggleSectionState, setSidebarHeight, setScrollContainerOffset, collapseOnMobile } =
+    useSidebar()
+  const { config: sidebarConfig, setBasePreset } = useSidebarConfig(workspaceId)
   const { streamId: activeStreamId, "*": splat } = useParams<{ streamId: string; "*": string }>()
   const location = useLocation()
   const syncStatus = useSyncStatus(`workspace:${workspaceId}`)
@@ -188,10 +182,10 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   const hasUserStreams = hasUserStreamsFromStreams || virtualDmStreams.length > 0
 
-  // Resolve the active view's preset config into ordered, sorted, capped lists.
+  // Resolve the persisted sidebar config into ordered, sorted, capped lists.
   const resolvedSections = useMemo(
-    () => resolveSections(presetForViewMode(viewMode), { processedStreams, virtualDmStreams, getUnreadCount }),
-    [viewMode, processedStreams, virtualDmStreams, getUnreadCount]
+    () => resolveSections(sidebarConfig, { processedStreams, virtualDmStreams, getUnreadCount }),
+    [sidebarConfig, processedStreams, virtualDmStreams, getUnreadCount]
   )
 
   // Track sidebar and scroll container dimensions for position calculations
@@ -317,8 +311,8 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       header={
         <SidebarHeader
           workspaceName={workspace?.name ?? ""}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
+          basePreset={sidebarConfig.basePreset}
+          onBasePresetChange={setBasePreset}
           hideViewToggle={!hasUserStreams}
         />
       }

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -1,13 +1,17 @@
-import type { StreamWithPreview } from "@threa/types"
+import type { StreamWithPreview, SidebarSectionKey } from "@threa/types"
 
 export type UrgencyLevel = "mentions" | "activity" | "quiet" | "ai"
 
 /** Sorting strategies for sidebar sections */
 export type SortType = "activity" | "importance" | "alphabetic_active_first"
 
-export const SMART_SECTION_KEYS = ["important", "recent", "pinned", "other"] as const
-
-export type SectionKey = (typeof SMART_SECTION_KEYS)[number]
+/**
+ * Smart-view bucket a stream is categorized into. The canonical list of keys
+ * lives in `@threa/types` (`SIDEBAR_SECTION_KEYS`) since it's also the persisted
+ * wire shape; this is the same domain value, so we derive from it rather than
+ * re-declaring the literal union and risking drift.
+ */
+export type SectionKey = SidebarSectionKey
 
 export interface StreamItemData extends StreamWithPreview {
   urgency: UrgencyLevel

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -43,7 +43,7 @@ export {
   type CoordinatedPhase,
   type StreamState,
 } from "./coordinated-loading-context"
-export { SidebarProvider, useSidebar, type ViewMode, type UrgencyBlock, type CollapseState } from "./sidebar-context"
+export { SidebarProvider, useSidebar, type UrgencyBlock, type CollapseState } from "./sidebar-context"
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
 export { DictationCoordinatorProvider, useDictationCoordinator } from "./dictation-coordinator-context"

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -13,8 +13,6 @@ type SidebarState = "collapsed" | "preview" | "pinned"
 /** Simplified open state for persistence (preview is transient) */
 type SidebarOpenState = "open" | "collapsed"
 
-type ViewMode = "smart" | "all"
-
 /**
  * Binary open/collapsed state for a collapsible sidebar section.
  * Sections with activity still surface an aggregate badge when collapsed so
@@ -38,7 +36,6 @@ interface UrgencyBlock {
 interface SidebarPersistedState {
   openState: SidebarOpenState
   width: number
-  viewMode: ViewMode
   /** Per-section open/collapsed state. Absent keys fall back to per-section defaults at the callsite. */
   sectionStates: Record<string, CollapseState>
 }
@@ -51,7 +48,6 @@ const SIDEBAR_STATE_KEY = "threa-sidebar-state"
 const DEFAULT_PERSISTED_STATE: SidebarPersistedState = {
   openState: "open",
   width: DEFAULT_SIDEBAR_WIDTH,
-  viewMode: "smart",
   sectionStates: {
     "quick-links": "open",
     other: "collapsed",
@@ -63,8 +59,6 @@ interface SidebarContextValue {
   state: SidebarState
   /** Current sidebar width in pixels */
   width: number
-  /** Current view mode (smart/all) */
-  viewMode: ViewMode
   /** Open/collapsed state per section key. Use `getSectionState` for reads with defaults. */
   sectionStates: Record<string, CollapseState>
   /** Read a section's state, falling back to the provided default (default: "open"). */
@@ -99,8 +93,6 @@ interface SidebarContextValue {
   stopResizing: () => void
   /** Set sidebar width */
   setWidth: (width: number) => void
-  /** Set view mode */
-  setViewMode: (mode: ViewMode) => void
   /**
    * Flip a section between open and collapsed.
    * If no state has been stored yet, flips from `defaultState` (default: "open").
@@ -178,7 +170,6 @@ function getStoredState(key: string): SidebarPersistedState {
           typeof parsed.width === "number" && parsed.width >= MIN_SIDEBAR_WIDTH && parsed.width <= MAX_SIDEBAR_WIDTH
             ? parsed.width
             : DEFAULT_PERSISTED_STATE.width,
-        viewMode: parsed.viewMode === "all" ? "all" : "smart",
         sectionStates: readSectionStates(parsed),
       }
     }
@@ -385,14 +376,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     [updatePersistedState]
   )
 
-  // View mode
-  const setViewMode = useCallback(
-    (mode: ViewMode) => {
-      updatePersistedState({ viewMode: mode })
-    },
-    [updatePersistedState]
-  )
-
   const getSectionState = useCallback(
     (section: string, defaultState: CollapseState = "open"): CollapseState => {
       return persistedState.sectionStates[section] ?? defaultState
@@ -490,7 +473,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       value={{
         state,
         width: persistedState.width,
-        viewMode: persistedState.viewMode,
         sectionStates: persistedState.sectionStates,
         getSectionState,
         isMobile,
@@ -508,7 +490,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
         startResizing,
         stopResizing,
         setWidth,
-        setViewMode,
         toggleSectionState,
         setSectionState,
         setUrgencyBlock,
@@ -530,4 +511,4 @@ export function useSidebar() {
   return context
 }
 
-export type { ViewMode, UrgencyBlock, CollapseState }
+export type { UrgencyBlock, CollapseState }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -6,6 +6,7 @@ import type {
   EventType,
   JSONContent,
   NotificationLevel,
+  SidebarConfig,
   StreamContextBagPayload,
   StreamType,
   WorkspaceRoleSlug,
@@ -352,6 +353,13 @@ export interface CachedUserPreferences {
   _cachedAt: number
 }
 
+export interface CachedSidebarConfig {
+  id: string // workspaceId
+  workspaceId: string
+  config: SidebarConfig
+  _cachedAt: number
+}
+
 /**
  * Persisted UI toggle state for a single collapsible markdown block inside
  * a message (code block, blockquote, or quote reply). Scoped per message so
@@ -636,6 +644,7 @@ export class ThreaDatabase extends Dexie {
   labelMemberships!: EntityTable<CachedLabelMembership, "id">
   labelAssignments!: EntityTable<CachedLabelAssignment, "id">
   e2eDeviceKeys!: EntityTable<CachedE2eDeviceKey, "id">
+  sidebarConfigs!: EntityTable<CachedSidebarConfig, "id">
 
   constructor(name: string) {
     super(name)
@@ -925,6 +934,12 @@ export class ThreaDatabase extends Dexie {
       labelAssignments: "id, workspaceId, labelId, _cachedAt",
     })
 
+    // v33: Per-(workspace, user) sidebar layout for offline-first reads. One row
+    // per workspace (keyed by workspaceId), mirroring userPreferences.
+    this.version(33).stores({
+      sidebarConfigs: "id, workspaceId",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -989,6 +1004,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.labels.clear(),
       db.labelMemberships.clear(),
       db.labelAssignments.clear(),
+      db.sidebarConfigs.clear(),
       // The persisted device key IS the unwrapped (non-extractable) private
       // key — sign-out must drop it so the next account can't resume this
       // identity's unlocked session.

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -10,6 +10,7 @@ export type {
   CachedBot,
   CachedUnreadState,
   CachedUserPreferences,
+  CachedSidebarConfig,
   CachedWorkspaceMetadata,
   PendingOperation,
   PendingMessage,

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -29,6 +29,8 @@ export {
 
 export { useEvents, eventKeys } from "./use-events"
 
+export { useSidebarConfig } from "./use-sidebar-config"
+
 export { useDraftScratchpads } from "./use-draft-scratchpads"
 
 export {

--- a/apps/frontend/src/hooks/use-sidebar-config.ts
+++ b/apps/frontend/src/hooks/use-sidebar-config.ts
@@ -1,0 +1,68 @@
+import { useCallback } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import {
+  type SidebarConfig,
+  type SidebarBasePreset,
+  type WorkspaceBootstrap,
+  DEFAULT_SIDEBAR_CONFIG,
+  sidebarConfigForPreset,
+} from "@threa/types"
+import { sidebarConfigApi } from "@/api"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useWorkspaceSidebarConfig } from "@/stores/workspace-store"
+import { db } from "@/db"
+
+/**
+ * Read + write the viewer's persisted sidebar layout for a workspace. Reads come
+ * from the IDB-backed store (instant + offline, like every other sidebar entity)
+ * and fall back to the default config; writes optimistically update both the
+ * bootstrap query cache and IDB, then persist server-side. The server broadcasts
+ * a `sidebar_config:updated` event so the user's other devices converge.
+ */
+export function useSidebarConfig(workspaceId: string) {
+  const queryClient = useQueryClient()
+  const cached = useWorkspaceSidebarConfig(workspaceId)
+  const config = cached?.config ?? DEFAULT_SIDEBAR_CONFIG
+
+  const mutation = useMutation({
+    mutationFn: (next: SidebarConfig) => sidebarConfigApi.update(workspaceId, next),
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) })
+      const previousBootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
+
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
+        old ? { ...old, sidebarConfig: next } : old
+      )
+      // Write to IDB immediately so the live-query consumers reflect the change
+      // without waiting for the socket round-trip.
+      db.sidebarConfigs.put({ id: workspaceId, workspaceId, config: next, _cachedAt: Date.now() })
+
+      return { previousBootstrap, previousConfig: cached }
+    },
+    onError: (_err, _next, context) => {
+      if (context?.previousBootstrap) {
+        queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), context.previousBootstrap)
+      }
+      if (context?.previousConfig) {
+        db.sidebarConfigs.put(context.previousConfig)
+      } else {
+        db.sidebarConfigs.delete(workspaceId)
+      }
+      toast.error("Failed to save sidebar layout")
+    },
+    onSuccess: (saved) => {
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
+        old ? { ...old, sidebarConfig: saved } : old
+      )
+    },
+  })
+
+  const setConfig = useCallback((next: SidebarConfig) => mutation.mutate(next), [mutation])
+  const setBasePreset = useCallback(
+    (preset: SidebarBasePreset) => mutation.mutate(sidebarConfigForPreset(preset)),
+    [mutation]
+  )
+
+  return { config, setConfig, setBasePreset, isSaving: mutation.isPending }
+}

--- a/apps/frontend/src/hooks/use-sidebar-config.ts
+++ b/apps/frontend/src/hooks/use-sidebar-config.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
@@ -22,12 +22,17 @@ import { db } from "@/db"
  */
 export function useSidebarConfig(workspaceId: string) {
   const queryClient = useQueryClient()
+  // Monotonic id so a slow earlier write can't clobber a newer choice when
+  // rapid Smart↔All toggles settle out of order — only the latest mutation's
+  // settlement is allowed to touch the cache / rollback.
+  const latestMutationIdRef = useRef(0)
   const cached = useWorkspaceSidebarConfig(workspaceId)
   const config = cached?.config ?? DEFAULT_SIDEBAR_CONFIG
 
   const mutation = useMutation({
     mutationFn: (next: SidebarConfig) => sidebarConfigApi.update(workspaceId, next),
     onMutate: async (next) => {
+      const mutationId = ++latestMutationIdRef.current
       await queryClient.cancelQueries({ queryKey: workspaceKeys.bootstrap(workspaceId) })
       const previousBootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
 
@@ -38,20 +43,24 @@ export function useSidebarConfig(workspaceId: string) {
       // without waiting for the socket round-trip.
       db.sidebarConfigs.put({ id: workspaceId, workspaceId, config: next, _cachedAt: Date.now() })
 
-      return { previousBootstrap, previousConfig: cached }
+      return { previousBootstrap, previousConfig: cached, mutationId }
     },
     onError: (_err, _next, context) => {
-      if (context?.previousBootstrap) {
+      // Ignore a stale failure once a newer toggle has superseded it.
+      if (!context || context.mutationId !== latestMutationIdRef.current) return
+      if (context.previousBootstrap) {
         queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), context.previousBootstrap)
       }
-      if (context?.previousConfig) {
+      if (context.previousConfig) {
         db.sidebarConfigs.put(context.previousConfig)
       } else {
         db.sidebarConfigs.delete(workspaceId)
       }
       toast.error("Failed to save sidebar layout")
     },
-    onSuccess: (saved) => {
+    onSuccess: (saved, _next, context) => {
+      // Ignore a stale success that resolved after a newer toggle.
+      if (!context || context.mutationId !== latestMutationIdRef.current) return
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
         old ? { ...old, sidebarConfig: saved } : old
       )

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
 import type { CreateStreamInput } from "@/api"
-import type { Stream, WorkspaceBootstrap } from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, type Stream, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useCreateStream } from "./use-streams"
 import * as syncEngineModule from "@/sync/sync-engine"
@@ -58,6 +58,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
     labelMemberships: [],
     labelAssignments: [],
     viewerPermissions: [],
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       workspaceId: "ws_1",
       userId: "member_1",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -4,7 +4,7 @@ import { createElement, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
-import type { StreamMember, WorkspaceBootstrap } from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, type StreamMember, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
@@ -66,6 +66,7 @@ function makeBootstrap(): WorkspaceBootstrap {
     labelMemberships: [],
     labelAssignments: [],
     viewerPermissions: [],
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       workspaceId: "ws_1",
       userId: "member_1",

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -14,6 +14,7 @@ import {
   type CachedLabelAssignment,
   type CachedUnreadState,
   type CachedUserPreferences,
+  type CachedSidebarConfig,
   type CachedWorkspaceMetadata,
 } from "@/db"
 
@@ -41,6 +42,7 @@ const cache = {
   labelAssignments: new Map<string, CachedLabelAssignment[]>(),
   unreadState: new Map<string, CachedUnreadState>(),
   userPreferences: new Map<string, CachedUserPreferences>(),
+  sidebarConfig: new Map<string, CachedSidebarConfig>(),
   metadata: new Map<string, CachedWorkspaceMetadata>(),
 }
 
@@ -115,6 +117,7 @@ export function resetWorkspaceStoreCache(): void {
   cache.labelAssignments.clear()
   cache.unreadState.clear()
   cache.userPreferences.clear()
+  cache.sidebarConfig.clear()
   cache.metadata.clear()
   cacheVersion.clear()
   for (const workspaceId of workspaceIds) {
@@ -148,6 +151,7 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     labelAssignments,
     unreadState,
     prefs,
+    sidebarConfig,
     metadata,
   ] = await Promise.all([
     db.workspaces.get(workspaceId),
@@ -162,6 +166,7 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
     db.unreadState.get(workspaceId),
     db.userPreferences.get(workspaceId),
+    db.sidebarConfigs.get(workspaceId),
     db.workspaceMetadata.get(workspaceId),
   ])
 
@@ -184,6 +189,7 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     labelAssignments,
     unreadState,
     userPreferences: prefs,
+    sidebarConfig,
     metadata,
   })
 
@@ -209,6 +215,7 @@ export function seedWorkspaceCache(
     labelAssignments?: CachedLabelAssignment[]
     unreadState?: CachedUnreadState
     userPreferences?: CachedUserPreferences
+    sidebarConfig?: CachedSidebarConfig
     metadata?: CachedWorkspaceMetadata
   }
 ): void {
@@ -226,6 +233,7 @@ export function seedWorkspaceCache(
   if (data.labelAssignments) cache.labelAssignments.set(workspaceId, data.labelAssignments)
   if (data.unreadState) cache.unreadState.set(workspaceId, data.unreadState)
   if (data.userPreferences) cache.userPreferences.set(workspaceId, data.userPreferences)
+  if (data.sidebarConfig) cache.sidebarConfig.set(workspaceId, data.sidebarConfig)
   if (data.metadata) cache.metadata.set(workspaceId, data.metadata)
   emitWorkspaceCacheChange(workspaceId)
 }
@@ -369,6 +377,16 @@ export function useWorkspaceUserPreferences(workspaceId: string | undefined): Ca
   const cached = workspaceId ? cache.userPreferences.get(workspaceId) : undefined
   return useSingletonStoreHook(
     () => (workspaceId ? db.userPreferences.get(workspaceId) : undefined),
+    [workspaceId],
+    cached
+  )
+}
+
+export function useWorkspaceSidebarConfig(workspaceId: string | undefined): CachedSidebarConfig | undefined {
+  useWorkspaceCacheSignal(workspaceId)
+  const cached = workspaceId ? cache.sidebarConfig.get(workspaceId) : undefined
+  return useSingletonStoreHook(
+    () => (workspaceId ? db.sidebarConfigs.get(workspaceId) : undefined),
     [workspaceId],
     cached
   )

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -4,7 +4,12 @@ import { QueryClient } from "@tanstack/react-query"
 import { SyncEngine } from "./sync-engine"
 import { SyncStatusStore } from "./sync-status"
 import { db } from "@/db"
-import { DEFAULT_USER_PREFERENCES, type WorkspaceBootstrap, type StreamBootstrap } from "@threa/types"
+import {
+  DEFAULT_USER_PREFERENCES,
+  DEFAULT_SIDEBAR_CONFIG,
+  type WorkspaceBootstrap,
+  type StreamBootstrap,
+} from "@threa/types"
 
 type EventHandler = (...args: unknown[]) => void
 
@@ -106,6 +111,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
     labelMemberships: [],
     labelAssignments: [],
     viewerPermissions: [],
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       ...DEFAULT_USER_PREFERENCES,
       workspaceId: "ws_1",

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -7,7 +7,7 @@ import {
   mergeReconnectWorkspaceBootstrap,
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
-import type { StreamBootstrap, WorkspaceBootstrap } from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, type StreamBootstrap, type WorkspaceBootstrap } from "@threa/types"
 import type { Socket } from "socket.io-client"
 
 function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
@@ -37,6 +37,7 @@ function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBo
     activityCounts: {},
     unreadActivityCount: 0,
     mutedStreamIds: [],
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
     userPreferences: {
       workspaceId: "ws_1",
       userId: "user_1",
@@ -192,6 +193,25 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     // Socket-handler stream MUST survive — _cachedAt > fetchStartedAt
     expect(await db.streams.get("stream_socket")).toBeDefined()
+  })
+
+  it("persists the bootstrap sidebar config to IDB", async () => {
+    await applyWorkspaceBootstrap(
+      "ws_1",
+      makeBootstrap({
+        sidebarConfig: {
+          basePreset: "all",
+          sections: [{ id: "channels", spec: { kind: "type", streamType: "channel" } }],
+        },
+      }),
+      Date.now()
+    )
+
+    const stored = await db.sidebarConfigs.get("ws_1")
+    expect(stored?.config).toEqual({
+      basePreset: "all",
+      sections: [{ id: "channels", spec: { kind: "type", streamType: "channel" } }],
+    })
   })
 
   it("removes stale users not in bootstrap", async () => {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -104,6 +104,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       db.bots.clear(),
       db.unreadState.clear(),
       db.userPreferences.clear(),
+      db.sidebarConfigs.clear(),
       db.workspaceMetadata.clear(),
     ])
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -14,6 +14,7 @@ import type {
   WorkspaceBootstrap,
   StreamMember,
   UserPreferences,
+  SidebarConfig,
   LastMessagePreview,
   ActivityCreatedPayload,
   SavedUpsertedPayload,
@@ -111,6 +112,12 @@ interface UserPreferencesUpdatedPayload {
   workspaceId: string
   authorId: string
   preferences: UserPreferences
+}
+
+interface SidebarConfigUpdatedPayload {
+  workspaceId: string
+  authorId: string
+  sidebarConfig: SidebarConfig
 }
 
 // ============================================================================
@@ -1155,6 +1162,24 @@ export function registerWorkspaceSocketHandlers(
     })
   }
 
+  // Handle sidebar config updated (from other sessions of the same user)
+  const handleSidebarConfigUpdated = (payload: SidebarConfigUpdatedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+
+    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+      if (!old) return old
+      return { ...old, sidebarConfig: payload.sidebarConfig }
+    })
+
+    // Write to IDB so the IDB-backed sidebar store hook reacts immediately.
+    db.sidebarConfigs.put({
+      id: workspaceId,
+      workspaceId,
+      config: payload.sidebarConfig,
+      _cachedAt: Date.now(),
+    })
+  }
+
   // Handle bot created
   const handleBotCreated = (payload: { workspaceId: string; bot: Bot }) => {
     if (payload.workspaceId !== workspaceId) return
@@ -1555,6 +1580,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("stream:member_added", handleStreamMemberAdded)
   socket.on("stream:member_removed", handleStreamMemberRemoved)
   socket.on("user_preferences:updated", handleUserPreferencesUpdated)
+  socket.on("sidebar_config:updated", handleSidebarConfigUpdated)
   socket.on("bot:created", handleBotCreated)
   socket.on("bot:updated", handleBotUpdated)
   socket.on("activity:created", handleActivityCreated)
@@ -1592,6 +1618,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("stream:member_added", handleStreamMemberAdded)
     socket.off("stream:member_removed", handleStreamMemberRemoved)
     socket.off("user_preferences:updated", handleUserPreferencesUpdated)
+    socket.off("sidebar_config:updated", handleSidebarConfigUpdated)
     socket.off("bot:created", handleBotCreated)
     socket.off("bot:updated", handleBotUpdated)
     socket.off("activity:created", handleActivityCreated)
@@ -1725,6 +1752,17 @@ export async function applyWorkspaceBootstrap(
         })
       }
     }),
+    db.transaction("rw", [db.sidebarConfigs], async () => {
+      const existing = await db.sidebarConfigs.get(workspaceId)
+      if (!existing || !fetchStartedAt || existing._cachedAt < fetchStartedAt) {
+        await db.sidebarConfigs.put({
+          id: workspaceId,
+          workspaceId,
+          config: bootstrap.sidebarConfig,
+          _cachedAt: now,
+        })
+      }
+    }),
     db.workspaceMetadata.put({
       id: workspaceId,
       workspaceId,
@@ -1801,6 +1839,12 @@ export async function applyWorkspaceBootstrap(
       sendMode: bootstrap.userPreferences.messageSendMode,
       _cachedAt: now,
     },
+    sidebarConfig: {
+      id: workspaceId,
+      workspaceId,
+      config: bootstrap.sidebarConfig,
+      _cachedAt: now,
+    },
     metadata: {
       id: workspaceId,
       workspaceId,
@@ -1859,6 +1903,7 @@ export async function applyReconnectBootstrapBatch(
       db.labelAssignments,
       db.unreadState,
       db.userPreferences,
+      db.sidebarConfigs,
       db.workspaceMetadata,
       db.events,
       db.pendingMessages,
@@ -1944,6 +1989,16 @@ export async function applyReconnectBootstrapBatch(
         })
       }
 
+      const existingSidebarConfig = await db.sidebarConfigs.get(workspaceId)
+      if (!existingSidebarConfig || !fetchStartedAt || existingSidebarConfig._cachedAt < fetchStartedAt) {
+        await db.sidebarConfigs.put({
+          id: workspaceId,
+          workspaceId,
+          config: finalBootstrap.sidebarConfig,
+          _cachedAt: now,
+        })
+      }
+
       for (const [streamId, bootstrap] of streamBootstraps) {
         await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now)
       }
@@ -2010,6 +2065,12 @@ export async function applyReconnectBootstrapBatch(
       id: workspaceId,
       workspaceId,
       sendMode: finalBootstrap.userPreferences.messageSendMode,
+      _cachedAt: now,
+    },
+    sidebarConfig: {
+      id: workspaceId,
+      workspaceId,
+      config: finalBootstrap.sidebarConfig,
       _cachedAt: now,
     },
     metadata: {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1673,6 +1673,12 @@ export async function applyWorkspaceBootstrap(
   const existingStreams = await db.streams.where("workspaceId").equals(workspaceId).toArray()
   const existingByStreamId = new Map(existingStreams.map((s) => [s.id, s]))
 
+  // Effective sidebar config for the in-memory seed below. If a newer
+  // `sidebar_config:updated` landed during the fetch window we keep the local
+  // row (the IDB write is skipped) and must seed that value, not the older
+  // snapshot, so the in-memory cache doesn't briefly regress to the old preset.
+  let effectiveSidebarConfig = bootstrap.sidebarConfig
+
   await Promise.all([
     db.workspaces.put({ ...bootstrap.workspace, _cachedAt: now }),
     db.workspaceUsers.bulkPut(bootstrap.users.map((u) => ({ ...u, _cachedAt: now }))),
@@ -1761,6 +1767,8 @@ export async function applyWorkspaceBootstrap(
           config: bootstrap.sidebarConfig,
           _cachedAt: now,
         })
+      } else {
+        effectiveSidebarConfig = existing.config
       }
     }),
     db.workspaceMetadata.put({
@@ -1842,7 +1850,7 @@ export async function applyWorkspaceBootstrap(
     sidebarConfig: {
       id: workspaceId,
       workspaceId,
-      config: bootstrap.sidebarConfig,
+      config: effectiveSidebarConfig,
       _cachedAt: now,
     },
     metadata: {
@@ -1887,6 +1895,11 @@ export async function applyReconnectBootstrapBatch(
   })
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
+
+  // See applyWorkspaceBootstrap: preserve a sidebar config written by a
+  // `sidebar_config:updated` event during the fetch window rather than seeding
+  // (and returning) the older snapshot.
+  let effectiveSidebarConfig = finalBootstrap.sidebarConfig
 
   await db.transaction(
     "rw",
@@ -1997,6 +2010,8 @@ export async function applyReconnectBootstrapBatch(
           config: finalBootstrap.sidebarConfig,
           _cachedAt: now,
         })
+      } else {
+        effectiveSidebarConfig = existingSidebarConfig.config
       }
 
       for (const [streamId, bootstrap] of streamBootstraps) {
@@ -2070,7 +2085,7 @@ export async function applyReconnectBootstrapBatch(
     sidebarConfig: {
       id: workspaceId,
       workspaceId,
-      config: finalBootstrap.sidebarConfig,
+      config: effectiveSidebarConfig,
       _cachedAt: now,
     },
     metadata: {
@@ -2082,6 +2097,11 @@ export async function applyReconnectBootstrapBatch(
       _cachedAt: now,
     },
   })
+
+  // The returned bootstrap is written to the bootstrap query cache by the
+  // caller; reflect the preserved local config so it doesn't carry the stale
+  // snapshot value.
+  finalBootstrap.sidebarConfig = effectiveSidebarConfig
 
   return { workspaceBootstrap: finalBootstrap, streamBootstraps }
 }

--- a/docs/plans/configurable-sidebar-and-visible-labels.md
+++ b/docs/plans/configurable-sidebar-and-visible-labels.md
@@ -103,12 +103,27 @@ either now would be speculative (INV-36). Smart's "Everything Else" is modeled a
 Recent vanish today, they do not fall through). `hideAboveShown` + `remainder`
 land in **PR4**, where additive label lenses are the first thing to exercise them.
 
-### PR2 — Sidebar editor + config persistence
+### PR2 — Config persistence (Smart/All toggle as the writer) ✅ implemented
 
-Backend per-user config (table + types + bootstrap field + sync events + API),
-plus the editor: inline add/remove and a "Sidebar" settings panel
-(drag-reorder, add/remove kinds, reset-to-preset). Existing users' configs
-seeded server-side from their last preset on first read.
+Shipped the full per-user persistence vertical slice: shared `SidebarConfig`
+wire type in `@threa/types`, `sidebar_configs` table (one JSONB document per
+(workspace, user), absent row → default Smart preset), backend feature folder
+(`apps/backend/src/features/sidebar-config/`: repository + service +
+Zod-validated handlers), `sidebar_config:updated` author-scoped outbox event,
+`WorkspaceBootstrap.sidebarConfig`, GET/PATCH routes, and the frontend offline
+mirror (Dexie `sidebarConfigs` table, store seed + `useWorkspaceSidebarConfig`,
+sync handler + socket registration, `sidebarConfigApi`, `useSidebarConfig` with
+optimistic write). The existing Smart/All toggle now persists the full config
+server-side and syncs across devices; `viewMode` was removed from the
+localStorage `SidebarProvider` (config is now the source of truth; collapse
+states stay device-local).
+
+**Deviation:** the rich editor (drag-reorder, inline add/remove kinds, a
+"Sidebar" settings panel, reset-to-preset) is deferred to a later stacked PR —
+it earns its place once PR4's label sections give a reason to reorder/add
+sections. Persisting from the toggle keeps PR2 a reviewable slice and avoids a
+speculative editor (INV-36). Existing users seed to the Smart preset on first
+read rather than migrating their prior localStorage `viewMode`.
 
 ### PR3 — Label model: unified membership + lifecycle
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -34,6 +34,7 @@ import type {
   Bot,
 } from "./domain"
 import type { UserPreferences } from "./preferences"
+import type { SidebarConfig } from "./sidebar"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
 
 // ============================================================================
@@ -568,6 +569,8 @@ export interface WorkspaceBootstrap {
   unreadActivityCount: number
   mutedStreamIds: string[]
   userPreferences: UserPreferences
+  /** Viewer's persisted sidebar layout for this workspace (defaults to the Smart preset). */
+  sidebarConfig: SidebarConfig
   /**
    * Labels visible to the viewer: all of the viewer's own private labels +
    * every public label in the workspace (joined or not — the Discover tab

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -560,6 +560,23 @@ export {
   type UpdateUserPreferencesInput,
 } from "./preferences"
 
+// Sidebar configuration
+export {
+  SIDEBAR_SECTION_KEYS,
+  type SidebarSectionKey,
+  SIDEBAR_TYPE_SECTIONS,
+  type SidebarTypeSection,
+  type SidebarSectionSpec,
+  type SidebarSection,
+  SIDEBAR_BASE_PRESETS,
+  type SidebarBasePreset,
+  type SidebarConfig,
+  SMART_SIDEBAR_CONFIG,
+  ALL_SIDEBAR_CONFIG,
+  sidebarConfigForPreset,
+  DEFAULT_SIDEBAR_CONFIG,
+} from "./sidebar"
+
 // API Keys
 export {
   SENT_VIA_API_PREFIX,

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -1,0 +1,66 @@
+/**
+ * Sidebar configuration — the wire contract for a user's per-workspace sidebar
+ * layout. The frontend renders from this object (see
+ * `apps/frontend/src/components/layout/sidebar/sidebar-config.ts`, which adds
+ * the purely-presentational labels/icons/collapse behavior on top); the backend
+ * persists it per (workspace, user) and broadcasts changes for cross-device sync.
+ *
+ * The two presets below are the only shapes a config takes today. A
+ * user-editable order and label-driven sections land in later steps — this
+ * module exists so the persisted shape is the full document, not a `smart|all`
+ * flag that a richer editor would have to migrate away from.
+ */
+
+/** Smart-view buckets a stream can be sorted into. */
+export const SIDEBAR_SECTION_KEYS = ["important", "recent", "pinned", "other"] as const
+export type SidebarSectionKey = (typeof SIDEBAR_SECTION_KEYS)[number]
+
+/** Stream types that can back a type-driven section ("All" view). */
+export const SIDEBAR_TYPE_SECTIONS = ["scratchpad", "channel", "dm"] as const
+export type SidebarTypeSection = (typeof SIDEBAR_TYPE_SECTIONS)[number]
+
+/** What streams a section draws from. Presentation is derived from this at render time. */
+export type SidebarSectionSpec =
+  | { kind: "smart"; bucket: SidebarSectionKey }
+  | { kind: "type"; streamType: SidebarTypeSection }
+
+export interface SidebarSection {
+  /** Stable key — also the collapse-state persistence key on the frontend. */
+  id: string
+  spec: SidebarSectionSpec
+}
+
+export const SIDEBAR_BASE_PRESETS = ["smart", "all"] as const
+export type SidebarBasePreset = (typeof SIDEBAR_BASE_PRESETS)[number]
+
+export interface SidebarConfig {
+  basePreset: SidebarBasePreset
+  sections: SidebarSection[]
+}
+
+/** Section ids double as collapse-state keys, so they must stay stable. */
+export const SMART_SIDEBAR_CONFIG: SidebarConfig = {
+  basePreset: "smart",
+  sections: [
+    { id: "important", spec: { kind: "smart", bucket: "important" } },
+    { id: "recent", spec: { kind: "smart", bucket: "recent" } },
+    { id: "pinned", spec: { kind: "smart", bucket: "pinned" } },
+    { id: "other", spec: { kind: "smart", bucket: "other" } },
+  ],
+}
+
+export const ALL_SIDEBAR_CONFIG: SidebarConfig = {
+  basePreset: "all",
+  sections: [
+    { id: "scratchpads", spec: { kind: "type", streamType: "scratchpad" } },
+    { id: "channels", spec: { kind: "type", streamType: "channel" } },
+    { id: "dms", spec: { kind: "type", streamType: "dm" } },
+  ],
+}
+
+export function sidebarConfigForPreset(preset: SidebarBasePreset): SidebarConfig {
+  return preset === "all" ? ALL_SIDEBAR_CONFIG : SMART_SIDEBAR_CONFIG
+}
+
+/** Seeded for users who have never customized their sidebar. */
+export const DEFAULT_SIDEBAR_CONFIG: SidebarConfig = SMART_SIDEBAR_CONFIG


### PR DESCRIPTION
## What & why

PR2 of the configurable-sidebar / visible-labels stack (PR1 = #667, the config-driven rendering refactor). This makes each user's sidebar layout a **persisted, cross-device resource** instead of a device-local `localStorage` flag.

The sidebar is now driven by a `SidebarConfig` document (`basePreset` + ordered `sections`) that is stored server-side per `(workspace, user)`, delivered in the workspace bootstrap, and kept in sync across the user's devices via an author-scoped outbox event. The existing **Smart / All toggle is the writer** — flipping it persists the full config and syncs everywhere.

This mirrors the existing `user-preferences` feature end-to-end (DB → bootstrap → read/write API → outbox event → frontend socket sync + offline IDB mirror).

## Changes

**`@threa/types`**
- New `sidebar.ts`: shared `SidebarConfig` wire contract (`SidebarSectionKey`, `SidebarTypeSection`, `SidebarSectionSpec`, `SidebarSection`, `SidebarBasePreset`), the Smart/All presets, `sidebarConfigForPreset`, `DEFAULT_SIDEBAR_CONFIG`.
- `WorkspaceBootstrap.sidebarConfig` added.

**Backend**
- Migration `20260529120000_sidebar_configs.sql`: one JSONB document per `(workspace, user)`, absent row → code-defined default (Smart). No FK (INV-1), no enum (INV-3), workspace-scoped (INV-8), composite natural PK (matches `user_preference_overrides`).
- `features/sidebar-config/`: race-safe upsert repository (INV-20), `withTransaction` service that writes the doc + the outbox event in one tx (INV-4/INV-7), Zod-validated handlers (INV-55), barrel.
- `sidebar_config:updated` registered as an **author-scoped** outbox event (delivered only to the author's sockets).
- GET/PATCH `/api/workspaces/:workspaceId/sidebar-config` behind the `authed` chain; bootstrap fetches the config.

**Frontend**
- Dexie `sidebarConfigs` table (schema v33) + store seed + `useWorkspaceSidebarConfig` live query (offline-first, like every other sidebar entity).
- `workspace-sync`: IDB write on initial + reconnect bootstrap, and a `sidebar_config:updated` socket handler (paired with bootstrap, INV-53; on/off symmetric).
- `sidebarConfigApi` + `useSidebarConfig` hook (optimistic write to the bootstrap query cache and IDB, rollback on error).
- Wired the Smart/All toggle through the hook; **removed the now-dead `viewMode`/`setViewMode`** from the localStorage `SidebarProvider` (INV-38) — config is the source of truth; collapse states stay device-local.
- Derived the sidebar `SectionKey` from the canonical `@threa/types` `SidebarSectionKey` so the wire shape and the frontend categorization type can't drift.

## Tests
- Backend `sidebar-config/service.test.ts` (scoped `spyOn`, INV-48): default fallback, stored-config read, and `updateConfig` persists + emits the author-scoped event.
- Frontend: new `applyWorkspaceBootstrap` case asserting the config is persisted to IDB; updated bootstrap fixtures.
- Full pre-commit gate (typecheck across all workspaces, lint, OpenAPI-docs check) green.

## Scoped out (deliberate)
The **rich editor** (drag-reorder, inline add/remove section kinds, a "Sidebar" settings panel, reset-to-preset) is deferred to a later stacked PR — it earns its place once PR4's label sections give a reason to reorder/add sections. Persisting from the existing toggle keeps this PR a reviewable slice and avoids speculative editor config (INV-36). Existing users seed to the Smart preset on first read rather than migrating their prior `localStorage` `viewMode`.

## Notes for reviewers
- Validation failures return `res.status(400).json({ error, details })` (structured Zod `fieldErrors`) to mirror `user-preferences/handlers.ts`, rather than throwing `HttpError`. Both patterns exist in the codebase; kept here for consistency with the sibling feature this mirrors.

Plan: `docs/plans/configurable-sidebar-and-visible-labels.md`

https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782623516&installation_id=129946197&pr_number=669&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F669&signature=900aabc543a3f8475dc7d6f7ea7e92392102ad6cf4215dc948cd817b0a77f44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->