### PR TITLE
fix(public-api): reject plaintext message writes into E2E streams

### DIFF
--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Request, Response } from "express"
-import { createPublicApiHandlers } from "./handlers"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
 import { E2eStreamsRepository } from "../e2e-streams"
+import type { EventService } from "../messaging"
+import type { StreamService } from "../streams"
 
 // The public API has no ciphertext message-write path, so plaintext sends/edits
 // into an E2E stream must be rejected before any insert (mirrors the first-party
@@ -14,27 +16,35 @@ function createResponse(): Response {
   return res
 }
 
-function createHandlers(overrides: { eventService?: unknown } = {}) {
-  const eventService = overrides.eventService ?? {
+// Only eventService + streamService are exercised by the E2E-stream gate; the
+// rest of the factory's deps are unused here. Typing the fixture as PublicApiDeps
+// (rather than `as never`) means a real shape change to the factory contract —
+// a renamed or removed dep — fails this test at compile time.
+function createHandlers(overrides: Partial<PublicApiDeps> = {}): ReturnType<typeof createPublicApiHandlers> {
+  const eventService = {
     createMessage: mock(() => Promise.resolve({ id: "msg_new" })),
     editMessage: mock(() => Promise.resolve({ id: "msg_new" })),
     getMessageById: mock(() =>
       Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
     ),
-  }
+  } as unknown as EventService
   const streamService = {
     tryAccess: mock(() => Promise.resolve({ id: "stream_1" })),
-  }
-  return createPublicApiHandlers({
+  } as unknown as StreamService
+
+  const deps: PublicApiDeps = {
     eventService,
     streamService,
-    botRuntimeService: {},
-    memoExplorerService: {},
-    botChannelService: {},
-    io: {},
-    pool: {},
-    personaService: {},
-  } as never)
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService: {} as PublicApiDeps["botRuntimeService"],
+    pool: {} as PublicApiDeps["pool"],
+    io: {} as PublicApiDeps["io"],
+    ...overrides,
+  }
+  return createPublicApiHandlers(deps)
 }
 
 function userRequest(extra: Partial<Request> = {}): Request {
@@ -57,7 +67,7 @@ describe("public API E2E-stream plaintext gate", () => {
     const isE2e = spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
     const createMessage = mock(() => Promise.resolve({ id: "msg_new" }))
     const handlers = createHandlers({
-      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) },
+      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) } as unknown as EventService,
     })
 
     await expect(handlers.sendMessage(userRequest(), createResponse())).rejects.toMatchObject({
@@ -78,7 +88,7 @@ describe("public API E2E-stream plaintext gate", () => {
         getMessageById: mock(() =>
           Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
         ),
-      },
+      } as unknown as EventService,
     })
 
     await expect(handlers.updateMessage(userRequest(), createResponse())).rejects.toMatchObject({
@@ -106,7 +116,7 @@ describe("public API E2E-stream plaintext gate", () => {
       })
     )
     const handlers = createHandlers({
-      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) },
+      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) } as unknown as EventService,
     })
 
     await handlers.sendMessage(userRequest(), createResponse())

--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { createPublicApiHandlers } from "./handlers"
+import { E2eStreamsRepository } from "../e2e-streams"
+
+// The public API has no ciphertext message-write path, so plaintext sends/edits
+// into an E2E stream must be rejected before any insert (mirrors the first-party
+// INV-E1 gate). These tests pin that gate by forcing `isE2eStream` true.
+
+function createResponse(): Response {
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock(() => res) as unknown as Response["json"]
+  return res
+}
+
+function createHandlers(overrides: { eventService?: unknown } = {}) {
+  const eventService = overrides.eventService ?? {
+    createMessage: mock(() => Promise.resolve({ id: "msg_new" })),
+    editMessage: mock(() => Promise.resolve({ id: "msg_new" })),
+    getMessageById: mock(() =>
+      Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
+    ),
+  }
+  const streamService = {
+    tryAccess: mock(() => Promise.resolve({ id: "stream_1" })),
+  }
+  return createPublicApiHandlers({
+    eventService,
+    streamService,
+    botRuntimeService: {},
+    memoExplorerService: {},
+    botChannelService: {},
+    io: {},
+    pool: {},
+    personaService: {},
+  } as never)
+}
+
+function userRequest(extra: Partial<Request> = {}): Request {
+  return {
+    workspaceId: "ws_1",
+    params: { streamId: "stream_1", messageId: "msg_1" },
+    body: { content: "hello" },
+    userApiKey: { id: "key_1" },
+    user: { id: "usr_1", name: "Tester" },
+    ...extra,
+  } as unknown as Request
+}
+
+describe("public API E2E-stream plaintext gate", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("rejects a plaintext sendMessage into an E2E stream with 400", async () => {
+    const isE2e = spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
+    const createMessage = mock(() => Promise.resolve({ id: "msg_new" }))
+    const handlers = createHandlers({
+      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) },
+    })
+
+    await expect(handlers.sendMessage(userRequest(), createResponse())).rejects.toMatchObject({
+      status: 400,
+      code: "E2E_STREAM_PLAINTEXT_UNSUPPORTED",
+    })
+    expect(isE2e).toHaveBeenCalledWith(expect.anything(), "ws_1", "stream_1")
+    // The gate fires before any write.
+    expect(createMessage).not.toHaveBeenCalled()
+  })
+
+  it("rejects a plaintext updateMessage into an E2E stream with 400", async () => {
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
+    const editMessage = mock(() => Promise.resolve({ id: "msg_1" }))
+    const handlers = createHandlers({
+      eventService: {
+        editMessage,
+        getMessageById: mock(() =>
+          Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
+        ),
+      },
+    })
+
+    await expect(handlers.updateMessage(userRequest(), createResponse())).rejects.toMatchObject({
+      status: 400,
+      code: "E2E_STREAM_PLAINTEXT_UNSUPPORTED",
+    })
+    expect(editMessage).not.toHaveBeenCalled()
+  })
+
+  it("lets a plaintext sendMessage into a non-E2E stream through to createMessage", async () => {
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    const createMessage = mock(() =>
+      Promise.resolve({
+        id: "msg_new",
+        streamId: "stream_1",
+        sequence: 1n,
+        authorId: "usr_1",
+        authorType: "user",
+        contentJson: { type: "doc", content: [] },
+        contentMarkdown: "hello",
+        reactions: {},
+        metadata: {},
+        editedAt: null,
+        createdAt: new Date(),
+      })
+    )
+    const handlers = createHandlers({
+      eventService: { createMessage, getMessageById: mock(() => Promise.resolve(null)) },
+    })
+
+    await handlers.sendMessage(userRequest(), createResponse())
+    expect(createMessage).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -16,6 +16,7 @@ import {
   type StreamService,
 } from "../streams"
 import { UserRepository } from "../workspaces"
+import { E2eStreamsRepository } from "../e2e-streams"
 import { PersonaRepository } from "../agents"
 import { type Memo, type MemoExplorerService, type MemoExplorerDetail, type MemoExplorerResult } from "../memos"
 import {
@@ -532,6 +533,23 @@ export function createPublicApiHandlers({
       return
     }
     throw new HttpError("No API key context", { status: 401, code: "UNAUTHORIZED" })
+  }
+
+  /**
+   * Reject a plaintext write into an end-to-end-encrypted stream. The public
+   * API has no ciphertext message path (send/update accept plaintext only), so
+   * a write here would persist a plaintext row in an E2E scratchpad and break
+   * the encryption guarantee — the same INV-E1 mismatch the first-party handler
+   * blocks. We fail before any insert. Lift this once the public API can carry
+   * a sealed payload.
+   */
+  async function assertNotE2eStream(workspaceId: string, streamId: string): Promise<void> {
+    if (await E2eStreamsRepository.isE2eStream(pool, workspaceId, streamId)) {
+      throw new HttpError("Stream is end-to-end encrypted; the public API cannot post plaintext to it", {
+        status: 400,
+        code: "E2E_STREAM_PLAINTEXT_UNSUPPORTED",
+      })
+    }
   }
 
   /** Find a message, verify stream access, and verify ownership. Used by update/delete. */
@@ -1638,6 +1656,7 @@ export function createPublicApiHandlers({
 
       // Verify stream access
       await assertStreamAccessible(req, streamId)
+      await assertNotE2eStream(workspaceId, streamId)
 
       // Normalize and parse content
       const contentMarkdown = normalizeMessage(content)
@@ -1717,6 +1736,7 @@ export function createPublicApiHandlers({
 
       const { content } = result.data
       const { message: existing, actorId, actorType, displayName } = await resolveOwnedMessage(messageId, req)
+      await assertNotE2eStream(workspaceId, existing.streamId)
 
       // Normalize and parse content
       const contentMarkdown = normalizeMessage(content)


### PR DESCRIPTION
## What

Closes the plaintext side of the public-API ↔ E2E mismatch surfaced in review of #716.

The public API has no ciphertext message path — `sendMessage`/`updateMessage` accept plaintext only — yet neither rejected a write **targeting an E2E stream**. A plaintext row landing in an end-to-end-encrypted scratchpad breaks the encryption guarantee. This is the same **INV-E1** mismatch the first-party messaging handler already blocks (`messaging/handlers.ts`).

## How

- New `assertNotE2eStream(workspaceId, streamId)` helper in the public-API handler factory — a thin gate over the existing `E2eStreamsRepository.isE2eStream` check (single `SELECT EXISTS`).
- Called right after the access check in **both** `sendMessage` and `updateMessage`, so the request fails with `400 E2E_STREAM_PLAINTEXT_UNSUPPORTED` **before any insert**.
- The companion *upload* path already rejects `e2e=true` with `E2E_UPLOAD_UNSUPPORTED` (#716); this closes the plaintext-write side of the same surface. Both lift once the public API can carry a sealed payload (the Pi-remote-with-files slice).

## Tests

New `public-api/e2e-stream-gate.test.ts` drives the handler factory with mocked deps and a scoped `spyOn` against `E2eStreamsRepository.isE2eStream` (INV-48):
- plaintext `sendMessage` into an E2E stream → 400, `createMessage` never called
- plaintext `updateMessage` into an E2E stream → 400, `editMessage` never called
- plaintext `sendMessage` into a non-E2E stream → passes through to `createMessage`

3 pass. Pre-commit gate (lint + all workspace typechecks + OpenAPI `--check`) clean.

## Stacking

⚠️ Stacked on **#716** — base is `claude/e2e-encrypted-scratchpads-yGDO5`, not `main`. The diff shown here is **only** this commit. Once #716 squash-merges, retarget this PR to `main` (and rebase to drop the squashed parent).

https://claude.ai/code/session_01U24CNMnpvpPeWpJ2YkxDdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U24CNMnpvpPeWpJ2YkxDdA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782843564&installation_id=129946197&pr_number=720&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F720&signature=997e67e6b95f60fb6fe3859c1c2e3e0081ef44687823a3d638304bd74fdbfd3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->