### PR TITLE
Quick switcher: reach every sidebar Quick Link

### DIFF
--- a/apps/frontend/src/components/quick-switcher/commands.test.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest"
-import { commands, type Command } from "./commands"
+import { describe, it, expect, vi } from "vitest"
+import { SIDEBAR_QUICK_LINKS, type SidebarQuickLinkKey } from "@threa/types"
+import { commands, type Command, type CommandContext } from "./commands"
 
 describe("commands", () => {
   it("should have at least one command defined", () => {
@@ -68,6 +69,57 @@ describe("commands", () => {
       expect(cmd).toBeDefined()
       expect(cmd?.label).toBe("Open Memory")
       expect(cmd?.keywords).toEqual(expect.arrayContaining(["memo", "memos", "knowledge"]))
+    })
+  })
+
+  // Every standing view in the sidebar's Quick Links block must also be
+  // reachable from the palette, so the two never drift. Most links navigate to
+  // `/w/:workspaceId/<key>`; `files` is special — it opens the attachment
+  // explorer (the same ExplorerShell the /files page renders) rather than
+  // routing to the page.
+  describe("sidebar quick-link parity", () => {
+    const WORKSPACE_ID = "workspace_test"
+
+    function makeContext() {
+      const navigate = vi.fn()
+      const openExplorer = vi.fn()
+      const context = {
+        workspaceId: WORKSPACE_ID,
+        navigate,
+        closeDialog: vi.fn(),
+        createDraftScratchpad: vi.fn(async () => "draft_x"),
+        createEncryptedScratchpad: vi.fn(async () => "stream_x"),
+        openCreateChannel: vi.fn(),
+        setMode: vi.fn(),
+        requestInput: vi.fn(),
+        openSettings: vi.fn(),
+        openExplorer,
+        openStreamSettings: vi.fn(),
+        requestArchiveStream: vi.fn(),
+        openLabelPicker: vi.fn(),
+      } as unknown as CommandContext
+      return { context, navigate, openExplorer }
+    }
+
+    /** The palette destination each sidebar quick link must be reachable through. */
+    const reachability: Record<SidebarQuickLinkKey, (ctx: ReturnType<typeof makeContext>) => void> = {
+      drafts: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/drafts`),
+      saved: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/saved`),
+      files: ({ openExplorer }) => expect(openExplorer).toHaveBeenCalled(),
+      scheduled: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/scheduled`),
+      memory: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/memory`),
+      labels: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/labels`),
+      activity: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/activity`),
+    }
+
+    it.each(SIDEBAR_QUICK_LINKS)("exposes a palette command that reaches the %s quick link", (key) => {
+      // Run every command's action and assert the key's destination was hit by
+      // at least one of them.
+      const harness = makeContext()
+      for (const command of commands) {
+        command.action(harness.context)
+      }
+      reachability[key](harness)
     })
   })
 })

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -1,5 +1,19 @@
 import type { NavigateFunction } from "react-router-dom"
-import { Brain, FileText, Hash, Paperclip, Search, FileEdit, Lock, Settings, StickyNote } from "lucide-react"
+import {
+  Bell,
+  Bookmark,
+  Brain,
+  CalendarClock,
+  FileText,
+  Hash,
+  Paperclip,
+  Search,
+  FileEdit,
+  Lock,
+  Settings,
+  StickyNote,
+  Tag,
+} from "lucide-react"
 import { toast } from "sonner"
 import type { SettingsTab } from "@threa/types"
 import type { ExplorerFilters } from "@/components/attachment-explorer"
@@ -139,6 +153,9 @@ export const commands: Command[] = [
       setMode?.("search")
     },
   },
+  // Destination commands mirror the sidebar's Quick Links block (drafts, saved,
+  // files, scheduled, memory, labels, activity) so every standing view is
+  // reachable from the palette, in the same order.
   {
     id: "view-drafts",
     label: "View Drafts",
@@ -147,6 +164,36 @@ export const commands: Command[] = [
     action: ({ workspaceId, navigate, closeDialog }) => {
       closeDialog()
       navigate(`/w/${workspaceId}/drafts`)
+    },
+  },
+  {
+    id: "view-saved",
+    label: "View Saved",
+    icon: Bookmark,
+    keywords: ["bookmark", "bookmarks", "starred", "later", "read later"],
+    action: ({ workspaceId, navigate, closeDialog }) => {
+      closeDialog()
+      navigate(`/w/${workspaceId}/saved`)
+    },
+  },
+  {
+    id: "browse-files",
+    label: "Browse files",
+    icon: Paperclip,
+    keywords: ["attachments", "uploads", "media", "files", "explorer"],
+    action: ({ closeDialog, openExplorer }) => {
+      closeDialog()
+      openExplorer({ streamIds: [] })
+    },
+  },
+  {
+    id: "view-scheduled",
+    label: "View Scheduled",
+    icon: CalendarClock,
+    keywords: ["schedule", "later", "send later", "queued", "upcoming"],
+    action: ({ workspaceId, navigate, closeDialog }) => {
+      closeDialog()
+      navigate(`/w/${workspaceId}/scheduled`)
     },
   },
   {
@@ -160,13 +207,23 @@ export const commands: Command[] = [
     },
   },
   {
-    id: "browse-files",
-    label: "Browse files",
-    icon: Paperclip,
-    keywords: ["attachments", "uploads", "media", "files", "explorer"],
-    action: ({ closeDialog, openExplorer }) => {
+    id: "view-labels",
+    label: "View Labels",
+    icon: Tag,
+    keywords: ["tag", "tags", "categories", "organize"],
+    action: ({ workspaceId, navigate, closeDialog }) => {
       closeDialog()
-      openExplorer({ streamIds: [] })
+      navigate(`/w/${workspaceId}/labels`)
+    },
+  },
+  {
+    id: "view-activity",
+    label: "View Activity",
+    icon: Bell,
+    keywords: ["notifications", "feed", "mentions", "updates", "inbox"],
+    action: ({ workspaceId, navigate, closeDialog }) => {
+      closeDialog()
+      navigate(`/w/${workspaceId}/activity`)
     },
   },
   {


### PR DESCRIPTION
## What

Brings the command palette (quick switcher) to parity with the sidebar's **Quick Links** block. Every standing view in the sidebar is now reachable from the palette.

### The gap

`SIDEBAR_QUICK_LINKS` defines seven destinations: `drafts, saved, files, scheduled, memory, labels, activity`. The palette's global commands only covered three of them:

| Quick link | Before | After |
|---|---|---|
| Drafts | ✅ View Drafts | ✅ View Drafts |
| Saved | ❌ | ✅ **View Saved** |
| Files | ✅ Browse files | ✅ Browse files |
| Scheduled | ❌ | ✅ **View Scheduled** |
| Memory | ✅ Open Memory | ✅ Open Memory |
| Labels | ❌ (only contextual stream "Labels…" picker) | ✅ **View Labels** |
| Activity | ❌ | ✅ **View Activity** |

## Changes

- `commands.ts`: added `view-saved`, `view-scheduled`, `view-labels`, `view-activity` destination commands, each navigating to `/w/:workspaceId/<route>` with sidebar-matching icons (Bookmark, CalendarClock, Tag, Bell) and search keywords. Reordered the destination block to mirror the sidebar's Quick Links order.
- `commands.test.ts`: added a parity test driven by `SIDEBAR_QUICK_LINKS` that asserts each quick link is reachable from the palette, guarding against future drift.

## Notes

- **Files** is reached via the existing `Browse files` command, which opens the attachment explorer — the same `ExplorerShell` the `/files` page renders (just `mode="modal"` vs `mode="page"`). Left as-is rather than changing it to route to the page, so palette behavior doesn't regress. The parity test documents and enforces this distinction.
- **Labels** keeps its contextual stream command (`Labels…`, which opens the label picker for the current stream); the new `View Labels` command navigates to the labels management page — distinct actions.

## Testing

- `vitest run src/components/quick-switcher/` — 254 passed
- `commands.test.ts` — 78 passed (includes new parity suite)
- `tsc --noEmit`, prettier, eslint — clean

https://claude.ai/code/session_0143jV3XNwerKEE1vyVF22WZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0143jV3XNwerKEE1vyVF22WZ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782715074&installation_id=129946197&pr_number=704&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F704&signature=de098faa78a9f4b528a2bd0630a6e52ec3848672fcb0ab85be51133470f1ee9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->