### PR TITLE
feat: schedule-aware scheduling presets with working-week/hours preferences

### DIFF
--- a/apps/backend/src/db/migrations/20260602070843_workspace_settings.sql
+++ b/apps/backend/src/db/migrations/20260602070843_workspace_settings.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Workspace Setting Overrides
+-- Sparse key-value storage for workspace-wide settings (e.g. the default
+-- working schedule members inherit). Mirrors user_preference_overrides: only
+-- values that differ from code-defined defaults are stored, so changing a
+-- default is a code deploy rather than a data migration.
+-- =============================================================================
+
+CREATE TABLE workspace_setting_overrides (
+    workspace_id TEXT NOT NULL,
+    key TEXT NOT NULL,              -- e.g., "defaultWorkSchedule"
+    value JSONB NOT NULL,           -- The override value (any JSON type)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (workspace_id, key)
+);

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -17,6 +17,7 @@ import {
   BLOCKQUOTE_COLLAPSE_THRESHOLD_MIN,
   BLOCKQUOTE_COLLAPSE_THRESHOLD_MAX,
 } from "@threa/types"
+import { workScheduleSchema } from "../../lib/schemas"
 
 const updatePreferencesSchema = z.object({
   theme: z.enum(THEME_OPTIONS).optional(),
@@ -46,6 +47,8 @@ const updatePreferencesSchema = z.object({
   // registry server-side when a session opens; this layer only bounds length.
   voiceTranscriptionModel: z.string().max(100).nullable().optional(),
   voicePolishLevel: z.enum(VOICE_POLISH_LEVEL_OPTIONS).optional(),
+  // null clears the personal override (revert to the workspace default).
+  workSchedule: workScheduleSchema.nullable().optional(),
   keyboardShortcuts: z.record(z.string(), z.string()).optional(),
   accessibility: z
     .object({

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -88,6 +88,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "blockquoteCollapseThreshold",
     "voiceTranscriptionModel",
     "voicePolishLevel",
+    "workSchedule",
   ] as const
 
   for (const key of simpleKeys) {

--- a/apps/backend/src/features/workspace-settings/handlers.ts
+++ b/apps/backend/src/features/workspace-settings/handlers.ts
@@ -1,0 +1,40 @@
+import { z } from "zod"
+import type { Request, Response } from "express"
+import type { WorkspaceSettingsService } from "./service"
+import { workScheduleSchema } from "../../lib/schemas"
+
+const updateWorkspaceSettingsSchema = z.object({
+  defaultWorkSchedule: workScheduleSchema.optional(),
+})
+
+export { updateWorkspaceSettingsSchema }
+
+interface Dependencies {
+  workspaceSettingsService: WorkspaceSettingsService
+}
+
+export function createWorkspaceSettingsHandlers({ workspaceSettingsService }: Dependencies) {
+  return {
+    async get(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+      const settings = await workspaceSettingsService.getSettings(workspaceId)
+      res.json({ settings })
+    },
+
+    // Write is gated to workspace admins at the route layer.
+    async update(req: Request, res: Response) {
+      const workspaceId = req.workspaceId!
+
+      const result = updateWorkspaceSettingsSchema.safeParse(req.body)
+      if (!result.success) {
+        return res.status(400).json({
+          error: "Validation failed",
+          details: z.flattenError(result.error).fieldErrors,
+        })
+      }
+
+      const settings = await workspaceSettingsService.updateSettings(workspaceId, result.data)
+      res.json({ settings })
+    },
+  }
+}

--- a/apps/backend/src/features/workspace-settings/index.ts
+++ b/apps/backend/src/features/workspace-settings/index.ts
@@ -1,0 +1,3 @@
+export { createWorkspaceSettingsHandlers, updateWorkspaceSettingsSchema } from "./handlers"
+export { WorkspaceSettingsService } from "./service"
+export { WorkspaceSettingsRepository, type WorkspaceSettingOverrideRecord } from "./repository"

--- a/apps/backend/src/features/workspace-settings/repository.ts
+++ b/apps/backend/src/features/workspace-settings/repository.ts
@@ -1,0 +1,51 @@
+import { sql, type Querier } from "../../db"
+
+/** Internal row type for workspace setting overrides (snake_case). */
+interface WorkspaceSettingOverrideRow {
+  key: string
+  value: unknown
+}
+
+/** Override record returned from the repository. */
+export interface WorkspaceSettingOverrideRecord {
+  key: string
+  value: unknown
+}
+
+export const WorkspaceSettingsRepository = {
+  /**
+   * Fetch all setting overrides for a workspace. Returns only the overrides —
+   * merge with defaults in the service layer.
+   */
+  async findOverrides(db: Querier, workspaceId: string): Promise<WorkspaceSettingOverrideRecord[]> {
+    const result = await db.query<WorkspaceSettingOverrideRow>(sql`
+      SELECT key, value
+      FROM workspace_setting_overrides
+      WHERE workspace_id = ${workspaceId}
+    `)
+    return result.rows.map((row) => ({ key: row.key, value: row.value }))
+  },
+
+  /**
+   * Upsert a single setting override. Race-safe via ON CONFLICT so concurrent
+   * admins don't clobber with a check-then-act (INV-20).
+   */
+  async setOverride(db: Querier, workspaceId: string, key: string, value: unknown): Promise<void> {
+    await db.query(sql`
+      INSERT INTO workspace_setting_overrides (workspace_id, key, value)
+      VALUES (${workspaceId}, ${key}, ${JSON.stringify(value)}::jsonb)
+      ON CONFLICT (workspace_id, key) DO UPDATE SET
+        value = EXCLUDED.value,
+        updated_at = NOW()
+    `)
+  },
+
+  /** Remove a setting override (revert to the code default). */
+  async deleteOverride(db: Querier, workspaceId: string, key: string): Promise<void> {
+    await db.query(sql`
+      DELETE FROM workspace_setting_overrides
+      WHERE workspace_id = ${workspaceId}
+        AND key = ${key}
+    `)
+  },
+}

--- a/apps/backend/src/features/workspace-settings/service.test.ts
+++ b/apps/backend/src/features/workspace-settings/service.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { PoolClient } from "pg"
+import { DEFAULT_WORK_SCHEDULE, type WorkSchedule } from "@threa/types"
+import { WorkspaceSettingsService } from "./service"
+import { WorkspaceSettingsRepository } from "./repository"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+
+const CUSTOM_SCHEDULE: WorkSchedule = {
+  days: {
+    0: [{ start: "09:00", end: "13:00" }],
+    1: [{ start: "08:00", end: "16:00" }],
+    2: [{ start: "08:00", end: "16:00" }],
+    3: [{ start: "08:00", end: "16:00" }],
+    4: [{ start: "08:00", end: "16:00" }],
+    5: [],
+    6: [],
+  },
+}
+
+function setupTransaction() {
+  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+}
+
+describe("WorkspaceSettingsService.getSettings", () => {
+  afterEach(() => mock.restore())
+
+  it("falls back to defaults when no overrides are stored", async () => {
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([])
+    const service = new WorkspaceSettingsService({} as any)
+
+    const settings = await service.getSettings(WORKSPACE_ID)
+
+    expect(settings.workspaceId).toBe(WORKSPACE_ID)
+    expect(settings.defaultWorkSchedule).toEqual(DEFAULT_WORK_SCHEDULE)
+  })
+
+  it("merges a stored override onto defaults", async () => {
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([
+      { key: "defaultWorkSchedule", value: CUSTOM_SCHEDULE },
+    ])
+    const service = new WorkspaceSettingsService({} as any)
+
+    const settings = await service.getSettings(WORKSPACE_ID)
+
+    expect(settings.defaultWorkSchedule).toEqual(CUSTOM_SCHEDULE)
+  })
+})
+
+describe("WorkspaceSettingsService.updateSettings", () => {
+  afterEach(() => mock.restore())
+
+  it("stores a non-default schedule as an override", async () => {
+    setupTransaction()
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    const deleteOverride = spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([
+      { key: "defaultWorkSchedule", value: CUSTOM_SCHEDULE },
+    ])
+    const service = new WorkspaceSettingsService({} as any)
+
+    const settings = await service.updateSettings(WORKSPACE_ID, { defaultWorkSchedule: CUSTOM_SCHEDULE })
+
+    expect(setOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "defaultWorkSchedule", CUSTOM_SCHEDULE)
+    expect(deleteOverride).not.toHaveBeenCalled()
+    expect(settings.defaultWorkSchedule).toEqual(CUSTOM_SCHEDULE)
+  })
+
+  it("clears the override when set back to the default", async () => {
+    setupTransaction()
+    const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
+    const deleteOverride = spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
+    spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([])
+    const service = new WorkspaceSettingsService({} as any)
+
+    await service.updateSettings(WORKSPACE_ID, { defaultWorkSchedule: DEFAULT_WORK_SCHEDULE })
+
+    expect(deleteOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "defaultWorkSchedule")
+    expect(setOverride).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/workspace-settings/service.test.ts
+++ b/apps/backend/src/features/workspace-settings/service.test.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg"
 import { DEFAULT_WORK_SCHEDULE, type WorkSchedule } from "@threa/types"
 import { WorkspaceSettingsService } from "./service"
 import { WorkspaceSettingsRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
 
 const WORKSPACE_ID = "ws_1"
@@ -51,13 +52,14 @@ describe("WorkspaceSettingsService.getSettings", () => {
 describe("WorkspaceSettingsService.updateSettings", () => {
   afterEach(() => mock.restore())
 
-  it("stores a non-default schedule as an override", async () => {
+  it("stores a non-default schedule as an override and broadcasts it", async () => {
     setupTransaction()
     const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
     const deleteOverride = spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
     spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([
       { key: "defaultWorkSchedule", value: CUSTOM_SCHEDULE },
     ])
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
     const service = new WorkspaceSettingsService({} as any)
 
     const settings = await service.updateSettings(WORKSPACE_ID, { defaultWorkSchedule: CUSTOM_SCHEDULE })
@@ -65,6 +67,8 @@ describe("WorkspaceSettingsService.updateSettings", () => {
     expect(setOverride).toHaveBeenCalledWith({}, WORKSPACE_ID, "defaultWorkSchedule", CUSTOM_SCHEDULE)
     expect(deleteOverride).not.toHaveBeenCalled()
     expect(settings.defaultWorkSchedule).toEqual(CUSTOM_SCHEDULE)
+    // Workspace-scoped broadcast so every member's bootstrap cache converges.
+    expect(insert).toHaveBeenCalledWith({}, "workspace_settings:updated", { workspaceId: WORKSPACE_ID, settings })
   })
 
   it("clears the override when set back to the default", async () => {
@@ -72,6 +76,7 @@ describe("WorkspaceSettingsService.updateSettings", () => {
     const setOverride = spyOn(WorkspaceSettingsRepository, "setOverride").mockResolvedValue()
     const deleteOverride = spyOn(WorkspaceSettingsRepository, "deleteOverride").mockResolvedValue()
     spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
     const service = new WorkspaceSettingsService({} as any)
 
     await service.updateSettings(WORKSPACE_ID, { defaultWorkSchedule: DEFAULT_WORK_SCHEDULE })

--- a/apps/backend/src/features/workspace-settings/service.ts
+++ b/apps/backend/src/features/workspace-settings/service.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg"
 import { withTransaction } from "../../db"
 import { WorkspaceSettingsRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
 import { type WorkspaceSettings, type UpdateWorkspaceSettingsInput, DEFAULT_WORKSPACE_SETTINGS } from "@threa/types"
 
 /** Merge sparse overrides onto code defaults to produce full settings. */
@@ -61,7 +62,14 @@ export class WorkspaceSettingsService {
       }
 
       const overrides = await WorkspaceSettingsRepository.findOverrides(client, workspaceId)
-      return mergeOverrides(workspaceId, overrides)
+      const settings = mergeOverrides(workspaceId, overrides)
+
+      // Broadcast to the workspace room so every member's bootstrap cache (and
+      // thus schedule-aware presets) picks up the new default without waiting
+      // for a reconnect. Written in the same transaction as the override (INV-7).
+      await OutboxRepository.insert(client, "workspace_settings:updated", { workspaceId, settings })
+
+      return settings
     })
   }
 }

--- a/apps/backend/src/features/workspace-settings/service.ts
+++ b/apps/backend/src/features/workspace-settings/service.ts
@@ -1,0 +1,67 @@
+import { Pool } from "pg"
+import { withTransaction } from "../../db"
+import { WorkspaceSettingsRepository } from "./repository"
+import { type WorkspaceSettings, type UpdateWorkspaceSettingsInput, DEFAULT_WORKSPACE_SETTINGS } from "@threa/types"
+
+/** Merge sparse overrides onto code defaults to produce full settings. */
+function mergeOverrides(workspaceId: string, overrides: Array<{ key: string; value: unknown }>): WorkspaceSettings {
+  const result: WorkspaceSettings = {
+    workspaceId,
+    ...structuredClone(DEFAULT_WORKSPACE_SETTINGS),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  for (const { key, value } of overrides) {
+    ;(result as unknown as Record<string, unknown>)[key] = value
+  }
+  return result
+}
+
+function getDefaultValue(key: string): unknown {
+  return (DEFAULT_WORKSPACE_SETTINGS as Record<string, unknown>)[key]
+}
+
+function matchesDefault(key: string, value: unknown): boolean {
+  return JSON.stringify(value) === JSON.stringify(getDefaultValue(key))
+}
+
+function flattenUpdates(updates: UpdateWorkspaceSettingsInput): Array<{ key: string; value: unknown }> {
+  const pairs: Array<{ key: string; value: unknown }> = []
+  const simpleKeys = ["defaultWorkSchedule"] as const
+  for (const key of simpleKeys) {
+    if (updates[key] !== undefined) {
+      pairs.push({ key, value: updates[key] })
+    }
+  }
+  return pairs
+}
+
+export class WorkspaceSettingsService {
+  constructor(private pool: Pool) {}
+
+  /** Get workspace settings, merging overrides with defaults. */
+  async getSettings(workspaceId: string): Promise<WorkspaceSettings> {
+    // Single query, INV-30
+    const overrides = await WorkspaceSettingsRepository.findOverrides(this.pool, workspaceId)
+    return mergeOverrides(workspaceId, overrides)
+  }
+
+  /**
+   * Update workspace settings. Only values differing from defaults are stored;
+   * setting a value back to the default clears the override.
+   */
+  async updateSettings(workspaceId: string, updates: UpdateWorkspaceSettingsInput): Promise<WorkspaceSettings> {
+    return withTransaction(this.pool, async (client) => {
+      for (const { key, value } of flattenUpdates(updates)) {
+        if (matchesDefault(key, value)) {
+          await WorkspaceSettingsRepository.deleteOverride(client, workspaceId, key)
+        } else {
+          await WorkspaceSettingsRepository.setOverride(client, workspaceId, key, value)
+        }
+      }
+
+      const overrides = await WorkspaceSettingsRepository.findOverrides(client, workspaceId)
+      return mergeOverrides(workspaceId, overrides)
+    })
+  }
+}

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express"
 import type { WorkspaceService } from "./service"
 import type { StreamService } from "../streams"
 import type { UserPreferencesService } from "../user-preferences"
+import type { WorkspaceSettingsService } from "../workspace-settings"
 import type { SidebarConfigService } from "../sidebar-config"
 import type { InvitationService } from "../invitations"
 import type { ActivityService } from "../activity"
@@ -50,6 +51,7 @@ interface Dependencies {
   workspaceService: WorkspaceService
   streamService: StreamService
   userPreferencesService: UserPreferencesService
+  workspaceSettingsService: WorkspaceSettingsService
   sidebarConfigService: SidebarConfigService
   invitationService: InvitationService
   activityService?: ActivityService
@@ -65,6 +67,7 @@ export function createWorkspaceHandlers({
   workspaceService,
   streamService,
   userPreferencesService,
+  workspaceSettingsService,
   sidebarConfigService,
   invitationService,
   activityService,
@@ -140,6 +143,7 @@ export function createWorkspaceHandlers({
         bots,
         emojiWeights,
         userPreferences,
+        workspaceSettings,
         sidebarConfig,
         dmPeers,
         labels,
@@ -153,6 +157,7 @@ export function createWorkspaceHandlers({
         BotRepository.listVisibleTo(pool, workspaceId, userId),
         workspaceService.getEmojiWeights(workspaceId, userId),
         userPreferencesService.getPreferences(workspaceId, userId),
+        workspaceSettingsService.getSettings(workspaceId),
         sidebarConfigService.getConfig(workspaceId, userId),
         streamService.listDmPeers(workspaceId, userId),
         labelService.listVisibleTo(workspaceId, userId),
@@ -240,6 +245,7 @@ export function createWorkspaceHandlers({
           mutedStreamIds,
           dmPeers,
           userPreferences,
+          workspaceSettings,
           sidebarConfig,
           labels,
           labelMemberships,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -8,6 +8,7 @@ import type {
   StreamEvent as WireStreamEvent,
   UserPreferences,
   SidebarConfig,
+  WorkspaceSettings,
   LastMessagePreview,
   Bot as WireBot,
   BotInvocationCapability,
@@ -59,6 +60,7 @@ export type OutboxEventType =
   | "agent_session:deleted"
   | "user_preferences:updated"
   | "sidebar_config:updated"
+  | "workspace_settings:updated"
   | "budget:alert"
   | "stream:member_joined"
   | "stream:member_added"
@@ -429,6 +431,12 @@ export interface SidebarConfigUpdatedOutboxPayload extends WorkspaceScopedPayloa
   sidebarConfig: SidebarConfig
 }
 
+// Workspace settings event payload (workspace-scoped - every member inherits
+// the default, so the broadcast falls through to the workspace room).
+export interface WorkspaceSettingsUpdatedOutboxPayload extends WorkspaceScopedPayload {
+  settings: WorkspaceSettings
+}
+
 // Invitation event payloads
 export interface InvitationSentOutboxPayload extends WorkspaceScopedPayload {
   invitationId: string
@@ -682,6 +690,7 @@ export interface OutboxEventPayloadMap {
   "agent_session:deleted": AgentSessionDeletedOutboxPayload
   "user_preferences:updated": UserPreferencesUpdatedOutboxPayload
   "sidebar_config:updated": SidebarConfigUpdatedOutboxPayload
+  "workspace_settings:updated": WorkspaceSettingsUpdatedOutboxPayload
   "budget:alert": BudgetAlertOutboxPayload
   "invitation:sent": InvitationSentOutboxPayload
   "invitation:link-created": InvitationLinkCreatedOutboxPayload

--- a/apps/backend/src/lib/schemas.ts
+++ b/apps/backend/src/lib/schemas.ts
@@ -6,6 +6,7 @@ import {
   CONTENT_FORMATS,
   AUTHOR_TYPES,
   NOTIFICATION_LEVELS,
+  parseHHMM,
 } from "@threa/types"
 
 export const streamTypeSchema = z.enum(STREAM_TYPES)
@@ -14,6 +15,30 @@ export const companionModeSchema = z.enum(COMPANION_MODES)
 export const contentFormatSchema = z.enum(CONTENT_FORMATS)
 export const authorTypeSchema = z.enum(AUTHOR_TYPES)
 export const notificationLevelSchema = z.enum(NOTIFICATION_LEVELS)
+
+// Working schedule — shared by user-preferences (per-user override) and
+// workspace-settings (workspace default) so both validate identically (INV-35).
+// A shift is a wall-clock "HH:MM" range that must not end before it starts.
+const hhmmSchema = z.string().refine((v) => parseHHMM(v) !== null, "Must be HH:MM (24h)")
+const shiftIntervalSchema = z
+  .object({ start: hhmmSchema, end: hhmmSchema })
+  .refine((s) => parseHHMM(s.end)! > parseHHMM(s.start)!, { message: "Shift end must be after start" })
+
+// Every weekday key (0–6) maps to an array of shifts; empty array = day off.
+// Cap shifts per day so a client can't store an unbounded blob. Keys are listed
+// explicitly so the inferred output matches Record<Weekday, ShiftInterval[]>.
+const dayShiftsSchema = z.array(shiftIntervalSchema).max(6)
+export const workScheduleSchema = z.object({
+  days: z.object({
+    0: dayShiftsSchema,
+    1: dayShiftsSchema,
+    2: dayShiftsSchema,
+    3: dayShiftsSchema,
+    4: dayShiftsSchema,
+    5: dayShiftsSchema,
+    6: dayShiftsSchema,
+  }),
+})
 
 // BIK registration — a runtime's per-session X25519 public key (base64, 32
 // bytes) and the short id used as `recipient_key_id` when a stream's SSK is

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -22,6 +22,7 @@ import { createEmojiHandlers } from "./features/emoji"
 import { createConversationHandlers } from "./features/conversations"
 import { CommandAvailabilityService, createCommandHandlers } from "./features/commands"
 import { createUserPreferencesHandlers } from "./features/user-preferences"
+import { createWorkspaceSettingsHandlers } from "./features/workspace-settings"
 import { createSidebarConfigHandlers } from "./features/sidebar-config"
 import { createUserE2eKeysHandlers } from "./features/user-e2e-keys"
 import { createAIUsageHandlers } from "./features/ai-usage"
@@ -73,6 +74,7 @@ import type { S3Config } from "./lib/env"
 import type { StorageProvider } from "./lib/storage/s3-client"
 import type { CommandRegistry } from "./features/commands"
 import type { UserPreferencesService } from "./features/user-preferences"
+import type { WorkspaceSettingsService } from "./features/workspace-settings"
 import type { SidebarConfigService } from "./features/sidebar-config"
 import type { UserE2eKeysService } from "./features/user-e2e-keys"
 import type { AvatarService } from "./features/workspaces"
@@ -97,6 +99,7 @@ interface Dependencies {
   memoExplorerService: MemoExplorerService
   conversationService: ConversationService
   userPreferencesService: UserPreferencesService
+  workspaceSettingsService: WorkspaceSettingsService
   sidebarConfigService: SidebarConfigService
   userE2eKeysService: UserE2eKeysService
   invitationService: InvitationService
@@ -143,6 +146,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     memoExplorerService,
     conversationService,
     userPreferencesService,
+    workspaceSettingsService,
     sidebarConfigService,
     userE2eKeysService,
     invitationService,
@@ -195,6 +199,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     workspaceService,
     streamService,
     userPreferencesService,
+    workspaceSettingsService,
     sidebarConfigService,
     invitationService,
     activityService,
@@ -227,6 +232,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const conversation = createConversationHandlers({ conversationService, streamService })
   const command = createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService })
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
+  const workspaceSettings = createWorkspaceSettingsHandlers({ workspaceSettingsService })
   const sidebarConfig = createSidebarConfigHandlers({ sidebarConfigService })
   const userE2eKeys = createUserE2eKeysHandlers({ userE2eKeysService })
   const aiUsage = createAIUsageHandlers({ pool })
@@ -318,6 +324,15 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   // User preferences
   app.get("/api/workspaces/:workspaceId/preferences", ...authed, preferences.get)
   app.patch("/api/workspaces/:workspaceId/preferences", ...authed, preferences.update)
+
+  // Workspace settings (workspace-wide defaults; writes are admin-only)
+  app.get("/api/workspaces/:workspaceId/workspace-settings", ...authed, workspaceSettings.get)
+  app.patch(
+    "/api/workspaces/:workspaceId/workspace-settings",
+    ...authed,
+    requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN),
+    workspaceSettings.update
+  )
 
   // Sidebar config (per-user, per-workspace layout)
   app.get("/api/workspaces/:workspaceId/sidebar-config", ...authed, sidebarConfig.get)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -74,6 +74,7 @@ import {
   StubBoundaryExtractor,
 } from "./features/conversations"
 import { UserPreferencesService } from "./features/user-preferences"
+import { WorkspaceSettingsService } from "./features/workspace-settings"
 import { SidebarConfigService } from "./features/sidebar-config"
 import { UserE2eKeysService } from "./features/user-e2e-keys"
 import { createS3Storage } from "./lib/storage/s3-client"
@@ -264,6 +265,7 @@ export async function startServer(): Promise<ServerInstance> {
     : new StreamNamingService(pool, ai, configResolver, messageFormatter)
   const conversationService = new ConversationService(pool)
   const userPreferencesService = new UserPreferencesService(pool)
+  const workspaceSettingsService = new WorkspaceSettingsService(pool)
   const sidebarConfigService = new SidebarConfigService(pool)
   const userE2eKeysService = new UserE2eKeysService(pool)
 
@@ -556,6 +558,7 @@ export async function startServer(): Promise<ServerInstance> {
     memoExplorerService,
     conversationService,
     userPreferencesService,
+    workspaceSettingsService,
     sidebarConfigService,
     userE2eKeysService,
     invitationService,

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./memos"
 export { conversationsApi, type ListConversationsParams } from "./conversations"
 export { preferencesApi } from "./preferences"
+export { workspaceSettingsApi } from "./workspace-settings"
 export { sidebarConfigApi } from "./sidebar-config"
 export { aiUsageApi } from "./ai-usage"
 export { agentSessionsApi } from "./agent-sessions"

--- a/apps/frontend/src/api/workspace-settings.ts
+++ b/apps/frontend/src/api/workspace-settings.ts
@@ -1,0 +1,17 @@
+import { api } from "./client"
+import type { WorkspaceSettings, UpdateWorkspaceSettingsInput } from "@threa/types"
+
+export const workspaceSettingsApi = {
+  async get(workspaceId: string): Promise<WorkspaceSettings> {
+    const res = await api.get<{ settings: WorkspaceSettings }>(`/api/workspaces/${workspaceId}/workspace-settings`)
+    return res.settings
+  },
+
+  async update(workspaceId: string, input: UpdateWorkspaceSettingsInput): Promise<WorkspaceSettings> {
+    const res = await api.patch<{ settings: WorkspaceSettings }>(
+      `/api/workspaces/${workspaceId}/workspace-settings`,
+      input
+    )
+    return res.settings
+  },
+}

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -14,6 +14,8 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useLongPress } from "@/hooks/use-long-press"
 import { usePreferencesOptional } from "@/contexts"
 import { REMINDER_PRESETS, computeRemindAt, type ReminderPreset } from "@/lib/reminder-presets"
+import { useEffectiveWorkSchedule } from "@/hooks/use-work-schedule"
+import type { WorkSchedule } from "@threa/types"
 import { DateTimeField } from "@/components/forms/date-time-field"
 import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/dates"
 import { ScheduledEditDialog } from "@/components/scheduled/scheduled-edit-dialog"
@@ -94,6 +96,10 @@ export function ScheduledMessagesPicker({
   // domain model and frequently null on accounts that haven't completed the
   // setup wizard, which silently disabled the alt-tz split for those users.
   const prefTimezone = usePreferencesOptional()?.preferences?.timezone ?? null
+  // Calendar presets ("Tomorrow morning", "Next week") resolve against the
+  // viewer's working schedule — start of work replaces 9am, working-week start
+  // replaces Monday.
+  const workSchedule = useEffectiveWorkSchedule(workspaceId)
 
   const count = items.length
   // Re-anchor relative-time labels each time the popover opens.
@@ -125,7 +131,7 @@ export function ScheduledMessagesPicker({
 
   const handlePreset = (preset: ReminderPreset, overrideTz?: string) => {
     // Default to device-local; pref-tz is opt-in via the split-button dropdown.
-    const when = computeRemindAt(preset, new Date(), overrideTz ?? timezone)
+    const when = computeRemindAt(preset, new Date(), overrideTz ?? timezone, workSchedule)
     onSchedule(when)
     setOpen(false)
     resetToList()
@@ -216,6 +222,7 @@ export function ScheduledMessagesPicker({
             <PickingMode
               timezone={timezone}
               prefTimezone={prefTimezone}
+              workSchedule={workSchedule}
               showCustom={showCustom}
               customDate={customDate}
               customTime={customTime}
@@ -352,6 +359,7 @@ function ListMode({
 interface PickingModeProps {
   timezone: string
   prefTimezone: string | null
+  workSchedule: WorkSchedule
   showCustom: boolean
   customDate: string
   customTime: string
@@ -368,6 +376,7 @@ interface PickingModeProps {
 function PickingMode({
   timezone,
   prefTimezone,
+  workSchedule,
   showCustom,
   customDate,
   customTime,
@@ -401,6 +410,7 @@ function PickingMode({
               preset={preset}
               timezone={timezone}
               prefTimezone={prefTimezone}
+              workSchedule={workSchedule}
               onPreset={onPreset}
             />
           ))}
@@ -442,6 +452,7 @@ interface PresetRowProps {
   preset: ReminderPreset
   timezone: string
   prefTimezone: string | null
+  workSchedule: WorkSchedule
   onPreset: (preset: ReminderPreset, overrideTz?: string) => void
 }
 
@@ -462,16 +473,19 @@ interface PresetRowProps {
  * Duration presets ("In 15 minutes") are timezone-invariant, so the split
  * never appears for them.
  */
-function PresetRow({ preset, timezone, prefTimezone, onPreset }: PresetRowProps) {
+function PresetRow({ preset, timezone, prefTimezone, workSchedule, onPreset }: PresetRowProps) {
   const now = useMemo(() => new Date(), [])
-  const localDate = useMemo(() => computeRemindAt(preset, now, timezone), [preset, now, timezone])
+  const localDate = useMemo(
+    () => computeRemindAt(preset, now, timezone, workSchedule),
+    [preset, now, timezone, workSchedule]
+  )
   // Calendar presets only — duration presets resolve to the same instant in
   // every timezone.
   const prefDate = useMemo(() => {
     if (preset.kind !== "calendar") return null
     if (!prefTimezone || prefTimezone === timezone) return null
-    return computeRemindAt(preset, now, prefTimezone)
-  }, [preset, now, timezone, prefTimezone])
+    return computeRemindAt(preset, now, prefTimezone, workSchedule)
+  }, [preset, now, timezone, prefTimezone, workSchedule])
   // Even with different tz strings the offsets can match at the resolved
   // wall-clock (e.g. London ↔ Lisbon at certain times of year). Don't show
   // the split when both options would fire at the same moment.

--- a/apps/frontend/src/components/settings/schedule-settings.tsx
+++ b/apps/frontend/src/components/settings/schedule-settings.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
+import type { WorkSchedule } from "@threa/types"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
+import { usePreferences } from "@/contexts"
+import { useWorkspaceDefaultWorkSchedule } from "@/hooks/use-work-schedule"
+import { WorkScheduleEditor } from "./work-schedule-editor"
+
+/**
+ * Personal working week + working hours. When the user has no override they
+ * inherit the workspace default; flipping "Use a custom schedule" seeds the
+ * editor from that default and stores a personal override. Schedule-aware
+ * scheduling presets ("Tomorrow morning", "Next week") resolve against it.
+ */
+export function ScheduleSettings() {
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+  const { preferences, updatePreference, isLoading } = usePreferences()
+  const workspaceDefault = useWorkspaceDefaultWorkSchedule(workspaceId ?? "")
+
+  const savedOverride = preferences?.workSchedule ?? null
+  const usingCustom = savedOverride !== null
+
+  // Local draft so editing time fields doesn't fire a mutation per keystroke;
+  // the explicit Save commits the override.
+  const [draft, setDraft] = useState<WorkSchedule>(savedOverride ?? workspaceDefault)
+
+  useEffect(() => {
+    setDraft(savedOverride ?? workspaceDefault)
+  }, [savedOverride, workspaceDefault])
+
+  const dirty = usingCustom && JSON.stringify(draft) !== JSON.stringify(savedOverride)
+
+  const toggleCustom = (on: boolean) => {
+    // Enabling seeds the override from the current effective default; disabling
+    // clears it (null → inherit workspace default).
+    void updatePreference("workSchedule", on ? workspaceDefault : null)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Working schedule</h3>
+          <p className="text-sm text-muted-foreground">
+            Your working week and hours. Scheduling shortcuts like “Tomorrow morning” and “Next week” snap to when you
+            start work, in your local time.
+          </p>
+        </div>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <Switch checked={usingCustom} onCheckedChange={toggleCustom} disabled={isLoading} />
+          <span className="text-sm">Use a custom schedule (otherwise inherit the workspace default)</span>
+        </label>
+      </section>
+
+      {usingCustom && (
+        <>
+          <Separator />
+          <section className="space-y-3">
+            <WorkScheduleEditor value={draft} onChange={setDraft} disabled={isLoading} />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!dirty || isLoading}
+                onClick={() => setDraft(savedOverride ?? workspaceDefault)}
+              >
+                Reset
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={!dirty || isLoading}
+                onClick={() => void updatePreference("workSchedule", draft)}
+              >
+                Save schedule
+              </Button>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -14,6 +14,7 @@ import { AISettings } from "./ai-settings"
 import { ProfileSettings } from "./profile-settings"
 import { AppearanceSettings } from "./appearance-settings"
 import { DateTimeSettings } from "./datetime-settings"
+import { ScheduleSettings } from "./schedule-settings"
 import { NotificationsSettings } from "./notifications-settings"
 import { KeyboardSettings } from "./keyboard-settings"
 import { AccessibilitySettings } from "./accessibility-settings"
@@ -23,6 +24,7 @@ const TAB_CONFIG: Record<SettingsTab, { label: string; description: string }> = 
   ai: { label: "AI", description: "Scratchpad behavior, guidance, and voice dictation" },
   appearance: { label: "Appearance", description: "Theme and message density" },
   datetime: { label: "Date & Time", description: "Timezone and formatting" },
+  schedule: { label: "Working hours", description: "Working week and shifts" },
   notifications: { label: "Notifications", description: "Alerts and push behavior" },
   keyboard: { label: "Keyboard", description: "Shortcuts and send behavior" },
   accessibility: { label: "Accessibility", description: "Motion, contrast, and fonts" },
@@ -85,6 +87,9 @@ export function SettingsDialog() {
               </TabsContent>
               <TabsContent value="datetime" className="mt-0">
                 <DateTimeSettings />
+              </TabsContent>
+              <TabsContent value="schedule" className="mt-0">
+                <ScheduleSettings />
               </TabsContent>
               <TabsContent value="notifications" className="mt-0">
                 <NotificationsSettings />

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -57,7 +57,7 @@ export function SettingsDialog() {
         <ResponsiveDialogHeader className="border-b px-4 py-4 sm:px-6 sm:py-5">
           <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
           <ResponsiveDialogDescription className="sr-only">
-            Manage your profile, AI preferences, notifications, and accessibility settings.
+            Manage your profile, AI preferences, working hours, notifications, and accessibility settings.
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 

--- a/apps/frontend/src/components/settings/work-schedule-editor.tsx
+++ b/apps/frontend/src/components/settings/work-schedule-editor.tsx
@@ -1,0 +1,170 @@
+import { Plus, X } from "lucide-react"
+import {
+  type WorkSchedule,
+  type Weekday,
+  type ShiftInterval,
+  WEEKDAYS_MONDAY_FIRST,
+  getDayShifts,
+  typicalStartMinutes,
+  minutesToHHMM,
+  parseHHMM,
+} from "@threa/types"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { cn } from "@/lib/utils"
+
+const DAY_END = 23 * 60 + 59
+
+/**
+ * Build a valid shift seeded at `startMin`. Start is capped so there's always
+ * room for an 8h (or shorter) shift that ends before midnight, guaranteeing
+ * end > start — which the backend requires.
+ */
+function makeShift(startMin: number): ShiftInterval {
+  const start = Math.min(Math.max(startMin, 0), DAY_END - 60)
+  const end = Math.min(start + 8 * 60, DAY_END)
+  return { start: minutesToHHMM(start), end: minutesToHHMM(end) }
+}
+
+const WEEKDAY_LABELS: Record<Weekday, string> = {
+  0: "Sunday",
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+}
+
+interface WorkScheduleEditorProps {
+  value: WorkSchedule
+  onChange: (next: WorkSchedule) => void
+  disabled?: boolean
+}
+
+/**
+ * Per-weekday working-hours editor shared by user settings (personal override)
+ * and workspace settings (workspace default). A weekday with no shifts is a day
+ * off; the switch toggles a day on with a sensible default shift and off by
+ * clearing its shifts. Multiple shifts per day cover split shifts / siesta.
+ */
+export function WorkScheduleEditor({ value, onChange, disabled }: WorkScheduleEditorProps) {
+  const setDay = (day: Weekday, shifts: ShiftInterval[]) => {
+    onChange({ days: { ...value.days, [day]: shifts } })
+  }
+
+  const toggleDay = (day: Weekday, on: boolean) => {
+    if (!on) {
+      setDay(day, [])
+      return
+    }
+    // Seed a new working day with one shift starting at the schedule's typical
+    // start so a freshly enabled day isn't empty (which would read as "off").
+    setDay(day, [makeShift(typicalStartMinutes(value))])
+  }
+
+  return (
+    <div className="space-y-2">
+      {WEEKDAYS_MONDAY_FIRST.map((day) => {
+        const shifts = getDayShifts(value, day)
+        const working = shifts.length > 0
+        return (
+          <div key={day} className="rounded-md border px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <Switch checked={working} onCheckedChange={(on) => toggleDay(day, on)} disabled={disabled} />
+                <span className={cn("text-sm font-medium", !working && "text-muted-foreground")}>
+                  {WEEKDAY_LABELS[day]}
+                </span>
+              </label>
+              {!working && <span className="text-xs text-muted-foreground">Day off</span>}
+            </div>
+
+            {working && (
+              <div className="mt-2 space-y-2 pl-[3.25rem]">
+                {shifts.map((shift, index) => (
+                  <ShiftRow
+                    key={index}
+                    shift={shift}
+                    disabled={disabled}
+                    onChange={(next) =>
+                      setDay(
+                        day,
+                        shifts.map((s, i) => (i === index ? next : s))
+                      )
+                    }
+                    onRemove={() =>
+                      setDay(
+                        day,
+                        shifts.filter((_, i) => i !== index)
+                      )
+                    }
+                  />
+                ))}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1 px-2 text-xs"
+                  disabled={disabled || shifts.length >= 6}
+                  onClick={() => {
+                    // Start the next shift where the last one ended (e.g. an
+                    // afternoon block after a morning shift).
+                    const lastEnd = parseHHMM(shifts[shifts.length - 1]?.end ?? "") ?? 9 * 60
+                    setDay(day, [...shifts, makeShift(lastEnd)])
+                  }}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add shift
+                </Button>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+interface ShiftRowProps {
+  shift: ShiftInterval
+  disabled?: boolean
+  onChange: (next: ShiftInterval) => void
+  onRemove: () => void
+}
+
+function ShiftRow({ shift, disabled, onChange, onRemove }: ShiftRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        type="time"
+        value={shift.start}
+        disabled={disabled}
+        onChange={(e) => onChange({ ...shift, start: e.target.value })}
+        className="h-8 w-28"
+        aria-label="Shift start"
+      />
+      <span className="text-xs text-muted-foreground">to</span>
+      <Input
+        type="time"
+        value={shift.end}
+        disabled={disabled}
+        onChange={(e) => onChange({ ...shift, end: e.target.value })}
+        className="h-8 w-28"
+        aria-label="Shift end"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-muted-foreground"
+        disabled={disabled}
+        onClick={onRemove}
+        aria-label="Remove shift"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/settings/work-schedule-editor.tsx
+++ b/apps/frontend/src/components/settings/work-schedule-editor.tsx
@@ -71,6 +71,10 @@ export function WorkScheduleEditor({ value, onChange, disabled }: WorkScheduleEd
       {WEEKDAYS_MONDAY_FIRST.map((day) => {
         const shifts = getDayShifts(value, day)
         const working = shifts.length > 0
+        // Once the last shift reaches midnight there's no room to append
+        // another — appending would seed an overlapping interval.
+        const lastShiftEnd = parseHHMM(shifts[shifts.length - 1]?.end ?? "")
+        const dayFull = lastShiftEnd !== null && lastShiftEnd >= DAY_END
         return (
           <div key={day} className="rounded-md border px-3 py-2.5">
             <div className="flex items-center justify-between">
@@ -109,12 +113,11 @@ export function WorkScheduleEditor({ value, onChange, disabled }: WorkScheduleEd
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1 px-2 text-xs"
-                  disabled={disabled || shifts.length >= 6}
+                  disabled={disabled || shifts.length >= 6 || dayFull}
                   onClick={() => {
                     // Start the next shift where the last one ended (e.g. an
                     // afternoon block after a morning shift).
-                    const lastEnd = parseHHMM(shifts[shifts.length - 1]?.end ?? "") ?? 9 * 60
-                    setDay(day, [...shifts, makeShift(lastEnd)])
+                    setDay(day, [...shifts, makeShift(lastShiftEnd ?? 9 * 60)])
                   }}
                 >
                   <Plus className="h-3.5 w-3.5" />

--- a/apps/frontend/src/components/settings/work-schedule-editor.tsx
+++ b/apps/frontend/src/components/settings/work-schedule-editor.tsx
@@ -22,7 +22,9 @@ const DAY_END = 23 * 60 + 59
  * end > start — which the backend requires.
  */
 function makeShift(startMin: number): ShiftInterval {
-  const start = Math.min(Math.max(startMin, 0), DAY_END - 60)
+  // Cap start at the last minute before midnight so a new shift never lands
+  // before the one it follows; end is clamped to midnight, so start < end holds.
+  const start = Math.min(Math.max(startMin, 0), DAY_END - 1)
   const end = Math.min(start + 8 * 60, DAY_END)
   return { start: minutesToHHMM(start), end: minutesToHHMM(end) }
 }

--- a/apps/frontend/src/components/settings/work-schedule-editor.tsx
+++ b/apps/frontend/src/components/settings/work-schedule-editor.tsx
@@ -71,10 +71,11 @@ export function WorkScheduleEditor({ value, onChange, disabled }: WorkScheduleEd
       {WEEKDAYS_MONDAY_FIRST.map((day) => {
         const shifts = getDayShifts(value, day)
         const working = shifts.length > 0
-        // Once the last shift reaches midnight there's no room to append
-        // another — appending would seed an overlapping interval.
+        // Can only append another shift when the last one has a parseable end
+        // before midnight — otherwise there's no room (or the row is invalid),
+        // and appending would seed an overlapping/reordered interval.
         const lastShiftEnd = parseHHMM(shifts[shifts.length - 1]?.end ?? "")
-        const dayFull = lastShiftEnd !== null && lastShiftEnd >= DAY_END
+        const canAppendShift = lastShiftEnd !== null && lastShiftEnd < DAY_END
         return (
           <div key={day} className="rounded-md border px-3 py-2.5">
             <div className="flex items-center justify-between">
@@ -113,11 +114,12 @@ export function WorkScheduleEditor({ value, onChange, disabled }: WorkScheduleEd
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1 px-2 text-xs"
-                  disabled={disabled || shifts.length >= 6 || dayFull}
+                  disabled={disabled || shifts.length >= 6 || !canAppendShift}
                   onClick={() => {
                     // Start the next shift where the last one ended (e.g. an
                     // afternoon block after a morning shift).
-                    setDay(day, [...shifts, makeShift(lastShiftEnd ?? 9 * 60)])
+                    if (!canAppendShift) return
+                    setDay(day, [...shifts, makeShift(lastShiftEnd)])
                   }}
                 >
                   <Plus className="h-3.5 w-3.5" />

--- a/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
+++ b/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { useSaveMessage, useUpdateSaved } from "@/hooks/use-saved"
 import { ReminderBadge } from "@/components/saved/reminder-badge"
 import { REMINDER_PRESETS, computeRemindAt } from "@/lib/reminder-presets"
+import { useEffectiveWorkSchedule } from "@/hooks/use-work-schedule"
 import { DateTimeField } from "@/components/forms/date-time-field"
 import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/dates"
 
@@ -33,6 +34,7 @@ export function ReminderPickerSheet({ open, onOpenChange, workspaceId, messageId
   // Browser-local timezone — never use `preferences.timezone` in the UI
   // because native pickers always operate in device-local.
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const workSchedule = useEffectiveWorkSchedule(workspaceId)
   const saveMutation = useSaveMessage(workspaceId)
   const updateMutation = useUpdateSaved(workspaceId)
   const [mode, setMode] = useState<"presets" | "custom">("presets")
@@ -134,7 +136,7 @@ export function ReminderPickerSheet({ open, onOpenChange, workspaceId, messageId
               {REMINDER_PRESETS.map((preset) => (
                 <SheetMenuButton
                   key={preset.label}
-                  onClick={() => setReminder(computeRemindAt(preset, new Date(), timezone))}
+                  onClick={() => setReminder(computeRemindAt(preset, new Date(), timezone, workSchedule))}
                 >
                   <Bell className="h-4 w-4 text-muted-foreground" />
                   {preset.label}

--- a/apps/frontend/src/components/timeline/reminder-popover-content.tsx
+++ b/apps/frontend/src/components/timeline/reminder-popover-content.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import { useSaveMessage, useUpdateSaved, useDeleteSaved } from "@/hooks/use-saved"
 import { ReminderBadge } from "@/components/saved/reminder-badge"
 import { REMINDER_PRESETS, computeRemindAt } from "@/lib/reminder-presets"
+import { useEffectiveWorkSchedule } from "@/hooks/use-work-schedule"
 
 interface ReminderPopoverContentProps {
   workspaceId: string
@@ -19,6 +20,7 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
   // here. Native pickers operate in device-local; any drift would silently
   // shift saved reminders by the device-vs-preference offset.
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const workSchedule = useEffectiveWorkSchedule(workspaceId)
   const saveMutation = useSaveMessage(workspaceId)
   const updateMutation = useUpdateSaved(workspaceId)
   const deleteMutation = useDeleteSaved(workspaceId)
@@ -114,7 +116,7 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
         {REMINDER_PRESETS.map((preset) => (
           <PopoverMenuButton
             key={preset.label}
-            onClick={() => setReminder(computeRemindAt(preset, new Date(), timezone))}
+            onClick={() => setReminder(computeRemindAt(preset, new Date(), timezone, workSchedule))}
           >
             <Bell className="h-3.5 w-3.5" />
             {preset.label}

--- a/apps/frontend/src/components/workspace-settings/schedule-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/schedule-tab.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { WORKSPACE_PERMISSION_SCOPES, type WorkSchedule, type WorkspaceBootstrap } from "@threa/types"
+import { workspaceSettingsApi } from "@/api"
+import { workspaceKeys, useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { useWorkspaceDefaultWorkSchedule } from "@/hooks/use-work-schedule"
+import { hasPermission } from "@/lib/permissions"
+import { Button } from "@/components/ui/button"
+import { WorkScheduleEditor } from "@/components/settings/work-schedule-editor"
+
+interface ScheduleTabProps {
+  workspaceId: string
+}
+
+/**
+ * Workspace-wide default working schedule. Members inherit this unless they set
+ * a personal override in their own settings. Editing is gated to admins; others
+ * see the schedule read-only.
+ */
+export function ScheduleTab({ workspaceId }: ScheduleTabProps) {
+  const queryClient = useQueryClient()
+  const bootstrap = useCachedWorkspaceBootstrap(workspaceId)
+  const canManage = hasPermission(bootstrap?.viewerPermissions, WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN)
+  const saved = useWorkspaceDefaultWorkSchedule(workspaceId)
+
+  const [draft, setDraft] = useState<WorkSchedule>(saved)
+  useEffect(() => {
+    setDraft(saved)
+  }, [saved])
+
+  const mutation = useMutation({
+    mutationFn: (defaultWorkSchedule: WorkSchedule) =>
+      workspaceSettingsApi.update(workspaceId, { defaultWorkSchedule }),
+    onSuccess: (settings) => {
+      // Reflect the new default in the bootstrap cache so every schedule-aware
+      // surface picks it up without a refetch.
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
+        old ? { ...old, workspaceSettings: settings } : old
+      )
+      toast.success("Workspace schedule saved")
+    },
+    onError: () => toast.error("Failed to save workspace schedule"),
+  })
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(saved)
+
+  return (
+    <div className="space-y-4 p-1">
+      <div>
+        <h3 className="text-sm font-medium">Default working schedule</h3>
+        <p className="text-sm text-muted-foreground">
+          The working week and hours new members inherit. Scheduling shortcuts like “Tomorrow morning” and “Next week”
+          snap to the start of work. Members can override this in their own settings.
+        </p>
+      </div>
+
+      <WorkScheduleEditor value={draft} onChange={setDraft} disabled={!canManage || mutation.isPending} />
+
+      {canManage ? (
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!dirty || mutation.isPending}
+            onClick={() => setDraft(saved)}
+          >
+            Reset
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!dirty || mutation.isPending}
+            onClick={() => mutation.mutate(draft)}
+          >
+            Save schedule
+          </Button>
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">Only workspace admins can change the default schedule.</p>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
@@ -14,12 +14,14 @@ import { UsersTab } from "./users-tab"
 import { ApiKeysTab } from "./api-keys-tab"
 import { BotsTab } from "./bots-tab"
 import { IntegrationsTab } from "./integrations-tab"
+import { ScheduleTab } from "./schedule-tab"
 
-const ALL_TABS = ["general", "users", "integrations", "bots", "api-keys"] as const
+const ALL_TABS = ["general", "schedule", "users", "integrations", "bots", "api-keys"] as const
 type WorkspaceSettingsTab = (typeof ALL_TABS)[number]
 
 const TAB_CONFIG: Record<WorkspaceSettingsTab, { label: string; description: string }> = {
   general: { label: "General", description: "Workspace identity and region" },
+  schedule: { label: "Working hours", description: "Default working week and shifts" },
   users: { label: "Users", description: "Members and pending invites" },
   integrations: { label: "Integrations", description: "Shared third-party connections" },
   bots: { label: "Bots", description: "Workspace automation accounts" },
@@ -86,6 +88,9 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
             <div data-slot="settings-content" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.content}>
               <TabsContent value="general" className="mt-0">
                 <GeneralTab workspaceId={workspaceId} />
+              </TabsContent>
+              <TabsContent value="schedule" className="mt-0">
+                <ScheduleTab workspaceId={workspaceId} />
               </TabsContent>
               <TabsContent value="users" className="mt-0">
                 <UsersTab workspaceId={workspaceId} />

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
 import type { CreateStreamInput } from "@/api"
-import { DEFAULT_SIDEBAR_CONFIG, type Stream, type WorkspaceBootstrap } from "@threa/types"
+import { DEFAULT_SIDEBAR_CONFIG, DEFAULT_WORKSPACE_SETTINGS, type Stream, type WorkspaceBootstrap } from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useCreateStream } from "./use-streams"
 import * as syncEngineModule from "@/sync/sync-engine"
@@ -77,6 +77,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       blockquoteCollapseThreshold: 6,
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
+      workSchedule: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",
@@ -84,6 +85,12 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
         highContrast: false,
       },
       keyboardShortcuts: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    workspaceSettings: {
+      ...DEFAULT_WORKSPACE_SETTINGS,
+      workspaceId: "ws_1",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -4,7 +4,12 @@ import { createElement, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
-import { DEFAULT_SIDEBAR_CONFIG, type StreamMember, type WorkspaceBootstrap } from "@threa/types"
+import {
+  DEFAULT_SIDEBAR_CONFIG,
+  DEFAULT_WORKSPACE_SETTINGS,
+  type StreamMember,
+  type WorkspaceBootstrap,
+} from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
@@ -85,6 +90,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       blockquoteCollapseThreshold: 6,
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
+      workSchedule: null,
       accessibility: {
         fontSize: "medium",
         fontFamily: "system",
@@ -92,6 +98,12 @@ function makeBootstrap(): WorkspaceBootstrap {
         highContrast: false,
       },
       keyboardShortcuts: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    workspaceSettings: {
+      ...DEFAULT_WORKSPACE_SETTINGS,
+      workspaceId: "ws_1",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },

--- a/apps/frontend/src/hooks/use-work-schedule.ts
+++ b/apps/frontend/src/hooks/use-work-schedule.ts
@@ -5,6 +5,17 @@ import { usePreferencesOptional } from "@/contexts"
 import { resolveWorkSchedule } from "@/lib/work-schedule"
 
 /**
+ * The working schedule that should drive schedule-aware presets for the current
+ * viewer: their personal override (IDB-backed, offline-safe) layered over the
+ * workspace default. Falls back to Mon–Fri 09:00 when neither is available.
+ */
+export function useEffectiveWorkSchedule(workspaceId: string): WorkSchedule {
+  const userSchedule = usePreferencesOptional()?.preferences?.workSchedule ?? null
+  const workspaceDefault = useWorkspaceDefaultWorkSchedule(workspaceId)
+  return resolveWorkSchedule(userSchedule, workspaceDefault)
+}
+
+/**
  * The workspace-wide default working schedule (read from the bootstrap cache via
  * the cache-only observer pattern). Falls back to Mon–Fri 09:00 when absent.
  * Used by settings surfaces that need the default independently of any personal
@@ -20,25 +31,4 @@ export function useWorkspaceDefaultWorkSchedule(workspaceId: string): WorkSchedu
     select: (bootstrap) => bootstrap?.workspaceSettings?.defaultWorkSchedule ?? null,
   })
   return data ?? DEFAULT_WORK_SCHEDULE
-}
-
-/**
- * The working schedule that should drive schedule-aware presets for the current
- * viewer: their personal override (IDB-backed, offline-safe) layered over the
- * workspace default (read from the bootstrap cache via the cache-only observer
- * pattern). Falls back to Mon–Fri 09:00 when neither is available.
- */
-export function useEffectiveWorkSchedule(workspaceId: string): WorkSchedule {
-  const queryClient = useQueryClient()
-  const userSchedule = usePreferencesOptional()?.preferences?.workSchedule ?? null
-
-  const { data: workspaceDefault } = useQuery({
-    queryKey: workspaceKeys.bootstrap(workspaceId),
-    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
-    enabled: false,
-    staleTime: Infinity,
-    select: (bootstrap) => bootstrap?.workspaceSettings?.defaultWorkSchedule ?? null,
-  })
-
-  return resolveWorkSchedule(userSchedule, workspaceDefault)
 }

--- a/apps/frontend/src/hooks/use-work-schedule.ts
+++ b/apps/frontend/src/hooks/use-work-schedule.ts
@@ -1,0 +1,44 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { type WorkspaceBootstrap, type WorkSchedule, DEFAULT_WORK_SCHEDULE } from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { usePreferencesOptional } from "@/contexts"
+import { resolveWorkSchedule } from "@/lib/work-schedule"
+
+/**
+ * The workspace-wide default working schedule (read from the bootstrap cache via
+ * the cache-only observer pattern). Falls back to Mon–Fri 09:00 when absent.
+ * Used by settings surfaces that need the default independently of any personal
+ * override.
+ */
+export function useWorkspaceDefaultWorkSchedule(workspaceId: string): WorkSchedule {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap) => bootstrap?.workspaceSettings?.defaultWorkSchedule ?? null,
+  })
+  return data ?? DEFAULT_WORK_SCHEDULE
+}
+
+/**
+ * The working schedule that should drive schedule-aware presets for the current
+ * viewer: their personal override (IDB-backed, offline-safe) layered over the
+ * workspace default (read from the bootstrap cache via the cache-only observer
+ * pattern). Falls back to Mon–Fri 09:00 when neither is available.
+ */
+export function useEffectiveWorkSchedule(workspaceId: string): WorkSchedule {
+  const queryClient = useQueryClient()
+  const userSchedule = usePreferencesOptional()?.preferences?.workSchedule ?? null
+
+  const { data: workspaceDefault } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap) => bootstrap?.workspaceSettings?.defaultWorkSchedule ?? null,
+  })
+
+  return resolveWorkSchedule(userSchedule, workspaceDefault)
+}

--- a/apps/frontend/src/lib/reminder-presets.test.ts
+++ b/apps/frontend/src/lib/reminder-presets.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "vitest"
+import { type WorkSchedule, type Weekday, type ShiftInterval } from "@threa/types"
+import { computeRemindAt, type ReminderPreset } from "./reminder-presets"
+
+function schedule(days: Partial<Record<Weekday, ShiftInterval[]>>): WorkSchedule {
+  const full: Record<Weekday, ShiftInterval[]> = { 0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] }
+  for (const [day, shifts] of Object.entries(days)) full[Number(day) as Weekday] = shifts ?? []
+  return { days: full }
+}
+
+const MON_FRI_9 = schedule({
+  1: [{ start: "09:00", end: "17:00" }],
+  2: [{ start: "09:00", end: "17:00" }],
+  3: [{ start: "09:00", end: "17:00" }],
+  4: [{ start: "09:00", end: "17:00" }],
+  5: [{ start: "09:00", end: "17:00" }],
+})
+
+const SUN_THU_8 = schedule({
+  0: [{ start: "08:00", end: "16:00" }],
+  1: [{ start: "08:00", end: "16:00" }],
+  2: [{ start: "08:00", end: "16:00" }],
+  3: [{ start: "08:00", end: "16:00" }],
+  4: [{ start: "08:00", end: "16:00" }],
+})
+
+// Wednesday 2026-06-03, noon UTC.
+const NOW = new Date("2026-06-03T12:00:00Z")
+const TZ = "UTC"
+
+const tomorrow: ReminderPreset = { label: "Tomorrow morning", kind: "calendar", calendar: "tomorrow-start" }
+const nextWeek: ReminderPreset = { label: "Next week", kind: "calendar", calendar: "next-week-start" }
+
+describe("computeRemindAt — duration presets", () => {
+  test("are schedule- and timezone-invariant", () => {
+    const preset: ReminderPreset = { label: "In 1 hour", kind: "duration", minutes: 60 }
+    expect(computeRemindAt(preset, NOW, TZ, MON_FRI_9).toISOString()).toBe("2026-06-03T13:00:00.000Z")
+  })
+})
+
+describe("computeRemindAt — working hours (start of work)", () => {
+  test("Tomorrow lands at the start of work, not a hardcoded 9am", () => {
+    // Thursday is a working day in both; start time follows the schedule.
+    expect(computeRemindAt(tomorrow, NOW, TZ, MON_FRI_9).toISOString()).toBe("2026-06-04T09:00:00.000Z")
+    expect(computeRemindAt(tomorrow, NOW, TZ, SUN_THU_8).toISOString()).toBe("2026-06-04T08:00:00.000Z")
+  })
+})
+
+describe("computeRemindAt — working week (next week)", () => {
+  test("Mon–Fri resolves Next week to Monday", () => {
+    expect(computeRemindAt(nextWeek, NOW, TZ, MON_FRI_9).toISOString()).toBe("2026-06-08T09:00:00.000Z")
+  })
+
+  test("Sun–Thu resolves Next week to 'this Sunday' (the working-week start)", () => {
+    // From Wednesday, the next working week starts on the coming Sunday (06-07),
+    // before the Monday that a hardcoded preset would have used.
+    expect(computeRemindAt(nextWeek, NOW, TZ, SUN_THU_8).toISOString()).toBe("2026-06-07T08:00:00.000Z")
+  })
+})

--- a/apps/frontend/src/lib/reminder-presets.test.ts
+++ b/apps/frontend/src/lib/reminder-presets.test.ts
@@ -46,6 +46,18 @@ describe("computeRemindAt — working hours (start of work)", () => {
   })
 })
 
+describe("computeRemindAt — DST safety", () => {
+  test("advances by calendar days across a fall-back transition, not fixed 24h", () => {
+    // Nov 1 2026 00:30 in America/New_York is the DST fall-back day (25h long),
+    // so `now + 24h` of milliseconds still reads as Nov 1 locally. Civil-date
+    // arithmetic must land "tomorrow" / "next week" on Monday Nov 2, not Nov 1.
+    const dstNow = new Date("2026-11-01T04:30:00Z")
+    const ny = "America/New_York"
+    expect(computeRemindAt(tomorrow, dstNow, ny, MON_FRI_9).toISOString()).toBe("2026-11-02T14:00:00.000Z")
+    expect(computeRemindAt(nextWeek, dstNow, ny, MON_FRI_9).toISOString()).toBe("2026-11-02T14:00:00.000Z")
+  })
+})
+
 describe("computeRemindAt — working week (next week)", () => {
   test("Mon–Fri resolves Next week to Monday", () => {
     expect(computeRemindAt(nextWeek, NOW, TZ, MON_FRI_9).toISOString()).toBe("2026-06-08T09:00:00.000Z")

--- a/apps/frontend/src/lib/reminder-presets.ts
+++ b/apps/frontend/src/lib/reminder-presets.ts
@@ -1,25 +1,37 @@
 /**
  * Shared reminder-preset logic for the desktop hover popover, mobile sheet,
  * and Saved-view row popover. Preset math is timezone-aware via
- * `Intl.DateTimeFormat` so "Tomorrow 9am" means the user's local morning, not
- * the browser's.
+ * `Intl.DateTimeFormat` so "Tomorrow morning" means the user's local morning,
+ * not the browser's.
+ *
+ * Calendar presets resolve against the viewer's {@link WorkSchedule}: "morning"
+ * is the start of work (replacing the old hardcoded 09:00) and "next week"
+ * lands on the first working day of the next working week (replacing the old
+ * hardcoded Monday — a Sun–Thu schedule resolves to Sunday).
  */
+import {
+  type WorkSchedule,
+  type Weekday,
+  DEFAULT_WORK_SCHEDULE,
+  startOfWorkForDay,
+  firstWorkingWeekday,
+} from "@threa/types"
 
 /**
  * Tagged union so "duration" presets (minutes from now) and "calendar" presets
- * (next Monday at 9am) don't share a field. Adding a new calendar kind is a
- * new tag, not a new magic number.
+ * (next week at start of work) don't share a field. Adding a new calendar kind
+ * is a new tag, not a new magic number.
  */
 export type ReminderPreset =
   | { label: string; kind: "duration"; minutes: number }
-  | { label: string; kind: "calendar"; calendar: "tomorrow-9am" | "next-monday-9am" }
+  | { label: string; kind: "calendar"; calendar: "tomorrow-start" | "next-week-start" }
 
 export const REMINDER_PRESETS: ReminderPreset[] = [
   { label: "In 15 minutes", kind: "duration", minutes: 15 },
   { label: "In 1 hour", kind: "duration", minutes: 60 },
   { label: "In 3 hours", kind: "duration", minutes: 180 },
-  { label: "Tomorrow 9am", kind: "calendar", calendar: "tomorrow-9am" },
-  { label: "Next Monday 9am", kind: "calendar", calendar: "next-monday-9am" },
+  { label: "Tomorrow morning", kind: "calendar", calendar: "tomorrow-start" },
+  { label: "Next week", kind: "calendar", calendar: "next-week-start" },
 ]
 
 /** Resolve calendar parts (y/m/d + weekday index) as the user's timezone sees them. */
@@ -79,25 +91,45 @@ function buildZonedDate(timezone: string, y: number, m: number, d: number, hours
   return candidate
 }
 
-function nextMondayAt9(now: Date, timezone: string): Date {
+/** Build the start-of-work instant for a given local calendar day + weekday. */
+function startOfWorkInstant(
+  timezone: string,
+  schedule: WorkSchedule,
+  day: { y: number; m: number; d: number; weekday: number }
+): Date {
+  const minutes = startOfWorkForDay(schedule, day.weekday as Weekday)
+  return buildZonedDate(timezone, day.y, day.m, day.d, Math.floor(minutes / 60), minutes % 60)
+}
+
+function nextWeekStart(now: Date, timezone: string, schedule: WorkSchedule): Date {
   const today = calendarInZone(now, timezone)
-  // Always skip to the next Monday — if today is Monday, jump a full week so
-  // "Next Monday 9am" never resolves to earlier today.
-  const daysUntilMonday = today.weekday === 1 ? 7 : (1 - today.weekday + 7) % 7 || 7
-  const target = calendarInZone(new Date(now.getTime() + daysUntilMonday * 24 * 60 * 60_000), timezone)
-  return buildZonedDate(timezone, target.y, target.m, target.d, 9, 0)
+  // First working day of the week (Mon–Fri → Monday, Sun–Thu → Sunday). Empty
+  // schedules fall back to Monday.
+  const startWeekday = firstWorkingWeekday(schedule) ?? 1
+  // Always skip into next week — if today already is the week-start day, jump a
+  // full week so "Next week" never resolves to earlier today.
+  const daysUntil = today.weekday === startWeekday ? 7 : (startWeekday - today.weekday + 7) % 7 || 7
+  const target = calendarInZone(new Date(now.getTime() + daysUntil * 24 * 60 * 60_000), timezone)
+  return startOfWorkInstant(timezone, schedule, target)
 }
 
-function tomorrowAt9(now: Date, timezone: string): Date {
+function tomorrowStart(now: Date, timezone: string, schedule: WorkSchedule): Date {
   const tomorrow = calendarInZone(new Date(now.getTime() + 24 * 60 * 60_000), timezone)
-  return buildZonedDate(timezone, tomorrow.y, tomorrow.m, tomorrow.d, 9, 0)
+  return startOfWorkInstant(timezone, schedule, tomorrow)
 }
 
-export function computeRemindAt(preset: ReminderPreset, now: Date, timezone: string): Date {
+export function computeRemindAt(
+  preset: ReminderPreset,
+  now: Date,
+  timezone: string,
+  schedule: WorkSchedule = DEFAULT_WORK_SCHEDULE
+): Date {
   switch (preset.kind) {
     case "duration":
       return new Date(now.getTime() + preset.minutes * 60_000)
     case "calendar":
-      return preset.calendar === "tomorrow-9am" ? tomorrowAt9(now, timezone) : nextMondayAt9(now, timezone)
+      return preset.calendar === "tomorrow-start"
+        ? tomorrowStart(now, timezone, schedule)
+        : nextWeekStart(now, timezone, schedule)
   }
 }

--- a/apps/frontend/src/lib/reminder-presets.ts
+++ b/apps/frontend/src/lib/reminder-presets.ts
@@ -91,12 +91,26 @@ function buildZonedDate(timezone: string, y: number, m: number, d: number, hours
   return candidate
 }
 
+type CalendarDay = { y: number; m: number; d: number; weekday: number }
+
+/**
+ * Advance a zoned calendar date by whole days using civil-date arithmetic.
+ * Adding fixed 24h chunks of milliseconds is wrong across DST transitions (a
+ * fall-back day is 25h long, so `now + 24h` can read as the same local day);
+ * incrementing the calendar `d` field instead always moves a whole day.
+ */
+function shiftCalendarDay(day: CalendarDay, delta: number): CalendarDay {
+  const shifted = new Date(Date.UTC(day.y, day.m, day.d + delta))
+  return {
+    y: shifted.getUTCFullYear(),
+    m: shifted.getUTCMonth(),
+    d: shifted.getUTCDate(),
+    weekday: (((day.weekday + delta) % 7) + 7) % 7,
+  }
+}
+
 /** Build the start-of-work instant for a given local calendar day + weekday. */
-function startOfWorkInstant(
-  timezone: string,
-  schedule: WorkSchedule,
-  day: { y: number; m: number; d: number; weekday: number }
-): Date {
+function startOfWorkInstant(timezone: string, schedule: WorkSchedule, day: CalendarDay): Date {
   const minutes = startOfWorkForDay(schedule, day.weekday as Weekday)
   return buildZonedDate(timezone, day.y, day.m, day.d, Math.floor(minutes / 60), minutes % 60)
 }
@@ -109,13 +123,11 @@ function nextWeekStart(now: Date, timezone: string, schedule: WorkSchedule): Dat
   // Always skip into next week — if today already is the week-start day, jump a
   // full week so "Next week" never resolves to earlier today.
   const daysUntil = today.weekday === startWeekday ? 7 : (startWeekday - today.weekday + 7) % 7 || 7
-  const target = calendarInZone(new Date(now.getTime() + daysUntil * 24 * 60 * 60_000), timezone)
-  return startOfWorkInstant(timezone, schedule, target)
+  return startOfWorkInstant(timezone, schedule, shiftCalendarDay(today, daysUntil))
 }
 
 function tomorrowStart(now: Date, timezone: string, schedule: WorkSchedule): Date {
-  const tomorrow = calendarInZone(new Date(now.getTime() + 24 * 60 * 60_000), timezone)
-  return startOfWorkInstant(timezone, schedule, tomorrow)
+  return startOfWorkInstant(timezone, schedule, shiftCalendarDay(calendarInZone(now, timezone), 1))
 }
 
 export function computeRemindAt(

--- a/apps/frontend/src/lib/work-schedule.ts
+++ b/apps/frontend/src/lib/work-schedule.ts
@@ -1,0 +1,14 @@
+import { type WorkSchedule, DEFAULT_WORK_SCHEDULE } from "@threa/types"
+
+/**
+ * Resolve the working schedule that applies to a viewer: their personal
+ * override wins, then the workspace default, then the hardcoded Mon–Fri 09:00.
+ * Mirrors the backend resolution chain so preset math matches what a server
+ * would compute.
+ */
+export function resolveWorkSchedule(
+  userSchedule: WorkSchedule | null | undefined,
+  workspaceDefault: WorkSchedule | null | undefined
+): WorkSchedule {
+  return userSchedule ?? workspaceDefault ?? DEFAULT_WORK_SCHEDULE
+}

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -6,6 +6,7 @@ import { SyncStatusStore } from "./sync-status"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
+  DEFAULT_WORKSPACE_SETTINGS,
   DEFAULT_SIDEBAR_CONFIG,
   type WorkspaceBootstrap,
   type StreamBootstrap,
@@ -116,6 +117,12 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       ...DEFAULT_USER_PREFERENCES,
       workspaceId: "ws_1",
       userId: "user_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+    workspaceSettings: {
+      ...DEFAULT_WORKSPACE_SETTINGS,
+      workspaceId: "ws_1",
       createdAt: now,
       updatedAt: now,
     },

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -15,6 +15,7 @@ import type {
   StreamMember,
   UserPreferences,
   SidebarConfig,
+  WorkspaceSettings,
   LastMessagePreview,
   ActivityCreatedPayload,
   SavedUpsertedPayload,
@@ -124,6 +125,11 @@ interface SidebarConfigUpdatedPayload {
   workspaceId: string
   authorId: string
   sidebarConfig: SidebarConfig
+}
+
+interface WorkspaceSettingsUpdatedPayload {
+  workspaceId: string
+  settings: WorkspaceSettings
 }
 
 // ============================================================================
@@ -1191,6 +1197,18 @@ export function registerWorkspaceSocketHandlers(
     })
   }
 
+  // Handle workspace settings updated (an admin changed the workspace default
+  // schedule). Workspace-scoped, so every member receives it. Lives only in the
+  // bootstrap query cache — no IDB table — matching how it's read.
+  const handleWorkspaceSettingsUpdated = (payload: WorkspaceSettingsUpdatedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+
+    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+      if (!old) return old
+      return { ...old, workspaceSettings: payload.settings }
+    })
+  }
+
   // Handle bot created
   const handleBotCreated = (payload: { workspaceId: string; bot: Bot }) => {
     if (payload.workspaceId !== workspaceId) return
@@ -1592,6 +1610,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("stream:member_removed", handleStreamMemberRemoved)
   socket.on("user_preferences:updated", handleUserPreferencesUpdated)
   socket.on("sidebar_config:updated", handleSidebarConfigUpdated)
+  socket.on("workspace_settings:updated", handleWorkspaceSettingsUpdated)
   socket.on("bot:created", handleBotCreated)
   socket.on("bot:updated", handleBotUpdated)
   socket.on("activity:created", handleActivityCreated)
@@ -1630,6 +1649,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("stream:member_removed", handleStreamMemberRemoved)
     socket.off("user_preferences:updated", handleUserPreferencesUpdated)
     socket.off("sidebar_config:updated", handleSidebarConfigUpdated)
+    socket.off("workspace_settings:updated", handleWorkspaceSettingsUpdated)
     socket.off("bot:created", handleBotCreated)
     socket.off("bot:updated", handleBotUpdated)
     socket.off("activity:created", handleActivityCreated)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1203,10 +1203,9 @@ export function registerWorkspaceSocketHandlers(
   const handleWorkspaceSettingsUpdated = (payload: WorkspaceSettingsUpdatedPayload) => {
     if (payload.workspaceId !== workspaceId) return
 
-    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-      if (!old) return old
-      return { ...old, workspaceSettings: payload.settings }
-    })
+    // Invalidate (forcing a refetch) when the bootstrap isn't cached yet so the
+    // event isn't dropped if it lands before the bootstrap fetch settles (INV-53).
+    updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({ ...old, workspaceSettings: payload.settings }))
   }
 
   // Handle bot created

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -35,6 +35,7 @@ import type {
   Bot,
 } from "./domain"
 import type { UserPreferences } from "./preferences"
+import type { WorkspaceSettings } from "./workspace-settings"
 import type { SidebarConfig } from "./sidebar"
 import type { ToolPrivacyCategory } from "./tool-privacy"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
@@ -770,6 +771,8 @@ export interface WorkspaceBootstrap {
    * older tokens. Frontend uses this to gate UI affordances.
    */
   viewerPermissions: WorkspacePermissionSlug[]
+  /** Workspace-wide settings (e.g. the default working schedule members inherit). */
+  workspaceSettings: WorkspaceSettings
 }
 
 // ============================================================================

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -581,6 +581,33 @@ export {
   type UpdateUserPreferencesInput,
 } from "./preferences"
 
+// Work schedule (working week + working hours)
+export {
+  type Weekday,
+  WEEKDAYS,
+  WEEKDAYS_MONDAY_FIRST,
+  type ShiftInterval,
+  type WorkSchedule,
+  DEFAULT_WORK_SCHEDULE,
+  parseHHMM,
+  minutesToHHMM,
+  getDayShifts,
+  isWorkingDay,
+  workingDays,
+  startOfWorkMinutes,
+  typicalStartMinutes,
+  startOfWorkForDay,
+  firstWorkingWeekday,
+} from "./work-schedule"
+
+// Workspace settings
+export {
+  type WorkspaceSettings,
+  DEFAULT_WORKSPACE_SETTINGS,
+  type UpdateWorkspaceSettingsInput,
+  type WorkspaceSettingKey,
+} from "./workspace-settings"
+
 // Sidebar configuration
 export {
   SIDEBAR_SECTION_KEYS,

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -1,3 +1,5 @@
+import type { WorkSchedule } from "./work-schedule"
+
 // =============================================================================
 // User Preferences Types
 // Workspace-scoped preferences that sync across devices
@@ -149,6 +151,7 @@ export const SETTINGS_TAB_OPTIONS = [
   "ai",
   "appearance",
   "datetime",
+  "schedule",
   "notifications",
   "keyboard",
   "accessibility",
@@ -224,6 +227,13 @@ export interface UserPreferences {
   voicePolishLevel: VoicePolishLevel
   keyboardShortcuts: KeyboardShortcuts
   accessibility: AccessibilityPreferences
+  /**
+   * The user's personal working week + working hours. `null` means "inherit the
+   * workspace default" — only a user who deliberately diverges from the
+   * workspace stores an override. Resolve the effective schedule with
+   * user.workSchedule ?? workspaceSettings.defaultWorkSchedule ?? DEFAULT_WORK_SCHEDULE.
+   */
+  workSchedule: WorkSchedule | null
   createdAt: string
   updatedAt: string
 }
@@ -249,6 +259,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   voicePolishLevel: "opinionated",
   keyboardShortcuts: {},
   accessibility: DEFAULT_ACCESSIBILITY,
+  workSchedule: null,
 }
 
 // =============================================================================
@@ -276,6 +287,7 @@ export interface UpdateUserPreferencesInput {
   voicePolishLevel?: VoicePolishLevel
   keyboardShortcuts?: KeyboardShortcuts
   accessibility?: Partial<AccessibilityPreferences>
+  workSchedule?: WorkSchedule | null
 }
 
 // =============================================================================

--- a/packages/types/src/work-schedule.test.ts
+++ b/packages/types/src/work-schedule.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "bun:test"
+import {
+  DEFAULT_WORK_SCHEDULE,
+  type WorkSchedule,
+  type Weekday,
+  type ShiftInterval,
+  parseHHMM,
+  minutesToHHMM,
+  isWorkingDay,
+  workingDays,
+  startOfWorkMinutes,
+  typicalStartMinutes,
+  startOfWorkForDay,
+  firstWorkingWeekday,
+} from "./work-schedule"
+
+/** Build a schedule where every listed weekday gets the same shift(s). */
+function schedule(days: Partial<Record<Weekday, ShiftInterval[]>>): WorkSchedule {
+  const full: Record<Weekday, ShiftInterval[]> = { 0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] }
+  for (const [day, shifts] of Object.entries(days)) {
+    full[Number(day) as Weekday] = shifts ?? []
+  }
+  return { days: full }
+}
+
+const NINE_FIVE: ShiftInterval[] = [{ start: "09:00", end: "17:00" }]
+
+describe("HH:MM parsing", () => {
+  test("round-trips valid times", () => {
+    expect(parseHHMM("09:00")).toBe(540)
+    expect(parseHHMM("00:00")).toBe(0)
+    expect(parseHHMM("23:59")).toBe(1439)
+    expect(minutesToHHMM(540)).toBe("09:00")
+    expect(minutesToHHMM(1439)).toBe("23:59")
+  })
+
+  test("rejects malformed times", () => {
+    expect(parseHHMM("24:00")).toBeNull()
+    expect(parseHHMM("9:00")).toBeNull()
+    expect(parseHHMM("09:60")).toBeNull()
+    expect(parseHHMM("")).toBeNull()
+  })
+})
+
+describe("working-day predicates", () => {
+  test("default schedule is Mon–Fri", () => {
+    expect(workingDays(DEFAULT_WORK_SCHEDULE)).toEqual([1, 2, 3, 4, 5])
+    expect(isWorkingDay(DEFAULT_WORK_SCHEDULE, 0)).toBe(false)
+    expect(isWorkingDay(DEFAULT_WORK_SCHEDULE, 6)).toBe(false)
+  })
+})
+
+describe("start of work", () => {
+  test("uses earliest shift start on a day with split shifts", () => {
+    const s = schedule({
+      1: [
+        { start: "15:00", end: "20:00" },
+        { start: "08:00", end: "11:00" },
+      ],
+    })
+    expect(startOfWorkMinutes(s, 1)).toBe(8 * 60)
+  })
+
+  test("returns null for a non-working day but falls back for the day-specific helper", () => {
+    expect(startOfWorkMinutes(DEFAULT_WORK_SCHEDULE, 0)).toBeNull()
+    // Sunday off → falls back to the typical (Monday) start of 09:00.
+    expect(startOfWorkForDay(DEFAULT_WORK_SCHEDULE, 0)).toBe(9 * 60)
+  })
+
+  test("typical start follows the first working day", () => {
+    const s = schedule({ 1: [{ start: "08:30", end: "16:00" }], 2: NINE_FIVE })
+    expect(typicalStartMinutes(s)).toBe(8 * 60 + 30)
+  })
+
+  test("empty schedule falls back to 09:00", () => {
+    expect(typicalStartMinutes(schedule({}))).toBe(9 * 60)
+  })
+})
+
+describe("first working weekday (start of the working week)", () => {
+  test("Mon–Fri starts on Monday", () => {
+    expect(firstWorkingWeekday(DEFAULT_WORK_SCHEDULE)).toBe(1)
+  })
+
+  test("Sun–Thu starts on Sunday (so 'next Monday' becomes 'this Sunday')", () => {
+    const s = schedule({ 0: NINE_FIVE, 1: NINE_FIVE, 2: NINE_FIVE, 3: NINE_FIVE, 4: NINE_FIVE })
+    expect(firstWorkingWeekday(s)).toBe(0)
+  })
+
+  test("holed week Mon/Tue/Fri breaks the tie toward Monday", () => {
+    const s = schedule({ 1: NINE_FIVE, 2: NINE_FIVE, 5: NINE_FIVE })
+    expect(firstWorkingWeekday(s)).toBe(1)
+  })
+
+  test("a single working day is the start of the week", () => {
+    expect(firstWorkingWeekday(schedule({ 3: NINE_FIVE }))).toBe(3)
+  })
+
+  test("all-seven defaults to Monday; empty is null", () => {
+    const all = schedule({
+      0: NINE_FIVE,
+      1: NINE_FIVE,
+      2: NINE_FIVE,
+      3: NINE_FIVE,
+      4: NINE_FIVE,
+      5: NINE_FIVE,
+      6: NINE_FIVE,
+    })
+    expect(firstWorkingWeekday(all)).toBe(1)
+    expect(firstWorkingWeekday(schedule({}))).toBeNull()
+  })
+})

--- a/packages/types/src/work-schedule.ts
+++ b/packages/types/src/work-schedule.ts
@@ -36,17 +36,19 @@ export interface WorkSchedule {
   days: Record<Weekday, ShiftInterval[]>
 }
 
-const NINE_TO_FIVE: ShiftInterval[] = [{ start: "09:00", end: "17:00" }]
+function nineToFive(): ShiftInterval[] {
+  return [{ start: "09:00", end: "17:00" }]
+}
 
 /** Mon–Fri, 09:00–17:00 — the fallback when nothing is configured. */
 export const DEFAULT_WORK_SCHEDULE: WorkSchedule = {
   days: {
     0: [],
-    1: [...NINE_TO_FIVE],
-    2: [...NINE_TO_FIVE],
-    3: [...NINE_TO_FIVE],
-    4: [...NINE_TO_FIVE],
-    5: [...NINE_TO_FIVE],
+    1: nineToFive(),
+    2: nineToFive(),
+    3: nineToFive(),
+    4: nineToFive(),
+    5: nineToFive(),
     6: [],
   },
 }

--- a/packages/types/src/work-schedule.ts
+++ b/packages/types/src/work-schedule.ts
@@ -1,0 +1,151 @@
+// =============================================================================
+// Work Schedule
+// Working week + working hours, shared by user preferences (per-user override)
+// and workspace settings (workspace default). Drives schedule-aware reminder /
+// scheduled-message presets: "start of work" replaces the hardcoded 09:00, and
+// "start of the working week" replaces the hardcoded Monday.
+// =============================================================================
+
+/** Weekday index, matching JS `Date.getDay()` (0 = Sunday … 6 = Saturday). */
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export const WEEKDAYS: readonly Weekday[] = [0, 1, 2, 3, 4, 5, 6]
+
+/**
+ * Weekdays in working-week reading order (Monday first, Sunday last). Used as
+ * the deterministic tie-breaker when picking the start of the working week so
+ * a plain Mon–Fri schedule resolves to Monday rather than some other day.
+ */
+export const WEEKDAYS_MONDAY_FIRST: readonly Weekday[] = [1, 2, 3, 4, 5, 6, 0]
+
+/** A single shift within a day, as local wall-clock `"HH:MM"` (24h) strings. */
+export interface ShiftInterval {
+  start: string
+  end: string
+}
+
+/**
+ * A user's (or workspace's) working schedule. Shifts are stored per weekday, so
+ * a day with an empty array is a non-working day. This one shape covers:
+ *   - plain working weeks (Mon–Fri populated, Sat/Sun empty),
+ *   - "holed" weeks (e.g. Mon/Tue/Fri populated, Wed/Thu empty),
+ *   - split shifts / siesta (e.g. `[{08:00–11:00}, {15:00–20:00}]`),
+ *   - per-day variation (short Fridays).
+ */
+export interface WorkSchedule {
+  days: Record<Weekday, ShiftInterval[]>
+}
+
+const NINE_TO_FIVE: ShiftInterval[] = [{ start: "09:00", end: "17:00" }]
+
+/** Mon–Fri, 09:00–17:00 — the fallback when nothing is configured. */
+export const DEFAULT_WORK_SCHEDULE: WorkSchedule = {
+  days: {
+    0: [],
+    1: [...NINE_TO_FIVE],
+    2: [...NINE_TO_FIVE],
+    3: [...NINE_TO_FIVE],
+    4: [...NINE_TO_FIVE],
+    5: [...NINE_TO_FIVE],
+    6: [],
+  },
+}
+
+const HHMM_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+/** Parse `"HH:MM"` to minutes-since-midnight, or `null` if malformed. */
+export function parseHHMM(value: string): number | null {
+  const match = HHMM_PATTERN.exec(value)
+  if (!match) return null
+  return Number(match[1]) * 60 + Number(match[2])
+}
+
+/** Render minutes-since-midnight back to `"HH:MM"`. */
+export function minutesToHHMM(minutes: number): string {
+  const clamped = ((minutes % 1440) + 1440) % 1440
+  const h = Math.floor(clamped / 60)
+  const m = clamped % 60
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`
+}
+
+/** Shifts for a weekday, always an array (treats malformed input as empty). */
+export function getDayShifts(schedule: WorkSchedule, weekday: Weekday): ShiftInterval[] {
+  return schedule.days[weekday] ?? []
+}
+
+/** A weekday is a working day iff it has at least one shift. */
+export function isWorkingDay(schedule: WorkSchedule, weekday: Weekday): boolean {
+  return getDayShifts(schedule, weekday).length > 0
+}
+
+/** Every weekday that has at least one shift, in 0–6 order. */
+export function workingDays(schedule: WorkSchedule): Weekday[] {
+  return WEEKDAYS.filter((d) => isWorkingDay(schedule, d))
+}
+
+/**
+ * Earliest shift start (minutes-since-midnight) on a given weekday, or `null`
+ * when that day has no shifts. Callers that need a meaningful time on a
+ * non-working day fall back to {@link typicalStartMinutes}.
+ */
+export function startOfWorkMinutes(schedule: WorkSchedule, weekday: Weekday): number | null {
+  const starts = getDayShifts(schedule, weekday)
+    .map((s) => parseHHMM(s.start))
+    .filter((m): m is number => m !== null)
+  return starts.length === 0 ? null : Math.min(...starts)
+}
+
+/**
+ * A representative "when work starts" time for the schedule — the start of work
+ * on the first working day of the week. Used for presets that land on a
+ * non-working day (e.g. "Tomorrow morning" when tomorrow is a day off), where
+ * there's no day-specific start to use. Falls back to 09:00 for an empty
+ * schedule.
+ */
+export function typicalStartMinutes(schedule: WorkSchedule): number {
+  const firstDay = firstWorkingWeekday(schedule)
+  if (firstDay === null) return 9 * 60
+  return startOfWorkMinutes(schedule, firstDay) ?? 9 * 60
+}
+
+/**
+ * Start-of-work for a specific day: that day's earliest shift start when it's a
+ * working day, otherwise the schedule's typical start so the preset still lands
+ * on a sensible morning time.
+ */
+export function startOfWorkForDay(schedule: WorkSchedule, weekday: Weekday): number {
+  return startOfWorkMinutes(schedule, weekday) ?? typicalStartMinutes(schedule)
+}
+
+/**
+ * The weekday the working week "starts" on — the working day immediately
+ * following the longest run of consecutive non-working days (the weekend gap),
+ * read cyclically. Mon–Fri → Monday; Sun–Thu → Sunday (so "next Monday"
+ * becomes "this Sunday"); Mon/Tue/Fri → Monday (tie broken toward Monday via
+ * {@link WEEKDAYS_MONDAY_FIRST}). Returns `null` for an empty schedule.
+ */
+export function firstWorkingWeekday(schedule: WorkSchedule): Weekday | null {
+  const working = new Set(workingDays(schedule))
+  if (working.size === 0) return null
+  if (working.size === 7) return 1 // every day worked → Monday by convention
+
+  // For each working day, count the consecutive non-working days immediately
+  // before it (wrapping around the week). The day with the largest preceding
+  // gap opens the working week.
+  let best: Weekday | null = null
+  let bestGap = -1
+  for (const day of WEEKDAYS_MONDAY_FIRST) {
+    if (!working.has(day)) continue
+    let gap = 0
+    for (let step = 1; step <= 7; step++) {
+      const prev = ((((day - step) % 7) + 7) % 7) as Weekday
+      if (working.has(prev)) break
+      gap++
+    }
+    if (gap > bestGap) {
+      bestGap = gap
+      best = day
+    }
+  }
+  return best
+}

--- a/packages/types/src/workspace-settings.ts
+++ b/packages/types/src/workspace-settings.ts
@@ -1,0 +1,33 @@
+// =============================================================================
+// Workspace Settings
+// Workspace-scoped configuration owned by admins. Currently the default working
+// schedule that every member inherits unless they set a personal override.
+// Stored sparsely (only non-default keys persisted) like user preferences.
+// =============================================================================
+
+import { type WorkSchedule, DEFAULT_WORK_SCHEDULE } from "./work-schedule"
+
+/** Full workspace settings (wire format). */
+export interface WorkspaceSettings {
+  workspaceId: string
+  /**
+   * The workspace-wide default working week + hours. Members inherit this when
+   * they have no personal `workSchedule` override. Falls back to Mon–Fri 09:00.
+   */
+  defaultWorkSchedule: WorkSchedule
+  createdAt: string
+  updatedAt: string
+}
+
+/** Defaults applied when a workspace has stored no overrides. */
+export const DEFAULT_WORKSPACE_SETTINGS: Omit<WorkspaceSettings, "workspaceId" | "createdAt" | "updatedAt"> = {
+  defaultWorkSchedule: DEFAULT_WORK_SCHEDULE,
+}
+
+/** Partial update — only provided fields are changed. */
+export interface UpdateWorkspaceSettingsInput {
+  defaultWorkSchedule?: WorkSchedule
+}
+
+/** Valid top-level settings keys that can be overridden. */
+export type WorkspaceSettingKey = keyof Omit<WorkspaceSettings, "workspaceId" | "createdAt" | "updatedAt">


### PR DESCRIPTION
## What & why

Scheduled-message and reminder **calendar presets now respect the viewer's working week and working hours** instead of hardcoding Monday + 09:00.

- **"Tomorrow morning"** → tomorrow at *start of work* (was a hardcoded `9am`)
- **"Next week"** → the *first working day of the next working week* — a Sun–Thu schedule resolves to **this Sunday** rather than next Monday

Defaults are workspace-configurable, with a per-user override, falling back to **Mon–Fri 09:00**.

## Design

**Timezone handling stays minimal by intent.** This is *frontend preset reshaping only* — presets resolve to an absolute instant on the client and the backend stores/fires that UTC instant unchanged. Nothing is snapped or deferred server-side, so we avoid round-tripping wall-clock + tz through the backend.

### Model (`packages/types/src/work-schedule.ts`)
```ts
WorkSchedule = { days: Record<Weekday, ShiftInterval[]> }  // empty array = day off
```
One shape covers everything: **split shifts / siesta** (multiple intervals), **per-weekday hours** (short Fridays), and **holed weeks** (Mon/Tue/Fri — just leave the others empty). "Start of the working week" is derived from the longest run of off-days, so Mon–Fri→Monday, Sun–Thu→Sunday, ties break toward Monday.

### Resolution chain
`user override ?? workspace default ?? Mon–Fri 09:00` — implemented once on the frontend; the backend just stores raw values.

- **User**: nullable `workSchedule` on `UserPreferences` (sparse store, no migration) + a **Settings → Working hours** tab.
- **Workspace**: new `workspace-settings` backend feature (sparse override table, admin-gated `PATCH`, folded into bootstrap) + an admin-only **Workspace settings → Working hours** tab. Both editors share one `WorkScheduleEditor` and one Zod schema.
- Workspace-default changes broadcast via a `workspace_settings:updated` outbox event (workspace room) so members' bootstrap caches converge live, mirroring `user_preferences:updated`.

### Surfaces
Composer scheduled-send picker + both reminder pickers (desktop popover, mobile sheet) — they share `computeRemindAt`, so reminders get the same treatment.

## Tests
- `work-schedule` pure logic (12 cases: start-of-work, split shifts, first-working-weekday incl. Sun–Thu and holed weeks).
- `reminder-presets` reshaping (4 cases incl. the Sun–Thu → this-Sunday behaviour).
- `workspace-settings` service: sparse merge, revert-to-default, and the outbox broadcast.

## Self-review
3-perspective review run before opening: correctness clean, one design finding (duplicate cache hooks → composed) and one spec finding (no live broadcast → added the outbox event) both addressed.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PL9enNVpvXBut7W1c5jZn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL9enNVpvXBut7W1c5jZn3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782986293&installation_id=129946197&pr_number=730&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F730&signature=d30361ded9360cbbb71f7e0f04be4ddf91463302932499ca50e32b8c9053fb9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->