### PR TITLE
test(browser-e2e): restore sidebar-driven nav + fix infinite-scroll under prod build

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,11 +75,17 @@ const webServerTimeout = 60000
 // contention timeouts. Locally we keep the dev server for fast iteration/HMR.
 // The build is port-independent (VITE_BACKEND_PORT only configures the preview
 // proxy at runtime), so the preview server still picks up the dynamic ports.
-const frontendCommand = isCI
+//
+// Set PLAYWRIGHT_PROD_FRONTEND=1 to opt into the prod build locally without the
+// rest of the CI environment (notably the 5454/9000 port remap). Prod-build-only
+// failures — e.g. virtualized-list scroll position differing from the dev server
+// — are otherwise impossible to reproduce on a dev machine.
+const useProdFrontend = isCI || !!process.env.PLAYWRIGHT_PROD_FRONTEND
+const frontendCommand = useProdFrontend
   ? "bun run --cwd apps/frontend build:e2e && bun run --cwd apps/frontend preview"
   : "bun run test:browser:frontend"
-// The CI build needs more headroom than a dev-server boot.
-const frontendServerTimeout = isCI ? 180000 : webServerTimeout
+// The prod build needs more headroom than a dev-server boot.
+const frontendServerTimeout = useProdFrontend ? 180000 : webServerTimeout
 
 // Only log once (when ports are first allocated)
 if (!process.env.PLAYWRIGHT_PORTS_LOGGED) {

--- a/tests/browser/helpers.ts
+++ b/tests/browser/helpers.ts
@@ -65,10 +65,47 @@ export async function loginAndCreateWorkspace(
   }
 
   await waitForWorkspaceProvisioned(page, workspaceId)
+  await setAllSidebarPreset(page, workspaceId)
   await page.goto(`/w/${workspaceId}`)
   await expect(page.getByRole("button", { name: "+ New Scratchpad" })).toBeVisible({ timeout: 10000 })
 
   return { testId, email, name, workspaceName }
+}
+
+/**
+ * Pin the type-based ("All") sidebar layout for a workspace+viewer.
+ *
+ * The product default is the "Smart" preset (urgency buckets: Important / Recent
+ * / Pinned / Everything Else), where a brand-new channel with no activity lands
+ * in the collapsed "Everything Else" bucket and isn't visible in the sidebar.
+ * The E2E suite navigates via the always-open Channels / Scratchpads / DMs
+ * sections, so it pins the deterministic All preset at setup. Smart-bucket
+ * resolution has its own unit coverage (`resolve-sections.test.ts`).
+ *
+ * Body mirrors `ALL_SIDEBAR_CONFIG` in `@threa/types` (not importable from the
+ * repo-root test runtime); `quickLinks` is omitted because the PATCH schema
+ * defaults + normalizes it to the full set. The backend Zod schema rejects any
+ * drift loudly, so a stale literal fails fast rather than silently.
+ */
+async function setAllSidebarPreset(page: Page, workspaceId: string): Promise<void> {
+  const response = await page.request.patch(`/api/workspaces/${workspaceId}/sidebar-config`, {
+    data: {
+      basePreset: "all",
+      sections: [
+        { id: "scratchpads", spec: { kind: "type", streamType: "scratchpad" } },
+        { id: "channels", spec: { kind: "type", streamType: "channel" } },
+        { id: "dms", spec: { kind: "type", streamType: "dm" } },
+      ],
+    },
+  })
+  await expectApiOk(response, "Set All sidebar preset")
+}
+
+/** Extract the workspace id from the current `/w/:workspaceId/...` URL. */
+function workspaceIdFromUrl(page: Page): string {
+  const match = page.url().match(/\/w\/([^/?]+)/)
+  if (!match) throw new Error(`Could not extract workspaceId from URL: ${page.url()}`)
+  return match[1]
 }
 
 /**
@@ -89,16 +126,26 @@ export async function loginInNewContext(
 }
 
 /**
- * Switch sidebar to "All" view mode (shows Channels/Scratchpads/DMs sections).
- * No-op if already in All view or if empty state (no view toggle).
+ * Ensure the sidebar shows the type-based Channels/Scratchpads/DMs sections.
+ *
+ * The old Smart/All view toggle is gone — the layout is now driven by the
+ * persisted sidebar config (see {@link setAllSidebarPreset}). Workspaces created
+ * via {@link loginAndCreateWorkspace} already pin the All preset, so for the
+ * creator this is a cheap wait once any stream exists. A second user context
+ * that joined a workspace mid-test is still on the default Smart preset, so we
+ * persist the All preset for that viewer and reload to repaint from it.
  */
 export async function switchToAllView(page: Page): Promise<void> {
-  const allButton = page.getByRole("button", { name: "All" })
-  await allButton.waitFor({ state: "visible", timeout: 3000 }).catch(() => {})
-  if (await allButton.isVisible()) {
-    await allButton.click()
-    await expect(page.getByRole("heading", { name: "Channels", level: 3 })).toBeVisible({ timeout: 5000 })
-  }
+  const channelsHeading = page.getByRole("heading", { name: "Channels", level: 3 })
+  const alreadyAllView = await channelsHeading
+    .waitFor({ state: "visible", timeout: 3000 })
+    .then(() => true)
+    .catch(() => false)
+  if (alreadyAllView) return
+
+  await setAllSidebarPreset(page, workspaceIdFromUrl(page))
+  await page.reload()
+  await expect(channelsHeading).toBeVisible({ timeout: 10000 })
 }
 
 /**

--- a/tests/browser/infinite-scroll.spec.ts
+++ b/tests/browser/infinite-scroll.spec.ts
@@ -85,23 +85,33 @@ async function scrollToTop(page: Page): Promise<void> {
 
   if (!isScrollable) return
 
-  await scroller.hover()
-  for (let i = 0; i < 3; i++) {
+  // Anchor at the bottom first, then sweep up to the top. A cold virtualized list
+  // can mount pinned at the top (the latest message never scrolled into view);
+  // from there an up-only wheel produces no scroll movement, so Virtuoso never
+  // re-emits the `rangeChanged` that arms the older-page fetch — and reaching the
+  // bottom is also what settles its at-bottom gate (the pagination triggers are
+  // gated on that). Jumping to the bottom then wheeling up guarantees the top
+  // boundary is genuinely re-crossed on every call.
+  await page.evaluate(() => {
+    const container = document.querySelector("[data-suppress-pull-refresh]")
+    if (container instanceof HTMLElement) container.scrollTop = container.scrollHeight
+  })
+  await page.waitForTimeout(50)
+
+  // Wheel from a point near the TOP of the scroller, not its center. Once we've
+  // scrolled up, the floating "Jump to latest" button mounts bottom-center with
+  // `pointer-events-auto`; `scroller.hover()` (which targets the center) then
+  // throws "subtree intercepts pointer events", and inside an expect.poll that
+  // throw is swallowed and retried until the whole test times out. The top strip
+  // is never covered by that button.
+  const box = await scroller.boundingBox()
+  if (box) {
+    await page.mouse.move(box.x + box.width / 2, box.y + 24)
+  }
+  for (let i = 0; i < 4; i++) {
     await page.mouse.wheel(0, -4000)
     await page.waitForTimeout(50)
   }
-
-  // Dispatch a few synthetic scroll events because heavily loaded runners can
-  // miss a single boundary transition while Virtuoso is still measuring items.
-  await page.evaluate(() => {
-    const container = document.querySelector("[data-suppress-pull-refresh]")
-    if (container instanceof HTMLElement) {
-      container.scrollTop = 0
-      for (let i = 0; i < 3; i++) {
-        container.dispatchEvent(new Event("scroll", { bubbles: true }))
-      }
-    }
-  })
   await page.waitForTimeout(100)
 }
 
@@ -115,6 +125,13 @@ test.describe("Infinite Scroll", () => {
   })
 
   test("should load older messages when scrolling to the top", async ({ page }) => {
+    // A short viewport forces Virtuoso to genuinely virtualize: with the default
+    // tall viewport all 50 bootstrap rows render at once, so the scroller barely
+    // overflows and reaching the very top (which arms `startReached` → fetch
+    // older) is unreliable. A small window keeps the bottom rows unmounted, so a
+    // scroll-to-top is a real boundary crossing that paginates deterministically.
+    await page.setViewportSize({ width: 1024, height: 400 })
+
     const PAGED_MESSAGE_COUNT = 51 // One item beyond bootstrap is enough to exercise pagination
     const channelName = `scroll-older-${testId}`
     await createChannel(page, channelName)
@@ -130,8 +147,22 @@ test.describe("Infinite Scroll", () => {
 
     await seedMessages(page, workspaceId, streamId, PAGED_MESSAGE_COUNT, prefix)
 
-    // Navigate fresh to get a clean bootstrap (with only the latest ~50 events)
+    // Navigate to the stream, then hard-reload to force a genuinely cold
+    // bootstrap. `createChannel` first navigated into the freshly-created (empty)
+    // stream, caching a bootstrap with `hasOlderEvents: false`. Seeding happens
+    // over the API while parked on /drafts (no live socket delivery to this
+    // client), so re-navigating can keep serving that stale empty-state snapshot
+    // — `startReached` then fires on scroll-to-top but bails because the cached
+    // `hasOlderEvents` is still false, and the older page never loads. A reload
+    // drops the in-memory query cache and refetches the real window (50 events,
+    // `hasOlderEvents: true`). Real clients don't hit this — they receive the
+    // messages live and invalidate the bootstrap on resubscribe (INV-53).
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    // Let the (possibly stale) first navigation settle before reloading — a
+    // reload fired back-to-back with the in-flight goto races its bootstrap and
+    // can re-cache the same stale snapshot. Wait for first paint, then reload.
+    await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 20000 })
+    await page.reload()
 
     // Wait for the bootstrap window to render. Don't pin on the very latest
     // message being in view: on a loaded runner the virtualized list can mount
@@ -141,28 +172,43 @@ test.describe("Infinite Scroll", () => {
     // scroll-up-loads-older assertion below needs.
     await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 20000 })
 
-    // The earliest message should NOT be visible yet (it's beyond the bootstrap window)
-    await expect(oldestMessage).not.toBeVisible()
+    // The earliest message should NOT be in the list yet (beyond the bootstrap window)
+    await expect(oldestMessage).toHaveCount(0)
 
-    // Keep nudging the scroller back to the top until the oldest message from
-    // the next page is actually rendered. After each prepend the browser keeps
-    // the user's visual position stable, so a second scroll-to-top is often
-    // required on slower runners before the earliest item is in view.
+    // Keep nudging the scroller to the top until the older page is fetched and
+    // the earliest message is rendered into the virtualized list. We assert it
+    // becomes attached (rendered) rather than pixel-visible: a prepend keeps the
+    // user's visual position stable by anchoring the previously-top row, so the
+    // freshly prepended item sits just above the fold and isn't in the viewport
+    // until a further scroll. Whether older messages *load* on scroll-to-top is
+    // the behavior under test; the post-prepend scroll-restoration is separate
+    // (and exercised via "Jump to latest" below). Virtuoso only mounts rows in
+    // its render window, so an attached oldest row proves the scroll reached the
+    // top and the older page paginated in.
     await expect
       .poll(
         async () => {
           await scrollToTop(page)
-          return await oldestMessage.isVisible()
+          return await oldestMessage.count()
         },
         {
           timeout: 30000,
           message: "should render older messages after repeated scrolls to the top",
         }
       )
-      .toBe(true)
+      .toBeGreaterThan(0)
   })
 
   test("should show 'Jump to latest' when scrolled far from bottom and hide when scrolled back", async ({ page }) => {
+    // The "Jump to latest" affordance keys off Virtuoso's rendered range
+    // (`distFromEnd > 10` items), so it only appears once the bottom of the list
+    // is virtualized out of view. On the default tall viewport these 55 short
+    // messages all fit inside Virtuoso's render window — the last item stays
+    // rendered even at the top, distFromEnd is ~0, and the button never shows.
+    // A short viewport forces genuine virtualization, which is the real
+    // condition under which the button matters.
+    await page.setViewportSize({ width: 1024, height: 400 })
+
     const channelName = `scroll-jump-${testId}`
     await createChannel(page, channelName)
 


### PR DESCRIPTION
## Summary

Follow-up to #679 / #682. The Browser E2E suite was **broadly red on `main`** — all four shards failed, masked by `continue-on-error: true`, so the run conclusion still showed green and nobody was gated on it. The failures are **deterministic** (they reproduce at `--workers=1`), not parallel flakiness.

This PR fixes the dominant root cause and the #682 infinite-scroll critical path, taking the suite from fully-red to **185/202 passing**.

## Dominant root cause: the sidebar redesign broke the shared test helpers

The "Customize sidebar" redesign (#691) replaced the Smart/All **view toggle** with a persisted sidebar config. The product default is now the **Smart** preset (urgency buckets: Important / Recent / Pinned / Everything Else), where a brand-new empty channel lands in the **collapsed "Everything Else"** bucket.

The shared helpers still assumed type sections:
- `switchToAllView` clicked an "All" button that no longer exists → silent no-op.
- `createChannel` then waited 30s for a channel link hidden inside a collapsed section.

`createChannel` is used in **21 spec files**, so this single drift broke most of the suite.

**Fix** (`tests/browser/helpers.ts`): `loginAndCreateWorkspace` pins the deterministic type-based **All** preset via `PATCH /api/workspaces/:id/sidebar-config` at setup, so Channels/Scratchpads/DMs render always-open. `switchToAllView` waits for the Channels heading and, for a second-user context still on the Smart default, persists the All preset and reloads to repaint from it. Smart-bucket resolution keeps its unit coverage (`resolve-sections.test.ts`).

## infinite-scroll (the #682 follow-up), fixed under the prod build

These only reproduce under the production frontend build (`vite preview`), not the dev server:

| Test | Root cause | Fix |
|------|-----------|-----|
| `scrollToTop` helper | `scroller.hover()` targets the center, which the floating "Jump to latest" button (`pointer-events-auto`) covers once scrolled up → "subtree intercepts pointer events", swallowed by `expect.poll` → timeout | Anchor at the bottom, then wheel up from the **top strip** (also re-crosses the top boundary so Virtuoso re-arms the older-page fetch even when the list mounted pinned at the top) |
| load older messages | `createChannel` first visits the empty stream, caching a `hasOlderEvents:false` bootstrap; seeding-while-away never refreshes it, so scroll-to-top fires `startReached` but bails | Wait for first paint, then **reload** for a clean cold bootstrap; assert the oldest row becomes **attached** (not pixel-visible — a prepend keeps the prior top row anchored). Real clients don't hit this — they receive messages live and invalidate bootstrap on resubscribe (INV-53) |
| Jump to latest | Button keys off Virtuoso item-distance (`distFromEnd > 10`); on the tall headless viewport all 55 short messages render so `distFromEnd ≈ 0` and it never shows | Short viewport (`1024×400`) forces real virtualization |

## Tooling

`PLAYWRIGHT_PROD_FRONTEND=1` opts into the prod build locally without the rest of the CI env (notably the 5454/9000 port remap), making prod-build-only failures reproducible on a dev machine — which is what unblocked all of the above.

## Verification

Local, under the prod build (`vite preview`):
- **Full suite: 185 passed / 17 failed** at `--workers=3`, `--retries=0`.
- **infinite-scroll: 3/3** at `--workers=1` and `--workers=3`.

No product code changed — all fixes are test/infra side.

## Out of scope — 17 remaining deterministic failures (triaged for a follow-up)

These survive the helper fix and are independent. Several reflect **intentional product UX restructures** the tests haven't caught up to and need product-intent confirmation rather than a blind test rewrite, so I've deliberately left them out of this PR:

- **message-share ×7** (`message-share-to-parent` ×3, `message-share-cross-stream` ×4) — threads are now lazily created (`panel=draft:` until first reply, so `waitForRealThreadPanel` must follow `sendPanelReply`); message lookups via `getByText(text).first()` now match the sidebar last-message preview (scope to `getByRole("main")`); and the share context menu no longer exposes the fast-path "Other share" submenu. Needs a call on regression-vs-intended.
- **sidebar-preview ×2** — pin behavior changed by the redesign (sidebar width 260px vs expected 6px).
- **push-notification-settings ×2** — the Settings dialog no longer shows the expected "Push Notifications" / "Notification Level" text (settings reorganized).
- **thread-breadcrumbs:92**, **message-reactions:257**, **reconnect-rehydrate:159**, **editor-auto-focus:39**, **user-journey:108**, **inline-code-boundary-caret ×2** — mixed independents.

Refs #682. Does not reopen #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682934&installation_id=129946197&pr_number=699&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F699&signature=41dfadc39adb600d3c21285c66e2dc690f2829ce364ec4813dacd2900880f35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->