### PR TITLE
fix(ci): harden railwayGql against non-JSON responses + retry transients

### DIFF
--- a/scripts/staging-pr.ts
+++ b/scripts/staging-pr.ts
@@ -261,20 +261,74 @@ async function updateWorkspaceSlug(dbName: string, branchName: string): Promise<
 
 const RAILWAY_API = "https://backboard.railway.com/graphql/v2"
 
+// Railway's API gateway intermittently answers with a non-JSON body (an HTML
+// 5xx page, an empty 502/504, or a rate-limit notice) instead of a GraphQL
+// envelope. The old code called `res.json()` blind, so those turned into an
+// opaque "SyntaxError: Failed to parse JSON" with no status or body — which
+// took down PR staging deploys with no way to tell a transient blip from a real
+// rejection. Read the body as text, surface the HTTP status + a snippet on
+// failure, and retry transient failures (network error, 5xx, non-JSON). Every
+// caller here is idempotent (serviceCreate is existence-guarded; instance
+// update and variable upsert are upserts), so retrying is safe.
+const RAILWAY_GQL_MAX_ATTEMPTS = 3
+
 async function railwayGql(query: string, variables?: Record<string, unknown>): Promise<unknown> {
-  const res = await fetch(RAILWAY_API, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${RAILWAY_TOKEN}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query, variables }),
-  })
-  const json = (await res.json()) as { data?: unknown; errors?: { message: string }[] }
-  if (json.errors?.length) {
-    throw new Error(`Railway API error: ${json.errors[0].message}`)
+  let lastError: Error | undefined
+  for (let attempt = 1; attempt <= RAILWAY_GQL_MAX_ATTEMPTS; attempt++) {
+    let res: Response
+    let text: string
+    try {
+      res = await fetch(RAILWAY_API, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${RAILWAY_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+      })
+      text = await res.text()
+    } catch (err) {
+      // Network-level failure (DNS, connection reset, timeout) — transient.
+      lastError = new Error(`Railway API network error: ${err instanceof Error ? err.message : String(err)}`)
+      if (attempt < RAILWAY_GQL_MAX_ATTEMPTS) {
+        await Bun.sleep(1000 * attempt)
+        continue
+      }
+      throw lastError
+    }
+
+    // Non-2xx: retry 5xx (gateway/transient), fail fast on 4xx (real rejection).
+    if (!res.ok) {
+      const snippet = text.slice(0, 500)
+      lastError = new Error(`Railway API HTTP ${res.status}: ${snippet}`)
+      if (res.status >= 500 && attempt < RAILWAY_GQL_MAX_ATTEMPTS) {
+        await Bun.sleep(1000 * attempt)
+        continue
+      }
+      throw lastError
+    }
+
+    let json: { data?: unknown; errors?: { message: string }[] }
+    try {
+      json = JSON.parse(text) as { data?: unknown; errors?: { message: string }[] }
+    } catch {
+      // 2xx but not JSON — almost always a gateway page slipped through. Retry.
+      lastError = new Error(`Railway API returned non-JSON (HTTP ${res.status}): ${text.slice(0, 500)}`)
+      if (attempt < RAILWAY_GQL_MAX_ATTEMPTS) {
+        await Bun.sleep(1000 * attempt)
+        continue
+      }
+      throw lastError
+    }
+
+    // A GraphQL `errors` array is a deterministic rejection — don't retry it.
+    if (json.errors?.length) {
+      throw new Error(`Railway API error: ${json.errors[0].message}`)
+    }
+    return json.data
   }
-  return json.data
+  // Unreachable: the loop either returns or throws on the final attempt.
+  throw lastError ?? new Error("Railway API request failed")
 }
 
 async function getEnvironmentId(): Promise<string> {


### PR DESCRIPTION
## Why

PR staging deploys (`Deploy staging` → `Deploy PR backend + database`) were failing with an opaque:
```
Staging PR script failed: SyntaxError: Failed to parse JSON
  at railwayGql (scripts/staging-pr.ts:273)
  at async createRailwayService (scripts/staging-pr.ts:360)
```
`railwayGql` called `res.json()` blind — no `res.ok` check, no body capture — so when Railway's API gateway answered with a **non-JSON body** (HTML 5xx page, empty 502/504, or a rate-limit notice) it surfaced as an unactionable parse error and took the deploy down, with no way to tell a transient blip from a real rejection.

Diagnosis: the failing call is the env-var `variableCollectionUpsert` at `createRailwayService:360`, and the copied payload is **tiny** (~3 KB across 43 vars), so it's not a size/WAF limit — it's gateway flakiness (it failed twice consecutively at the same call).

## What changed

`railwayGql` now:
- reads the body as **text** and surfaces `Railway API HTTP <status>: <snippet>` / `non-JSON (HTTP <status>): <snippet>` on failure, so a real rejection is diagnosable instead of opaque;
- **retries transient failures** (network error, 5xx, non-JSON 2xx) up to 3× with linear backoff;
- treats a GraphQL `errors` array as a **deterministic** rejection and does **not** retry it.

Retrying is safe because every caller in this script is idempotent: `serviceCreate` is existence-guarded, `serviceInstanceUpdate` and `variableCollectionUpsert` are upserts.

## Validation

This PR's own `Deploy staging` job exercises the changed code path — green here means the fix holds. If it's *not* transient, the run now prints the real `HTTP <status>: <body>` so we can fix the actual rejection.

## Context

Surfaced while investigating app boot times (#712). Unrelated to that work — split out as its own change since it's CI/deploy tooling affecting every PR. #712 will rebase onto this once merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782813538&installation_id=129946197&pr_number=713&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F713&signature=b595cf30a1f1bf5e5dd64469cd9e27aa2d831b00011ecc90b6e772ce6380d58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->