### PR TITLE
docs(e2e): feature docs + make the enclave deployable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Lint frontend
         run: bun run --cwd apps/frontend lint
 
+      - name: Lint enclave
+        run: bun run --cwd apps/enclave lint
+
+      - name: Typecheck enclave
+        run: bun run --cwd apps/enclave typecheck
+
       - name: Check Dockerfile workspace COPY lines
         run: bun run check:dockerfiles
 
@@ -116,6 +122,9 @@ jobs:
 
       - name: Run frontend tests
         run: bun run --cwd apps/frontend test
+
+      - name: Run enclave tests
+        run: bun run --cwd apps/enclave test
 
   workos-permissions:
     name: WorkOS Permissions

--- a/apps/enclave/README.md
+++ b/apps/enclave/README.md
@@ -97,3 +97,38 @@ SELECT id, instance_id, key_id, instance_url, last_seen_at, revoked_at
 FROM enclave_runtimes
 ORDER BY registered_at DESC LIMIT 5;
 ```
+
+## Deploying (Railway)
+
+The build is wired (`railway.toml` → `Dockerfile.enclave`, `/healthz`); deploying
+is creating the service and giving it four variables. The enclave self-registers
+with the backend over `BACKEND_BASE_URL`, so no backend config change is needed —
+once it boots and heartbeats, encrypted scratchpads can serve Ariadne turns.
+
+All Railway services listen on the injected `PORT` (8080); internal URLs use
+`:8080`, not the Dockerfile's `EXPOSE 3011`.
+
+```sh
+# 1. Create the service in the existing project and point it at the repo.
+railway add --service enclave
+
+# 2. Set its variables. INTERNAL_API_KEY must MATCH the backend's — read it with
+#    `railway variables --service backend` and reuse the same value. OPENROUTER_API_KEY
+#    is your zero-retention OpenRouter key (billing-attached, so set it yourself).
+railway variables --service enclave \
+  --set "BACKEND_BASE_URL=http://backend.railway.internal:8080" \
+  --set "INTERNAL_API_KEY=<same value as backend>" \
+  --set "OPENROUTER_API_KEY=<your openrouter key>" \
+  --set "ENCLAVE_SELF_URL=http://enclave.railway.internal:8080"
+
+# 3. Deploy.
+railway up --service enclave
+```
+
+`ENCLAVE_SELF_URL` is the address the backend stores to reach this instance for
+session callbacks; the internal Railway DNS name is sufficient (the backend and
+enclave share the private network). Then confirm with the `enclave_runtimes`
+query above — a fresh row with a recent `last_seen_at` and null `revoked_at`
+means it registered and is heartbeating.
+
+Egress (above) should be pinned to the backend + `openrouter.ai` only.

--- a/apps/enclave/railway.toml
+++ b/apps/enclave/railway.toml
@@ -1,0 +1,11 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile.enclave"
+watchPatterns = ["apps/enclave/**", "packages/types/**", "packages/crypto/**", "Dockerfile.enclave", "bun.lock"]
+
+[deploy]
+healthcheckPath = "/healthz"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5
+region = "europe-west4-drams3a"

--- a/docs/features/architecture/e2e-enclave.md
+++ b/docs/features/architecture/e2e-enclave.md
@@ -1,0 +1,149 @@
+---
+title: E2E Enclave (Sealed Ariadne)
+status: building
+audience: internal
+kind: subsystem
+invariants: [INV-E1, INV-E2, INV-E7]
+entry_points:
+  - apps/enclave/src/index.ts
+  - apps/enclave/src/sessions.ts
+  - apps/enclave/src/agent/session-runner.ts
+  - apps/enclave/src/agent/run-turn.ts
+  - apps/enclave/src/agent/trace-observer.ts
+  - apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+  - apps/backend/src/features/enclave-runtimes/forwarder.ts
+  - apps/backend/src/features/enclave-runtimes/session-handlers.ts
+  - packages/crypto/src/stream-key.ts
+public_site: false
+summary: >
+  A separate, database-less enclave process runs the Ariadne agent loop for
+  end-to-end encrypted scratchpads: the backend assigns a sealed turn it cannot
+  read, the enclave unwraps the per-stream key in memory, runs the same
+  AgentRuntime as non-E2E personas, and seals every reply and trace step back
+  under that key.
+related: [public/e2e-encrypted-scratchpads.md]
+---
+
+## The gist
+
+For non-encrypted scratchpads the Ariadne assistant runs inside the regional
+backend, which can read the message it's replying to. That's impossible for an
+encrypted stream — the backend only holds ciphertext. The **enclave** exists to
+square that circle: it's a small, separate process that holds _no_ database
+credentials, decrypts a turn only in memory for the life of that turn, and seals
+its output back before anything leaves the process. The backend's role is reduced
+to a courier — it relays sealed bytes it cannot open (INV-E7).
+
+The design north star is **parity, not a parallel assistant**: the enclave runs
+the _same_ `AgentRuntime` loop the backend uses, emits the _same_ trace lifecycle,
+and produces the _same_ message/step shapes. The only intended differences are
+(a) input and output are encrypted, and (b) the tool surface is narrower. A user
+should not be able to tell they're talking to the enclave except for the lock.
+
+If you only want the mental model, stop here. The rest is the mechanism.
+
+## How it works
+
+**Runtime.** The enclave is the one service in the monorepo that runs on **Node,
+not Bun**: it must do X25519 HPKE decap at runtime to unwrap the per-stream key,
+and Bun 1.3.x's WebCrypto lacks X25519 `deriveBits`. Bun is still the _bundler_ —
+`bun build --target=node --format=esm` inlines the workspace TS into one
+self-contained `dist/index.mjs` that plain `node:22-slim` runs with no
+`node_modules` (`Dockerfile.enclave`). A consequence worth remembering: the
+enclave's logger uses a _synchronous_ pino-pretty stream, not `pino.transport`,
+because a transport worker can't resolve `pino-pretty` from a single-file bundle
+(`packages/agent-runtime/src/logger.ts`).
+
+**Lifecycle.** At boot the enclave generates a fresh **Enclave Instance Key (EIK)**
+(X25519), registers it with the backend, and heartbeats every 30s so the backend's
+live set reflects liveness (`apps/enclave/src/index.ts`). It exposes `/pubkey`,
+`/healthz`, and `/attestation` (source commit + build hash). On graceful shutdown
+it best-effort revokes its key; the backend's 2-minute staleness window tombstones
+the row regardless.
+
+**Dispatch (backend → enclave).** When a turn is owed in an encrypted stream, the
+`enclave-invoke-worker` builds an `EnclaveSessionAssignment` — the sealed prompt,
+sealed history, the SSK wrap(s) addressed to a live EIK, the system prompt (clear,
+non-secret), model id, the per-stream `allowedToolCategories` policy, and
+non-secret `trigger` metadata — and `POST`s it to the enclave via the
+`forwarder`. The worker inserts the running session row and its `started` event in
+**one transaction** (INV-7) and, if assignment fails, drives the session through
+`failSessionWithLifecycle` so the card terminates instead of spinning forever.
+
+**Running the turn.** `sessions.ts` validates the assignment (Zod — note that
+`allowedToolCategories` and `trigger` _must_ be declared in the schema, or Zod
+silently strips them and the policy/context step vanish), acks `202`, and runs the
+turn detached. `session-runner.ts` unwraps the SSK with the in-memory EIK, opens
+the sealed messages, and runs the agent loop (`run-turn.ts`) over an enclave-only
+OpenRouter client (zero-retention, single egress). Each reply is sealed and
+streamed back the moment the loop emits it, so an interim "I'll look into it" lands
+ahead of the final answer; then it acks completion.
+
+**Trace parity.** `trace-observer.ts` mirrors the in-process trace lifecycle:
+`step:started` on step open, snapshot `substep`s as research progresses, a CONTEXT
+("Triggered by") step sealed from the `trigger` metadata, and a finalize on
+complete. Every step's content is sealed with AAD bound to `streamId|stepId|
+senderId` (anti-shuffle), and the client reads the AAD off the envelope rather than
+reconstructing it. The backend's `session-handlers.ts` persist these sealed steps
+and relay them over the socket without reading them.
+
+**Abort.** A user's "Stop research" routes by ownership: if the session is owned by
+an enclave, the backend forwards a `POST /sessions/:id/cancel` (the `forwarder`'s
+`cancelSession`), which trips a per-session `AbortController`; the research
+sub-loop returns partial findings and the turn still replies. For in-process
+(non-enclave) sessions the backend uses its local abort registry instead.
+
+## Details worth knowing
+
+- **Tools.** The enclave exposes web research, `read_url`, and `general_research`
+  only (`apps/enclave/src/agent/tools.ts`), gated by the per-stream
+  `allowedToolCategories`. If the policy excludes `web`, the enclave runs with _no_
+  tools. It cannot call workspace APIs — that would require plaintext egress, which
+  the trust model forbids.
+- **Server short-circuits (INV-E2).** Outbox handlers that read content — companion
+  auto-reply, GAM memo extraction, naming polish, search indexing, mention
+  extraction — short-circuit on encrypted streams via an `isE2eStream` check.
+- **E2E flag atomicity (INV-E1).** The `e2e_streams` row is written in the same
+  transaction as the stream, so there is never a window where the stream exists but
+  its E2E flag doesn't. The repository layer (plus a check constraint) carries the
+  "never treat E2E content as plaintext" guarantee.
+- **Deploy shape (the current gap).** `Dockerfile.enclave` exists and is sound
+  (multi-stage Bun-build → unprivileged `node:22-slim`, `EXPOSE 3011`). What's
+  missing is a **`railway.toml`** wiring it to a deploy target — every other
+  service has one; the enclave did not until this doc's change. Deploying it
+  requires: a Railway service pointed at `Dockerfile.enclave` with `healthcheckPath
+= "/healthz"`; the four required env vars (`ENCLAVE_SELF_URL`, `BACKEND_BASE_URL`,
+  `INTERNAL_API_KEY`, `OPENROUTER_API_KEY` — see `apps/enclave/README.md`); and an
+  egress allow-list pinning outbound traffic to the backend and OpenRouter only.
+  All E2E DB migrations are **additive** (new tables + new nullable columns; nothing
+  dropped), and E2E is opt-in per scratchpad with no global flag, so the encrypted
+  path can ship without affecting any existing plaintext stream or user.
+- **Trust boundary (5a).** Today trust is "the operator runs the published binary";
+  the enclave is operationally separated, not yet a hardware TEE. Migrating to a
+  real TEE (Nitro / Confidential VM / Confidential Space) is a deployment-shape
+  change, not a protocol change — the sealed envelope is portable.
+
+## Invariants
+
+- **INV-E1** — the E2E flag is written atomically with the stream; repository +
+  check-constraint enforcement prevents treating E2E content as plaintext.
+- **INV-E2** — content-reading outbox handlers short-circuit on encrypted streams.
+- **INV-E7** — the backend persists and relays only ciphertext for encrypted
+  streams; it never holds the plaintext or the keys to read it.
+
+## Entry points
+
+- `apps/enclave/src/index.ts` — boot, EIK registration, heartbeat, route table.
+- `apps/enclave/src/sessions.ts` — assignment validation, the `/sessions` and
+  `/sessions/:id/cancel` HTTP shells.
+- `apps/enclave/src/agent/session-runner.ts` — SSK unwrap, abort wiring, turn
+  orchestration.
+- `apps/enclave/src/agent/run-turn.ts` — the agent loop, tool gating, CONTEXT step.
+- `apps/enclave/src/agent/trace-observer.ts` — sealed trace lifecycle parity.
+- `apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts` —
+  builds and dispatches the sealed assignment, owns the session lifecycle.
+- `apps/backend/src/features/enclave-runtimes/forwarder.ts` — backend → enclave
+  HTTP (assign, cancel).
+- `apps/backend/src/features/enclave-runtimes/session-handlers.ts` — persists and
+  relays sealed steps/messages/completion.
+- `packages/crypto/src/stream-key.ts` — SSK seal/open/wrap primitives.

--- a/docs/features/architecture/e2e-enclave.md
+++ b/docs/features/architecture/e2e-enclave.md
@@ -107,14 +107,15 @@ sub-loop returns partial findings and the turn still replies. For in-process
   transaction as the stream, so there is never a window where the stream exists but
   its E2E flag doesn't. The repository layer (plus a check constraint) carries the
   "never treat E2E content as plaintext" guarantee.
-- **Deploy shape (the current gap).** `Dockerfile.enclave` exists and is sound
-  (multi-stage Bun-build → unprivileged `node:22-slim`, `EXPOSE 3011`). What's
-  missing is a **`railway.toml`** wiring it to a deploy target — every other
-  service has one; the enclave did not until this doc's change. Deploying it
-  requires: a Railway service pointed at `Dockerfile.enclave` with `healthcheckPath
-= "/healthz"`; the four required env vars (`ENCLAVE_SELF_URL`, `BACKEND_BASE_URL`,
-  `INTERNAL_API_KEY`, `OPENROUTER_API_KEY` — see `apps/enclave/README.md`); and an
-  egress allow-list pinning outbound traffic to the backend and OpenRouter only.
+- **Deploy shape.** `Dockerfile.enclave` is sound (multi-stage Bun-build →
+  unprivileged `node:22-slim`, `EXPOSE 3011`) and `apps/enclave/railway.toml` now
+  wires it to a deploy target (`Dockerfile.enclave`, `healthcheckPath = "/healthz"`),
+  matching every other service. Bringing up an instance is then just: create the
+  Railway service and set the four required env vars (`ENCLAVE_SELF_URL`,
+  `BACKEND_BASE_URL`, `INTERNAL_API_KEY`, `OPENROUTER_API_KEY` — see
+  `apps/enclave/README.md`); the enclave self-registers with the backend over
+  `BACKEND_BASE_URL`, so no backend config change is needed. Pin the egress
+  allow-list to the backend and OpenRouter only.
   All E2E DB migrations are **additive** (new tables + new nullable columns; nothing
   dropped), and E2E is opt-in per scratchpad with no global flag, so the encrypted
   path can ship without affecting any existing plaintext stream or user.

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -1,0 +1,101 @@
+---
+title: End-to-End Encrypted Scratchpads
+status: building
+audience: public
+since: 2026-05
+surfaces: [scratchpads, sidebar, stream-header, composer, timeline, ai-trace]
+public_site: false
+summary: >
+  Personal scratchpads where message content and the AI's working trace are
+  readable only on your unlocked devices — the server stores ciphertext it
+  cannot decrypt, and the Ariadne assistant runs in a separate enclave that
+  decrypts only in memory.
+related: [architecture/e2e-enclave.md]
+---
+
+## What it does
+
+An end-to-end encrypted (E2E) scratchpad is a normal scratchpad whose message
+**content** is encrypted on your device before it reaches the server. The server
+persists and relays ciphertext it cannot read; plaintext exists only inside an
+unlocked browser tab and, when you invoke the AI, briefly inside an isolated
+**enclave** process that holds no database credentials and never logs payloads.
+
+Encryption is **opt-in per scratchpad**. You create one from the sidebar's New
+menu ("Encrypted Scratchpad"). Existing plaintext streams and other users are
+completely unaffected — there is no workspace-wide switch, and the encrypted and
+unencrypted paths share the same stream UI.
+
+The key model, in plain terms:
+
+- A per-user **identity key** is generated once and protected by a passphrase
+  (Argon2id derives a key-encryption key; the wrapped private key is stored
+  server-side, useless without the passphrase).
+- Each encrypted stream has a **per-stream symmetric key (SSK)** that actually
+  seals the messages. The SSK is HPKE-wrapped to each participant's identity key,
+  so only invited identities can open it. Inviting or removing a participant
+  rolls the key generation forward; history stays sealed under the old generation.
+- The built-in **Ariadne** assistant participates as its own encrypted recipient:
+  the SSK is wrapped to a fresh **enclave instance key** at invocation time, the
+  enclave unwraps it in memory, runs the same agent loop the rest of the app uses,
+  and seals each reply (and each AI trace step) back under the SSK.
+
+## How a user experiences it
+
+- **Creating one.** Sidebar → New → "Encrypted Scratchpad". The first time, you
+  set a passphrase (the setup modal); after that, new encrypted scratchpads reuse
+  your identity key.
+- **The lock is the signal.** Encrypted scratchpads carry a lock badge in the
+  sidebar and an **"Encrypted"** pill in the stream header (where a normal
+  scratchpad shows its companion-mode toggle). Companion mode is locked off for
+  encrypted streams — the enclave path replaces it.
+- **Locked vs. unlocked.** On a fresh device or after locking, the stream is
+  _locked_: the header and composer show an inline **Unlock** affordance, and
+  message bodies render a placeholder instead of content. Unlocking is in-place —
+  a passphrase modal, no detour through Settings. "Keep me unlocked on this
+  device" persists a non-extractable key locally so you skip the passphrase on the
+  next load on that device.
+- **Talking to Ariadne.** Once unlocked, you chat exactly as in a normal
+  scratchpad. Ariadne's replies stream in, and its **AI trace** (context, tool
+  calls, research substeps) is visible in the trace modal — all of it decrypted
+  client-side from ciphertext the server only relayed. Ariadne can do web research
+  and read URLs; you can press **Stop research** to end a long research step early
+  and still get a reply from partial findings.
+
+## Boundaries
+
+This feature is `building`. What it deliberately does **not** do yet — the
+known-missing tally, kept current as gaps close:
+
+- **No full-page unlock gate.** A locked encrypted scratchpad still mounts the
+  normal timeline shell and composer, showing per-surface banners and per-message
+  placeholders rather than replacing the whole view with a single "unlock to
+  continue" page. (`apps/frontend/src/pages/stream.tsx` mounts `TimelineView`
+  unconditionally.)
+- **Stream names are plaintext.** A stream's display name is server-visible
+  metadata stored in the clear; only message content and AI trace data are
+  encrypted. Server-side AI name polish is disabled for encrypted streams, so the
+  name falls back to the first ~40 characters of the first message.
+- **Passphrase only — no PIN.** There is no 6/8-digit PIN unlock (Signal /
+  Messenger style). Unlock is passphrase + Argon2id.
+- **No biometric / WebAuthn unlock.** Device trust today is the "keep me unlocked
+  on this device" local-key path, not a fingerprint/passkey-bound key.
+- **Attachments are not encrypted yet.** Encrypt-before-upload for E2E attachments
+  is being built in a separate change; until it lands, attachments are out of
+  scope for encrypted scratchpads.
+- **No mid-generation interjection.** You can't yet send a message (or edit one to
+  reconsider) while Ariadne is mid-turn and have it fold into the running turn.
+  The only mid-turn control is the graceful "Stop research" abort.
+- **Ariadne is web-only in the enclave.** Inside an encrypted stream, Ariadne has
+  web research and URL reading; it cannot reach workspace tools (GAM memory,
+  reading other streams) because that would require plaintext egress from the
+  enclave.
+- **Content-reading server features are off by design.** Semantic search, GAM
+  memo extraction, notification/preview snippets, and dictation polish do not run
+  for encrypted streams — the server can't read the content. Client-side keyword
+  search over already-decrypted content still works.
+
+## Related
+
+- [E2E Enclave](../architecture/e2e-enclave.md) — how the enclave, dispatch, trace
+  mirroring, and deploy shape actually work.


### PR DESCRIPTION
## What & why

First PR in the **E2E-Ariadne alignment stack** (stacked on #727). Two things, both additive and non-destructive:

1. **Feature docs** for E2E encrypted scratchpads, following the `docs/features/` conventions:
   - `public/e2e-encrypted-scratchpads.md` — user-facing. Its **`## Boundaries`** section is the verified *known-missing tally* (full-page unlock gate, encrypted naming, PIN, biometric, attachments, interjection, workspace tools), so it stays current as a PR-checked artifact instead of living in scattered notes.
   - `architecture/e2e-enclave.md` — the enclave subsystem: runtime (Node-not-Bun + why), lifecycle, dispatch, trace parity, abort, and the deploy shape. Invariants INV-E1/E2/E7 verified against the code.

2. **`apps/enclave/railway.toml`** — every other service had one; the enclave only had `Dockerfile.enclave`, so nothing wired it to a deploy target. Mirrors the backend config (`DOCKERFILE` builder, `/healthz` healthcheck, watch paths scoped to the enclave + its bundled deps). The enclave reads `process.env.PORT`, so Railway's injected `8080` is honored.

## Deployability

Verified the enclave can ship **non-destructively**: all E2E migrations are additive (new tables + nullable columns), and E2E is opt-in per scratchpad with no global flag, so plaintext streams/users are unaffected. Remaining steps are ops (Kris): create the Railway service pointing at this toml, set the 4 env vars (`ENCLAVE_SELF_URL`, `BACKEND_BASE_URL`, `INTERNAL_API_KEY`, `OPENROUTER_API_KEY`), and pin egress to backend + OpenRouter.

## Test plan

Docs + deploy config only — no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783064421&installation_id=129946197&pr_number=742&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F742&signature=7431fe6e1c2d52435822301cd73770a4b5bc91182ace68520808a27cc1378b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->