### PR TITLE
fix(loading): reveal cached content immediately, don't gate app open on avatar preload

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -307,6 +307,63 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("phase").textContent).toBe("ready")
   })
 
+  it("reveals cached content immediately when IDB is primed even while avatars are still preloading", async () => {
+    // Offline-first regression: a returning user's read model is fully in IDB,
+    // but avatar preloading hits the network. On a flaky connection those image
+    // requests hang until the 2s preload timeout, so gating the reveal on them
+    // made the app slower "out and about" than offline (where they error
+    // instantly). A primed cache must reveal immediately and let avatars stream
+    // in afterward.
+    makeReadyWorkspaceState()
+    mockSeedCacheFromIdbResult = true
+    mockUsers = [{ id: "user_1", avatarUrl: "https://cdn.example/avatar.png" }]
+    vi.spyOn(usePreloadImagesModule, "usePreloadImages").mockReturnValue(false)
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("still waits on avatar preload during a genuine cold load (nothing cached)", async () => {
+    // Counterpart to the primed-cache case: with no IDB cache there is nothing
+    // to reveal early, so the cold-load nicety of preloading avatars before the
+    // first paint (avoiding an initials→avatar flash) still applies — the gate
+    // holds until the preload resolves.
+    makeReadyWorkspaceState()
+    mockSeedCacheFromIdbResult = false // cache not primed
+    mockUsers = [{ id: "user_1", avatarUrl: "https://cdn.example/avatar.png" }]
+    const preloadSpy = vi.spyOn(usePreloadImagesModule, "usePreloadImages").mockReturnValue(false)
+
+    const { rerender } = render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    // Data is ready but avatars are not preloaded and the cache isn't primed —
+    // the gate must not open yet.
+    expect(screen.getByTestId("phase").textContent).not.toBe("ready")
+
+    preloadSpy.mockReturnValue(true)
+    rerender(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
   it("reports stream state as idle during the initial coordinated load", async () => {
     mockStreamResults = [{ status: "pending", fetchStatus: "fetching", isLoading: true, isError: false, error: null }]
 

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -188,6 +188,16 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   }, [idbUsers, workspaceId])
   const avatarsReady = usePreloadImages(avatarUrls)
 
+  // Avatar preloading avoids an avatar pop-in on the very first cold load, but
+  // it hits the network — on a flaky connection those image requests hang until
+  // the preload's 2s timeout, while offline they `onerror` instantly. Gating
+  // the reveal on it makes a returning user wait longer "out and about" than
+  // offline: their entire read model is already in IDB. So when the cache is
+  // primed we reveal immediately (offline-first: cached content is never held
+  // behind a network wait) and let avatars stream in through their own <img>
+  // loads. Only a genuine cold load (nothing cached) still waits on the preload.
+  const revealReady = avatarsReady || idbCachePrimed
+
   // After the initial coordinated load completes, stream-specific bootstraps
   // (triggered by navigating to a new stream) should not re-trigger the
   // top-bar loading indicator. Individual stream loading is handled by
@@ -253,13 +263,14 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
     return "loading"
   }, [isReady, showSkeleton])
 
-  // Mark initial load as complete once data + avatar images are ready
+  // Mark initial load as complete once data is ready (and, on a cold load,
+  // avatars preloaded — see `revealReady`).
   useEffect(() => {
-    if (!isLoading && avatarsReady && !initialLoadCompleteRef.current) {
+    if (!isLoading && revealReady && !initialLoadCompleteRef.current) {
       initialLoadCompleteRef.current = true
       setIsReady(true)
     }
-  }, [isLoading, avatarsReady])
+  }, [isLoading, revealReady])
 
   // Show skeleton after delay if still loading during initial load
   useEffect(() => {


### PR DESCRIPTION
## Problem

The app is offline-first under the hood (Dexie cache, `useLiveQuery`-fed timeline, IDB-bypass in the load gate), yet it felt **worse on a flaky connection than fully offline**. That inversion was the tell.

On reopen, `CoordinatedLoadingProvider` decides when to reveal content. Every gate it checks clears from **local IDB reads in milliseconds** (workspace seeded, streams cached, drafts seeded) — except **avatar preloading**.

`usePreloadImages` only resolves once every avatar image loads **or a 2s timeout fires**, and `isReady` waited on it:

```ts
if (!isLoading && avatarsReady && !initialLoadCompleteRef.current) { … }
```

- **Offline:** the image requests `onerror` instantly → gate opens → cached messages show immediately.
- **Out and about (slow/flaky):** the requests hang for up to 2s → the user stares at a skeleton that is **hiding messages already in IDB**.

That's the "it loads a fuckton of data before showing anything" symptom — the reveal was held hostage to the network for avatar images. It slipped through because every existing test mocked `usePreloadImages` → `true`, so the network-bound path was never exercised.

## Fix

Scope the avatar gate to genuine cold loads:

```ts
const revealReady = avatarsReady || idbCachePrimed
```

When the IDB cache is primed (a returning user — the offline-first path), reveal **immediately** and let avatars stream in through their own `<img>` loads. A cold load with nothing cached still preloads avatars first to avoid an initials→avatar flash. Avatar preloading keeps running in the background either way.

Result: cached content paints instantly on open, then the background bootstrap refreshes — "show it immediately, then load more."

## Not touched

The recent jump fixes (#663 `firstItemIndex` re-anchoring, #668 composer re-anchor) are left alone — they keep the timeline *stable* when the background bootstrap slides the event window, a separate concern from the reveal gate. The timeline render was already offline-first (renders IDB events synchronously, never blanks a non-empty cache). This was purely the app-open gate blocking on the network.

## Tests

- New regression: with IDB primed and `usePreloadImages` still pending, the gate reaches `ready` immediately.
- New counterpart: a cold load (nothing cached) still holds until the preload resolves.
- Full suite green (19 tests in `coordinated-loading-context.test.tsx`); monorepo lint + typecheck pass via pre-commit.

https://claude.ai/code/session_01Qr3Xfqzy7P4g1bWH9FiJ4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qr3Xfqzy7P4g1bWH9FiJ4C)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782639412&installation_id=129946197&pr_number=675&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F675&signature=acfcb4e392f80455e31e713c1424bd8dc4f155a40e006525aff726f3b6a50764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->