### PR TITLE
fix(link-previews): capture metadata streamed into body after </head>

### DIFF
--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -395,6 +395,83 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  test('ignores body attributes like name="descriptionField" and still captures real metadata', async () => {
+    // A body attribute whose value merely starts with "description" must not flip the early-stop
+    // gate: if it did, the loop would stop at </head> and drop the real og:* tags streamed after it.
+    const headChunk =
+      `<html><head><meta name="theme-color" content="#000"/></head>` +
+      `<body><form><input name="descriptionField" value="not metadata"/></form>`
+    const metaChunk =
+      `<title>Real Page Title</title>` +
+      `<meta property="og:title" content="Real Page Title">` +
+      `<meta property="og:description" content="The genuine description.">` +
+      `</body></html>`
+
+    const fetchMock = mock(async () => streamingHtmlResponse([headChunk, metaChunk]))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_901", url: "https://example.com/article" }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_901",
+          workspaceId: "ws_123",
+          url: "https://example.com/article",
+          normalizedUrl: "https://example.com/article",
+          title: null,
+          description: null,
+          imageUrl: null,
+          faviconUrl: null,
+          siteName: null,
+          contentType: "website",
+          status: "pending",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: null,
+          expiresAt: null,
+          createdAt: new Date("2026-05-29T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: {
+        getGithubClient: mock(async () => null),
+      } as any,
+    })
+
+    await worker({
+      id: "job_901",
+      name: "link_preview.extract",
+      data: {
+        workspaceId: "ws_123",
+        streamId: "stream_123",
+        messageId: "msg_901",
+        contentMarkdown: "https://example.com/article",
+      },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_901",
+      [
+        expect.objectContaining({
+          id: "lp_901",
+          metadata: expect.objectContaining({
+            title: "Real Page Title",
+            description: "The genuine description.",
+          }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
+  })
+
   test("keeps existing rich GitHub previews when refresh falls back from GitHub", async () => {
     const fetchMock = mock(async () => {
       throw new Error("generic fetch should not run when rich preview data already exists")

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -287,12 +287,112 @@ describe("extractOEmbedDescription", () => {
   })
 })
 
+/** Build a streaming text/html Response that yields the given chunks in order. */
+function streamingHtmlResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } })
+}
+
 describe("createLinkPreviewWorker", () => {
   const originalFetch = globalThis.fetch
 
   afterEach(() => {
     globalThis.fetch = originalFetch
     mock.restore()
+  })
+
+  test("captures metadata streamed into <body> after </head> (Next.js App Router)", async () => {
+    // Streaming-SSR frameworks emit a metadata-less <head> first, then stream the real
+    // <title>/<meta og:*> into the body. The head closes in chunk 1; metadata arrives in chunk 2.
+    const headChunk =
+      `<html><head><link rel="preload" href="/_next/static/x.js"/>` +
+      `<meta name="theme-color" content="#141413"/></head>` +
+      `<body><header>nav</header><main>article body</main>`
+    const metaChunk =
+      `<title>Introducing Claude Opus 4.8 \\ Anthropic</title>` +
+      `<meta name="description" content="Our latest model, Claude Opus 4.8, is an upgrade.">` +
+      `<meta property="og:title" content="Introducing Claude Opus 4.8">` +
+      `<meta property="og:description" content="Our latest model, Claude Opus 4.8, is an upgrade.">` +
+      `<meta property="og:image" content="https://cdn.example.com/opus.jpg">` +
+      `<meta property="og:site_name" content="Anthropic">` +
+      `</body></html>`
+
+    const fetchMock = mock(async () => streamingHtmlResponse([headChunk, metaChunk]))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [
+          { id: "lp_900", url: "https://www.anthropic.com/news/claude-opus-4-8" },
+        ]),
+        getPreviewById: mock(async () => ({
+          id: "lp_900",
+          workspaceId: "ws_123",
+          url: "https://www.anthropic.com/news/claude-opus-4-8",
+          normalizedUrl: "https://www.anthropic.com/news/claude-opus-4-8",
+          title: null,
+          description: null,
+          imageUrl: null,
+          faviconUrl: null,
+          siteName: null,
+          contentType: "website",
+          status: "pending",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: null,
+          expiresAt: null,
+          createdAt: new Date("2026-05-29T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: {
+        getGithubClient: mock(async () => null),
+      } as any,
+    })
+
+    await worker({
+      id: "job_900",
+      name: "link_preview.extract",
+      data: {
+        workspaceId: "ws_123",
+        streamId: "stream_123",
+        messageId: "msg_900",
+        contentMarkdown: "https://www.anthropic.com/news/claude-opus-4-8",
+      },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_900",
+      [
+        expect.objectContaining({
+          id: "lp_900",
+          skipped: false,
+          overwrite: false,
+          metadata: expect.objectContaining({
+            title: "Introducing Claude Opus 4.8",
+            description: "Our latest model, Claude Opus 4.8, is an upgrade.",
+            imageUrl: "https://cdn.example.com/opus.jpg",
+            siteName: "Anthropic",
+            status: "completed",
+          }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
   })
 
   test("keeps existing rich GitHub previews when refresh falls back from GitHub", async () => {

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -264,12 +264,20 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
 
     const chunks: Uint8Array[] = []
     let totalBytes = 0
-    // Rolling ASCII view of the tail of what we've received, used only to detect </head>
-    // so we can stop reading early. Latin-1 is byte-faithful for the ASCII characters in the
-    // sentinel, independent of the page's true encoding.
+    // Rolling ASCII view of the tail of what we've received, used only to detect </head>.
+    // Latin-1 is byte-faithful for the ASCII characters in the sentinel, independent of the
+    // page's true encoding.
     let asciiTail = ""
     const HEAD_CLOSE = "</head>"
     const TAIL_WINDOW = 4096
+    // Streaming-SSR frameworks (Next.js App Router and friends) emit a metadata-less <head>
+    // and then stream the real <title>/<meta og:*> into the <body> after </head> closes. So
+    // </head> alone is not a safe stop signal — only stop once we've actually seen a metadata
+    // signal. Pages that never provide one are bounded by MAX_HTML_BYTES. Scanned per-chunk
+    // (not on the trimmed tail) so a signal isn't lost when a large chunk overflows the window.
+    const META_SIGNAL =
+      /<title[\s>]|og:title|og:image|og:description|twitter:title|twitter:description|name=["']?description/i
+    let seenMeta = false
 
     try {
       while (totalBytes < MAX_HTML_BYTES) {
@@ -278,9 +286,12 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
         chunks.push(value)
         totalBytes += value.byteLength
 
-        asciiTail += new TextDecoder("latin1").decode(value)
+        const chunkStr = new TextDecoder("latin1").decode(value)
+        if (!seenMeta && META_SIGNAL.test(chunkStr)) seenMeta = true
+
+        asciiTail += chunkStr
         if (asciiTail.length > TAIL_WINDOW) asciiTail = asciiTail.slice(-TAIL_WINDOW)
-        if (asciiTail.toLowerCase().includes(HEAD_CLOSE)) break
+        if (seenMeta && asciiTail.toLowerCase().includes(HEAD_CLOSE)) break
       }
     } finally {
       reader.cancel()

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -275,8 +275,12 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
     // </head> alone is not a safe stop signal — only stop once we've actually seen a metadata
     // signal. Pages that never provide one are bounded by MAX_HTML_BYTES. Scanned per-chunk
     // (not on the trimmed tail) so a signal isn't lost when a large chunk overflows the window.
+    // This is a best-effort early-stop gate, not a correctness gate: a missed signal only costs
+    // extra bytes (parseHtmlMeta runs on the full buffer regardless). The `name=…description`
+    // arm is anchored on the value's end so body attributes like `name="descriptionField"`
+    // don't flip the gate early and re-trigger the very </head> bug this guards against.
     const META_SIGNAL =
-      /<title[\s>]|og:title|og:image|og:description|twitter:title|twitter:description|name=["']?description/i
+      /<title[\s>]|og:title|twitter:title|og:image|twitter:image|og:description|twitter:description|name=["']?description["'\s>]/i
     let seenMeta = false
 
     try {


### PR DESCRIPTION
Streaming-SSR frameworks (Next.js App Router and friends) emit a
metadata-less <head> and then stream the real <title>/<meta og:*> tags
into the <body> after </head> closes. The generic metadata fetcher
stopped reading at the first </head>, so it never saw those tags and
fell back to a URL-slug title with no description or image — e.g. an
anthropic.com/news link unfurled as just "claude opus 4 8".

Stop reading at </head> only after a metadata signal has been observed;
pages that never provide one stay bounded by MAX_HTML_BYTES. The signal
is scanned per-chunk rather than on the trimmed tail window so it isn't
lost when a large chunk overflows the window.

https://claude.ai/code/session_01DSvSfn7xgx4UX6p7ZQ5hYE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782632047&installation_id=129946197&pr_number=673&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F673&signature=f488797d66a12557edf60638e67a141eea54f411c838d8b8a2bba578b6c2bb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->