### PR TITLE
fix(sw): don't serve stream bootstrap from the push cache (fixes #700 residual)

### DIFF
--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -131,10 +131,11 @@ self.addEventListener("fetch", (event) => {
 precacheAndRoute(self.__WB_MANIFEST)
 
 // ============================================================================
-// Push bootstrap pre-fetch — cache stream data so it's instant on notification tap
+// Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
+// (stream: IndexedDB; workspace: the Cache API entry served by the interceptor)
 // ============================================================================
 
-/** Cache name for pre-fetched bootstrap responses triggered by push or background sync. */
+/** Cache name for pre-fetched workspace bootstrap responses triggered by push or background sync. */
 const PUSH_BOOTSTRAP_CACHE = "push-bootstrap"
 
 /** Cache name used to persist pending Background Sync targets across SW restarts. */
@@ -145,9 +146,6 @@ const BOOTSTRAP_SYNC_TAG = "threa-bootstrap-refresh"
 
 /** Cache key for the persisted sync target. Last write wins; only the most recent target is replayed. */
 const PENDING_SYNC_KEY = `/_sync/${BOOTSTRAP_SYNC_TAG}`
-
-/** Regex matching stream bootstrap API paths. */
-const STREAM_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/streams\/[^/]+\/bootstrap$/
 
 /** Regex matching workspace bootstrap API paths. */
 const WORKSPACE_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/bootstrap$/
@@ -192,13 +190,12 @@ async function prefetchStreamBootstrap(workspaceId: string, streamId: string): P
   const response = await fetch(url, { credentials: "include" })
   if (!response.ok) return
 
-  // Clone before consuming body — Cache API and IDB write need separate copies
-  const cacheResponse = response.clone()
-  const cache = await caches.open(PUSH_BOOTSTRAP_CACHE)
-  await cache.put(url, cacheResponse)
-
-  // Write events to IndexedDB so useLiveQuery renders them instantly when the
-  // user taps the notification. Best-effort: errors are swallowed.
+  // Warm IndexedDB so useLiveQuery renders the stream instantly when the user
+  // taps the notification. We deliberately do NOT cache the response for the
+  // fetch interceptor to replay: the page's own bootstrap GET passes through to
+  // the network and applies the fresh result on top of this warm paint
+  // (stale-while-revalidate), so replaying a snapshot captured before later
+  // activity would only reintroduce staleness. Best-effort: errors are swallowed.
   try {
     const body = await response.json()
     const bootstrap = body.data ?? body
@@ -442,8 +439,20 @@ self.addEventListener("fetch", (event) => {
 })
 
 /**
- * Fetch interceptor: serve pre-fetched bootstrap responses from the push cache.
- * Entries are one-shot — deleted after being served so subsequent fetches hit the network.
+ * Fetch interceptor: serve the pre-fetched WORKSPACE bootstrap response from the
+ * push cache. Entries are one-shot — deleted after being served so subsequent
+ * fetches hit the network.
+ *
+ * Stream bootstrap is deliberately NOT served from this cache. The prefetch
+ * warms IndexedDB, so the timeline paints instantly from useLiveQuery either
+ * way; the page's own bootstrap GET is left to pass through to the network and
+ * apply the fresh result on top of that warm paint (stale-while-revalidate, in
+ * the page's own sync pipeline). Replaying a cached stream snapshot instead
+ * would (a) serve data captured before activity that landed while the tab was
+ * away — a reaction, an edit — with no revalidation, and (b) make the request
+ * service-worker-initiated, so the page's catch-up fetch never reaches the
+ * network. The workspace bootstrap has no SW-side IDB apply path, so its
+ * cache serve stays.
  *
  * Uses a regex guard (not an in-memory Set) because mobile browsers terminate
  * the SW between push receipt and notification tap — any in-memory state would
@@ -454,7 +463,7 @@ self.addEventListener("fetch", (event) => {
  */
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url)
-  if (!STREAM_BOOTSTRAP_PATH_RE.test(url.pathname) && !WORKSPACE_BOOTSTRAP_PATH_RE.test(url.pathname)) return
+  if (!WORKSPACE_BOOTSTRAP_PATH_RE.test(url.pathname)) return
 
   event.respondWith(
     (async () => {


### PR DESCRIPTION
## What

The push / background-sync prefetch caches a stream bootstrap snapshot, and the service-worker fetch interceptor replayed it (one-shot) on the next bootstrap GET. That single behavior caused **both** remaining prod-build-only E2E failures tracked in #700:

- **`message-reactions:257`** — the replayed snapshot was captured on tab-hide, *before* a reaction landed while away, and there was no revalidation, so the reaction never appeared after navigating back.
- **`reconnect-rehydrate:159`** — replaying made the request service-worker-initiated, so the page's reconnect catch-up GET never reached the network (and Playwright's `page.route` delay, which surfaces the topbar loading indicator, never applied).

These only reproduce under the production frontend build because the service worker doesn't run on the dev server.

## Fix

`apps/frontend/src/sw.ts`: the fetch interceptor now serves only the **workspace** bootstrap from the push cache. **Stream** bootstrap passes through to the network in the page's own context.

- Stream instant-paint is unaffected — it comes from the prefetch's **IndexedDB warming** (its documented primary mechanism: `useLiveQuery` renders the warm rows immediately).
- The page's own network bootstrap then applies fresh data on top through the normal sync pipeline → **stale-while-revalidate, for free**, with no fragile cross-context Dexie propagation.
- Removed the now-dead stream Cache-API write in `prefetchStreamBootstrap` and the unused `STREAM_BOOTSTRAP_PATH_RE` (INV-38).

> Note: an earlier attempt did SWR *inside* the SW (serve cached + revalidate-to-IDB). That was only ~1/3 reliable because the fresh write landed in the SW context and raced the page's initial `useLiveQuery` read; cross-context change propagation isn't dependable within the window. Letting the page fetch in its own context is the robust fix.

## Verification

Under `PLAYWRIGHT_PROD_FRONTEND=1` (local prod build, `--workers=1 --retries=0`):

- `message-reactions:257` — **3/3** (repeat-each)
- `reconnect-rehydrate:159` — **3/3** (repeat-each)
- full `reconnect-rehydrate` + `message-reactions` specs — **13/13**
- **full browser suite — 202/202 green** (2.7m)

Pre-commit lint + cross-workspace typecheck pass. This clears the last residual deterministic failures from #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782711286&installation_id=129946197&pr_number=702&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F702&signature=f3cae5f64a5a7f6edeaa1cc2336dda2f2af2c9288691bf32142665ca55808193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->