### PR TITLE
feat(e2e): inline encryption onboarding (no Settings detour)

### DIFF
--- a/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
+++ b/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
@@ -13,6 +13,10 @@ interface OpenUnlockOptions {
 
 interface OpenSetupOptions {
   defaultTrustDevice?: boolean
+  /** Run once setup succeeds — lets a caller continue the action that needed a
+   *  key (e.g. finish creating the encrypted scratchpad the user just asked for)
+   *  instead of dead-ending on a "set up encryption first" message. */
+  onComplete?: () => void
 }
 
 export interface E2eUnlockContextValue {
@@ -53,6 +57,7 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
   const [unlockDefaultTrust, setUnlockDefaultTrust] = useState(true)
   const [setupDefaultTrust, setSetupDefaultTrust] = useState(true)
   const onUnlockedRef = useRef<(() => void) | null>(null)
+  const onSetupRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     if (userId) void loadE2eKeyForUser(workspaceId, userId)
@@ -66,6 +71,7 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
 
   const openSetup = useCallback((opts?: OpenSetupOptions) => {
     setSetupDefaultTrust(opts?.defaultTrustDevice ?? true)
+    onSetupRef.current = opts?.onComplete ?? null
     setSetupOpen(true)
   }, [])
 
@@ -90,6 +96,7 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
             userId={userId}
             defaultTrustDevice={setupDefaultTrust}
             onOpenChange={setSetupOpen}
+            onSetupComplete={() => onSetupRef.current?.()}
           />
         </>
       )}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -333,9 +333,16 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   }
 
   const openCreatedEncryptedScratchpad = async (withAriadne: boolean) => {
-    const streamId = await createEncryptedScratchpad(withAriadne)
-    collapseOnMobile()
-    navigate(`/w/${workspaceId}/s/${streamId}`)
+    // Called both directly and deferred (via the modal's onComplete, fired as
+    // `void`), so it must own its own error feedback — an unhandled rejection
+    // after setup/unlock would otherwise leave the user with no signal.
+    try {
+      const streamId = await createEncryptedScratchpad(withAriadne)
+      collapseOnMobile()
+      navigate(`/w/${workspaceId}/s/${streamId}`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't create the encrypted scratchpad")
+    }
   }
 
   // Asking for an encrypted scratchpad IS the onboarding trigger: if the user
@@ -344,13 +351,17 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // first" message. Falls back to a direct create only outside the unlock
   // provider (unit harnesses); the provider is always present in the app.
   const handleCreateEncryptedScratchpad = async (withAriadne: boolean) => {
-    const session = currentUser ? getE2eSessionState(workspaceId, currentUser.id) : null
-    if (!e2eUnlock || session?.status === "unlocked") {
+    // The create needs a resolved workspace user; without one the onboarding
+    // modals would run for an action that can't succeed. Bail early (briefly,
+    // until the workspace finishes hydrating) rather than route through setup.
+    if (!currentUser) return
+    const session = getE2eSessionState(workspaceId, currentUser.id)
+    if (!e2eUnlock || session.status === "unlocked") {
       await openCreatedEncryptedScratchpad(withAriadne)
       return
     }
     const finish = () => void openCreatedEncryptedScratchpad(withAriadne)
-    if (session?.status === "no-key") {
+    if (session.status === "no-key") {
       e2eUnlock.openSetup({ onComplete: finish })
     } else {
       e2eUnlock.openUnlock({ onUnlocked: finish })

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -4,6 +4,8 @@ import { FileText, Lock, RefreshCw, StickyNote } from "lucide-react"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
+import { useE2eUnlockOptional } from "@/components/encryption/e2e-unlock-provider"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
 import {
   useActivityCounts,
   useAllDrafts,
@@ -83,6 +85,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const navigate = useNavigate()
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
   const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
+  const e2eUnlock = useE2eUnlockOptional()
 
   const draftCount = allDrafts.length
   const savedCount = useLiveSavedCount(workspaceId)
@@ -329,13 +332,29 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     navigate(`/w/${workspaceId}/s/${draftId}`)
   }
 
-  // `runSidebarAction` toasts on throw, so let the encrypted creator's session
-  // checks propagate ("Unlock encrypted scratchpads first…") rather than
-  // swallowing them here.
-  const handleCreateEncryptedScratchpad = async (withAriadne: boolean) => {
+  const openCreatedEncryptedScratchpad = async (withAriadne: boolean) => {
     const streamId = await createEncryptedScratchpad(withAriadne)
     collapseOnMobile()
     navigate(`/w/${workspaceId}/s/${streamId}`)
+  }
+
+  // Asking for an encrypted scratchpad IS the onboarding trigger: if the user
+  // has no key yet (or is locked), open setup/unlock inline and create the
+  // scratchpad the moment they finish — never dead-end on a "set up encryption
+  // first" message. Falls back to a direct create only outside the unlock
+  // provider (unit harnesses); the provider is always present in the app.
+  const handleCreateEncryptedScratchpad = async (withAriadne: boolean) => {
+    const session = currentUser ? getE2eSessionState(workspaceId, currentUser.id) : null
+    if (!e2eUnlock || session?.status === "unlocked") {
+      await openCreatedEncryptedScratchpad(withAriadne)
+      return
+    }
+    const finish = () => void openCreatedEncryptedScratchpad(withAriadne)
+    if (session?.status === "no-key") {
+      e2eUnlock.openSetup({ onComplete: finish })
+    } else {
+      e2eUnlock.openUnlock({ onUnlocked: finish })
+    }
   }
 
   const scratchpadAddMenuActions: SidebarActionItem[] = [

--- a/apps/frontend/src/hooks/use-create-encrypted-scratchpad.ts
+++ b/apps/frontend/src/hooks/use-create-encrypted-scratchpad.ts
@@ -31,7 +31,10 @@ export function useCreateEncryptedScratchpad(workspaceId: string, currentUserId:
       }
       const session = getE2eSessionState(workspaceId, currentUserId)
       if (session.status !== "unlocked" || !session.keyId || !session.publicKey) {
-        throw new Error("Unlock encrypted scratchpads first (Settings → Encryption)")
+        // Callers onboard first (the sidebar opens setup/unlock inline before
+        // calling this), so reaching here is a programming error, not a
+        // user-facing state — never surface a "go set up encryption" message.
+        throw new Error("createEncryptedScratchpad called without an unlocked E2E session")
       }
       const ownerKeyId = session.keyId
       const ownerPublicKey = session.publicKey

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test"
+import { loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * Browser verification for the E2E-alignment stack's user-facing surfaces that
+ * don't need a live enclave (the enclave isn't started under dev:test):
+ *
+ *  - the full-page unlock GATE replaces the timeline/composer when an encrypted
+ *    scratchpad is locked, and yields to the timeline once unlocked;
+ *  - the header "Encrypted" pill marks the stream;
+ *  - renaming an unlocked encrypted scratchpad persists and displays.
+ *
+ * Interjection catch-up is exercised by the backend unit + integration suites
+ * (it runs a real enclave turn, which dev:test doesn't host).
+ */
+
+const PASSPHRASE = "correct horse battery staple"
+
+test.describe("E2E encrypted scratchpads", () => {
+  test("unlock gate, Encrypted pill, and encrypted rename", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "e2e-enc")
+
+    // Open the sidebar "New" create menu and pick the encrypted scratchpad.
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+
+    // First-time setup: passphrase + confirm + acknowledge. Leave the device
+    // UNtrusted so a reload lands locked — that's how we drive the gate.
+    const setup = page.getByRole("dialog")
+    await expect(setup.getByText("Set up encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await setup.locator("#e2e-passphrase").fill(PASSPHRASE)
+    await setup.locator("#e2e-passphrase-confirm").fill(PASSPHRASE)
+    await setup.locator("#e2e-acknowledged").check()
+    const trustDevice = setup.locator("#e2e-setup-trust-device")
+    if (await trustDevice.isChecked()) await trustDevice.uncheck()
+    await setup.getByRole("button", { name: "Enable encryption" }).click()
+
+    // Created and unlocked: the gate yields to the timeline, and the header shows
+    // the "Encrypted" pill. The gate's locked copy must NOT be present.
+    await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0)
+    await expect(page.getByText("Encrypted", { exact: true })).toBeVisible({ timeout: 15_000 })
+
+    // Rename while unlocked → the new name shows in the header. Clicking the
+    // header title swaps in an Input with the "Scratchpad name" placeholder.
+    const newName = "Therapy notes"
+    await page.getByRole("heading", { level: 1 }).click()
+    const rename = page.getByPlaceholder("Scratchpad name")
+    await rename.fill(newName)
+    await rename.press("Enter")
+    await expect(page.getByRole("heading", { name: newName })).toBeVisible({ timeout: 10_000 })
+
+    // Reload: device wasn't trusted, so the session is locked → the full-page
+    // gate replaces the timeline, and the inline Unlock affordance appears.
+    await page.reload()
+    await expect(page.getByText("This scratchpad is encrypted")).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole("button", { name: /^Unlock$/ }).first()).toBeVisible()
+
+    // Unlock from the gate → the gate clears and the timeline returns.
+    await page.getByRole("button", { name: /^Unlock$/ }).first().click()
+    const unlock = page.getByRole("dialog")
+    await expect(unlock.getByText("Unlock encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await unlock.locator("input[type='password'], input[type='text']").first().fill(PASSPHRASE)
+    await unlock.getByRole("button", { name: /^Unlock$/ }).click()
+    await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0, { timeout: 15_000 })
+  })
+})

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -63,4 +63,38 @@ test.describe("E2E encrypted scratchpads", () => {
     await unlock.getByRole("button", { name: /^Unlock$/ }).click()
     await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0, { timeout: 15_000 })
   })
+
+  test("creating an encrypted scratchpad while locked unlocks inline, then creates", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "e2e-enc-locked")
+
+    // First-time setup via the create flow, with device trust OFF so a reload
+    // lands locked (key exists, device not trusted) — the `locked` create branch.
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+    const setup = page.getByRole("dialog")
+    await expect(setup.getByText("Set up encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await setup.locator("#e2e-passphrase").fill(PASSPHRASE)
+    await setup.locator("#e2e-passphrase-confirm").fill(PASSPHRASE)
+    await setup.locator("#e2e-acknowledged").check()
+    const trustDevice = setup.locator("#e2e-setup-trust-device")
+    if (await trustDevice.isChecked()) await trustDevice.uncheck()
+    await setup.getByRole("button", { name: "Enable encryption" }).click()
+    await expect(page.getByText("Encrypted", { exact: true })).toBeVisible({ timeout: 15_000 })
+
+    await page.reload()
+    await expect(page.getByText("This scratchpad is encrypted")).toBeVisible({ timeout: 15_000 })
+
+    // Now the key exists but the session is locked. Asking for a new encrypted
+    // scratchpad should open the unlock modal (not a dead-end), then create it.
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+    const unlock = page.getByRole("dialog")
+    await expect(unlock.getByText("Unlock encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await unlock.locator("input[type='password'], input[type='text']").first().fill(PASSPHRASE)
+    await unlock.getByRole("button", { name: /^Unlock$/ }).click()
+
+    // The deferred create runs after unlock → a fresh encrypted scratchpad opens.
+    await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.getByText("Encrypted", { exact: true })).toBeVisible({ timeout: 15_000 })
+  })
 })


### PR DESCRIPTION
## What & why

Sixth PR in the **E2E-Ariadne alignment stack** (stacked on #716). Fixes the encryption onboarding UX.

**The problem:** to set an encryption passphrase you had to detour into **Settings → AI** (an odd home for encryption), and asking for an encrypted scratchpad with no key threw a toast: *"Unlock encrypted scratchpads first (Settings → Encryption)."* A "you must go do X first" dialog is itself the failure — the action should onboard you.

**The fix:** asking for an encrypted scratchpad **is** the onboarding trigger. The sidebar create-handler now:
- unlocked → creates immediately (unchanged);
- **no key → opens the setup modal inline**, and creates + opens the scratchpad the moment you finish;
- locked → opens the unlock modal inline, then creates.

No Settings trip, no dead-end message. The unlock gate's "Set up encryption" CTA already onboarded inline; this closes the remaining create path.

## How

- `E2eUnlockProvider.openSetup` gains an `onComplete` callback (symmetric with `openUnlock`'s `onUnlocked`), wired to the setup modal's existing `onSetupComplete`.
- `sidebar.tsx` `handleCreateEncryptedScratchpad` reads the session and routes to setup/unlock-then-create.
- The hook's no-session guard is reworded to a developer-facing invariant (callers onboard first), so the old "go to Settings" string can't reach a user.

Settings keeps the `EncryptedScratchpadsSection` as a *management* surface (lock / rotate / revoke) — it's just no longer the only way in.

## Test plan

- **Playwright (passing), browser-verified end-to-end:** New Encrypted Scratchpad → setup modal appears inline → created & unlocked (gate yields to the timeline, header shows the **Encrypted** pill) → encrypted rename displays → reload → locked **full-page gate** → unlock → timeline returns. This is also the first green browser coverage for the gate (#744) and encrypted naming (#745).
- Encryption component tests: 19 pass. Frontend typecheck + eslint clean.

> Note: verifying this required installing a missing `resend` dependency (declared in control-plane but absent from `node_modules`) that was crashing `dev:test` boot — unrelated to this change, flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783073800&installation_id=129946197&pr_number=747&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F747&signature=ba3387c1adea7fad709ad7ed094144ac88e440a49c5ab40a3bdf141666364f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->