### PR TITLE
feat(labels): unified membership model + last-member-archive lifecycle (PR3 of configurable sidebar)

### DIFF
--- a/apps/backend/src/db/migrations/20260529140000_label_members_backfill.sql
+++ b/apps/backend/src/db/migrations/20260529140000_label_members_backfill.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Label members: backfill creator memberships
+-- Unifies the membership model — every label now carries a `label_members` row
+-- for its creator, including private labels (which previously derived ownership
+-- implicitly from `creator_user_id`). Public labels already have this row from
+-- the create path, so the upsert is a no-op for them. Archived labels are
+-- skipped: archiving deletes their memberships, and they must not be revived.
+-- joined_at mirrors the label's creation time for historical accuracy.
+-- =============================================================================
+
+INSERT INTO label_members (label_id, user_id, workspace_id, joined_at)
+SELECT id, creator_user_id, workspace_id, created_at
+FROM labels
+WHERE archived_at IS NULL
+ON CONFLICT (label_id, user_id) DO NOTHING;

--- a/apps/backend/src/features/labels/repository.ts
+++ b/apps/backend/src/features/labels/repository.ts
@@ -112,9 +112,29 @@ export const LabelRepository = {
   },
 
   /**
-   * List labels visible to the viewer: all public labels in the workspace
-   * (joined or not — the Discover tab needs both) plus the viewer's own
-   * private labels. Archived rows are excluded.
+   * Like {@link findById} but takes a row lock so callers can serialize a
+   * read-decide-write against concurrent writers (INV-20). Used by the
+   * last-member-leave path to make the "is this the final member?" check
+   * race-safe: concurrent `leave`s on the same label queue on this lock.
+   */
+  async findByIdForUpdate(db: Querier, workspaceId: string, labelId: string): Promise<Label | null> {
+    const result = await db.query<LabelRow>(sql`
+      SELECT ${sql.raw(LABEL_COLUMNS)}
+      FROM labels
+      WHERE id = ${labelId} AND workspace_id = ${workspaceId}
+      FOR UPDATE
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /**
+   * List labels visible to the viewer, expressed against the uniform membership
+   * set: every public label in the workspace (joined or not — the Discover tab
+   * needs both) plus any label the viewer is a member of. Since every label —
+   * including private ones — now carries a creator membership row, the viewer's
+   * own private labels surface via membership rather than a `creator_user_id`
+   * special case (and visibility would automatically follow any future
+   * shared-private model). Archived rows are excluded.
    */
   async listVisibleTo(db: Querier, workspaceId: string, userId: string): Promise<Label[]> {
     const result = await db.query<LabelRow>(sql`
@@ -124,7 +144,10 @@ export const LabelRepository = {
         AND archived_at IS NULL
         AND (
           visibility = ${Visibilities.PUBLIC}
-          OR (visibility = ${Visibilities.PRIVATE} AND creator_user_id = ${userId})
+          OR EXISTS (
+            SELECT 1 FROM label_members m
+            WHERE m.label_id = labels.id AND m.user_id = ${userId}
+          )
         )
       ORDER BY created_at DESC
     `)
@@ -240,6 +263,14 @@ export const LabelMemberRepository = {
       WHERE label_id = ${params.labelId} AND user_id = ${params.userId}
     `)
     return (result.rowCount ?? 0) > 0
+  },
+
+  /** Count current members of a label. Used by the last-member-leave check. */
+  async countForLabel(db: Querier, labelId: string): Promise<number> {
+    const result = await db.query<{ count: string }>(sql`
+      SELECT COUNT(*)::text AS count FROM label_members WHERE label_id = ${labelId}
+    `)
+    return Number(result.rows[0]?.count ?? "0")
   },
 
   async listForUser(db: Querier, workspaceId: string, userId: string): Promise<LabelMember[]> {

--- a/apps/backend/src/features/labels/repository.ts
+++ b/apps/backend/src/features/labels/repository.ts
@@ -146,7 +146,9 @@ export const LabelRepository = {
           visibility = ${Visibilities.PUBLIC}
           OR EXISTS (
             SELECT 1 FROM label_members m
-            WHERE m.label_id = labels.id AND m.user_id = ${userId}
+            WHERE m.label_id = labels.id
+              AND m.user_id = ${userId}
+              AND m.workspace_id = ${workspaceId}
           )
         )
       ORDER BY created_at DESC
@@ -266,9 +268,11 @@ export const LabelMemberRepository = {
   },
 
   /** Count current members of a label. Used by the last-member-leave check. */
-  async countForLabel(db: Querier, labelId: string): Promise<number> {
+  async countForLabel(db: Querier, workspaceId: string, labelId: string): Promise<number> {
     const result = await db.query<{ count: string }>(sql`
-      SELECT COUNT(*)::text AS count FROM label_members WHERE label_id = ${labelId}
+      SELECT COUNT(*)::text AS count
+      FROM label_members
+      WHERE workspace_id = ${workspaceId} AND label_id = ${labelId}
     `)
     return Number(result.rows[0]?.count ?? "0")
   },

--- a/apps/backend/src/features/labels/service.test.ts
+++ b/apps/backend/src/features/labels/service.test.ts
@@ -62,3 +62,96 @@ describe("LabelService.archive", () => {
     expect(assignmentCleanup).not.toHaveBeenCalled()
   })
 })
+
+describe("LabelService.create", () => {
+  afterEach(() => mock.restore())
+
+  it("auto-joins the creator and emits member_joined even for a private label", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "privateSlugExists").mockResolvedValue(false)
+    spyOn(LabelRepository, "insert").mockResolvedValue(fakeLabel({ visibility: Visibilities.PRIVATE }))
+    const join = spyOn(LabelMemberRepository, "join").mockResolvedValue({
+      labelId: LABEL_ID,
+      userId: USER_ID,
+      workspaceId: WORKSPACE_ID,
+      joinedAt: NOW,
+    })
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.create({
+      workspaceId: WORKSPACE_ID,
+      userId: USER_ID,
+      name: "Secret",
+      visibility: Visibilities.PRIVATE,
+      color: "#ff0000",
+      emoji: null,
+      description: null,
+    })
+
+    expect(join).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId: USER_ID, workspaceId: WORKSPACE_ID })
+    )
+    expect(outbox).toHaveBeenCalledWith(
+      expect.anything(),
+      "label:member_joined",
+      expect.objectContaining({ targetUserId: USER_ID })
+    )
+  })
+})
+
+describe("LabelService.leave", () => {
+  afterEach(() => mock.restore())
+
+  it("archives the label and clears its assignments when the last member leaves", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findByIdForUpdate").mockResolvedValue(fakeLabel())
+    spyOn(LabelMemberRepository, "leave").mockResolvedValue(true)
+    spyOn(LabelMemberRepository, "countForLabel").mockResolvedValue(0)
+    const archive = spyOn(LabelRepository, "archive").mockResolvedValue(true)
+    spyOn(LabelMemberRepository, "deleteAllForLabel").mockResolvedValue(undefined)
+    const assignmentCleanup = spyOn(LabelAssignmentRepository, "deleteAllForLabel").mockResolvedValue(undefined)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.leave({ workspaceId: WORKSPACE_ID, userId: USER_ID, labelId: LABEL_ID })
+
+    expect(archive).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, LABEL_ID)
+    expect(assignmentCleanup).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, LABEL_ID)
+    expect(outbox).toHaveBeenCalledWith(
+      expect.anything(),
+      "label:deleted",
+      expect.objectContaining({ labelId: LABEL_ID })
+    )
+  })
+
+  it("emits member_left and keeps the label when other members remain", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findByIdForUpdate").mockResolvedValue(fakeLabel())
+    spyOn(LabelMemberRepository, "leave").mockResolvedValue(true)
+    spyOn(LabelMemberRepository, "countForLabel").mockResolvedValue(2)
+    const archive = spyOn(LabelRepository, "archive").mockResolvedValue(true)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.leave({ workspaceId: WORKSPACE_ID, userId: USER_ID, labelId: LABEL_ID })
+
+    expect(archive).not.toHaveBeenCalled()
+    expect(outbox).toHaveBeenCalledWith(
+      expect.anything(),
+      "label:member_left",
+      expect.objectContaining({ labelId: LABEL_ID, userId: USER_ID, targetUserId: USER_ID })
+    )
+  })
+
+  it("is a no-op when the caller was not a member (no count, no events)", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findByIdForUpdate").mockResolvedValue(fakeLabel())
+    spyOn(LabelMemberRepository, "leave").mockResolvedValue(false)
+    const count = spyOn(LabelMemberRepository, "countForLabel").mockResolvedValue(0)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.leave({ workspaceId: WORKSPACE_ID, userId: USER_ID, labelId: LABEL_ID })
+
+    expect(count).not.toHaveBeenCalled()
+    expect(outbox).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/labels/service.ts
+++ b/apps/backend/src/features/labels/service.ts
@@ -201,7 +201,10 @@ export class LabelService {
 
   async join(params: { workspaceId: string; userId: string; labelId: string }): Promise<LabelMember> {
     return withTransaction(this.pool, async (client) => {
-      const existing = await LabelRepository.findById(client, params.workspaceId, params.labelId)
+      // Lock the label row so a join can't race the last-member-leave archival:
+      // either we observe the archived label and reject, or we add our member
+      // before leave's count runs and it sees us as a survivor (INV-20).
+      const existing = await LabelRepository.findByIdForUpdate(client, params.workspaceId, params.labelId)
       if (!existing || existing.archivedAt) {
         throw new HttpError("Label not found", { status: 404, code: "LABEL_NOT_FOUND" })
       }
@@ -248,7 +251,7 @@ export class LabelService {
       // the workspace (and, for a private label, leaving is its deletion).
       // Clients learn of this via the `label:deleted` emitted by archiveCascade
       // — deliberately not `label:member_left`, since the whole label is gone.
-      const remaining = await LabelMemberRepository.countForLabel(client, params.labelId)
+      const remaining = await LabelMemberRepository.countForLabel(client, params.workspaceId, params.labelId)
       if (remaining === 0) {
         await this.archiveCascade(client, existing)
         return

--- a/apps/backend/src/features/labels/service.ts
+++ b/apps/backend/src/features/labels/service.ts
@@ -82,16 +82,15 @@ export class LabelService {
         description: params.description,
       })
 
-      // Creator auto-joins their own public labels so the "My Labels" tab
-      // shows them without a separate join hop. Private labels skip this —
-      // ownership is derived from `creatorUserId`.
-      if (params.visibility === Visibilities.PUBLIC) {
-        await LabelMemberRepository.join(client, {
-          labelId: id,
-          userId: params.userId,
-          workspaceId: params.workspaceId,
-        })
-      }
+      // Every label — public or private — gets a creator membership row so
+      // "joined" is one uniform concept across the model. `creator_user_id`
+      // still drives edit/archive/promote permissions; membership drives the
+      // "My Labels" view and real-time fan-out.
+      const member = await LabelMemberRepository.join(client, {
+        labelId: id,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
+      })
 
       await OutboxRepository.insert(client, "label:created", {
         workspaceId: params.workspaceId,
@@ -99,19 +98,13 @@ export class LabelService {
         label,
       })
 
-      if (params.visibility === Visibilities.PUBLIC) {
-        const member: LabelMember = {
-          labelId: id,
-          userId: params.userId,
-          workspaceId: params.workspaceId,
-          joinedAt: label.createdAt,
-        }
-        await OutboxRepository.insert(client, "label:member_joined", {
-          workspaceId: params.workspaceId,
-          targetUserId: params.userId,
-          member,
-        })
-      }
+      // Member events are always delivered to the affected member only, so this
+      // is creator-scoped regardless of label visibility.
+      await OutboxRepository.insert(client, "label:member_joined", {
+        workspaceId: params.workspaceId,
+        targetUserId: params.userId,
+        member,
+      })
 
       return label
     })
@@ -181,20 +174,28 @@ export class LabelService {
         throw new HttpError("Forbidden", { status: 403, code: "FORBIDDEN" })
       }
 
-      const archived = await LabelRepository.archive(client, params.workspaceId, params.labelId)
-      if (!archived) return
+      await this.archiveCascade(client, existing)
+    })
+  }
 
-      await LabelMemberRepository.deleteAllForLabel(client, params.labelId)
-      // Drop assignments too so no resource keeps a chip for the dead label.
-      // No per-row unassign events: `label:deleted` already tells clients the
-      // label is gone, and they skip orphaned assignments on render.
-      await LabelAssignmentRepository.deleteAllForLabel(client, params.workspaceId, params.labelId)
+  /**
+   * Soft-archive a label and tear down everything that hangs off it: member
+   * rows, resource assignments, and a `label:deleted` event. Shared by the
+   * creator-initiated `archive` and the last-member `leave` path. No per-row
+   * unassign events — `label:deleted` already tells clients the label is gone
+   * and they skip orphaned assignments on render. No-op if already archived.
+   */
+  private async archiveCascade(client: import("pg").PoolClient, label: Label): Promise<void> {
+    const archived = await LabelRepository.archive(client, label.workspaceId, label.id)
+    if (!archived) return
 
-      await OutboxRepository.insert(client, "label:deleted", {
-        workspaceId: params.workspaceId,
-        targetUserId: existing.visibility === Visibilities.PRIVATE ? existing.creatorUserId : null,
-        labelId: params.labelId,
-      })
+    await LabelMemberRepository.deleteAllForLabel(client, label.id)
+    await LabelAssignmentRepository.deleteAllForLabel(client, label.workspaceId, label.id)
+
+    await OutboxRepository.insert(client, "label:deleted", {
+      workspaceId: label.workspaceId,
+      targetUserId: label.visibility === Visibilities.PRIVATE ? label.creatorUserId : null,
+      labelId: label.id,
     })
   }
 
@@ -226,16 +227,32 @@ export class LabelService {
 
   async leave(params: { workspaceId: string; userId: string; labelId: string }): Promise<void> {
     await withTransaction(this.pool, async (client) => {
-      const existing = await LabelRepository.findById(client, params.workspaceId, params.labelId)
+      // Lock the label row so concurrent leaves serialize: the last-member
+      // check below must not race two callers into both seeing a survivor
+      // (orphaned label) or both archiving (INV-20).
+      const existing = await LabelRepository.findByIdForUpdate(client, params.workspaceId, params.labelId)
       if (!existing) {
         throw new HttpError("Label not found", { status: 404, code: "LABEL_NOT_FOUND" })
       }
 
+      // No explicit visibility gate: a private label only ever has its creator
+      // as a member (join() rejects private labels), so a non-creator's leave
+      // no-ops here via `removed === false`.
       const removed = await LabelMemberRepository.leave(client, {
         labelId: params.labelId,
         userId: params.userId,
       })
       if (!removed) return
+
+      // The last member out archives the label so no ownerless label lingers in
+      // the workspace (and, for a private label, leaving is its deletion).
+      // Clients learn of this via the `label:deleted` emitted by archiveCascade
+      // — deliberately not `label:member_left`, since the whole label is gone.
+      const remaining = await LabelMemberRepository.countForLabel(client, params.labelId)
+      if (remaining === 0) {
+        await this.archiveCascade(client, existing)
+        return
+      }
 
       await OutboxRepository.insert(client, "label:member_left", {
         workspaceId: params.workspaceId,
@@ -277,19 +294,22 @@ export class LabelService {
         throw new HttpError("Label not found", { status: 404, code: "LABEL_NOT_FOUND" })
       }
 
-      // A private-only label has no member rows — auto-add the creator so the
-      // promoted label still shows in their "My Labels" tab.
+      // The creator already has a membership row (every label gets one at
+      // create time), so this join is idempotent — it just re-reads the row to
+      // carry in the member_joined event below.
       const member = await LabelMemberRepository.join(client, {
         labelId: promoted.id,
         userId: params.userId,
         workspaceId: params.workspaceId,
       })
 
-      // The private creator already had the row; we emit `label:deleted` to
-      // the creator's private channel (so their private view drops it) and a
-      // workspace-wide `label:created` so everyone else picks it up. A single
-      // `label:updated` could not switch routing because the old row was
-      // user-scoped and the new row is workspace-scoped.
+      // We emit `label:deleted` to the creator's private channel (so their
+      // private view drops the now-stale user-scoped row, membership included)
+      // and a workspace-wide `label:created` so everyone picks up the public
+      // row. A single `label:updated` could not switch routing because the old
+      // row was user-scoped and the new row is workspace-scoped. The
+      // `label:member_joined` below then re-adds the creator's membership that
+      // `label:deleted` cleared on their client.
       await OutboxRepository.insert(client, "label:deleted", {
         workspaceId: params.workspaceId,
         targetUserId: existing.creatorUserId,

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -208,7 +208,11 @@ export interface LabelViewerContext {
   publicLabels: CachedLabel[]
   /** Public labels the viewer has not joined and did not create. */
   discoverable: CachedLabel[]
-  /** Set of public labelIds the viewer has joined (excludes creator-implicit membership). */
+  /**
+   * labelIds the viewer has a membership row for (every label they created or
+   * joined now has one). Only consulted to bucket public labels created by
+   * *others*; the viewer's own labels are bucketed via `creatorUserId`.
+   */
   joinedLabelIds: Set<string>
   rawLabels: CachedLabel[]
   rawMemberships: CachedLabelMembership[]
@@ -218,8 +222,10 @@ export interface LabelViewerContext {
  * Bucket the workspace's labels into the views the Labels page needs. Private
  * labels are only visible to their creator (bootstrap already enforces this on
  * the wire). Public labels are visible to everyone in the workspace; "joined"
- * means the viewer has an explicit `LabelMember` row, "discoverable" is the
- * rest. Creators of a public label are joined implicitly (no membership row).
+ * means the viewer has a `LabelMember` row, "discoverable" is the rest. Every
+ * label now carries a creator membership row, so the viewer's own labels are
+ * bucketed via `creatorUserId` (into `mine`) and their membership row is not
+ * consulted for them.
  */
 export function useLabelsView(workspaceId: string): LabelViewerContext {
   const { user } = useAuth()

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -578,9 +578,10 @@ export interface WorkspaceBootstrap {
    */
   labels: Label[]
   /**
-   * Viewer's `label_members` rows. Private labels are implicitly "joined" by
-   * their creator and are NOT represented here — the viewer derives ownership
-   * from `Label.creatorUserId` instead.
+   * Viewer's `label_members` rows. Every label the viewer created or joined —
+   * public or private — has a membership row (the creator is auto-joined at
+   * create time), so "joined" is one uniform check. `Label.creatorUserId` is
+   * retained for edit/archive/promote permissions.
    */
   labelMemberships: LabelMember[]
   /**


### PR DESCRIPTION
## What & why

PR3 of the configurable-sidebar / visible-labels stack (PR1 #667, PR2 #669). **Backend + tests only — no UI.** This is the model groundwork that PR4 (sidebar label sections) and PR5 (top-bar chips) build on.

Today label membership is split: public labels have a `label_members` row, while private labels have none and ownership is derived from `creator_user_id`. That split forces every read to special-case private labels. PR3 makes membership **uniform** (every label has a creator membership row) and gives labels a **self-cleaning lifecycle** (last member out → archive).

## Changes

**Unified membership**
- `create()` now inserts a creator `label_members` row + emits `label:member_joined` for **every** label, public *and* private (previously private labels skipped both).
- Backfill migration (`20260529140000_label_members_backfill.sql`) adds creator memberships to existing non-archived labels — idempotent (`ON CONFLICT DO NOTHING`), no-op for public labels that already have them, skips archived labels.
- `listVisibleTo` is now expressed against the uniform set — `visibility = public OR EXISTS(membership)` — instead of a `creator_user_id` special-case. Result-equivalent today (private labels only ever have the creator's row), and visibility now automatically follows membership for any future shared-private model.
- `WorkspaceBootstrap.labelMemberships` therefore now carries private creator rows too. The frontend `useLabelsView` already buckets the viewer's own labels by `creator_user_id`, so the extra rows are inert — no UI change needed (stale comments corrected).

**Lifecycle**
- `leave()`: the last member out soft-archives the label and tears down its memberships + assignments, emitting `label:deleted` (not `label:member_left`, since the whole label is gone). Shared `archiveCascade` helper, also used by `archive()`.
- **Race-safe** (INV-20): `leave()` locks the label row `FOR UPDATE` so concurrent leavers serialize — they can't both see a survivor (orphan) or both archive.
- `creator_user_id` retained for edit/archive/promote permissions.

## Tests
- `service.test.ts`: create-private auto-joins + emits `member_joined`; last-member leave archives + clears assignments + emits `label:deleted`; non-last leave emits `member_left` and keeps the label; non-member leave is a no-op. Scoped `spyOn` (INV-48), event-content assertions (INV-23).
- All 17 labels tests green; full pre-commit gate (typecheck across all workspaces, lint, OpenAPI-docs check) passing.

## Self-review
Ran a 3-perspective review (spec/plan, correctness/concurrency, design/data-model). No logic bugs; folded in the `listVisibleTo` simplification (plan deliverable) and comment/doc accuracy fixes. Deliberately did **not** redesign `promote()`'s private→public event choreography — it's pre-existing, intentional, and out of scope.

Plan: `docs/plans/configurable-sidebar-and-visible-labels.md` (PR3 section).

https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782631529&installation_id=129946197&pr_number=672&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F672&signature=493f52537a1d554dc029b985bbd36ecaa855a89057b9bf888f5091e571a4645e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->