### PR TITLE
Fix sidebar urgency glow positioning and enable it on mobile

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback } from "react"
 import { RefreshCw } from "lucide-react"
-import { useSidebar, useCoordinatedLoading } from "@/contexts"
+import { useSidebar, useCoordinatedLoading, type UrgencyBlock } from "@/contexts"
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh } from "@/hooks"
 import { useSyncEngine } from "@/sync/sync-engine"
 import { TopbarLoadingIndicator } from "./topbar-loading-indicator"
@@ -57,6 +57,39 @@ function PullIndicator({ distance, progress, pulling, refreshing, mode }: PullIn
       >
         {config.label}
       </span>
+    </>
+  )
+}
+
+/**
+ * Soft, position-matched urgency glow blocks. Each block is a single blurred
+ * bar sized to its stream row (expanded 150% and centered) so the color diffuses
+ * out as a glow rather than a hard bar. Shared by the desktop edge strip and the
+ * mobile left-edge hint. The `position`/`height` fractions are measured against
+ * the sidebar in `useUrgencyTracking`, so both surfaces render the same column.
+ */
+function UrgencyGlowBlocks({ blocks }: { blocks: Map<string, UrgencyBlock> }) {
+  return (
+    <>
+      {Array.from(blocks.entries()).map(([streamId, block]) => {
+        const expandedHeight = block.height * 1.5
+        const centeredTop = block.position - block.height * 0.25
+        return (
+          <div
+            key={streamId}
+            className="absolute transition-opacity duration-300"
+            style={{
+              left: "-4px",
+              width: "14px",
+              top: `${centeredTop * 100}%`,
+              height: `${Math.max(expandedHeight * 100, 4)}%`,
+              backgroundColor: block.color,
+              filter: "blur(12px)",
+              opacity: block.opacity,
+            }}
+          />
+        )
+      })}
     </>
   )
 }
@@ -238,6 +271,20 @@ export function AppShell({ sidebar, children }: AppShellProps) {
             />
           )}
 
+          {/* Mobile urgency glow - the sidebar itself is off-screen, so this is the
+               only at-a-glance hint that there's something worth opening it for.
+               Sits below the backdrop (z-30) so it's covered once the drawer opens,
+               and bleeds rightward into content (left edge clipped at the screen edge). */}
+          {isMobile && !isOpen && (
+            <div
+              className="fixed left-0 top-0 z-20 h-full w-[6px] pointer-events-none"
+              style={{ clipPath: "inset(-50px -50px -50px 0)" }}
+              aria-hidden="true"
+            >
+              <UrgencyGlowBlocks blocks={urgencyBlocks} />
+            </div>
+          )}
+
           {/* Sidebar wrapper - handles positioning */}
           <div
             className={cn(
@@ -265,25 +312,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
                 {/* Grey baseline - always visible */}
                 <div className="absolute inset-0" style={{ backgroundColor: "hsl(var(--muted-foreground) / 0.3)" }} />
                 {/* Activity blocks - single blurred bar per stream, 150% height centered */}
-                {Array.from(urgencyBlocks.entries()).map(([streamId, block]) => {
-                  const expandedHeight = block.height * 1.5
-                  const centeredTop = block.position - block.height * 0.25
-                  return (
-                    <div
-                      key={streamId}
-                      className="absolute transition-opacity duration-300"
-                      style={{
-                        left: "-4px",
-                        width: "14px",
-                        top: `${centeredTop * 100}%`,
-                        height: `${Math.max(expandedHeight * 100, 4)}%`,
-                        backgroundColor: block.color,
-                        filter: "blur(12px)",
-                        opacity: block.opacity,
-                      }}
-                    />
-                  )
-                })}
+                <UrgencyGlowBlocks blocks={urgencyBlocks} />
               </div>
             )}
 
@@ -315,7 +344,11 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               className={cn(
                 "relative flex h-full flex-col border-r bg-background overflow-hidden z-40",
                 // Positioning - preview is absolute, or always absolute on mobile
-                (isPreview || isMobile) && "absolute left-0 top-0 shadow-[4px_0_24px_hsl(var(--foreground)/0.08)]",
+                (isPreview || isMobile) && "absolute left-0 top-0",
+                // Depth shadow only when the drawer is actually showing — on mobile the
+                // closed drawer is off-screen and its right-edge shadow would otherwise
+                // bleed onto the screen's left edge as a meaningless grey glow.
+                (isPreview || (isMobile && isOpen)) && "shadow-[4px_0_24px_hsl(var(--foreground)/0.08)]",
                 // Mobile: transform-based positioning (GPU-composited, swipe-compatible)
                 isMobile && sidebarTransform,
                 // Transitions - disable during resize/swipe for smooth dragging

--- a/apps/frontend/src/components/layout/sidebar/config.ts
+++ b/apps/frontend/src/components/layout/sidebar/config.ts
@@ -2,10 +2,11 @@ import { FileEdit, Hash, User, type LucideIcon } from "lucide-react"
 import type { SectionKey, SortType, UrgencyLevel } from "./types"
 
 export const URGENCY_COLORS: Record<UrgencyLevel, string> = {
-  mentions: "hsl(0 90% 55%)", // Vibrant red
-  activity: "hsl(210 100% 55%)", // Bright blue
+  mentions: "hsl(0 90% 55%)", // Vibrant red — someone mentioned you
+  ai: "hsl(45 100% 50%)", // Bright gold/amber — AI persona activity
+  bot: "hsl(145 63% 45%)", // Green — bot / integration activity
+  activity: "hsl(210 100% 55%)", // Bright blue — other unread activity
   quiet: "transparent", // Hidden when no activity
-  ai: "hsl(45 100% 50%)", // Bright gold/amber
 }
 
 interface BadgeConfig {

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -50,8 +50,14 @@ interface SidebarProps {
 
 export function Sidebar({ workspaceId }: SidebarProps) {
   const { phase } = useCoordinatedLoading()
-  const { getSectionState, toggleSectionState, setSidebarHeight, setScrollContainerOffset, collapseOnMobile } =
-    useSidebar()
+  const {
+    getSectionState,
+    toggleSectionState,
+    setSidebarHeight,
+    setScrollContainerOffset,
+    bumpScrollVersion,
+    collapseOnMobile,
+  } = useSidebar()
   const { config: sidebarConfig } = useSidebarConfig(workspaceId)
   const [isEditorOpen, setIsEditorOpen] = useState(false)
   const { streamId: activeStreamId, "*": splat } = useParams<{ streamId: string; "*": string }>()
@@ -228,15 +234,20 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     const sidebar = sidebarRef.current
     if (!container || !sidebar) return
 
+    // The element that actually scrolls is Radix's viewport, not the padded
+    // content div — measure the header offset and listen for scroll on it.
+    const viewport = container.closest<HTMLElement>("[data-radix-scroll-area-viewport]")
+    const offsetRef = viewport ?? container
+
     const updateDimensions = () => {
       // Get sidebar total height
       setSidebarHeight(sidebar.offsetHeight)
 
-      // Calculate scroll container offset from sidebar top
-      // This accounts for header + quick links sections
-      const containerRect = container.getBoundingClientRect()
+      // Offset from sidebar top to the scroll viewport top (the header region).
+      // Scroll-independent, so glow blocks can add their own scroll delta on top.
+      const refRect = offsetRef.getBoundingClientRect()
       const sidebarRect = sidebar.getBoundingClientRect()
-      setScrollContainerOffset(containerRect.top - sidebarRect.top)
+      setScrollContainerOffset(refRect.top - sidebarRect.top)
     }
 
     // Initial measurement
@@ -247,8 +258,24 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     observer.observe(container)
     observer.observe(sidebar)
 
-    return () => observer.disconnect()
-  }, [setSidebarHeight, setScrollContainerOffset])
+    // Re-measure glow positions as the list scrolls so blocks stay flush with
+    // their rows. rAF-coalesced to one update per frame.
+    let frame = 0
+    const handleScroll = () => {
+      if (frame) return
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        bumpScrollVersion()
+      })
+    }
+    viewport?.addEventListener("scroll", handleScroll, { passive: true })
+
+    return () => {
+      observer.disconnect()
+      viewport?.removeEventListener("scroll", handleScroll)
+      if (frame) cancelAnimationFrame(frame)
+    }
+  }, [setSidebarHeight, setScrollContainerOffset, bumpScrollVersion])
 
   // During initial coordinated loading, show skeleton
   if (phase !== "ready") {

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -1,6 +1,6 @@
 import type { StreamWithPreview, SidebarSectionKey } from "@threa/types"
 
-export type UrgencyLevel = "mentions" | "activity" | "quiet" | "ai"
+export type UrgencyLevel = "mentions" | "ai" | "bot" | "activity" | "quiet"
 
 /** Sorting strategies for sidebar sections */
 export type SortType = "activity" | "importance" | "alphabetic_active_first"

--- a/apps/frontend/src/components/layout/sidebar/use-urgency-tracking.ts
+++ b/apps/frontend/src/components/layout/sidebar/use-urgency-tracking.ts
@@ -10,7 +10,7 @@ export function useUrgencyTracking(
   urgency: UrgencyLevel,
   scrollContainerRef: RefObject<HTMLDivElement | null> | undefined
 ) {
-  const { setUrgencyBlock, sidebarHeight, scrollContainerOffset } = useSidebar()
+  const { setUrgencyBlock, sidebarHeight, scrollContainerOffset, scrollVersion } = useSidebar()
 
   useLayoutEffect(() => {
     const el = itemRef.current
@@ -22,8 +22,18 @@ export function useUrgencyTracking(
       return
     }
 
-    const position = (scrollContainerOffset + el.offsetTop) / sidebarHeight
-    const height = el.offsetHeight / sidebarHeight
+    // Measure against the scroll viewport instead of `offsetTop`. Each row is
+    // wrapped in a positioned `.group` ancestor, which makes it the row's
+    // offsetParent — so `offsetTop` is ~0 for every item and would stack all
+    // blocks at the same spot. getBoundingClientRect is offsetParent-independent
+    // and reflects the live scroll position, keeping the glow flush with its row
+    // as the list scrolls (re-runs via `scrollVersion`).
+    const viewport = container.closest("[data-radix-scroll-area-viewport]") ?? container
+    const viewportTop = viewport.getBoundingClientRect().top
+    const itemRect = el.getBoundingClientRect()
+
+    const position = (scrollContainerOffset + (itemRect.top - viewportTop)) / sidebarHeight
+    const height = itemRect.height / sidebarHeight
 
     setUrgencyBlock(streamId, {
       position,
@@ -32,5 +42,14 @@ export function useUrgencyTracking(
     })
 
     return () => setUrgencyBlock(streamId, null)
-  }, [streamId, urgency, scrollContainerRef, sidebarHeight, scrollContainerOffset, setUrgencyBlock, itemRef])
+  }, [
+    streamId,
+    urgency,
+    scrollContainerRef,
+    sidebarHeight,
+    scrollContainerOffset,
+    scrollVersion,
+    setUrgencyBlock,
+    itemRef,
+  ])
 }

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { StreamTypes, Visibilities, type StreamWithPreview } from "@threa/types"
-import { categorizeStream } from "./utils"
+import { AuthorTypes, StreamTypes, Visibilities, type AuthorType, type StreamWithPreview } from "@threa/types"
+import { calculateUrgency, categorizeStream } from "./utils"
 
 function makeStream(overrides: Partial<StreamWithPreview> = {}): StreamWithPreview {
   return {
@@ -24,6 +24,40 @@ function makeStream(overrides: Partial<StreamWithPreview> = {}): StreamWithPrevi
     ...overrides,
   }
 }
+
+describe("calculateUrgency", () => {
+  function streamWith(authorType: AuthorType | null) {
+    return { lastMessagePreview: authorType ? { authorType } : null }
+  }
+
+  it("returns quiet when muted regardless of unread/mentions", () => {
+    expect(calculateUrgency(streamWith("user"), 5, 3, true)).toBe("quiet")
+  })
+
+  it("prioritizes mentions ahead of any author signal", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.PERSONA), 2, 1, false)).toBe("mentions")
+  })
+
+  it("returns ai for unread persona activity", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.PERSONA), 1, 0, false)).toBe("ai")
+  })
+
+  it("returns bot for unread bot activity", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.BOT), 1, 0, false)).toBe("bot")
+  })
+
+  it("returns activity for unread human activity", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.USER), 1, 0, false)).toBe("activity")
+  })
+
+  it("returns activity for unread with no cached preview author", () => {
+    expect(calculateUrgency(streamWith(null), 1, 0, false)).toBe("activity")
+  })
+
+  it("returns quiet with no unread and no mentions", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.BOT), 0, 0, false)).toBe("quiet")
+  })
+})
 
 describe("categorizeStream", () => {
   beforeEach(() => {

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -20,11 +20,12 @@ export function calculateUrgency(
 
   if (mentionCount > 0) return "mentions"
 
-  if (stream.lastMessagePreview?.authorType === AuthorTypes.PERSONA && unreadCount > 0) {
-    return "ai"
+  if (unreadCount > 0) {
+    const authorType = stream.lastMessagePreview?.authorType
+    if (authorType === AuthorTypes.PERSONA) return "ai"
+    if (authorType === AuthorTypes.BOT) return "bot"
+    return "activity"
   }
-
-  if (unreadCount > 0) return "activity"
 
   return "quiet"
 }

--- a/apps/frontend/src/contexts/sidebar-context.tsx
+++ b/apps/frontend/src/contexts/sidebar-context.tsx
@@ -73,8 +73,10 @@ interface SidebarContextValue {
   urgencyBlocks: Map<string, UrgencyBlock>
   /** Total height of sidebar (for position calculations) */
   sidebarHeight: number
-  /** Offset from sidebar top to scroll container top (header) */
+  /** Offset from sidebar top to scroll viewport top (header) */
   scrollContainerOffset: number
+  /** Monotonic counter bumped on sidebar scroll so position-tracked glow blocks re-measure */
+  scrollVersion: number
   /** Show preview state on hover (only from collapsed) */
   showPreview: () => void
   /** Hide preview state after delay */
@@ -106,6 +108,8 @@ interface SidebarContextValue {
   setSidebarHeight: (height: number) => void
   /** Set scroll container offset from sidebar top */
   setScrollContainerOffset: (offset: number) => void
+  /** Bump `scrollVersion` to trigger re-measurement of glow block positions */
+  bumpScrollVersion: () => void
   /** Notify that a menu inside the sidebar opened/closed (prevents collapse while open) */
   setMenuOpen: (open: boolean) => void
 }
@@ -210,6 +214,7 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   const [urgencyBlocks, setUrgencyBlocks] = useState<Map<string, UrgencyBlock>>(new Map())
   const [sidebarHeight, setSidebarHeight] = useState(0)
   const [scrollContainerOffset, setScrollContainerOffset] = useState(0)
+  const [scrollVersion, setScrollVersion] = useState(0)
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fadeOutTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const menuOpenCountRef = useRef(0)
@@ -456,6 +461,8 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     }
   }, [])
 
+  const bumpScrollVersion = useCallback(() => setScrollVersion((v) => v + 1), [])
+
   // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
@@ -481,6 +488,7 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
         urgencyBlocks,
         sidebarHeight,
         scrollContainerOffset,
+        scrollVersion,
         showPreview,
         hidePreview,
         togglePinned,
@@ -495,6 +503,7 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
         setUrgencyBlock,
         setSidebarHeight,
         setScrollContainerOffset,
+        bumpScrollVersion,
         setMenuOpen,
       }}
     >

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -7,8 +7,8 @@ import { streamLabel } from "@/lib/streams"
 /** Sort modes used by stream pickers (quick switcher, share modal, share picker). */
 export type StreamSortMode = "recency" | "alphabetical"
 
-/** Urgency priority for sorting: mentions > ai > activity > quiet (lower wins). */
-export const URGENCY_ORDER: Record<UrgencyLevel, number> = { mentions: 0, ai: 1, activity: 2, quiet: 3 }
+/** Urgency priority for sorting: mentions > ai > activity > bot > quiet (lower wins). */
+export const URGENCY_ORDER: Record<UrgencyLevel, number> = { mentions: 0, ai: 1, activity: 2, bot: 3, quiet: 4 }
 
 /** Minimal shape pickers need for sorting — name lookup + activity time. */
 export type SortableStream = Pick<Stream, "id" | "type" | "createdAt"> & {


### PR DESCRIPTION
## Problem

The collapsed-sidebar urgency glow (the color strip that hints "there's something worth looking at" — red mentions, gold AI, blue activity) stopped tracking item positions and all blocks stacked at the top of the list. On mobile the feature was off entirely, and a meaningless grey glow leaked onto the left screen edge.

## Root cause

`useUrgencyTracking` derived each block's vertical position from `el.offsetTop`. During the sidebar work each row's `<Link>` was wrapped in a positioned `.group` ancestor (for the hover action menu), which became the row's `offsetParent` — so `offsetTop` is ~0 for **every** row and all glow blocks collapsed to the same spot just below the header.

The mobile "weird glow" was the closed drawer's right-edge `box-shadow` (`4px 0 24px …`): with the drawer translated off-screen its shadow projected onto the screen's left edge, adding nothing.

## Changes

- **Position fix:** measure rows with `getBoundingClientRect` against the Radix scroll viewport instead of `offsetTop`. This is `offsetParent`-independent and reflects the live scroll position.
- **Follow scroll:** a rAF-coalesced scroll listener bumps a `scrollVersion` counter so only the (few) non-quiet blocks re-measure and stay flush with their rows as the list scrolls. `scrollContainerOffset` is now based on the actual scroll viewport.
- **Mobile:** render the same glow as a thin left-edge hint (the drawer is off-screen, so this is the only at-a-glance signal). The blurred blocks bleed rightward into content; the left edge is clipped at the screen edge. The drawer's depth shadow is now gated to the open state, removing the leaking grey glow.
- **Bot color:** new green `bot` urgency for unread bot/integration activity, completing the red (mentions) / gold (AI) / green (bots) / blue (other) scheme described in the design system. Exhaustive `URGENCY_COLORS` and `URGENCY_ORDER` records updated.

## Design decisions

- Reused the existing measured `urgencyBlocks` for both desktop and mobile by extracting a module-level `UrgencyGlowBlocks` renderer, so both surfaces draw the identical column with no duplicate logic.
- Kept the soft diffused aesthetic (150% expanded, blurred, centered on the row) — only the position math was wrong, not the look.
- Bot ranks below human "activity" in `URGENCY_ORDER` (automation is lower priority than a person's unread message); it stays out of the "Important" smart section.

## Tests

- Added `calculateUrgency` coverage (mute precedence, mentions, ai/bot/activity author branches, quiet).
- `bun run test` across the affected surfaces (sidebar, contexts, pickers, share) — all green; typecheck and lint clean.

https://claude.ai/code/session_019vUFRgtZKj7fbtVd76sXTq

---
_Generated by [Claude Code](https://claude.ai/code/session_019vUFRgtZKj7fbtVd76sXTq)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782838650&installation_id=129946197&pr_number=718&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F718&signature=77065bdc33ec621cc966f6bb4eb092a2efc28e906213ad4bef81f67d44e77c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->