### PR TITLE
perf(browser-tests): cut wall time ~14m → ~9.5m (3 of 4 shards now ~5m)

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 25
     continue-on-error: true
     env:
-      TOTAL_SHARDS: 3
+      TOTAL_SHARDS: 4
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [1, 2, 3]
+        shard_index: [1, 2, 3, 4]
 
     services:
       postgres:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -47,6 +47,16 @@ jobs:
 
       - name: Start MinIO
         run: |
+          # Pull explicitly with retries — Docker Hub manifest fetches fail
+          # transiently, and the shards pull concurrently which makes a blip on
+          # any one of them abort the whole shard before tests even start.
+          for attempt in 1 2 3 4 5; do
+            if docker pull minio/minio:latest; then
+              break
+            fi
+            echo "docker pull minio failed (attempt $attempt/5) — retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
           docker run -d --name minio \
             -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin \

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:e2e": "vite build",
     "preview": "vite preview",
     "test": "bun ../../scripts/test-silent.ts frontend",
     "test:watch": "vitest",

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -68,6 +68,26 @@ function withForwardedHostHeaders() {
   }
 }
 
+function buildProxyConfig() {
+  // /api and /test-auth-login are proxied to the backend (the workspace-router
+  // in E2E). Socket.io connects directly to the backend's wsUrl, so it does not
+  // need a proxy entry here. Shared by the dev server and the E2E preview server.
+  return {
+    "/api": {
+      target: backendTarget,
+      changeOrigin: true,
+      xfwd: true,
+      ...withForwardedHostHeaders(),
+    },
+    "/test-auth-login": {
+      target: backendTarget,
+      changeOrigin: true,
+      xfwd: true,
+      ...withForwardedHostHeaders(),
+    },
+  }
+}
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(buildVersion),
@@ -82,7 +102,12 @@ export default defineConfig({
       injectRegister: false, // we register manually in main.tsx with updateViaCache: 'none'
       manifest: false, // use existing public/manifest.json
       injectManifest: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+        // E2E serves a fresh build behind `vite preview`, so precaching ~14 MiB
+        // of assets into CacheStorage on every test's first load just adds
+        // hundreds of background requests per test and competes with the run.
+        // The SW still registers (push tests need it) and its navigation handler
+        // falls through to the network when nothing is precached.
+        globPatterns: isE2ETest ? [] : ["**/*.{js,css,html,ico,png,svg}"],
         // recover.html is the nuclear-option SW-unregister page (public/recover.html).
         // Precaching it would defeat its purpose — and with CF Pages Pretty URLs, the
         // /recover ↔ /recover.html rewrite loop in _redirects causes the SW install
@@ -111,23 +136,18 @@ export default defineConfig({
     host: "0.0.0.0",
     port: frontendPort,
     hmr: isE2ETest ? false : undefined,
-    proxy: {
-      "/api": {
-        target: backendTarget,
-        changeOrigin: true,
-        xfwd: true,
-        ...withForwardedHostHeaders(),
-      },
-      "/test-auth-login": {
-        target: backendTarget,
-        changeOrigin: true,
-        xfwd: true,
-        ...withForwardedHostHeaders(),
-      },
-    },
+    proxy: buildProxyConfig(),
     watch: {
       usePolling: true,
       interval: 100,
     },
+  },
+  // E2E runs against a production build served by `vite preview` (see
+  // playwright.config.ts). The preview server needs the same proxy as the dev
+  // server, since proxy config does not carry over from `server`.
+  preview: {
+    host: "0.0.0.0",
+    port: frontendPort,
+    proxy: buildProxyConfig(),
   },
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -91,7 +91,11 @@ export default defineConfig({
   fullyParallel: true, // Each test creates unique user + workspace — safe to parallelize
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 3 : undefined, // CI: 3 workers — 4 oversubscribed the 4-vCPU runner (shared backend/frontend), causing tests to fail under contention and pass only on isolated retry; local: auto (half CPU cores)
+  // CI: 3 workers. The 4-vCPU runner also hosts the backend, control-plane,
+  // wrangler and Vite dev server, so higher worker counts oversubscribe it and
+  // tests fail under contention (only passing on the isolated retry).
+  // Local: auto (half CPU cores).
+  workers: process.env.CI ? 3 : undefined,
   reporter: process.env.CI ? [["github"], ["line"], ["html", { open: "never" }]] : "list",
   timeout: 30000, // 30s per test
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -69,6 +69,18 @@ const cpDbName = `${dbName}_cp`
 const setupBrowserInfraCommand = "bun tests/browser/setup-infra.ts"
 const webServerTimeout = 60000
 
+// In CI the frontend is served as a production build via `vite preview` rather
+// than the Vite dev server: dev-mode on-demand transform competes for CPU with
+// the parallel workers and the shared backend, which was the dominant source of
+// contention timeouts. Locally we keep the dev server for fast iteration/HMR.
+// The build is port-independent (VITE_BACKEND_PORT only configures the preview
+// proxy at runtime), so the preview server still picks up the dynamic ports.
+const frontendCommand = isCI
+  ? "bun run --cwd apps/frontend build:e2e && bun run --cwd apps/frontend preview"
+  : "bun run test:browser:frontend"
+// The CI build needs more headroom than a dev-server boot.
+const frontendServerTimeout = isCI ? 180000 : webServerTimeout
+
 // Only log once (when ports are first allocated)
 if (!process.env.PLAYWRIGHT_PORTS_LOGGED) {
   console.log(
@@ -171,10 +183,10 @@ export default defineConfig({
       timeout: webServerTimeout,
     },
     {
-      command: "bun run test:browser:frontend",
+      command: frontendCommand,
       url: `http://localhost:${frontendPort}`,
       reuseExistingServer: !process.env.CI,
-      timeout: webServerTimeout,
+      timeout: frontendServerTimeout,
       env: {
         VITE_BACKEND_PORT: String(routerPort),
         VITE_PORT: String(frontendPort),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
   fullyParallel: true, // Each test creates unique user + workspace — safe to parallelize
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 4 : undefined, // CI: 4 parallel workers; local: auto (half CPU cores)
+  workers: process.env.CI ? 3 : undefined, // CI: 3 workers — 4 oversubscribed the 4-vCPU runner (shared backend/frontend), causing tests to fail under contention and pass only on isolated retry; local: auto (half CPU cores)
   reporter: process.env.CI ? [["github"], ["line"], ["html", { open: "never" }]] : "list",
   timeout: 30000, // 30s per test
 

--- a/tests/browser/infinite-scroll.spec.ts
+++ b/tests/browser/infinite-scroll.spec.ts
@@ -23,9 +23,11 @@ async function seedMessages(
   count: number,
   prefix: string
 ): Promise<void> {
-  // Send in parallel batches to speed up seeding. Batches run sequentially so
-  // cross-batch ordering (which the pagination assertions rely on) is preserved.
-  const BATCH_SIZE = 10
+  // Send in small parallel batches to speed up seeding. Batches are kept small
+  // so the assertions that depend on the oldest message (msg-001) staying the
+  // single message outside the bootstrap window are not destabilised by
+  // within-batch ordering races between concurrent POSTs.
+  const BATCH_SIZE = 5
   for (let start = 1; start <= count; start += BATCH_SIZE) {
     const end = Math.min(start + BATCH_SIZE - 1, count)
     const promises: Promise<void>[] = []

--- a/tests/browser/infinite-scroll.spec.ts
+++ b/tests/browser/infinite-scroll.spec.ts
@@ -23,8 +23,9 @@ async function seedMessages(
   count: number,
   prefix: string
 ): Promise<void> {
-  // Send in small parallel batches to speed up seeding while preserving order
-  const BATCH_SIZE = 5
+  // Send in parallel batches to speed up seeding. Batches run sequentially so
+  // cross-batch ordering (which the pagination assertions rely on) is preserved.
+  const BATCH_SIZE = 10
   for (let start = 1; start <= count; start += BATCH_SIZE) {
     const end = Math.min(start + BATCH_SIZE - 1, count)
     const promises: Promise<void>[] = []
@@ -64,10 +65,23 @@ function messageLocator(page: Page, prefix: string, num: number) {
 /** Scroll to top and dispatch a scroll event so React's onScroll handler fires. */
 async function scrollToTop(page: Page): Promise<void> {
   const scroller = page.locator("[data-suppress-pull-refresh]")
-  await page.waitForFunction(() => {
-    const container = document.querySelector("[data-suppress-pull-refresh]")
-    return container instanceof HTMLElement && container.scrollHeight > container.clientHeight
-  })
+  // The list may not overflow its container (e.g. when only a handful of
+  // messages fit on screen). That's a valid state — there is nothing to
+  // scroll — so bound the wait and bail out instead of hanging on a
+  // waitForFunction that never resolves until the whole test times out.
+  const isScrollable = await page
+    .waitForFunction(
+      () => {
+        const container = document.querySelector("[data-suppress-pull-refresh]")
+        return container instanceof HTMLElement && container.scrollHeight > container.clientHeight
+      },
+      undefined,
+      { timeout: 5000 }
+    )
+    .then(() => true)
+    .catch(() => false)
+
+  if (!isScrollable) return
 
   await scroller.hover()
   for (let i = 0; i < 3; i++) {
@@ -117,8 +131,9 @@ test.describe("Infinite Scroll", () => {
     // Navigate fresh to get a clean bootstrap (with only the latest ~50 events)
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
 
-    // Wait for messages to render — the latest message should be visible
-    await expect(messageLocator(page, prefix, PAGED_MESSAGE_COUNT)).toBeVisible({ timeout: 10000 })
+    // Wait for messages to render — the latest message should be visible.
+    // Bootstrap render can lag on a loaded CI runner, so allow generous headroom.
+    await expect(messageLocator(page, prefix, PAGED_MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
 
     // The earliest message should NOT be visible yet (it's beyond the bootstrap window)
     await expect(oldestMessage).not.toBeVisible()
@@ -151,7 +166,7 @@ test.describe("Infinite Scroll", () => {
     await seedMessages(page, workspaceId, streamId, MESSAGE_COUNT, prefix)
 
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
-    await expect(messageLocator(page, prefix, MESSAGE_COUNT)).toBeVisible({ timeout: 10000 })
+    await expect(messageLocator(page, prefix, MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
 
     // "Jump to latest" button should not be visible when at the bottom
     const jumpButton = page.getByRole("button", { name: "Jump to latest" })
@@ -202,8 +217,8 @@ test.describe("Infinite Scroll", () => {
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
 
     // First and last messages should be visible
-    await expect(messageLocator(page, prefix, 1)).toBeVisible({ timeout: 10000 })
-    await expect(messageLocator(page, prefix, 10)).toBeVisible({ timeout: 10000 })
+    await expect(messageLocator(page, prefix, 1)).toBeVisible({ timeout: 20000 })
+    await expect(messageLocator(page, prefix, 10)).toBeVisible({ timeout: 20000 })
 
     // Scroll to top
     await scrollToTop(page)


### PR DESCRIPTION
## Problem

The Browser E2E suite took ~14–15.6m of wall time, gated by **shard 1** (~14m vs ~6–8m for the others).

## Diagnosis (from CI blob reports + job step timings)

Setup (install, browsers, DB) is only ~1m. The time went to two things:

1. **Count-based sharding clustered the slow files.** Playwright shards by *test count*, not duration, so the alphabetically-early (and slow) files all landed on shard 1.
2. **Flakiness dominated by resource contention.** Many tests across `drafts-modal`, `agent-activity`, `emoji-shortcuts`, `activity-feed`, `infinite-scroll`, `message-share-*` fail/time-out on all in-run retry attempts under parallel load, then pass in the isolated `--last-failed` retry on fresh servers — the signature of the workers + shared single-process backend + Vite **dev** server oversubscribing the 4-vCPU runner.

## Changes

- **4 shards** (`browser-tests.yml`) — splits the slow-file cluster. Downstream evaluate/merge jobs already derive the shard list dynamically.
- **`infinite-scroll.spec.ts`** — bound `scrollToTop`'s overflow wait (the "no pagination" test seeded only 10 messages, never overflowed, and hung `waitForFunction` until the 90s timeout, every run); raised first-render visibility checks 10s → 20s.
- **workers 4 → 3** (`playwright.config.ts`) — cut runner contention.
- **Frontend served as a prod build via `vite preview` in CI** — the Vite dev server's on-demand transform was the main CPU cost competing with the workers; build once per shard and serve static instead (dev server kept locally for HMR). Added a `preview` proxy block (sockets connect directly to the backend, so only `/api` + `/test-auth-login` need proxying); the build is port-independent. **SW precaching disabled for E2E** (`isE2ETest`) so the SW still registers for push tests but skips precaching ~14 MiB per test.
- **MinIO image pull retried** — a transient Docker Hub `manifests/latest: unknown` aborted a shard before tests ran; 4 concurrent pulls makes a blip likelier.

## Results (measured via CI on this branch)

| Stage | Critical path (slowest shard) |
|-------|-------------------------------|
| Baseline (3 shards, 4 workers) | ~14–15.6m |
| 4 shards + `infinite-scroll` fix | 10.2m |
| 4 shards + workers=3 | 8.7m |
| **4 shards + workers=3 + prod build** | **9.5m** — but shards 2/3/4 now **4.3 / 6.2 / 5.4m** |

The prod build got **3 of 4 shards to ~5m**. Shard 1 remains ~9.5m because it concentrates **event-delivery-sensitive tests** (`drafts-modal` ×4 hang 30s, `activity-feed` badge counts, `infinite-scroll` render, `agent-activity`) that are fragile under the **single shared backend** at 3-worker load — they fail every in-run attempt and only pass on the isolated retry (which now also rebuilds, inflating shard 1's retry step).

## Remaining work to reach ~5m

The last mile is shard-1-specific and is a **test-quality issue** (parallel-fragile, event-delivery-dependent tests), not a single infra knob. Candidate next steps:
- Harden the specific tests (await the actual event/projection rather than a fixed timeout), as done for `infinite-scroll`'s hang.
- Spread the heavy cluster further (5–6 shards) and/or build the frontend once in a setup job + share the artifact so neither the initial run nor the isolated retry pays a per-shard build.

## Verification

Browser tests can't run in the web session environment, so each change was validated by running the workflow on this branch and reading per-shard timings. Lint + typecheck pass via the pre-commit hook; the frontend prod build + `vite preview` (SPA routing, `/sw.js`, proxy) were smoke-tested locally.

https://claude.ai/code/session_01KWC87njgNB3vYcv4qDwmLk