### PR TITLE
docs: feature-doc inventory + document-feature skill

### DIFF
--- a/.agents/skills/document-feature/SKILL.md
+++ b/.agents/skills/document-feature/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: document-feature
+description: Write ONE feature doc from docs/features/INVENTORY.md, verified against the code, and open a small PR for it. Use when asked to "document <feature>", "fill in the feature doc for X", "do the next feature doc", "backfill feature docs", or when a remote agent is started with a feature name to document.
+---
+
+# Document Feature
+
+Write exactly one feature doc per run, verified against the code, shipped as its own
+small PR. The doc system's spec lives in `docs/features/README.md`; this skill is the
+workflow for filling it in, one inventory row at a time.
+
+## Input
+
+- An inventory row name (`saved-messages`, `concepts/race-safe-writes`, etc.), or free
+  text describing the feature.
+- No argument: open `docs/features/INVENTORY.md` and pick the first undocumented row,
+  preferring the backfill order suggested under "Open questions".
+
+## Process
+
+### 1. Load the spec and an exemplar
+
+- Read `docs/features/README.md` in full: the three buckets, frontmatter schemas,
+  document structure, and altitude rules. It is authoritative; this skill doesn't
+  restate it.
+- Read one existing doc in the target bucket as the exemplar:
+  `public/configurable-sidebar.md`, `concepts/subscribe-then-bootstrap.md`, or
+  `architecture/sync-engine.md`.
+
+### 2. Verify against code (this is the whole point)
+
+- The inventory one-liner and its "where to look" pointers are hints, not facts. The
+  sweep that produced them has already been wrong at least once.
+- `docs/plans/*` describes the feature we wanted, not the feature we have. Never source
+  a claim from a plan.
+- Explore the real implementation. A good cheap path: spawn an Explore agent asking for
+  (a) current behavior with file:line citations and (b) an explicit list of what is
+  absent or half-wired: TODO/FIXME markers, commented-out branches, sections that render
+  but are never populated, flags that nothing sets.
+- Decide `status` honestly. `shipped` only if it's fully wired end to end; `building` if
+  anything user-visible is stubbed or backend-unbacked. If the user has said a feature is
+  unfinished, that is authoritative over any code sweep.
+- `public_site: true` only when the doc is in `public/` AND status is `shipped`. Building
+  features stay off the marketing site.
+
+### 3. Write the doc
+
+- Path: `docs/features/<bucket>/<name>.md`. Frontmatter must match the README schema for
+  that bucket exactly (concepts get no `entry_points`; architecture docs get
+  `kind: subsystem`, concepts `kind: concept`).
+- Structure per the README. Architecture docs read colleague-first: the gist, how it
+  works, then a "Details worth knowing" reference layer, with an explicit "you can stop
+  here" off-ramp. Concept docs state the principle at a level that would survive a
+  rewrite. Public docs: what it does, how a user experiences it, boundaries.
+- A Boundaries/Status section states plainly what does NOT exist. Honest gaps beat
+  smooth overclaims; an unfinished edge described accurately is a feature of the doc.
+- Tone: plain, casual, clear. Apply the deslopify skill's rules; at minimum
+  `grep -c '—' <file>` must return 0, and no hype words or rhetorical flourishes.
+- Watch markdown footguns: a `+` or `-` that wraps to line start becomes a list bullet
+  and prettier will lock that in. Re-read after the pre-commit hook rewrites the file.
+
+### 4. Wire it in
+
+- `INVENTORY.md`: link the row's name to the new doc and append ✅ (plus
+  "(building)" when applicable).
+- Cross-link `related:` in both directions when a concept/subsystem/public pairing
+  exists.
+- If verification contradicted another feature doc or the inventory, fix that in the
+  same PR and call it out. Drift discoveries are a deliverable, not a distraction.
+
+### 5. Ship a small PR
+
+- One doc per PR. Branch from a freshly fetched main:
+  `git fetch origin main && git checkout -b docs/feature-<name> origin/main`.
+- Commit as `docs(features): add <bucket>/<name>`, push, and open the PR with the
+  `create-pr` skill. If `gh` is unavailable (web/remote session), fall back to the
+  `github-api-web` skill.
+- PR body, written to be read on a phone: what was verified and how, the status call and
+  why, any drift discovered, and what was deliberately left out of scope.
+
+## Guardrails
+
+- Docs only. If verification surfaces a product bug, flag it in the PR body; don't fix
+  code in this PR.
+- One doc per run. If the chosen row turns out to be two docs (see the granularity
+  notes in INVENTORY's open questions), write the narrower one and record the call in
+  the PR body.
+- Don't rewrite an existing doc unless verification proves it wrong; when it does, say
+  exactly what was wrong and how you know.

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -1,0 +1,110 @@
+# Feature Doc Inventory
+
+A catalog of what exists in the codebase today, bucketed the way this tree is organized,
+so backfill can proceed deliberately instead of ad hoc. Compiled from a code sweep on
+2026-06-02: backend feature folders (`apps/backend/src/features/*`), frontend routes and
+components, the CLAUDE.md invariants, and the packages and services.
+
+Two rules for using it:
+
+- **One-liners are sweep-level.** Good enough to scope a doc, not verified claims.
+  Verification happens when the doc gets written, against the code, the way the pilot
+  docs were. (The sweep itself produced at least one wrong claim that the pilot had
+  already disproven, so treat unverified rows with suspicion.)
+- **A row is done when the doc exists** and its frontmatter status reflects reality.
+
+## Public features
+
+| Doc                                                                  | Covers                                                                           | Where to look                                                       |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [configurable-sidebar](public/configurable-sidebar.md) ✅ (building) | Sections, presets, quick links, label sections                                   | done                                                                |
+| scratchpads                                                          | The solo-first entry point: personal streams, AI companion on/off, auto-naming   | `features/streams`, `docs/core-concepts.md`                         |
+| channels-and-dms                                                     | Channels (public/private), DMs (lazy creation), archive, rename                  | `features/streams`                                                  |
+| threads-and-conversations                                            | Nested threads, breadcrumbs, conversation grouping, thread unreads               | `components/thread/`, `features/conversations`                      |
+| message-composer                                                     | Rich text, mentions, emoji, formatting toolbar, fullscreen document mode         | `components/composer/message-composer.tsx`                          |
+| voice-dictation                                                      | Recording, live transcript, polished vs raw chunks                               | `hooks/use-voice-dictation.ts`, `features/voice-transcription`      |
+| reactions                                                            | Emoji reactions, reactor details                                                 | `components/timeline/message-reactions.tsx`                         |
+| message-sharing                                                      | Share a message into another stream, quote replies                               | `components/share/`, `quote-reply-extension.ts`                     |
+| slash-commands                                                       | Command registry, stream-scoped commands, routing to bots                        | `features/commands`                                                 |
+| search                                                               | Global search with filters, in-stream search, quick switcher                     | `features/search`, `components/quick-switcher/`                     |
+| saved-messages                                                       | Save for later, done/archived lifecycle, reminders                               | `features/saved-messages`, `pages/saved.tsx`                        |
+| scheduled-messages                                                   | Compose now, send later; edit and send-now                                       | `features/scheduled-messages`                                       |
+| drafts                                                               | Autosave, stashing, drafts page                                                  | `stores/draft-store.ts`, `pages/drafts.tsx`                         |
+| labels                                                               | Create/join, color and emoji, assign to streams, public/private                  | `features/labels`, `pages/labels.tsx`                               |
+| memory-explorer                                                      | Browse and search memos, tags, knowledge types, memo embeds in messages          | `features/memos`, `pages/memory.tsx`                                |
+| activity-feed                                                        | All/unread/me filters, mark read                                                 | `features/activity`, `pages/activity.tsx`                           |
+| notifications                                                        | Web push, per-stream notification levels, device-aware suppression               | `features/push`                                                     |
+| attachments-and-files                                                | Uploads, extraction-backed previews, files page, gallery, per-stream explorer    | `features/attachments`, `pages/files.tsx`                           |
+| link-previews                                                        | URL preview cards on messages                                                    | `features/link-previews`                                            |
+| e2e-encrypted-scratchpads                                            | Passphrase setup/unlock, inviting actors, encrypted AI companion via the enclave | `components/encryption/`, `features/e2e-streams`                    |
+| invitations                                                          | Invite links, claiming, joining a workspace                                      | `features/invitations`, `pages/join.tsx`                            |
+| multi-account                                                        | Account switcher, add account, scoped logout                                     | `components/account-switcher/`                                      |
+| user-settings                                                        | Appearance, keyboard shortcuts, notification prefs, date/time, accessibility     | `components/settings/`                                              |
+| workspace-settings                                                   | Members and roles, bots, GitHub/Linear integrations, AI usage dashboard          | `components/workspace-settings/`, `features/workspace-integrations` |
+| public-api                                                           | REST API for integrations, user API keys                                         | `features/public-api`, `docs/public-api/openapi.json`               |
+| share-target                                                         | OS-level share into a workspace (PWA), destination picker                        | `pages/share-target.tsx`                                            |
+| offline                                                              | Composing offline, queued operations, connection status                          | `sw.ts`, `sync/operation-queue.ts`                                  |
+| ai-companions                                                        | Personas, companion mode, bot status strip, agent traces                         | `features/agents`, `docs/core-concepts.md`                          |
+
+## Concepts
+
+| Doc                                                                 | The guarantee                                                                                       | Invariants          |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
+| [subscribe-then-bootstrap](concepts/subscribe-then-bootstrap.md) ✅ | Confirm the subscription before fetching the snapshot, then merge                                   | INV-53              |
+| streams-all-the-way-down                                            | Everything that sends messages is a stream; threads are streams; visibility inherits from the root  | (domain model)      |
+| memos-are-pointers                                                  | GAM stores semantic pointers to source messages, never copies                                       | (domain model)      |
+| workspace-is-the-boundary                                           | Workspace is the ownership, query, sharding, and residency boundary                                 | INV-8, INV-50       |
+| integrity-in-app-code                                               | No FKs, prefixed ULIDs, TEXT plus code validation; relational integrity lives in the application    | INV-1, INV-2, INV-3 |
+| race-safe-writes                                                    | Write paths tolerate concurrent callers; no select-then-update, prefer set-based ops                | INV-20, INV-56      |
+| events-and-projections                                              | Append-only `stream_events` is the source of truth; read projections commit in the same transaction | INV-7               |
+| optimistic-then-reconcile                                           | Optimistic events land in IDB with temp ids; server events replace them by `clientMessageId`        | (frontend pattern)  |
+| idb-is-the-client-source-of-truth                                   | The UI reads IndexedDB via live queries; sync writes IDB, never components directly                 | (frontend pattern)  |
+| content-canonical-form                                              | `contentJson` is the internal canon; markdown only at the wire; previews strip markdown at render   | INV-58, INV-60      |
+| language-by-model                                                   | Semantic decisions about language go through a model, never English-only heuristics                 | INV-54              |
+| personas-are-data                                                   | Agents are data-driven personas with declarative tools, not hardcoded implementations               | (domain model)      |
+
+Note: the three domain-model rows (streams, memos, personas) live in `docs/core-concepts.md`
+today. Open question below.
+
+## Architecture
+
+| Doc                                                 | Covers                                                                                        | Where to look                                               |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [outbox-pattern](architecture/outbox-pattern.md) ✅ | Transactional events, dispatcher, gap-safe cursors                                            | done                                                        |
+| [sync-engine](architecture/sync-engine.md) ✅       | Client sync lifecycle, reconnect, IDB reconciliation                                          | done                                                        |
+| job-queue                                           | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                 | `apps/backend/src/lib/queue/`                               |
+| ai-wrapper                                          | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets | `packages/agent-runtime/src/ai/`                            |
+| socket-rooms                                        | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                   | `apps/backend/src/socket.ts`                                |
+| agent-runtime                                       | Persona sessions, tool execution, traces, per-stream tool privacy policies                    | `packages/agent-runtime/`, `features/agents`                |
+| bot-runtimes                                        | External bot runtime connections and session links                                            | `features/bot-runtimes`                                     |
+| e2e-encryption                                      | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                    | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
+| push-pipeline                                       | Subscriptions, device/session suppression logic, outbox-driven delivery                       | `features/push`                                             |
+| attachment-pipeline                                 | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                            | `features/attachments`, `lib/storage/`                      |
+| search-architecture                                 | Hybrid full-text and pgvector search, embedding jobs, access control                          | `features/search`                                           |
+| memo-pipeline                                       | The GAM machinery: boundary extraction, classification, memo accumulation                     | `features/memos` and its outbox handlers                    |
+
+## Probably skip, or covered elsewhere
+
+- **Service topology** (control-plane, workspace-router, backoffice, db-read-proxy):
+  `docs/system-overview.md` already covers it. Link, don't duplicate.
+- **Coding conventions** (DI factories, service-owned transactions, thin handlers,
+  append-only migrations): CLAUDE.md and `docs/backend/` own these. A concept doc here
+  would just restate them.
+- **Solo-first philosophy**: belongs in the scratchpads public doc and CLAUDE.md, not a
+  standalone concept.
+- **Minor infra** (operation-leases, observability/metrics wiring, emoji): document
+  inline in whichever doc touches them, or not at all.
+
+## Open questions
+
+1. **Does `docs/core-concepts.md` migrate?** Streams, memos/GAM, and personas are
+   documented there today. Either those sections move into `concepts/` (one doc each,
+   with frontmatter) and core-concepts.md becomes a pointer, or the concept rows above
+   stay links. Migrating keeps one system; linking avoids churn.
+2. **Backfill order.** Suggested: start where docs pay rent fastest. That's the surfaces
+   under active change (e2e-encrypted-scratchpads, ai-companions, agent-runtime) and the
+   concepts that prevent recurring bugs (optimistic-then-reconcile,
+   content-canonical-form, race-safe-writes).
+3. **Granularity calls** to make at writing time: split user-settings from
+   workspace-settings or merge; whether public-api belongs in `public/` (developer
+   audience) or its own bucket.

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -64,7 +64,10 @@ Two rules for using it:
 | personas-are-data                                                   | Agents are data-driven personas with declarative tools, not hardcoded implementations               | (domain model)      |
 
 Note: the three domain-model rows (streams, memos, personas) live in `docs/core-concepts.md`
-today. Open question below.
+today. Decided: they migrate into `concepts/` (one doc each, normal document-feature runs,
+with core-concepts.md as the starting source but verified against code like everything
+else). Once all three have landed, core-concepts.md is reduced to a short pointer into
+this tree. See Decisions below.
 
 ## Architecture
 
@@ -95,16 +98,19 @@ today. Open question below.
 - **Minor infra** (operation-leases, observability/metrics wiring, emoji): document
   inline in whichever doc touches them, or not at all.
 
+## Decisions
+
+1. **`docs/core-concepts.md` migrates** (decided 2026-06-02). The streams, memos/GAM,
+   and personas sections each become a `concepts/` doc through normal document-feature
+   runs. Whichever run lands the last of the three also reduces core-concepts.md to a
+   short pointer into this tree, so external references keep working.
+
 ## Open questions
 
-1. **Does `docs/core-concepts.md` migrate?** Streams, memos/GAM, and personas are
-   documented there today. Either those sections move into `concepts/` (one doc each,
-   with frontmatter) and core-concepts.md becomes a pointer, or the concept rows above
-   stay links. Migrating keeps one system; linking avoids churn.
-2. **Backfill order.** Suggested: start where docs pay rent fastest. That's the surfaces
+1. **Backfill order.** Suggested: start where docs pay rent fastest. That's the surfaces
    under active change (e2e-encrypted-scratchpads, ai-companions, agent-runtime) and the
    concepts that prevent recurring bugs (optimistic-then-reconcile,
    content-canonical-form, race-safe-writes).
-3. **Granularity calls** to make at writing time: split user-settings from
+2. **Granularity calls** to make at writing time: split user-settings from
    workspace-settings or merge; whether public-api belongs in `public/` (developer
    audience) or its own bucket.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -181,8 +181,9 @@ chore:
 
 - **A feature PR updates its feature doc** in the same PR. New feature → new doc;
   changed behavior → edited doc. The `create-pr` and `code-review` skills check for this.
-- **Greptile reviews the diff against the feature doc**, not a stale plan. Because the
-  doc is present-tense and accurate, design-adherence review actually means something.
+- **The automated PR reviewer (CodeRabbit) checks the diff against the feature doc**, not
+  a stale plan. Because the doc is present-tense and accurate, design-adherence review
+  actually means something.
 - **Plans become transient scratch.** Plans are still useful while _building_ — they're
   just not committed artifacts. They live as local agent state and are gitignored. The
   durable record is the feature doc.
@@ -200,6 +201,9 @@ This started as a pilot:
 - `architecture/sync-engine.md` — the subsystem that implements that principle.
 - `architecture/outbox-pattern.md` — a self-contained pattern + its one implementation.
 
-Once the shape is approved, the follow-on work is: backfill docs for the other shipped
-features, wire the Astro content collection in the public-site worktree, update the
-`create-pr` / `code-review` / `sync-plan` skills, and remove the committed plans.
+The shape is approved (PR #706). [`INVENTORY.md`](INVENTORY.md) catalogs everything left
+to document, bucket by bucket, with sweep-level one-liners and pointers; backfill works
+through it row by row, verifying each doc against the code as it's written. Remaining
+follow-on work beyond backfill: wire the Astro content collection in the public-site
+worktree, update the `create-pr` / `code-review` / `sync-plan` skills, and remove the
+committed plans.


### PR DESCRIPTION
## What this is

Two things that together make the doc backfill executable piece by piece:

1. **`docs/features/INVENTORY.md`**: a catalog of everything in the codebase worth a feature doc.
2. **`.agents/skills/document-feature/SKILL.md`**: a skill that turns one inventory row into one verified doc and one small PR. Built so you can start a remote agent from your phone with just a feature name.

## The inventory

Compiled from four parallel code sweeps (backend feature folders, frontend routes and components, the CLAUDE.md invariants, packages and services), then curated rather than pasted:

- **28 public features**: scratchpads, channels and DMs, threads, composer, voice dictation, reactions, sharing, slash commands, search, saved, scheduled, drafts, labels, memory explorer, activity, notifications, attachments and files, link previews, E2E scratchpads, invitations, multi-account, settings, public API, share target, offline, AI companions.
- **12 concepts**: workspace-is-the-boundary, integrity-in-app-code, race-safe-writes, events-and-projections, optimistic-then-reconcile, idb-is-the-client-source-of-truth, content-canonical-form, language-by-model, plus the three domain models (streams, memos-are-pointers, personas-are-data).
- **12 architecture subsystems**: job queue, AI wrapper, socket rooms, agent runtime, bot runtimes, E2E encryption, push pipeline, attachment pipeline, search, memo pipeline (plus the two already documented).
- **A probably-skip list**: service topology (system-overview.md owns it), coding conventions (CLAUDE.md owns them), minor infra.

**The honesty rule is baked in.** One-liners are marked sweep-level, not verified. One sweep claim was already provably wrong (it reported sidebar pinning works; the pilot proved it doesn't), so the inventory says outright to treat unverified rows with suspicion. Verification happens when each doc is written.

## The skill

`/document-feature <row>` (or no argument: it picks the next undocumented row). Per run it:

1. Reads the README spec and an exemplar doc from the target bucket.
2. Verifies the feature against the actual code, explicitly hunting for what's absent or half-wired. Plans are banned as a source.
3. Writes the doc with the right frontmatter, structure, and altitude, deslopified.
4. Links the inventory row, cross-links related docs, and fixes any drift it found.
5. Ships a dedicated small PR branched off fresh origin/main, with a phone-readable body covering the status call and any drift discovered.

Guardrails: one doc per run, docs only (bugs get flagged, not fixed), never rewrite an existing doc unless verification proves it wrong.

## Also in here

README touch-ups: the stay-current section now says CodeRabbit (main moved off Greptile), and Rollout points at the inventory as the backfill roadmap.

## Three open questions (yours to call, listed in the inventory)

1. **Does `docs/core-concepts.md` migrate?** Streams, memos/GAM, and personas live there today. Move each into `concepts/` with frontmatter, or leave the inventory rows pointing there?
2. **Backfill order.** Suggested: surfaces under active change first (e2e-encrypted-scratchpads, ai-companions, agent-runtime) plus the bug-preventing concepts (optimistic-then-reconcile, content-canonical-form, race-safe-writes).
3. **Granularity**: split user-settings from workspace-settings or merge; where public-api lives given its developer audience.

## New files

| File | Purpose |
| --- | --- |
| `docs/features/INVENTORY.md` | The catalog: 28 + 12 + 12 rows, skip list, open questions |
| `.agents/skills/document-feature/SKILL.md` | One row in, one verified doc + small PR out |

## Modified files

| File | Change |
| --- | --- |
| `docs/features/README.md` | Greptile to CodeRabbit; Rollout now points at INVENTORY.md |

## Test plan

- [x] Lint, typecheck, prettier pass (docs and skill only)
- [x] Em-dash sweep on new docs returns 0
- [ ] You read the inventory and answer the three open questions
- [ ] First real run: start a remote agent with `/document-feature` and review its PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782977625&installation_id=129946197&pr_number=729&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F729&signature=f3004685949a6049f45e995ddca0d45511fa6b82e9caf161f3024a4292a0625a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->