### PR TITLE
feat(e2e): run Ariadne in the encryption enclave with full main-app parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ playwright-report/
 # Agent tmp files
 .tmp/
 .threa-attachments/
+
+# Dev-only persisted enclave EIK (never committed; prod uses ephemeral keys)
+apps/enclave/.enclave-key.dev.json

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -4,6 +4,7 @@ import helmet from "helmet"
 import cookieParser from "cookie-parser"
 import pinoHttp from "pino-http"
 import { randomUUID } from "crypto"
+import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import { logger } from "./lib/logger"
 import { bigIntReplacer } from "@threa/backend-common"
 import { createMetricsMiddleware } from "./middleware/metrics"
@@ -65,7 +66,17 @@ export function createApp(options: CreateAppOptions): Express {
       },
       genReqId: (req) => (req.headers["x-request-id"] as string) || randomUUID(),
       redact: {
-        paths: ["req.headers.authorization", "req.headers.cookie", "res.headers['set-cookie']"],
+        // The default pino-http req serializer logs the full headers object, so
+        // every secret-bearing header must be redacted here or it lands in the
+        // log on any 4xx/5xx. `x-internal-api-key` is the shared internal-auth
+        // secret (enclave/control-plane → backend); Node lowercases header names,
+        // and the path is derived from the constant so it can't drift.
+        paths: [
+          "req.headers.authorization",
+          "req.headers.cookie",
+          `req.headers["${INTERNAL_API_KEY_HEADER.toLowerCase()}"]`,
+          "res.headers['set-cookie']",
+        ],
         censor: "[REDACTED]",
       },
       customSuccessMessage: (req, res) => {

--- a/apps/backend/src/features/agents/enclave-system-prompt.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.ts
@@ -1,0 +1,67 @@
+import type { Pool } from "pg"
+import { AgentToolNames, type UserPreferences } from "@threa/types"
+import type { Stream } from "../streams"
+import { buildStreamContext } from "./context-builder"
+import { buildSystemPrompt } from "./companion/prompt/system-prompt"
+import type { Persona } from "./persona-repository"
+import type { BuiltInAgentConfig } from "./built-in-agents"
+
+/**
+ * Ariadne runs the *same* agent loop in the enclave as in the main app, so she
+ * must run the *same* system prompt — assembled by the shared `buildSystemPrompt`
+ * (temporal grounding, response style, send_message rules, tool sections, the
+ * trust boundary, and the owner's scratchpad custom instructions), not the bare
+ * `persona.systemPrompt`. The regional backend builds it here (it has the DB)
+ * and ships the raw text to the enclave; the only inherent deltas are that I/O
+ * is encrypted and the toolset is reduced.
+ *
+ * Tools are the one real difference: the enclave has no DB, so only the web
+ * tools are available — never `workspace_research`, attachments, or memos. We
+ * pass that reduced set so the prompt advertises exactly what the enclave wires.
+ */
+const ENCLAVE_ENABLED_TOOLS: string[] = [
+  AgentToolNames.WEB_SEARCH,
+  AgentToolNames.READ_URL,
+  AgentToolNames.GENERAL_RESEARCH,
+]
+
+export async function buildEnclaveSystemPrompt(params: {
+  pool: Pool
+  stream: Stream
+  /** The owner whose timezone + scratchpad custom instructions ground the prompt. */
+  preferences: UserPreferences
+  /** The persona (Ariadne) — its base prompt is the seed buildSystemPrompt layers on. */
+  persona: BuiltInAgentConfig
+}): Promise<string> {
+  const { pool, stream, preferences, persona } = params
+
+  // Same context builder the main app uses. For E2E it can't read message
+  // plaintext, but the system prompt depends only on stream metadata + temporal
+  // (not conversation content), so building it server-side is faithful — the
+  // encrypted history is shipped separately and decrypted inside the enclave.
+  const context = await buildStreamContext(pool, stream, { preferences, currentTime: new Date() })
+
+  // Built-in config is structurally a persona; override the toolset to the
+  // enclave-available subset so the prompt advertises exactly what's wired.
+  // (buildSystemPrompt only reads name/systemPrompt/enabledTools; createdAt /
+  // updatedAt are filled to satisfy the Persona shape.)
+  const enclavePersona: Persona = {
+    ...persona,
+    enabledTools: ENCLAVE_ENABLED_TOOLS,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  return buildSystemPrompt(
+    enclavePersona,
+    context,
+    preferences.scratchpadCustomPrompt,
+    undefined,
+    undefined,
+    // No rolling conversation summary — that's derived from plaintext history
+    // the backend can't read for an E2E stream.
+    null,
+    // workspace_research needs the DB; the enclave has none.
+    false
+  )
+}

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -163,6 +163,10 @@ export { resolveActorNames } from "./actor-names"
 
 // Context builder
 export { buildStreamContext, enrichMessagesWithAttachments } from "./context-builder"
+
+// Enclave system-prompt assembly (shared builder + reduced toolset) so the
+// enclave runs Ariadne on the same prompt as the main app.
+export { buildEnclaveSystemPrompt } from "./enclave-system-prompt"
 export type {
   Participant,
   AnchorMessage,

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -109,7 +109,7 @@ export type {
 // Workers
 export { createPersonaAgentWorker, checkForUnseenMessages } from "./persona-agent-worker"
 export type { PersonaAgentLike, PersonaAgentWorkerDeps } from "./persona-agent-worker"
-export { createOrphanSessionCleanup } from "./orphan-session-cleanup"
+export { createOrphanSessionCleanup, failSessionWithLifecycle } from "./orphan-session-cleanup"
 export type { OrphanSessionCleanup } from "./orphan-session-cleanup"
 
 // Repositories

--- a/apps/backend/src/features/agents/orphan-session-cleanup.test.ts
+++ b/apps/backend/src/features/agents/orphan-session-cleanup.test.ts
@@ -5,11 +5,12 @@ import * as db from "../../db"
 import { AgentSessionRepository, SessionStatuses } from "./session-repository"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
-import { failOrphanedSession } from "./orphan-session-cleanup"
+import { failSessionWithLifecycle } from "./orphan-session-cleanup"
 
 const pool = {} as Pool
 
 const ORPHAN = { id: "session_1", streamId: "stream_1", personaId: "persona_ariadne" }
+const ERROR = "Session orphaned (stale heartbeat)"
 
 afterEach(() => mock.restore())
 
@@ -19,7 +20,7 @@ function fakeIo() {
   return { io, emit }
 }
 
-describe("failOrphanedSession", () => {
+describe("failSessionWithLifecycle", () => {
   it("marks FAILED only from RUNNING and emits the failed lifecycle (stream event + outbox + session room)", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
     const tx = {} as never
@@ -31,16 +32,16 @@ describe("failOrphanedSession", () => {
     const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
     const { io, emit } = fakeIo()
 
-    const won = await failOrphanedSession(pool, io, ORPHAN)
+    const won = await failSessionWithLifecycle(pool, io, ORPHAN, ERROR)
 
     expect(won).toBe(true)
     // Conditional transition: never clobbers a session that already left RUNNING.
-    expect(update.mock.calls[0]![3]).toMatchObject({ onlyIfStatus: SessionStatuses.RUNNING })
+    expect(update.mock.calls[0]![3]).toMatchObject({ error: ERROR, onlyIfStatus: SessionStatuses.RUNNING })
     // The lifecycle event is what unblocks the inline indicator + keeps refresh consistent.
     expect(insertEvent.mock.calls[0]![1]).toMatchObject({
       streamId: "stream_1",
       eventType: "agent_session:failed",
-      payload: { sessionId: "session_1", stepCount: 2 },
+      payload: { sessionId: "session_1", stepCount: 2, error: ERROR },
     })
     expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:failed")
     // And a live-open trace dialog (session room) is updated directly.
@@ -58,7 +59,7 @@ describe("failOrphanedSession", () => {
     const insertOutbox = spyOn(OutboxRepository, "insert")
     const { io, emit } = fakeIo()
 
-    const won = await failOrphanedSession(pool, io, ORPHAN)
+    const won = await failSessionWithLifecycle(pool, io, ORPHAN, ERROR)
 
     expect(won).toBe(false)
     expect(insertEvent).not.toHaveBeenCalled()
@@ -75,7 +76,7 @@ describe("failOrphanedSession", () => {
     const insertEvent = spyOn(StreamEventRepository, "insert")
     const { io, emit } = fakeIo()
 
-    const won = await failOrphanedSession(pool, io, ORPHAN)
+    const won = await failSessionWithLifecycle(pool, io, ORPHAN, ERROR)
 
     expect(won).toBe(true)
     expect(update).toHaveBeenCalledTimes(1)

--- a/apps/backend/src/features/agents/orphan-session-cleanup.test.ts
+++ b/apps/backend/src/features/agents/orphan-session-cleanup.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import * as db from "../../db"
+import { AgentSessionRepository, SessionStatuses } from "./session-repository"
+import { StreamRepository, StreamEventRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+import { failOrphanedSession } from "./orphan-session-cleanup"
+
+const pool = {} as Pool
+
+const ORPHAN = { id: "session_1", streamId: "stream_1", personaId: "persona_ariadne" }
+
+afterEach(() => mock.restore())
+
+function fakeIo() {
+  const emit = mock((_event: string, _payload: unknown) => {})
+  const io = { to: mock((_room: string) => ({ emit })) } as unknown as Server
+  return { io, emit }
+}
+
+describe("failOrphanedSession", () => {
+  it("marks FAILED only from RUNNING and emits the failed lifecycle (stream event + outbox + session room)", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const update = spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue({ id: "session_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([{}, {}] as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const { io, emit } = fakeIo()
+
+    const won = await failOrphanedSession(pool, io, ORPHAN)
+
+    expect(won).toBe(true)
+    // Conditional transition: never clobbers a session that already left RUNNING.
+    expect(update.mock.calls[0]![3]).toMatchObject({ onlyIfStatus: SessionStatuses.RUNNING })
+    // The lifecycle event is what unblocks the inline indicator + keeps refresh consistent.
+    expect(insertEvent.mock.calls[0]![1]).toMatchObject({
+      streamId: "stream_1",
+      eventType: "agent_session:failed",
+      payload: { sessionId: "session_1", stepCount: 2 },
+    })
+    expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:failed")
+    // And a live-open trace dialog (session room) is updated directly.
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:failed")).toBe(true)
+  })
+
+  it("does not emit when the session already left RUNNING (lost the race)", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue(null) // transition not won
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const insertOutbox = spyOn(OutboxRepository, "insert")
+    const { io, emit } = fakeIo()
+
+    const won = await failOrphanedSession(pool, io, ORPHAN)
+
+    expect(won).toBe(false)
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(insertOutbox).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it("still marks FAILED durably when the stream is gone, without broadcasting", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue(null)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const update = spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue({ id: "session_1" } as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const { io, emit } = fakeIo()
+
+    const won = await failOrphanedSession(pool, io, ORPHAN)
+
+    expect(won).toBe(true)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/agents/orphan-session-cleanup.ts
+++ b/apps/backend/src/features/agents/orphan-session-cleanup.ts
@@ -15,15 +15,18 @@ export interface OrphanSessionCleanup {
 const ORPHAN_ERROR = "Session orphaned (stale heartbeat)"
 
 /**
- * Mark one orphaned session FAILED and emit the failure lifecycle (stream event +
+ * Mark one RUNNING session FAILED and emit the failure lifecycle (stream event +
  * outbox + session-room socket), mirroring the in-process failure path. Returns
  * whether we won the RUNNING→FAILED transition (false if it terminated under us).
- * Exported for direct testing of the emission.
+ * Shared by orphan cleanup and the enclave dispatch worker (assign-failure path),
+ * which can't rely on cleanup as a backstop: cleanup only scans RUNNING sessions,
+ * so a session it marks FAILED itself must emit its own lifecycle.
  */
-export async function failOrphanedSession(
+export async function failSessionWithLifecycle(
   pool: Pool,
   io: Server,
-  session: { id: string; streamId: string; personaId: string }
+  session: { id: string; streamId: string; personaId: string },
+  error: string
 ): Promise<boolean> {
   const { id: sessionId, streamId, personaId } = session
   // Resolve the workspace from the stream (agent_sessions don't carry it) so we
@@ -35,7 +38,7 @@ export async function failOrphanedSession(
   // completed concurrently isn't clobbered and we don't double-emit a failure.
   const won = await withTransaction(pool, async (tx) => {
     const failed = await AgentSessionRepository.updateStatus(tx, sessionId, SessionStatuses.FAILED, {
-      error: ORPHAN_ERROR,
+      error,
       onlyIfStatus: SessionStatuses.RUNNING,
     })
     if (!failed) return false
@@ -51,7 +54,7 @@ export async function failOrphanedSession(
         payload: {
           sessionId,
           stepCount: steps.length,
-          error: ORPHAN_ERROR,
+          error,
           traceId: sessionId,
           failedAt: new Date().toISOString(),
         },
@@ -112,7 +115,7 @@ export function createOrphanSessionCleanup(
 
       for (const session of orphaned) {
         try {
-          const won = await failOrphanedSession(pool, io, session)
+          const won = await failSessionWithLifecycle(pool, io, session, ORPHAN_ERROR)
           if (won) {
             logger.info({ sessionId: session.id, streamId: session.streamId }, "Marked orphaned session as failed")
           }

--- a/apps/backend/src/features/agents/orphan-session-cleanup.ts
+++ b/apps/backend/src/features/agents/orphan-session-cleanup.ts
@@ -1,10 +1,78 @@
 import type { Pool } from "pg"
+import type { Server } from "socket.io"
 import { AgentSessionRepository, SessionStatuses } from "./session-repository"
+import { StreamRepository, StreamEventRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+import { withTransaction } from "../../db"
+import { eventId } from "../../lib/id"
 import { logger } from "../../lib/logger"
 
 export interface OrphanSessionCleanup {
   start(): void
   stop(): void
+}
+
+const ORPHAN_ERROR = "Session orphaned (stale heartbeat)"
+
+/**
+ * Mark one orphaned session FAILED and emit the failure lifecycle (stream event +
+ * outbox + session-room socket), mirroring the in-process failure path. Returns
+ * whether we won the RUNNING→FAILED transition (false if it terminated under us).
+ * Exported for direct testing of the emission.
+ */
+export async function failOrphanedSession(
+  pool: Pool,
+  io: Server,
+  session: { id: string; streamId: string; personaId: string }
+): Promise<boolean> {
+  const { id: sessionId, streamId, personaId } = session
+  // Resolve the workspace from the stream (agent_sessions don't carry it) so we
+  // can address the workspace-scoped rooms, same as the enclave complete path.
+  const stream = await StreamRepository.findById(pool, streamId)
+
+  // Mark FAILED + write the lifecycle event in one transaction (INV-7), and only
+  // when we actually win the RUNNING→FAILED transition — so a session that
+  // completed concurrently isn't clobbered and we don't double-emit a failure.
+  const won = await withTransaction(pool, async (tx) => {
+    const failed = await AgentSessionRepository.updateStatus(tx, sessionId, SessionStatuses.FAILED, {
+      error: ORPHAN_ERROR,
+      onlyIfStatus: SessionStatuses.RUNNING,
+    })
+    if (!failed) return false
+    // The stream event + outbox is what unblocks the UI (clears the inline
+    // indicator and keeps a refresh consistent). Without a stream we can't address
+    // the rooms, but the session is still durably FAILED.
+    if (stream) {
+      const steps = await AgentSessionRepository.findStepsBySession(tx, sessionId)
+      const streamEvent = await StreamEventRepository.insert(tx, {
+        id: eventId(),
+        streamId,
+        eventType: "agent_session:failed",
+        payload: {
+          sessionId,
+          stepCount: steps.length,
+          error: ORPHAN_ERROR,
+          traceId: sessionId,
+          failedAt: new Date().toISOString(),
+        },
+        actorId: personaId,
+        actorType: "persona",
+      })
+      await OutboxRepository.insert(tx, "agent_session:failed", {
+        workspaceId: stream.workspaceId,
+        streamId,
+        event: streamEvent,
+      })
+    }
+    return true
+  })
+
+  // Live-update an open trace dialog (session room) the way the in-process
+  // `trace.notifyFailed()` does — the outbox only reaches the stream room.
+  if (won && stream) {
+    io.to(`ws:${stream.workspaceId}:agent_session:${sessionId}`).emit("agent_session:failed", { sessionId })
+  }
+  return won
 }
 
 /**
@@ -14,12 +82,17 @@ export interface OrphanSessionCleanup {
  * - Server crashes during AI work
  * - completeSession() fails after work succeeded
  * - Process killed without graceful shutdown
+ * - An enclave that owned an E2E turn restarts mid-session (its heartbeats stop)
  *
- * The cleanup marks these sessions as FAILED so the stream is unblocked
- * for new requests.
+ * The cleanup marks these sessions as FAILED *and emits the failure lifecycle*
+ * (an `agent_session:failed` stream event + outbox, plus a session-room socket
+ * event) — exactly like the in-process failure path. Without that emission the
+ * status flips in the DB but the UI never hears: the inline "Ariadne is working…"
+ * indicator and an open trace dialog hang forever until a manual refresh.
  */
 export function createOrphanSessionCleanup(
   pool: Pool,
+  io: Server,
   options: {
     intervalMs?: number
     staleThresholdSeconds?: number
@@ -39,10 +112,10 @@ export function createOrphanSessionCleanup(
 
       for (const session of orphaned) {
         try {
-          await AgentSessionRepository.updateStatus(pool, session.id, SessionStatuses.FAILED, {
-            error: "Session orphaned (stale heartbeat)",
-          })
-          logger.info({ sessionId: session.id, streamId: session.streamId }, "Marked orphaned session as failed")
+          const won = await failOrphanedSession(pool, io, session)
+          if (won) {
+            logger.info({ sessionId: session.id, streamId: session.streamId }, "Marked orphaned session as failed")
+          }
         } catch (err) {
           logger.error({ err, sessionId: session.id }, "Failed to mark orphaned session as failed")
         }

--- a/apps/backend/src/features/agents/session-handlers.ts
+++ b/apps/backend/src/features/agents/session-handlers.ts
@@ -1,6 +1,5 @@
 import type { Request, Response } from "express"
 import type { Pool } from "pg"
-import { withClient } from "../../db"
 import { AgentSessionRepository } from "./session-repository"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { StreamMemberRepository } from "../streams"
@@ -25,18 +24,22 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
       const workspaceId = req.workspaceId!
       const { sessionId } = req.params
 
-      const result = await withClient(pool, async (db) => {
-        const session = await AgentSessionRepository.findById(db, sessionId)
+      // Independent reads — run against the pool (a connection per query) rather
+      // than one withClient client, which cannot execute concurrent queries: the
+      // Promise.all below would fire five queries on a single client (pg warns
+      // today and pg@9 will throw). No transaction is needed; these are reads.
+      const result = await (async () => {
+        const session = await AgentSessionRepository.findById(pool, sessionId)
         if (!session) {
           return { error: "Session not found", status: 404 }
         }
 
         const [stream, membership, persona, bot, steps] = await Promise.all([
-          StreamRepository.findById(db, session.streamId),
-          StreamMemberRepository.findByStreamAndMember(db, session.streamId, userId),
-          PersonaRepository.findById(db, session.personaId, workspaceId),
-          BotRepository.findById(db, workspaceId, session.personaId),
-          AgentSessionRepository.findStepsBySession(db, sessionId),
+          StreamRepository.findById(pool, session.streamId),
+          StreamMemberRepository.findByStreamAndMember(pool, session.streamId, userId),
+          PersonaRepository.findById(pool, session.personaId, workspaceId),
+          BotRepository.findById(pool, workspaceId, session.personaId),
+          AgentSessionRepository.findStepsBySession(pool, sessionId),
         ])
 
         if (!stream || stream.workspaceId !== workspaceId) {
@@ -56,11 +59,11 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
         }
 
         const relatedSessions = (
-          await AgentSessionRepository.listByTriggerMessage(db, session.triggerMessageId)
+          await AgentSessionRepository.listByTriggerMessage(pool, session.triggerMessageId)
         ).filter((relatedSession) => relatedSession.streamId === session.streamId)
         const sessionIds = [...new Set([session.id, ...relatedSessions.map((relatedSession) => relatedSession.id)])]
         const rerunContextBySessionId = await StreamEventRepository.listRerunContextBySessionIds(
-          db,
+          pool,
           session.streamId,
           sessionIds
         )
@@ -104,7 +107,7 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
         }
 
         return { data: response }
-      })
+      })()
 
       if (result.error) {
         return res.status(result.status).json({ error: result.error })

--- a/apps/backend/src/features/agents/session-repository.test.ts
+++ b/apps/backend/src/features/agents/session-repository.test.ts
@@ -94,3 +94,31 @@ describe("AgentSessionRepository.updateStatus SQL guards", () => {
     expect(captured.text).not.toContain("AND status = ANY(")
   })
 })
+
+describe("AgentSessionRepository.updateStep finalize-race guard", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("gates the update on a still-running step when requireRunning is set", async () => {
+    const captured = { text: null as string | null, values: null as unknown[] | null }
+    const db = createQuerierCapture(captured)
+
+    await AgentSessionRepository.updateStep(db, "step_1", {
+      contentCiphertext: "ct",
+      contentEnvelope: { keyGeneration: 1 },
+      requireRunning: true,
+    })
+
+    expect(captured.text).toContain("AND completed_at IS NULL")
+  })
+
+  it("updates unconditionally when requireRunning is not set (finalize path)", async () => {
+    const captured = { text: null as string | null, values: null as unknown[] | null }
+    const db = createQuerierCapture(captured)
+
+    await AgentSessionRepository.updateStep(db, "step_1", { completedAt: new Date(), content: { done: true } })
+
+    expect(captured.text).not.toContain("AND completed_at IS NULL")
+  })
+})

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -658,6 +658,14 @@ export const AgentSessionRepository = {
       sources?: TraceSource[]
       messageId?: string
       completedAt?: Date
+      /**
+       * Guard against overwriting a finalized step. A mid-run substep snapshot can
+       * race a finalize (`/steps`): network reordering or a retry can land the
+       * snapshot after completion, clobbering the final content with a partial one.
+       * When set, the row updates only while still running — a no-op (null) once
+       * finalized, so the final content always wins.
+       */
+      requireRunning?: boolean
     }
   ): Promise<AgentSessionStep | null> {
     const result = await db.query<StepRow>(
@@ -671,6 +679,7 @@ export const AgentSessionRepository = {
           message_id = COALESCE(${params.messageId ?? null}, message_id),
           completed_at = COALESCE(${params.completedAt ?? null}, completed_at)
         WHERE id = ${stepId}
+          ${sql.raw(params.requireRunning ? "AND completed_at IS NULL" : "")}
         RETURNING ${sql.raw(STEP_SELECT_FIELDS)}
       `
     )

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -652,6 +652,9 @@ export const AgentSessionRepository = {
     stepId: string,
     params: {
       content?: unknown
+      /** E2E (enclave) finalize: SSK-sealed content + envelope set in place on the in-flight row. */
+      contentCiphertext?: string
+      contentEnvelope?: unknown
       sources?: TraceSource[]
       messageId?: string
       completedAt?: Date
@@ -662,6 +665,8 @@ export const AgentSessionRepository = {
         UPDATE agent_session_steps
         SET
           content = COALESCE(${params.content != null ? JSON.stringify(params.content) : null}, content),
+          content_ciphertext = COALESCE(${params.contentCiphertext ?? null}, content_ciphertext),
+          content_envelope = COALESCE(${params.contentEnvelope ? JSON.stringify(params.contentEnvelope) : null}, content_envelope),
           sources = COALESCE(${params.sources ? JSON.stringify(params.sources) : null}, sources),
           message_id = COALESCE(${params.messageId ?? null}, message_id),
           completed_at = COALESCE(${params.completedAt ?? null}, completed_at)

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import * as db from "../../../db"
+import * as agents from "../../agents"
+import { AgentSessionRepository } from "../../agents"
+import { StreamRepository, StreamEventRepository } from "../../streams"
+import { OutboxRepository } from "../../../lib/outbox"
+import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
+import type { E2eStream, E2eStreamActor, StreamE2eKeyWrap } from "../../e2e-streams"
+import { MessageRepository } from "../../messaging"
+import type { Message } from "../../messaging"
+import { UserRepository } from "../../workspaces"
+import { UserPreferencesService } from "../../user-preferences"
+import { EnclaveRuntimesRepository, type EnclaveRuntime } from "../repository"
+import type { EnclaveForwarder } from "../forwarder"
+import { createEnclaveInvokeWorker } from "./enclave-invoke-worker"
+
+const pool = {} as Pool
+const JOB = { data: { workspaceId: "ws_1", streamId: "stream_1", messageId: "msg_trigger" } } as never
+
+const E2E: E2eStream = {
+  streamId: "stream_1",
+  workspaceId: "ws_1",
+  enabledAt: new Date(),
+  ownerUserId: "usr_owner",
+  ownerUserKeyId: "e2ek_owner",
+  currentKeyGeneration: 1,
+  allowedToolCategories: null,
+}
+const ENCLAVE_ACTOR: E2eStreamActor = { kind: "enclave", actorId: "enclave", keyId: null }
+const EIK: EnclaveRuntime = {
+  id: "elr_1",
+  instanceId: "enci_1",
+  keyId: "eik_live",
+  publicKey: new Uint8Array([1, 2, 3]),
+  instanceUrl: "https://enclave-1.internal",
+  registeredAt: new Date(),
+  lastSeenAt: new Date(),
+  revokedAt: null,
+}
+const WRAP: StreamE2eKeyWrap = {
+  keyGeneration: 1,
+  recipientKeyId: "eik_live",
+  recipientKind: "enclave",
+  wrapEnc: "enc_1",
+  wrapCt: "ct_1",
+}
+const TRIGGER = {
+  id: "msg_trigger",
+  authorType: "user",
+  authorId: "usr_kris",
+  createdAt: new Date("2026-06-02T09:27:00.000Z"),
+  ciphertext: Buffer.from("cipher:hello"),
+  envelope: { v: 2, keyGeneration: 1, iv: "aXY=", aad: "YWFk" },
+} as unknown as Message
+
+afterEach(() => mock.restore())
+
+function fakeIo() {
+  const emit = mock((_event: string, _payload: unknown) => {})
+  const io = { to: mock((_room: string) => ({ emit })) } as unknown as Server
+  return { io, emit }
+}
+
+/** Stub everything up to the enclave handoff; returns the sentinel tx withTransaction runs on. */
+function arrangeDispatch() {
+  spyOn(E2eStreamsRepository, "getByStreamId").mockResolvedValue(E2E)
+  spyOn(E2eStreamActorsRepository, "listForStream").mockResolvedValue([ENCLAVE_ACTOR])
+  spyOn(AgentSessionRepository, "findByTriggerMessage").mockResolvedValue(null)
+  spyOn(MessageRepository, "findById").mockResolvedValue(TRIGGER)
+  spyOn(EnclaveRuntimesRepository, "listLive").mockResolvedValue([EIK])
+  spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([WRAP])
+  spyOn(MessageRepository, "findSurrounding").mockResolvedValue([])
+  spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
+  spyOn(UserPreferencesService.prototype, "getPreferences").mockResolvedValue({} as never)
+  spyOn(UserRepository, "findByIds").mockResolvedValue([{ name: "Kris" }] as never)
+  spyOn(agents, "buildEnclaveSystemPrompt").mockResolvedValue("You are Ariadne.")
+
+  const tx = { __tx: true } as never
+  spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+    fn(tx)) as never)
+  return tx
+}
+
+describe("createEnclaveInvokeWorker", () => {
+  it("commits the session row and the started lifecycle event in one transaction (INV-7)", async () => {
+    const tx = arrangeDispatch()
+    const insertSession = spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue({
+      id: "session_1",
+      createdAt: new Date("2026-06-02T09:27:01.000Z"),
+    } as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const assignSession = mock(async () => {})
+    const { io } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+    })
+    await worker(JOB)
+
+    // Both writes ran on the same transaction client — a crash between them can't
+    // leave a RUNNING session with no started event (invisible to the stream view
+    // yet blocking the one-running guard).
+    expect(insertSession.mock.calls[0]![0]).toBe(tx)
+    expect(insertEvent.mock.calls[0]![0]).toBe(tx)
+    expect(insertEvent.mock.calls[0]![1]).toMatchObject({
+      streamId: "stream_1",
+      eventType: "agent_session:started",
+      payload: { personaId: agents.ARIADNE_AGENT_ID, triggerMessageId: "msg_trigger" },
+    })
+    expect(insertOutbox.mock.calls[0]![0]).toBe(tx)
+    expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:started")
+    expect(assignSession).toHaveBeenCalledTimes(1)
+  })
+
+  it("emits no started event when the one-running guard skips the session", async () => {
+    arrangeDispatch()
+    spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue(null)
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const assignSession = mock(async () => {})
+    const { io } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+    })
+    await worker(JOB)
+
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(assignSession).not.toHaveBeenCalled()
+  })
+
+  it("fails the session with the full lifecycle when the enclave handoff fails", async () => {
+    arrangeDispatch()
+    spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue({
+      id: "session_1",
+      createdAt: new Date("2026-06-02T09:27:01.000Z"),
+    } as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    // The helper's internals: RUNNING→FAILED transition won, steps counted.
+    const update = spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue({ id: "session_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([])
+    const assignSession = mock(async () => {
+      throw new Error("enclave unreachable")
+    })
+    const { io, emit } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+    })
+    // The original assign error still propagates so the job retries.
+    await expect(worker(JOB)).rejects.toThrow("enclave unreachable")
+
+    // The started card must terminate: orphan-cleanup only scans RUNNING sessions,
+    // so a session marked FAILED here gets no backstop emission.
+    expect(update.mock.calls[0]![3]).toMatchObject({ error: "Enclave assignment failed" })
+    const failedEvent = insertEvent.mock.calls.find(
+      (c) => (c[1] as { eventType: string }).eventType === "agent_session:failed"
+    )
+    expect(failedEvent?.[1]).toMatchObject({
+      streamId: "stream_1",
+      eventType: "agent_session:failed",
+      payload: { sessionId: "session_1", error: "Enclave assignment failed" },
+    })
+    // And a live-open trace dialog hears it directly via the session room.
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:failed")).toBe(true)
+  })
+})

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -3,7 +3,8 @@ import { sessionId as newSessionId, eventId } from "../../../lib/id"
 import { logger } from "../../../lib/logger"
 import { withTransaction } from "../../../db"
 import { OutboxRepository } from "../../../lib/outbox"
-import { StreamEventRepository } from "../../streams"
+import { StreamEventRepository, StreamRepository } from "../../streams"
+import { UserPreferencesService } from "../../user-preferences"
 import type { EnclaveInvokeJobData, JobHandler } from "../../../lib/queue/job-queue"
 import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
 import { MessageRepository } from "../../messaging"
@@ -11,6 +12,7 @@ import {
   AgentSessionRepository,
   SessionStatuses,
   ARIADNE_AGENT_ID,
+  buildEnclaveSystemPrompt,
   getBuiltInAgentConfig,
   isE2eCapablePersona,
 } from "../../agents"
@@ -36,6 +38,7 @@ export interface EnclaveInvokeWorkerDeps {
  */
 export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHandler<EnclaveInvokeJobData> {
   const { pool, enclaveForwarder } = deps
+  const userPreferencesService = new UserPreferencesService(pool)
 
   return async (job) => {
     const { workspaceId, streamId, messageId: triggerId } = job.data
@@ -62,11 +65,22 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     const trigger = await MessageRepository.findById(pool, triggerId)
     if (!trigger || !trigger.ciphertext) return // gone, or not an E2E message
 
-    const [liveEiks, wraps, surrounding] = await Promise.all([
+    const [liveEiks, wraps, surrounding, stream, preferences] = await Promise.all([
       EnclaveRuntimesRepository.listLive(pool, ENCLAVE_RUNTIME_STALENESS_MS),
       StreamE2eKeyWrapsRepository.listForStream(pool, workspaceId, streamId),
       MessageRepository.findSurrounding(pool, triggerId, streamId, MAX_HISTORY_MESSAGES, 0),
+      StreamRepository.findById(pool, streamId),
+      userPreferencesService.getPreferences(workspaceId, trigger.authorId),
     ])
+    if (!stream) return
+
+    // Assemble Ariadne's system prompt with the SAME shared builder the main app
+    // uses (temporal grounding, response style, send_message rules, tool sections,
+    // trust boundary, and the owner's scratchpad custom instructions) — only the
+    // toolset is reduced. The enclave runs the same loop on the same prompt; just
+    // the I/O is encrypted. This is the raw text the backend ships; the message
+    // content stays ciphertext.
+    const systemPrompt = await buildEnclaveSystemPrompt({ pool, stream, preferences, persona })
 
     const sid = newSessionId()
     const built = buildEnclaveSessionAssignment({
@@ -77,7 +91,7 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       trigger,
       priorMessages: surrounding.filter((m) => m.id !== triggerId),
       persona: {
-        systemPrompt: persona.systemPrompt,
+        systemPrompt,
         model: persona.model,
         temperature: persona.temperature,
         maxTokens: persona.maxTokens,

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "pg"
+import type { Server } from "socket.io"
 import { sessionId as newSessionId, eventId } from "../../../lib/id"
 import { logger } from "../../../lib/logger"
 import { withTransaction } from "../../../db"
@@ -14,6 +15,7 @@ import {
   SessionStatuses,
   ARIADNE_AGENT_ID,
   buildEnclaveSystemPrompt,
+  failSessionWithLifecycle,
   getBuiltInAgentConfig,
   isE2eCapablePersona,
 } from "../../agents"
@@ -27,6 +29,7 @@ const MAX_HISTORY_MESSAGES = 30
 
 export interface EnclaveInvokeWorkerDeps {
   pool: Pool
+  io: Server
   enclaveForwarder: EnclaveForwarder
 }
 
@@ -38,7 +41,7 @@ export interface EnclaveInvokeWorkerDeps {
  * Ariadne's replies are written by the `/complete` callback, not here.
  */
 export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHandler<EnclaveInvokeJobData> {
-  const { pool, enclaveForwarder } = deps
+  const { pool, io, enclaveForwarder } = deps
   const userPreferencesService = new UserPreferencesService(pool)
 
   return async (job) => {
@@ -109,27 +112,29 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       return
     }
 
-    // Create the session row owned by the chosen EIK. Skip if another session is
-    // already RUNNING for this stream (one-running-per-stream guard, INV-20).
+    // Create the session row owned by the chosen EIK — skip if another session is
+    // already RUNNING for this stream (one-running-per-stream guard, INV-20) — and
+    // surface the turn in the stream view in the same transaction (INV-7), so a
+    // session row never exists without its started event (a crash between the two
+    // would leave an invisible RUNNING session the one-running guard then blocks
+    // on). The enclave path otherwise emits only sealed
+    // `agent_session:step:completed` to the session room (the trace dialog) —
+    // nothing the inline `useAgentActivity` surface subscribes to. Emitting the
+    // same `agent_session:started` lifecycle event the in-process companion emits
+    // makes the scratchpad show "Ariadne is working…" and the trace reachable.
+    // Plaintext-free: the payload carries only ids + the persona name.
     // last_seen_sequence is an inert placeholder here; mid-turn reconsideration
     // (which uses it) is a later slice.
-    const session = await AgentSessionRepository.insertRunningOrSkip(pool, {
-      id: sid,
-      streamId,
-      personaId: ARIADNE_AGENT_ID,
-      triggerMessageId: triggerId,
-      serverId: built.keyId,
-      initialSequence: 0n,
-    })
-    if (!session) return
-
-    // Surface the turn in the stream view. The enclave path otherwise emits only
-    // sealed `agent_session:step:completed` to the session room (the trace
-    // dialog) — nothing the inline `useAgentActivity` surface subscribes to. Emit
-    // the same `agent_session:started` lifecycle event the in-process companion
-    // emits so the scratchpad shows "Ariadne is working…" and the trace becomes
-    // reachable. Plaintext-free: the payload carries only ids + the persona name.
-    await withTransaction(pool, async (tx) => {
+    const session = await withTransaction(pool, async (tx) => {
+      const created = await AgentSessionRepository.insertRunningOrSkip(tx, {
+        id: sid,
+        streamId,
+        personaId: ARIADNE_AGENT_ID,
+        triggerMessageId: triggerId,
+        serverId: built.keyId,
+        initialSequence: 0n,
+      })
+      if (!created) return null
       const startedEvent = await StreamEventRepository.insert(tx, {
         id: eventId(),
         streamId,
@@ -140,28 +145,33 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
           personaName: persona.name,
           triggerMessageId: triggerId,
           rerunContext: null,
-          startedAt: session.createdAt.toISOString(),
+          startedAt: created.createdAt.toISOString(),
         },
         actorId: ARIADNE_AGENT_ID,
         actorType: "persona",
       })
       await OutboxRepository.insert(tx, "agent_session:started", { workspaceId, streamId, event: startedEvent })
+      return created
     })
+    if (!session) return
 
     try {
       await enclaveForwarder.assignSession(built.instanceUrl, built.assignment)
     } catch (err) {
-      // Handoff failed — mark the session FAILED so the retry (and the
-      // one-running guard) can re-assign a fresh session. If that write *also*
-      // fails, log it loudly (INV-11, not a silent swallow) and still rethrow the
-      // original assign error: orphan-cleanup reclaims a RUNNING session with no
-      // live enclave heartbeating it — the same backstop that covers an enclave
-      // dying mid-turn. A durable pre-handoff state is part of the resume rework
-      // (Slice C).
-      await AgentSessionRepository.updateStatus(pool, session.id, SessionStatuses.FAILED, {
-        error: "enclave assign failed",
-        onlyIfStatus: SessionStatuses.RUNNING,
-      }).catch((statusErr) =>
+      // Handoff failed — mark the session FAILED *and emit the failed lifecycle*
+      // so the started card above terminates instead of spinning: orphan-cleanup
+      // can't backstop a session we mark FAILED ourselves (it only scans RUNNING).
+      // The retry (and the one-running guard) can then re-assign a fresh session.
+      // If this write fails too, log it loudly (INV-11, not a silent swallow) and
+      // still rethrow the original assign error: the session stays RUNNING with no
+      // live enclave heartbeating it, which orphan-cleanup *does* reclaim. A
+      // durable pre-handoff state is part of the resume rework (Slice C).
+      await failSessionWithLifecycle(
+        pool,
+        io,
+        { id: session.id, streamId, personaId: ARIADNE_AGENT_ID },
+        "Enclave assignment failed"
+      ).catch((statusErr) =>
         logger.error({ statusErr, sessionId: session.id }, "Failed to mark session FAILED after assign failure")
       )
       throw err

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -79,7 +79,9 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     ])
     if (!stream) return
     // Display name for the enclave's "Triggered by" CONTEXT step (metadata only).
-    const triggerAuthorName = authors[0]?.name ?? "Unknown"
+    // Left undefined when unresolved → the enclave suppresses the row rather than
+    // rendering a misleading "Unknown" author.
+    const triggerAuthorName = authors[0]?.name
 
     // Assemble Ariadne's system prompt with the SAME shared builder the main app
     // uses (temporal grounding, response style, send_message rules, tool sections,

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -4,6 +4,7 @@ import { logger } from "../../../lib/logger"
 import { withTransaction } from "../../../db"
 import { OutboxRepository } from "../../../lib/outbox"
 import { StreamEventRepository, StreamRepository } from "../../streams"
+import { UserRepository } from "../../workspaces"
 import { UserPreferencesService } from "../../user-preferences"
 import type { EnclaveInvokeJobData, JobHandler } from "../../../lib/queue/job-queue"
 import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
@@ -65,14 +66,17 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     const trigger = await MessageRepository.findById(pool, triggerId)
     if (!trigger || !trigger.ciphertext) return // gone, or not an E2E message
 
-    const [liveEiks, wraps, surrounding, stream, preferences] = await Promise.all([
+    const [liveEiks, wraps, surrounding, stream, preferences, authors] = await Promise.all([
       EnclaveRuntimesRepository.listLive(pool, ENCLAVE_RUNTIME_STALENESS_MS),
       StreamE2eKeyWrapsRepository.listForStream(pool, workspaceId, streamId),
       MessageRepository.findSurrounding(pool, triggerId, streamId, MAX_HISTORY_MESSAGES, 0),
       StreamRepository.findById(pool, streamId),
       userPreferencesService.getPreferences(workspaceId, trigger.authorId),
+      UserRepository.findByIds(pool, workspaceId, [trigger.authorId]),
     ])
     if (!stream) return
+    // Display name for the enclave's "Triggered by" CONTEXT step (metadata only).
+    const triggerAuthorName = authors[0]?.name ?? "Unknown"
 
     // Assemble Ariadne's system prompt with the SAME shared builder the main app
     // uses (temporal grounding, response style, send_message rules, tool sections,
@@ -89,6 +93,7 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       liveEiks,
       wraps,
       trigger,
+      triggerAuthorName,
       priorMessages: surrounding.filter((m) => m.id !== triggerId),
       persona: {
         systemPrompt,

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -1,6 +1,9 @@
 import type { Pool } from "pg"
-import { sessionId as newSessionId } from "../../../lib/id"
+import { sessionId as newSessionId, eventId } from "../../../lib/id"
 import { logger } from "../../../lib/logger"
+import { withTransaction } from "../../../db"
+import { OutboxRepository } from "../../../lib/outbox"
+import { StreamEventRepository } from "../../streams"
 import type { EnclaveInvokeJobData, JobHandler } from "../../../lib/queue/job-queue"
 import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
 import { MessageRepository } from "../../messaging"
@@ -100,6 +103,31 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       initialSequence: 0n,
     })
     if (!session) return
+
+    // Surface the turn in the stream view. The enclave path otherwise emits only
+    // sealed `agent_session:step:completed` to the session room (the trace
+    // dialog) — nothing the inline `useAgentActivity` surface subscribes to. Emit
+    // the same `agent_session:started` lifecycle event the in-process companion
+    // emits so the scratchpad shows "Ariadne is working…" and the trace becomes
+    // reachable. Plaintext-free: the payload carries only ids + the persona name.
+    await withTransaction(pool, async (tx) => {
+      const startedEvent = await StreamEventRepository.insert(tx, {
+        id: eventId(),
+        streamId,
+        eventType: "agent_session:started",
+        payload: {
+          sessionId: sid,
+          personaId: ARIADNE_AGENT_ID,
+          personaName: persona.name,
+          triggerMessageId: triggerId,
+          rerunContext: null,
+          startedAt: session.createdAt.toISOString(),
+        },
+        actorId: ARIADNE_AGENT_ID,
+        actorType: "persona",
+      })
+      await OutboxRepository.insert(tx, "agent_session:started", { workspaceId, streamId, event: startedEvent })
+    })
 
     try {
       await enclaveForwarder.assignSession(built.instanceUrl, built.assignment)

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -43,6 +43,8 @@ function msg(id: string, authorType: "user" | "persona", text: string, gen = 1):
   return {
     id,
     authorType,
+    authorId: "usr_kris",
+    createdAt: new Date("2026-06-02T09:27:00.000Z"),
     ciphertext: Buffer.from(`cipher:${text}`),
     envelope: { v: 2, keyGeneration: gen, iv: "aXY=", aad: "YWFk" },
   } as unknown as Message
@@ -62,6 +64,7 @@ function inputs(over: Partial<BuildInvokeInputs> = {}): BuildInvokeInputs {
     liveEiks: [eik("eik_live", "https://enclave-1.internal")],
     wraps: [wrap("eik_live", 1)],
     trigger: msg("msg_trigger", "user", "hello"),
+    triggerAuthorName: "Kris",
     priorMessages: [],
     persona: PERSONA,
     replySenderId: "persona_ariadne",
@@ -86,6 +89,8 @@ describe("buildEnclaveSessionAssignment", () => {
         reply: { keyGeneration: 1, senderId: "persona_ariadne" },
         prompt: { ciphertext: Buffer.from("cipher:hello").toString("base64") },
         wraps: [{ keyGeneration: 1, wrapEnc: "enc_eik_live_1", wrapCt: "ct_eik_live_1" }],
+        // Clear trigger metadata for the enclave's "Triggered by" CONTEXT step.
+        trigger: { messageId: "msg_trigger", authorName: "Kris", authorType: "user" },
       },
     })
     expect(built!.assignment).not.toHaveProperty("maxTokens") // null → omitted

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -96,6 +96,13 @@ describe("buildEnclaveSessionAssignment", () => {
     expect(built!.assignment).not.toHaveProperty("maxTokens") // null → omitted
   })
 
+  it("omits the trigger metadata when the author name can't be resolved", () => {
+    const built = buildEnclaveSessionAssignment(inputs({ triggerAuthorName: undefined }))
+    // No misleading "Unknown" placeholder row — the enclave suppresses the
+    // CONTEXT "Triggered by" step entirely when there's no name.
+    expect(built!.assignment).not.toHaveProperty("trigger")
+  })
+
   it("returns null when no enclave actor is invited", () => {
     expect(
       buildEnclaveSessionAssignment(inputs({ actors: [{ kind: "bot", actorId: "bot_x", keyId: null }] }))

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -79,6 +79,8 @@ describe("buildEnclaveSessionAssignment", () => {
       assignment: {
         sessionId: "session_test",
         model: "anthropic/claude-sonnet-4.6", // openrouter: prefix stripped
+        // The full system prompt is assembled upstream (buildEnclaveSystemPrompt)
+        // and passed through here verbatim as persona.systemPrompt.
         system: "You are Ariadne.",
         temperature: 0.7,
         reply: { keyGeneration: 1, senderId: "persona_ariadne" },

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -30,8 +30,12 @@ export interface BuildInvokeInputs {
   wraps: StreamE2eKeyWrap[]
   /** The triggering user message (its ciphertext becomes the prompt). */
   trigger: Message
-  /** Display name of the trigger's author, for the enclave's CONTEXT trace step. */
-  triggerAuthorName: string
+  /**
+   * Display name of the trigger's author, for the enclave's CONTEXT trace step.
+   * Omitted when the author can't be resolved — the enclave then suppresses the
+   * "Triggered by" row rather than rendering a misleading placeholder.
+   */
+  triggerAuthorName?: string
   /** Prior messages, oldest→newest, for context. */
   priorMessages: Message[]
   persona: PersonaInvokeConfig
@@ -102,13 +106,19 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     ...(e2e.allowedToolCategories ? { allowedToolCategories: e2e.allowedToolCategories } : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
     // Clear metadata for the enclave's "Triggered by" CONTEXT step; the body is
-    // the decrypted prompt, sealed enclave-side.
-    trigger: {
-      messageId: trigger.id,
-      authorName: inputs.triggerAuthorName,
-      authorType: trigger.authorType,
-      createdAt: trigger.createdAt.toISOString(),
-    },
+    // the decrypted prompt, sealed enclave-side. Omitted when the author name
+    // can't be resolved, so the enclave suppresses the row instead of rendering
+    // a misleading placeholder.
+    ...(inputs.triggerAuthorName
+      ? {
+          trigger: {
+            messageId: trigger.id,
+            authorName: inputs.triggerAuthorName,
+            authorType: trigger.authorType,
+            createdAt: trigger.createdAt.toISOString(),
+          },
+        }
+      : {}),
   }
 
   return { instanceUrl: chosen.instanceUrl, keyId: chosen.keyId, assignment }

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -30,6 +30,8 @@ export interface BuildInvokeInputs {
   wraps: StreamE2eKeyWrap[]
   /** The triggering user message (its ciphertext becomes the prompt). */
   trigger: Message
+  /** Display name of the trigger's author, for the enclave's CONTEXT trace step. */
+  triggerAuthorName: string
   /** Prior messages, oldest→newest, for context. */
   priorMessages: Message[]
   persona: PersonaInvokeConfig
@@ -99,6 +101,14 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     // web surface, today's behavior).
     ...(e2e.allowedToolCategories ? { allowedToolCategories: e2e.allowedToolCategories } : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
+    // Clear metadata for the enclave's "Triggered by" CONTEXT step; the body is
+    // the decrypted prompt, sealed enclave-side.
+    trigger: {
+      messageId: trigger.id,
+      authorName: inputs.triggerAuthorName,
+      authorType: trigger.authorType,
+      createdAt: trigger.createdAt.toISOString(),
+    },
   }
 
   return { instanceUrl: chosen.instanceUrl, keyId: chosen.keyId, assignment }

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -88,6 +88,8 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
       ciphertext: trigger.ciphertext.toString("base64"),
       envelope: trigger.envelope as EnclaveStreamEnvelope,
     },
+    // The worker assembles the full system prompt via the shared
+    // `buildEnclaveSystemPrompt` and passes it through here as `systemPrompt`.
     system: persona.systemPrompt,
     model: persona.model.replace(/^openrouter:/, ""),
     ...(persona.temperature !== null ? { temperature: persona.temperature } : {}),

--- a/apps/backend/src/features/enclave-runtimes/forwarder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/forwarder.test.ts
@@ -72,3 +72,37 @@ describe("EnclaveForwarder.assignSession", () => {
     expect((err as EnclaveForwardError).message).not.toContain(ASSIGNMENT.streamId)
   })
 })
+
+describe("EnclaveForwarder.cancelSession", () => {
+  it("POSTs to <instanceUrl>/sessions/:id/cancel with the key and returns true on 202", async () => {
+    const captured: { url?: string; method?: string; headers?: Record<string, string> } = {}
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      captured.url = String(url)
+      captured.method = init?.method
+      captured.headers = (init?.headers ?? {}) as Record<string, string>
+      return new Response(null, { status: 202 })
+    }) as unknown as typeof fetch
+
+    const forwarder = new EnclaveForwarder({ internalApiKey: "shared-secret" })
+    const ok = await forwarder.cancelSession("https://enclave-1.internal/", "session_1")
+
+    expect(ok).toBe(true)
+    expect(captured.url).toBe("https://enclave-1.internal/sessions/session_1/cancel")
+    expect(captured.method).toBe("POST")
+    expect(captured.headers?.[INTERNAL_API_KEY_HEADER]).toBe("shared-secret")
+  })
+
+  it("returns false (not throw) on a non-202 — the turn may have already finished", async () => {
+    globalThis.fetch = mock(async () => new Response(null, { status: 404 })) as unknown as typeof fetch
+    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    expect(await forwarder.cancelSession("https://enclave-1.internal", "session_1")).toBe(false)
+  })
+
+  it("returns false (not throw) on a network failure", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED")
+    }) as unknown as typeof fetch
+    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    expect(await forwarder.cancelSession("https://enclave-1.internal", "session_1")).toBe(false)
+  })
+})

--- a/apps/backend/src/features/enclave-runtimes/forwarder.ts
+++ b/apps/backend/src/features/enclave-runtimes/forwarder.ts
@@ -58,4 +58,25 @@ export class EnclaveForwarder {
       throw new EnclaveForwardError(`Enclave assign returned ${res.status}`, res.status)
     }
   }
+
+  /**
+   * Forward a user's "Stop research" to the enclave that owns the session, so it
+   * gracefully aborts the in-flight turn's long-running tools (partial findings,
+   * the turn still replies). Resolves `true` on the enclave's 202 ack; `false` on
+   * any non-202 or network failure — the caller treats a failed cancel as "nothing
+   * to abort" rather than surfacing an error (the turn may have already finished).
+   */
+  async cancelSession(instanceUrl: string, sessionId: string): Promise<boolean> {
+    const url = `${instanceUrl.replace(/\/$/, "")}/sessions/${sessionId}/cancel`
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { [INTERNAL_API_KEY_HEADER]: this.internalApiKey },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      return res.status === 202
+    } catch {
+      return false
+    }
+  }
 }

--- a/apps/backend/src/features/enclave-runtimes/repository.ts
+++ b/apps/backend/src/features/enclave-runtimes/repository.ts
@@ -107,6 +107,21 @@ export const EnclaveRuntimesRepository = {
   },
 
   /**
+   * Resolve one (non-revoked) runtime by its EIK key id — used to find the
+   * instance owning a session (its `server_id` is the EIK) so an abort can be
+   * forwarded there. Returns null if revoked or unknown.
+   */
+  async findByKeyId(db: Querier, keyId: string): Promise<EnclaveRuntime | null> {
+    const result = await db.query<EnclaveRuntimeRow>(sql`
+      SELECT ${sql.raw(COLUMNS)}
+      FROM enclave_runtimes
+      WHERE key_id = ${keyId} AND revoked_at IS NULL
+      LIMIT 1
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /**
    * Mark a key revoked. Idempotent: running this against an already-revoked
    * row keeps the original `revoked_at` timestamp.
    */

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -6,7 +6,8 @@ import { AuthorTypes } from "@threa/types"
 import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
 import { AgentSessionRepository, SessionStatuses } from "../agents"
-import { StreamRepository } from "../streams"
+import { StreamRepository, StreamEventRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
 import type { EventService } from "../messaging"
 import { createEnclaveSessionHandlers } from "./session-handlers"
 
@@ -41,6 +42,7 @@ const SESSION = {
   personaId: "persona_ariadne",
   status: SessionStatuses.RUNNING,
   lastSeenSequence: null,
+  createdAt: new Date("2026-05-30T00:00:00.000Z"),
 } as unknown as Awaited<ReturnType<typeof AgentSessionRepository.findById>>
 
 const MESSAGE_BODY = {
@@ -137,9 +139,16 @@ describe("createEnclaveSessionHandlers.complete", () => {
     await expect(handlers.complete(req("session_1", COMPLETE_BODY), fakeRes())).rejects.toMatchObject({ status: 409 })
   })
 
-  it("records the sent ids and completes the session (without writing messages)", async () => {
+  it("records the sent ids, completes the session, and emits agent_session:completed", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     const complete = spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
     const { handlers, createMessage } = makeHandlers()
     const res = fakeRes()
 
@@ -152,6 +161,14 @@ describe("createEnclaveSessionHandlers.complete", () => {
       sentMessageIds: ["msg_a", "msg_b"],
       responseMessageId: "msg_a",
     })
+    // The completed lifecycle event is what clears the inline stream-view trace
+    // (useAgentActivity) — emitted via a stream event + outbox, like in-process.
+    expect(insertEvent.mock.calls[0]![1]).toMatchObject({
+      streamId: "stream_1",
+      eventType: "agent_session:completed",
+      payload: { sessionId: "session_1", messageCount: 2 },
+    })
+    expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:completed")
   })
 })
 
@@ -221,6 +238,16 @@ describe("createEnclaveSessionHandlers.steps", () => {
       stepType: "thinking",
       contentCiphertext: "Y3Q=",
       contentEnvelope: STEP_BODY.envelope,
+    })
+
+    // Also drives the inline stream-view trace (useAgentActivity), which listens
+    // on the *stream* room — a plaintext progress event carrying step type only.
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:stream:stream_1")
+    const progress = emit.mock.calls.find((c) => c[0] === "agent_session:progress")
+    expect(progress?.[1]).toMatchObject({
+      sessionId: "session_1",
+      streamId: "stream_1",
+      currentStepType: "thinking",
     })
   })
 })

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -156,7 +156,7 @@ describe("createEnclaveSessionHandlers.complete", () => {
       fn(tx)) as never)
     const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
     const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
-    const { handlers, createMessage } = makeHandlers()
+    const { handlers, createMessage, io, emit } = makeHandlers()
     const res = fakeRes()
 
     await handlers.complete(req("session_1", COMPLETE_BODY), res)
@@ -164,6 +164,9 @@ describe("createEnclaveSessionHandlers.complete", () => {
     expect(res.statusCode).toBe(204)
     expect(createMessage).not.toHaveBeenCalled() // replies were already streamed via /messages
     expect(complete).toHaveBeenCalledTimes(1)
+    // Completion + event are one atomic transaction (INV-7): completeSession runs
+    // on the tx client, not the bare pool.
+    expect(complete.mock.calls[0]![0]).toBe(tx)
     expect(complete.mock.calls[0]![2]).toMatchObject({
       sentMessageIds: ["msg_a", "msg_b"],
       responseMessageId: "msg_a",
@@ -176,6 +179,28 @@ describe("createEnclaveSessionHandlers.complete", () => {
       payload: { sessionId: "session_1", messageCount: 2 },
     })
     expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:completed")
+    // And a live-open trace dialog (session room) is transitioned to completed.
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:completed")).toBe(true)
+  })
+
+  it("does not emit the completed event when the session raced to a terminal state", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    // Won by another redelivery between assertRunning and the transaction.
+    spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(null)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const { handlers, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", COMPLETE_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(insertEvent).not.toHaveBeenCalled() // no double-emit
+    expect(emit).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -60,6 +60,13 @@ const STEP_BODY = {
   durationMs: 1500,
 }
 
+// A tool's step:start — no content yet (the result isn't known), so ciphertext +
+// envelope are absent. Only stepType + stepId travel.
+const STEP_START_BODY = {
+  stepId: "step_b",
+  stepType: "web_search",
+}
+
 afterEach(() => mock.restore())
 
 // Fake socket server exposing the `emit` spy so step-broadcast assertions can
@@ -172,6 +179,68 @@ describe("createEnclaveSessionHandlers.complete", () => {
   })
 })
 
+describe("createEnclaveSessionHandlers.stepStarted", () => {
+  it("400s an invalid body", async () => {
+    const { handlers } = makeHandlers()
+    await expect(handlers.stepStarted(req("session_1", { bad: true }), fakeRes())).rejects.toMatchObject({
+      status: 400,
+    })
+  })
+
+  it("404s when the session is gone", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(null)
+    const { handlers } = makeHandlers()
+    await expect(handlers.stepStarted(req("session_1", STEP_START_BODY), fakeRes())).rejects.toMatchObject({
+      status: 404,
+    })
+  })
+
+  it("409s when the session is no longer running", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...SESSION!, status: SessionStatuses.FAILED })
+    const { handlers } = makeHandlers()
+    await expect(handlers.stepStarted(req("session_1", STEP_START_BODY), fakeRes())).rejects.toMatchObject({
+      status: 409,
+    })
+  })
+
+  it("opens an in-flight row (no completedAt) + current_step_type in one tx, broadcasts step:started + progress", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const append = spyOn(AgentSessionRepository, "appendStep").mockResolvedValue({
+      id: "step_b",
+      sessionId: "session_1",
+      stepNumber: 2,
+      stepType: "web_search",
+      contentCiphertext: null,
+      contentEnvelope: null,
+      startedAt: new Date("2026-05-30T00:00:00.000Z"),
+      completedAt: null,
+    } as never)
+    const stepType = spyOn(AgentSessionRepository, "updateCurrentStepType").mockResolvedValue(undefined)
+    const { handlers, io, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.stepStarted(req("session_1", STEP_START_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    // The row is opened in-progress — no completedAt — so the dialog renders it live.
+    expect(append.mock.calls[0]![0]).toBe(tx)
+    expect(append.mock.calls[0]![1]).toMatchObject({ id: "step_b", stepType: "web_search" })
+    expect((append.mock.calls[0]![1] as { completedAt?: Date }).completedAt).toBeUndefined()
+    expect(stepType).toHaveBeenCalledWith(tx, "session_1", "web_search")
+
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:step:started")).toBe(true)
+    // Inline indicator advances at step *start* (mirrors in-process startStep).
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:stream:stream_1")
+    const progress = emit.mock.calls.find((c) => c[0] === "agent_session:progress")
+    expect(progress?.[1]).toMatchObject({ sessionId: "session_1", currentStepType: "web_search" })
+  })
+})
+
 describe("createEnclaveSessionHandlers.steps", () => {
   it("400s an invalid body", async () => {
     const { handlers } = makeHandlers()
@@ -190,11 +259,49 @@ describe("createEnclaveSessionHandlers.steps", () => {
     await expect(handlers.steps(req("session_1", STEP_BODY), fakeRes())).rejects.toMatchObject({ status: 409 })
   })
 
-  it("appends the sealed step + current_step_type in one transaction, broadcasts it, and 204s", async () => {
+  it("finalizes the in-flight step in place (sealed content + completedAt), broadcasts step:completed, and 204s", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
-    // Run the transaction body against a fake client so the repo spies observe
-    // the calls (INV-6: append + current_step_type are wrapped in withTransaction).
+    const update = spyOn(AgentSessionRepository, "updateStep").mockResolvedValue({
+      id: "step_a",
+      sessionId: "session_1",
+      stepNumber: 1,
+      stepType: "thinking",
+      contentCiphertext: "Y3Q=",
+      contentEnvelope: STEP_BODY.envelope,
+      startedAt: new Date("2026-05-30T00:00:00.000Z"),
+      completedAt: new Date("2026-05-30T00:00:01.500Z"),
+    } as never)
+    const append = spyOn(AgentSessionRepository, "appendStep")
+    const { handlers, io, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.steps(req("session_1", STEP_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    // Updates the existing row in place — no insert on the happy path.
+    expect(append).not.toHaveBeenCalled()
+    expect(update.mock.calls[0]![0]).toBe(pool) // single query → bare pool (INV-30)
+    expect(update.mock.calls[0]![1]).toBe("step_a")
+    expect(update.mock.calls[0]![2]).toMatchObject({
+      contentCiphertext: "Y3Q=", // sealed content — the server never holds plaintext (INV-E7)
+      contentEnvelope: STEP_BODY.envelope,
+    })
+    expect((update.mock.calls[0]![2] as { completedAt?: Date }).completedAt).toBeInstanceOf(Date)
+
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls[0]![0]).toBe("agent_session:step:completed")
+    const emitted = emit.mock.calls[0]![1] as { sessionId: string; step: Record<string, unknown> }
+    expect(emitted.step).toMatchObject({ id: "step_a", stepType: "thinking", contentCiphertext: "Y3Q=" })
+    // No progress on the happy path — the indicator already advanced at step:started.
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:progress")).toBe(false)
+  })
+
+  it("falls back to a completed insert + progress when the start POST was dropped", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    // No in-flight row to finalize.
+    spyOn(AgentSessionRepository, "updateStep").mockResolvedValue(null)
     const tx = {} as never
     spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
       fn(tx)) as never)
@@ -209,46 +316,18 @@ describe("createEnclaveSessionHandlers.steps", () => {
       completedAt: new Date("2026-05-30T00:00:01.500Z"),
     } as never)
     const stepType = spyOn(AgentSessionRepository, "updateCurrentStepType").mockResolvedValue(undefined)
-    const { handlers, io, emit } = makeHandlers()
+    const { handlers, emit } = makeHandlers()
     const res = fakeRes()
 
     await handlers.steps(req("session_1", STEP_BODY), res)
 
     expect(res.statusCode).toBe(204)
-    expect(append).toHaveBeenCalledTimes(1)
-    // Both writes run on the same transaction client, not the bare pool.
+    // Inserts a completed row + advances current_step_type so the trace still lands.
     expect(append.mock.calls[0]![0]).toBe(tx)
-    expect(append.mock.calls[0]![1]).toMatchObject({
-      id: "step_a",
-      sessionId: "session_1",
-      stepType: "thinking",
-      contentCiphertext: "Y3Q=", // sealed content — the server never holds plaintext (INV-E7)
-      contentEnvelope: STEP_BODY.envelope,
-    })
+    expect(append.mock.calls[0]![1]).toMatchObject({ id: "step_a", contentCiphertext: "Y3Q=" })
     expect(stepType).toHaveBeenCalledWith(tx, "session_1", "thinking")
-
-    // Live broadcast to the workspace-scoped session room via the canonical
-    // serializer — payload carries ciphertext + envelope only (INV-E7).
-    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
-    expect(emit.mock.calls[0]![0]).toBe("agent_session:step:completed")
-    const emitted = emit.mock.calls[0]![1] as { sessionId: string; step: Record<string, unknown> }
-    expect(emitted.sessionId).toBe("session_1")
-    expect(emitted.step).toMatchObject({
-      id: "step_a",
-      stepType: "thinking",
-      contentCiphertext: "Y3Q=",
-      contentEnvelope: STEP_BODY.envelope,
-    })
-
-    // Also drives the inline stream-view trace (useAgentActivity), which listens
-    // on the *stream* room — a plaintext progress event carrying step type only.
-    expect(io.to).toHaveBeenCalledWith("ws:ws_1:stream:stream_1")
-    const progress = emit.mock.calls.find((c) => c[0] === "agent_session:progress")
-    expect(progress?.[1]).toMatchObject({
-      sessionId: "session_1",
-      streamId: "stream_1",
-      currentStepType: "thinking",
-    })
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:step:completed")).toBe(true)
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:progress")).toBe(true)
   })
 })
 

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -202,6 +202,26 @@ describe("createEnclaveSessionHandlers.complete", () => {
     expect(insertEvent).not.toHaveBeenCalled() // no double-emit
     expect(emit).not.toHaveBeenCalled()
   })
+
+  it("still completes the session durably when the stream is gone, skipping broadcast", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    const complete = spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue(null) // stream deleted mid-turn
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const { handlers, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", COMPLETE_BODY), res)
+
+    // The session is still marked COMPLETED (durable); only the broadcast is skipped.
+    expect(res.statusCode).toBe(204)
+    expect(complete).toHaveBeenCalledTimes(1)
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
+  })
 })
 
 describe("createEnclaveSessionHandlers.stepStarted", () => {

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -331,6 +331,58 @@ describe("createEnclaveSessionHandlers.steps", () => {
   })
 })
 
+describe("createEnclaveSessionHandlers.substep", () => {
+  const SUBSTEP_BODY = {
+    stepType: "research",
+    ciphertext: "Y3Q=",
+    envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
+  }
+  const SUBSTEP_WITH_SNAPSHOT = {
+    ...SUBSTEP_BODY,
+    stepId: "step_a",
+    snapshotCiphertext: "c25hcA==",
+    snapshotEnvelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
+  }
+
+  it("broadcasts the sealed phase to the stream + session rooms without persisting (no snapshot)", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const update = spyOn(AgentSessionRepository, "updateStep")
+    const { handlers, io, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.substep(req("session_1", SUBSTEP_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(update).not.toHaveBeenCalled() // broadcast-only — no step row to persist onto
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:stream:stream_1")
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.every((c) => c[0] === "agent_session:substep")).toBe(true)
+    expect((emit.mock.calls[0]![1] as { ciphertext: string }).ciphertext).toBe("Y3Q=")
+  })
+
+  it("persists the running snapshot onto the in-flight step (sealed, no completion) when one travels", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const update = spyOn(AgentSessionRepository, "updateStep").mockResolvedValue(null)
+    const { handlers, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.substep(req("session_1", SUBSTEP_WITH_SNAPSHOT), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(update.mock.calls[0]![1]).toBe("step_a")
+    expect(update.mock.calls[0]![2]).toMatchObject({
+      contentCiphertext: "c25hcA==",
+      contentEnvelope: SUBSTEP_WITH_SNAPSHOT.snapshotEnvelope,
+    })
+    // No completedAt — the step stays in-flight; the snapshot only seeds refresh recovery.
+    expect((update.mock.calls[0]![2] as { completedAt?: Date }).completedAt).toBeUndefined()
+    // Still broadcasts the live phase.
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:substep")).toBe(true)
+  })
+})
+
 describe("createEnclaveSessionHandlers.heartbeat", () => {
   it("400s without a session id", async () => {
     const handlers = createEnclaveSessionHandlers({ pool, eventService: {} as EventService, io: fakeIo().io })

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -83,6 +83,11 @@ const sealedSubstepSchema = z.object({
   stepType: z.enum(AGENT_STEP_TYPES),
   ciphertext: z.base64().min(1),
   envelope: streamEnvelopeSchema,
+  // The in-flight step + running snapshot: when present, the snapshot is
+  // persisted onto the step row so a refresh / open mid-run replays the phases.
+  stepId: z.string().min(1).optional(),
+  snapshotCiphertext: z.base64().min(1).optional(),
+  snapshotEnvelope: streamEnvelopeSchema.optional(),
 })
 
 interface Dependencies {
@@ -316,11 +321,14 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
 
     /**
      * POST /internal/enclave-runtimes/sessions/:id/substeps
-     * Relay one sealed substep — ephemeral mid-run phase text (e.g. the research
-     * sub-agent's "Searching the web: …"). Broadcast-only (no DB): the text is
-     * ciphertext the browser decrypts (INV-E7); only `stepType` is clear. Emitted
-     * to both the stream room (inline "Ariadne is …" indicator) and the session
-     * room (trace dialog), mirroring the in-process `emitSubstep` fan-out.
+     * Relay one sealed substep — mid-run phase text (e.g. the research sub-agent's
+     * "Searching the web: …"). The single new phase is broadcast ephemerally to
+     * both the stream room (inline "Ariadne is …" indicator) and the session room
+     * (trace dialog), mirroring the in-process `emitSubstep` fan-out. When a
+     * `stepId` + running `snapshotCiphertext` travel, the snapshot is *also*
+     * persisted onto the in-flight step row (no completion) so a refresh / opening
+     * the trace mid-run replays the phases so far — mirroring `updateSubsteps`.
+     * Everything is ciphertext the browser decrypts (INV-E7); only `stepType` is clear.
      */
     async substep(req: Request, res: Response) {
       const id = req.params.id
@@ -335,6 +343,18 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
       if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
 
       const sub = parsed.data
+
+      // Persist the running snapshot onto the in-flight step row (sealed, no
+      // completion) so a bootstrap refetch recovers the phase timeline. The
+      // browser decrypts step.content → { substeps } exactly as for a finalized
+      // step. Skipped when the step row isn't known yet (broadcast-only).
+      if (sub.stepId && sub.snapshotCiphertext && sub.snapshotEnvelope) {
+        await AgentSessionRepository.updateStep(pool, sub.stepId, {
+          contentCiphertext: sub.snapshotCiphertext,
+          contentEnvelope: sub.snapshotEnvelope,
+        })
+      }
+
       const payload = {
         workspaceId: stream.workspaceId,
         streamId: session.streamId,

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -349,9 +349,13 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
       // browser decrypts step.content → { substeps } exactly as for a finalized
       // step. Skipped when the step row isn't known yet (broadcast-only).
       if (sub.stepId && sub.snapshotCiphertext && sub.snapshotEnvelope) {
+        // `requireRunning` guards the finalize race: a snapshot that lands after
+        // the step's `/steps` finalize (reordering / retry) must not overwrite the
+        // final content with a mid-run partial. Once finalized this no-ops.
         await AgentSessionRepository.updateStep(pool, sub.stepId, {
           contentCiphertext: sub.snapshotCiphertext,
           contentEnvelope: sub.snapshotEnvelope,
+          requireRunning: true,
         })
       }
 

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -392,21 +392,27 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
       assertRunning(session)
 
       const messageIds = parsed.data.messageIds
-      await AgentSessionRepository.completeSession(pool, id, {
-        lastSeenSequence: session.lastSeenSequence ?? 0n,
-        responseMessageId: messageIds[0] ?? null,
-        sentMessageIds: messageIds,
-      })
-
-      // Clear the inline stream-view trace: emit the same agent_session:completed
-      // lifecycle event the in-process path emits so `useAgentActivity` drops the
-      // "Ariadne is working…" indicator (and the persisted event keeps a refresh
-      // consistent). Plaintext-free: counts + timing only.
+      // Resolve the workspace from the stream (the internal-auth context carries
+      // none) so we can address the workspace-scoped rooms, as the other callbacks do.
       const stream = await StreamRepository.findById(pool, session.streamId)
-      if (stream) {
-        const steps = await AgentSessionRepository.findStepsBySession(pool, id)
-        const completedAt = new Date()
-        await withTransaction(pool, async (tx) => {
+      const completedAt = new Date()
+
+      // Complete the session AND emit the `agent_session:completed` lifecycle event
+      // in ONE transaction (INV-7): the status flip and the event the UI needs to
+      // drop the "Ariadne is working…" indicator must never diverge. Without the
+      // single transaction a crash between them strands a COMPLETED session with no
+      // event — and orphan-cleanup only recovers RUNNING sessions, so it would hang
+      // forever. Gated on winning the RUNNING→COMPLETED transition so a redelivery
+      // that raced doesn't double-emit. Plaintext-free: counts + timing only.
+      const committed = await withTransaction(pool, async (tx) => {
+        const completed = await AgentSessionRepository.completeSession(tx, id, {
+          lastSeenSequence: session.lastSeenSequence ?? 0n,
+          responseMessageId: messageIds[0] ?? null,
+          sentMessageIds: messageIds,
+        })
+        if (!completed) return false // raced to a terminal state under us
+        if (stream) {
+          const steps = await AgentSessionRepository.findStepsBySession(tx, id)
           const completedEvent = await StreamEventRepository.insert(tx, {
             id: eventId(),
             streamId: session.streamId,
@@ -426,7 +432,15 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
             streamId: session.streamId,
             event: completedEvent,
           })
-        })
+        }
+        return true
+      })
+
+      // Live-update an open trace dialog (session room) the way the in-process
+      // `trace.notifyCompleted()` does — the outbox broadcast only reaches the
+      // stream room, so the dialog wouldn't otherwise transition until a refetch.
+      if (committed && stream) {
+        io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:completed", { sessionId: id })
       }
 
       res.status(204).end()

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -4,9 +4,11 @@ import type { Pool } from "pg"
 import type { Server } from "socket.io"
 import { AGENT_STEP_TYPES, AuthorTypes, E2E_PLACEHOLDER_CONTENT_MARKDOWN, type JSONContent } from "@threa/types"
 import { withTransaction } from "../../db"
+import { eventId } from "../../lib/id"
+import { OutboxRepository } from "../../lib/outbox"
 import { HttpError } from "../../lib/errors"
-import { AgentSessionRepository, SessionStatuses, type AgentSession } from "../agents"
-import { StreamRepository } from "../streams"
+import { AgentSessionRepository, SessionStatuses, getBuiltInAgentConfig, type AgentSession } from "../agents"
+import { StreamRepository, StreamEventRepository } from "../streams"
 import { serializeTraceStep } from "../public-api"
 import type { EventService } from "../messaging"
 
@@ -197,6 +199,24 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
         step: serializeTraceStep(persisted),
       })
 
+      // Also drive the inline stream-view trace (`useAgentActivity`), which
+      // subscribes to the *stream* room, not the session room. Mirror the
+      // in-process `agent_session:progress` payload so the "Ariadne is …"
+      // indicator reflects the current step type. Plaintext-free: step *type*
+      // only, never content. The enclave seals append-only (no step:started),
+      // so this advances on each completed step rather than mid-step.
+      const personaName = getBuiltInAgentConfig(session.personaId)?.name ?? "Ariadne"
+      io.to(`ws:${stream.workspaceId}:stream:${session.streamId}`).emit("agent_session:progress", {
+        workspaceId: stream.workspaceId,
+        streamId: session.streamId,
+        sessionId: id,
+        triggerMessageId: session.triggerMessageId,
+        personaName,
+        stepCount: persisted.stepNumber,
+        messageCount: 0,
+        currentStepType: persisted.stepType,
+      })
+
       res.status(204).end()
     },
 
@@ -226,6 +246,37 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
         responseMessageId: messageIds[0] ?? null,
         sentMessageIds: messageIds,
       })
+
+      // Clear the inline stream-view trace: emit the same agent_session:completed
+      // lifecycle event the in-process path emits so `useAgentActivity` drops the
+      // "Ariadne is working…" indicator (and the persisted event keeps a refresh
+      // consistent). Plaintext-free: counts + timing only.
+      const stream = await StreamRepository.findById(pool, session.streamId)
+      if (stream) {
+        const steps = await AgentSessionRepository.findStepsBySession(pool, id)
+        const completedAt = new Date()
+        await withTransaction(pool, async (tx) => {
+          const completedEvent = await StreamEventRepository.insert(tx, {
+            id: eventId(),
+            streamId: session.streamId,
+            eventType: "agent_session:completed",
+            payload: {
+              sessionId: id,
+              stepCount: steps.length,
+              messageCount: messageIds.length,
+              duration: completedAt.getTime() - session.createdAt.getTime(),
+              completedAt: completedAt.toISOString(),
+            },
+            actorId: session.personaId,
+            actorType: "persona",
+          })
+          await OutboxRepository.insert(tx, "agent_session:completed", {
+            workspaceId: stream.workspaceId,
+            streamId: session.streamId,
+            event: completedEvent,
+          })
+        })
+      }
 
       res.status(204).end()
     },

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -65,6 +65,17 @@ const sealedStepSchema = z.object({
   durationMs: z.number().int().min(0).optional(),
 })
 
+// One in-flight step *start*. `stepType` + `stepId` are clear; content is sealed
+// when already known (reasoning/reply) and absent for tools (no result yet), so
+// ciphertext + envelope are optional here (unlike the finalize, which always has them).
+const sealedStepStartSchema = z.object({
+  stepId: z.string().min(1),
+  stepType: z.enum(AGENT_STEP_TYPES),
+  messageId: z.string().min(1).optional(),
+  ciphertext: z.base64().min(1).optional(),
+  envelope: streamEnvelopeSchema.optional(),
+})
+
 // One sealed substep — ephemeral mid-run phase text (e.g. research progress).
 // `stepType` is clear metadata; the text is ciphertext (derived from encrypted
 // content, INV-E7). Broadcast only, never persisted.
@@ -92,6 +103,33 @@ function assertRunning(session: AgentSession | null): asserts session is AgentSe
   if (session.status !== SessionStatuses.RUNNING) {
     throw new HttpError("Session is not running", { status: 409, code: "SESSION_NOT_RUNNING" })
   }
+}
+
+/**
+ * Drive the inline stream-view indicator (`useAgentActivity`, which subscribes to
+ * the *stream* room, not the session room) with the same `agent_session:progress`
+ * payload the in-process `startStep` emits. Plaintext-free: step *type* only,
+ * never content. Emitted at step *start* so "Ariadne is …" reflects the current
+ * step the moment it begins.
+ */
+function emitInlineProgress(
+  io: Server,
+  session: AgentSession,
+  workspaceId: string,
+  stepCount: number,
+  currentStepType: string | null
+): void {
+  const personaName = getBuiltInAgentConfig(session.personaId)?.name ?? "Ariadne"
+  io.to(`ws:${workspaceId}:stream:${session.streamId}`).emit("agent_session:progress", {
+    workspaceId,
+    streamId: session.streamId,
+    sessionId: session.id,
+    triggerMessageId: session.triggerMessageId,
+    personaName,
+    stepCount,
+    messageCount: 0,
+    currentStepType,
+  })
 }
 
 export function createEnclaveSessionHandlers({ pool, eventService, io }: Dependencies) {
@@ -152,18 +190,19 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
     },
 
     /**
-     * POST /internal/enclave-runtimes/sessions/:id/steps
-     * Append one sealed trace step the moment the loop emits it, so an open
-     * trace dialog renders "Ariadne is thinking…" / her reply in real time. The
-     * content is ciphertext only — the browser decrypts it with the stream key
-     * (INV-E7). Persisted via the atomic appendStep (step_number computed in the
-     * INSERT, INV-20), so concurrent step POSTs never clobber each other.
+     * POST /internal/enclave-runtimes/sessions/:id/steps/started
+     * Open one in-flight sealed trace step the moment the loop starts it, so an
+     * open trace dialog renders the in-progress step (and hangs its live substeps
+     * under it) before completion — the exact lifecycle the non-E2E runtime emits,
+     * only sealed. Content is ciphertext when already known (reasoning/reply) and
+     * absent for tools (no result yet); only `stepType` is clear. A later
+     * `/steps` POST finalizes this same `stepId` in place.
      */
-    async steps(req: Request, res: Response) {
+    async stepStarted(req: Request, res: Response) {
       const id = req.params.id
       if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
 
-      const parsed = sealedStepSchema.safeParse(req.body)
+      const parsed = sealedStepStartSchema.safeParse(req.body)
       if (!parsed.success) throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
 
       const session = await AgentSessionRepository.findById(pool, id)
@@ -174,15 +213,11 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
       if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
 
       const step = parsed.data
-      const now = Date.now()
-      const startedAt = new Date(now - (step.durationMs ?? 0))
-      const completedAt = new Date(now)
 
-      // Append + current_step_type in one transaction (INV-6) so a reader never
-      // sees a new step row without the matching current_step_type. The latter
-      // is plaintext metadata (the step *kind*, no content) driving the
-      // cross-stream "Ariadne is working…" display, same as the in-process
-      // trace; it's cleared when the session completes.
+      // Insert the in-flight row (no completed_at) + current_step_type in one
+      // transaction (INV-6) so a reader never sees a new step row without the
+      // matching current_step_type. step_number is computed atomically in the
+      // INSERT (INV-20) so concurrent starts never clobber each other.
       const persisted = await withTransaction(pool, async (tx) => {
         const created = await AgentSessionRepository.appendStep(tx, {
           id: step.stepId,
@@ -191,39 +226,89 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
           messageId: step.messageId,
           contentCiphertext: step.ciphertext,
           contentEnvelope: step.envelope,
-          startedAt,
-          completedAt,
+          startedAt: new Date(),
         })
         await AgentSessionRepository.updateCurrentStepType(tx, id, step.stepType)
         return created
       })
 
-      // Live trace: relay the completed step to the session room using the same
-      // canonical serializer as the in-process and Pi step paths, so the
-      // frontend handler is source-agnostic. The payload carries only ciphertext
-      // + envelope (no plaintext, INV-E7); the browser decrypts. A bootstrap
-      // refetch reads the same persisted row, so refresh stays consistent.
-      io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:step:completed", {
+      // Live trace: relay the in-progress step to the session room (same
+      // serializer as the in-process and Pi paths, so the frontend handler is
+      // source-agnostic). completedAt is absent — the dialog shows it in-flight.
+      io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:step:started", {
         sessionId: id,
         step: serializeTraceStep(persisted),
       })
 
-      // Also drive the inline stream-view trace (`useAgentActivity`), which
-      // subscribes to the *stream* room, not the session room. Mirror the
-      // in-process `agent_session:progress` payload so the "Ariadne is …"
-      // indicator reflects the current step type. Plaintext-free: step *type*
-      // only, never content. The enclave seals append-only (no step:started),
-      // so this advances on each completed step rather than mid-step.
-      const personaName = getBuiltInAgentConfig(session.personaId)?.name ?? "Ariadne"
-      io.to(`ws:${stream.workspaceId}:stream:${session.streamId}`).emit("agent_session:progress", {
-        workspaceId: stream.workspaceId,
-        streamId: session.streamId,
+      // Drive the inline stream-view indicator (`useAgentActivity`, stream room)
+      // at step *start* — the same point startStep emits progress in-process —
+      // so "Ariadne is …" reflects the new step the moment it begins.
+      emitInlineProgress(io, session, stream.workspaceId, persisted.stepNumber, persisted.stepType)
+
+      res.status(204).end()
+    },
+
+    /**
+     * POST /internal/enclave-runtimes/sessions/:id/steps
+     * Finalize one sealed trace step in place when it completes — set the sealed
+     * content + completed_at on the row opened at /steps/started, keeping its
+     * original started_at so the duration is real. The content is ciphertext only;
+     * the browser decrypts it with the stream key (INV-E7). If the start POST was
+     * dropped, fall back to a race-safe completed insert so the trace still lands.
+     */
+    async steps(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
+
+      const parsed = sealedStepSchema.safeParse(req.body)
+      if (!parsed.success) throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+
+      const session = await AgentSessionRepository.findById(pool, id)
+      assertRunning(session)
+      const stream = await StreamRepository.findById(pool, session.streamId)
+      if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+
+      const step = parsed.data
+      const completedAt = new Date()
+
+      // Finalize the in-flight row opened at step:started — sealed content +
+      // completed_at, in place (started_at is preserved, so duration is real).
+      let persisted = await AgentSessionRepository.updateStep(pool, step.stepId, {
+        contentCiphertext: step.ciphertext,
+        contentEnvelope: step.envelope,
+        messageId: step.messageId,
+        completedAt,
+      })
+
+      // Fallback: the start POST never landed (dropped/raced), so there's no row
+      // to finalize. Insert a completed row + advance current_step_type (INV-6,
+      // INV-20) so the trace and inline indicator still reflect this step.
+      if (!persisted) {
+        const startedAt = new Date(completedAt.getTime() - (step.durationMs ?? 0))
+        persisted = await withTransaction(pool, async (tx) => {
+          const created = await AgentSessionRepository.appendStep(tx, {
+            id: step.stepId,
+            sessionId: id,
+            stepType: step.stepType,
+            messageId: step.messageId,
+            contentCiphertext: step.ciphertext,
+            contentEnvelope: step.envelope,
+            startedAt,
+            completedAt,
+          })
+          await AgentSessionRepository.updateCurrentStepType(tx, id, step.stepType)
+          return created
+        })
+        emitInlineProgress(io, session, stream.workspaceId, persisted.stepNumber, persisted.stepType)
+      }
+
+      // Live trace: relay the finalized step to the session room (browser
+      // decrypts; a bootstrap refetch reads the same row, so refresh is stable).
+      // No progress emit on the happy path — the inline indicator already
+      // advanced at step:started, mirroring ActiveStep.complete (socket-only).
+      io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:step:completed", {
         sessionId: id,
-        triggerMessageId: session.triggerMessageId,
-        personaName,
-        stepCount: persisted.stepNumber,
-        messageCount: 0,
-        currentStepType: persisted.stepType,
+        step: serializeTraceStep(persisted),
       })
 
       res.status(204).end()

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -65,6 +65,15 @@ const sealedStepSchema = z.object({
   durationMs: z.number().int().min(0).optional(),
 })
 
+// One sealed substep — ephemeral mid-run phase text (e.g. research progress).
+// `stepType` is clear metadata; the text is ciphertext (derived from encrypted
+// content, INV-E7). Broadcast only, never persisted.
+const sealedSubstepSchema = z.object({
+  stepType: z.enum(AGENT_STEP_TYPES),
+  ciphertext: z.base64().min(1),
+  envelope: streamEnvelopeSchema,
+})
+
 interface Dependencies {
   pool: Pool
   eventService: EventService
@@ -216,6 +225,43 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
         messageCount: 0,
         currentStepType: persisted.stepType,
       })
+
+      res.status(204).end()
+    },
+
+    /**
+     * POST /internal/enclave-runtimes/sessions/:id/substeps
+     * Relay one sealed substep — ephemeral mid-run phase text (e.g. the research
+     * sub-agent's "Searching the web: …"). Broadcast-only (no DB): the text is
+     * ciphertext the browser decrypts (INV-E7); only `stepType` is clear. Emitted
+     * to both the stream room (inline "Ariadne is …" indicator) and the session
+     * room (trace dialog), mirroring the in-process `emitSubstep` fan-out.
+     */
+    async substep(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
+
+      const parsed = sealedSubstepSchema.safeParse(req.body)
+      if (!parsed.success) throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+
+      const session = await AgentSessionRepository.findById(pool, id)
+      assertRunning(session)
+      const stream = await StreamRepository.findById(pool, session.streamId)
+      if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+
+      const sub = parsed.data
+      const payload = {
+        workspaceId: stream.workspaceId,
+        streamId: session.streamId,
+        sessionId: id,
+        triggerMessageId: session.triggerMessageId,
+        stepType: sub.stepType,
+        ciphertext: sub.ciphertext,
+        envelope: sub.envelope,
+        updatedAt: new Date().toISOString(),
+      }
+      io.to(`ws:${stream.workspaceId}:stream:${session.streamId}`).emit("agent_session:substep", payload)
+      io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:substep", payload)
 
       res.status(204).end()
     },

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -411,6 +411,11 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
           sentMessageIds: messageIds,
         })
         if (!completed) return false // raced to a terminal state under us
+        // Broadcast needs the workspace (room addressing). A missing stream is an
+        // edge (deleted mid-turn): the session is still marked COMPLETED durably,
+        // but the lifecycle event/outbox are skipped — same tradeoff the orphan
+        // cleanup makes for a streamless reclaim. An open dialog on a now-deleted
+        // stream then reconciles on its next bootstrap rather than live.
         if (stream) {
           const steps = await AgentSessionRepository.findStepsBySession(tx, id)
           const completedEvent = await StreamEventRepository.insert(tx, {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -281,6 +281,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     const enclaveSession = createEnclaveSessionHandlers({ pool, eventService, io: deps.io })
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
+    app.post("/internal/enclave-runtimes/sessions/:id/steps/started", internalAuth, enclaveSession.stepStarted)
     app.post("/internal/enclave-runtimes/sessions/:id/steps", internalAuth, enclaveSession.steps)
     app.post("/internal/enclave-runtimes/sessions/:id/substeps", internalAuth, enclaveSession.substep)
     app.post("/internal/enclave-runtimes/sessions/:id/complete", internalAuth, enclaveSession.complete)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -282,6 +282,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
     app.post("/internal/enclave-runtimes/sessions/:id/steps", internalAuth, enclaveSession.steps)
+    app.post("/internal/enclave-runtimes/sessions/:id/substeps", internalAuth, enclaveSession.substep)
     app.post("/internal/enclave-runtimes/sessions/:id/complete", internalAuth, enclaveSession.complete)
   }
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -704,7 +704,7 @@ export async function startServer(): Promise<ServerInstance> {
   // is configured — the forwarder authenticates to the enclave with it, and the
   // enclave rejects callers that don't present it.
   if (enclaveForwarder) {
-    const enclaveInvokeWorker = createEnclaveInvokeWorker({ pool, enclaveForwarder })
+    const enclaveInvokeWorker = createEnclaveInvokeWorker({ pool, io, enclaveForwarder })
     jobQueue.registerHandler(JobQueues.ENCLAVE_INVOKE, enclaveInvokeWorker, {
       tier: QueueTiers.INTERACTIVE,
       fairness: QueueFairness.NONE,

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1059,7 +1059,7 @@ export async function startServer(): Promise<ServerInstance> {
   await outboxDispatcher.start()
   outboxRetentionWorker.start()
 
-  const orphanSessionCleanup = createOrphanSessionCleanup(pools.main)
+  const orphanSessionCleanup = createOrphanSessionCleanup(pools.main, io)
   orphanSessionCleanup.start()
 
   const pushSessionCleanup = createPushSessionCleanup(pushService)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -616,6 +616,13 @@ export async function startServer(): Promise<ServerInstance> {
   // claim endpoint every second.
   attachBotNamespace({ io, botRuntimeService, botApiKeyService, botSocketRegistry })
 
+  // Built once here so both the socket layer (forwarding a user "Stop research"
+  // to the enclave that owns an E2E session) and the enclave-invoke worker below
+  // share it. Null when no internal key — enclave dispatch/cancel are then off.
+  const enclaveForwarder = config.internalApiKey
+    ? new EnclaveForwarder({ internalApiKey: config.internalApiKey })
+    : undefined
+
   registerSocketHandlers(io, {
     pool,
     authService,
@@ -623,6 +630,7 @@ export async function startServer(): Promise<ServerInstance> {
     pushService,
     userSocketRegistry,
     sessionAbortRegistry,
+    enclaveForwarder,
   })
 
   // Dedicated voice relay on its own namespace so audio frames don't share the
@@ -695,9 +703,6 @@ export async function startServer(): Promise<ServerInstance> {
   // Enclave (Ariadne E2E) forwarder + worker. Only wired when an internal key
   // is configured — the forwarder authenticates to the enclave with it, and the
   // enclave rejects callers that don't present it.
-  const enclaveForwarder = config.internalApiKey
-    ? new EnclaveForwarder({ internalApiKey: config.internalApiKey })
-    : null
   if (enclaveForwarder) {
     const enclaveInvokeWorker = createEnclaveInvokeWorker({ pool, enclaveForwarder })
     jobQueue.registerHandler(JobQueues.ENCLAVE_INVOKE, enclaveInvokeWorker, {

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -8,6 +8,8 @@ import type { PushService } from "./features/push"
 import type { UserSocketRegistry } from "./lib/user-socket-registry"
 import { AgentSessionRepository, PersonaRepository } from "./features/agents"
 import type { SessionAbortRegistry } from "./features/agents"
+import { EnclaveRuntimesRepository } from "./features/enclave-runtimes"
+import type { EnclaveForwarder } from "./features/enclave-runtimes"
 import { UserRepository } from "./features/workspaces"
 import { HttpError } from "./lib/errors"
 import { logger } from "./lib/logger"
@@ -55,8 +57,10 @@ interface Dependencies {
   streamService: StreamService
   pushService: PushService
   userSocketRegistry: UserSocketRegistry
-  /** Registry for graceful tool cancellation (e.g. workspace_research). */
+  /** Registry for graceful tool cancellation (e.g. workspace_research) — in-process sessions. */
   sessionAbortRegistry: SessionAbortRegistry
+  /** Forwards a graceful cancel to the enclave that owns an E2E session. Null when no internal key. */
+  enclaveForwarder?: EnclaveForwarder
 }
 
 /**
@@ -70,7 +74,8 @@ function deriveDeviceKey(userAgent: string | undefined): string {
 }
 
 export function registerSocketHandlers(io: Server, deps: Dependencies) {
-  const { pool, authService, streamService, pushService, userSocketRegistry, sessionAbortRegistry } = deps
+  const { pool, authService, streamService, pushService, userSocketRegistry, sessionAbortRegistry, enclaveForwarder } =
+    deps
 
   // ===========================================================================
   // Authentication middleware (shared with the voice namespace — see lib/socket-auth)
@@ -324,7 +329,16 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
             callback?.({ ok: false, error: "Not authorized" })
             return
           }
-          const aborted = sessionAbortRegistry.abort(sessionId, "user_abort")
+          // Route the abort by ownership: an E2E turn runs in the enclave (its
+          // server_id is that EIK), so forward the cancel there; an in-process
+          // turn lives in this server's abort registry. Both are graceful —
+          // research returns partial findings and the turn still replies.
+          const owningEnclave = session.serverId
+            ? await EnclaveRuntimesRepository.findByKeyId(pool, session.serverId)
+            : null
+          const aborted = owningEnclave
+            ? ((await enclaveForwarder?.cancelSession(owningEnclave.instanceUrl, sessionId)) ?? false)
+            : sessionAbortRegistry.abort(sessionId, "user_abort")
           wsMessagesTotal.inc({
             workspace_id: workspaceIdFromPayload,
             direction: "received",

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -4,6 +4,7 @@ import helmet from "helmet"
 import cookieParser from "cookie-parser"
 import pinoHttp from "pino-http"
 import { randomUUID } from "crypto"
+import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import { logger, createCorsOriginChecker } from "@threa/backend-common"
 
 interface CreateAppOptions {
@@ -51,7 +52,17 @@ export function createApp(options: CreateAppOptions): Express {
       },
       genReqId: (req) => (req.headers["x-request-id"] as string) || randomUUID(),
       redact: {
-        paths: ["req.headers.authorization", "req.headers.cookie", "res.headers['set-cookie']"],
+        // The default pino-http req serializer logs the full headers object, so
+        // every secret-bearing header must be redacted here or it lands in the
+        // log on any 4xx/5xx. `x-internal-api-key` is the shared internal-auth
+        // secret (backend → control-plane); Node lowercases header names, and the
+        // path is derived from the constant so it can't drift.
+        paths: [
+          "req.headers.authorization",
+          "req.headers.cookie",
+          `req.headers["${INTERNAL_API_KEY_HEADER.toLowerCase()}"]`,
+          "res.headers['set-cookie']",
+        ],
         censor: "[REDACTED]",
       },
     })

--- a/apps/enclave/src/access-log.ts
+++ b/apps/enclave/src/access-log.ts
@@ -1,5 +1,5 @@
 import pinoHttp from "pino-http"
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import { randomUUID } from "crypto"
 
 /**
@@ -8,10 +8,10 @@ import { randomUUID } from "crypto"
  *
  * Authorization headers and cookies are redacted at the pino layer.
  */
-const baseLogger = pino({ name: "enclave-access" })
-
 export const accessLog = pinoHttp({
-  logger: baseLogger,
+  // Share the regional backend's logger config (level, pretty-in-dev / JSON-in-prod,
+  // error serializer) via a named child, so enclave access logs match the backend's.
+  logger: baseLogger.child({ name: "enclave-access" }),
   autoLogging: {
     ignore: (req) => req.url === "/healthz" || req.url === "/pubkey",
   },

--- a/apps/enclave/src/agent/backend-callbacks.ts
+++ b/apps/enclave/src/agent/backend-callbacks.ts
@@ -2,6 +2,7 @@ import {
   INTERNAL_API_KEY_HEADER,
   type EnclaveSealedReply,
   type EnclaveSealedStep,
+  type EnclaveSealedSubstep,
   type EnclaveSessionResult,
 } from "@threa/types"
 import type { EnclaveConfig } from "../config"
@@ -20,6 +21,8 @@ export interface BackendCallbacks {
   message(sessionId: string, reply: EnclaveSealedReply): Promise<void>
   /** Stream one sealed trace step back the moment the loop emits it (persisted + broadcast now). */
   step(sessionId: string, step: EnclaveSealedStep): Promise<void>
+  /** Stream one sealed substep — ephemeral mid-run phase text (broadcast only, not persisted). */
+  substep(sessionId: string, substep: EnclaveSealedSubstep): Promise<void>
   /** Mark the session complete once the loop finishes (replies already streamed). */
   complete(sessionId: string, result: EnclaveSessionResult): Promise<void>
 }
@@ -64,6 +67,16 @@ export function createBackendCallbacks(config: EnclaveConfig): BackendCallbacks 
         signal: AbortSignal.timeout(STEP_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`session step failed: ${res.status}`)
+    },
+
+    async substep(sessionId, substep) {
+      const res = await fetch(`${base}/internal/enclave-runtimes/sessions/${sessionId}/substeps`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(substep),
+        signal: AbortSignal.timeout(STEP_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`session substep failed: ${res.status}`)
     },
 
     async complete(sessionId, result) {

--- a/apps/enclave/src/agent/backend-callbacks.ts
+++ b/apps/enclave/src/agent/backend-callbacks.ts
@@ -2,6 +2,7 @@ import {
   INTERNAL_API_KEY_HEADER,
   type EnclaveSealedReply,
   type EnclaveSealedStep,
+  type EnclaveSealedStepStart,
   type EnclaveSealedSubstep,
   type EnclaveSessionResult,
 } from "@threa/types"
@@ -19,7 +20,9 @@ export interface BackendCallbacks {
   heartbeat(sessionId: string): Promise<void>
   /** Stream one sealed reply back the moment the loop sends it (written + broadcast now). */
   message(sessionId: string, reply: EnclaveSealedReply): Promise<void>
-  /** Stream one sealed trace step back the moment the loop emits it (persisted + broadcast now). */
+  /** Open one in-flight sealed trace step the moment the loop starts it (persisted + broadcast now). */
+  stepStarted(sessionId: string, step: EnclaveSealedStepStart): Promise<void>
+  /** Finalize one sealed trace step in place the moment it completes (persisted + broadcast now). */
   step(sessionId: string, step: EnclaveSealedStep): Promise<void>
   /** Stream one sealed substep — ephemeral mid-run phase text (broadcast only, not persisted). */
   substep(sessionId: string, substep: EnclaveSealedSubstep): Promise<void>
@@ -57,6 +60,16 @@ export function createBackendCallbacks(config: EnclaveConfig): BackendCallbacks 
         signal: AbortSignal.timeout(MESSAGE_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`session message failed: ${res.status}`)
+    },
+
+    async stepStarted(sessionId, step) {
+      const res = await fetch(`${base}/internal/enclave-runtimes/sessions/${sessionId}/steps/started`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(step),
+        signal: AbortSignal.timeout(STEP_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`session step:started failed: ${res.status}`)
     },
 
     async step(sessionId, step) {

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -8,7 +8,12 @@ import {
   sealMessage,
   wrapStreamKey,
 } from "@threa/crypto"
-import type { EnclaveSealedReply, EnclaveSealedStep, EnclaveSessionAssignment } from "@threa/types"
+import type {
+  EnclaveSealedReply,
+  EnclaveSealedStep,
+  EnclaveSealedSubstep,
+  EnclaveSessionAssignment,
+} from "@threa/types"
 import { createEnclaveKeyPair, type EnclaveKeyPair } from "../keystore"
 import type { RawChatFn, RawChatRequest, RawChatResult } from "../llm"
 import { InvokeError, runEnclaveTurn } from "./run-turn"
@@ -16,16 +21,26 @@ import { InvokeError, runEnclaveTurn } from "./run-turn"
 const STREAM_ID = "stream_journal"
 const GEN = 0
 
-/** Collects the replies and sealed trace steps the loop streams back. */
+/** Collects the replies and sealed trace steps/substeps the loop streams back. */
 function collector(): {
   onMessage: (r: EnclaveSealedReply) => Promise<void>
   onStep: (s: EnclaveSealedStep) => Promise<void>
+  onSubstep: (s: EnclaveSealedSubstep) => Promise<void>
   sent: EnclaveSealedReply[]
   steps: EnclaveSealedStep[]
+  substeps: EnclaveSealedSubstep[]
 } {
   const sent: EnclaveSealedReply[] = []
   const steps: EnclaveSealedStep[] = []
-  return { sent, steps, onMessage: async (r) => void sent.push(r), onStep: async (s) => void steps.push(s) }
+  const substeps: EnclaveSealedSubstep[] = []
+  return {
+    sent,
+    steps,
+    substeps,
+    onMessage: async (r) => void sent.push(r),
+    onStep: async (s) => void steps.push(s),
+    onSubstep: async (s) => void substeps.push(s),
+  }
 }
 
 async function wrapSskToEnclave(keyPair: EnclaveKeyPair, ssk: Uint8Array, keyGeneration = GEN) {
@@ -109,10 +124,10 @@ describe("runEnclaveTurn", () => {
     const wrap = await wrapSskToEnclave(keyPair, ssk)
     const prompt = await sealUnder(ssk, "What's the capital of France?", "msg_user", "usr_owner")
     const chat = stubChat(textReply("Paris."))
-    const { onMessage, onStep, sent, steps } = collector()
+    const { onMessage, onStep, onSubstep, sent, steps } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep },
+      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -160,10 +175,10 @@ describe("runEnclaveTurn", () => {
     const wrap = await wrapSskToEnclave(keyPair, ssk)
     const prompt = await sealUnder(ssk, "Give me two notes.", "msg_user", "usr_owner")
     const chat = stubChat(sendMessageReply("First.", "Second."))
-    const { onMessage, onStep, sent } = collector()
+    const { onMessage, onStep, onSubstep, sent } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep },
+      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -192,7 +207,13 @@ describe("runEnclaveTurn", () => {
 
     const collected = collector()
     await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage: collected.onMessage, onStep: collected.onStep },
+      {
+        keyPair,
+        rawChat: chat.fn,
+        onMessage: collected.onMessage,
+        onStep: collected.onStep,
+        onSubstep: collected.onSubstep,
+      },
       baseRequest({
         wraps: [wrap],
         history: [
@@ -221,10 +242,10 @@ describe("runEnclaveTurn", () => {
       toolCallReply("read_url", { url: "http://localhost/secret" }),
       textReply("Couldn't read it."),
     ])
-    const { onMessage, onStep, sent, steps } = collector()
+    const { onMessage, onStep, onSubstep, sent, steps } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep, tools: { tavilyApiKey: "tvly-test" } },
+      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep, tools: { tavilyApiKey: "tvly-test" } },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -259,7 +280,13 @@ describe("runEnclaveTurn", () => {
     const collected = collector()
     await expect(
       runEnclaveTurn(
-        { keyPair, rawChat: stubChat(textReply("x")).fn, onMessage: collected.onMessage, onStep: collected.onStep },
+        {
+          keyPair,
+          rawChat: stubChat(textReply("x")).fn,
+          onMessage: collected.onMessage,
+          onStep: collected.onStep,
+          onSubstep: collected.onSubstep,
+        },
         baseRequest({ wraps: [wrap], prompt, reply: { keyGeneration: 7, senderId: "persona_ariadne" } })
       )
     ).rejects.toBeInstanceOf(InvokeError)

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -11,6 +11,7 @@ import {
 import type {
   EnclaveSealedReply,
   EnclaveSealedStep,
+  EnclaveSealedStepStart,
   EnclaveSealedSubstep,
   EnclaveSessionAssignment,
 } from "@threa/types"
@@ -24,20 +25,25 @@ const GEN = 0
 /** Collects the replies and sealed trace steps/substeps the loop streams back. */
 function collector(): {
   onMessage: (r: EnclaveSealedReply) => Promise<void>
+  onStepStarted: (s: EnclaveSealedStepStart) => Promise<void>
   onStep: (s: EnclaveSealedStep) => Promise<void>
   onSubstep: (s: EnclaveSealedSubstep) => Promise<void>
   sent: EnclaveSealedReply[]
+  started: EnclaveSealedStepStart[]
   steps: EnclaveSealedStep[]
   substeps: EnclaveSealedSubstep[]
 } {
   const sent: EnclaveSealedReply[] = []
+  const started: EnclaveSealedStepStart[] = []
   const steps: EnclaveSealedStep[] = []
   const substeps: EnclaveSealedSubstep[] = []
   return {
     sent,
+    started,
     steps,
     substeps,
     onMessage: async (r) => void sent.push(r),
+    onStepStarted: async (s) => void started.push(s),
     onStep: async (s) => void steps.push(s),
     onSubstep: async (s) => void substeps.push(s),
   }
@@ -124,10 +130,10 @@ describe("runEnclaveTurn", () => {
     const wrap = await wrapSskToEnclave(keyPair, ssk)
     const prompt = await sealUnder(ssk, "What's the capital of France?", "msg_user", "usr_owner")
     const chat = stubChat(textReply("Paris."))
-    const { onMessage, onStep, onSubstep, sent, steps } = collector()
+    const { onMessage, onStepStarted, onStep, onSubstep, sent, steps } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep },
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -175,10 +181,10 @@ describe("runEnclaveTurn", () => {
     const wrap = await wrapSskToEnclave(keyPair, ssk)
     const prompt = await sealUnder(ssk, "Give me two notes.", "msg_user", "usr_owner")
     const chat = stubChat(sendMessageReply("First.", "Second."))
-    const { onMessage, onStep, onSubstep, sent } = collector()
+    const { onMessage, onStepStarted, onStep, onSubstep, sent } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep },
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -211,6 +217,7 @@ describe("runEnclaveTurn", () => {
         keyPair,
         rawChat: chat.fn,
         onMessage: collected.onMessage,
+        onStepStarted: collected.onStepStarted,
         onStep: collected.onStep,
         onSubstep: collected.onSubstep,
       },
@@ -242,10 +249,10 @@ describe("runEnclaveTurn", () => {
       toolCallReply("read_url", { url: "http://localhost/secret" }),
       textReply("Couldn't read it."),
     ])
-    const { onMessage, onStep, onSubstep, sent, steps } = collector()
+    const { onMessage, onStepStarted, onStep, onSubstep, sent, steps } = collector()
 
     const result = await runEnclaveTurn(
-      { keyPair, rawChat: chat.fn, onMessage, onStep, onSubstep, tools: { tavilyApiKey: "tvly-test" } },
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep, tools: { tavilyApiKey: "tvly-test" } },
       baseRequest({ wraps: [wrap], prompt })
     )
 
@@ -284,6 +291,7 @@ describe("runEnclaveTurn", () => {
           keyPair,
           rawChat: stubChat(textReply("x")).fn,
           onMessage: collected.onMessage,
+          onStepStarted: collected.onStepStarted,
           onStep: collected.onStep,
           onSubstep: collected.onSubstep,
         },

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -186,6 +186,14 @@ export async function runEnclaveTurn(
     },
   })
 
+  // Lead with the CONTEXT step ("Triggered by: …") before the loop runs — the
+  // enclave's stand-in for the in-process persona-agent orchestration step. The
+  // body is the decrypted prompt, sealed by the observer; metadata is clear.
+  // Best-effort: a trace failure must never block the actual turn.
+  if (request.trigger) {
+    await traceObserver.emitContext({ ...request.trigger, content: promptText }).catch(() => {})
+  }
+
   await runtime.run()
 
   return {

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -14,6 +14,7 @@ import type {
   EnclaveSessionResult,
   EnclaveSealedReply,
   EnclaveSealedStep,
+  EnclaveSealedSubstep,
   EnclaveSskWrap,
 } from "@threa/types"
 import { AgentRuntime } from "@threa/agent-runtime/runtime"
@@ -62,6 +63,8 @@ export interface EnclaveTurnDeps {
    * ciphertext only.
    */
   onStep: (step: EnclaveSealedStep) => Promise<void>
+  /** Stream a sealed substep — ephemeral mid-run phase text (e.g. research progress). */
+  onSubstep: (substep: EnclaveSealedSubstep) => Promise<void>
   /**
    * Web-tool configuration. Absent or keyless degrades gracefully: no Tavily key
    * means no `web_search` (URL reads + research still work). Omitting `tools`
@@ -78,7 +81,7 @@ export async function runEnclaveTurn(
   deps: EnclaveTurnDeps,
   request: EnclaveSessionAssignment
 ): Promise<EnclaveSessionResult> {
-  const { keyPair, rawChat, onMessage, onStep, tools } = deps
+  const { keyPair, rawChat, onMessage, onStep, onSubstep, tools } = deps
 
   // Recover the SSK for every generation the backend wrapped to us. The wrap AAD
   // binds to our own keyId — a wrap addressed elsewhere simply won't open.
@@ -131,6 +134,7 @@ export async function runEnclaveTurn(
     replyKeyGeneration: request.reply.keyGeneration,
     senderId: request.reply.senderId,
     sendStep: onStep,
+    sendSubstep: onSubstep,
   })
 
   const runtime = new AgentRuntime({

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -14,6 +14,7 @@ import type {
   EnclaveSessionResult,
   EnclaveSealedReply,
   EnclaveSealedStep,
+  EnclaveSealedStepStart,
   EnclaveSealedSubstep,
   EnclaveSskWrap,
 } from "@threa/types"
@@ -58,9 +59,15 @@ export interface EnclaveTurnDeps {
    */
   onMessage: (reply: EnclaveSealedReply) => Promise<void>
   /**
-   * Stream a sealed trace step back as the loop emits it (thinking, tool calls,
-   * message_sent). Sealed under the same SSK as replies; the backend persists
-   * ciphertext only.
+   * Open a sealed in-flight step the moment the loop starts it (tool:start, and
+   * the leading edge of thinking/message_sent). Lets an open trace dialog render
+   * the in-progress step before it finishes, mirroring the non-E2E runtime.
+   */
+  onStepStarted: (step: EnclaveSealedStepStart) => Promise<void>
+  /**
+   * Finalize a sealed trace step in place when it completes (thinking, tool
+   * calls, message_sent). Sealed under the same SSK as replies; the backend
+   * persists ciphertext only.
    */
   onStep: (step: EnclaveSealedStep) => Promise<void>
   /** Stream a sealed substep — ephemeral mid-run phase text (e.g. research progress). */
@@ -81,7 +88,7 @@ export async function runEnclaveTurn(
   deps: EnclaveTurnDeps,
   request: EnclaveSessionAssignment
 ): Promise<EnclaveSessionResult> {
-  const { keyPair, rawChat, onMessage, onStep, onSubstep, tools } = deps
+  const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, tools } = deps
 
   // Recover the SSK for every generation the backend wrapped to us. The wrap AAD
   // binds to our own keyId — a wrap addressed elsewhere simply won't open.
@@ -133,6 +140,7 @@ export async function runEnclaveTurn(
     replySsk,
     replyKeyGeneration: request.reply.keyGeneration,
     senderId: request.reply.senderId,
+    sendStepStarted: onStepStarted,
     sendStep: onStep,
     sendSubstep: onSubstep,
   })

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -9,6 +9,7 @@ import {
   sealMessage,
   unwrapStreamKey,
 } from "@threa/crypto"
+import { AgentToolNames } from "@threa/types"
 import type {
   EnclaveSessionAssignment,
   EnclaveSessionResult,
@@ -172,10 +173,16 @@ export async function runEnclaveTurn(
     observers: [traceObserver],
     maxTokens: request.maxTokens,
     temperature: request.temperature,
-    // Hand long-running tools (research) the session's cancel signal so a user
-    // "Stop research" aborts the web sub-loop gracefully (partial findings, the
-    // turn still replies) — the enclave mirror of the in-process abort registry.
-    ...(abortSignal ? { toolSignalProvider: () => abortSignal } : {}),
+    // Hand ONLY the long-running research sub-loop the session's cancel signal so
+    // a user "Stop research" aborts it gracefully (partial findings, the turn
+    // still replies). Gated by tool name exactly like the in-process path, so a
+    // short/uninterruptible tool never receives an already-aborted signal.
+    ...(abortSignal
+      ? {
+          toolSignalProvider: (_toolCallId: string, toolName: string) =>
+            toolName === AgentToolNames.GENERAL_RESEARCH ? abortSignal : undefined,
+        }
+      : {}),
     // Terminal action: mint each reply's id, seal it under the current SSK bound
     // to that id, and stream it back now (awaited, so it's delivered before the
     // loop moves on). The backend stores ciphertext under this id.

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -73,6 +73,13 @@ export interface EnclaveTurnDeps {
   /** Stream a sealed substep — ephemeral mid-run phase text (e.g. research progress). */
   onSubstep: (substep: EnclaveSealedSubstep) => Promise<void>
   /**
+   * Cooperative cancellation for long-running tools (research). Wired to the
+   * runtime's `toolSignalProvider`, so the user's "Stop research" aborts the web
+   * sub-loop gracefully — it returns partial findings and the turn still replies,
+   * exactly like the in-process `SessionAbortRegistry` path. Omitted → no cancel.
+   */
+  abortSignal?: AbortSignal
+  /**
    * Web-tool configuration. Absent or keyless degrades gracefully: no Tavily key
    * means no `web_search` (URL reads + research still work). Omitting `tools`
    * entirely runs the loop with `read_url` + research only.
@@ -88,7 +95,7 @@ export async function runEnclaveTurn(
   deps: EnclaveTurnDeps,
   request: EnclaveSessionAssignment
 ): Promise<EnclaveSessionResult> {
-  const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, tools } = deps
+  const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, tools, abortSignal } = deps
 
   // Recover the SSK for every generation the backend wrapped to us. The wrap AAD
   // binds to our own keyId — a wrap addressed elsewhere simply won't open.
@@ -165,6 +172,10 @@ export async function runEnclaveTurn(
     observers: [traceObserver],
     maxTokens: request.maxTokens,
     temperature: request.temperature,
+    // Hand long-running tools (research) the session's cancel signal so a user
+    // "Stop research" aborts the web sub-loop gracefully (partial findings, the
+    // turn still replies) — the enclave mirror of the in-process abort registry.
+    ...(abortSignal ? { toolSignalProvider: () => abortSignal } : {}),
     // Terminal action: mint each reply's id, seal it under the current SSK bound
     // to that id, and stream it back now (awaited, so it's delivered before the
     // loop moves on). The backend stores ciphertext under this id.

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -46,6 +46,7 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
         onMessage: (reply) => deps.callbacks.message(sessionId, reply),
         // Stream each sealed trace step back as the loop emits it (live trace).
         onStep: (step) => deps.callbacks.step(sessionId, step),
+        onSubstep: (substep) => deps.callbacks.substep(sessionId, substep),
         tools: deps.toolConfig ? { tavilyApiKey: deps.toolConfig.tavilyApiKey } : undefined,
       },
       assignment

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -1,11 +1,11 @@
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import type { EnclaveSessionAssignment } from "@threa/types"
 import type { EnclaveKeyPair } from "../keystore"
 import type { RawChatFn } from "../llm"
 import type { BackendCallbacks } from "./backend-callbacks"
 import { runEnclaveTurn } from "./run-turn"
 
-const logger = pino({ name: "enclave-session" })
+const logger = baseLogger.child({ name: "enclave-session" })
 
 /**
  * Refresh interval for the session heartbeat. The backend reclaims a session

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -19,6 +19,12 @@ export interface SessionRunnerDeps {
   callbacks: BackendCallbacks
   /** Web-tool config for the turn loop (Tavily key). Absent → research/read_url only. */
   toolConfig?: { tavilyApiKey?: string }
+  /**
+   * Per-session cancel controllers, keyed by sessionId. The runner registers one
+   * for the turn so the `/sessions/:id/cancel` endpoint can abort it (graceful
+   * "Stop research"); it's removed when the turn ends.
+   */
+  aborts?: Map<string, AbortController>
 }
 
 /**
@@ -37,6 +43,11 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
     })
   }, HEARTBEAT_INTERVAL_MS)
 
+  // Register a cancel controller so `/sessions/:id/cancel` can gracefully abort
+  // this turn's long-running tools (research). Removed in `finally`.
+  const abortController = new AbortController()
+  deps.aborts?.set(sessionId, abortController)
+
   try {
     const result = await runEnclaveTurn(
       {
@@ -50,6 +61,7 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
         onStep: (step) => deps.callbacks.step(sessionId, step),
         onSubstep: (substep) => deps.callbacks.substep(sessionId, substep),
         tools: deps.toolConfig ? { tavilyApiKey: deps.toolConfig.tavilyApiKey } : undefined,
+        abortSignal: abortController.signal,
       },
       assignment
     )
@@ -64,5 +76,6 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
     logger.error({ errorName, sessionId }, "Enclave session failed")
   } finally {
     clearInterval(heartbeat)
+    deps.aborts?.delete(sessionId)
   }
 }

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -44,7 +44,9 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
         rawChat: deps.rawChat,
         // Stream each reply back as the loop sends it (delivered before the loop continues).
         onMessage: (reply) => deps.callbacks.message(sessionId, reply),
-        // Stream each sealed trace step back as the loop emits it (live trace).
+        // Open each in-flight step as the loop starts it, then finalize it on
+        // completion — the same lifecycle the non-E2E runtime emits (live trace).
+        onStepStarted: (step) => deps.callbacks.stepStarted(sessionId, step),
         onStep: (step) => deps.callbacks.step(sessionId, step),
         onSubstep: (substep) => deps.callbacks.substep(sessionId, substep),
         tools: deps.toolConfig ? { tavilyApiKey: deps.toolConfig.tavilyApiKey } : undefined,

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -263,9 +263,7 @@ describe("EnclaveTraceObserver", () => {
     await observer.handle({ type: "message:sent", messageId: "msg_reply", content: "Paris." })
 
     expect(started).toHaveLength(0) // the start frame never landed…
-    expect(steps).toHaveLength(1) // …but the finalize did
-    expect(steps[0]!.stepType).toBe("message_sent")
-    expect(steps[0]!.messageId).toBe("msg_reply")
+    expect(steps).toMatchObject([{ stepType: "message_sent", messageId: "msg_reply" }]) // …but the finalize did
     expect(await open(ssk, steps[0]!)).toBe("Paris.")
   })
 

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { generateStreamKey, openMessageAsString } from "@threa/crypto"
-import type { EnclaveSealedStep, EnclaveSealedSubstep } from "@threa/types"
+import type { EnclaveSealedStep, EnclaveSealedStepStart, EnclaveSealedSubstep } from "@threa/types"
 import { EnclaveTraceObserver } from "./trace-observer"
 
 const STREAM_ID = "stream_x"
@@ -10,10 +10,12 @@ const SENDER = "persona_ariadne"
 function makeObserver(): {
   observer: EnclaveTraceObserver
   ssk: Uint8Array
+  started: EnclaveSealedStepStart[]
   steps: EnclaveSealedStep[]
   substeps: EnclaveSealedSubstep[]
 } {
   const ssk = generateStreamKey()
+  const started: EnclaveSealedStepStart[] = []
   const steps: EnclaveSealedStep[] = []
   const substeps: EnclaveSealedSubstep[] = []
   const observer = new EnclaveTraceObserver({
@@ -21,6 +23,9 @@ function makeObserver(): {
     replySsk: ssk,
     replyKeyGeneration: GEN,
     senderId: SENDER,
+    sendStepStarted: async (step) => {
+      started.push(step)
+    },
     sendStep: async (step) => {
       steps.push(step)
     },
@@ -28,73 +33,69 @@ function makeObserver(): {
       substeps.push(substep)
     },
   })
-  return { observer, ssk, steps, substeps }
+  return { observer, ssk, started, steps, substeps }
+}
+
+async function open(ssk: Uint8Array, sealed: { ciphertext?: string; envelope?: { keyGeneration: number } }) {
+  return openMessageAsString({
+    key: ssk,
+    envelope: sealed.envelope as Parameters<typeof openMessageAsString>[0]["envelope"],
+    ciphertext: Buffer.from(sealed.ciphertext!, "base64"),
+  })
 }
 
 describe("EnclaveTraceObserver", () => {
-  it("seals a thinking step under the SSK and forwards it", async () => {
-    const { observer, ssk, steps } = makeObserver()
+  it("opens then finalizes a thinking step under the SSK, sharing one stepId", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
 
     await observer.handle({ type: "thinking", content: "Let me reason about this.", durationMs: 42 })
 
+    // Lifecycle parity: a step:started precedes the finalized step, same id.
+    expect(started).toHaveLength(1)
     expect(steps).toHaveLength(1)
-    const step = steps[0]!
-    expect(step.stepType).toBe("thinking")
-    expect(step.stepId).toMatch(/^step_/)
-    expect(step.durationMs).toBe(42)
-    expect(step.envelope.keyGeneration).toBe(GEN)
-    // The content is sealed — only the SSK opens it (the server never sees plaintext).
-    const opened = await openMessageAsString({
-      key: ssk,
-      envelope: step.envelope,
-      ciphertext: Buffer.from(step.ciphertext, "base64"),
-    })
-    expect(opened).toBe("Let me reason about this.")
+    const open1 = started[0]!
+    const done = steps[0]!
+    expect(open1.stepId).toBe(done.stepId)
+    expect(open1.stepType).toBe("thinking")
+    expect(done.stepType).toBe("thinking")
+    expect(done.durationMs).toBe(42)
+    expect(done.envelope.keyGeneration).toBe(GEN)
+    // Content (known up front) is sealed on both the start and the finalize.
+    expect(await open(ssk, open1)).toBe("Let me reason about this.")
+    expect(await open(ssk, done)).toBe("Let me reason about this.")
   })
 
-  it("seals a message_sent step and carries the reply id in the clear", async () => {
-    const { observer, ssk, steps } = makeObserver()
+  it("opens then finalizes a message_sent step, carrying the reply id on completion", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
 
     await observer.handle({ type: "message:sent", messageId: "msg_reply", content: "Paris." })
 
+    expect(started).toHaveLength(1)
     expect(steps).toHaveLength(1)
-    const step = steps[0]!
-    expect(step.stepType).toBe("message_sent")
-    expect(step.messageId).toBe("msg_reply")
-    const opened = await openMessageAsString({
-      key: ssk,
-      envelope: step.envelope,
-      ciphertext: Buffer.from(step.ciphertext, "base64"),
-    })
-    expect(opened).toBe("Paris.")
+    const done = steps[0]!
+    expect(started[0]!.stepId).toBe(done.stepId)
+    expect(done.stepType).toBe("message_sent")
+    expect(done.messageId).toBe("msg_reply")
+    expect(await open(ssk, done)).toBe("Paris.")
   })
 
-  it("seals a tool:progress substep under the SSK and forwards it without a step row", async () => {
-    const { observer, ssk, steps, substeps } = makeObserver()
+  it("opens a contentless in-flight step at tool:start, then finalizes it at tool:complete", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
 
     await observer.handle({
-      type: "tool:progress",
+      type: "tool:start",
       toolCallId: "tc_1",
-      toolName: "general_research",
-      stepType: "research",
-      substep: 'Searching the web: "weather in paris"',
+      toolName: "web_search",
+      stepType: "web_search",
+      input: { query: "weather" },
     })
 
-    expect(steps).toHaveLength(0) // ephemeral phase text — never a persisted step
-    expect(substeps).toHaveLength(1)
-    const sub = substeps[0]!
-    expect(sub.stepType).toBe("research")
-    // The phase text is sealed (it's derived from the encrypted prompt).
-    const opened = await openMessageAsString({
-      key: ssk,
-      envelope: sub.envelope,
-      ciphertext: Buffer.from(sub.ciphertext, "base64"),
-    })
-    expect(opened).toBe('Searching the web: "weather in paris"')
-  })
-
-  it("seals a completed tool call under its declared step type and content", async () => {
-    const { observer, ssk, steps } = makeObserver()
+    // The in-flight step is opened with no content (the result isn't known yet),
+    // so the trace dialog renders it as in-progress and hangs substeps under it.
+    expect(started).toHaveLength(1)
+    expect(started[0]!.stepType).toBe("web_search")
+    expect(started[0]!.ciphertext).toBeUndefined()
+    expect(steps).toHaveLength(0)
 
     await observer.handle({
       type: "tool:complete",
@@ -106,19 +107,54 @@ describe("EnclaveTraceObserver", () => {
       trace: { stepType: "web_search", content: "weather", sources: [] },
     })
 
-    const step = steps.find((s) => s.stepType === "web_search")
-    expect(step).toBeDefined()
-    expect(step!.durationMs).toBe(850)
-    const opened = await openMessageAsString({
-      key: ssk,
-      envelope: step!.envelope,
-      ciphertext: Buffer.from(step!.ciphertext, "base64"),
-    })
-    expect(opened).toBe("weather")
+    expect(steps).toHaveLength(1)
+    const done = steps[0]!
+    expect(done.stepId).toBe(started[0]!.stepId) // finalizes the same row
+    expect(done.stepType).toBe("web_search")
+    expect(done.durationMs).toBe(850)
+    expect(await open(ssk, done)).toBe("weather")
   })
 
-  it("seals a tool error as a tool_error step", async () => {
-    const { observer, ssk, steps } = makeObserver()
+  it("seals a tool:progress substep under the SSK and forwards it without a step row", async () => {
+    const { observer, ssk, started, steps, substeps } = makeObserver()
+
+    await observer.handle({
+      type: "tool:progress",
+      toolCallId: "tc_1",
+      toolName: "general_research",
+      stepType: "research",
+      substep: 'Searching the web: "weather in paris"',
+    })
+
+    expect(started).toHaveLength(0)
+    expect(steps).toHaveLength(0) // ephemeral phase text — never a persisted step
+    expect(substeps).toHaveLength(1)
+    const sub = substeps[0]!
+    expect(sub.stepType).toBe("research")
+    // The phase text is sealed (it's derived from the encrypted prompt).
+    expect(await open(ssk, sub)).toBe('Searching the web: "weather in paris"')
+  })
+
+  it("drops a tool:complete with no matching tool:start (hidden tool)", async () => {
+    const { observer, started, steps } = makeObserver()
+
+    await observer.handle({
+      type: "tool:complete",
+      toolCallId: "tc_hidden",
+      toolName: "search_users",
+      input: {},
+      output: "{}",
+      durationMs: 5,
+      trace: { stepType: "workspace_search", content: "…", sources: [] },
+    })
+
+    // No tool:start was recorded (it was hidden), so nothing surfaces in the trace.
+    expect(started).toHaveLength(0)
+    expect(steps).toHaveLength(0)
+  })
+
+  it("synthesizes a started+finalized tool_error when the tool was never opened", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
 
     await observer.handle({
       type: "tool:error",
@@ -128,22 +164,45 @@ describe("EnclaveTraceObserver", () => {
       durationMs: 12,
     })
 
+    expect(started).toHaveLength(1)
+    expect(started[0]!.stepType).toBe("tool_error")
     const errorStep = steps.find((s) => s.stepType === "tool_error")
     expect(errorStep).toBeDefined()
-    const opened = await openMessageAsString({
-      key: ssk,
-      envelope: errorStep!.envelope,
-      ciphertext: Buffer.from(errorStep!.ciphertext, "base64"),
+    expect(await open(ssk, errorStep!)).toBe("read_url failed: URL blocked by SSRF protection")
+  })
+
+  it("finalizes the in-flight step with the error when a tool:start preceded it", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
+
+    await observer.handle({
+      type: "tool:start",
+      toolCallId: "tc_1",
+      toolName: "read_url",
+      stepType: "visit_page",
+      input: { url: "http://x" },
     })
-    expect(opened).toBe("URL blocked by SSRF protection")
+    await observer.handle({
+      type: "tool:error",
+      toolCallId: "tc_1",
+      toolName: "read_url",
+      error: "boom",
+      durationMs: 7,
+    })
+
+    // One started (visit_page, contentless) + one finalize carrying the error.
+    expect(started).toHaveLength(1)
+    expect(steps).toHaveLength(1)
+    expect(steps[0]!.stepId).toBe(started[0]!.stepId)
+    expect(await open(ssk, steps[0]!)).toBe("read_url failed: boom")
   })
 
   it("ignores non-step lifecycle events", async () => {
-    const { observer, steps } = makeObserver()
+    const { observer, started, steps } = makeObserver()
 
     await observer.handle({ type: "session:start", sessionId: "session_1" })
     await observer.handle({ type: "session:end", messagesSent: 1, sourceCount: 0 })
 
+    expect(started).toHaveLength(0)
     expect(steps).toHaveLength(0)
   })
 })

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -269,6 +269,35 @@ describe("EnclaveTraceObserver", () => {
     expect(await open(ssk, steps[0]!)).toBe("Paris.")
   })
 
+  it("emits a sealed CONTEXT step for the trigger (started + finalized, isTrigger)", async () => {
+    const { observer, ssk, started, steps } = makeObserver()
+
+    await observer.emitContext({
+      messageId: "msg_trigger",
+      authorName: "Kris",
+      authorType: "user",
+      createdAt: "2026-06-02T09:27:00.000Z",
+      content: "Hi 👋",
+    })
+
+    expect(started).toHaveLength(1)
+    expect(steps).toHaveLength(1)
+    expect(started[0]!.stepId).toBe(steps[0]!.stepId)
+    expect(steps[0]!.stepType).toBe("context_received")
+    // The body is sealed; decrypts to the same { messages:[{…isTrigger}] } shape
+    // the in-process CONTEXT_RECEIVED step persists, so the same renderer applies.
+    const parsed = JSON.parse(await open(ssk, steps[0]!)) as {
+      messages: Array<{ messageId: string; authorName: string; content: string; isTrigger: boolean }>
+    }
+    expect(parsed.messages).toHaveLength(1)
+    expect(parsed.messages[0]).toMatchObject({
+      messageId: "msg_trigger",
+      authorName: "Kris",
+      content: "Hi 👋",
+      isTrigger: true,
+    })
+  })
+
   it("ignores non-step lifecycle events", async () => {
     const { observer, started, steps } = makeObserver()
 

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -240,6 +240,35 @@ describe("EnclaveTraceObserver", () => {
     expect(await open(ssk, steps[0]!)).toBe("read_url failed: boom")
   })
 
+  it("still finalizes the step when the step:started frame fails (best-effort start)", async () => {
+    // A backend missing /steps/started (or a transient blip) makes sendStepStarted
+    // reject. That must never drop the durable finalized step.
+    const ssk = generateStreamKey()
+    const started: EnclaveSealedStepStart[] = []
+    const steps: EnclaveSealedStep[] = []
+    const observer = new EnclaveTraceObserver({
+      streamId: STREAM_ID,
+      replySsk: ssk,
+      replyKeyGeneration: GEN,
+      senderId: SENDER,
+      sendStepStarted: async () => {
+        throw new Error("session step:started failed: 404")
+      },
+      sendStep: async (step) => {
+        steps.push(step)
+      },
+      sendSubstep: async () => {},
+    })
+
+    await observer.handle({ type: "message:sent", messageId: "msg_reply", content: "Paris." })
+
+    expect(started).toHaveLength(0) // the start frame never landed…
+    expect(steps).toHaveLength(1) // …but the finalize did
+    expect(steps[0]!.stepType).toBe("message_sent")
+    expect(steps[0]!.messageId).toBe("msg_reply")
+    expect(await open(ssk, steps[0]!)).toBe("Paris.")
+  })
+
   it("ignores non-step lifecycle events", async () => {
     const { observer, started, steps } = makeObserver()
 

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -115,9 +115,16 @@ describe("EnclaveTraceObserver", () => {
     expect(await open(ssk, done)).toBe("weather")
   })
 
-  it("seals a tool:progress substep under the SSK and forwards it without a step row", async () => {
+  it("seals each tool:progress phase and persists a running snapshot onto the in-flight step", async () => {
     const { observer, ssk, started, steps, substeps } = makeObserver()
 
+    await observer.handle({
+      type: "tool:start",
+      toolCallId: "tc_1",
+      toolName: "general_research",
+      stepType: "research",
+      input: {},
+    })
     await observer.handle({
       type: "tool:progress",
       toolCallId: "tc_1",
@@ -125,14 +132,51 @@ describe("EnclaveTraceObserver", () => {
       stepType: "research",
       substep: 'Searching the web: "weather in paris"',
     })
+    await observer.handle({
+      type: "tool:progress",
+      toolCallId: "tc_1",
+      toolName: "general_research",
+      stepType: "research",
+      substep: "Reading https://example.com",
+    })
 
-    expect(started).toHaveLength(0)
-    expect(steps).toHaveLength(0) // ephemeral phase text — never a persisted step
+    expect(started).toHaveLength(1) // the step:started — substeps don't open new rows
+    expect(steps).toHaveLength(0) // not finalized yet
+    expect(substeps).toHaveLength(2)
+
+    // Each broadcast carries the single new phase, sealed, bound to the in-flight step.
+    const second = substeps[1]!
+    expect(second.stepType).toBe("research")
+    expect(second.stepId).toBe(started[0]!.stepId)
+    expect(await open(ssk, second)).toBe("Reading https://example.com")
+
+    // …and the running snapshot — the full { substeps } list — sealed for refresh
+    // recovery. It accumulates: the 2nd snapshot holds both phases in order.
+    const snapshot = JSON.parse(
+      await open(ssk, { ciphertext: second.snapshotCiphertext, envelope: second.snapshotEnvelope })
+    ) as { substeps: Array<{ text: string; at: string }> }
+    expect(snapshot.substeps.map((s) => s.text)).toEqual([
+      'Searching the web: "weather in paris"',
+      "Reading https://example.com",
+    ])
+    expect(snapshot.substeps.every((s) => typeof s.at === "string")).toBe(true)
+  })
+
+  it("broadcasts a substep without a snapshot when no step was opened (hidden tool)", async () => {
+    const { observer, ssk, substeps } = makeObserver()
+
+    await observer.handle({
+      type: "tool:progress",
+      toolCallId: "tc_hidden",
+      toolName: "general_research",
+      stepType: "research",
+      substep: "phase",
+    })
+
     expect(substeps).toHaveLength(1)
-    const sub = substeps[0]!
-    expect(sub.stepType).toBe("research")
-    // The phase text is sealed (it's derived from the encrypted prompt).
-    expect(await open(ssk, sub)).toBe('Searching the web: "weather in paris"')
+    expect(substeps[0]!.stepId).toBeUndefined()
+    expect(substeps[0]!.snapshotCiphertext).toBeUndefined()
+    expect(await open(ssk, substeps[0]!)).toBe("phase")
   })
 
   it("drops a tool:complete with no matching tool:start (hidden tool)", async () => {

--- a/apps/enclave/src/agent/trace-observer.test.ts
+++ b/apps/enclave/src/agent/trace-observer.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it } from "vitest"
 import { generateStreamKey, openMessageAsString } from "@threa/crypto"
-import type { EnclaveSealedStep } from "@threa/types"
+import type { EnclaveSealedStep, EnclaveSealedSubstep } from "@threa/types"
 import { EnclaveTraceObserver } from "./trace-observer"
 
 const STREAM_ID = "stream_x"
 const GEN = 2
 const SENDER = "persona_ariadne"
 
-function makeObserver(): { observer: EnclaveTraceObserver; ssk: Uint8Array; steps: EnclaveSealedStep[] } {
+function makeObserver(): {
+  observer: EnclaveTraceObserver
+  ssk: Uint8Array
+  steps: EnclaveSealedStep[]
+  substeps: EnclaveSealedSubstep[]
+} {
   const ssk = generateStreamKey()
   const steps: EnclaveSealedStep[] = []
+  const substeps: EnclaveSealedSubstep[] = []
   const observer = new EnclaveTraceObserver({
     streamId: STREAM_ID,
     replySsk: ssk,
@@ -18,8 +24,11 @@ function makeObserver(): { observer: EnclaveTraceObserver; ssk: Uint8Array; step
     sendStep: async (step) => {
       steps.push(step)
     },
+    sendSubstep: async (substep) => {
+      substeps.push(substep)
+    },
   })
-  return { observer, ssk, steps }
+  return { observer, ssk, steps, substeps }
 }
 
 describe("EnclaveTraceObserver", () => {
@@ -58,6 +67,30 @@ describe("EnclaveTraceObserver", () => {
       ciphertext: Buffer.from(step.ciphertext, "base64"),
     })
     expect(opened).toBe("Paris.")
+  })
+
+  it("seals a tool:progress substep under the SSK and forwards it without a step row", async () => {
+    const { observer, ssk, steps, substeps } = makeObserver()
+
+    await observer.handle({
+      type: "tool:progress",
+      toolCallId: "tc_1",
+      toolName: "general_research",
+      stepType: "research",
+      substep: 'Searching the web: "weather in paris"',
+    })
+
+    expect(steps).toHaveLength(0) // ephemeral phase text — never a persisted step
+    expect(substeps).toHaveLength(1)
+    const sub = substeps[0]!
+    expect(sub.stepType).toBe("research")
+    // The phase text is sealed (it's derived from the encrypted prompt).
+    const opened = await openMessageAsString({
+      key: ssk,
+      envelope: sub.envelope,
+      ciphertext: Buffer.from(sub.ciphertext, "base64"),
+    })
+    expect(opened).toBe('Searching the web: "weather in paris"')
   })
 
   it("seals a completed tool call under its declared step type and content", async () => {

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -64,7 +64,7 @@ export class EnclaveTraceObserver implements AgentObserver {
         // AAD-bound to this step's id, reused for both the start and the finalize.
         const stepId = mintStepId()
         const sealed = await this.seal(event.content, stepId)
-        await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.THINKING, ...sealed })
+        await this.openStep({ stepId, stepType: AgentStepTypes.THINKING, ...sealed })
         await this.deps.sendStep({ stepId, stepType: AgentStepTypes.THINKING, ...sealed, durationMs: event.durationMs })
         return
       }
@@ -80,7 +80,7 @@ export class EnclaveTraceObserver implements AgentObserver {
         const stepId = mintStepId()
         this.stepIdByToolCallId.set(event.toolCallId, stepId)
         this.substepsByToolCallId.set(event.toolCallId, [])
-        await this.deps.sendStepStarted({ stepId, stepType: event.stepType })
+        await this.openStep({ stepId, stepType: event.stepType })
         return
       }
 
@@ -145,7 +145,7 @@ export class EnclaveTraceObserver implements AgentObserver {
           // Synthesize a started + finalized error step so it's still visible.
           const stepId = mintStepId()
           const sealed = await this.seal(content, stepId)
-          await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.TOOL_ERROR, ...sealed })
+          await this.openStep({ stepId, stepType: AgentStepTypes.TOOL_ERROR, ...sealed })
           await this.deps.sendStep({
             stepId,
             stepType: AgentStepTypes.TOOL_ERROR,
@@ -160,7 +160,7 @@ export class EnclaveTraceObserver implements AgentObserver {
       case "message:sent": {
         const stepId = mintStepId()
         const sealed = await this.seal(event.content, stepId)
-        await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.MESSAGE_SENT, ...sealed })
+        await this.openStep({ stepId, stepType: AgentStepTypes.MESSAGE_SENT, ...sealed })
         await this.deps.sendStep({
           stepId,
           stepType: AgentStepTypes.MESSAGE_SENT,
@@ -170,6 +170,18 @@ export class EnclaveTraceObserver implements AgentObserver {
         return
       }
     }
+  }
+
+  /**
+   * Open an in-flight step — best-effort. The `step:started` frame is live-UX
+   * only (it lets an open trace dialog render the in-progress step); the durable
+   * record is the *finalize* (`sendStep`), which has its own persistence fallback.
+   * So a failed/unsupported start POST must NOT abort the handler and drop the
+   * finalize — swallow it. (This is why a backend missing the `/steps/started`
+   * route still records every step, just without the live in-flight frame.)
+   */
+  private async openStep(step: EnclaveSealedStepStart): Promise<void> {
+    await this.deps.sendStepStarted(step).catch(() => {})
   }
 
   /**

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -1,6 +1,11 @@
 import { ulid } from "ulid"
 import { buildMessageAad, bytesToBase64, sealMessage } from "@threa/crypto"
-import { AgentStepTypes, type EnclaveSealedStep, type EnclaveSealedSubstep } from "@threa/types"
+import {
+  AgentStepTypes,
+  type EnclaveSealedStep,
+  type EnclaveSealedStepStart,
+  type EnclaveSealedSubstep,
+} from "@threa/types"
 import type { AgentEvent, AgentObserver } from "@threa/agent-runtime/runtime"
 
 /**
@@ -15,12 +20,15 @@ import type { AgentEvent, AgentObserver } from "@threa/agent-runtime/runtime"
  * ids). Plaintext exists only here, for the duration of the loop, and is never
  * logged or persisted in the clear.
  *
- * This mirrors the backend `SessionTraceObserver`'s event→step mapping for the
- * events the enclave loop emits: the LLM's reasoning (`thinking`), each completed
- * tool call (`tool:complete` → its trace step type, e.g. web_search / visit_page
- * / research) or failure (`tool:error`), and each reply (`message:sent`). The
- * enclave seals append-only, so it maps the *terminal* tool events (not the
- * tool:start/progress lifecycle the backend uses for in-place step updates).
+ * This mirrors the backend `SessionTraceObserver`'s event→step lifecycle exactly
+ * — only the sink differs (seal + POST instead of DB + socket). Every step opens
+ * with a `step:started` (so a refresh / open trace dialog sees the in-flight step
+ * and hangs its live substeps under it) and closes with the finalized step:
+ * - `thinking` / `message:sent`: started + finalized back-to-back (content known up front)
+ * - `tool:start` → `tool:progress`* → `tool:complete`/`tool:error`: the real
+ *   in-flight window — started carries no content (the result isn't known yet),
+ *   substeps stream the phase text, and the finalize seals the tool's result.
+ * Hidden tools (trace.hidden) are skipped entirely (OTEL-only), same as the backend.
  */
 export interface EnclaveTraceObserverDeps {
   streamId: string
@@ -29,45 +37,112 @@ export interface EnclaveTraceObserverDeps {
   replyKeyGeneration: number
   /** Ariadne's sender id, bound into each step's seal AAD. */
   senderId: string
-  /** Deliver one sealed step to the backend the moment it's produced (awaited, so steps land in order). */
+  /** Open an in-flight step the moment the loop starts it (awaited, so it lands before the finalize). */
+  sendStepStarted: (step: EnclaveSealedStepStart) => Promise<void>
+  /** Finalize a step in place once it completes (awaited, so steps land in order). */
   sendStep: (step: EnclaveSealedStep) => Promise<void>
   /** Deliver one sealed substep — ephemeral mid-run phase text (e.g. research progress). */
   sendSubstep: (substep: EnclaveSealedSubstep) => Promise<void>
 }
 
 export class EnclaveTraceObserver implements AgentObserver {
+  /** Maps an in-flight tool call to the step id minted at tool:start, so completion finalizes the same row. */
+  private readonly stepIdByToolCallId = new Map<string, string>()
+  /** Tool calls hidden at tool:start — distinguishes "hidden, skip" from "unknown, synthesize error step". */
+  private readonly hiddenToolCallIds = new Set<string>()
+
   constructor(private readonly deps: EnclaveTraceObserverDeps) {}
 
   async handle(event: AgentEvent): Promise<void> {
-    // Mid-run phase text (e.g. the research sub-agent's "Searching the web: …").
-    // It's derived from the encrypted prompt, so seal it under the SSK exactly
-    // like a step and relay it ephemerally — the owner's browser decrypts it for
-    // the live "Ariadne is …" indicator. Never persisted.
-    if (event.type === "tool:progress") {
-      const text = event.substep?.trim()
-      if (text) {
-        const sealed = await this.seal(text)
-        await this.deps.sendSubstep({
-          stepType: event.stepType,
-          ciphertext: sealed.ciphertext,
-          envelope: sealed.envelope,
-        })
+    switch (event.type) {
+      case "thinking": {
+        // Content is known up front: open + finalize the same step back-to-back,
+        // mirroring the backend's startStep(content) → complete().
+        const stepId = mintStepId()
+        const sealed = await this.seal(event.content)
+        await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.THINKING, ...sealed })
+        await this.deps.sendStep({ stepId, stepType: AgentStepTypes.THINKING, ...sealed, durationMs: event.durationMs })
+        return
       }
-      return
+
+      case "tool:start": {
+        // Hidden tools are recorded in OTEL but never surface in the trace.
+        if (event.hidden) {
+          this.hiddenToolCallIds.add(event.toolCallId)
+          return
+        }
+        // Open the in-flight step with no content (the result isn't known yet);
+        // cache the minted id so tool:complete/tool:error finalizes the same row.
+        const stepId = mintStepId()
+        this.stepIdByToolCallId.set(event.toolCallId, stepId)
+        await this.deps.sendStepStarted({ stepId, stepType: event.stepType })
+        return
+      }
+
+      case "tool:progress": {
+        // Mid-run phase text (e.g. the research sub-agent's "Searching the web: …").
+        // Derived from the encrypted prompt, so seal it under the SSK like a step
+        // and relay it ephemerally — the owner's browser decrypts it for the live
+        // "Ariadne is …" indicator and the in-flight step's substep timeline.
+        const text = event.substep?.trim()
+        if (text) {
+          const sealed = await this.seal(text)
+          await this.deps.sendSubstep({ stepType: event.stepType, ...sealed })
+        }
+        return
+      }
+
+      case "tool:complete": {
+        const stepId = this.stepIdByToolCallId.get(event.toolCallId)
+        if (!stepId) return // hidden tool — no step row was opened
+        this.stepIdByToolCallId.delete(event.toolCallId)
+        const sealed = await this.seal(event.trace.content)
+        await this.deps.sendStep({ stepId, stepType: event.trace.stepType, ...sealed, durationMs: event.durationMs })
+        return
+      }
+
+      case "tool:error": {
+        const content = `${event.toolName} failed: ${event.error}`
+        const sealed = await this.seal(content)
+        const cachedId = this.stepIdByToolCallId.get(event.toolCallId)
+        if (cachedId) {
+          // Finalize the in-flight step with the error.
+          this.stepIdByToolCallId.delete(event.toolCallId)
+          await this.deps.sendStep({
+            stepId: cachedId,
+            stepType: AgentStepTypes.TOOL_ERROR,
+            ...sealed,
+            durationMs: event.durationMs,
+          })
+        } else if (!this.hiddenToolCallIds.has(event.toolCallId)) {
+          // Unknown tool: the runtime emits tool:error with no preceding tool:start.
+          // Synthesize a started + finalized error step so it's still visible.
+          const stepId = mintStepId()
+          await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.TOOL_ERROR, ...sealed })
+          await this.deps.sendStep({
+            stepId,
+            stepType: AgentStepTypes.TOOL_ERROR,
+            ...sealed,
+            durationMs: event.durationMs,
+          })
+        }
+        this.hiddenToolCallIds.delete(event.toolCallId)
+        return
+      }
+
+      case "message:sent": {
+        const stepId = mintStepId()
+        const sealed = await this.seal(event.content)
+        await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.MESSAGE_SENT, ...sealed })
+        await this.deps.sendStep({
+          stepId,
+          stepType: AgentStepTypes.MESSAGE_SENT,
+          messageId: event.messageId,
+          ...sealed,
+        })
+        return
+      }
     }
-
-    const descriptor = toStepDescriptor(event)
-    if (!descriptor) return
-
-    const sealed = await this.seal(descriptor.content)
-    await this.deps.sendStep({
-      stepId: `step_${ulid()}`,
-      stepType: descriptor.stepType,
-      messageId: descriptor.messageId,
-      ciphertext: sealed.ciphertext,
-      envelope: sealed.envelope,
-      durationMs: descriptor.durationMs,
-    })
   }
 
   /** Seal one plaintext trace string under the reply SSK, AAD-bound to a fresh id. */
@@ -76,34 +151,12 @@ export class EnclaveTraceObserver implements AgentObserver {
       key: this.deps.replySsk,
       keyGeneration: this.deps.replyKeyGeneration,
       payload: content,
-      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: `step_${ulid()}`, senderId: this.deps.senderId }),
+      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: mintStepId(), senderId: this.deps.senderId }),
     })
     return { ciphertext: bytesToBase64(sealed.ciphertext), envelope: sealed.envelope }
   }
 }
 
-interface StepDescriptor {
-  stepType: EnclaveSealedStep["stepType"]
-  /** The renderable step content — the same string a plaintext step persists in `content`. */
-  content: string
-  messageId?: string
-  durationMs?: number
-}
-
-/** Map a runtime event to the sealed step it produces, or null for non-step events. */
-function toStepDescriptor(event: AgentEvent): StepDescriptor | null {
-  switch (event.type) {
-    case "thinking":
-      return { stepType: AgentStepTypes.THINKING, content: event.content, durationMs: event.durationMs }
-    case "tool:complete":
-      // The tool declares its own step type + rendered content (e.g. the search
-      // query, the page title, the research brief). Seal that verbatim.
-      return { stepType: event.trace.stepType, content: event.trace.content, durationMs: event.durationMs }
-    case "tool:error":
-      return { stepType: AgentStepTypes.TOOL_ERROR, content: event.error, durationMs: event.durationMs }
-    case "message:sent":
-      return { stepType: AgentStepTypes.MESSAGE_SENT, content: event.content, messageId: event.messageId }
-    default:
-      return null
-  }
+function mintStepId(): string {
+  return `step_${ulid()}`
 }

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -1,6 +1,6 @@
 import { ulid } from "ulid"
 import { buildMessageAad, bytesToBase64, sealMessage } from "@threa/crypto"
-import { AgentStepTypes, type EnclaveSealedStep } from "@threa/types"
+import { AgentStepTypes, type EnclaveSealedStep, type EnclaveSealedSubstep } from "@threa/types"
 import type { AgentEvent, AgentObserver } from "@threa/agent-runtime/runtime"
 
 /**
@@ -31,31 +31,54 @@ export interface EnclaveTraceObserverDeps {
   senderId: string
   /** Deliver one sealed step to the backend the moment it's produced (awaited, so steps land in order). */
   sendStep: (step: EnclaveSealedStep) => Promise<void>
+  /** Deliver one sealed substep — ephemeral mid-run phase text (e.g. research progress). */
+  sendSubstep: (substep: EnclaveSealedSubstep) => Promise<void>
 }
 
 export class EnclaveTraceObserver implements AgentObserver {
   constructor(private readonly deps: EnclaveTraceObserverDeps) {}
 
   async handle(event: AgentEvent): Promise<void> {
+    // Mid-run phase text (e.g. the research sub-agent's "Searching the web: …").
+    // It's derived from the encrypted prompt, so seal it under the SSK exactly
+    // like a step and relay it ephemerally — the owner's browser decrypts it for
+    // the live "Ariadne is …" indicator. Never persisted.
+    if (event.type === "tool:progress") {
+      const text = event.substep?.trim()
+      if (text) {
+        const sealed = await this.seal(text)
+        await this.deps.sendSubstep({
+          stepType: event.stepType,
+          ciphertext: sealed.ciphertext,
+          envelope: sealed.envelope,
+        })
+      }
+      return
+    }
+
     const descriptor = toStepDescriptor(event)
     if (!descriptor) return
 
-    const stepId = `step_${ulid()}`
-    const sealed = await sealMessage({
-      key: this.deps.replySsk,
-      keyGeneration: this.deps.replyKeyGeneration,
-      payload: descriptor.content,
-      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: stepId, senderId: this.deps.senderId }),
-    })
-
+    const sealed = await this.seal(descriptor.content)
     await this.deps.sendStep({
-      stepId,
+      stepId: `step_${ulid()}`,
       stepType: descriptor.stepType,
       messageId: descriptor.messageId,
-      ciphertext: bytesToBase64(sealed.ciphertext),
+      ciphertext: sealed.ciphertext,
       envelope: sealed.envelope,
       durationMs: descriptor.durationMs,
     })
+  }
+
+  /** Seal one plaintext trace string under the reply SSK, AAD-bound to a fresh id. */
+  private async seal(content: string): Promise<{ ciphertext: string; envelope: EnclaveSealedStep["envelope"] }> {
+    const sealed = await sealMessage({
+      key: this.deps.replySsk,
+      keyGeneration: this.deps.replyKeyGeneration,
+      payload: content,
+      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: `step_${ulid()}`, senderId: this.deps.senderId }),
+    })
+    return { ciphertext: bytesToBase64(sealed.ciphertext), envelope: sealed.envelope }
   }
 }
 

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -17,8 +17,9 @@ import type { AgentEvent, AgentObserver } from "@threa/agent-runtime/runtime"
  * Each step's content is sealed under the *reply* SSK (the current generation),
  * bound by AAD to `streamId|stepId|senderId` — the same message-AAD scheme,
  * with the enclave-minted `step_…` id in the id slot (no collision with `msg_…`
- * ids). Plaintext exists only here, for the duration of the loop, and is never
- * logged or persisted in the clear.
+ * ids) so the server can't shuffle a step's ciphertext onto a different row.
+ * Plaintext exists only here, for the duration of the loop, and is never logged
+ * or persisted in the clear.
  *
  * This mirrors the backend `SessionTraceObserver`'s event→step lifecycle exactly
  * — only the sink differs (seal + POST instead of DB + socket). Every step opens
@@ -59,9 +60,10 @@ export class EnclaveTraceObserver implements AgentObserver {
     switch (event.type) {
       case "thinking": {
         // Content is known up front: open + finalize the same step back-to-back,
-        // mirroring the backend's startStep(content) → complete().
+        // mirroring the backend's startStep(content) → complete(). One seal,
+        // AAD-bound to this step's id, reused for both the start and the finalize.
         const stepId = mintStepId()
-        const sealed = await this.seal(event.content)
+        const sealed = await this.seal(event.content, stepId)
         await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.THINKING, ...sealed })
         await this.deps.sendStep({ stepId, stepType: AgentStepTypes.THINKING, ...sealed, durationMs: event.durationMs })
         return
@@ -91,13 +93,15 @@ export class EnclaveTraceObserver implements AgentObserver {
         // (persisted onto the step row so a refresh / open mid-run replays it).
         const text = event.substep?.trim()
         if (!text) return
-        const sealed = await this.seal(text)
         const stepId = this.stepIdByToolCallId.get(event.toolCallId)
+        // Bind the seal AAD to the in-flight step (fall back to a fresh id only when
+        // there's no opened step to bind to — a hidden/never-started tool).
+        const sealed = await this.seal(text, stepId ?? mintStepId())
         const log = this.substepsByToolCallId.get(event.toolCallId)
         let snapshot: { ciphertext: string; envelope: EnclaveSealedStep["envelope"] } | undefined
         if (stepId && log) {
           log.push({ text, at: new Date().toISOString() })
-          snapshot = await this.seal(JSON.stringify({ substeps: [...log] }))
+          snapshot = await this.seal(JSON.stringify({ substeps: [...log] }), stepId)
         }
         await this.deps.sendSubstep({
           stepType: event.stepType,
@@ -111,22 +115,25 @@ export class EnclaveTraceObserver implements AgentObserver {
 
       case "tool:complete": {
         const stepId = this.stepIdByToolCallId.get(event.toolCallId)
-        if (!stepId) return // hidden tool — no step row was opened
+        // Clear all per-tool-call state up front (matches SessionTraceObserver,
+        // which deletes the hidden marker on complete too) so nothing leaks.
         this.stepIdByToolCallId.delete(event.toolCallId)
         this.substepsByToolCallId.delete(event.toolCallId)
-        const sealed = await this.seal(event.trace.content)
+        this.hiddenToolCallIds.delete(event.toolCallId)
+        if (!stepId) return // hidden tool — no step row was opened
+        const sealed = await this.seal(event.trace.content, stepId)
         await this.deps.sendStep({ stepId, stepType: event.trace.stepType, ...sealed, durationMs: event.durationMs })
         return
       }
 
       case "tool:error": {
         const content = `${event.toolName} failed: ${event.error}`
-        const sealed = await this.seal(content)
         const cachedId = this.stepIdByToolCallId.get(event.toolCallId)
         if (cachedId) {
           // Finalize the in-flight step with the error.
           this.stepIdByToolCallId.delete(event.toolCallId)
           this.substepsByToolCallId.delete(event.toolCallId)
+          const sealed = await this.seal(content, cachedId)
           await this.deps.sendStep({
             stepId: cachedId,
             stepType: AgentStepTypes.TOOL_ERROR,
@@ -137,6 +144,7 @@ export class EnclaveTraceObserver implements AgentObserver {
           // Unknown tool: the runtime emits tool:error with no preceding tool:start.
           // Synthesize a started + finalized error step so it's still visible.
           const stepId = mintStepId()
+          const sealed = await this.seal(content, stepId)
           await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.TOOL_ERROR, ...sealed })
           await this.deps.sendStep({
             stepId,
@@ -151,7 +159,7 @@ export class EnclaveTraceObserver implements AgentObserver {
 
       case "message:sent": {
         const stepId = mintStepId()
-        const sealed = await this.seal(event.content)
+        const sealed = await this.seal(event.content, stepId)
         await this.deps.sendStepStarted({ stepId, stepType: AgentStepTypes.MESSAGE_SENT, ...sealed })
         await this.deps.sendStep({
           stepId,
@@ -164,13 +172,20 @@ export class EnclaveTraceObserver implements AgentObserver {
     }
   }
 
-  /** Seal one plaintext trace string under the reply SSK, AAD-bound to a fresh id. */
-  private async seal(content: string): Promise<{ ciphertext: string; envelope: EnclaveSealedStep["envelope"] }> {
+  /**
+   * Seal one plaintext trace string under the reply SSK, AAD-bound to the step's
+   * id (`streamId|stepId|senderId`) so the ciphertext can't be moved onto another
+   * step row undetected — the same anti-shuffle binding messages use.
+   */
+  private async seal(
+    content: string,
+    stepId: string
+  ): Promise<{ ciphertext: string; envelope: EnclaveSealedStep["envelope"] }> {
     const sealed = await sealMessage({
       key: this.deps.replySsk,
       keyGeneration: this.deps.replyKeyGeneration,
       payload: content,
-      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: mintStepId(), senderId: this.deps.senderId }),
+      aad: buildMessageAad({ streamId: this.deps.streamId, messageId: stepId, senderId: this.deps.senderId }),
     })
     return { ciphertext: bytesToBase64(sealed.ciphertext), envelope: sealed.envelope }
   }

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -48,6 +48,8 @@ export interface EnclaveTraceObserverDeps {
 export class EnclaveTraceObserver implements AgentObserver {
   /** Maps an in-flight tool call to the step id minted at tool:start, so completion finalizes the same row. */
   private readonly stepIdByToolCallId = new Map<string, string>()
+  /** Running substep log per in-flight tool call — sealed and persisted on each progress so a refresh replays it. */
+  private readonly substepsByToolCallId = new Map<string, Array<{ text: string; at: string }>>()
   /** Tool calls hidden at tool:start — distinguishes "hidden, skip" from "unknown, synthesize error step". */
   private readonly hiddenToolCallIds = new Set<string>()
 
@@ -75,20 +77,35 @@ export class EnclaveTraceObserver implements AgentObserver {
         // cache the minted id so tool:complete/tool:error finalizes the same row.
         const stepId = mintStepId()
         this.stepIdByToolCallId.set(event.toolCallId, stepId)
+        this.substepsByToolCallId.set(event.toolCallId, [])
         await this.deps.sendStepStarted({ stepId, stepType: event.stepType })
         return
       }
 
       case "tool:progress": {
         // Mid-run phase text (e.g. the research sub-agent's "Searching the web: …").
-        // Derived from the encrypted prompt, so seal it under the SSK like a step
-        // and relay it ephemerally — the owner's browser decrypts it for the live
-        // "Ariadne is …" indicator and the in-flight step's substep timeline.
+        // Derived from the encrypted prompt, so seal it under the SSK like a step.
+        // Two sealed payloads travel in one POST, mirroring the unencrypted
+        // observer's emitSubstep + updateSubsteps: the single new phase (ephemeral,
+        // drives the live "Ariadne is …" indicator) and the running snapshot
+        // (persisted onto the step row so a refresh / open mid-run replays it).
         const text = event.substep?.trim()
-        if (text) {
-          const sealed = await this.seal(text)
-          await this.deps.sendSubstep({ stepType: event.stepType, ...sealed })
+        if (!text) return
+        const sealed = await this.seal(text)
+        const stepId = this.stepIdByToolCallId.get(event.toolCallId)
+        const log = this.substepsByToolCallId.get(event.toolCallId)
+        let snapshot: { ciphertext: string; envelope: EnclaveSealedStep["envelope"] } | undefined
+        if (stepId && log) {
+          log.push({ text, at: new Date().toISOString() })
+          snapshot = await this.seal(JSON.stringify({ substeps: [...log] }))
         }
+        await this.deps.sendSubstep({
+          stepType: event.stepType,
+          ...sealed,
+          stepId,
+          snapshotCiphertext: snapshot?.ciphertext,
+          snapshotEnvelope: snapshot?.envelope,
+        })
         return
       }
 
@@ -96,6 +113,7 @@ export class EnclaveTraceObserver implements AgentObserver {
         const stepId = this.stepIdByToolCallId.get(event.toolCallId)
         if (!stepId) return // hidden tool — no step row was opened
         this.stepIdByToolCallId.delete(event.toolCallId)
+        this.substepsByToolCallId.delete(event.toolCallId)
         const sealed = await this.seal(event.trace.content)
         await this.deps.sendStep({ stepId, stepType: event.trace.stepType, ...sealed, durationMs: event.durationMs })
         return
@@ -108,6 +126,7 @@ export class EnclaveTraceObserver implements AgentObserver {
         if (cachedId) {
           // Finalize the in-flight step with the error.
           this.stepIdByToolCallId.delete(event.toolCallId)
+          this.substepsByToolCallId.delete(event.toolCallId)
           await this.deps.sendStep({
             stepId: cachedId,
             stepType: AgentStepTypes.TOOL_ERROR,

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -197,7 +197,7 @@ export class EnclaveTraceObserver implements AgentObserver {
             authorName: trigger.authorName,
             authorType: trigger.authorType,
             createdAt: trigger.createdAt,
-            content: trigger.content.slice(0, 300),
+            content: trigger.content,
             isTrigger: true,
           },
         ],
@@ -217,7 +217,14 @@ export class EnclaveTraceObserver implements AgentObserver {
    * route still records every step, just without the live in-flight frame.)
    */
   private async openStep(step: EnclaveSealedStepStart): Promise<void> {
-    await this.deps.sendStepStarted(step).catch(() => {})
+    // Swallow both a rejected promise AND a synchronous throw — a bad
+    // `sendStepStarted` must never abort the handler and drop the durable
+    // finalize. `.catch()` alone misses a sync throw before the promise exists.
+    try {
+      await this.deps.sendStepStarted(step)
+    } catch {
+      // best-effort: the live `step:started` frame is UX-only (see above)
+    }
   }
 
   /**

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -173,6 +173,42 @@ export class EnclaveTraceObserver implements AgentObserver {
   }
 
   /**
+   * Emit the leading CONTEXT step — the enclave's equivalent of the in-process
+   * persona-agent's CONTEXT_RECEIVED step ("Triggered by: …"). The runtime never
+   * emits this for the initial trigger (only `context:received` for mid-turn new
+   * messages), so the enclave's orchestration layer (run-turn) drives it once,
+   * before the loop. The message body is the decrypted prompt, sealed under the
+   * SSK exactly like a step; id/author/time are clear metadata. Content shape
+   * matches the in-process step so the same frontend renderer applies.
+   */
+  async emitContext(trigger: {
+    messageId: string
+    authorName: string
+    authorType: string
+    createdAt: string
+    content: string
+  }): Promise<void> {
+    const stepId = mintStepId()
+    const sealed = await this.seal(
+      JSON.stringify({
+        messages: [
+          {
+            messageId: trigger.messageId,
+            authorName: trigger.authorName,
+            authorType: trigger.authorType,
+            createdAt: trigger.createdAt,
+            content: trigger.content.slice(0, 300),
+            isTrigger: true,
+          },
+        ],
+      }),
+      stepId
+    )
+    await this.openStep({ stepId, stepType: AgentStepTypes.CONTEXT_RECEIVED, ...sealed })
+    await this.deps.sendStep({ stepId, stepType: AgentStepTypes.CONTEXT_RECEIVED, ...sealed })
+  }
+
+  /**
    * Open an in-flight step — best-effort. The `step:started` frame is live-UX
    * only (it lets an open trace dialog render the in-progress step); the durable
    * record is the *finalize* (`sendStep`), which has its own persistence fallback.

--- a/apps/enclave/src/heartbeat.ts
+++ b/apps/enclave/src/heartbeat.ts
@@ -1,9 +1,9 @@
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import type { EnclaveConfig } from "./config"
 import type { EnclaveKeyPair } from "./keystore"
 
-const logger = pino({ name: "enclave-heartbeat" })
+const logger = baseLogger.child({ name: "enclave-heartbeat" })
 
 export interface Heartbeat {
   stop: () => void

--- a/apps/enclave/src/index.ts
+++ b/apps/enclave/src/index.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import { loadEnclaveConfig } from "./config"
 import { createEnclaveKeyPair } from "./keystore"
 import { registerWithBackend, revokeWithBackend } from "./register"
@@ -9,7 +9,7 @@ import { createOpenRouterChat } from "./llm"
 import { createBackendCallbacks } from "./agent/backend-callbacks"
 import { createCancelHandler, createSessionsHandler, requireInternalKey } from "./sessions"
 
-const logger = pino({ name: "enclave" })
+const logger = baseLogger.child({ name: "enclave" })
 
 async function main() {
   const config = loadEnclaveConfig()

--- a/apps/enclave/src/index.ts
+++ b/apps/enclave/src/index.ts
@@ -16,8 +16,6 @@ async function main() {
   const keyPair = await createEnclaveKeyPair()
   logger.info({ instanceId: keyPair.instanceId, keyId: keyPair.keyId }, "Enclave EIK generated")
 
-  await registerWithBackend(config, keyPair)
-
   const app = express()
   app.disable("x-powered-by")
   app.use(accessLog)
@@ -62,12 +60,30 @@ async function main() {
     res.status(500).json({ error: "Internal Server Error" })
   })
 
-  const heartbeat = startHeartbeat(config, keyPair, async () => {
-    await registerWithBackend(config, keyPair)
-  })
-
   const server = app.listen(config.port, () => {
     logger.info({ port: config.port, selfUrl: config.selfUrl }, "Enclave listening")
+  })
+
+  // Initial registration is best-effort: in local/dev every service boots at
+  // once, so the backend may not be listening yet. Retry briefly, then serve
+  // regardless — the heartbeat (backend 404 → re-register) brings us into the
+  // live set once the backend is reachable, so a slow or absent backend at boot
+  // never crashes the enclave (the HTTP server is already up for liveness).
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    try {
+      await registerWithBackend(config, keyPair)
+      break
+    } catch (err) {
+      if (attempt === 10) {
+        logger.warn({ err }, "Initial registration failed after retries; relying on heartbeat re-registration")
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+    }
+  }
+
+  const heartbeat = startHeartbeat(config, keyPair, async () => {
+    await registerWithBackend(config, keyPair)
   })
 
   // On a graceful signal, how long to let in-flight sessions finish before exit.

--- a/apps/enclave/src/index.ts
+++ b/apps/enclave/src/index.ts
@@ -7,7 +7,7 @@ import { startHeartbeat } from "./heartbeat"
 import { accessLog } from "./access-log"
 import { createOpenRouterChat } from "./llm"
 import { createBackendCallbacks } from "./agent/backend-callbacks"
-import { createSessionsHandler, requireInternalKey } from "./sessions"
+import { createCancelHandler, createSessionsHandler, requireInternalKey } from "./sessions"
 
 const logger = pino({ name: "enclave" })
 
@@ -48,12 +48,24 @@ async function main() {
   const rawChat = createOpenRouterChat(config)
   const callbacks = createBackendCallbacks(config)
   const inFlight = new Set<string>()
+  const aborts = new Map<string, AbortController>()
   app.post(
     "/sessions",
     requireInternalKey(config.internalApiKey),
     express.json({ limit: "4mb" }),
-    createSessionsHandler({ keyPair, rawChat, callbacks, inFlight, toolConfig: { tavilyApiKey: config.tavilyApiKey } })
+    createSessionsHandler({
+      keyPair,
+      rawChat,
+      callbacks,
+      inFlight,
+      aborts,
+      toolConfig: { tavilyApiKey: config.tavilyApiKey },
+    })
   )
+
+  // Graceful "Stop research": the backend forwards a user abort here. No body —
+  // the session id is in the path; the key gate is enough (same secret as /sessions).
+  app.post("/sessions/:id/cancel", requireInternalKey(config.internalApiKey), createCancelHandler({ aborts }))
 
   app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
     logger.error({ err }, "Enclave request failed")

--- a/apps/enclave/src/keystore.ts
+++ b/apps/enclave/src/keystore.ts
@@ -8,9 +8,9 @@ import {
   generateKeyPair,
   importRecipientPrivateKey,
 } from "@threa/crypto"
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 
-const logger = pino({ name: "enclave-keystore" })
+const logger = baseLogger.child({ name: "enclave-keystore" })
 
 export interface EnclaveKeyPair {
   /** Stable identifier for this instance (one per process lifetime). */

--- a/apps/enclave/src/keystore.ts
+++ b/apps/enclave/src/keystore.ts
@@ -1,5 +1,16 @@
+import * as fs from "fs"
 import { ulid } from "ulid"
-import { bytesToBase64, exportPublicKey, generateKeyPair } from "@threa/crypto"
+import {
+  base64ToBytes,
+  bytesToBase64,
+  exportPrivateKey,
+  exportPublicKey,
+  generateKeyPair,
+  importRecipientPrivateKey,
+} from "@threa/crypto"
+import pino from "pino"
+
+const logger = pino({ name: "enclave-keystore" })
 
 export interface EnclaveKeyPair {
   /** Stable identifier for this instance (one per process lifetime). */
@@ -13,19 +24,82 @@ export interface EnclaveKeyPair {
   privateKey: CryptoKey
 }
 
+interface PersistedKey {
+  instanceId: string
+  keyId: string
+  publicKey: string
+  privateKey: string
+}
+
 /**
  * Generate this instance's Enclave Instance Key. Stays in memory for the
  * process lifetime; rotation is per-instance and means restarting the
  * process (the new boot tombstones the old row via heartbeat staleness).
+ *
+ * **Dev only:** when `ENCLAVE_KEY_PERSIST_PATH` is set, the keypair is loaded
+ * from (or saved to) that file so `node --watch` restarts keep the same EIK —
+ * otherwise every restart mints a fresh key, invalidating every stream's SSK
+ * wrap and silently dropping E2E turns. Production never sets this var, so the
+ * key stays ephemeral (a compromised host can't decrypt past the live process).
  */
 export async function createEnclaveKeyPair(): Promise<EnclaveKeyPair> {
+  const persistPath = process.env.ENCLAVE_KEY_PERSIST_PATH
+
+  if (persistPath) {
+    const loaded = await loadPersistedKey(persistPath)
+    if (loaded) {
+      logger.warn({ keyId: loaded.keyId, persistPath }, "Loaded persisted EIK (dev) — key is NOT ephemeral")
+      return loaded
+    }
+  }
+
   const pair = await generateKeyPair()
   const publicKey = await exportPublicKey(pair.publicKey)
-  return {
+  const keyPair: EnclaveKeyPair = {
     instanceId: `enci_${ulid()}`,
     keyId: `eik_${ulid()}`,
     publicKeyBase64: bytesToBase64(publicKey),
     publicKey,
     privateKey: pair.privateKey,
   }
+
+  if (persistPath) {
+    await savePersistedKey(persistPath, keyPair, pair.privateKey)
+    logger.warn({ keyId: keyPair.keyId, persistPath }, "Persisted a fresh EIK (dev) — key is NOT ephemeral")
+  }
+
+  return keyPair
+}
+
+async function loadPersistedKey(persistPath: string): Promise<EnclaveKeyPair | null> {
+  if (!fs.existsSync(persistPath)) return null
+  try {
+    const parsed = JSON.parse(fs.readFileSync(persistPath, "utf-8")) as PersistedKey
+    const publicKey = base64ToBytes(parsed.publicKey)
+    // Re-import extractable (matches a freshly generated key); the enclave only
+    // uses it to `open` HPKE envelopes.
+    const privateKey = await importRecipientPrivateKey(base64ToBytes(parsed.privateKey))
+    return {
+      instanceId: parsed.instanceId,
+      keyId: parsed.keyId,
+      publicKeyBase64: parsed.publicKey,
+      publicKey,
+      privateKey,
+    }
+  } catch (err) {
+    // A corrupt/incompatible file shouldn't wedge boot — fall back to a fresh key.
+    logger.warn({ err, persistPath }, "Failed to load persisted EIK; generating a fresh one")
+    return null
+  }
+}
+
+async function savePersistedKey(persistPath: string, keyPair: EnclaveKeyPair, privateKey: CryptoKey): Promise<void> {
+  const privateBytes = await exportPrivateKey(privateKey)
+  const record: PersistedKey = {
+    instanceId: keyPair.instanceId,
+    keyId: keyPair.keyId,
+    publicKey: keyPair.publicKeyBase64,
+    privateKey: bytesToBase64(privateBytes),
+  }
+  fs.writeFileSync(persistPath, JSON.stringify(record), { mode: 0o600 })
 }

--- a/apps/enclave/src/register.ts
+++ b/apps/enclave/src/register.ts
@@ -1,9 +1,9 @@
-import pino from "pino"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import type { EnclaveConfig } from "./config"
 import type { EnclaveKeyPair } from "./keystore"
 
-const logger = pino({ name: "enclave-register" })
+const logger = baseLogger.child({ name: "enclave-register" })
 
 /**
  * Registers this instance's EIK with the backend. Idempotent: backend's

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -137,6 +137,7 @@ describe("createSessionsHandler", () => {
         streamed.push({ sessionId, reply })
       },
       step: async () => {},
+      substep: async () => {},
       complete: async (sessionId, result) => {
         completed = { sessionId, result }
       },
@@ -179,6 +180,7 @@ describe("createSessionsHandler", () => {
       heartbeat: async () => {},
       message: async () => {},
       step: async () => {},
+      substep: async () => {},
       complete: async () => {
         completed = true
       },
@@ -206,7 +208,13 @@ describe("createSessionsHandler", () => {
         ran = true
         return { message: { content: "x" }, model: "stub" }
       }) as RawChatFn,
-      callbacks: { heartbeat: async () => {}, message: async () => {}, step: async () => {}, complete: async () => {} },
+      callbacks: {
+        heartbeat: async () => {},
+        message: async () => {},
+        step: async () => {},
+        substep: async () => {},
+        complete: async () => {},
+      },
       inFlight: new Set([assignment.sessionId]), // already running
     })
     const res = fakeRes()

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -18,7 +18,7 @@ import {
 import { createEnclaveKeyPair, type EnclaveKeyPair } from "./keystore"
 import type { BackendCallbacks } from "./agent/backend-callbacks"
 import type { RawChatFn } from "./llm"
-import { createSessionsHandler, requireInternalKey } from "./sessions"
+import { createCancelHandler, createSessionsHandler, requireInternalKey } from "./sessions"
 
 const STREAM_ID = "stream_x"
 const GEN = 0
@@ -117,6 +117,7 @@ describe("createSessionsHandler", () => {
       }) as unknown as RawChatFn,
       callbacks: {} as BackendCallbacks,
       inFlight: new Set(),
+      aborts: new Map(),
     })
     const res = fakeRes()
     handler({ body: { not: "valid" } } as unknown as Request, res)
@@ -144,7 +145,7 @@ describe("createSessionsHandler", () => {
       },
     }
     const inFlight = new Set<string>()
-    const handler = createSessionsHandler({ keyPair, rawChat, callbacks, inFlight })
+    const handler = createSessionsHandler({ keyPair, rawChat, callbacks, inFlight, aborts: new Map() })
 
     const res = fakeRes()
     handler({ body: assignment } as unknown as Request, res)
@@ -188,7 +189,7 @@ describe("createSessionsHandler", () => {
       },
     }
     const inFlight = new Set<string>()
-    const handler = createSessionsHandler({ keyPair, rawChat, callbacks, inFlight })
+    const handler = createSessionsHandler({ keyPair, rawChat, callbacks, inFlight, aborts: new Map() })
 
     const res = fakeRes()
     handler({ body: assignment } as unknown as Request, res)
@@ -219,10 +220,34 @@ describe("createSessionsHandler", () => {
         complete: async () => {},
       },
       inFlight: new Set([assignment.sessionId]), // already running
+      aborts: new Map(),
     })
     const res = fakeRes()
     handler({ body: assignment } as unknown as Request, res)
     expect(res.statusCode).toBe(202)
     expect(ran).toBe(false)
+  })
+})
+
+describe("createCancelHandler", () => {
+  it("aborts the registered controller for a known session", () => {
+    const controller = new AbortController()
+    const aborts = new Map([["session_1", controller]])
+    const handler = createCancelHandler({ aborts })
+    const res = fakeRes()
+
+    handler({ params: { id: "session_1" } } as unknown as Request, res)
+
+    expect(controller.signal.aborted).toBe(true)
+    expect(res.statusCode).toBe(202)
+  })
+
+  it("202s idempotently for an unknown session (turn already finished)", () => {
+    const handler = createCancelHandler({ aborts: new Map() })
+    const res = fakeRes()
+
+    handler({ params: { id: "session_gone" } } as unknown as Request, res)
+
+    expect(res.statusCode).toBe(202)
   })
 })

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -136,6 +136,7 @@ describe("createSessionsHandler", () => {
       message: async (sessionId, reply) => {
         streamed.push({ sessionId, reply })
       },
+      stepStarted: async () => {},
       step: async () => {},
       substep: async () => {},
       complete: async (sessionId, result) => {
@@ -179,6 +180,7 @@ describe("createSessionsHandler", () => {
     const callbacks: BackendCallbacks = {
       heartbeat: async () => {},
       message: async () => {},
+      stepStarted: async () => {},
       step: async () => {},
       substep: async () => {},
       complete: async () => {
@@ -211,6 +213,7 @@ describe("createSessionsHandler", () => {
       callbacks: {
         heartbeat: async () => {},
         message: async () => {},
+        stepStarted: async () => {},
         step: async () => {},
         substep: async () => {},
         complete: async () => {},

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -251,3 +251,12 @@ describe("createCancelHandler", () => {
     expect(res.statusCode).toBe(202)
   })
 })
+
+describe("createCancelHandler validation", () => {
+  it("400s when the session id param is missing (INV-55 Zod validation)", () => {
+    const handler = createCancelHandler({ aborts: new Map() })
+    const res = fakeRes()
+    handler({ params: {} } as unknown as Request, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/apps/enclave/src/sessions.ts
+++ b/apps/enclave/src/sessions.ts
@@ -177,10 +177,16 @@ export function createSessionsHandler(deps: SessionsDeps) {
  * it does NOT kill the session. 202 whether or not a turn was found (idempotent —
  * the turn may have already finished). Gated by `requireInternalKey` upstream.
  */
+const cancelParamsSchema = z.object({ id: z.string().min(1) })
+
 export function createCancelHandler(deps: { aborts: Map<string, AbortController> }) {
   return (req: Request, res: Response): void => {
-    const sessionId = req.params.id
-    if (sessionId) deps.aborts.get(sessionId)?.abort()
+    const parsed = cancelParamsSchema.safeParse(req.params)
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid session id" })
+      return
+    }
+    deps.aborts.get(parsed.data.id)?.abort()
     res.status(202).end()
   }
 }

--- a/apps/enclave/src/sessions.ts
+++ b/apps/enclave/src/sessions.ts
@@ -1,7 +1,12 @@
 import type { NextFunction, Request, Response } from "express"
 import { timingSafeEqual } from "node:crypto"
 import { z } from "zod"
-import { INTERNAL_API_KEY_HEADER, type EnclaveSessionAssignment } from "@threa/types"
+import {
+  AUTHOR_TYPES,
+  INTERNAL_API_KEY_HEADER,
+  TOOL_PRIVACY_CATEGORIES,
+  type EnclaveSessionAssignment,
+} from "@threa/types"
 import type { EnclaveKeyPair } from "./keystore"
 import type { RawChatFn } from "./llm"
 import type { BackendCallbacks } from "./agent/backend-callbacks"
@@ -69,6 +74,26 @@ export const sessionAssignmentSchema = z.object({
     keyGeneration: z.number().int().min(0),
     senderId: z.string().min(1),
   }),
+  /**
+   * Per-stream tool-privacy policy. MUST be in the schema: Zod strips unknown
+   * keys, so omitting it here silently drops the policy and the enclave runs its
+   * full web surface regardless of the stream's setting. Optional → unrestricted.
+   */
+  allowedToolCategories: z.array(z.enum(TOOL_PRIVACY_CATEGORIES)).optional(),
+  /**
+   * Non-secret trigger metadata for the "Triggered by" CONTEXT trace step. Same
+   * reason it must be declared: an unschema'd field never reaches `run-turn`, so
+   * the context step would silently never render. The body is the decrypted
+   * prompt, sealed enclave-side.
+   */
+  trigger: z
+    .object({
+      messageId: z.string().min(1),
+      authorName: z.string(),
+      authorType: z.enum(AUTHOR_TYPES),
+      createdAt: z.string().min(1),
+    })
+    .optional(),
 })
 
 export interface SessionsDeps {
@@ -77,6 +102,8 @@ export interface SessionsDeps {
   callbacks: BackendCallbacks
   /** Session ids currently running in this process, to dedupe a redelivered assignment. */
   inFlight: Set<string>
+  /** Per-session cancel controllers so `/sessions/:id/cancel` can abort a turn's research. */
+  aborts: Map<string, AbortController>
   /** Web-tool config for the turn loop (Tavily key). Absent → research/read_url only. */
   toolConfig?: { tavilyApiKey?: string }
 }
@@ -131,8 +158,29 @@ export function createSessionsHandler(deps: SessionsDeps) {
     // Ack first; the loop runs detached and reports back over the callbacks.
     res.status(202).end()
     void runEnclaveSession(
-      { keyPair: deps.keyPair, rawChat: deps.rawChat, callbacks: deps.callbacks, toolConfig: deps.toolConfig },
+      {
+        keyPair: deps.keyPair,
+        rawChat: deps.rawChat,
+        callbacks: deps.callbacks,
+        toolConfig: deps.toolConfig,
+        aborts: deps.aborts,
+      },
       assignment
     ).finally(() => deps.inFlight.delete(assignment.sessionId))
+  }
+}
+
+/**
+ * Express adapter for `POST /sessions/:id/cancel` — the backend forwards a user's
+ * "Stop research" here. Gracefully aborts the in-flight turn's long-running tools
+ * (the web research sub-loop returns partial findings and the turn still replies);
+ * it does NOT kill the session. 202 whether or not a turn was found (idempotent —
+ * the turn may have already finished). Gated by `requireInternalKey` upstream.
+ */
+export function createCancelHandler(deps: { aborts: Map<string, AbortController> }) {
+  return (req: Request, res: Response): void => {
+    const sessionId = req.params.id
+    if (sessionId) deps.aborts.get(sessionId)?.abort()
+    res.status(202).end()
   }
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -332,8 +332,8 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // `runSidebarAction` toasts on throw, so let the encrypted creator's session
   // checks propagate ("Unlock encrypted scratchpads first…") rather than
   // swallowing them here.
-  const handleCreateEncryptedScratchpad = async () => {
-    const streamId = await createEncryptedScratchpad()
+  const handleCreateEncryptedScratchpad = async (withAriadne: boolean) => {
+    const streamId = await createEncryptedScratchpad(withAriadne)
     collapseOnMobile()
     navigate(`/w/${workspaceId}/s/${streamId}`)
   }
@@ -355,8 +355,14 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       id: "new-encrypted-scratchpad",
       label: "New Encrypted Scratchpad",
       icon: Lock,
-      onSelect: handleCreateEncryptedScratchpad,
+      onSelect: () => handleCreateEncryptedScratchpad(true),
       separatorBefore: true,
+    },
+    {
+      id: "new-encrypted-quick-note",
+      label: "New Encrypted Quick Note",
+      icon: Lock,
+      onSelect: () => handleCreateEncryptedScratchpad(false),
     },
   ]
 

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -39,9 +39,10 @@ export interface CommandContext {
    * Drafts don't apply here — the stream must exist on the server so the
    * `e2e_streams` row can be written atomically with the stream insert
    * (INV-7). Returns the new stream id; throws/toasts if the user's E2E
-   * session isn't unlocked.
+   * session isn't unlocked. `withAriadne` invites the enclave actor so the
+   * scratchpad gets AI replies; pass false for a no-AI encrypted quick note.
    */
-  createEncryptedScratchpad: () => Promise<string>
+  createEncryptedScratchpad: (withAriadne: boolean) => Promise<string>
   openCreateChannel: () => void
   setMode?: (mode: "stream" | "command" | "search") => void
   requestInput: (request: InputRequest) => void
@@ -122,14 +123,30 @@ export const commands: Command[] = [
     id: "new-encrypted-scratchpad",
     label: "New Encrypted Scratchpad",
     icon: Lock,
-    keywords: ["create", "encrypted", "e2e", "private", "secret", "secure"],
+    keywords: ["create", "encrypted", "e2e", "private", "secret", "secure", "ariadne", "ai"],
     action: async ({ workspaceId, navigate, closeDialog, createEncryptedScratchpad }) => {
       try {
-        const streamId = await createEncryptedScratchpad()
+        const streamId = await createEncryptedScratchpad(true)
         closeDialog()
         navigate(`/w/${workspaceId}/s/${streamId}`)
       } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to create encrypted scratchpad"
+        toast.error(message)
+      }
+    },
+  },
+  {
+    id: "new-encrypted-quick-note",
+    label: "New Encrypted Quick Note",
+    icon: Lock,
+    keywords: ["create", "encrypted", "e2e", "private", "secret", "secure", "no ai", "no companion", "quiet", "silent"],
+    action: async ({ workspaceId, navigate, closeDialog, createEncryptedScratchpad }) => {
+      try {
+        const streamId = await createEncryptedScratchpad(false)
+        closeDialog()
+        navigate(`/w/${workspaceId}/s/${streamId}`)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to create encrypted quick note"
         toast.error(message)
       }
     },

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -64,7 +64,8 @@ export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
 
       {isE2e && (
         <p className="text-xs text-muted-foreground">
-          End-to-end encrypted streams keep the companion off — responses would be plaintext.
+          Companion mode stays off on encrypted scratchpads — it would reply in plaintext. Ariadne still replies here,
+          running in the encryption enclave so your content stays end-to-end encrypted.
         </p>
       )}
     </div>

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1576,6 +1576,27 @@ function applyDecryptedContent(payload: MessagePayload, decrypted: DecryptedMess
   }
 }
 
+/**
+ * Sized, message-aligned skeleton shown for the ~frame an E2E message is
+ * decrypting on first paint. Matches the message row's gutter/padding so it
+ * doesn't jump on resolve, and crucially has non-zero height so react-virtuoso
+ * can measure it (a zero-height item warns and corrupts scroll math).
+ */
+function DecryptingPlaceholder({ groupContinuation }: { groupContinuation: boolean }) {
+  return (
+    <div className="flex gap-3 px-3 py-1 sm:px-6" aria-hidden="true">
+      {groupContinuation ? (
+        <div className="w-8 shrink-0" />
+      ) : (
+        <div className="h-8 w-8 shrink-0 rounded-full bg-muted/40" />
+      )}
+      <div className="flex-1 self-center">
+        <div className="h-3 max-w-[14rem] rounded bg-muted/30" />
+      </div>
+    </div>
+  )
+}
+
 export function MessageEvent({
   event,
   workspaceId,
@@ -1599,14 +1620,15 @@ export function MessageEvent({
 
   const actorName = getActorName(event.actorId, event.actorType)
 
-  // While an E2E message is still decrypting on first paint, withhold the row
-  // entirely rather than flashing a "🔒 Decrypting…" placeholder. Decryption is
-  // near-instant local crypto, so the message appears decrypted within a frame;
-  // the wrapping `<div data-event-id>` stays mounted, so this runs the decrypt
-  // effect and reserves the row without churning list keys. Self-sent messages
-  // don't hit this branch — the send path seeds the decrypt cache with the
-  // plaintext, so their server event resolves as decrypted on arrival.
-  if (decrypted.status === "pending") return null
+  // While an E2E message is still decrypting on first paint, withhold the
+  // content rather than flashing a "🔒 Decrypting…" placeholder — but render a
+  // sized skeleton, never a zero-height row: the timeline is virtualized
+  // (react-virtuoso), and a zero-sized item warns and breaks scroll
+  // measurement. Decryption is near-instant local crypto and the result is
+  // cached, so this shows for ~a frame on first decrypt only (re-scroll hits
+  // the cache and renders decrypted directly). Self-sent messages don't hit
+  // this branch — the send path seeds the decrypt cache with the plaintext.
+  if (decrypted.status === "pending") return <DecryptingPlaceholder groupContinuation={groupContinuation} />
 
   switch (status) {
     // Pending/failed/editing rows aren't selectable (they don't have a

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1565,10 +1565,10 @@ function applyDecryptedContent(payload: MessagePayload, decrypted: DecryptedMess
       const text = "🔒 Locked — unlock to view"
       return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
     }
-    case "pending": {
-      const text = "🔒 Decrypting…"
-      return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
-    }
+    case "pending":
+      // The row is withheld while pending (see MessageEvent), so this payload is
+      // never rendered — return it untouched rather than a placeholder.
+      return payload
     case "failed": {
       const text = "🔒 Decryption failed"
       return { ...payload, contentMarkdown: text, contentJson: makePlaceholderJson(text) }
@@ -1598,6 +1598,15 @@ export function MessageEvent({
   const status = getStatus(event.id)
 
   const actorName = getActorName(event.actorId, event.actorType)
+
+  // While an E2E message is still decrypting on first paint, withhold the row
+  // entirely rather than flashing a "🔒 Decrypting…" placeholder. Decryption is
+  // near-instant local crypto, so the message appears decrypted within a frame;
+  // the wrapping `<div data-event-id>` stays mounted, so this runs the decrypt
+  // effect and reserves the row without churning list keys. Self-sent messages
+  // don't hit this branch — the send path seeds the decrypt cache with the
+  // plaintext, so their server event resolves as decrypted on arrival.
+  if (decrypted.status === "pending") return null
 
   switch (status) {
     // Pending/failed/editing rows aren't selectable (they don't have a

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -328,7 +328,7 @@ export function StreamContent({
   // Track live agent session progress for all stream types (step/message counts on session cards).
   // In channels, session cards are hidden (responses go to threads) and inline activity shows on trigger messages instead.
   const isChannel = stream?.type === StreamTypes.CHANNEL
-  const agentActivity = useAgentActivity(events, socket)
+  const agentActivity = useAgentActivity(events, socket, workspaceId, currentWorkspaceUserId)
 
   // --- In-stream search ---
   const streamSearch = useStreamSearch({ workspaceId, streamId })

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -48,7 +48,9 @@ describe("useAgentActivity", () => {
             startedAt: "2026-05-25T00:00:00.000Z",
           }),
         ],
-        null
+        null,
+        "ws_test",
+        "usr_test"
       )
     )
 
@@ -77,7 +79,9 @@ describe("useAgentActivity", () => {
             startedAt: "2026-05-25T00:00:00.000Z",
           }),
         ],
-        socket
+        socket,
+        "ws_test",
+        "usr_test"
       )
     )
 

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -13,6 +13,8 @@ import type {
   AgentActivityEndedPayload,
 } from "@threa/types"
 import { getStepInlineLabel } from "@/lib/step-config"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
 
 export interface MessageAgentActivity {
   sessionId: string
@@ -54,7 +56,12 @@ interface ProgressEntry {
  * The activity_started event fires immediately when the session begins (no step yet),
  * progress events update the step type, and activity_ended cleans up.
  */
-export function useAgentActivity(events: StreamEvent[], socket: Socket | null): Map<string, MessageAgentActivity> {
+export function useAgentActivity(
+  events: StreamEvent[],
+  socket: Socket | null,
+  workspaceId: string,
+  userId: string | null
+): Map<string, MessageAgentActivity> {
   // Track live activity from socket: sessionId → { triggerMessageId, personaName, currentStepType }
   const [progressBySession, setProgressBySession] = useState<Map<string, ProgressEntry>>(new Map())
 
@@ -168,20 +175,41 @@ export function useAgentActivity(events: StreamEvent[], socket: Socket | null): 
     })
   }, [])
 
-  // Substep: ephemeral phase text from a long-running tool. Only updates the entry
-  // for the matching session — does NOT touch step counts or step type.
-  const handleSubstep = useCallback((payload: AgentSessionSubstepPayload) => {
+  const applySubstep = useCallback((sessionId: string, text: string) => {
     setProgressBySession((prev) => {
-      const existing = prev.get(payload.sessionId)
+      const existing = prev.get(sessionId)
       if (!existing) return prev
       const next = new Map(prev)
-      next.set(payload.sessionId, {
-        ...existing,
-        substep: payload.substep,
-      })
+      next.set(sessionId, { ...existing, substep: text })
       return next
     })
   }, [])
+
+  // Substep: ephemeral phase text from a long-running tool. Only updates the entry
+  // for the matching session — does NOT touch step counts or step type. For E2E
+  // (enclave) sessions the text is sealed under the stream key, so decrypt it the
+  // same way message/step content is before applying.
+  const handleSubstep = useCallback(
+    (payload: AgentSessionSubstepPayload) => {
+      if (typeof payload.substep === "string" && payload.substep) {
+        applySubstep(payload.sessionId, payload.substep)
+        return
+      }
+      if (typeof payload.ciphertext === "string" && payload.envelope) {
+        const session = getE2eSessionState(workspaceId, userId ?? "")
+        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return
+        void tryDecryptMessagePayload(
+          { contentMarkdown: "", ciphertext: payload.ciphertext, envelope: payload.envelope },
+          { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId: payload.streamId }
+        )
+          .then((decrypted) => {
+            if (decrypted?.contentMarkdown) applySubstep(payload.sessionId, decrypted.contentMarkdown)
+          })
+          .catch(() => {})
+      }
+    },
+    [workspaceId, userId, applySubstep]
+  )
 
   // Activity ended: session completed/failed, remove from map
   const handleActivityEnded = useCallback((payload: AgentActivityEndedPayload) => {

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useCallback } from "react"
+import { useMemo, useState, useEffect, useCallback, useRef } from "react"
 import type { Socket } from "socket.io-client"
 import type {
   StreamEvent,
@@ -43,6 +43,12 @@ interface ProgressEntry {
   stepCount: number
   messageCount: number
   substep: string | null
+  /**
+   * `updatedAt` of the currently-applied substep. Gates out-of-order writes: a
+   * decrypt that resolves after a newer one (or a duplicate redelivery) carries an
+   * older/equal timestamp and is dropped, so the latest phase always wins.
+   */
+  substepUpdatedAt?: string
   threadStreamId?: string
 }
 
@@ -64,6 +70,14 @@ export function useAgentActivity(
 ): Map<string, MessageAgentActivity> {
   // Track live activity from socket: sessionId → { triggerMessageId, personaName, currentStepType }
   const [progressBySession, setProgressBySession] = useState<Map<string, ProgressEntry>>(new Map())
+
+  // Mirror of `progressBySession` for synchronous reads inside event handlers —
+  // lets a substep capture the session's step generation at *arrival* time so a
+  // late async decrypt can't apply onto a step that has since moved on.
+  const progressRef = useRef(progressBySession)
+  useEffect(() => {
+    progressRef.current = progressBySession
+  }, [progressBySession])
 
   // Derive running sessions from events array (bootstrap source of truth for streams
   // that contain session lifecycle events, e.g. threads and scratchpads)
@@ -169,21 +183,31 @@ export function useAgentActivity(
         stepCount: payload.stepCount,
         messageCount: payload.messageCount,
         substep: sameStep ? (prior?.substep ?? null) : null,
+        substepUpdatedAt: sameStep ? prior?.substepUpdatedAt : undefined,
         threadStreamId: payload.threadStreamId,
       })
       return next
     })
   }, [])
 
-  const applySubstep = useCallback((sessionId: string, text: string) => {
-    setProgressBySession((prev) => {
-      const existing = prev.get(sessionId)
-      if (!existing) return prev
-      const next = new Map(prev)
-      next.set(sessionId, { ...existing, substep: text })
-      return next
-    })
-  }, [])
+  // Apply a decoded substep, gated against races: drop it if the session's step
+  // generation advanced since the substep arrived (`stepCountAtArrival`), or if a
+  // newer substep already landed (`updatedAt` ordering). Both guard the async E2E
+  // decrypt, whose resolution order isn't the arrival order.
+  const applySubstep = useCallback(
+    (sessionId: string, text: string, updatedAt: string, stepCountAtArrival: number | undefined) => {
+      setProgressBySession((prev) => {
+        const existing = prev.get(sessionId)
+        if (!existing) return prev
+        if (stepCountAtArrival !== undefined && existing.stepCount !== stepCountAtArrival) return prev
+        if (existing.substepUpdatedAt && updatedAt <= existing.substepUpdatedAt) return prev
+        const next = new Map(prev)
+        next.set(sessionId, { ...existing, substep: text, substepUpdatedAt: updatedAt })
+        return next
+      })
+    },
+    []
+  )
 
   // Substep: ephemeral phase text from a long-running tool. Only updates the entry
   // for the matching session — does NOT touch step counts or step type. For E2E
@@ -191,8 +215,11 @@ export function useAgentActivity(
   // same way message/step content is before applying.
   const handleSubstep = useCallback(
     (payload: AgentSessionSubstepPayload) => {
+      // Capture the step generation at arrival so a late decrypt can't apply onto
+      // a step that has since advanced.
+      const stepCountAtArrival = progressRef.current.get(payload.sessionId)?.stepCount
       if (typeof payload.substep === "string" && payload.substep) {
-        applySubstep(payload.sessionId, payload.substep)
+        applySubstep(payload.sessionId, payload.substep, payload.updatedAt, stepCountAtArrival)
         return
       }
       if (typeof payload.ciphertext === "string" && payload.envelope) {
@@ -203,7 +230,8 @@ export function useAgentActivity(
           { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId: payload.streamId }
         )
           .then((decrypted) => {
-            if (decrypted?.contentMarkdown) applySubstep(payload.sessionId, decrypted.contentMarkdown)
+            if (decrypted?.contentMarkdown)
+              applySubstep(payload.sessionId, decrypted.contentMarkdown, payload.updatedAt, stepCountAtArrival)
           })
           .catch(() => {})
       }

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useSocket } from "@/contexts"
 import { agentSessionsApi } from "@/api"
@@ -70,6 +70,10 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
   const [streamingContent, setStreamingContent] = useState<Record<string, string>>({})
   const [streamingSubsteps, setStreamingSubsteps] = useState<Partial<Record<AgentStepType, StreamingSubstep[]>>>({})
   const [terminalStatus, setTerminalStatus] = useState<"completed" | "failed" | null>(null)
+  // Per step type, the `at` of its last completion. A substep that resolves with
+  // an older/equal timestamp belongs to that finished instance — dropping it stops
+  // a late E2E decrypt from resurrecting a cleared step's phase timeline.
+  const closedAtByTypeRef = useRef<Map<AgentStepType, string>>(new Map())
   // Track if socket is subscribed (enables query after subscription)
   const [isSubscribed, setIsSubscribed] = useState(false)
   const [isSubscribing, setIsSubscribing] = useState(false)
@@ -138,6 +142,9 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
       // carries the canonical history, so refresh-stable rendering takes over.
       const completedType = payload.step.stepType
       if (completedType) {
+        // Watermark the completion so a late decrypt for this instance can't
+        // re-add a phase after we clear it (see `closedAtByTypeRef`).
+        closedAtByTypeRef.current.set(completedType, payload.step.completedAt ?? new Date().toISOString())
         setStreamingSubsteps((prev) => {
           if (!(completedType in prev)) return prev
           const next = { ...prev }
@@ -153,11 +160,18 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
   // step type so the trace dialog can render an inline timeline of phases for the
   // currently in-flight step. Cleared on step completion (handleStepCompleted).
   const appendSubstep = useCallback((stepType: AgentStepType, text: string, at: string) => {
+    // Drop a substep that belongs to an already-finished instance of this step
+    // type (a stale decrypt resolving after completion).
+    const closedAt = closedAtByTypeRef.current.get(stepType)
+    if (closedAt && at <= closedAt) return
     setStreamingSubsteps((prev) => {
       const list = prev[stepType] ?? []
-      // Dedupe consecutive identical substeps (the backend may emit the same phase twice on retry)
-      if (list.length > 0 && list[list.length - 1]?.text === text) return prev
-      return { ...prev, [stepType]: [...list, { text, at }] }
+      if (list.some((s) => s.text === text && s.at === at)) return prev
+      // Order by `at`, not promise-resolution order, so out-of-order decrypts land
+      // in emission order. Then dedupe consecutive identical phase text.
+      const merged = [...list, { text, at }].sort((a, b) => a.at.localeCompare(b.at))
+      const deduped = merged.filter((s, i) => i === 0 || s.text !== merged[i - 1]?.text)
+      return { ...prev, [stepType]: deduped }
     })
   }, [])
 
@@ -217,6 +231,7 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
     setRealtimeSteps(new Map())
     setStreamingContent({})
     setStreamingSubsteps({})
+    closedAtByTypeRef.current = new Map()
     setTerminalStatus(null)
     setIsSubscribed(false)
     setIsSubscribing(true)

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -4,6 +4,9 @@ import { useSocket } from "@/contexts"
 import { agentSessionsApi } from "@/api"
 import { debugBootstrap } from "@/lib/bootstrap-debug"
 import { joinRoomWithAck } from "@/lib/socket-room"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
 import type {
   AgentSessionStep,
   AgentSession,
@@ -60,6 +63,7 @@ interface UseAgentTraceResult {
  */
 export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentTraceResult {
   const socket = useSocket()
+  const userId = useWorkspaceUserId(workspaceId)
 
   // Real-time state accumulated from socket events
   const [realtimeSteps, setRealtimeSteps] = useState<Map<string, AgentSessionStep>>(new Map())
@@ -148,20 +152,41 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
   // Substep: ephemeral phase text from a long-running tool. We accumulate per
   // step type so the trace dialog can render an inline timeline of phases for the
   // currently in-flight step. Cleared on step completion (handleStepCompleted).
+  const appendSubstep = useCallback((stepType: AgentStepType, text: string, at: string) => {
+    setStreamingSubsteps((prev) => {
+      const list = prev[stepType] ?? []
+      // Dedupe consecutive identical substeps (the backend may emit the same phase twice on retry)
+      if (list.length > 0 && list[list.length - 1]?.text === text) return prev
+      return { ...prev, [stepType]: [...list, { text, at }] }
+    })
+  }, [])
+
   const handleSubstep = useCallback(
     (payload: AgentSessionSubstepPayload) => {
-      if (payload?.sessionId !== sessionId || !payload.stepType || !payload.substep) return
-      setStreamingSubsteps((prev) => {
-        const list = prev[payload.stepType] ?? []
-        // Dedupe consecutive identical substeps (the backend may emit the same phase twice on retry)
-        if (list.length > 0 && list[list.length - 1]?.text === payload.substep) return prev
-        return {
-          ...prev,
-          [payload.stepType]: [...list, { text: payload.substep, at: payload.updatedAt }],
-        }
-      })
+      if (payload?.sessionId !== sessionId || !payload.stepType) return
+      // Plaintext (non-E2E) substep.
+      if (typeof payload.substep === "string" && payload.substep) {
+        appendSubstep(payload.stepType, payload.substep, payload.updatedAt)
+        return
+      }
+      // E2E: the phase text is sealed under the stream key (it's derived from the
+      // encrypted prompt). Decrypt it the same way message/step content is, then
+      // apply. Silently skip if the session isn't unlocked.
+      if (typeof payload.ciphertext === "string" && payload.envelope) {
+        const session = getE2eSessionState(workspaceId, userId ?? "")
+        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return
+        void tryDecryptMessagePayload(
+          { contentMarkdown: "", ciphertext: payload.ciphertext, envelope: payload.envelope },
+          { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId: payload.streamId }
+        )
+          .then((decrypted) => {
+            if (decrypted?.contentMarkdown)
+              appendSubstep(payload.stepType, decrypted.contentMarkdown, payload.updatedAt)
+          })
+          .catch(() => {})
+      }
     },
-    [sessionId]
+    [sessionId, workspaceId, userId, appendSubstep]
   )
 
   const handleCompleted = useCallback(

--- a/apps/frontend/src/hooks/use-create-encrypted-scratchpad.ts
+++ b/apps/frontend/src/hooks/use-create-encrypted-scratchpad.ts
@@ -7,76 +7,54 @@ import {
   type WorkspaceBootstrap,
   type StreamWithPreview,
 } from "@threa/types"
+import { toast } from "sonner"
 import { db } from "@/db"
 import { useStreamService } from "@/contexts"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { provisionOwnerStreamKey } from "@/lib/crypto/stream-key-cache"
 import { useSyncEngine } from "@/sync/sync-engine"
+import { inviteActorToStream } from "@/hooks/use-invite-actor"
 
 export function useCreateEncryptedScratchpad(workspaceId: string, currentUserId: string | null) {
   const streamService = useStreamService()
   const queryClient = useQueryClient()
   const syncEngine = useSyncEngine()
 
-  return useCallback(async (): Promise<string> => {
-    if (!currentUserId) {
-      throw new Error("Workspace user not resolved yet — try again in a moment")
-    }
-    const session = getE2eSessionState(workspaceId, currentUserId)
-    if (session.status !== "unlocked" || !session.keyId || !session.publicKey) {
-      throw new Error("Unlock encrypted scratchpads first (Settings → Encryption)")
-    }
-    const ownerKeyId = session.keyId
-    const ownerPublicKey = session.publicKey
-    const stream = await streamService.create(workspaceId, {
-      type: StreamTypes.SCRATCHPAD,
-      e2eEnabled: true,
-      e2eOwnerKeyId: ownerKeyId,
-    })
-
-    // Two-phase E2E setup: the stream id is minted server-side, and the SSK
-    // wrap's AAD binds to that id — so we provision the generation-0 SSK only
-    // once the id is known. INV-E1: no plaintext can be written before this
-    // lands — the send path refuses to seal until it can resolve the SSK. If
-    // this throws (e.g. the wrap store fails) the stream is left with zero
-    // wraps; rather than tear it down, the locked-state repair affordance
-    // re-runs the same provisioning path to finish setup.
-    await provisionOwnerStreamKey({ workspaceId, streamId: stream.id, ownerKeyId, ownerPublicKey })
-
-    // Mirror useCreateStream: subscribe immediately so creator gets stream-level
-    // realtime before the workspace socket echo or next bootstrap catches up.
-    void syncEngine.subscribeStream(stream.id)
-
-    const membership: StreamMember = {
-      streamId: stream.id,
-      memberId: stream.createdBy,
-      pinned: false,
-      pinnedAt: null,
-      notificationLevel: null,
-      lastReadEventId: null,
-      lastReadAt: null,
-      joinedAt: stream.createdAt,
-    }
-
-    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-      if (!old) return old
-      const exists = old.streams?.some((s: Stream) => s.id === stream.id)
-      if (exists) return old
-      const withPreview: StreamWithPreview = { ...stream, lastMessagePreview: null }
-      return {
-        ...old,
-        streams: [...(old.streams ?? []), withPreview],
-        streamMemberships: [...(old.streamMemberships ?? []), membership],
+  // E2E scratchpads default to having Ariadne (the enclave actor) invited so
+  // they get AI replies out of the box; the no-AI "encrypted quick note" path
+  // passes `withAriadne: false`.
+  return useCallback(
+    async (withAriadne: boolean = true): Promise<string> => {
+      if (!currentUserId) {
+        throw new Error("Workspace user not resolved yet — try again in a moment")
       }
-    })
+      const session = getE2eSessionState(workspaceId, currentUserId)
+      if (session.status !== "unlocked" || !session.keyId || !session.publicKey) {
+        throw new Error("Unlock encrypted scratchpads first (Settings → Encryption)")
+      }
+      const ownerKeyId = session.keyId
+      const ownerPublicKey = session.publicKey
+      const stream = await streamService.create(workspaceId, {
+        type: StreamTypes.SCRATCHPAD,
+        e2eEnabled: true,
+        e2eOwnerKeyId: ownerKeyId,
+      })
 
-    const now = Date.now()
-    await Promise.all([
-      db.streams.put({ ...stream, lastMessagePreview: null, _cachedAt: now }),
-      db.streamMemberships.put({
-        id: `${workspaceId}:${stream.id}`,
-        workspaceId,
+      // Two-phase E2E setup: the stream id is minted server-side, and the SSK
+      // wrap's AAD binds to that id — so we provision the generation-0 SSK only
+      // once the id is known. INV-E1: no plaintext can be written before this
+      // lands — the send path refuses to seal until it can resolve the SSK. If
+      // this throws (e.g. the wrap store fails) the stream is left with zero
+      // wraps; rather than tear it down, the locked-state repair affordance
+      // re-runs the same provisioning path to finish setup.
+      await provisionOwnerStreamKey({ workspaceId, streamId: stream.id, ownerKeyId, ownerPublicKey })
+
+      // Mirror useCreateStream: subscribe immediately so creator gets stream-level
+      // realtime before the workspace socket echo or next bootstrap catches up.
+      void syncEngine.subscribeStream(stream.id)
+
+      const membership: StreamMember = {
         streamId: stream.id,
         memberId: stream.createdBy,
         pinned: false,
@@ -85,10 +63,59 @@ export function useCreateEncryptedScratchpad(workspaceId: string, currentUserId:
         lastReadEventId: null,
         lastReadAt: null,
         joinedAt: stream.createdAt,
-        _cachedAt: now,
-      }),
-    ])
+      }
 
-    return stream.id
-  }, [workspaceId, currentUserId, streamService, queryClient, syncEngine])
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+        if (!old) return old
+        const exists = old.streams?.some((s: Stream) => s.id === stream.id)
+        if (exists) return old
+        const withPreview: StreamWithPreview = { ...stream, lastMessagePreview: null }
+        return {
+          ...old,
+          streams: [...(old.streams ?? []), withPreview],
+          streamMemberships: [...(old.streamMemberships ?? []), membership],
+        }
+      })
+
+      const now = Date.now()
+      await Promise.all([
+        db.streams.put({ ...stream, lastMessagePreview: null, _cachedAt: now }),
+        db.streamMemberships.put({
+          id: `${workspaceId}:${stream.id}`,
+          workspaceId,
+          streamId: stream.id,
+          memberId: stream.createdBy,
+          pinned: false,
+          pinnedAt: null,
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: stream.createdAt,
+          _cachedAt: now,
+        }),
+      ])
+
+      // Primary path: invite Ariadne (the enclave actor) so encrypted scratchpads
+      // get AI replies by default. Best-effort — the scratchpad already exists and
+      // is usable; surface a non-fatal toast if the invite/wrap fails so the user
+      // can re-invite via the in-stream affordance.
+      if (withAriadne) {
+        try {
+          await inviteActorToStream({
+            workspaceId,
+            streamId: stream.id,
+            kind: "enclave",
+            queryClient,
+            owner: { keyId: ownerKeyId, publicKey: ownerPublicKey },
+          })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Couldn't enable Ariadne for this scratchpad"
+          toast.error(message)
+        }
+      }
+
+      return stream.id
+    },
+    [workspaceId, currentUserId, streamService, queryClient, syncEngine]
+  )
 }

--- a/apps/frontend/src/hooks/use-invite-actor.ts
+++ b/apps/frontend/src/hooks/use-invite-actor.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { useQueryClient } from "@tanstack/react-query"
+import { useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { StreamTypes, type E2eActorKind, type WorkspaceBootstrap } from "@threa/types"
 import { e2eActorsApi } from "@/api/e2e-actors"
@@ -36,6 +36,64 @@ export function isActorInvited(
   return stream?.e2eActors?.some((a) => a.kind === kind) ?? false
 }
 
+/**
+ * Invite an actor into a server-side E2E scratchpad and wrap the rolled SSK to
+ * the new recipient set. Shared by the manual invite affordance
+ * (`useInviteActor`) and the create-with-Ariadne path, so both go through one
+ * code path (no drift). Returns `"wrapped"` when the SSK was rolled + wrapped,
+ * or `"invited-unwrapped"` when the actor was recorded but no owner credentials
+ * were available to wrap (the re-key happens later via the repair affordance).
+ */
+export async function inviteActorToStream(params: {
+  workspaceId: string
+  streamId: string
+  kind: E2eActorKind
+  actorId?: string
+  queryClient: QueryClient
+  /** Unlocked owner credentials for the SSK rewrap; null skips the wrap. */
+  owner: { keyId: string; publicKey: Uint8Array } | null
+}): Promise<"wrapped" | "invited-unwrapped"> {
+  const { workspaceId, streamId, kind, actorId, queryClient, owner } = params
+  const { stream, keyRoll } = await e2eActorsApi.invite(workspaceId, streamId, kind, actorId)
+
+  // Reactive source of truth for the open stream is the IDB row
+  // (useWorkspaceStreams → useLiveQuery), so update it surgically.
+  await db.streams.update(streamId, { e2eActors: stream.e2eActors })
+
+  queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
+    if (!old || typeof old !== "object") return old
+    return { ...old, stream }
+  })
+
+  queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+    if (!old) return old
+    return {
+      ...old,
+      streams: old.streams.map((s) =>
+        s.id === streamId ? { ...s, ...stream, lastMessagePreview: s.lastMessagePreview } : s
+      ),
+    }
+  })
+
+  // The actor is recorded; now roll the SSK forward and wrap it to the new
+  // recipient set so the agent can actually decrypt. `keyRoll` is null when the
+  // actor has no live key yet — nothing to wrap to, so the invite stands and a
+  // re-key happens once a key exists.
+  if (keyRoll) {
+    if (!owner) return "invited-unwrapped"
+    await rekeyStream({
+      workspaceId,
+      streamId,
+      nextGeneration: keyRoll.nextGeneration,
+      ownerKeyId: owner.keyId,
+      ownerPublicKey: owner.publicKey,
+      actorRecipients: keyRoll.recipients,
+    })
+  }
+
+  return "wrapped"
+}
+
 export function useInviteActor(workspaceId: string, streamId: string) {
   const queryClient = useQueryClient()
   const userId = useWorkspaceUserId(workspaceId)
@@ -46,48 +104,16 @@ export function useInviteActor(workspaceId: string, streamId: string) {
     async (kind: E2eActorKind, actorId?: string) => {
       setIsInviting(true)
       try {
-        const { stream, keyRoll } = await e2eActorsApi.invite(workspaceId, streamId, kind, actorId)
-
-        // Reactive source of truth for the open stream is the IDB row
-        // (useWorkspaceStreams → useLiveQuery), so update it surgically.
-        await db.streams.update(streamId, { e2eActors: stream.e2eActors })
-
-        queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
-          if (!old || typeof old !== "object") return old
-          return { ...old, stream }
-        })
-
-        queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            streams: old.streams.map((s) =>
-              s.id === streamId ? { ...s, ...stream, lastMessagePreview: s.lastMessagePreview } : s
-            ),
-          }
-        })
-
-        // The actor is recorded; now roll the SSK forward and wrap it to the
-        // new recipient set so the agent can actually decrypt. The roll needs
-        // the owner's unlocked UIK (it mints + wraps a fresh key client-side).
-        // `keyRoll` is null when the actor has no live key yet — nothing to
-        // wrap to, so the invite stands and a re-key happens once a key exists.
-        if (keyRoll) {
-          if (session.status !== "unlocked" || !session.keyId || !session.publicKey) {
-            toast.success(`${E2E_ACTOR_LABELS[kind]} invited — unlock this scratchpad's encryption to grant it access.`)
-            return
-          }
-          await rekeyStream({
-            workspaceId,
-            streamId,
-            nextGeneration: keyRoll.nextGeneration,
-            ownerKeyId: session.keyId,
-            ownerPublicKey: session.publicKey,
-            actorRecipients: keyRoll.recipients,
-          })
+        const owner =
+          session.status === "unlocked" && session.keyId && session.publicKey
+            ? { keyId: session.keyId, publicKey: session.publicKey }
+            : null
+        const result = await inviteActorToStream({ workspaceId, streamId, kind, actorId, queryClient, owner })
+        if (result === "invited-unwrapped") {
+          toast.success(`${E2E_ACTOR_LABELS[kind]} invited — unlock this scratchpad's encryption to grant it access.`)
+        } else {
+          toast.success(`${E2E_ACTOR_LABELS[kind]} invited to this scratchpad`)
         }
-
-        toast.success(`${E2E_ACTOR_LABELS[kind]} invited to this scratchpad`)
       } catch (err) {
         const message = err instanceof Error ? err.message : `Failed to invite ${E2E_ACTOR_LABELS[kind]}`
         toast.error(message)

--- a/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { clearDecryptCache, getCachedDecryption, requestDecryption, subscribeToDecryption } from "../decrypt-cache"
+import {
+  clearDecryptCache,
+  getCachedDecryption,
+  requestDecryption,
+  seedDecryption,
+  subscribeToDecryption,
+} from "../decrypt-cache"
 import * as messageEnvelope from "../message-envelope"
 
 const STUB_OPTS = {
@@ -102,6 +108,36 @@ describe("decrypt-cache", () => {
     resolveDecrypt({ contentMarkdown: "secret", contentJson: { type: "doc", content: [] } })
     await pending
     expect(getCachedDecryption("evt_race")).toBeUndefined()
+  })
+
+  it("seeds known plaintext as decrypted and skips a later decrypt", async () => {
+    const decrypt = stubDecrypt({ contentMarkdown: "from-crypto", contentJson: { type: "doc", content: [] } })
+    seedDecryption("evt_seed", { contentMarkdown: "from-sender", contentJson: { type: "doc", content: [] } })
+
+    const cached = getCachedDecryption("evt_seed")
+    expect(cached?.status).toBe("decrypted")
+    expect(cached?.content?.contentMarkdown).toBe("from-sender")
+
+    // A render-time request for the same event must short-circuit on the seed.
+    await requestDecryption("evt_seed", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    expect(decrypt).not.toHaveBeenCalled()
+  })
+
+  it("notifies subscribers when a seed lands", () => {
+    const listener = vi.fn()
+    subscribeToDecryption("evt_seed_sub", listener)
+    seedDecryption("evt_seed_sub", { contentMarkdown: "x", contentJson: { type: "doc", content: [] } })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not overwrite an existing decrypted entry when seeding", async () => {
+    stubDecrypt({ contentMarkdown: "real", contentJson: { type: "doc", content: [] } })
+    await requestDecryption("evt_decrypted", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
+    seedDecryption("evt_decrypted", {
+      contentMarkdown: "should-not-replace",
+      contentJson: { type: "doc", content: [] },
+    })
+    expect(getCachedDecryption("evt_decrypted")?.content?.contentMarkdown).toBe("real")
   })
 
   it("evicts the least recently used entry when the cache exceeds its cap", async () => {

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -107,6 +107,22 @@ export function requestDecryption(
   return promise
 }
 
+/**
+ * Seed the cache with already-known plaintext for an event id, marking it
+ * decrypted without running crypto. Used on send reconciliation: the sender
+ * already holds the plaintext it just encrypted, so the incoming server event —
+ * which carries only ciphertext — can render its content immediately instead of
+ * flashing a "decrypting" placeholder as the optimistic row is swapped for the
+ * sent row. No-op if the event already has a decrypted entry.
+ */
+export function seedDecryption(eventId: string, content: DecryptedMessageContent): void {
+  const existing = entries.get(eventId)
+  if (existing && existing.status === "decrypted") return
+  touch(eventId, { status: "decrypted", content })
+  inflight.delete(eventId)
+  emit(eventId)
+}
+
 export function clearDecryptCache(): void {
   generation++
   const ids = Array.from(entries.keys())

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -11,6 +11,7 @@ import {
   type CachedStreamBootstrap,
 } from "./stream-sync"
 import { streamKeys } from "@/hooks/use-streams"
+import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { BotRuntimePresenceSummary, StreamBootstrap, StreamEvent } from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
@@ -950,6 +951,153 @@ describe("registerStreamSocketHandlers — bot_runtime:presence cache patching",
 
     const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
     expect(after).toBe(before)
+
+    cleanup()
+  })
+})
+
+describe("registerStreamSocketHandlers — E2E send reconciliation seeds the decrypt cache", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+    clearDecryptCache()
+  })
+
+  it("seeds the server event id with the optimistic plaintext so it renders decrypted on arrival", async () => {
+    const streamId = "stream_e2e_echo"
+    const plaintextJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "secret" }] }] }
+
+    // Optimistic (self-sent) event holds the plaintext we just encrypted.
+    await db.events.put({
+      id: "temp_1",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      eventType: "message_created",
+      payload: { messageId: "temp_1", contentMarkdown: "secret", contentJson: plaintextJson },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+    await db.pendingMessages.add({
+      clientId: "temp_1",
+      workspaceId: "ws_1",
+      streamId,
+      content: "secret",
+      contentFormat: "markdown",
+      createdAt: Date.now(),
+      retryCount: 0,
+    })
+
+    const { socket, emit } = createTestSocket()
+    const queryClient = new QueryClient()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    // Server echoes the message back as ciphertext + envelope, with clientMessageId.
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: "evt_server",
+        streamId,
+        sequence: "1000",
+        eventType: "message_created",
+        payload: {
+          messageId: "evt_server",
+          clientMessageId: "temp_1",
+          contentMarkdown: "🔒 Encrypted",
+          contentJson: null,
+          ciphertext: "base64ciphertext",
+          envelope: { v: 2 },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    // Optimistic row swapped for the server row, and the decrypt cache is
+    // pre-seeded so the encrypted server event never flashes "decrypting".
+    expect(await db.events.get("temp_1")).toBeUndefined()
+    expect(await db.events.get("evt_server")).toBeDefined()
+    const cached = getCachedDecryption("evt_server")
+    expect(cached?.status).toBe("decrypted")
+    expect(cached?.content?.contentMarkdown).toBe("secret")
+    expect(cached?.content?.contentJson).toEqual(plaintextJson)
+
+    cleanup()
+  })
+
+  it("does not seed when the server event is plaintext (non-E2E)", async () => {
+    const streamId = "stream_plain_echo"
+
+    await db.events.put({
+      id: "temp_2",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      eventType: "message_created",
+      payload: { messageId: "temp_2", contentMarkdown: "hi", contentJson: { type: "doc", content: [] } },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const queryClient = new QueryClient()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: "evt_plain",
+        streamId,
+        sequence: "1000",
+        eventType: "message_created",
+        payload: {
+          messageId: "evt_plain",
+          clientMessageId: "temp_2",
+          contentMarkdown: "hi",
+          contentJson: { type: "doc", content: [] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    // Plaintext events render straight from their payload; the cache stays empty.
+    expect(getCachedDecryption("evt_plain")).toBeUndefined()
 
     cleanup()
   })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -9,7 +9,9 @@ import {
   type ThreadSummary,
   type WorkspaceBootstrap,
   type BotRuntimePresenceSummary,
+  type JSONContent,
 } from "@threa/types"
+import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { Socket } from "socket.io-client"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
@@ -477,6 +479,19 @@ function contentHasSharedMessage(contentJson: unknown): boolean {
   return false
 }
 
+/** Plaintext content carried by an optimistic (self-sent) event payload, if present. */
+function readPlaintextContent(payload: unknown): { contentMarkdown: string; contentJson: JSONContent } | null {
+  const p = payload as { contentMarkdown?: unknown; contentJson?: unknown } | undefined
+  if (!p || typeof p.contentMarkdown !== "string" || !p.contentJson) return null
+  return { contentMarkdown: p.contentMarkdown, contentJson: p.contentJson as JSONContent }
+}
+
+/** Whether a server event payload is E2E-sealed (ciphertext + envelope on the wire). */
+function isEncryptedPayload(payload: unknown): boolean {
+  const p = payload as { ciphertext?: unknown; envelope?: unknown } | undefined
+  return !!p && typeof p.ciphertext === "string" && !!p.envelope
+}
+
 export function registerStreamSocketHandlers(
   socket: Socket,
   workspaceId: string,
@@ -498,6 +513,12 @@ export function registerStreamSocketHandlers(
     }
     const now = Date.now()
 
+    // When this is the echo of a message we sent, the optimistic row still holds
+    // the plaintext we just encrypted. Capture it so we can seed the decrypt
+    // cache for the server event id below — otherwise the encrypted server event
+    // would flash "decrypting" as the optimistic row is swapped for the sent row.
+    let optimisticPlaintext: { contentMarkdown: string; contentJson: JSONContent } | null = null
+
     await db.transaction("rw", [db.events, db.pendingMessages], async () => {
       // Dedupe by event ID
       const existing = await db.events.get(newEvent.id)
@@ -509,10 +530,19 @@ export function registerStreamSocketHandlers(
 
       // Now remove the optimistic event, keyed by the client id the server echoes back.
       if (newPayload.clientMessageId) {
+        const optimistic = await db.events.get(newPayload.clientMessageId)
+        optimisticPlaintext = readPlaintextContent(optimistic?.payload)
         await db.events.delete(newPayload.clientMessageId).catch(() => {})
         await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
       }
     })
+
+    // Seed the decrypt cache so the encrypted server event renders its content
+    // immediately. Only meaningful for E2E events (the wire payload carries a
+    // ciphertext); for plaintext sends the render path ignores the cache.
+    if (optimisticPlaintext && isEncryptedPayload(newEvent.payload)) {
+      seedDecryption(newEvent.id, optimisticPlaintext)
+    }
 
     // Update sidebar preview in both TanStack cache and IDB so the sort order
     // and preview text survive cold starts (offline-first).

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./runtime": "./src/runtime/enclave-runtime.ts",
+    "./logger": "./src/logger.ts",
     "./test-otel-setup": "./src/runtime/test-otel-setup.ts"
   },
   "scripts": {

--- a/packages/agent-runtime/src/logger.ts
+++ b/packages/agent-runtime/src/logger.ts
@@ -20,10 +20,15 @@ const baseOptions = {
 // which spawns a worker thread that resolves the target module ("pino-pretty")
 // from disk at runtime. The enclave ships as a single-file bundle with no
 // node_modules for that worker to resolve, so the transport throws at
-// construction there. A synchronous stream is bundled inline, so the SAME logger
-// runs identically from source (the regional backend) and inside the enclave
-// bundle — keeping their dev output aligned. Production stays plain JSON on
-// stdout (no pretty) for log aggregation.
+// construction there. A synchronous stream is bundled inline, so this logger
+// works identically run from source and inside the enclave bundle.
+//
+// The enclave routes its module loggers through this (the `./logger` subpath),
+// using the same pino-pretty options the regional backend's logger
+// (`@threa/backend-common`) uses — colorized, `HH:MM:ss`, pid/hostname ignored —
+// so the two render the same way in dev. Production stays plain JSON on stdout
+// (no pretty) for log aggregation. (The backend keeps its own logger because the
+// enclave can't import backend-common; both share these options by convention.)
 export const logger = (() => {
   if (!testLogFile) {
     return isProduction ? pino(baseOptions) : pino(baseOptions, pretty(prettyOptions))

--- a/packages/agent-runtime/src/logger.ts
+++ b/packages/agent-runtime/src/logger.ts
@@ -1,14 +1,12 @@
 import pino from "pino"
+import pretty from "pino-pretty"
 
 const isProduction = process.env.NODE_ENV === "production"
 const testLogFile = process.env.THREA_TEST_LOG_FILE
-const prettyTransport = {
-  target: "pino-pretty",
-  options: {
-    colorize: true,
-    translateTime: "HH:MM:ss",
-    ignore: "pid,hostname",
-  },
+const prettyOptions = {
+  colorize: true,
+  translateTime: "HH:MM:ss",
+  ignore: "pid,hostname",
 }
 
 const baseOptions = {
@@ -18,27 +16,20 @@ const baseOptions = {
   },
 }
 
-// pino-pretty runs as a worker thread that resolves its target module from
-// disk. The enclave ships as a single-file bundle with no node_modules, so the
-// transport can't be resolved there and pino throws at construction. Build it
-// behind a guard and fall back to plain JSON on stdout when it isn't available,
-// so the same code runs both from source (backend) and bundled (enclave).
-function tryPrettyStream(): pino.DestinationStream | undefined {
-  try {
-    return pino.transport(prettyTransport)
-  } catch {
-    return undefined
-  }
-}
-
+// pino-pretty as a directly-imported, *synchronous* stream — NOT `pino.transport`,
+// which spawns a worker thread that resolves the target module ("pino-pretty")
+// from disk at runtime. The enclave ships as a single-file bundle with no
+// node_modules for that worker to resolve, so the transport throws at
+// construction there. A synchronous stream is bundled inline, so the SAME logger
+// runs identically from source (the regional backend) and inside the enclave
+// bundle — keeping their dev output aligned. Production stays plain JSON on
+// stdout (no pretty) for log aggregation.
 export const logger = (() => {
   if (!testLogFile) {
-    if (isProduction) return pino(baseOptions)
-    const pretty = tryPrettyStream()
-    return pretty ? pino(baseOptions, pretty) : pino(baseOptions)
+    return isProduction ? pino(baseOptions) : pino(baseOptions, pretty(prettyOptions))
   }
 
-  const primaryStream = isProduction ? process.stdout : (tryPrettyStream() ?? process.stdout)
+  const primaryStream = isProduction ? process.stdout : pretty(prettyOptions)
   const fileStream = pino.destination({
     dest: testLogFile,
     mkdir: true,

--- a/packages/agent-runtime/src/logger.ts
+++ b/packages/agent-runtime/src/logger.ts
@@ -18,15 +18,27 @@ const baseOptions = {
   },
 }
 
+// pino-pretty runs as a worker thread that resolves its target module from
+// disk. The enclave ships as a single-file bundle with no node_modules, so the
+// transport can't be resolved there and pino throws at construction. Build it
+// behind a guard and fall back to plain JSON on stdout when it isn't available,
+// so the same code runs both from source (backend) and bundled (enclave).
+function tryPrettyStream(): pino.DestinationStream | undefined {
+  try {
+    return pino.transport(prettyTransport)
+  } catch {
+    return undefined
+  }
+}
+
 export const logger = (() => {
   if (!testLogFile) {
-    return pino({
-      ...baseOptions,
-      transport: isProduction ? undefined : prettyTransport,
-    })
+    if (isProduction) return pino(baseOptions)
+    const pretty = tryPrettyStream()
+    return pretty ? pino(baseOptions, pretty) : pino(baseOptions)
   }
 
-  const primaryStream = isProduction ? process.stdout : pino.transport(prettyTransport)
+  const primaryStream = isProduction ? process.stdout : (tryPrettyStream() ?? process.stdout)
   const fileStream = pino.destination({
     dest: testLogFile,
     mkdir: true,

--- a/packages/agent-runtime/src/research/config.ts
+++ b/packages/agent-runtime/src/research/config.ts
@@ -17,12 +17,14 @@ export const GENERAL_RESEARCH_MODEL_ID = "openrouter:anthropic/claude-sonnet-4.6
 export const GENERAL_RESEARCH_TEMPERATURE = 0.3
 
 /**
- * Hard cap on agent-loop iterations. Each iteration is one model turn that may
- * issue several tool calls, so six turns is plenty for a focused investigation
- * while keeping worst-case cost bounded. The wall-clock budget below is the real
- * limiter and usually bites first.
+ * Soft cap on agent-loop iterations. Each iteration is one model turn that may
+ * issue several tool calls. The wall-clock budget below is the real limiter and
+ * usually bites first; this is the cost backstop. Hitting it degrades to partial
+ * findings (not a failure — see `allowNoMessageOutput` in general-researcher),
+ * so it can be generous: a focused investigation often needs more than a couple
+ * of search→read→synthesise rounds.
  */
-export const GENERAL_RESEARCH_MAX_ITERATIONS = 6
+export const GENERAL_RESEARCH_MAX_ITERATIONS = 12
 
 /**
  * Hard wall-clock budget for a single general_research run in milliseconds. When

--- a/packages/agent-runtime/src/research/general-researcher.ts
+++ b/packages/agent-runtime/src/research/general-researcher.ts
@@ -36,7 +36,7 @@ export interface GeneralResearchResult {
    * redundant field.
    */
   partial?: boolean
-  partialReason?: "user_abort" | "timeout"
+  partialReason?: "user_abort" | "timeout" | "max_iterations"
 }
 
 /**
@@ -132,6 +132,11 @@ export async function runGeneralResearch(
     tools: input.tools,
     temperature: deps.temperature ?? GENERAL_RESEARCH_TEMPERATURE,
     maxIterations: deps.maxIterations ?? GENERAL_RESEARCH_MAX_ITERATIONS,
+    // Running out of iterations is a degrade-to-partial outcome, not a failure:
+    // return whatever the loop gathered (handled as `partial` below) instead of
+    // throwing "completed without sending a message" and surfacing the whole
+    // research call as failed. The wall-clock deadline already bounds runtime.
+    allowNoMessageOutput: true,
     costContext: input.costContext,
     telemetry: deps.telemetry,
     observers: [observer],
@@ -155,9 +160,11 @@ export async function runGeneralResearch(
     // call — the canonical citation list. Just cap it.
     const sources = result.sources.slice(0, MAX_RESULT_SOURCES)
     if (!brief) {
-      // Loop finished without producing a brief (rare). Treat as partial so the
-      // caller acknowledges incomplete research rather than asserting an answer.
-      return { brief: "", sources, substeps, partial: true, partialReason: "timeout" }
+      // Loop returned without a brief — it ran out of iterations before
+      // synthesising (allowNoMessageOutput makes that a graceful return, not a
+      // throw). Treat as partial so the caller acknowledges incomplete research
+      // and leans on the gathered sources rather than asserting an answer.
+      return { brief: "", sources, substeps, partial: true, partialReason: "max_iterations" }
     }
     return { brief, sources, substeps }
   } catch (err) {

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -179,8 +179,17 @@ export interface AgentSessionSubstepPayload {
   triggerMessageId: string
   /** The step type this substep belongs to (e.g. "workspace_search"). */
   stepType: AgentStepType
-  /** Human-readable phase text — e.g. "Planning queries…", "Evaluating results…". */
-  substep: string
+  /**
+   * Human-readable phase text — e.g. "Planning queries…", "Evaluating results…".
+   * Present for plaintext (non-E2E) sessions. For E2E sessions the text is sealed
+   * (derived from encrypted content), so it ships as `ciphertext`/`envelope`
+   * instead and the client decrypts it.
+   */
+  substep?: string
+  /** E2E: sealed phase text — base64 ciphertext the client decrypts under the SSK. */
+  ciphertext?: string
+  /** E2E: stream envelope for `ciphertext` (HPKE/SSK metadata). */
+  envelope?: unknown
   /** ISO timestamp for ordering when multiple substeps arrive rapidly. */
   updatedAt: string
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -475,6 +475,20 @@ export interface EnclaveSealedStep {
 }
 
 /**
+ * One sealed *substep* — the ephemeral mid-run phase text a tool emits (e.g. the
+ * research sub-agent's "Searching the web: …" / "Reading …"). Because that text
+ * is derived from the user's encrypted prompt it is sealed under the SSK exactly
+ * like a step; the backend relays the ciphertext and the owner's browser
+ * decrypts it. Never persisted — it drives the live "Ariadne is …" indicator.
+ */
+export interface EnclaveSealedSubstep {
+  /** The step type this substep belongs to (clear metadata, same as steps). */
+  stepType: AgentStepType
+  ciphertext: string
+  envelope: EnclaveStreamEnvelope
+}
+
+/**
  * The work the backend assigns to a live enclave via `POST /sessions`. The
  * backend never decrypts: it ships ciphertext + the wraps addressed to that EIK
  * plus the `sessionId` it created the `agent_sessions` row under. The enclave

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -504,8 +504,24 @@ export interface EnclaveSealedStepStart {
 export interface EnclaveSealedSubstep {
   /** The step type this substep belongs to (clear metadata, same as steps). */
   stepType: AgentStepType
+  /** The single new phase text, sealed — drives the live "Ariadne is …" indicator (ephemeral). */
   ciphertext: string
   envelope: EnclaveStreamEnvelope
+  /**
+   * The in-flight step this substep belongs to. Present once the step has been
+   * opened (tool:start); lets the backend persist the running snapshot onto that
+   * row so a refresh / opening the trace mid-run replays the phases so far —
+   * mirroring the unencrypted `ActiveStep.updateSubsteps`.
+   */
+  stepId?: string
+  /**
+   * The running `{ substeps: [{ text, at }] }` snapshot, sealed as a JSON string
+   * exactly like a step's content. Persisted (not just broadcast) onto the step
+   * row so the trace recovers the full phase timeline on refresh; the owner's
+   * browser decrypts it the same way it decrypts step content (INV-E7).
+   */
+  snapshotCiphertext?: string
+  snapshotEnvelope?: EnclaveStreamEnvelope
 }
 
 /**

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -475,6 +475,26 @@ export interface EnclaveSealedStep {
 }
 
 /**
+ * One sealed trace step *start* — emitted the moment the agent loop opens a step
+ * (the LLM's reasoning, a tool call, a reply), mirroring the unencrypted runtime's
+ * `tool:start`/`startStep`. It lets an open trace dialog render the in-flight step
+ * (and hang its live substeps under it) before completion, exactly as it does for
+ * non-E2E personas. `stepType` + `stepId` travel in clear; content is sealed under
+ * the reply SSK when it's already known (reasoning/reply text) and absent for tools
+ * whose result isn't known yet. A matching `EnclaveSealedStep` finalizes the same
+ * `stepId` in place when the step completes.
+ */
+export interface EnclaveSealedStepStart {
+  stepId: string
+  stepType: AgentStepType
+  /** For message_sent steps: the reply id this step describes (clear, same as the finalize). */
+  messageId?: string
+  /** Sealed content when known at start (reasoning/reply); absent for tools (no result yet). */
+  ciphertext?: string
+  envelope?: EnclaveStreamEnvelope
+}
+
+/**
  * One sealed *substep* — the ephemeral mid-run phase text a tool emits (e.g. the
  * research sub-agent's "Searching the web: …" / "Reading …"). Because that text
  * is derived from the user's encrypted prompt it is sealed under the SSK exactly

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -546,6 +546,15 @@ export interface EnclaveSessionAssignment {
   maxTokens?: number
   reply: { keyGeneration: number; senderId: string }
   /**
+   * Non-secret metadata about the triggering message, so the enclave can emit the
+   * same "Triggered by" CONTEXT trace step the in-process orchestration layer does
+   * (`persona-agent` → CONTEXT_RECEIVED). The step's *content* is the message body
+   * — the decrypted prompt — which the enclave seals under the SSK like any step;
+   * only this id/author/time metadata travels in the clear. Omitted → no context
+   * step (e.g. a turn with no resolvable trigger author).
+   */
+  trigger?: { messageId: string; authorName: string; authorType: AuthorType; createdAt: string }
+  /**
    * Per-stream tool-privacy policy: the tool categories the enclave may use this
    * turn. Omitted means no restriction (today's behavior). Present (even `[]`)
    * restricts the agent to exactly those categories — the enclave currently only

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -352,6 +352,7 @@ export type {
   EnclaveSskWrap,
   EnclaveSealedReply,
   EnclaveSealedStep,
+  EnclaveSealedStepStart,
   EnclaveSealedSubstep,
   EnclaveSessionAssignment,
   EnclaveSessionResult,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -352,6 +352,7 @@ export type {
   EnclaveSskWrap,
   EnclaveSealedReply,
   EnclaveSealedStep,
+  EnclaveSealedSubstep,
   EnclaveSessionAssignment,
   EnclaveSessionResult,
   UpdateStreamInput,

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -304,7 +304,7 @@ async function main() {
     await ensureMinioBucket()
   }
 
-  console.log("Starting control-plane, workspace-router, backend and frontend...")
+  console.log("Starting control-plane, workspace-router, backend, enclave and frontend...")
 
   // Load .env files (worktree-specific DATABASE_URL, etc.)
   const backendEnvPath = path.join(process.cwd(), "apps/backend/.env")
@@ -314,6 +314,11 @@ async function main() {
 
   const dbBase = backendEnv.DATABASE_URL ?? process.env.DATABASE_URL ?? "postgresql://threa:threa@localhost:5454/threa"
   const useStubAuth = backendEnv.USE_STUB_AUTH ?? process.env.USE_STUB_AUTH ?? "false"
+
+  // Shared internal secret. The backend mounts /internal/enclave-runtimes/* only
+  // when this is set, and the enclave must present the same value — so they
+  // resolve from one source to avoid drift.
+  const internalApiKey = backendEnv.INTERNAL_API_KEY ?? "dev-internal-key"
 
   // Derive control-plane DB URL from the backend's DATABASE_URL by appending _cp
   const cpDbUrl = dbBase.replace(/\/([^/?]+)(\?.*)?$/, "/$1_cp$2")
@@ -398,7 +403,7 @@ async function main() {
       DATABASE_URL: dbBase,
       USE_STUB_AUTH: useStubAuth,
       CONTROL_PLANE_URL: "http://localhost:3003",
-      INTERNAL_API_KEY: backendEnv.INTERNAL_API_KEY ?? "dev-internal-key",
+      INTERNAL_API_KEY: internalApiKey,
       CORS_ALLOWED_ORIGINS: corsOrigins.join(","),
       REGION: "local",
     },
@@ -428,6 +433,37 @@ async function main() {
     stderr: "inherit",
   })
 
+  // Enclave (Ariadne E2E). It runs on Node, not Bun — Bun 1.3.x's WebCrypto
+  // lacks X25519 `deriveBits`, which the enclave needs to unwrap the per-stream
+  // key. Bun only bundles it. Build once up front so `node --watch` has a file
+  // to load, then run a rebuild-watcher beside the Node process. It registers
+  // with the backend at :3002 (not the :3001 router) using the shared key.
+  const enclaveDir = path.join(process.cwd(), "apps/enclave")
+  console.log("Building enclave bundle...")
+  await $`bun build src/index.ts --target=node --format=esm --outfile dist/index.mjs`.cwd(enclaveDir).quiet()
+
+  const enclaveBuilder = Bun.spawn(
+    ["bun", "build", "src/index.ts", "--target=node", "--format=esm", "--outfile", "dist/index.mjs", "--watch"],
+    {
+      cwd: enclaveDir,
+      stdout: "inherit",
+      stderr: "inherit",
+    }
+  )
+
+  const enclave = Bun.spawn(["node", "--watch", "dist/index.mjs"], {
+    cwd: enclaveDir,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: {
+      ...process.env,
+      PORT: "3011",
+      ENCLAVE_SELF_URL: "http://localhost:3011",
+      BACKEND_BASE_URL: "http://localhost:3002",
+      INTERNAL_API_KEY: internalApiKey,
+    },
+  })
+
   // Track if we're shutting down to avoid double-kill
   let isShuttingDown = false
 
@@ -444,6 +480,8 @@ async function main() {
     backofficeRouter.kill("SIGKILL")
     frontend.kill("SIGKILL")
     backoffice.kill("SIGKILL")
+    enclaveBuilder.kill("SIGKILL")
+    enclave.kill("SIGKILL")
 
     // Wait for processes to fully terminate
     await Promise.all([
@@ -453,6 +491,8 @@ async function main() {
       backofficeRouter.exited,
       frontend.exited,
       backoffice.exited,
+      enclaveBuilder.exited,
+      enclave.exited,
     ])
     process.exit(0)
   }
@@ -467,6 +507,8 @@ async function main() {
     backofficeRouter.exited,
     frontend.exited,
     backoffice.exited,
+    enclaveBuilder.exited,
+    enclave.exited,
   ])
 }
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -461,6 +461,10 @@ async function main() {
       ENCLAVE_SELF_URL: "http://localhost:3011",
       BACKEND_BASE_URL: "http://localhost:3002",
       INTERNAL_API_KEY: internalApiKey,
+      // Dev only: persist the EIK across `node --watch` restarts so a code
+      // change doesn't mint a fresh key and silently break every E2E stream's
+      // wraps. Prod never sets this — the key stays ephemeral.
+      ENCLAVE_KEY_PERSIST_PATH: path.join(enclaveDir, ".enclave-key.dev.json"),
     },
   })
 


### PR DESCRIPTION
## Problem

Ariadne couldn't actually run inside the E2E-encryption enclave end to end. The enclave existed but wasn't wired into dev; encrypted scratchpads didn't default Ariadne on and showed false "unavailable" copy; enclave turns never surfaced in the stream view; the live trace showed nothing; the enclave ran a **stripped** system prompt (lost temporal grounding + custom instructions, so it "forgot what year it is"); research **hard-failed** on iteration exhaustion; and the research sub-step feedback was gone.

The throughline: the enclave had quietly **diverged** from the main-app agent path. The mandate for this branch is the opposite — the enclave's Ariadne must be *one and the same* as the main app's, reused almost entirely, the **only** differences being (a) input/output is encrypted and (b) tool capabilities.

## Solution

Make the enclave run the *same* `AgentRuntime` and emit the *same* event lifecycle as the in-process path — only sealed. The regional backend stays zero-knowledge (INV-E7): it relays/persists ciphertext it can't read; the owner's browser decrypts under the stream key exactly as it does message content.

### Key design decisions

**1. Shared system-prompt assembler (no drift).** `buildEnclaveSystemPrompt` composes the same builder the in-process path uses (temporal grounding, response style, send_message rules, tool sections, trust boundary, scratchpad custom instructions); the backend assembles everything *except* the encrypted context and ships the raw-text prompt. Only the toolset differs.

**2. Full sealed step lifecycle — not append-only.** The enclave's trace observer was a lossy reimplementation that only sent a step once *completed*, so the trace dialog (which hangs live substeps on the *in-flight* row) had nothing to attach them to. It now mirrors `SessionTraceObserver` exactly: `step:started` → substeps → `step:completed`, finalized in place by `stepId`. Backend gains `/steps/started` (in-progress insert) and `/steps` finalizes-in-place with a race-safe fallback. The frontend handles enclave sessions identically to non-E2E ones. A failed `step:started` frame never drops the durable finalize (best-effort `openStep`).

**3. Sealed substeps, persisted for refresh.** Mid-run phase text is sealed and streamed (live indicator) *and* the running `{ substeps }` snapshot is sealed + persisted onto the step row, so a refresh / opening the trace mid-run replays the phases — mirroring the in-process `updateSubsteps`. The backend never sees the query text. AAD binds each seal to the step's `stepId` (anti-shuffle), matching the message scheme.

**4. The "Triggered by" CONTEXT step.** In-process this is emitted by the persona-agent orchestration layer, which the enclave doesn't run — so its trace lacked it. The enclave's orchestration layer (run-turn) now emits a sealed `CONTEXT_RECEIVED` step from trigger metadata (plumbed on the assignment); the body is the decrypted prompt, sealed like any step, in the same `{messages:[{…isTrigger}]}` shape so the existing renderer applies.

**5. Stop-research propagates to the enclave (graceful).** `agent_session:research:abort` only hit the in-process `SessionAbortRegistry`, which has no entry for an enclave turn — so Stop did nothing. The socket handler now routes by ownership: if the session's `server_id` is a live EIK, it forwards `POST /sessions/:id/cancel` to that enclave; the enclave aborts the turn's `AbortController`, wired into the runtime via `toolSignalProvider` (gated to the research sub-loop), so research returns partial findings and the turn still replies — identical to in-process.

**6. Reliability: no silent hangs.** Orphan-session-cleanup now emits the full `agent_session:failed` lifecycle (stream event + outbox + session-room socket) when reclaiming a stale session, instead of flipping the DB status silently — so an enclave restart mid-turn surfaces a "failed" trace card rather than spinning forever. The enclave `complete` handler writes completion + the `agent_session:completed` event in one transaction (INV-7) and closes a live trace dialog via the session room.

**7. Research degrades instead of failing.** Iteration exhaustion returns partial findings (cap raised to 12) rather than hard-failing the turn.

**8. Security: redact the internal-auth secret from logs.** `pino-http`'s default req serializer logged full headers; the redact list missed `x-internal-api-key`, so the shared internal secret landed in backend + control-plane logs on any 4xx/5xx. Now redacted in both (path derived from the constant). Separately, the enclave's `sessionAssignmentSchema` was silently stripping `allowedToolCategories` (Zod drops unknown keys) — the per-stream tool-privacy policy was ignored; now declared.

**9. Logger alignment.** The enclave's per-module loggers now route through the shared bundle-safe `@threa/agent-runtime` logger (LOG_LEVEL, error serializer, pretty-in-dev / JSON-in-prod) instead of bare `pino({ name })`. The shared logger uses pino-pretty as a directly-imported sync stream (works inside the enclave's single-file bundle, where the transport worker can't resolve), so enclave dev logs render like the backend's.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/enclave-system-prompt.ts` | Enclave system prompt via the shared assembler |
| `apps/backend/src/features/agents/orphan-session-cleanup.test.ts` | Tests the failed-lifecycle emission on reclaim |

## Modified files (highlights)

| File | Change |
| ---- | ------ |
| `apps/enclave/src/agent/trace-observer.ts` | Full sealed step lifecycle, substep snapshots, CONTEXT step, stepId-bound AAD |
| `apps/enclave/src/agent/{run-turn,session-runner}.ts` | step-started + substep snapshot + per-session AbortController + gated toolSignalProvider |
| `apps/enclave/src/sessions.ts`, `index.ts` | `trigger`/`allowedToolCategories` in the schema; `/sessions/:id/cancel` endpoint |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | `/steps/started`, finalize-in-place `/steps`, snapshot-persisting `/substeps`, atomic `complete` |
| `apps/backend/src/features/enclave-runtimes/{forwarder,repository}.ts` | `cancelSession` + `findByKeyId` (resolve a session's owning enclave) |
| `apps/backend/src/socket.ts`, `server.ts` | Route research-abort by ownership (in-process registry vs enclave forward) |
| `apps/backend/src/features/agents/orphan-session-cleanup.ts` | Emit `agent_session:failed` lifecycle on reclaim |
| `apps/{backend,control-plane}/src/app.ts` | Redact `x-internal-api-key` from request logs |
| `apps/frontend/src/hooks/{use-agent-trace,use-agent-activity}.ts` | Decrypt sealed steps/substeps for the trace + inline indicator |
| `packages/types/src/api.ts` | `EnclaveSealedStepStart`, substep snapshot fields, assignment `trigger` |
| `packages/agent-runtime/src/logger.ts` | Bundle-safe sync pino-pretty; exported via `./logger` subpath |

## Test plan

- [x] `bun run test` / `bun test` — enclave (43), backend enclave-runtimes (48, incl. lifecycle/atomicity/raced/null-stream/substep/cancel cases), orphan-cleanup (3), forwarder (cancelSession), agent-runtime (141) — all green
- [x] Full monorepo typecheck + lint + OpenAPI check (pre-commit hook) green
- [x] Runtime-verified the `x-internal-api-key` redaction and the bundled logger (pretty output on node, no crash)
- [x] Two rounds of multi-perspective self-review (correctness / design / spec); all ≥80 findings fixed
- [ ] **Manual (fresh Encrypted Scratchpad, clean backend boot):** a research turn shows CONTEXT → THINKING → RESEARCH (live, phases streaming, replays on refresh) → RESPONSE; Stop ends research with a partial answer; an enclave restart mid-turn surfaces a failed card, not an infinite spinner

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
