### PR TITLE
test(browser-e2e): fix deterministic shard-1 failures stalling the suite

### DIFF
--- a/tests/browser/activity-feed.spec.ts
+++ b/tests/browser/activity-feed.spec.ts
@@ -18,6 +18,27 @@ function activityLink(page: Page, workspaceId: string) {
   return page.locator(`a[href="/w/${workspaceId}/activity"]`)
 }
 
+// The Activity badge shows the aggregate unread-activity count, which includes
+// incidental rows like the `member_added` activity created when the user joins
+// the channel — not just the mention. Match any positive count rather than a
+// brittle exact number; mention-specific assertions live on the activity feed.
+const ACTIVITY_BADGE_COUNT = /^[1-9]\d*$/
+
+/** Poll the bootstrap until the stream has accrued the expected number of mentions. */
+async function waitForMentionCount(page: Page, workspaceId: string, streamId: string, expected: number) {
+  await expect
+    .poll(
+      async () => {
+        const bootstrapRes = await page.request.get(`/api/workspaces/${workspaceId}/bootstrap`)
+        if (!bootstrapRes.ok()) return -1
+        const body = (await bootstrapRes.json()) as { data: { mentionCounts: Record<string, number> } }
+        return body.data.mentionCounts[streamId] ?? 0
+      },
+      { timeout: 20000 }
+    )
+    .toBe(expected)
+}
+
 async function waitForStreamReadState(page: Page, workspaceId: string, streamId: string) {
   await expect
     .poll(
@@ -113,24 +134,28 @@ test.describe("Activity Feed", () => {
 
       // ──── User B: Verify activity count badge on Activity link ────
 
-      await expect(actLink.getByText("1")).toBeVisible({ timeout: 10000 })
+      await expect(actLink.getByText(ACTIVITY_BADGE_COUNT)).toBeVisible({ timeout: 10000 })
 
       // ──── User B: Navigate to Activity page ────
 
       await actLink.click()
       await expect(ctxB.page).toHaveURL(new RegExp(`/w/${workspaceId}/activity`))
 
-      // Should see the activity item with actor name and stream context
+      // Should see the activity item with actor name and stream context.
+      // Scope to the mention row: the feed also lists the member_added row from
+      // joining the channel, which references the same #channel — an unscoped
+      // getByText(`#${channelSlug}`) would hit a strict-mode violation.
       const mainContent = ctxB.page.getByRole("main")
-      await expect(mainContent.getByText("mentioned you in")).toBeVisible({ timeout: 10000 })
-      await expect(mainContent.getByText(`#${channelSlug}`)).toBeVisible()
+      const mentionActivity = mainContent.getByRole("link").filter({ hasText: "mentioned you in" })
+      await expect(mentionActivity).toBeVisible({ timeout: 10000 })
+      await expect(mentionActivity.getByText(`#${channelSlug}`)).toBeVisible()
 
       // Content preview should include part of the message
-      await expect(mainContent.getByText(/please review this/)).toBeVisible()
+      await expect(mentionActivity.getByText(/please review this/)).toBeVisible()
 
       // ──── User B: Click activity item → navigates to stream ────
 
-      await mainContent.getByText("mentioned you in").click()
+      await mentionActivity.click()
       await expect(ctxB.page).toHaveURL(new RegExp(`/w/${workspaceId}/s/${streamId}`))
 
       // The message should be visible in the stream
@@ -145,7 +170,7 @@ test.describe("Activity Feed", () => {
 
       // The mention indicator should be gone since stream was read
       await expect(channelLink.locator("span.text-destructive")).not.toBeVisible({ timeout: 10000 })
-      await expect(actLink.getByText("1")).not.toBeVisible({ timeout: 10000 })
+      await expect(actLink.getByText(ACTIVITY_BADGE_COUNT)).not.toBeVisible({ timeout: 10000 })
     } finally {
       await ctxA.context.close()
       if (ctxB) await ctxB.context.close()
@@ -284,9 +309,13 @@ test.describe("Activity Feed", () => {
         expect(res.ok()).toBeTruthy()
       }
 
-      // Wait for both mentions to arrive — activity count shows 2
+      // Wait until both mentions have actually been delivered before marking
+      // everything read — otherwise a late mention re-raises the badge after the
+      // mark-all-read click. Gate on the mention projection (decoupled from the
+      // aggregate activity badge, which also counts the join's member_added row).
+      await waitForMentionCount(ctxB.page, workspaceId, streamId, 2)
       const channelLink = ctxB.page.getByRole("link", { name: `#${channelSlug}` })
-      await expect(actLink.getByText("2")).toBeVisible({ timeout: 20000 })
+      await expect(actLink.getByText(ACTIVITY_BADGE_COUNT)).toBeVisible({ timeout: 10000 })
       await expect(channelLink.locator("span.text-destructive")).toBeVisible()
 
       // Navigate to Activity page

--- a/tests/browser/agent-activity.spec.ts
+++ b/tests/browser/agent-activity.spec.ts
@@ -85,8 +85,12 @@ test.describe("Agent Activity", () => {
     const { workspaceId, streamId, threadId } = await waitForThreadId(page, messageText)
     await page.goto(`/w/${workspaceId}/s/${streamId}?panel=${threadId}`)
 
-    // Wait for thread panel to load with content (not just the empty "Start a new thread" state)
-    await expect(page.getByText("stub response from the companion")).toBeVisible({ timeout: 10000 })
+    // Wait for thread panel to load with content (not just the empty "Start a new thread" state).
+    // Scope to the panel: the channel timeline also renders a truncated reply preview with the
+    // same text, so an unscoped getByText hits a strict-mode violation once that preview renders.
+    await expect(page.getByTestId("panel").getByText("stub response from the companion")).toBeVisible({
+      timeout: 10000,
+    })
   }
 
   test("should show agent response in thread after @mention in channel", async ({ page }) => {

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type Page } from "@playwright/test"
-import { clickReplyInThread, createChannel, loginAndCreateWorkspace, switchToAllView } from "./helpers"
+import {
+  clickReplyInThread,
+  createChannel,
+  createScratchpadFromSidebar,
+  loginAndCreateWorkspace,
+  switchToAllView,
+} from "./helpers"
 
 /**
  * Tests for the Drafts page feature.
@@ -61,12 +67,8 @@ test.describe("Drafts Page", () => {
     // Wait for draft to be saved (debounced at 500ms)
     await waitForDraftSaved(page)
 
-    // Navigate away to another location (switch to All view to access button, then create scratchpad)
-    await switchToAllView(page)
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByText(/Type a message|No messages yet|Start a conversation/).first()).toBeVisible({
-      timeout: 5000,
-    })
+    // Navigate away to another location by creating a new scratchpad
+    await createScratchpadFromSidebar(page)
 
     // Verify Drafts link is highlighted (no longer greyed out)
     const draftsLink = page.locator('a[href*="/drafts"]')
@@ -86,12 +88,8 @@ test.describe("Drafts Page", () => {
     await page.keyboard.type(draftContent)
     await waitForDraftSaved(page)
 
-    // Navigate away (switch to All view to access button)
-    await switchToAllView(page)
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByText(/Type a message|No messages yet|Start a conversation/).first()).toBeVisible({
-      timeout: 5000,
-    })
+    // Navigate away by creating a new scratchpad
+    await createScratchpadFromSidebar(page)
 
     // Click Drafts link to navigate to page
     await page.locator('a[href*="/drafts"]').click()
@@ -209,12 +207,8 @@ test.describe("Drafts Page", () => {
     await page.keyboard.type(`QS test ${testId}`)
     await waitForDraftSaved(page)
 
-    // Navigate away (switch to All view to access button)
-    await switchToAllView(page)
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByText(/Type a message|No messages yet|Start a conversation/).first()).toBeVisible({
-      timeout: 5000,
-    })
+    // Navigate away by creating a new scratchpad
+    await createScratchpadFromSidebar(page)
 
     // Open quick switcher with Cmd+K. Blur the editor first to prevent
     // the editor from intercepting the keyboard shortcut.
@@ -273,12 +267,8 @@ test.describe("Drafts Page", () => {
     // and the IndexedDB write to land before navigating away.
     await waitForDraftSaved(page)
 
-    // Navigate away (switch to All view to access button)
-    await switchToAllView(page)
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByText(/Type a message|No messages yet|Start a conversation/).first()).toBeVisible({
-      timeout: 5000,
-    })
+    // Navigate away by creating a new scratchpad
+    await createScratchpadFromSidebar(page)
 
     // Drafts link should not be greyed (attachment-only draft counts)
     const draftsLink = page.locator('a[href*="/drafts"]')

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -210,10 +210,11 @@ test.describe("Drafts Page", () => {
     // Navigate away by creating a new scratchpad
     await createScratchpadFromSidebar(page)
 
-    // Open quick switcher with Cmd+K. Blur the editor first to prevent
-    // the editor from intercepting the keyboard shortcut.
-    await page.locator("header").first().click()
-    await page.keyboard.press("Meta+k")
+    // Open the quick switcher via its toolbar button rather than the Cmd+K
+    // accelerator: headless Chromium intermittently swallows browser-reserved
+    // Cmd/Ctrl shortcuts before the app sees them. This test covers the
+    // "> drafts" command path, not the keybinding itself.
+    await page.getByRole("button", { name: /Jump to stream/i }).click()
     await expect(page.getByRole("tab", { name: "Stream search" })).toBeVisible({ timeout: 5000 })
 
     // Type command prefix and search for drafts

--- a/tests/browser/emoji-shortcuts.spec.ts
+++ b/tests/browser/emoji-shortcuts.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "@playwright/test"
 import { loginAndCreateWorkspace } from "./helpers"
 
+// Emoji is inserted as plain text (the unicode character), not a `[data-type='emoji']`
+// atom node — the composer switched to editable text so mobile browsers can delete it
+// natively. Assert the inserted grapheme rather than the legacy node.
+const EMOJI_RE = /\p{Extended_Pictographic}/u
+
 /**
  * Emoji shortcut E2E tests.
  *
@@ -65,8 +70,8 @@ test.describe("Emoji Shortcuts", () => {
     // Click the first emoji in the grid
     await page.locator("[data-emoji-grid] button").first().click()
 
-    // Emoji should be inserted - check for emoji node in editor
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible()
+    // Emoji should be inserted as text into the editor
+    await expect(editor).toContainText(EMOJI_RE)
 
     // Grid should close after selection
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
@@ -85,7 +90,7 @@ test.describe("Emoji Shortcuts", () => {
     await page.keyboard.press("Enter")
 
     // Emoji should be inserted
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible()
+    await expect(editor).toContainText(EMOJI_RE)
 
     // Grid should close
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
@@ -104,7 +109,7 @@ test.describe("Emoji Shortcuts", () => {
     await page.keyboard.press("Tab")
 
     // Emoji should be inserted
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible()
+    await expect(editor).toContainText(EMOJI_RE)
 
     // Grid should close
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
@@ -124,7 +129,7 @@ test.describe("Emoji Shortcuts", () => {
     await page.keyboard.press("Tab")
 
     // Emoji should be inserted
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible()
+    await expect(editor).toContainText(EMOJI_RE)
   })
 
   test("should auto-convert :shortcode: when typing closing colon", async ({ page }) => {
@@ -133,8 +138,8 @@ test.describe("Emoji Shortcuts", () => {
     // Type a complete shortcode with closing colon
     await page.keyboard.type(":fire:")
 
-    // Emoji should be auto-converted to emoji node
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible({ timeout: 2000 })
+    // Emoji should be auto-converted to the emoji character
+    await expect(editor).toContainText(EMOJI_RE, { timeout: 2000 })
 
     // The emoji picker should NOT be visible (input rule handled it)
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
@@ -247,7 +252,7 @@ test.describe("Emoji Shortcuts", () => {
     await page.keyboard.type(":fire:")
 
     // Wait for emoji to convert in editor
-    await expect(editor.locator("[data-type='emoji']")).toBeVisible({ timeout: 2000 })
+    await expect(editor).toContainText(EMOJI_RE, { timeout: 2000 })
 
     // Type additional text after the emoji
     await page.keyboard.type(" Great job!")

--- a/tests/browser/helpers.ts
+++ b/tests/browser/helpers.ts
@@ -126,6 +126,26 @@ export function createDmDraftId(userId: string): string {
 }
 
 /**
+ * Create a new scratchpad from the sidebar when the workspace already has streams.
+ *
+ * The big "+ New Scratchpad" button only renders in the empty state (a brand-new
+ * workspace with no streams). Once any stream exists, the Scratchpads section header
+ * exposes a "New scratchpad…" menu trigger whose dropdown carries the New Scratchpad /
+ * Quick Note / Encrypted Scratchpad actions — so tests that already created a channel
+ * must go through the menu, not the empty-state button.
+ */
+export async function createScratchpadFromSidebar(page: Page): Promise<void> {
+  await switchToAllView(page)
+  const addButton = page.getByRole("button", { name: /New scratchpad/i })
+  await expect(addButton).toBeVisible({ timeout: 10000 })
+  await addButton.click()
+  await page.getByRole("menuitem", { name: "New Scratchpad", exact: true }).click()
+  await expect(page.getByText(/Type a message|No messages yet|Start a conversation/).first()).toBeVisible({
+    timeout: 10000,
+  })
+}
+
+/**
  * Create a channel via the create channel modal and wait for it to load.
  * By default switches to "All" view after creation so the channel appears in sidebar.
  */

--- a/tests/browser/infinite-scroll.spec.ts
+++ b/tests/browser/infinite-scroll.spec.ts
@@ -133,9 +133,13 @@ test.describe("Infinite Scroll", () => {
     // Navigate fresh to get a clean bootstrap (with only the latest ~50 events)
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
 
-    // Wait for messages to render — the latest message should be visible.
-    // Bootstrap render can lag on a loaded CI runner, so allow generous headroom.
-    await expect(messageLocator(page, prefix, PAGED_MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
+    // Wait for the bootstrap window to render. Don't pin on the very latest
+    // message being in view: on a loaded runner the virtualized list can mount
+    // scrolled to the top of the window (oldest-in-window first) rather than
+    // anchored to the bottom, so msg-051 is real but outside the rendered range.
+    // Any rendered message confirms the cold bootstrap landed — which is all the
+    // scroll-up-loads-older assertion below needs.
+    await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 20000 })
 
     // The earliest message should NOT be visible yet (it's beyond the bootstrap window)
     await expect(oldestMessage).not.toBeVisible()


### PR DESCRIPTION
## Summary

Follow-up to #679. Shard 1 was the Browser E2E critical path (~9.5m) and #682 attributed it to "parallel-fragile" tests that only pass on the isolated `--last-failed` retry.

**That diagnosis turned out to be wrong for the bulk of them.** Replaying the #679 merge run's blob report and reproducing locally at `--retries=0` showed the heavy shard-1 cluster fails on **every** attempt — initial run, all in-run retries, *and* the isolated retry (which also rebuilds the frontend, inflating the shard). They fail **even in isolation with zero load**. They aren't flaky; their assertions drifted from current product behaviour. Burning 3 retries + a rebuild on deterministic failures every run is what kept shard 1 at ~9.5m.

## Root causes & fixes (test-only)

| File | Why it failed (deterministically) | Fix |
|------|-----------------------------------|-----|
| `emoji-shortcuts` ×6 | Emoji now inserts as plain **text** (the unicode char), not a `[data-type='emoji']` atom node — the composer switched to editable text for native mobile deletion (#449). The assertion still looked for the removed node. | Assert the inserted grapheme (`/\p{Extended_Pictographic}/u`). |
| `agent-activity` ×3 | The channel timeline renders a truncated reply-preview with the same text as the panel message → unscoped `getByText` strict-mode violation once it renders. | Scope to `getByTestId("panel")`. |
| `drafts-modal` ×4 | The `+ New Scratchpad` button only exists in the **empty state**. Once a stream exists, the Scratchpads section shows a `New scratchpad…` **menu trigger** — so the test waited 30s for a label that no longer exists. | New `createScratchpadFromSidebar` helper that drives the menu. |
| `activity-feed` ×2 | A `member_added` activity (created when the user joins the channel) inflates the aggregate badge past the hardcoded `"1"`/`"2"` and adds a second feed row for the same channel. | Match any positive badge count, scope feed assertions to the mention row, gate "mark all read" on the mention projection (bootstrap poll) instead of the brittle badge number. |

No product code changed — these are all stale test assertions vs. intentional product behaviour. Where a real timing dependency exists (mark-all-read), it now awaits the real signal (`expect.poll` on the projection) rather than racing a fixed timeout, per the issue's fix philosophy.

## Verification

Local, full shard 1, **first attempt, `--retries=0`** (the bar #682 set):

- `--workers=3` (CI worker count): **51 passed (1.4m)**
- `--workers=6` (≈2× CI contention to simulate congestion): **51 passed (1.6m)**

The dm-lazy `ECONNRESET` seen during early reproduction was load induced by the 13 simultaneously-failing tests hammering the shared backend; it no longer reproduces once the cluster passes, so per minimal-patch it's left untouched (CI's `retries=2` backstops genuine infra blips).

## Expected CI impact

With the shard-1 cluster passing first-try, CI no longer triggers the in-run retries **or** the isolated `--last-failed` rebuild step on shard 1 — that step was the dominant remaining cost. Slowest shard should land well under the ~5m target.

Refs #682. Does not reopen #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782645619&installation_id=129946197&pr_number=687&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F687&signature=95c51af23681350a875f5ad058416c6dd8b1b583d71c77ac6d0167233a1d5cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->