### PR TITLE
Stop dragged sidebar-editor rows scaling to the Quick Links row

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -67,17 +67,6 @@ import {
 
 const PRESET_LABELS: Record<SidebarBasePreset, string> = { smart: "Smart", all: "All" }
 
-/**
- * Disable dnd-kit's post-reorder FLIP animation on these rows. That animation
- * (`useDerivedTransform`) is the only code path that gives a sortable item a
- * non-1 `scaleY`, derived from `initialRect.height / currentRect.height`. With
- * variable-height rows — the Quick Links row is tall because it nests its whole
- * link editor — that ratio is wrong, so a dragged row visibly stretches when it
- * passes the oversized neighbor. The live drag-shuffle (the sorting strategy's
- * translation) is unaffected; we only lose the settle animation after a drop.
- */
-const noLayoutAnimation = () => false
-
 /** Tray draggable ids are prefixed so they never collide with section sortable ids. */
 const ADD_PREFIX = "add:"
 /** Droppable id for the sections list, so a tray drop into an empty list appends. */
@@ -338,11 +327,10 @@ function SortableSectionRow({
   onSetQuickLinkVisibility: (key: SidebarQuickLink["key"], visibility: SidebarQuickLinkVisibility) => void
   onMoveQuickLink: (activeKey: string, overKey: string) => void
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: section.id,
-    animateLayoutChanges: noLayoutAnimation,
-  })
-  const style = { transform: CSS.Transform.toString(transform), transition: reduceMotion ? undefined : transition }
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: section.id })
+  // Translate only, never scale: dnd-kit scales the dragged element to its drop
+  // target's size, which stretches a normal row to the tall Quick Links row.
+  const style = { transform: CSS.Translate.toString(transform), transition: reduceMotion ? undefined : transition }
   const name = sectionDisplayName(section, labelsById)
   const isQuickLinks = section.spec.kind === "quicklinks"
 
@@ -440,11 +428,9 @@ function SortableQuickLinkRow({
   reduceMotion: boolean
   onSetVisibility: (visibility: SidebarQuickLinkVisibility) => void
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: link.key,
-    animateLayoutChanges: noLayoutAnimation,
-  })
-  const style = { transform: CSS.Transform.toString(transform), transition: reduceMotion ? undefined : transition }
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: link.key })
+  // Translate only, never scale — see SortableSectionRow.
+  const style = { transform: CSS.Translate.toString(transform), transition: reduceMotion ? undefined : transition }
   const { label, icon: Icon } = QUICK_LINK_META[link.key]
 
   return (


### PR DESCRIPTION
## Problem

Follow-up to #732 — the dragged row in the "Customize sidebar" editor **still stretches** when dragged over the Quick Links section (reported again with the same elongated "Recent" row).

## Why #732 didn't fix it

#732 disabled the post-reorder FLIP animation (`useDerivedTransform`), believing that was the only `scaleY` source. It isn't — and the stretch happens *during* the drag, not after a drop, so that change had no effect on the symptom.

## Actual root cause

dnd-kit **core** scales the active dragged element to match whatever it's hovering over. In `@dnd-kit/core` (`core.esm.js:2997`):

```js
const transform = adjustScale(appliedTranslate, over?.rect, activeNodeRect)
// adjustScale → scaleY = over.rect.height / activeNodeRect.height
```

This is harmless in a uniform-height list (`scaleY ≈ 1`). But the **Quick Links row is very tall** — it nests its entire link editor inside the same sortable `<li>`. So when a normal row is dragged over it, `scaleY = quickLinksHeight / rowHeight` ≫ 1 and the dragged row stretches to the Quick Links height. The component fed this through `CSS.Transform.toString(transform)`, which emits `translate3d(…) scaleX(..) scaleY(..)`.

## Fix

Stringify the sortable transform with **`CSS.Translate.toString(transform)`** (reads `x`/`y`, ignores `scaleX`/`scaleY`) instead of `CSS.Transform.toString`, for both the section rows and the nested quick-link rows. These rows should never resize to their drop target. The Add-tray chips in this same file already use `CSS.Translate.toString`, so this is consistent.

Also reverts the now-unnecessary `animateLayoutChanges` helper from #732 — `CSS.Translate.toString` already drops any scale (drag *and* FLIP), and the position-settle animation is preserved.

## Testing

- `sidebar-editor.test.tsx` — 13/13 pass.
- Frontend typecheck — clean.

This is a transform/layout artifact jsdom can't reproduce (`getBoundingClientRect` returns zeros), so there's no practical unit regression test; verified by source analysis against the installed dnd-kit. **Please re-test on mobile** — this one targets the mechanism that's actually firing during the drag.

https://claude.ai/code/session_01B7hWdoo1NBeR4MiNVTP3xn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hWdoo1NBeR4MiNVTP3xn)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023893&installation_id=129946197&pr_number=735&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F735&signature=d3fda585fa3a5de890558e22fc785fc2f0688231a3c98d2034b00307a5026a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->