### PR TITLE
fix(workspace-router): forward OPTIONS preflight for /api/waitlist (CORS)

### DIFF
--- a/apps/workspace-router/src/index.test.ts
+++ b/apps/workspace-router/src/index.test.ts
@@ -325,6 +325,17 @@ describe("workspace-router", () => {
       }
     })
 
+    test("proxies the OPTIONS preflight for /api/waitlist to control-plane (CORS)", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mockFetchFn()
+      try {
+        await worker.fetch(makeRequest("/api/waitlist", "OPTIONS"), makeEnv({ CONTROL_PLANE_URL: CP_URL }))
+        expect(getProxiedUrl(fn)).toBe("http://localhost:3003/api/waitlist")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
     test("proxies POST /api/workspaces to control-plane", async () => {
       const originalFetch = globalThis.fetch
       const fn = mockFetchFn()

--- a/apps/workspace-router/src/index.ts
+++ b/apps/workspace-router/src/index.ts
@@ -39,7 +39,12 @@ const INVITATION_ACCEPT_RE = /^\/api\/invitations\/[^/]+\/accept$/
 /** Public link-invite lookup + claim (handled by control-plane, unauthenticated) */
 const INVITATION_LOOKUP_RE = /^\/api\/invitations\/lookup$/
 const INVITATION_CLAIM_RE = /^\/api\/invitations\/claim$/
-/** Public waitlist signup from the marketing site (handled by control-plane, unauthenticated) */
+/**
+ * Public waitlist signup from the marketing site (handled by control-plane,
+ * unauthenticated). Proxied for POST *and* OPTIONS: the marketing site is a
+ * different origin (threa.io -> app.threa.io), so the browser sends a CORS
+ * preflight that must reach control-plane's cors() middleware to be answered.
+ */
 const WAITLIST_ROUTE_RE = /^\/api\/waitlist\/?$/
 
 /** Matches /api/workspaces/:workspaceId with optional trailing path */
@@ -136,7 +141,7 @@ export default {
           (INVITATION_ACCEPT_RE.test(path) && method === "POST") ||
           (INVITATION_LOOKUP_RE.test(path) && method === "GET") ||
           (INVITATION_CLAIM_RE.test(path) && method === "POST") ||
-          (WAITLIST_ROUTE_RE.test(path) && method === "POST")
+          (WAITLIST_ROUTE_RE.test(path) && (method === "POST" || method === "OPTIONS"))
         ) {
           try {
             return await proxyRequest(request, env.CONTROL_PLANE_URL)
@@ -183,7 +188,7 @@ export default {
         (INVITATION_ACCEPT_RE.test(path) && method === "POST") ||
         (INVITATION_LOOKUP_RE.test(path) && method === "GET") ||
         (INVITATION_CLAIM_RE.test(path) && method === "POST") ||
-        (WAITLIST_ROUTE_RE.test(path) && method === "POST")
+        (WAITLIST_ROUTE_RE.test(path) && (method === "POST" || method === "OPTIONS"))
       ) {
         try {
           return await proxyRequest(request, env.CONTROL_PLANE_URL)


### PR DESCRIPTION
## Problem

The marketing site (`threa.io`) submits the waitlist form cross-origin to `app.threa.io/api/waitlist`. The browser sends a CORS **preflight `OPTIONS`** first, but the worker's route guard only matched `POST`, so the preflight fell through to a 404 with no `Access-Control-Allow-Origin` header. The browser then blocked the real POST — the live form showed "Something went wrong" even though the endpoint worked over curl (curl skips preflight).

Caught while babysitting the #728 deploy: post-merge, the backend worked but the real browser form failed.

## Fix

Forward `OPTIONS` as well as `POST` for `/api/waitlist` in both router dispatch blocks, so the preflight reaches control-plane's `cors()` middleware, which answers it with the `threa.io` allow-origin.

## Verified live (worker hot-deployed ahead of this PR to unblock the form)

- Preflight: `OPTIONS` → **204** with `access-control-allow-origin: https://threa.io`
- Form on `threa.io` submits → **"You're on the list"**
- Added an OPTIONS-proxy test next to the POST one (52 worker tests pass)

This PR lands the same fix in `main` so a future deploy doesn't revert the worker to POST-only.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783027041&installation_id=129946197&pr_number=736&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F736&signature=e7fe8b3320542feeb0b7fd4c90e9bd959c7da9b9b46e8d8f9e7f351230ec3971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->