### PR TITLE
feat(e2e): biometric unlock via WebAuthn PRF

### DIFF
--- a/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { Fingerprint } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { unlockWithBiometric, useE2eSession } from "@/stores/e2e-session-store"
+
+interface BiometricUnlockModalProps {
+  open: boolean
+  workspaceId: string
+  userId: string
+  onOpenChange: (open: boolean) => void
+  onUnlocked?: () => void
+  /** Fall back to passphrase entry (biometric unavailable / failed / declined). */
+  onUsePassphrase: () => void
+}
+
+/**
+ * Quick-unlock for a device with biometric (WebAuthn PRF) set. The single button
+ * triggers the OS biometric prompt from the user's click (a gesture is required
+ * for WebAuthn); on success the session unlocks. Any failure surfaces the
+ * session's inline error and leaves the passphrase fallback available.
+ */
+export function BiometricUnlockModal({
+  open,
+  workspaceId,
+  userId,
+  onOpenChange,
+  onUnlocked,
+  onUsePassphrase,
+}: BiometricUnlockModalProps) {
+  const session = useE2eSession(workspaceId, userId)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleUnlock = async () => {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      await unlockWithBiometric(workspaceId, userId)
+      toast.success("Encrypted scratchpads unlocked")
+      onUnlocked?.()
+      onOpenChange(false)
+    } catch {
+      // The store set the inline error; let the user retry or use the passphrase.
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={(next) => !submitting && onOpenChange(next)}>
+      <ResponsiveDialogContent desktopClassName="sm:max-w-sm">
+        <ResponsiveDialogHeader className="px-6 pt-6">
+          <ResponsiveDialogTitle>Unlock with biometrics</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Use this device's fingerprint or face unlock to reopen your encrypted scratchpads.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <ResponsiveDialogBody className="flex flex-col items-center gap-3 py-6">
+          <Button type="button" size="lg" className="gap-2" disabled={submitting} onClick={handleUnlock}>
+            <Fingerprint className="h-5 w-5" />
+            {submitting ? "Waiting for biometrics…" : "Unlock with biometrics"}
+          </Button>
+          {session.error && <p className="text-center text-xs text-destructive">{session.error}</p>}
+        </ResponsiveDialogBody>
+        <ResponsiveDialogFooter className="px-6 pb-6">
+          <Button type="button" variant="ghost" onClick={onUsePassphrase} disabled={submitting}>
+            Use passphrase
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
@@ -46,6 +46,9 @@ export function BiometricUnlockModal({
     try {
       await unlockWithBiometric(workspaceId, userId)
       toast.success("Encrypted scratchpads unlocked")
+      // The modal stays mounted under the provider, so clear the busy flag or a
+      // reopen would render a stuck "Waiting for biometrics…" button.
+      setSubmitting(false)
       onUnlocked?.()
       onOpenChange(false)
     } catch {

--- a/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
+++ b/apps/frontend/src/components/encryption/e2e-unlock-provider.tsx
@@ -4,6 +4,7 @@ import { getE2eSessionState, loadE2eKeyForUser } from "@/stores/e2e-session-stor
 import { PassphraseSetupModal } from "./passphrase-setup-modal"
 import { PassphraseUnlockModal } from "./passphrase-unlock-modal"
 import { PinUnlockModal } from "./pin-unlock-modal"
+import { BiometricUnlockModal } from "./biometric-unlock-modal"
 
 interface OpenUnlockOptions {
   /** Pre-check the "keep me unlocked on this device" box. Inline entry points
@@ -55,6 +56,7 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
   const userId = useWorkspaceUserId(workspaceId)
   const [unlockOpen, setUnlockOpen] = useState(false)
   const [pinUnlockOpen, setPinUnlockOpen] = useState(false)
+  const [biometricUnlockOpen, setBiometricUnlockOpen] = useState(false)
   const [setupOpen, setSetupOpen] = useState(false)
   const [unlockDefaultTrust, setUnlockDefaultTrust] = useState(true)
   const [setupDefaultTrust, setSetupDefaultTrust] = useState(true)
@@ -69,10 +71,11 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
     (opts?: OpenUnlockOptions) => {
       setUnlockDefaultTrust(opts?.defaultTrustDevice ?? true)
       onUnlockedRef.current = opts?.onUnlocked ?? null
-      // A device with a PIN set gets the quick PIN prompt (with a passphrase
-      // fallback inside it); otherwise the passphrase modal.
+      // Route to the device's quick-unlock method (each modal has a passphrase
+      // fallback); otherwise the passphrase modal.
       const session = userId ? getE2eSessionState(workspaceId, userId) : null
-      if (session?.pinProtected) setPinUnlockOpen(true)
+      if (session?.webauthnProtected) setBiometricUnlockOpen(true)
+      else if (session?.pinProtected) setPinUnlockOpen(true)
       else setUnlockOpen(true)
     },
     [workspaceId, userId]
@@ -107,6 +110,17 @@ export function E2eUnlockProvider({ workspaceId, children }: { workspaceId: stri
             onUnlocked={() => onUnlockedRef.current?.()}
             onUsePassphrase={() => {
               setPinUnlockOpen(false)
+              setUnlockOpen(true)
+            }}
+          />
+          <BiometricUnlockModal
+            open={biometricUnlockOpen}
+            workspaceId={workspaceId}
+            userId={userId}
+            onOpenChange={setBiometricUnlockOpen}
+            onUnlocked={() => onUnlockedRef.current?.()}
+            onUsePassphrase={() => {
+              setBiometricUnlockOpen(false)
               setUnlockOpen(true)
             }}
           />

--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -18,6 +18,8 @@ import { scorePassphrase, type PassphraseScore } from "./passphrase-strength"
 import { RevealablePassphraseInput } from "./revealable-passphrase-input"
 import { PinInput, PIN_LENGTH } from "./pin-input"
 import { isValidPin } from "@/lib/crypto/pin-device-key"
+import { isWebAuthnAvailable, registerPrfCredential, type PrfRegistration } from "@/lib/crypto/webauthn-device-key"
+import { Fingerprint } from "lucide-react"
 
 interface PassphraseSetupModalProps {
   open: boolean
@@ -77,6 +79,8 @@ export function PassphraseSetupModal({
   const [acknowledged, setAcknowledged] = useState(false)
   const [trustDevice, setTrustDevice] = useState(defaultTrustDevice)
   const [pin, setPin] = useState("")
+  const [biometric, setBiometric] = useState<PrfRegistration | null>(null)
+  const [registeringBiometric, setRegisteringBiometric] = useState(false)
   const [submitting, setSubmitting] = useState(false)
 
   // Reset the toggle to the caller's default each time the modal opens.
@@ -88,7 +92,7 @@ export function PassphraseSetupModal({
   const mismatched = confirm.length > 0 && passphrase !== confirm
   // The PIN is optional, but a partial/invalid entry blocks submit so it can't
   // be silently dropped. Only offered alongside device trust.
-  const pinInvalid = trustDevice && pin.length > 0 && !isValidPin(pin)
+  const pinInvalid = trustDevice && !biometric && pin.length > 0 && !isValidPin(pin)
   const strength = useMemo(() => scorePassphrase(passphrase), [passphrase])
   const canSubmit =
     !submitting &&
@@ -105,7 +109,28 @@ export function PassphraseSetupModal({
     setAcknowledged(false)
     setTrustDevice(defaultTrustDevice)
     setPin("")
+    setBiometric(null)
+    setRegisteringBiometric(false)
     setSubmitting(false)
+  }
+
+  const handleSetupBiometric = async () => {
+    if (registeringBiometric) return
+    setRegisteringBiometric(true)
+    try {
+      const registration = await registerPrfCredential({
+        rpId: window.location.hostname,
+        rpName: "Threa",
+        userId: new TextEncoder().encode(userId),
+        userName: userId,
+      })
+      setBiometric(registration)
+      toast.success("Biometric unlock ready")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't set up biometric unlock")
+    } finally {
+      setRegisteringBiometric(false)
+    }
   }
 
   const handleOpenChange = (next: boolean) => {
@@ -119,8 +144,9 @@ export function PassphraseSetupModal({
     if (!canSubmit) return
     setSubmitting(true)
     try {
-      const devicePin = trustDevice && isValidPin(pin) ? pin : undefined
-      const result = await setupNewKey(workspaceId, userId, passphrase, { trustDevice, pin: devicePin })
+      const webauthn = trustDevice && biometric ? biometric : undefined
+      const devicePin = !webauthn && trustDevice && isValidPin(pin) ? pin : undefined
+      const result = await setupNewKey(workspaceId, userId, passphrase, { trustDevice, pin: devicePin, webauthn })
       if (result?.trustRequested && !result.trustPersisted) {
         toast.warning(
           "Encryption enabled, but couldn't keep you unlocked on this device. You'll need your passphrase next time."
@@ -215,16 +241,50 @@ export function PassphraseSetupModal({
             </div>
 
             {trustDevice && (
-              <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
-                <Label className="font-normal">
-                  Quick-unlock PIN <span className="text-muted-foreground">(optional)</span>
-                  <span className="mt-0.5 block text-xs text-muted-foreground">
-                    Set a {PIN_LENGTH}-digit PIN to reopen on this device without your full passphrase. The PIN never
-                    leaves this device.
-                  </span>
-                </Label>
-                <PinInput value={pin} onChange={setPin} disabled={submitting} ariaLabel="Quick-unlock PIN" />
-                {pinInvalid && <p className="text-xs text-destructive">Enter all {PIN_LENGTH} digits, or leave blank.</p>}
+              <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
+                {!biometric && (
+                  <div className="space-y-2">
+                    <Label className="font-normal">
+                      Quick-unlock PIN <span className="text-muted-foreground">(optional)</span>
+                      <span className="mt-0.5 block text-xs text-muted-foreground">
+                        Set a {PIN_LENGTH}-digit PIN to reopen on this device without your full passphrase. The PIN
+                        never leaves this device.
+                      </span>
+                    </Label>
+                    <PinInput value={pin} onChange={setPin} disabled={submitting} ariaLabel="Quick-unlock PIN" />
+                    {pinInvalid && (
+                      <p className="text-xs text-destructive">Enter all {PIN_LENGTH} digits, or leave blank.</p>
+                    )}
+                  </div>
+                )}
+                {isWebAuthnAvailable() && (
+                  <div className="space-y-1.5 border-t border-border pt-3 first:border-t-0 first:pt-0">
+                    <Label className="font-normal">
+                      Biometric unlock <span className="text-muted-foreground">(optional)</span>
+                      <span className="mt-0.5 block text-xs text-muted-foreground">
+                        Use this device's fingerprint or face unlock instead of a PIN.
+                      </span>
+                    </Label>
+                    {biometric ? (
+                      <p className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                        <Fingerprint className="h-3.5 w-3.5" />
+                        Biometric unlock enabled for this device.
+                      </p>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="gap-1.5"
+                        disabled={registeringBiometric || submitting}
+                        onClick={handleSetupBiometric}
+                      >
+                        <Fingerprint className="h-4 w-4" />
+                        {registeringBiometric ? "Waiting…" : "Set up biometric unlock"}
+                      </Button>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </ResponsiveDialogBody>

--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -177,10 +177,10 @@ export function PassphraseSetupModal({
         <form onSubmit={handleSubmit}>
           <ResponsiveDialogBody className="space-y-4 py-4">
             <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
-              <p className="font-medium">There is no recovery.</p>
+              <p className="font-medium">Save your passphrase now — there is no recovery.</p>
               <p className="mt-1 text-destructive/90">
-                If you forget this passphrase, every message you encrypt with this key becomes permanently unreadable.
-                Write it down somewhere safe.
+                Store it in a password manager, or write it down somewhere safe. No one can reset it for you: if you
+                forget it, everything in your encrypted scratchpads becomes permanently unreadable.
               </p>
             </div>
 
@@ -221,7 +221,8 @@ export function PassphraseSetupModal({
                 className="mt-0.5"
               />
               <Label htmlFor="e2e-acknowledged" className="cursor-pointer font-normal leading-snug">
-                I understand that losing this passphrase means losing access to my encrypted scratchpads permanently.
+                I've saved my passphrase somewhere safe. I understand it can't be recovered, and losing it means losing
+                access to my encrypted scratchpads permanently.
               </Label>
             </div>
 

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -605,6 +605,16 @@ export interface CachedE2eDeviceKey {
   pinSalt?: string
   pinKdfParams?: KdfParams
   pinFailedAttempts?: number
+  /**
+   * Biometric (WebAuthn PRF) quick-unlock: the UIK private key wrapped under the
+   * authenticator's PRF-derived secret, plus the credential id and PRF salt
+   * needed to reproduce that secret via a biometric assertion. Present only when
+   * biometric unlock is set; mutually exclusive with `privateKey`/`pin*`. The
+   * secret itself is never stored — it's re-derived from the authenticator.
+   */
+  webauthnCredentialId?: string
+  webauthnPrfSalt?: string
+  webauthnWrappedPrivate?: string
   trustedAt: string
 }
 

--- a/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { generateUIK } from "../keys"
+import { unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "../webauthn-device-key"
+
+// The PRF secret is a uniformly-random 32 bytes the authenticator would return;
+// the ceremony itself (navigator.credentials) is covered by the Playwright
+// virtual-authenticator E2E. Here we verify the pure wrap/unwrap around it.
+function fakePrfSecret(seed: number): Uint8Array {
+  const b = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) b[i] = (seed + i * 7) % 256
+  return b
+}
+
+describe("wrapPrivateKeyWithPrf / unwrapPrivateKeyWithPrf", () => {
+  it("round-trips the UIK private key under the PRF secret", async () => {
+    const uik = await generateUIK()
+    const secret = fakePrfSecret(1)
+    const bundle = await wrapPrivateKeyWithPrf(uik.privateKey, secret)
+    expect(bundle.length).toBeGreaterThan(0)
+
+    const recovered = await unwrapPrivateKeyWithPrf(bundle, secret)
+    expect(recovered).toBeDefined()
+    expect(recovered.extractable).toBe(false)
+  })
+
+  it("fails to unwrap under a different PRF secret (AES-GCM tag check)", async () => {
+    const uik = await generateUIK()
+    const bundle = await wrapPrivateKeyWithPrf(uik.privateKey, fakePrfSecret(1))
+    await expect(unwrapPrivateKeyWithPrf(bundle, fakePrfSecret(2))).rejects.toThrow()
+  })
+
+  it("rejects a too-short PRF secret", async () => {
+    const uik = await generateUIK()
+    await expect(wrapPrivateKeyWithPrf(uik.privateKey, new Uint8Array(16))).rejects.toThrow(/at least 32/)
+  })
+})

--- a/apps/frontend/src/lib/crypto/webauthn-device-key.ts
+++ b/apps/frontend/src/lib/crypto/webauthn-device-key.ts
@@ -1,0 +1,120 @@
+import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
+import { unwrapPrivate, wrapPrivate } from "./keys"
+
+/**
+ * Biometric device quick-unlock via the WebAuthn PRF extension.
+ *
+ * A passkey/biometric authenticator deterministically derives a high-entropy
+ * secret (the PRF output) for a given salt. We use that secret directly as the
+ * AES-GCM key-encryption key wrapping the UIK private key — so the wrapped key
+ * is cryptographically bound to the authenticator and only the device's
+ * biometric (user verification) can reproduce it. No Argon2 is needed: the PRF
+ * output is already uniformly random.
+ *
+ * Like the PIN path this only guards device-local material; the passphrase stays
+ * the recovery root, and PRF support varies by browser/OS/authenticator, so
+ * callers must keep the passphrase fallback working.
+ *
+ * The pure wrap/unwrap helpers below are unit-tested with a synthetic secret;
+ * the `navigator.credentials` ceremony is exercised by a Playwright
+ * virtual-authenticator E2E (WebAuthn is unavailable in jsdom).
+ */
+
+function randomBytes(n: number): Uint8Array<ArrayBuffer> {
+  const b = new Uint8Array(n)
+  crypto.getRandomValues(b)
+  return b
+}
+
+// WebAuthn's BufferSource params reject `Uint8Array<ArrayBufferLike>` under
+// TS 5.7+. Copy onto a fresh ArrayBuffer-backed view (same fix as keys.ts).
+function buf(x: Uint8Array): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(x)
+}
+
+/** AES-GCM KEK straight from the 32-byte PRF secret (no KDF — it's already random). */
+async function importPrfKek(prfSecret: Uint8Array): Promise<CryptoKey> {
+  if (prfSecret.byteLength < 32) throw new Error("PRF secret must be at least 32 bytes")
+  return crypto.subtle.importKey("raw", prfSecret.slice(0, 32), { name: "AES-GCM" }, false, ["encrypt", "decrypt"])
+}
+
+/** Wrap the UIK private key under the PRF-derived KEK. Returns a base64 bundle. */
+export async function wrapPrivateKeyWithPrf(privateKey: CryptoKey, prfSecret: Uint8Array): Promise<string> {
+  const kek = await importPrfKek(prfSecret)
+  return bytesToBase64(await wrapPrivate(privateKey, kek))
+}
+
+/** Recover the (non-extractable) UIK private key from a PRF-wrapped bundle. */
+export async function unwrapPrivateKeyWithPrf(bundleB64: string, prfSecret: Uint8Array): Promise<CryptoKey> {
+  const kek = await importPrfKek(prfSecret)
+  return unwrapPrivate(base64ToBytes(bundleB64), kek)
+}
+
+/** Coarse capability gate; the real PRF support is only known after a ceremony. */
+export function isWebAuthnAvailable(): boolean {
+  return typeof window !== "undefined" && !!window.PublicKeyCredential && !!navigator.credentials?.create
+}
+
+export interface PrfRegistration {
+  /** base64 of the credential's raw id — stored to address it on unlock. */
+  credentialId: string
+  /** base64 PRF salt (the eval input) — not secret; stored to reproduce the secret. */
+  prfSalt: string
+  /** The PRF output to wrap the key under right now. Never stored. */
+  prfSecret: Uint8Array
+}
+
+/**
+ * Register a resident passkey with the PRF extension and obtain its PRF secret
+ * for a fresh salt. PRF results aren't reliably returned at create time across
+ * authenticators, so we always follow with a get() to read the secret — the
+ * same call unlock uses later. Throws if the user cancels or the authenticator
+ * doesn't support PRF.
+ */
+export async function registerPrfCredential(opts: {
+  rpId: string
+  rpName: string
+  userId: Uint8Array
+  userName: string
+}): Promise<PrfRegistration> {
+  const created = (await navigator.credentials.create({
+    publicKey: {
+      rp: { id: opts.rpId, name: opts.rpName },
+      user: { id: buf(opts.userId), name: opts.userName, displayName: opts.userName },
+      challenge: randomBytes(32),
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 },
+        { type: "public-key", alg: -257 },
+      ],
+      authenticatorSelection: { residentKey: "required", userVerification: "required" },
+      extensions: { prf: {} },
+    },
+  })) as PublicKeyCredential | null
+  if (!created) throw new Error("Biometric setup was cancelled")
+
+  const credentialId = bytesToBase64(new Uint8Array(created.rawId))
+  const prfSalt = bytesToBase64(randomBytes(32))
+  const prfSecret = await getPrfSecret(credentialId, prfSalt)
+  return { credentialId, prfSalt, prfSecret }
+}
+
+/**
+ * Run a WebAuthn assertion (user verification = biometric) and read the PRF
+ * secret for `prfSalt`. Throws if cancelled or the authenticator returns no PRF
+ * result — callers fall back to the passphrase.
+ */
+export async function getPrfSecret(credentialIdB64: string, prfSaltB64: string): Promise<Uint8Array> {
+  const asserted = (await navigator.credentials.get({
+    publicKey: {
+      challenge: randomBytes(32),
+      allowCredentials: [{ type: "public-key", id: buf(base64ToBytes(credentialIdB64)) }],
+      userVerification: "required",
+      extensions: { prf: { eval: { first: buf(base64ToBytes(prfSaltB64)) } } },
+    },
+  })) as PublicKeyCredential | null
+  if (!asserted) throw new Error("Biometric unlock was cancelled")
+  const ext = asserted.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } }
+  const first = ext.prf?.results?.first
+  if (!first) throw new Error("This device's authenticator didn't return a biometric secret")
+  return new Uint8Array(first)
+}

--- a/apps/frontend/src/stores/e2e-session-store.test.ts
+++ b/apps/frontend/src/stores/e2e-session-store.test.ts
@@ -10,6 +10,7 @@ import {
   setupNewKey,
   unlock,
   unlockWithPin,
+  unlockWithWebAuthn,
 } from "./e2e-session-store"
 import { e2eKeysApi } from "@/api/e2e-keys"
 import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
@@ -301,6 +302,39 @@ describe("e2e session store — keep me unlocked on this device", () => {
       const s = getE2eSessionState(WORKSPACE_ID, USER_ID)
       expect(s.status).toBe("locked")
       expect(s.pinProtected).toBe(false)
+    })
+  })
+
+  describe("device biometric (WebAuthn PRF) quick-unlock", () => {
+    // The ceremony (navigator.credentials) is covered by the Playwright
+    // virtual-authenticator E2E; here the PRF secret is supplied directly.
+    const SECRET = new Uint8Array(32).fill(7)
+    const WEBAUTHN = { credentialId: "cred_test", prfSalt: "c2FsdHk=", prfSecret: SECRET }
+
+    it("setup with biometric resumes webauthn-locked, and the secret unlocks", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp-correct", { params: FAST_PARAMS, webauthn: WEBAUTHN })
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+      const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(row!.webauthnWrappedPrivate).toBeTruthy()
+      expect(row!.privateKey).toBeUndefined()
+
+      await reload()
+      const locked = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(locked.status).toBe("locked")
+      expect(locked.webauthnProtected).toBe(true)
+
+      await unlockWithWebAuthn(WORKSPACE_ID, USER_ID, SECRET)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+    })
+
+    it("a wrong PRF secret keeps the session locked", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, webauthn: WEBAUTHN })
+      await reload()
+
+      await expect(unlockWithWebAuthn(WORKSPACE_ID, USER_ID, new Uint8Array(32).fill(9))).rejects.toThrow()
+      const s = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(s.status).toBe("locked")
+      expect(s.webauthnProtected).toBe(true)
     })
   })
 

--- a/apps/frontend/src/stores/e2e-session-store.test.ts
+++ b/apps/frontend/src/stores/e2e-session-store.test.ts
@@ -289,6 +289,21 @@ describe("e2e session store — keep me unlocked on this device", () => {
       expect(after!.pinFailedAttempts).toBe(0)
     })
 
+    it("rotating the passphrase clears a PIN device key instead of silently downgrading", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "old-passphrase", { params: FAST_PARAMS, pin: PIN })
+      await rotatePassphrase(WORKSPACE_ID, USER_ID, "old-passphrase", "new-passphrase", FAST_PARAMS)
+
+      // The PIN-gated device key is gone — not re-persisted as a plain auto-resume
+      // key, which would have dropped the PIN gate.
+      expect(await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)).toBeUndefined()
+
+      // A reload now requires the passphrase (no PIN, no auto-resume).
+      await reload()
+      const s = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(s.status).toBe("locked")
+      expect(s.pinProtected).toBeFalsy()
+    })
+
     it("forgets the PIN after MAX_PIN_ATTEMPTS so only the passphrase recovers", async () => {
       await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, pin: PIN })
       await reload()

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -11,7 +11,7 @@ import {
   wrapPrivateKeyWithPin,
   type PinWrappedKey,
 } from "@/lib/crypto/pin-device-key"
-import { unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "@/lib/crypto/webauthn-device-key"
+import { getPrfSecret, unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "@/lib/crypto/webauthn-device-key"
 import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "@/lib/crypto/passphrase"
 import { db, type CachedE2eDeviceKey, type CachedE2eKey } from "@/db"
 
@@ -683,6 +683,31 @@ export async function unlockWithPin(workspaceId: string, userId: string, pin: st
     pinProtected: false,
     error: null,
   })
+}
+
+/**
+ * Whether this device has a biometric (WebAuthn PRF) key set — lets the UI offer
+ * the biometric prompt without reaching into IDB itself (INV-15).
+ */
+export async function hasBiometricUnlock(workspaceId: string, userId: string): Promise<boolean> {
+  const row = await readDeviceKey(workspaceId, userId)
+  return !!row?.webauthnWrappedPrivate
+}
+
+/**
+ * End-to-end biometric unlock from a user gesture: read this device's credential,
+ * run the WebAuthn assertion (the OS biometric prompt) to recover the PRF secret,
+ * and unlock with it. Keeps the credential lookup + ceremony in the store so the
+ * modal stays a thin button. Throws (cancelled / no biometric / bad secret) so
+ * the caller can fall back to the passphrase.
+ */
+export async function unlockWithBiometric(workspaceId: string, userId: string): Promise<void> {
+  const row = await readDeviceKey(workspaceId, userId)
+  if (!row?.webauthnWrappedPrivate || !row.webauthnCredentialId || !row.webauthnPrfSalt) {
+    throw new Error("No biometric unlock is set")
+  }
+  const prfSecret = await getPrfSecret(row.webauthnCredentialId, row.webauthnPrfSalt)
+  await unlockWithWebAuthn(workspaceId, userId, prfSecret)
 }
 
 /**

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -11,6 +11,7 @@ import {
   wrapPrivateKeyWithPin,
   type PinWrappedKey,
 } from "@/lib/crypto/pin-device-key"
+import { unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "@/lib/crypto/webauthn-device-key"
 import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "@/lib/crypto/passphrase"
 import { db, type CachedE2eDeviceKey, type CachedE2eKey } from "@/db"
 
@@ -54,6 +55,12 @@ export interface E2eSessionState {
    * alongside `status: "locked"`; cleared once unlocked.
    */
   pinProtected?: boolean
+  /**
+   * `true` when this device's trusted key is gated behind a biometric (WebAuthn
+   * PRF) — the unlock surface should offer the biometric prompt (with a
+   * passphrase fallback). Only meaningful alongside `status: "locked"`.
+   */
+  webauthnProtected?: boolean
   /** Last error from a setup / unlock / rotate attempt. Cleared on the next action. */
   error: string | null
 }
@@ -245,6 +252,39 @@ async function tryPersistPinDeviceKey(
   }
 }
 
+/**
+ * Persist a biometric (WebAuthn PRF) device key: the PRF-wrapped private bundle
+ * + the credential id and PRF salt needed to re-derive the secret. No
+ * `privateKey` is stored, so a reload requires a biometric assertion
+ * (`unlockWithWebAuthn`). Best-effort like its siblings.
+ */
+async function tryPersistWebAuthnDeviceKey(
+  workspaceId: string,
+  userId: string,
+  keyId: string,
+  publicKey: Uint8Array,
+  webauthn: { credentialId: string; prfSalt: string; wrappedPrivate: string }
+): Promise<boolean> {
+  try {
+    const row: CachedE2eDeviceKey = {
+      id: `${workspaceId}:${userId}`,
+      workspaceId,
+      userId,
+      keyId,
+      publicKey: bytesToBase64(publicKey),
+      webauthnCredentialId: webauthn.credentialId,
+      webauthnPrfSalt: webauthn.prfSalt,
+      webauthnWrappedPrivate: webauthn.wrappedPrivate,
+      trustedAt: new Date().toISOString(),
+    }
+    await db.e2eDeviceKeys.put(row)
+    return true
+  } catch (err) {
+    console.warn("[e2e] device biometric persist failed; staying unlocked for this session only", err)
+    return false
+  }
+}
+
 /** Forget this device's trusted key (explicit lock, rotation mismatch, sign-out). */
 function deleteDeviceKey(workspaceId: string, userId: string): Promise<void> {
   return db.e2eDeviceKeys.delete(`${workspaceId}:${userId}`)
@@ -293,6 +333,17 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       publicKey: base64ToBytes(deviceKey.publicKey),
       deviceTrusted: false,
       pinProtected: true,
+      error: null,
+    })
+  } else if (deviceKey?.webauthnWrappedPrivate) {
+    // Biometric-gated: sealed under the authenticator's PRF secret; resume
+    // `locked` and flag `webauthnProtected` so the surface offers the biometric.
+    setState(workspaceId, userId, {
+      status: "locked",
+      keyId: deviceKey.keyId,
+      publicKey: base64ToBytes(deviceKey.publicKey),
+      deviceTrusted: false,
+      webauthnProtected: true,
       error: null,
     })
   } else if (cachedRow) {
@@ -398,7 +449,12 @@ export async function setupNewKey(
   workspaceId: string,
   userId: string,
   passphrase: string,
-  opts?: { params?: KdfParams; trustDevice?: boolean; pin?: string }
+  opts?: {
+    params?: KdfParams
+    trustDevice?: boolean
+    pin?: string
+    webauthn?: { credentialId: string; prfSalt: string; prfSecret: Uint8Array }
+  }
 ): Promise<DeviceTrustResult | undefined> {
   const params = opts?.params ?? DEFAULT_KDF_PARAMS
   const scope = getOrCreateScope(workspaceId, userId)
@@ -433,8 +489,19 @@ export async function setupNewKey(
 
   const trustDevice = opts?.trustDevice ?? false
   const pin = opts?.pin
+  const webauthn = opts?.webauthn
   let trustPersisted = false
-  if (pin) {
+  if (webauthn) {
+    // Biometric quick-unlock: seal the (extractable) fresh key under the
+    // authenticator's PRF secret. A reload requires a biometric assertion.
+    const wrappedPrivate = await wrapPrivateKeyWithPrf(uik.privateKey, webauthn.prfSecret)
+    trustPersisted = await tryPersistWebAuthnDeviceKey(workspaceId, userId, view.keyId, view.publicKey, {
+      credentialId: webauthn.credentialId,
+      prfSalt: webauthn.prfSalt,
+      wrappedPrivate,
+    })
+    if (scope.loadGeneration !== generation) return
+  } else if (pin) {
     // PIN quick-unlock: seal the (extractable) fresh key under the PIN-derived
     // KEK and store the bundle — a reload will require the PIN, not auto-resume.
     const wrapped = await wrapPrivateKeyWithPin(uik.privateKey, pin)
@@ -457,9 +524,10 @@ export async function setupNewKey(
     privateKey: uik.privateKey,
     deviceTrusted: trustPersisted,
     pinProtected: false,
+    webauthnProtected: false,
     error: null,
   })
-  return { trustRequested: trustDevice || !!pin, trustPersisted }
+  return { trustRequested: trustDevice || !!pin || !!webauthn, trustPersisted }
 }
 
 /**
@@ -471,7 +539,11 @@ export async function unlock(
   workspaceId: string,
   userId: string,
   passphrase: string,
-  opts?: { trustDevice?: boolean; pin?: string }
+  opts?: {
+    trustDevice?: boolean
+    pin?: string
+    webauthn?: { credentialId: string; prfSalt: string; prfSecret: Uint8Array }
+  }
 ): Promise<DeviceTrustResult | undefined> {
   const scope = getOrCreateScope(workspaceId, userId)
   const cached = scope.cachedKey
@@ -480,6 +552,7 @@ export async function unlock(
   }
   const trustDevice = opts?.trustDevice ?? false
   const pin = opts?.pin
+  const webauthn = opts?.webauthn
   const generation = ++scope.loadGeneration
   setState(workspaceId, userId, { status: "unlocking", error: null })
 
@@ -487,9 +560,9 @@ export async function unlock(
   try {
     const kek = await deriveKEK(passphrase, cached.kdfSalt, cached.kdfParams)
     // Non-extractable by default — the session never needs the raw bytes back.
-    // Setting a device PIN is the exception: it must re-seal the private key
-    // under the PIN-KEK, which requires an extractable key to export.
-    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek, { extractable: !!pin })
+    // Setting a device PIN or biometric is the exception: it must re-seal the
+    // private key under the new KEK, which requires an extractable key to export.
+    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek, { extractable: !!pin || !!webauthn })
   } catch (err) {
     // Only a derive/unwrap failure is the wrong-passphrase (or tampered-bundle)
     // case — the one condition the modal surfaces as "try again". Failures in
@@ -507,7 +580,15 @@ export async function unlock(
   // device-trust write does. Persisting (or clearing) trust is best-effort: a
   // failed IDB write means "not kept unlocked", never a failed unlock.
   let trustPersisted = false
-  if (pin) {
+  if (webauthn) {
+    // Re-seal under the authenticator's PRF secret: a reload requires biometric.
+    const wrappedPrivate = await wrapPrivateKeyWithPrf(privateKey, webauthn.prfSecret)
+    trustPersisted = await tryPersistWebAuthnDeviceKey(workspaceId, userId, cached.keyId, cached.publicKey, {
+      credentialId: webauthn.credentialId,
+      prfSalt: webauthn.prfSalt,
+      wrappedPrivate,
+    })
+  } else if (pin) {
     // Re-seal under the PIN: a reload will require the PIN, not auto-resume.
     const wrapped = await wrapPrivateKeyWithPin(privateKey, pin)
     trustPersisted = await tryPersistPinDeviceKey(workspaceId, userId, cached.keyId, cached.publicKey, wrapped)
@@ -530,9 +611,10 @@ export async function unlock(
     privateKey,
     deviceTrusted: trustPersisted,
     pinProtected: false,
+    webauthnProtected: false,
     error: null,
   })
-  return { trustRequested: trustDevice || !!pin, trustPersisted }
+  return { trustRequested: trustDevice || !!pin || !!webauthn, trustPersisted }
 }
 
 /**
@@ -599,6 +681,51 @@ export async function unlockWithPin(workspaceId: string, userId: string, pin: st
     privateKey,
     deviceTrusted: true,
     pinProtected: false,
+    error: null,
+  })
+}
+
+/**
+ * Resume an unlocked session from this device's biometric (WebAuthn PRF) key.
+ * The caller runs the biometric assertion (`getPrfSecret`) and passes the PRF
+ * secret here; we unwrap the stored bundle with it. No app-side attempt counter
+ * — the authenticator gates biometric attempts itself; a failure here means a
+ * bad/foreign secret, surfaced inline with a passphrase fallback. Throws on
+ * failure so the modal can react.
+ */
+export async function unlockWithWebAuthn(workspaceId: string, userId: string, prfSecret: Uint8Array): Promise<void> {
+  const scope = getOrCreateScope(workspaceId, userId)
+  const row = await readDeviceKey(workspaceId, userId)
+  if (!row?.webauthnWrappedPrivate) {
+    throw new Error("No biometric unlock is set")
+  }
+  const generation = ++scope.loadGeneration
+  setState(workspaceId, userId, { status: "unlocking", error: null })
+
+  let privateKey: CryptoKey
+  try {
+    privateKey = await unwrapPrivateKeyWithPrf(row.webauthnWrappedPrivate, prfSecret)
+  } catch (err) {
+    if (scope.loadGeneration === generation) {
+      setState(workspaceId, userId, {
+        status: "locked",
+        webauthnProtected: true,
+        privateKey: null,
+        error: "Biometric unlock failed — try again or use your passphrase.",
+      })
+    }
+    throw err instanceof Error ? err : new Error("Biometric unlock failed")
+  }
+
+  if (scope.loadGeneration !== generation) return
+
+  setState(workspaceId, userId, {
+    status: "unlocked",
+    keyId: row.keyId,
+    publicKey: base64ToBytes(row.publicKey),
+    privateKey,
+    deviceTrusted: true,
+    webauthnProtected: false,
     error: null,
   })
 }

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -93,6 +93,12 @@ const INITIAL_STATE: E2eSessionState = {
   error: null,
 }
 
+// `setState` merges, so a definitive transition that only set one device-unlock
+// flag could let the other survive stale (e.g. `webauthnProtected: true` lingering
+// after a switch to a PIN-only device, mis-routing the unlock prompt). Spread this
+// into every locked/unlocked transition and override the one that should be true.
+const NO_UNLOCK_PROMPT = { pinProtected: false, webauthnProtected: false } as const
+
 interface ScopeState {
   state: E2eSessionState
   cachedKey: CachedKeyView | null
@@ -321,7 +327,7 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       publicKey: base64ToBytes(deviceKey.publicKey),
       privateKey: deviceKey.privateKey,
       deviceTrusted: true,
-      pinProtected: false,
+      ...NO_UNLOCK_PROMPT,
       error: null,
     })
   } else if (deviceKey?.pinWrappedPrivate) {
@@ -332,6 +338,7 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       keyId: deviceKey.keyId,
       publicKey: base64ToBytes(deviceKey.publicKey),
       deviceTrusted: false,
+      ...NO_UNLOCK_PROMPT,
       pinProtected: true,
       error: null,
     })
@@ -343,12 +350,14 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       keyId: deviceKey.keyId,
       publicKey: base64ToBytes(deviceKey.publicKey),
       deviceTrusted: false,
+      ...NO_UNLOCK_PROMPT,
       webauthnProtected: true,
       error: null,
     })
   } else if (cachedRow) {
     setState(workspaceId, userId, {
       status: "locked",
+      ...NO_UNLOCK_PROMPT,
       keyId: scope.cachedKey!.keyId,
       publicKey: scope.cachedKey!.publicKey,
       deviceTrusted: false,
@@ -383,6 +392,7 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       publicKey: null,
       privateKey: null,
       deviceTrusted: false,
+      ...NO_UNLOCK_PROMPT,
       error: null,
     })
     return
@@ -416,6 +426,7 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
       publicKey: view.publicKey,
       privateKey: null,
       deviceTrusted: false,
+      ...NO_UNLOCK_PROMPT,
       error: null,
     })
     return
@@ -650,7 +661,7 @@ export async function unlockWithPin(workspaceId: string, userId: string, pin: st
       if (scope.loadGeneration === generation) {
         setState(workspaceId, userId, {
           status: "locked",
-          pinProtected: false,
+          ...NO_UNLOCK_PROMPT,
           privateKey: null,
           error: "Too many PIN attempts — unlock with your passphrase.",
         })
@@ -661,6 +672,7 @@ export async function unlockWithPin(workspaceId: string, userId: string, pin: st
         const left = MAX_PIN_ATTEMPTS - attempts
         setState(workspaceId, userId, {
           status: "locked",
+          ...NO_UNLOCK_PROMPT,
           pinProtected: true,
           privateKey: null,
           error: `Incorrect PIN — ${left} attempt${left === 1 ? "" : "s"} left.`,
@@ -680,7 +692,7 @@ export async function unlockWithPin(workspaceId: string, userId: string, pin: st
     publicKey: base64ToBytes(row.publicKey),
     privateKey,
     deviceTrusted: true,
-    pinProtected: false,
+    ...NO_UNLOCK_PROMPT,
     error: null,
   })
 }
@@ -734,6 +746,7 @@ export async function unlockWithWebAuthn(workspaceId: string, userId: string, pr
     if (scope.loadGeneration === generation) {
       setState(workspaceId, userId, {
         status: "locked",
+        ...NO_UNLOCK_PROMPT,
         webauthnProtected: true,
         privateKey: null,
         error: "Biometric unlock failed — try again or use your passphrase.",
@@ -750,7 +763,7 @@ export async function unlockWithWebAuthn(workspaceId: string, userId: string, pr
     publicKey: base64ToBytes(row.publicKey),
     privateKey,
     deviceTrusted: true,
-    webauthnProtected: false,
+    ...NO_UNLOCK_PROMPT,
     error: null,
   })
 }
@@ -803,13 +816,21 @@ export async function rotatePassphrase(
   if (scope.loadGeneration !== generation) return
 
   // Rotation mints a fresh keyId. If this device was trusted, re-persist the
-  // device key under the new keyId (as non-extractable) so the next reload
-  // still resumes unlocked instead of being treated as a stale rotation.
-  // Best-effort: a failed re-persist just drops trust, it doesn't fail rotate.
+  // device key under the new keyId so the next reload still resumes instead of
+  // being treated as a stale rotation. But a PIN/biometric-gated device must not
+  // be silently re-persisted as a plain auto-resume key — that would DOWNGRADE
+  // security by dropping the gate. For those, clear the device key so the user
+  // re-establishes their PIN/biometric under the new passphrase; only plain
+  // trusted devices re-persist automatically. Best-effort either way.
   let trustPersisted = false
   if (wasTrusted) {
-    const hardened = await toNonExtractable(privateKey)
-    trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, hardened)
+    const existing = await readDeviceKey(workspaceId, userId)
+    if (existing?.pinWrappedPrivate || existing?.webauthnWrappedPrivate) {
+      await deleteDeviceKey(workspaceId, userId).catch(() => {})
+    } else {
+      const hardened = await toNonExtractable(privateKey)
+      trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, hardened)
+    }
     if (scope.loadGeneration !== generation) return
   }
   scope.cachedKey = view
@@ -819,6 +840,7 @@ export async function rotatePassphrase(
     publicKey: view.publicKey,
     privateKey,
     deviceTrusted: trustPersisted,
+    ...NO_UNLOCK_PROMPT,
     error: null,
   })
 }

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -80,8 +80,12 @@ known-missing tally, kept current as gaps close:
   locally-stored key, with a lockout that falls back to the passphrase after a few
   wrong tries. The passphrase remains the only recovery root — there's no PIN-based
   account recovery, by design.
-- **No biometric / WebAuthn unlock.** Device trust today is the "keep me unlocked
-  on this device" local-key path, not a fingerprint/passkey-bound key.
+- **Biometric unlock is bound to the device authenticator.** You can set up
+  fingerprint/face unlock (WebAuthn PRF): the local key is wrapped under a secret
+  only your device's authenticator can reproduce, so a reload prompts for the
+  biometric. It needs a PRF-capable passkey/authenticator; where that's
+  unavailable the passphrase (and PIN) paths still work, and the passphrase
+  remains the recovery root.
 - **Attachments: sending is encrypted; the viewer half is still landing.** When you
   attach a file in an encrypted scratchpad it's encrypted on your device before
   upload — the server stores opaque bytes and a placeholder row, and the

--- a/tests/browser/e2e-biometric-unlock.spec.ts
+++ b/tests/browser/e2e-biometric-unlock.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test"
+import { loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * Biometric (WebAuthn PRF) device unlock, end-to-end against a CDP virtual
+ * authenticator (WebAuthn is unavailable in jsdom, so this is the only place the
+ * register→wrap and assert→unwrap ceremony is exercised). A probe confirmed this
+ * Chrome's virtual authenticator supports PRF.
+ */
+
+const PASSPHRASE = "correct horse battery staple"
+
+test.describe("E2E biometric unlock", () => {
+  test("set up with biometric, then unlock via biometric after reload", async ({ page }) => {
+    // A PRF-capable virtual authenticator that auto-satisfies user presence +
+    // verification, attached before any WebAuthn call. It lives on the context,
+    // so the registered credential survives the reload below.
+    const client = await page.context().newCDPSession(page)
+    await client.send("WebAuthn.enable")
+    await client.send("WebAuthn.addVirtualAuthenticator", {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        automaticPresenceSimulation: true,
+        isUserVerified: true,
+        hasPrf: true,
+      },
+    })
+
+    await loginAndCreateWorkspace(page, "e2e-bio")
+
+    // Create an encrypted scratchpad → inline setup modal.
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+    const setup = page.getByRole("dialog")
+    await expect(setup.getByText("Set up encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await setup.locator("#e2e-passphrase").fill(PASSPHRASE)
+    await setup.locator("#e2e-passphrase-confirm").fill(PASSPHRASE)
+    await setup.locator("#e2e-acknowledged").check()
+
+    // Enable biometric (trust-device defaults on, so the option is shown).
+    await setup.getByRole("button", { name: /Set up biometric unlock/i }).click()
+    await expect(setup.getByText(/Biometric unlock enabled/i)).toBeVisible({ timeout: 10_000 })
+    await setup.getByRole("button", { name: "Enable encryption" }).click()
+
+    // Created + unlocked: gate yields, Encrypted pill shows.
+    await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0)
+    await expect(page.getByText("Encrypted", { exact: true })).toBeVisible({ timeout: 15_000 })
+
+    // Reload: biometric-gated, so the full-page gate returns.
+    await page.reload()
+    await expect(page.getByText("This scratchpad is encrypted")).toBeVisible({ timeout: 15_000 })
+
+    // Unlock → provider opens the biometric modal (device is webauthnProtected) →
+    // the assertion is auto-verified by the virtual authenticator.
+    await page.getByRole("button", { name: /^Unlock$/ }).first().click()
+    const bio = page.getByRole("dialog")
+    await expect(bio.getByRole("heading", { name: "Unlock with biometrics" })).toBeVisible({ timeout: 10_000 })
+    await bio.getByRole("button", { name: /Unlock with biometrics/i }).click()
+
+    await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0, { timeout: 15_000 })
+  })
+})


### PR DESCRIPTION
## What & why

Eighth PR in the **E2E-Ariadne alignment stack** (stacked on #748). Adds biometric (fingerprint / face) device quick-unlock via the **WebAuthn PRF extension** — the strongest of the device-unlock options, since the key is cryptographically bound to the authenticator.

A passkey deterministically derives a high-entropy secret (the PRF output) for a salt; we use it directly as the AES-GCM KEK around the UIK private key. Only the device's biometric (user verification) reproduces it. Like PIN, it guards device-local material; **the passphrase stays the recovery root**, and we keep a passphrase fallback everywhere since PRF support varies by browser/OS/authenticator.

## How (four verified commits)

1. **Crypto** (`webauthn-device-key.ts`) — `wrapPrivateKeyWithPrf`/`unwrapPrivateKeyWithPrf` (PRF secret → AES-GCM KEK → existing `wrapPrivate`); the `navigator.credentials` ceremony (`registerPrfCredential`/`getPrfSecret`). (3 unit tests on the pure crypto.)
2. **Store** — `setupNewKey`/`unlock` take an optional `webauthn`; the key is stored `webauthnWrappedPrivate` (no auto-resume), so a reload resumes `locked` + `webauthnProtected`. `unlockWithWebAuthn`/`unlockWithBiometric` recover it. (22 store tests.)
3. **UI** — a "Set up biometric unlock" action in the setup modal (biometric > PIN), a one-tap `BiometricUnlockModal` (with passphrase fallback), and provider routing so `openUnlock` picks biometric → PIN → passphrase. The gate + every unlock affordance get it for free.
4. **E2E** — a CDP **virtual-authenticator** Playwright spec (`hasPrf`) driving register → reload → biometric unlock end-to-end. A throwaway probe first confirmed this Chrome's virtual authenticator does PRF.

## Test plan

- crypto 3 + store 22 + encryption components green; typecheck + eslint clean.
- **Biometric E2E passes** (virtual authenticator): setup-with-biometric → reload → biometric-locked gate → biometric unlock → timeline.

## Boundaries

- PRF support varies (browser/OS/authenticator); the passphrase fallback is always present, and the setup option only shows when WebAuthn is available.
- No app-side attempt counter for biometric — the authenticator gates attempts itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783079535&installation_id=129946197&pr_number=749&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F749&signature=6fdf852a31366a64939097489f883f20a90c237d7ed390f7788ec95ed29e01dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->