### PR TITLE
feat(e2e): full-page unlock gate for locked encrypted scratchpads

### DIFF
--- a/apps/frontend/src/components/encryption/stream-encryption-gate.test.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-gate.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import { e2eKeysApi } from "@/api/e2e-keys"
+import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
+import { getE2eSessionState, lock, resetE2eSessionStoreCache, setupNewKey } from "@/stores/e2e-session-store"
+import { clearStreamKeyCache } from "@/lib/crypto/stream-key-cache"
+import { E2eUnlockProvider } from "./e2e-unlock-provider"
+import { StreamEncryptionGate } from "./stream-encryption-gate"
+
+const FAST_PARAMS = { ...DEFAULT_KDF_PARAMS, m: 8 * 1024, t: 1 }
+const USER_ID = "usr_test"
+const TIMELINE = "timeline-content"
+
+interface InMemoryServerKey {
+  keyId: string
+  publicKey: string
+  encryptedPrivateBundle: string
+  kdfSalt: string
+  kdfParams: typeof FAST_PARAMS
+  createdAt: string
+}
+
+let serverKey: InMemoryServerKey | null = null
+let keyCounter = 0
+let wsCounter = 0
+
+function freshWorkspaceId(): string {
+  return `ws_test_${++wsCounter}`
+}
+
+beforeEach(() => {
+  serverKey = null
+  keyCounter = 0
+  vi.spyOn(e2eKeysApi, "get").mockImplementation(async () => serverKey)
+  vi.spyOn(e2eKeysApi, "set").mockImplementation(async (_ws, input) => {
+    const rotated = serverKey !== null
+    serverKey = {
+      keyId: `e2ek_test_${++keyCounter}`,
+      publicKey: input.publicKey,
+      encryptedPrivateBundle: input.encryptedPrivateBundle,
+      kdfSalt: input.kdfSalt,
+      kdfParams: input.kdfParams as typeof FAST_PARAMS,
+      createdAt: new Date().toISOString(),
+    }
+    return { key: serverKey, rotated }
+  })
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER_ID)
+})
+
+afterEach(() => {
+  resetE2eSessionStoreCache()
+  clearStreamKeyCache()
+  vi.restoreAllMocks()
+})
+
+function renderGate(workspaceId: string, encrypted: boolean) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <E2eUnlockProvider workspaceId={workspaceId}>
+        <StreamEncryptionGate workspaceId={workspaceId} encrypted={encrypted}>
+          <div>{TIMELINE}</div>
+        </StreamEncryptionGate>
+      </E2eUnlockProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe("StreamEncryptionGate", () => {
+  it("renders children for an unencrypted stream", () => {
+    const ws = freshWorkspaceId()
+    renderGate(ws, false)
+    expect(screen.getByText(TIMELINE)).toBeInTheDocument()
+  })
+
+  it("renders children once the session is unlocked", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "correct-horse-battery-staple", { params: FAST_PARAMS })
+    renderGate(ws, true)
+    expect(await screen.findByText(TIMELINE)).toBeInTheDocument()
+    expect(getE2eSessionState(ws, USER_ID).status).toBe("unlocked")
+  })
+
+  it("hides the timeline and shows an unlock page for a locked stream", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "correct-horse-battery-staple", { params: FAST_PARAMS })
+    await lock(ws, USER_ID)
+
+    renderGate(ws, true)
+
+    expect(await screen.findByText("This scratchpad is encrypted")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^unlock$/i })).toBeInTheDocument()
+    // The gate replaces the timeline entirely — children must not be mounted.
+    expect(screen.queryByText(TIMELINE)).not.toBeInTheDocument()
+  })
+
+  it("shows a setup page (no timeline) when the user has no key yet", async () => {
+    const ws = freshWorkspaceId()
+    renderGate(ws, true)
+
+    expect(await screen.findByRole("heading", { name: "Set up encryption" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /set up encryption/i })).toBeInTheDocument()
+    expect(screen.queryByText(TIMELINE)).not.toBeInTheDocument()
+  })
+
+  it("opens the unlock modal from the gate's Unlock button", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "correct-horse-battery-staple", { params: FAST_PARAMS })
+    await lock(ws, USER_ID)
+
+    renderGate(ws, true)
+
+    await userEvent.click(await screen.findByRole("button", { name: /^unlock$/i }))
+    expect(await screen.findByText("Unlock encrypted scratchpads")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/encryption/stream-encryption-gate.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-gate.tsx
@@ -1,0 +1,99 @@
+import { Loader2, Lock, LockOpen, ShieldPlus } from "lucide-react"
+import type { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { useE2eUnlockOptional } from "./e2e-unlock-provider"
+
+/**
+ * Full-page gate for an encrypted scratchpad. While the viewer's E2E session is
+ * locked (or not yet set up), the stream's timeline and composer are replaced
+ * entirely by a single unlock/setup page — rather than mounting the timeline with
+ * per-message "locked" placeholders and a composer banner. Once unlocked, the
+ * children render unchanged and the gate is invisible.
+ *
+ * The session is per-(workspace, user), not per-stream, so unlocking here unlocks
+ * every encrypted scratchpad at once; the provider mounted at the workspace layer
+ * drives the load, so `unknown` is a brief hydration window, not a dead end.
+ *
+ * Passes children through verbatim for non-encrypted streams or when the unlock
+ * provider is absent (unit harnesses), so callers can wrap unconditionally.
+ */
+export function StreamEncryptionGate({
+  workspaceId,
+  encrypted,
+  children,
+}: {
+  workspaceId: string
+  encrypted: boolean
+  children: ReactNode
+}) {
+  const unlock = useE2eUnlockOptional()
+  const userId = useWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+
+  if (!encrypted || !unlock) return <>{children}</>
+
+  // For an encrypted stream we never reveal the timeline until we know the
+  // session is unlocked: while the user is unresolved or the session is still
+  // hydrating, show a quiet spinner instead of flashing the gate or placeholders.
+  if (!userId || session.status === "unknown") {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-label="Checking encryption" />
+      </div>
+    )
+  }
+
+  if (session.status === "unlocked") return <>{children}</>
+
+  if (session.status === "no-key") {
+    return <GatePanel kind="setup" onAction={() => unlock.openSetup()} />
+  }
+  return (
+    <GatePanel kind="unlock" pending={session.status === "unlocking"} onAction={() => unlock.openUnlock()} />
+  )
+}
+
+function GatePanel({
+  kind,
+  pending,
+  onAction,
+}: {
+  kind: "setup" | "unlock"
+  pending?: boolean
+  onAction: () => void
+}) {
+  const isSetup = kind === "setup"
+  let buttonLabel = "Set up encryption"
+  if (!isSetup) buttonLabel = pending ? "Unlocking…" : "Unlock"
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        {isSetup ? (
+          <ShieldPlus className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <Lock className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        )}
+      </div>
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold">
+          {isSetup ? "Set up encryption" : "This scratchpad is encrypted"}
+        </h2>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          {isSetup
+            ? "Create your encryption key to read and write in encrypted scratchpads."
+            : "Unlock with your passphrase to read and write messages. Your messages stay encrypted on the server."}
+        </p>
+      </div>
+      <Button onClick={onAction} disabled={pending} className="gap-1.5">
+        {isSetup ? (
+          <ShieldPlus className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <LockOpen className="h-4 w-4" aria-hidden="true" />
+        )}
+        {buttonLabel}
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -36,6 +36,7 @@ import { TimelineView } from "@/components/timeline"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
+import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
@@ -463,7 +464,9 @@ export function StreamPage() {
         </div>
       </header>
       <main className="relative flex-1 overflow-hidden" data-editor-zone="main">
-        <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
+        <StreamEncryptionGate workspaceId={workspaceId} encrypted={isEncryptedScratchpad && !isDraft}>
+          <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
+        </StreamEncryptionGate>
       </main>
       {stream && !isDraft && (
         <LabelPicker

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -50,11 +50,12 @@ The key model, in plain terms:
   scratchpad shows its companion-mode toggle). Companion mode is locked off for
   encrypted streams — the enclave path replaces it.
 - **Locked vs. unlocked.** On a fresh device or after locking, the stream is
-  _locked_: the header and composer show an inline **Unlock** affordance, and
-  message bodies render a placeholder instead of content. Unlocking is in-place —
-  a passphrase modal, no detour through Settings. "Keep me unlocked on this
-  device" persists a non-extractable key locally so you skip the passphrase on the
-  next load on that device.
+  _locked_: the timeline and composer are replaced by a single full-page unlock
+  view (with the header keeping its inline **Unlock** affordance too), so you never
+  scroll a wall of locked placeholders. Unlocking is in-place — a passphrase modal,
+  no detour through Settings. "Keep me unlocked on this device" persists a
+  non-extractable key locally so you skip the passphrase on the next load on that
+  device.
 - **Talking to Ariadne.** Once unlocked, you chat exactly as in a normal
   scratchpad. Ariadne's replies stream in, and its **AI trace** (context, tool
   calls, research substeps) is visible in the trace modal — all of it decrypted
@@ -67,11 +68,6 @@ The key model, in plain terms:
 This feature is `building`. What it deliberately does **not** do yet — the
 known-missing tally, kept current as gaps close:
 
-- **No full-page unlock gate.** A locked encrypted scratchpad still mounts the
-  normal timeline shell and composer, showing per-surface banners and per-message
-  placeholders rather than replacing the whole view with a single "unlock to
-  continue" page. (`apps/frontend/src/pages/stream.tsx` mounts `TimelineView`
-  unconditionally.)
 - **Stream names are plaintext.** A stream's display name is server-visible
   metadata stored in the clear; only message content and AI trace data are
   encrypted. Server-side AI name polish is disabled for encrypted streams, so the


### PR DESCRIPTION
## What & why

Second PR in the **E2E-Ariadne alignment stack** (stacked on #742). Closes the "no full-page unlock gate" gap from the feature doc's Boundaries.

A locked encrypted scratchpad used to mount the normal timeline + composer, showing per-message "🔒 locked" placeholders and a composer banner. This replaces that, for the locked/no-key states, with a **single full-page unlock/setup view** inside the stream's main area — so the user sees one clear "unlock to continue" page instead of a wall of placeholders. Once unlocked, the timeline renders unchanged and the gate is invisible.

## How

New `StreamEncryptionGate` (`apps/frontend/src/components/encryption/stream-encryption-gate.tsx`) wraps `TimelineView` in `stream.tsx`. It reads the existing per-(workspace, user) E2E session and the existing unlock provider — **no parallel unlock path**:

- unencrypted / provider absent → children verbatim
- session `unlocked` → children verbatim
- `unknown` or user unresolved → a quiet centered spinner (avoids flashing the gate or placeholders during the brief hydration window driven by the workspace-level provider)
- `no-key` → setup page → `openSetup()`
- `locked` / `unlocking` → unlock page → `openUnlock()`

The header's inline Unlock/Set-up affordance is unchanged; the gate is the in-body surface.

## Test plan

- New `stream-encryption-gate.test.tsx` (5 tests, mounts real components per INV-39): renders children when unencrypted/unlocked; hides the timeline and shows the unlock page when locked; shows the setup page with no key; opens the unlock modal from the gate.
- `bun run typecheck` clean; eslint clean on changed files.

Feature doc updated: `public/e2e-encrypted-scratchpads.md` Boundaries (gap removed) + the locked/unlocked UX description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783064780&installation_id=129946197&pr_number=744&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F744&signature=7c9fb6c98c41709061893bfbed7f36ed29b91bd1c28f00ab5966ac74e933ac7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->