### PR TITLE
Rewrite README: link live site, refresh content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,116 @@
 # Threa
 
-**AI-powered knowledge chat — where conversations build lasting knowledge.**
+Workplace chat that remembers.
 
-## The Problem
+Website: [threa.io](https://threa.io) · App: [app.threa.io](https://app.threa.io)
 
-Critical information shared in team chat disappears into an endless scroll. Decisions, context, and tribal knowledge get buried and forgotten. Teams repeat discussions, lose context, and watch institutional memory decay.
+Channels, threads, and DMs, with a memory underneath. The decisions you make and
+the reasons behind them stay attached to the conversation, so they're still
+there when the question comes up again.
 
-## What Threa Does
+## The problem
 
-Threa is a chat application with an AI memory layer called **GAM (General Agentic Memory)**. As conversations happen, GAM automatically classifies messages and extracts important knowledge into structured **memos** — summaries linked back to the original messages. These memos are searchable via both full-text and semantic (vector) search, turning everyday chat into a durable knowledge base.
+Decisions get made in chat and then scroll away. Two months later someone asks
+why a project was paused, nobody can find the thread, and the discussion happens
+again. The reasoning was there; it just wasn't reachable.
 
-### Solo-First Design
+## How memory works
 
-Unlike traditional team chat that starts with channels, Threa starts with **scratchpads** — personal, AI-assisted notes. Users get AI-powered personal knowledge management first, which naturally expands into team collaboration through channels and direct messages.
+Threa reads the conversation, finds the part where a decision actually gets
+settled, and keeps it as a short **memo** that links back to the messages it came
+from. The subsystem that does this is **GAM (General Agentic Memory)**. Memos are
+searchable by full text and by meaning (vector search), and they surface on their
+own when the topic returns, without anyone remembering to go looking.
 
-### Core Features
+- **Capture.** Most of a channel is noise; the part worth keeping is usually a
+  handful of lines. GAM finds those and writes a memo.
+- **Hold.** The memo is short and sourced, so it stays useful after the thread
+  has scrolled away.
+- **Return.** When the topic comes up again, the relevant memos come with it.
 
-- **Scratchpads** — personal notes with an AI companion
-- **Channels** — public or private team conversations
-- **Direct messages** — one-on-one chat
-- **Threads** — nested discussions off any message
-- **AI companion** — a per-conversation assistant powered by customizable personas
-- **Memos** — automatically extracted knowledge from conversations (GAM)
-- **Search** — combined full-text and semantic search with filters
+## Ariadne
+
+Ariadne is the built-in agent, available in any conversation. Ask it why
+something was decided and it answers from the memos and their source messages,
+with links and timestamps. Personas let you adjust how it behaves per stream.
+
+You can also bring your own agent. Threa exposes a read API over your workspace
+with scoped keys: memos come back as JSON, messages as markdown, so Claude,
+Cursor, or your own setup can read the same memory Ariadne does.
+
+## Features
+
+- **Scratchpads.** Personal, AI-assisted notes. Threa starts solo, with
+  scratchpads as the entry point rather than channels.
+- **Channels.** Public or private team conversations.
+- **Direct messages.** One-on-one chat.
+- **Threads.** Nested discussions off any message, including threads inside
+  threads. A stray reply can be moved into a thread after the fact.
+- **Quote replies.** Reply to the exact line someone wrote, quoted inline.
+- **Markdown composer.** Fenced code with syntax highlighting, a full-screen
+  editor, and a stash for half-written messages.
+- **Memos.** Decisions and context extracted from conversations (GAM).
+- **Search.** Full-text and semantic search with filters.
+- **End-to-end encryption.** Turn it on for sensitive conversations. Threa keeps
+  only ciphertext for those, and they don't become memos.
 
 ## Architecture
 
-Threa is a monorepo with four services:
+Threa is a Bun monorepo. The request path for the main app:
 
 ```
-Browser ──→ Cloudflare Pages (Frontend)
-         ──→ Cloudflare Worker (Workspace Router) ──→ Control Plane
-                                                  ──→ Regional Backend
-         ──→ WebSocket (direct to Regional Backend)
+Browser ──→ Frontend (Cloudflare Pages)
+        ──→ Workspace Router (Cloudflare Worker) ──→ Control Plane
+                                                 ──→ Regional Backend
+        ──→ WebSocket (direct to Regional Backend)
 ```
 
-**Frontend** — React SPA served from Cloudflare Pages. Real-time updates via Socket.io.
+- **Frontend** (`apps/frontend`). React 19 + Vite SPA on Cloudflare Pages.
+  Real-time updates over Socket.io; offline drafts in IndexedDB.
+- **Workspace Router** (`apps/workspace-router`). Cloudflare Worker that routes
+  `/api/*` to the control plane (auth, workspace creation) or the right regional
+  backend, resolving workspace-to-region from Cloudflare KV.
+- **Control Plane** (`apps/control-plane`). Global service for authentication
+  (WorkOS), workspace creation, and region assignment. Runs on Railway with its
+  own PostgreSQL database.
+- **Backend** (`apps/backend`). Regional application server for all domain logic:
+  messaging, streams, agents, memos, search, and files. PostgreSQL 17 with
+  pgvector, AWS S3 for files, OpenRouter as the model gateway. Event sourcing
+  with an outbox pattern drives real-time delivery.
+- **Enclave** (`apps/enclave`). Runs Ariadne for end-to-end encrypted
+  scratchpads. Holds no database credentials and never logs payload contents.
+- **Backoffice** (`apps/backoffice`, `apps/backoffice-router`). Internal
+  platform-admin SPA and its edge router, gated to platform admins.
 
-**Workspace Router** — Cloudflare Worker at the edge. Routes API requests to either the control plane (auth, workspace creation) or the correct regional backend, using Cloudflare KV to resolve workspace-to-region mappings.
+Shared code lives in `packages/`: domain types and API contracts (`types`), the
+ProseMirror editor wrapper (`prosemirror`), backend infrastructure
+(`backend-common`), the agent runtime (`agent-runtime`), and encryption
+primitives (`crypto`).
 
-**Control Plane** — Global service handling authentication (via WorkOS), workspace creation, and region assignment. Runs on Railway with its own PostgreSQL database.
+The design is multi-region: each region gets its own backend, database, and
+storage, though a single region is active today.
 
-**Backend** — Regional application server running all domain logic: messaging, streams, AI agents, memos, search, and file handling. Backed by PostgreSQL 17 with pgvector, AWS S3 for files, and OpenRouter as the AI model gateway. Uses event sourcing with an outbox pattern for reliable real-time delivery.
+## Development
 
-The architecture is multi-region by design — each region gets its own backend, database, and storage — though currently a single region is active.
+Threa uses [Bun](https://bun.sh).
+
+```bash
+bun install
+bun run db:start   # PostgreSQL + MinIO via Docker
+bun run dev        # all services
+```
+
+The app comes up at `http://localhost:5173`.
+
+```bash
+bun run test       # unit/integration (backend)
+bun run test:e2e   # end-to-end
+bun run typecheck  # types across the monorepo
+bun run lint
+```
+
+Architecture and conventions are documented in [`docs/`](docs/). Start with
+[`docs/system-overview.md`](docs/system-overview.md),
+[`docs/architecture.md`](docs/architecture.md), and
+[`docs/core-concepts.md`](docs/core-concepts.md). Code constraints live in
+[`CLAUDE.md`](CLAUDE.md).

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Threa uses [Bun](https://bun.sh).
 ```bash
 bun install
 bun run db:start   # PostgreSQL + MinIO via Docker
-bun run dev        # all services
+bun run dev        # control-plane, workspace-router, backend, frontend, backoffice
 ```
 
-The app comes up at `http://localhost:5173`.
+The app comes up at `http://localhost:3000`.
 
 ```bash
 bun run test       # unit/integration (backend)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Cursor, or your own setup can read the same memory Ariadne does.
 
 Threa is a Bun monorepo. The request path for the main app:
 
-```
+```text
 Browser ──→ Frontend (Cloudflare Pages)
         ──→ Workspace Router (Cloudflare Worker) ──→ Control Plane
                                                  ──→ Regional Backend
@@ -68,8 +68,10 @@ Browser ──→ Frontend (Cloudflare Pages)
 - **Frontend** (`apps/frontend`). React 19 + Vite SPA on Cloudflare Pages.
   Real-time updates over Socket.io; offline drafts in IndexedDB.
 - **Workspace Router** (`apps/workspace-router`). Cloudflare Worker that routes
-  `/api/*` to the control plane (auth, workspace creation) or the right regional
-  backend, resolving workspace-to-region from Cloudflare KV.
+  `/api/*`: auth and workspace creation go to the control plane, and
+  `/api/workspaces/:id/*` to the right regional backend (resolved from Cloudflare
+  KV). It answers `GET /api/workspaces/:id/config` directly with
+  `{ region, wsUrl }`, which the frontend uses to open its WebSocket.
 - **Control Plane** (`apps/control-plane`). Global service for authentication
   (WorkOS), workspace creation, and region assignment. Runs on Railway with its
   own PostgreSQL database.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,44 @@
 # Threa
 
-Workplace chat that remembers.
+Threa is a workplace chat application (channels, threads, DMs, scratchpads) with
+an automatic memory layer that extracts decisions and context from conversations
+into searchable notes linked back to their source messages.
 
-Website: [threa.io](https://threa.io) · App: [app.threa.io](https://app.threa.io)
+- Website: [threa.io](https://threa.io)
+- App: [app.threa.io](https://app.threa.io)
 
-Channels, threads, and DMs, with a memory underneath. The decisions you make and
-the reasons behind them stay attached to the conversation, so they're still
-there when the question comes up again.
+## Memory (GAM)
 
-## The problem
-
-Decisions get made in chat and then scroll away. Two months later someone asks
-why a project was paused, nobody can find the thread, and the discussion happens
-again. The reasoning was there; it just wasn't reachable.
-
-## How memory works
-
-Threa reads the conversation, finds the part where a decision actually gets
-settled, and keeps it as a short **memo** that links back to the messages it came
-from. The subsystem that does this is **GAM (General Agentic Memory)**. Memos are
-searchable by full text and by meaning (vector search), and they surface on their
-own when the topic returns, without anyone remembering to go looking.
-
-- **Capture.** Most of a channel is noise; the part worth keeping is usually a
-  handful of lines. GAM finds those and writes a memo.
-- **Hold.** The memo is short and sourced, so it stays useful after the thread
-  has scrolled away.
-- **Return.** When the topic comes up again, the relevant memos come with it.
+The memory layer is **GAM (General Agentic Memory)**. As messages arrive, GAM
+classifies them, extracts the ones that record a decision or its context, and
+stores each as a **memo**: a short summary that links back to the messages it was
+derived from. Memos are indexed for full-text and vector (semantic) search and
+are retrieved automatically when a related topic comes up.
 
 ## Ariadne
 
-Ariadne is the built-in agent, available in any conversation. Ask it why
-something was decided and it answers from the memos and their source messages,
-with links and timestamps. Personas let you adjust how it behaves per stream.
+Ariadne is the built-in conversational agent, available in any stream. It answers
+from memos and their source messages, citing links and timestamps. Its behavior
+is configurable per stream via personas.
 
-You can also bring your own agent. Threa exposes a read API over your workspace
-with scoped keys: memos come back as JSON, messages as markdown, so Claude,
-Cursor, or your own setup can read the same memory Ariadne does.
+Threa also exposes a read API over the workspace with scoped keys (memos as JSON,
+messages as markdown), so an external agent can read the same data Ariadne does.
 
 ## Features
 
-- **Scratchpads.** Personal, AI-assisted notes. Threa starts solo, with
-  scratchpads as the entry point rather than channels.
+- **Scratchpads.** Personal, AI-assisted notes; the default entry point for solo
+  use.
 - **Channels.** Public or private team conversations.
 - **Direct messages.** One-on-one chat.
-- **Threads.** Nested discussions off any message, including threads inside
-  threads. A stray reply can be moved into a thread after the fact.
-- **Quote replies.** Reply to the exact line someone wrote, quoted inline.
+- **Threads.** Nested discussions off any message, including threads within
+  threads; a message can be moved into a thread after the fact.
+- **Quote replies.** Inline quotes of a specific line.
 - **Markdown composer.** Fenced code with syntax highlighting, a full-screen
-  editor, and a stash for half-written messages.
+  editor, and saved drafts.
 - **Memos.** Decisions and context extracted from conversations (GAM).
 - **Search.** Full-text and semantic search with filters.
-- **End-to-end encryption.** Turn it on for sensitive conversations. Threa keeps
-  only ciphertext for those, and they don't become memos.
+- **End-to-end encryption.** Opt-in per conversation; encrypted streams store
+  only ciphertext and are excluded from memo extraction.
 
 ## Architecture
 
@@ -68,9 +54,9 @@ Browser ──→ Frontend (Cloudflare Pages)
 - **Frontend** (`apps/frontend`). React 19 + Vite SPA on Cloudflare Pages.
   Real-time updates over Socket.io; offline drafts in IndexedDB.
 - **Workspace Router** (`apps/workspace-router`). Cloudflare Worker that routes
-  `/api/*`: auth and workspace creation go to the control plane, and
-  `/api/workspaces/:id/*` to the right regional backend (resolved from Cloudflare
-  KV). It answers `GET /api/workspaces/:id/config` directly with
+  `/api/*`: auth, workspace creation, and `/api/regions` go to the control plane,
+  and `/api/workspaces/:id/*` to the right regional backend (resolved from
+  Cloudflare KV). It answers `GET /api/workspaces/:id/config` directly with
   `{ region, wsUrl }`, which the frontend uses to open its WebSocket.
 - **Control Plane** (`apps/control-plane`). Global service for authentication
   (WorkOS), workspace creation, and region assignment. Runs on Railway with its

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ into searchable notes linked back to their source messages.
 
 - Website: [threa.io](https://threa.io)
 - App: [app.threa.io](https://app.threa.io)
+- Developer docs: [threa.io/developers](https://threa.io/developers)
 
 ## Memory (GAM)
 
@@ -23,6 +24,8 @@ is configurable per stream via personas.
 
 Threa also exposes a read API over the workspace with scoped keys (memos as JSON,
 messages as markdown), so an external agent can read the same data Ariadne does.
+The [developer docs](https://threa.io/developers) cover authentication, the API
+reference, and recipes.
 
 ## Features
 
@@ -54,10 +57,11 @@ Browser ──→ Frontend (Cloudflare Pages)
 - **Frontend** (`apps/frontend`). React 19 + Vite SPA on Cloudflare Pages.
   Real-time updates over Socket.io; offline drafts in IndexedDB.
 - **Workspace Router** (`apps/workspace-router`). Cloudflare Worker that routes
-  `/api/*`: auth, workspace creation, and `/api/regions` go to the control plane,
-  and `/api/workspaces/:id/*` to the right regional backend (resolved from
-  Cloudflare KV). It answers `GET /api/workspaces/:id/config` directly with
-  `{ region, wsUrl }`, which the frontend uses to open its WebSocket.
+  `/api/*`: auth, `GET/POST /api/workspaces`, and `/api/regions` go to the
+  control plane, and `/api/workspaces/:id/*` to the right regional backend
+  (resolved from Cloudflare KV). It answers `GET /api/workspaces/:id/config`
+  directly with `{ region, wsUrl }`, which the frontend uses to open its
+  WebSocket.
 - **Control Plane** (`apps/control-plane`). Global service for authentication
   (WorkOS), workspace creation, and region assignment. Runs on Railway with its
   own PostgreSQL database.


### PR DESCRIPTION
## What

Rewrites the README, which was out of date. Highlights:

- Links the now-live marketing site ([threa.io](https://threa.io)) and the app ([app.threa.io](https://app.threa.io)).
- Reframes around the current positioning ("workplace chat that remembers"): the problem, how memory/GAM works (capture → hold → return), and Ariadne as the built-in agent plus the bring-your-own-agent read API.
- Refreshes the feature list (scratchpads, channels, DMs, threads, quote replies, markdown composer, memos, search, end-to-end encryption).
- Updates the architecture section to match the current services. The old README claimed "four services"; it now also covers the enclave (E2E-encrypted Ariadne) and backoffice, plus the `packages/` layout, and uses the actual Bun dev/test/typecheck/lint commands.

## Notes

- Copy was run through the `/deslopify` skill: no em-dashes, no hype/clichés, plain declaratives.
- The marketing site describes Threa as open source / self-hostable, but there's no `LICENSE` file in the repo yet, so I deliberately did **not** add an open-source/license claim to the README. Worth adding a `LICENSE` separately if that positioning is intended.

https://claude.ai/code/session_01HJWJ9R7Virn8ZJVNigQRtL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJWJ9R7Virn8ZJVNigQRtL)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783059199&installation_id=129946197&pr_number=739&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F739&signature=aeeee31c806f907660d49078028c25193442da90926231dc3e2c4937862a1ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->