### PR TITLE
fix(editor): make the /memo picker escapable and trap keys while open

### DIFF
--- a/apps/frontend/src/components/editor/triggers/memo-search-extension.test.ts
+++ b/apps/frontend/src/components/editor/triggers/memo-search-extension.test.ts
@@ -71,4 +71,19 @@ describe("MemoSearchExtension trigger matching", () => {
     expect(state.active).toBe(true)
     expect(state.query).toBe("")
   })
+
+  it("does NOT activate inside inline code", () => {
+    const editor = makeEditor()
+    editor.commands.focus()
+    editor.chain().focus().setMark("code").run()
+    typeText(editor, "/memo auth")
+    expect(memoState(editor).active).toBe(false)
+  })
+
+  it("does NOT activate when a backtick sits directly before /memo (`` `/memo`` )", () => {
+    const editor = makeEditor()
+    editor.commands.focus()
+    typeText(editor, "see `/memo auth")
+    expect(memoState(editor).active).toBe(false)
+  })
 })

--- a/apps/frontend/src/components/editor/triggers/memo-search-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/memo-search-extension.ts
@@ -93,6 +93,9 @@ export const MemoSearchExtension = Extension.create<MemoSearchOptions>({
         startOfLine: false,
         findSuggestionMatch: findMemoSearchMatch,
         // Suppress inside code blocks / inline code (mirrors createTriggerExtension).
+        // A literal backtick directly before `/memo` (`` `/memo`` ) can't match the
+        // trigger anyway — MEMO_TRIGGER requires whitespace or block-start before
+        // `/memo`, and a backtick is neither.
         allow: ({ state, range }) => {
           const $from = state.doc.resolve(range.from)
           for (let depth = $from.depth; depth >= 0; depth--) {

--- a/apps/frontend/src/components/editor/triggers/memo-suggestion-empty-state.test.tsx
+++ b/apps/frontend/src/components/editor/triggers/memo-suggestion-empty-state.test.tsx
@@ -17,10 +17,16 @@ function Harness({ capture }: { capture: (cfg: MemoSuggestionConfig) => void }) 
 
 // Drive the picker for the given query with the given results. onStart only
 // reads editor.storage, items, query, clientRect and command, so a partial
-// props object is sufficient.
-function activateWith(cfg: MemoSuggestionConfig, query: string, items: Memo[]) {
+// props object is sufficient. `storage` is the editor.storage.memoSearch object
+// the hook writes popupVisible into — pass one in to assert on it.
+function activateWith(
+  cfg: MemoSuggestionConfig,
+  query: string,
+  items: Memo[],
+  storage: Record<string, unknown> = {}
+) {
   const props = {
-    editor: { storage: { memoSearch: {} } },
+    editor: { storage: { memoSearch: storage } },
     items,
     query,
     clientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) }),
@@ -84,5 +90,14 @@ describe("/memo picker discoverability", () => {
     const getCfg = renderPicker()
     activateWith(getCfg(), "auth rewrite", [])
     expect(screen.getByText("No memos found")).toBeInTheDocument()
+  })
+
+  it("marks the popup visible even with zero results so Escape dismisses it (not blur the editor)", () => {
+    const getCfg = renderPicker()
+    const storage: { popupVisible?: boolean } = {}
+    // An empty result set still renders the empty-state popup; popupVisible must
+    // be true so isSuggestionActive reports it and Escape/Enter route to the picker.
+    activateWith(getCfg(), "", [], storage)
+    expect(storage.popupVisible).toBe(true)
   })
 })

--- a/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
@@ -60,6 +60,11 @@ export function useMemoSuggestion() {
     extensionName: "memoSearch",
     searchItems,
     renderList,
+    // While the picker is open it always renders something — recent memos, search
+    // results, or the "No memos found" empty state — so treat it as visible even
+    // with zero results. That way Escape dismisses the picker (instead of blurring
+    // the editor) and Enter is trapped while it's open — see isSuggestionActive.
+    rendersEmptyState: true,
   })
 
   return {

--- a/apps/frontend/src/components/editor/triggers/use-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-suggestion.tsx
@@ -31,6 +31,16 @@ export interface UseSuggestionConfig<T> {
    * straight to TipTap's suggestion plugin, which awaits it before rendering.
    */
   searchItems?: (query: string) => Promise<T[]>
+  /**
+   * Whether `renderList` shows an empty state, so the popup stays on-screen even
+   * with zero items. When true, `popupVisible` tracks whether the suggestion is
+   * active rather than whether it has items — so `isSuggestionActive` reports the
+   * popup, and Escape dismisses it (instead of blurring the editor) while Enter
+   * is trapped by the picker. Triggers that render nothing on empty results
+   * (mention/channel/slash/emoji) leave this false so zero-result queries don't
+   * block Enter from sending.
+   */
+  rendersEmptyState?: boolean
   /** Render the suggestion list component */
   renderList: (props: {
     ref: RefObject<SuggestionListRef | null>
@@ -65,7 +75,7 @@ export interface UseSuggestionResult<T> {
  * Handles the lifecycle callbacks and portal rendering.
  */
 export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionResult<T> {
-  const { extensionName, getItems, filterItems, searchItems, renderList } = config
+  const { extensionName, getItems, filterItems, searchItems, rendersEmptyState, renderList } = config
   const [state, setState] = useState<SuggestionState<T> | null>(null)
   const listRef = useRef<SuggestionListRef>(null)
   const editorRef = useRef<Editor | null>(null)
@@ -115,7 +125,7 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
   const onStart = useCallback(
     (props: SuggestionProps<T>) => {
       editorRef.current = props.editor
-      setPopupVisible(props.editor, props.items.length > 0)
+      setPopupVisible(props.editor, rendersEmptyState || props.items.length > 0)
       setState({
         items: props.items,
         query: props.query,
@@ -123,7 +133,7 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
         command: props.command,
       })
     },
-    [setPopupVisible]
+    [setPopupVisible, rendersEmptyState]
   )
 
   const onUpdate = useCallback(
@@ -131,7 +141,7 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
       // Drop out-of-order async resolutions: only the latest requested query's
       // results may update the popup (see latestQueryRef).
       if (searchItemsRef.current && props.query !== latestQueryRef.current) return
-      setPopupVisible(props.editor, props.items.length > 0)
+      setPopupVisible(props.editor, rendersEmptyState || props.items.length > 0)
       setState({
         items: props.items,
         query: props.query,
@@ -139,7 +149,7 @@ export function useSuggestion<T>(config: UseSuggestionConfig<T>): UseSuggestionR
         command: props.command,
       })
     },
-    [setPopupVisible]
+    [setPopupVisible, rendersEmptyState]
   )
 
   const onExit = useCallback(


### PR DESCRIPTION
## Problem

The inline `/memo` search popup couldn't be dismissed with **Escape** and lingered open after sending a message — and **Enter** sent the message straight through the open picker.

## Root cause

`isSuggestionActive()` — which gates Escape (blur vs. dismiss), Enter-to-send, Tab, etc. — reads `editor.storage.memoSearch.popupVisible`. The shared `useSuggestion` hook set that flag to `items.length > 0`. That's correct for triggers that render *nothing* on empty results (`@mention`, `#channel`, `/slash`, `:emoji:`), but the memo list **always renders an empty state** ("Type to search memos" / "No memos found").

So whenever the picker was on-screen with a short or no-match query, `popupVisible` was `false`:

- **Escape** → `isSuggestionActive` false → the editor's `handleKeyDown` blurred the editor *instead of* deferring to the suggestion plugin, leaving the popup mounted (its React state was never cleared).
- **Enter** → not trapped → the message sent through the open picker.

The TipTap suggestion plugin (3.22.3) already has solid native Escape + `dismissedRange` handling; it just never received the keystroke.

## Fix

- Add a `rendersEmptyState` option to `useSuggestion` that ties `popupVisible` to *the picker being active* rather than to item count.
- Set `rendersEmptyState: true` on the memo picker only. The other triggers keep their items-based behavior, so their zero-result queries (e.g. `:)`) still don't block Enter.

Now Escape dismisses the picker (and the plugin's `dismissedRange` keeps it closed as you keep typing), and Enter/Tab are trapped while it's open. Focus already stayed in the editor with an inline query — escapability was the missing piece. Multi-word queries (`/memo auth rewrite`) still work; a space does not close the picker.

## On the backtick / inline-code report

Triggering `/memo` inside inline code (`` `/memo` ``) is **already prevented** in the current code: `MEMO_TRIGGER` requires whitespace or block-start immediately before `/memo` (a backtick is neither), plus a code-mark guard covers established inline code. Verified it doesn't fire today; this was likely seen on an older build. Added regression tests + a clarifying comment so it stays that way.

## Tests

- New: `popupVisible` is `true` for the empty-results memo picker (so Escape/Enter route to it).
- New: `/memo` does not activate inside inline code, nor when a backtick sits directly before it.
- All 312 editor tests pass; monorepo typecheck + lint clean.

https://claude.ai/code/session_01Rtu92B25eTpe1xgVbPH6gE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rtu92B25eTpe1xgVbPH6gE)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782639510&installation_id=129946197&pr_number=677&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F677&signature=3b29ff238b33c6c67f410864b44e31fc7391460e43c2c513d412fb7cc3562d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->