### PR TITLE
feat(push): make reaction notifications read as reactions

### DIFF
--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -290,7 +290,7 @@ export class PushService {
 
     // 4. Build structured push payload — display text is formatted by the service worker (INV-46)
     const context = activity.context as
-      | { contentPreview?: string; streamName?: string; authorName?: string }
+      | { contentPreview?: string; streamName?: string; authorName?: string; emoji?: string }
       | null
       | undefined
     const pushPayload = JSON.stringify({
@@ -303,6 +303,9 @@ export class PushService {
         contentPreview: context?.contentPreview?.slice(0, 200),
         streamName: context?.streamName,
         authorName: context?.authorName,
+        // Reaction emoji — lets the SW render "Alice reacted 👍 to …" instead of
+        // formatting a reaction like a plain incoming message. Absent for non-reactions.
+        emoji: context?.emoji,
       },
     })
 

--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -703,6 +703,39 @@ describe("Push Notifications", () => {
       expect(payload.data).not.toHaveProperty("workosUserId")
     })
 
+    test("reaction payload carries the emoji so the SW can render a reaction line", async () => {
+      const service = createServiceWithLookups()
+
+      await PushSubscriptionRepository.insert(pool, {
+        workspaceId: testWorkspaceId,
+        userId: testUserId,
+        endpoint: "https://push.example.com/sub/reaction-emoji",
+        p256dh: "p",
+        auth: "a",
+        deviceKey: "d",
+      })
+      await createRecentInactiveSession(testWorkspaceId, testUserId)
+
+      await service.deliverPushForActivity(
+        makePayload({
+          activity: {
+            ...makePayload().activity,
+            activityType: ActivityTypes.REACTION,
+            context: { contentPreview: "ship it", streamName: "general", authorName: "Pierre", emoji: "🫡" },
+          },
+        })
+      )
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse(sendSpy.mock.calls[0][1] as string)
+      expect(payload.data).toMatchObject({
+        activityType: ActivityTypes.REACTION,
+        authorName: "Pierre",
+        contentPreview: "ship it",
+        emoji: "🫡",
+      })
+    })
+
     test("focused device with recent interaction → only pushes to that device", async () => {
       const service = createServiceWithLookups()
 

--- a/apps/frontend/src/lib/sw-notification-format.test.ts
+++ b/apps/frontend/src/lib/sw-notification-format.test.ts
@@ -131,4 +131,27 @@ describe("formatBody", () => {
     // "Alice: " + 79 chars + "…" = within limit
     expect(body).toBe(`Alice: ${"a".repeat(79)}…`)
   })
+
+  it("formats a reaction with author, emoji, and preview", () => {
+    const messages: NotificationMessage[] = [{ authorName: "Pierre", contentPreview: "ship it", emoji: "🫡" }]
+    expect(formatBody(messages)).toBe('Pierre reacted 🫡 to "ship it"')
+  })
+
+  it("formats a reaction without a preview", () => {
+    const messages: NotificationMessage[] = [{ authorName: "Pierre", emoji: "🫡" }]
+    expect(formatBody(messages)).toBe("Pierre reacted 🫡")
+  })
+
+  it("formats a reaction without an author", () => {
+    const messages: NotificationMessage[] = [{ contentPreview: "ship it", emoji: "🫡" }]
+    expect(formatBody(messages)).toBe('Someone reacted 🫡 to "ship it"')
+  })
+
+  it("mixes reaction and message lines in a grouped body", () => {
+    const messages: NotificationMessage[] = [
+      { authorName: "Alice", contentPreview: "hello" },
+      { authorName: "Pierre", contentPreview: "hello", emoji: "🫡" },
+    ]
+    expect(formatBody(messages)).toBe('Alice: hello\nPierre reacted 🫡 to "hello"')
+  })
 })

--- a/apps/frontend/src/lib/sw-notification-format.ts
+++ b/apps/frontend/src/lib/sw-notification-format.ts
@@ -4,6 +4,8 @@ import { ActivityTypes } from "@threa/types"
 export interface NotificationMessage {
   authorName?: string
   contentPreview?: string
+  /** Set for reaction entries — the emoji the actor reacted with. Renders a distinct line. */
+  emoji?: string
 }
 
 /** Max messages to keep in a grouped notification's rolling history. */
@@ -55,9 +57,16 @@ function truncate(text: string, maxLen: number): string {
   return text.slice(0, maxLen - 1) + "…"
 }
 
-/** Format a single message line: "AuthorName: preview text…" */
+/**
+ * Format a single line. Reactions read "Alice reacted 👍 to "preview…"" so they
+ * are unmistakably a reaction, not a new message; plain messages stay "Alice: preview…".
+ */
 function formatLine(msg: NotificationMessage): string {
   const preview = msg.contentPreview ? truncate(msg.contentPreview, MAX_PREVIEW_CHARS) : ""
+  if (msg.emoji) {
+    const who = msg.authorName ?? "Someone"
+    return preview ? `${who} reacted ${msg.emoji} to "${preview}"` : `${who} reacted ${msg.emoji}`
+  }
   if (msg.authorName) {
     return preview ? `${msg.authorName}: ${preview}` : msg.authorName
   }

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -554,8 +554,10 @@ interface PushData {
   contentPreview?: string
   streamName?: string
   authorName?: string
+  /** Reaction emoji — present only for "reaction" activity; drives the "X reacted 👍 to …" line. */
+  emoji?: string
   /** Rolling message history accumulated by the SW for grouped notifications. */
-  messages?: Array<{ authorName?: string; contentPreview?: string }>
+  messages?: Array<{ authorName?: string; contentPreview?: string; emoji?: string }>
   /** Backend-driven action: "clear" dismisses notifications for the stream; "session_expired" prompts re-login. */
   action?: "clear" | "session_expired"
   /** Payload kind: "test" is sent by the in-app diagnostic to verify end-to-end delivery. */
@@ -644,6 +646,7 @@ self.addEventListener("push", (event) => {
         const messages = appendMessage(previousMessages, {
           authorName: data.authorName,
           contentPreview: data.contentPreview,
+          emoji: data.emoji,
         })
 
         const title = formatTitle(messages, data.streamName, data.activityType)


### PR DESCRIPTION
## What

Reaction push notifications were formatted identically to incoming messages — `Alice: <message text>` — so a reaction looked like Alice had *sent* the message rather than *reacted* to it. The notification gave no signal that it was a reaction, and the emoji was nowhere to be seen.

Reactions now render as:

> **Pierre reacted 🫡 to "ship it"**

distinct from a plain message line (`Pierre: ship it`).

## Why it was broken

The reaction emoji was already extracted and stored in the activity `context` (`activity/service.ts`), but it was dropped at the push payload boundary — `push/service.ts` never copied it into the structured payload, so the service worker had no way to know a notification was a reaction.

## Changes

- **`apps/backend/src/features/push/service.ts`** — include `context.emoji` in the structured push payload. Absent for non-reactions. Display text is still formatted in the SW, not the backend (INV-46) — the backend only ships structured data.
- **`apps/frontend/src/sw.ts`** — thread `emoji` through the `PushData` wire type and the rolling grouped-message history.
- **`apps/frontend/src/lib/sw-notification-format.ts`** — `formatLine` renders a reaction line (`X reacted <emoji> to "<excerpt>"`) when an entry carries an emoji, falling back to `X reacted <emoji>` when there's no preview, and `Someone` when the actor name is missing.

Reactions and messages still share a stream notification tag and group together; the per-line formatting distinguishes them, so a mixed group reads correctly (e.g. `Alice: hello` / `Pierre reacted 🫡 to "hello"`).

## Tests

- `sw-notification-format.test.ts`: reaction line with author + emoji + preview, without preview, without author, and a mixed reaction/message grouped body. (24/24 pass.)
- `push.test.ts` (integration): a `reaction` activity payload carries the emoji through to the sent push payload.

Frontend unit tests and full-monorepo typecheck/lint (pre-commit) pass. The DB-backed `push.test.ts` integration test could not be executed in this environment (no Postgres/Docker), but it typechecks and follows the existing fixtures in that file.

https://claude.ai/code/session_01XhK1mDFu6cP6Z1nSz3hhm1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhK1mDFu6cP6Z1nSz3hhm1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783058998&installation_id=129946197&pr_number=737&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F737&signature=2f3975569f9b93061a51edf7c6377dc2a5aaca5caa64235db779e2ea92232ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->