### PR TITLE
fix(sidebar): restyle the "New" create button with the gold thread accent

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -259,6 +259,28 @@ export function SidebarFooter({
   )
 }
 
+// Shared face for the create control. A gold "thread" chip carries the emphasis
+// (per the design system, --primary is the single accent that signals primary
+// actions), the label sits left-aligned so the control reads as a sidebar row
+// rather than a form button, and the trailing chevron telegraphs the upward
+// menu — rhyming with the account row beneath it. The whole face reacts to the
+// trigger's `data-state` so hover and open share one warm treatment; both the
+// Radix desktop trigger and the manual mobile button expose that attribute.
+function SidebarCreateButtonFace() {
+  return (
+    <>
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary transition-colors group-hover/new:bg-primary/25 group-data-[state=open]/new:bg-primary/25">
+        <Plus className="h-4 w-4" />
+      </span>
+      <span className="flex-1 text-left font-medium">New</span>
+      <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/new:rotate-180" />
+    </>
+  )
+}
+
+const CREATE_BUTTON_CLASS =
+  "group/new w-full justify-start gap-2.5 px-2.5 bg-primary/[0.04] hover:bg-primary/10 hover:text-foreground data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
+
 /**
  * The always-visible "New" control at the bottom of the sidebar. Opens a menu of
  * every stream flavor (scratchpad variants + channel). Uses a bottom drawer on
@@ -272,15 +294,15 @@ function SidebarCreateButton({ actions, isMobile }: { actions: SidebarActionItem
     return (
       <>
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
-          className="w-full gap-2"
+          className={CREATE_BUTTON_CLASS}
+          data-state={open ? "open" : "closed"}
           aria-haspopup="dialog"
           aria-expanded={open}
           onClick={() => setOpen(true)}
         >
-          <Plus className="h-4 w-4" />
-          New
+          <SidebarCreateButtonFace />
         </Button>
         <SidebarActionDrawer
           open={open}
@@ -293,9 +315,6 @@ function SidebarCreateButton({ actions, isMobile }: { actions: SidebarActionItem
     )
   }
 
-  // Outline (not filled) so it sits with the ghost account row beneath it rather
-  // than reading as a floating action bar — the app reserves filled primary for
-  // content-area CTAs. Radix wires aria-haspopup/expanded on the trigger.
   return (
     <SidebarActionMenu
       actions={actions}
@@ -304,9 +323,8 @@ function SidebarCreateButton({ actions, isMobile }: { actions: SidebarActionItem
       align="start"
       contentClassName="w-56"
       trigger={
-        <Button variant="outline" size="sm" className="w-full gap-2">
-          <Plus className="h-4 w-4" />
-          New
+        <Button variant="ghost" size="sm" className={CREATE_BUTTON_CLASS}>
+          <SidebarCreateButtonFace />
         </Button>
       }
     />


### PR DESCRIPTION
## Problem

The always-visible "+ New" create control at the bottom of the sidebar read as a generic neutral `outline` rectangle with a centered `+ New` — a form submit button, not the warm, inviting create affordance it should be. It had no brand character, no use of the gold thread accent, and no signal that it opens a menu of stream flavors. It felt "backendy" against the rest of the warm, restrained sidebar.

## Solution

Rework the control to sit inside Threa's own design language (per `DESIGN.md` §0 "Gold on paper, ink for substance" and §6) rather than against it:

### Key design decisions

**1. The gold thread carries the emphasis.**
The `+` now lives in a small gold "thread" chip (`bg-primary/15` with a gold icon). The design system reserves `--primary` as the single accent for primary actions, and *create* is exactly that. The row gets a faint warm wash (`bg-primary/[0.04]`) at rest so it reads as the inviting create CTA rather than a third grey menu row — deepening to `bg-primary/10` on hover/open.

**2. Reads as a sidebar row, not a form button.**
Switched from the `outline` variant to `ghost` and left-aligned the content (chip · label · trailing chevron). It now visually rhymes with the account row directly beneath it — both are ghost rows with a leading glyph and a trailing `ChevronUp` — forming a cohesive footer "menu pair."

**3. Telegraphs the menu.**
A trailing `ChevronUp` rotates 180° when the menu opens, on a 0.2s transition (the app's standard `ease-out` duration). No layout shift (INV-21).

**4. One warm treatment for hover + open, on both platforms.**
Hover and open share a single gold treatment driven off the trigger's `data-state`. The Radix desktop dropdown sets `data-state` automatically; I set it manually on the mobile drawer button so the shared `group-data-[state=open]` styling works identically on both.

The shared face is extracted into a top-level `SidebarCreateButtonFace` component (INV-18: no nested component definitions), and the change sticks to existing primitives and icons (Shadcn `Button`, lucide `Plus`/`ChevronUp`) — no new dependencies, tokens, or colors introduced.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | Reworked `SidebarCreateButton` to a ghost row with a gold thread chip, left-aligned label, and a state-reactive chevron; extracted `SidebarCreateButtonFace` and a shared class constant |

## Test plan

- [x] `apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx` — all 3 existing tests pass (button's accessible name is still "New")
- [x] Frontend typecheck clean (`tsc --noEmit`)
- [ ] Visual check on the per-PR staging environment (desktop dropdown + mobile drawer, light/dark) — couldn't render the authenticated workspace shell locally

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0142wwQi87v5HKbiSxCgD3nt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782935077&installation_id=129946197&pr_number=723&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F723&signature=1f0ae310f040c50bebe5a975db024119d45c259eabe9ab60ce99f7dff9e74204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->