### PR TITLE
fix(quickswitcher): move Archive to the bottom of the stream commands

### DIFF
--- a/apps/frontend/src/components/quick-switcher/stream-commands.ts
+++ b/apps/frontend/src/components/quick-switcher/stream-commands.ts
@@ -4,21 +4,12 @@ import type { Command } from "./commands"
 /**
  * Commands that act on the stream currently in view. `use-command-items` only
  * surfaces these when `CommandContext.currentStreamId` is set, so the guard in
- * each action is belt-and-suspenders. Ordering mirrors the approved palette
- * layout (archive first, labels last). Real streams archive (reversible);
- * draft scratchpads are deleted via `draftStreamCommands` instead.
+ * each action is belt-and-suspenders. Archive is destructive, so it sits last
+ * to keep it away from the default-focused top of the palette where users could
+ * trigger it by accident. Real streams archive (reversible); draft scratchpads
+ * are deleted via `draftStreamCommands` instead.
  */
 export const streamCommands: Command[] = [
-  {
-    id: "stream-archive",
-    label: "Archive this stream",
-    icon: Archive,
-    keywords: ["hide", "remove", "close", "current stream"],
-    action: ({ currentStreamId, requestArchiveStream }) => {
-      if (!currentStreamId) return
-      requestArchiveStream(currentStreamId)
-    },
-  },
   {
     id: "stream-settings",
     label: "Open stream settings",
@@ -48,6 +39,16 @@ export const streamCommands: Command[] = [
     action: ({ currentStreamId, openLabelPicker }) => {
       if (!currentStreamId) return
       openLabelPicker(currentStreamId)
+    },
+  },
+  {
+    id: "stream-archive",
+    label: "Archive this stream",
+    icon: Archive,
+    keywords: ["hide", "remove", "close", "current stream"],
+    action: ({ currentStreamId, requestArchiveStream }) => {
+      if (!currentStreamId) return
+      requestArchiveStream(currentStreamId)
     },
   },
 ]


### PR DESCRIPTION
## Problem

In the quick-switcher, the per-stream command list put **"Archive this stream"** first. Because the top entry is the default-focused item in the palette, the most destructive action was the easiest one to trigger by accident — open the switcher on a stream, hit Enter, and you've archived it. The remaining commands (settings, files, labels) are all non-destructive, so Archive being first inverted the safe default.

(The order wasn't alphabetical, as it first appeared — it was an explicit hardcoded order with Archive deliberately placed first. Same result either way: it needed to move.)

## Solution

Reorder `streamCommands` so the non-destructive actions come first and **Archive sits last**, away from the default-focused top of the palette:

1. Open stream settings
2. Browse files in this stream
3. Labels…
4. **Archive this stream** ← moved to the bottom

The `stream-archive` command object is moved verbatim — action logic, `id`, icon, and keywords are unchanged, so it's still searchable by "archive/hide/remove/close". The doc comment is updated to explain *why* Archive is last so it doesn't get reordered back.

Only real (server-persisted) streams are affected. Draft scratchpads use the separate `draftStreamCommands` list (single "Delete this draft" entry) — untouched.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/quick-switcher/stream-commands.ts` | Move `stream-archive` from first to last in `streamCommands`; update doc comment to explain the destructive-action ordering |

## Test plan

- [x] `quick-switcher.integration.test.tsx` — all 75 tests pass (assert command presence/behavior, not order)
- [x] Lint + typecheck green across the monorepo (pre-commit hook)
- [x] Verified no consumer depends on Archive being first — the only consumer (`use-command-items.ts`) spreads the array in order; nothing indexes `streamCommands[0]`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01At7rokbjxeLLN3GxKsp1H6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782838609&installation_id=129946197&pr_number=717&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F717&signature=b655c6ae21e78860e3be78fd40acfa1d3ff476d570eec2f7056691fde731e5bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->