### PR TITLE
fix(frontend): flatten nested quote replies with a compact rail

### DIFF
--- a/apps/frontend/src/lib/markdown/blockquote-block.tsx
+++ b/apps/frontend/src/lib/markdown/blockquote-block.tsx
@@ -7,8 +7,10 @@ import { useBlockCollapse } from "./use-block-collapse"
 import { useMeasuredLineCount } from "./use-measured-line-count"
 import {
   InsideCollapsibleBlockProvider,
+  QuoteNestingDepthProvider,
   useIsInsideCollapsibleBlock,
   useMarkdownBlockContext,
+  useQuoteNestingDepth,
 } from "./markdown-block-context"
 import { extractBlockText } from "./extract-block-text"
 
@@ -25,6 +27,7 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
 
   const messageContext = useMarkdownBlockContext()
   const nested = useIsInsideCollapsibleBlock()
+  const depth = useQuoteNestingDepth()
   // Whether folding is even possible here is a synchronous fact (is there a
   // message to persist against, and are we the outermost block?). Branching
   // the DOM on this — not on the async measurement — keeps the measured node
@@ -53,8 +56,15 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
   // swaps with the foldable structure mid-life.
   if (!foldable) {
     return (
-      <blockquote className="my-2 border-l-2 border-primary/50 pl-4 text-muted-foreground italic">
-        {children}
+      <blockquote
+        className={cn(
+          "border-l-2 border-primary/50 text-muted-foreground italic",
+          // Nested quotes use a tighter inset so depth doesn't march the text
+          // off the right edge on mobile; top-level keeps the roomier pl-4.
+          depth > 0 ? "my-1.5 pl-3" : "my-2 pl-4"
+        )}
+      >
+        <QuoteNestingDepthProvider>{children}</QuoteNestingDepthProvider>
       </blockquote>
     )
   }
@@ -103,7 +113,7 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
             style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
             onClick={bodyExpandable ? toggle : undefined}
           >
-            {children}
+            <QuoteNestingDepthProvider>{children}</QuoteNestingDepthProvider>
           </div>
           {collapsed && (
             <div

--- a/apps/frontend/src/lib/markdown/markdown-block-context.tsx
+++ b/apps/frontend/src/lib/markdown/markdown-block-context.tsx
@@ -61,6 +61,26 @@ export function useIsInsideCollapsibleBlock(): boolean {
 }
 
 /**
+ * Tracks how deeply quoted content is nested (quote-reply or blockquote inside
+ * another). Depth 0 is the outermost quote in a message; anything deeper is a
+ * nested quote. Rendering uses this to keep only the outermost quote as a full
+ * card and render nested quotes as a lightweight left-rail, so repeated box
+ * chrome and padding don't compound — which got unreadable on mobile past two
+ * levels. The provider reads the parent depth and increments, so callers just
+ * wrap their children without threading a number through.
+ */
+const QuoteNestingDepthContext = createContext<number>(0)
+
+export function QuoteNestingDepthProvider({ children }: { children: ReactNode }) {
+  const parentDepth = useContext(QuoteNestingDepthContext)
+  return <QuoteNestingDepthContext.Provider value={parentDepth + 1}>{children}</QuoteNestingDepthContext.Provider>
+}
+
+export function useQuoteNestingDepth(): number {
+  return useContext(QuoteNestingDepthContext)
+}
+
+/**
  * DJB2 hash of `namespace\0content`. Namespacing keeps the hash spaces of
  * different block kinds (and of different code-block languages) disjoint so
  * identical content doesn't alias across them. Not cryptographic.

--- a/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.test.tsx
@@ -153,6 +153,42 @@ describe("QuoteReplyBlock collapse behavior", () => {
     expect(row?.kind).toBe("quote-reply")
   })
 
+  it("renders the outermost quote reply as a card and nested replies as a compact rail", () => {
+    renderQuoteReply(
+      <QuoteReplyBlock
+        authorName="Alex"
+        authorId="user_alex"
+        actorType="user"
+        streamId="stream_src"
+        messageId="msg_src"
+      >
+        <p>Outer reply text.</p>
+        <QuoteReplyBlock
+          authorName="Bea"
+          authorId="user_bea"
+          actorType="user"
+          streamId="stream_inner"
+          messageId="msg_inner"
+        >
+          <p>Inner reply text.</p>
+        </QuoteReplyBlock>
+      </QuoteReplyBlock>,
+      "msg_nested_card"
+    )
+
+    // Both quoted bodies and authors survive the nesting.
+    expect(screen.getByText("Outer reply text.")).toBeInTheDocument()
+    expect(screen.getByText("Inner reply text.")).toBeInTheDocument()
+    expect(screen.getByText("Bea")).toBeInTheDocument()
+
+    // Only the outermost card carries the leading Quote glyph; the nested rail
+    // drops it so the heavy card chrome doesn't repeat at every level.
+    expect(document.querySelectorAll(".lucide-quote")).toHaveLength(1)
+
+    // The single card fill belongs to the outer block; the nested rail has none.
+    expect(document.querySelectorAll(".bg-muted\\/30")).toHaveLength(1)
+  })
+
   it("only the outer quote-reply folds when a blockquote is nested inside it", () => {
     // Outer is long enough to be collapsible, so it owns the only fold toggle
     // and suppresses the nested blockquote's chrome.

--- a/apps/frontend/src/lib/markdown/quote-reply-block.tsx
+++ b/apps/frontend/src/lib/markdown/quote-reply-block.tsx
@@ -10,7 +10,11 @@ import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
 import { useBlockCollapse } from "./use-block-collapse"
 import { useMeasuredLineCount } from "./use-measured-line-count"
-import { InsideCollapsibleBlockProvider } from "./markdown-block-context"
+import {
+  InsideCollapsibleBlockProvider,
+  QuoteNestingDepthProvider,
+  useQuoteNestingDepth,
+} from "./markdown-block-context"
 import { extractBlockText } from "./extract-block-text"
 
 interface QuoteReplyBlockProps {
@@ -37,6 +41,12 @@ export function QuoteReplyBlock({
   children,
 }: QuoteReplyBlockProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
+
+  // Depth 0 is the outermost quote in a message and keeps the full card. Nested
+  // quotes render as a compact left-rail so box chrome and padding don't
+  // compound into an unreadable staircase on mobile.
+  const depth = useQuoteNestingDepth()
+  const isRail = depth > 0
 
   const quotedText = useMemo(() => extractBlockText(children), [children])
 
@@ -73,53 +83,80 @@ export function QuoteReplyBlock({
   const collapsedMaxHeight =
     collapsed && measured.lineHeightPx !== null ? (threshold + 0.5) * measured.lineHeightPx : undefined
 
+  const header = (
+    <div className="flex items-center gap-1.5">
+      <QuoteAuthor
+        workspaceId={workspaceId}
+        authorName={authorName}
+        authorId={authorId}
+        actorType={actorType as AuthorType}
+      />
+      {canToggle && (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-label={collapseLabel}
+          title={collapseLabel}
+          className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-primary/10 hover:text-foreground"
+        >
+          {collapsed ? (
+            <ChevronRight className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3 w-3" aria-hidden="true" />
+          )}
+        </button>
+      )}
+    </div>
+  )
+
+  const body = (
+    <Link
+      to={url}
+      className="relative mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
+    >
+      <div
+        ref={bodyRef}
+        className={cn("[&_p]:mb-0", collapsed && "overflow-hidden")}
+        style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
+      >
+        <QuoteNestingDepthProvider>{children}</QuoteNestingDepthProvider>
+      </div>
+      {collapsed && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent",
+            // Fade into whatever sits behind: the card's muted fill, or the
+            // message background for the nested rail (no fill of its own).
+            isRail ? "to-background" : "to-muted/30"
+          )}
+        />
+      )}
+    </Link>
+  )
+
+  // Nested quotes drop the card and the leading Quote glyph for a thin
+  // primary-accent rail (the same vocabulary as a plain blockquote), so each
+  // level adds ~14px of inset instead of a full bordered box.
+  if (isRail) {
+    return (
+      <InsideCollapsibleBlockProvider active={canToggle}>
+        <div className="my-1.5 min-w-0 border-l-2 border-primary/40 pl-3 text-sm">
+          {header}
+          {body}
+        </div>
+      </InsideCollapsibleBlockProvider>
+    )
+  }
+
   return (
     <InsideCollapsibleBlockProvider active={canToggle}>
       <div className="my-2 flex items-start gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-sm">
         <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <QuoteAuthor
-              workspaceId={workspaceId}
-              authorName={authorName}
-              authorId={authorId}
-              actorType={actorType as AuthorType}
-            />
-            {canToggle && (
-              <button
-                type="button"
-                onClick={toggle}
-                aria-expanded={!collapsed}
-                aria-label={collapseLabel}
-                title={collapseLabel}
-                className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-primary/10 hover:text-foreground"
-              >
-                {collapsed ? (
-                  <ChevronRight className="h-3 w-3" aria-hidden="true" />
-                ) : (
-                  <ChevronDown className="h-3 w-3" aria-hidden="true" />
-                )}
-              </button>
-            )}
-          </div>
-          <Link
-            to={url}
-            className="relative mt-0.5 block text-muted-foreground no-underline transition-colors hover:text-foreground"
-          >
-            <div
-              ref={bodyRef}
-              className={cn("[&_p]:mb-0", collapsed && "overflow-hidden")}
-              style={collapsedMaxHeight !== undefined ? { maxHeight: collapsedMaxHeight } : undefined}
-            >
-              {children}
-            </div>
-            {collapsed && (
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-muted/30"
-              />
-            )}
-          </Link>
+          {header}
+          {body}
         </div>
       </div>
     </InsideCollapsibleBlockProvider>


### PR DESCRIPTION
## Problem

Quote replies render as a "card": a bordered box with a muted fill, a leading `Quote` glyph, and an avatar/author header. That works for a single quote, but quote replies nest — a reply quoting a reply quoting a reply. At every level the **entire card repeats**, so:

- horizontal padding compounds (~36px of left inset per level: `px-3` both sides + a 16px icon + an 8px gap),
- the `bg-muted/30` fills stack and the background gets progressively muddier,
- the `Quote` glyph and avatar chrome are repeated at every depth.

Three levels deep on a ~360px phone leaves almost no room for the actual text. It got unreadable past two levels of nesting.

## Solution

Keep the **outermost** quote as the familiar card, but render **nested** quotes as a lightweight left **rail** — the same `border-l-2 border-primary/…` accent the app already uses for plain blockquotes (`index.css`, `BlockquoteBlock`). No box, no fill, no repeated glyph.

| | Old (every level) | New (nested levels) |
| --- | --- | --- |
| Container | bordered box + `bg-muted/30` fill | thin `border-l-2 border-primary/40` rail |
| Leading icon | `Quote` glyph repeated | dropped (the rail signals "quote") |
| Left inset / level | ~36px | ~14px |
| Background | stacks, gets muddier | none — sits on the message background |

The author line is preserved at every level so you still see who said what, and collapse behavior is unchanged.

### Key design decisions

**1. Depth context instead of a boolean "nested" flag.** A new `QuoteNestingDepthContext` (in `markdown-block-context.tsx`) auto-increments from its parent, and **both** `QuoteReplyBlock` and `BlockquoteBlock` provide it for their children. This keeps the card-vs-rail decision correct across mixed nesting (a quote reply inside a markdown blockquote, or vice versa), not just quote-reply-in-quote-reply. Depth 0 = card, deeper = rail.

**2. Reuse the existing blockquote vocabulary, not a new style.** Per the project's frontend-design guidance for working inside an existing app, the rail is the same `border-l-2 border-primary` left-accent already used for plain blockquotes and the ProseMirror editor, so nothing reads as foreign. Nested plain blockquotes also tighten their inset (`pl-4 → pl-3`) so deep nesting doesn't march text off the right edge on mobile.

**3. Shared header/body, branch only on the wrapper.** `QuoteReplyBlock` builds the author header and quoted body once, then chooses the card or rail wrapper — avoiding two divergent copies of the collapse/link logic.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/lib/markdown/markdown-block-context.tsx` | Add `QuoteNestingDepthContext` + provider/hook |
| `apps/frontend/src/lib/markdown/quote-reply-block.tsx` | Shared header/body; card-vs-rail split driven by nesting depth |
| `apps/frontend/src/lib/markdown/blockquote-block.tsx` | Thread depth to children; tighten nested plain-blockquote inset |
| `apps/frontend/src/lib/markdown/quote-reply-block.test.tsx` | Test: outer keeps the card glyph/fill, nested replies render the rail |

## Test plan

- [x] `bun run test` on the markdown suite (112 passing, incl. the new nesting test)
- [x] Full-monorepo `typecheck` (passes; runs in pre-commit)
- [x] ESLint (passes in pre-commit)
- [ ] Visual confirmation on a real 3-level nest at mobile width (staging env)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01KnkFPgwXybJ7GSjRB4jBpC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782938605&installation_id=129946197&pr_number=724&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F724&signature=c2ad91fe50412f84f3435125a517085dc73977b5ca33165af474126fa212136a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->