### PR TITLE
fix(timeline): re-anchor last message when persisted composer height was wrong

### DIFF
--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { useRef } from "react"
+import { useRef, type CSSProperties } from "react"
 import { render } from "@testing-library/react"
 import { useComposerHeightPublish } from "./use-composer-height-publish"
 
@@ -44,11 +44,23 @@ function pinInitialHeight(px: number): () => void {
   }
 }
 
-function Harness({ onHeightChange, active = true }: { onHeightChange: (px: number) => void; active?: boolean }) {
+function Harness({
+  onHeightChange,
+  active = true,
+  zoneHeight,
+}: {
+  onHeightChange: (px: number) => void
+  active?: boolean
+  /** Pre-existing `--composer-height` on the zone, simulating the first-paint value. */
+  zoneHeight?: string
+}) {
   const ref = useRef<HTMLDivElement>(null)
   useComposerHeightPublish(ref, { active, onHeightChange })
   return (
-    <div data-editor-zone="main">
+    <div
+      data-editor-zone="main"
+      style={zoneHeight ? ({ "--composer-height": zoneHeight } as CSSProperties) : undefined}
+    >
       <div ref={ref}>composer</div>
     </div>
   )
@@ -86,6 +98,35 @@ describe("useComposerHeightPublish", () => {
       render(<Harness onHeightChange={onHeightChange} />)
       // Mount seeded the baseline at 80px; no change has happened yet.
       expect(onHeightChange).not.toHaveBeenCalled()
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("does NOT fire on the initial measure when it matches the first-paint height", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      // Footer already rendered at 80px (persisted `:root` fallback); the
+      // composer measures the same 80px (pinned in beforeEach) — seed silently.
+      render(<Harness onHeightChange={onHeightChange} zoneHeight="80px" />)
+      expect(onHeightChange).not.toHaveBeenCalled()
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("fires on the initial measure when the persisted footer height was wrong", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      // Footer first painted at 120px (stale persisted value), but the actual
+      // composer measures 80px: the spacer will shrink after mount, so the
+      // virtualized list must re-anchor (last message would otherwise park too
+      // high). The same drift the other direction hides the last message.
+      render(<Harness onHeightChange={onHeightChange} zoneHeight="120px" />)
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+      expect(onHeightChange).toHaveBeenLastCalledWith(80)
     } finally {
       ro.restore()
     }

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -4,16 +4,20 @@ import { persistComposerHeight } from "@/lib/composer-height-storage"
 interface UseComposerHeightPublishOptions {
   active?: boolean
   /**
-   * Fired whenever the published height *changes* from a previously-measured
-   * value (never on the initial measurement). The timeline uses this to
-   * re-anchor a virtualized list to the bottom: the footer spacer that keeps
-   * the last message above the composer is sized from `--composer-height`, but
-   * Virtuoso's scroll position is frozen when that spacer grows (its
-   * `followOutput` only reacts to new items, and its resize safety-net only
-   * watches the scroller's own height — not footer growth). Without this
-   * notification a composer that settles taller a few frames after a message
-   * lands (the 200ms height transition, async encryption notice / attachment
-   * chips) covers the bottom of the last message until the next reload.
+   * Fired whenever the published height *changes* from the height the footer
+   * spacer was last sized for — including the initial measurement when it
+   * differs from what first paint rendered with (the persisted `:root`
+   * fallback), but not when the first measurement matches that fallback. The
+   * timeline uses this to re-anchor a virtualized list to the bottom: the
+   * footer spacer that keeps the last message above the composer is sized from
+   * `--composer-height`, but Virtuoso's scroll position is frozen when that
+   * spacer resizes (its `followOutput` only reacts to new items, and its resize
+   * safety-net only watches the scroller's own height — not footer growth).
+   * Without this notification a composer that settles to a different height a
+   * few frames after mount (the persisted default not matching the actual
+   * composer, the 200ms height transition, async encryption notice / attachment
+   * chips) leaves the last message hidden behind the composer — or the list
+   * parked too high — until the next reload.
    */
   onHeightChange?: (px: number) => void
 }
@@ -50,15 +54,28 @@ export function useComposerHeightPublish(
     const zone = el.closest<HTMLElement>("[data-editor-zone]")
     if (!zone) return
 
-    let lastPublished: number | null = null
+    // Seed the baseline from the height the footer spacer is *currently*
+    // rendered with: the persisted `:root` fallback applied at boot, or a value
+    // a prior composer left on the zone. `getComputedStyle(zone)` resolves the
+    // inherited value, so this matches what `var(--composer-height)` paints
+    // with right now. When the first real measurement differs from this — the
+    // persisted default didn't match the actual composer (density/zoom change,
+    // a restored multi-line draft, attachment chips, the async encryption
+    // notice) — the footer spacer resizes after first paint, so we must notify
+    // even on the initial measure. Otherwise the virtualized list stays
+    // anchored to the stale height: the last message ends up hidden behind the
+    // composer, or the list parks too high. A first measurement that matches
+    // seeds silently, exactly as before (no spurious snap on a clean reload).
+    const rendered = Number.parseFloat(getComputedStyle(zone).getPropertyValue("--composer-height"))
+    let lastPublished: number | null = Number.isFinite(rendered) ? Math.ceil(rendered) : null
 
     const write = (h: number) => {
       const px = Math.ceil(h)
       zone.style.setProperty("--composer-height", `${px}px`)
       persistComposerHeight(px)
-      // Only notify on an actual change from an already-established height —
-      // the initial measure just seeds the baseline (the footer spacer is
-      // already sized for it via the persisted `:root` fallback).
+      // Notify on any change from the height the footer was last sized for —
+      // including the initial measure when it differs from first paint (see the
+      // baseline note above). The timeline re-anchors to the bottom on this.
       if (lastPublished !== null && px !== lastPublished) onHeightChangeRef.current?.(px)
       lastPublished = px
     }


### PR DESCRIPTION
## Problem

The recurring "missing padding on the last message" bug (and its opposite, "loads in too high").

The bottom footer spacer that pushes the last message above the floating composer (`ComposerFooterSpacer`) is sized purely from `--composer-height`. At first paint that variable is the **persisted** `:root` value (default `80px`, applied in `main.tsx` before React mounts). Virtuoso mounts with `initialTopMostItemIndex: { index: "LAST", align: "end" }` and lands the last message above a footer of that persisted size.

Then `useComposerHeightPublish`'s effect runs, measures the **actual** composer, and rewrites `--composer-height` on the editor zone. The footer resizes — but Virtuoso freezes its `scrollTop` across that resize (`followOutput` only reacts to new items; the resize safety-net in `use-virtuoso-scroll.ts` only watches the *scroller's own* `clientHeight`, never footer growth). The re-anchor that exists for exactly this (`onHeightChange` → `handleComposerHeightChange` → `virtualScrollToBottom`) was **deliberately suppressed on the initial measurement**.

So when persisted height ≠ actual height at mount:
- **persisted too small** → footer grows after paint → last message slides behind the composer = **missing padding**
- **persisted too large** → footer shrinks → list lands too high / with a gap = **loaded in too high**

It's rare because it only bites when the persisted default doesn't match the real composer at that moment: density/zoom change, a restored multi-line draft, attachment chips or the encryption notice making the composer taller, a fresh install (default 80), or carrying a different stream's composer height across navigation.

## Fix

Seed the change-detection baseline in `useComposerHeightPublish` from the height the footer **actually rendered with** at first paint (the inherited/effective `--composer-height` via `getComputedStyle`), instead of `null`. The first measurement that *differs* from first paint then fires `onHeightChange`, routing through the already-built, already-guarded re-anchor (`virtualScrollToBottom` self-guards on `isAtBottomRef`, so deep-link jumps and scrolled-up reading are untouched). A measurement that *matches* seeds silently — identical to today, no spurious snap on a clean reload.

## Design notes

- Minimal patch, entirely within `useComposerHeightPublish`; no change to the Virtuoso wiring or the delicate reveal-gate sequence.
- The corrective snap is `behavior: "auto"` (instant) and guarded to at-bottom, so on healthy reloads (persisted == actual) there is **no** new motion. In the genuine drift case there's a single instant settle ~120ms after load, replacing a layout that was previously broken until reload. (A follow-up makes even that settle invisible — see the stacked PR.)

## Tests

`apps/frontend/src/hooks/use-composer-height-publish.test.tsx` — added coverage for: initial measure matching first paint stays silent; initial measure differing from a stale persisted footer fires. Full hook + timeline suites green (`bun run test`), clean typecheck.

https://claude.ai/code/session_01XoENDacxXxscFmCPgLUAgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoENDacxXxscFmCPgLUAgz)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782734104&installation_id=129946197&pr_number=707&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F707&signature=aa96789858ef84b70d056e92f4caad10b258cbf340a23f786c9ced65fe3675da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->