### PR TITLE
Scope /memo search to the composing stream

### DIFF
--- a/apps/backend/src/features/memos/handlers.ts
+++ b/apps/backend/src/features/memos/handlers.ts
@@ -11,7 +11,7 @@ import type { Memo } from "./repository"
 
 const memoSearchSchema = z.object({
   query: z.string().optional().default(""),
-  streamId: z.string().optional(),
+  anchorStreamId: z.string().optional(),
   in: z.array(z.string()).optional(),
   memoType: z.array(z.enum(MEMO_TYPES)).optional(),
   knowledgeType: z.array(z.enum(KNOWLEDGE_TYPES)).optional(),
@@ -25,41 +25,47 @@ const memoSearchSchema = z.object({
 /**
  * Resolve which streams a memo search may read from.
  *
- * The memory explorer (no `streamId`) browses everything the user can access.
- * The inline `/memo` picker passes the stream being composed in, and must be
- * scoped exactly like an agent invoked there (`computeAgentAccessSpec`): a
- * private channel sees public memos + that channel, a public channel or DM sees
- * only what is shareable into it. Without this, a memo from an unrelated private
- * stream could be surfaced — and embedded as a reference — into a stream it does
- * not belong to, leaking it (or a link to it) to that stream's audience.
+ * `anchorStreamId` is not a "memos in this stream" filter — it is the access
+ * anchor: the stream the search is being run from. The memory explorer has no
+ * anchor and browses everything the user can access. The inline `/memo` picker
+ * anchors to the stream being composed in, and must be scoped exactly like an
+ * agent invoked there (`computeAgentAccessSpec`): a private channel sees public
+ * memos + that channel, a public channel or DM sees only what is shareable into
+ * it. Without this, a memo from an unrelated private stream could be surfaced —
+ * and embedded as a reference — into a stream it does not belong to, leaking it
+ * (or a link to it) to that stream's audience.
+ *
+ * The anchor may be a thread or its root; callers pass whichever stream they are
+ * in and `computeAgentAccessSpec` resolves the root, so access is always decided
+ * from the root stream's type/visibility.
  */
 async function resolveMemoSearchScope(
   pool: Pool,
   workspaceId: string,
   userId: string,
-  streamId: string | undefined
+  anchorStreamId: string | undefined
 ): Promise<string[]> {
   const userAccessibleStreamIds = await resolveUserAccessibleStreamIds(pool, workspaceId, userId, {
     archiveStatus: ["active", "archived"],
   })
 
-  if (!streamId) {
+  if (!anchorStreamId) {
     return userAccessibleStreamIds
   }
 
-  const stream = await StreamRepository.findById(pool, streamId)
-  if (!stream || stream.workspaceId !== workspaceId) {
+  const anchorStream = await StreamRepository.findById(pool, anchorStreamId)
+  if (!anchorStream || anchorStream.workspaceId !== workspaceId) {
     throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
   }
 
-  const accessSpec = await computeAgentAccessSpec(pool, { stream, invokingUserId: userId })
+  const accessSpec = await computeAgentAccessSpec(pool, { stream: anchorStream, invokingUserId: userId })
   const scopedStreamIds = await SearchRepository.getAccessibleStreamsForAgent(pool, accessSpec, workspaceId, {
     archiveStatus: ["active", "archived"],
   })
 
   // The access spec is derived from stream type/visibility, not membership, so
   // intersect with the user's own access: the scoped result can never exceed
-  // what the user could already see, even if they pass a stream they aren't in.
+  // what the user could already see, even if they anchor to a stream they aren't in.
   const userAccessibleSet = new Set(userAccessibleStreamIds)
   return scopedStreamIds.filter((id) => userAccessibleSet.has(id))
 }
@@ -123,10 +129,21 @@ export function createMemoHandlers({ pool, memoExplorerService }: Dependencies) 
         throw new HttpError("Invalid search request", { status: 400, code: "VALIDATION_ERROR" })
       }
 
-      const { query, exact, streamId, in: inStreams, memoType, knowledgeType, tags, before, after, limit } = result.data
+      const {
+        query,
+        exact,
+        anchorStreamId,
+        in: inStreams,
+        memoType,
+        knowledgeType,
+        tags,
+        before,
+        after,
+        limit,
+      } = result.data
       const normalized = normalizeSearchMode(query, exact)
 
-      const accessibleStreamIds = await resolveMemoSearchScope(pool, workspaceId, userId, streamId)
+      const accessibleStreamIds = await resolveMemoSearchScope(pool, workspaceId, userId, anchorStreamId)
 
       const results = await memoExplorerService.search({
         workspaceId,

--- a/apps/backend/src/features/memos/handlers.ts
+++ b/apps/backend/src/features/memos/handlers.ts
@@ -3,12 +3,15 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import { KNOWLEDGE_TYPES, MEMO_TYPES } from "@threa/types"
 import { HttpError } from "../../lib/errors"
-import { resolveUserAccessibleStreamIds } from "../search"
+import { resolveUserAccessibleStreamIds, SearchRepository } from "../search"
+import { computeAgentAccessSpec } from "../agents"
+import { StreamRepository } from "../streams"
 import type { MemoExplorerDetail, MemoExplorerResult, MemoExplorerService } from "./explorer-service"
 import type { Memo } from "./repository"
 
 const memoSearchSchema = z.object({
   query: z.string().optional().default(""),
+  streamId: z.string().optional(),
   in: z.array(z.string()).optional(),
   memoType: z.array(z.enum(MEMO_TYPES)).optional(),
   knowledgeType: z.array(z.enum(KNOWLEDGE_TYPES)).optional(),
@@ -18,6 +21,48 @@ const memoSearchSchema = z.object({
   exact: z.boolean().optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 })
+
+/**
+ * Resolve which streams a memo search may read from.
+ *
+ * The memory explorer (no `streamId`) browses everything the user can access.
+ * The inline `/memo` picker passes the stream being composed in, and must be
+ * scoped exactly like an agent invoked there (`computeAgentAccessSpec`): a
+ * private channel sees public memos + that channel, a public channel or DM sees
+ * only what is shareable into it. Without this, a memo from an unrelated private
+ * stream could be surfaced — and embedded as a reference — into a stream it does
+ * not belong to, leaking it (or a link to it) to that stream's audience.
+ */
+async function resolveMemoSearchScope(
+  pool: Pool,
+  workspaceId: string,
+  userId: string,
+  streamId: string | undefined
+): Promise<string[]> {
+  const userAccessibleStreamIds = await resolveUserAccessibleStreamIds(pool, workspaceId, userId, {
+    archiveStatus: ["active", "archived"],
+  })
+
+  if (!streamId) {
+    return userAccessibleStreamIds
+  }
+
+  const stream = await StreamRepository.findById(pool, streamId)
+  if (!stream || stream.workspaceId !== workspaceId) {
+    throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
+  }
+
+  const accessSpec = await computeAgentAccessSpec(pool, { stream, invokingUserId: userId })
+  const scopedStreamIds = await SearchRepository.getAccessibleStreamsForAgent(pool, accessSpec, workspaceId, {
+    archiveStatus: ["active", "archived"],
+  })
+
+  // The access spec is derived from stream type/visibility, not membership, so
+  // intersect with the user's own access: the scoped result can never exceed
+  // what the user could already see, even if they pass a stream they aren't in.
+  const userAccessibleSet = new Set(userAccessibleStreamIds)
+  return scopedStreamIds.filter((id) => userAccessibleSet.has(id))
+}
 
 function normalizeSearchMode(query: string, exact?: boolean): { query: string; exact: boolean } {
   const trimmed = query.trim()
@@ -78,12 +123,10 @@ export function createMemoHandlers({ pool, memoExplorerService }: Dependencies) 
         throw new HttpError("Invalid search request", { status: 400, code: "VALIDATION_ERROR" })
       }
 
-      const { query, exact, in: inStreams, memoType, knowledgeType, tags, before, after, limit } = result.data
+      const { query, exact, streamId, in: inStreams, memoType, knowledgeType, tags, before, after, limit } = result.data
       const normalized = normalizeSearchMode(query, exact)
 
-      const accessibleStreamIds = await resolveUserAccessibleStreamIds(pool, workspaceId, userId, {
-        archiveStatus: ["active", "archived"],
-      })
+      const accessibleStreamIds = await resolveMemoSearchScope(pool, workspaceId, userId, streamId)
 
       const results = await memoExplorerService.search({
         workspaceId,

--- a/apps/backend/tests/e2e/memos.test.ts
+++ b/apps/backend/tests/e2e/memos.test.ts
@@ -177,11 +177,11 @@ describe("Memo Explorer E2E Tests", () => {
     expect(explorerResponse.status).toBe(200)
     expect(explorerResponse.data.results.map((result) => result.memo.id)).toContain(scratchpadMemoId)
 
-    // Composing in a public channel scopes to public content only, so the
+    // Anchoring to a public channel scopes to public content only, so the
     // private-scratchpad memo is excluded — no leak into the shared stream.
     const scopedResponse = await client.post<MemoSearchApiResponse>(`/api/workspaces/${workspace.id}/memos/search`, {
       query: `"${scopedPhrase}"`,
-      streamId: publicChannel.id,
+      anchorStreamId: publicChannel.id,
     })
     expect(scopedResponse.status).toBe(200)
     expect(scopedResponse.data.results).toHaveLength(0)

--- a/apps/backend/tests/e2e/memos.test.ts
+++ b/apps/backend/tests/e2e/memos.test.ts
@@ -149,6 +149,44 @@ describe("Memo Explorer E2E Tests", () => {
     expect(data.memo.sourceMessages[0]?.streamId).toBe(thread.id)
   })
 
+  test("scopes /memo search to the composing stream like an agent invoked there", async () => {
+    const client = new TestClient()
+    await loginAs(client, testEmail("scope"), "Memo Scope")
+    const workspace = await createWorkspace(client, `Memo Scope ${testRunId}`)
+
+    // A private scratchpad holds knowledge the owner can reach from anywhere...
+    const scratchpad = await createScratchpad(client, workspace.id, "off")
+    const privateMessage = await sendMessage(client, workspace.id, scratchpad.id, "Secret roadmap note")
+    const scopedPhrase = `scratchpad secret ${testRunId}`
+    const scratchpadMemoId = await insertMemo({
+      pool,
+      workspaceId: workspace.id,
+      sourceMessageId: privateMessage.id,
+      participantIds: [privateMessage.authorId],
+      title: "Scratchpad secret",
+      abstract: `This ${scopedPhrase} lives in a private scratchpad.`,
+    })
+
+    // ...and a public channel is the stream we compose `/memo` from.
+    const publicChannel = await createChannel(client, workspace.id, `memo-scope-${testRunId}`, "public")
+
+    // Without a composing stream (the memory explorer) the owner sees the memo.
+    const explorerResponse = await client.post<MemoSearchApiResponse>(`/api/workspaces/${workspace.id}/memos/search`, {
+      query: `"${scopedPhrase}"`,
+    })
+    expect(explorerResponse.status).toBe(200)
+    expect(explorerResponse.data.results.map((result) => result.memo.id)).toContain(scratchpadMemoId)
+
+    // Composing in a public channel scopes to public content only, so the
+    // private-scratchpad memo is excluded — no leak into the shared stream.
+    const scopedResponse = await client.post<MemoSearchApiResponse>(`/api/workspaces/${workspace.id}/memos/search`, {
+      query: `"${scopedPhrase}"`,
+      streamId: publicChannel.id,
+    })
+    expect(scopedResponse.status).toBe(200)
+    expect(scopedResponse.data.results).toHaveLength(0)
+  })
+
   test("hides private-channel memos from non-participants", async () => {
     const ownerClient = new TestClient()
     await loginAs(ownerClient, testEmail("owner"), "Memo Owner")

--- a/apps/frontend/src/api/memos.ts
+++ b/apps/frontend/src/api/memos.ts
@@ -43,12 +43,14 @@ export interface MemoSearchRequest {
   exact?: boolean
   limit?: number
   /**
-   * The stream the search is being run from (e.g. the `/memo` picker in a
-   * composer). When set, results are scoped to what is shareable into that
-   * stream so memos from unrelated streams can't leak in. Omit for the memory
-   * explorer, which browses everything the user can access.
+   * Access anchor: the stream the search is being run from (e.g. the `/memo`
+   * picker in a composer). Not a "memos in this stream" filter — when set,
+   * results are scoped to what is shareable into that stream so memos from
+   * unrelated streams can't leak in. May be a thread or its root; the backend
+   * resolves the root. Omit for the memory explorer, which browses everything
+   * the user can access.
    */
-  streamId?: string
+  anchorStreamId?: string
   filters?: MemoSearchFilters
 }
 
@@ -65,7 +67,7 @@ export async function searchMemos(workspaceId: string, request: MemoSearchReques
     query: request.query ?? "",
     exact: request.exact,
     limit: request.limit,
-    streamId: request.streamId,
+    anchorStreamId: request.anchorStreamId,
     in: request.filters?.in,
     memoType: request.filters?.memoType,
     knowledgeType: request.filters?.knowledgeType,

--- a/apps/frontend/src/api/memos.ts
+++ b/apps/frontend/src/api/memos.ts
@@ -42,6 +42,13 @@ export interface MemoSearchRequest {
   query?: string
   exact?: boolean
   limit?: number
+  /**
+   * The stream the search is being run from (e.g. the `/memo` picker in a
+   * composer). When set, results are scoped to what is shareable into that
+   * stream so memos from unrelated streams can't leak in. Omit for the memory
+   * explorer, which browses everything the user can access.
+   */
+  streamId?: string
   filters?: MemoSearchFilters
 }
 
@@ -58,6 +65,7 @@ export async function searchMemos(workspaceId: string, request: MemoSearchReques
     query: request.query ?? "",
     exact: request.exact,
     limit: request.limit,
+    streamId: request.streamId,
     in: request.filters?.in,
     memoType: request.filters?.memoType,
     knowledgeType: request.filters?.knowledgeType,

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -132,6 +132,13 @@ export interface MessageComposerProps {
   contextRefs?: DraftContextRef[]
   /** Stream id; required only when `contextRefs` is non-empty so the strip can build deep-links. */
   streamId?: string
+  /**
+   * Access anchor for the `/memo` picker. Defaults to `streamId`; pass it
+   * explicitly when the composer has no real `streamId` yet (e.g. a draft thread
+   * anchors to its parent stream). May be a thread or root — the backend resolves
+   * the root.
+   */
+  memoAnchorStreamId?: string
   /** Workspace id; required only when `contextRefs` is non-empty so the strip can fetch source metadata. */
   workspaceId?: string
   fileInputRef: RefObject<HTMLInputElement | null>
@@ -229,6 +236,7 @@ export function MessageComposer({
   onRemoveAttachment,
   contextRefs,
   streamId,
+  memoAnchorStreamId = streamId,
   workspaceId,
   fileInputRef,
   onFileSelect,
@@ -508,7 +516,7 @@ export function MessageComposer({
       ariaDescribedBy={instructionsId}
       blurOnEscape
       streamContext={streamContext}
-      streamId={streamId}
+      memoAnchorStreamId={memoAnchorStreamId}
     />
   )
 
@@ -674,7 +682,7 @@ export function MessageComposer({
               blurOnEscape
               onEscapeBlur={focusExpandedShell}
               streamContext={streamContext}
-              streamId={streamId}
+              memoAnchorStreamId={memoAnchorStreamId}
               belowToolbarContent={
                 pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
                   <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -508,6 +508,7 @@ export function MessageComposer({
       ariaDescribedBy={instructionsId}
       blurOnEscape
       streamContext={streamContext}
+      streamId={streamId}
     />
   )
 
@@ -673,6 +674,7 @@ export function MessageComposer({
               blurOnEscape
               onEscapeBlur={focusExpandedShell}
               streamContext={streamContext}
+              streamId={streamId}
               belowToolbarContent={
                 pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
                   <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -120,6 +120,11 @@ interface RichEditorProps {
   onEscapeBlur?: () => void
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
+  /**
+   * The stream this editor composes into. Scopes the `/memo` picker so memos
+   * from unrelated streams can't be embedded into — and leaked to — this one.
+   */
+  streamId?: string
   /** Whether @mentions should be parsed and autocompleted. */
   enableMentions?: boolean
   /** Whether #channel references should be parsed and autocompleted. */
@@ -190,6 +195,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     blurOnEscape = false,
     onEscapeBlur,
     streamContext,
+    streamId,
     enableMentions = true,
     enableChannels = true,
     enableCommands = true,
@@ -234,7 +240,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const { suggestionConfig: commandConfig, renderCommandList } = useCommandSuggestion({
     includeMemoSearch: enableMemoEmbed,
   })
-  const { suggestionConfig: memoConfig, renderMemoList } = useMemoSuggestion()
+  const { suggestionConfig: memoConfig, renderMemoList } = useMemoSuggestion(streamId)
 
   // Emoji autocomplete
   const { workspaceId } = useParams<{ workspaceId: string }>()

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -121,10 +121,12 @@ interface RichEditorProps {
   /** Stream context for filtering which broadcast mentions (@channel, @here) are available */
   streamContext?: MentionStreamContext
   /**
-   * The stream this editor composes into. Scopes the `/memo` picker so memos
-   * from unrelated streams can't be embedded into — and leaked to — this one.
+   * Access anchor for the `/memo` picker: the stream this editor composes into.
+   * Scopes the picker to memos shareable into that stream so they can't be
+   * embedded into — and leaked to — a stream they don't belong to. Pass the
+   * current stream (thread or root); the backend resolves the thread root.
    */
-  streamId?: string
+  memoAnchorStreamId?: string
   /** Whether @mentions should be parsed and autocompleted. */
   enableMentions?: boolean
   /** Whether #channel references should be parsed and autocompleted. */
@@ -195,7 +197,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     blurOnEscape = false,
     onEscapeBlur,
     streamContext,
-    streamId,
+    memoAnchorStreamId,
     enableMentions = true,
     enableChannels = true,
     enableCommands = true,
@@ -240,7 +242,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const { suggestionConfig: commandConfig, renderCommandList } = useCommandSuggestion({
     includeMemoSearch: enableMemoEmbed,
   })
-  const { suggestionConfig: memoConfig, renderMemoList } = useMemoSuggestion(streamId)
+  const { suggestionConfig: memoConfig, renderMemoList } = useMemoSuggestion(memoAnchorStreamId)
 
   // Emoji autocomplete
   const { workspaceId } = useParams<{ workspaceId: string }>()

--- a/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
@@ -14,12 +14,13 @@ const MEMO_SEARCH_LIMIT = 8
  * same keyword + semantic memo search the memory explorer uses, fetched through
  * the shared query cache so repeated queries are instant and consistent.
  *
- * `streamId` is the stream being composed in. Passing it scopes results to what
- * is shareable into that stream (the backend applies the same access spec an
- * agent invoked there would), so a memo from an unrelated private stream can't
- * be embedded into — and thereby leaked to — this one.
+ * `anchorStreamId` is the access anchor: the stream being composed in. Passing
+ * it scopes results to what is shareable into that stream (the backend applies
+ * the same access spec an agent invoked there would, resolving the thread root),
+ * so a memo from an unrelated private stream can't be embedded into — and thereby
+ * leaked to — this one.
  */
-export function useMemoSuggestion(streamId?: string) {
+export function useMemoSuggestion(anchorStreamId?: string) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const queryClient = useQueryClient()
 
@@ -31,7 +32,7 @@ export function useMemoSuggestion(streamId?: string) {
       // search for. The backend orders an empty search by recency; typing a
       // query switches it to keyword + semantic ranking.
       const trimmed = query.trim()
-      const request = { query: trimmed, limit: MEMO_SEARCH_LIMIT, streamId }
+      const request = { query: trimmed, limit: MEMO_SEARCH_LIMIT, anchorStreamId }
       const response = await queryClient.fetchQuery({
         queryKey: memoKeys.search(workspaceId, request),
         queryFn: () => searchMemos(workspaceId, request),
@@ -39,7 +40,7 @@ export function useMemoSuggestion(streamId?: string) {
       })
       return response.results.map((result) => result.memo)
     },
-    [workspaceId, queryClient, streamId]
+    [workspaceId, queryClient, anchorStreamId]
   )
 
   const renderList = useCallback(

--- a/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-memo-suggestion.tsx
@@ -13,8 +13,13 @@ const MEMO_SEARCH_LIMIT = 8
  * Manages the inline `/memo` search picker. Backs the suggestion list with the
  * same keyword + semantic memo search the memory explorer uses, fetched through
  * the shared query cache so repeated queries are instant and consistent.
+ *
+ * `streamId` is the stream being composed in. Passing it scopes results to what
+ * is shareable into that stream (the backend applies the same access spec an
+ * agent invoked there would), so a memo from an unrelated private stream can't
+ * be embedded into — and thereby leaked to — this one.
  */
-export function useMemoSuggestion() {
+export function useMemoSuggestion(streamId?: string) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const queryClient = useQueryClient()
 
@@ -26,7 +31,7 @@ export function useMemoSuggestion() {
       // search for. The backend orders an empty search by recency; typing a
       // query switches it to keyword + semantic ranking.
       const trimmed = query.trim()
-      const request = { query: trimmed, limit: MEMO_SEARCH_LIMIT }
+      const request = { query: trimmed, limit: MEMO_SEARCH_LIMIT, streamId }
       const response = await queryClient.fetchQuery({
         queryKey: memoKeys.search(workspaceId, request),
         queryFn: () => searchMemos(workspaceId, request),
@@ -34,7 +39,7 @@ export function useMemoSuggestion() {
       })
       return response.results.map((result) => result.memo)
     },
-    [workspaceId, queryClient]
+    [workspaceId, queryClient, streamId]
   )
 
   const renderList = useCallback(

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -282,6 +282,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       disableSelectionToolbar={isMobile}
       blurOnEscape
       scopeId={scheduled?.id}
+      streamId={scheduled?.streamId}
       streamContext={streamContext}
       staticToolbarOpen={!isMobile && formatOpen}
       belowToolbarContent={

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -282,7 +282,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       disableSelectionToolbar={isMobile}
       blurOnEscape
       scopeId={scheduled?.id}
-      streamId={scheduled?.streamId}
+      memoAnchorStreamId={scheduled?.streamId}
       streamContext={streamContext}
       staticToolbarOpen={!isMobile && formatOpen}
       belowToolbarContent={

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -102,7 +102,10 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const draftThreadPendingEvents = useStreamEvents(isDraft ? (panelId ?? undefined) : undefined)
   const hasDraftThreadPendingEvents = isDraft && draftThreadPendingEvents && draftThreadPendingEvents.length > 0
   const draftThreadTimelineItems = useMemo(
-    () => (hasDraftThreadPendingEvents ? groupTimelineItems(draftThreadPendingEvents!, currentWorkspaceUserId ?? undefined) : []),
+    () =>
+      hasDraftThreadPendingEvents
+        ? groupTimelineItems(draftThreadPendingEvents!, currentWorkspaceUserId ?? undefined)
+        : [],
     [hasDraftThreadPendingEvents, draftThreadPendingEvents, currentWorkspaceUserId]
   )
   const cachedParentMessage = useMemo(() => {
@@ -468,6 +471,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                     placeholder="Write your reply..."
                     workspaceId={workspaceId}
                     scopeId={panelId}
+                    streamId={draftInfo.parentStreamId}
                     expanded
                     onCollapse={handleDraftCollapse}
                     autoFocus
@@ -537,6 +541,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                   autoFocus={!isMobile}
                   workspaceId={workspaceId}
                   scopeId={panelId}
+                  streamId={draftInfo.parentStreamId}
                   onExpandClick={handleDraftExpand}
                   streamContext={draftStreamContext}
                   onStashDraft={stash.handleStashDraft}

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -471,7 +471,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                     placeholder="Write your reply..."
                     workspaceId={workspaceId}
                     scopeId={panelId}
-                    streamId={draftInfo.parentStreamId}
+                    memoAnchorStreamId={draftInfo.parentStreamId}
                     expanded
                     onCollapse={handleDraftCollapse}
                     autoFocus
@@ -541,7 +541,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                   autoFocus={!isMobile}
                   workspaceId={workspaceId}
                   scopeId={panelId}
-                  streamId={draftInfo.parentStreamId}
+                  memoAnchorStreamId={draftInfo.parentStreamId}
                   onExpandClick={handleDraftExpand}
                   streamContext={draftStreamContext}
                   onStashDraft={stash.handleStashDraft}

--- a/apps/frontend/src/components/timeline/message-edit-form.test.tsx
+++ b/apps/frontend/src/components/timeline/message-edit-form.test.tsx
@@ -120,6 +120,7 @@ function renderForm(props: Partial<React.ComponentProps<typeof MessageEditForm>>
         <MessageEditForm
           messageId="msg_1"
           workspaceId="ws_1"
+          streamId="stream_1"
           initialContentJson={initialContentJson}
           onSave={vi.fn()}
           onCancel={vi.fn()}

--- a/apps/frontend/src/components/timeline/message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/message-edit-form.tsx
@@ -228,7 +228,7 @@ export function MessageEditForm({
                 disableSelectionToolbar
                 blurOnEscape
                 onEscapeBlur={focusMobileActionBar}
-                streamId={streamId}
+                memoAnchorStreamId={streamId}
               />
             </div>
           </div>
@@ -282,7 +282,7 @@ export function MessageEditForm({
           ariaLabel="Edit message"
           ariaDescribedBy={instructionsId}
           autoFocus
-          streamId={streamId}
+          memoAnchorStreamId={streamId}
         />
       </div>
       <div className="flex items-center gap-1.5 mt-1">

--- a/apps/frontend/src/components/timeline/message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/message-edit-form.tsx
@@ -21,6 +21,8 @@ const MOD_KEY_NAME = navigator.platform?.toLowerCase().includes("mac") ? "Comman
 interface MessageEditFormProps {
   messageId: string
   workspaceId: string
+  /** The stream this message belongs to — scopes the `/memo` picker. */
+  streamId: string
   initialContentJson?: JSONContent
   onSave: () => void
   onCancel: () => void
@@ -33,6 +35,7 @@ interface MessageEditFormProps {
 export function MessageEditForm({
   messageId,
   workspaceId,
+  streamId,
   initialContentJson,
   onSave,
   onCancel,
@@ -225,6 +228,7 @@ export function MessageEditForm({
                 disableSelectionToolbar
                 blurOnEscape
                 onEscapeBlur={focusMobileActionBar}
+                streamId={streamId}
               />
             </div>
           </div>
@@ -278,6 +282,7 @@ export function MessageEditForm({
           ariaLabel="Edit message"
           ariaDescribedBy={instructionsId}
           autoFocus
+          streamId={streamId}
         />
       </div>
       <div className="flex items-center gap-1.5 mt-1">

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1229,6 +1229,7 @@ function SentMessageEvent({
           <MessageEditForm
             messageId={payload.messageId}
             workspaceId={workspaceId}
+            streamId={streamId}
             initialContentJson={payload.contentJson}
             onSave={stopEditing}
             onCancel={stopEditing}
@@ -1244,6 +1245,7 @@ function SentMessageEvent({
         <MessageEditForm
           messageId={payload.messageId}
           workspaceId={workspaceId}
+          streamId={streamId}
           initialContentJson={payload.contentJson}
           onSave={stopEditing}
           onCancel={stopEditing}
@@ -1523,12 +1525,18 @@ function EditingMessageEvent({
         statusIndicator={<span className="text-xs text-muted-foreground">Editing unsent message</span>}
       >
         {!isMobile ? (
-          <UnsentMessageEditForm messageId={event.id} initialContentJson={payload.contentJson} onDone={stopEditing} />
+          <UnsentMessageEditForm
+            messageId={event.id}
+            streamId={streamId}
+            initialContentJson={payload.contentJson}
+            onDone={stopEditing}
+          />
         ) : undefined}
       </MessageLayout>
       {isMobile && (
         <UnsentMessageEditForm
           messageId={event.id}
+          streamId={streamId}
           initialContentJson={payload.contentJson}
           onDone={stopEditing}
           authorName={actorName}

--- a/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
@@ -210,7 +210,7 @@ export function UnsentMessageEditForm({
                 disableSelectionToolbar
                 blurOnEscape
                 onEscapeBlur={focusMobileActionBar}
-                streamId={streamId}
+                memoAnchorStreamId={streamId}
               />
             </div>
           </div>
@@ -263,7 +263,7 @@ export function UnsentMessageEditForm({
           ariaLabel="Edit unsent message"
           ariaDescribedBy={instructionsId}
           autoFocus
-          streamId={streamId}
+          memoAnchorStreamId={streamId}
         />
       </div>
       <div className="flex items-center gap-1.5 mt-1">

--- a/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
@@ -16,6 +16,8 @@ const MOD_KEY_NAME = navigator.platform?.toLowerCase().includes("mac") ? "Comman
 
 interface UnsentMessageEditFormProps {
   messageId: string
+  /** The stream this message belongs to — scopes the `/memo` picker. */
+  streamId: string
   initialContentJson?: JSONContent
   onDone: () => void
   authorName?: string
@@ -23,6 +25,7 @@ interface UnsentMessageEditFormProps {
 
 export function UnsentMessageEditForm({
   messageId,
+  streamId,
   initialContentJson,
   onDone,
   authorName,
@@ -207,6 +210,7 @@ export function UnsentMessageEditForm({
                 disableSelectionToolbar
                 blurOnEscape
                 onEscapeBlur={focusMobileActionBar}
+                streamId={streamId}
               />
             </div>
           </div>
@@ -259,6 +263,7 @@ export function UnsentMessageEditForm({
           ariaLabel="Edit unsent message"
           ariaDescribedBy={instructionsId}
           autoFocus
+          streamId={streamId}
         />
       </div>
       <div className="flex items-center gap-1.5 mt-1">


### PR DESCRIPTION
## Problem

The inline `/memo` picker and the memory-explorer page share one endpoint: `POST /api/workspaces/:workspaceId/memos/search`. The handler scoped results with `resolveUserAccessibleStreamIds` — **every** stream the user can access workspace-wide.

So when composing in any stream (including a shared / external-facing one), `/memo` surfaced memos — and let you embed references/links to them — from completely unrelated **private** streams. That leaks internal knowledge (or links to it) into a stream it doesn't belong to.

Ariadne never does this: when invoked in a stream it scopes via `computeAgentAccessSpec` + `SearchRepository.getAccessibleStreamsForAgent` (private channel → public memos + that channel; public channel / DM → only what's shareable into it; private scratchpad → full user access). `/memo` simply wasn't applying that.

## Fix

**Backend** (`apps/backend/src/features/memos/handlers.ts`) — the authorization boundary:
- Added optional `streamId` to the search schema.
- New `resolveMemoSearchScope`: no `streamId` → full user access (the memory explorer, unchanged); with `streamId` → runs the **same** `computeAgentAccessSpec` / `getAccessibleStreamsForAgent` path Ariadne uses, then **intersects** with the user's own access so a passed-in stream can never *widen* visibility (defense against a client sending a stream the user isn't in). An unknown/foreign `streamId` 404s.

**Frontend** — threads the composing stream id from `RichEditor` → `useMemoSuggestion(streamId)` → request, wired at every memo-embed composer:
- live + expanded composer (`MessageComposer`)
- thread drafts (`stream-panel`, scoped to the parent stream the thread inherits access from)
- scheduled-message edit dialog
- sent / unsent message edit forms (`message-event` → edit forms)

The `streamId` participates in the TanStack Query cache key (`memoKeys.search` keys off the full request), so scoped and explorer results don't collide.

## Notes

- `getById` (the memo-card render path) was already correctly **per-viewer** scoped, so other members of a shared stream can't resolve a card they lack access to. That didn't stop the *picker* from surfacing the memo to the composer — which is what this changes. `getById` is intentionally left unchanged.
- The public API v1 memo search (`/api/v1/...`, API-key auth) is a separate trust model and is out of scope.

## Tests

- Added an e2e case in `apps/backend/tests/e2e/memos.test.ts`: a private-scratchpad memo appears in the explorer (no `streamId`) but is excluded when composing `/memo` from a public channel.
- Backend + frontend typecheck clean; pre-commit ran full-monorepo typecheck, lint, and the OpenAPI check.
- 74 frontend tests pass (editor triggers, edit forms, composer, message-event).
- The backend integration/e2e suites could **not** run in the dev container (no test Postgres reachable, no running server). The new e2e test reuses functions already covered by `agent-access-scope.test.ts` and runs in CI where the stack is provisioned.

https://claude.ai/code/session_01KAVacZZKNFjak7PpGr1jxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAVacZZKNFjak7PpGr1jxa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782643084&installation_id=129946197&pr_number=683&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F683&signature=35eea9e64cc0cb0420f944ccd28b1263149a3aeb7c05787bdc0d88c3f7426367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->