### PR TITLE
feat(quick-switcher): contextual stream commands in the command palette

### DIFF
--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -33,6 +33,20 @@ export interface CommandContext {
   requestInput: (request: InputRequest) => void
   openSettings: (tab?: SettingsTab) => void
   openExplorer: (overrides?: Partial<ExplorerFilters>) => void
+  /**
+   * The stream currently in view (route param), or null on non-stream routes.
+   * Contextual stream commands (archive, settings, files, labels) read this to
+   * know what they act on; they are only surfaced when it is set.
+   */
+  currentStreamId?: string | null
+  /** Resolved display name of `currentStreamId`, for section headers/confirm copy. */
+  currentStreamName?: string | null
+  /** Open the stream settings dialog for a stream. */
+  openStreamSettings: (streamId: string) => void
+  /** Open the destructive confirmation for archiving (or deleting a draft) a stream. */
+  requestArchiveStream: (streamId: string) => void
+  /** Open the label picker for a stream. */
+  openLabelPicker: (streamId: string) => void
 }
 
 export interface Command {

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -16,6 +16,7 @@ import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as streamsApiModule from "@/api/streams"
 import * as contextsModule from "@/contexts"
+import * as streamSettingsModule from "@/components/stream-settings/use-stream-settings"
 
 // Note: DOM polyfills (ResizeObserver, Range, Element.getClientRects, etc.)
 // are in src/test/setup.ts which runs before tests via vitest config
@@ -31,6 +32,11 @@ const mockSearchState = {
   search: vi.fn(),
   clear: vi.fn(),
 }
+
+// Contextual stream-command collaborators, asserted on across tests.
+const mockArchiveMutateAsync = vi.fn()
+const mockDeleteDraft = vi.fn()
+const mockOpenStreamSettings = vi.fn()
 
 const mockWorkspaceBootstrap = {
   data: {} as {
@@ -125,7 +131,16 @@ function installSpies() {
   } as unknown as ReturnType<typeof hooksModule.useWorkspaceBootstrap>)
   vi.spyOn(hooksModule, "useDraftScratchpads").mockReturnValue({
     createDraft: vi.fn(),
+    deleteDraft: mockDeleteDraft,
   } as unknown as ReturnType<typeof hooksModule.useDraftScratchpads>)
+  vi.spyOn(hooksModule, "useArchiveStream").mockReturnValue({
+    mutateAsync: mockArchiveMutateAsync,
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof hooksModule.useArchiveStream>)
+  vi.spyOn(streamSettingsModule, "useStreamSettings").mockReturnValue({
+    openStreamSettings: mockOpenStreamSettings,
+  } as unknown as ReturnType<typeof streamSettingsModule.useStreamSettings>)
   vi.spyOn(hooksModule, "useCreateStream").mockReturnValue({
     mutateAsync: vi.fn(),
   } as unknown as ReturnType<typeof hooksModule.useCreateStream>)
@@ -229,6 +244,9 @@ describe("QuickSwitcher Integration Tests", () => {
     mockSearchState.isLoading = false
     mockSearchState.search = vi.fn()
     mockSearchState.clear = vi.fn()
+    mockArchiveMutateAsync.mockReset()
+    mockDeleteDraft.mockReset()
+    mockOpenStreamSettings.mockReset()
     mockWorkspaceBootstrap.data = {
       streams: mockStreamsList,
       streamMemberships: [],
@@ -1364,6 +1382,79 @@ describe("QuickSwitcher Integration Tests", () => {
 
       await waitFor(() => {
         expect(document.querySelector('a[href="/w/workspace_1/s/draft_dm_member_3"]')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("contextual stream commands", () => {
+    it("should surface current-stream commands under a stream-named section in command mode", async () => {
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)
+
+      // Section header names the stream so it stays clear these are stream-specific.
+      await waitFor(() => {
+        expect(screen.getByText("This stream — #general")).toBeInTheDocument()
+      })
+      expect(screen.getByText("Archive this stream")).toBeInTheDocument()
+      expect(screen.getByText("Open stream settings")).toBeInTheDocument()
+      expect(screen.getByText("Browse files in this stream")).toBeInTheDocument()
+      expect(screen.getByText("Labels…")).toBeInTheDocument()
+      // Global commands remain available below the contextual section.
+      expect(screen.getByText("New Channel")).toBeInTheDocument()
+    })
+
+    it("should not surface contextual commands when no stream is in view", async () => {
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" />)
+
+      await waitFor(() => {
+        expect(screen.getByText("New Channel")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Archive this stream")).not.toBeInTheDocument()
+      expect(screen.queryByText(/This stream/)).not.toBeInTheDocument()
+    })
+
+    it("should keep contextual commands visible (with their section) while filtering", async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)
+
+      await user.type(screen.getByLabelText("Quick switcher input"), "archive")
+
+      await waitFor(() => {
+        expect(screen.getByText("Archive this stream")).toBeInTheDocument()
+      })
+      expect(screen.getByText("This stream — #general")).toBeInTheDocument()
+    })
+
+    it("should open stream settings for the current stream", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)
+
+      await waitFor(() => {
+        expect(screen.getByText("Open stream settings")).toBeInTheDocument()
+      })
+      await user.click(screen.getByText("Open stream settings"))
+
+      expect(mockOpenStreamSettings).toHaveBeenCalledWith("stream_channel1")
+    })
+
+    it("should confirm before archiving, and only archive after confirmation", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)
+
+      await waitFor(() => {
+        expect(screen.getByText("Archive this stream")).toBeInTheDocument()
+      })
+      await user.click(screen.getByText("Archive this stream"))
+
+      // Confirmation modal appears; nothing is archived yet.
+      await waitFor(() => {
+        expect(screen.getByText("Archive #general?")).toBeInTheDocument()
+      })
+      expect(mockArchiveMutateAsync).not.toHaveBeenCalled()
+
+      await user.click(screen.getByRole("button", { name: "Archive" }))
+
+      await waitFor(() => {
+        expect(mockArchiveMutateAsync).toHaveBeenCalledWith("stream_channel1")
       })
     })
   })

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -1,8 +1,20 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import { useNavigate } from "react-router-dom"
 import { Search, Terminal, FileText } from "lucide-react"
+import { toast } from "sonner"
+import { LabelableResourceTypes } from "@threa/types"
 import { ResponsiveDialog, ResponsiveDialogContent } from "@/components/ui/responsive-dialog"
-import { useDraftScratchpads } from "@/hooks"
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@/components/ui/responsive-alert-dialog"
+import { useDraftScratchpads, useArchiveStream, useStreamName, isDraftId } from "@/hooks"
 import {
   useWorkspaceUsers,
   useWorkspaceStreams,
@@ -15,6 +27,8 @@ import { useUser } from "@/auth"
 import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
 import { useCreateChannel } from "@/components/create-channel"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
+import { LabelPicker } from "@/components/labels/label-picker"
 import { useStreamItems } from "./use-stream-items"
 import { useCommandItems } from "./use-command-items"
 import { useSearchItems } from "./use-search-items"
@@ -32,6 +46,8 @@ interface QuickSwitcherProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   initialMode?: QuickSwitcherMode
+  /** Stream currently in view (route param) — drives contextual stream commands. */
+  currentStreamId?: string | null
 }
 
 const MODE_PREFIXES: Record<QuickSwitcherMode, string> = {
@@ -68,13 +84,27 @@ export function getDisplayQuery(query: string, mode: QuickSwitcherMode): string 
   return query
 }
 
-export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: QuickSwitcherProps) {
+export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, currentStreamId }: QuickSwitcherProps) {
   const navigate = useNavigate()
   const user = useUser()
-  const { createDraft } = useDraftScratchpads(workspaceId)
+  const { createDraft, deleteDraft } = useDraftScratchpads(workspaceId)
   const { openSettings } = useSettings()
   const { openCreateChannel } = useCreateChannel()
   const { open: openExplorer } = useExplorerUrlState()
+  const { openStreamSettings } = useStreamSettings()
+  const archiveStream = useArchiveStream(workspaceId)
+  const currentStreamName = useStreamName(workspaceId, currentStreamId ?? "")
+
+  // Destructive stream actions confirm before running; the label picker is a
+  // standalone dialog opened after the palette closes. The pending-archive
+  // target captures its name/draft-status at request time so the confirm copy
+  // can't drift if the route (and thus `currentStreamId`) changes underneath.
+  const [pendingArchive, setPendingArchive] = useState<{
+    streamId: string
+    name: string
+    isDraft: boolean
+  } | null>(null)
+  const [labelPickerStreamId, setLabelPickerStreamId] = useState<string | null>(null)
 
   const streams = useWorkspaceStreams(workspaceId)
   const streamMemberships = useWorkspaceStreamMemberships(workspaceId)
@@ -137,6 +167,39 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
     setInputValue("")
   }, [])
 
+  // Contextual stream actions close the palette first, then open their own
+  // surface (settings dialog, confirm modal, label picker), which render as
+  // siblings so they survive the palette unmounting its content.
+  const handleOpenStreamSettings = useCallback(
+    (streamId: string) => {
+      handleClose()
+      openStreamSettings(streamId)
+    },
+    [handleClose, openStreamSettings]
+  )
+
+  const requestArchiveStream = useCallback(
+    (streamId: string) => {
+      handleClose()
+      // Contextual archive only ever targets the current stream, so its
+      // resolved name is correct here — freeze it for the confirm dialog.
+      setPendingArchive({
+        streamId,
+        name: currentStreamName ?? "this stream",
+        isDraft: isDraftId(streamId),
+      })
+    },
+    [handleClose, currentStreamName]
+  )
+
+  const openLabelPicker = useCallback(
+    (streamId: string) => {
+      handleClose()
+      setLabelPickerStreamId(streamId)
+    },
+    [handleClose]
+  )
+
   const commandContext: CommandContext = useMemo(
     () => ({
       workspaceId,
@@ -149,6 +212,11 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
       requestInput,
       openSettings,
       openExplorer,
+      currentStreamId,
+      currentStreamName,
+      openStreamSettings: handleOpenStreamSettings,
+      requestArchiveStream,
+      openLabelPicker,
     }),
     [
       workspaceId,
@@ -161,6 +229,11 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
       requestInput,
       openSettings,
       openExplorer,
+      currentStreamId,
+      currentStreamName,
+      handleOpenStreamSettings,
+      requestArchiveStream,
+      openLabelPicker,
     ]
   )
 
@@ -294,201 +367,264 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode }: 
     [inputRequest, inputValue]
   )
 
+  const handleConfirmArchive = useCallback(async () => {
+    if (!pendingArchive) return
+    const { streamId, isDraft } = pendingArchive
+    try {
+      if (isDraft) {
+        await deleteDraft(streamId)
+        // Drafts are fully deleted — leave the (now-gone) stream if viewing it.
+        if (currentStreamId === streamId) navigate(`/w/${workspaceId}`)
+        toast.success("Draft deleted")
+      } else {
+        await archiveStream.mutateAsync(streamId)
+        toast.success("Stream archived")
+      }
+    } catch {
+      toast.error(isDraft ? "Failed to delete draft" : "Failed to archive stream")
+    } finally {
+      setPendingArchive(null)
+    }
+  }, [pendingArchive, deleteDraft, navigate, workspaceId, currentStreamId, archiveStream])
+
+  const archiveIsDraft = pendingArchive?.isDraft ?? false
+  const archiveStreamLabel = pendingArchive?.name ?? "this stream"
+
   const ModeIcon = inputRequest?.icon ?? MODE_ICONS[mode]
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent
-        ref={dialogRef}
-        desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[20%] sm:!translate-y-0 sm:max-w-[600px] sm:rounded-2xl sm:border"
-        drawerClassName="overflow-hidden p-0"
-        hideCloseButton
-        onPointerDownOutside={(e) => {
-          // Prevent closing when clicking on suggestion popover (rendered via portal)
-          const target = e.target as HTMLElement
-          if (target.closest('[role="listbox"]')) {
-            e.preventDefault()
-          }
-        }}
-        onEscapeKeyDown={(e) => {
-          // If TipTap already handled this event (closed a popover), don't close dialog
-          if (e.defaultPrevented) return
-
-          // Use ref for synchronous access (state updates are batched)
-          // When suggestion popover is open, close it instead of closing dialog
-          // (Radix intercepts Escape before TipTap sees it, so we close imperatively)
-          if (isSuggestionPopoverActiveRef.current) {
-            e.preventDefault()
-            richInputRef.current?.closePopovers()
-            return
-          }
-          // When filter select picker is open, close it instead of closing dialog
-          if (currentResult.isFilterSelectActive && currentResult.closeFilterSelect) {
-            e.preventDefault()
-            currentResult.closeFilterSelect()
-            return
-          }
-          // When in inputRequest mode, Escape returns to command list instead of closing
-          if (inputRequest) {
-            e.preventDefault()
-            clearInputRequest()
-            requestAnimationFrame(() => {
-              richInputRef.current?.focus()
-            })
-          }
-        }}
-        onKeyDown={(e) => {
-          // If TipTap already handled this event (e.g., popover keyboard nav), don't interfere
-          if (e.defaultPrevented) return
-
-          const isMod = e.metaKey || e.ctrlKey
-          // Use ref for synchronous access (state updates are batched)
-          // When suggestion popover is open, let TipTap handle keyboard events
-          if (isSuggestionPopoverActiveRef.current) return
-
-          // Global arrow key navigation - works even when focus is on tabs
-          // Refocus input so Enter works on items (not mode tabs)
-          switch (true) {
-            case !inputRequest && e.key === "ArrowDown":
+    <>
+      <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+        <ResponsiveDialogContent
+          ref={dialogRef}
+          desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[20%] sm:!translate-y-0 sm:max-w-[600px] sm:rounded-2xl sm:border"
+          drawerClassName="overflow-hidden p-0"
+          hideCloseButton
+          onPointerDownOutside={(e) => {
+            // Prevent closing when clicking on suggestion popover (rendered via portal)
+            const target = e.target as HTMLElement
+            if (target.closest('[role="listbox"]')) {
               e.preventDefault()
-              setSelectedIndex((prev) => clamp(prev + 1, 0, items.length - 1))
-              if (focusedTabIndex !== null) {
-                focusInput()
-              }
-              break
-            case !inputRequest && e.key === "ArrowUp":
-              e.preventDefault()
-              setSelectedIndex((prev) => clamp(prev - 1, 0, items.length - 1))
-              if (focusedTabIndex !== null) {
-                focusInput()
-              }
-              break
-            case !inputRequest && e.key === "Enter" && focusedTabIndex === null:
-              e.preventDefault()
-              const item = items[selectedIndex]
-              if (!item) return
-              handleSelectItem(item, isMod)
-              break
-          }
-        }}
-      >
-        {/* Mobile: mode tabs above the input for better hierarchy */}
-        {!inputRequest && isMobile && (
-          <ModeTabs
-            currentMode={mode}
-            onModeChange={handleModeChange}
-            focusedTabIndex={focusedTabIndex}
-            onFocusedTabIndexChange={setFocusedTabIndex}
-            onTabSelect={focusInput}
-          />
-        )}
+            }
+          }}
+          onEscapeKeyDown={(e) => {
+            // If TipTap already handled this event (closed a popover), don't close dialog
+            if (e.defaultPrevented) return
 
-        {/* Input area */}
-        <div className="p-4 border-b border-border">
-          <div className="flex items-center gap-3 px-4 py-3 rounded-[10px] border border-border bg-background transition-all focus-within:border-primary/60 focus-within:shadow-[0_0_0_2px_hsl(var(--primary)/0.06)]">
-            <ModeIcon className="h-4 w-4 shrink-0 opacity-50" />
-            {inputRequest ? (
-              // Plain input for command input requests (e.g., "Enter channel name")
-              <input
-                ref={inputRef}
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleInputKeyDown}
-                placeholder={inputRequest.placeholder}
-                className="flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                autoFocus={!isMobile}
-                aria-label="Command input"
-              />
-            ) : (
-              // RichInput for all modes - triggers only enabled for search mode
-              <RichInput
-                ref={richInputRef}
-                value={query}
-                onChange={(value) => {
-                  // Normalize the query in two steps:
-                  // 1. Remove redundant prefixes: "? ? foo" → "? foo", "> > bar" → "> bar"
-                  // 2. Ensure space after prefix: "?foo" → "? foo" (TipTap strips trailing whitespace)
-                  const withoutRedundant = value.replace(/^([?>])\s*\1/, "$1")
-                  const normalized = withoutRedundant.replace(/^([?>])(?=\S)/, "$1 ")
-                  setQuery(normalized)
-                  setSelectedIndex(0)
-                }}
-                onSubmit={(withModifier) => {
-                  // Enter pressed with no popover open - select current item
-                  const item = items[selectedIndex]
-                  if (item) {
-                    handleSelectItem(item, withModifier)
-                  }
-                }}
-                onPopoverActiveChange={handlePopoverActiveChange}
-                triggers={triggers}
-                placeholder={MODE_PLACEHOLDERS[mode]}
-                ariaLabel={mode === "search" ? "Search query input" : "Quick switcher input"}
-                autoFocus={!isMobile}
-              />
-            )}
+            // Use ref for synchronous access (state updates are batched)
+            // When suggestion popover is open, close it instead of closing dialog
+            // (Radix intercepts Escape before TipTap sees it, so we close imperatively)
+            if (isSuggestionPopoverActiveRef.current) {
+              e.preventDefault()
+              richInputRef.current?.closePopovers()
+              return
+            }
+            // When filter select picker is open, close it instead of closing dialog
+            if (currentResult.isFilterSelectActive && currentResult.closeFilterSelect) {
+              e.preventDefault()
+              currentResult.closeFilterSelect()
+              return
+            }
+            // When in inputRequest mode, Escape returns to command list instead of closing
+            if (inputRequest) {
+              e.preventDefault()
+              clearInputRequest()
+              requestAnimationFrame(() => {
+                richInputRef.current?.focus()
+              })
+            }
+          }}
+          onKeyDown={(e) => {
+            // If TipTap already handled this event (e.g., popover keyboard nav), don't interfere
+            if (e.defaultPrevented) return
+
+            const isMod = e.metaKey || e.ctrlKey
+            // Use ref for synchronous access (state updates are batched)
+            // When suggestion popover is open, let TipTap handle keyboard events
+            if (isSuggestionPopoverActiveRef.current) return
+
+            // Global arrow key navigation - works even when focus is on tabs
+            // Refocus input so Enter works on items (not mode tabs)
+            switch (true) {
+              case !inputRequest && e.key === "ArrowDown":
+                e.preventDefault()
+                setSelectedIndex((prev) => clamp(prev + 1, 0, items.length - 1))
+                if (focusedTabIndex !== null) {
+                  focusInput()
+                }
+                break
+              case !inputRequest && e.key === "ArrowUp":
+                e.preventDefault()
+                setSelectedIndex((prev) => clamp(prev - 1, 0, items.length - 1))
+                if (focusedTabIndex !== null) {
+                  focusInput()
+                }
+                break
+              case !inputRequest && e.key === "Enter" && focusedTabIndex === null:
+                e.preventDefault()
+                const item = items[selectedIndex]
+                if (!item) return
+                handleSelectItem(item, isMod)
+                break
+            }
+          }}
+        >
+          {/* Mobile: mode tabs above the input for better hierarchy */}
+          {!inputRequest && isMobile && (
+            <ModeTabs
+              currentMode={mode}
+              onModeChange={handleModeChange}
+              focusedTabIndex={focusedTabIndex}
+              onFocusedTabIndexChange={setFocusedTabIndex}
+              onTabSelect={focusInput}
+            />
+          )}
+
+          {/* Input area */}
+          <div className="p-4 border-b border-border">
+            <div className="flex items-center gap-3 px-4 py-3 rounded-[10px] border border-border bg-background transition-all focus-within:border-primary/60 focus-within:shadow-[0_0_0_2px_hsl(var(--primary)/0.06)]">
+              <ModeIcon className="h-4 w-4 shrink-0 opacity-50" />
+              {inputRequest ? (
+                // Plain input for command input requests (e.g., "Enter channel name")
+                <input
+                  ref={inputRef}
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleInputKeyDown}
+                  placeholder={inputRequest.placeholder}
+                  className="flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  autoFocus={!isMobile}
+                  aria-label="Command input"
+                />
+              ) : (
+                // RichInput for all modes - triggers only enabled for search mode
+                <RichInput
+                  ref={richInputRef}
+                  value={query}
+                  onChange={(value) => {
+                    // Normalize the query in two steps:
+                    // 1. Remove redundant prefixes: "? ? foo" → "? foo", "> > bar" → "> bar"
+                    // 2. Ensure space after prefix: "?foo" → "? foo" (TipTap strips trailing whitespace)
+                    const withoutRedundant = value.replace(/^([?>])\s*\1/, "$1")
+                    const normalized = withoutRedundant.replace(/^([?>])(?=\S)/, "$1 ")
+                    setQuery(normalized)
+                    setSelectedIndex(0)
+                  }}
+                  onSubmit={(withModifier) => {
+                    // Enter pressed with no popover open - select current item
+                    const item = items[selectedIndex]
+                    if (item) {
+                      handleSelectItem(item, withModifier)
+                    }
+                  }}
+                  onPopoverActiveChange={handlePopoverActiveChange}
+                  triggers={triggers}
+                  placeholder={MODE_PLACEHOLDERS[mode]}
+                  ariaLabel={mode === "search" ? "Search query input" : "Quick switcher input"}
+                  autoFocus={!isMobile}
+                />
+              )}
+            </div>
           </div>
-        </div>
 
-        {/* Desktop: mode tabs below the input (keyboard-navigable) */}
-        {!inputRequest && !isMobile && (
-          <ModeTabs
-            currentMode={mode}
-            onModeChange={handleModeChange}
-            focusedTabIndex={focusedTabIndex}
-            onFocusedTabIndexChange={setFocusedTabIndex}
-            onTabSelect={focusInput}
-          />
-        )}
+          {/* Desktop: mode tabs below the input (keyboard-navigable) */}
+          {!inputRequest && !isMobile && (
+            <ModeTabs
+              currentMode={mode}
+              onModeChange={handleModeChange}
+              focusedTabIndex={focusedTabIndex}
+              onFocusedTabIndexChange={setFocusedTabIndex}
+              onTabSelect={focusInput}
+            />
+          )}
 
-        {/* Hint from input request */}
-        {inputRequest && (
-          <div className="px-4 py-3 text-xs text-muted-foreground border-b border-border">{inputRequest.hint}</div>
-        )}
+          {/* Hint from input request */}
+          {inputRequest && (
+            <div className="px-4 py-3 text-xs text-muted-foreground border-b border-border">{inputRequest.hint}</div>
+          )}
 
-        {/* Mode-specific header (e.g., search filters) */}
-        {!inputRequest && currentResult.header}
+          {/* Mode-specific header (e.g., search filters) */}
+          {!inputRequest && currentResult.header}
 
-        {/* Item list */}
-        {!inputRequest && (
-          <ItemList
-            items={items}
-            selectedIndex={selectedIndex}
-            onSelectIndex={setSelectedIndex}
-            onSelectItem={handleSelectItem}
-            isLoading={currentResult.isLoading}
-            emptyMessage={currentResult.emptyMessage}
-          />
-        )}
+          {/* Item list */}
+          {!inputRequest && (
+            <ItemList
+              items={items}
+              selectedIndex={selectedIndex}
+              onSelectIndex={setSelectedIndex}
+              onSelectItem={handleSelectItem}
+              isLoading={currentResult.isLoading}
+              emptyMessage={currentResult.emptyMessage}
+            />
+          )}
 
-        {/* Keyboard hints footer — hidden on mobile (no physical keyboard) */}
-        {!inputRequest && (
-          <div className="hidden sm:flex items-center justify-between border-t border-border px-4 py-3 text-[11px] text-muted-foreground">
-            <div className="flex gap-4">
+          {/* Keyboard hints footer — hidden on mobile (no physical keyboard) */}
+          {!inputRequest && (
+            <div className="hidden sm:flex items-center justify-between border-t border-border px-4 py-3 text-[11px] text-muted-foreground">
+              <div className="flex gap-4">
+                <span>
+                  <kbd className="kbd-hint">↑↓</kbd> Navigate
+                </span>
+                <span>
+                  <kbd className="kbd-hint">↵</kbd> Open
+                </span>
+                <span>
+                  <kbd className="kbd-hint">{navigator.platform.includes("Mac") ? "⌘" : "Ctrl+"}↵</kbd> New tab
+                </span>
+              </div>
               <span>
-                <kbd className="kbd-hint">↑↓</kbd> Navigate
-              </span>
-              <span>
-                <kbd className="kbd-hint">↵</kbd> Open
-              </span>
-              <span>
-                <kbd className="kbd-hint">{navigator.platform.includes("Mac") ? "⌘" : "Ctrl+"}↵</kbd> New tab
+                <kbd className="kbd-hint">esc</kbd> Close
               </span>
             </div>
-            <span>
-              <kbd className="kbd-hint">esc</kbd> Close
-            </span>
-          </div>
-        )}
+          )}
 
-        {/* Escape hint - shown after 2s to help users with Vimium or similar */}
-        {/* Uses absolute positioning to avoid layout shift (INV-21) */}
-        {showEscapeHint && (
-          <div className="absolute -bottom-8 left-0 right-0 text-xs text-muted-foreground/80 text-center animate-in fade-in duration-500">
-            Tip: Use <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Ctrl+[</kbd> or click outside to close
-          </div>
-        )}
-      </ResponsiveDialogContent>
-    </ResponsiveDialog>
+          {/* Escape hint - shown after 2s to help users with Vimium or similar */}
+          {/* Uses absolute positioning to avoid layout shift (INV-21) */}
+          {showEscapeHint && (
+            <div className="absolute -bottom-8 left-0 right-0 text-xs text-muted-foreground/80 text-center animate-in fade-in duration-500">
+              Tip: Use <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">Ctrl+[</kbd> or click outside to close
+            </div>
+          )}
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+
+      <ResponsiveAlertDialog
+        open={pendingArchive !== null}
+        onOpenChange={(next) => {
+          if (!next) setPendingArchive(null)
+        }}
+      >
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>
+              {archiveIsDraft ? "Delete this draft?" : `Archive ${archiveStreamLabel}?`}
+            </ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              {archiveIsDraft
+                ? "This draft will be permanently deleted. This can't be undone."
+                : "This stream will be hidden from the sidebar. You can unarchive it later."}
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel>Cancel</ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction onClick={handleConfirmArchive}>
+              {archiveIsDraft ? "Delete" : "Archive"}
+            </ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
+
+      {labelPickerStreamId && (
+        <LabelPicker
+          workspaceId={workspaceId}
+          resourceType={LabelableResourceTypes.STREAM}
+          resourceId={labelPickerStreamId}
+          open={labelPickerStreamId !== null}
+          onOpenChange={(next) => {
+            if (!next) setLabelPickerStreamId(null)
+          }}
+        />
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/quick-switcher/stream-commands.ts
+++ b/apps/frontend/src/components/quick-switcher/stream-commands.ts
@@ -1,0 +1,67 @@
+import { Archive, Paperclip, Settings, Tag, Trash2 } from "lucide-react"
+import type { Command } from "./commands"
+
+/**
+ * Commands that act on the stream currently in view. `use-command-items` only
+ * surfaces these when `CommandContext.currentStreamId` is set, so the guard in
+ * each action is belt-and-suspenders. Ordering mirrors the approved palette
+ * layout (archive first, labels last). Real streams archive (reversible);
+ * draft scratchpads are deleted via `draftStreamCommands` instead.
+ */
+export const streamCommands: Command[] = [
+  {
+    id: "stream-archive",
+    label: "Archive this stream",
+    icon: Archive,
+    keywords: ["hide", "remove", "close", "current stream"],
+    action: ({ currentStreamId, requestArchiveStream }) => {
+      if (!currentStreamId) return
+      requestArchiveStream(currentStreamId)
+    },
+  },
+  {
+    id: "stream-settings",
+    label: "Open stream settings",
+    icon: Settings,
+    keywords: ["configure", "rename", "notifications", "preferences", "current stream"],
+    action: ({ currentStreamId, openStreamSettings }) => {
+      if (!currentStreamId) return
+      openStreamSettings(currentStreamId)
+    },
+  },
+  {
+    id: "stream-files",
+    label: "Browse files in this stream",
+    icon: Paperclip,
+    keywords: ["attachments", "uploads", "media", "explorer", "current stream"],
+    action: ({ currentStreamId, openExplorer, closeDialog }) => {
+      if (!currentStreamId) return
+      closeDialog()
+      openExplorer({ streamIds: [currentStreamId] })
+    },
+  },
+  {
+    id: "stream-labels",
+    label: "Labels…",
+    icon: Tag,
+    keywords: ["tag", "categorize", "organize", "current stream"],
+    action: ({ currentStreamId, openLabelPicker }) => {
+      if (!currentStreamId) return
+      openLabelPicker(currentStreamId)
+    },
+  },
+]
+
+/** Draft scratchpads have no server-side settings/files/labels — only deletion. */
+export const draftStreamCommands: Command[] = [
+  {
+    id: "stream-delete-draft",
+    label: "Delete this draft",
+    icon: Trash2,
+    keywords: ["remove", "discard", "trash", "current stream"],
+    action: ({ currentStreamId, requestArchiveStream }) => {
+      if (!currentStreamId) return
+      requestArchiveStream(currentStreamId)
+    },
+  },
+]

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -1,5 +1,7 @@
 import { useMemo } from "react"
-import { commands, type CommandContext } from "./commands"
+import { isDraftId } from "@/hooks"
+import { commands, type Command, type CommandContext } from "./commands"
+import { draftStreamCommands, streamCommands } from "./stream-commands"
 import type { ModeResult, QuickSwitcherItem } from "./types"
 
 interface UseCommandItemsParams {
@@ -9,26 +11,39 @@ interface UseCommandItemsParams {
 
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {
   const items = useMemo(() => {
+    const { currentStreamId, currentStreamName } = commandContext
     const lowerQuery = query.toLowerCase()
 
-    const filteredCommands = query
-      ? commands.filter((command) => {
-          const searchValue = [command.id, command.label, ...(command.keywords ?? [])].join(" ").toLowerCase()
-          return searchValue.includes(lowerQuery)
-        })
-      : commands
+    const matchesQuery = (command: Command) => {
+      if (!query) return true
+      const searchValue = [command.id, command.label, ...(command.keywords ?? [])].join(" ").toLowerCase()
+      return searchValue.includes(lowerQuery)
+    }
 
-    return filteredCommands.map(
-      (command): QuickSwitcherItem => ({
-        id: command.id,
-        label: command.label,
-        icon: command.icon,
-        group: "Commands",
-        onSelect: () => {
-          command.action(commandContext)
-        },
-      })
-    )
+    const toItem = (command: Command, group: string): QuickSwitcherItem => ({
+      id: command.id,
+      label: command.label,
+      icon: command.icon,
+      group,
+      onSelect: () => {
+        command.action(commandContext)
+      },
+    })
+
+    // Contextual commands act on the stream in view. The section header names
+    // the stream so it stays clear these are stream-specific even while the
+    // list is filtered down by a query. Draft scratchpads have no server-side
+    // settings/files/labels, so they only get a delete command.
+    let contextualCommands: Command[] = []
+    if (currentStreamId) {
+      contextualCommands = isDraftId(currentStreamId) ? draftStreamCommands : streamCommands
+    }
+    const contextualGroup = currentStreamName ? `This stream — ${currentStreamName}` : "This stream"
+    const contextualItems = contextualCommands.filter(matchesQuery).map((c) => toItem(c, contextualGroup))
+
+    const globalItems = commands.filter(matchesQuery).map((c) => toItem(c, "Commands"))
+
+    return [...contextualItems, ...globalItems]
   }, [query, commandContext])
 
   return {

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -387,6 +387,7 @@ export function WorkspaceLayout() {
                                         open={switcherOpen}
                                         onOpenChange={setSwitcherOpen}
                                         initialMode={switcherMode}
+                                        currentStreamId={streamId}
                                       />
                                       <SettingsDialog />
                                       <WorkspaceSettingsDialog workspaceId={workspaceId} />


### PR DESCRIPTION
## What

Adds **contextual stream commands** to the command palette (the `>` mode of the quick-switcher, reachable via `Cmd/Ctrl+Shift+K` or by typing `>` after `Cmd/Ctrl+K`). When a stream is in view, the palette shows a stream-named section above the global commands:

```
This stream — #general
  Archive this stream
  Open stream settings
  Browse files in this stream
  Labels…
Commands
  New Scratchpad
  New Channel
  …
```

This brings the stream's context-menu actions into the palette so they can be reached by keyboard, without navigating to the sidebar.

## How

- **New `stream-commands.ts`** holds the contextual command definitions (`streamCommands` for real streams, `draftStreamCommands` for drafts).
- **`commands.ts`** extends `CommandContext` with the current stream (`currentStreamId`/`currentStreamName`) and three callbacks (`openStreamSettings`, `requestArchiveStream`, `openLabelPicker`).
- **`use-command-items.ts`** prepends the contextual commands under a stream-named section header when a stream is in context.
- **`quick-switcher.tsx`** wires the existing handlers and renders the archive-confirmation modal + label picker as siblings to the palette dialog (so they survive the palette closing).
- **`workspace-layout.tsx`** passes the route's `streamId` as `currentStreamId`.

Each action **reuses existing abstractions** rather than reimplementing: `useArchiveStream`, `useStreamSettings().openStreamSettings`, the attachment explorer's `streamIds` filter, and the standalone `LabelPicker`.

## Design decisions

- **Confirmation for destructive actions.** Archive opens a `ResponsiveAlertDialog` ("Archive #general? — you can unarchive later"); the confirm copy captures the target's name/draft-status at request time so it can't drift if the route changes. Draft scratchpads instead get a single **Delete this draft** command with an irreversible-delete confirmation.
- **Stays stream-specific while filtering.** The section header names the stream and `ItemList` groups by section regardless of the query, so it remains clear which stream the actions target even as the list filters down.
- **Current route stream only.** Contextual commands appear only when viewing a stream; non-stream routes show the palette unchanged.
- **Drafts** only get the delete command — they have no server-side settings/files/labels.

## Testing

- 5 new integration tests: section appears & is named, absent without a stream, survives filtering, settings invocation, and archive-confirms-then-archives.
- **227 quick-switcher tests passing**; monorepo typecheck + lint clean (pre-commit hook).

## Review

Ran a 3-perspective pre-PR self-review (spec/correctness/design). Two minor issues found and fixed before opening: a confirm-dialog title that could drift if the route changed (now frozen at request time), and a redundant `useMemo` dep array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782644674&installation_id=129946197&pr_number=686&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F686&signature=eba58f966a33320652a20788fb3e99ed9c374562717b108c55deb2620e3fed0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->