### PR TITLE
refactor: remove urgency glow on mobile

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -64,16 +64,11 @@ function PullIndicator({ distance, progress, pulling, refreshing, mode }: PullIn
 /**
  * Soft, position-matched urgency glow blocks. Each block is a single blurred
  * bar sized to its stream row (expanded 150% and centered) so the color diffuses
- * out as a glow rather than a hard bar. Shared by the desktop edge strip and the
- * mobile left-edge hint. The `position`/`height` fractions are measured against
- * the sidebar in `useUrgencyTracking`, so both surfaces render the same column.
- *
- * `opacityScale` dims the whole column for surfaces that need a gentler hint.
- * On mobile the strip bleeds rightward into the content area (the sidebar is
- * off-screen), so a full-strength glow reads as aggressive; scaling it down
- * keeps it a subtle "worth a glance" cue rather than a demand for attention.
+ * out as a glow rather than a hard bar. Rendered on the desktop edge strip; the
+ * `position`/`height` fractions are measured against the sidebar in
+ * `useUrgencyTracking`.
  */
-function UrgencyGlowBlocks({ blocks, opacityScale = 1 }: { blocks: Map<string, UrgencyBlock>; opacityScale?: number }) {
+function UrgencyGlowBlocks({ blocks }: { blocks: Map<string, UrgencyBlock> }) {
   return (
     <>
       {Array.from(blocks.entries()).map(([streamId, block]) => {
@@ -90,7 +85,7 @@ function UrgencyGlowBlocks({ blocks, opacityScale = 1 }: { blocks: Map<string, U
               height: `${Math.max(expandedHeight * 100, 4)}%`,
               backgroundColor: block.color,
               filter: "blur(12px)",
-              opacity: block.opacity * opacityScale,
+              opacity: block.opacity,
             }}
           />
         )
@@ -274,20 +269,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               onClick={!isSwiping ? handleBackdropClick : undefined}
               aria-hidden="true"
             />
-          )}
-
-          {/* Mobile urgency glow - the sidebar itself is off-screen, so this is the
-               only at-a-glance hint that there's something worth opening it for.
-               Sits below the backdrop (z-30) so it's covered once the drawer opens,
-               and bleeds rightward into content (left edge clipped at the screen edge). */}
-          {isMobile && !isOpen && (
-            <div
-              className="fixed left-0 top-0 z-20 h-full w-[6px] pointer-events-none"
-              style={{ clipPath: "inset(-50px -50px -50px 0)" }}
-              aria-hidden="true"
-            >
-              <UrgencyGlowBlocks blocks={urgencyBlocks} opacityScale={0.3} />
-            </div>
           )}
 
           {/* Sidebar wrapper - handles positioning */}


### PR DESCRIPTION
## Problem

On mobile the urgency strip rendered as a soft, blurred glow pinned to the screen's left edge, bleeding rightward into the content area (the sidebar drawer is off-screen, so the strip had nowhere else to live). Even dimmed to 30% opacity it read as more aggressive than helpful — a glow demanding attention rather than the subtle at-a-glance cue it was meant to be.

## Solution

Drop the mobile-only urgency glow block and keep the strip on desktop, where it sits on the always-visible sidebar edge and behaves as intended.

### Key design decisions

**1. Remove rather than further dim**

The mobile block was already scaled to `opacityScale={0.3}`. Rather than keep tuning a value that still felt like too much, the glow is removed entirely on mobile. Desktop is untouched.

**2. Drop the now-dead `opacityScale` prop**

`opacityScale` existed solely to dim the mobile column; the desktop caller always used the default `1`. With the mobile block gone the prop has no remaining caller, so it's removed from `UrgencyGlowBlocks` (INV-38, delete dead code). The component's JSDoc is trimmed to describe its single desktop use.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/app-shell.tsx` | Remove the `isMobile && !isOpen` urgency glow block; drop the unused `opacityScale` prop from `UrgencyGlowBlocks` and update its JSDoc |

## Test plan

- [x] `tsc --noEmit` across the monorepo (pre-commit hook) — passes
- [x] eslint across all apps (pre-commit hook) — passes
- [ ] Manual: on mobile, no glow bleeds into content when the drawer is closed
- [ ] Manual: on desktop, the left-edge urgency strip still renders unchanged

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT2d6GUF9kiyPCmBrLTou8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783019834&installation_id=129946197&pr_number=734&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F734&signature=61e220e18d98d808aac6f681caded8890ed0c49436186ec29e577a527f36a48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->