### PR TITLE
feat(agent-runtime): handle JSON in read_url with shape, preview, and drill-in

### DIFF
--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -167,12 +167,13 @@ ${recencyGroundingBullet}
 
 ## Reading URLs
 
-You have a \`read_url\` tool to fetch and read the full content of a web page.
+You have a \`read_url\` tool to fetch and read the content of a web page or JSON resource.
 
 When to use read_url:
 - After web_search when you need more detail than the snippet provides
 - When the user shares a specific URL they want you to analyze
-- To verify information or get complete context from a source`
+- To verify information or get complete context from a source
+- To read JSON APIs: small responses come back in full. For large ones you get the data's \`shape\` (a schema sketch), a sampled \`preview\`, and a \`hint\` — then call read_url again with a \`select\` path (e.g. \`.data.items[0:20]\`, \`.results[3].name\`, \`.users[*].email\`) to drill into the part you need.`
   }
 
   // Add attachment tool instructions if enabled

--- a/packages/agent-runtime/src/tools/json-inspect.test.ts
+++ b/packages/agent-runtime/src/tools/json-inspect.test.ts
@@ -74,6 +74,14 @@ describe("json-inspect", () => {
       const value = { a: 1, b: [true, false], c: "hi" }
       expect(structuralPreview(value)).toEqual(value)
     })
+
+    it("truncates pathologically long key names", () => {
+      const longKey = "k".repeat(500)
+      const preview = structuralPreview({ [longKey]: 1 }) as Record<string, unknown>
+      const outKey = Object.keys(preview)[0]!
+      expect(outKey.length).toBeLessThan(500)
+      expect(outKey).toContain("…(500 chars)")
+    })
   })
 
   describe("applySelect", () => {

--- a/packages/agent-runtime/src/tools/json-inspect.test.ts
+++ b/packages/agent-runtime/src/tools/json-inspect.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "bun:test"
+import { applySelect, describeShape, structuralPreview, typeName } from "./json-inspect"
+
+describe("json-inspect", () => {
+  describe("typeName", () => {
+    it("names primitives, arrays, objects, and null", () => {
+      expect(typeName(null)).toBe("null")
+      expect(typeName([])).toBe("array")
+      expect(typeName({})).toBe("object")
+      expect(typeName("x")).toBe("string")
+      expect(typeName(1)).toBe("number")
+      expect(typeName(true)).toBe("boolean")
+    })
+  })
+
+  describe("describeShape", () => {
+    it("collapses arrays to a length + inline element shape", () => {
+      const value = {
+        data: {
+          items: [
+            { id: "a", name: "Apple", price: 1 },
+            { id: "b", name: "Banana", price: 2 },
+          ],
+          total: 2,
+          nextCursor: null,
+        },
+      }
+      expect(describeShape(value)).toEqual({
+        data: {
+          items: "array[2] of {id:string, name:string, price:number}",
+          total: "number",
+          nextCursor: "null",
+        },
+      })
+    })
+
+    it("describes a top-level array", () => {
+      expect(describeShape([1, 2, 3])).toBe("array[3] of number")
+      expect(describeShape([])).toBe("array[0]")
+    })
+
+    it("caps the number of object keys it expands", () => {
+      const wide: Record<string, number> = {}
+      for (let i = 0; i < 60; i++) wide[`k${i}`] = i
+      const shape = describeShape(wide) as Record<string, unknown>
+      expect(shape["…"]).toBe("(10 more keys)")
+    })
+  })
+
+  describe("structuralPreview", () => {
+    it("samples long arrays and reports how many were dropped", () => {
+      const value = Array.from({ length: 1043 }, (_, i) => ({ id: i }))
+      const preview = structuralPreview(value) as unknown[]
+      expect(preview.length).toBe(4) // 3 samples + summary marker
+      expect(preview[3]).toBe("…(1040 more items)")
+      expect(preview[0]).toEqual({ id: 0 })
+    })
+
+    it("truncates long strings but keeps the total length", () => {
+      const value = { blob: "x".repeat(5000) }
+      const preview = structuralPreview(value) as { blob: string }
+      expect(preview.blob).toContain("…(5000 chars total)")
+      expect(preview.blob.length).toBeLessThan(5000)
+    })
+
+    it("caps wide objects", () => {
+      const wide: Record<string, number> = {}
+      for (let i = 0; i < 40; i++) wide[`k${i}`] = i
+      const preview = structuralPreview(wide) as Record<string, unknown>
+      expect(preview["…"]).toBe("(10 more keys)")
+    })
+
+    it("leaves small data untouched", () => {
+      const value = { a: 1, b: [true, false], c: "hi" }
+      expect(structuralPreview(value)).toEqual(value)
+    })
+  })
+
+  describe("applySelect", () => {
+    const doc = {
+      data: {
+        items: [
+          { id: "a", name: "Apple", tags: ["fruit", "red"] },
+          { id: "b", name: "Banana", tags: ["fruit", "yellow"] },
+          { id: "c", name: "Cherry", tags: ["fruit", "red"] },
+        ],
+        total: 3,
+      },
+      "weird key": 42,
+    }
+
+    it("resolves a dotted key path", () => {
+      expect(applySelect(doc, ".data.total")).toEqual({ value: 3 })
+    })
+
+    it("tolerates a leading bare key and a $ root", () => {
+      expect(applySelect(doc, "data.total")).toEqual({ value: 3 })
+      expect(applySelect(doc, "$.data.total")).toEqual({ value: 3 })
+    })
+
+    it("indexes into arrays", () => {
+      expect(applySelect(doc, ".data.items[1].name")).toEqual({ value: "Banana" })
+    })
+
+    it("supports negative indices", () => {
+      expect(applySelect(doc, ".data.items[-1].name")).toEqual({ value: "Cherry" })
+    })
+
+    it("slices arrays", () => {
+      const r = applySelect(doc, ".data.items[0:2]") as { value: unknown[] }
+      expect(r.value).toHaveLength(2)
+      expect((r.value[0] as { id: string }).id).toBe("a")
+    })
+
+    it("supports open-ended slices", () => {
+      const r = applySelect(doc, ".data.items[1:]") as { value: unknown[] }
+      expect(r.value).toHaveLength(2)
+    })
+
+    it("maps a field over a wildcard", () => {
+      expect(applySelect(doc, ".data.items[*].name")).toEqual({ value: ["Apple", "Banana", "Cherry"] })
+    })
+
+    it("resolves quoted keys with special characters", () => {
+      expect(applySelect(doc, '["weird key"]')).toEqual({ value: 42 })
+    })
+
+    it("null-fills wildcard elements missing a field but keeps the ones present", () => {
+      const heterogeneous = { users: [{ email: "a@x.com" }, { name: "no email" }, { email: "c@x.com" }] }
+      expect(applySelect(heterogeneous, ".users[*].email")).toEqual({ value: ["a@x.com", null, "c@x.com"] })
+    })
+
+    it("errors on a wildcard path when no element matches", () => {
+      const heterogeneous = { users: [{ name: "x" }, { name: "y" }] }
+      const r = applySelect(heterogeneous, ".users[*].email") as { error: string }
+      expect(r.error).toContain("'email' not found")
+    })
+
+    it("errors with available keys on a missing key", () => {
+      const r = applySelect(doc, ".data.missing") as { error: string }
+      expect(r.error).toContain("'missing' not found")
+      expect(r.error).toContain("items")
+      expect(r.error).toContain("total")
+    })
+
+    it("errors when indexing a non-array", () => {
+      const r = applySelect(doc, ".data[0]") as { error: string }
+      expect(r.error).toContain("not an array")
+    })
+
+    it("errors when reading a key from a non-object", () => {
+      const r = applySelect(doc, ".data.total.nope") as { error: string }
+      expect(r.error).toContain("not an object")
+    })
+
+    it("errors on out-of-range index", () => {
+      const r = applySelect(doc, ".data.items[99]") as { error: string }
+      expect(r.error).toContain("out of range")
+    })
+
+    it("errors on a malformed selector", () => {
+      expect(applySelect(doc, "")).toHaveProperty("error")
+      expect(applySelect(doc, ".data.items[")).toHaveProperty("error")
+    })
+  })
+})

--- a/packages/agent-runtime/src/tools/json-inspect.ts
+++ b/packages/agent-runtime/src/tools/json-inspect.ts
@@ -23,9 +23,16 @@ const PREVIEW_MAX_DEPTH = 6
 const PREVIEW_ARRAY_SAMPLE = 3
 const PREVIEW_OBJECT_KEYS = 30
 const PREVIEW_STRING_MAX = 200
+// Cap key *length* too, not just key count — pathologically long property names
+// would otherwise be copied verbatim and defeat the large-payload size guard.
+const SUMMARY_KEY_MAX = 120
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function summarizeKeyName(key: string): string {
+  return key.length <= SUMMARY_KEY_MAX ? key : `${key.slice(0, SUMMARY_KEY_MAX)}…(${key.length} chars)`
 }
 
 export function typeName(value: unknown): string {
@@ -47,7 +54,7 @@ function inlineShape(value: unknown, depth = 0): string {
     if (depth >= INLINE_MAX_DEPTH) return "object"
     const keys = Object.keys(value)
     const shown = keys.slice(0, INLINE_MAX_KEYS)
-    const parts = shown.map((k) => `${k}:${inlineShape(value[k], depth + 1)}`)
+    const parts = shown.map((k) => `${summarizeKeyName(k)}:${inlineShape(value[k], depth + 1)}`)
     if (keys.length > shown.length) parts.push("…")
     return `{${parts.join(", ")}}`
   }
@@ -68,7 +75,7 @@ export function describeShape(value: unknown, depth = 0): unknown {
     const keys = Object.keys(value)
     const shown = keys.slice(0, SHAPE_MAX_KEYS)
     const out: Record<string, unknown> = {}
-    for (const k of shown) out[k] = describeShape(value[k], depth + 1)
+    for (const k of shown) out[summarizeKeyName(k)] = describeShape(value[k], depth + 1)
     if (keys.length > shown.length) out["…"] = `(${keys.length - shown.length} more keys)`
     return out
   }
@@ -104,7 +111,7 @@ export function structuralPreview(value: unknown, depth = 0): unknown {
     const keys = Object.keys(value)
     const shown = keys.slice(0, PREVIEW_OBJECT_KEYS)
     const out: Record<string, unknown> = {}
-    for (const k of shown) out[k] = structuralPreview(value[k], depth + 1)
+    for (const k of shown) out[summarizeKeyName(k)] = structuralPreview(value[k], depth + 1)
     if (keys.length > shown.length) out["…"] = `(${keys.length - shown.length} more keys)`
     return out
   }

--- a/packages/agent-runtime/src/tools/json-inspect.ts
+++ b/packages/agent-runtime/src/tools/json-inspect.ts
@@ -1,0 +1,293 @@
+/**
+ * Pure helpers for inspecting JSON fetched by read_url.
+ *
+ * Large JSON responses are useless to a model when truncated mid-structure, so
+ * instead of slicing the serialized string we expose three views:
+ *  - describeShape: a recursive schema skeleton (keys -> types, array element
+ *    shape + length) so the model can see the structure at a glance.
+ *  - structuralPreview: a sampled copy of the data (first N array items, capped
+ *    keys, truncated strings) that stays valid JSON with representative values.
+ *  - applySelect: a minimal jq-like path resolver so the model can re-fetch and
+ *    drill into a specific subtree.
+ */
+
+// Shape skeleton: objects stay nested, arrays/primitives collapse to a string
+// descriptor (e.g. "array[42] of {id:string, name:string}", "number").
+const SHAPE_MAX_DEPTH = 6
+const SHAPE_MAX_KEYS = 50
+const INLINE_MAX_DEPTH = 2
+const INLINE_MAX_KEYS = 8
+
+// Structural preview: how much real data to keep.
+const PREVIEW_MAX_DEPTH = 6
+const PREVIEW_ARRAY_SAMPLE = 3
+const PREVIEW_OBJECT_KEYS = 30
+const PREVIEW_STRING_MAX = 200
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+export function typeName(value: unknown): string {
+  if (value === null) return "null"
+  if (Array.isArray(value)) return "array"
+  return typeof value
+}
+
+// --- Shape summary -------------------------------------------------------
+
+/** One-line compact descriptor of a value's structure. */
+function inlineShape(value: unknown, depth = 0): string {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "array[0]"
+    if (depth >= INLINE_MAX_DEPTH) return `array[${value.length}]`
+    return `array[${value.length}] of ${inlineShape(value[0], depth + 1)}`
+  }
+  if (isPlainObject(value)) {
+    if (depth >= INLINE_MAX_DEPTH) return "object"
+    const keys = Object.keys(value)
+    const shown = keys.slice(0, INLINE_MAX_KEYS)
+    const parts = shown.map((k) => `${k}:${inlineShape(value[k], depth + 1)}`)
+    if (keys.length > shown.length) parts.push("…")
+    return `{${parts.join(", ")}}`
+  }
+  return typeName(value)
+}
+
+/**
+ * Recursive schema skeleton. Top-level objects stay nested so keys are easy to
+ * scan; arrays and primitives collapse to a one-line descriptor string.
+ */
+export function describeShape(value: unknown, depth = 0): unknown {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "array[0]"
+    return `array[${value.length}] of ${inlineShape(value[0])}`
+  }
+  if (isPlainObject(value)) {
+    if (depth >= SHAPE_MAX_DEPTH) return inlineShape(value)
+    const keys = Object.keys(value)
+    const shown = keys.slice(0, SHAPE_MAX_KEYS)
+    const out: Record<string, unknown> = {}
+    for (const k of shown) out[k] = describeShape(value[k], depth + 1)
+    if (keys.length > shown.length) out["…"] = `(${keys.length - shown.length} more keys)`
+    return out
+  }
+  return typeName(value)
+}
+
+// --- Structural preview --------------------------------------------------
+
+/**
+ * A sampled copy of the data that stays valid JSON: keeps the first few array
+ * items, caps object keys, and truncates long strings. Conveys real example
+ * values without serializing the whole payload.
+ */
+export function structuralPreview(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") {
+    if (value.length > PREVIEW_STRING_MAX) {
+      return `${value.slice(0, PREVIEW_STRING_MAX)}…(${value.length} chars total)`
+    }
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= PREVIEW_MAX_DEPTH) return `array[${value.length}]`
+    const sample = value.slice(0, PREVIEW_ARRAY_SAMPLE).map((v) => structuralPreview(v, depth + 1))
+    if (value.length > PREVIEW_ARRAY_SAMPLE) {
+      sample.push(`…(${value.length - PREVIEW_ARRAY_SAMPLE} more items)`)
+    }
+    return sample
+  }
+
+  if (isPlainObject(value)) {
+    if (depth >= PREVIEW_MAX_DEPTH) return inlineShape(value)
+    const keys = Object.keys(value)
+    const shown = keys.slice(0, PREVIEW_OBJECT_KEYS)
+    const out: Record<string, unknown> = {}
+    for (const k of shown) out[k] = structuralPreview(value[k], depth + 1)
+    if (keys.length > shown.length) out["…"] = `(${keys.length - shown.length} more keys)`
+    return out
+  }
+
+  return value
+}
+
+// --- Path selector (minimal jq-like) -------------------------------------
+
+type PathSegment =
+  | { kind: "key"; key: string }
+  | { kind: "index"; index: number }
+  | { kind: "slice"; start: number | null; end: number | null }
+  | { kind: "wild" }
+
+const KEY_CHARS = /[A-Za-z0-9_$-]/
+
+function parseBracket(inner: string): PathSegment | { error: string } {
+  const trimmed = inner.trim()
+  if (trimmed === "*") return { kind: "wild" }
+
+  // Quoted key: ["weird key"] or ['weird key']
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return { kind: "key", key: trimmed.slice(1, -1) }
+  }
+
+  // Slice: a:b, :b, a:, :
+  if (trimmed.includes(":")) {
+    const [rawStart, rawEnd, extra] = trimmed.split(":")
+    if (extra !== undefined) return { error: `Invalid slice '[${inner}]'` }
+    const parseBound = (s: string): number | null | { error: string } => {
+      if (s.trim() === "") return null
+      const n = Number(s)
+      if (!Number.isInteger(n)) return { error: `Invalid slice bound '${s}' in '[${inner}]'` }
+      return n
+    }
+    const start = parseBound(rawStart)
+    const end = parseBound(rawEnd)
+    if (start !== null && typeof start === "object") return start
+    if (end !== null && typeof end === "object") return end
+    return { kind: "slice", start, end }
+  }
+
+  // Integer index (allows negative)
+  if (/^-?\d+$/.test(trimmed)) {
+    return { kind: "index", index: Number(trimmed) }
+  }
+
+  // Bare unquoted key inside brackets
+  if (trimmed.length > 0) return { kind: "key", key: trimmed }
+
+  return { error: `Empty bracket '[]'` }
+}
+
+function parsePath(input: string): { segments: PathSegment[] } | { error: string } {
+  const s = input.trim()
+  const segments: PathSegment[] = []
+  let i = 0
+
+  if (s[i] === "$") i++ // tolerate JSONPath-style root
+
+  while (i < s.length) {
+    const c = s[i]
+
+    if (c === ".") {
+      i++
+      const start = i
+      while (i < s.length && KEY_CHARS.test(s[i]!)) i++
+      if (i === start) return { error: `Expected a key after '.' in '${input}'` }
+      segments.push({ kind: "key", key: s.slice(start, i) })
+      continue
+    }
+
+    if (c === "[") {
+      const end = s.indexOf("]", i)
+      if (end === -1) return { error: `Missing ']' in '${input}'` }
+      const seg = parseBracket(s.slice(i + 1, end))
+      if ("error" in seg) return seg
+      segments.push(seg)
+      i = end + 1
+      continue
+    }
+
+    // Leading bare key, e.g. "data.items"
+    if (segments.length === 0 && KEY_CHARS.test(c!)) {
+      const start = i
+      while (i < s.length && KEY_CHARS.test(s[i]!)) i++
+      segments.push({ kind: "key", key: s.slice(start, i) })
+      continue
+    }
+
+    return { error: `Unexpected character '${c}' at position ${i} in '${input}'` }
+  }
+
+  if (segments.length === 0) return { error: `Empty selector` }
+  return { segments }
+}
+
+function resolve(value: unknown, segments: PathSegment[], pathSoFar: string): { value: unknown } | { error: string } {
+  if (segments.length === 0) return { value }
+  const [seg, ...rest] = segments
+
+  switch (seg!.kind) {
+    case "key": {
+      if (!isPlainObject(value)) {
+        return {
+          error: `Cannot read key '${seg!.key}' at '${pathSoFar || "(root)"}': value is ${typeName(value)}, not an object`,
+        }
+      }
+      if (!Object.prototype.hasOwnProperty.call(value, seg.key)) {
+        const available = Object.keys(value).slice(0, 20).join(", ")
+        return {
+          error: `Key '${seg.key}' not found at '${pathSoFar || "(root)"}'. Available keys: ${available || "(none)"}`,
+        }
+      }
+      return resolve(value[seg.key], rest, `${pathSoFar}.${seg.key}`)
+    }
+
+    case "index": {
+      if (!Array.isArray(value)) {
+        return {
+          error: `Cannot index [${seg.index}] at '${pathSoFar || "(root)"}': value is ${typeName(value)}, not an array`,
+        }
+      }
+      const idx = seg.index < 0 ? value.length + seg.index : seg.index
+      if (idx < 0 || idx >= value.length) {
+        return { error: `Index ${seg.index} out of range at '${pathSoFar || "(root)"}' (array length ${value.length})` }
+      }
+      return resolve(value[idx], rest, `${pathSoFar}[${seg.index}]`)
+    }
+
+    case "slice": {
+      if (!Array.isArray(value)) {
+        return { error: `Cannot slice at '${pathSoFar || "(root)"}': value is ${typeName(value)}, not an array` }
+      }
+      const len = value.length
+      const norm = (n: number | null, dflt: number): number => {
+        if (n === null) return dflt
+        return n < 0 ? Math.max(0, len + n) : Math.min(n, len)
+      }
+      const sliced = value.slice(norm(seg.start, 0), norm(seg.end, len))
+      return resolve(sliced, rest, `${pathSoFar}[${seg.start ?? ""}:${seg.end ?? ""}]`)
+    }
+
+    case "wild": {
+      let items: unknown[]
+      if (Array.isArray(value)) items = value
+      else if (isPlainObject(value)) items = Object.values(value)
+      else {
+        return {
+          error: `Cannot use [*] at '${pathSoFar || "(root)"}': value is ${typeName(value)}, not an array or object`,
+        }
+      }
+      // Map the rest of the path over each element. Tolerate per-element
+      // failures (heterogeneous arrays with optional fields are common) by
+      // null-filling them, but if nothing matched, surface the error so the
+      // model gets feedback on a wholesale-wrong path rather than all-null.
+      const out: unknown[] = []
+      let firstError: { error: string } | null = null
+      let matched = 0
+      for (const item of items) {
+        const r = resolve(item, rest, `${pathSoFar}[*]`)
+        if ("error" in r) {
+          if (!firstError) firstError = r
+          out.push(null)
+        } else {
+          matched++
+          out.push(r.value)
+        }
+      }
+      if (matched === 0 && firstError) return firstError
+      return { value: out }
+    }
+  }
+}
+
+/**
+ * Apply a minimal jq-like path to a JSON value. Supports `.key`, `["quoted key"]`,
+ * `[index]` (negative allowed), `[start:end]` slices, and `[*]` wildcards.
+ * Returns the selected value or an actionable error.
+ */
+export function applySelect(value: unknown, select: string): { value: unknown } | { error: string } {
+  const parsed = parsePath(select)
+  if ("error" in parsed) return parsed
+  return resolve(value, parsed.segments, "")
+}

--- a/packages/agent-runtime/src/tools/read-url-tool.test.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.test.ts
@@ -270,6 +270,17 @@ describe("read-url-tool", () => {
       expect(parsed.content).toEqual({ served: "as text/plain" })
     })
 
+    it("matches content types case-insensitively", async () => {
+      globalThis.fetch = jsonResponse({ ok: true }, "Application/JSON; charset=UTF-8")
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/data" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.content).toEqual({ ok: true })
+    })
+
     it("keeps real plain text as text", async () => {
       globalThis.fetch = jsonResponse("just some prose, not json", "text/plain")
 

--- a/packages/agent-runtime/src/tools/read-url-tool.test.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.test.ts
@@ -157,6 +157,131 @@ describe("read-url-tool", () => {
     expect(parsed.content).toBe("This is plain text content.")
   })
 
+  const jsonResponse = (data: unknown, contentType = "application/json") =>
+    mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": contentType }),
+        text: () => Promise.resolve(typeof data === "string" ? data : JSON.stringify(data)),
+      } as Response)
+    ) as unknown as typeof fetch
+
+  describe("JSON handling", () => {
+    it("returns small JSON in full", async () => {
+      globalThis.fetch = jsonResponse({ hello: "world", nums: [1, 2, 3] })
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/data" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.truncated).toBeUndefined()
+      expect(parsed.content).toEqual({ hello: "world", nums: [1, 2, 3] })
+    })
+
+    it("handles JSON with a +json content type suffix", async () => {
+      globalThis.fetch = jsonResponse({ ok: true }, "application/vnd.api+json")
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/data" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.content).toEqual({ ok: true })
+    })
+
+    it("summarizes large JSON with shape, preview, and a hint instead of truncating", async () => {
+      const big = {
+        data: {
+          items: Array.from({ length: 2000 }, (_, i) => ({ id: `item_${i}`, name: `Name ${i}`, score: i })),
+          total: 2000,
+        },
+      }
+      globalThis.fetch = jsonResponse(big)
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/big" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.truncated).toBe(true)
+      expect(parsed.byteSize).toBeGreaterThan(50000)
+      expect(parsed.shape.data.items).toContain("array[2000]")
+      expect(parsed.hint).toContain("select")
+      // preview keeps a few real items, not the whole array
+      expect(parsed.preview.data.items.length).toBeLessThan(10)
+      expect(parsed.preview.data.items[0]).toEqual({ id: "item_0", name: "Name 0", score: 0 })
+    })
+
+    it("drills into a subtree with a select path", async () => {
+      const big = {
+        data: {
+          items: Array.from({ length: 2000 }, (_, i) => ({ id: `item_${i}` })),
+        },
+      }
+      globalThis.fetch = jsonResponse(big)
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute(
+        { url: "https://api.example.com/big", select: ".data.items[0:2]" },
+        toolOpts
+      )
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.select).toBe(".data.items[0:2]")
+      expect(parsed.content).toEqual([{ id: "item_0" }, { id: "item_1" }])
+    })
+
+    it("returns an actionable error for a bad select path", async () => {
+      globalThis.fetch = jsonResponse({ data: { total: 5 } })
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute(
+        { url: "https://api.example.com/data", select: ".data.missing" },
+        toolOpts
+      )
+      const parsed = JSON.parse(output)
+
+      expect(parsed.error).toContain("not found")
+      expect(parsed.error).toContain("total") // surfaces the keys that do exist
+      expect(parsed.select).toBe(".data.missing")
+    })
+
+    it("errors when content declares JSON but does not parse", async () => {
+      globalThis.fetch = jsonResponse("<html>not json</html>")
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/broken" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.error).toContain("did not parse as JSON")
+    })
+
+    it("treats plain text that is actually JSON as JSON", async () => {
+      globalThis.fetch = jsonResponse('{"served":"as text/plain"}', "text/plain")
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://api.example.com/data" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBe("json")
+      expect(parsed.content).toEqual({ served: "as text/plain" })
+    })
+
+    it("keeps real plain text as text", async () => {
+      globalThis.fetch = jsonResponse("just some prose, not json", "text/plain")
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://example.com/file.txt" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.kind).toBeUndefined()
+      expect(parsed.content).toBe("just some prose, not json")
+    })
+  })
+
   it("should return timeout error when request takes too long", async () => {
     const abortError = new Error("The operation was aborted")
     abortError.name = "AbortError"

--- a/packages/agent-runtime/src/tools/read-url-tool.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.ts
@@ -240,10 +240,11 @@ export function createReadUrlTool() {
           }
         }
 
-        const contentType = response.headers.get("content-type") || ""
+        // Media types are case-insensitive (RFC 9110), so normalize before matching.
+        const contentType = (response.headers.get("content-type") || "").toLowerCase()
         const isHtml = contentType.includes("text/html")
         const isPlain = contentType.includes("text/plain")
-        const declaresJson = /\bjson\b/i.test(contentType) || contentType.includes("+json")
+        const declaresJson = /\bjson\b/.test(contentType) || contentType.includes("+json")
 
         if (!isHtml && !isPlain && !declaresJson) {
           return {

--- a/packages/agent-runtime/src/tools/read-url-tool.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.ts
@@ -5,9 +5,17 @@ import { NodeHtmlMarkdown } from "node-html-markdown"
 import { AgentStepTypes } from "@threa/types"
 import { logger } from "../logger"
 import { defineAgentTool, type AgentToolResult } from "../runtime"
+import { applySelect, describeShape, structuralPreview } from "./json-inspect"
 
 const ReadUrlSchema = z.object({
-  url: z.string().url().describe("The URL of the web page to read"),
+  url: z.string().url().describe("The URL of the web page or JSON resource to read"),
+  select: z
+    .string()
+    .optional()
+    .describe(
+      "Optional path to extract from a JSON response, e.g. '.data.items[0:20]', '.results[3].name', or '.users[*].email'. " +
+        "Use this to drill into a specific part after an initial read reports that the JSON is large."
+    ),
 })
 
 export type ReadUrlInput = z.infer<typeof ReadUrlSchema>
@@ -165,7 +173,7 @@ async function fetchWithRedirectValidation(
     signal,
     headers: {
       "User-Agent": "Threa-Agent/1.0 (https://threa.app)",
-      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      Accept: "text/html,application/xhtml+xml,application/json;q=0.9,application/xml;q=0.8,*/*;q=0.8",
     },
     redirect: "manual", // Don't follow redirects automatically
   })
@@ -197,7 +205,8 @@ export function createReadUrlTool() {
   return defineAgentTool({
     name: "read_url",
     description:
-      "Fetch and read the full content of a web page. Use this after web_search when you need more detail than the snippet provides, or when the user shares a specific URL to analyze.",
+      "Fetch and read the content of a web page or JSON resource. Use this after web_search when you need more detail than the snippet provides, or when the user shares a specific URL to analyze. " +
+      "HTML pages are returned as markdown. JSON is returned in full when small; when large, you instead get the data's `shape` (a schema sketch), a sampled `preview`, and a `hint` — then call again with `select` (e.g. '.data.items[0:20]') to drill into a specific part.",
     inputSchema: ReadUrlSchema,
 
     execute: async (input): Promise<AgentToolResult> => {
@@ -232,24 +241,40 @@ export function createReadUrlTool() {
         }
 
         const contentType = response.headers.get("content-type") || ""
-        if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
+        const isHtml = contentType.includes("text/html")
+        const isPlain = contentType.includes("text/plain")
+        const declaresJson = /\bjson\b/i.test(contentType) || contentType.includes("+json")
+
+        if (!isHtml && !isPlain && !declaresJson) {
           return {
             output: JSON.stringify({
-              error: `Unsupported content type: ${contentType}. Only HTML and plain text are supported.`,
+              error: `Unsupported content type: ${contentType}. Only HTML, plain text, and JSON are supported.`,
               url: input.url,
             }),
           }
         }
 
-        const html = await response.text()
-        const title = extractTitle(html)
+        const body = await response.text()
 
-        let content: string
-        if (contentType.includes("text/plain")) {
-          content = html
-        } else {
-          content = nhm.translate(html)
+        // JSON handling: declared JSON, an explicit drill-in select, or plain
+        // text that is actually JSON.
+        const json = tryParseJson(body, { declaresJson, hasSelect: input.select !== undefined, isPlain })
+        if ("error" in json) {
+          return {
+            output: JSON.stringify({
+              error: json.error,
+              url: input.url,
+              ...(input.select !== undefined ? { select: input.select } : {}),
+            }),
+          }
         }
+        if (json.matched) {
+          return buildJsonOutput(input.url, input.select, json.value)
+        }
+
+        // HTML / plain-text handling
+        const title = extractTitle(body)
+        let content = isPlain ? body : nhm.translate(body)
 
         if (content.length > MAX_CONTENT_LENGTH) {
           content = content.slice(0, MAX_CONTENT_LENGTH) + "\n\n[Content truncated...]"
@@ -316,4 +341,119 @@ export function createReadUrlTool() {
 function extractTitle(html: string): string {
   const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
   return titleMatch?.[1]?.trim() || "Untitled"
+}
+
+type ParseJsonResult = { matched: true; value: unknown } | { matched: false } | { error: string }
+
+/**
+ * Decide whether a response body should be handled as JSON, and parse it.
+ * JSON is wanted when the content type declares it or the caller passed a
+ * `select`; for plain text we only opt in when the body actually looks like
+ * (and parses as) JSON, otherwise it falls through to text handling.
+ */
+function tryParseJson(
+  body: string,
+  opts: { declaresJson: boolean; hasSelect: boolean; isPlain: boolean }
+): ParseJsonResult {
+  const wantsJson = opts.declaresJson || opts.hasSelect
+
+  if (!wantsJson) {
+    if (opts.isPlain) {
+      const trimmed = body.trim()
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        try {
+          return { matched: true, value: JSON.parse(body) }
+        } catch {
+          return { matched: false }
+        }
+      }
+    }
+    return { matched: false }
+  }
+
+  try {
+    return { matched: true, value: JSON.parse(body) }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "parse error"
+    return {
+      error: opts.declaresJson
+        ? `Response declared a JSON content type but did not parse as JSON: ${reason}`
+        : `A 'select' was provided but the response is not valid JSON: ${reason}`,
+    }
+  }
+}
+
+/** Guidance telling the model how to drill into a large JSON value. */
+function buildJsonHint(value: unknown, select: string | undefined): string {
+  const prefix = select !== undefined ? `Subtree at '${select}'.` : "This JSON response is large."
+  const base = select ?? ""
+
+  if (Array.isArray(value)) {
+    return (
+      `${prefix} It is an array of ${value.length} items. Call read_url again with select='${base}[0:20]' ` +
+      `to read a page of items, or select='${base}[0]' for a single item. ` +
+      `See 'shape' for the structure and 'preview' for sampled values.`
+    )
+  }
+
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value)
+    const list = keys.slice(0, 20).join(", ") + (keys.length > 20 ? ", …" : "")
+    return (
+      `${prefix} Top-level keys: ${list}. Call read_url again with select='${base}.<key>' to drill into one. ` +
+      `See 'shape' for the structure and 'preview' for sampled values.`
+    )
+  }
+
+  return `${prefix} See 'preview' for the value.`
+}
+
+/** Build the tool output for a parsed JSON value, applying `select` and sizing. */
+function buildJsonOutput(url: string, select: string | undefined, parsed: unknown): AgentToolResult {
+  let value: unknown = parsed
+
+  if (select !== undefined) {
+    const selected = applySelect(parsed, select)
+    if ("error" in selected) {
+      return { output: JSON.stringify({ error: selected.error, url, select }) }
+    }
+    value = selected.value
+  }
+
+  if (value === undefined) {
+    return {
+      output: JSON.stringify({
+        error: "Selection resolved to no value.",
+        url,
+        ...(select !== undefined ? { select } : {}),
+      }),
+    }
+  }
+
+  // Measure the compact serialization — that is what we actually return to the
+  // model, and it matches how MAX_CONTENT_LENGTH bounds the text/markdown path.
+  const serialized = JSON.stringify(value)
+  if (serialized.length <= MAX_CONTENT_LENGTH) {
+    return {
+      output: JSON.stringify({ url, kind: "json", ...(select !== undefined ? { select } : {}), content: value }),
+    }
+  }
+
+  // Too large to return verbatim: hand back structure + a sampled preview so the
+  // model can drill in with a follow-up select instead of receiving a truncated blob.
+  const byteSize = new TextEncoder().encode(serialized).length
+  logger.debug({ url, byteSize, select }, "Large JSON summarized for read_url")
+
+  return {
+    output: JSON.stringify({
+      url,
+      kind: "json",
+      truncated: true,
+      byteSize,
+      ...(select !== undefined ? { select } : {}),
+      shape: describeShape(value),
+      preview: structuralPreview(value),
+      hint: buildJsonHint(value, select),
+    }),
+  }
 }


### PR DESCRIPTION
## Problem

The `read_url` agent tool (used by Ariadne and other personas) only handled HTML and plain text. For JSON it did two unhelpful things:

- **Rejected it outright** — `application/json` returned `"Unsupported content type. Only HTML and plain text are supported."`, so the agent couldn't read JSON APIs at all.
- **Truncated mid-structure** — the 50k-char fallback sliced the serialized string, which for JSON produces invalid, un-navigable text. The model can neither parse it nor tell what was cut.

We want the agent to read JSON: small payloads loaded in full, and large payloads inspected partially — see the shape, sample the values, and drill into the part that matters.

## Solution

`read_url` now treats JSON as a first-class content type.

- **Small JSON** → returned verbatim as `{ kind: "json", content: <object> }`.
- **Large JSON** (compact serialization over `MAX_CONTENT_LENGTH` = 50k chars) → instead of a truncated blob, returns three views:
  - `shape` — a recursive schema skeleton. Objects stay nested for scanning; arrays/primitives collapse to one-line descriptors like `"array[1043] of {id:string, name:string, price:number}"`.
  - `preview` — a *structural* sample that stays valid JSON: first few array items + `"…(N more items)"`, capped object keys, strings truncated with the original length noted.
  - `hint` + `byteSize` — tells the model the scale and exactly how to drill in.
- **Drill-in** → an optional `select` path argument. The model calls `read_url` again with e.g. `select=".data.items[0:20]"`; the tool re-fetches, navigates to that subtree, and re-applies the size logic.

### How it works

```
fetch → content-type?
  ├─ text/html  → markdown (unchanged)
  ├─ text/plain → text, OR JSON if the body actually parses (unchanged path otherwise)
  └─ application/json (+ *+json, or any body when `select` is given)
        parse → apply `select` if present →
          compact size ≤ 50k ? return full `content`
                              : return { shape, preview, hint, byteSize, truncated:true }
```

The drill-in is **stateless** — `select` re-fetches the URL rather than caching the body. That matches how the tool already works (every call re-fetches) and is correct for idempotent GET APIs; a per-turn body cache is a clean future optimization if re-fetch cost ever matters.

### Key design decisions

**1. Shape + structural preview instead of string truncation**

Slicing serialized JSON yields corrupt, un-parseable output. A schema skeleton plus a sampled-but-valid preview lets the model understand the whole structure and request exactly the branch it wants. This is the genuinely useful (and hard) part of the feature.

**2. Minimal custom path selector, not full jq or a JSONPath dependency**

`select` supports `.key`, `["quoted key"]`, `[index]` (negatives allowed), `[start:end]` slices, and `[*]` wildcards — pure JS, zero new dependencies, fully controlled and safe. Real jq would require a native binary in the runtime image; JSONPath would add a dependency for power we don't need yet.

**3. Direct paths are strict; wildcards are tolerant**

A missing key on a direct path returns an actionable error naming the keys that *do* exist (great self-correction signal for the model). A `[*]` wildcard null-fills elements missing the sub-path (heterogeneous arrays with optional fields are common — jq-like), but still errors if *every* element fails, so a wholesale-wrong path doesn't silently return all-null.

**4. JSON-aware `Accept` header**

Added `application/json;q=0.9` so content-negotiating APIs prefer serving JSON, while HTML stays top priority for normal web pages.

## New files

| File | Purpose |
| --- | --- |
| `packages/agent-runtime/src/tools/json-inspect.ts` | Pure helpers: `describeShape`, `structuralPreview`, `applySelect` (path parser + resolver) |
| `packages/agent-runtime/src/tools/json-inspect.test.ts` | 23 unit tests for the pure helpers |

## Modified files

| File | Change |
| --- | --- |
| `packages/agent-runtime/src/tools/read-url-tool.ts` | Accept JSON content types (+`*+json`, JSON-as-text/plain); add optional `select` arg; branch small-vs-large on compact serialized size; JSON-aware `Accept` header |
| `packages/agent-runtime/src/tools/read-url-tool.test.ts` | Added JSON handling tests (full, large summary, drill-in, bad-select error, content-type edge cases) |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` | Document JSON reading + `select` usage for the companion persona |

## Test plan

- [x] `bun test` in `packages/agent-runtime` — 127 tests pass (58 in the two touched files, incl. 25 new)
- [x] `bun run typecheck` — clean (agent-runtime + backend)
- [x] Pre-PR multi-perspective review (spec / correctness / design); all surviving findings addressed: wildcard tolerance, compact-size gate, `Accept` header, test assertion
- [ ] Manual: point Ariadne at a large JSON API, confirm it gets `shape`/`preview`/`hint` then drills in with `select`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782681361&installation_id=129946197&pr_number=697&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F697&signature=9fb4055f9b2a9e607d4c6e113c3e295a859de5b290592d100135732cbd4ba9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->