### PR TITLE
feat: add subtle drop shadow to inline message composer card

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -889,6 +889,9 @@ export function MessageComposer({
           <div
             className={cn(
               "rounded-[16px] border border-input bg-card flex flex-col flex-1 min-h-0",
+              // Subtle drop shadow on the resting inline composer (not when expanded into a sheet)
+              !mobileExpanded &&
+                "shadow-[inset_0_1px_0_hsl(33_28%_97%),0_8px_24px_-14px_hsl(28_30%_22%/0.18),0_2px_6px_-2px_hsl(28_30%_22%/0.06)] dark:shadow-[0_8px_24px_-14px_rgb(0_0_0/0.35),0_2px_6px_-2px_rgb(0_0_0/0.12)]",
               // Compact padding when mobile-unfocused (single line), normal otherwise
               isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
               // When mobile-expanded, let the editor grow and override its internal max-height


### PR DESCRIPTION
## Problem

The inline message composer card sits flush against the timeline with no visual elevation. It needs a subtle drop shadow to create a small lift effect — fitting the gold-on-paper theme — without changing its border, padding, radius, or background.

## Solution

Added a single Tailwind arbitrary shadow to the inline composer card container, gated behind `!mobileExpanded` so the mobile sheet variant remains flat. The shadow uses the warm-ink values from the mockup in light mode and switches to a visible black-based shadow in dark mode (where a light-foreground shadow would be invisible against the dark background).

### Key design decisions

**1. Mockup-accurate light mode shadow**

The light mode shadow matches the provided mockup exactly: `inset 0 1px 0 hsl(33 28% 97%)` for the faint top-edge highlight, plus the two directional shadows at `0.18` and `0.06` opacity anchored to `hsl(28 30% 22%)` (warm dark ink).

**2. Dark mode uses black-based shadow**

In dark mode `--foreground` is `hsl(35 15% 92%)` (light grey). A shadow made from that would be invisible. Switched to `rgb(0 0 0 / 0.35)` and `rgb(0 0 0 / 0.12)` which produce visible, gentle depth on the `--background: 30 15% 8%` canvas.

**3. No inset highlight in dark mode**

The white-ish inset highlight (`hsl(33 28% 97%)`) would read as an unintended bright top strip on dark backgrounds. Omitted in the `dark:` variant.

**4. Pure Tailwind — no CSS files or inline styles**

The shadow is expressed entirely via Tailwind's arbitrary value syntax: `shadow-[...] dark:shadow-[...]` in the `cn()` call.

**5. Gated behind `!mobileExpanded`**

When the user expands the mobile composer into the 75dvh sheet, the shadow drops away so the sheet reads as a flat overlay from the bottom (consistent with iOS-style sheet patterns).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/composer/message-composer.tsx` | Added Tailwind shadow classes to the inline composer card `div` |

## Test plan

- [ ] Build succeeds and TypeScript typecheck passes
- [ ] Visual check in light mode: soft warm shadow with subtle top-edge highlight
- [ ] Visual check in dark mode: shadow is visible (not washed out), no bright top highlight
- [ ] Shadow disappears when mobile sheet is expanded (`mobileExpanded` state)
- [ ] Shadow is absent in expanded/fullscreen mode
- [ ] No regressions in border, radius, padding, or background of the composer card

---

🤖 _PR by Claude Code_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782667675&installation_id=129946197&pr_number=692&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F692&signature=11496c8d10d85e86cc9024ca97f2b2972f569a6bf1eb67ce8ed697947cd3c618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->