### PR TITLE
fix(sidebar): stop the undefined-label crash and the default-layout flash

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -38,6 +38,7 @@ let mockPersonas: Array<{ id: string }> = []
 let mockBots: Array<{ id: string }> = []
 let mockUnreadState: { id: string } | undefined
 let mockMetadata: { id: string } | undefined
+let mockSidebarConfig: { id: string } | undefined
 let mockHasSeededDraftCache = false
 let mockSyncStatuses = new Map<string, string>()
 let mockSyncErrors = new Map<string, { status: number | null; error: Error }>()
@@ -93,6 +94,9 @@ function installSpies() {
   vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockImplementation(
     () => mockMetadata as ReturnType<typeof workspaceStoreModule.useWorkspaceMetadata>
   )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceSidebarConfig").mockImplementation(
+    () => mockSidebarConfig as ReturnType<typeof workspaceStoreModule.useWorkspaceSidebarConfig>
+  )
   vi.spyOn(draftStoreModule, "seedDraftCacheFromIdb").mockImplementation(async () => undefined)
   vi.spyOn(draftStoreModule, "hasSeededDraftCache").mockImplementation(() => mockHasSeededDraftCache)
   vi.spyOn(loadingComponentsModule, "StreamContentSkeleton").mockImplementation(() => (
@@ -129,6 +133,7 @@ function makeReadyWorkspaceState() {
   mockStreams = [{ id: "stream_1" }]
   mockUnreadState = { id: "workspace_1" }
   mockMetadata = { id: "workspace_1" }
+  mockSidebarConfig = { id: "workspace_1" }
 }
 
 describe("CoordinatedLoadingProvider", () => {
@@ -149,6 +154,7 @@ describe("CoordinatedLoadingProvider", () => {
     mockBots = []
     mockUnreadState = undefined
     mockMetadata = undefined
+    mockSidebarConfig = undefined
     mockHasSeededDraftCache = false
     mockSyncStatuses = new Map()
     mockSyncErrors = new Map()
@@ -202,6 +208,7 @@ describe("CoordinatedLoadingProvider", () => {
     mockStreams = [{ id: "stream_1" }]
     mockUnreadState = { id: "workspace_1" }
     mockMetadata = { id: "workspace_1" }
+    mockSidebarConfig = { id: "workspace_1" }
 
     render(
       <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
@@ -231,6 +238,36 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("phase").textContent).toBe("loading")
 
     mockMetadata = { id: "workspace_1" }
+    rerender(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("waits for the sidebar config before becoming ready (no default-layout flash)", async () => {
+    // Regression: the sidebar renders its DEFAULT layout when no config is
+    // resolved, so revealing before the persisted config loaded flashed the
+    // default sections for a frame before popping to the user's real layout.
+    makeReadyWorkspaceState()
+    mockSidebarConfig = undefined
+    mockSeedCacheFromIdbResult = true
+
+    const { rerender } = render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("loading")
+
+    mockSidebarConfig = { id: "workspace_1" }
     rerender(
       <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
         <TestConsumer />
@@ -496,6 +533,7 @@ describe("CoordinatedLoadingGate", () => {
     mockStreams = []
     mockUnreadState = undefined
     mockMetadata = undefined
+    mockSidebarConfig = undefined
     installSpies()
   })
 
@@ -566,6 +604,7 @@ describe("MainContentGate", () => {
     mockStreams = []
     mockUnreadState = undefined
     mockMetadata = undefined
+    mockSidebarConfig = undefined
     installSpies()
   })
 

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -9,6 +9,7 @@ import {
   useWorkspaceFromStore,
   useWorkspaceMetadata,
   useWorkspacePersonas,
+  useWorkspaceSidebarConfig,
   useWorkspaceStreamMemberships,
   useWorkspaceStreams,
   useWorkspaceUnreadState,
@@ -147,9 +148,19 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   const idbBots = useWorkspaceBots(workspaceId)
   const idbUnreadState = useWorkspaceUnreadState(workspaceId)
   const idbMetadata = useWorkspaceMetadata(workspaceId)
+  // The sidebar config gates the reveal alongside the other workspace entities:
+  // without it the gate could open before the persisted layout resolved, and the
+  // sidebar would render its DEFAULT fallback for a frame before popping to the
+  // user's real layout. A row always exists after the first bootstrap (the server
+  // seeds the default), so this only ever waits on a genuinely-unloaded config.
+  const idbSidebarConfig = useWorkspaceSidebarConfig(workspaceId)
   const streamById = useMemo(() => new Map(idbStreams.map((stream) => [stream.id, stream])), [idbStreams])
   const workspaceDataReady =
-    hasSeededWorkspaceCache(workspaceId) && !!idbWorkspace && idbUnreadState !== undefined && idbMetadata !== undefined
+    hasSeededWorkspaceCache(workspaceId) &&
+    !!idbWorkspace &&
+    idbUnreadState !== undefined &&
+    idbMetadata !== undefined &&
+    idbSidebarConfig !== undefined
   const draftDataReady = primedDraftWorkspaceId === workspaceId && hasSeededDraftCache(workspaceId)
   const streamQueryStates = useMemo(
     () =>
@@ -230,6 +241,7 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       botCount: idbBots.length,
       hasUnreadState: idbUnreadState !== undefined,
       hasMetadata: idbMetadata !== undefined,
+      hasSidebarConfig: idbSidebarConfig !== undefined,
       workspaceLoading,
       streamsLoading,
       draftsLoading,

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "bun:test"
+import {
+  normalizeSidebarConfig,
+  SIDEBAR_CONFIG_VERSION,
+  QUICK_LINKS_SECTION_ID,
+  type RawSidebarConfig,
+  type SidebarSection,
+} from "./sidebar"
+
+describe("normalizeSidebarConfig section sanitization", () => {
+  test("drops sections whose spec is an unknown smart bucket", () => {
+    const config: RawSidebarConfig = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        { id: "important", spec: { kind: "smart", bucket: "important" } },
+        // Stale row from an older client — bucket no longer exists. Rendering it
+        // would crash the whole sidebar via the presentation lookup.
+        { id: "legacy", spec: { kind: "smart", bucket: "urgent" } } as unknown as SidebarSection,
+        { id: "recent", spec: { kind: "smart", bucket: "recent" } },
+      ],
+      quickLinks: [],
+    }
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections.map((s) => s.id)).toEqual(["important", "recent"])
+  })
+
+  test("drops sections with an unknown stream type or a label missing its id", () => {
+    const config: RawSidebarConfig = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "all",
+      sections: [
+        { id: "channels", spec: { kind: "type", streamType: "channel" } },
+        { id: "ghosts", spec: { kind: "type", streamType: "ghost" } } as unknown as SidebarSection,
+        { id: "label:", spec: { kind: "label", labelId: "" } } as unknown as SidebarSection,
+        { id: "label:keep", spec: { kind: "label", labelId: "label_123" } },
+      ],
+      quickLinks: [],
+    }
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections.map((s) => s.id)).toEqual(["channels", "label:keep"])
+  })
+
+  test("drops malformed (spec-less) section rows without throwing", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        { id: "important", spec: { kind: "smart", bucket: "important" } },
+        { id: "broken" }, // missing spec entirely
+        null,
+      ],
+      quickLinks: [],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections.map((s) => s.id)).toEqual(["important"])
+  })
+
+  test("keeps the quick-links section and all valid specs intact", () => {
+    const config: RawSidebarConfig = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        { id: QUICK_LINKS_SECTION_ID, spec: { kind: "quicklinks" } },
+        { id: "important", spec: { kind: "smart", bucket: "important" } },
+      ],
+      quickLinks: [],
+    }
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections.map((s) => s.spec.kind)).toEqual(["quicklinks", "smart"])
+  })
+})

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -140,6 +140,11 @@ export type RawSidebarConfig = {
  * label section missing its id — must be dropped on read. Otherwise one bad row
  * takes down the whole sidebar (and the workspace layout it lives in) with a
  * `Cannot read properties of undefined` when the presentation lookup misses.
+ *
+ * This is the read-time counterpart to the write-time `sidebarSectionSpecSchema`
+ * (backend `sidebar-config/handlers.ts`): a new spec `kind` must be added to both
+ * — and to the `SidebarSectionSpec` union above — or the backend accepts a spec
+ * the renderer silently drops here via the `default` arm.
  */
 function isRenderableSectionSpec(spec: SidebarSectionSpec | undefined | null): spec is SidebarSectionSpec {
   if (!spec) return false

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -132,6 +132,31 @@ export type RawSidebarConfig = {
   quickLinks?: StoredQuickLink[]
 }
 
+/**
+ * Whether a section's spec is one the renderer knows how to present. The render
+ * path (`sectionPresentation`, `resolveSections`) assumes every spec it receives
+ * resolves to a known bucket / stream type, so a stale or malformed persisted
+ * section — an unknown smart bucket or stream type written by an older client, a
+ * label section missing its id — must be dropped on read. Otherwise one bad row
+ * takes down the whole sidebar (and the workspace layout it lives in) with a
+ * `Cannot read properties of undefined` when the presentation lookup misses.
+ */
+function isRenderableSectionSpec(spec: SidebarSectionSpec | undefined | null): spec is SidebarSectionSpec {
+  if (!spec) return false
+  switch (spec.kind) {
+    case "smart":
+      return (SIDEBAR_SECTION_KEYS as readonly string[]).includes(spec.bucket)
+    case "type":
+      return (SIDEBAR_TYPE_SECTIONS as readonly string[]).includes(spec.streamType)
+    case "label":
+      return typeof spec.labelId === "string" && spec.labelId.length > 0
+    case "quicklinks":
+      return true
+    default:
+      return false
+  }
+}
+
 /** Resolve a stored link's visibility, migrating the pre-v2 boolean and coercing invalid `active`. */
 function normalizeQuickLinkVisibility(link: StoredQuickLink): SidebarQuickLinkVisibility {
   const stored = link.visibility
@@ -172,11 +197,15 @@ export function normalizeSidebarConfig(config: RawSidebarConfig): SidebarConfig 
     if (!seen.has(key)) quickLinks.push({ key, visibility: "show" })
   }
 
-  // Drop any duplicate section ids so the document is fully idempotent — two
-  // sections sharing an id would trip React keys and the drag list's sortable
-  // ids. The write path already dedups via addSection; this guards stray data.
+  // Drop unrenderable and duplicate sections so the document is safe to render
+  // and fully idempotent. An unknown/malformed spec (stale data from an older
+  // client) would crash the presentation lookup; two sections sharing an id
+  // would trip React keys and the drag list's sortable ids. The write path
+  // already validates (Zod) + dedups via addSection; this guards stray data on
+  // every read boundary (bootstrap, IDB rehydrate, socket sync).
   const seenSectionIds = new Set<string>()
   let sections = (config.sections ?? []).filter((section) => {
+    if (!section || !isRenderableSectionSpec(section.spec)) return false
     if (seenSectionIds.has(section.id)) return false
     seenSectionIds.add(section.id)
     return true


### PR DESCRIPTION
## Summary

Fixes two sidebar bugs that share a root cause — the persisted sidebar config reaching the render path without being fully validated or fully loaded.

### 1. Crash: `Cannot read properties of undefined (reading 'label')`

`sectionPresentation` does an unchecked `SMART_SECTIONS[spec.bucket]` lookup. A persisted section with an unrenderable spec (an unknown smart `bucket`/stream type from an older client, a label section missing its id, or a malformed/spec-less row) returned `undefined` from that lookup, and `.label` threw — taking down the **entire sidebar and the workspace layout it lives in**, not just the one section.

`normalizeSidebarConfig` is the one sanitizer every read boundary flows through (backend `getConfig` → bootstrap, IDB rehydrate, socket sync), but it only deduped ids and migrated quick links — it never checked that each section's spec was renderable. Added an `isRenderableSectionSpec` guard to its section filter so a single bad row is dropped on read instead of crashing the layout. This also heals existing bad rows on next load.

### 2. Flash of the default layout before the real one

The coordinated-loading gate (`workspaceDataReady`) waited on the workspace record, unread state, and metadata — but **not** the persisted sidebar config. When the config row resolved a beat after the gate opened (or was written by another device), the sidebar rendered its `DEFAULT_SIDEBAR_CONFIG` fallback for a frame and then popped to the user's real layout once the live query resolved.

Added the sidebar config to `workspaceDataReady` so the reveal holds until the persisted layout is known. A config row always exists after the first bootstrap (the server seeds the default), so this only ever waits on a genuinely-unloaded config; an errored sync still releases the gate, so an offline/inconsistent IDB can't hang on the skeleton. This follows the exact same pattern already used for `idbUnreadState` and `idbMetadata`.

## Changes

- `packages/types/src/sidebar.ts` — `isRenderableSectionSpec` guard in `normalizeSidebarConfig`; cross-reference comment tying it to the backend write-time `sidebarSectionSpecSchema`.
- `apps/frontend/src/contexts/coordinated-loading-context.tsx` — gate the reveal on `idbSidebarConfig !== undefined`.
- Tests: `packages/types/src/sidebar.test.ts` (4 cases: unknown bucket, unknown stream type / empty labelId, malformed-null rows, valid specs preserved) and a new `coordinated-loading-context.test.tsx` case (gate waits for the sidebar config; 20/20 pass).

## Testing

- `bun test packages/types/src/sidebar.test.ts` — 4/4 pass
- `vitest run coordinated-loading-context.test.tsx` — 20/20 pass
- Full monorepo lint + typecheck via pre-commit gate — pass

## Self-review

Ran a 3-perspective review (spec-compliance, correctness/security, design) before opening:
- Spec-compliance: clean (INV-48 scoped `spyOn`, INV-25 comments, INV-36 no speculative code).
- Correctness/security: clean — traced the gate path and confirmed no permanent hang (error-release valve + backend always returns a config).
- Design: flagged read/write drift risk for a future spec `kind`; addressed with the cross-reference comment rather than introducing an exhaustiveness idiom the codebase doesn't otherwise use.

https://claude.ai/code/session_0183sNrUTsF9ogyMTJgdjHtx

---
_Generated by [Claude Code](https://claude.ai/code/session_0183sNrUTsF9ogyMTJgdjHtx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782715284&installation_id=129946197&pr_number=705&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F705&signature=6ec84d2e3cbb0d377008d509cc3b30d78c7da2c295c40c1362b0460e23a7cee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->