### PR TITLE
feat(agents): GitHub tools read public repos without an integration

### DIFF
--- a/apps/backend/src/features/agents/tools/github/client-accessor.test.ts
+++ b/apps/backend/src/features/agents/tools/github/client-accessor.test.ts
@@ -6,6 +6,21 @@ function makeService(fn: () => Promise<GitHubClient | null>): WorkspaceIntegrati
   return { getGithubClient: fn } as unknown as WorkspaceIntegrationService
 }
 
+describe("createMemoizedGithubClient options", () => {
+  it("requests the unauthenticated fallback so agent tools can read public repos without an integration", async () => {
+    let receivedOptions: unknown
+    const service = {
+      getGithubClient: async (_workspaceId: string, options?: unknown) => {
+        receivedOptions = options
+        return null
+      },
+    } as unknown as WorkspaceIntegrationService
+    const getClient = createMemoizedGithubClient(service, "ws_1")
+    await getClient()
+    expect(receivedOptions).toEqual({ allowUnauthenticatedFallback: true })
+  })
+})
+
 describe("createMemoizedGithubClient", () => {
   it("fetches once and reuses the resolved client across calls", async () => {
     let calls = 0

--- a/apps/backend/src/features/agents/tools/github/client-accessor.ts
+++ b/apps/backend/src/features/agents/tools/github/client-accessor.ts
@@ -37,6 +37,10 @@ export async function withGithubClient<T>(
  * agent turn so chained GitHub tool calls share one DB fetch and (possibly) one token
  * refresh. A rejection clears the cache so a later call in the same turn gets a fresh
  * attempt instead of inheriting a transient failure.
+ *
+ * Agent tools opt into the unauthenticated fallback: when the workspace has no GitHub
+ * integration, the tools still work against public/open-source repositories instead of
+ * reporting GITHUB_NOT_CONNECTED.
  */
 export function createMemoizedGithubClient(
   service: WorkspaceIntegrationService,
@@ -44,7 +48,7 @@ export function createMemoizedGithubClient(
 ): () => Promise<GitHubClient | null> {
   let cached: Promise<GitHubClient | null> | null = null
   return async () => {
-    if (cached === null) cached = service.getGithubClient(workspaceId)
+    if (cached === null) cached = service.getGithubClient(workspaceId, { allowUnauthenticatedFallback: true })
     try {
       return await cached
     } catch (err) {

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test"
+import type { Pool } from "pg"
+import { GitHubClient, WorkspaceIntegrationService } from "./service"
+import type { GitHubAppConfig, LinearOAuthConfig } from "../../lib/env"
+
+const githubDisabled: GitHubAppConfig = {
+  enabled: false,
+  appId: "",
+  appSlug: "",
+  privateKey: "",
+  integrationSecret: "secret",
+}
+
+const linearDisabled: LinearOAuthConfig = {
+  enabled: false,
+  clientId: "",
+  clientSecret: "",
+  redirectUri: "",
+  integrationSecret: "secret",
+}
+
+// A pool that throws if touched — the no-app paths must resolve before any query.
+const explodingPool = {
+  query: () => {
+    throw new Error("pool should not be queried when no GitHub app is configured")
+  },
+} as unknown as Pool
+
+function makeService(): WorkspaceIntegrationService {
+  return new WorkspaceIntegrationService({ pool: explodingPool, github: githubDisabled, linear: linearDisabled })
+}
+
+describe("getGithubClient unauthenticated fallback", () => {
+  it("returns null when no app is configured and no fallback is requested", async () => {
+    const service = makeService()
+    expect(await service.getGithubClient("ws_1")).toBeNull()
+  })
+
+  it("returns an anonymous GitHub client when the fallback is requested, so public repos still work", async () => {
+    const service = makeService()
+    const client = await service.getGithubClient("ws_1", { allowUnauthenticatedFallback: true })
+    expect(client).toBeInstanceOf(GitHubClient)
+  })
+
+  it("builds an anonymous client without installation state", () => {
+    const service = makeService()
+    const client = GitHubClient.anonymous(service, "ws_1")
+    expect(client).toBeInstanceOf(GitHubClient)
+  })
+})

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -19,6 +19,14 @@ const linearDisabled: LinearOAuthConfig = {
   integrationSecret: "secret",
 }
 
+const githubEnabled: GitHubAppConfig = {
+  enabled: true,
+  appId: "123456",
+  appSlug: "threa-test",
+  privateKey: "-----BEGIN RSA PRIVATE KEY-----\nMIItest\n-----END RSA PRIVATE KEY-----",
+  integrationSecret: "secret",
+}
+
 // A pool that throws if touched — the no-app paths must resolve before any query.
 const explodingPool = {
   query: () => {
@@ -28,6 +36,13 @@ const explodingPool = {
 
 function makeService(): WorkspaceIntegrationService {
   return new WorkspaceIntegrationService({ pool: explodingPool, github: githubDisabled, linear: linearDisabled })
+}
+
+// Build a service whose app is configured and whose integration lookup returns a
+// single canned row, so the rate-limit branch is reachable without a real DB.
+function makeServiceWithRow(row: Record<string, unknown>): WorkspaceIntegrationService {
+  const pool = { query: async () => ({ rows: [row] }) } as unknown as Pool
+  return new WorkspaceIntegrationService({ pool, github: githubEnabled, linear: linearDisabled })
 }
 
 describe("getGithubClient unauthenticated fallback", () => {
@@ -46,5 +61,25 @@ describe("getGithubClient unauthenticated fallback", () => {
     const service = makeService()
     const client = GitHubClient.anonymous(service, "ws_1")
     expect(client).toBeInstanceOf(GitHubClient)
+  })
+
+  it("does NOT fall back to anonymous when an active integration is near its rate limit", async () => {
+    // A throttled installation is a back-off circuit-breaker, not a missing
+    // integration: it must keep returning null (surfaced as GITHUB_NOT_CONNECTED)
+    // rather than silently downgrade a heavy user onto the per-IP anonymous quota.
+    const resetInFuture = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    const service = makeServiceWithRow({
+      id: "wsi_1",
+      workspace_id: "ws_1",
+      provider: "github",
+      status: "active",
+      credentials: {},
+      metadata: { rateLimitRemaining: 5, rateLimitResetAt: resetInFuture },
+      installed_by: "user_1",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    const client = await service.getGithubClient("ws_1", { allowUnauthenticatedFallback: true })
+    expect(client).toBeNull()
   })
 })

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -76,14 +76,28 @@ interface GitHubApiHeaders {
 export class GitHubClient {
   private octokit: Octokit
 
+  // `record`/`credentials`/`metadata` are null for an anonymous client. GitHub's
+  // REST API serves public repositories without auth, so an unauthenticated
+  // client still works for open-source repos; private resources answer 404,
+  // which the tool layer surfaces as GITHUB_NOT_FOUND.
   constructor(
     private service: WorkspaceIntegrationService,
     private workspaceId: string,
-    private record: WorkspaceIntegrationRecord,
-    private credentials: GitHubIntegrationCredentials,
-    private metadata: GitHubIntegrationMetadata
+    private record: WorkspaceIntegrationRecord | null,
+    private credentials: GitHubIntegrationCredentials | null,
+    private metadata: GitHubIntegrationMetadata | null
   ) {
-    this.octokit = new Octokit({ auth: credentials.accessToken })
+    this.octokit = credentials ? new Octokit({ auth: credentials.accessToken }) : new Octokit()
+  }
+
+  /**
+   * Build a client with no installation state. It reads public repositories via
+   * GitHub's anonymous REST access; private resources answer 404. Use this when
+   * the workspace has no usable GitHub integration but a caller still wants
+   * open-source reads.
+   */
+  static anonymous(service: WorkspaceIntegrationService, workspaceId: string): GitHubClient {
+    return new GitHubClient(service, workspaceId, null, null, null)
   }
 
   async request<T>(route: string, parameters: Record<string, unknown> = {}): Promise<T> {
@@ -100,7 +114,9 @@ export class GitHubClient {
       const headers = getErrorHeaders(error)
       await this.captureRateLimit(headers)
 
-      if (status === 401 && !retried) {
+      // Only authenticated installations can refresh; an anonymous client has
+      // no credentials to renew, so its 401 propagates as-is.
+      if (status === 401 && !retried && this.record && this.credentials) {
         const refreshed = await this.service.refreshGithubCredentialsForClient(this.workspaceId, this.record)
         if (!refreshed) {
           throw error
@@ -117,7 +133,9 @@ export class GitHubClient {
   }
 
   private async captureRateLimit(headers: GitHubApiHeaders | undefined): Promise<void> {
-    if (!headers) return
+    // Anonymous clients have no integration record to persist against, and their
+    // rate-limit headers are per-IP rather than workspace state.
+    if (!headers || !this.metadata) return
     const remaining = parseIntegerHeader(headers["x-ratelimit-remaining"])
     const resetSeconds = parseIntegerHeader(headers["x-ratelimit-reset"])
     const resetAt = resetSeconds ? new Date(resetSeconds * 1000).toISOString() : null
@@ -333,8 +351,29 @@ export class WorkspaceIntegrationService {
     return { workspaceId }
   }
 
-  async getGithubClient(workspaceId: string): Promise<GitHubClient | null> {
-    if (!this.app) return null
+  /**
+   * Resolve a GitHub client for a workspace.
+   *
+   * When `allowUnauthenticatedFallback` is set, the paths where the workspace
+   * has no usable installation (no app configured, no active integration,
+   * undecryptable or unrefreshable credentials) return an anonymous client that
+   * can still read public/open-source repositories instead of `null`. Callers
+   * that only want authenticated access (e.g. link-preview enrichment) omit the
+   * flag and keep the original null-on-missing behavior.
+   *
+   * The near-rate-limit branch deliberately does NOT fall back: it is a
+   * back-off circuit-breaker for an installation that exists but is throttled.
+   * Handing back an anonymous client there would silently downgrade a heavy
+   * GitHub user to the shared per-IP anonymous quota and mask the rate-limit
+   * state, so it keeps returning `null` (surfaced as GITHUB_NOT_CONNECTED).
+   */
+  async getGithubClient(
+    workspaceId: string,
+    options: { allowUnauthenticatedFallback?: boolean } = {}
+  ): Promise<GitHubClient | null> {
+    const fallback = () => (options.allowUnauthenticatedFallback ? GitHubClient.anonymous(this, workspaceId) : null)
+
+    if (!this.app) return fallback()
 
     const record = await WorkspaceIntegrationRepository.findByWorkspaceAndProvider(
       this.deps.pool,
@@ -342,7 +381,7 @@ export class WorkspaceIntegrationService {
       WorkspaceIntegrationProviders.GITHUB
     )
     if (!record || record.status !== WorkspaceIntegrationStatuses.ACTIVE) {
-      return null
+      return fallback()
     }
 
     const metadata = this.parseMetadata(record.metadata)
@@ -355,12 +394,12 @@ export class WorkspaceIntegrationService {
       credentials = this.parseCredentials(workspaceId, record.credentials)
     } catch (error) {
       log.warn({ err: error, workspaceId }, "GitHub integration credentials could not be decrypted")
-      return null
+      return fallback()
     }
 
     if (this.shouldRefreshToken(credentials.tokenExpiresAt)) {
       const refreshed = await this.refreshGithubCredentialsForClient(workspaceId, record)
-      if (!refreshed) return null
+      if (!refreshed) return fallback()
       return new GitHubClient(this, workspaceId, refreshed.record, refreshed.credentials, refreshed.metadata)
     }
 


### PR DESCRIPTION
## What

Ariadne — and any persona with GitHub tools enabled — can now read **public / open-source** GitHub repositories even when the workspace has **not** connected a GitHub App integration. Private repositories still require credentials.

GitHub's REST API serves public repos anonymously, so an unauthenticated Octokit client works for them; private resources answer `404`, which the tool layer already surfaces as `GITHUB_NOT_FOUND`.

## Why

Previously, the GitHub tools were registered for Ariadne but every call returned `GITHUB_NOT_CONNECTED` until a workspace admin connected the GitHub App. That blocked the common case of "look at this open-source repo" — which needs no credentials at all.

## How

- **`GitHubClient`** accepts `null` `record`/`credentials`/`metadata` and uses an unauthenticated `Octokit` in that mode. In anonymous mode it skips token refresh (no credentials to renew) and skips rate-limit persistence (anonymous limits are per-IP, not workspace state). `GitHubClient.anonymous()` is the named factory.
- **`getGithubClient`** gains an `allowUnauthenticatedFallback` option. The *no-usable-installation* paths (no app configured, no active record, undecryptable or unrefreshable credentials) return an anonymous client when the flag is set. The default (`false`) preserves the existing null-on-missing behavior, so **link-preview enrichment is unchanged**.
- The **near-rate-limit branch deliberately does *not* fall back**. It stays a back-off circuit-breaker (keeps returning `null` → `GITHUB_NOT_CONNECTED`) so a throttled installation isn't silently downgraded onto the shared per-IP anonymous quota, and the rate-limit state stays visible (INV-11: fail loudly).
- **Agent tools** opt in via `createMemoizedGithubClient`, so `GITHUB_NOT_CONNECTED` no longer blocks public-repo reads.

## Design decisions

- **Option flag rather than always-on fallback.** Link previews intentionally keep authenticated-only semantics; only the agent-tool path opts into anonymous reads.
- **Rate-limit branch is not a fallback path.** This was raised in self-review (two independent reviewers, INV-11) — handing back an anonymous client when an authenticated installation is throttled would mask the throttle and burn the shared anonymous IP quota.

## Tests

- `service.test.ts` (new): no-app path returns `null` without the flag and an anonymous `GitHubClient` with it; an exploding pool asserts the no-app path never touches the DB; `GitHubClient.anonymous()` builds without installation state.
- `client-accessor.test.ts`: asserts the agent-tool accessor opts into `{ allowUnauthenticatedFallback: true }` (regression guard so Ariadne doesn't silently lose public-repo access).
- All GitHub tool + link-preview tests pass (32/32). Full-monorepo lint + typecheck pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782679444&installation_id=129946197&pr_number=695&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F695&signature=ac240ad2e15e1f8e4ff99f98a4a4832867d487dfb3090361029a778bb5a53a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->