### PR TITLE
perf(boot): render IDB-cached content without blocking on hydration or nagging a sync spinner

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -440,6 +440,33 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("stream-state").textContent).toBe("loading")
   })
 
+  it("keeps the topbar indicator dark for the initial background sync that overlaps the first reveal", async () => {
+    // Offline-first: a returning user reveals from IDB while the very first
+    // workspace bootstrap is still syncing in the background. That initial sync
+    // is a refresh of already-visible content, not a load, so the topbar
+    // indicator must stay dark — surfacing it made online feel slower than
+    // offline, which never syncs and so never shows it.
+    makeReadyWorkspaceState()
+    mockSyncStatuses = new Map([["workspace:workspace_1", "syncing"]])
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+    // Revealed from IDB despite the in-flight sync...
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+
+    // ...and the indicator stays off even past the reveal delay.
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("show-loading-indicator").textContent).toBe("false")
+  })
+
   it("shows the delayed topbar indicator while reconnect sync is in progress after initial load", async () => {
     makeReadyWorkspaceState()
 

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -98,6 +98,21 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   const loadingIndicatorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hideIndicatorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loggedSuppressedStreamErrorsRef = useRef(new Set<string>())
+  // The first bootstrap after an IDB reveal still reports "syncing" — but that
+  // is a background refresh of already-visible content, not a load. Surfacing
+  // it on the topbar indicator made online feel slower than offline (which
+  // never syncs, so never shows it). We only treat "syncing" as indicator-worthy
+  // once that initial sync has gone quiet, so a later reconnect resync still
+  // surfaces while the initial freshness pass stays silent.
+  //
+  // This is a one-way latch (false → true, never back), which is the whole
+  // point: it must STAY true across the `isAnySyncing` false→true transition a
+  // reconnect causes, so the reconnect indicator can fire. A plain
+  // `!isAnySyncing` check inline would instead suppress the reconnect indicator
+  // too (`!isAnySyncing && isAnySyncing` is always false). Reading it in render
+  // is safe precisely because it's monotone — the render that needs the latched
+  // value is driven by the reactive `isAnySyncing` flip, not by the ref write.
+  const hasSettledInitialSyncRef = useRef(false)
 
   // Prime the in-memory cache from IndexedDB on mount. If IDB has workspace
   // data from a previous session, this populates the cache so store hooks
@@ -213,7 +228,11 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   // (triggered by navigating to a new stream) should not re-trigger the
   // top-bar loading indicator. Individual stream loading is handled by
   // EventList's skeleton/loading state within the stream content area.
-  const isLoading = workspaceLoading || (!isReady && streamsLoading) || draftsLoading || (isReady && isAnySyncing)
+  const isLoading =
+    workspaceLoading ||
+    (!isReady && streamsLoading) ||
+    draftsLoading ||
+    (isReady && hasSettledInitialSyncRef.current && isAnySyncing)
 
   if (isBootstrapDebugEnabled()) {
     debugBootstrap("Coordinated loading state", {
@@ -283,6 +302,14 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       setIsReady(true)
     }
   }, [isLoading, revealReady])
+
+  // Once the content is revealed AND the initial background sync has gone quiet,
+  // any future "syncing" is a reconnect resync — that one is worth surfacing on
+  // the topbar indicator (see `isLoading`). The initial freshness pass that
+  // overlaps the first reveal is deliberately excluded so it stays silent.
+  useEffect(() => {
+    if (isReady && !isAnySyncing) hasSettledInitialSyncRef.current = true
+  }, [isReady, isAnySyncing])
 
   // Show skeleton after delay if still loading during initial load
   useEffect(() => {

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -70,6 +70,13 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
 
       const s = io(wsUrl, {
         path: "/socket.io/",
+        // Prefer a direct WebSocket so the socket skips Engine.IO's HTTP
+        // long-polling handshake (several round-trips before it upgrades). On a
+        // cold boot the workspace/stream bootstrap is gated on the socket
+        // connecting (SyncEngine.onConnect → subscribe-then-fetch), so a faster
+        // connect directly shortens time-to-fresh-data. Polling stays as a
+        // fallback for networks that block raw WebSocket.
+        transports: ["websocket", "polling"],
         withCredentials: true,
         autoConnect: true,
       })

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -48,35 +48,22 @@ if ("serviceWorker" in navigator) {
   })
 }
 
-// Bulk-load persisted markdown-block + link-preview collapse state into the
-// in-memory mirror before mounting React. Synchronous consumers
-// (`useBlockCollapse`, `useLinkPreviewCollapse`) see the persisted choices on
-// their first render, eliminating the post-mount resize cascade that Virtuoso
-// otherwise compensates for by shifting sibling rows.
-//
-// We race hydration against a deadline: when IDB is healthy (the common case,
-// ~5–20ms) the await returns almost immediately; the deadline only fires when
-// `db.open()` itself is slow — cold-boot schema migrations, a contended IDB
-// connection, or a multi-thousand-row collapse table. 500ms is the headroom
-// we need to clear those cases without bailing too early; the previous 100ms
-// cap was tight enough that returning users with large collapse tables would
-// mount with an empty cache and then flip a previously-expanded long code
-// block from its default collapsed clamp to fully expanded once the persisted
-// override landed on the next render — the "mega jump" reported in prod.
-// At the deadline we mount with whatever the cache holds; `hydrateCollapseCache`
-// keeps running and `notify()` still wakes subscribers, so the cache heals
-// even if the deadline fired.
-const HYDRATION_CAP_MS = 500
+// Migrate persisted markdown-block + link-preview collapse state from the
+// legacy IndexedDB tables into the in-memory mirror — but do NOT block first
+// paint on it. The synchronous localStorage hydrate at collapse-cache import
+// time already populates the cache for anyone who has toggled a block before,
+// so the common case needs nothing from this call. `hydrateCollapseCache()`
+// only does real work — a cold `db.open()` + table read — for users whose
+// state predates the localStorage mirror, and awaiting that put an IndexedDB
+// open on the critical path ahead of first paint (including the IDB-cached
+// content render) for no benefit. It calls `notify()` when it resolves, so
+// `useSyncExternalStore` consumers re-render and collapse state heals a few ms
+// after paint for that shrinking legacy cohort, instead of stalling every
+// boot's first paint behind it.
+void hydrateCollapseCache()
 
-const waitMs = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
-async function bootstrap() {
-  await Promise.race([hydrateCollapseCache(), waitMs(HYDRATION_CAP_MS)])
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <App />
-    </StrictMode>
-  )
-}
-
-void bootstrap()
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)


### PR DESCRIPTION
## Why

Investigating slow/inconsistent app boots. The offline-first contract is *render from IndexedDB immediately, never block first paint on the network; subscribe-then-fetch runs in parallel*. Live tracing on prod (Playwright + the in-app `debugBootstrap` log) showed the IDB-first reveal **does** fire and is **not** network-gated — content revealed at ~717ms with `workspaceSyncStatus: "syncing"` still in flight. But two things made the online boot feel worse than offline, plus the socket sat on a slow handshake. This PR fixes those three, all **without touching the sync ordering**.

## What changed

**1. `main.tsx` — stop blocking first paint on collapse-cache hydration.**
The boot awaited `hydrateCollapseCache()` (500ms-capped) before `createRoot().render()`. But `hydrateFromLocalStorageSync()` already populates the collapse cache *synchronously at module import*, so the awaited call only does real work — a cold `db.open()` + table read — for the legacy IDB-migration cohort. Awaiting it put an IndexedDB open on the critical path ahead of first paint (including the IDB-cached content render) for no benefit. Now fire-and-forget; `notify()` heals the legacy cohort a few ms post-paint.

**2. `coordinated-loading-context.tsx` — don't present the initial background sync as a boot spinner.**
The topbar loading indicator's `isLoading` included `(isReady && isAnySyncing)`, so after revealing cached content it stayed lit for the whole initial sync. Since `isAnySyncing` is only ever true online (offline never syncs), this is literally why online felt slower than offline — a spinner over already-visible content, lasting as long as the (socket-gated) bootstrap. Now the initial freshness pass stays silent; a later **reconnect** resync still surfaces, gated by a one-way `hasSettledInitialSyncRef` latch.

**3. `socket-context.tsx` — prefer a direct WebSocket.**
`transports: ["websocket", "polling"]` skips Engine.IO's polling-first handshake (several round-trips before upgrade). On a cold boot the workspace/stream bootstrap is gated on the socket connecting (`SyncEngine.onConnect` → subscribe-then-fetch), so a faster connect shortens time-to-fresh-data. Polling stays as a fallback for networks that block raw WebSocket.

## INV-53 (subscribe-then-fetch) is untouched
None of these change sync ordering. #1 is paint timing, #2 is indicator presentation, #3 is transport. `reconnectCount` still increments on reconnect, so re-bootstrap consumers are intact.

## Tests
- New regression test: cached content reveals from IDB while the initial sync runs, and the topbar indicator stays dark.
- Existing reconnect-indicator test still green (proves the latch is necessary — a plain `!isAnySyncing` check would break reconnect).
- `coordinated-loading` 21/21, `connection-status` 6/6, frontend typecheck + full monorepo pre-commit lint/typecheck green.

## Self-review
3 parallel reviewers (correctness / spec-compliance / design). Correctness and spec-compliance clean. Design suggested collapsing the latch into `initialLoadCompleteRef.current && !isAnySyncing` — **rejected**: that would make the reconnect term `!isAnySyncing && isAnySyncing` (always false) and silently kill the reconnect indicator. Added a comment documenting why the latch must persist across the reconnect transition.

## Scope / not included
This is the fast-wifi "feels sluggish / online worse than offline" tier. It does **not** address the intermittent 10–25s loads — those look server-side (Railway cold start and/or WorkOS session-refresh stampede with no single-flight) and are being investigated separately.

## Note for reviewers
`apps/frontend/src/contexts/sidebar-context.test.tsx` fails on this branch with `localStorage.removeItem is not a function` — verified **pre-existing** (fails identically with this PR's changes stashed), unrelated to these files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782769464&installation_id=129946197&pr_number=712&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F712&signature=30c28cafd3ce39551b3b7314a270bc6707e93cb85f990892b59d0d2afd264f9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->