### PR TITLE
fix(sidebar): match truncation ellipsis color to trailing parent-stream context

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -359,11 +359,18 @@ export function StreamItem({
               )}
             >
               <div className="flex items-center gap-2 pr-8">
-                <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
-                  {name}
-                  {threadRootContext && (
-                    <span className="font-normal text-muted-foreground/60 text-xs"> · {threadRootContext}</span>
+                <span
+                  className={cn(
+                    "truncate text-sm",
+                    hasUnread ? "font-semibold" : "font-medium",
+                    // The truncation ellipsis inherits the color of this element. When a grey parent-stream
+                    // context trails the title it's the usual cut point, so tint the container grey (and keep
+                    // the title itself at foreground) so the ellipsis matches the text it's shortening.
+                    threadRootContext && "text-muted-foreground/60"
                   )}
+                >
+                  {threadRootContext ? <span className="text-foreground">{name}</span> : name}
+                  {threadRootContext && <span className="font-normal text-xs"> · {threadRootContext}</span>}
                 </span>
                 {stream.type === StreamTypes.CHANNEL && stream.visibility === Visibilities.PRIVATE && (
                   <Lock className="h-3 w-3 shrink-0 text-muted-foreground/60" />


### PR DESCRIPTION
## Problem

In the sidebar stream list, a thread row renders its title followed by a greyed-out parent-stream context (`Greeting Exchange · User Greet…`). The whole label lives in one `truncate` span, so when the row overflows the trailing grey context is what gets cut.

The `…` produced by `truncate` (`text-overflow: ellipsis`) is a CSS artifact that inherits the color of the **truncating element**, not the run of text it happens to be clipping. Because the title color sat on that outer span (foreground/white), the ellipsis rendered white even when it was shortening the grey parent-stream name — so the cut-off looked mismatched against the grey text it belonged to.

## Solution

When a parent-stream context trails the title (the usual cut point), tint the truncating container with `text-muted-foreground/60` so the ellipsis inherits grey, and move the foreground color onto the title text itself via an inner `text-foreground` span. When there's no parent context, the title renders bare and keeps owning the white ellipsis exactly as before — no behavior change for plain titles.

### Key design decisions

**1. Condition the recolor on `threadRootContext` rather than always greying the ellipsis**

CSS can't recolor the ellipsis per-character at an arbitrary cut point — it's one color for the whole element. Keying the grey tint off "does this row have a trailing grey context" fixes the reported case without affecting context-less rows, whose ellipsis should stay white.

**2. Drop the now-redundant color on the context span**

The inner `· {context}` span previously carried `text-muted-foreground/60`; it now inherits grey from the container, so the explicit class was removed to keep one source of truth for the color.

Known residual edge case: a thread whose *title alone* is long enough to truncate before reaching the `·` would show a grey ellipsis. This is rare and handling it precisely would require measuring the cut position; left out deliberately per minimal-patch scope.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Tint the truncating title span grey when a parent context trails it; wrap the title in a `text-foreground` span so the ellipsis matches the text it shortens. |

## Test plan

- [x] `bun run test src/components/layout/sidebar/stream-item.test.tsx` — 5 passing
- [x] Lint + monorepo typecheck (pre-commit hooks) green
- [ ] Visual check in the sidebar: thread row with a long grey parent context shows a grey `…`; a context-less row with a long title still shows a white `…`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEJ3fLotohRzB7ngQdYFJa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782623930&installation_id=129946197&pr_number=670&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F670&signature=4ae2b81642283fcec21a990af6052296a898314e861c8385195d62e78d8b34d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->