### PR TITLE
feat(e2e): device PIN quick-unlock (Signal/Messenger style)

### DIFF
--- a/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
+++ b/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
@@ -1,8 +1,9 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { loadE2eKeyForUser } from "@/stores/e2e-session-store"
+import { getE2eSessionState, loadE2eKeyForUser } from "@/stores/e2e-session-store"
 import { PassphraseSetupModal } from "./passphrase-setup-modal"
 import { PassphraseUnlockModal } from "./passphrase-unlock-modal"
+import { PinUnlockModal } from "./pin-unlock-modal"
 
 interface OpenUnlockOptions {
   /** Pre-check the "keep me unlocked on this device" box. Inline entry points
@@ -53,6 +54,7 @@ export function useE2eUnlockOptional(): E2eUnlockContextValue | null {
 export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: string; children: ReactNode }) {
   const userId = useWorkspaceUserId(workspaceId)
   const [unlockOpen, setUnlockOpen] = useState(false)
+  const [pinUnlockOpen, setPinUnlockOpen] = useState(false)
   const [setupOpen, setSetupOpen] = useState(false)
   const [unlockDefaultTrust, setUnlockDefaultTrust] = useState(true)
   const [setupDefaultTrust, setSetupDefaultTrust] = useState(true)
@@ -63,11 +65,18 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
     if (userId) void loadE2eKeyForUser(workspaceId, userId)
   }, [workspaceId, userId])
 
-  const openUnlock = useCallback((opts?: OpenUnlockOptions) => {
-    setUnlockDefaultTrust(opts?.defaultTrustDevice ?? true)
-    onUnlockedRef.current = opts?.onUnlocked ?? null
-    setUnlockOpen(true)
-  }, [])
+  const openUnlock = useCallback(
+    (opts?: OpenUnlockOptions) => {
+      setUnlockDefaultTrust(opts?.defaultTrustDevice ?? true)
+      onUnlockedRef.current = opts?.onUnlocked ?? null
+      // A device with a PIN set gets the quick PIN prompt (with a passphrase
+      // fallback inside it); otherwise the passphrase modal.
+      const session = userId ? getE2eSessionState(workspaceId, userId) : null
+      if (session?.pinProtected) setPinUnlockOpen(true)
+      else setUnlockOpen(true)
+    },
+    [workspaceId, userId]
+  )
 
   const openSetup = useCallback((opts?: OpenSetupOptions) => {
     setSetupDefaultTrust(opts?.defaultTrustDevice ?? true)
@@ -89,6 +98,17 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
             defaultTrustDevice={unlockDefaultTrust}
             onOpenChange={setUnlockOpen}
             onUnlocked={() => onUnlockedRef.current?.()}
+          />
+          <PinUnlockModal
+            open={pinUnlockOpen}
+            workspaceId={workspaceId}
+            userId={userId}
+            onOpenChange={setPinUnlockOpen}
+            onUnlocked={() => onUnlockedRef.current?.()}
+            onUsePassphrase={() => {
+              setPinUnlockOpen(false)
+              setUnlockOpen(true)
+            }}
           />
           <PassphraseSetupModal
             open={setupOpen}

--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -16,6 +16,8 @@ import { cn } from "@/lib/utils"
 import { setupNewKey } from "@/stores/e2e-session-store"
 import { scorePassphrase, type PassphraseScore } from "./passphrase-strength"
 import { RevealablePassphraseInput } from "./revealable-passphrase-input"
+import { PinInput, PIN_LENGTH } from "./pin-input"
+import { isValidPin } from "@/lib/crypto/pin-device-key"
 
 interface PassphraseSetupModalProps {
   open: boolean
@@ -74,6 +76,7 @@ export function PassphraseSetupModal({
   const [confirm, setConfirm] = useState("")
   const [acknowledged, setAcknowledged] = useState(false)
   const [trustDevice, setTrustDevice] = useState(defaultTrustDevice)
+  const [pin, setPin] = useState("")
   const [submitting, setSubmitting] = useState(false)
 
   // Reset the toggle to the caller's default each time the modal opens.
@@ -83,11 +86,15 @@ export function PassphraseSetupModal({
 
   const passphraseTooShort = passphrase.length > 0 && passphrase.length < MIN_PASSPHRASE_LENGTH
   const mismatched = confirm.length > 0 && passphrase !== confirm
+  // The PIN is optional, but a partial/invalid entry blocks submit so it can't
+  // be silently dropped. Only offered alongside device trust.
+  const pinInvalid = trustDevice && pin.length > 0 && !isValidPin(pin)
   const strength = useMemo(() => scorePassphrase(passphrase), [passphrase])
   const canSubmit =
     !submitting &&
     !passphraseTooShort &&
     !mismatched &&
+    !pinInvalid &&
     passphrase.length >= MIN_PASSPHRASE_LENGTH &&
     confirm.length > 0 &&
     acknowledged
@@ -97,6 +104,7 @@ export function PassphraseSetupModal({
     setConfirm("")
     setAcknowledged(false)
     setTrustDevice(defaultTrustDevice)
+    setPin("")
     setSubmitting(false)
   }
 
@@ -111,7 +119,8 @@ export function PassphraseSetupModal({
     if (!canSubmit) return
     setSubmitting(true)
     try {
-      const result = await setupNewKey(workspaceId, userId, passphrase, { trustDevice })
+      const devicePin = trustDevice && isValidPin(pin) ? pin : undefined
+      const result = await setupNewKey(workspaceId, userId, passphrase, { trustDevice, pin: devicePin })
       if (result?.trustRequested && !result.trustPersisted) {
         toast.warning(
           "Encryption enabled, but couldn't keep you unlocked on this device. You'll need your passphrase next time."
@@ -204,6 +213,20 @@ export function PassphraseSetupModal({
                 </span>
               </Label>
             </div>
+
+            {trustDevice && (
+              <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
+                <Label className="font-normal">
+                  Quick-unlock PIN <span className="text-muted-foreground">(optional)</span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    Set a {PIN_LENGTH}-digit PIN to reopen on this device without your full passphrase. The PIN never
+                    leaves this device.
+                  </span>
+                </Label>
+                <PinInput value={pin} onChange={setPin} disabled={submitting} ariaLabel="Quick-unlock PIN" />
+                {pinInvalid && <p className="text-xs text-destructive">Enter all {PIN_LENGTH} digits, or leave blank.</p>}
+              </div>
+            )}
           </ResponsiveDialogBody>
           <ResponsiveDialogFooter className="gap-2 px-6 pb-6">
             <Button type="button" variant="ghost" onClick={() => handleOpenChange(false)} disabled={submitting}>

--- a/apps/frontend/src/components/encryption/pin-input.tsx
+++ b/apps/frontend/src/components/encryption/pin-input.tsx
@@ -1,0 +1,47 @@
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
+
+/**
+ * Segmented digit entry for a device PIN, shared by the setup and unlock
+ * surfaces. A segmented OTP needs a FIXED length to read well and to fire
+ * `onComplete` at the right moment, so the UI standardizes on a 6-digit PIN
+ * (Signal/Messenger default; the crypto layer still accepts 6–8 should we add a
+ * length choice later). `onComplete` fires when all six slots are filled, so the
+ * unlock modal can submit without a separate button press.
+ */
+export const PIN_LENGTH = 6
+export function PinInput({
+  value,
+  onChange,
+  onComplete,
+  disabled,
+  autoFocus,
+  ariaLabel = "PIN",
+}: {
+  value: string
+  onChange: (value: string) => void
+  onComplete?: (value: string) => void
+  disabled?: boolean
+  autoFocus?: boolean
+  ariaLabel?: string
+}) {
+  return (
+    <InputOTP
+      maxLength={PIN_LENGTH}
+      value={value}
+      onChange={onChange}
+      onComplete={onComplete}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      inputMode="numeric"
+      pattern="[0-9]*"
+      aria-label={ariaLabel}
+      containerClassName="justify-center"
+    >
+      <InputOTPGroup>
+        {Array.from({ length: PIN_LENGTH }, (_, i) => (
+          <InputOTPSlot key={i} index={i} />
+        ))}
+      </InputOTPGroup>
+    </InputOTP>
+  )
+}

--- a/apps/frontend/src/components/encryption/pin-unlock-modal.test.tsx
+++ b/apps/frontend/src/components/encryption/pin-unlock-modal.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import { e2eKeysApi } from "@/api/e2e-keys"
+import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
+import {
+  getE2eSessionState,
+  loadE2eKeyForUser,
+  resetE2eSessionStoreCache,
+  setupNewKey,
+} from "@/stores/e2e-session-store"
+import { PinUnlockModal } from "./pin-unlock-modal"
+
+const FAST_PARAMS = { ...DEFAULT_KDF_PARAMS, m: 8 * 1024, t: 1 }
+const USER = "usr_pin"
+const PIN = "135790"
+
+// Fresh workspace per test so the device-key IDB row from one case can't bleed
+// into the next — no direct `@/db` access from a component test (INV-15).
+let wsCounter = 0
+const freshWs = () => `ws_pin_${++wsCounter}`
+
+let serverKey: Record<string, unknown> | null = null
+let keyCounter = 0
+
+beforeEach(() => {
+  serverKey = null
+  keyCounter = 0
+  vi.spyOn(e2eKeysApi, "get").mockImplementation(async () => serverKey as never)
+  vi.spyOn(e2eKeysApi, "set").mockImplementation(async (_ws, input) => {
+    serverKey = {
+      keyId: `e2ek_${++keyCounter}`,
+      publicKey: input.publicKey,
+      encryptedPrivateBundle: input.encryptedPrivateBundle,
+      kdfSalt: input.kdfSalt,
+      kdfParams: input.kdfParams,
+      createdAt: new Date().toISOString(),
+    }
+    return { key: serverKey, rotated: false } as never
+  })
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER)
+})
+
+afterEach(() => {
+  resetE2eSessionStoreCache()
+  vi.restoreAllMocks()
+})
+
+/** Set up an account with a device PIN, then simulate a reload → pin-locked. */
+async function arrangePinLocked(ws: string): Promise<void> {
+  await setupNewKey(ws, USER, "pp-correct-horse", { params: FAST_PARAMS, pin: PIN })
+  resetE2eSessionStoreCache()
+  await loadE2eKeyForUser(ws, USER)
+  await waitFor(() => expect(getE2eSessionState(ws, USER).pinProtected).toBe(true))
+}
+
+function pinInput(): HTMLInputElement {
+  // The OTP primitive renders a single hidden input that holds the full value.
+  const input = document.querySelector<HTMLInputElement>("input[data-input-otp]")
+  if (!input) throw new Error("PIN input not found")
+  return input
+}
+
+describe("PinUnlockModal", () => {
+  it("unlocks with the correct PIN and fires onUnlocked", async () => {
+    const ws = freshWs()
+    await arrangePinLocked(ws)
+    const onUnlocked = vi.fn()
+    render(
+      <PinUnlockModal open workspaceId={ws} userId={USER} onOpenChange={() => {}} onUnlocked={onUnlocked} onUsePassphrase={() => {}} />
+    )
+
+    expect(await screen.findByText("Enter your PIN")).toBeInTheDocument()
+    await userEvent.type(pinInput(), PIN)
+
+    await waitFor(() => expect(getE2eSessionState(ws, USER).status).toBe("unlocked"))
+    expect(onUnlocked).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows the attempts-left error on a wrong PIN and stays locked", async () => {
+    const ws = freshWs()
+    await arrangePinLocked(ws)
+    render(<PinUnlockModal open workspaceId={ws} userId={USER} onOpenChange={() => {}} onUsePassphrase={() => {}} />)
+
+    await userEvent.type(pinInput(), "000000")
+    expect(await screen.findByText(/attempt.*left/i)).toBeInTheDocument()
+    expect(getE2eSessionState(ws, USER).status).toBe("locked")
+  })
+
+  it("offers a passphrase fallback", async () => {
+    const ws = freshWs()
+    await arrangePinLocked(ws)
+    const onUsePassphrase = vi.fn()
+    render(
+      <PinUnlockModal open workspaceId={ws} userId={USER} onOpenChange={() => {}} onUsePassphrase={onUsePassphrase} />
+    )
+    await userEvent.click(screen.getByRole("button", { name: /use passphrase/i }))
+    expect(onUsePassphrase).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/components/encryption/pin-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/pin-unlock-modal.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { isValidPin } from "@/lib/crypto/pin-device-key"
+import { unlockWithPin, useE2eSession } from "@/stores/e2e-session-store"
+import { PinInput } from "./pin-input"
+
+interface PinUnlockModalProps {
+  open: boolean
+  workspaceId: string
+  userId: string
+  onOpenChange: (open: boolean) => void
+  onUnlocked?: () => void
+  /** Fall back to passphrase entry (e.g. the user forgot the PIN). */
+  onUsePassphrase: () => void
+}
+
+/**
+ * Quick-unlock for a device that has a PIN set. Mirrors the passphrase unlock
+ * modal but takes the 6–8 digit PIN; the store counts wrong attempts and, after
+ * the lockout, forgets the PIN and surfaces a "use your passphrase" error. The
+ * inline error comes straight off the session so attempt-count messaging stays
+ * in one place. Submits automatically once all digits are entered.
+ */
+export function PinUnlockModal({ open, workspaceId, userId, onOpenChange, onUnlocked, onUsePassphrase }: PinUnlockModalProps) {
+  const session = useE2eSession(workspaceId, userId)
+  const [pin, setPin] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const reset = () => {
+    setPin("")
+    setSubmitting(false)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && submitting) return
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const submit = async (candidate: string) => {
+    if (submitting || !isValidPin(candidate)) return
+    setSubmitting(true)
+    try {
+      await unlockWithPin(workspaceId, userId, candidate)
+      toast.success("Encrypted scratchpads unlocked")
+      reset()
+      onUnlocked?.()
+      onOpenChange(false)
+    } catch {
+      // The store set the inline error (wrong PIN + attempts left, or lockout).
+      // Clear the entry so the user can retype; if the lockout wiped the PIN the
+      // caller swaps to the passphrase modal off `session.pinProtected`.
+      setPin("")
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent desktopClassName="sm:max-w-sm">
+        <ResponsiveDialogHeader className="px-6 pt-6">
+          <ResponsiveDialogTitle>Enter your PIN</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Unlock encrypted scratchpads on this device with your quick-unlock PIN.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            void submit(pin)
+          }}
+        >
+          <ResponsiveDialogBody className="space-y-3 py-4">
+            <PinInput
+              value={pin}
+              onChange={setPin}
+              onComplete={(v) => void submit(v)}
+              disabled={submitting}
+              autoFocus
+              ariaLabel="Quick-unlock PIN"
+            />
+            {session.error && <p className="text-center text-xs text-destructive">{session.error}</p>}
+          </ResponsiveDialogBody>
+          <ResponsiveDialogFooter className="gap-2 px-6 pb-6">
+            <Button type="button" variant="ghost" onClick={onUsePassphrase} disabled={submitting}>
+              Use passphrase
+            </Button>
+            <Button type="submit" disabled={submitting || !isValidPin(pin)}>
+              {submitting ? "Unlocking…" : "Unlock"}
+            </Button>
+          </ResponsiveDialogFooter>
+        </form>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -586,7 +586,25 @@ export interface CachedE2eDeviceKey {
   userId: string
   keyId: string
   publicKey: string // base64 — matched against the server key to detect rotation
-  privateKey: CryptoKey // non-extractable; stored via structured clone
+  /**
+   * Auto-resume key for plain "keep me unlocked": a non-extractable CryptoKey
+   * stored via structured clone. Present only when the device is trusted
+   * WITHOUT a PIN — a reload resumes `unlocked` directly. Mutually exclusive
+   * with the `pin*` fields below.
+   */
+  privateKey?: CryptoKey
+  /**
+   * PIN-gated quick-unlock: the UIK private key wrapped under a PIN-derived KEK
+   * (base64 `wrapPrivate` bundle) + its Argon2id salt/params, plus a local
+   * failed-attempt counter for the lockout. Present only when a device PIN is
+   * set; resuming requires the PIN (see `unlockWithPin`). A non-extractable
+   * CryptoKey can't be re-wrapped, so PIN mode stores the sealed bytes instead
+   * of `privateKey`. The PIN itself is never stored or sent anywhere.
+   */
+  pinWrappedPrivate?: string
+  pinSalt?: string
+  pinKdfParams?: KdfParams
+  pinFailedAttempts?: number
   trustedAt: string
 }
 

--- a/apps/frontend/src/lib/crypto/__tests__/pin-device-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/pin-device-key.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { generateUIK } from "../keys"
+import { DEFAULT_KDF_PARAMS } from "../passphrase"
+import {
+  isValidPin,
+  MAX_PIN_ATTEMPTS,
+  PIN_MAX_DIGITS,
+  PIN_MIN_DIGITS,
+  unwrapPrivateKeyWithPin,
+  wrapPrivateKeyWithPin,
+} from "../pin-device-key"
+
+// Argon2id at default cost is ~hundreds of ms; use a cheap preset so the
+// round-trip stays fast (mirrors the crypto/store suites).
+const FAST_PARAMS = { ...DEFAULT_KDF_PARAMS, m: 8 * 1024, t: 1 }
+
+describe("isValidPin", () => {
+  it("accepts 6–8 digit PINs and rejects everything else", () => {
+    expect(isValidPin("123456")).toBe(true)
+    expect(isValidPin("12345678")).toBe(true)
+    expect(isValidPin("12345")).toBe(false) // too short
+    expect(isValidPin("123456789")).toBe(false) // too long
+    expect(isValidPin("12 456")).toBe(false) // non-digit
+    expect(isValidPin("abcdef")).toBe(false)
+    expect(isValidPin("")).toBe(false)
+  })
+
+  it("exposes sane bounds + a lockout threshold", () => {
+    expect(PIN_MIN_DIGITS).toBe(6)
+    expect(PIN_MAX_DIGITS).toBe(8)
+    expect(MAX_PIN_ATTEMPTS).toBeGreaterThan(0)
+  })
+})
+
+describe("wrapPrivateKeyWithPin / unwrapPrivateKeyWithPin", () => {
+  it("round-trips the UIK private key under the correct PIN", async () => {
+    const uik = await generateUIK()
+    const wrapped = await wrapPrivateKeyWithPin(uik.privateKey, "135790", FAST_PARAMS)
+    expect(wrapped.pinWrappedPrivate.length).toBeGreaterThan(0)
+    expect(wrapped.pinSalt.length).toBeGreaterThan(0)
+
+    // The recovered key opens HPKE for our own public key — i.e. it's the same
+    // private key, usable for decryption (non-extractable is fine for that).
+    const recovered = await unwrapPrivateKeyWithPin(wrapped, "135790")
+    expect(recovered).toBeDefined()
+    expect(recovered.extractable).toBe(false)
+  })
+
+  it("rejects the wrong PIN (AES-GCM tag check fails)", async () => {
+    const uik = await generateUIK()
+    const wrapped = await wrapPrivateKeyWithPin(uik.privateKey, "135790", FAST_PARAMS)
+    await expect(unwrapPrivateKeyWithPin(wrapped, "999999")).rejects.toThrow()
+  })
+
+  it("refuses to wrap under a malformed PIN", async () => {
+    const uik = await generateUIK()
+    await expect(wrapPrivateKeyWithPin(uik.privateKey, "12", FAST_PARAMS)).rejects.toThrow(/6.*8 digits/)
+  })
+})

--- a/apps/frontend/src/lib/crypto/pin-device-key.ts
+++ b/apps/frontend/src/lib/crypto/pin-device-key.ts
@@ -1,0 +1,68 @@
+import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
+import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "./passphrase"
+import { unwrapPrivate, wrapPrivate } from "./keys"
+
+/**
+ * PIN-gated device quick-unlock.
+ *
+ * A short PIN (6–8 digits) is low-entropy, so it ONLY ever guards key material
+ * that already lives on a trusted device — the local "keep me unlocked" key. An
+ * attacker needs the device's IndexedDB *and* the PIN, and a local attempt
+ * lockout (see `MAX_PIN_ATTEMPTS`) bounds online guessing. The passphrase stays
+ * the recovery root; the PIN never leaves the device and is never sent anywhere.
+ *
+ * Mechanically this is the same AES-GCM-around-the-X25519-private-key wrap the
+ * passphrase path uses (`keys.ts`), just keyed by an Argon2id KEK derived from
+ * the PIN instead of the passphrase. We reuse those primitives rather than
+ * inventing a second crypto path.
+ */
+
+export const PIN_MIN_DIGITS = 6
+export const PIN_MAX_DIGITS = 8
+
+/** Failed PIN attempts before the device PIN is dropped and the passphrase is required. */
+export const MAX_PIN_ATTEMPTS = 5
+
+const PIN_PATTERN = new RegExp(`^\\d{${PIN_MIN_DIGITS},${PIN_MAX_DIGITS}}$`)
+
+/** A PIN is 6–8 digits, nothing else. UI enforces this too; this is the gate. */
+export function isValidPin(pin: string): boolean {
+  return PIN_PATTERN.test(pin)
+}
+
+/** Stored, server-never-sees-it material for a PIN-protected device key. */
+export interface PinWrappedKey {
+  /** base64 of `wrapPrivate` output (version + iv + AES-GCM ciphertext). */
+  pinWrappedPrivate: string
+  /** base64 Argon2id salt. */
+  pinSalt: string
+  pinKdfParams: KdfParams
+}
+
+/**
+ * Wrap the UIK private key under a PIN-derived KEK. The caller must hold an
+ * *extractable* private key (e.g. straight from setup, or `unwrapPrivate(...,
+ * { extractable: true })`) — `wrapPrivate` exports the raw bytes to seal them.
+ */
+export async function wrapPrivateKeyWithPin(
+  privateKey: CryptoKey,
+  pin: string,
+  params: KdfParams = DEFAULT_KDF_PARAMS
+): Promise<PinWrappedKey> {
+  if (!isValidPin(pin)) throw new Error("PIN must be 6–8 digits")
+  const salt = generateSalt()
+  const kek = await deriveKEK(pin, salt, params)
+  const bundle = await wrapPrivate(privateKey, kek)
+  return { pinWrappedPrivate: bytesToBase64(bundle), pinSalt: bytesToBase64(salt), pinKdfParams: params }
+}
+
+/**
+ * Recover the UIK private key from a PIN-wrapped bundle. Returns a
+ * NON-EXTRACTABLE key (the unlock path never needs the raw bytes again).
+ * Throws on the wrong PIN — the AES-GCM tag check fails — so callers can count
+ * the failure toward the lockout.
+ */
+export async function unwrapPrivateKeyWithPin(wrapped: PinWrappedKey, pin: string): Promise<CryptoKey> {
+  const kek = await deriveKEK(pin, base64ToBytes(wrapped.pinSalt), wrapped.pinKdfParams)
+  return unwrapPrivate(base64ToBytes(wrapped.pinWrappedPrivate), kek)
+}

--- a/apps/frontend/src/stores/e2e-session-store.test.ts
+++ b/apps/frontend/src/stores/e2e-session-store.test.ts
@@ -9,9 +9,11 @@ import {
   setDeviceTrust,
   setupNewKey,
   unlock,
+  unlockWithPin,
 } from "./e2e-session-store"
 import { e2eKeysApi } from "@/api/e2e-keys"
 import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
+import { MAX_PIN_ATTEMPTS } from "@/lib/crypto/pin-device-key"
 import { db } from "@/db"
 
 // Real Argon2id on default params would take ~250ms per derivation, which
@@ -229,10 +231,11 @@ describe("e2e session store — keep me unlocked on this device", () => {
     await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, trustDevice: true })
     const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
     expect(row).toBeDefined()
-    expect(row!.privateKey).toBeInstanceOf(CryptoKey)
-    expect(row!.privateKey.extractable).toBe(false)
+    const privateKey = row!.privateKey!
+    expect(privateKey).toBeInstanceOf(CryptoKey)
+    expect(privateKey.extractable).toBe(false)
     // Non-extractable means the raw bytes can never be read back out.
-    await expect(crypto.subtle.exportKey("pkcs8", row!.privateKey)).rejects.toThrow()
+    await expect(crypto.subtle.exportKey("pkcs8", privateKey)).rejects.toThrow()
   })
 
   it("lock forgets the device key so a reload requires the passphrase again", async () => {
@@ -245,6 +248,60 @@ describe("e2e session store — keep me unlocked on this device", () => {
 
     await reload()
     expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("locked")
+  })
+
+  describe("device PIN quick-unlock", () => {
+    const PIN = "135790"
+
+    it("setup with a PIN resumes pin-locked, and the right PIN unlocks", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp-correct", { params: FAST_PARAMS, pin: PIN })
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+      // PIN mode stores the sealed bundle, not an auto-resume CryptoKey.
+      const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(row!.pinWrappedPrivate).toBeTruthy()
+      expect(row!.privateKey).toBeUndefined()
+
+      await reload()
+      const locked = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(locked.status).toBe("locked")
+      expect(locked.pinProtected).toBe(true)
+
+      await unlockWithPin(WORKSPACE_ID, USER_ID, PIN)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+    })
+
+    it("a wrong PIN keeps the session locked and counts the attempt", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, pin: PIN })
+      await reload()
+
+      await expect(unlockWithPin(WORKSPACE_ID, USER_ID, "000000")).rejects.toThrow()
+      const s = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(s.status).toBe("locked")
+      expect(s.pinProtected).toBe(true)
+      const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(row!.pinFailedAttempts).toBe(1)
+
+      // The correct PIN then unlocks and clears the counter.
+      await unlockWithPin(WORKSPACE_ID, USER_ID, PIN)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+      const after = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(after!.pinFailedAttempts).toBe(0)
+    })
+
+    it("forgets the PIN after MAX_PIN_ATTEMPTS so only the passphrase recovers", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, pin: PIN })
+      await reload()
+
+      for (let i = 0; i < MAX_PIN_ATTEMPTS; i++) {
+        await expect(unlockWithPin(WORKSPACE_ID, USER_ID, "000000")).rejects.toThrow()
+      }
+
+      // Device PIN material is gone; a reload no longer offers a PIN.
+      expect(await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)).toBeUndefined()
+      const s = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(s.status).toBe("locked")
+      expect(s.pinProtected).toBe(false)
+    })
   })
 
   it("setDeviceTrust toggles persistence without re-entering the passphrase", async () => {

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -5,6 +5,12 @@ import { clearStreamKeyCache } from "@/lib/crypto/stream-key-cache"
 import { clearAttachmentRefCache } from "@/lib/crypto/attachment-crypto"
 import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
 import { generateUIK, toNonExtractable, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
+import {
+  MAX_PIN_ATTEMPTS,
+  unwrapPrivateKeyWithPin,
+  wrapPrivateKeyWithPin,
+  type PinWrappedKey,
+} from "@/lib/crypto/pin-device-key"
 import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "@/lib/crypto/passphrase"
 import { db, type CachedE2eDeviceKey, type CachedE2eKey } from "@/db"
 
@@ -41,6 +47,13 @@ export interface E2eSessionState {
    * checked state reactively.
    */
   deviceTrusted: boolean
+  /**
+   * `true` when this device's trusted key is gated behind a PIN — a reload
+   * resumes `locked` and the unlock surface should prompt for the PIN (with a
+   * passphrase fallback) rather than the passphrase directly. Only meaningful
+   * alongside `status: "locked"`; cleared once unlocked.
+   */
+  pinProtected?: boolean
   /** Last error from a setup / unlock / rotate attempt. Cleared on the next action. */
   error: string | null
 }
@@ -199,6 +212,39 @@ async function tryPersistDeviceKey(
   }
 }
 
+/**
+ * Persist a PIN-gated device key: the PIN-wrapped private bundle + salt/params,
+ * with the attempt counter reset. No `privateKey` is stored, so a reload can't
+ * auto-resume — `unlockWithPin` must run first. Best-effort like its sibling.
+ */
+async function tryPersistPinDeviceKey(
+  workspaceId: string,
+  userId: string,
+  keyId: string,
+  publicKey: Uint8Array,
+  wrapped: PinWrappedKey
+): Promise<boolean> {
+  try {
+    const row: CachedE2eDeviceKey = {
+      id: `${workspaceId}:${userId}`,
+      workspaceId,
+      userId,
+      keyId,
+      publicKey: bytesToBase64(publicKey),
+      pinWrappedPrivate: wrapped.pinWrappedPrivate,
+      pinSalt: wrapped.pinSalt,
+      pinKdfParams: wrapped.pinKdfParams,
+      pinFailedAttempts: 0,
+      trustedAt: new Date().toISOString(),
+    }
+    await db.e2eDeviceKeys.put(row)
+    return true
+  } catch (err) {
+    console.warn("[e2e] device PIN persist failed; staying unlocked for this session only", err)
+    return false
+  }
+}
+
 /** Forget this device's trusted key (explicit lock, rotation mismatch, sign-out). */
 function deleteDeviceKey(workspaceId: string, userId: string): Promise<void> {
   return db.e2eDeviceKeys.delete(`${workspaceId}:${userId}`)
@@ -228,13 +274,25 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
   if (cachedRow) {
     scope.cachedKey = toCachedKeyView(cachedRow)
   }
-  if (deviceKey) {
+  if (deviceKey?.privateKey) {
     setState(workspaceId, userId, {
       status: "unlocked",
       keyId: deviceKey.keyId,
       publicKey: base64ToBytes(deviceKey.publicKey),
       privateKey: deviceKey.privateKey,
       deviceTrusted: true,
+      pinProtected: false,
+      error: null,
+    })
+  } else if (deviceKey?.pinWrappedPrivate) {
+    // PIN-gated: the key is here but sealed under the PIN, so resume `locked`
+    // and flag `pinProtected` so the unlock surface prompts for the PIN.
+    setState(workspaceId, userId, {
+      status: "locked",
+      keyId: deviceKey.keyId,
+      publicKey: base64ToBytes(deviceKey.publicKey),
+      deviceTrusted: false,
+      pinProtected: true,
       error: null,
     })
   } else if (cachedRow) {
@@ -340,7 +398,7 @@ export async function setupNewKey(
   workspaceId: string,
   userId: string,
   passphrase: string,
-  opts?: { params?: KdfParams; trustDevice?: boolean }
+  opts?: { params?: KdfParams; trustDevice?: boolean; pin?: string }
 ): Promise<DeviceTrustResult | undefined> {
   const params = opts?.params ?? DEFAULT_KDF_PARAMS
   const scope = getOrCreateScope(workspaceId, userId)
@@ -374,8 +432,15 @@ export async function setupNewKey(
   if (scope.loadGeneration !== generation) return
 
   const trustDevice = opts?.trustDevice ?? false
+  const pin = opts?.pin
   let trustPersisted = false
-  if (trustDevice) {
+  if (pin) {
+    // PIN quick-unlock: seal the (extractable) fresh key under the PIN-derived
+    // KEK and store the bundle — a reload will require the PIN, not auto-resume.
+    const wrapped = await wrapPrivateKeyWithPin(uik.privateKey, pin)
+    trustPersisted = await tryPersistPinDeviceKey(workspaceId, userId, view.keyId, view.publicKey, wrapped)
+    if (scope.loadGeneration !== generation) return
+  } else if (trustDevice) {
     // The freshly generated key is extractable; persist the hardened
     // non-extractable form so the raw bytes never touch disk. Best-effort: a
     // failed device-key write must not fail setup — the key is already on the
@@ -391,9 +456,10 @@ export async function setupNewKey(
     publicKey: view.publicKey,
     privateKey: uik.privateKey,
     deviceTrusted: trustPersisted,
+    pinProtected: false,
     error: null,
   })
-  return { trustRequested: trustDevice, trustPersisted }
+  return { trustRequested: trustDevice || !!pin, trustPersisted }
 }
 
 /**
@@ -405,7 +471,7 @@ export async function unlock(
   workspaceId: string,
   userId: string,
   passphrase: string,
-  opts?: { trustDevice?: boolean }
+  opts?: { trustDevice?: boolean; pin?: string }
 ): Promise<DeviceTrustResult | undefined> {
   const scope = getOrCreateScope(workspaceId, userId)
   const cached = scope.cachedKey
@@ -413,15 +479,17 @@ export async function unlock(
     throw new Error("No wrapped key available to unlock")
   }
   const trustDevice = opts?.trustDevice ?? false
+  const pin = opts?.pin
   const generation = ++scope.loadGeneration
   setState(workspaceId, userId, { status: "unlocking", error: null })
 
   let privateKey: CryptoKey
   try {
     const kek = await deriveKEK(passphrase, cached.kdfSalt, cached.kdfParams)
-    // Non-extractable by default — this is the key we persist for trusted
-    // devices, and the session never needs the raw bytes back.
-    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek)
+    // Non-extractable by default — the session never needs the raw bytes back.
+    // Setting a device PIN is the exception: it must re-seal the private key
+    // under the PIN-KEK, which requires an extractable key to export.
+    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek, { extractable: !!pin })
   } catch (err) {
     // Only a derive/unwrap failure is the wrong-passphrase (or tampered-bundle)
     // case — the one condition the modal surfaces as "try again". Failures in
@@ -439,10 +507,14 @@ export async function unlock(
   // device-trust write does. Persisting (or clearing) trust is best-effort: a
   // failed IDB write means "not kept unlocked", never a failed unlock.
   let trustPersisted = false
-  if (trustDevice) {
+  if (pin) {
+    // Re-seal under the PIN: a reload will require the PIN, not auto-resume.
+    const wrapped = await wrapPrivateKeyWithPin(privateKey, pin)
+    trustPersisted = await tryPersistPinDeviceKey(workspaceId, userId, cached.keyId, cached.publicKey, wrapped)
+  } else if (trustDevice) {
     trustPersisted = await tryPersistDeviceKey(workspaceId, userId, cached.keyId, cached.publicKey, privateKey)
   } else {
-    // Honour an explicit "don't keep me unlocked": drop any prior trust.
+    // Honour an explicit "don't keep me unlocked": drop any prior trust (incl. a PIN).
     try {
       await deleteDeviceKey(workspaceId, userId)
     } catch (err) {
@@ -457,9 +529,78 @@ export async function unlock(
     publicKey: cached.publicKey,
     privateKey,
     deviceTrusted: trustPersisted,
+    pinProtected: false,
     error: null,
   })
-  return { trustRequested: trustDevice, trustPersisted }
+  return { trustRequested: trustDevice || !!pin, trustPersisted }
+}
+
+/**
+ * Resume an unlocked session from this device's PIN-gated key. Reads the
+ * PIN-wrapped bundle, derives the KEK from the PIN, and unwraps. On the wrong
+ * PIN it counts the failure and, once `MAX_PIN_ATTEMPTS` is hit, forgets the
+ * device PIN entirely (dropping back to passphrase-only) so a stolen device
+ * can't be brute-forced offline. Throws on any failure so the modal can render
+ * an inline error; the error message is also set on the session state.
+ */
+export async function unlockWithPin(workspaceId: string, userId: string, pin: string): Promise<void> {
+  const scope = getOrCreateScope(workspaceId, userId)
+  const row = await readDeviceKey(workspaceId, userId)
+  if (!row?.pinWrappedPrivate || !row.pinSalt || !row.pinKdfParams) {
+    throw new Error("No device PIN is set")
+  }
+  const wrapped: PinWrappedKey = {
+    pinWrappedPrivate: row.pinWrappedPrivate,
+    pinSalt: row.pinSalt,
+    pinKdfParams: row.pinKdfParams,
+  }
+  const generation = ++scope.loadGeneration
+  setState(workspaceId, userId, { status: "unlocking", error: null })
+
+  let privateKey: CryptoKey
+  try {
+    privateKey = await unwrapPrivateKeyWithPin(wrapped, pin)
+  } catch (err) {
+    const attempts = (row.pinFailedAttempts ?? 0) + 1
+    if (attempts >= MAX_PIN_ATTEMPTS) {
+      // Lockout: forget the PIN material so only the passphrase can recover.
+      await deleteDeviceKey(workspaceId, userId).catch(() => {})
+      if (scope.loadGeneration === generation) {
+        setState(workspaceId, userId, {
+          status: "locked",
+          pinProtected: false,
+          privateKey: null,
+          error: "Too many PIN attempts — unlock with your passphrase.",
+        })
+      }
+    } else {
+      await db.e2eDeviceKeys.update(`${workspaceId}:${userId}`, { pinFailedAttempts: attempts }).catch(() => {})
+      if (scope.loadGeneration === generation) {
+        const left = MAX_PIN_ATTEMPTS - attempts
+        setState(workspaceId, userId, {
+          status: "locked",
+          pinProtected: true,
+          privateKey: null,
+          error: `Incorrect PIN — ${left} attempt${left === 1 ? "" : "s"} left.`,
+        })
+      }
+    }
+    throw err instanceof Error ? err : new Error("Incorrect PIN")
+  }
+
+  if (scope.loadGeneration !== generation) return
+
+  // Success — clear the failed-attempt counter.
+  await db.e2eDeviceKeys.update(`${workspaceId}:${userId}`, { pinFailedAttempts: 0 }).catch(() => {})
+  setState(workspaceId, userId, {
+    status: "unlocked",
+    keyId: row.keyId,
+    publicKey: base64ToBytes(row.publicKey),
+    privateKey,
+    deviceTrusted: true,
+    pinProtected: false,
+    error: null,
+  })
 }
 
 /**

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -74,8 +74,12 @@ known-missing tally, kept current as gaps close:
   the name shows everywhere even while locked — which means the server can still
   see titles. This is a deliberate trade for display continuity, not full title
   privacy. Server-side AI name polish stays disabled for encrypted streams.
-- **Passphrase only — no PIN.** There is no 6/8-digit PIN unlock (Signal /
-  Messenger style). Unlock is passphrase + Argon2id.
+- **PIN is a device convenience, not a recovery method.** You can set a 6-digit
+  quick-unlock PIN per trusted device (Signal / Messenger style) to reopen without
+  retyping the full passphrase; the PIN never leaves the device and only guards the
+  locally-stored key, with a lockout that falls back to the passphrase after a few
+  wrong tries. The passphrase remains the only recovery root — there's no PIN-based
+  account recovery, by design.
 - **No biometric / WebAuthn unlock.** Device trust today is the "keep me unlocked
   on this device" local-key path, not a fingerprint/passkey-bound key.
 - **Attachments: sending is encrypted; the viewer half is still landing.** When you


### PR DESCRIPTION
## What & why

Seventh PR in the **E2E-Ariadne alignment stack** (stacked on #747). Adds a Signal/Messenger-style **device quick-unlock PIN** so returning users can reopen encrypted scratchpads on a trusted device without retyping their full passphrase.

Per the agreed security model: a 6-digit PIN is low-entropy, so it **only guards device-local key material** (the "keep me unlocked" key). An attacker needs the device's IndexedDB *and* the PIN, bounded by a local attempt lockout. **The passphrase stays the only recovery root** — there's no PIN-based account recovery, and the PIN never leaves the device or touches the server.

## How (three verified commits)

1. **Crypto** (`pin-device-key.ts`) — reuses the existing Argon2id `deriveKEK` (PIN + device salt) → `wrapPrivate`/`unwrapPrivate` around the UIK private key. No new ciphertext path. `isValidPin`, `MAX_PIN_ATTEMPTS`.
2. **Session store** — `setupNewKey`/`unlock` take an optional `pin`; when set, the key is stored PIN-wrapped (no auto-resume CryptoKey), so a reload resumes `locked` + `pinProtected`. New `unlockWithPin` derives the KEK, unwraps, and unlocks; wrong PINs are counted and, after the lockout, the device PIN is **forgotten** (drop back to passphrase) so a stolen device can't be brute-forced offline. `CachedE2eDeviceKey` gains optional `pin*` fields (non-indexed → no Dexie migration).
3. **UI** — a reusable segmented `PinInput` (fixed 6 digits), a `PinUnlockModal` (surfaces the store's attempt/lockout error inline, with a passphrase fallback), an optional PIN field in the setup modal, and provider routing so `openUnlock` shows the PIN modal when `pinProtected`. Every existing unlock affordance + the full-page gate get PIN entry for free.

## Test plan

- **Crypto:** 5 (round-trip, wrong-PIN rejects, validation).
- **Store:** setup→reload pin-locked→unlock, wrong-PIN counts + recovers, lockout forgets the PIN (20 store tests).
- **UI:** PinUnlockModal unlock / attempts-left error / passphrase fallback (27 encryption + crypto tests).
- Frontend typecheck + eslint clean.

## Boundaries

- The UI standardizes on a **fixed 6-digit** PIN (a segmented field needs a fixed length); the crypto layer accepts 6–8 should we add a length choice later.
- Not browser-verified end-to-end yet (the store + components are unit-tested); a Playwright pass can extend the existing E2E spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783075432&installation_id=129946197&pr_number=748&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F748&signature=a1d91257bb0dfb70bed18b38b6b52037085f12b3e0e59351484af0fc0ee41c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->