### PR TITLE
Dim the mobile urgency glow strip to a subtler hint

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -67,8 +67,13 @@ function PullIndicator({ distance, progress, pulling, refreshing, mode }: PullIn
  * out as a glow rather than a hard bar. Shared by the desktop edge strip and the
  * mobile left-edge hint. The `position`/`height` fractions are measured against
  * the sidebar in `useUrgencyTracking`, so both surfaces render the same column.
+ *
+ * `opacityScale` dims the whole column for surfaces that need a gentler hint.
+ * On mobile the strip bleeds rightward into the content area (the sidebar is
+ * off-screen), so a full-strength glow reads as aggressive; scaling it down
+ * keeps it a subtle "worth a glance" cue rather than a demand for attention.
  */
-function UrgencyGlowBlocks({ blocks }: { blocks: Map<string, UrgencyBlock> }) {
+function UrgencyGlowBlocks({ blocks, opacityScale = 1 }: { blocks: Map<string, UrgencyBlock>; opacityScale?: number }) {
   return (
     <>
       {Array.from(blocks.entries()).map(([streamId, block]) => {
@@ -85,7 +90,7 @@ function UrgencyGlowBlocks({ blocks }: { blocks: Map<string, UrgencyBlock> }) {
               height: `${Math.max(expandedHeight * 100, 4)}%`,
               backgroundColor: block.color,
               filter: "blur(12px)",
-              opacity: block.opacity,
+              opacity: block.opacity * opacityScale,
             }}
           />
         )
@@ -281,7 +286,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               style={{ clipPath: "inset(-50px -50px -50px 0)" }}
               aria-hidden="true"
             >
-              <UrgencyGlowBlocks blocks={urgencyBlocks} />
+              <UrgencyGlowBlocks blocks={urgencyBlocks} opacityScale={0.3} />
             </div>
           )}
 


### PR DESCRIPTION
## What

Dims the mobile urgency glow strip (the colored left-edge bar that signals per-stream attention) so it reads as a gentle "worth a glance" cue rather than an aggressive demand for attention.

## Why

The urgency strip is shared between desktop and mobile via `UrgencyGlowBlocks`. On mobile the sidebar is off-screen, so the strip's `clipPath` lets the blurred glow **bleed rightward into the content area** — whereas on desktop it bleeds off-screen to the left and stays subtle. At full strength that mobile bleed read as too loud. The goal of the strip is to *very subtly* let the user know whether there's something worth their attention.

## How

- Added an optional `opacityScale` prop to `UrgencyGlowBlocks` (defaults to `1`, so the desktop edge strip is an exact no-op), multiplied into each block's opacity.
- The mobile strip now renders at `opacityScale={0.3}` — roughly a third of the previous intensity.

Because `block.opacity` is only ever `0` or `1` (fade in/out), the multiplier composes cleanly and the `transition-opacity` fade still animates.

Desktop behavior is unchanged.

## Notes / further knobs

Scoped to mobile only, since that's where the strip read as aggressive. If desktop should be softened too, or `0.3` wants tuning, it's a one-number change. Related levers left untouched: `filter: blur(12px)` (glow diffuseness) and `URGENCY_COLORS` in `sidebar/config.ts` (per-level saturation/lightness).

https://claude.ai/code/session_01JBC3Ag2Mb7jZNsGwf9Mtgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBC3Ag2Mb7jZNsGwf9Mtgs)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782841733&installation_id=129946197&pr_number=719&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F719&signature=13e01b0ec12f12ad67fb50f2be2f94d992b3faf3e26b88faa0c70419dd68594b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->