### PR TITLE
Fix dragged sidebar-editor row stretching near Quick Links

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -67,6 +67,17 @@ import {
 
 const PRESET_LABELS: Record<SidebarBasePreset, string> = { smart: "Smart", all: "All" }
 
+/**
+ * Disable dnd-kit's post-reorder FLIP animation on these rows. That animation
+ * (`useDerivedTransform`) is the only code path that gives a sortable item a
+ * non-1 `scaleY`, derived from `initialRect.height / currentRect.height`. With
+ * variable-height rows — the Quick Links row is tall because it nests its whole
+ * link editor — that ratio is wrong, so a dragged row visibly stretches when it
+ * passes the oversized neighbor. The live drag-shuffle (the sorting strategy's
+ * translation) is unaffected; we only lose the settle animation after a drop.
+ */
+const noLayoutAnimation = () => false
+
 /** Tray draggable ids are prefixed so they never collide with section sortable ids. */
 const ADD_PREFIX = "add:"
 /** Droppable id for the sections list, so a tray drop into an empty list appends. */
@@ -327,7 +338,10 @@ function SortableSectionRow({
   onSetQuickLinkVisibility: (key: SidebarQuickLink["key"], visibility: SidebarQuickLinkVisibility) => void
   onMoveQuickLink: (activeKey: string, overKey: string) => void
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: section.id })
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: section.id,
+    animateLayoutChanges: noLayoutAnimation,
+  })
   const style = { transform: CSS.Transform.toString(transform), transition: reduceMotion ? undefined : transition }
   const name = sectionDisplayName(section, labelsById)
   const isQuickLinks = section.spec.kind === "quicklinks"
@@ -426,7 +440,10 @@ function SortableQuickLinkRow({
   reduceMotion: boolean
   onSetVisibility: (visibility: SidebarQuickLinkVisibility) => void
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: link.key })
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: link.key,
+    animateLayoutChanges: noLayoutAnimation,
+  })
   const style = { transform: CSS.Transform.toString(transform), transition: reduceMotion ? undefined : transition }
   const { label, icon: Icon } = QUICK_LINK_META[link.key]
 


### PR DESCRIPTION
## Problem

In the "Customize sidebar" editor, dragging a normal section row past the **Quick Links** section made the dragged row stretch to a huge height — its text, icon, grip, and X were all vertically elongated (most visible on mobile). Moving the row further away normalized it.

<img src="https://github.com/user-attachments/assets/placeholder" alt="stretched Recent row" width="280" />

## Root cause

The stretch is a `scaleY` transform on the dragged element, not a height change.

In `@dnd-kit/sortable`, the `transform` returned by `useSortable` is `derivedTransform ?? finalTransform`:

- `finalTransform` for the dragged item is always pure translation (`scaleX/scaleY = 1`).
- `derivedTransform` (the post-reorder FLIP animation, `useDerivedTransform`) is the **only** path that produces a non-1 scale: `scaleY = initialRect.height / currentRect.height`.

The **Quick Links section renders its entire nested link editor inside the same sortable `<li>`**, so that row is far taller than its siblings. When a normal row is dragged past this oversized neighbor, the captured-vs-live rect heights mismatch and `scaleY` balloons. Because the editor's `DndContext` has no `DragOverlay` (unlike the live sidebar in `sidebar-stream-list.tsx`), the distorted in-flow element is exactly what the user sees and grabs.

## Fix

Pass `animateLayoutChanges={() => false}` to the two `useSortable` calls in `sidebar-editor.tsx` (section rows + nested quick-link rows). This disables only the FLIP settle animation — the sole `scaleY` source. The live drag-shuffle (other rows opening a gap, driven by the sorting strategy + `isSorting`) is unaffected; we only lose the brief snap-into-place animation after a drop.

### Design decisions

- **Why not a `DragOverlay`?** That's the other idiomatic dnd-kit remedy and matches the live sidebar, but it's a larger refactor (render a preview, hide the in-flow source, across two contexts + the add tray). The one-line-per-row `animateLayoutChanges` change removes the exact mechanism causing the bug with far less surface area.
- **Applied to both sortable surfaces** (sections and quick links) even though uniform-height quick-link rows don't exhibit the stretch — keeps both surfaces consistent (both snap on drop instead of one settling and one snapping).

## Testing

- `sidebar-editor.test.tsx` — 13/13 pass.
- Frontend typecheck — clean.

This is a layout/transform artifact that jsdom can't reproduce (no real layout — `getBoundingClientRect` returns zeros), so a meaningful regression test would require a real browser (Playwright). Happy to add one that drags a row past Quick Links and asserts the dragged element's computed transform has no scale, if wanted.

https://claude.ai/code/session_01B7hWdoo1NBeR4MiNVTP3xn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hWdoo1NBeR4MiNVTP3xn)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014067&installation_id=129946197&pr_number=732&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F732&signature=9f859e52e2410eeff47a6c5fdefd32c2d78d723a1f29a6e4efeccf7d135bc420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->