### PR TITLE
fix: reset message slide when a swipe-to-quote touch is cancelled

### DIFF
--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -170,6 +170,7 @@ interface MessageLayoutProps {
     onTouchStart: (e: React.TouchEvent) => void
     onTouchEnd: () => void
     onTouchMove: (e: React.TouchEvent) => void
+    onTouchCancel: () => void
     onContextMenu: (e: React.MouseEvent) => void
   }
   /** Horizontal swipe offset for mobile swipe-to-quote (px, negative = left) */
@@ -1217,6 +1218,10 @@ function SentMessageEvent({
                 onTouchMove: (e: React.TouchEvent) => {
                   longPress.handlers.onTouchMove(e)
                   swipe.handlers.onTouchMove(e)
+                },
+                onTouchCancel: () => {
+                  longPress.handlers.onTouchCancel()
+                  swipe.handlers.onTouchCancel()
                 },
                 onContextMenu: longPress.handlers.onContextMenu,
               }

--- a/apps/frontend/src/hooks/use-long-press.ts
+++ b/apps/frontend/src/hooks/use-long-press.ts
@@ -24,6 +24,7 @@ interface LongPressHandlers {
   onTouchStart: (e: React.TouchEvent) => void
   onTouchEnd: () => void
   onTouchMove: (e: React.TouchEvent) => void
+  onTouchCancel: () => void
   onContextMenu: (e: React.MouseEvent) => void
 }
 
@@ -101,6 +102,12 @@ export function useLongPress({
     clear()
   }, [clear])
 
+  // `touchcancel` fires (instead of `touchend`) when the browser/OS steals the
+  // gesture; clear the pending timer and pressed state so neither gets stuck.
+  const onTouchCancel = useCallback(() => {
+    clear()
+  }, [clear])
+
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
       if (!startPos.current) return
@@ -141,7 +148,7 @@ export function useLongPress({
   )
 
   return {
-    handlers: { onTouchStart, onTouchEnd, onTouchMove, onContextMenu },
+    handlers: { onTouchStart, onTouchEnd, onTouchMove, onTouchCancel, onContextMenu },
     isPressed,
   }
 }

--- a/apps/frontend/src/hooks/use-swipe-action.test.tsx
+++ b/apps/frontend/src/hooks/use-swipe-action.test.tsx
@@ -79,4 +79,32 @@ describe("useSwipeAction", () => {
 
     target.remove()
   })
+
+  it("snaps back to 0 and does not fire onSwipe when the touch is cancelled mid-swipe", () => {
+    const onSwipe = vi.fn()
+    const { result } = renderHook(() => useSwipeAction({ onSwipe, threshold: 80 }))
+    const target = document.createElement("div")
+    document.body.appendChild(target)
+
+    act(() => {
+      result.current.handlers.onTouchStart(touchEvent(target, 200, 100))
+      result.current.handlers.onTouchMove(touchEvent(target, 110, 100))
+    })
+
+    // Mid-swipe the message is shifted left.
+    expect(result.current.offset).toBeLessThan(0)
+
+    act(() => {
+      // The browser/OS takes over the gesture and fires touchcancel
+      // instead of touchend.
+      result.current.handlers.onTouchCancel()
+    })
+
+    // Offset must reset so the message does not stay stuck shifted left.
+    expect(result.current.offset).toBe(0)
+    expect(result.current.isLocked).toBe(false)
+    expect(onSwipe).not.toHaveBeenCalled()
+
+    target.remove()
+  })
 })

--- a/apps/frontend/src/hooks/use-swipe-action.ts
+++ b/apps/frontend/src/hooks/use-swipe-action.ts
@@ -13,6 +13,7 @@ interface SwipeHandlers {
   onTouchStart: (e: React.TouchEvent) => void
   onTouchEnd: () => void
   onTouchMove: (e: React.TouchEvent) => void
+  onTouchCancel: () => void
 }
 
 interface UseSwipeActionReturn {
@@ -133,10 +134,19 @@ export function useSwipeAction({
     reset()
   }, [reset])
 
+  // The browser/OS can steal an in-flight touch (system gesture navigation,
+  // scroll takeover, a second finger), in which case it fires `touchcancel`
+  // instead of `touchend`. Without this the offset would stay frozen and the
+  // message would remain visibly shifted left. Snap back without triggering
+  // the action — a cancelled gesture is not a deliberate swipe.
+  const onTouchCancel = useCallback(() => {
+    reset()
+  }, [reset])
+
   useEffect(() => reset, [reset])
 
   return {
-    handlers: { onTouchStart, onTouchEnd, onTouchMove },
+    handlers: { onTouchStart, onTouchEnd, onTouchMove, onTouchCancel },
     offset,
     isLocked,
   }


### PR DESCRIPTION
## Problem

On mobile, sliding a message left to quote-reply would sometimes leave the message **stuck slightly shifted to the left** after the finger lifted — it looked buggy and cheap.

The root cause: `useSwipeAction` only reset its horizontal offset on `touchend`. But mobile browsers fire **`touchcancel`** — *not* `touchend` — whenever the OS/browser steals an in-flight touch: edge-swipe system gesture navigation, the scroller taking over the gesture, or a second finger landing. Nothing handled `touchcancel`, so `reset()` never ran and the row stayed frozen at its last `translateX` offset.

`useLongPress` had the same gap (its pending timer and `isPressed` highlight could linger), though it has no visible transform so the symptom was far less noticeable.

## Solution

Add an `onTouchCancel` handler to both gesture hooks that runs the existing reset path, and wire it through the message row's combined touch handlers.

### Key design decisions

**1. Cancel resets, but does not fire the action**

`onTouchCancel` calls `reset()` only — it never invokes the `onSwipe` callback. A gesture the OS aborted is not a deliberate quote-reply, so we snap back silently rather than firing on a touch the user didn't complete. (`touchend` keeps its existing behavior: fire if past threshold, then reset.)

**2. Scope kept to the reported surface**

Five other consumers of `useLongPress` (`scheduled-item`, `scheduled-messages-picker`, `attachment-list`, `reaction-details`, `use-sidebar-item-drawer`) pick the handlers individually and are long-press-only surfaces with no visible horizontal transform — a cancelled touch there leaves at most a transient highlight, not a stuck-slid row. They gain the new handler on the hook but aren't re-wired here, keeping the change a minimal patch (INV-36). The hook now supports `onTouchCancel` for any surface that later wants it.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-swipe-action.ts` | Add `onTouchCancel` handler (snaps offset back to 0 without firing `onSwipe`); expose it on `handlers` |
| `apps/frontend/src/hooks/use-long-press.ts` | Add `onTouchCancel` handler (clears pending timer + pressed state); expose it on `handlers` |
| `apps/frontend/src/components/timeline/message-event.tsx` | Add `onTouchCancel` to the `touchHandlers` prop type and the combined handler so both hooks reset together |
| `apps/frontend/src/hooks/use-swipe-action.test.tsx` | New test: a cancelled mid-swipe resets `offset` to 0, leaves `isLocked` false, and does not fire `onSwipe` |

## Test plan

- [x] `bun run test src/hooks/use-swipe-action.test.tsx` — 4/4 pass, including the new cancellation case
- [x] Full monorepo lint + typecheck (pre-commit gate) clean
- [ ] Manual: on a phone, start a left-swipe on a message and trigger an edge/system gesture mid-swipe — row snaps back to rest instead of staying shifted left

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVNiRE22fNuebcGaGGmGf8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782742413&installation_id=129946197&pr_number=709&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F709&signature=713a4b8a82d7a9be124691c8d3c909cff6610ab054cbd89d4c99faecc45d19ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->