### PR TITLE
fix(sidebar): keep unread + hover-preview live for unopened streams

### DIFF
--- a/apps/frontend/src/components/attachment-explorer/explorer-filters.tsx
+++ b/apps/frontend/src/components/attachment-explorer/explorer-filters.tsx
@@ -62,7 +62,7 @@ export function ExplorerFilters({ workspaceId, filters, parentStreamId, onUpdate
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
-  const { getMentionCount } = useActivityCounts(workspaceId)
+  const { getMentionCount, getActivityCount } = useActivityCounts(workspaceId)
   const unreadState = useWorkspaceUnreadState(workspaceId)
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
 
@@ -110,13 +110,14 @@ export function ExplorerFilters({ workspaceId, filters, parentStreamId, onUpdate
         const score = scoreStreamMatch(stream, lowerQuery)
         const unreadCount = getUnreadCount(stream.id)
         const mentionCount = getMentionCount(stream.id)
+        const activityCount = getActivityCount(stream.id)
         const isMuted = mutedStreamIds.has(stream.id)
-        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted, activityCount)
         return { stream, score, urgency }
       })
       .filter(({ score }) => score !== Infinity)
       .sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: "recency" }))
-  }, [streams, streamSearch, filters.streamIds, getUnreadCount, getMentionCount, mutedStreamIds])
+  }, [streams, streamSearch, filters.streamIds, getUnreadCount, getMentionCount, getActivityCount, mutedStreamIds])
 
   const labelForStream = (stream: { type: string; displayName?: string | null; slug?: string | null }) =>
     streamLabel(stream)

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -75,7 +75,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const labelAssignments = useWorkspaceLabelAssignments(workspaceId)
   const { createDraft } = useDraftScratchpads(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
-  const { getMentionCount, unreadActivityCount } = useActivityCounts(workspaceId)
+  const { getMentionCount, getActivityCount, unreadActivityCount } = useActivityCounts(workspaceId)
   const { drafts: allDrafts } = useAllDrafts(workspaceId)
   const { openCreateChannel } = useCreateChannel()
   const { user } = useAuth()
@@ -120,8 +120,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
         const streamWithPreview = { ...stream, lastMessagePreview: stream.lastMessagePreview ?? null }
         const unreadCount = getUnreadCount(stream.id)
         const mentionCount = getMentionCount(stream.id)
+        const activityCount = getActivityCount(stream.id)
         const isMuted = mutedStreamIdSet.has(stream.id)
-        const urgency = calculateUrgency(streamWithPreview, unreadCount, mentionCount, isMuted)
+        const urgency = calculateUrgency(streamWithPreview, unreadCount, mentionCount, isMuted, activityCount)
         const section = categorizeStream(streamWithPreview, unreadCount, urgency)
         const dmPeerUserId = dmPeerByStreamId.get(stream.id) ?? dmPeerByStreamId.get(stream.rootStreamId ?? "")
 
@@ -147,6 +148,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     mutedStreamIdSet,
     getUnreadCount,
     getMentionCount,
+    getActivityCount,
     dmPeerByStreamId,
     idbDmPeers,
     workspaceUsers,

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -140,6 +140,22 @@ describe("categorizeStream", () => {
     expect(categorizeStream(stream, 1, "activity")).toBe("recent")
   })
 
+  it("promotes activity-only streams to 'recent' even when the cached preview is stale", () => {
+    // A notification arrived via the always-joined user room (urgency "activity")
+    // before the per-stream stream:activity bumped the unread count. The sidebar
+    // row glows, so it must not sink into "other" just because its last cached
+    // message is older than 7 days.
+    const stream = makeStream({
+      lastMessagePreview: {
+        authorId: "user_2",
+        authorType: "user",
+        content: "hello",
+        createdAt: "2026-03-01T12:00:00Z", // >7 days ago
+      },
+    })
+    expect(categorizeStream(stream, 0, "activity")).toBe("recent")
+  })
+
   it("puts streams with no preview and no unread in 'other'", () => {
     const stream = makeStream({ lastMessagePreview: null })
     expect(categorizeStream(stream, 0, "quiet")).toBe("other")

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -57,6 +57,25 @@ describe("calculateUrgency", () => {
   it("returns quiet with no unread and no mentions", () => {
     expect(calculateUrgency(streamWith(AuthorTypes.BOT), 0, 0, false)).toBe("quiet")
   })
+
+  it("surfaces activity when a notification landed but unread was missed", () => {
+    // activity:created bumped activityCount via the user room, but the per-stream
+    // stream:activity that drives unreadCount never arrived — the sidebar should
+    // still light up to match the Activity feed.
+    expect(calculateUrgency(streamWith("user"), 0, 0, false, 2)).toBe("activity")
+  })
+
+  it("prefers mentions over the activity fallback", () => {
+    expect(calculateUrgency(streamWith("user"), 0, 1, false, 2)).toBe("mentions")
+  })
+
+  it("prefers unread author-typed urgency over the activity fallback", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.PERSONA), 1, 0, false, 2)).toBe("ai")
+  })
+
+  it("stays quiet when muted even with pending activity", () => {
+    expect(calculateUrgency(streamWith("user"), 0, 0, true, 2)).toBe("quiet")
+  })
 })
 
 describe("categorizeStream", () => {

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -49,12 +49,14 @@ export function categorizeStream(stream: StreamWithPreview, unreadCount: number,
     return "important"
   }
 
-  // Any stream with unread activity stays in Recent regardless of age or
-  // whether a preview has been cached yet. An active chat should never sink
-  // into "Everything else" while the user is still catching up. Muted streams
+  // A stream the user is still catching up on stays in Recent regardless of age
+  // or whether a preview has been cached yet — it should never sink into
+  // "Everything else". This covers unread messages and activity-only streams: a
+  // notification can arrive via the always-joined user room (urgency "activity")
+  // before the per-stream stream:activity bumps the unread count. Muted streams
   // (urgency "quiet") are excluded — muting is an explicit deprioritization
   // signal, so unread messages in a muted stream should not resurface.
-  if (unreadCount > 0 && urgency !== "quiet") {
+  if (urgency !== "quiet" && (unreadCount > 0 || urgency === "activity")) {
     return "recent"
   }
 

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -9,12 +9,13 @@ interface StreamWithOptionalPreview {
   lastMessagePreview?: { authorType: AuthorType } | null
 }
 
-/** Calculate urgency level for a stream based on unread and mention state */
+/** Calculate urgency level for a stream based on unread, mention, and activity state */
 export function calculateUrgency(
   stream: StreamWithOptionalPreview,
   unreadCount: number,
   mentionCount: number,
-  isMuted: boolean
+  isMuted: boolean,
+  activityCount = 0
 ): UrgencyLevel {
   if (isMuted) return "quiet"
 
@@ -26,6 +27,13 @@ export function calculateUrgency(
     if (authorType === AuthorTypes.BOT) return "bot"
     return "activity"
   }
+
+  // A notification reached the always-joined per-user room (activity:created)
+  // but the per-stream stream:activity that drives unreadCount was missed — e.g.
+  // before the stream-room join lands, or while it's briefly disconnected. Light
+  // the stream so the sidebar never stays quiet for something the Activity feed
+  // is already showing.
+  if (activityCount > 0) return "activity"
 
   return "quiet"
 }

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -73,7 +73,7 @@ export function useStreamItems(context: ModeContext): ModeResult {
   } = context
 
   const { getUnreadCount } = useUnreadCounts(workspaceId)
-  const { getMentionCount } = useActivityCounts(workspaceId)
+  const { getMentionCount, getActivityCount } = useActivityCounts(workspaceId)
   const unreadState = useWorkspaceUnreadState(workspaceId)
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
 
@@ -171,8 +171,9 @@ export function useStreamItems(context: ModeContext): ModeResult {
         const score = scoreStreamMatch(stream, lowerQuery)
         const unreadCount = getUnreadCount(stream.id)
         const mentionCount = getMentionCount(stream.id)
+        const activityCount = getActivityCount(stream.id)
         const isMuted = mutedStreamIds.has(stream.id)
-        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted, activityCount)
         return { stream, score, unreadCount, mentionCount, urgency }
       })
       .filter(({ score }) => score !== Infinity)
@@ -271,6 +272,7 @@ export function useStreamItems(context: ModeContext): ModeResult {
     closeDialog,
     getUnreadCount,
     getMentionCount,
+    getActivityCount,
     mutedStreamIds,
   ])
 

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -67,6 +67,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
   const unreadState = useWorkspaceUnreadState(workspaceId)
   const unreadCounts = unreadState?.unreadCounts ?? EMPTY_COUNTS
   const mentionCounts = unreadState?.mentionCounts ?? EMPTY_COUNTS
+  const activityCounts = unreadState?.activityCounts ?? EMPTY_COUNTS
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   // The Drawer/Dialog split is owned by ResponsiveDialog; isMobile here only
   // governs the post-select navigation contract (mobile strips `?panel=…`).
@@ -94,8 +95,9 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
         const score = scoreStreamMatch(stream, lower)
         const unreadCount = unreadCounts[stream.id] ?? 0
         const mentionCount = mentionCounts[stream.id] ?? 0
+        const activityCount = activityCounts[stream.id] ?? 0
         const isMuted = mutedStreamIds.has(stream.id)
-        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted, activityCount)
         return { stream, score, urgency }
       })
       .filter(({ score }) => score !== Infinity)
@@ -110,7 +112,7 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
       list.sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: sortMode }))
     }
     return byType
-  }, [streams, memberStreamIds, search, sortMode, unreadCounts, mentionCounts, mutedStreamIds])
+  }, [streams, memberStreamIds, search, sortMode, unreadCounts, mentionCounts, activityCounts, mutedStreamIds])
 
   // Wrap the parent's open-change so search resets on every close path
   // (Esc, backdrop, X, programmatic). Without this, dismissing without

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -70,6 +70,7 @@ export function SharePickerPage() {
   const unreadState = useWorkspaceUnreadState(workspaceId!)
   const unreadCounts = unreadState?.unreadCounts ?? EMPTY_COUNTS
   const mentionCounts = unreadState?.mentionCounts ?? EMPTY_COUNTS
+  const activityCounts = unreadState?.activityCounts ?? EMPTY_COUNTS
   const mutedStreamIds = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   const { createShareDraft, saveShareContent } = useShareTarget()
 
@@ -197,8 +198,9 @@ export function SharePickerPage() {
         const score = scoreStreamMatch(stream, lowerQuery)
         const unreadCount = unreadCounts[stream.id] ?? 0
         const mentionCount = mentionCounts[stream.id] ?? 0
+        const activityCount = activityCounts[stream.id] ?? 0
         const isMuted = mutedStreamIds.has(stream.id)
-        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted)
+        const urgency = calculateUrgency(stream, unreadCount, mentionCount, isMuted, activityCount)
         return { stream, score, urgency, unreadCount, mentionCount }
       })
       .filter(({ score }) => score !== Infinity)
@@ -238,6 +240,7 @@ export function SharePickerPage() {
     handleSelectStream,
     unreadCounts,
     mentionCounts,
+    activityCounts,
     mutedStreamIds,
   ])
 

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -453,4 +453,71 @@ describe("SyncEngine.handlePageResume", () => {
       expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", undefined)
     })
   })
+
+  it("joins every member-stream room after a successful bootstrap", async () => {
+    const deps = makeDeps()
+    const bootstrap = makeWorkspaceBootstrap()
+    bootstrap.streamMemberships = [
+      {
+        streamId: "stream_7",
+        memberId: "user_1",
+        pinned: false,
+        pinnedAt: null,
+        notificationLevel: null,
+        lastReadEventId: null,
+        lastReadAt: null,
+        joinedAt: new Date().toISOString(),
+      },
+    ]
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(bootstrap)
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+
+    await vi.waitFor(() => {
+      const joinedRooms = socket.emittedEvents.filter((event) => event.event === "join").map((event) => event.args[0])
+      expect(joinedRooms).toContain("ws:ws_1:stream:stream_7")
+    })
+  })
+
+  it("joins member-stream rooms from the cache when the fresh bootstrap fails", async () => {
+    // Regression: a slow/failed first bootstrap must not leave the user in zero
+    // stream rooms. Without the cache fallback, stream:activity (sidebar unread +
+    // hover preview) only flows for streams opened this session.
+    const now = new Date().toISOString()
+    await db.workspaces.put({
+      id: "ws_1",
+      name: "Test",
+      slug: "test",
+      createdAt: now,
+      updatedAt: now,
+      _cachedAt: Date.now(),
+    })
+    await db.streamMemberships.put({
+      id: "ws_1:stream_42",
+      workspaceId: "ws_1",
+      streamId: "stream_42",
+      memberId: "user_1",
+      pinned: false,
+      pinnedAt: null,
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: now,
+      _cachedAt: Date.now(),
+    })
+
+    const deps = makeDeps()
+    deps.workspaceService.bootstrap.mockRejectedValueOnce(new Error("network down"))
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+
+    await vi.waitFor(() => {
+      const joinedRooms = socket.emittedEvents.filter((event) => event.event === "join").map((event) => event.args[0])
+      expect(joinedRooms).toContain("ws:ws_1:stream:stream_42")
+    })
+  })
 })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -364,16 +364,10 @@ export class SyncEngine {
       this.lastWorkspaceError = null
       syncStatus.set(`workspace:${workspaceId}`, "synced")
 
-      // Subscribe all member streams
-      const memberStreamIds = bootstrap.streamMemberships.map((sm) => sm.streamId)
       // Subscribe all member streams: join rooms + register socket handlers.
       // On reconnect, cleanupStreamHandlers() already cleared the old handlers,
       // so these are fresh registrations.
-      for (const streamId of memberStreamIds) {
-        if (!this.subscribedStreams.has(streamId)) {
-          await this.ensureStreamSubscription(streamId)
-        }
-      }
+      await this.subscribeMemberStreams(bootstrap.streamMemberships.map((sm) => sm.streamId))
     } catch (error) {
       this.lastWorkspaceError = error
       const hasCachedData = (await db.workspaces.get(workspaceId)) !== undefined
@@ -384,7 +378,14 @@ export class SyncEngine {
         }
       }
 
-      if (!hasCachedData) {
+      if (hasCachedData) {
+        // The fresh bootstrap failed but cached data is already on screen. Join
+        // the member-stream rooms from the cached membership list anyway, so
+        // `stream:activity` — which carries the sidebar unread bump *and* the
+        // last-message preview that powers hover-to-preview — keeps flowing and
+        // self-heals, instead of going dark until the user opens each stream.
+        await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
+      } else {
         // Propagate to TanStack so coordinated-loading shows the error
         queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), undefined)
       }
@@ -429,6 +430,28 @@ export class SyncEngine {
     return Array.from(
       new Set(streamIds.filter((streamId) => !streamId.startsWith("draft_") && !streamId.startsWith("draft:")))
     )
+  }
+
+  /**
+   * Join rooms + register socket handlers for a set of member streams.
+   * Idempotent per stream — skips ones already subscribed. Runs on every
+   * bootstrap (success path and the cache-only failure path) so `stream:activity`
+   * reaches every stream the user belongs to, not just the ones they opened this
+   * session. Without it the sidebar unread badge and hover-to-preview only update
+   * for streams whose room the user has explicitly joined.
+   */
+  private async subscribeMemberStreams(streamIds: string[]): Promise<void> {
+    for (const streamId of streamIds) {
+      if (!this.subscribedStreams.has(streamId)) {
+        await this.ensureStreamSubscription(streamId)
+      }
+    }
+  }
+
+  /** Member stream ids from the offline cache, for the bootstrap-failure path. */
+  private async cachedMemberStreamIds(): Promise<string[]> {
+    const memberships = await db.streamMemberships.where("workspaceId").equals(this.deps.workspaceId).toArray()
+    return memberships.map((membership) => membership.streamId)
   }
 
   private async ensureStreamSubscription(streamId: string, options?: { awaitJoin?: boolean }): Promise<void> {

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -382,8 +382,12 @@ export class SyncEngine {
         // The fresh bootstrap failed but cached data is already on screen. Join
         // the member-stream rooms from the cached membership list anyway, so
         // `stream:activity` — which carries the sidebar unread bump *and* the
-        // last-message preview that powers hover-to-preview — keeps flowing and
-        // self-heals, instead of going dark until the user opens each stream.
+        // last-message preview that powers hover-to-preview — keeps flowing onto
+        // the cached rows instead of going dark until the user opens each stream.
+        // This mirrors the success-path subscription (member rooms only ever
+        // carry sidebar-level deltas; the per-stream bootstrap fetch happens on
+        // navigation). The next successful bootstrap re-applies authoritative
+        // counts/previews, closing any gap (INV-53).
         await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
       } else {
         // Propagate to TanStack so coordinated-loading shows the error


### PR DESCRIPTION
## Problem

A stream the user hadn't opened this session could show a notification in the **Activity feed** while its **sidebar row stayed quiet** and its hover-to-preview went stale. Reported symptom: "notifications show in Activity for a stream that doesn't highlight as unread," suspected to be tied to recent app-start changes.

## Root cause

The sidebar unread highlight + hover preview and the Activity feed are fed by **two different socket events on two different rooms**:

| Signal | Event | Room | Reaches you when… |
|---|---|---|---|
| Sidebar unread badge **+ hover preview** (`lastMessagePreview`) | `stream:activity` | per-**stream** `ws:…:stream:{id}` | you've joined that stream's room |
| Activity feed | `activity:created` | per-**user** `ws:…:user:{id}` | always (auto-joined on connect) |

`stream:activity` only reaches a socket that has joined the stream's room. The client bulk-joins all member-stream rooms at boot in `SyncEngine.bootstrapWorkspace()` — but that join sat **after** the workspace bootstrap fetch, **inside the same `try`**. A slow or failed first bootstrap (much easier to miss now that boot reveals IDB-cached content immediately) skipped it entirely, leaving the user in zero stream rooms until they manually opened each one. Meanwhile `activity:created` kept arriving on the always-joined user room, so Activity lit up but the sidebar didn't.

Only `stream:activity` carries `lastMessagePreview`, so an activity-only fallback can light the badge but can't keep the hover preview fresh — both layers are needed.

## Fix

**1. Harden the member-stream room joins** (`sync-engine.ts`)
- Extract `subscribeMemberStreams()` and also call it from the **failure path** using the cached IDB membership list, so `stream:activity` (unread bump **and** preview) keeps flowing and self-heals instead of going dark until the user opens each stream.

**2. Sidebar reflects the reliably-delivered activity signal** (`utils.ts`, `sidebar.tsx`)
- `calculateUrgency` now lights a stream when `activityCount > 0` even if `unreadCount` is 0, so anything the Activity feed shows also surfaces in the sidebar during the connect/join window. (Mentions already worked via `mentionCount`; this covers replies/reactions.)

**3. Self-review follow-ups**
- `categorizeStream` keeps an activity-only stream in **Recent** instead of letting it glow while sitting in "Everything else".
- Threaded `activityCount` through the remaining `calculateUrgency` callers (quick-switcher, share modal, share picker, attachment explorer) so urgency is consistent across every stream-list surface.

## Design notes

- **INV-53:** The member-stream rooms only ever carry sidebar-level deltas; the per-stream bootstrap fetch happens on navigation, and the workspace-level subscribe→fetch pairing is unchanged. The failure-path subscription mirrors the success path and the next successful bootstrap re-applies authoritative counts/previews, closing any gap.
- Bootstrap-failure subscription uses cached memberships, consistent with the offline-first IDB-as-source-of-truth model.

## Tests
- `sync-engine.test.ts`: member-stream rooms are joined after a successful bootstrap **and** when the fresh bootstrap fails (cache fallback).
- `utils.test.ts`: activity-only urgency fallback (and that mentions/unread/muted still take precedence); activity-only stream lands in Recent even with a stale preview.
- Full affected suites: **426 passing**; `tsc --noEmit` clean.

https://claude.ai/code/session_01Jz2BdGVpkaoygVsVQn3ZZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz2BdGVpkaoygVsVQn3ZZ6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782942658&installation_id=129946197&pr_number=725&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F725&signature=aa46af46beec8f8a5f28b107fd4a7ef190e2e69c394cb98c159928e775b424d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->