### PR TITLE
fix(pwa): cache avatars in the service worker so they stop re-fetching every load

### DIFF
--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -46,6 +46,19 @@ interface ExtendedNotificationOptions extends NotificationOptions {
 // and most desktop browsers ignore it and fall back to the OS default.
 const THREA_VIBRATION_PATTERN = [30, 10, 100]
 
+// Avatar images are versioned and immutable (URL is
+// `.../avatar/<timestamp>.<size>.webp`), but the API response carries
+// `Vary: Origin` from the credentialed CORS layer, which defeats the browser's
+// HTTP cache — so avatars re-fetch from the network on *every* load and visibly
+// pop in after the page paints (the "christmas tree" flash, made obvious once
+// first paint stopped waiting on hydration). Serve them CacheFirst from a
+// dedicated CacheStorage bucket: the first load fetches + stores, every
+// subsequent load is an instant local hit with zero network. Safe because the
+// URL changes whenever the avatar changes, so a cached entry is never stale.
+const AVATAR_CACHE = "threa-avatars-v1"
+const AVATAR_PATH_RE = /^\/api\/workspaces\/[^/]+\/(?:users|bots)\/[^/]+\/avatar\//
+const AVATAR_CACHE_MAX_ENTRIES = 300
+
 // Activate new service worker immediately so users get fresh code
 // without needing to close all tabs.
 self.addEventListener("install", () => self.skipWaiting())
@@ -55,7 +68,7 @@ self.addEventListener("activate", (event) => {
       // Clean stale caches from previous SW versions. Keep only the current
       // workbox precache, push-bootstrap, and share-target caches. Without this,
       // old precache buckets linger and can serve stale HTML/CSS after an update.
-      const currentCaches = new Set([PUSH_BOOTSTRAP_CACHE, SHARE_TARGET_CACHE, PENDING_SYNC_CACHE])
+      const currentCaches = new Set([PUSH_BOOTSTRAP_CACHE, SHARE_TARGET_CACHE, PENDING_SYNC_CACHE, AVATAR_CACHE])
       const allCaches = await caches.keys()
       await Promise.all(
         allCaches
@@ -129,6 +142,46 @@ self.addEventListener("fetch", (event) => {
 // Vite content-hashes these filenames so they're immutable). Navigation
 // requests are intercepted by the listener above before reaching this.
 precacheAndRoute(self.__WB_MANIFEST)
+
+// Bound the avatar cache so it can't grow without limit. `cache.keys()`
+// preserves insertion order, so the oldest entries are evicted first (FIFO).
+async function trimAvatarCache(cache: Cache): Promise<void> {
+  const keys = await cache.keys()
+  if (keys.length <= AVATAR_CACHE_MAX_ENTRIES) return
+  await Promise.all(keys.slice(0, keys.length - AVATAR_CACHE_MAX_ENTRIES).map((key) => cache.delete(key)))
+}
+
+// CacheFirst for avatar images (see AVATAR_CACHE rationale above). Coexists with
+// the other fetch listeners: this one only calls respondWith for avatar GETs and
+// is inert for everything else, and the navigation/bootstrap listeners never
+// match avatar URLs (they bail on `/api/*` or a non-matching path).
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return
+  const url = new URL(event.request.url)
+  if (url.origin !== self.location.origin || !AVATAR_PATH_RE.test(url.pathname)) return
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(AVATAR_CACHE)
+      const cached = await cache.match(event.request, { ignoreVary: true })
+      if (cached) return cached
+
+      const response = await fetch(event.request)
+      // Only store a complete, same-origin 200 — never partials, errors, or
+      // opaque cross-origin responses (which can't be read back reliably).
+      if (response.status === 200 && response.type === "basic") {
+        const copy = response.clone()
+        event.waitUntil(
+          cache
+            .put(event.request, copy)
+            .then(() => trimAvatarCache(cache))
+            .catch(() => {})
+        )
+      }
+      return response
+    })()
+  )
+})
 
 // ============================================================================
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap


### PR DESCRIPTION
## Problem

After #712, avatars visibly popped in *after* the page painted — a "christmas tree" flicker, one avatar at a time.

## Root cause (measured on prod)

The backend already sets `Cache-Control: public, max-age=31536000, immutable` on avatar responses (`handlers.ts:345`) — but they also carry **`Vary: Origin`** from the credentialed CORS layer, which defeats the browser's local HTTP cache. Live measurement on a *normal* reload (cache enabled): **every avatar re-fetches from the network**, `avatarsFromCache: 0`, real transfer bytes, `cf-cache-status: HIT` (i.e. the request still left the browser to Cloudflare's edge rather than being served locally). Since Radix `Avatar.Image` shows a fallback until `onLoad`, the per-avatar network round-trip means they all swap fallback→image in a visible wave. #712's faster first paint didn't cause it — it just stopped masking a pre-existing problem.

## Fix

A self-contained **CacheFirst** fetch handler in the service worker for avatar GETs (`/api/workspaces/*/{users,bots}/*/avatar/*`):
- dedicated `threa-avatars-v1` CacheStorage bucket, **allowlisted in the activate cleanup** so it survives SW updates;
- bounded to 300 entries (FIFO via `cache.keys()` insertion order);
- `ignoreVary: true` on lookup — sidesteps the `Vary: Origin` header that was breaking the HTTP cache;
- only stores complete same-origin `200`/`basic` responses.

After the first fetch, every subsequent load serves avatar bytes locally with **zero network**, so the fallback→image swap is instant rather than a per-avatar network wait. Safe because avatar URLs are versioned + immutable (change-on-update), so a cached entry is never stale.

## Scope / notes
- **Avatars only.** Attachment thumbnails resolve to *presigned S3 URLs* that vary per request, so URL-keyed caching wouldn't help them — separate problem.
- **No new deps** — hand-rolled rather than pulling in `workbox-routing`/`-strategies`/`-expiration`.
- Coexists with the existing navigation + bootstrap fetch listeners (each bails on requests it doesn't own; this one only `respondWith`s avatar GETs).
- SW behavior is exercised by the browser-e2e suite. I'll also re-measure on prod post-deploy to confirm `avatarsFromCache > 0`.

Follow-up to #712 (boot times).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782818152&installation_id=129946197&pr_number=714&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F714&signature=4896a00ea522c3323211fc877306aee2e1360be9aa6f30ec0189ebccdf53deca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->