### PR TITLE
feat(memos): show first page of memos when /memo picker opens

### DIFF
--- a/apps/frontend/src/components/editor/triggers/memo-suggestion-empty-state.test.tsx
+++ b/apps/frontend/src/components/editor/triggers/memo-suggestion-empty-state.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest"
-import { act, render, screen } from "@testing-library/react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { SuggestionProps } from "@tiptap/suggestion"
 import type { Memo } from "@threa/types"
+import { api } from "@/api/client"
 import { useMemoSuggestion } from "./use-memo-suggestion"
 
 type MemoSuggestionConfig = ReturnType<typeof useMemoSuggestion>["suggestionConfig"]
@@ -14,13 +15,13 @@ function Harness({ capture }: { capture: (cfg: MemoSuggestionConfig) => void }) 
   return <>{renderMemoList()}</>
 }
 
-// Drive the picker into an empty-results state for the given query. onStart only
-// reads editor.storage, items, query, clientRect and command, so a partial props
-// object is sufficient.
-function activateWithEmptyResults(cfg: MemoSuggestionConfig, query: string) {
+// Drive the picker for the given query with the given results. onStart only
+// reads editor.storage, items, query, clientRect and command, so a partial
+// props object is sufficient.
+function activateWith(cfg: MemoSuggestionConfig, query: string, items: Memo[]) {
   const props = {
     editor: { storage: { memoSearch: {} } },
-    items: [] as Memo[],
+    items,
     query,
     clientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) }),
     command: () => {},
@@ -54,16 +55,34 @@ function renderPicker() {
   return () => cfg!
 }
 
-describe("/memo picker empty state", () => {
-  it("prompts to keep typing before the query is long enough to search", () => {
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeMemo(overrides: Partial<Memo>): Memo {
+  return { id: "memo_1", title: "Recent memo", knowledgeType: "decision", tags: [], ...overrides } as unknown as Memo
+}
+
+describe("/memo picker discoverability", () => {
+  it("fetches and shows the first page of memos when /memo opens with no query typed", async () => {
+    const postSpy = vi
+      .spyOn(api, "post")
+      .mockResolvedValue({ results: [{ memo: makeMemo({ title: "Recent memo" }) }] } as never)
     const getCfg = renderPicker()
-    activateWithEmptyResults(getCfg(), "")
-    expect(screen.getByText("Type to search memos")).toBeInTheDocument()
+
+    const items = (await getCfg().items({ query: "" })) as Memo[]
+
+    // An empty query searches (returns recent memos) rather than short-circuiting.
+    expect(postSpy).toHaveBeenCalledWith("/api/workspaces/ws_1/memos/search", expect.objectContaining({ query: "" }))
+    expect(items.map((m) => m.title)).toEqual(["Recent memo"])
+
+    activateWith(getCfg(), "", items)
+    await waitFor(() => expect(screen.getByText("Recent memo")).toBeInTheDocument())
   })
 
-  it("says nothing matched once the query is searchable but returns no memos", () => {
+  it("says nothing matched when a query returns no memos", () => {
     const getCfg = renderPicker()
-    activateWithEmptyResults(getCfg(), "auth rewrite")
+    activateWith(getCfg(), "auth rewrite", [])
     expect(screen.getByText("No memos found")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
@@ -8,8 +8,6 @@ import { MemoSuggestionList } from "./memo-suggestion-list"
 import { useSuggestion } from "./use-suggestion"
 
 const MEMO_SEARCH_LIMIT = 8
-/** Below this, searching is noise — wait for a more specific query. */
-const MIN_QUERY_LENGTH = 2
 
 /**
  * Manages the inline `/memo` search picker. Backs the suggestion list with the
@@ -22,8 +20,12 @@ export function useMemoSuggestion() {
 
   const searchItems = useCallback(
     async (query: string): Promise<Memo[]> => {
+      if (!workspaceId) return []
+      // An empty query is intentional: opening `/memo ` should immediately show
+      // the first page of memos so they're discoverable before you know what to
+      // search for. The backend orders an empty search by recency; typing a
+      // query switches it to keyword + semantic ranking.
       const trimmed = query.trim()
-      if (!workspaceId || trimmed.length < MIN_QUERY_LENGTH) return []
       const request = { query: trimmed, limit: MEMO_SEARCH_LIMIT }
       const response = await queryClient.fetchQuery({
         queryKey: memoKeys.search(workspaceId, request),
@@ -48,9 +50,7 @@ export function useMemoSuggestion() {
         items={props.items}
         clientRect={props.clientRect}
         command={props.command}
-        // Before the query is long enough to search, the empty list means
-        // "keep typing", not "nothing matched" — say so.
-        emptyState={props.query.trim().length < MIN_QUERY_LENGTH ? "Type to search memos" : "No memos found"}
+        emptyState="No memos found"
       />
     ),
     []


### PR DESCRIPTION
## Why

The inline `/memo` picker had no discoverability. A `MIN_QUERY_LENGTH = 2` gate meant `searchItems` returned `[]` and the picker showed "Type to search memos" until you'd typed two characters — so there was no signal that any memos existed unless you already knew what to search for. The whole point of the command is that memos should be discoverable.

## What

Opening `/memo ` now immediately fetches and shows the first page of memos, then re-ranks as you type.

- **`use-memo-suggestion.tsx`**: dropped the `MIN_QUERY_LENGTH` gate so an empty query fetches the first page. The backend already orders an empty search by recency (`fullTextSearch("")` → active memos by `updated_at DESC`, scoped to the user's accessible streams), so this is a frontend-only lift — typing a query switches it to keyword + semantic ranking.
- Removed the now-dead "Type to search memos" empty state; the only remaining empty state is the genuine "No memos found".

This is the small first step ("show the first page"); richer filtering can layer on later once that surface exists.

## Tests

- Rewrote `memo-suggestion-empty-state.test.tsx` → `/memo picker discoverability`: asserts an empty query hits the search endpoint with `query: ""` and renders the returned memo, plus keeps the "No memos found" case.
- Existing trigger test already covers `/memo ` activating with an empty query.
- Verified: trigger test files pass (7 tests), frontend `typecheck` clean, eslint clean.

https://claude.ai/code/session_01TvGidVs4pMboduZNvuDaSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvGidVs4pMboduZNvuDaSb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782639492&installation_id=129946197&pr_number=676&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F676&signature=f10a3b7cc9892bce073bb42ace661193293fb406ef2896293fcd35bf2fab23d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->