### PR TITLE
docs(features): add concepts/optimistic-then-reconcile

### DIFF
--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -48,20 +48,20 @@ Two rules for using it:
 
 ## Concepts
 
-| Doc                                                                 | The guarantee                                                                                       | Invariants          |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
-| [subscribe-then-bootstrap](concepts/subscribe-then-bootstrap.md) ✅ | Confirm the subscription before fetching the snapshot, then merge                                   | INV-53              |
-| streams-all-the-way-down                                            | Everything that sends messages is a stream; threads are streams; visibility inherits from the root  | (domain model)      |
-| memos-are-pointers                                                  | GAM stores semantic pointers to source messages, never copies                                       | (domain model)      |
-| workspace-is-the-boundary                                           | Workspace is the ownership, query, sharding, and residency boundary                                 | INV-8, INV-50       |
-| integrity-in-app-code                                               | No FKs, prefixed ULIDs, TEXT plus code validation; relational integrity lives in the application    | INV-1, INV-2, INV-3 |
-| race-safe-writes                                                    | Write paths tolerate concurrent callers; no select-then-update, prefer set-based ops                | INV-20, INV-56      |
-| events-and-projections                                              | Append-only `stream_events` is the source of truth; read projections commit in the same transaction | INV-7               |
-| optimistic-then-reconcile                                           | Optimistic events land in IDB with temp ids; server events replace them by `clientMessageId`        | (frontend pattern)  |
-| idb-is-the-client-source-of-truth                                   | The UI reads IndexedDB via live queries; sync writes IDB, never components directly                 | (frontend pattern)  |
-| content-canonical-form                                              | `contentJson` is the internal canon; markdown only at the wire; previews strip markdown at render   | INV-58, INV-60      |
-| language-by-model                                                   | Semantic decisions about language go through a model, never English-only heuristics                 | INV-54              |
-| personas-are-data                                                   | Agents are data-driven personas with declarative tools, not hardcoded implementations               | (domain model)      |
+| Doc                                                                   | The guarantee                                                                                       | Invariants          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
+| [subscribe-then-bootstrap](concepts/subscribe-then-bootstrap.md) ✅   | Confirm the subscription before fetching the snapshot, then merge                                   | INV-53              |
+| streams-all-the-way-down                                              | Everything that sends messages is a stream; threads are streams; visibility inherits from the root  | (domain model)      |
+| memos-are-pointers                                                    | GAM stores semantic pointers to source messages, never copies                                       | (domain model)      |
+| workspace-is-the-boundary                                             | Workspace is the ownership, query, sharding, and residency boundary                                 | INV-8, INV-50       |
+| integrity-in-app-code                                                 | No FKs, prefixed ULIDs, TEXT plus code validation; relational integrity lives in the application    | INV-1, INV-2, INV-3 |
+| race-safe-writes                                                      | Write paths tolerate concurrent callers; no select-then-update, prefer set-based ops                | INV-20, INV-56      |
+| events-and-projections                                                | Append-only `stream_events` is the source of truth; read projections commit in the same transaction | INV-7               |
+| [optimistic-then-reconcile](concepts/optimistic-then-reconcile.md) ✅ | Optimistic events land in IDB with temp ids; server events replace them by `clientMessageId`        | (frontend pattern)  |
+| idb-is-the-client-source-of-truth                                     | The UI reads IndexedDB via live queries; sync writes IDB, never components directly                 | (frontend pattern)  |
+| content-canonical-form                                                | `contentJson` is the internal canon; markdown only at the wire; previews strip markdown at render   | INV-58, INV-60      |
+| language-by-model                                                     | Semantic decisions about language go through a model, never English-only heuristics                 | INV-54              |
+| personas-are-data                                                     | Agents are data-driven personas with declarative tools, not hardcoded implementations               | (domain model)      |
 
 Note: the three domain-model rows (streams, memos, personas) live in `docs/core-concepts.md`
 today. Decided: they migrate into `concepts/` (one doc each, normal document-feature runs,

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -14,7 +14,7 @@ summary: >
   One per-workspace class that owns the whole client sync lifecycle: bootstrap the
   workspace and its streams (subscribe-then-bootstrap), keep them live over the socket,
   and re-sync everything on reconnect or page resume.
-related: [concepts/subscribe-then-bootstrap.md, architecture/outbox-pattern.md]
+related: [concepts/subscribe-then-bootstrap.md, concepts/optimistic-then-reconcile.md, architecture/outbox-pattern.md]
 ---
 
 ## The gist

--- a/docs/features/concepts/optimistic-then-reconcile.md
+++ b/docs/features/concepts/optimistic-then-reconcile.md
@@ -1,0 +1,124 @@
+---
+title: Optimistic-Then-Reconcile
+status: shipped
+audience: internal
+kind: concept
+invariants: []
+public_site: false
+summary: >
+  A send shows up instantly: the client writes an optimistic event to IndexedDB
+  with a temp id, then the server's authoritative event replaces it by client id
+  in one atomic swap. Failures stay put and retry; they never silently vanish.
+related: [architecture/sync-engine.md]
+---
+
+## The principle
+
+Optimistic-then-reconcile is how a write feels instant without lying about what the
+server actually did. When the user sends a message, the client writes an optimistic
+copy of the resulting event into IndexedDB right away, tagged with a client-minted
+temp id and a `pending` status. The UI reads from IDB, so it renders that copy on the
+next frame. The real send goes out in the background. When the server's authoritative
+event arrives over the socket, it carries the same client id back, and the socket
+handler swaps the optimistic row for the real one in a single transaction. The user
+never waited; the durable record is still the server's.
+
+Two ids do the work. A temp id the client mints (`temp_...`) is the local row's key. A
+`clientMessageId` rides along on the send request and comes back on the server's event.
+That round-trip id is what makes reconciliation exact instead of a guess.
+
+It's a pattern, not a component. The canonical implementation is the message-send path,
+and it leans on the same IDB-as-source-of-truth model the [Sync Engine](../architecture/sync-engine.md)
+owns: the engine writes server state into IDB, the UI reads it back, and the
+reconciliation handler is one of the stream socket handlers the engine registers.
+
+## The problem it prevents
+
+Two naive approaches both fail:
+
+1. **Send, await, then render.** Every send feels as slow as the network. Offline, it
+   feels broken.
+2. **Render optimistically, but reconcile by content or timing.** This breaks the moment
+   two identical messages are in flight, or the same event arrives twice (the socket echo
+   plus a bootstrap snapshot can both deliver it). You get duplicates, or you delete the
+   wrong row, or you get a flicker where the message briefly disappears in the gap between
+   "remove optimistic" and "insert real."
+
+An explicit, server-echoed client id closes all three holes: it identifies exactly which
+optimistic row a given server event retires, it survives duplicate delivery, and it lets
+the swap be ordered so no frame ever shows neither row.
+
+## What an implementation must do
+
+1. **Write optimistically with a client id and a status marker.** The read path renders
+   it immediately and can tell optimistic state apart from confirmed state.
+2. **Carry a stable client id on the request, and require the server to echo it** on the
+   resulting event.
+3. **Reconcile by that id, insert-before-delete, atomically.** Put the authoritative
+   event in first, then remove the optimistic one, all in one transaction, so a live-query
+   observer never sees a frame with neither.
+4. **Dedupe the authoritative event against itself.** It can arrive twice (socket plus
+   snapshot), so the handler no-ops if the real id is already present.
+5. **On failure, keep the row and mark it failed.** Never drop it silently. Let the user
+   see it and retry, and make retries idempotent (same client id) so a late success can't
+   double-insert.
+
+## How Threa implements it
+
+**Send.** `useStreamOrDraft.sendMessage` (`apps/frontend/src/hooks/use-stream-or-draft.ts:539`)
+mints the temp id with `generateClientId` (`:36`, format `temp_<base36 time><base36 random>`),
+builds the optimistic `message_created` event using `Date.now()` as a placeholder sequence
+so it sorts after real events (which carry small monotonic sequences), then writes a durable
+row to `db.pendingMessages` and the optimistic event to `db.events` with `_clientId` and
+`_status: "pending"` (`:617-637`). The `CachedEvent._status` field
+(`apps/frontend/src/db/database.ts:137`) is the `"pending" | "sent" | "failed" | "editing"`
+marker the rest of the pattern keys off.
+
+**Drain.** `useMessageQueue` (`apps/frontend/src/hooks/use-message-queue.ts:163`) sends
+pending rows one at a time in `createdAt` order, passing `clientMessageId: next.clientId`
+to the API (`:235`, `:244`). On success it deletes the `pendingMessages` row but
+deliberately leaves the optimistic `db.events` row for the socket handler to swap
+(`:249-255`). A Web Lock keeps two tabs from sending the same row.
+
+**Reconcile.** `handleMessageCreated` in `apps/frontend/src/sync/stream-sync.ts:486` runs
+one Dexie transaction that no-ops if the real event id is already present (`:504-505`),
+inserts the real event first (`:509`), then deletes the optimistic event and its pending
+row keyed by `payload.clientMessageId` (`:512-514`). A comment at `:507` cites the
+insert-before-delete ordering directly. A content-based fallback (`:516-528`) covers
+legacy events that predate `clientMessageId`.
+
+**Render merge.** `loadStreamEvents` (`apps/frontend/src/stores/stream-store.ts:27`) reads
+confirmed events by the `[streamId+_sequenceNum]` index and merges in any `pending` or
+`failed` rows off the `_status` index, then re-sorts, so optimistic and failed sends land
+in their natural slot by sequence rather than being appended at the end.
+
+**Failure.** The queue never deletes a row on failure (`:155`). A failed send is marked
+`_status: "failed"` on its event and given an exponential backoff (`:286-294`); a
+privacy-boundary rejection is held as `blocked-privacy` and surfaces a toast instead of
+auto-retrying (`:262-279`). The row stays visible until the server confirms it or the user
+deletes it.
+
+## Boundaries
+
+- **Only message sends get the full pattern.** Reactions, message edits, and deletes route
+  through the offline operation queue (`enqueueOperation` in
+  `apps/frontend/src/sync/operation-queue.ts:73`), which retries with backoff but writes no
+  optimistic event. They appear in the UI only once the server's event arrives.
+- **Slash-command dispatch is a near relative, not the same path.** It writes an optimistic
+  event and, on a permanent dispatch error, marks it failed via a separate `command_failed`
+  event (`operation-queue.ts:38-66`) rather than the `clientMessageId` swap.
+- **Saved-message actions** (save / done / archive) use TanStack mutations with cache
+  invalidation against `db.savedMessages`, not the IDB-durable optimistic queue
+  (`apps/frontend/src/hooks/use-saved.ts`).
+- **The content-based fallback is a compatibility shim**, not the primary path. It can
+  mis-dedupe two identical messages sent in quick succession, and it does not match E2E
+  messages (whose wire `contentMarkdown` is placeholder ciphertext). Current sends always
+  carry a `clientMessageId`, so the fallback only fires for events that predate it.
+
+## Invariants
+
+This is a frontend pattern, not codified as an `INV-*`. It pairs with
+[subscribe-then-bootstrap](subscribe-then-bootstrap.md) (INV-53): the bootstrap apply
+merges rather than replaces precisely so a snapshot can't clobber an optimistic or
+live-delivered event. The reconciliation handler and the IDB-as-source-of-truth model it
+relies on live in the [Sync Engine](../architecture/sync-engine.md).

--- a/docs/features/concepts/optimistic-then-reconcile.md
+++ b/docs/features/concepts/optimistic-then-reconcile.md
@@ -71,8 +71,10 @@ builds the optimistic `message_created` event using `Date.now()` as a placeholde
 so it sorts after real events (which carry small monotonic sequences), then writes a durable
 row to `db.pendingMessages` and the optimistic event to `db.events` with `_clientId` and
 `_status: "pending"` (`:617-637`). The `CachedEvent._status` field
-(`apps/frontend/src/db/database.ts:137`) is the `"pending" | "sent" | "failed" | "editing"`
-marker the rest of the pattern keys off.
+(`apps/frontend/src/db/database.ts:137`) is the marker the rest of the pattern keys off.
+Its type is `"pending" | "sent" | "failed" | "editing"`, but only `pending`, `failed`, and
+`editing` are ever written to IDB; `"sent"` is declared and never written (the queue's
+`markSent` updates React context state, not the row).
 
 **Drain.** `useMessageQueue` (`apps/frontend/src/hooks/use-message-queue.ts:163`) sends
 pending rows one at a time in `createdAt` order, passing `clientMessageId: next.clientId`
@@ -92,11 +94,14 @@ confirmed events by the `[streamId+_sequenceNum]` index and merges in any `pendi
 `failed` rows off the `_status` index, then re-sorts, so optimistic and failed sends land
 in their natural slot by sequence rather than being appended at the end.
 
-**Failure.** The queue never deletes a row on failure (`:155`). A failed send is marked
-`_status: "failed"` on its event and given an exponential backoff (`:286-294`); a
-privacy-boundary rejection is held as `blocked-privacy` and surfaces a toast instead of
-auto-retrying (`:262-279`). The row stays visible until the server confirms it or the user
-deletes it.
+**Failure.** The queue never deletes a row on failure (`:155`). A failed send marks the
+event `_status: "failed"` and gives the queue row an exponential backoff (`:286-294`). A
+privacy-boundary rejection is handled on a separate track: the event still goes to
+`_status: "failed"`, but the `pendingMessages` row's own `status` field (typed
+`"editing" | "blocked-privacy"` at `database.ts:227`, distinct from the event's `_status`)
+is set to `blocked-privacy` so the drain skips it, and a toast is surfaced instead of
+auto-retrying (`:262-279`). Either way the row stays visible until the server confirms it
+or the user deletes it.
 
 ## Boundaries
 


### PR DESCRIPTION
## What this is

One feature doc: `concepts/optimistic-then-reconcile.md`, the next undocumented concept row. It states the principle (write optimistically to IDB with a temp id, let the server's event replace it by `clientMessageId` in one atomic swap, keep failures visible), the race it prevents, the implementer's checklist, and where Threa implements it.

## How I verified it (not from the inventory one-liner)

Traced the real path with file:line citations, all of which I read directly:

- **Send** — `use-stream-or-draft.ts:539` mints `temp_<base36>` via `generateClientId` (`:36`), writes a `pendingMessages` row + an optimistic `db.events` row with `_status: "pending"` (`:617-637`). `_status` enum lives at `database.ts:137`.
- **Drain** — `use-message-queue.ts:163` sends with `clientMessageId: next.clientId` (`:235`,`:244`), deletes only the pending row, leaves the event for the socket swap (`:249-255`). Web Lock `"threa-outbox"` (`:326`).
- **Reconcile** — `stream-sync.ts:486` runs one Dexie txn: dedupe by real id (`:504`), insert-before-delete (`:507-514`).
- **Render merge** — `stream-store.ts:54` merges `pending`/`failed` rows by `_sequenceNum`.

## Status call: `shipped`

The message-send path is wired end to end. The non-optimistic mutations aren't stubs of this pattern, they're deliberately not optimistic, so they belong in Boundaries, not as a `building` flag.

## Wiring

- INVENTORY row linked + ✅ (prettier realigned the table).
- `related:` cross-linked both ways with `architecture/sync-engine.md`.
- 0 em-dashes; pre-commit typecheck + prettier passed clean.

## Poking holes at my own description

Where this doc is soft, so a reviewer knows where to look hard:

1. **`invariants: []`.** This pattern isn't an `INV-*`, so I left the array empty. If the Astro content schema requires min-1, this breaks validation — but the site only reads `public/*.md` and this is an internal concept, so I believe it's never validated. Lower confidence than I'd like; flag if you know the schema.
2. **Slash-command claim is second-hand.** I characterized command dispatch ("writes an optimistic event, marks it failed via `command_failed`") from the *failure* path in `operation-queue.ts:38-66`, which reads an optimistic event but `return`s if absent. I did not trace where the optimistic command event is written. Slash-commands has its own inventory row; I kept it at arm's length on purpose. If that one sentence is wrong, it's the likeliest spot.
3. **The unused `"sent"` status.** `CachedEvent._status` declares `"sent"` but nothing ever writes it to IDB (`markSent` only touches React context). I didn't surface this in the doc — arguably a minor half-wired detail worth a Boundaries line. Left out to avoid scope creep; happy to add.
4. **Saved-messages framing.** I called it "TanStack mutations with cache invalidation against `db.savedMessages`." It does write IDB (`bulkPut`/`bulkDelete`), so "cache invalidation" undersells it slightly. The load-bearing claim — "not the optimistic-then-reconcile queue" — is correct; the adjective is loose.
5. **Reactions/edits/deletes = no optimistic UI.** Verified they route through `enqueueOperation` with no optimistic event write, but I confirmed by absence (grep + reading the handlers), not by running the UI. Reasonably confident, not eyeballed live.

## Out of scope

Docs only. No code touched. The `"sent"` dead enum value and the loose saved-messages adjective are flagged above rather than fixed here.

https://claude.ai/code/session_011LYw5FKFZky5FNYSzzb71M

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYw5FKFZky5FNYSzzb71M)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783019790&installation_id=129946197&pr_number=733&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F733&signature=433a22d0bfa637438887bdb7cfaec2289a7c0ea590f489514f35ce1ce29b656d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->