### PR TITLE
feat(sidebar): support pinning channels into the Pinned section

### DIFF
--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -152,6 +152,13 @@ export const streamsApi = {
     return res.membership
   },
 
+  async pin(workspaceId: string, streamId: string, pinned: boolean): Promise<StreamMember> {
+    const res = await api.post<{ membership: StreamMember }>(`/api/workspaces/${workspaceId}/streams/${streamId}/pin`, {
+      pinned,
+    })
+    return res.membership
+  },
+
   async join(workspaceId: string, streamId: string): Promise<StreamMember> {
     const res = await api.post<{ data: { membership: StreamMember } }>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/join`

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -104,6 +104,14 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   // Build set of muted streams (for suppressing unread badges)
   const mutedStreamIdSet = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
+
+  // Streams the viewer pinned — drives the smart "Pinned" section. Pinned state
+  // is per-membership (not on the stream row), so derive it from memberships.
+  const pinnedStreamIdSet = useMemo(() => {
+    const ids = new Set<string>()
+    for (const m of idbStreamMemberships) if (m.pinned) ids.add(m.streamId)
+    return ids
+  }, [idbStreamMemberships])
   const dmPeerByStreamId = useMemo(() => new Map(idbDmPeers.map((peer) => [peer.streamId, peer.userId])), [idbDmPeers])
 
   // Process streams into enriched data with urgency and section
@@ -123,8 +131,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
         const mentionCount = getMentionCount(stream.id)
         const activityCount = getActivityCount(stream.id)
         const isMuted = mutedStreamIdSet.has(stream.id)
+        const isPinned = pinnedStreamIdSet.has(stream.id)
         const urgency = calculateUrgency(streamWithPreview, unreadCount, mentionCount, isMuted, activityCount)
-        const section = categorizeStream(streamWithPreview, unreadCount, urgency)
+        const section = categorizeStream(streamWithPreview, unreadCount, urgency, isPinned)
         const dmPeerUserId = dmPeerByStreamId.get(stream.id) ?? dmPeerByStreamId.get(stream.rootStreamId ?? "")
 
         // DM names are viewer-specific and can be stale/null in the cached stream
@@ -141,12 +150,14 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           urgency,
           section,
           dmPeerUserId,
+          isPinned,
         }
       })
   }, [
     idbStreams,
     memberStreamIds,
     mutedStreamIdSet,
+    pinnedStreamIdSet,
     getUnreadCount,
     getMentionCount,
     getActivityCount,

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -16,6 +16,7 @@ import * as urgencyTrackingModule from "./use-urgency-tracking"
 const collapseOnMobile = vi.fn()
 const openStreamSettings = vi.fn()
 const setMenuOpen = vi.fn()
+const pinStream = vi.fn()
 
 const mobileState = {
   isMobileValue: true,
@@ -62,6 +63,7 @@ describe("StreamItem", () => {
     collapseOnMobile.mockReset()
     openStreamSettings.mockReset()
     setMenuOpen.mockReset()
+    pinStream.mockReset()
     mobileState.isMobileValue = true
 
     vi.spyOn(contextsModule, "useSidebar").mockReturnValue({
@@ -73,6 +75,9 @@ describe("StreamItem", () => {
     } as unknown as ReturnType<typeof contextsModule.useSidebar>)
 
     vi.spyOn(hooksModule, "isDraftId").mockImplementation(() => false)
+    vi.spyOn(hooksModule, "usePinStream").mockReturnValue({
+      mutate: pinStream,
+    } as unknown as ReturnType<typeof hooksModule.usePinStream>)
     vi.spyOn(hooksModule, "useActors").mockReturnValue({
       getActorName: () => "Ariadne",
       getActorAvatar: () => null,
@@ -158,6 +163,56 @@ describe("StreamItem", () => {
     fireEvent.click(screen.getByRole("button", { name: "Settings" }))
 
     expect(openStreamSettings).toHaveBeenCalledWith("stream_general")
+  })
+
+  it("pins an unpinned stream from the action menu", async () => {
+    const stream = createStream({ isPinned: false })
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    fireEvent.touchStart(screen.getByRole("link", { name: /general/i }), {
+      touches: [{ clientX: 16, clientY: 16 }],
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin" }))
+    expect(pinStream).toHaveBeenCalledWith({ streamId: "stream_general", pinned: true })
+  })
+
+  it("unpins a pinned stream from the action menu", async () => {
+    const stream = createStream({ isPinned: true })
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    fireEvent.touchStart(screen.getByRole("link", { name: /general/i }), {
+      touches: [{ clientX: 16, clientY: 16 }],
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Unpin" }))
+    expect(pinStream).toHaveBeenCalledWith({ streamId: "stream_general", pinned: false })
   })
 
   it("keeps compact hover previews hidden on mobile", () => {

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -1,5 +1,17 @@
 import { useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
-import { Bell, FileEdit, FolderPlus, Hash, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
+import {
+  Bell,
+  FileEdit,
+  FolderPlus,
+  Hash,
+  Lock,
+  MessageSquareText,
+  Pin,
+  PinOff,
+  Settings,
+  Tag,
+  User,
+} from "lucide-react"
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { SectionPicker } from "./section-picker"
@@ -7,7 +19,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { RelativeTime } from "@/components/relative-time"
 import { getThreadRootContext } from "@/components/thread/breadcrumb-helpers"
-import { isDraftId, useActors } from "@/hooks"
+import { isDraftId, useActors, usePinStream } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
@@ -203,6 +215,7 @@ export function StreamItem({
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const { openStreamSettings } = useStreamSettings()
   const { collapseOnMobile } = useSidebar()
+  const pinStream = usePinStream(workspaceId)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
   const itemRef = useRef<HTMLAnchorElement>(null)
@@ -262,11 +275,18 @@ export function StreamItem({
     return config ?? null
   })()
 
+  const isPinned = stream.isPinned ?? false
   const actions = useMemo<SidebarActionItem[]>(
     () =>
       isVirtualDraft
         ? []
         : [
+            {
+              id: "pin",
+              label: isPinned ? "Unpin" : "Pin",
+              icon: isPinned ? PinOff : Pin,
+              onSelect: () => pinStream.mutate({ streamId: stream.id, pinned: !isPinned }),
+            },
             {
               id: "settings",
               label: "Settings",
@@ -286,7 +306,7 @@ export function StreamItem({
               onSelect: () => setSectionPickerOpen(true),
             },
           ],
-    [isVirtualDraft, openStreamSettings, stream.id]
+    [isVirtualDraft, isPinned, pinStream, openStreamSettings, stream.id]
   )
 
   let drawerPreview: SidebarActionPreview | null = null

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -17,4 +17,6 @@ export interface StreamItemData extends StreamWithPreview {
   urgency: UrgencyLevel
   section: SectionKey
   dmPeerUserId?: string
+  /** Whether the viewer has pinned this stream (drives the Pinned section + action label). */
+  isPinned?: boolean
 }

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -88,6 +88,21 @@ describe("categorizeStream", () => {
     vi.useRealTimers()
   })
 
+  it("puts pinned streams in 'pinned' regardless of read state", () => {
+    expect(categorizeStream(makeStream(), 0, "quiet", true)).toBe("pinned")
+  })
+
+  it("keeps a pinned stream in 'pinned' even when it would otherwise be 'important'", () => {
+    // Pinning is sticky: an explicit pin keeps the stream in the Pinned section
+    // so the user retains one-click access, even with an unread mention. The
+    // urgency strip still flags the mention in place.
+    expect(categorizeStream(makeStream(), 3, "mentions", true)).toBe("pinned")
+  })
+
+  it("ignores pinned when the flag is not set", () => {
+    expect(categorizeStream(makeStream(), 3, "mentions", false)).toBe("important")
+  })
+
   it("puts mentioned streams in 'important'", () => {
     expect(categorizeStream(makeStream(), 3, "mentions")).toBe("important")
   })

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -39,10 +39,19 @@ export function calculateUrgency(
 }
 
 /** Categorize stream into smart section */
-export function categorizeStream(stream: StreamWithPreview, unreadCount: number, urgency: UrgencyLevel): SectionKey {
-  // TODO: Add pinned support when backend implements it
-  // if (stream.isPinned && unreadCount > 0) return "important"
-  // if (stream.isPinned) return "pinned"
+export function categorizeStream(
+  stream: StreamWithPreview,
+  unreadCount: number,
+  urgency: UrgencyLevel,
+  isPinned = false
+): SectionKey {
+  // Explicit pins are sticky: a pinned stream always lives in the Pinned section
+  // so the user keeps one-click access to it regardless of read state. Its
+  // urgency strip and unread badge still surface activity in place. A custom
+  // section filing still wins over this — resolveSections withholds custom-section
+  // members from every smart bucket (including Pinned) — and a labeled stream is
+  // claimed by whichever of its Pinned/label section sits higher in the order.
+  if (isPinned) return "pinned"
 
   // Important: mentions or AI activity with unread
   if (urgency === "mentions" || (urgency === "ai" && unreadCount > 0)) {

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -38,6 +38,7 @@ export interface StreamService {
   markAsRead: typeof streamsApi.markAsRead
   checkSlugAvailable: typeof streamsApi.checkSlugAvailable
   setNotificationLevel: typeof streamsApi.setNotificationLevel
+  pin: typeof streamsApi.pin
   addMember: typeof streamsApi.addMember
   removeMember: typeof streamsApi.removeMember
 }

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -22,6 +22,7 @@ export {
   useArchiveStream,
   useUnarchiveStream,
   useSetNotificationLevel,
+  usePinStream,
   useAddStreamMember,
   useRemoveStreamMember,
   streamKeys,

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -5,12 +5,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
 import type { CreateStreamInput } from "@/api"
-import { DEFAULT_SIDEBAR_CONFIG, DEFAULT_WORKSPACE_SETTINGS, type Stream, type WorkspaceBootstrap } from "@threa/types"
+import {
+  DEFAULT_SIDEBAR_CONFIG,
+  DEFAULT_WORKSPACE_SETTINGS,
+  type Stream,
+  type StreamMember,
+  type WorkspaceBootstrap,
+} from "@threa/types"
 import { workspaceKeys } from "./use-workspaces"
-import { useCreateStream } from "./use-streams"
+import { useCreateStream, usePinStream } from "./use-streams"
 import * as syncEngineModule from "@/sync/sync-engine"
 
 const mockCreate = vi.fn<(workspaceId: string, data: CreateStreamInput) => Promise<Stream>>()
+const mockPin = vi.fn<(workspaceId: string, streamId: string, pinned: boolean) => Promise<StreamMember>>()
 const mockSubscribeStream = vi.fn<(streamId: string) => Promise<void>>()
 
 function createWrapper(queryClient: QueryClient) {
@@ -22,6 +29,7 @@ function createWrapper(queryClient: QueryClient) {
         services: {
           streams: {
             create: mockCreate,
+            pin: mockPin,
           } as unknown as StreamService,
         },
         children,
@@ -156,5 +164,76 @@ describe("useCreateStream", () => {
     const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
     expect(bootstrap?.streams.map((stream) => stream.id)).toEqual(["stream_new"])
     expect(bootstrap?.streamMemberships.map((membership) => membership.streamId)).toEqual(["stream_new"])
+  })
+})
+
+describe("usePinStream", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    mockPin.mockReset()
+    await clearAllCachedData()
+  })
+
+  async function seedMembership(pinned: boolean) {
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      pinned,
+      pinnedAt: pinned ? new Date().toISOString() : null,
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+  }
+
+  it("writes the pin to IndexedDB and reconciles the server pinnedAt", async () => {
+    await seedMembership(false)
+    const serverPinnedAt = "2026-04-05T12:00:00.000Z"
+    mockPin.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      pinned: true,
+      pinnedAt: serverPinnedAt,
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date(),
+    } as unknown as StreamMember)
+
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeWorkspaceBootstrap(),
+      streamMemberships: [{ streamId: "stream_1", pinned: false, pinnedAt: null } as unknown as StreamMember],
+    })
+
+    const { result } = renderHook(() => usePinStream("ws_1"), { wrapper: createWrapper(queryClient) })
+
+    await act(async () => {
+      await result.current.mutateAsync({ streamId: "stream_1", pinned: true })
+    })
+
+    expect(mockPin).toHaveBeenCalledWith("ws_1", "stream_1", true)
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ pinned: true, pinnedAt: serverPinnedAt })
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.streamMemberships[0]).toMatchObject({ pinned: true, pinnedAt: serverPinnedAt })
+  })
+
+  it("reverts the optimistic IndexedDB write when the request fails", async () => {
+    await seedMembership(false)
+    mockPin.mockRejectedValue(new Error("network"))
+
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => usePinStream("ws_1"), { wrapper: createWrapper(queryClient) })
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ streamId: "stream_1", pinned: true })).rejects.toThrow("network")
+    })
+
+    expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ pinned: false, pinnedAt: null })
   })
 })

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -329,6 +329,62 @@ export function useSetNotificationLevel(workspaceId: string, streamId: string) {
   })
 }
 
+/**
+ * Pin / unpin a stream for the viewer. Pinning is a per-membership setting that
+ * drives the sidebar's "Pinned" section, which reads memberships straight from
+ * IDB — so this writes the new state to IDB optimistically (reverting on error)
+ * for an instant sidebar update, then reconciles with the server's authoritative
+ * `pinnedAt` and keeps the workspace bootstrap query cache in sync.
+ */
+export function usePinStream(workspaceId: string) {
+  const queryClient = useQueryClient()
+  const streamService = useStreamService()
+
+  return useMutation({
+    mutationFn: ({ streamId, pinned }: { streamId: string; pinned: boolean }) =>
+      streamService.pin(workspaceId, streamId, pinned),
+    onMutate: async ({ streamId, pinned }) => {
+      const membershipId = `${workspaceId}:${streamId}`
+      const previous = await db.streamMemberships.get(membershipId)
+      if (previous) {
+        await db.streamMemberships.put({
+          ...previous,
+          pinned,
+          pinnedAt: pinned ? (previous.pinnedAt ?? new Date().toISOString()) : null,
+          _cachedAt: Date.now(),
+        })
+      }
+      return { previous }
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous) void db.streamMemberships.put(context.previous)
+    },
+    onSuccess: async (membership, { streamId }) => {
+      const membershipId = `${workspaceId}:${streamId}`
+      const current = await db.streamMemberships.get(membershipId)
+      if (current) {
+        await db.streamMemberships.put({
+          ...current,
+          ...membership,
+          id: membershipId,
+          workspaceId,
+          _cachedAt: Date.now(),
+        })
+      }
+
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+        if (!old) return old
+        return {
+          ...old,
+          streamMemberships: old.streamMemberships.map((sm) =>
+            sm.streamId === streamId ? { ...sm, pinned: membership.pinned, pinnedAt: membership.pinnedAt } : sm
+          ),
+        }
+      })
+    },
+  })
+}
+
 export function useAddStreamMember(workspaceId: string, streamId: string) {
   const streamService = useStreamService()
   const queryClient = useQueryClient()


### PR DESCRIPTION
## What

Wires channel pinning end-to-end so the sidebar's **Pinned** section works, composing correctly with labeled streams and custom sections.

The backend was already complete — `stream_members.pinned`/`pinned_at`, `POST /api/workspaces/:id/streams/:id/pin`, and `resolveSections` already resolved the `"pinned"` smart bucket. The gap was entirely the frontend: nothing set a stream's section to `"pinned"`, and there was no way to pin one. `categorizeStream` even carried a `// TODO: Add pinned support when backend implements it`.

## Changes (frontend only)

- **`categorizeStream`** now takes an `isPinned` flag; a pinned stream always lands in the Pinned section regardless of read state.
- **`sidebar.tsx`** derives the pinned set from IDB memberships (pin state is per-membership, not on the stream row) and threads `isPinned` into categorization and onto `StreamItemData`.
- **`streamsApi.pin` + `usePinStream`** — optimistically writes the pin to IDB (reverting on error) so the Pinned section updates instantly, then reconciles the server's authoritative `pinnedAt` and the workspace bootstrap cache. Mirrors the existing `markAsRead` / `setNotificationLevel` patterns.
- **`StreamItem`** gains a **Pin / Unpin** action.

## Composing with labels & custom sections

This was the key constraint, and it falls out of the existing `resolveSections` precedence — pinning just feeds the same `"pinned"` bucket those rules already handle:

- **Custom sections** stay exclusive and trump pinning: a stream filed into a custom section shows only there (custom members are withheld from every smart bucket, including Pinned).
- **Labels** stay topmost-wins: a pinned + labeled stream is claimed by whichever of its Pinned / label section sits higher in the user's order.

## Behavior note

Pins are **sticky** — a pinned stream stays in Pinned even with an unread mention (the urgency strip still flags it in place), rather than being promoted to Important. This keeps the section stable and predictable. Easy to switch to promote-on-unread if preferred.

## Tests

- `categorizeStream` pinned cases.
- Pin / Unpin action fires the mutation with the right args.
- `usePinStream` optimistic IDB write + error revert + cache reconcile.
- All 110 sidebar tests pass; frontend typecheck clean. The pre-commit hook ran the full monorepo lint + typecheck — all green.

https://claude.ai/code/session_01BzeaUxkzYkyShM7UspT7qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzeaUxkzYkyShM7UspT7qG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783060011&installation_id=129946197&pr_number=741&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F741&signature=a0957171dc11aeba5f9e3e739c965f5f83ad86a3d37234947abefe2ed29fac0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->