### PR TITLE
feat(sidebar): label sections + shared tinted LabelChip (PR4 of configurable sidebar)

### DIFF
--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -7,6 +7,7 @@ import { SIDEBAR_SECTION_KEYS, SIDEBAR_TYPE_SECTIONS, SIDEBAR_BASE_PRESETS } fro
 const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("smart"), bucket: z.enum(SIDEBAR_SECTION_KEYS) }),
   z.object({ kind: z.literal("type"), streamType: z.enum(SIDEBAR_TYPE_SECTIONS) }),
+  z.object({ kind: z.literal("label"), labelId: z.string().min(1).max(64) }),
 ])
 
 const sidebarSectionSchema = z.object({

--- a/apps/frontend/src/components/labels/label-chip.tsx
+++ b/apps/frontend/src/components/labels/label-chip.tsx
@@ -1,0 +1,80 @@
+import { Tag } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { badgeVariants } from "@/components/ui/badge"
+import { hexToRgba } from "@/lib/labels"
+
+/**
+ * Minimal shape a chip needs to render a label. `CachedLabel` / `Label` satisfy
+ * it structurally, so callers can pass either without mapping.
+ */
+export interface LabelChipLabel {
+  color: string
+  emoji: string | null
+  name: string
+}
+
+/**
+ * A label's mark: its emoji on a faintly tinted disc, or — when the label has
+ * no emoji — a `fallback` in the authored color (a solid dot for chips, a tag
+ * glyph for catalog rows). Size/extra styles come via `className`. Used
+ * standalone (collapsed surfaces) and as the chip's leading element.
+ */
+export function LabelGlyph({
+  label,
+  className,
+  fallback = "dot",
+}: {
+  label: LabelChipLabel
+  className?: string
+  fallback?: "dot" | "tag"
+}) {
+  if (label.emoji) {
+    return (
+      <span
+        className={cn("flex h-4 w-4 shrink-0 items-center justify-center rounded text-[11px] leading-none", className)}
+        style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
+        aria-hidden
+      >
+        {label.emoji}
+      </span>
+    )
+  }
+  if (fallback === "tag") {
+    return (
+      <span
+        className={cn("flex h-4 w-4 shrink-0 items-center justify-center rounded", className)}
+        style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
+        aria-hidden
+      >
+        <Tag className="h-3 w-3" />
+      </span>
+    )
+  }
+  return (
+    <span
+      className={cn("h-2.5 w-2.5 shrink-0 rounded-full", className)}
+      style={{ backgroundColor: label.color }}
+      aria-hidden
+    />
+  )
+}
+
+/**
+ * Shared tinted label chip: the authored color tints the background and border,
+ * the emoji (or a solid color dot) leads, and the name renders in ink. The one
+ * visual language for labels across the sidebar label-section header and the
+ * stream top-bar stack. Composes the Shadcn `badgeVariants` pill (INV-14) and
+ * layers per-label authored color on top — no global accent tokens (DESIGN.md
+ * §2.2, like trace hues).
+ */
+export function LabelChip({ label, className }: { label: LabelChipLabel; className?: string }) {
+  return (
+    <span
+      className={cn(badgeVariants({ variant: "outline" }), "max-w-full gap-1.5 font-medium", className)}
+      style={{ backgroundColor: hexToRgba(label.color, 0.12), borderColor: hexToRgba(label.color, 0.3) }}
+    >
+      <LabelGlyph label={label} />
+      <span className="truncate">{label.name}</span>
+    </span>
+  )
+}

--- a/apps/frontend/src/components/labels/label-picker.tsx
+++ b/apps/frontend/src/components/labels/label-picker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { Loader2, Search, Tag } from "lucide-react"
+import { Loader2, Search } from "lucide-react"
 import { Link } from "react-router-dom"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { useIsOnline } from "@/components/layout/connection-status"
 import { cn } from "@/lib/utils"
-import { hexToRgba } from "@/lib/labels"
+import { LabelGlyph } from "./label-chip"
 import { useAssignLabel, useLabelsView, useResourceLabelAssignments, useUnassignLabel, type CachedLabel } from "@/hooks"
 import type { LabelableResourceType } from "@threa/types"
 
@@ -32,18 +32,6 @@ interface LabelPickerProps {
 // flashing a spinner; past it the round-trip is slow enough that silent UI
 // reads as broken. Mirrors the app's other anti-flicker delays.
 const LOADING_DELAY_MS = 300
-
-function LabelGlyph({ label }: { label: CachedLabel }) {
-  return (
-    <span
-      className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-xs leading-none"
-      style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
-      aria-hidden
-    >
-      {label.emoji ?? <Tag className="h-3 w-3" />}
-    </span>
-  )
-}
 
 function NoLabelsYet({ workspaceId }: { workspaceId: string }) {
   return (
@@ -108,7 +96,7 @@ function LabelRow({
           disabled ? "cursor-not-allowed" : "cursor-pointer"
         )}
       >
-        <LabelGlyph label={label} />
+        <LabelGlyph label={label} className="h-5 w-5 text-xs" fallback="tag" />
         <span className="min-w-0 flex-1 truncate">{label.name}</span>
       </label>
     </div>

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { StreamTypes, Visibilities, ALL_SIDEBAR_CONFIG, SMART_SIDEBAR_CONFIG } from "@threa/types"
 import { resolveSections, type ResolveSectionsInput } from "./resolve-sections"
+import { labelSectionId } from "./sidebar-config"
 import type { SectionKey, StreamItemData, UrgencyLevel } from "./types"
 
 interface ItemOverrides {
@@ -40,9 +41,16 @@ function makeItem(overrides: ItemOverrides): StreamItemData {
   }
 }
 
+/** Fill resolver-input defaults so each test only states what it cares about. */
+function makeInput(
+  over: Partial<ResolveSectionsInput> & Pick<ResolveSectionsInput, "processedStreams">
+): ResolveSectionsInput {
+  return { virtualDmStreams: [], getUnreadCount: () => 0, streamIdsByLabel: new Map(), ...over }
+}
+
 /** Collapse the resolver output to a comparable shape: section id → item ids. */
-function shape(input: ResolveSectionsInput, preset = SMART_SIDEBAR_CONFIG) {
-  return resolveSections(preset, input).map((resolved) => ({
+function shape(over: Parameters<typeof makeInput>[0], preset = SMART_SIDEBAR_CONFIG) {
+  return resolveSections(preset, makeInput(over)).map((resolved) => ({
     id: resolved.section.id,
     items: resolved.items.map((item) => item.id),
   }))
@@ -76,11 +84,7 @@ describe("resolveSections — Smart preset", () => {
     const processedStreams = Array.from({ length: 13 }, (_, i) =>
       makeItem({ id: `imp_${i}`, section: "important", urgency: "mentions", activity: i })
     )
-    const resolved = resolveSections(SMART_SIDEBAR_CONFIG, {
-      processedStreams,
-      virtualDmStreams: [],
-      getUnreadCount: () => 1,
-    })
+    const resolved = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams, getUnreadCount: () => 1 }))
     expect(resolved.find((r) => r.section.id === "important")?.items).toHaveLength(10)
   })
 
@@ -94,11 +98,9 @@ describe("resolveSections — Smart preset", () => {
       makeItem({ id: "r4", section: "recent", activity: 50 }),
     ]
     const getUnreadCount = unreadFrom(new Set(["u1", "u2"]))
-    const recent = resolveSections(SMART_SIDEBAR_CONFIG, {
-      processedStreams,
-      virtualDmStreams: [],
-      getUnreadCount,
-    }).find((r) => r.section.id === "recent")
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams, getUnreadCount })).find(
+      (r) => r.section.id === "recent"
+    )
     // 2 unreads + 3 reads = 5, dropping r4.
     expect(recent?.items.map((i) => i.id)).toEqual(["u1", "u2", "r1", "r2", "r3"])
   })
@@ -108,11 +110,9 @@ describe("resolveSections — Smart preset", () => {
       makeItem({ id: `u${i}`, section: "recent", activity: 100 - i })
     )
     const getUnreadCount = () => 1
-    const recent = resolveSections(SMART_SIDEBAR_CONFIG, {
-      processedStreams,
-      virtualDmStreams: [],
-      getUnreadCount,
-    }).find((r) => r.section.id === "recent")
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams, getUnreadCount })).find(
+      (r) => r.section.id === "recent"
+    )
     expect(recent?.items).toHaveLength(7)
   })
 })
@@ -138,5 +138,44 @@ describe("resolveSections — All preset", () => {
       // Real DMs (activity), then system streams, then synthetic drafts.
       { id: "dms", items: ["dm_new", "dm_old", "sys_1", "vdm_1"] },
     ])
+  })
+})
+
+describe("resolveSections — label sections", () => {
+  const config = {
+    basePreset: "smart" as const,
+    sections: [
+      { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+      { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+    ],
+  }
+
+  it("filters streams by assignment, sorts by activity, and is additive (a labeled stream still shows in its bucket)", () => {
+    const processedStreams = [
+      makeItem({ id: "s_old", section: "recent", activity: 1 }),
+      makeItem({ id: "s_new", section: "recent", activity: 9 }),
+      makeItem({ id: "s_other", section: "pinned", activity: 5 }),
+    ]
+    // s_new and s_other carry the label; s_old does not.
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["s_new", "s_other"])]])
+
+    const result = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      // Recent bucket is unchanged by the label section above/below it.
+      { id: "recent", items: ["s_new", "s_old"] },
+      // Label lens: both labeled streams, by activity — s_new (recent) also
+      // appears here (additive), s_other (a pinned stream) is pulled in too.
+      { id: labelSectionId("lbl_1"), items: ["s_new", "s_other"] },
+    ])
+  })
+
+  it("resolves to an empty section when the label has no assigned streams", () => {
+    const processedStreams = [makeItem({ id: "s_1", section: "recent", activity: 1 })]
+    const result = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel: new Map() }))
+    expect(result.find((r) => r.section.id === labelSectionId("lbl_1"))?.items).toEqual([])
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -17,6 +17,11 @@ export interface ResolveSectionsInput {
   /** Synthetic DM drafts for members the user hasn't messaged yet. */
   virtualDmStreams: StreamItemData[]
   getUnreadCount: (streamId: string) => number
+  /**
+   * For each label id, the set of stream ids the viewer can see that carry it.
+   * Drives `{ kind: "label" }` sections; an absent label resolves to empty.
+   */
+  streamIdsByLabel: Map<string, Set<string>>
 }
 
 export interface ResolvedSection {
@@ -27,9 +32,10 @@ export interface ResolvedSection {
 /**
  * Turn a {@link SidebarConfig} into the ordered, capped, sorted stream lists the
  * sidebar renders. Pure — no React, no IO — so it is exercised directly in tests
- * and reused by every view. Each spec is mutually exclusive today (a stream
- * lands in exactly one smart bucket and is exactly one type), so sections are
- * resolved independently against the shared pool.
+ * and reused by every view. Sections are resolved independently against the
+ * shared pool with no cross-section dedup: smart buckets and stream types are
+ * mutually exclusive by construction, while a label section is deliberately an
+ * additive lens (a labeled stream still appears in its smart/type section).
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
   return config.sections.map((section) => ({
@@ -40,7 +46,19 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
 
 function resolveItems(spec: SidebarSectionSpec, input: ResolveSectionsInput): StreamItemData[] {
   if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input)
-  return resolveTypeSection(spec.streamType, input)
+  if (spec.kind === "type") return resolveTypeSection(spec.streamType, input)
+  return resolveLabelSection(spec.labelId, input)
+}
+
+/** Streams carrying a label, by activity. Draws from real streams only (synthetic DM drafts can't be labeled). */
+function resolveLabelSection(
+  labelId: string,
+  { processedStreams, streamIdsByLabel, getUnreadCount }: ResolveSectionsInput
+): StreamItemData[] {
+  const streamIds = streamIdsByLabel.get(labelId)
+  if (!streamIds || streamIds.size === 0) return []
+  const items = processedStreams.filter((stream) => streamIds.has(stream.id))
+  return sortStreams(items, "activity", getUnreadCount)
 }
 
 function resolveSmartBucket(

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -11,6 +11,11 @@ import { getActivityTime } from "./utils"
 interface SectionHeaderProps {
   label: string
   icon?: string
+  /**
+   * Renders in place of the plain `{icon} {label}` title (chevron and right-side
+   * controls are kept). Used by label sections to show a tinted `LabelChip`.
+   */
+  titleContent?: ReactNode
   /** Current collapse state. If omitted, header renders as static (non-clickable). */
   state?: CollapseState
   /** Toggle callback. If omitted, header renders as static. */
@@ -37,6 +42,7 @@ interface SectionHeaderProps {
 export function SectionHeader({
   label,
   icon,
+  titleContent,
   state,
   onToggle,
   unreadAggregate = 0,
@@ -49,7 +55,12 @@ export function SectionHeader({
   const isInteractive = !!onToggle && !!state
   const isCollapsed = state === "collapsed"
   let headerTitle: string | undefined
-  if (state) headerTitle = isCollapsed ? "Expand section" : "Collapse section"
+  if (state) {
+    const verb = isCollapsed ? "Expand" : "Collapse"
+    // Name the section so multiple collapsed headers (e.g. several label
+    // sections) stay distinguishable to screen readers and on hover.
+    headerTitle = label ? `${verb} ${label}` : `${verb} section`
+  }
   const hasAggregate = isCollapsed && unreadAggregate > 0
   const hasMentions = mentionAggregate > 0
   const hasMenu = !!addMenuActions && addMenuActions.length > 0
@@ -78,16 +89,22 @@ export function SectionHeader({
   const headingContent = (
     <div className="flex items-center gap-1.5 min-w-0">
       {isInteractive && <Chevron className="h-3 w-3 text-muted-foreground/70 shrink-0" aria-hidden />}
-      <h3
-        className={cn(
-          "font-semibold uppercase tracking-wide text-muted-foreground m-0 truncate",
-          nested ? "text-[10px]" : "text-xs",
-          hasAggregate && "text-foreground"
-        )}
-      >
-        {icon && `${icon} `}
-        {label}
-      </h3>
+      {titleContent ? (
+        // Keep the heading element (and its name) so screen-readers navigating by
+        // heading still reach label sections; the chip supplies its own styling.
+        <h3 className="m-0 min-w-0 truncate">{titleContent}</h3>
+      ) : (
+        <h3
+          className={cn(
+            "font-semibold uppercase tracking-wide text-muted-foreground m-0 truncate",
+            nested ? "text-[10px]" : "text-xs",
+            hasAggregate && "text-foreground"
+          )}
+        >
+          {icon && `${icon} `}
+          {label}
+        </h3>
+      )}
     </div>
   )
 
@@ -195,6 +212,8 @@ function filterActiveByRecency(
 interface StreamSectionProps {
   label: string
   icon?: string
+  /** Custom header title node (e.g. a label chip), forwarded to SectionHeader. */
+  titleContent?: ReactNode
   items: StreamItemData[]
   allStreams: StreamItemData[]
   workspaceId: string
@@ -222,6 +241,7 @@ interface StreamSectionProps {
 export function StreamSection({
   label,
   icon,
+  titleContent,
   items,
   allStreams,
   workspaceId,
@@ -247,6 +267,7 @@ export function StreamSection({
       <SectionHeader
         label={label}
         icon={icon}
+        titleContent={titleContent}
         state={state}
         onToggle={onToggle}
         unreadAggregate={unreadAggregate}
@@ -314,6 +335,7 @@ const TIER_VISIBLE_LIMIT = 10
 export function TieredStreamSection({
   label,
   icon,
+  titleContent,
   items,
   allStreams,
   workspaceId,
@@ -369,6 +391,7 @@ export function TieredStreamSection({
       <SectionHeader
         label={label}
         icon={icon}
+        titleContent={titleContent}
         state={state}
         onToggle={onToggle}
         unreadAggregate={unreadAggregate}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { SMART_SIDEBAR_CONFIG } from "@threa/types"
+import { hasLabelSection, labelSectionId, toggleLabelSection } from "./sidebar-config"
+
+describe("toggleLabelSection", () => {
+  it("appends a label section when absent and reports it as pinned", () => {
+    expect(hasLabelSection(SMART_SIDEBAR_CONFIG, "lbl_1")).toBe(false)
+
+    const next = toggleLabelSection(SMART_SIDEBAR_CONFIG, "lbl_1")
+
+    expect(hasLabelSection(next, "lbl_1")).toBe(true)
+    // Appended at the end; existing sections untouched.
+    expect(next.sections.slice(0, -1)).toEqual(SMART_SIDEBAR_CONFIG.sections)
+    expect(next.sections.at(-1)).toEqual({
+      id: labelSectionId("lbl_1"),
+      spec: { kind: "label", labelId: "lbl_1" },
+    })
+  })
+
+  it("removes the label section when already present (idempotent toggle)", () => {
+    const pinned = toggleLabelSection(SMART_SIDEBAR_CONFIG, "lbl_1")
+    const unpinned = toggleLabelSection(pinned, "lbl_1")
+
+    expect(hasLabelSection(unpinned, "lbl_1")).toBe(false)
+    expect(unpinned.sections).toEqual(SMART_SIDEBAR_CONFIG.sections)
+  })
+
+  it("only toggles the targeted label, leaving other label sections intact", () => {
+    const withTwo = toggleLabelSection(toggleLabelSection(SMART_SIDEBAR_CONFIG, "lbl_1"), "lbl_2")
+    const dropped = toggleLabelSection(withTwo, "lbl_1")
+
+    expect(hasLabelSection(dropped, "lbl_1")).toBe(false)
+    expect(hasLabelSection(dropped, "lbl_2")).toBe(true)
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -11,6 +11,37 @@ import { SMART_SECTIONS } from "./config"
  */
 export type { SidebarConfig, SidebarSection, SidebarSectionSpec, SidebarBasePreset }
 
+/**
+ * Section id for a label lens. Deterministic (one section per label) so the
+ * toggle below is idempotent and the id doubles as the collapse-state key.
+ */
+export function labelSectionId(labelId: string): string {
+  return `label:${labelId}`
+}
+
+/** Whether the config already pins the given label as a sidebar section. */
+export function hasLabelSection(config: SidebarConfig, labelId: string): boolean {
+  return config.sections.some((s) => s.spec.kind === "label" && s.spec.labelId === labelId)
+}
+
+/**
+ * Add the label section if absent, remove it if present. New sections append to
+ * the end (reordering is a later editor concern). Pure — the caller persists
+ * the result via `useSidebarConfig().setConfig`.
+ */
+export function toggleLabelSection(config: SidebarConfig, labelId: string): SidebarConfig {
+  if (hasLabelSection(config, labelId)) {
+    return {
+      ...config,
+      sections: config.sections.filter((s) => !(s.spec.kind === "label" && s.spec.labelId === labelId)),
+    }
+  }
+  return {
+    ...config,
+    sections: [...config.sections, { id: labelSectionId(labelId), spec: { kind: "label", labelId } }],
+  }
+}
+
 /** How a resolved section renders. Derived purely from its spec. */
 export interface SectionPresentation {
   label: string
@@ -53,9 +84,26 @@ const TYPE_PRESENTATION: Record<Extract<StreamType, "scratchpad" | "channel" | "
   },
 }
 
+/**
+ * Presentation for a label section. The header is rendered as a tinted
+ * `LabelChip` from the labels cache (the spec only carries the id), so `label`
+ * here is just an accessibility/fallback string the caller overrides. Tiered so
+ * a heavily-used label doesn't flood the sidebar; kept visible when empty since
+ * the user deliberately pinned it.
+ */
+const LABEL_PRESENTATION: SectionPresentation = {
+  label: "",
+  tiered: true,
+  compact: true,
+  showPreviewOnHover: true,
+  hideWhenEmpty: false,
+  defaultCollapse: "open",
+}
+
 /** Resolve how a section should render from its spec. */
 export function sectionPresentation(spec: SidebarSectionSpec): SectionPresentation {
   if (spec.kind === "type") return TYPE_PRESENTATION[spec.streamType]
+  if (spec.kind === "label") return LABEL_PRESENTATION
 
   const config = SMART_SECTIONS[spec.bucket]
   return {

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -1,6 +1,8 @@
 import type { RefObject } from "react"
 import type { CollapseState } from "@/contexts"
 import { Button } from "@/components/ui/button"
+import { LabelChip } from "@/components/labels/label-chip"
+import type { CachedLabel } from "@/hooks"
 import { StreamSection, TieredStreamSection } from "./sections"
 import { sectionPresentation, type SidebarSectionSpec } from "./sidebar-config"
 import type { ResolvedSection } from "./resolve-sections"
@@ -30,6 +32,8 @@ interface SidebarStreamListProps {
   processedStreams: StreamItemData[]
   /** Ordered sections with their resolved, sorted, capped stream lists. */
   resolvedSections: ResolvedSection[]
+  /** Labels visible to the viewer, by id — resolves the header chip for `label` sections. */
+  labelsById: Map<string, CachedLabel>
   getUnreadCount: (streamId: string) => number
   getMentionCount: (streamId: string) => number
   getSectionState: (section: string, defaultState?: CollapseState) => CollapseState
@@ -52,6 +56,7 @@ export function SidebarStreamList({
   activeStreamId,
   processedStreams,
   resolvedSections,
+  labelsById,
   getUnreadCount,
   getMentionCount,
   getSectionState,
@@ -101,6 +106,13 @@ export function SidebarStreamList({
         const presentation = sectionPresentation(section.spec)
         if (presentation.hideWhenEmpty && items.length === 0) return null
 
+        // Label sections render a tinted chip header resolved from the labels
+        // cache; a section whose label was archived/deleted is an orphan — skip it.
+        const label = section.spec.kind === "label" ? labelsById.get(section.spec.labelId) : undefined
+        if (section.spec.kind === "label" && !label) return null
+        const titleContent = label ? <LabelChip label={label} /> : undefined
+        const headerLabel = label ? label.name : presentation.label
+
         const state = getSectionState(section.id, presentation.defaultCollapse)
         const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
         const add = addWiringFor(section.spec)
@@ -110,7 +122,8 @@ export function SidebarStreamList({
             <TieredStreamSection
               key={section.id}
               sectionKey={section.id}
-              label={presentation.label}
+              label={headerLabel}
+              titleContent={titleContent}
               icon={presentation.icon}
               items={items}
               allStreams={processedStreams}
@@ -135,7 +148,8 @@ export function SidebarStreamList({
         return (
           <StreamSection
             key={section.id}
-            label={presentation.label}
+            label={headerLabel}
+            titleContent={titleContent}
             icon={presentation.icon}
             items={items}
             allStreams={processedStreams}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -23,6 +23,8 @@ import {
   useWorkspaceDmPeers,
   useWorkspaceFromStore,
   useWorkspaceUnreadState,
+  useWorkspaceLabels,
+  useWorkspaceLabelAssignments,
 } from "@/stores/workspace-store"
 import { useCoordinatedLoading, useSidebar } from "@/contexts"
 import { useCreateChannel } from "@/components/create-channel"
@@ -38,7 +40,8 @@ import type { SidebarActionItem } from "./sidebar-actions"
 import { calculateUrgency, categorizeStream } from "./utils"
 import type { StreamItemData } from "./types"
 import { resolveDmDisplayName } from "@/lib/streams"
-import { StreamTypes, Visibilities } from "@threa/types"
+import type { CachedLabel } from "@/hooks"
+import { StreamTypes, Visibilities, LabelableResourceTypes } from "@threa/types"
 
 interface SidebarProps {
   workspaceId: string
@@ -60,6 +63,8 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const idbStreams = useWorkspaceStreams(workspaceId)
   const idbStreamMemberships = useWorkspaceStreamMemberships(workspaceId)
   const idbDmPeers = useWorkspaceDmPeers(workspaceId)
+  const labels = useWorkspaceLabels(workspaceId)
+  const labelAssignments = useWorkspaceLabelAssignments(workspaceId)
   const { createDraft } = useDraftScratchpads(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getMentionCount, unreadActivityCount } = useActivityCounts(workspaceId)
@@ -182,10 +187,29 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   const hasUserStreams = hasUserStreamsFromStreams || virtualDmStreams.length > 0
 
+  // Active labels by id — resolves the chip header for label sections.
+  const labelsById = useMemo(() => {
+    const map = new Map<string, CachedLabel>()
+    for (const label of labels) if (!label.archivedAt) map.set(label.id, label)
+    return map
+  }, [labels])
+
+  // labelId → set of stream ids the viewer can see carrying that label.
+  const streamIdsByLabel = useMemo(() => {
+    const map = new Map<string, Set<string>>()
+    for (const assignment of labelAssignments) {
+      if (assignment.resourceType !== LabelableResourceTypes.STREAM) continue
+      const set = map.get(assignment.labelId) ?? new Set<string>()
+      set.add(assignment.resourceId)
+      map.set(assignment.labelId, set)
+    }
+    return map
+  }, [labelAssignments])
+
   // Resolve the persisted sidebar config into ordered, sorted, capped lists.
   const resolvedSections = useMemo(
-    () => resolveSections(sidebarConfig, { processedStreams, virtualDmStreams, getUnreadCount }),
-    [sidebarConfig, processedStreams, virtualDmStreams, getUnreadCount]
+    () => resolveSections(sidebarConfig, { processedStreams, virtualDmStreams, getUnreadCount, streamIdsByLabel }),
+    [sidebarConfig, processedStreams, virtualDmStreams, getUnreadCount, streamIdsByLabel]
   )
 
   // Track sidebar and scroll container dimensions for position calculations
@@ -341,6 +365,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             activeStreamId={activeStreamId}
             processedStreams={processedStreams}
             resolvedSections={resolvedSections}
+            labelsById={labelsById}
             getUnreadCount={getUnreadCount}
             getMentionCount={getMentionCount}
             getSectionState={getSectionState}

--- a/apps/frontend/src/pages/labels.tsx
+++ b/apps/frontend/src/pages/labels.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState, type FormEvent } from "react"
 import { Link, useParams } from "react-router-dom"
-import { ArrowLeft, Tag, Plus, Globe, Lock, Trash2, Pencil, LogOut, SmilePlus, X } from "lucide-react"
+import { ArrowLeft, Tag, Plus, Globe, Lock, Trash2, Pencil, LogOut, SmilePlus, X, PanelLeft } from "lucide-react"
 import { toast } from "sonner"
 import { Visibilities } from "@threa/types"
-import type { Visibility } from "@threa/types"
+import type { Visibility, SidebarConfig } from "@threa/types"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -43,10 +43,12 @@ import {
   useLabelsView,
   useLeaveLabel,
   usePromoteLabel,
+  useSidebarConfig,
   useUpdateLabel,
   type CachedLabel,
   type LabelViewerContext,
 } from "@/hooks"
+import { hasLabelSection, toggleLabelSection } from "@/components/layout/sidebar/sidebar-config"
 
 // A curated palette of saturated, distinct colors that read well as full-bleed
 // swatches. Users can override via hex input; these are the suggestions.
@@ -82,6 +84,9 @@ function LabelsPageInner({ workspaceId }: { workspaceId: string }) {
   useLabelsSync(workspaceId)
   const view = useLabelsView(workspaceId)
   const { myLabels, currentUserId } = view
+  // One sidebar-config instance for the whole catalog so the per-card pin
+  // buttons share its optimistic-write guard (see SidebarPinButton).
+  const { config: sidebarConfig, setConfig: setSidebarConfig } = useSidebarConfig(workspaceId)
   const [addOpen, setAddOpen] = useState(false)
 
   return (
@@ -127,13 +132,21 @@ function LabelsPageInner({ workspaceId }: { workspaceId: string }) {
               <AddLabelTile onClick={() => setAddOpen(true)} />
               {myLabels.map((label) =>
                 label.creatorUserId === currentUserId ? (
-                  <OwnedLabelCard key={label.id} workspaceId={workspaceId} label={label} />
+                  <OwnedLabelCard
+                    key={label.id}
+                    workspaceId={workspaceId}
+                    label={label}
+                    sidebarConfig={sidebarConfig}
+                    onSidebarConfigChange={setSidebarConfig}
+                  />
                 ) : (
                   <JoinedLabelCard
                     key={label.id}
                     workspaceId={workspaceId}
                     label={label}
                     userId={currentUserId ?? ""}
+                    sidebarConfig={sidebarConfig}
+                    onSidebarConfigChange={setSidebarConfig}
                   />
                 )
               )}
@@ -355,7 +368,48 @@ function JoinMatchRow({ label, disabled, onJoin }: { label: CachedLabel; disable
 // Catalog cards
 // ---------------------------------------------------------------------------
 
-function OwnedLabelCard({ workspaceId, label }: { workspaceId: string; label: CachedLabel }) {
+/**
+ * Toggles a `{ kind: "label" }` section for this label in the viewer's sidebar
+ * config. One section per label; appended on add, removed on toggle-off. The
+ * config + setter are threaded from the page so every card shares one
+ * `useSidebarConfig` instance (its optimistic-write guard is per-instance, so
+ * per-card instances would race on rapid toggles across labels).
+ */
+function SidebarPinButton({
+  config,
+  onConfigChange,
+  labelId,
+}: {
+  config: SidebarConfig
+  onConfigChange: (config: SidebarConfig) => void
+  labelId: string
+}) {
+  const pinned = hasLabelSection(config, labelId)
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      aria-pressed={pinned}
+      className={cn("h-7 gap-1.5 px-2 text-xs", pinned && "text-primary")}
+      onClick={() => onConfigChange(toggleLabelSection(config, labelId))}
+    >
+      <PanelLeft className="h-3 w-3" />
+      {pinned ? "In sidebar" : "Show in sidebar"}
+    </Button>
+  )
+}
+
+function OwnedLabelCard({
+  workspaceId,
+  label,
+  sidebarConfig,
+  onSidebarConfigChange,
+}: {
+  workspaceId: string
+  label: CachedLabel
+  sidebarConfig: SidebarConfig
+  onSidebarConfigChange: (config: SidebarConfig) => void
+}) {
   const isOnline = useIsOnline()
   const [editing, setEditing] = useState(false)
   const [confirmKind, setConfirmKind] = useState<"delete" | "promote" | null>(null)
@@ -422,6 +476,7 @@ function OwnedLabelCard({ workspaceId, label }: { workspaceId: string; label: Ca
             <Trash2 className="h-3 w-3" />
             Delete
           </Button>
+          <SidebarPinButton config={sidebarConfig} onConfigChange={onSidebarConfigChange} labelId={label.id} />
         </div>
       </LabelSwatchCard>
 
@@ -529,7 +584,19 @@ function LabelEditCard({
   )
 }
 
-function JoinedLabelCard({ workspaceId, label, userId }: { workspaceId: string; label: CachedLabel; userId: string }) {
+function JoinedLabelCard({
+  workspaceId,
+  label,
+  userId,
+  sidebarConfig,
+  onSidebarConfigChange,
+}: {
+  workspaceId: string
+  label: CachedLabel
+  userId: string
+  sidebarConfig: SidebarConfig
+  onSidebarConfigChange: (config: SidebarConfig) => void
+}) {
   const isOnline = useIsOnline()
   const leaveMutation = useLeaveLabel(workspaceId)
 
@@ -545,16 +612,19 @@ function JoinedLabelCard({ workspaceId, label, userId }: { workspaceId: string; 
 
   return (
     <LabelSwatchCard label={label}>
-      <Button
-        size="sm"
-        variant="ghost"
-        className="mt-3 h-7 w-fit gap-1.5 px-3 text-xs"
-        onClick={handleLeave}
-        disabled={!isOnline || leaveMutation.isPending}
-      >
-        <LogOut className="h-3 w-3" />
-        Leave
-      </Button>
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 gap-1.5 px-2 text-xs"
+          onClick={handleLeave}
+          disabled={!isOnline || leaveMutation.isPending}
+        >
+          <LogOut className="h-3 w-3" />
+          Leave
+        </Button>
+        <SidebarPinButton config={sidebarConfig} onConfigChange={onSidebarConfigChange} labelId={label.id} />
+      </div>
     </LabelSwatchCard>
   )
 }

--- a/docs/plans/configurable-sidebar-and-visible-labels.md
+++ b/docs/plans/configurable-sidebar-and-visible-labels.md
@@ -132,11 +132,34 @@ label; backfill migration for existing private labels; `leave()` →
 last-member-archive (race-safe). `listVisibleTo`/membership reads simplified to
 the uniform set; `creator_user_id` retained for permissions.
 
-### PR4 — Sidebar label sections + shared chip
+### PR4 — Sidebar label sections + shared chip ✅ implemented
 
-Shared tinted `LabelChip` (`components/labels/label-chip.tsx`). Add the `label`
-section kind end-to-end (resolver filter by assignment, tinted section header,
-add/remove entry points: label picker, labels page, section-header menu).
+Shipped the `label` section kind end-to-end + the shared tinted `LabelChip`:
+
+- **`LabelChip`** (`components/labels/label-chip.tsx`): tinted pill —
+  `hexToRgba(color, 0.12)` bg, ~30% border, name in ink, leading `LabelGlyph`
+  (emoji on a tinted disc, or a solid color dot when the label has no emoji).
+  Per-label authored color only (DESIGN.md §2.2). Reused by PR5.
+- **`{ kind: "label"; labelId }`** added to `SidebarSectionSpec` (`@threa/types`)
+  - the backend Zod schema. Resolver filters real streams by assignment and
+    sorts by activity; it's an **additive lens** — a labeled stream still appears
+    in its smart/type section (the resolver never dedups, so this needs no
+    `hideAboveShown`). Orphan sections (label archived) are skipped at render.
+- **Tinted header**: `SectionHeader` gained an optional `titleContent`; label
+  sections render the `LabelChip` there, resolved from the labels cache by id
+  (so rename/recolor stays live). `sidebar.tsx` builds `labelsById` +
+  `streamIdsByLabel` from the workspace caches.
+- **Entry point**: a "Show in sidebar" toggle on each owned/joined label card
+  (Labels page) adds/removes the section via `toggleLabelSection` →
+  `useSidebarConfig().setConfig`. One deterministic section per label.
+- Tests: resolver label-section (additive + empty), `toggleLabelSection`
+  helpers (object-compare, INV-24). Typecheck + lint clean.
+
+**Deviations (deferred, not dropped):** `hideAboveShown` + the `remainder` kind
+remain deferred — additive label lenses work without them (no dedup), so adding
+them now would be speculative (INV-36). The roomy "Sidebar" settings panel,
+drag-reorder, and the label-picker / section-header-menu add paths are deferred;
+the Labels-page toggle is the single add/remove surface for now.
 
 ### PR5 — Stream top-bar label stack
 

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -23,6 +23,13 @@ export type SidebarTypeSection = (typeof SIDEBAR_TYPE_SECTIONS)[number]
 export type SidebarSectionSpec =
   | { kind: "smart"; bucket: SidebarSectionKey }
   | { kind: "type"; streamType: SidebarTypeSection }
+  /**
+   * A label lens: streams the viewer can see that carry this label. Additive —
+   * a labeled stream still appears in its smart/type section too. The label's
+   * name/color/emoji are resolved from the labels cache at render time, not
+   * stored here (only the id, so a renamed/recolored label stays in sync).
+   */
+  | { kind: "label"; labelId: string }
 
 export interface SidebarSection {
   /** Stable key — also the collapse-state persistence key on the frontend. */


### PR DESCRIPTION
## What & why

PR4 of the configurable-sidebar / visible-labels stack (PR1 #667, PR2 #669, PR3 #672). This is the payoff phase: **labels become visible in the sidebar** as label-driven sections, built on PR3's unified membership.

> **Stacked on #672** — base is `claude/label-model-unified-membership` so the diff shows only PR4. I'll rebase onto `main` once #672 squash-merges.

## Changes

- **Shared `LabelChip`** (`components/labels/label-chip.tsx`): the one tinted visual language for labels — authored color tints bg + border, emoji-on-disc (or solid color dot) glyph leads, name in ink. Composes the Shadcn `badgeVariants` pill (INV-14); per-label authored color only (DESIGN.md §2.2). Reused by PR5's top-bar stack.
- **`{ kind: "label"; labelId }` section** (`@threa/types` `SidebarSectionSpec` + backend Zod). The resolver filters real streams by label assignment and sorts by activity. It's an **additive lens** — a labeled stream still appears in its smart/type section (the resolver never dedups), so this needs no `hideAboveShown`. Orphan sections (label archived) are skipped at render.
- **Tinted header**: `SectionHeader` gained an optional `titleContent` (kept inside an `<h3>` so heading semantics survive); label sections render the `LabelChip` there, resolved from the labels cache by id so rename/recolor stays live. `sidebar.tsx` builds `labelsById` + `streamIdsByLabel` from the workspace caches.
- **Entry point**: a "Show in sidebar" toggle on each owned/joined label card (Labels page) adds/removes the section via the pure `toggleLabelSection` helper. One deterministic section per label; the page holds a single `useSidebarConfig` instance shared by all cards.

## Tests
- Resolver: label-section filter + additive behavior + empty case.
- `toggleLabelSection` / `hasLabelSection` helpers (object-compare, INV-24).
- Existing sidebar/context/label-picker suites green (53 in the touched dirs). Full pre-commit gate (typecheck across all workspaces, lint, OpenAPI-docs) passing.

## Self-review
3-perspective review (spec/plan, correctness/reactivity, design/consistency). Folded in:
- **Single `useSidebarConfig`** hoisted to the Labels page — per-card instances each had their own optimistic-write guard and could lose-update on rapid cross-label toggles.
- **Heading a11y**: `titleContent` now renders inside an `<h3>`, and the collapse `aria-label`/tooltip names the section ("Collapse «Bug»").
- **INV-14**: `LabelChip` composes `badgeVariants` instead of a hand-rolled pill.
- **INV-37**: migrated `label-picker`'s private `LabelGlyph` to the shared one (added a `fallback: "dot" | "tag"` prop) and deleted the duplicate.
- **INV-33**: test uses `labelSectionId()` instead of a hardcoded `"label:"` literal.

## Deviations (deferred, documented)
`hideAboveShown` + the `remainder` kind remain deferred — additive label lenses work without them (no dedup), so adding them now would be speculative (INV-36). The roomy "Sidebar" settings panel, drag-reorder, and the label-picker / section-header-menu add paths are deferred; the Labels-page toggle is the single add/remove surface for now. The two larger label-swatch glyphs on the Labels page (`LabelSwatchCard`, `JoinMatchRow`, both 8–9px card discs) were left on their bespoke rendering — a separate cleanup, distinct from the small-glyph collision this PR resolved.

Plan: `docs/plans/configurable-sidebar-and-visible-labels.md` (PR4 section).

https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782639018&installation_id=129946197&pr_number=674&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F674&signature=67cd76a69048828cd2add57fc84518bc639d7caf3f4cc876d286e845e1f9c3fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->