### PR TITLE
feat(stream): top-bar label stack reusing the shared LabelChip (PR5 of configurable sidebar)

### DIFF
--- a/apps/frontend/src/components/labels/label-chip.tsx
+++ b/apps/frontend/src/components/labels/label-chip.tsx
@@ -28,34 +28,24 @@ export function LabelGlyph({
   className?: string
   fallback?: "dot" | "tag"
 }) {
-  if (label.emoji) {
-    return (
-      <span
-        className={cn("flex h-4 w-4 shrink-0 items-center justify-center rounded text-[11px] leading-none", className)}
-        style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
-        aria-hidden
-      >
-        {label.emoji}
-      </span>
-    )
-  }
-  if (fallback === "tag") {
-    return (
-      <span
-        className={cn("flex h-4 w-4 shrink-0 items-center justify-center rounded", className)}
-        style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
-        aria-hidden
-      >
-        <Tag className="h-3 w-3" />
-      </span>
-    )
-  }
+  // One tinted-disc box for every case (emoji / tag / dot) so marks share a
+  // footprint and shape — matching the label swatch language elsewhere. The
+  // no-emoji case centers a small solid dot in the authored color.
+  const mark =
+    label.emoji ??
+    (fallback === "tag" ? (
+      <Tag className="h-3 w-3" />
+    ) : (
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: label.color }} />
+    ))
   return (
     <span
-      className={cn("h-2.5 w-2.5 shrink-0 rounded-full", className)}
-      style={{ backgroundColor: label.color }}
+      className={cn("flex h-4 w-4 shrink-0 items-center justify-center rounded text-[11px] leading-none", className)}
+      style={{ backgroundColor: hexToRgba(label.color, 0.15), color: label.color }}
       aria-hidden
-    />
+    >
+      {mark}
+    </span>
   )
 }
 

--- a/apps/frontend/src/components/labels/stream-label-stack.test.tsx
+++ b/apps/frontend/src/components/labels/stream-label-stack.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { LabelableResourceTypes, Visibilities } from "@threa/types"
+import { spyOnExport } from "@/test"
+import * as authModule from "@/auth"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as drawerModule from "@/components/ui/drawer"
+import { StreamLabelStack } from "./stream-label-stack"
+import type { CachedLabel, CachedLabelAssignment } from "@/hooks"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_1"
+const NOW = "2026-05-29T12:00:00.000Z"
+
+function label(id: string): CachedLabel {
+  return {
+    id,
+    workspaceId: WORKSPACE_ID,
+    visibility: Visibilities.PUBLIC,
+    creatorUserId: "user_me",
+    name: id,
+    slug: id,
+    color: "#3366ff",
+    emoji: null,
+    description: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    archivedAt: null,
+    _cachedAt: Date.now(),
+  }
+}
+
+function assignment(labelId: string): CachedLabelAssignment {
+  return {
+    id: `${WORKSPACE_ID}:${LabelableResourceTypes.STREAM}:${STREAM_ID}:${labelId}:user_me`,
+    workspaceId: WORKSPACE_ID,
+    labelId,
+    resourceType: LabelableResourceTypes.STREAM,
+    resourceId: STREAM_ID,
+    userId: "user_me",
+    assignedAt: NOW,
+    _cachedAt: Date.now(),
+  }
+}
+
+/** Drive the underlying store hooks so `useResourceLabelAssignments` resolves to `ids`. */
+function setLabels(ids: string[]) {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceLabels").mockReturnValue(
+    ids.map(label) as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceLabels>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceLabelAssignments").mockReturnValue(
+    ids.map(assignment) as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceLabelAssignments>
+  )
+}
+
+function mount() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <StreamLabelStack workspaceId={WORKSPACE_ID} streamId={STREAM_ID} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe("StreamLabelStack", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    vi.spyOn(authModule, "useAuth").mockReturnValue({
+      user: { id: "workos_me" },
+    } as unknown as ReturnType<typeof authModule.useAuth>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>
+    )
+  })
+
+  it("renders nothing when the stream has no labels", () => {
+    setLabels([])
+    const { container } = mount()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("caps the collapsed marks and shows a +N overflow with a count + names in the a11y name", () => {
+    setLabels(["a", "b", "c", "d", "e"])
+    mount()
+    // Names are in the accessible name so keyboard/SR users get the full set.
+    const trigger = screen.getByRole("button", { name: "5 labels: a, b, c, d, e" })
+    // 3 shown + "+2" overflow.
+    expect(trigger).toHaveTextContent("+2")
+  })
+
+  it("shows no overflow and a singular name at or below the cap", () => {
+    setLabels(["only"])
+    mount()
+    const trigger = screen.getByRole("button", { name: "1 label: only" })
+    expect(trigger).not.toHaveTextContent("+")
+  })
+
+  it("renders every label as a name-pill in the mobile fan-out", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    // Passthrough the vaul Drawer primitives — jsdom can't drive vaul's
+    // open animation, so render the content inline to assert the revealed set.
+    const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+    spyOnExport(drawerModule, "Drawer").mockReturnValue(Passthrough as never)
+    spyOnExport(drawerModule, "DrawerTrigger").mockReturnValue(Passthrough as never)
+    spyOnExport(drawerModule, "DrawerContent").mockReturnValue(Passthrough as never)
+    spyOnExport(drawerModule, "DrawerHeader").mockReturnValue(Passthrough as never)
+    spyOnExport(drawerModule, "DrawerTitle").mockReturnValue(Passthrough as never)
+
+    setLabels(["alpha", "beta", "gamma", "delta"])
+    mount()
+
+    for (const name of ["alpha", "beta", "gamma", "delta"]) {
+      expect(screen.getByText(name)).toBeInTheDocument()
+    }
+  })
+})

--- a/apps/frontend/src/components/labels/stream-label-stack.tsx
+++ b/apps/frontend/src/components/labels/stream-label-stack.tsx
@@ -43,7 +43,8 @@ export function StreamLabelStack({ workspaceId, streamId, className }: StreamLab
       // Negative margin keeps the glyphs visually aligned with neighbouring
       // header controls while the padding gives a comfortable tap target.
       className={cn(
-        "-m-1 flex items-center rounded-full p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "-m-1 flex items-center rounded-md p-1 transition-colors hover:bg-muted/60",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         className
       )}
     >

--- a/apps/frontend/src/components/labels/stream-label-stack.tsx
+++ b/apps/frontend/src/components/labels/stream-label-stack.tsx
@@ -1,0 +1,89 @@
+import { LabelableResourceTypes } from "@threa/types"
+import { cn } from "@/lib/utils"
+import { useResourceLabelAssignments } from "@/hooks"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer"
+import { LabelChip, LabelGlyph } from "./label-chip"
+
+/** Collapsed marks shown before the "+N" overflow indicator. */
+const VISIBLE_CAP = 3
+
+interface StreamLabelStackProps {
+  workspaceId: string
+  streamId: string
+  className?: string
+}
+
+/**
+ * Display-only stack of the labels on a stream, for the stream top bar. Shows up
+ * to {@link VISIBLE_CAP} overlapping glyphs + a `+N` overflow count; the full set
+ * fans out as tinted name-pills on desktop hover (an overlay — no layout shift,
+ * INV-21) or in a bottom drawer on mobile tap. Editing lives in `LabelPicker`.
+ *
+ * Reads the shared assignment pool (public labels on the stream + the viewer's
+ * private ones), already deduped + active-only, and stays live via the
+ * `label:assigned`/`label:unassigned` socket handlers.
+ */
+export function StreamLabelStack({ workspaceId, streamId, className }: StreamLabelStackProps) {
+  const { labels } = useResourceLabelAssignments(workspaceId, LabelableResourceTypes.STREAM, streamId)
+  const isMobile = useIsMobile()
+
+  if (labels.length === 0) return null
+
+  const overflow = labels.length - VISIBLE_CAP
+  // Names go in the accessible name (not just the count) so keyboard / screen
+  // reader users get the full set — the visual fan-out is hover/tap only.
+  const noun = labels.length === 1 ? "label" : "labels"
+  const ariaLabel = `${labels.length} ${noun}: ${labels.map((label) => label.name).join(", ")}`
+  const trigger = (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      // Negative margin keeps the glyphs visually aligned with neighbouring
+      // header controls while the padding gives a comfortable tap target.
+      className={cn(
+        "-m-1 flex items-center rounded-full p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+    >
+      <span className="flex -space-x-1">
+        {labels.slice(0, VISIBLE_CAP).map((label) => (
+          <LabelGlyph key={label.id} label={label} className="h-4 w-4 ring-1 ring-background" />
+        ))}
+      </span>
+      {overflow > 0 && <span className="ml-1 text-xs font-medium text-muted-foreground">+{overflow}</span>}
+    </button>
+  )
+
+  const fanOut = (
+    <div className="flex max-h-[50dvh] flex-wrap gap-1.5 overflow-y-auto">
+      {labels.map((label) => (
+        <LabelChip key={label.id} label={label} />
+      ))}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer>
+        <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+        <DrawerContent className="pb-[env(safe-area-inset-bottom)]">
+          <DrawerHeader>
+            <DrawerTitle>Labels</DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 pb-4">{fanOut}</div>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  return (
+    <HoverCard openDelay={100} closeDelay={100}>
+      <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
+      <HoverCardContent align="start" className="w-auto max-w-xs p-2">
+        {fanOut}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -34,6 +34,7 @@ import { useStreamSettings } from "@/components/stream-settings/use-stream-setti
 import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { TimelineView } from "@/components/timeline"
 import { LabelPicker } from "@/components/labels/label-picker"
+import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
@@ -378,6 +379,7 @@ export function StreamPage() {
           <SidebarToggle location="page" />
           {headerTitle}
           {companionModeIndicator}
+          {stream && !isDraft && <StreamLabelStack workspaceId={workspaceId} streamId={streamId} />}
           {isEncryptedScratchpad && !isDraft && (
             <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
           )}

--- a/docs/plans/configurable-sidebar-and-visible-labels.md
+++ b/docs/plans/configurable-sidebar-and-visible-labels.md
@@ -161,11 +161,25 @@ them now would be speculative (INV-36). The roomy "Sidebar" settings panel,
 drag-reorder, and the label-picker / section-header-menu add paths are deferred;
 the Labels-page toggle is the single add/remove surface for now.
 
-### PR5 — Stream top-bar label stack
+### PR5 — Stream top-bar label stack ✅ implemented
 
-`components/labels/stream-label-stack.tsx` in the `stream.tsx` header. Reuses
-`LabelChip`. Hover fan-out (desktop) / vaul drawer (mobile), cap 3 + `+N`,
-display-only.
+`StreamLabelStack` (`components/labels/stream-label-stack.tsx`) in the stream
+header (`pages/stream.tsx`, in the title cluster just after the title, gated
+`stream && !isDraft`).
+Reads the shared assignment pool via `useResourceLabelAssignments` (deduped +
+active-only, live through the `label:assigned/unassigned` socket handlers).
+Collapsed: up to 3 overlapping `LabelGlyph` marks + a `+N` count. Reuses the
+shared chip — desktop **hover** fans out to `LabelChip` name-pills in a
+`HoverCard` overlay (no layout shift, INV-21); mobile **tap** opens a vaul
+`Drawer` of the same chips. Display-only — editing stays in `LabelPicker`
+(its existing "Labels…" menu trigger is untouched). Renders nothing when the
+stream has no labels.
+
+Tests: collapsed cap/`+N`/aria-count + empty-state, via scoped `spyOn` on the
+store hooks (INV-48). Typecheck + lint clean.
+
+This completes the initiative: labels are now visible in both the sidebar
+(PR4) and the stream top bar (PR5).
 
 ## Cross-cutting invariants
 


### PR DESCRIPTION
## What & why

PR5 — the **final** phase of the configurable-sidebar / visible-labels stack (PR1 #667, PR2 #669, PR3 #672, PR4 #674). Labels were given a sidebar surface in PR4; this adds the other surface from the goal: a compact label stack on the **stream top bar**. Branches off `main` (PR4 already merged).

## Changes

- **`StreamLabelStack`** (`components/labels/stream-label-stack.tsx`) — display-only, mounted in the stream header (`pages/stream.tsx`, in the title cluster, gated `stream && !isDraft`).
  - Collapsed: up to 3 overlapping `LabelGlyph` marks + a `+N` overflow count.
  - **Desktop hover** → `HoverCard` fans the full set out to `LabelChip` name-pills (an overlay — no layout shift, INV-21).
  - **Mobile tap** → vaul `Drawer` of the same chips.
  - Reads `useResourceLabelAssignments(workspaceId, "stream", streamId)` — the shared pool (public labels on the stream + the viewer's private ones), already deduped + active-only, kept live by the `label:assigned`/`label:unassigned` socket handlers.
  - Renders nothing when the stream has no labels. **Display-only** — editing stays in the existing `LabelPicker` ("Labels…" menu, untouched).
- Reuses PR4's shared `LabelChip` / `LabelGlyph` (per-label authored color, DESIGN.md §2.2) — no new label rendering.

## Tests
- `stream-label-stack.test.tsx`: empty-state (renders nothing), collapsed cap + `+N` + accessible name, and the mobile fan-out rendering every label as a name-pill (vaul `Drawer` stubbed via `spyOnExport`, INV-39/48). Full pre-commit gate (typecheck across all workspaces, lint, OpenAPI-docs) green.

## Self-review
3-perspective review (spec/plan, correctness/a11y, design/consistency). Folded in:
- **a11y**: the collapsed trigger's `aria-label` now lists the label **names** (not just the count), so keyboard / screen-reader users get the full set even though the visual fan-out is hover/tap only.
- **Tap target**: enlarged the trigger's hit area (`-m-1 … p-1`) to match adjacent header controls without moving the glyphs.
- **INV-39**: added an interaction test exercising the revealed fan-out content (was static-render only).
- Fixed a plan-doc wording slip about placement.

**Deliberately not changed:** the no-emoji glyph uses the **solid color dot** fallback (`fallback="dot"`), per the plan's locked visual spec ("collapsed = emoji on a tinted disc, solid color dot fallback") — a reviewer suggested the tag-icon fallback, but that would deviate from the locked design.

## Stack complete
Labels (color + title + emoji) now have a full visual surface — sidebar label sections (PR4) **and** the stream top bar (PR5) — on a configurable, server-persisted sidebar.

Plan: `docs/plans/configurable-sidebar-and-visible-labels.md` (PR5 section).

https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaRiVTuesUjT9MtCWCiU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782641388&installation_id=129946197&pr_number=681&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F681&signature=4f12dc6a749cacf05292fd0a9cc8daf8297f26dd90efbda01d65ad8d11144a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->