### PR TITLE
feat(memos): open in-stream memo previews in a modal/drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dev-dist/
 *.tsbuildinfo
 .DS_Store
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Playwright
 test-results/

--- a/apps/frontend/src/components/memo/memo-detail.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.tsx
@@ -1,0 +1,221 @@
+import { BookOpen, ExternalLink, Hash, MessageSquareQuote } from "lucide-react"
+import { Link } from "react-router-dom"
+import type { StreamType } from "@threa/types"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+import { RelativeTime } from "@/components/relative-time"
+import { cn } from "@/lib/utils"
+import { streamFallbackLabel } from "@/lib/streams"
+import { getKnowledgeConfig, memoLabel } from "@/lib/memo-display"
+import type { MemoExplorerDetail, MemoExplorerStreamRef } from "@/api"
+
+/**
+ * Full memo detail renderer — title, abstract, key points, provenance, and
+ * source messages. Shared by the memory explorer page (`MemoryPage`) and the
+ * in-stream memo preview dialog (`MemoPreviewDialog`) so both surfaces render
+ * a memo identically. The helpers below (`KnowledgeTypeBadge`,
+ * `formatStreamRef`, `buildSourceLink`) are exported for callers that compose
+ * their own memo rows (e.g. the explorer's result list).
+ */
+
+export function formatStreamRef(stream: MemoExplorerStreamRef | null): string | null {
+  if (!stream) return null
+
+  if (stream.name) {
+    return stream.type === "channel" && !stream.name.startsWith("#") ? `#${stream.name}` : stream.name
+  }
+
+  return streamFallbackLabel(stream.type as StreamType, "generic")
+}
+
+export function buildSourceLink(workspaceId: string, streamId: string, messageId?: string): string {
+  const search = messageId ? `?m=${messageId}` : ""
+  return `/w/${workspaceId}/s/${streamId}${search}`
+}
+
+export function KnowledgeTypeBadge({ type, size = "sm" }: { type: string; size?: "sm" | "xs" }) {
+  const config = getKnowledgeConfig(type)
+  const Icon = config.icon
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border font-medium",
+        config.className,
+        size === "sm" ? "px-2 py-0.5 text-xs" : "px-1.5 py-px text-[10px]"
+      )}
+    >
+      <Icon className={size === "sm" ? "h-3 w-3" : "h-2.5 w-2.5"} />
+      {config.label}
+    </span>
+  )
+}
+
+function DetailSection({
+  title,
+  children,
+  className,
+}: {
+  title: string
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <section className={cn("space-y-3", className)}>
+      <h3 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/60">{title}</h3>
+      {children}
+    </section>
+  )
+}
+
+export function MemoDetailContent({
+  data,
+  workspaceId,
+  isLoading,
+}: {
+  data: MemoExplorerDetail | null
+  workspaceId: string
+  isLoading: boolean
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-8 w-3/4" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+        <Skeleton className="h-32 w-full rounded-lg" />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <div className="rounded-full bg-muted/50 p-4 mb-4">
+          <BookOpen className="h-6 w-6 text-muted-foreground/30" />
+        </div>
+        <p className="text-sm text-muted-foreground/60">Select a memo to view its details and provenance</p>
+      </div>
+    )
+  }
+
+  return (
+    // [overflow-wrap:anywhere] is inherited by descendants so long unbreakable
+    // strings collapse in min-content calculations. Without this, the Radix
+    // ScrollArea / Drawer viewport can be forced wider than the screen on mobile.
+    <div className="min-w-0 space-y-8 [overflow-wrap:anywhere]">
+      {/* Title section */}
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <KnowledgeTypeBadge type={data.memo.knowledgeType} size="sm" />
+          <Badge variant="secondary" className="text-[10px] font-medium">
+            {memoLabel(data.memo.memoType)}
+          </Badge>
+          <span className="text-[11px] tabular-nums text-muted-foreground/50">v{data.memo.version}</span>
+          <span className="text-muted-foreground/30">&middot;</span>
+          <RelativeTime date={data.memo.updatedAt} className="text-[11px] text-muted-foreground/50" />
+        </div>
+
+        <h2 className="text-xl font-semibold tracking-tight leading-tight">{data.memo.title}</h2>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{data.memo.abstract}</p>
+
+        {data.memo.tags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {data.memo.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex max-w-full items-center gap-0.5 rounded-md bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground"
+              >
+                <Hash className="h-2.5 w-2.5 shrink-0" />
+                <span className="min-w-0 truncate">{tag}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Key points */}
+      {data.memo.keyPoints.length > 0 && (
+        <DetailSection title="Key points">
+          <ul className="space-y-2">
+            {data.memo.keyPoints.map((keyPoint) => (
+              <li
+                key={keyPoint}
+                className="relative min-w-0 pl-4 text-sm leading-relaxed before:absolute before:left-0 before:top-[0.6em] before:h-1.5 before:w-1.5 before:rounded-full before:bg-primary/40"
+              >
+                {keyPoint}
+              </li>
+            ))}
+          </ul>
+        </DetailSection>
+      )}
+
+      {/* Provenance */}
+      <DetailSection title="Provenance">
+        <div className="flex min-w-0 flex-wrap gap-2">
+          {data.sourceStream && (
+            <Link
+              to={buildSourceLink(workspaceId, data.sourceStream.id)}
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
+            >
+              <MessageSquareQuote className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.sourceStream)}</span>
+              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
+            </Link>
+          )}
+
+          {data.rootStream && data.rootStream.id !== data.sourceStream?.id && (
+            <Link
+              to={buildSourceLink(workspaceId, data.rootStream.id)}
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
+            >
+              <span className="shrink-0 text-xs text-muted-foreground/60">in</span>
+              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.rootStream)}</span>
+              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
+            </Link>
+          )}
+
+          {!data.sourceStream && !data.rootStream && (
+            <span className="text-sm text-muted-foreground/50">Source unavailable</span>
+          )}
+        </div>
+      </DetailSection>
+
+      {/* Source messages */}
+      <DetailSection title="Source messages">
+        {data.sourceMessages.length === 0 ? (
+          <p className="text-sm text-muted-foreground/50">No accessible source messages were retained for this memo.</p>
+        ) : (
+          <div className="space-y-3">
+            {data.sourceMessages.map((message) => (
+              <div key={message.id} className="min-w-0 overflow-hidden rounded-lg border border-border/50 bg-card">
+                <div className="flex min-w-0 items-center gap-2 border-b border-border/30 px-4 py-2">
+                  <span className="min-w-0 truncate text-xs font-semibold">{message.authorName}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground/40">in</span>
+                  <Link
+                    to={buildSourceLink(workspaceId, message.streamId, message.id)}
+                    className="min-w-0 truncate text-xs text-primary/80 hover:text-primary hover:underline"
+                  >
+                    {message.streamName}
+                  </Link>
+                  <span className="ml-auto shrink-0">
+                    <RelativeTime
+                      date={message.createdAt}
+                      className="text-[10px] tabular-nums text-muted-foreground/40"
+                    />
+                  </span>
+                </div>
+                <div className="min-w-0 overflow-hidden px-4 py-3 text-sm leading-relaxed">
+                  <MarkdownContent content={message.content} className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </DetailSection>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/memo/memo-detail.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.tsx
@@ -14,9 +14,8 @@ import type { MemoExplorerDetail, MemoExplorerStreamRef } from "@/api"
  * Full memo detail renderer — title, abstract, key points, provenance, and
  * source messages. Shared by the memory explorer page (`MemoryPage`) and the
  * in-stream memo preview dialog (`MemoPreviewDialog`) so both surfaces render
- * a memo identically. The helpers below (`KnowledgeTypeBadge`,
- * `formatStreamRef`, `buildSourceLink`) are exported for callers that compose
- * their own memo rows (e.g. the explorer's result list).
+ * a memo identically. `KnowledgeTypeBadge` and `formatStreamRef` are also
+ * exported because the explorer's result list composes its own memo rows.
  */
 
 export function formatStreamRef(stream: MemoExplorerStreamRef | null): string | null {
@@ -29,7 +28,7 @@ export function formatStreamRef(stream: MemoExplorerStreamRef | null): string | 
   return streamFallbackLabel(stream.type as StreamType, "generic")
 }
 
-export function buildSourceLink(workspaceId: string, streamId: string, messageId?: string): string {
+function buildSourceLink(workspaceId: string, streamId: string, messageId?: string): string {
   const search = messageId ? `?m=${messageId}` : ""
   return `/w/${workspaceId}/s/${streamId}${search}`
 }

--- a/apps/frontend/src/components/memo/memo-preview-dialog.tsx
+++ b/apps/frontend/src/components/memo/memo-preview-dialog.tsx
@@ -1,0 +1,83 @@
+import { BookOpen, ExternalLink } from "lucide-react"
+import { Link } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { useMemoDetail } from "@/hooks/use-memos"
+import { MemoDetailContent } from "@/components/memo/memo-detail"
+
+interface MemoPreviewDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  memoId: string
+  /** Title parsed from the inline reference; shown while the memo resolves. */
+  fallbackTitle: string
+}
+
+/**
+ * In-stream preview of a referenced memo — a centered modal on desktop, a
+ * snap-pointed drawer on mobile (via `ResponsiveDialog`). Reuses the memory
+ * explorer's `MemoDetailContent`, so the rendered memo matches the explorer
+ * page exactly. Shares the `memoKeys.detail` cache with the embed card's
+ * resolver, so opening a card whose memo already resolved is instant. The
+ * footer links through to the full memory explorer.
+ */
+export function MemoPreviewDialog({ open, onOpenChange, workspaceId, memoId, fallbackTitle }: MemoPreviewDialogProps) {
+  // Only fetch once opened; shares the detail cache key with the embed card.
+  const { data, isLoading } = useMemoDetail(workspaceId, open ? memoId : null)
+  const detail = data?.memo ?? null
+  // Settled with nothing to show — the memo 404'd (archived / no access) or
+  // otherwise resolved empty. Covers `isError` since the query yields no data
+  // then. We never fall through to `MemoDetailContent`'s explorer-flavored
+  // "Select a memo" empty state in the dialog context.
+  const unavailable = !isLoading && !detail
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent
+        desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col gap-0 p-0"
+        drawerClassName="flex flex-col"
+        aria-describedby={undefined}
+      >
+        <ResponsiveDialogHeader className="border-b px-4 py-3 sm:px-6">
+          <ResponsiveDialogTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <BookOpen className="h-4 w-4 text-primary" aria-hidden="true" />
+            {detail?.memo.title || fallbackTitle || "Memo"}
+          </ResponsiveDialogTitle>
+        </ResponsiveDialogHeader>
+
+        <ResponsiveDialogBody data-vaul-no-drag className="min-w-0 py-5 sm:py-6">
+          {unavailable ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <div className="mb-4 rounded-full bg-muted/50 p-4">
+                <BookOpen className="h-6 w-6 text-muted-foreground/30" />
+              </div>
+              <p className="text-sm font-medium text-muted-foreground/70">Memo no longer available</p>
+              <p className="mt-1 max-w-[16rem] text-xs text-muted-foreground/50">
+                It may have been archived or you no longer have access to it.
+              </p>
+            </div>
+          ) : (
+            <MemoDetailContent data={detail} workspaceId={workspaceId} isLoading={isLoading} />
+          )}
+        </ResponsiveDialogBody>
+
+        <ResponsiveDialogFooter className="border-t px-4 py-3 sm:px-6">
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link to={`/w/${workspaceId}/memory?memo=${memoId}`} onClick={() => onOpenChange(false)}>
+              Open in memory
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/timeline/memo-preview-list.test.tsx
+++ b/apps/frontend/src/components/timeline/memo-preview-list.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoPreviewList } from "./memo-preview-list"
@@ -23,16 +24,31 @@ describe("MemoPreviewList", () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it("renders one preview card per referenced memo, linking to the memory explorer", () => {
+  it("renders one preview card per referenced memo as a button that opens a preview (not a link)", () => {
     renderPreviews("See [Auth rewrite](memo:memo_01ABC) and [Roadmap](memo:memo_02DEF)")
 
     const cards = document.querySelectorAll('[data-type="memo-embed"]')
     expect(cards).toHaveLength(2)
-    const hrefs = Array.from(cards, (card) => card.closest("a")?.getAttribute("href"))
-    expect(hrefs).toEqual(["/w/ws_1/memory?memo=memo_01ABC", "/w/ws_1/memory?memo=memo_02DEF"])
+    // Clicking a card opens an in-stream preview dialog, so the card is a
+    // button rather than a navigating link.
+    cards.forEach((card) => {
+      expect(card.closest("button")).not.toBeNull()
+      expect(card.closest("a")).toBeNull()
+    })
     // Pre-hydration the card shows the title parsed from the reference.
     expect(screen.getByText("Auth rewrite")).toBeInTheDocument()
     expect(screen.getByText("Roadmap")).toBeInTheDocument()
+  })
+
+  it("opens a preview dialog linking to the memory explorer when a card is clicked", async () => {
+    renderPreviews("[Auth rewrite](memo:memo_01ABC)")
+
+    const card = document.querySelector('[data-type="memo-embed"]')
+    await userEvent.click(card!.closest("button")!)
+
+    // The dialog footer links through to the full memo in the memory explorer.
+    const link = await screen.findByRole("link", { name: /open in memory/i })
+    expect(link.getAttribute("href")).toBe("/w/ws_1/memory?memo=memo_01ABC")
   })
 
   it("de-duplicates repeated references to the same memo", () => {

--- a/apps/frontend/src/lib/markdown/memo-embed-block.tsx
+++ b/apps/frontend/src/lib/markdown/memo-embed-block.tsx
@@ -1,7 +1,9 @@
-import { Link, useParams } from "react-router-dom"
+import { useState } from "react"
+import { useParams } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { useMemoEmbedSource } from "@/hooks/use-memo-embed-source"
 import { MemoEmbedCardBody, MemoEmbedDate } from "@/components/memo-embed/card-body"
+import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 
 interface MemoEmbedBlockProps {
   memoId: string
@@ -14,17 +16,20 @@ interface MemoEmbedBlockProps {
  * per memo referenced in the body — mirroring how link previews surface. The
  * inline reference itself renders as a `MemoChip`. The card body routes through
  * the shared resolver hook + `MemoEmbedCardBody` so cache + render behavior
- * match the composer chip. The card links to the memo in the memory explorer.
+ * match the composer chip. Clicking the card opens an in-stream preview
+ * (`MemoPreviewDialog`) — a modal on desktop, a drawer on mobile — which links
+ * through to the full memo in the memory explorer.
  */
 export function MemoEmbedBlock({ memoId, title }: MemoEmbedBlockProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const source = useMemoEmbedSource(memoId)
+  const [open, setOpen] = useState(false)
 
   const card = (
     <div
       className={cn(
-        "my-1 rounded-md border border-border border-l-2 border-l-primary/70 bg-card px-3 py-2 text-sm",
-        "transition-colors hover:border-l-primary hover:bg-primary/[0.04]"
+        "rounded-md border border-border border-l-2 border-l-primary/70 bg-card px-3 py-2 text-sm",
+        "transition-colors group-hover:border-l-primary group-hover:bg-primary/[0.04]"
       )}
       data-type="memo-embed"
     >
@@ -32,11 +37,29 @@ export function MemoEmbedBlock({ memoId, title }: MemoEmbedBlockProps) {
     </div>
   )
 
-  if (!workspaceId) return card
+  // No workspace context (shouldn't happen in-stream) — render a static card.
+  if (!workspaceId) return <div className="my-1">{card}</div>
 
   return (
-    <Link to={`/w/${workspaceId}/memory?memo=${memoId}`} className="block no-underline">
-      {card}
-    </Link>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        className={cn(
+          "group my-1 block w-full rounded-md text-left",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        )}
+      >
+        {card}
+      </button>
+      <MemoPreviewDialog
+        open={open}
+        onOpenChange={setOpen}
+        workspaceId={workspaceId}
+        memoId={memoId}
+        fallbackTitle={title}
+      />
+    </>
   )
 }

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -1,16 +1,6 @@
 import { startTransition, useEffect, useRef, useState } from "react"
-import {
-  ArrowLeft,
-  BookOpen,
-  Search,
-  RefreshCw,
-  Hash,
-  MessageSquareQuote,
-  ExternalLink,
-  Check,
-  ChevronsUpDown,
-} from "lucide-react"
-import { KNOWLEDGE_TYPES, MEMO_TYPES, type KnowledgeType, type MemoType, type StreamType } from "@threa/types"
+import { ArrowLeft, Search, RefreshCw, Hash, MessageSquareQuote, Check, ChevronsUpDown } from "lucide-react"
+import { KNOWLEDGE_TYPES, MEMO_TYPES, type KnowledgeType, type MemoType } from "@threa/types"
 import { Link, useParams, useSearchParams } from "react-router-dom"
 import { useMemoDetail, useMemoSearch } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -19,18 +9,17 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import { MarkdownContent } from "@/components/ui/markdown-content"
 import { Drawer, DrawerContent } from "@/components/ui/drawer"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { RelativeTime } from "@/components/relative-time"
 import { SidebarToggle } from "@/components/layout"
+import { KnowledgeTypeBadge, MemoDetailContent, formatStreamRef } from "@/components/memo/memo-detail"
 import { cn } from "@/lib/utils"
-import { streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { streamLabel } from "@/lib/streams"
 import { getKnowledgeConfig, memoLabel } from "@/lib/memo-display"
-import type { MemoExplorerDetail, MemoExplorerResult, MemoExplorerStreamRef } from "@/api"
+import type { MemoExplorerResult } from "@/api"
 
 const ALL_MEMO_TYPES = "all-memo-types"
 const ALL_KNOWLEDGE_TYPES = "all-knowledge-types"
@@ -50,39 +39,6 @@ function updateParams(
   }
 
   return next
-}
-
-function formatStreamRef(stream: MemoExplorerStreamRef | null): string | null {
-  if (!stream) return null
-
-  if (stream.name) {
-    return stream.type === "channel" && !stream.name.startsWith("#") ? `#${stream.name}` : stream.name
-  }
-
-  return streamFallbackLabel(stream.type as StreamType, "generic")
-}
-
-function buildSourceLink(workspaceId: string, streamId: string, messageId?: string): string {
-  const search = messageId ? `?m=${messageId}` : ""
-  return `/w/${workspaceId}/s/${streamId}${search}`
-}
-
-function KnowledgeTypeBadge({ type, size = "sm" }: { type: string; size?: "sm" | "xs" }) {
-  const config = getKnowledgeConfig(type)
-  const Icon = config.icon
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-md border font-medium",
-        config.className,
-        size === "sm" ? "px-2 py-0.5 text-xs" : "px-1.5 py-px text-[10px]"
-      )}
-    >
-      <Icon className={size === "sm" ? "h-3 w-3" : "h-2.5 w-2.5"} />
-      {config.label}
-    </span>
-  )
 }
 
 function MemoResultItem({ result, isActive, href }: { result: MemoExplorerResult; isActive: boolean; href: string }) {
@@ -149,174 +105,6 @@ function MemoResultItem({ result, isActive, href }: { result: MemoExplorerResult
         )}
       </div>
     </Link>
-  )
-}
-
-function DetailSection({
-  title,
-  children,
-  className,
-}: {
-  title: string
-  children: React.ReactNode
-  className?: string
-}) {
-  return (
-    <section className={cn("space-y-3", className)}>
-      <h3 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/60">{title}</h3>
-      {children}
-    </section>
-  )
-}
-
-function MemoDetailContent({
-  data,
-  workspaceId,
-  isLoading,
-}: {
-  data: MemoExplorerDetail | null
-  workspaceId: string
-  isLoading: boolean
-}) {
-  if (isLoading) {
-    return (
-      <div className="space-y-6">
-        <div className="space-y-3">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-16 w-full" />
-        </div>
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    )
-  }
-
-  if (!data) {
-    return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <div className="rounded-full bg-muted/50 p-4 mb-4">
-          <BookOpen className="h-6 w-6 text-muted-foreground/30" />
-        </div>
-        <p className="text-sm text-muted-foreground/60">Select a memo to view its details and provenance</p>
-      </div>
-    )
-  }
-
-  return (
-    // [overflow-wrap:anywhere] is inherited by descendants so long unbreakable
-    // strings collapse in min-content calculations. Without this, the Radix
-    // ScrollArea / Drawer viewport can be forced wider than the screen on mobile.
-    <div className="min-w-0 space-y-8 [overflow-wrap:anywhere]">
-      {/* Title section */}
-      <div className="min-w-0">
-        <div className="flex flex-wrap items-center gap-2 mb-3">
-          <KnowledgeTypeBadge type={data.memo.knowledgeType} size="sm" />
-          <Badge variant="secondary" className="text-[10px] font-medium">
-            {memoLabel(data.memo.memoType)}
-          </Badge>
-          <span className="text-[11px] tabular-nums text-muted-foreground/50">v{data.memo.version}</span>
-          <span className="text-muted-foreground/30">&middot;</span>
-          <RelativeTime date={data.memo.updatedAt} className="text-[11px] text-muted-foreground/50" />
-        </div>
-
-        <h2 className="text-xl font-semibold tracking-tight leading-tight">{data.memo.title}</h2>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{data.memo.abstract}</p>
-
-        {data.memo.tags.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-1.5">
-            {data.memo.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex max-w-full items-center gap-0.5 rounded-md bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground"
-              >
-                <Hash className="h-2.5 w-2.5 shrink-0" />
-                <span className="min-w-0 truncate">{tag}</span>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Key points */}
-      {data.memo.keyPoints.length > 0 && (
-        <DetailSection title="Key points">
-          <ul className="space-y-2">
-            {data.memo.keyPoints.map((keyPoint) => (
-              <li
-                key={keyPoint}
-                className="relative min-w-0 pl-4 text-sm leading-relaxed before:absolute before:left-0 before:top-[0.6em] before:h-1.5 before:w-1.5 before:rounded-full before:bg-primary/40"
-              >
-                {keyPoint}
-              </li>
-            ))}
-          </ul>
-        </DetailSection>
-      )}
-
-      {/* Provenance */}
-      <DetailSection title="Provenance">
-        <div className="flex min-w-0 flex-wrap gap-2">
-          {data.sourceStream && (
-            <Link
-              to={buildSourceLink(workspaceId, data.sourceStream.id)}
-              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
-            >
-              <MessageSquareQuote className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.sourceStream)}</span>
-              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
-            </Link>
-          )}
-
-          {data.rootStream && data.rootStream.id !== data.sourceStream?.id && (
-            <Link
-              to={buildSourceLink(workspaceId, data.rootStream.id)}
-              className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border/50 bg-card px-3 py-2 text-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
-            >
-              <span className="shrink-0 text-xs text-muted-foreground/60">in</span>
-              <span className="min-w-0 truncate font-medium">{formatStreamRef(data.rootStream)}</span>
-              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/40" />
-            </Link>
-          )}
-
-          {!data.sourceStream && !data.rootStream && (
-            <span className="text-sm text-muted-foreground/50">Source unavailable</span>
-          )}
-        </div>
-      </DetailSection>
-
-      {/* Source messages */}
-      <DetailSection title="Source messages">
-        {data.sourceMessages.length === 0 ? (
-          <p className="text-sm text-muted-foreground/50">No accessible source messages were retained for this memo.</p>
-        ) : (
-          <div className="space-y-3">
-            {data.sourceMessages.map((message) => (
-              <div key={message.id} className="min-w-0 overflow-hidden rounded-lg border border-border/50 bg-card">
-                <div className="flex min-w-0 items-center gap-2 border-b border-border/30 px-4 py-2">
-                  <span className="min-w-0 truncate text-xs font-semibold">{message.authorName}</span>
-                  <span className="shrink-0 text-[10px] text-muted-foreground/40">in</span>
-                  <Link
-                    to={buildSourceLink(workspaceId, message.streamId, message.id)}
-                    className="min-w-0 truncate text-xs text-primary/80 hover:text-primary hover:underline"
-                  >
-                    {message.streamName}
-                  </Link>
-                  <span className="ml-auto shrink-0">
-                    <RelativeTime
-                      date={message.createdAt}
-                      className="text-[10px] tabular-nums text-muted-foreground/40"
-                    />
-                  </span>
-                </div>
-                <div className="min-w-0 overflow-hidden px-4 py-3 text-sm leading-relaxed">
-                  <MarkdownContent content={message.content} className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0" />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </DetailSection>
-    </div>
   )
 }
 


### PR DESCRIPTION
## Problem

In-stream memo preview cards (the hydrated cards rendered below a message for each `memo:` reference) were links: clicking one navigated away to the memory explorer (`/w/:workspaceId/memory?memo=…`). That yanks you out of the conversation just to glance at what a referenced memo says — a heavy interaction for a quick look.

## Solution

Clicking a memo preview card now opens an **in-stream preview dialog** — a centered **modal on desktop**, a **bottom drawer on mobile** — that renders the full memo in place (title, abstract, key points, provenance, source messages). A footer link still routes through to the full memory explorer for the complete surface.

### How it works

- The card is now a `<button>` that toggles dialog `open` state (it was a navigating `<Link>`; opening a dialog is an action, so a button is the correct affordance per INV-40). Navigation moved to the dialog's "Open in memory" footer link.
- The dialog is built on the existing `ResponsiveDialog` primitive (the same modal↔drawer switch used by the share modal, edit-history dialog, quick-switcher, etc.), so the affordance stays consistent with the rest of the app.
- The dialog fetches via `useMemoDetail`, which shares the `memoKeys.detail` query cache with the embed card's resolver (`useMemoEmbedSource`) — so opening a card whose memo already resolved is instant, no refetch.

### Key design decisions

**1. Extract the memo detail renderer into a shared module**
`MemoDetailContent` (plus `KnowledgeTypeBadge`, `formatStreamRef`, `buildSourceLink`, `DetailSection`) lived inside `pages/memory.tsx`. To render a memo identically in both the explorer page and the new dialog without a parallel implementation (INV-35), it's moved verbatim into `components/memo/memo-detail.tsx` and re-imported by the page. ~220 lines of page code become a shared, single-source renderer.

**2. Reuse the same `MemoDetailContent`, don't reimplement**
The dialog passes the fetched `MemoExplorerDetail` straight into `MemoDetailContent`. No second detail layout to drift.

**3. Dialog-appropriate empty state**
`MemoDetailContent`'s built-in empty copy ("Select a memo…") is explorer-flavored. In the dialog, `unavailable = !isLoading && !detail` short-circuits to a "Memo no longer available" state (covers archived / no-access 404s) so the explorer copy can never leak into the dialog.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/memo/memo-detail.tsx` | Shared full-memo renderer (`MemoDetailContent` + `KnowledgeTypeBadge`, `formatStreamRef`, `buildSourceLink`), extracted from the memory page |
| `apps/frontend/src/components/memo/memo-preview-dialog.tsx` | Responsive in-stream preview — modal on desktop, drawer on mobile |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/markdown/memo-embed-block.tsx` | Card is now a `<button>` that opens `MemoPreviewDialog` instead of a navigating `<Link>` |
| `apps/frontend/src/pages/memory.tsx` | Imports the shared detail module; removes the now-duplicated detail/helper code |
| `apps/frontend/src/components/timeline/memo-preview-list.test.tsx` | Updated for the button-opens-dialog behavior; adds a test asserting the dialog opens with the "Open in memory" link |

## Test plan

- [x] `tsc --noEmit` clean (full monorepo, via pre-commit hook)
- [x] `eslint` clean (full monorepo, via pre-commit hook)
- [x] `vitest` — 13/13 across `memo-preview-list`, `memo-embed-block`, `memory` suites
- [x] Pre-PR multi-perspective review (spec / correctness / design) — findings addressed
- [ ] Manual: click a memo card in a stream → modal opens on desktop, drawer on mobile; "Open in memory" routes to the explorer; archived/no-access memo shows the unavailable state

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782643396&installation_id=129946197&pr_number=684&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F684&signature=cf5bf67728b51eddb2a4fc3853751b30d815036419703ce9b9dacf8cb54ff7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->