### PR TITLE
test(browser-e2e): fix 13 deterministic prod-build failures from #700 (UX-restructure drift)

### DIFF
--- a/tests/browser/editor-auto-focus.spec.ts
+++ b/tests/browser/editor-auto-focus.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test"
-import { createChannel, loginAndCreateWorkspace } from "./helpers"
+import { createChannel, loginAndCreateWorkspace, switchToAllView } from "./helpers"
 
 /**
  * Tests for editor auto-focus behavior:
@@ -43,8 +43,10 @@ test.describe("Editor Auto-Focus", () => {
     const channelName = `focus-nav-${testId}`
     await createChannel(page, channelName, { switchToAll: false })
 
-    // Switch to "All" sidebar view so channels are always visible
-    await page.locator("button", { hasText: /^All$/ }).click()
+    // Switch to the type-based "All" sidebar layout so the channel link is
+    // always visible (the old Smart/All toggle button is gone — layout is now
+    // driven by the persisted sidebar config).
+    await switchToAllView(page)
 
     // Navigate to Drafts (away from channel)
     await page.getByRole("link", { name: "Drafts" }).click()

--- a/tests/browser/helpers.ts
+++ b/tests/browser/helpers.ts
@@ -101,6 +101,50 @@ async function setAllSidebarPreset(page: Page, workspaceId: string): Promise<voi
   await expectApiOk(response, "Set All sidebar preset")
 }
 
+/**
+ * Switch a workspace+viewer back to the product-default "Smart" preset
+ * (urgency buckets) and reload so the sidebar repaints from it.
+ *
+ * The suite pins the deterministic All preset by default (see
+ * {@link setAllSidebarPreset}), but the All preset's sections are by stream
+ * *type* (Channels / Scratchpads / DMs) and so never include threads. Threads
+ * only surface in the Smart preset's urgency buckets, so tests that assert on a
+ * sidebar thread entry must opt back into Smart. Body mirrors
+ * `SMART_SIDEBAR_CONFIG` in `@threa/types` (not importable from the repo-root
+ * test runtime); the backend Zod schema rejects drift loudly.
+ */
+export async function setSmartSidebarPreset(page: Page): Promise<void> {
+  const response = await page.request.patch(`/api/workspaces/${workspaceIdFromUrl(page)}/sidebar-config`, {
+    data: {
+      basePreset: "smart",
+      sections: [
+        { id: "important", spec: { kind: "smart", bucket: "important" } },
+        { id: "recent", spec: { kind: "smart", bucket: "recent" } },
+        { id: "pinned", spec: { kind: "smart", bucket: "pinned" } },
+        { id: "other", spec: { kind: "smart", bucket: "other" } },
+      ],
+    },
+  })
+  await expectApiOk(response, "Set Smart sidebar preset")
+  await page.reload()
+}
+
+/**
+ * Expand every collapsed sidebar section so stream items in any urgency bucket
+ * render. Section headers are buttons exposing `aria-expanded`; a collapsed
+ * bucket (e.g. "Everything Else") unmounts its items, so a test that needs an
+ * item which may have landed in a collapsed bucket expands them all first.
+ */
+export async function expandCollapsedSidebarSections(page: Page): Promise<void> {
+  const sidebar = page.getByRole("navigation", { name: "Sidebar navigation" })
+  for (let i = 0; i < 6; i += 1) {
+    const collapsed = sidebar.getByRole("button", { expanded: false })
+    if ((await collapsed.count()) === 0) break
+    await collapsed.first().click()
+    await page.waitForTimeout(100)
+  }
+}
+
 /** Extract the workspace id from the current `/w/:workspaceId/...` URL. */
 function workspaceIdFromUrl(page: Page): string {
   const match = page.url().match(/\/w\/([^/?]+)/)

--- a/tests/browser/message-share-cross-stream.spec.ts
+++ b/tests/browser/message-share-cross-stream.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test"
+import { test, expect, type Locator, type Page } from "@playwright/test"
 import { createChannel, expectApiOk, generateTestId, loginAndCreateWorkspace, loginInNewContext } from "./helpers"
 
 /**
@@ -78,21 +78,39 @@ async function getWorkspaceUserIdByEmail(page: Page, workspaceId: string, email:
   return user.id
 }
 
+/**
+ * Locate a message row by its text within the main timeline. Scoping to
+ * `main` matters: the channel's last-message preview in the sidebar
+ * (`navigation`) also renders the message text but has no `data-message-id`
+ * ancestor, so an unscoped `getByText(...).first()` grabs the preview and the
+ * row lookup resolves to nothing.
+ */
+function mainMessageRow(page: Page, text: string): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: text }).first()
+}
+
 async function openMessageContextMenu(page: Page, text: string): Promise<void> {
-  const row = page.getByText(text, { exact: false }).first().locator("xpath=ancestor::*[@data-message-id][1]")
+  const row = mainMessageRow(page, text)
   await row.hover()
   await row.getByRole("button", { name: /message actions/i }).click()
 }
 
-async function createScratchpad(page: Page, name: string): Promise<string> {
-  await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-  // The new-scratchpad action navigates immediately to the draft route.
-  // Wait for the URL to settle on /s/<id> so subsequent helpers can read it.
-  await expect(page).toHaveURL(/\/w\/[^/]+\/s\/[^/?]+/, { timeout: 5000 })
-  // Optional rename via the page header — best-effort; skipped if not exposed.
-  const header = page.getByRole("heading", { level: 1 }).first()
-  await header.waitFor({ state: "visible", timeout: 5000 })
-  return name
+/**
+ * Create a scratchpad via the streams API. The in-sidebar "+ New Scratchpad"
+ * affordance only renders in the empty state or the "All" preset's Scratchpads
+ * section, so it's not reachable from the default Smart preset this test runs
+ * in. The picker reads its targets from the workspace bootstrap, so an
+ * API-created scratchpad shows up once the source stream is (re)loaded.
+ */
+async function createScratchpad(page: Page): Promise<string> {
+  const workspaceId = page.url().match(/\/w\/([^/]+)/)?.[1] ?? ""
+  expect(workspaceId, "workspace id should be resolvable from the URL").not.toBe("")
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+    data: { type: "scratchpad" },
+  })
+  await expectApiOk(response, "Create scratchpad")
+  const body = (await response.json()) as { stream: { id: string } }
+  return body.stream.id
 }
 
 test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
@@ -111,8 +129,7 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
 
     const sourceUrl = page.url()
     // Pre-create the scratchpad target so it shows up in the picker.
-    const scratchpadName = `Saved ${testId}`
-    await createScratchpad(page, scratchpadName)
+    await createScratchpad(page)
     // Hop back to the source channel.
     await page.goto(sourceUrl)
     await expect(page.getByRole("heading", { name: `#${channelName}`, level: 1 })).toBeVisible()
@@ -233,7 +250,7 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
 
       const sourceText = `secret-${testId}`
       await sendChannelMessageViaApi(page, sourceText)
-      await expect(page.getByText(sourceText, { exact: false }).first()).toBeVisible({ timeout: 5000 })
+      await expect(mainMessageRow(page, sourceText)).toBeVisible({ timeout: 5000 })
 
       await openMessageContextMenu(page, sourceText)
       await page.getByRole("menuitem", { name: /^share message$/i }).click()
@@ -261,21 +278,34 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
       const toast = page.getByText(/expose the source to people outside the source stream/i)
       await expect(toast).toBeVisible({ timeout: 10000 })
 
-      // The pointer must NOT appear in the public timeline before confirmation.
-      // We check inside `[role='main']` so the composer's transient share node
-      // (still mounted because the send was rejected) doesn't false-positive.
-      const publishedPointer = page
+      // The real privacy contract is about the *recipient*. A rejected send
+      // still renders locally for the sender as an optimistic "Failed to send"
+      // bubble (with Retry) in their own timeline — that's a device-local UI
+      // state, not a leak. What must hold is that User B, who is in `pub` but
+      // not in the private source, never receives the pointer before User A
+      // explicitly confirms. Verify that from User B's own session.
+      const otherPointer = otherUser.page
         .getByRole("main")
         .locator("[data-type='shared-message']")
         .filter({ hasText: new RegExp(sourceText) })
-      await expect(publishedPointer).toHaveCount(0)
+      await otherUser.page.goto(`/w/${workspaceId}/s/${pubStreamId}`)
+      await expect(otherUser.page.getByRole("heading", { name: `#${pubSlug}`, level: 1 })).toBeVisible({
+        timeout: 10000,
+      })
+      await expect(otherPointer).toHaveCount(0)
 
       // ---- Confirm: click "Share anyway" → re-enqueue with the flag set.
       await page.getByRole("button", { name: /share anyway/i }).click()
 
-      // Now — and only now — the pointer should land in the public channel.
-      // For User A (a member of the source) it hydrates with the original text.
+      // Now — and only now — the pointer is delivered. User A's failed bubble
+      // settles into a delivered pointer, and User B receives it over the
+      // socket into the already-open `pub` timeline.
+      const publishedPointer = page
+        .getByRole("main")
+        .locator("[data-type='shared-message']")
+        .filter({ hasText: new RegExp(sourceText) })
       await expect(publishedPointer).toBeVisible({ timeout: 10000 })
+      await expect(otherPointer).toBeVisible({ timeout: 10000 })
 
       // The toast should be dismissed once the retry is in flight.
       await expect(toast).not.toBeVisible({ timeout: 5000 })
@@ -321,7 +351,7 @@ test.describe("Message share — cross-stream picker modal (Slice 2)", () => {
 
       const sourceText = `do-not-leak-${testId}`
       await sendChannelMessageViaApi(page, sourceText)
-      await expect(page.getByText(sourceText, { exact: false }).first()).toBeVisible({ timeout: 5000 })
+      await expect(mainMessageRow(page, sourceText)).toBeVisible({ timeout: 5000 })
 
       await openMessageContextMenu(page, sourceText)
       await page.getByRole("menuitem", { name: /^share message$/i }).click()

--- a/tests/browser/message-share-to-parent.spec.ts
+++ b/tests/browser/message-share-to-parent.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test"
+import { test, expect, type Locator, type Page } from "@playwright/test"
 import {
   clickReplyInThread,
   createChannel,
@@ -50,8 +50,23 @@ async function sendChannelMessageViaApi(page: Page, text: string): Promise<strin
   return body.message?.id ?? body.id ?? ""
 }
 
-async function openMessageContextMenu(page: Page, text: string): Promise<void> {
-  const row = page.getByText(text, { exact: false }).first().locator("xpath=ancestor::*[@data-message-id][1]")
+/**
+ * Locate a message row by its text within the main timeline. Scoping to
+ * `main` matters: the channel's last-message preview in the sidebar
+ * (`navigation`) also renders the message text, but it has no
+ * `data-message-id` ancestor, so an unscoped `getByText(...).first()` grabs
+ * the preview and the row lookup resolves to nothing.
+ */
+function mainMessageRow(page: Page, text: string): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: text }).first()
+}
+
+/** Locate a message row by its text within the open thread panel. */
+function panelMessageRow(page: Page, text: string): Locator {
+  return page.getByTestId("panel").locator("[data-message-id]").filter({ hasText: text }).first()
+}
+
+async function openRowContextMenu(row: Locator): Promise<void> {
   await row.hover()
   await row.getByRole("button", { name: /message actions/i }).click()
 }
@@ -73,27 +88,25 @@ async function setUpSharedPointer(
   const parentText = `Parent ${generateTestId()}`
   await sendChannelMessageViaApi(page, parentText)
 
-  const parentRow = page
-    .getByText(parentText, { exact: false })
-    .first()
-    .locator("xpath=ancestor::*[@data-message-id][1]")
+  const parentRow = mainMessageRow(page, parentText)
   await expect(parentRow).toBeVisible()
   await clickReplyInThread(parentRow)
-  await waitForRealThreadPanel(page)
 
+  // Threads are created lazily: the panel stays a `draft:` until the first
+  // reply is sent, so the reply must go in before we wait for the panel to
+  // settle into a real thread (canonical order in
+  // `nested-thread-navigation.spec.ts`).
   await sendPanelReply(page, opts.threadText)
+  await waitForRealThreadPanel(page)
 
   // Capture the thread-reply's message id — that's the source we'll later
   // edit / delete via the API and watch propagate to the channel pointer.
-  const threadRow = page
-    .getByText(opts.threadText, { exact: false })
-    .first()
-    .locator("xpath=ancestor::*[@data-message-id][1]")
+  const threadRow = panelMessageRow(page, opts.threadText)
   await expect(threadRow).toBeVisible()
   const threadMessageId = (await threadRow.getAttribute("data-message-id")) ?? ""
   expect(threadMessageId, "thread reply should expose data-message-id").not.toBe("")
 
-  await openMessageContextMenu(page, opts.threadText)
+  await openRowContextMenu(threadRow)
   // The default `share` entry (modal) sits as the primary in the share group;
   // share-to-root and share-to-parent ride alongside as alternatives behind
   // the chevron sub-menu (aria-label "Other share").

--- a/tests/browser/push-notification-settings.spec.ts
+++ b/tests/browser/push-notification-settings.spec.ts
@@ -24,9 +24,9 @@ test.describe("Push Notification Settings", () => {
     await expect(dialog).toBeVisible({ timeout: 10000 })
 
     // Verify notification cards are present
-    await expect(dialog.getByText("Notification Level")).toBeVisible()
-    await expect(dialog.getByText("Push Notifications", { exact: true })).toBeVisible()
-    await expect(dialog.getByText("Get notified even when you're away from the app")).toBeVisible()
+    await expect(dialog.getByText("Notification level")).toBeVisible()
+    await expect(dialog.getByText("Push notifications", { exact: true })).toBeVisible()
+    await expect(dialog.getByText(/Get notified on this device even when Threa isn't open/i)).toBeVisible()
   })
 
   test("shows blocked message in headless browser (default denied permission)", async ({ page }) => {
@@ -40,7 +40,7 @@ test.describe("Push Notification Settings", () => {
 
     // Headless Chromium denies notification permission by default,
     // so the card should show the "blocked" message
-    await expect(dialog.getByText("Push notifications are blocked")).toBeVisible({ timeout: 5000 })
+    await expect(dialog.getByText(/blocked at the browser level/i)).toBeVisible({ timeout: 5000 })
   })
 
   test("VAPID key endpoint responds", async ({ page }) => {

--- a/tests/browser/sidebar-preview.spec.ts
+++ b/tests/browser/sidebar-preview.spec.ts
@@ -31,12 +31,19 @@ test.describe("Sidebar Preview Behavior", () => {
     const channelName = `preview-test-${testId}`
     await createChannel(page, channelName)
 
-    // Navigate away so the channel link becomes clickable in sidebar
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByRole("main").getByText(/Type a message|No messages yet/)).toBeVisible({ timeout: 5000 })
+    // Navigate away (to Drafts) so the channel link becomes a navigation
+    // target in the sidebar rather than the currently-open view. The big
+    // "+ New Scratchpad" button only exists in the empty state, so use the
+    // always-present Drafts quick link instead.
+    await page.getByRole("link", { name: "Drafts" }).click()
+    await expect(page).toHaveURL(/\/drafts/, { timeout: 5000 })
 
-    // Collapse the sidebar via topbar
+    // Collapse the sidebar via topbar, then move the mouse away: the redesign's
+    // hover-preview re-expands the sidebar while the pointer sits near the
+    // left-edge toggle, so the collapsed 6px state is only observable once the
+    // pointer leaves the magnetic zone.
     await page.getByRole("button", { name: "Collapse sidebar" }).click()
+    await moveAwayFromSidebar(page)
     await expect(sidebar).toHaveCSS("width", "6px", { timeout: 3000 })
 
     // Hover near left edge to trigger preview
@@ -64,15 +71,24 @@ test.describe("Sidebar Preview Behavior", () => {
     // Sidebar starts pinned
     await expect(sidebar).not.toHaveCSS("width", "6px")
 
-    // Collapse via topbar
+    // Collapse via topbar, then move the mouse away so the hover-preview
+    // doesn't keep the sidebar expanded while the pointer rests on the toggle.
     await page.getByRole("button", { name: "Collapse sidebar" }).click()
+    await moveAwayFromSidebar(page)
     await expect(sidebar).toHaveCSS("width", "6px", { timeout: 3000 })
 
-    // Pin via topbar
-    await page.getByRole("button", { name: "Pin sidebar" }).click()
+    // Pin from collapsed: hover the left edge to reveal the preview, then click
+    // the Pin toggle inside the revealed sidebar header. (The page-topbar copy
+    // sits under the preview's 30px "coyote-time" hover zone, which intercepts
+    // the click — and moving the pointer toward it is what opens the preview in
+    // the first place. Scope to the sidebar nav: the page topbar renders its own
+    // "Pin sidebar" copy too.)
+    await hoverToPreview(page)
     await expect(sidebar).not.toHaveCSS("width", "6px", { timeout: 3000 })
+    await sidebar.getByRole("button", { name: "Pin sidebar" }).click()
 
-    // Move mouse away - sidebar should stay open because it's pinned
+    // Move mouse away - sidebar should stay open because it's pinned (a mere
+    // preview would collapse back to 6px once the pointer leaves).
     await moveAwayFromSidebar(page)
     await expect(sidebar).not.toHaveCSS("width", "6px")
   })

--- a/tests/browser/thread-breadcrumbs.spec.ts
+++ b/tests/browser/thread-breadcrumbs.spec.ts
@@ -2,9 +2,11 @@ import { test, expect } from "@playwright/test"
 import {
   clickReplyInThread,
   createChannel,
+  expandCollapsedSidebarSections,
   generateTestId,
   loginAndCreateWorkspace,
   sendPanelReply,
+  setSmartSidebarPreset,
   waitForRealThreadPanel,
 } from "./helpers"
 
@@ -117,9 +119,13 @@ test.describe("Thread Breadcrumbs", () => {
     await expect(page.getByText(/Start a new thread/)).not.toBeVisible({ timeout: 3000 })
     await waitForRealThreadPanel(page)
 
-    // Reload to ensure workspace bootstrap reflects the new thread in sidebar
-    await page.reload()
+    // Threads only appear in the Smart preset's urgency buckets — the suite's
+    // default All preset has type sections (Channels/Scratchpads/DMs) that never
+    // include threads. Switch to Smart (reloads, so the bootstrap also reflects
+    // the new thread) and expand any collapsed bucket the thread landed in.
+    await setSmartSidebarPreset(page)
     await expect(page.getByRole("navigation", { name: "Sidebar navigation" })).toBeVisible({ timeout: 10000 })
+    await expandCollapsedSidebarSections(page)
 
     // The sidebar should show the thread with a root context suffix " · #channel-name"
     // This unique format (dot separator + channel slug) only appears on thread entries

--- a/tests/browser/user-journey.spec.ts
+++ b/tests/browser/user-journey.spec.ts
@@ -119,13 +119,11 @@ test.describe("User Journey", () => {
     // Creating a channel navigates to it - verify via main content heading
     await expect(page.getByRole("heading", { name: `#${quickSwitchChannel}`, level: 1 })).toBeVisible({ timeout: 5000 })
 
-    // Switch to All view to access the "+ New Scratchpad" button (not visible in Smart view with content)
-    await page.getByRole("button", { name: "All" }).click()
-    await expect(page.getByRole("heading", { name: "Scratchpads", level: 3 })).toBeVisible({ timeout: 5000 })
-
-    // Create a scratchpad to navigate away from the channel
-    await page.getByRole("button", { name: "+ New Scratchpad" }).click()
-    await expect(page.getByText(/Type a message|No messages yet/)).toBeVisible({ timeout: 5000 })
+    // Navigate away from the channel via the Drafts quick link. Drafts is a
+    // list page with no autofocused composer, so the Cmd+K quick-switcher opens
+    // cleanly (a focused message editor can otherwise swallow the shortcut).
+    await page.getByRole("link", { name: "Drafts" }).click()
+    await expect(page.getByRole("heading", { name: "Drafts" })).toBeVisible({ timeout: 5000 })
 
     // Now test the quick switcher - open with Cmd+K (Meta+K on Mac)
     await page.keyboard.press("Meta+k")


### PR DESCRIPTION
Follow-up to #699 / #700. Clears the **test-drift** portion of the residual Browser E2E failures the sidebar redesign (#691) and other UX restructures left behind. All reproduced + verified under the production frontend build (`PLAYWRIGHT_PROD_FRONTEND=1`).

## Fixed (13 tests, verified green under prod build)

**message-share ×7** (`message-share-to-parent` ×3, `message-share-cross-stream` ×4)
- Wrong lazy-thread call order: `waitForRealThreadPanel` must come **after** `sendPanelReply` — a lazy thread stays a `draft:` until the first reply is sent (canonical order in `nested-thread-navigation.spec.ts`).
- Unscoped `getByText(text).first()` matched the **sidebar last-message preview** (no `data-message-id` ancestor). Row lookups now scope to `getByRole("main")` / `getByTestId("panel")`.
- Scratchpad target created via the streams API (the `"+ New Scratchpad"` button only exists in the empty state / All preset).
- The **privacy-confirm** test now verifies the real contract at the **recipient**: User B (in the public channel, not the private source) never sees the share before "Share anyway", and does after. The old assertion checked the *sender's* own timeline, where a rejected send legitimately renders a local "Failed to send" optimistic bubble — never delivered.

**push-notification-settings ×2** — settings were re-copied ("Notification level", "Push notifications", new blocked-message text). Assertions updated.

**sidebar-preview ×2** — the redesign's hover-preview re-expands the sidebar while the pointer rests near the left-edge toggle, so the collapsed 6px state is observed only after moving the pointer away. Pinning from collapsed now hovers to reveal the preview and clicks the in-sidebar toggle (the topbar copy sits under the preview's 30px coyote-time hover zone, which intercepts the click).

**editor-auto-focus:39 + user-journey:108** — the Smart/All toggle button is gone; use `switchToAllView()` / navigate via the Drafts quick link.

**thread-breadcrumbs:92** — threads only surface in the **Smart** preset's urgency buckets (the suite's default All preset has type sections that exclude threads). Switch to Smart and expand collapsed buckets before asserting the `· #channel` suffix.

**inline-code-boundary-caret ×2** — no change needed; they pass under the prod build (the #700 triage entry was stale).

## Deferred — genuine bugs, reported not papered over (tracked in #700)

Two residual failures are **not** test drift — both are **prod-build-only service-worker bootstrap-cache** issues (the SW only runs in the prod build, which is why they surface there):

- **message-reactions:257** — root-caused: the SW bootstrap-prefetch interceptor (`apps/frontend/src/sw.ts`) serves the app a **stale cached stream bootstrap** on re-navigation (prefetched before a reaction was added while the client was away). A direct API GET from the same context returns the reaction; the page's SW-served fetch does not, so the reaction never renders.
- **reconnect-rehydrate:159** — the test's delayed-bootstrap route is **never hit** during reconnect under the prod build (the catch-up bypasses the instrumented HTTP path — socket/SW-served), so `isAnySyncing` never trips and the topbar "Loading" indicator never shows.

These want a focused, SW-aware fix (the prefetch cache exists to make notification-taps instant — changing its serve strategy is a sensitive, separate change). Left failing and documented rather than hidden.

Net: the deterministic-failure set shrinks from ~18 to 2, and the 2 remaining are real product bugs with a shared root cause.

Refs #682, #699, #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782687756&installation_id=129946197&pr_number=701&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F701&signature=67b6e403e75707fdd16105fdd0026deb722a648fce1f801a1b5eadf1af9e97eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->