### PR TITLE
fix(timeline): anchor read-only composer banner to bottom

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -587,14 +587,16 @@ function MessageInputComponent({
   )
 
   if (disabled && disabledReason) {
+    // Use the same floating shell as the live composer so the banner anchors to
+    // the bottom and publishes its height to `--composer-height` (via selfRef).
+    // A plain in-flow div lands at the top of the absolutely-positioned stream
+    // area and overlaps the first messages instead.
     return (
-      <div className="border-t">
-        <div className="p-6 mx-auto max-w-[800px] w-full min-w-0">
-          <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
-            <p className="text-sm text-muted-foreground text-center">{disabledReason}</p>
-          </div>
+      <FloatingComposerShell ref={selfRef} data-message-composer-root>
+        <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
+          <p className="text-sm text-muted-foreground text-center">{disabledReason}</p>
         </div>
-      </div>
+      </FloatingComposerShell>
     )
   }
 


### PR DESCRIPTION
## Problem

In read-only streams (system notifications, sealed/archived threads) the disabled-composer banner — e.g. "System notifications are read-only." — overlapped the messages at the **top** of the stream instead of sitting at the bottom:

The live composer renders inside `FloatingComposerShell` (`absolute inset-x-0 bottom-0`) and publishes its height to the `--composer-height` CSS variable so the timeline pads its bottom and messages never sit behind it. The read-only branch of `MessageInput` took a shortcut and returned a plain in-flow `<div className="border-t">` with no positioning and no `selfRef`. Because the timeline scroller is absolutely positioned (`inset-0`), that in-flow div had nowhere to land but the top of the container, where it collided with the first message's header/timestamp. It also never published a height, so the timeline reserved no space for it.

## Fix

Route the read-only banner through the same `FloatingComposerShell` with `selfRef` that the live composer uses:

- It anchors to the bottom (`absolute inset-x-0 bottom-0`) where a composer would be.
- `selfRef` lets the already-unconditional `useComposerHeightPublish(selfRef, ...)` measure it and publish `--composer-height`, so the timeline pads correctly.
- `data-message-composer-root` is preserved, matching the live-composer path (used by the mobile inline-edit hide rule).

This covers both read-only cases — system notifications and sealed/archived threads.

## Testing

- `apps/frontend/src/components/timeline/message-input.test.tsx` — 19 pass (incl. the disabled↔enabled toggle test)
- `apps/frontend/src/hooks/use-composer-height-publish.test.tsx` — 6 pass
- Frontend `tsc --noEmit` clean; pre-commit lint + full-monorepo typecheck passed

## Self-review

Ran a 3-perspective review (spec compliance / correctness / design) — all clean, no issues ≥80. Confirmed there's no parallel read-only banner in `stream-panel.tsx` needing the same fix (its draft path has no `disabledReason` branch; regular streams go through this `MessageInput`).

https://claude.ai/code/session_01VFL1eqn56Gk41PpwEUC4kY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFL1eqn56Gk41PpwEUC4kY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782821994&installation_id=129946197&pr_number=715&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F715&signature=6eac8fd4e9e6e162c3a24369dd1f54ebeae32637b9611a02ff373193f30536d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->