### PR TITLE
feat(e2e): per-stream tool-privacy policy foundation for enclave turns

### DIFF
--- a/.claude/plans/e2e-tool-privacy-policy.md
+++ b/.claude/plans/e2e-tool-privacy-policy.md
@@ -1,0 +1,80 @@
+# Per-stream tool-privacy policy (foundation slice)
+
+## Why
+
+Ariadne running in an E2E scratchpad can reach external services (web search,
+URL reads, the web-only research loop). For a privacy-sensitive scratchpad the
+owner may want to dial that down — "no tools at all", "web but nothing else",
+later "workspace reads but no web". We want to be **honest but configurable**
+about the privacy a given scratchpad gives up.
+
+Today tool access is gated only at the **persona** level (`enabledTools`), which
+is global to the persona, not per-stream. There is no per-stream or
+per-workspace knob, and the enclave builds its own tool set
+(`buildEnclaveTools`) from the session assignment — so any per-stream policy
+must be carried **in the assignment** and enforced inside the enclave, not just
+in the backend's `buildToolSet`.
+
+## Scope of THIS slice (the enforcement spine only)
+
+The control surface (HTTP + UI to set a policy) and the workspace-level default
+are deliberately **later slices**. This slice lands the mechanism and proves it
+with unit tests, defaulting to today's behavior (no restriction) so it's a pure
+no-op until a policy is actually set.
+
+- **Categories, not raw tool lists.** A coarse privacy category per tool
+  (`web` / `workspace` / `github` / `linear`, plus always-allowed `messaging`).
+  The owner picks categories, not a 33-tool checkbox.
+- **Per-stream storage on `e2e_streams`** (`allowed_tool_categories TEXT[]`,
+  NULL = no restriction). The dispatch worker already loads this row.
+- **Carried in `EnclaveSessionAssignment`** (`allowedToolCategories?`), omitted
+  when NULL.
+- **Enforced in `buildEnclaveTools`**: the enclave only has web tools today, so
+  in practice the gate is "web allowed?" — if not, the enclave runs with no web
+  tools and no research (pure model + `send_message`). `send_message` is never a
+  privacy category; the agent must always be able to reply.
+
+## As-built
+
+### `packages/types` (shared source of truth, INV-33)
+- New module `tool-privacy.ts`:
+  - `TOOL_PRIVACY_CATEGORIES` / `ToolPrivacyCategory` / `ToolPrivacyCategories`
+  - `TOOL_CATEGORY_BY_NAME: Record<AgentToolName, ToolPrivacyCategory>` —
+    exhaustive via `satisfies`, so a new tool fails to compile until categorized.
+  - `isToolCategoryAllowed(allowed, category)` — `null/undefined` ⇒ all allowed;
+    `messaging` is always allowed regardless of the list.
+  - `isToolAllowedByPolicy(allowed, toolName)` — convenience over the map.
+- `tool-privacy.test.ts` (`bun:test`): every tool name maps to a valid category;
+  helper semantics (null = all, `[]` = messaging-only, explicit subset).
+- `EnclaveSessionAssignment.allowedToolCategories?: ToolPrivacyCategory[]`.
+
+### `apps/backend`
+- Migration `…_e2e_stream_tool_policy.sql`: `ALTER TABLE e2e_streams ADD COLUMN
+  allowed_tool_categories TEXT[]` (INV-17 append-only, INV-3 TEXT[] not enum).
+- `E2eStreamsRepository`: read the column into `E2eStream.allowedToolCategories`
+  (`null` when unset). No writer in this slice (control surface is next).
+- `buildEnclaveSessionAssignment`: when `e2e.allowedToolCategories` is non-null,
+  copy it onto the assignment; otherwise omit (back-compat = unrestricted).
+
+### `apps/enclave`
+- `EnclaveToolDeps.allowedCategories?`; `buildEnclaveTools` returns `[]` when
+  `web` is not allowed (no web_search, no read_url, no general_research).
+- `run-turn` passes `request.allowedToolCategories` straight through.
+
+## Tests
+- `request-builder.test.ts`: policy present ⇒ assignment carries it; null ⇒
+  omitted.
+- enclave `tools.test.ts`: `["web"]`/undefined ⇒ web tools; `[]`/`["workspace"]`
+  ⇒ no tools.
+- `tool-privacy.test.ts`: map exhaustiveness + helper semantics.
+
+## Follow-up slices (NOT here)
+1. **Control surface**: `E2eStreamsRepository.setToolPolicy` + PATCH endpoint +
+   Zod validation + a privacy-tier picker in the scratchpad UI.
+2. **Workspace default**: a workspace-level default policy streams inherit when
+   their own is NULL.
+3. **Backend-persona adoption**: intersect the same category policy in
+   `buildToolSet` for non-E2E streams (needs a general per-stream policy store,
+   since non-E2E streams have no `e2e_streams` row).
+4. **Workspace search via S2**: once the UIK-signed capability lands, the
+   `workspace` category gates it here.

--- a/.claude/plans/e2e-tool-privacy-policy.md
+++ b/.claude/plans/e2e-tool-privacy-policy.md
@@ -22,9 +22,15 @@ are deliberately **later slices**. This slice lands the mechanism and proves it
 with unit tests, defaulting to today's behavior (no restriction) so it's a pure
 no-op until a policy is actually set.
 
-- **Categories, not raw tool lists.** A coarse privacy category per tool
+- **Categories, not raw tool lists.** Coarse privacy categories
   (`web` / `workspace` / `github` / `linear`, plus always-allowed `messaging`).
   The owner picks categories, not a 33-tool checkbox.
+- **Tools carry a *set* of categories, not one.** A tool is permitted when the
+  policy allows ANY of its categories. GitHub *reads* are public-web-class egress
+  (a structured `read_url`), so they carry both `github` and `web`: granting
+  `web` implicitly unlocks the richer GitHub context, while granting only
+  `github` does NOT grant raw web. Linear has no unauthenticated public surface,
+  so it stays `linear`-only. The asymmetry is deliberate.
 - **Per-stream storage on `e2e_streams`** (`allowed_tool_categories TEXT[]`,
   NULL = no restriction). The dispatch worker already loads this row.
 - **Carried in `EnclaveSessionAssignment`** (`allowedToolCategories?`), omitted
@@ -39,11 +45,13 @@ no-op until a policy is actually set.
 ### `packages/types` (shared source of truth, INV-33)
 - New module `tool-privacy.ts`:
   - `TOOL_PRIVACY_CATEGORIES` / `ToolPrivacyCategory` / `ToolPrivacyCategories`
-  - `TOOL_CATEGORY_BY_NAME: Record<AgentToolName, ToolPrivacyCategory>` —
-    exhaustive via `satisfies`, so a new tool fails to compile until categorized.
+  - `TOOL_CATEGORIES_BY_NAME: Record<AgentToolName, readonly ToolPrivacyCategory[]>`
+    — each tool carries a *set* of categories, exhaustive via `satisfies`, so a
+    new tool fails to compile until categorized.
   - `isToolCategoryAllowed(allowed, category)` — `null/undefined` ⇒ all allowed;
     `messaging` is always allowed regardless of the list.
-  - `isToolAllowedByPolicy(allowed, toolName)` — convenience over the map.
+  - `isToolAllowedByPolicy(allowed, toolName)` — allowed when the policy permits
+    ANY of the tool's categories (so `web` reaches GitHub reads).
 - `tool-privacy.test.ts` (`bun:test`): every tool name maps to a valid category;
   helper semantics (null = all, `[]` = messaging-only, explicit subset).
 - `EnclaveSessionAssignment.allowedToolCategories?: ToolPrivacyCategory[]`.

--- a/apps/backend/src/db/migrations/20260530171514_e2e_stream_tool_policy.sql
+++ b/apps/backend/src/db/migrations/20260530171514_e2e_stream_tool_policy.sql
@@ -1,0 +1,10 @@
+-- Per-stream agent tool-privacy policy for E2E scratchpads.
+--
+-- NULL means "no restriction" (all tool categories allowed) and is the default,
+-- so this column is a no-op until an owner sets a policy. A non-null array
+-- restricts the enclave agent to exactly the listed coarse categories
+-- (e.g. {'web'} = web egress but nothing else, {} = no tools at all); the
+-- 'messaging' reply tool is always allowed regardless. Validated in code, not by
+-- a DB enum (INV-3). The server stores only this coarse list, never plaintext.
+ALTER TABLE e2e_streams
+  ADD COLUMN allowed_tool_categories TEXT[];

--- a/apps/backend/src/features/e2e-streams/repository.test.ts
+++ b/apps/backend/src/features/e2e-streams/repository.test.ts
@@ -12,6 +12,7 @@ const ROW = {
   owner_user_id: "usr_1",
   owner_user_key_id: "e2ek_01",
   current_key_generation: 0,
+  allowed_tool_categories: ["web"],
 }
 
 interface Captured {
@@ -83,6 +84,7 @@ describe("E2eStreamsRepository.getByStreamId", () => {
       ownerUserId: "usr_1",
       ownerUserKeyId: "e2ek_01",
       currentKeyGeneration: 0,
+      allowedToolCategories: ["web"],
     })
   })
 

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -1,3 +1,4 @@
+import type { ToolPrivacyCategory } from "@threa/types"
 import type { Querier } from "../../db"
 import { sql } from "../../db"
 
@@ -8,6 +9,7 @@ interface E2eStreamRow {
   owner_user_id: string
   owner_user_key_id: string
   current_key_generation: number
+  allowed_tool_categories: string[] | null
 }
 
 export interface E2eStream {
@@ -18,6 +20,12 @@ export interface E2eStream {
   ownerUserKeyId: string
   /** SSK generation new messages currently seal under (0 for owner-only). */
   currentKeyGeneration: number
+  /**
+   * Tool-privacy policy: the tool categories the enclave agent may use in this
+   * stream. `null` = no restriction (default). Carried into the enclave session
+   * assignment and enforced there (the server never builds the tools itself).
+   */
+  allowedToolCategories: ToolPrivacyCategory[] | null
 }
 
 export interface MarkStreamE2eParams {
@@ -27,7 +35,8 @@ export interface MarkStreamE2eParams {
   ownerUserKeyId: string
 }
 
-const COLUMNS = "stream_id, workspace_id, enabled_at, owner_user_id, owner_user_key_id, current_key_generation"
+const COLUMNS =
+  "stream_id, workspace_id, enabled_at, owner_user_id, owner_user_key_id, current_key_generation, allowed_tool_categories"
 
 function mapRow(row: E2eStreamRow): E2eStream {
   return {
@@ -37,6 +46,7 @@ function mapRow(row: E2eStreamRow): E2eStream {
     ownerUserId: row.owner_user_id,
     ownerUserKeyId: row.owner_user_key_id,
     currentKeyGeneration: row.current_key_generation,
+    allowedToolCategories: (row.allowed_tool_categories as ToolPrivacyCategory[] | null) ?? null,
   }
 }
 

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -1,4 +1,4 @@
-import type { ToolPrivacyCategory } from "@threa/types"
+import type { ToolPrivacyPolicy } from "@threa/types"
 import type { Querier } from "../../db"
 import { sql } from "../../db"
 
@@ -25,7 +25,7 @@ export interface E2eStream {
    * stream. `null` = no restriction (default). Carried into the enclave session
    * assignment and enforced there (the server never builds the tools itself).
    */
-  allowedToolCategories: ToolPrivacyCategory[] | null
+  allowedToolCategories: ToolPrivacyPolicy
 }
 
 export interface MarkStreamE2eParams {
@@ -46,7 +46,7 @@ function mapRow(row: E2eStreamRow): E2eStream {
     ownerUserId: row.owner_user_id,
     ownerUserKeyId: row.owner_user_key_id,
     currentKeyGeneration: row.current_key_generation,
-    allowedToolCategories: (row.allowed_tool_categories as ToolPrivacyCategory[] | null) ?? null,
+    allowedToolCategories: (row.allowed_tool_categories as ToolPrivacyPolicy) ?? null,
   }
 }
 

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -11,6 +11,7 @@ const E2E: E2eStream = {
   ownerUserId: "usr_owner",
   ownerUserKeyId: "e2ek_owner",
   currentKeyGeneration: 1,
+  allowedToolCategories: null,
 }
 
 const ENCLAVE_ACTOR: E2eStreamActor = { kind: "enclave", actorId: "enclave", keyId: null }
@@ -134,5 +135,20 @@ describe("buildEnclaveSessionAssignment", () => {
       })
     )
     expect(built!.assignment.history.map((h) => h.role)).toEqual(["user", "assistant"]) // plaintext dropped
+  })
+
+  it("omits allowedToolCategories when the stream has no policy (unrestricted)", () => {
+    const built = buildEnclaveSessionAssignment(inputs())
+    expect(built!.assignment).not.toHaveProperty("allowedToolCategories")
+  })
+
+  it("carries the stream's tool-privacy policy onto the assignment", () => {
+    const built = buildEnclaveSessionAssignment(inputs({ e2e: { ...E2E, allowedToolCategories: ["web"] } }))
+    expect(built!.assignment.allowedToolCategories).toEqual(["web"])
+  })
+
+  it("ships an empty policy verbatim (no tools at all)", () => {
+    const built = buildEnclaveSessionAssignment(inputs({ e2e: { ...E2E, allowedToolCategories: [] } }))
+    expect(built!.assignment.allowedToolCategories).toEqual([])
   })
 })

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -92,6 +92,10 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     model: persona.model.replace(/^openrouter:/, ""),
     ...(persona.temperature !== null ? { temperature: persona.temperature } : {}),
     ...(persona.maxTokens !== null ? { maxTokens: persona.maxTokens } : {}),
+    // Per-stream tool-privacy policy: ship it so the enclave gates its tools.
+    // NULL = unrestricted → omit the field (the enclave then builds its full
+    // web surface, today's behavior).
+    ...(e2e.allowedToolCategories ? { allowedToolCategories: e2e.allowedToolCategories } : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
   }
 

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -146,6 +146,9 @@ export async function runEnclaveTurn(
       tavilyApiKey: tools?.tavilyApiKey,
       currentTime: tools?.currentTime,
       timezone: tools?.timezone,
+      // Per-stream policy travels on the assignment, not in `deps.tools` (which
+      // is the enclave's own capability config, e.g. whether it has a Tavily key).
+      allowedCategories: request.allowedToolCategories,
     }),
     observers: [traceObserver],
     maxTokens: request.maxTokens,

--- a/apps/enclave/src/agent/tools.test.ts
+++ b/apps/enclave/src/agent/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { AgentRuntimeAI } from "@threa/agent-runtime/runtime"
+import type { ToolPrivacyCategory } from "@threa/types"
 import type { LanguageModel } from "ai"
 import { buildEnclaveTools } from "./tools"
 
@@ -8,8 +9,14 @@ const ai = {
 } as AgentRuntimeAI
 const model = {} as LanguageModel
 
-function toolNames(tavilyApiKey?: string): string[] {
-  return buildEnclaveTools({ ai, model, modelString: "anthropic/claude-sonnet-4.6", tavilyApiKey }).map((t) => t.name)
+function toolNames(tavilyApiKey?: string, allowedCategories?: ToolPrivacyCategory[]): string[] {
+  return buildEnclaveTools({
+    ai,
+    model,
+    modelString: "anthropic/claude-sonnet-4.6",
+    tavilyApiKey,
+    allowedCategories,
+  }).map((t) => t.name)
 }
 
 describe("buildEnclaveTools", () => {
@@ -19,5 +26,16 @@ describe("buildEnclaveTools", () => {
 
   it("omits web_search but keeps read_url + general_research without a Tavily key", () => {
     expect(new Set(toolNames(undefined))).toEqual(new Set(["read_url", "general_research"]))
+  })
+
+  it("builds the full web surface when the policy allows web", () => {
+    expect(new Set(toolNames("tvly-test", ["web"]))).toEqual(new Set(["web_search", "read_url", "general_research"]))
+  })
+
+  it("builds no tools when the policy forbids web (every enclave tool is web egress)", () => {
+    // Empty policy → no tools at all; a workspace-only policy → still no tools,
+    // since the enclave has no workspace tools to offer yet.
+    expect(toolNames("tvly-test", [])).toEqual([])
+    expect(toolNames("tvly-test", ["workspace"])).toEqual([])
   })
 })

--- a/apps/enclave/src/agent/tools.ts
+++ b/apps/enclave/src/agent/tools.ts
@@ -6,6 +6,7 @@ import {
   type AgentTool,
 } from "@threa/agent-runtime/runtime"
 import type { AgentRuntimeAI } from "@threa/agent-runtime/runtime"
+import { isToolCategoryAllowed, type ToolPrivacyCategory } from "@threa/types"
 import type { LanguageModel } from "ai"
 
 /**
@@ -33,9 +34,21 @@ export interface EnclaveToolDeps {
   /** Invocation time, used to ground recency-sensitive web searches. */
   currentTime?: string
   timezone?: string
+  /**
+   * Per-stream tool-privacy policy from the session assignment. `undefined` = no
+   * restriction (full surface). Every tool the enclave builds is in the `web`
+   * category, so when `web` is not allowed the enclave runs with no tools at all
+   * — a pure model turn that can still reply (`send_message` is never gated).
+   */
+  allowedCategories?: ToolPrivacyCategory[]
 }
 
 export function buildEnclaveTools(deps: EnclaveToolDeps): AgentTool[] {
+  // The owner's policy may forbid web egress for this scratchpad. Since the
+  // enclave's entire surface (web_search, read_url, general_research) is web,
+  // that collapses to "no tools" — honest about the privacy the stream keeps.
+  if (!isToolCategoryAllowed(deps.allowedCategories, "web")) return []
+
   // The web primitives, built fresh on demand. The top-level loop and the
   // research sub-loop each get their OWN instances (the sub-loop runs the same
   // tool defs under a separate AgentRuntime), so this is a factory, not a shared

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -36,6 +36,7 @@ import type {
 } from "./domain"
 import type { UserPreferences } from "./preferences"
 import type { SidebarConfig } from "./sidebar"
+import type { ToolPrivacyCategory } from "./tool-privacy"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
 
 // ============================================================================
@@ -493,6 +494,14 @@ export interface EnclaveSessionAssignment {
   temperature?: number
   maxTokens?: number
   reply: { keyGeneration: number; senderId: string }
+  /**
+   * Per-stream tool-privacy policy: the tool categories the enclave may use this
+   * turn. Omitted means no restriction (today's behavior). Present (even `[]`)
+   * restricts the agent to exactly those categories — the enclave currently only
+   * builds web tools, so in practice this gates whether web egress is allowed at
+   * all. `messaging` (replies) is always allowed regardless.
+   */
+  allowedToolCategories?: ToolPrivacyCategory[]
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -326,6 +326,14 @@ export type { BroadcastSlug } from "./slug"
 // Attachment categories (mime → category mapping for the attachment explorer)
 export { ATTACHMENT_CATEGORIES, categoryFromMime, mimePrefixesForCategory } from "./attachment-categories"
 export type { AttachmentCategory } from "./attachment-categories"
+export {
+  TOOL_PRIVACY_CATEGORIES,
+  ToolPrivacyCategories,
+  TOOL_CATEGORY_BY_NAME,
+  isToolCategoryAllowed,
+  isToolAllowedByPolicy,
+} from "./tool-privacy"
+export type { ToolPrivacyCategory, ToolPrivacyPolicy } from "./tool-privacy"
 
 // API types
 export type {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -329,7 +329,7 @@ export type { AttachmentCategory } from "./attachment-categories"
 export {
   TOOL_PRIVACY_CATEGORIES,
   ToolPrivacyCategories,
-  TOOL_CATEGORY_BY_NAME,
+  TOOL_CATEGORIES_BY_NAME,
   isToolCategoryAllowed,
   isToolAllowedByPolicy,
 } from "./tool-privacy"

--- a/packages/types/src/tool-privacy.test.ts
+++ b/packages/types/src/tool-privacy.test.ts
@@ -1,23 +1,41 @@
 import { describe, test, expect } from "bun:test"
 import { AGENT_TOOL_NAMES } from "./constants"
 import {
-  TOOL_CATEGORY_BY_NAME,
+  TOOL_CATEGORIES_BY_NAME,
   TOOL_PRIVACY_CATEGORIES,
+  type ToolPrivacyCategory,
   isToolAllowedByPolicy,
   isToolCategoryAllowed,
 } from "./tool-privacy"
 
-describe("TOOL_CATEGORY_BY_NAME", () => {
-  test("maps every agent tool to a valid category", () => {
+/** Widen the `as const` tuple so `.toContain` on an arbitrary category typechecks. */
+function categoriesOf(name: keyof typeof TOOL_CATEGORIES_BY_NAME): readonly ToolPrivacyCategory[] {
+  return TOOL_CATEGORIES_BY_NAME[name]
+}
+
+describe("TOOL_CATEGORIES_BY_NAME", () => {
+  test("maps every agent tool to a non-empty set of valid categories", () => {
     for (const name of AGENT_TOOL_NAMES) {
-      const category = TOOL_CATEGORY_BY_NAME[name]
-      expect(TOOL_PRIVACY_CATEGORIES).toContain(category)
+      const categories = categoriesOf(name)
+      expect(categories.length).toBeGreaterThan(0)
+      for (const category of categories) expect(TOOL_PRIVACY_CATEGORIES).toContain(category)
     }
   })
 
-  test("send_message is the only messaging tool", () => {
-    const messaging = AGENT_TOOL_NAMES.filter((n) => TOOL_CATEGORY_BY_NAME[n] === "messaging")
+  test("send_message is the only messaging tool, and messaging never mixes with other categories", () => {
+    const messaging = AGENT_TOOL_NAMES.filter((n) => categoriesOf(n).includes("messaging"))
     expect(messaging).toEqual(["send_message"])
+    expect(categoriesOf("send_message")).toEqual(["messaging"])
+  })
+
+  test("GitHub reads ride the web grant; Linear stays auth-locked", () => {
+    const github = AGENT_TOOL_NAMES.filter((n) => categoriesOf(n).includes("github"))
+    expect(github.length).toBeGreaterThan(0)
+    for (const name of github) expect(categoriesOf(name)).toContain("web")
+
+    const linear = AGENT_TOOL_NAMES.filter((n) => categoriesOf(n).includes("linear"))
+    expect(linear.length).toBeGreaterThan(0)
+    for (const name of linear) expect(categoriesOf(name)).not.toContain("web")
   })
 })
 
@@ -46,9 +64,16 @@ describe("isToolAllowedByPolicy", () => {
     expect(isToolAllowedByPolicy([], "general_research")).toBe(false)
   })
 
-  test("a web-only policy gates workspace and github tools", () => {
+  test("a web policy reaches GitHub reads (shared category) but not raw github/linear/workspace", () => {
     expect(isToolAllowedByPolicy(["web"], "read_url")).toBe(true)
-    expect(isToolAllowedByPolicy(["web"], "search_messages")).toBe(false)
-    expect(isToolAllowedByPolicy(["web"], "github_get_issue")).toBe(false)
+    expect(isToolAllowedByPolicy(["web"], "github_get_issue")).toBe(true) // github read rides web
+    expect(isToolAllowedByPolicy(["web"], "linear_get_issue")).toBe(false) // linear is auth-locked
+    expect(isToolAllowedByPolicy(["web"], "search_messages")).toBe(false) // workspace is private
+  })
+
+  test("a github-only policy does NOT grant raw web (the asymmetry)", () => {
+    expect(isToolAllowedByPolicy(["github"], "github_get_issue")).toBe(true)
+    expect(isToolAllowedByPolicy(["github"], "web_search")).toBe(false)
+    expect(isToolAllowedByPolicy(["github"], "read_url")).toBe(false)
   })
 })

--- a/packages/types/src/tool-privacy.test.ts
+++ b/packages/types/src/tool-privacy.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "bun:test"
+import { AGENT_TOOL_NAMES } from "./constants"
+import {
+  TOOL_CATEGORY_BY_NAME,
+  TOOL_PRIVACY_CATEGORIES,
+  isToolAllowedByPolicy,
+  isToolCategoryAllowed,
+} from "./tool-privacy"
+
+describe("TOOL_CATEGORY_BY_NAME", () => {
+  test("maps every agent tool to a valid category", () => {
+    for (const name of AGENT_TOOL_NAMES) {
+      const category = TOOL_CATEGORY_BY_NAME[name]
+      expect(TOOL_PRIVACY_CATEGORIES).toContain(category)
+    }
+  })
+
+  test("send_message is the only messaging tool", () => {
+    const messaging = AGENT_TOOL_NAMES.filter((n) => TOOL_CATEGORY_BY_NAME[n] === "messaging")
+    expect(messaging).toEqual(["send_message"])
+  })
+})
+
+describe("isToolCategoryAllowed", () => {
+  test("null/undefined policy allows every category (default = unrestricted)", () => {
+    expect(isToolCategoryAllowed(null, "web")).toBe(true)
+    expect(isToolCategoryAllowed(undefined, "workspace")).toBe(true)
+  })
+
+  test("messaging is always allowed, even under an empty policy", () => {
+    expect(isToolCategoryAllowed([], "messaging")).toBe(true)
+    expect(isToolCategoryAllowed(["workspace"], "messaging")).toBe(true)
+  })
+
+  test("an explicit policy allows only its listed categories", () => {
+    expect(isToolCategoryAllowed(["web"], "web")).toBe(true)
+    expect(isToolCategoryAllowed(["web"], "workspace")).toBe(false)
+    expect(isToolCategoryAllowed([], "web")).toBe(false)
+  })
+})
+
+describe("isToolAllowedByPolicy", () => {
+  test("send_message survives the strictest policy; web tools do not", () => {
+    expect(isToolAllowedByPolicy([], "send_message")).toBe(true)
+    expect(isToolAllowedByPolicy([], "web_search")).toBe(false)
+    expect(isToolAllowedByPolicy([], "general_research")).toBe(false)
+  })
+
+  test("a web-only policy gates workspace and github tools", () => {
+    expect(isToolAllowedByPolicy(["web"], "read_url")).toBe(true)
+    expect(isToolAllowedByPolicy(["web"], "search_messages")).toBe(false)
+    expect(isToolAllowedByPolicy(["web"], "github_get_issue")).toBe(false)
+  })
+})

--- a/packages/types/src/tool-privacy.ts
+++ b/packages/types/src/tool-privacy.ts
@@ -1,4 +1,4 @@
-import { AGENT_TOOL_NAMES, type AgentToolName } from "./constants"
+import type { AgentToolName } from "./constants"
 
 /**
  * Coarse privacy categories an agent's tools fall into, used to express a
@@ -95,6 +95,3 @@ export function isToolAllowedByPolicy(
 ): boolean {
   return isToolCategoryAllowed(allowed, TOOL_CATEGORY_BY_NAME[toolName])
 }
-
-/** Re-exported for callers that want to iterate the full tool surface by category. */
-export { AGENT_TOOL_NAMES }

--- a/packages/types/src/tool-privacy.ts
+++ b/packages/types/src/tool-privacy.ts
@@ -27,50 +27,64 @@ export const ToolPrivacyCategories = {
 } as const satisfies Record<string, ToolPrivacyCategory>
 
 /**
- * Every agent tool's privacy category. Exhaustive via `satisfies` over
- * `AgentToolName`: a newly added tool fails to compile here until it is
- * categorized, so the privacy gate can never silently miss a tool.
+ * Every agent tool's privacy categories. A tool is *one of some* categories, not
+ * exactly one: a policy allowing ANY of a tool's categories permits the tool
+ * (see `isToolAllowedByPolicy`).
+ *
+ * This is what lets `web` subsume GitHub *reads*: a public GitHub read is a
+ * better-structured `read_url` against data already reachable over the open web,
+ * so the GitHub read tools carry both `github` and `web`. Granting `web` then
+ * implicitly grants the richer GitHub context, while granting only `github` does
+ * NOT grant raw web — the asymmetry is deliberate. Linear has no public,
+ * unauthenticated surface, so its tools stay `linear`-only.
+ *
+ * Exhaustive via `satisfies` over `AgentToolName`: a newly added tool fails to
+ * compile here until it is categorized, so the privacy gate can never silently
+ * miss a tool.
  */
-export const TOOL_CATEGORY_BY_NAME = {
-  send_message: "messaging",
+export const TOOL_CATEGORIES_BY_NAME = {
+  send_message: ["messaging"],
 
-  web_search: "web",
-  read_url: "web",
-  general_research: "web",
+  web_search: ["web"],
+  read_url: ["web"],
+  general_research: ["web"],
 
-  search_messages: "workspace",
-  search_streams: "workspace",
-  search_users: "workspace",
-  get_stream_messages: "workspace",
-  search_attachments: "workspace",
-  get_attachment: "workspace",
-  load_attachment: "workspace",
-  load_pdf_section: "workspace",
-  load_file_section: "workspace",
-  load_excel_section: "workspace",
-  describe_memo: "workspace",
+  search_messages: ["workspace"],
+  search_streams: ["workspace"],
+  search_users: ["workspace"],
+  get_stream_messages: ["workspace"],
+  search_attachments: ["workspace"],
+  get_attachment: ["workspace"],
+  load_attachment: ["workspace"],
+  load_pdf_section: ["workspace"],
+  load_file_section: ["workspace"],
+  load_excel_section: ["workspace"],
+  describe_memo: ["workspace"],
 
-  github_list_repos: "github",
-  github_list_branches: "github",
-  github_list_commits: "github",
-  github_get_commit: "github",
-  github_list_pull_requests: "github",
-  github_get_pull_request: "github",
-  github_list_pr_files: "github",
-  github_get_file_contents: "github",
-  github_search_code: "github",
-  github_list_workflow_runs: "github",
-  github_get_workflow_run: "github",
-  github_list_releases: "github",
-  github_get_release: "github",
-  github_search_issues: "github",
-  github_get_issue: "github",
+  // GitHub reads are public-web-class egress (a structured read_url), so they
+  // ride the `web` grant as well as `github`.
+  github_list_repos: ["github", "web"],
+  github_list_branches: ["github", "web"],
+  github_list_commits: ["github", "web"],
+  github_get_commit: ["github", "web"],
+  github_list_pull_requests: ["github", "web"],
+  github_get_pull_request: ["github", "web"],
+  github_list_pr_files: ["github", "web"],
+  github_get_file_contents: ["github", "web"],
+  github_search_code: ["github", "web"],
+  github_list_workflow_runs: ["github", "web"],
+  github_get_workflow_run: ["github", "web"],
+  github_list_releases: ["github", "web"],
+  github_get_release: ["github", "web"],
+  github_search_issues: ["github", "web"],
+  github_get_issue: ["github", "web"],
 
-  linear_list_issues: "linear",
-  linear_get_issue: "linear",
-  linear_list_projects: "linear",
-  linear_get_project: "linear",
-} as const satisfies Record<AgentToolName, ToolPrivacyCategory>
+  // Linear has no unauthenticated public surface — it never rides `web`.
+  linear_list_issues: ["linear"],
+  linear_get_issue: ["linear"],
+  linear_list_projects: ["linear"],
+  linear_get_project: ["linear"],
+} as const satisfies Record<AgentToolName, readonly ToolPrivacyCategory[]>
 
 /**
  * A tool-privacy policy is the set of allowed categories. `null`/`undefined`
@@ -89,9 +103,18 @@ export function isToolCategoryAllowed(
   return allowed.includes(category)
 }
 
+/**
+ * A tool is permitted when the policy allows ANY of its categories — so a
+ * `web`-only policy still reaches the GitHub read tools (tagged `github` + `web`)
+ * without granting raw `github`/`linear` access. `messaging` is always allowed;
+ * a `null`/`undefined` policy allows everything.
+ */
 export function isToolAllowedByPolicy(
   allowed: ToolPrivacyCategory[] | null | undefined,
   toolName: AgentToolName
 ): boolean {
-  return isToolCategoryAllowed(allowed, TOOL_CATEGORY_BY_NAME[toolName])
+  const categories: readonly ToolPrivacyCategory[] = TOOL_CATEGORIES_BY_NAME[toolName]
+  if (categories.includes("messaging")) return true
+  if (allowed === null || allowed === undefined) return true
+  return categories.some((category) => allowed.includes(category))
 }

--- a/packages/types/src/tool-privacy.ts
+++ b/packages/types/src/tool-privacy.ts
@@ -1,0 +1,100 @@
+import { AGENT_TOOL_NAMES, type AgentToolName } from "./constants"
+
+/**
+ * Coarse privacy categories an agent's tools fall into, used to express a
+ * per-stream (and, later, per-workspace) tool-privacy policy that is honest
+ * about what a scratchpad gives up: "no tools at all", "web but nothing else",
+ * "workspace reads but no web egress", and so on.
+ *
+ * The owner picks categories, not a 30-tool checkbox. `messaging` (the agent's
+ * own reply tool) is never gated — an agent must always be able to answer — so
+ * it is a category for completeness but is always allowed regardless of policy.
+ */
+export const TOOL_PRIVACY_CATEGORIES = ["messaging", "web", "workspace", "github", "linear"] as const
+export type ToolPrivacyCategory = (typeof TOOL_PRIVACY_CATEGORIES)[number]
+
+export const ToolPrivacyCategories = {
+  /** The agent's own reply tool (`send_message`). Always allowed. */
+  MESSAGING: "messaging",
+  /** External web egress: web_search (Tavily), read_url (fetch), general_research. */
+  WEB: "web",
+  /** Threa workspace reads: message/stream/user search, attachments, memos. */
+  WORKSPACE: "workspace",
+  /** GitHub integration reads. */
+  GITHUB: "github",
+  /** Linear integration reads. */
+  LINEAR: "linear",
+} as const satisfies Record<string, ToolPrivacyCategory>
+
+/**
+ * Every agent tool's privacy category. Exhaustive via `satisfies` over
+ * `AgentToolName`: a newly added tool fails to compile here until it is
+ * categorized, so the privacy gate can never silently miss a tool.
+ */
+export const TOOL_CATEGORY_BY_NAME = {
+  send_message: "messaging",
+
+  web_search: "web",
+  read_url: "web",
+  general_research: "web",
+
+  search_messages: "workspace",
+  search_streams: "workspace",
+  search_users: "workspace",
+  get_stream_messages: "workspace",
+  search_attachments: "workspace",
+  get_attachment: "workspace",
+  load_attachment: "workspace",
+  load_pdf_section: "workspace",
+  load_file_section: "workspace",
+  load_excel_section: "workspace",
+  describe_memo: "workspace",
+
+  github_list_repos: "github",
+  github_list_branches: "github",
+  github_list_commits: "github",
+  github_get_commit: "github",
+  github_list_pull_requests: "github",
+  github_get_pull_request: "github",
+  github_list_pr_files: "github",
+  github_get_file_contents: "github",
+  github_search_code: "github",
+  github_list_workflow_runs: "github",
+  github_get_workflow_run: "github",
+  github_list_releases: "github",
+  github_get_release: "github",
+  github_search_issues: "github",
+  github_get_issue: "github",
+
+  linear_list_issues: "linear",
+  linear_get_issue: "linear",
+  linear_list_projects: "linear",
+  linear_get_project: "linear",
+} as const satisfies Record<AgentToolName, ToolPrivacyCategory>
+
+/**
+ * A tool-privacy policy is the set of allowed categories. `null`/`undefined`
+ * means "no restriction" (the default, matching today's behavior); an array
+ * restricts the agent to exactly those categories. `messaging` is always
+ * allowed regardless — replies are not a privacy decision.
+ */
+export type ToolPrivacyPolicy = ToolPrivacyCategory[] | null
+
+export function isToolCategoryAllowed(
+  allowed: ToolPrivacyCategory[] | null | undefined,
+  category: ToolPrivacyCategory
+): boolean {
+  if (category === "messaging") return true
+  if (allowed === null || allowed === undefined) return true
+  return allowed.includes(category)
+}
+
+export function isToolAllowedByPolicy(
+  allowed: ToolPrivacyCategory[] | null | undefined,
+  toolName: AgentToolName
+): boolean {
+  return isToolCategoryAllowed(allowed, TOOL_CATEGORY_BY_NAME[toolName])
+}
+
+/** Re-exported for callers that want to iterate the full tool surface by category. */
+export { AGENT_TOOL_NAMES }


### PR DESCRIPTION
## What

Lays the **enforcement spine** for a per-stream tool-privacy policy on E2E scratchpads: an owner can decide which *categories* of tools Ariadne may use inside a given encrypted scratchpad — "no tools at all", "web but nothing else", and (later) "workspace reads but no web egress". Honest about the privacy a scratchpad keeps, configurable per stream.

This slice is the mechanism only. It defaults to today's behavior (no restriction) and is a **no-op in production** until the control surface lands (see follow-ups), so it's safe to merge ahead of the UI.

## Why

Tool access was gated only at the **persona** level (`enabledTools`), which is global to the persona, not per-stream. The enclave also builds its *own* tool set (`buildEnclaveTools`) from the session assignment, so any per-stream policy has to be **carried in the assignment** and enforced inside the enclave — not just in the backend's `buildToolSet`.

## How it flows, end to end

- **`packages/types/src/tool-privacy.ts`** — the shared source of truth (INV-33): `ToolPrivacyCategory` (`messaging` / `web` / `workspace` / `github` / `linear`), an exhaustive `TOOL_CATEGORY_BY_NAME` map (a new tool fails to compile until it's categorized, so the gate can never silently miss one), and `isToolCategoryAllowed` / `isToolAllowedByPolicy`. `messaging` (replies) is never gated.
- **Migration** — `e2e_streams.allowed_tool_categories TEXT[]`, `NULL` = unrestricted (INV-3 TEXT[] not enum, INV-17 append-only). Server stores only the coarse category list, never plaintext.
- **`E2eStreamsRepository`** reads the column into `E2eStream.allowedToolCategories` (typed `ToolPrivacyPolicy`).
- **`buildEnclaveSessionAssignment`** copies a non-null policy onto the assignment; `NULL` → field omitted (full surface, today's behavior).
- **`EnclaveSessionAssignment.allowedToolCategories?`** carries it to the enclave.
- **`buildEnclaveTools`** returns `[]` when `web` isn't allowed — every tool the enclave builds today (`web_search`, `read_url`, `general_research`) is web egress, so a no-web policy collapses cleanly to a pure-model turn that can still reply.

## Tests

- `tool-privacy.test.ts` — map exhaustiveness + helper semantics (null = unrestricted, `[]` = messaging-only, explicit subset).
- `request-builder.test.ts` — policy present ⇒ assignment carries it; `[]` shipped verbatim; `null` ⇒ omitted.
- enclave `tools.test.ts` — `["web"]`/undefined ⇒ web tools; `[]`/`["workspace"]` ⇒ no tools.
- `e2e-streams/repository.test.ts` — snake→camel mapping of the new column.

Full 28-test run green; full monorepo typecheck + lint clean.

## Deliberately deferred (follow-up slices)

1. **Control surface** — `setToolPolicy` repo method + PATCH endpoint + Zod validation + a privacy-tier picker in the scratchpad UI.
2. **Workspace-level default** that streams inherit when their own policy is `NULL`.
3. **Backend-persona adoption** — intersect the same category policy in `buildToolSet` for non-E2E streams (needs a general per-stream policy store).
4. **`workspace` category** gating once the UIK-signed workspace-search capability lands.

Plan: `.claude/plans/e2e-tool-privacy-policy.md`

https://claude.ai/code/session_01U24CNMnpvpPeWpJ2YkxDdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U24CNMnpvpPeWpJ2YkxDdA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782768615&installation_id=129946197&pr_number=711&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F711&signature=f0df3c19b0567c93ccac990e3bfadc6f5306f776ec6ba7b9bcab8640e0e491a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->