### PR TITLE
fix(sidebar): show each stream only in its topmost section

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -142,17 +142,17 @@ describe("resolveSections — All preset", () => {
 })
 
 describe("resolveSections — label sections", () => {
-  const config = {
+  const labelFirst = {
     basePreset: "smart" as const,
     sections: [
-      { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
       { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+      { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
     ],
     // Quick links are irrelevant to section resolution; an empty list satisfies the type.
     quickLinks: [],
   }
 
-  it("filters streams by assignment, sorts by activity, and is additive (a labeled stream still shows in its bucket)", () => {
+  it("claims labeled streams for the topmost label section, removing them from buckets below", () => {
     const processedStreams = [
       makeItem({ id: "s_old", section: "recent", activity: 1 }),
       makeItem({ id: "s_new", section: "recent", activity: 9 }),
@@ -161,23 +161,51 @@ describe("resolveSections — label sections", () => {
     // s_new and s_other carry the label; s_old does not.
     const streamIdsByLabel = new Map([["lbl_1", new Set(["s_new", "s_other"])]])
 
-    const result = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
+    const result = resolveSections(labelFirst, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
       id: r.section.id,
       items: r.items.map((i) => i.id),
     }))
 
     expect(result).toEqual([
-      // Recent bucket is unchanged by the label section above/below it.
-      { id: "recent", items: ["s_new", "s_old"] },
-      // Label lens: both labeled streams, by activity — s_new (recent) also
-      // appears here (additive), s_other (a pinned stream) is pulled in too.
+      // Label lens (topmost): both labeled streams, by activity.
       { id: labelSectionId("lbl_1"), items: ["s_new", "s_other"] },
+      // Recent no longer shows s_new — it was claimed by the label section above.
+      { id: "recent", items: ["s_old"] },
+    ])
+  })
+
+  it("keeps a stream in the bucket above and drops it from the label section below", () => {
+    const recentFirst = {
+      basePreset: "smart" as const,
+      sections: [
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "s_old", section: "recent", activity: 1 }),
+      makeItem({ id: "s_new", section: "recent", activity: 9 }),
+      makeItem({ id: "s_other", section: "pinned", activity: 5 }),
+    ]
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["s_new", "s_other"])]])
+
+    const result = resolveSections(recentFirst, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      // Recent (topmost) keeps s_new; s_old is read but within the cap.
+      { id: "recent", items: ["s_new", "s_old"] },
+      // Label section only keeps s_other; s_new was claimed by Recent above.
+      { id: labelSectionId("lbl_1"), items: ["s_other"] },
     ])
   })
 
   it("resolves to an empty section when the label has no assigned streams", () => {
     const processedStreams = [makeItem({ id: "s_1", section: "recent", activity: 1 })]
-    const result = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel: new Map() }))
+    const result = resolveSections(labelFirst, makeInput({ processedStreams, streamIdsByLabel: new Map() }))
     expect(result.find((r) => r.section.id === labelSectionId("lbl_1"))?.items).toEqual([])
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -32,40 +32,52 @@ export interface ResolvedSection {
 /**
  * Turn a {@link SidebarConfig} into the ordered, capped, sorted stream lists the
  * sidebar renders. Pure — no React, no IO — so it is exercised directly in tests
- * and reused by every view. Sections are resolved independently against the
- * shared pool with no cross-section dedup: smart buckets and stream types are
- * mutually exclusive by construction, while a label section is deliberately an
- * additive lens (a labeled stream still appears in its smart/type section).
+ * and reused by every view. Each stream appears in the topmost section that
+ * claims it: sections resolve in order and a stream already shown above is
+ * excluded from every section below. Smart buckets and stream types are mutually
+ * exclusive by construction, but label sections overlap with them (a labeled
+ * stream also matches its smart/type bucket), so without this the same stream
+ * would show twice — once in its label lens and again lower down. Exclusion runs
+ * before each section's caps, so a capped bucket (e.g. Recent) backfills the
+ * slots freed by streams claimed above it.
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
-  return config.sections.map((section) => ({
-    section,
-    items: resolveItems(section.spec, input),
-  }))
+  const claimed = new Set<string>()
+  return config.sections.map((section) => {
+    const items = resolveItems(section.spec, input, claimed)
+    for (const item of items) claimed.add(item.id)
+    return { section, items }
+  })
 }
 
-function resolveItems(spec: SidebarSectionSpec, input: ResolveSectionsInput): StreamItemData[] {
-  if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input)
-  if (spec.kind === "type") return resolveTypeSection(spec.streamType, input)
-  return resolveLabelSection(spec.labelId, input)
+function resolveItems(
+  spec: SidebarSectionSpec,
+  input: ResolveSectionsInput,
+  exclude: ReadonlySet<string>
+): StreamItemData[] {
+  if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input, exclude)
+  if (spec.kind === "type") return resolveTypeSection(spec.streamType, input, exclude)
+  return resolveLabelSection(spec.labelId, input, exclude)
 }
 
 /** Streams carrying a label, by activity. Draws from real streams only (synthetic DM drafts can't be labeled). */
 function resolveLabelSection(
   labelId: string,
-  { processedStreams, streamIdsByLabel, getUnreadCount }: ResolveSectionsInput
+  { processedStreams, streamIdsByLabel, getUnreadCount }: ResolveSectionsInput,
+  exclude: ReadonlySet<string>
 ): StreamItemData[] {
   const streamIds = streamIdsByLabel.get(labelId)
   if (!streamIds || streamIds.size === 0) return []
-  const items = processedStreams.filter((stream) => streamIds.has(stream.id))
+  const items = processedStreams.filter((stream) => streamIds.has(stream.id) && !exclude.has(stream.id))
   return sortStreams(items, "activity", getUnreadCount)
 }
 
 function resolveSmartBucket(
   bucket: SectionKey,
-  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput
+  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput,
+  exclude: ReadonlySet<string>
 ): StreamItemData[] {
-  const pool = [...processedStreams, ...virtualDmStreams]
+  const pool = [...processedStreams, ...virtualDmStreams].filter((stream) => !exclude.has(stream.id))
   const items = pool.filter((stream) => stream.section === bucket)
 
   switch (bucket) {
@@ -97,22 +109,26 @@ function resolveSmartBucket(
 
 function resolveTypeSection(
   streamType: TypeSectionStream,
-  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput
+  { processedStreams, virtualDmStreams, getUnreadCount }: ResolveSectionsInput,
+  exclude: ReadonlySet<string>
 ): StreamItemData[] {
+  const streams = processedStreams.filter((stream) => !exclude.has(stream.id))
+
   if (streamType === "scratchpad") {
-    const items = processedStreams.filter((stream) => stream.type === StreamTypes.SCRATCHPAD)
+    const items = streams.filter((stream) => stream.type === StreamTypes.SCRATCHPAD)
     return sortStreams(items, ALL_SECTIONS.scratchpads.sortType, getUnreadCount)
   }
 
   if (streamType === "channel") {
-    const items = processedStreams.filter((stream) => stream.type === StreamTypes.CHANNEL)
+    const items = streams.filter((stream) => stream.type === StreamTypes.CHANNEL)
     return sortStreams(items, ALL_SECTIONS.channels.sortType, getUnreadCount)
   }
 
   // DMs: real DMs by activity, then system streams, then synthetic DM drafts.
-  const realDms = processedStreams.filter((stream) => stream.type === StreamTypes.DM)
-  const systemStreams = processedStreams.filter((stream) => stream.type === StreamTypes.SYSTEM)
+  const realDms = streams.filter((stream) => stream.type === StreamTypes.DM)
+  const systemStreams = streams.filter((stream) => stream.type === StreamTypes.SYSTEM)
+  const drafts = virtualDmStreams.filter((stream) => !exclude.has(stream.id))
   sortStreams(realDms, "activity", getUnreadCount)
   sortStreams(systemStreams, ALL_SECTIONS.dms.sortType, getUnreadCount)
-  return [...realDms, ...systemStreams, ...virtualDmStreams]
+  return [...realDms, ...systemStreams, ...drafts]
 }


### PR DESCRIPTION
## Problem

We recently made the sidebar highly configurable, which made it possible for the **same stream to appear in multiple sections at once** — e.g. a label section pinned at the top plus Important / Recent / Other below it. That duplication is noisy and confusing.

The root cause is in `resolveSections` (`apps/frontend/src/components/layout/sidebar/resolve-sections.ts`): sections were resolved **independently** against the shared stream pool with no cross-section dedup. Smart buckets and stream types are mutually exclusive by construction, but label sections deliberately overlap with the smart/type bucket a stream already matches — so a labeled stream surfaced twice.

## Solution

Make each stream appear only in the **topmost section that claims it**.

`resolveSections` now walks `config.sections` in order, accumulating a `claimed` set of stream ids, and passes it as an `exclude` set into each resolver. Each resolver filters its pool to drop already-claimed streams **before** applying its caps, so a capped bucket (e.g. Recent, capped at 5) backfills the slots freed by streams claimed above it rather than rendering short.

### Key design decisions

**1. Exclusion threaded into each resolver, applied before caps**

The `exclude: ReadonlySet<string>` is passed through `resolveItems` into `resolveLabelSection` / `resolveSmartBucket` / `resolveTypeSection`. Filtering happens on each resolver's pool *before* the Important/Recent caps so the caps see only eligible streams. Passing a `ReadonlySet` at the boundary keeps the accumulator immutable from a resolver's view.

**2. Order = priority**

Topmost section wins. A labeled stream in a label section above the smart buckets drops out of Important/Recent/Other; if the smart bucket is ordered above the label section instead, the stream stays in the bucket and is removed from the label lens. This falls out naturally from in-order accumulation and gives users direct control via section ordering.

**3. No new config knobs**

Behavior is derived purely from existing section order — no per-section "exclusive" flag or escape hatch (INV-36).

Empty smart buckets already `hideWhenEmpty`, so they disappear cleanly when fully claimed above. Type/label sections keep their headers visible by existing (pre-change) policy.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.ts` | In-order `claimed` accumulation in `resolveSections`; `exclude` set threaded into each resolver and applied to the pool before caps; updated doc comment |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts` | Replaced the old "additive" label-section assertion with two cases proving topmost-wins in both orderings (label-first and bucket-first), plus the empty-label case |

## Test plan

- [x] `bun run test src/components/layout/sidebar/` — 65 passing, 0 failing
- [x] Pre-commit hook: full monorepo lint + typecheck green
- [ ] Manual: in a config with a label section above Important/Recent, confirm a labeled stream shows only under the label; reorder so a smart bucket is on top and confirm it stays there and leaves the label section

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782680269&installation_id=129946197&pr_number=696&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F696&signature=79c2969a09b9d22498ccd7f06ad9249f8383ea210f45523a9cbbaf2ebb16fb02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->