### PR TITLE
feat(e2e): enclave interjection catch-up (parity with main app)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -9,6 +9,7 @@ import { AgentSessionRepository, SessionStatuses } from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
 import type { EventService } from "../messaging"
+import type { QueueManager } from "../../lib/queue"
 import { createEnclaveSessionHandlers } from "./session-handlers"
 
 const pool = {} as Pool
@@ -42,6 +43,7 @@ const SESSION = {
   personaId: "persona_ariadne",
   status: SessionStatuses.RUNNING,
   lastSeenSequence: null,
+  triggerMessageId: "msg_trigger",
   createdAt: new Date("2026-05-30T00:00:00.000Z"),
 } as unknown as Awaited<ReturnType<typeof AgentSessionRepository.findById>>
 
@@ -77,10 +79,16 @@ function fakeIo() {
   return { io, emit }
 }
 
+function fakeJobQueue() {
+  const send = mock(async (_queue: string, _data: unknown) => "job_test")
+  return { jobQueue: { send } as unknown as QueueManager, send }
+}
+
 function makeHandlers(createMessage = mock(async (_input: Record<string, unknown>) => ({}) as never)) {
   const eventService = { createMessage } as unknown as EventService
   const { io, emit } = fakeIo()
-  return { handlers: createEnclaveSessionHandlers({ pool, eventService, io }), createMessage, io, emit }
+  const { jobQueue, send } = fakeJobQueue()
+  return { handlers: createEnclaveSessionHandlers({ pool, eventService, io, jobQueue }), createMessage, io, emit, send }
 }
 
 describe("createEnclaveSessionHandlers.message", () => {
@@ -156,12 +164,16 @@ describe("createEnclaveSessionHandlers.complete", () => {
       fn(tx)) as never)
     const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
     const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
-    const { handlers, createMessage, io, emit } = makeHandlers()
+    // No user message arrived during the turn → no follow-up dispatch.
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
+    spyOn(StreamEventRepository, "getLatestUnseenUserMessage").mockResolvedValue(null)
+    const { handlers, createMessage, io, emit, send } = makeHandlers()
     const res = fakeRes()
 
     await handlers.complete(req("session_1", COMPLETE_BODY), res)
 
     expect(res.statusCode).toBe(204)
+    expect(send).not.toHaveBeenCalled() // nothing unseen → no catch-up turn
     expect(createMessage).not.toHaveBeenCalled() // replies were already streamed via /messages
     expect(complete).toHaveBeenCalledTimes(1)
     // Completion + event are one atomic transaction (INV-7): completeSession runs
@@ -182,6 +194,39 @@ describe("createEnclaveSessionHandlers.complete", () => {
     // And a live-open trace dialog (session room) is transitioned to completed.
     expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
     expect(emit.mock.calls.some((c) => c[0] === "agent_session:completed")).toBe(true)
+  })
+
+  it("dispatches a catch-up enclave turn for a user message that arrived mid-turn", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    // The trigger was at sequence 5; a user message landed at 9 while the turn ran.
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
+    spyOn(StreamEventRepository, "getLatestUnseenUserMessage").mockResolvedValue({
+      messageId: "msg_new",
+      authorId: "usr_1",
+      sequence: 9n,
+    })
+    const { handlers, send } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", COMPLETE_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0]![0]).toBe("enclave.invoke")
+    expect(send.mock.calls[0]![1]).toMatchObject({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      messageId: "msg_new",
+      triggeredBy: "usr_1",
+    })
   })
 
   it("does not emit the completed event when the session raced to a terminal state", async () => {
@@ -430,13 +475,23 @@ describe("createEnclaveSessionHandlers.substep", () => {
 
 describe("createEnclaveSessionHandlers.heartbeat", () => {
   it("400s without a session id", async () => {
-    const handlers = createEnclaveSessionHandlers({ pool, eventService: {} as EventService, io: fakeIo().io })
+    const handlers = createEnclaveSessionHandlers({
+      pool,
+      eventService: {} as EventService,
+      io: fakeIo().io,
+      jobQueue: fakeJobQueue().jobQueue,
+    })
     await expect(handlers.heartbeat(req(undefined, {}), fakeRes())).rejects.toBeInstanceOf(HttpError)
   })
 
   it("refreshes the heartbeat and 204s", async () => {
     const beat = spyOn(AgentSessionRepository, "updateHeartbeat").mockResolvedValue(undefined)
-    const handlers = createEnclaveSessionHandlers({ pool, eventService: {} as EventService, io: fakeIo().io })
+    const handlers = createEnclaveSessionHandlers({
+      pool,
+      eventService: {} as EventService,
+      io: fakeIo().io,
+      jobQueue: fakeJobQueue().jobQueue,
+    })
     const res = fakeRes()
     await handlers.heartbeat(req("session_1", {}), res)
     expect(beat).toHaveBeenCalledWith(pool, "session_1")

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -5,7 +5,9 @@ import type { Server } from "socket.io"
 import { AGENT_STEP_TYPES, AuthorTypes, E2E_PLACEHOLDER_CONTENT_MARKDOWN, type JSONContent } from "@threa/types"
 import { withTransaction } from "../../db"
 import { eventId } from "../../lib/id"
+import { logger } from "../../lib/logger"
 import { OutboxRepository } from "../../lib/outbox"
+import { JobQueues, type QueueManager } from "../../lib/queue"
 import { HttpError } from "../../lib/errors"
 import { AgentSessionRepository, SessionStatuses, getBuiltInAgentConfig, type AgentSession } from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
@@ -95,6 +97,8 @@ interface Dependencies {
   eventService: EventService
   /** Sealed steps broadcast to the session room for live trace rendering. Always present in the API process. */
   io: Server
+  /** Enqueues the catch-up follow-up turn on completion (enclave interjection parity). */
+  jobQueue: QueueManager
 }
 
 /**
@@ -137,7 +141,7 @@ function emitInlineProgress(
   })
 }
 
-export function createEnclaveSessionHandlers({ pool, eventService, io }: Dependencies) {
+export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue }: Dependencies) {
   return {
     /**
      * POST /internal/enclave-runtimes/sessions/:id/heartbeat
@@ -450,6 +454,40 @@ export function createEnclaveSessionHandlers({ pool, eventService, io }: Depende
       // stream room, so the dialog wouldn't otherwise transition until a refetch.
       if (committed && stream) {
         io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:completed", { sessionId: id })
+      }
+
+      // Interjection catch-up (parity with the main app's `checkForUnseenMessages`,
+      // persona-agent-worker.ts): a user message that landed while this turn ran was
+      // suppressed by the one-running guard in the enclave-invoke worker, so dispatch
+      // a follow-up turn for the latest such message. The enclave saw history up to
+      // its trigger and nothing after, so the trigger's sequence is the "seen"
+      // boundary. Only after we actually won the completion, so a raced redelivery
+      // doesn't double-dispatch. Best-effort: a failed enqueue is logged, not fatal —
+      // the next user message would re-trigger anyway.
+      if (committed && stream && session.triggerMessageId) {
+        try {
+          const triggerSeq = await StreamEventRepository.getMessageSequence(
+            pool,
+            session.streamId,
+            session.triggerMessageId
+          )
+          if (triggerSeq !== null) {
+            const unseen = await StreamEventRepository.getLatestUnseenUserMessage(pool, session.streamId, triggerSeq)
+            if (unseen) {
+              await jobQueue.send(JobQueues.ENCLAVE_INVOKE, {
+                workspaceId: stream.workspaceId,
+                streamId: session.streamId,
+                messageId: unseen.messageId,
+                triggeredBy: unseen.authorId,
+              })
+            }
+          }
+        } catch (err) {
+          logger.error(
+            { err, sessionId: id, streamId: session.streamId },
+            "Enclave interjection follow-up dispatch failed"
+          )
+        }
       }
 
       res.status(204).end()

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -463,6 +463,51 @@ export const StreamEventRepository = {
   },
 
   /**
+   * The most recent USER message that arrived strictly after `afterSequence`,
+   * with its id and sequence — or null if none. Used by the enclave catch-up on
+   * session completion: it dispatches a follow-up turn for the latest message a
+   * just-finished turn never saw (the enclave mirror of `checkForUnseenMessages`).
+   * USER-only, so a persona reply never re-triggers the follow-up.
+   */
+  async getLatestUnseenUserMessage(
+    db: Querier,
+    streamId: string,
+    afterSequence: bigint
+  ): Promise<{ messageId: string; authorId: string; sequence: bigint } | null> {
+    const result = await db.query<{ message_id: string; actor_id: string; sequence: string }>(sql`
+      SELECT payload->>'messageId' AS message_id, actor_id, sequence
+      FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type = 'message_created'
+        AND actor_type = 'user'
+        AND sequence > ${afterSequence.toString()}
+        AND payload->>'messageId' IS NOT NULL
+        AND actor_id IS NOT NULL
+      ORDER BY sequence DESC
+      LIMIT 1
+    `)
+    const row = result.rows[0]
+    return row ? { messageId: row.message_id, authorId: row.actor_id, sequence: BigInt(row.sequence) } : null
+  },
+
+  /**
+   * The sequence of a message's `message_created` event, or null if it has none
+   * (deleted, or never a message event). The enclave uses the trigger's sequence
+   * as the "seen up to here" boundary on completion — the enclave was given
+   * history up to its trigger and nothing after it.
+   */
+  async getMessageSequence(db: Querier, streamId: string, messageId: string): Promise<bigint | null> {
+    const result = await db.query<{ sequence: string }>(sql`
+      SELECT sequence FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type = 'message_created'
+        AND payload->>'messageId' = ${messageId}
+      LIMIT 1
+    `)
+    return result.rows[0] ? BigInt(result.rows[0].sequence) : null
+  },
+
+  /**
    * List message IDs emitted by a specific agent session.
    * Uses message_created event payload.sessionId to include messages sent before
    * session completion (when agent_sessions.sent_message_ids may still be empty).

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -85,6 +85,7 @@ import type { WorkosOrgService } from "@threa/backend-common"
 import type { BotApiKeyService } from "./features/public-api"
 import type { Pool } from "pg"
 import type { PoolMonitor } from "./lib/observability"
+import type { QueueManager } from "./lib/queue"
 
 interface Dependencies {
   pool: Pool
@@ -131,6 +132,7 @@ interface Dependencies {
   storage: StorageProvider
   ai: AI
   controlPlaneClient: ControlPlaneClient | null
+  jobQueue: QueueManager
 }
 
 export function registerRoutes(app: Express, deps: Dependencies) {
@@ -278,7 +280,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
     // Session callbacks: a live enclave drives an assigned turn over these
     // (liveness refresh + sealed replies on completion). Same shared-secret gate.
-    const enclaveSession = createEnclaveSessionHandlers({ pool, eventService, io: deps.io })
+    const enclaveSession = createEnclaveSessionHandlers({ pool, eventService, io: deps.io, jobQueue: deps.jobQueue })
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
     app.post("/internal/enclave-runtimes/sessions/:id/steps/started", internalAuth, enclaveSession.stepStarted)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -548,6 +548,7 @@ export async function startServer(): Promise<ServerInstance> {
   registerRoutes(app, {
     pool,
     io,
+    jobQueue,
     poolMonitor,
     authService,
     workspaceService,

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -81,9 +81,13 @@ known-missing tally, kept current as gaps close:
 - **Attachments are not encrypted yet.** Encrypt-before-upload for E2E attachments
   is being built in a separate change; until it lands, attachments are out of
   scope for encrypted scratchpads.
-- **No mid-generation interjection.** You can't yet send a message (or edit one to
-  reconsider) while Ariadne is mid-turn and have it fold into the running turn.
-  The only mid-turn control is the graceful "Stop research" abort.
+- **Interjections are picked up after the current turn, not folded into it.** If you
+  send a message while Ariadne is mid-turn, it isn't ignored: when the running turn
+  finishes, a follow-up turn automatically runs for the message(s) that arrived
+  during it — the same finish-then-catch-up behavior the non-encrypted Ariadne uses.
+  What's still missing is *mid-turn* adaptation (folding the new message into the
+  in-flight turn) and edit-to-reconsider. The mid-turn control today is the graceful
+  "Stop research" abort.
 - **Ariadne is web-only in the enclave.** Inside an encrypted stream, Ariadne has
   web research and URL reading; it cannot reach workspace tools (GAM memory,
   reading other streams) because that would require plaintext egress from the


### PR DESCRIPTION
## What & why

Fourth PR in the **E2E-Ariadne alignment stack** (stacked on #745). Fixes interjection in encrypted scratchpads — and does it the way the **main app already does**, not by superseding.

**The bug:** `EnclaveDispatchHandler` enqueues an invoke for every user message, but the invoke worker's one-running-per-stream guard (`insertRunningOrSkip`) *skips* a new invocation while a session is RUNNING. So a message sent while Ariadne is mid-turn was silently stranded.

**The fix (parity):** the non-encrypted Ariadne handles this via `persona-agent-worker`'s `checkForUnseenMessages` — finish the current turn, then dispatch a follow-up for messages that arrived during it. This PR gives the enclave path the same behavior: on `/complete`, if a user message arrived after the trigger's sequence (the enclave's "seen" boundary — it received history up to its trigger and nothing after), dispatch a follow-up `ENCLAVE_INVOKE` for the latest one.

We deliberately did **not** implement supersede (cancel-and-restart): it would make enclave Ariadne behave differently from main-app Ariadne (against the "one and the same" mandate) and would fight the one-running guard / the deferred `agent_sessions` PK refactor. (Decision discussed with @kristoffer.)

## How

- `StreamEventRepository.getMessageSequence` (trigger's seen boundary) + `getLatestUnseenUserMessage` (latest USER message after a sequence, with author for `triggeredBy`).
- `/complete`, after the completion commits, dispatches the follow-up. Best-effort (logged, not fatal). Gated on winning the completion so a raced redelivery can't double-dispatch.
- Threads `jobQueue` into `createEnclaveSessionHandlers` (routes + server wiring).

Terminates cleanly: the follow-up turn's own trigger becomes the new boundary, so once no newer user message exists, no further follow-up fires.

## Test plan

- `session-handlers` unit: 24 pass, incl. a new test asserting the catch-up dispatches `enclave.invoke` with the unseen message, and the happy path asserting **no** dispatch when nothing's unseen.
- Backend typecheck + eslint clean.
- Integration (boots the full server with the new `jobQueue` route dep): access-control 19 pass — confirms the DI wiring doesn't break boot.

Feature doc updated: `public/e2e-encrypted-scratchpads.md` Boundaries (interjection bullet).

## Boundaries

Still not done (by design, this PR): *mid-turn* folding of a new message into the in-flight turn, and edit-to-reconsider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783069756&installation_id=129946197&pr_number=746&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F746&signature=e31e46f4ff53821483814e9dde902fbb9edee1094f133c845f5ee2e8a0c8868d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->