### PR TITLE
Keep push notifications alive across socket-session timeouts

### DIFF
--- a/apps/backend/src/features/push/repository.ts
+++ b/apps/backend/src/features/push/repository.ts
@@ -25,6 +25,12 @@ export interface PushSubscription {
   deviceKey: string
   userAgent: string | null
   createdAt: Date
+  /**
+   * Bumped on every (idempotent) re-registration via {@link insert}, which is
+   * the only write path to this table. Push delivery reads it as "last time an
+   * authenticated client confirmed this device" so a subscription survives a
+   * backend socket-session timeout and only expires after genuine inactivity.
+   */
   updatedAt: Date
 }
 

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -535,12 +535,29 @@ export class PushService {
     })
     if (allSubs.length === 0) return { active: [], expired: [] }
 
-    // Partition subscriptions: devices with no session in the expiry window are expired.
-    // Devices that have a recent session (even if not active right now) are still valid.
+    // Partition subscriptions by whether the device still looks logged in.
+    //
+    // Two independent signals prove a device is still authenticated, and EITHER
+    // keeps the subscription alive:
+    //   1. A socket heartbeat for the device within the window (recentDeviceKeys,
+    //      cross-workspace since the auth cookie is global).
+    //   2. A recent authenticated re-registration of the subscription itself
+    //      (updatedAt — the only write to this row). The frontend re-runs the
+    //      idempotent subscribe handshake over HTTP on every app open/foreground.
+    //      This is the signal that survives a backend socket-session timeout: on
+    //      devices where WebSockets are flaky or short-lived (mobile, iOS PWA,
+    //      proxies that block WS) the heartbeat never lands, but the HTTP
+    //      re-register does, so the user who keeps opening the app keeps push.
+    //
+    // A subscription is only "expired" (→ session-expired push + cleanup) once
+    // BOTH signals are stale for the full window — i.e. the device genuinely
+    // hasn't logged in for ~30 days (matching the auth cookie TTL).
+    const expiryThreshold = Date.now() - SESSION_EXPIRY_WINDOW_MS
     const activeSubs: PushSubscription[] = []
     const expiredSubs: PushSubscription[] = []
     for (const sub of allSubs) {
-      if (recentDeviceKeys.has(sub.deviceKey)) {
+      const seenRecently = sub.updatedAt.getTime() > expiryThreshold
+      if (recentDeviceKeys.has(sub.deviceKey) || seenRecently) {
         activeSubs.push(sub)
       } else {
         expiredSubs.push(sub)

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -92,6 +92,28 @@ describe("Push Notifications", () => {
       expect(all).toHaveLength(1)
     })
 
+    test("re-registering an endpoint refreshes updated_at (its last-seen signal)", async () => {
+      const params = {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/last-seen",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d",
+      }
+      const first = await PushSubscriptionRepository.insert(pool, params)
+      expect(first.updatedAt).toBeInstanceOf(Date)
+
+      // Backdate so we can prove the re-register moves it forward.
+      await pool.query(`UPDATE push_subscriptions SET updated_at = now() - interval '40 days' WHERE id = $1`, [
+        first.id,
+      ])
+
+      const second = await PushSubscriptionRepository.insert(pool, params)
+      expect(second.id).toBe(first.id)
+      expect(second.updatedAt.getTime()).toBeGreaterThan(Date.now() - 60_000)
+    })
+
     test("deleteByEndpoint removes subscription and returns true; false for non-existent", async () => {
       await PushSubscriptionRepository.insert(pool, {
         workspaceId: testWorkspaceId,
@@ -450,6 +472,19 @@ describe("Push Notifications", () => {
     async function createRecentInactiveSession(wId: string, uId: string, deviceKey = "d") {
       const s = await UserSessionRepository.upsert(pool, { workspaceId: wId, userId: uId, deviceKey })
       await pool.query(`UPDATE user_sessions SET last_active_at = now() - interval '2 minutes' WHERE id = $1`, [s.id])
+    }
+
+    /**
+     * Backdate a subscription's updated_at (its last-registration time) so the
+     * "recent re-registration" signal no longer keeps it alive. Lets tests
+     * exercise the genuine-expiry path (a subscription must be stale on BOTH
+     * the heartbeat and the re-registration signal to be expired).
+     */
+    async function backdateSubscriptionRegistration(endpoint: string, interval: string) {
+      await pool.query(`UPDATE push_subscriptions SET updated_at = now() - $2::interval WHERE endpoint = $1`, [
+        endpoint,
+        interval,
+      ])
     }
 
     function makePayload(overrides?: Partial<ActivityCreatedOutboxPayload>): ActivityCreatedOutboxPayload {
@@ -961,6 +996,9 @@ describe("Push Notifications", () => {
         auth: "a2",
         deviceKey: "device-2",
       })
+      // No socket session AND no recent re-registration → genuinely expired.
+      await backdateSubscriptionRegistration("https://push.example.com/sub/expired-1", "60 days")
+      await backdateSubscriptionRegistration("https://push.example.com/sub/expired-2", "60 days")
 
       await service.deliverPushForActivity(makePayload())
 
@@ -998,6 +1036,8 @@ describe("Push Notifications", () => {
 
       // Only device-1 has a recent session (within 30-day expiry window)
       await createRecentInactiveSession(testWorkspaceId, testUserId, "device-1")
+      // device-2 has neither a session nor a recent re-registration → expired.
+      await backdateSubscriptionRegistration("https://push.example.com/sub/expired-device", "60 days")
 
       await service.deliverPushForActivity(makePayload())
 
@@ -1070,6 +1110,9 @@ describe("Push Notifications", () => {
         auth: "a",
         deviceKey: "device-1",
       })
+      // Backdate the local re-registration so ONLY the cross-workspace session
+      // can keep this subscription alive — that's what this test asserts.
+      await backdateSubscriptionRegistration("https://push.example.com/sub/cross-ws", "60 days")
 
       // Session exists on the SAME device but in a DIFFERENT workspace.
       // Auth is global (single cookie), so this proves the device is still logged in.
@@ -1090,6 +1133,34 @@ describe("Push Notifications", () => {
       // Subscription should still exist
       const subs = await PushSubscriptionRepository.findByUserId(pool, testWorkspaceId, testUserId)
       expect(subs).toHaveLength(1)
+    })
+
+    test("recent re-registration with no socket session anywhere → delivers normally (survives backend socket-session timeout)", async () => {
+      const service = createServiceWithLookups()
+
+      // Subscription was re-registered recently over HTTP (auto-subscribe on app
+      // open), but the device has NO user_sessions row at all — the WebSocket
+      // heartbeat never landed (flaky mobile WS, iOS PWA, proxy blocking WS).
+      // The old behaviour deleted this subscription as "expired"; it must now
+      // survive because the device clearly logged in recently.
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/http-only",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "device-http-only",
+      })
+
+      await service.deliverPushForActivity(makePayload())
+
+      // Normal push (not session_expired), and the subscription is retained.
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse(sendSpy.mock.calls[0][1] as string)
+      expect(payload.data.action).toBeUndefined()
+      expect(payload.data.activityType).toBe(ActivityTypes.MENTION)
+      const remaining = await PushSubscriptionRepository.findByUserId(pool, testWorkspaceId, testUserId)
+      expect(remaining).toHaveLength(1)
     })
 
     test("stale subscription cleanup on 410 response", async () => {

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -111,7 +111,9 @@ describe("Push Notifications", () => {
 
       const second = await PushSubscriptionRepository.insert(pool, params)
       expect(second.id).toBe(first.id)
-      expect(second.updatedAt.getTime()).toBeGreaterThan(Date.now() - 60_000)
+      // Compare against the prior DB timestamp (both DB-clock, monotonic) rather
+      // than the app clock, which would couple the assertion to DB/app skew.
+      expect(second.updatedAt.getTime()).toBeGreaterThan(first.updatedAt.getTime())
     })
 
     test("deleteByEndpoint removes subscription and returns true; false for non-existent", async () => {

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -43,6 +43,16 @@ interface UsePushNotificationsResult {
 /** Hard cap on the subscribe round-trip so a hung fetch never strands the UI in "subscribing". */
 const SUBSCRIBE_TIMEOUT_MS = 15_000
 
+/**
+ * Minimum gap between opportunistic re-subscribes triggered by foreground/online
+ * events. The subscribe flow is idempotent, but we throttle it so rapid tab
+ * switches don't spam the backend. Recovering a browser-dropped subscription is
+ * still prompt via the `pushsubscriptionchanged` event; these triggers are the
+ * safety net that also keeps the server-side "last seen" recency fresh so an
+ * active device never ages into push expiry.
+ */
+const RESUBSCRIBE_THROTTLE_MS = 5 * 60_000
+
 class SubscribeTimeoutError extends Error {
   constructor() {
     super("Timed out while subscribing to push notifications")
@@ -215,6 +225,9 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   // user already retried successfully) can't clobber the latest result.
   const subscribeGenRef = useRef(0)
   const currentAbortRef = useRef<AbortController | null>(null)
+  // Timestamp of the last subscribe() invocation, used to throttle the
+  // opportunistic foreground/online re-subscribes.
+  const lastSubscribeAtRef = useRef(0)
 
   // Re-sync opt-out state when workspaceId/account changes (initializer only runs on mount)
   useEffect(() => {
@@ -234,6 +247,7 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     // racing toward a terminal state we no longer want.
     const gen = ++subscribeGenRef.current
     const isLatest = () => subscribeGenRef.current === gen
+    lastSubscribeAtRef.current = Date.now()
     currentAbortRef.current?.abort()
     const controller = new AbortController()
     currentAbortRef.current = controller
@@ -313,8 +327,33 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     const handleSubscriptionChange = () => {
       void subscribe()
     }
+
+    // Opportunistically re-register when the app is foregrounded or comes back
+    // online. A push subscription can silently lapse while a tab sits idle or
+    // backgrounded (browser eviction, OS sleep, network loss); re-running the
+    // idempotent flow on resume recreates it and refreshes the server-side
+    // recency so an active device never ages into push expiry. Throttled so
+    // rapid tab switching doesn't hammer the backend.
+    const resubscribeThrottled = () => {
+      if (Date.now() - lastSubscribeAtRef.current < RESUBSCRIBE_THROTTLE_MS) return
+      void subscribe()
+    }
+    // visibilitychange fires on both show and hide — only act on becoming
+    // visible. `online`, by contrast, is worth acting on even while
+    // backgrounded: the re-register is a plain HTTP call that works fine in a
+    // hidden tab and keeps the subscription from aging out.
+    const handleVisible = () => {
+      if (document.visibilityState !== "visible") return
+      resubscribeThrottled()
+    }
     window.addEventListener("pushsubscriptionchanged", handleSubscriptionChange)
-    return () => window.removeEventListener("pushsubscriptionchanged", handleSubscriptionChange)
+    document.addEventListener("visibilitychange", handleVisible)
+    window.addEventListener("online", resubscribeThrottled)
+    return () => {
+      window.removeEventListener("pushsubscriptionchanged", handleSubscriptionChange)
+      document.removeEventListener("visibilitychange", handleVisible)
+      window.removeEventListener("online", resubscribeThrottled)
+    }
   }, [permission, workspaceId, subscribe, optedOut])
 
   // Unsubscribe from push notifications for this workspace.

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -225,8 +225,10 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
   // user already retried successfully) can't clobber the latest result.
   const subscribeGenRef = useRef(0)
   const currentAbortRef = useRef<AbortController | null>(null)
-  // Timestamp of the last subscribe() invocation, used to throttle the
-  // opportunistic foreground/online re-subscribes.
+  // Timestamp of the last *completed* subscribe handshake, used to throttle the
+  // opportunistic foreground/online re-subscribes. Only advanced on a finished
+  // attempt — a failed/aborted one leaves it untouched so a transient error
+  // doesn't block the next recovery retry for the throttle window.
   const lastSubscribeAtRef = useRef(0)
 
   // Re-sync opt-out state when workspaceId/account changes (initializer only runs on mount)
@@ -247,7 +249,6 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
     // racing toward a terminal state we no longer want.
     const gen = ++subscribeGenRef.current
     const isLatest = () => subscribeGenRef.current === gen
-    lastSubscribeAtRef.current = Date.now()
     currentAbortRef.current?.abort()
     const controller = new AbortController()
     currentAbortRef.current = controller
@@ -277,6 +278,11 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       ])
 
       if (!isLatest()) return
+
+      // Handshake completed (subscribed or disabled-on-server) — start the
+      // opportunistic re-subscribe cooldown. Failed attempts skip this (the
+      // catch block doesn't set it) so recovery retries aren't throttled.
+      lastSubscribeAtRef.current = Date.now()
 
       if (result.kind === "disabled-on-server") {
         setIsSubscribed(false)


### PR DESCRIPTION
## Problem

Push notifications were intermittently dying — a user who had push enabled on a device would silently stop receiving notifications, with no action on their part.

Root cause: **subscription lifetime was governed by the socket-heartbeat session (`user_sessions`), not by whether the device was actually logged in.**

In `PushService.getTargetSubscriptions`, a subscription was classified **expired** (→ a one-shot `session_expired` push sent + the **subscription deleted**) whenever the device had no `user_sessions` row within the 30-day window. But `user_sessions.last_active_at` is *only* bumped by the socket.io heartbeat/join — which requires a **live WebSocket**. The actual auth session is the WorkOS sealed cookie: valid 30 days and silently refreshed on every authenticated **HTTP** request.

So on any device where WebSockets are flaky or short-lived — mobile, iOS PWAs, corporate proxies that block WS — the heartbeat never landed, and the push subscription got **deleted after 30 days even though the user was actively opening the app and fully logged in** (the HTTP auto-subscribe ran on every open, bumping `updated_at`, but delivery never looked at that signal).

This directly violated the intended behavior that push should survive a backend device-session timeout, and only eventually disable when the user genuinely hasn't logged in for a while.

## Fix

A device is treated as **still logged in** when **either**:
1. it has a socket heartbeat within the window (`recentDeviceKeys`, cross-workspace — the auth cookie is global), **or**
2. the subscription was re-registered (over HTTP) within the window.

A subscription is only expired/cleaned up when **both** signals are stale for the full 30-day window — i.e. the device genuinely hasn't logged in for ~30 days (matching the auth cookie TTL). This preserves the intended eventual-disable-after-inactivity while making push robust to socket-session timeouts.

The re-registration signal is the subscription's existing `updated_at` column, which is bumped on every idempotent subscribe upsert and is the **only** write path to the row — so it reliably means "last time an authenticated client confirmed this device." (No new column / migration: a dedicated `last_seen_at` would have been written in lock-step with `updated_at` for zero behavioral difference — flagged and dropped in self-review.)

### Frontend resilience

The push hook now opportunistically re-runs the (idempotent) subscribe flow when the app is **foregrounded** (`visibilitychange` → visible) and when it comes back **online** — throttled to once per 5 min. This recreates a browser-dropped subscription promptly and keeps the re-registration recency fresh, so an enabled device stays subscribed unless the user explicitly turns it off. The `online` trigger intentionally runs even while the tab is backgrounded (a plain HTTP re-register works fine there); only the `visibilitychange` trigger is gated on visibility.

## What is unchanged (intentional)

- **Eventual disable after real inactivity** — still happens at ~30 days with no login of either kind.
- **Logout** still tears down the browser subscription + cross-workspace records; re-login auto-resubscribes since browser permission and the per-device opt-out setting both persist, so the user's on/off choice survives logout.
- **410/Gone pruning** and the per-device focus/interaction push-routing logic are untouched.

## Tests

- All 38 push integration tests pass.
- Added a regression test: a subscription re-registered recently over HTTP with **no socket session anywhere** is delivered to normally (not `session_expired`) and retained.
- Updated the expiry / cross-workspace tests to backdate the registration timestamp so they still exercise the genuine-expiry path under the new two-signal rule.
- Backend + frontend `tsc` and ESLint clean (verified via pre-commit hook running the full monorepo check).

## Self-review

Ran a multi-perspective self-review (spec/CLAUDE.md compliance, correctness/security, design). Two design findings surfaced and were both applied before this PR: (1) dropped the redundant `last_seen_at` column in favor of `updated_at`; (2) split the `online` handler from the visibility-gated one so a backgrounded-but-online device can still refresh.

https://claude.ai/code/session_014FyXf3KYgBNgjzP14pZoYa

---
_Generated by [Claude Code](https://claude.ai/code/session_014FyXf3KYgBNgjzP14pZoYa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782974270&installation_id=129946197&pr_number=726&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F726&signature=6baa8800d6fd02e65879e0427baa82acc491e116e90ce8ed76a9b146c46624a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->