### PR TITLE
fix(sidebar): align New button chevron with account row

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -279,7 +279,7 @@ function SidebarCreateButtonFace() {
 }
 
 const CREATE_BUTTON_CLASS =
-  "group/new w-full justify-start gap-2.5 px-2.5 bg-primary/[0.04] hover:bg-primary/10 hover:text-foreground data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
+  "group/new w-full justify-start gap-2.5 px-3 bg-primary/[0.04] hover:bg-primary/10 hover:text-foreground data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
 
 /**
  * The always-visible "New" control at the bottom of the sidebar. Opens a menu of


### PR DESCRIPTION
The footer's New button used px-2.5 while the account row beneath it
used px-3, so their trailing up-chevrons (designed to rhyme) sat 2px
apart — a subtle but noticeable misalignment. Match the New button to
the account row's px-3 so both chevrons (and the leading icons) line up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783094361&installation_id=129946197&pr_number=751&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F751&signature=733cad375ba59af847d50ccaee95c073defcccdbfcb2bb5de25674f59ee1aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->