### PR TITLE
Fix infinite "Updating Threa" loop on stale-deploy recovery

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -153,11 +153,21 @@
             }
           }
           if (hasStyles) {
-            // Styles loaded successfully — reset counter so future breaks can recover
-            sessionStorage.removeItem("sw-recovery-attempts")
+            // Styles loaded — but a broken JS chunk loads CSS fine too, so
+            // "hasStyles" is NOT proof the last recovery worked. Only clear the
+            // counter when the last attempt is old enough that the app has
+            // clearly been healthy since; otherwise a chunk-error reload loop
+            // would keep zeroing this and never reach the cap that surfaces the
+            // escape UI. Cooldown mirrors the note in src/lib/sw-recovery.ts.
+            var last = parseInt(sessionStorage.getItem("sw-recovery-last") || "0", 10)
+            if (!last || Date.now() - last > 60000) {
+              sessionStorage.removeItem("sw-recovery-attempts")
+              sessionStorage.removeItem("sw-recovery-last")
+            }
             return
           }
           sessionStorage.setItem("sw-recovery-attempts", String(attempts + 1))
+          sessionStorage.setItem("sw-recovery-last", String(Date.now()))
           var tasks = []
           if (navigator.serviceWorker) {
             tasks.push(

--- a/apps/frontend/src/lib/sw-recovery.test.ts
+++ b/apps/frontend/src/lib/sw-recovery.test.ts
@@ -47,6 +47,7 @@ describe("runSwRecovery", () => {
   afterEach(() => {
     Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
     sessionStorage.clear()
+    vi.restoreAllMocks()
   })
 
   it("returns false without reloading once the per-session cap is reached", async () => {

--- a/apps/frontend/src/lib/sw-recovery.test.ts
+++ b/apps/frontend/src/lib/sw-recovery.test.ts
@@ -63,6 +63,22 @@ describe("runSwRecovery", () => {
     expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("2")
   })
 
+  it("stamps the last-attempt time so the watchdog's reset can be cooldown-gated", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+    await runSwRecovery()
+    // The index.html CSS watchdog reads this stamp and refuses to clear the
+    // shared counter while it's recent — that's what stops a broken-chunk
+    // reload loop from zeroing the counter and never reaching the cap.
+    expect(sessionStorage.getItem("sw-recovery-last")).toBe(String(now))
+  })
+
+  it("force: true does not stamp the last-attempt time", async () => {
+    const result = await runSwRecovery({ force: true })
+    expect(result).toBe(true)
+    expect(sessionStorage.getItem("sw-recovery-last")).toBeNull()
+  })
+
   it("force: true bypasses the cap and does not touch the counter", async () => {
     sessionStorage.setItem("sw-recovery-attempts", "2")
     const result = await runSwRecovery({ force: true })

--- a/apps/frontend/src/lib/sw-recovery.ts
+++ b/apps/frontend/src/lib/sw-recovery.ts
@@ -13,8 +13,9 @@
  * index.html watchdog only clears the counter on a healthy load when that
  * stamp is older than its reset cooldown — so a broken JS chunk (CSS still
  * loads fine!) can't keep zeroing the counter on every reload and loop past
- * the cap. The cooldown lives in index.html (it can't import this module);
- * keep the two in sync.
+ * the cap. The reset cooldown (60s) is enforced in index.html, which owns the
+ * only read of the stamp — it can't import this module, so keep the two in
+ * sync.
  */
 
 const ATTEMPTS_KEY = "sw-recovery-attempts"

--- a/apps/frontend/src/lib/sw-recovery.ts
+++ b/apps/frontend/src/lib/sw-recovery.ts
@@ -8,9 +8,17 @@
  * The sessionStorage counter is shared (same key) so both paths together
  * can only reload at most MAX_ATTEMPTS times before falling through to the
  * normal error UI — otherwise a persistent failure could loop forever.
+ *
+ * Every increment also stamps LAST_ATTEMPT_KEY with the current time. The
+ * index.html watchdog only clears the counter on a healthy load when that
+ * stamp is older than its reset cooldown — so a broken JS chunk (CSS still
+ * loads fine!) can't keep zeroing the counter on every reload and loop past
+ * the cap. The cooldown lives in index.html (it can't import this module);
+ * keep the two in sync.
  */
 
 const ATTEMPTS_KEY = "sw-recovery-attempts"
+const LAST_ATTEMPT_KEY = "sw-recovery-last"
 const MAX_ATTEMPTS = 2
 
 /**
@@ -48,6 +56,7 @@ export async function runSwRecovery(options?: { force?: boolean }): Promise<bool
     const attempts = Number.parseInt(sessionStorage.getItem(ATTEMPTS_KEY) ?? "0", 10)
     if (attempts >= MAX_ATTEMPTS) return false
     sessionStorage.setItem(ATTEMPTS_KEY, String(attempts + 1))
+    sessionStorage.setItem(LAST_ATTEMPT_KEY, String(Date.now()))
   }
 
   const tasks: Promise<unknown>[] = []


### PR DESCRIPTION
## Problem

A tab could get permanently trapped on the chunk-load auto-recovery screen — **"Updating Threa / Fetching the latest version…"** — with no way out (no buttons, just a spinner). Reported from a mobile/PWA session.

That screen is the stale-deploy recovery state in `error-boundary.tsx`: when an old tab requests a lazy JS chunk whose content-hashed filename was replaced by a newer build, the import 404s and the app tries to self-heal (unregister SW, clear caches, hard-reload). The escape hatch — the error card with **Try Again / Back to Workspaces / Clear cache & reload** — only appears once `runSwRecovery()` reaches its per-session cap (`MAX_ATTEMPTS = 2`), returns `false`, and flips `recoveryDeclined = true`.

## Root cause

The cap could never be reached. The CSS watchdog in `index.html` cleared the shared `sw-recovery-attempts` counter on **every** load where stylesheets were present:

```js
if (hasStyles) {
  sessionStorage.removeItem("sw-recovery-attempts")  // ← the bug
  return
}
```

A broken **JS** chunk loads **CSS** just fine. So each reload cycle went: load → watchdog sees styles, zeroes the counter → router re-enters the dead route → chunk 404 → `runSwRecovery()` (counter 0→1) → reload → repeat. The counter ping-ponged 0↔1 forever, the cap was never hit, the escape buttons never rendered. Permanent spinner.

## Fix

Stamp each recovery attempt with a timestamp (`sw-recovery-last`), and only clear the counter on a healthy load when that stamp is older than a 60s cooldown:

- In a tight reload loop, attempts are seconds apart → the counter accumulates to the cap → the escape UI surfaces (within ~2 cycles).
- A genuine one-off recovery (app heals and stays up) still clears the counter later, so future unrelated breaks can recover.

The cooldown/keys are duplicated across `index.html` (plain JS, can't import TS) and `sw-recovery.ts`, mirroring the existing `MAX_ATTEMPTS` duplication; both sides document the sync requirement.

## Testing

- `apps/frontend/src/lib/sw-recovery.test.ts` — added coverage that each auto-recovery attempt stamps `sw-recovery-last`, and that `force: true` does not. 10/10 green.
- Existing cap/increment/force tests still pass.
- Full pre-commit suite (monorepo lint + typecheck) passed on push.

## Follow-up (not in this PR)

This guarantees escape from the loop but doesn't address *why* reloads weren't curing the underlying 404 — that points at stale assets being served post-deploy (CDN/edge cache on `index.html`, or the SW re-serving old content). Worth a separate look at the deploy/caching layer.

https://claude.ai/code/session_019CUa7RRYsV54b29dX6i5qs

---
_Generated by [Claude Code](https://claude.ai/code/session_019CUa7RRYsV54b29dX6i5qs)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782845138&installation_id=129946197&pr_number=721&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F721&signature=47daf9d2c9616bd864971da34075dc72935cf830ee131eaff357f0231fd7e451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->