### PR TITLE
feat(e2e): encrypted stream naming (sealed name + plaintext fallback)

### DIFF
--- a/apps/backend/src/db/migrations/20260603100000_e2e_stream_sealed_name.sql
+++ b/apps/backend/src/db/migrations/20260603100000_e2e_stream_sealed_name.sql
@@ -1,0 +1,13 @@
+-- Encrypted copy of an E2E stream's display name.
+--
+-- The plaintext `streams.display_name` stays as the always-visible fallback
+-- (shown while the viewer's E2E session is locked); this sealed copy is the
+-- authoritative name an unlocked client decrypts and prefers. Sealed under the
+-- stream SSK with AAD bound to (streamId, "name", generation) — the server
+-- stores opaque ciphertext + framing it cannot read.
+--
+-- Additive and nullable: existing E2E streams simply have no sealed name until
+-- the next rename writes one, and plaintext streams never get these columns set.
+ALTER TABLE e2e_streams
+  ADD COLUMN name_ciphertext BYTEA,
+  ADD COLUMN name_envelope JSONB;

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -78,23 +78,31 @@ export const E2eStreamsRepository = {
   },
 
   /**
-   * Store the sealed (encrypted) display name for an E2E stream. The plaintext
+   * Store (or clear) the sealed display name for an E2E stream. The plaintext
    * `streams.display_name` is updated separately on the same rename; this is the
    * authoritative name an unlocked client prefers. The server holds opaque bytes
-   * + framing it cannot read. Returns whether a row was updated (false for a
-   * plaintext stream id — the WHERE matches nothing), so the caller only re-reads
-   * the joined stream when a sealed name actually landed.
+   * + framing it cannot read. Passing `null` clears both columns — used when a
+   * rename can't produce a fresh seal (locked session), so a stale sealed name
+   * can't outrank the new plaintext one after the next unlock.
+   *
+   * Returns whether a row was updated (false for a plaintext stream id — the
+   * WHERE matches nothing). `Buffer.from(_, "base64")` is permissive, so we
+   * round-trip-check the ciphertext and reject anything that isn't canonical
+   * base64 rather than silently persisting a corrupt blob.
    */
   async updateSealedName(
     db: Querier,
     workspaceId: string,
     streamId: string,
-    sealed: { ciphertext: string; envelope: unknown }
+    sealed: { ciphertext: string; envelope: unknown } | null
   ): Promise<boolean> {
+    if (sealed && Buffer.from(sealed.ciphertext, "base64").toString("base64") !== sealed.ciphertext) {
+      throw new Error("updateSealedName: ciphertext is not canonical base64")
+    }
     const result = await db.query(sql`
       UPDATE e2e_streams
-      SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
-          name_envelope = ${JSON.stringify(sealed.envelope)}
+      SET name_ciphertext = ${sealed ? Buffer.from(sealed.ciphertext, "base64") : null},
+          name_envelope = ${sealed ? JSON.stringify(sealed.envelope) : null}
       WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
     `)
     return (result.rowCount ?? 0) > 0

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -77,6 +77,29 @@ export const E2eStreamsRepository = {
     return result.rows.map((row) => row.stream_id)
   },
 
+  /**
+   * Store the sealed (encrypted) display name for an E2E stream. The plaintext
+   * `streams.display_name` is updated separately on the same rename; this is the
+   * authoritative name an unlocked client prefers. The server holds opaque bytes
+   * + framing it cannot read. Returns whether a row was updated (false for a
+   * plaintext stream id — the WHERE matches nothing), so the caller only re-reads
+   * the joined stream when a sealed name actually landed.
+   */
+  async updateSealedName(
+    db: Querier,
+    workspaceId: string,
+    streamId: string,
+    sealed: { ciphertext: string; envelope: unknown }
+  ): Promise<boolean> {
+    const result = await db.query(sql`
+      UPDATE e2e_streams
+      SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
+          name_envelope = ${JSON.stringify(sealed.envelope)}
+      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
+    `)
+    return (result.rowCount ?? 0) > 0
+  },
+
   async getByStreamId(db: Querier, workspaceId: string, streamId: string): Promise<E2eStream | null> {
     const result = await db.query<E2eStreamRow>(sql`
       SELECT ${sql.raw(COLUMNS)}

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -88,17 +88,36 @@ const createStreamSchema = z
     path: ["e2eEnabled"],
   })
 
-const updateStreamSchema = z.object({
-  displayName: z.string().min(1).max(100).optional(),
-  slug: z
-    .string()
-    .regex(SLUG_PATTERN, {
-      message: "Slug must start with a letter and contain only lowercase letters, numbers, hyphens, or underscores",
-    })
-    .optional(),
-  description: z.string().max(500).optional(),
-  visibility: visibilitySchema.optional(),
+// Sealed display name for an E2E stream: SSK-sealed ciphertext + its framing.
+// The server stores these opaque (it can't read them); the envelope shape
+// mirrors `StreamEnvelope` from @threa/crypto without importing it here.
+const sealedNameEnvelopeSchema = z.object({
+  v: z.number(),
+  keyGeneration: z.number().int().min(0),
+  iv: z.string().min(1),
+  aad: z.string().min(1),
 })
+
+const updateStreamSchema = z
+  .object({
+    displayName: z.string().min(1).max(100).optional(),
+    slug: z
+      .string()
+      .regex(SLUG_PATTERN, {
+        message: "Slug must start with a letter and contain only lowercase letters, numbers, hyphens, or underscores",
+      })
+      .optional(),
+    description: z.string().max(500).optional(),
+    visibility: visibilitySchema.optional(),
+    // Optional encrypted name. Both halves travel together or not at all — a
+    // ciphertext without its envelope (or vice versa) is unopenable.
+    sealedNameCiphertext: z.string().min(1).optional(),
+    sealedNameEnvelope: sealedNameEnvelopeSchema.optional(),
+  })
+  .refine((v) => (v.sealedNameCiphertext === undefined) === (v.sealedNameEnvelope === undefined), {
+    message: "sealedNameCiphertext and sealedNameEnvelope must be sent together",
+    path: ["sealedNameCiphertext"],
+  })
 
 const updateCompanionModeSchema = z.object({
   companionMode: companionModeSchema,
@@ -552,9 +571,21 @@ export function createStreamHandlers({
         })
       }
 
-      const { displayName, slug, description, visibility } = result.data
+      const { displayName, slug, description, visibility, sealedNameCiphertext, sealedNameEnvelope } = result.data
 
-      const updated = await streamService.updateStream(streamId, { displayName, slug, description, visibility })
+      // Schema guarantees both halves arrive together; pair them for the service.
+      const sealedName =
+        sealedNameCiphertext && sealedNameEnvelope
+          ? { ciphertext: sealedNameCiphertext, envelope: sealedNameEnvelope }
+          : undefined
+
+      const updated = await streamService.updateStream(streamId, {
+        displayName,
+        slug,
+        description,
+        visibility,
+        sealedName,
+      })
       res.json({ stream: updated })
     },
 

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -88,6 +88,10 @@ const createStreamSchema = z
     path: ["e2eEnabled"],
   })
 
+// Canonical base64 (correct alphabet + padding/length). Rejects e.g. "!!!!" or
+// "YWJj$" so a malformed sealed ciphertext can't be Buffer.from-decoded to junk.
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
 // Sealed display name for an E2E stream: SSK-sealed ciphertext + its framing.
 // The server stores these opaque (it can't read them); the envelope shape
 // mirrors `StreamEnvelope` from @threa/crypto without importing it here.
@@ -109,15 +113,26 @@ const updateStreamSchema = z
       .optional(),
     description: z.string().max(500).optional(),
     visibility: visibilitySchema.optional(),
-    // Optional encrypted name. Both halves travel together or not at all — a
-    // ciphertext without its envelope (or vice versa) is unopenable.
-    sealedNameCiphertext: z.string().min(1).optional(),
-    sealedNameEnvelope: sealedNameEnvelopeSchema.optional(),
+    // Optional encrypted name. Strict base64 so a malformed ciphertext can't be
+    // decoded to garbage by the permissive Buffer.from. `null` on both clears the
+    // sealed name (rename without a fresh seal); a ciphertext without its
+    // envelope (or vice versa) is unopenable.
+    sealedNameCiphertext: z.string().min(1).regex(BASE64_PATTERN, "must be base64").nullable().optional(),
+    sealedNameEnvelope: sealedNameEnvelopeSchema.nullable().optional(),
   })
-  .refine((v) => (v.sealedNameCiphertext === undefined) === (v.sealedNameEnvelope === undefined), {
-    message: "sealedNameCiphertext and sealedNameEnvelope must be sent together",
-    path: ["sealedNameCiphertext"],
-  })
+  .refine(
+    (v) => {
+      const c = v.sealedNameCiphertext
+      const e = v.sealedNameEnvelope
+      if (c === undefined && e === undefined) return true // omitted: leave untouched
+      if (c === null && e === null) return true // cleared together
+      return typeof c === "string" && e != null // set together
+    },
+    {
+      message: "sealedNameCiphertext and sealedNameEnvelope must be set together, cleared together, or omitted",
+      path: ["sealedNameCiphertext"],
+    }
+  )
 
 const updateCompanionModeSchema = z.object({
   companionMode: companionModeSchema,
@@ -573,11 +588,13 @@ export function createStreamHandlers({
 
       const { displayName, slug, description, visibility, sealedNameCiphertext, sealedNameEnvelope } = result.data
 
-      // Schema guarantees both halves arrive together; pair them for the service.
-      const sealedName =
-        sealedNameCiphertext && sealedNameEnvelope
-          ? { ciphertext: sealedNameCiphertext, envelope: sealedNameEnvelope }
-          : undefined
+      // Schema guarantees one of: both set, both null (clear), or both omitted.
+      let sealedName: { ciphertext: string; envelope: unknown } | null | undefined
+      if (sealedNameCiphertext != null && sealedNameEnvelope != null) {
+        sealedName = { ciphertext: sealedNameCiphertext, envelope: sealedNameEnvelope }
+      } else if (sealedNameCiphertext === null || sealedNameEnvelope === null) {
+        sealedName = null
+      }
 
       const updated = await streamService.updateStream(streamId, {
         displayName,

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -31,6 +31,9 @@ interface StreamRow {
    */
   e2e_owner_user_key_id?: string | null
   e2e_actors?: { kind: string; keyId: string | null }[] | null
+  /** Sealed display name (E2E streams only) — BYTEA + JSONB framing, both NULL until first rename. */
+  e2e_name_ciphertext?: Buffer | null
+  e2e_name_envelope?: unknown | null
 }
 
 /**
@@ -186,6 +189,9 @@ function mapRowToStream(row: StreamRow): Stream {
       e2eEnabled: true,
       e2eOwnerKeyId,
       e2eActors: (row.e2e_actors ?? []) as E2eActor[],
+      // Sealed name travels base64 on the wire; both are null until first rename.
+      sealedNameCiphertext: row.e2e_name_ciphertext ? row.e2e_name_ciphertext.toString("base64") : null,
+      sealedNameEnvelope: row.e2e_name_envelope ?? null,
     }),
   }
 }
@@ -232,6 +238,8 @@ const SELECT_FIELDS_WITH_E2E = `
   s.companion_mode, s.companion_persona_id,
   s.created_by, s.created_at, s.updated_at, s.archived_at, s.display_name_generated_at,
   e.owner_user_key_id AS e2e_owner_user_key_id,
+  e.name_ciphertext AS e2e_name_ciphertext,
+  e.name_envelope AS e2e_name_envelope,
   (
     SELECT COALESCE(json_agg(json_build_object('kind', a.kind, 'actorId', a.actor_id, 'keyId', a.key_id) ORDER BY a.added_at), '[]'::json)
     FROM e2e_stream_actors a
@@ -536,6 +544,8 @@ export const StreamRepository = {
         lm.content_json as last_message_content,
         lm.created_at as last_message_at,
         e.owner_user_key_id AS e2e_owner_user_key_id,
+        e.name_ciphertext AS e2e_name_ciphertext,
+        e.name_envelope AS e2e_name_envelope,
         (
           SELECT COALESCE(json_agg(json_build_object('kind', a.kind, 'actorId', a.actor_id, 'keyId', a.key_id) ORDER BY a.added_at), '[]'::json)
           FROM e2e_stream_actors a

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -681,35 +681,62 @@ export class StreamService {
 
   async updateStream(
     streamId: string,
-    data: { displayName?: string; slug?: string; description?: string; visibility?: Visibility }
+    data: {
+      displayName?: string
+      slug?: string
+      description?: string
+      visibility?: Visibility
+      /**
+       * Sealed (encrypted) display name for an E2E stream — stored on
+       * `e2e_streams`, not `streams`. The plaintext `displayName` above is still
+       * sent and stays the locked-state fallback; this is the authoritative name
+       * an unlocked client prefers. Ignored (no-op) for plaintext streams.
+       */
+      sealedName?: { ciphertext: string; envelope: unknown }
+    }
   ): Promise<Stream | null> {
+    const { sealedName, ...streamData } = data
     try {
       return await withTransaction(this.pool, async (client) => {
         // Slug uniqueness check (exclude current stream)
-        if (data.slug) {
+        if (streamData.slug) {
           const current = await StreamRepository.findById(client, streamId)
-          if (current && data.slug !== current.slug) {
-            const slugExists = await StreamRepository.slugExistsInWorkspace(client, current.workspaceId, data.slug)
+          if (current && streamData.slug !== current.slug) {
+            const slugExists = await StreamRepository.slugExistsInWorkspace(
+              client,
+              current.workspaceId,
+              streamData.slug
+            )
             if (slugExists) {
-              throw new DuplicateSlugError(data.slug)
+              throw new DuplicateSlugError(streamData.slug)
             }
           }
         }
 
-        const stream = await StreamRepository.update(client, streamId, data)
-        if (stream) {
-          await OutboxRepository.insert(client, "stream:updated", {
-            workspaceId: stream.workspaceId,
-            streamId: stream.id,
-            stream,
-          })
+        const stream = await StreamRepository.update(client, streamId, streamData)
+        if (!stream) return null
+
+        // The sealed name lives on a different table; persist it in the same
+        // transaction, then re-read the joined stream so the emitted event and
+        // the response carry the new sealed name. The UPDATE no-ops on a
+        // plaintext stream id, so the re-read only happens for real E2E renames.
+        let result = stream
+        if (sealedName && (await E2eStreamsRepository.updateSealedName(client, stream.workspaceId, streamId, sealedName))) {
+          const full = await StreamRepository.findById(client, streamId)
+          if (full) result = full
         }
-        return stream
+
+        await OutboxRepository.insert(client, "stream:updated", {
+          workspaceId: result.workspaceId,
+          streamId: result.id,
+          stream: result,
+        })
+        return result
       })
     } catch (error) {
       // DB unique constraint catches races the application check misses
-      if (data.slug && isUniqueViolation(error, "streams_workspace_id_slug_key")) {
-        throw new DuplicateSlugError(data.slug)
+      if (streamData.slug && isUniqueViolation(error, "streams_workspace_id_slug_key")) {
+        throw new DuplicateSlugError(streamData.slug)
       }
       throw error
     }

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -688,14 +688,25 @@ export class StreamService {
       visibility?: Visibility
       /**
        * Sealed (encrypted) display name for an E2E stream — stored on
-       * `e2e_streams`, not `streams`. The plaintext `displayName` above is still
-       * sent and stays the locked-state fallback; this is the authoritative name
-       * an unlocked client prefers. Ignored (no-op) for plaintext streams.
+       * `e2e_streams`, not `streams`. The plaintext `displayName` stays the
+       * locked-state fallback; this is the authoritative name an unlocked client
+       * prefers. `{ciphertext, envelope}` sets it, `null` clears it (rename
+       * without a fresh seal), `undefined` leaves it untouched. Required to come
+       * with a `displayName` so the two never desync.
        */
-      sealedName?: { ciphertext: string; envelope: unknown }
+      sealedName?: { ciphertext: string; envelope: unknown } | null
     }
   ): Promise<Stream | null> {
     const { sealedName, ...streamData } = data
+    // A sealed-name change (set or clear) must accompany a plaintext displayName,
+    // or `streams.display_name` and the sealed copy desync (locked/sidebar
+    // surfaces show the old label while unlocked clients decrypt the new one).
+    if (sealedName !== undefined && streamData.displayName === undefined) {
+      throw new HttpError("displayName is required when sealedName is provided", {
+        status: 400,
+        code: "SEALED_NAME_REQUIRES_DISPLAY_NAME",
+      })
+    }
     try {
       return await withTransaction(this.pool, async (client) => {
         // Slug uniqueness check (exclude current stream)
@@ -716,15 +727,15 @@ export class StreamService {
         const stream = await StreamRepository.update(client, streamId, streamData)
         if (!stream) return null
 
-        // The sealed name lives on a different table; persist it in the same
-        // transaction, then re-read the joined stream so the emitted event and
-        // the response carry the new sealed name. The UPDATE no-ops on a
-        // plaintext stream id, so the re-read only happens for real E2E renames.
-        let result = stream
-        if (sealedName && (await E2eStreamsRepository.updateSealedName(client, stream.workspaceId, streamId, sealedName))) {
-          const full = await StreamRepository.findById(client, streamId)
-          if (full) result = full
+        // The sealed name lives on a different table; set/clear it in the same
+        // transaction. `StreamRepository.update` returns only the plaintext
+        // columns, so always re-read the e2e-joined stream before emitting —
+        // otherwise an E2E `stream:updated` would ship a partial shape (missing
+        // e2eEnabled / actors / sealed name). INV-7.
+        if (sealedName !== undefined) {
+          await E2eStreamsRepository.updateSealedName(client, stream.workspaceId, streamId, sealedName)
         }
+        const result = (await StreamRepository.findById(client, streamId)) ?? stream
 
         await OutboxRepository.insert(client, "stream:updated", {
           workspaceId: result.workspaceId,

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -1,0 +1,98 @@
+/**
+ * E2E sealed-stream-name integration tests.
+ *
+ * Exercises the runtime path that unit tests can't: the additive migration
+ * columns on `e2e_streams`, `updateSealedName`'s BYTEA + JSONB binding, the
+ * `streams ⋈ e2e_streams` read projection, and `mapRowToStream`'s base64
+ * surfacing — end-to-end against a real Postgres.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { StreamTypes } from "@threa/types"
+import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { E2eStreamsRepository } from "../../src/features/e2e-streams"
+import { userId, workspaceId, streamId } from "../../src/lib/id"
+
+const ENVELOPE = { v: 2, keyGeneration: 0, iv: "aXYxMjM0NTY3OA==", aad: "c3RyZWFtfG5hbWV8MA==" }
+
+describe("E2E sealed stream name", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  /** Insert a workspace + member + scratchpad, optionally marking it E2E. */
+  async function seedStream(e2e: boolean): Promise<{ wsId: string; sId: string; ownerId: string }> {
+    const wsId = workspaceId()
+    let ownerId = userId()
+    const sId = streamId()
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Sealed Name WS",
+        slug: `sealed-name-${wsId}`,
+        createdBy: ownerId,
+      })
+      ownerId = (await addTestMember(client, wsId, ownerId)).id
+      await StreamRepository.insert(client, {
+        id: sId,
+        workspaceId: wsId,
+        type: StreamTypes.SCRATCHPAD,
+        createdBy: ownerId,
+      })
+      if (e2e) {
+        await E2eStreamsRepository.markStreamE2e(client, {
+          streamId: sId,
+          workspaceId: wsId,
+          ownerUserId: ownerId,
+          ownerUserKeyId: "e2ek_owner",
+        })
+      }
+    })
+    return { wsId, sId, ownerId }
+  }
+
+  test("stores the sealed name and surfaces it (base64 + envelope) on the joined stream", async () => {
+    const { wsId, sId } = await seedStream(true)
+    const ciphertext = Buffer.from("sealed-display-name-ciphertext").toString("base64")
+
+    const updated = await E2eStreamsRepository.updateSealedName(pool, wsId, sId, { ciphertext, envelope: ENVELOPE })
+    expect(updated).toBe(true)
+
+    const stream = await StreamRepository.findById(pool, sId)
+    expect(stream?.e2eEnabled).toBe(true)
+    expect(stream?.sealedNameCiphertext).toBe(ciphertext)
+    expect(stream?.sealedNameEnvelope).toEqual(ENVELOPE)
+  })
+
+  test("a freshly-marked E2E stream has a null sealed name until first rename", async () => {
+    const { sId } = await seedStream(true)
+    const stream = await StreamRepository.findById(pool, sId)
+    expect(stream?.e2eEnabled).toBe(true)
+    expect(stream?.sealedNameCiphertext).toBeNull()
+    expect(stream?.sealedNameEnvelope).toBeNull()
+  })
+
+  test("updateSealedName no-ops for a plaintext (non-E2E) stream", async () => {
+    const { wsId, sId } = await seedStream(false)
+
+    const updated = await E2eStreamsRepository.updateSealedName(pool, wsId, sId, {
+      ciphertext: Buffer.from("x").toString("base64"),
+      envelope: ENVELOPE,
+    })
+    expect(updated).toBe(false)
+
+    const stream = await StreamRepository.findById(pool, sId)
+    // Plaintext streams omit the E2E join fields entirely.
+    expect(stream?.e2eEnabled).toBeUndefined()
+    expect(stream?.sealedNameCiphertext).toBeUndefined()
+  })
+})

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -95,4 +95,24 @@ describe("E2E sealed stream name", () => {
     expect(stream?.e2eEnabled).toBeUndefined()
     expect(stream?.sealedNameCiphertext).toBeUndefined()
   })
+
+  test("null clears a previously-stored sealed name (rename without a fresh seal)", async () => {
+    const { wsId, sId } = await seedStream(true)
+    const ciphertext = Buffer.from("sealed-name").toString("base64")
+    await E2eStreamsRepository.updateSealedName(pool, wsId, sId, { ciphertext, envelope: ENVELOPE })
+    expect((await StreamRepository.findById(pool, sId))?.sealedNameCiphertext).toBe(ciphertext)
+
+    const cleared = await E2eStreamsRepository.updateSealedName(pool, wsId, sId, null)
+    expect(cleared).toBe(true)
+    const stream = await StreamRepository.findById(pool, sId)
+    expect(stream?.sealedNameCiphertext).toBeNull()
+    expect(stream?.sealedNameEnvelope).toBeNull()
+  })
+
+  test("rejects non-canonical base64 instead of storing a corrupt blob", async () => {
+    const { wsId, sId } = await seedStream(true)
+    await expect(
+      E2eStreamsRepository.updateSealedName(pool, wsId, sId, { ciphertext: "!!!!", envelope: ENVELOPE })
+    ).rejects.toThrow(/base64/)
+  })
 })

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -25,7 +25,6 @@ export function useDecryptedStreamName(
 ): string | null {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
-  const [name, setName] = useState<string | null>(null)
 
   const streamId = stream?.id
   const e2eEnabled = stream?.e2eEnabled ?? false
@@ -35,9 +34,22 @@ export function useDecryptedStreamName(
   const keyId = session.keyId
   const privateKey = session.privateKey
 
+  // A stable key for the exact inputs a decrypted name depends on. The decrypted
+  // value is stored against it and only returned when it still matches, so a
+  // previous stream's name (or a pre-rename name) is never shown after the inputs
+  // change but before the async decrypt resolves.
+  const sourceKey =
+    e2eEnabled && streamId && ciphertext && sealedEnvelope && unlocked && keyId && privateKey
+      ? `${workspaceId}:${streamId}:${ciphertext}:${keyId}`
+      : null
+  const [result, setResult] = useState<{ sourceKey: string | null; name: string | null }>({
+    sourceKey: null,
+    name: null,
+  })
+
   useEffect(() => {
-    if (!e2eEnabled || !streamId || !ciphertext || !sealedEnvelope || !unlocked || !keyId || !privateKey) {
-      setName(null)
+    if (!sourceKey || !streamId || !ciphertext || !sealedEnvelope || !keyId || !privateKey) {
+      setResult({ sourceKey: null, name: null })
       return
     }
     let cancelled = false
@@ -45,12 +57,12 @@ export function useDecryptedStreamName(
       { ciphertext, envelope: sealedEnvelope },
       { workspaceId, streamId, recipientKeyId: keyId, privateKey }
     ).then((decrypted) => {
-      if (!cancelled) setName(decrypted)
+      if (!cancelled) setResult({ sourceKey, name: decrypted })
     })
     return () => {
       cancelled = true
     }
-  }, [workspaceId, streamId, e2eEnabled, ciphertext, sealedEnvelope, unlocked, keyId, privateKey])
+  }, [sourceKey, workspaceId, streamId, ciphertext, sealedEnvelope, keyId, privateKey])
 
-  return name
+  return result.sourceKey === sourceKey ? result.name : null
 }

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { tryOpenStreamName } from "@/lib/crypto/message-envelope"
+
+interface SealedNameStream {
+  id: string
+  e2eEnabled?: boolean
+  sealedNameCiphertext?: string | null
+  sealedNameEnvelope?: unknown
+}
+
+/**
+ * The decrypted display name for an E2E stream when the viewer is unlocked, else
+ * null. The plaintext `displayName` is server-mutable; the sealed name is
+ * AAD-bound to its stream (see `buildNameAad`), so preferring the decrypted copy
+ * for an unlocked stream means a malicious server can't silently relabel what the
+ * user sees. Returns null for plaintext streams, a locked session, a missing
+ * sealed name, or any decrypt failure — callers fall back to the plaintext label
+ * (which is also what a locked session shows).
+ */
+export function useDecryptedStreamName(
+  workspaceId: string,
+  stream: SealedNameStream | null | undefined
+): string | null {
+  const userId = useWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const [name, setName] = useState<string | null>(null)
+
+  const streamId = stream?.id
+  const e2eEnabled = stream?.e2eEnabled ?? false
+  const ciphertext = stream?.sealedNameCiphertext ?? null
+  const sealedEnvelope = stream?.sealedNameEnvelope ?? null
+  const unlocked = session.status === "unlocked"
+  const keyId = session.keyId
+  const privateKey = session.privateKey
+
+  useEffect(() => {
+    if (!e2eEnabled || !streamId || !ciphertext || !sealedEnvelope || !unlocked || !keyId || !privateKey) {
+      setName(null)
+      return
+    }
+    let cancelled = false
+    void tryOpenStreamName(
+      { ciphertext, envelope: sealedEnvelope },
+      { workspaceId, streamId, recipientKeyId: keyId, privateKey }
+    ).then((decrypted) => {
+      if (!cancelled) setName(decrypted)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId, streamId, e2eEnabled, ciphertext, sealedEnvelope, unlocked, keyId, privateKey])
+
+  return name
+}

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -469,12 +469,15 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
   const rename = useCallback(
     async (newName: string) => {
-      // For an encrypted stream, also seal the name under the SSK so the server
-      // stores a tamper-evident copy beside the plaintext fallback. Best-effort:
-      // if the session is locked or the key can't be resolved, the rename still
-      // updates the plaintext name (the locked-state fallback) rather than failing.
-      let sealedNameFields: { sealedNameCiphertext: string; sealedNameEnvelope: unknown } | undefined
+      // For an encrypted stream the name has two copies: the plaintext fallback
+      // and a sealed (tamper-evident) copy an unlocked client prefers. We must
+      // never leave a STALE sealed name — if we can't produce a fresh seal (the
+      // session is locked or the key can't be resolved), explicitly CLEAR it
+      // (null) so the new plaintext name is authoritative, instead of leaving the
+      // old ciphertext to outrank it after the next unlock.
+      let sealedNameFields: { sealedNameCiphertext: string | null; sealedNameEnvelope: unknown } | undefined
       if (baseStream?.e2eEnabled && currentUserId) {
+        sealedNameFields = { sealedNameCiphertext: null, sealedNameEnvelope: null }
         const session = getE2eSessionState(workspaceId, currentUserId)
         if (session.status === "unlocked" && session.privateKey && session.keyId) {
           const streamKey = await resolveCurrentStreamKey({

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -5,7 +5,7 @@ import { db, sequenceToNum, type CachedStream } from "@/db"
 import { useStreamService, useMessageService, usePendingMessages } from "@/contexts"
 import { useUser } from "@/auth"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { sealStreamMessage } from "@/lib/crypto/message-envelope"
+import { sealStreamMessage, sealStreamName } from "@/lib/crypto/message-envelope"
 import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
@@ -469,8 +469,35 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
   const rename = useCallback(
     async (newName: string) => {
+      // For an encrypted stream, also seal the name under the SSK so the server
+      // stores a tamper-evident copy beside the plaintext fallback. Best-effort:
+      // if the session is locked or the key can't be resolved, the rename still
+      // updates the plaintext name (the locked-state fallback) rather than failing.
+      let sealedNameFields: { sealedNameCiphertext: string; sealedNameEnvelope: unknown } | undefined
+      if (baseStream?.e2eEnabled && currentUserId) {
+        const session = getE2eSessionState(workspaceId, currentUserId)
+        if (session.status === "unlocked" && session.privateKey && session.keyId) {
+          const streamKey = await resolveCurrentStreamKey({
+            workspaceId,
+            streamId,
+            recipientKeyId: session.keyId,
+            privateKey: session.privateKey,
+          })
+          if (streamKey) {
+            const sealed = await sealStreamName({
+              name: newName,
+              streamId,
+              ssk: streamKey.key,
+              keyGeneration: streamKey.keyGeneration,
+            })
+            sealedNameFields = { sealedNameCiphertext: sealed.ciphertext, sealedNameEnvelope: sealed.envelope }
+          }
+        }
+      }
+
       const updatedStream = await streamService.update(workspaceId, streamId, {
         displayName: newName,
+        ...sealedNameFields,
       })
       await db.streams.put(toCachedStream(updatedStream, idbStream))
 
@@ -489,7 +516,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         }
       })
     },
-    [streamId, workspaceId, streamService, queryClient, idbStream]
+    [streamId, workspaceId, streamService, queryClient, idbStream, baseStream?.e2eEnabled, currentUserId]
   )
 
   const archive = useCallback(async () => {

--- a/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
@@ -8,7 +8,7 @@ import {
   type StreamEnvelope,
 } from "@threa/crypto"
 import { generateUIK } from "../keys"
-import { sealStreamMessage, tryDecryptMessagePayload } from "../message-envelope"
+import { sealStreamMessage, sealStreamName, tryDecryptMessagePayload, tryOpenStreamName } from "../message-envelope"
 import { clearStreamKeyCache } from "../stream-key-cache"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
 
@@ -114,6 +114,46 @@ describe("sealStreamMessage + tryDecryptMessagePayload (v2 SSK loopback)", () =>
       { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: STREAM }
     )
     expect(result).toBeNull()
+  })
+})
+
+describe("sealStreamName + tryOpenStreamName (sealed stream name loopback)", () => {
+  it("round-trips a name sealed under the SSK and opened via the resolved wrap", async () => {
+    const uik = await generateUIK()
+    const ssk = generateStreamKey()
+    await stubOwnerWrap(ssk, uik.publicKey)
+
+    const sealed = await sealStreamName({ name: "Therapy notes", streamId: STREAM, ssk, keyGeneration: 0 })
+    expect(sealed.envelope.keyGeneration).toBe(0)
+
+    const name = await tryOpenStreamName(
+      { ciphertext: sealed.ciphertext, envelope: sealed.envelope },
+      { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: STREAM }
+    )
+    expect(name).toBe("Therapy notes")
+  })
+
+  it("returns null when there is no sealed name", async () => {
+    const uik = await generateUIK()
+    const name = await tryOpenStreamName(
+      { ciphertext: null, envelope: null },
+      { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: STREAM }
+    )
+    expect(name).toBeNull()
+  })
+
+  it("returns null when the viewer holds no wrap for the name's generation", async () => {
+    const uik = await generateUIK()
+    const ssk = generateStreamKey()
+    await stubOwnerWrap(ssk, uik.publicKey, "e2ek_someone_else")
+
+    const sealed = await sealStreamName({ name: "Secret name", streamId: STREAM, ssk, keyGeneration: 0 })
+
+    const name = await tryOpenStreamName(
+      { ciphertext: sealed.ciphertext, envelope: sealed.envelope },
+      { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: STREAM }
+    )
+    expect(name).toBeNull()
   })
 })
 

--- a/apps/frontend/src/lib/crypto/message-envelope.ts
+++ b/apps/frontend/src/lib/crypto/message-envelope.ts
@@ -3,6 +3,7 @@ import type { JSONContent } from "@tiptap/react"
 import {
   base64ToBytes,
   buildMessageAad,
+  buildNameAad,
   bytesToBase64,
   decryptPayloadAsString,
   ENVELOPE_VERSION,
@@ -58,6 +59,56 @@ export async function sealStreamMessage(input: SealStreamMessageInput): Promise<
     aad,
   })
   return { ciphertext: bytesToBase64(ciphertext), envelope, e2eVersion: STREAM_ENVELOPE_VERSION }
+}
+
+/**
+ * Seal a stream's display name under its SSK, bound to `(streamId, "name",
+ * generation)` so a malicious server can't relocate it onto another stream or
+ * swap it with a message body. Stored alongside the plaintext `displayName`
+ * (which stays the locked-state fallback); an unlocked client prefers this
+ * tamper-evident copy. Reuses the same SSK ciphertext path as messages.
+ */
+export async function sealStreamName(input: {
+  name: string
+  streamId: string
+  ssk: Uint8Array
+  keyGeneration: number
+}): Promise<{ ciphertext: string; envelope: StreamEnvelope }> {
+  const aad = buildNameAad({ streamId: input.streamId, keyGeneration: input.keyGeneration })
+  const { envelope, ciphertext } = await sealMessage({
+    key: input.ssk,
+    keyGeneration: input.keyGeneration,
+    payload: input.name,
+    aad,
+  })
+  return { ciphertext: bytesToBase64(ciphertext), envelope }
+}
+
+/**
+ * Open a sealed stream name. Resolves the SSK for the envelope's generation via
+ * the stream's wraps and decrypts. Returns null when there's no sealed name, the
+ * envelope is unparseable, the SSK can't be resolved (not a recipient / locked),
+ * or the AAD is forged — callers fall back to the plaintext name.
+ */
+export async function tryOpenStreamName(
+  payload: { ciphertext?: string | null; envelope?: unknown },
+  opts: DecryptMessageOpts
+): Promise<string | null> {
+  const env = parseStreamEnvelope(payload.envelope)
+  if (!env || typeof payload.ciphertext !== "string") return null
+  try {
+    const ssk = await resolveStreamKey({
+      workspaceId: opts.workspaceId,
+      streamId: opts.streamId,
+      keyGeneration: env.keyGeneration,
+      recipientKeyId: opts.recipientKeyId,
+      privateKey: opts.privateKey,
+    })
+    if (!ssk) return null
+    return await openMessageAsString({ key: ssk, envelope: env, ciphertext: base64ToBytes(payload.ciphertext) })
+  } catch {
+    return null
+  }
 }
 
 export interface DecryptMessagePayload {

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -37,6 +37,7 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
+import { useDecryptedStreamName } from "@/hooks/use-decrypted-stream-name"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
@@ -105,6 +106,9 @@ export function StreamPage() {
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
   const dmPeers = useWorkspaceDmPeers(workspaceId ?? "")
+  // For an unlocked encrypted stream, the tamper-evident decrypted name; null
+  // otherwise (plaintext stream, locked, or not yet decrypted) → plaintext label.
+  const decryptedStreamName = useDecryptedStreamName(workspaceId ?? "", stream)
 
   const isThread = stream?.type === StreamTypes.THREAD
   const isChannel = stream?.type === StreamTypes.CHANNEL
@@ -143,7 +147,7 @@ export function StreamPage() {
   const isDmDraft = isDraft && isDmDraftId(streamId)
   let streamName = "Stream"
   if (stream) {
-    streamName = streamLabel(stream)
+    streamName = decryptedStreamName ?? streamLabel(stream)
   } else if (isDraft) {
     streamName = streamFallbackLabel(isDmDraft ? "dm" : "scratchpad", "sidebar")
   }

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -68,10 +68,12 @@ The key model, in plain terms:
 This feature is `building`. What it deliberately does **not** do yet — the
 known-missing tally, kept current as gaps close:
 
-- **Stream names are plaintext.** A stream's display name is server-visible
-  metadata stored in the clear; only message content and AI trace data are
-  encrypted. Server-side AI name polish is disabled for encrypted streams, so the
-  name falls back to the first ~40 characters of the first message.
+- **Stream names keep a server-visible plaintext copy.** Renaming an encrypted
+  scratchpad now also seals the name under the stream key (a tamper-evident copy
+  the app prefers once unlocked), but a plaintext `displayName` is still stored so
+  the name shows everywhere even while locked — which means the server can still
+  see titles. This is a deliberate trade for display continuity, not full title
+  privacy. Server-side AI name polish stays disabled for encrypted streams.
 - **Passphrase only — no PIN.** There is no 6/8-digit PIN unlock (Signal /
   Messenger style). Unlock is passphrase + Argon2id.
 - **No biometric / WebAuthn unlock.** Device trust today is the "keep me unlocked

--- a/packages/crypto/src/__tests__/stream-key.test.ts
+++ b/packages/crypto/src/__tests__/stream-key.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { utf8Decode, utf8Encode } from "../encoding"
+import { bytesToBase64, utf8Decode, utf8Encode } from "../encoding"
 import { buildMessageAad } from "../envelope"
 import { exportPublicKey, generateKeyPair } from "../hpke"
 import {
+  buildNameAad,
   buildWrapAad,
   generateStreamKey,
   openMessage,
@@ -29,6 +30,44 @@ describe("generateStreamKey", () => {
     expect(a).toHaveLength(32)
     expect(b).toHaveLength(32)
     expect(a).not.toEqual(b)
+  })
+})
+
+describe("buildNameAad", () => {
+  it("binds streamId, a fixed 'name' label, and generation", () => {
+    const aad = buildNameAad({ streamId: "stream_1", keyGeneration: 0 })
+    expect(utf8Decode(aad)).toBe("stream_1|name|0")
+  })
+
+  it("is disjoint from a wrap AAD with the same stream + generation", () => {
+    const name = buildNameAad({ streamId: "stream_1", keyGeneration: 1 })
+    const wrap = buildWrapAad({ streamId: "stream_1", keyGeneration: 1, recipientKeyId: "uik_alice" })
+    expect(utf8Decode(name)).not.toBe(utf8Decode(wrap))
+  })
+
+  it("rejects an empty streamId, a delimiter in the id, and a bad generation", () => {
+    expect(() => buildNameAad({ streamId: "", keyGeneration: 0 })).toThrow()
+    expect(() => buildNameAad({ streamId: "a|b", keyGeneration: 0 })).toThrow()
+    expect(() => buildNameAad({ streamId: "stream_1", keyGeneration: -1 })).toThrow()
+    expect(() => buildNameAad({ streamId: "stream_1", keyGeneration: 1.5 })).toThrow()
+  })
+
+  it("seals a name that opens under the same slot and rejects a relocated one", async () => {
+    const key = generateStreamKey()
+    const { envelope, ciphertext } = await sealMessage({
+      key,
+      keyGeneration: 0,
+      payload: "Therapy notes",
+      aad: buildNameAad({ streamId: "stream_1", keyGeneration: 0 }),
+    })
+
+    // The AAD travels on the envelope, so a faithful open recovers the name.
+    await expect(openMessageAsString({ key, envelope, ciphertext })).resolves.toBe("Therapy notes")
+
+    // A server that relocates the sealed name onto another stream forges the AAD;
+    // opening with the relocated binding must fail (AES-GCM tag check).
+    const relocated = { ...envelope, aad: bytesToBase64(buildNameAad({ streamId: "stream_2", keyGeneration: 0 })) }
+    await expect(openMessageAsString({ key, envelope: relocated, ciphertext })).rejects.toThrow()
   })
 })
 

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -35,6 +35,7 @@ export {
   wrapStreamKey,
   unwrapStreamKey,
   buildWrapAad,
+  buildNameAad,
   type StreamEnvelope,
   type SealMessageInput,
   type SealMessageResult,

--- a/packages/crypto/src/stream-key.ts
+++ b/packages/crypto/src/stream-key.ts
@@ -236,3 +236,32 @@ export function buildWrapAad(parts: {
     utf8Encode(parts.recipientKeyId)
   )
 }
+
+/**
+ * Canonical AAD for a stream's *sealed name* — the encrypted copy of a stream's
+ * display name stored alongside the plaintext fallback. Binds the ciphertext to
+ * its `(streamId, generation)` slot plus a fixed `name` label, so a malicious
+ * server can't relocate a sealed name onto another stream or swap it with a
+ * sealed message body (whose AAD is `streamId|messageId|senderId`). The `name`
+ * literal keeps this namespace disjoint from `buildWrapAad`'s layout even though
+ * both start with `streamId|generation`. Keep stable — changing it breaks every
+ * existing sealed name. Same delimiter-safety rules as `buildWrapAad`.
+ */
+export function buildNameAad(parts: { streamId: string; keyGeneration: number }): Uint8Array<ArrayBuffer> {
+  if (parts.streamId.length === 0) {
+    throw new Error("buildNameAad: streamId must be non-empty")
+  }
+  if (parts.streamId.includes("|")) {
+    throw new Error("buildNameAad: streamId must not contain '|'")
+  }
+  if (!Number.isInteger(parts.keyGeneration) || parts.keyGeneration < 0) {
+    throw new Error("buildNameAad: keyGeneration must be a non-negative integer")
+  }
+  return concatBytes(
+    utf8Encode(parts.streamId),
+    utf8Encode("|"),
+    utf8Encode("name"),
+    utf8Encode("|"),
+    utf8Encode(String(parts.keyGeneration))
+  )
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -86,10 +86,11 @@ export interface UpdateStreamInput {
   /**
    * Encrypted display name for an E2E stream — base64 ciphertext + its
    * `StreamEnvelope` framing (typed `unknown` to keep this package crypto-free).
-   * Sent alongside the plaintext `displayName` on rename; both halves travel
-   * together or not at all.
+   * Sent alongside the plaintext `displayName` on rename. Both halves travel
+   * together (set), both `null` together (clear the sealed name when a rename
+   * can't produce a fresh seal), or both omitted.
    */
-  sealedNameCiphertext?: string
+  sealedNameCiphertext?: string | null
   sealedNameEnvelope?: unknown
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -83,6 +83,14 @@ export interface UpdateStreamInput {
   visibility?: Visibility
   companionMode?: CompanionMode
   companionPersonaId?: string
+  /**
+   * Encrypted display name for an E2E stream — base64 ciphertext + its
+   * `StreamEnvelope` framing (typed `unknown` to keep this package crypto-free).
+   * Sent alongside the plaintext `displayName` on rename; both halves travel
+   * together or not at all.
+   */
+  sealedNameCiphertext?: string
+  sealedNameEnvelope?: unknown
 }
 
 export interface UpdateCompanionModeInput {

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -186,6 +186,15 @@ export interface Stream {
    * E2E JOIN is omitted entirely.
    */
   e2eActors?: E2eActor[]
+  /**
+   * The stream's display name sealed under the SSK (base64 ciphertext + its
+   * `StreamEnvelope` framing, typed `unknown` to keep this package crypto-free).
+   * Both null until the stream is first renamed while E2E. An unlocked client
+   * decrypts and prefers this; `displayName` above stays the locked-state
+   * fallback. Present (possibly null) only on E2E streams.
+   */
+  sealedNameCiphertext?: string | null
+  sealedNameEnvelope?: unknown | null
 }
 
 /** A non-human participant the stream key is wrapped to in an E2E stream. */


### PR DESCRIPTION
## What & why

Third PR in the **E2E-Ariadne alignment stack** (stacked on #744). Encrypted stream naming, per the agreed shape: store **both** a plaintext `displayName` (always visible, the locked-state fallback) **and** a sealed copy under the stream key. Names keep working exactly as before; the sealed copy adds a tamper-evident, authoritative name when unlocked.

Trade-off (chosen deliberately): the plaintext copy means the **server can still see titles**. This is display continuity over full title privacy — the sealed copy is the foundation for a future placeholder-plaintext mode.

## How (three verified commits)

1. **`crypto`** — `buildNameAad({ streamId, generation })` binds the sealed name to `streamId|"name"|generation`, disjoint from `buildWrapAad`/`buildMessageAad`. Reuses the existing `sealMessage`/`openMessage` SSK path. (+4 tests)
2. **backend + types** — additive `name_ciphertext`/`name_envelope` on `e2e_streams`; rename seals client-side and the backend stores it on `e2e_streams` in the **same transaction** as the plaintext update, then re-reads the joined stream so `stream:updated` and the response carry it. Surfaced on the wire `Stream` via the existing e2e LEFT JOIN (both read projections + `mapRowToStream`). `updateStream` splits the sealed name out of the streams UPDATE; the `e2e_streams` UPDATE no-ops on plaintext ids so non-E2E renames are untouched.
3. **frontend** — `sealStreamName`/`tryOpenStreamName` helpers; rename seals for E2E streams (best-effort — locked session still renames the plaintext); the stream header prefers the decrypted name when unlocked (`useDecryptedStreamName`). The server can mutate the plaintext `displayName` but not the AAD-bound sealed copy, so an unlocked stream shows a name the server can't silently relabel.

## Boundaries / scope notes

- The decrypted-name read is wired into the **stream header** (the highest-value surface, with the integrity rationale above). The sidebar/breadcrumbs keep showing the plaintext label — identical to the sealed value today, so no divergence — rather than threading the decrypt through every name surface. Easy to widen later if we move the plaintext to a placeholder.
- AI auto-naming stays short-circuited for E2E (unchanged).

## Test plan

- `crypto`: 25 pass (incl. 4 new `buildNameAad`).
- `frontend`: `message-envelope` 8 pass (incl. 3 new sealed-name round-trips); typecheck + eslint clean.
- `backend`: streams handlers/service/repository + e2e-streams repository — 63 pass; backend typecheck clean.

Feature doc updated: `public/e2e-encrypted-scratchpads.md` Boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783066709&installation_id=129946197&pr_number=745&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F745&signature=fd057ab9631665ce6d7dec64d2d9038593831e886d0924d6f9df90957f996c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->