### PR TITLE
fix(public-site): make the marketing + docs site work on mobile

### DIFF
--- a/apps/public-site/src/layouts/DocsLayout.astro
+++ b/apps/public-site/src/layouts/DocsLayout.astro
@@ -64,11 +64,25 @@ for (const s of sections) {
     <SvgDefs />
 
     <header class="docs-nav">
-      <a class="brand" href="/developers" style="text-decoration:none;">
-        <svg><use href="#threa-mark" /></svg>
-        <span class="wordmark">Threa</span>
-        <span class="tag">Developers</span>
-      </a>
+      <div class="docs-nav-left">
+        <button
+          type="button"
+          class="docs-menu-toggle"
+          id="docs-menu-toggle"
+          aria-expanded="false"
+          aria-controls="docs-side"
+          aria-label="Open navigation"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+            <path d="M2 4.5h14M2 9h14M2 13.5h14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+          </svg>
+        </button>
+        <a class="brand" href="/developers" style="text-decoration:none;">
+          <svg><use href="#threa-mark" /></svg>
+          <span class="wordmark">Threa</span>
+          <span class="tag">Developers</span>
+        </a>
+      </div>
       <div class="docs-nav-right">
         <nav class="docs-nav-links">
           <a href="/developers/reference">Reference</a>
@@ -121,8 +135,12 @@ for (const s of sections) {
       </div>
     </div>
 
+    <!-- Mobile drawer scrim: covers the page when the side nav is open and
+         closes it on tap. Inert on desktop (the side nav is always in flow). -->
+    <div class="docs-side-backdrop" id="docs-side-backdrop" hidden></div>
+
     <div class="docs-shell">
-      <aside class="docs-side">
+      <aside class="docs-side" id="docs-side">
         {nav.map((g) => (
           <div class="docs-side-group">
             <h4>{g.group}</h4>
@@ -160,6 +178,13 @@ for (const s of sections) {
             ))}
           </div>
         ))}
+
+        <!-- Utility links that live in the top nav on desktop; surfaced here so
+             the mobile drawer is a complete navigation surface. -->
+        <div class="docs-side-foot">
+          <a href="/openapi.json">OpenAPI spec</a>
+          <a href="/">↩ threa.io</a>
+        </div>
       </aside>
 
       <main class="docs-main">

--- a/apps/public-site/src/scripts/playground.ts
+++ b/apps/public-site/src/scripts/playground.ts
@@ -415,9 +415,40 @@ function bindSubnavCollapse(): void {
   })
 }
 
+/* Mobile navigation drawer. On narrow viewports the side nav is hidden off
+   canvas; the hamburger slides it in. Closing on backdrop tap, link tap, or
+   Escape keeps it out of the way once the reader has chosen where to go. */
+function bindMobileNav(): void {
+  const toggle = document.getElementById("docs-menu-toggle")
+  const side = document.getElementById("docs-side")
+  const backdrop = document.getElementById("docs-side-backdrop")
+  if (!toggle || !side || !backdrop) return
+  backdrop.removeAttribute("hidden") // JS owns visibility from here via CSS
+
+  const isOpen = () => document.body.classList.contains("docs-nav-open")
+  const open = () => {
+    document.body.classList.add("docs-nav-open")
+    toggle.setAttribute("aria-expanded", "true")
+  }
+  const close = () => {
+    document.body.classList.remove("docs-nav-open")
+    toggle.setAttribute("aria-expanded", "false")
+  }
+
+  toggle.addEventListener("click", () => (isOpen() ? close() : open()))
+  backdrop.addEventListener("click", close)
+  side.addEventListener("click", (e) => {
+    if ((e.target as HTMLElement).closest("a")) close()
+  })
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && isOpen()) close()
+  })
+}
+
 function boot(): void {
   hydrateTokens(readCreds())
   bindPanel()
+  bindMobileNav()
   bindCredentialsBar()
   bindVarTooltips()
   bindTokenFocus()

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -29,10 +29,46 @@ a {
   backdrop-filter: blur(10px);
   border-bottom: 1px solid hsl(var(--line));
 }
+.docs-nav-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+/* Hamburger: hidden on desktop (the side nav is always in flow); revealed at
+   the mobile breakpoint where the side nav becomes an off-canvas drawer. */
+.docs-menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-left: -6px;
+  border: 1px solid hsl(var(--line));
+  border-radius: 8px;
+  background: hsl(var(--paper));
+  color: hsl(var(--ink-soft));
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.docs-menu-toggle:hover {
+  color: hsl(var(--ink));
+  border-color: hsl(var(--muted));
+}
+/* Drawer-only footer links; the same destinations sit in the top nav on
+   desktop, so hide them there to avoid duplication. */
+.docs-side-foot {
+  display: none;
+}
+/* Scrim behind the open drawer. Sits unused (hidden) on desktop. */
+.docs-side-backdrop {
+  display: none;
+}
 .docs-nav .brand {
   display: flex;
   align-items: center;
   gap: 11px;
+  min-width: 0;
 }
 .docs-nav .brand svg {
   width: 20px;
@@ -48,10 +84,7 @@ a {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: hsl(var(--gold));
-  border: 1px solid hsl(var(--gold) / 0.4);
-  border-radius: 999px;
-  padding: 2px 8px;
-  margin-left: 2px;
+  margin-left: 4px;
 }
 .docs-nav-links {
   display: flex;
@@ -761,12 +794,8 @@ a {
 }
 .scope-chip {
   font-family: var(--font-mono);
-  font-size: 12px;
-  background: hsl(var(--gold) / 0.1);
-  border: 1px solid hsl(var(--gold) / 0.35);
+  font-size: 12.5px;
   color: hsl(var(--gold-dim));
-  border-radius: 4px;
-  padding: 1px 6px;
 }
 
 /* key-type cards */
@@ -974,14 +1003,23 @@ a {
   text-transform: uppercase;
   color: hsl(var(--muted));
 }
-.api-scope {
+/* Required scopes — plain gold-tinted mono tokens, no chip. .api-scope is a
+   <code> element, so explicitly drop the generic in-article code chrome
+   (background/border/padding) that would otherwise box it. The flex gap on
+   .api-scopes keeps multiple scopes legible as a list. */
+.docs-article .api-scopes code.api-scope {
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: 12px;
   color: hsl(var(--gold-dim));
-  background: hsl(var(--gold) / 0.1);
-  border: 1px solid hsl(var(--gold) / 0.3);
-  border-radius: 5px;
-  padding: 2px 8px;
+}
+.api-scope + .api-scope::before {
+  content: "·";
+  color: hsl(var(--muted));
+  margin-right: 7px;
 }
 .api-scope-none {
   font-size: 13px;
@@ -1095,9 +1133,76 @@ a {
   .docs-shell {
     grid-template-columns: 1fr;
   }
-  .docs-side {
+
+  /* Reveal the hamburger; the horizontal top links collapse into the drawer
+     (whose nav groups + foot cover every destination). */
+  .docs-menu-toggle {
+    display: inline-flex;
+  }
+  .docs-nav-links {
     display: none;
   }
+
+  /* Side nav becomes an off-canvas drawer that slides in below the sticky
+     top bar (which stays above it, so the hamburger keeps toggling it). */
+  .docs-side {
+    position: fixed;
+    top: 52px;
+    left: 0;
+    bottom: 0;
+    z-index: 35;
+    width: min(82vw, 320px);
+    height: auto;
+    padding: 26px 22px 40px;
+    background: hsl(var(--paper));
+    border-right: 1px solid hsl(var(--line));
+    box-shadow: 0 0 60px -18px hsl(28 30% 22% / 0.5);
+    transform: translateX(-100%);
+    transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  body.docs-nav-open {
+    overflow: hidden;
+  }
+  body.docs-nav-open .docs-side {
+    transform: translateX(0);
+  }
+
+  .docs-side-backdrop {
+    display: block;
+    position: fixed;
+    inset: 52px 0 0;
+    z-index: 30;
+    background: hsl(var(--ink) / 0.34);
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      opacity 0.22s,
+      visibility 0.22s;
+  }
+  body.docs-nav-open .docs-side-backdrop {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .docs-side-foot {
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+    margin-top: 24px;
+    padding-top: 20px;
+    border-top: 1px solid hsl(var(--line));
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+  }
+  .docs-side-foot a {
+    color: hsl(var(--muted));
+    text-decoration: none;
+  }
+  .docs-side-foot a:hover {
+    color: hsl(var(--ink));
+  }
+
   .pg-fields {
     grid-template-columns: 1fr;
   }

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -151,6 +151,7 @@ body {
   border-radius: 2px;
   border: none;
   cursor: pointer;
+  white-space: nowrap;
 }
 .cta::after {
   content: "→";
@@ -360,15 +361,12 @@ body {
   border-radius: 4px;
   font-weight: 500;
 }
+/* Channel reference (e.g. #api-v3) — plain gold-tinted mono text, no chip.
+   It reads as a channel handle inline rather than a boxed pill. */
 .ref-pill {
-  display: inline-block;
-  background: hsl(var(--paper-warm));
-  border: 1px solid hsl(var(--line));
-  color: hsl(var(--ink-soft));
-  padding: 0 8px;
-  border-radius: 4px;
+  color: hsl(var(--gold-dim));
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: 0.92em;
 }
 
 /* ---------- COMPOSER ----------
@@ -1559,11 +1557,18 @@ body {
 @media (max-width: 880px) {
   .memory-flow {
     grid-template-columns: 1fr;
-    gap: 36px;
+    gap: 44px;
   }
   .memory-flow::before,
   .memory-flow::after {
     display: none;
+  }
+  /* Stacked columns: the connector points DOWN into the next step, centered
+     in the gap above it, instead of sideways into a column that isn't there. */
+  .memory-col + .memory-col::before {
+    left: 50%;
+    top: -32px;
+    transform: translateX(-50%) rotate(90deg);
   }
 }
 
@@ -2030,5 +2035,81 @@ body {
   .missing-grid {
     grid-template-columns: 1fr;
     gap: 20px;
+  }
+}
+
+/* ---------- HERO / NAV / CTA / FOOTER RESPONSIVE ----------
+   The hero and waitlist strips are two-column grids by default; without a
+   breakpoint they stay two-up on phones, which crushed the chat demo into a
+   sliver and pushed it off-screen (horizontal scroll). Collapse them to one
+   column, tighten the page gutter, and let the chat demo own a full-width row
+   below the copy. */
+@media (max-width: 880px) {
+  :root {
+    --pad-x: 28px;
+  }
+
+  .hero-inner {
+    padding: 40px var(--pad-x) 56px;
+  }
+  .hero-inner .nav-row {
+    margin-bottom: 40px;
+  }
+
+  .hero-stage {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .hero-stage .actions {
+    flex-wrap: wrap;
+  }
+  /* Full-width demo on its own row reads as a real conversation again instead
+     of a squeezed column. */
+  .hero-right .tl {
+    height: clamp(480px, 72vh, 560px);
+  }
+
+  .cta-shell {
+    grid-template-columns: 1fr;
+    gap: 28px;
+    padding: 56px var(--pad-x);
+  }
+
+  .footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 18px;
+    padding: 28px var(--pad-x) 48px;
+  }
+}
+
+@media (max-width: 560px) {
+  .nav-links {
+    gap: 16px;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+  }
+
+  /* The chat demo's composer mirrors the real one with a full action row. At
+     phone width nine icons plus send overflow the card, so we keep the
+     essential controls (format, emoji, mention, attach) and the send button,
+     and drop the secondary ones — the demo still reads as the real composer. */
+  .composer-actions .cb[aria-label="Expand editor"],
+  .composer-actions .cb[aria-label="Insert command"],
+  .composer-actions .cb[aria-label="Dictate a message"],
+  .composer-actions .cb[aria-label="Drafts"],
+  .composer-actions .cb[aria-label="Scheduled"] {
+    display: none;
+  }
+
+  /* Waitlist form: input over a full-width button instead of side by side. */
+  .cta-shell .form-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+  .cta-shell .form-row .cta {
+    width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Problem

The public site shipped (#728) without a mobile pass, and several surfaces were broken on phones:

**Homepage**
- The hero (`.hero-stage`) and waitlist (`.cta-shell`) are two-column grids with **no breakpoint collapsing them**. On a phone they stayed two-up: the animated chat demo was crushed into a ~150px sliver and pushed off-screen, causing **horizontal scroll** (184px overflow at 390px).
- "Join the waitlist" wrapped to three lines with a floating arrow.
- The waitlist email field + button ran off the right edge.
- The memory-flow connector arrows kept pointing **sideways** into a column that isn't there once the steps stack.

**Developer docs**
- No mobile navigation at all: `.docs-side` was `display:none` with no replacement, so the sidebar (the only real nav) just vanished and the page couldn't be navigated.
- The nav overflowed by ~296px; the **Credentials toggle sat fully off-screen** (x=561 on a 390px viewport).

## Solution

Pure CSS/markup/JS changes scoped to `apps/public-site` — no behavior change on desktop.

### Homepage
- Collapse `.hero-stage` and `.cta-shell` to one column under 880px; the chat demo gets a full-width row and reads as a real conversation again. Horizontal overflow is now **0px**.
- Tighten the page gutter (`--pad-x` 56→28), stack the footer, and force the CTA onto one line (`white-space: nowrap`).
- Under 560px, trim the demo composer's action row (nine icons + send overflowed the card) down to the essentials — format, emoji, mention, attach + send — so it still reads as the real composer.
- Stack the waitlist form (input over a full-width button) under 560px.
- Rotate the memory-flow connector arrows to point **down** into the next step when the columns stack.

### Developer docs
- Add a hamburger that slides `.docs-side` in as an off-canvas drawer **below** the sticky top bar (which stays above it, so the hamburger keeps toggling it). Scrim behind; closes on backdrop tap, link tap, or Escape; locks body scroll while open.
- Hide the redundant horizontal top links on mobile and surface the utility links (OpenAPI spec, threa.io) inside the drawer so it's a complete navigation surface.
- Credentials toggle now fits and its popover stays within the viewport.

### Pills
Per request, drop the boxed chips for **channel references (`#api-v3`)**, the **"Developers" tag**, and **API scope tokens** — they now render as plain gold-tinted text. (`.api-scope` is a `<code>`, so the reset explicitly out-specifies the generic in-article code chrome.) **Mentions and reactions keep their pills** since they mirror the real product.

## Modified files

| File | Change |
| --- | --- |
| `src/styles/global.css` | Homepage responsive block (hero/CTA/nav/footer/composer), memo-arrow rotation, `.ref-pill` → plain text, `.cta` nowrap |
| `src/styles/docs.css` | Mobile drawer + hamburger + scrim + drawer-foot styles, `.tag`/`.scope-chip`/`.api-scope` → plain text |
| `src/layouts/DocsLayout.astro` | Hamburger button, `id`s for drawer wiring, backdrop, drawer-foot utility links |
| `src/scripts/playground.ts` | `bindMobileNav()` — open/close drawer on hamburger/backdrop/link/Escape |

## Test plan

- [x] `bun run build` — 8 pages built, clean
- [x] `bun run typecheck` (`astro check`) — 0 errors / 0 warnings / 0 hints
- [x] Pre-commit hook: full monorepo `tsc`, `astro check`, dockerfile check, `generate-api-docs --check` (spec up to date) all pass
- [x] Browser-verified at 390px and 768px: homepage (overflow 0), composer, memo arrows, waitlist form, footer; developer reference + authentication (overflow 0), drawer open/close (backdrop/link/Escape), Credentials popover within viewport, scope/ref/tag pills render as plain text
- [x] About page checked for regression (overflow 0)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783059989&installation_id=129946197&pr_number=740&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F740&signature=7330a45c4ae14b1662ab3dd49a3074ed7b6dc390664f52cb1a3d4ef5ace09fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->