### PR TITLE
test: de-flake message-move, emoji usage, and queue onDLQ CI tests

### DIFF
--- a/apps/backend/tests/e2e/emoji.test.ts
+++ b/apps/backend/tests/e2e/emoji.test.ts
@@ -23,8 +23,24 @@ import {
 const testRunId = Math.random().toString(36).substring(7)
 const testEmail = (name: string) => `${name}-${testRunId}@test.com`
 
-// Helper to wait for async outbox processing
-const waitForOutbox = () => new Promise((resolve) => setTimeout(resolve, 500))
+// Emoji usage weights are computed asynchronously by the outbox listener after
+// a message/reaction is persisted. Poll the bootstrap until the expected weights
+// land instead of sleeping a fixed interval — a fixed `setTimeout` is racy under
+// CI load and was the source of intermittent failures (INV-22).
+const waitForEmojiWeights = async (
+  client: TestClient,
+  workspaceId: string,
+  predicate: (weights: Record<string, number>) => boolean,
+  { timeoutMs = 5000, intervalMs = 100 }: { timeoutMs?: number; intervalMs?: number } = {}
+) => {
+  const deadline = Date.now() + timeoutMs
+  let bootstrap = await getWorkspaceBootstrap(client, workspaceId)
+  while (!predicate(bootstrap.emojiWeights ?? {}) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+    bootstrap = await getWorkspaceBootstrap(client, workspaceId)
+  }
+  return bootstrap
+}
 
 describe("Emoji E2E Tests", () => {
   describe("Emoji List", () => {
@@ -178,11 +194,12 @@ describe("Emoji E2E Tests", () => {
       await sendMessage(client, workspace.id, scratchpad.id, "Another thumbs up 👍")
       await sendMessage(client, workspace.id, scratchpad.id, "Fire! 🔥")
 
-      // Wait for outbox listener to process events
-      await waitForOutbox()
-
-      // Get bootstrap to check weights
-      const bootstrap = await getWorkspaceBootstrap(client, workspace.id)
+      // Wait for the outbox listener to record both emojis
+      const bootstrap = await waitForEmojiWeights(
+        client,
+        workspace.id,
+        (weights) => (weights["+1"] ?? 0) >= 2 && (weights["fire"] ?? 0) >= 1
+      )
 
       // Should have tracked +1 emoji (used twice)
       expect(bootstrap.emojiWeights["+1"]).toBeGreaterThanOrEqual(2)
@@ -200,10 +217,12 @@ describe("Emoji E2E Tests", () => {
       await addReaction(client, workspace.id, message.id, "❤️")
       await addReaction(client, workspace.id, message.id, "🎉")
 
-      // Wait for outbox listener to process events
-      await waitForOutbox()
-
-      const bootstrap = await getWorkspaceBootstrap(client, workspace.id)
+      // Wait for the outbox listener to record both reaction emojis
+      const bootstrap = await waitForEmojiWeights(
+        client,
+        workspace.id,
+        (weights) => (weights["heart"] ?? 0) >= 1 && (weights["tada"] ?? 0) >= 1
+      )
 
       // Should have tracked heart and tada
       expect(bootstrap.emojiWeights["heart"]).toBeGreaterThanOrEqual(1)
@@ -219,10 +238,8 @@ describe("Emoji E2E Tests", () => {
       // Wall of same emoji
       await sendMessage(client, workspace.id, scratchpad.id, "👍👍👍👍👍")
 
-      // Wait for outbox listener to process events
-      await waitForOutbox()
-
-      const bootstrap = await getWorkspaceBootstrap(client, workspace.id)
+      // Wait for the outbox listener to count all 5 occurrences
+      const bootstrap = await waitForEmojiWeights(client, workspace.id, (weights) => (weights["+1"] ?? 0) >= 5)
 
       // Should count all 5 occurrences
       expect(bootstrap.emojiWeights["+1"]).toBeGreaterThanOrEqual(5)
@@ -236,14 +253,12 @@ describe("Emoji E2E Tests", () => {
 
       // First message
       await sendMessage(client, workspace.id, scratchpad.id, "First 👍")
-      await waitForOutbox()
-      const bootstrap1 = await getWorkspaceBootstrap(client, workspace.id)
+      const bootstrap1 = await waitForEmojiWeights(client, workspace.id, (weights) => (weights["+1"] ?? 0) >= 1)
       const weight1 = bootstrap1.emojiWeights["+1"] ?? 0
 
-      // Second message
+      // Second message — wait until the weight climbs past the first reading
       await sendMessage(client, workspace.id, scratchpad.id, "Second 👍")
-      await waitForOutbox()
-      const bootstrap2 = await getWorkspaceBootstrap(client, workspace.id)
+      const bootstrap2 = await waitForEmojiWeights(client, workspace.id, (weights) => (weights["+1"] ?? 0) > weight1)
       const weight2 = bootstrap2.emojiWeights["+1"] ?? 0
 
       // Weight should have increased

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -3,7 +3,7 @@ import type { Pool } from "pg"
 import { EventService } from "../../src/features/messaging"
 import { AgentSessionRepository, SessionStatuses } from "../../src/features/agents"
 import { StreamEventRepository, StreamMemberRepository, StreamRepository } from "../../src/features/streams"
-import { eventId, personaId, sessionId, streamId, userId, workspaceId } from "../../src/lib/id"
+import { eventId, messageId, personaId, sessionId, streamId, userId, workspaceId } from "../../src/lib/id"
 import { addTestMember, setupTestDatabase, testMessageContent } from "./setup"
 
 describe("message move integration", () => {
@@ -50,6 +50,27 @@ describe("message move integration", () => {
     })
     await StreamMemberRepository.insert(pool, sourceStreamId, actor.id)
 
+    // Claim the stream's single RUNNING agent-session slot *before* any user
+    // message exists. The integration suite preloads a live server
+    // (tests/setup.ts) whose companion worker polls this same database, and a
+    // companion-on scratchpad dispatches a persona-agent job for every USER
+    // message. That worker's `insertRunningOrSkip` would otherwise race this
+    // test's plain `insert` on `idx_agent_sessions_one_running_per_stream`
+    // (23505, flaky). With the slot already held, `CompanionHandler`
+    // suppresses the dispatch (it skips while a session is RUNNING) and any
+    // job that did dispatch no-ops in `insertRunningOrSkip` — so no second
+    // running session, and no stub response leaks onto the stream. The
+    // `triggerMessageId` is a placeholder; nothing reads the session's
+    // `trigger_message_id`, and the started-event payload below still records
+    // the real `target.id`.
+    const traceSession = await AgentSessionRepository.insert(pool, {
+      id: sessionId(),
+      streamId: sourceStreamId,
+      personaId: personaId(),
+      triggerMessageId: messageId(),
+      status: SessionStatuses.RUNNING,
+    })
+
     const target = await eventService.createMessage({
       workspaceId: testWorkspaceId,
       streamId: sourceStreamId,
@@ -79,13 +100,6 @@ describe("message move integration", () => {
       ...testMessageContent("moved b"),
     })
 
-    const traceSession = await AgentSessionRepository.insert(pool, {
-      id: sessionId(),
-      streamId: sourceStreamId,
-      personaId: personaId(),
-      triggerMessageId: target.id,
-      status: SessionStatuses.RUNNING,
-    })
     const traceStartedEventId = eventId()
     await StreamEventRepository.insert(pool, {
       id: traceStartedEventId,

--- a/apps/backend/tests/integration/queue-manager.test.ts
+++ b/apps/backend/tests/integration/queue-manager.test.ts
@@ -113,6 +113,15 @@ describe("QueueManager", () => {
         expect(hookCalls[0].meta.failedCount).toBe(0)
         expect(hookCalls[0].meta.insertedAt).toBeInstanceOf(Date)
 
+        // The onDLQ hook resolves `hookCalled` from inside the DLQ-move
+        // transaction's savepoint — i.e. before the outer transaction commits.
+        // Wait until the committed DLQ state is visible on a fresh connection
+        // rather than reading once and racing the commit (INV-22).
+        await waitForCondition(
+          async () => (await QueueRepository.getById(pool, messageId))?.dlqAt != null,
+          2000,
+          `Message ${messageId} did not reach a committed DLQ state`
+        )
         const message = await QueueRepository.getById(pool, messageId)
         expect(message).not.toBeNull()
         expect(message!.dlqAt).not.toBeNull()


### PR DESCRIPTION
## Problem

Three tests intermittently failed CI on `main` over the past two weeks and were masked by re-runs. All three are integration/e2e tests that run against a **live test server** (preloaded via `tests/setup.ts`) whose outbox dispatcher and queue workers poll the **same shared test database**. The flakes are races between the test and that background machinery:

1. **`message-move` integration** (the worst / most recent — e.g. [run 26632039351](https://github.com/threahq/threa/actions/runs/26632039351/job/78483029568)): `duplicate key value violates unique constraint "idx_agent_sessions_one_running_per_stream"` (23505). The test creates a companion-on scratchpad with user messages, which makes the live companion worker dispatch a persona-agent job and `insertRunningOrSkip` a RUNNING `agent_session` on the test's stream — racing the test's own plain `AgentSessionRepository.insert(RUNNING)` on the per-stream "one running session" unique index.
2. **`emoji` e2e — Emoji Usage Tracking** (2 tests): asserted async-computed `emojiWeights` after a fixed `setTimeout(500ms)`. Under CI load the outbox listener hadn't finished computing weights within 500ms → stale/missing weights.
3. **`queue-manager` integration — onDLQ hook**: the `onDLQ` hook resolves the test's `hookCalled` promise from **inside the DLQ-move transaction's savepoint** (before the outer transaction commits), so reading committed `dlqAt` immediately after raced the commit (`Received: null`).

(The other 2-week CI failures were CI infra flakes — `setup-bun`/`502` download failures — or a deterministic, already-resolved `EXCEL_MAX_ROWS_PER_REQUEST` init bug. Left alone per "fix flaky, ignore one-offs that haven't recurred.")

## Solution

Make each test deterministic against the shared live workers, without weakening what they verify.

### Key design decisions

**1. `message-move`: claim the running-session slot before any user message exists.**
The test now inserts its RUNNING trace session as the *first* operation on the stream (before `target`/`keep`/`movedA`/`movedB`). With the slot already held, `CompanionHandler` suppresses the dispatch (it skips while a session is RUNNING) and any job that did dispatch no-ops in `insertRunningOrSkip` — so there is no competing insert and no stub response leaks onto the stream. `triggerMessageId` uses a placeholder `messageId()` (nothing reads the session's `trigger_message_id`; the started-event payload still records the real `target.id`). The `companionMode: "on"` inheritance assertion is preserved. Alternative considered: turning companion off — rejected because it's the only test asserting companion-mode inheritance on move.

**2. `emoji`: poll-until-condition instead of fixed sleep.**
Added `waitForEmojiWeights(client, workspaceId, predicate, {timeoutMs, intervalMs})` — bounded (5s/100ms) poll of the bootstrap until the expected weights land. Predicates are scoped per test (e.g. the accumulate test waits for `> weight1`, not a fixed threshold). All four usage-tracking tests converted; the unused `waitForOutbox` helper removed.

**3. `queue-manager`: wait for the committed DLQ state.**
Reuse the file's existing `waitForCondition` helper to poll `getById` until `dlqAt` is committed-visible, then assert. `waitForCondition` throws a descriptive error on timeout (fail-loudly) rather than reading once.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/tests/integration/message-move.test.ts` | Claim RUNNING agent-session slot before user messages (placeholder trigger id) |
| `apps/backend/tests/e2e/emoji.test.ts` | Replace fixed `waitForOutbox()` sleeps with bounded `waitForEmojiWeights` poll |
| `apps/backend/tests/integration/queue-manager.test.ts` | Poll `waitForCondition` until committed `dlqAt` is visible before asserting |

## Test plan

- [x] `message-move.test.ts` — green 15× in isolation + 5× under full-suite contention
- [x] Full backend integration suite — **434 pass × 5 runs**
- [x] Full backend e2e suite — **307 pass**; `emoji.test.ts` green 3×; `queue-manager.test.ts` green 3×
- [x] `tsc` (app + tests configs) — 0 errors; `eslint` on changed files — 0 errors
- [x] Pre-PR multi-perspective review (spec / correctness / design): 1 design issue found (duplicate poll loop) and fixed by reusing `waitForCondition`

> Note: the races are CI-load-sensitive and didn't reproduce locally even under repeated full-suite runs, but both the insert-race and the read-race are eliminated by construction (claim the slot before any competitor exists; wait for the committed state instead of reading once).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782645708&installation_id=129946197&pr_number=688&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F688&signature=d548ebb513225dd3e17ffcc7ac9a7b132720d660030b0a89e384b5c12c698ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->