### PR TITLE
feat(sidebar): user-defined custom sections

### DIFF
--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -9,6 +9,7 @@ import {
   SIDEBAR_QUICK_LINKS,
   SIDEBAR_QUICK_LINK_VISIBILITIES,
   MAX_CUSTOM_SECTION_NAME_LENGTH,
+  MAX_CUSTOM_SECTION_STREAM_IDS,
 } from "@threa/types"
 
 const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
@@ -22,7 +23,7 @@ const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
     kind: z.literal("custom"),
     sectionId: z.string().min(1).max(64),
     name: z.string().trim().min(1).max(MAX_CUSTOM_SECTION_NAME_LENGTH),
-    streamIds: z.array(z.string().min(1).max(64)).max(500).optional().default([]),
+    streamIds: z.array(z.string().min(1).max(64)).max(MAX_CUSTOM_SECTION_STREAM_IDS).optional().default([]),
   }),
   z.object({ kind: z.literal("quicklinks") }),
 ])

--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -8,12 +8,22 @@ import {
   SIDEBAR_BASE_PRESETS,
   SIDEBAR_QUICK_LINKS,
   SIDEBAR_QUICK_LINK_VISIBILITIES,
+  MAX_CUSTOM_SECTION_NAME_LENGTH,
 } from "@threa/types"
 
 const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("smart"), bucket: z.enum(SIDEBAR_SECTION_KEYS) }),
   z.object({ kind: z.literal("type"), streamType: z.enum(SIDEBAR_TYPE_SECTIONS) }),
   z.object({ kind: z.literal("label"), labelId: z.string().min(1).max(64) }),
+  // Custom section: a hand-curated membership the service normalizes (sanitizes
+  // streamIds, enforces single membership) on write. Cap streamIds so the
+  // per-user config document can't grow unbounded.
+  z.object({
+    kind: z.literal("custom"),
+    sectionId: z.string().min(1).max(64),
+    name: z.string().trim().min(1).max(MAX_CUSTOM_SECTION_NAME_LENGTH),
+    streamIds: z.array(z.string().min(1).max(64)).max(500).optional().default([]),
+  }),
   z.object({ kind: z.literal("quicklinks") }),
 ])
 

--- a/apps/backend/src/features/sidebar-config/service.test.ts
+++ b/apps/backend/src/features/sidebar-config/service.test.ts
@@ -159,4 +159,30 @@ describe("updateSidebarConfigSchema", () => {
     })
     expect(parsed.sections[0].spec).toEqual({ kind: "quicklinks" })
   })
+
+  it("accepts a custom section spec and defaults missing streamIds to an empty list", () => {
+    const parsed = updateSidebarConfigSchema.parse({
+      basePreset: "smart",
+      sections: [
+        { id: "custom:work", spec: { kind: "custom", sectionId: "work", name: "Work", streamIds: ["stream_1"] } },
+        // streamIds omitted — the schema defaults it.
+        { id: "custom:home", spec: { kind: "custom", sectionId: "home", name: "Home" } },
+      ],
+    })
+    expect(parsed.sections[0].spec).toEqual({
+      kind: "custom",
+      sectionId: "work",
+      name: "Work",
+      streamIds: ["stream_1"],
+    })
+    expect(parsed.sections[1].spec).toMatchObject({ kind: "custom", name: "Home", streamIds: [] })
+  })
+
+  it("rejects a custom section with a blank name", () => {
+    const result = updateSidebarConfigSchema.safeParse({
+      basePreset: "smart",
+      sections: [{ id: "custom:x", spec: { kind: "custom", sectionId: "x", name: "   ", streamIds: [] } }],
+    })
+    expect(result.success).toBe(false)
+  })
 })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -7,7 +7,7 @@ import {
   SIDEBAR_CONFIG_VERSION,
 } from "@threa/types"
 import { resolveSections, type ResolveSectionsInput } from "./resolve-sections"
-import { labelSectionId } from "./sidebar-config"
+import { customSectionId, labelSectionId } from "./sidebar-config"
 import type { SectionKey, StreamItemData, UrgencyLevel } from "./types"
 
 interface ItemOverrides {
@@ -221,5 +221,109 @@ describe("resolveSections — label sections", () => {
     const processedStreams = [makeItem({ id: "s_1", section: "recent", activity: 1 })]
     const result = resolveSections(labelFirst, makeInput({ processedStreams, streamIdsByLabel: new Map() }))
     expect(result.find((r) => r.section.id === labelSectionId("lbl_1"))?.items).toEqual([])
+  })
+})
+
+describe("resolveSections — custom sections", () => {
+  function customSpec(sectionId: string, streamIds: string[]) {
+    return { kind: "custom" as const, sectionId, name: sectionId, streamIds }
+  }
+
+  it("trumps order: a stream filed in a custom section shows only there, even when a section above would claim it", () => {
+    // Recent is ordered first and would normally claim s_new, but s_new is filed
+    // into the custom section below — so it appears only in the custom section.
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        { id: customSectionId("sec_1"), spec: customSpec("sec_1", ["s_new"]) },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "s_old", section: "recent", activity: 1 }),
+      makeItem({ id: "s_new", section: "recent", activity: 9 }),
+    ]
+
+    const result = resolveSections(config, makeInput({ processedStreams })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      { id: "recent", items: ["s_old"] },
+      { id: customSectionId("sec_1"), items: ["s_new"] },
+    ])
+  })
+
+  it("withholds custom-filed streams from a label lens regardless of order", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+        { id: customSectionId("sec_1"), spec: customSpec("sec_1", ["s_lab"]) },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "s_lab", section: "recent", activity: 5 }),
+      makeItem({ id: "s_other", section: "recent", activity: 3 }),
+    ]
+    // Both streams carry the label, but s_lab is also filed into the custom section.
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["s_lab", "s_other"])]])
+
+    const result = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      // Label lens keeps only s_other; s_lab is trumped by its custom section.
+      { id: labelSectionId("lbl_1"), items: ["s_other"] },
+      { id: customSectionId("sec_1"), items: ["s_lab"] },
+    ])
+  })
+
+  it("sorts custom members by activity and ignores ids with no matching stream", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart" as const,
+      sections: [{ id: customSectionId("sec_1"), spec: customSpec("sec_1", ["a", "b", "ghost"]) }],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "a", section: "other", activity: 1 }),
+      makeItem({ id: "b", section: "other", activity: 9 }),
+    ]
+    const custom = resolveSections(config, makeInput({ processedStreams })).find(
+      (r) => r.section.id === customSectionId("sec_1")
+    )
+    // b (activity 9) before a (activity 1); "ghost" has no stream and is dropped.
+    expect(custom?.items.map((i) => i.id)).toEqual(["b", "a"])
+  })
+
+  it("keeps a stream in only the first custom section when two list it (single membership)", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: customSectionId("sec_a"), spec: customSpec("sec_a", ["s_x"]) },
+        { id: customSectionId("sec_b"), spec: customSpec("sec_b", ["s_x"]) },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [makeItem({ id: "s_x", section: "other", activity: 1 })]
+
+    const result = resolveSections(config, makeInput({ processedStreams })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      { id: customSectionId("sec_a"), items: ["s_x"] },
+      { id: customSectionId("sec_b"), items: [] },
+    ])
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -40,11 +40,23 @@ export interface ResolvedSection {
  * would show twice — once in its label lens and again lower down. Exclusion runs
  * before each section's caps, so a capped bucket (e.g. Recent) backfills the
  * slots freed by streams claimed above it.
+ *
+ * Custom sections are the exception to topmost-wins: a stream filed into one
+ * shows **only** there, even when a smart/label/type section ordered above it
+ * would also match. Their membership is collected up front and excluded from
+ * every non-custom section regardless of order — so a custom section "trumps"
+ * the layout order rather than competing for the topmost claim.
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
   const claimed = new Set<string>()
+  // Streams pinned to any custom section, gathered before resolving so they can
+  // be withheld from non-custom sections wherever those sit in the order.
+  const customClaimed = new Set<string>()
+  for (const section of config.sections) {
+    if (section.spec.kind === "custom") for (const id of section.spec.streamIds) customClaimed.add(id)
+  }
   return config.sections.map((section) => {
-    const items = resolveItems(section.spec, input, claimed)
+    const items = resolveItems(section.spec, input, claimed, customClaimed)
     for (const item of items) claimed.add(item.id)
     return { section, items }
   })
@@ -53,14 +65,38 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
 function resolveItems(
   spec: SidebarSectionSpec,
   input: ResolveSectionsInput,
-  exclude: ReadonlySet<string>
+  claimed: ReadonlySet<string>,
+  customClaimed: ReadonlySet<string>
 ): StreamItemData[] {
+  // A custom section draws only its own membership, minus anything an earlier
+  // custom section already took (single-membership; topmost custom wins).
+  if (spec.kind === "custom") return resolveCustomSection(spec.streamIds, input, claimed)
+  // Non-custom sections never show a stream filed into a custom section, so fold
+  // the custom membership into their exclusion set on top of the running claims.
+  const exclude = customClaimed.size === 0 ? claimed : new Set([...claimed, ...customClaimed])
   if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input, exclude)
   if (spec.kind === "type") return resolveTypeSection(spec.streamType, input, exclude)
   if (spec.kind === "label") return resolveLabelSection(spec.labelId, input, exclude)
   // Quick links draw no streams — the block renders its own link list, so the
   // resolved section is a positional placeholder the stream list renders specially.
   return []
+}
+
+/**
+ * Streams the viewer filed into a custom section, by activity. Draws from real
+ * streams only (synthetic DM drafts can't be filed). Preserves the membership's
+ * resolution against `claimed` so a stream duplicated across custom sections
+ * (stray data) only surfaces in the first.
+ */
+function resolveCustomSection(
+  streamIds: readonly string[],
+  { processedStreams, getUnreadCount }: ResolveSectionsInput,
+  exclude: ReadonlySet<string>
+): StreamItemData[] {
+  if (streamIds.length === 0) return []
+  const members = new Set(streamIds)
+  const items = processedStreams.filter((stream) => members.has(stream.id) && !exclude.has(stream.id))
+  return sortStreams(items, "activity", getUnreadCount)
 }
 
 /** Streams carrying a label, by activity. Draws from real streams only (synthetic DM drafts can't be labeled). */

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useRef, useState, type RefObject } from "react"
-import { Archive, FileEdit, Lock, Settings, Sparkles, Tag } from "lucide-react"
+import { Archive, FileEdit, FolderPlus, Lock, Settings, Sparkles, Tag } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
+import { SectionPicker } from "./section-picker"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
@@ -54,6 +55,7 @@ export function ScratchpadItem({
   const { openStreamSettings } = useStreamSettings()
   const itemRef = useRef<HTMLAnchorElement>(null)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
+  const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
   const hasUnread = unreadCount > 0
   const isDraft = isDraftId(streamWithPreview.id)
 
@@ -91,6 +93,12 @@ export function ScratchpadItem({
               label: "Labels…",
               icon: Tag,
               onSelect: () => setLabelPickerOpen(true),
+            } satisfies SidebarActionItem,
+            {
+              id: "add-to-section",
+              label: "Add to section…",
+              icon: FolderPlus,
+              onSelect: () => setSectionPickerOpen(true),
             } satisfies SidebarActionItem,
           ]
         : []),
@@ -196,6 +204,14 @@ export function ScratchpadItem({
           resourceId={streamWithPreview.id}
           open
           onOpenChange={setLabelPickerOpen}
+        />
+      )}
+      {sectionPickerOpen && (
+        <SectionPicker
+          workspaceId={workspaceId}
+          streamId={streamWithPreview.id}
+          open
+          onOpenChange={setSectionPickerOpen}
         />
       )}
       {isMobile && actions.length > 0 && (

--- a/apps/frontend/src/components/layout/sidebar/section-picker.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/section-picker.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { render, screen, userEvent, spyOnExport } from "@/test"
+import { SMART_SIDEBAR_CONFIG, type SidebarConfig } from "@threa/types"
+import * as sidebarConfigHook from "@/hooks/use-sidebar-config"
+import * as dialogModule from "@/components/ui/responsive-dialog"
+import { SectionPicker } from "./section-picker"
+import { createCustomSection, setStreamCustomSection } from "./sidebar-config"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_1"
+
+const setConfig = vi.fn()
+
+function useConfig(config: SidebarConfig) {
+  vi.spyOn(sidebarConfigHook, "useSidebarConfig").mockReturnValue({
+    config,
+    setConfig,
+    setBasePreset: vi.fn(),
+    isSaving: false,
+  })
+}
+
+/** Render dialog content inline so the radix portal/open-state doesn't gate assertions. */
+function Passthrough({ children }: { children?: React.ReactNode }) {
+  return <div>{children}</div>
+}
+
+function withTwoSections(): SidebarConfig {
+  return createCustomSection(createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "Alpha"), "sec_b", "Beta")
+}
+
+function mount() {
+  return render(<SectionPicker workspaceId={WORKSPACE_ID} streamId={STREAM_ID} open onOpenChange={vi.fn()} />)
+}
+
+describe("SectionPicker", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    setConfig.mockClear()
+    for (const key of [
+      "ResponsiveDialog",
+      "ResponsiveDialogContent",
+      "ResponsiveDialogHeader",
+      "ResponsiveDialogTitle",
+      "ResponsiveDialogDescription",
+    ] as const) {
+      spyOnExport(dialogModule, key).mockReturnValue(Passthrough as never)
+    }
+  })
+
+  it("files the stream into the picked section (exclusively)", async () => {
+    const config = withTwoSections()
+    useConfig(config)
+    mount()
+
+    await userEvent.click(screen.getByRole("button", { name: /Alpha/ }))
+
+    expect(setConfig).toHaveBeenCalledWith(setStreamCustomSection(config, STREAM_ID, "sec_a"))
+  })
+
+  it("removes the stream when the section it's already in is picked again", async () => {
+    const config = setStreamCustomSection(withTwoSections(), STREAM_ID, "sec_a")
+    useConfig(config)
+    mount()
+
+    await userEvent.click(screen.getByRole("button", { name: /Alpha/ }))
+
+    expect(setConfig).toHaveBeenCalledWith(setStreamCustomSection(config, STREAM_ID, null))
+  })
+
+  it("creates a section and files the stream into it in one step", async () => {
+    const config = withTwoSections()
+    useConfig(config)
+    mount()
+
+    await userEvent.type(screen.getByRole("textbox", { name: "New section name" }), "Gamma")
+    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+
+    expect(setConfig).toHaveBeenCalledTimes(1)
+    const next = setConfig.mock.calls[0][0] as SidebarConfig
+    const created = next.sections.find((s) => s.spec.kind === "custom" && s.spec.name === "Gamma")
+    expect(created?.spec).toMatchObject({ kind: "custom", name: "Gamma", streamIds: [STREAM_ID] })
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/section-picker.tsx
+++ b/apps/frontend/src/components/layout/sidebar/section-picker.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react"
+import { Check, FolderPlus, Plus } from "lucide-react"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useSidebarConfig } from "@/hooks/use-sidebar-config"
+import { MAX_CUSTOM_SECTION_NAME_LENGTH } from "@threa/types"
+import {
+  createCustomSection,
+  customSections,
+  getStreamCustomSectionId,
+  newCustomSectionId,
+  setStreamCustomSection,
+} from "./sidebar-config"
+
+interface SectionPickerProps {
+  workspaceId: string
+  streamId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * File a single stream into a custom sidebar section — the picker behind the
+ * "Add to section…" action (a dialog on desktop, a bottom drawer on mobile, via
+ * ResponsiveDialog). Membership is exclusive: picking a section moves the stream
+ * there and out of any other; picking the section it's already in removes it.
+ * A stream filed here shows only in that section, trumping its smart/label
+ * placement. New sections can be created inline and the stream filed into the
+ * fresh one in a single step.
+ */
+export function SectionPicker({ workspaceId, streamId, open, onOpenChange }: SectionPickerProps) {
+  const { config, setConfig } = useSidebarConfig(workspaceId)
+  const sections = customSections(config)
+  const currentId = getStreamCustomSectionId(config, streamId)
+  const [newName, setNewName] = useState("")
+
+  const choose = (sectionId: string) => {
+    setConfig(setStreamCustomSection(config, streamId, currentId === sectionId ? null : sectionId))
+  }
+
+  const createAndFile = () => {
+    const trimmed = newName.trim()
+    if (!trimmed) return
+    const id = newCustomSectionId()
+    setConfig(setStreamCustomSection(createCustomSection(config, id, trimmed), streamId, id))
+    setNewName("")
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
+      <ResponsiveDialogContent
+        desktopClassName="sm:max-w-sm gap-0 p-0"
+        drawerClassName="flex max-h-[80dvh] flex-col gap-0 pb-[env(safe-area-inset-bottom)]"
+      >
+        <ResponsiveDialogHeader className="border-b px-4 py-3 text-left">
+          <ResponsiveDialogTitle className="text-base">Add to section</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="sr-only">
+            File this stream into one of your custom sidebar sections.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {sections.length > 0 && (
+            <div className="max-h-[min(50vh,320px)] min-h-0 flex-1 overflow-y-auto overscroll-contain p-2">
+              {sections.map((section) => {
+                const selected = section.sectionId === currentId
+                return (
+                  <button
+                    key={section.sectionId}
+                    type="button"
+                    onClick={() => choose(section.sectionId)}
+                    aria-pressed={selected}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-sm transition-colors",
+                      "hover:bg-muted/50 active:bg-muted"
+                    )}
+                  >
+                    <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="min-w-0 flex-1 truncate">{section.name}</span>
+                    {selected && <Check className="h-4 w-4 shrink-0 text-primary" aria-label="Current section" />}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          <div className={cn("flex items-center gap-2 px-4 py-3", sections.length > 0 && "border-t")}>
+            <input
+              type="text"
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                  createAndFile()
+                }
+              }}
+              maxLength={MAX_CUSTOM_SECTION_NAME_LENGTH}
+              placeholder="New section name…"
+              aria-label="New section name"
+              // text-base keeps the font ≥16px so iOS doesn't zoom on focus.
+              className="min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-muted-foreground sm:text-sm"
+            />
+            <Button type="button" size="sm" variant="outline" onClick={createAndFile} disabled={!newName.trim()}>
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              Add
+            </Button>
+          </div>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -3,6 +3,7 @@ import { Fragment, type ReactNode, type RefObject } from "react"
 import type { CollapseState } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { UnreadBadge } from "@/components/unread-badge"
+import { isDraftId } from "@/hooks"
 import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
 import { StreamItem } from "./stream-item"
 import { DraggableStreamRow } from "./sidebar-dnd"
@@ -280,9 +281,12 @@ export function StreamSection({
         scrollContainerRef={scrollContainerRef}
       />
     )
-    // Only wrap as a drag source when dragging is on (desktop) — wrapping every
-    // row when disabled would register a dead draggable per stream for nothing.
-    return streamDragEnabled ? (
+    // Wrap as a drag source only when dragging is on (desktop) and the row is a
+    // persisted stream — drafts (incl. virtual DMs) carry transient ids that
+    // must never be filed into config, and wrapping a disabled row would
+    // register a dead draggable for nothing.
+    const dragEnabled = streamDragEnabled && !isDraftId(stream.id)
+    return dragEnabled ? (
       <DraggableStreamRow key={stream.id} streamId={stream.id}>
         {item}
       </DraggableStreamRow>
@@ -398,8 +402,9 @@ export function TieredStreamSection({
         scrollContainerRef={scrollContainerRef}
       />
     )
-    // Drag source only when dragging is on (desktop); see StreamSection.renderRow.
-    return streamDragEnabled ? (
+    // Drag source only for persisted streams when dragging is on; see StreamSection.renderRow.
+    const dragEnabled = streamDragEnabled && !isDraftId(stream.id)
+    return dragEnabled ? (
       <DraggableStreamRow key={stream.id} streamId={stream.id}>
         {item}
       </DraggableStreamRow>

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 import { UnreadBadge } from "@/components/unread-badge"
 import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
 import { StreamItem } from "./stream-item"
+import { DraggableStreamRow } from "./sidebar-dnd"
 import type { StreamItemData } from "./types"
 import { getActivityTime } from "./utils"
 
@@ -235,6 +236,8 @@ interface StreamSectionProps {
   addTooltip?: string
   /** Dropdown actions for the "+" button. Overrides `onAdd` when provided. */
   addMenuActions?: SidebarActionItem[] | null
+  /** When true, each stream row is a drag source for filing into a custom section (desktop). */
+  streamDragEnabled?: boolean
 }
 
 /** Simple binary collapsible section used for Important / Recent / Pinned. */
@@ -257,6 +260,7 @@ export function StreamSection({
   onAdd,
   addTooltip,
   addMenuActions,
+  streamDragEnabled = false,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -280,18 +284,19 @@ export function StreamSection({
       {!isCollapsed && items.length > 0 && (
         <div className="mt-1 flex flex-col gap-0.5">
           {items.map((stream) => (
-            <StreamItem
-              key={stream.id}
-              workspaceId={workspaceId}
-              stream={stream}
-              isActive={stream.id === activeStreamId}
-              unreadCount={getUnreadCount(stream.id)}
-              mentionCount={getMentionCount(stream.id)}
-              allStreams={allStreams}
-              compact={compact}
-              showPreviewOnHover={showPreviewOnHover}
-              scrollContainerRef={scrollContainerRef}
-            />
+            <DraggableStreamRow key={stream.id} streamId={stream.id} enabled={streamDragEnabled}>
+              <StreamItem
+                workspaceId={workspaceId}
+                stream={stream}
+                isActive={stream.id === activeStreamId}
+                unreadCount={getUnreadCount(stream.id)}
+                mentionCount={getMentionCount(stream.id)}
+                allStreams={allStreams}
+                compact={compact}
+                showPreviewOnHover={showPreviewOnHover}
+                scrollContainerRef={scrollContainerRef}
+              />
+            </DraggableStreamRow>
           ))}
         </div>
       )}
@@ -353,6 +358,7 @@ export function TieredStreamSection({
   onAdd,
   addTooltip,
   addMenuActions,
+  streamDragEnabled = false,
 }: TieredStreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -372,18 +378,19 @@ export function TieredStreamSection({
   const visibleItems = isMoreOpen ? [...activeItems, ...quietItems] : [...activeItems, ...quietVisible]
 
   const renderItem = (stream: StreamItemData) => (
-    <StreamItem
-      key={stream.id}
-      workspaceId={workspaceId}
-      stream={stream}
-      isActive={stream.id === activeStreamId}
-      unreadCount={getUnreadCount(stream.id)}
-      mentionCount={getMentionCount(stream.id)}
-      allStreams={allStreams}
-      compact={compact}
-      showPreviewOnHover={showPreviewOnHover}
-      scrollContainerRef={scrollContainerRef}
-    />
+    <DraggableStreamRow key={stream.id} streamId={stream.id} enabled={streamDragEnabled}>
+      <StreamItem
+        workspaceId={workspaceId}
+        stream={stream}
+        isActive={stream.id === activeStreamId}
+        unreadCount={getUnreadCount(stream.id)}
+        mentionCount={getMentionCount(stream.id)}
+        allStreams={allStreams}
+        compact={compact}
+        showPreviewOnHover={showPreviewOnHover}
+        scrollContainerRef={scrollContainerRef}
+      />
+    </DraggableStreamRow>
   )
 
   return (

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight, ChevronUp, Plus } from "lucide-react"
-import type { ReactNode, RefObject } from "react"
+import { Fragment, type ReactNode, type RefObject } from "react"
 import type { CollapseState } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { UnreadBadge } from "@/components/unread-badge"
@@ -266,6 +266,31 @@ export function StreamSection({
   const unreadAggregate = sumUnread(items, getUnreadCount)
   const mentionAggregate = sumMentions(items, getMentionCount)
 
+  const renderRow = (stream: StreamItemData) => {
+    const item = (
+      <StreamItem
+        workspaceId={workspaceId}
+        stream={stream}
+        isActive={stream.id === activeStreamId}
+        unreadCount={getUnreadCount(stream.id)}
+        mentionCount={getMentionCount(stream.id)}
+        allStreams={allStreams}
+        compact={compact}
+        showPreviewOnHover={showPreviewOnHover}
+        scrollContainerRef={scrollContainerRef}
+      />
+    )
+    // Only wrap as a drag source when dragging is on (desktop) — wrapping every
+    // row when disabled would register a dead draggable per stream for nothing.
+    return streamDragEnabled ? (
+      <DraggableStreamRow key={stream.id} streamId={stream.id}>
+        {item}
+      </DraggableStreamRow>
+    ) : (
+      <Fragment key={stream.id}>{item}</Fragment>
+    )
+  }
+
   return (
     <div className="mb-4">
       <SectionHeader
@@ -281,25 +306,7 @@ export function StreamSection({
         addMenuActions={addMenuActions}
       />
 
-      {!isCollapsed && items.length > 0 && (
-        <div className="mt-1 flex flex-col gap-0.5">
-          {items.map((stream) => (
-            <DraggableStreamRow key={stream.id} streamId={stream.id} enabled={streamDragEnabled}>
-              <StreamItem
-                workspaceId={workspaceId}
-                stream={stream}
-                isActive={stream.id === activeStreamId}
-                unreadCount={getUnreadCount(stream.id)}
-                mentionCount={getMentionCount(stream.id)}
-                allStreams={allStreams}
-                compact={compact}
-                showPreviewOnHover={showPreviewOnHover}
-                scrollContainerRef={scrollContainerRef}
-              />
-            </DraggableStreamRow>
-          ))}
-        </div>
-      )}
+      {!isCollapsed && items.length > 0 && <div className="mt-1 flex flex-col gap-0.5">{items.map(renderRow)}</div>}
 
       {!isCollapsed && action}
     </div>
@@ -377,8 +384,8 @@ export function TieredStreamSection({
   const isMoreOpen = moreState === "open"
   const visibleItems = isMoreOpen ? [...activeItems, ...quietItems] : [...activeItems, ...quietVisible]
 
-  const renderItem = (stream: StreamItemData) => (
-    <DraggableStreamRow key={stream.id} streamId={stream.id} enabled={streamDragEnabled}>
+  const renderItem = (stream: StreamItemData) => {
+    const item = (
       <StreamItem
         workspaceId={workspaceId}
         stream={stream}
@@ -390,8 +397,16 @@ export function TieredStreamSection({
         showPreviewOnHover={showPreviewOnHover}
         scrollContainerRef={scrollContainerRef}
       />
-    </DraggableStreamRow>
-  )
+    )
+    // Drag source only when dragging is on (desktop); see StreamSection.renderRow.
+    return streamDragEnabled ? (
+      <DraggableStreamRow key={stream.id} streamId={stream.id}>
+        {item}
+      </DraggableStreamRow>
+    ) : (
+      <Fragment key={stream.id}>{item}</Fragment>
+    )
+  }
 
   return (
     <div className="mb-4">

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -5,6 +5,7 @@ import {
   labelSectionId,
   toggleLabelSection,
   sectionIdForSpec,
+  customSectionId,
   hasSection,
   addSection,
   addSectionAt,
@@ -13,6 +14,11 @@ import {
   isPristinePreset,
   setQuickLinkVisibility,
   moveQuickLink,
+  createCustomSection,
+  renameCustomSection,
+  customSections,
+  getStreamCustomSectionId,
+  setStreamCustomSection,
 } from "./sidebar-config"
 
 describe("toggleLabelSection", () => {
@@ -53,7 +59,61 @@ describe("sectionIdForSpec", () => {
     expect(sectionIdForSpec({ kind: "type", streamType: "scratchpad" })).toBe("scratchpads")
     expect(sectionIdForSpec({ kind: "type", streamType: "dm" })).toBe("dms")
     expect(sectionIdForSpec({ kind: "label", labelId: "lbl_1" })).toBe(labelSectionId("lbl_1"))
+    expect(sectionIdForSpec({ kind: "custom", sectionId: "sec_1", name: "Work", streamIds: [] })).toBe(
+      customSectionId("sec_1")
+    )
     expect(sectionIdForSpec({ kind: "quicklinks" })).toBe(QUICK_LINKS_SECTION_ID)
+  })
+})
+
+describe("custom sections", () => {
+  it("createCustomSection appends a trimmed, empty section and rejects a blank name", () => {
+    const next = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_1", "  Work  ")
+    expect(next.sections.at(-1)).toEqual({
+      id: customSectionId("sec_1"),
+      spec: { kind: "custom", sectionId: "sec_1", name: "Work", streamIds: [] },
+    })
+    // Existing sections untouched.
+    expect(next.sections.slice(0, -1)).toEqual(SMART_SIDEBAR_CONFIG.sections)
+    // A blank name is a no-op.
+    expect(createCustomSection(SMART_SIDEBAR_CONFIG, "sec_2", "   ")).toEqual(SMART_SIDEBAR_CONFIG)
+  })
+
+  it("renameCustomSection trims the new name and no-ops for blanks / unknown ids", () => {
+    const created = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_1", "Work")
+    const renamed = renameCustomSection(created, "sec_1", "  Personal ")
+    expect(customSections(renamed)).toEqual([{ kind: "custom", sectionId: "sec_1", name: "Personal", streamIds: [] }])
+    expect(renameCustomSection(created, "sec_1", "  ")).toEqual(created)
+    expect(renameCustomSection(created, "ghost", "X")).toEqual(created)
+  })
+
+  it("setStreamCustomSection files a stream exclusively, moving it between sections", () => {
+    let config = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "A")
+    config = createCustomSection(config, "sec_b", "B")
+
+    const filed = setStreamCustomSection(config, "stream_1", "sec_a")
+    expect(getStreamCustomSectionId(filed, "stream_1")).toBe("sec_a")
+
+    // Moving to B removes it from A — a stream lives in only one custom section.
+    const moved = setStreamCustomSection(filed, "stream_1", "sec_b")
+    expect(getStreamCustomSectionId(moved, "stream_1")).toBe("sec_b")
+    expect(customSections(moved).find((s) => s.sectionId === "sec_a")?.streamIds).toEqual([])
+    expect(customSections(moved).find((s) => s.sectionId === "sec_b")?.streamIds).toEqual(["stream_1"])
+  })
+
+  it("setStreamCustomSection with null removes the stream from every custom section", () => {
+    const config = setStreamCustomSection(createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "A"), "stream_1", "sec_a")
+    const cleared = setStreamCustomSection(config, "stream_1", null)
+    expect(getStreamCustomSectionId(cleared, "stream_1")).toBeNull()
+  })
+
+  it("getStreamCustomSectionId returns null when the stream is unfiled", () => {
+    const config = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "A")
+    expect(getStreamCustomSectionId(config, "stream_x")).toBeNull()
+  })
+
+  it("makes the layout diverge from its preset (custom is never pristine)", () => {
+    expect(isPristinePreset(createCustomSection(SMART_SIDEBAR_CONFIG, "sec_1", "Work"))).toBeNull()
   })
 })
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -87,6 +87,24 @@ describe("custom sections", () => {
     expect(renameCustomSection(created, "ghost", "X")).toEqual(created)
   })
 
+  it("renameCustomSection preserves referential identity on a no-op rename", () => {
+    const created = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_1", "Work")
+    // Same name (after trim) and unknown id both return the original object, so
+    // the optimistic-write identity check skips a needless persist + resubscribe.
+    expect(renameCustomSection(created, "sec_1", "Work")).toBe(created)
+    expect(renameCustomSection(created, "sec_1", "  Work  ")).toBe(created)
+    expect(renameCustomSection(created, "ghost", "Other")).toBe(created)
+  })
+
+  it("setStreamCustomSection leaves membership untouched when the target section is missing", () => {
+    const config = setStreamCustomSection(createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "A"), "stream_1", "sec_a")
+    // Filing into a section that no longer exists must not strip the stream from
+    // the section it's currently in — it's a no-op that returns the same object.
+    const result = setStreamCustomSection(config, "stream_1", "ghost")
+    expect(result).toBe(config)
+    expect(getStreamCustomSectionId(result, "stream_1")).toBe("sec_a")
+  })
+
   it("setStreamCustomSection files a stream exclusively, moving it between sections", () => {
     let config = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_a", "A")
     config = createCustomSection(config, "sec_b", "B")

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -35,6 +35,19 @@ export function labelSectionId(labelId: string): string {
   return `label:${labelId}`
 }
 
+/**
+ * Section id for a custom section. Derived from the spec's own `sectionId` (a
+ * generated uuid) so it doubles as the collapse-state key and dnd sortable id.
+ */
+export function customSectionId(sectionId: string): string {
+  return `custom:${sectionId}`
+}
+
+/** Mint a fresh id for a new custom section. Config-local, not a domain entity. */
+export function newCustomSectionId(): string {
+  return crypto.randomUUID()
+}
+
 /** Whether the config already pins the given label as a sidebar section. */
 export function hasLabelSection(config: SidebarConfig, labelId: string): boolean {
   return config.sections.some((s) => s.spec.kind === "label" && s.spec.labelId === labelId)
@@ -62,6 +75,8 @@ export function sectionIdForSpec(spec: SidebarSectionSpec): string {
       return TYPE_SECTION_IDS[spec.streamType]
     case "label":
       return labelSectionId(spec.labelId)
+    case "custom":
+      return customSectionId(spec.sectionId)
     case "quicklinks":
       return QUICK_LINKS_SECTION_ID
   }
@@ -184,6 +199,71 @@ export function toggleLabelSection(config: SidebarConfig, labelId: string): Side
   return hasSection(config, spec) ? removeSection(config, labelSectionId(labelId)) : addSection(config, spec)
 }
 
+/** A custom section's spec, narrowed for callers that only handle this kind. */
+export type CustomSectionSpec = Extract<SidebarSectionSpec, { kind: "custom" }>
+
+/** The custom sections in the layout, in order. The picker/editor list these. */
+export function customSections(config: SidebarConfig): CustomSectionSpec[] {
+  return config.sections.flatMap((s) => (s.spec.kind === "custom" ? [s.spec] : []))
+}
+
+/**
+ * Append a new, empty custom section with the given name. Pure — the caller
+ * mints the id (so this stays testable) and persists the result. The name is
+ * trimmed; an all-whitespace name is rejected (returns the config unchanged).
+ */
+export function createCustomSection(config: SidebarConfig, sectionId: string, name: string): SidebarConfig {
+  const trimmed = name.trim()
+  if (!trimmed) return config
+  const spec: CustomSectionSpec = { kind: "custom", sectionId, name: trimmed, streamIds: [] }
+  return { ...config, sections: [...config.sections, { id: customSectionId(sectionId), spec }] }
+}
+
+/** Rename a custom section. Pure; no-op for an unknown id or a blank name. */
+export function renameCustomSection(config: SidebarConfig, sectionId: string, name: string): SidebarConfig {
+  const trimmed = name.trim()
+  if (!trimmed) return config
+  return {
+    ...config,
+    sections: config.sections.map((s) =>
+      s.spec.kind === "custom" && s.spec.sectionId === sectionId ? { ...s, spec: { ...s.spec, name: trimmed } } : s
+    ),
+  }
+}
+
+/** The id of the custom section a stream is filed under, or `null` if none. */
+export function getStreamCustomSectionId(config: SidebarConfig, streamId: string): string | null {
+  for (const s of config.sections) {
+    if (s.spec.kind === "custom" && s.spec.streamIds.includes(streamId)) return s.spec.sectionId
+  }
+  return null
+}
+
+/**
+ * File a stream into a single custom section (or remove it from all when
+ * `sectionId` is null). Membership is exclusive — the stream is first removed
+ * from every custom section, then appended to the target — so a stream lives in
+ * at most one custom section. Pure; the caller persists the result.
+ */
+export function setStreamCustomSection(
+  config: SidebarConfig,
+  streamId: string,
+  sectionId: string | null
+): SidebarConfig {
+  return {
+    ...config,
+    sections: config.sections.map((section) => {
+      const spec = section.spec
+      if (spec.kind !== "custom") return section
+      const without = spec.streamIds.filter((id) => id !== streamId)
+      const next = spec.sectionId === sectionId ? [...without, streamId] : without
+      // Preserve referential identity when nothing changed (avoids needless churn).
+      if (next.length === spec.streamIds.length && next.every((id, i) => id === spec.streamIds[i])) return section
+      return { ...section, spec: { ...spec, streamIds: next } }
+    }),
+  }
+}
+
 /** How a resolved section renders. Derived purely from its spec. */
 export interface SectionPresentation {
   label: string
@@ -257,10 +337,28 @@ const QUICK_LINKS_PRESENTATION: SectionPresentation = {
   defaultCollapse: "open",
 }
 
+/**
+ * Presentation for a custom section. The user named it deliberately, so it stays
+ * visible when empty — both as a reminder it exists and as a drop target. Tiered
+ * so a large hand-curated set doesn't flood the sidebar. `label` carries the
+ * user's name (the spec owns it, unlike labels whose name is resolved at render).
+ */
+function customSectionPresentation(name: string): SectionPresentation {
+  return {
+    label: name,
+    tiered: true,
+    compact: true,
+    showPreviewOnHover: true,
+    hideWhenEmpty: false,
+    defaultCollapse: "open",
+  }
+}
+
 /** Resolve how a section should render from its spec. */
 export function sectionPresentation(spec: SidebarSectionSpec): SectionPresentation {
   if (spec.kind === "type") return TYPE_PRESENTATION[spec.streamType]
   if (spec.kind === "label") return LABEL_PRESENTATION
+  if (spec.kind === "custom") return customSectionPresentation(spec.name)
   if (spec.kind === "quicklinks") return QUICK_LINKS_PRESENTATION
 
   const config = SMART_SECTIONS[spec.bucket]

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -223,12 +223,16 @@ export function createCustomSection(config: SidebarConfig, sectionId: string, na
 export function renameCustomSection(config: SidebarConfig, sectionId: string, name: string): SidebarConfig {
   const trimmed = name.trim()
   if (!trimmed) return config
-  return {
-    ...config,
-    sections: config.sections.map((s) =>
-      s.spec.kind === "custom" && s.spec.sectionId === sectionId ? { ...s, spec: { ...s.spec, name: trimmed } } : s
-    ),
-  }
+  let changed = false
+  const sections = config.sections.map((section) => {
+    if (section.spec.kind !== "custom" || section.spec.sectionId !== sectionId) return section
+    if (section.spec.name === trimmed) return section
+    changed = true
+    return { ...section, spec: { ...section.spec, name: trimmed } }
+  })
+  // Unknown id or a no-op rename returns the original object so the caller's
+  // identity check skips a needless persist + resubscribe.
+  return changed ? { ...config, sections } : config
 }
 
 /** The id of the custom section a stream is filed under, or `null` if none. */
@@ -250,18 +254,26 @@ export function setStreamCustomSection(
   streamId: string,
   sectionId: string | null
 ): SidebarConfig {
-  return {
-    ...config,
-    sections: config.sections.map((section) => {
-      const spec = section.spec
-      if (spec.kind !== "custom") return section
-      const without = spec.streamIds.filter((id) => id !== streamId)
-      const next = spec.sectionId === sectionId ? [...without, streamId] : without
-      // Preserve referential identity when nothing changed (avoids needless churn).
-      if (next.length === spec.streamIds.length && next.every((id, i) => id === spec.streamIds[i])) return section
-      return { ...section, spec: { ...spec, streamIds: next } }
-    }),
-  }
+  // A non-null target that no longer exists (e.g. the section was removed on
+  // another device between render and drop) must not silently unfile the
+  // stream from wherever it currently lives — treat it as a no-op.
+  const targetExists =
+    sectionId === null ||
+    config.sections.some((section) => section.spec.kind === "custom" && section.spec.sectionId === sectionId)
+  if (!targetExists) return config
+
+  let changed = false
+  const sections = config.sections.map((section) => {
+    const spec = section.spec
+    if (spec.kind !== "custom") return section
+    const without = spec.streamIds.filter((id) => id !== streamId)
+    const next = spec.sectionId === sectionId ? [...without, streamId] : without
+    // Preserve referential identity when nothing changed (avoids needless churn).
+    if (next.length === spec.streamIds.length && next.every((id, i) => id === spec.streamIds[i])) return section
+    changed = true
+    return { ...section, spec: { ...spec, streamIds: next } }
+  })
+  return changed ? { ...config, sections } : config
 }
 
 /** How a resolved section renders. Derived purely from its spec. */

--- a/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react"
 import { useDraggable, useDroppable } from "@dnd-kit/core"
 import { cn } from "@/lib/utils"
+import { customSectionId } from "./sidebar-config"
 
 /**
  * Drag-and-drop wiring for filing streams into custom sidebar sections. A stream
@@ -34,43 +35,42 @@ export function customSectionIdFromDropData(data: unknown): string | null {
 }
 
 /**
- * Wraps a sidebar stream row to make it draggable. Only the pointer listeners
- * are spread (not dnd-kit's keyboard `attributes`) so the wrapper doesn't turn
- * into a focusable button around the row's `<Link>` — keyboard users file
- * streams through the accessible "Add to section…" action instead. With an
- * activation distance on the sensor, a plain click still navigates the link.
+ * Wraps a sidebar stream row to make it draggable. Rendered only where dragging
+ * is enabled (desktop) — the caller renders the row bare otherwise, so we never
+ * register a dead draggable per row. Only the pointer listeners are spread (not
+ * dnd-kit's keyboard `attributes`) so the wrapper doesn't turn into a focusable
+ * button around the row's `<Link>` — keyboard users file streams through the
+ * accessible "Add to section…" action instead. With an activation distance on
+ * the sensor, a plain click still navigates the link.
  */
-export function DraggableStreamRow({
-  streamId,
-  enabled,
-  children,
-}: {
-  streamId: string
-  enabled: boolean
-  children: ReactNode
-}) {
+export function DraggableStreamRow({ streamId, children }: { streamId: string; children: ReactNode }) {
   const data: StreamDragData = { type: "stream", streamId }
-  const { setNodeRef, listeners, isDragging } = useDraggable({ id: `stream:${streamId}`, data, disabled: !enabled })
+  const { setNodeRef, listeners, isDragging } = useDraggable({ id: `stream:${streamId}`, data })
 
   return (
-    <div ref={setNodeRef} {...(enabled ? listeners : {})} className={cn(isDragging && "opacity-40")}>
+    <div ref={setNodeRef} {...listeners} className={cn(isDragging && "opacity-40")}>
       {children}
     </div>
   )
 }
 
-/** A droppable wrapper that highlights a custom section while a stream hovers it. */
+/**
+ * A droppable wrapper that highlights a custom section while a stream hovers it.
+ * The droppable id reuses the section's stable id ({@link customSectionId}) so
+ * the `custom:`-prefix convention lives in one place; the handler reads the
+ * section id from the data payload, not by parsing the id.
+ */
 export function CustomSectionDropZone({
-  customSectionId,
+  sectionId,
   enabled,
   children,
 }: {
-  customSectionId: string
+  sectionId: string
   enabled: boolean
   children: ReactNode
 }) {
-  const data: CustomSectionDropData = { type: "custom-section", customSectionId }
-  const { setNodeRef, isOver } = useDroppable({ id: `custom-section:${customSectionId}`, data, disabled: !enabled })
+  const data: CustomSectionDropData = { type: "custom-section", customSectionId: sectionId }
+  const { setNodeRef, isOver } = useDroppable({ id: customSectionId(sectionId), data, disabled: !enabled })
 
   return (
     <div

--- a/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react"
+import { useDraggable, useDroppable } from "@dnd-kit/core"
+import { cn } from "@/lib/utils"
+
+/**
+ * Drag-and-drop wiring for filing streams into custom sidebar sections. A stream
+ * row is the drag source; a custom section is the drop target. The data payloads
+ * (not the ids) carry the resolved ids, so the drop handler reads them directly
+ * without parsing prefixes. Desktop-only — mobile files streams through the
+ * action drawer's section picker instead, so dragging is `disabled` there to
+ * leave touch scrolling and long-press untouched.
+ */
+
+interface StreamDragData {
+  type: "stream"
+  streamId: string
+}
+
+interface CustomSectionDropData {
+  type: "custom-section"
+  customSectionId: string
+}
+
+/** The stream id of an in-flight drag, or null when the drag isn't a stream. */
+export function streamIdFromDragData(data: unknown): string | null {
+  const d = data as StreamDragData | undefined
+  return d?.type === "stream" ? d.streamId : null
+}
+
+/** The target custom-section id under the pointer, or null when not over one. */
+export function customSectionIdFromDropData(data: unknown): string | null {
+  const d = data as CustomSectionDropData | undefined
+  return d?.type === "custom-section" ? d.customSectionId : null
+}
+
+/**
+ * Wraps a sidebar stream row to make it draggable. Only the pointer listeners
+ * are spread (not dnd-kit's keyboard `attributes`) so the wrapper doesn't turn
+ * into a focusable button around the row's `<Link>` — keyboard users file
+ * streams through the accessible "Add to section…" action instead. With an
+ * activation distance on the sensor, a plain click still navigates the link.
+ */
+export function DraggableStreamRow({
+  streamId,
+  enabled,
+  children,
+}: {
+  streamId: string
+  enabled: boolean
+  children: ReactNode
+}) {
+  const data: StreamDragData = { type: "stream", streamId }
+  const { setNodeRef, listeners, isDragging } = useDraggable({ id: `stream:${streamId}`, data, disabled: !enabled })
+
+  return (
+    <div ref={setNodeRef} {...(enabled ? listeners : {})} className={cn(isDragging && "opacity-40")}>
+      {children}
+    </div>
+  )
+}
+
+/** A droppable wrapper that highlights a custom section while a stream hovers it. */
+export function CustomSectionDropZone({
+  customSectionId,
+  enabled,
+  children,
+}: {
+  customSectionId: string
+  enabled: boolean
+  children: ReactNode
+}) {
+  const data: CustomSectionDropData = { type: "custom-section", customSectionId }
+  const { setNodeRef, isOver } = useDroppable({ id: `custom-section:${customSectionId}`, data, disabled: !enabled })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn("rounded-lg transition-colors", isOver && "bg-primary/5 ring-2 ring-primary/40 ring-inset")}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
@@ -6,7 +6,7 @@ import * as workspaceStore from "@/stores/workspace-store"
 import * as contexts from "@/contexts"
 import * as dialogModule from "@/components/ui/responsive-dialog"
 import { SidebarEditorDialog } from "./sidebar-editor"
-import { moveSection, removeSection } from "./sidebar-config"
+import { createCustomSection, moveSection, removeSection, renameCustomSection } from "./sidebar-config"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -179,5 +179,32 @@ describe("SidebarEditorDialog", () => {
       ...ALL_SIDEBAR_CONFIG,
       sections: [...ALL_SIDEBAR_CONFIG.sections, { id: "important", spec: { kind: "smart", bucket: "important" } }],
     })
+  })
+
+  it("creates a custom section from the inline creator", async () => {
+    useConfig(SMART_SIDEBAR_CONFIG)
+    mount()
+
+    await userEvent.type(screen.getByRole("textbox", { name: "New custom section name" }), "Work")
+    await userEvent.click(screen.getByRole("button", { name: "Add section" }))
+
+    expect(setConfig).toHaveBeenCalledTimes(1)
+    const next = setConfig.mock.calls[0][0] as SidebarConfig
+    // Appended as an empty custom section (the id is minted at create time).
+    expect(next.sections.at(-1)?.spec).toMatchObject({ kind: "custom", name: "Work", streamIds: [] })
+    expect(next.sections.slice(0, -1)).toEqual(SMART_SIDEBAR_CONFIG.sections)
+  })
+
+  it("renames a custom section on blur", async () => {
+    const config = createCustomSection(SMART_SIDEBAR_CONFIG, "sec_1", "Work")
+    useConfig(config)
+    mount()
+
+    const input = screen.getByRole("textbox", { name: "Section name" })
+    await userEvent.clear(input)
+    await userEvent.type(input, "Personal")
+    await userEvent.tab()
+
+    expect(setConfig).toHaveBeenCalledWith(renameCustomSection(config, "sec_1", "Personal"))
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react"
-import { CircleDot, Eye, EyeOff, GripVertical, RotateCcw, X } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { CircleDot, Eye, EyeOff, FolderInput, GripVertical, Plus, RotateCcw, X } from "lucide-react"
 import {
   DndContext,
   KeyboardSensor,
@@ -22,6 +22,7 @@ import {
   SIDEBAR_SECTION_KEYS,
   SIDEBAR_TYPE_SECTIONS,
   SIDEBAR_BASE_PRESETS,
+  MAX_CUSTOM_SECTION_NAME_LENGTH,
   type SidebarSection,
   type SidebarSectionSpec,
   type SidebarQuickLink,
@@ -59,6 +60,9 @@ import {
   sectionIdForSpec,
   setQuickLinkVisibility,
   moveQuickLink,
+  createCustomSection,
+  renameCustomSection,
+  newCustomSectionId,
 } from "./sidebar-config"
 
 const PRESET_LABELS: Record<SidebarBasePreset, string> = { smart: "Smart", all: "All" }
@@ -206,6 +210,7 @@ export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: Sidebar
                 quickLinks={config.quickLinks}
                 reduceMotion={reduceMotion}
                 onRemoveSection={(id) => setConfig(removeSection(config, id))}
+                onRenameCustomSection={(sectionId, name) => setConfig(renameCustomSection(config, sectionId, name))}
                 onSetQuickLinkVisibility={(key, visibility) =>
                   setConfig(setQuickLinkVisibility(config, key, visibility))
                 }
@@ -218,6 +223,10 @@ export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: Sidebar
                 onAdd={(spec) => setConfig(addSection(config, spec))}
               />
             </DndContext>
+
+            <CustomSectionCreator
+              onCreate={(name) => setConfig(createCustomSection(config, newCustomSectionId(), name))}
+            />
           </section>
         </ResponsiveDialogBody>
 
@@ -244,6 +253,7 @@ function SectionsList({
   quickLinks,
   reduceMotion,
   onRemoveSection,
+  onRenameCustomSection,
   onSetQuickLinkVisibility,
   onMoveQuickLink,
 }: {
@@ -253,6 +263,7 @@ function SectionsList({
   quickLinks: SidebarQuickLink[]
   reduceMotion: boolean
   onRemoveSection: (id: string) => void
+  onRenameCustomSection: (sectionId: string, name: string) => void
   onSetQuickLinkVisibility: (key: SidebarQuickLink["key"], visibility: SidebarQuickLinkVisibility) => void
   onMoveQuickLink: (activeKey: string, overKey: string) => void
 }) {
@@ -284,6 +295,7 @@ function SectionsList({
               quickLinks={quickLinks}
               reduceMotion={reduceMotion}
               onRemove={() => onRemoveSection(section.id)}
+              onRenameCustomSection={onRenameCustomSection}
               onSetQuickLinkVisibility={onSetQuickLinkVisibility}
               onMoveQuickLink={onMoveQuickLink}
             />
@@ -302,6 +314,7 @@ function SortableSectionRow({
   quickLinks,
   reduceMotion,
   onRemove,
+  onRenameCustomSection,
   onSetQuickLinkVisibility,
   onMoveQuickLink,
 }: {
@@ -310,6 +323,7 @@ function SortableSectionRow({
   quickLinks: SidebarQuickLink[]
   reduceMotion: boolean
   onRemove: () => void
+  onRenameCustomSection: (sectionId: string, name: string) => void
   onSetQuickLinkVisibility: (key: SidebarQuickLink["key"], visibility: SidebarQuickLinkVisibility) => void
   onMoveQuickLink: (activeKey: string, overKey: string) => void
 }) {
@@ -331,7 +345,7 @@ function SortableSectionRow({
       >
         <DragHandle label={`Reorder ${name}`} attributes={attributes} listeners={listeners} />
         <div className="min-w-0 flex-1">
-          <SectionRowContent section={section} labelsById={labelsById} />
+          <SectionRowContent section={section} labelsById={labelsById} onRenameCustomSection={onRenameCustomSection} />
         </div>
         <button
           type="button"
@@ -518,12 +532,31 @@ function DragHandle({
   )
 }
 
-/** The visual for a section row: a tinted chip for labels, icon + name otherwise. */
-function SectionRowContent({ section, labelsById }: { section: SidebarSection; labelsById: Map<string, CachedLabel> }) {
+/** The visual for a section row: a tinted chip for labels, an editable name for
+ *  custom sections, icon + name otherwise. */
+function SectionRowContent({
+  section,
+  labelsById,
+  onRenameCustomSection,
+}: {
+  section: SidebarSection
+  labelsById: Map<string, CachedLabel>
+  onRenameCustomSection: (sectionId: string, name: string) => void
+}) {
   if (section.spec.kind === "label") {
     const label = labelsById.get(section.spec.labelId)
     if (!label) return <span className="truncate text-sm italic text-muted-foreground">Unavailable label</span>
     return <LabelChip label={label} />
+  }
+  // Custom sections own their name, so the row doubles as a rename field.
+  if (section.spec.kind === "custom") {
+    return (
+      <CustomSectionNameInput
+        sectionId={section.spec.sectionId}
+        name={section.spec.name}
+        onRename={onRenameCustomSection}
+      />
+    )
   }
   // Stream-type sections carry no emoji; mirror the live sidebar's lucide glyph
   // (BADGE_CONFIG) so a reordered "Channels"/"Scratchpads"/"DMs" row stays
@@ -546,7 +579,92 @@ function SectionRowContent({ section, labelsById }: { section: SidebarSection; l
 /** Plain-text name for a section, for the reorder/remove button aria-labels. */
 function sectionDisplayName(section: SidebarSection, labelsById: Map<string, CachedLabel>): string {
   if (section.spec.kind === "label") return labelsById.get(section.spec.labelId)?.name ?? "label section"
+  if (section.spec.kind === "custom") return section.spec.name
   return sectionPresentation(section.spec).label
+}
+
+/** Inline rename field for a custom section row. Commits on blur / Enter (not per
+ *  keystroke) so renaming doesn't fire a write — and a persisted change reflects
+ *  back. Top-level per INV-18. */
+function CustomSectionNameInput({
+  sectionId,
+  name,
+  onRename,
+}: {
+  sectionId: string
+  name: string
+  onRename: (sectionId: string, name: string) => void
+}) {
+  const [value, setValue] = useState(name)
+  // Reflect a name changed elsewhere (another device) when not mid-edit.
+  useEffect(() => setValue(name), [name])
+
+  const commit = () => {
+    const trimmed = value.trim()
+    if (!trimmed || trimmed === name) {
+      setValue(name)
+      return
+    }
+    onRename(sectionId, trimmed)
+  }
+
+  return (
+    <span className="flex items-center gap-1.5">
+      <FolderInput className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            e.currentTarget.blur()
+          }
+        }}
+        maxLength={MAX_CUSTOM_SECTION_NAME_LENGTH}
+        aria-label="Section name"
+        className="min-w-0 flex-1 rounded bg-transparent px-0.5 text-sm font-medium outline-none focus:ring-1 focus:ring-ring"
+      />
+    </span>
+  )
+}
+
+/** Inline form to create a new, empty custom section by name. Top-level per INV-18. */
+function CustomSectionCreator({ onCreate }: { onCreate: (name: string) => void }) {
+  const [name, setName] = useState("")
+
+  const submit = () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onCreate(trimmed)
+    setName("")
+  }
+
+  return (
+    <div className="space-y-1.5 pt-3">
+      <p className="text-xs text-muted-foreground">Create a custom section:</p>
+      <div className="flex items-center gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault()
+              submit()
+            }
+          }}
+          maxLength={MAX_CUSTOM_SECTION_NAME_LENGTH}
+          placeholder="Section name…"
+          aria-label="New custom section name"
+          className="min-w-0 flex-1 rounded-md border bg-card px-2.5 py-1.5 text-base outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring sm:text-sm"
+        />
+        <Button type="button" size="sm" variant="outline" onClick={submit} disabled={!name.trim()} className="shrink-0">
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Add section
+        </Button>
+      </div>
+    </div>
+  )
 }
 
 /** The always-visible tray of addable sections. Each chip can be dragged onto the

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -1,9 +1,22 @@
-import { Fragment, type ReactNode, type RefObject } from "react"
+import { Fragment, useState, type ReactNode, type RefObject } from "react"
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core"
 import type { CollapseState } from "@/contexts"
 import { Button } from "@/components/ui/button"
 import { LabelChip } from "@/components/labels/label-chip"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { streamLabel } from "@/lib/streams"
 import type { CachedLabel } from "@/hooks"
 import { StreamSection, TieredStreamSection } from "./sections"
+import { CustomSectionDropZone, customSectionIdFromDropData, streamIdFromDragData } from "./sidebar-dnd"
 import { sectionPresentation, type SidebarSectionSpec } from "./sidebar-config"
 import type { ResolvedSection } from "./resolve-sections"
 import type { SidebarActionItem } from "./sidebar-actions"
@@ -52,6 +65,11 @@ interface SidebarStreamListProps {
    * counts/route signals the sidebar owns; `null` when the user removed the block.
    */
   quickLinksSlot?: ReactNode
+  /**
+   * File a stream into the custom section with this id (drag-and-drop drop). The
+   * parent owns the sidebar config, so the membership write lives there.
+   */
+  onFileStreamToSection: (streamId: string, customSectionId: string) => void
   scrollContainerRef: RefObject<HTMLDivElement | null>
 }
 
@@ -71,8 +89,30 @@ export function SidebarStreamList({
   onCreateChannel,
   scratchpadAddMenuActions,
   quickLinksSlot,
+  onFileStreamToSection,
   scrollContainerRef,
 }: SidebarStreamListProps) {
+  // Dragging streams into sections is a desktop interaction; on mobile the same
+  // is done through the action drawer's section picker, so we leave touch
+  // gestures (scroll, long-press) untouched by disabling drag entirely.
+  const isMobile = useIsMobile()
+  const streamDragEnabled = !isMobile
+  const [draggingStreamId, setDraggingStreamId] = useState<string | null>(null)
+  // Distance constraint so a click still navigates the row's link — a drag only
+  // begins once the pointer has moved past the threshold.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggingStreamId(streamIdFromDragData(event.active.data.current))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setDraggingStreamId(null)
+    const streamId = streamIdFromDragData(event.active.data.current)
+    const customSectionId = customSectionIdFromDropData(event.over?.data.current)
+    if (streamId && customSectionId) onFileStreamToSection(streamId, customSectionId)
+  }
+
   if (hasError) {
     return <p className="px-2 py-4 text-xs text-destructive text-center">Failed to load</p>
   }
@@ -110,8 +150,16 @@ export function SidebarStreamList({
     return undefined
   }
 
+  const draggingStream = draggingStreamId ? processedStreams.find((s) => s.id === draggingStreamId) : null
+
   return (
-    <>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setDraggingStreamId(null)}
+    >
       {resolvedSections.map(({ section, items }) => {
         // The Quick Links block renders its own link list at this position. The
         // slot owns its spacing (and may render null when every link is hidden),
@@ -134,37 +182,32 @@ export function SidebarStreamList({
         const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
         const add = addWiringFor(section.spec)
 
-        if (presentation.tiered) {
-          return (
-            <TieredStreamSection
-              key={section.id}
-              sectionKey={section.id}
-              label={headerLabel}
-              titleContent={titleContent}
-              icon={presentation.icon}
-              items={items}
-              allStreams={processedStreams}
-              workspaceId={workspaceId}
-              activeStreamId={activeStreamId}
-              getUnreadCount={getUnreadCount}
-              getMentionCount={getMentionCount}
-              state={state}
-              onToggle={onToggle}
-              moreState={getSectionState(moreKey(section.id), MORE_DEFAULT)}
-              onToggleMore={() => toggleSectionState(moreKey(section.id), MORE_DEFAULT)}
-              compact={presentation.compact}
-              showPreviewOnHover={presentation.showPreviewOnHover}
-              scrollContainerRef={scrollContainerRef}
-              onAdd={add?.onAdd}
-              addTooltip={add?.addTooltip}
-              addMenuActions={add?.addMenuActions}
-            />
-          )
-        }
-
-        return (
+        const sectionEl = presentation.tiered ? (
+          <TieredStreamSection
+            sectionKey={section.id}
+            label={headerLabel}
+            titleContent={titleContent}
+            icon={presentation.icon}
+            items={items}
+            allStreams={processedStreams}
+            workspaceId={workspaceId}
+            activeStreamId={activeStreamId}
+            getUnreadCount={getUnreadCount}
+            getMentionCount={getMentionCount}
+            state={state}
+            onToggle={onToggle}
+            moreState={getSectionState(moreKey(section.id), MORE_DEFAULT)}
+            onToggleMore={() => toggleSectionState(moreKey(section.id), MORE_DEFAULT)}
+            compact={presentation.compact}
+            showPreviewOnHover={presentation.showPreviewOnHover}
+            scrollContainerRef={scrollContainerRef}
+            onAdd={add?.onAdd}
+            addTooltip={add?.addTooltip}
+            addMenuActions={add?.addMenuActions}
+            streamDragEnabled={streamDragEnabled}
+          />
+        ) : (
           <StreamSection
-            key={section.id}
             label={headerLabel}
             titleContent={titleContent}
             icon={presentation.icon}
@@ -179,9 +222,35 @@ export function SidebarStreamList({
             compact={presentation.compact}
             showPreviewOnHover={presentation.showPreviewOnHover}
             scrollContainerRef={scrollContainerRef}
+            streamDragEnabled={streamDragEnabled}
           />
         )
+
+        // Custom sections are drop targets — a stream dragged onto one is filed
+        // there. Other section kinds render as-is.
+        if (section.spec.kind === "custom") {
+          return (
+            <CustomSectionDropZone
+              key={section.id}
+              customSectionId={section.spec.sectionId}
+              enabled={streamDragEnabled}
+            >
+              {sectionEl}
+            </CustomSectionDropZone>
+          )
+        }
+        return <Fragment key={section.id}>{sectionEl}</Fragment>
       })}
-    </>
+
+      {/* A small chip trails the cursor while filing a stream, so the drag reads
+          as intentional even though the source row stays put (dimmed). */}
+      <DragOverlay dropAnimation={null}>
+        {draggingStream ? (
+          <div className="pointer-events-none rounded-md border bg-card px-2.5 py-1.5 text-sm font-medium shadow-md">
+            {streamLabel(draggingStream, "sidebar")}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -230,11 +230,7 @@ export function SidebarStreamList({
         // there. Other section kinds render as-is.
         if (section.spec.kind === "custom") {
           return (
-            <CustomSectionDropZone
-              key={section.id}
-              customSectionId={section.spec.sectionId}
-              enabled={streamDragEnabled}
-            >
+            <CustomSectionDropZone key={section.id} sectionId={section.spec.sectionId} enabled={streamDragEnabled}>
               {sectionEl}
             </CustomSectionDropZone>
           )

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -37,6 +37,7 @@ import { HeaderSkeleton, QuickLinksSkeleton, StreamListSkeleton } from "./skelet
 import { SidebarFooter } from "./sidebar-footer"
 import { SidebarEditorDialog } from "./sidebar-editor"
 import { resolveSections } from "./resolve-sections"
+import { setStreamCustomSection } from "./sidebar-config"
 import type { SidebarActionItem } from "./sidebar-actions"
 import { calculateUrgency, categorizeStream } from "./utils"
 import type { StreamItemData } from "./types"
@@ -58,7 +59,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     bumpScrollVersion,
     collapseOnMobile,
   } = useSidebar()
-  const { config: sidebarConfig } = useSidebarConfig(workspaceId)
+  const { config: sidebarConfig, setConfig: setSidebarConfig } = useSidebarConfig(workspaceId)
   const [isEditorOpen, setIsEditorOpen] = useState(false)
   const { streamId: activeStreamId, "*": splat } = useParams<{ streamId: string; "*": string }>()
   const location = useLocation()
@@ -364,6 +365,12 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     openCreateChannel()
   }
 
+  // Drag-and-drop drop: file the stream into the target custom section.
+  // setStreamCustomSection keeps membership exclusive (removed from any other).
+  const handleFileStreamToSection = (streamId: string, customSectionId: string) => {
+    setSidebarConfig(setStreamCustomSection(sidebarConfig, streamId, customSectionId))
+  }
+
   return (
     <>
       <SidebarShell
@@ -392,6 +399,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             onCreateScratchpad={handleCreateScratchpad}
             onCreateChannel={handleCreateChannel}
             scratchpadAddMenuActions={scratchpadAddMenuActions}
+            onFileStreamToSection={handleFileStreamToSection}
             quickLinksSlot={
               hasQuickLinksSection ? (
                 <SidebarQuickLinks

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
-import { Bell, FileEdit, Hash, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
+import { Bell, FileEdit, FolderPlus, Hash, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
+import { SectionPicker } from "./section-picker"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { RelativeTime } from "@/components/relative-time"
@@ -203,6 +204,7 @@ export function StreamItem({
   const { openStreamSettings } = useStreamSettings()
   const { collapseOnMobile } = useSidebar()
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
+  const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
   const itemRef = useRef<HTMLAnchorElement>(null)
   const hasUnread = unreadCount > 0
   const preview = stream.lastMessagePreview
@@ -276,6 +278,12 @@ export function StreamItem({
               label: "Labels…",
               icon: Tag,
               onSelect: () => setLabelPickerOpen(true),
+            },
+            {
+              id: "add-to-section",
+              label: "Add to section…",
+              icon: FolderPlus,
+              onSelect: () => setSectionPickerOpen(true),
             },
           ],
     [isVirtualDraft, openStreamSettings, stream.id]
@@ -400,6 +408,9 @@ export function StreamItem({
           open
           onOpenChange={setLabelPickerOpen}
         />
+      )}
+      {sectionPickerOpen && (
+        <SectionPicker workspaceId={workspaceId} streamId={stream.id} open onOpenChange={setSectionPickerOpen} />
       )}
       {isMobile && canOpenDrawer && (
         <SidebarActionDrawer

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -614,6 +614,7 @@ export {
   type SidebarSectionKey,
   SIDEBAR_TYPE_SECTIONS,
   type SidebarTypeSection,
+  MAX_CUSTOM_SECTION_NAME_LENGTH,
   type SidebarSectionSpec,
   type SidebarSection,
   SIDEBAR_BASE_PRESETS,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -615,6 +615,7 @@ export {
   SIDEBAR_TYPE_SECTIONS,
   type SidebarTypeSection,
   MAX_CUSTOM_SECTION_NAME_LENGTH,
+  MAX_CUSTOM_SECTION_STREAM_IDS,
   type SidebarSectionSpec,
   type SidebarSection,
   SIDEBAR_BASE_PRESETS,

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -143,8 +143,10 @@ describe("normalizeSidebarConfig section sanitization", () => {
     const result = normalizeSidebarConfig(config)
     const customs = result.sections.filter((s) => s.spec.kind === "custom")
 
-    expect(customs).toHaveLength(1)
-    expect(customs[0].id).toBe("custom:work")
+    // First listing wins; the drifted-id duplicate is dropped entirely.
+    expect(customs).toEqual([
+      { id: "custom:work", spec: { kind: "custom", sectionId: "work", name: "Work", streamIds: ["s1"] } },
+    ])
   })
 
   test("caps a custom section's streamIds at the write-time bound on read", () => {

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -128,6 +128,25 @@ describe("normalizeSidebarConfig section sanitization", () => {
     expect(result.sections[0].spec).toMatchObject({ kind: "custom", streamIds: [] })
   })
 
+  test("dedupes custom sections sharing a sectionId even when their stored ids differ", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        { id: "custom:work", spec: { kind: "custom", sectionId: "work", name: "Work", streamIds: ["s1"] } },
+        // A drifted id that still points at the same sectionId — must not survive.
+        { id: "foo", spec: { kind: "custom", sectionId: "work", name: "Work dup", streamIds: ["s2"] } },
+      ],
+      quickLinks: [],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+    const customs = result.sections.filter((s) => s.spec.kind === "custom")
+
+    expect(customs).toHaveLength(1)
+    expect(customs[0].id).toBe("custom:work")
+  })
+
   test("caps a custom section's streamIds at the write-time bound on read", () => {
     const streamIds = Array.from({ length: MAX_CUSTOM_SECTION_STREAM_IDS + 25 }, (_, i) => `s${i}`)
     const config = {

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeSidebarConfig,
   SIDEBAR_CONFIG_VERSION,
   QUICK_LINKS_SECTION_ID,
+  MAX_CUSTOM_SECTION_STREAM_IDS,
   type RawSidebarConfig,
   type SidebarSection,
 } from "./sidebar"
@@ -125,5 +126,20 @@ describe("normalizeSidebarConfig section sanitization", () => {
     const result = normalizeSidebarConfig(config)
 
     expect(result.sections[0].spec).toMatchObject({ kind: "custom", streamIds: [] })
+  })
+
+  test("caps a custom section's streamIds at the write-time bound on read", () => {
+    const streamIds = Array.from({ length: MAX_CUSTOM_SECTION_STREAM_IDS + 25 }, (_, i) => `s${i}`)
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [{ id: "custom:a", spec: { kind: "custom", sectionId: "a", name: "A", streamIds } }],
+      quickLinks: [],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+    const spec = result.sections[0].spec
+    if (spec.kind !== "custom") throw new Error("expected a custom section")
+    expect(spec.streamIds).toHaveLength(MAX_CUSTOM_SECTION_STREAM_IDS)
   })
 })

--- a/packages/types/src/sidebar.test.ts
+++ b/packages/types/src/sidebar.test.ts
@@ -77,4 +77,53 @@ describe("normalizeSidebarConfig section sanitization", () => {
 
     expect(result.sections.map((s) => s.spec.kind)).toEqual(["quicklinks", "smart"])
   })
+
+  test("drops a custom section with a blank name but keeps a valid one", () => {
+    const config: RawSidebarConfig = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        { id: "custom:blank", spec: { kind: "custom", sectionId: "blank", name: "   ", streamIds: [] } },
+        { id: "custom:work", spec: { kind: "custom", sectionId: "work", name: "Work", streamIds: ["s1"] } },
+      ],
+      quickLinks: [],
+    }
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections.map((s) => s.id)).toEqual(["custom:work"])
+  })
+
+  test("sanitizes custom-section streamIds and enforces single membership across sections", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [
+        // Non-string ids and an in-section duplicate are stripped.
+        { id: "custom:a", spec: { kind: "custom", sectionId: "a", name: "A", streamIds: ["s1", "s1", 7, "s2"] } },
+        // s2 already lives in A, so the first listing wins and B keeps only s3.
+        { id: "custom:b", spec: { kind: "custom", sectionId: "b", name: "B", streamIds: ["s2", "s3"] } },
+      ],
+      quickLinks: [],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+    const byId = (id: string) => result.sections.find((s) => s.id === id)?.spec
+
+    expect(byId("custom:a")).toMatchObject({ streamIds: ["s1", "s2"] })
+    expect(byId("custom:b")).toMatchObject({ streamIds: ["s3"] })
+  })
+
+  test("coerces a custom section's missing/non-array streamIds to an empty list", () => {
+    const config = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart",
+      sections: [{ id: "custom:a", spec: { kind: "custom", sectionId: "a", name: "A" } }],
+      quickLinks: [],
+    } as unknown as RawSidebarConfig
+
+    const result = normalizeSidebarConfig(config)
+
+    expect(result.sections[0].spec).toMatchObject({ kind: "custom", streamIds: [] })
+  })
 })

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -20,6 +20,9 @@ export type SidebarSectionKey = (typeof SIDEBAR_SECTION_KEYS)[number]
 export const SIDEBAR_TYPE_SECTIONS = ["scratchpad", "channel", "dm"] as const
 export type SidebarTypeSection = (typeof SIDEBAR_TYPE_SECTIONS)[number]
 
+/** Max length of a user-supplied custom-section name (validated on write, trimmed on render). */
+export const MAX_CUSTOM_SECTION_NAME_LENGTH = 80
+
 /** What streams a section draws from. Presentation is derived from this at render time. */
 export type SidebarSectionSpec =
   | { kind: "smart"; bucket: SidebarSectionKey }
@@ -31,6 +34,17 @@ export type SidebarSectionSpec =
    * stored here (only the id, so a renamed/recolored label stays in sync).
    */
   | { kind: "label"; labelId: string }
+  /**
+   * A user-defined section: a hand-curated set of streams the viewer files here,
+   * the lightweight cousin of a label (no shared catalog, no per-stream
+   * attribution — the membership lives inline in {@link streamIds}). Unlike a
+   * label lens, a custom section is **exclusive and trumps order**: a stream
+   * pinned here shows only here, even if a smart/label/type section ordered above
+   * it would also match (see `resolveSections`). A stream belongs to at most one
+   * custom section — `normalizeSidebarConfig` enforces this, keeping a duplicated
+   * id only in the first custom section that lists it.
+   */
+  | { kind: "custom"; sectionId: string; name: string; streamIds: string[] }
   /**
    * The Quick Links block (Drafts / Saved / Files / …). A position-only marker:
    * the links themselves — their order and per-link visibility — live in
@@ -155,11 +169,37 @@ function isRenderableSectionSpec(spec: SidebarSectionSpec | undefined | null): s
       return (SIDEBAR_TYPE_SECTIONS as readonly string[]).includes(spec.streamType)
     case "label":
       return typeof spec.labelId === "string" && spec.labelId.length > 0
+    case "custom":
+      // A blank-named section would render an unlabeled, indistinguishable
+      // header; streamIds is sanitized separately (see normalizeSidebarConfig).
+      return (
+        typeof spec.sectionId === "string" &&
+        spec.sectionId.length > 0 &&
+        typeof spec.name === "string" &&
+        spec.name.trim().length > 0
+      )
     case "quicklinks":
       return true
     default:
       return false
   }
+}
+
+/**
+ * Sanitize a custom section's membership: keep only string stream ids, and drop
+ * any id already claimed by an earlier custom section so a stream lives in at
+ * most one (the write path enforces this too; this guards stray data on read).
+ * Mutates `claimed` with the ids it keeps.
+ */
+function sanitizeCustomStreamIds(streamIds: unknown, claimed: Set<string>): string[] {
+  if (!Array.isArray(streamIds)) return []
+  const kept: string[] = []
+  for (const id of streamIds) {
+    if (typeof id !== "string" || id.length === 0 || claimed.has(id)) continue
+    claimed.add(id)
+    kept.push(id)
+  }
+  return kept
 }
 
 /** Resolve a stored link's visibility, migrating the pre-v2 boolean and coercing invalid `active`. */
@@ -215,6 +255,20 @@ export function normalizeSidebarConfig(config: RawSidebarConfig): SidebarConfig 
     seenSectionIds.add(section.id)
     return true
   })
+
+  // Custom-section membership is exclusive: a stream may appear in only one
+  // custom section. Sanitize each section's streamIds and enforce single
+  // membership across them (first listing wins), so a duplicate written by a
+  // racing client can't surface the same stream in two custom sections.
+  const claimedCustomStreamIds = new Set<string>()
+  sections = sections.map((section) =>
+    section.spec.kind === "custom"
+      ? {
+          ...section,
+          spec: { ...section.spec, streamIds: sanitizeCustomStreamIds(section.spec.streamIds, claimedCustomStreamIds) },
+        }
+      : section
+  )
 
   // v1 → v2: existing users had quick links rendered above their sections, not
   // as a section. Prepend the block so it stays visible after the upgrade. Only

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -255,9 +255,19 @@ export function normalizeSidebarConfig(config: RawSidebarConfig): SidebarConfig 
   // already validates (Zod) + dedups via addSection; this guards stray data on
   // every read boundary (bootstrap, IDB rehydrate, socket sync).
   const seenSectionIds = new Set<string>()
+  const seenCustomSectionIds = new Set<string>()
   let sections = (config.sections ?? []).filter((section) => {
     if (!section || !isRenderableSectionSpec(section.spec)) return false
     if (seenSectionIds.has(section.id)) return false
+    // A custom section carries its own identity (`sectionId`) that the filing /
+    // rename helpers and the drop-zone id key off, independent of the dedup key
+    // `id`. Dedupe on it too so a drifted or duplicated `id` can't leave two
+    // custom sections sharing a `sectionId` — which would desync membership and
+    // collide drop-zone ids.
+    if (section.spec.kind === "custom") {
+      if (seenCustomSectionIds.has(section.spec.sectionId)) return false
+      seenCustomSectionIds.add(section.spec.sectionId)
+    }
     seenSectionIds.add(section.id)
     return true
   })

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -23,6 +23,9 @@ export type SidebarTypeSection = (typeof SIDEBAR_TYPE_SECTIONS)[number]
 /** Max length of a user-supplied custom-section name (validated on write, trimmed on render). */
 export const MAX_CUSTOM_SECTION_NAME_LENGTH = 80
 
+/** Max streams a custom section may hold — bounds the per-user config document. Enforced on write (Zod) and read (sanitizer). */
+export const MAX_CUSTOM_SECTION_STREAM_IDS = 500
+
 /** What streams a section draws from. Presentation is derived from this at render time. */
 export type SidebarSectionSpec =
   | { kind: "smart"; bucket: SidebarSectionKey }
@@ -195,6 +198,9 @@ function sanitizeCustomStreamIds(streamIds: unknown, claimed: Set<string>): stri
   if (!Array.isArray(streamIds)) return []
   const kept: string[] = []
   for (const id of streamIds) {
+    // Cap on read too, so a stale/oversized persisted row can't exceed the
+    // write-time bound and keep inflating bootstrap/socket payloads.
+    if (kept.length >= MAX_CUSTOM_SECTION_STREAM_IDS) break
     if (typeof id !== "string" || id.length === 0 || claimed.has(id)) continue
     claimed.add(id)
     kept.push(id)


### PR DESCRIPTION
## What

Adds hand-curated **custom sections** to the sidebar — the lightweight cousin of labels. You name a section in the sidebar editor, then file streams into it. No shared catalog, no per-stream attribution: membership is per-user and lives inline in the sidebar config (the same place quick-links and label sections already live), so there's no new DB table to sync.

## Three ways to file a stream

All three enforce **one section per stream** (filing into one removes it from any other):

- **Desktop drag-and-drop** — drag a stream row onto a custom section. A pill follows the cursor, the source row dims, and the target section highlights. Disabled on mobile so touch scroll / long-press stay untouched.
- **"Add to section…"** action — in the desktop hover menu and the mobile action drawer. Opens a picker (centered dialog on desktop, bottom drawer on mobile via `ResponsiveDialog`) to pick/unpick a section or create a new one and file in one step.
- **The editor** — create sections by name, rename them inline, reorder and remove them like any other section.

## "Custom trumps order"

A stream filed into a custom section shows **only** there — even when a smart/label/type section ordered *above* it would also match. Custom membership is collected up front and withheld from every non-custom section regardless of position, rather than competing for the topmost claim. (The headline example from the request — a stream that fits the first labeled section but is put in the second custom section shows only in the custom section — is the first `resolve-sections` test.)

## Implementation

- **Types** (`packages/types/src/sidebar.ts`): new `{ kind: "custom"; sectionId; name; streamIds }` section spec. `normalizeSidebarConfig` sanitizes `streamIds` (strings only, in-section dedupe) and enforces single-membership across sections on every read/write boundary — first listing wins — and drops blank-named sections.
- **Backend** (`sidebar-config/handlers.ts`): the `custom` branch added to the Zod discriminated union (trimmed name, length cap, `streamIds` capped + defaulted).
- **Resolution** (`resolve-sections.ts`): two-pass — gather custom membership, then exclude it from every non-custom section regardless of order. Zero overhead for users without custom sections (no extra Set allocation when none exist).
- **Config helpers** (`sidebar-config.ts`): pure, tested `createCustomSection` / `renameCustomSection` / `setStreamCustomSection` / `getStreamCustomSectionId` / `customSections`, plus the shared `customSectionId()` id helper.
- **DnD** (`sidebar-dnd.tsx`, `sections.tsx`, `sidebar-stream-list.tsx`): stream rows become drag sources (desktop only — bare rows on mobile, no dead draggables); custom sections become drop targets. Pointer sensor with an 8px activation distance so a plain click still navigates. Keyboard users file via the accessible "Add to section…" action rather than keyboard drag.
- **Surfaces**: `SectionPicker` (new), wired into both `stream-item.tsx` and `scratchpad-item.tsx`.

## Design notes

- **Membership in per-user JSONB config, not a DB table.** Matches the "without the hassle of labels" intent and reuses the existing optimistic + cross-device sync path that quick-links/label sections already use. Stale ids (archived/deleted streams) are benign — `resolveCustomSection` filters against visible streams, so a lingering id simply resolves to nothing, exactly like a lingering label assignment.
- The new `custom` kind is handled at every `spec.kind` exhaustion site (presentation, id derivation, resolver, editor row, normalize, Zod schema).

## Testing

`bun run typecheck` (whole monorepo), lint, and unit suites green. **+103 sidebar tests pass**, with new coverage for:
- the resolver (trumps-order, label/custom interaction, activity sort, single-membership)
- config helpers (create/rename/file/move/clear, exclusivity)
- `normalizeSidebarConfig` sanitization (blank name, non-array/dup streamIds, cross-section dedupe)
- the backend Zod schema (accepts custom, defaults `streamIds`, rejects blank name)
- the editor (inline create + rename) and `SectionPicker` (pick / unpick / create-and-file)

## Review

Self-reviewed with a 3-perspective pass (spec-compliance, correctness/security, design). Spec and correctness came back clean; two design findings (a dead-draggable registration on mobile, and a duplicated id-prefix convention) were fixed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018PdtjFBBX1cy6mW18na17F

---
_Generated by [Claude Code](https://claude.ai/code/session_018PdtjFBBX1cy6mW18na17F)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007818&installation_id=129946197&pr_number=731&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F731&signature=556287ed6d6632d843334af96bf27d761ec9a22d99254b3a797bc9f1d44397a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->