### PR TITLE
fix(timeline): correct composer-height drift before paint, no visible jump

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -40,11 +40,14 @@ interface MessageInputProps {
   disabledReason?: string
   autoFocus?: boolean
   /**
-   * Notified when the composer's measured height changes (after the initial
-   * measure). The virtualized timeline uses this to re-anchor to the bottom so
-   * the last message isn't left covered by a composer that settled taller.
+   * Notified when the composer's measured height changes (or when the initial
+   * measurement differs from the persisted footer the list first painted with).
+   * The virtualized timeline uses this to re-anchor to the bottom so the last
+   * message isn't left covered by a composer that settled taller. `opts.initial`
+   * marks the pre-paint first measurement so the timeline can correct it
+   * synchronously instead of debouncing.
    */
-  onComposerHeightChange?: (px: number) => void
+  onComposerHeightChange?: (px: number, opts: { initial: boolean }) => void
 }
 
 function attachmentMatchKey(attachment: Pick<PendingAttachment, "filename" | "mimeType">): string {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -790,10 +790,20 @@ export function StreamContent({
   // bottom of the last message until the next reload. virtualScrollToBottom
   // self-guards on isAtBottomRef, so this is a no-op unless the user is parked
   // at the live tail (never fires during a deep-link jump or while scrolled up
-  // reading). Debounced so the snap lands once after the transition settles
-  // rather than fighting Virtuoso's reflow on every intermediate frame. The
-  // plain-scroll (thread/draft) path needs none of this: its `padding-bottom`
-  // reflows the content so the bottom row is never frozen behind the composer.
+  // reading). The plain-scroll (thread/draft) path needs none of this: its
+  // `padding-bottom` reflows the content so the bottom row is never frozen
+  // behind the composer.
+  //
+  // Two arrival paths, handled differently:
+  //  - `initial`: the composer's first measurement, fired from a layout effect
+  //    *before paint*. The list first scrolled to LAST against the approximate
+  //    persisted footer height; when the real composer differs (cold boot with
+  //    a restored draft, density/zoom change) we correct it synchronously here,
+  //    in the same frame the list reveals, so there is no visible jump.
+  //  - runtime changes: arrive async from the ResizeObserver after paint (the
+  //    200ms height transition, attachment chips settling). Debounced so the
+  //    snap lands once after the transition settles rather than fighting
+  //    Virtuoso's reflow on every intermediate frame.
   //
   // Called through a ref so the handler identity stays stable: virtualScrollToBottom
   // is rebuilt on every itemCount change, and a changing prop would re-render
@@ -802,8 +812,12 @@ export function StreamContent({
   const virtualScrollToBottomRef = useRef(virtualScrollToBottom)
   virtualScrollToBottomRef.current = virtualScrollToBottom
   const composerResizeTimerRef = useRef<number | undefined>(undefined)
-  const handleComposerHeightChange = useCallback(() => {
+  const handleComposerHeightChange = useCallback((_px: number, opts: { initial: boolean }) => {
     window.clearTimeout(composerResizeTimerRef.current)
+    if (opts.initial) {
+      virtualScrollToBottomRef.current()
+      return
+    }
     composerResizeTimerRef.current = window.setTimeout(() => {
       virtualScrollToBottomRef.current()
     }, 120)

--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -124,9 +124,11 @@ describe("useComposerHeightPublish", () => {
       // composer measures 80px: the spacer will shrink after mount, so the
       // virtualized list must re-anchor (last message would otherwise park too
       // high). The same drift the other direction hides the last message.
+      // This fires from a layout effect (pre-paint), flagged `initial: true` so
+      // the timeline corrects it synchronously instead of debouncing.
       render(<Harness onHeightChange={onHeightChange} zoneHeight="120px" />)
       expect(onHeightChange).toHaveBeenCalledTimes(1)
-      expect(onHeightChange).toHaveBeenLastCalledWith(80)
+      expect(onHeightChange).toHaveBeenLastCalledWith(80, { initial: true })
     } finally {
       ro.restore()
     }
@@ -142,10 +144,11 @@ describe("useComposerHeightPublish", () => {
       ro.fire(80)
       expect(onHeightChange).not.toHaveBeenCalled()
 
-      // Composer grows (e.g. multi-line draft / attachments settle).
+      // Composer grows (e.g. multi-line draft / attachments settle). Runtime
+      // changes arrive from the ResizeObserver, flagged `initial: false`.
       ro.fire(160)
       expect(onHeightChange).toHaveBeenCalledTimes(1)
-      expect(onHeightChange).toHaveBeenLastCalledWith(160)
+      expect(onHeightChange).toHaveBeenLastCalledWith(160, { initial: false })
 
       // A redundant fire at the same height must not re-notify.
       ro.fire(160)
@@ -154,7 +157,24 @@ describe("useComposerHeightPublish", () => {
       // Composer shrinks back (message sent, draft cleared).
       ro.fire(80)
       expect(onHeightChange).toHaveBeenCalledTimes(2)
-      expect(onHeightChange).toHaveBeenLastCalledWith(80)
+      expect(onHeightChange).toHaveBeenLastCalledWith(80, { initial: false })
+    } finally {
+      ro.restore()
+    }
+  })
+
+  it("flags only the first measurement as initial, even when it drifts", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      // Pre-paint initial measure drifts (120 -> 80, initial: true); then a
+      // later runtime change must NOT be flagged initial.
+      render(<Harness onHeightChange={onHeightChange} zoneHeight="120px" />)
+      expect(onHeightChange).toHaveBeenLastCalledWith(80, { initial: true })
+
+      ro.fire(160)
+      expect(onHeightChange).toHaveBeenCalledTimes(2)
+      expect(onHeightChange).toHaveBeenLastCalledWith(160, { initial: false })
     } finally {
       ro.restore()
     }

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useLayoutEffect, useRef } from "react"
 import { persistComposerHeight } from "@/lib/composer-height-storage"
 
 interface UseComposerHeightPublishOptions {
@@ -18,8 +18,14 @@ interface UseComposerHeightPublishOptions {
    * composer, the 200ms height transition, async encryption notice / attachment
    * chips) leaves the last message hidden behind the composer — or the list
    * parked too high — until the next reload.
+   *
+   * `opts.initial` is true only for the very first measurement of this mount,
+   * which runs inside a layout effect *before the browser paints*. The timeline
+   * uses that to correct the approximate persisted footer height synchronously
+   * (no visible jump) instead of debouncing — later, async runtime changes
+   * arrive with `initial: false`.
    */
-  onHeightChange?: (px: number) => void
+  onHeightChange?: (px: number, opts: { initial: boolean }) => void
 }
 
 /**
@@ -28,6 +34,10 @@ interface UseComposerHeightPublishOptions {
  * siblings inside the same editor zone can consume the variable (e.g.
  * plain-scroll `padding-bottom`) to reserve space for the floating composer
  * pill.
+ *
+ * The first measurement runs in a layout effect (before paint) so the variable
+ * and the timeline's bottom anchor can be corrected in the same frame the list
+ * first reveals, rather than one paint later.
  *
  * Pass `active: false` (e.g. while the expand-to-fullscreen overlay is open)
  * to disconnect the observer. The CSS variable is intentionally *not* cleared
@@ -47,7 +57,7 @@ export function useComposerHeightPublish(
   const onHeightChangeRef = useRef(onHeightChange)
   onHeightChangeRef.current = onHeightChange
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current
     if (!el || !active) return
 
@@ -68,6 +78,7 @@ export function useComposerHeightPublish(
     // seeds silently, exactly as before (no spurious snap on a clean reload).
     const rendered = Number.parseFloat(getComputedStyle(zone).getPropertyValue("--composer-height"))
     let lastPublished: number | null = Number.isFinite(rendered) ? Math.ceil(rendered) : null
+    let isInitialMeasure = true
 
     const write = (h: number) => {
       const px = Math.ceil(h)
@@ -75,11 +86,17 @@ export function useComposerHeightPublish(
       persistComposerHeight(px)
       // Notify on any change from the height the footer was last sized for —
       // including the initial measure when it differs from first paint (see the
-      // baseline note above). The timeline re-anchors to the bottom on this.
-      if (lastPublished !== null && px !== lastPublished) onHeightChangeRef.current?.(px)
+      // baseline note above). The timeline re-anchors to the bottom on this;
+      // `initial` lets it do so synchronously, pre-paint, on the first measure.
+      if (lastPublished !== null && px !== lastPublished) {
+        onHeightChangeRef.current?.(px, { initial: isInitialMeasure })
+      }
       lastPublished = px
+      isInitialMeasure = false
     }
 
+    // Runs in the layout phase, before paint: the list reveals this frame with
+    // the corrected footer already accounted for.
     write(el.getBoundingClientRect().height)
 
     const ro = new ResizeObserver((entries) => {

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -5,16 +5,20 @@
  * Why: the timeline's footer spacer reserves vertical space for the floating
  * composer pill via `var(--composer-height, 0px)`. That variable is set by
  * `useComposerHeightPublish` on the nearest `[data-editor-zone]` ancestor —
- * but the ResizeObserver runs inside `useEffect`, after the first commit.
- * Until then the fallback (0px) wins, and the footer spacer grows from 0 to
- * ~80px on first paint. Inside Virtuoso's `stickToBottom` mode that growth
- * forces the list to shift content up by the same amount, which the user
- * sees as the timeline "jumping" on every hard refresh.
+ * but the composer measures in a layout effect, which runs after the first
+ * render commits. Until then the fallback (0px) would win, so Virtuoso's
+ * mount-time measurement (which precedes the composer's layout effect) sizes
+ * the footer at 0 and the spacer grows from 0 to ~80px before paint. Inside
+ * Virtuoso's `stickToBottom` mode that growth forces the list to shift content
+ * up by the same amount, which the user sees as the timeline "jumping" on
+ * every hard refresh.
  *
  * Persisting the last-known height to `localStorage` and applying it to
  * `:root` before React mounts means the first render of the spacer already
- * reserves roughly the right space. The editor-zone override that runs in
- * the composer's effect later corrects any drift without a visible jump.
+ * reserves roughly the right space. The editor-zone override that runs in the
+ * composer's layout effect later corrects any residual drift pre-paint (and
+ * notifies the timeline to re-anchor in the same frame), so there is no
+ * visible jump.
  */
 
 const STORAGE_KEY = "threa:composer-height"


### PR DESCRIPTION
## Context

Follow-up to #707 (now **merged**). This PR is rebased onto `main` and targets `main` directly — it contains only its own commit.

#707 fixes the bug, but corrects the persisted-vs-actual composer-height drift via a 120ms **post-paint** snap — visible as a single one-time settle in the drift case. This makes that correction invisible.

## Change

- Measure the composer in a **layout effect** (was `useEffect`) so `--composer-height` is corrected **before the browser paints**, in the same frame the list reveals.
- Tag the first measurement `initial: true`. The timeline snaps to the bottom **synchronously** for that pre-paint correction instead of debouncing, so the list reveals already glued to the right position — no visible jump even in the drift case.
- Async runtime changes (the 200ms composer height transition, attachment chips settling) still arrive `initial: false` and stay **debounced** so they don't fight Virtuoso's reflow on every intermediate frame.

The signature of `onHeightChange` / `onComposerHeightChange` gains an `{ initial }` flag, threaded through `MessageInput`. Backward compatible — the thread-panel caller passes no callback.

## Why this approach (B)

Of the options to guarantee a correct footer before the list's first scroll, this is the smallest / lowest-risk: no reorder (which would change tab order) and no gating of the reveal (which would couple the list to the composer and add no-composer edge cases). Trade-off: the pre-paint guarantee depends on react-virtuoso's reveal timing, so it's not a 100% hard guarantee in every rare sub-frame case — the #707 re-anchor still backstops it regardless, and gating the reveal remains the fallback if a residual flash ever shows up.

## Tests

Extended `use-composer-height-publish.test.tsx` to assert the `{ initial }` flag (pre-paint initial drift vs. async runtime change, and that only the first measurement is flagged initial). Updated the stale timing note in `composer-height-storage.ts`. Full hook + timeline suites green (544 tests), clean monorepo typecheck + lint.

https://claude.ai/code/session_01XoENDacxXxscFmCPgLUAgz