### PR TITLE
Add waitlist view to backoffice admin

### DIFF
--- a/apps/backoffice/src/api/backoffice.ts
+++ b/apps/backoffice/src/api/backoffice.ts
@@ -96,12 +96,34 @@ export interface WorkspaceInvitation {
   } | null
 }
 
+export interface WaitlistEntry {
+  id: string
+  email: string
+  source: string | null
+  status: string
+  createdAt: string
+}
+
+export interface WaitlistStats {
+  total: number
+  pending: number
+  invited: number
+}
+
+export interface WaitlistOverview {
+  entries: WaitlistEntry[]
+  stats: WaitlistStats
+  /** True when there are more signups than `entries` contains (list is capped). */
+  truncated: boolean
+}
+
 export const backofficeKeys = {
   workspaces: ["backoffice", "workspaces"] as const,
   workspace: (id: string) => ["backoffice", "workspaces", id] as const,
   workspaceMembers: (id: string) => ["backoffice", "workspaces", id, "members"] as const,
   workspaceInvitations: (id: string) => ["backoffice", "workspaces", id, "invitations"] as const,
   invitations: ["backoffice", "invitations"] as const,
+  waitlist: ["backoffice", "waitlist"] as const,
   config: ["backoffice", "config"] as const,
 }
 
@@ -143,6 +165,10 @@ export function revokeWorkspaceOwnerInvitation(id: string): Promise<void> {
 
 export function getBackofficeConfig(): Promise<BackofficeConfig> {
   return api.get<{ config: BackofficeConfig }>("/api/backoffice/config").then((r) => r.config)
+}
+
+export function getWaitlist(): Promise<WaitlistOverview> {
+  return api.get<{ waitlist: WaitlistOverview }>("/api/backoffice/waitlist").then((r) => r.waitlist)
 }
 
 export function listWorkspaceMembers(id: string): Promise<WorkspaceMember[]> {

--- a/apps/backoffice/src/components/layout/backoffice-shell.tsx
+++ b/apps/backoffice/src/components/layout/backoffice-shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react"
 import { Link, NavLink, Outlet } from "react-router-dom"
-import { LayoutDashboard, Users, MailPlus } from "lucide-react"
+import { LayoutDashboard, Users, MailPlus, ClipboardList } from "lucide-react"
 import { ThreaLogo } from "@/components/threa-logo"
 import { useAuth } from "@/auth"
 import { cn } from "@/lib/utils"
@@ -17,6 +17,7 @@ const NAV_ITEMS: Array<{ to: string; label: string; icon: ReactNode; end?: boole
   { to: "/", label: "Overview", icon: <LayoutDashboard className="size-4" />, end: true },
   // `end` is omitted so NavLink treats `/workspaces/:id` as active too.
   { to: "/workspaces", label: "Workspaces", icon: <Users className="size-4" /> },
+  { to: "/waitlist", label: "Waitlist", icon: <ClipboardList className="size-4" /> },
   { to: "/invites/workspace-owners", label: "Invitations", icon: <MailPlus className="size-4" /> },
 ]
 

--- a/apps/backoffice/src/lib/format.ts
+++ b/apps/backoffice/src/lib/format.ts
@@ -12,3 +12,16 @@ export function formatDateTime(iso: string): string {
     minute: "2-digit",
   })
 }
+
+/**
+ * Date-only variant of {@link formatDateTime} for list rows and previews where
+ * the time-of-day would be noise. Same en-GB convention so dates read the same
+ * across the backoffice (INV-35).
+ */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  })
+}

--- a/apps/backoffice/src/pages/waitlist.test.tsx
+++ b/apps/backoffice/src/pages/waitlist.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import { WaitlistPage } from "./waitlist"
+import type { WaitlistOverview } from "@/api/backoffice"
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <WaitlistPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function installFetch(body: { waitlist?: WaitlistOverview; error?: string; code?: string }, status = 200) {
+  const fetchMock = vi.fn(async () => {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function makeOverview(overrides: Partial<WaitlistOverview> = {}): WaitlistOverview {
+  return {
+    entries: [],
+    stats: { total: 0, pending: 0, invited: 0 },
+    truncated: false,
+    ...overrides,
+  }
+}
+
+describe("WaitlistPage", () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("renders the empty state when no one has joined", async () => {
+    const fetchMock = installFetch({ waitlist: makeOverview() })
+    renderPage()
+
+    await screen.findByText(/No one has joined the waitlist yet/)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/backoffice/waitlist"),
+      expect.objectContaining({ method: "GET" })
+    )
+  })
+
+  it("renders the exact counts and one row per signup", async () => {
+    installFetch({
+      waitlist: makeOverview({
+        stats: { total: 2, pending: 1, invited: 1 },
+        entries: [
+          {
+            id: "wl_1",
+            email: "alice@example.com",
+            source: "marketing-hero",
+            status: "pending",
+            createdAt: new Date("2026-05-01T10:00:00Z").toISOString(),
+          },
+          {
+            id: "wl_2",
+            email: "bob@example.com",
+            source: null,
+            status: "invited",
+            createdAt: new Date("2026-04-20T10:00:00Z").toISOString(),
+          },
+        ],
+      }),
+    })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("alice@example.com")).toBeInTheDocument()
+    })
+    // Both signups render
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument()
+    // Source shows through, and a missing source falls back to "direct"
+    expect(screen.getByText("marketing-hero")).toBeInTheDocument()
+    expect(screen.getByText("direct")).toBeInTheDocument()
+    // Status badges
+    expect(screen.getByText("pending")).toBeInTheDocument()
+    expect(screen.getByText("invited")).toBeInTheDocument()
+    // Exact headline counts (Total / Pending / Invited each render their value)
+    expect(screen.getByText("Total signups")).toBeInTheDocument()
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("filters the list by the search query", async () => {
+    installFetch({
+      waitlist: makeOverview({
+        stats: { total: 2, pending: 2, invited: 0 },
+        entries: [
+          {
+            id: "wl_1",
+            email: "alice@example.com",
+            source: null,
+            status: "pending",
+            createdAt: new Date().toISOString(),
+          },
+          {
+            id: "wl_2",
+            email: "bob@example.com",
+            source: null,
+            status: "pending",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    })
+
+    renderPage()
+
+    await screen.findByText("alice@example.com")
+
+    fireEvent.change(screen.getByPlaceholderText(/Search by email/), { target: { value: "bob" } })
+
+    expect(screen.queryByText("alice@example.com")).not.toBeInTheDocument()
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument()
+  })
+
+  it("notes when the list is truncated", async () => {
+    installFetch({
+      waitlist: makeOverview({
+        stats: { total: 600, pending: 600, invited: 0 },
+        truncated: true,
+        entries: [
+          {
+            id: "wl_1",
+            email: "newest@example.com",
+            source: null,
+            status: "pending",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    })
+
+    renderPage()
+
+    await screen.findByText(/most recent signups of/)
+  })
+})

--- a/apps/backoffice/src/pages/waitlist.tsx
+++ b/apps/backoffice/src/pages/waitlist.tsx
@@ -4,15 +4,8 @@ import { Search } from "lucide-react"
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { PageHeader } from "@/components/layout/page-header"
+import { formatDate } from "@/lib/format"
 import { backofficeKeys, getWaitlist, type WaitlistEntry } from "@/api/backoffice"
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  })
-}
 
 /** Known statuses get a deliberate colour; anything unexpected falls back to outline. */
 const STATUS_VARIANT: Record<string, BadgeProps["variant"]> = {

--- a/apps/backoffice/src/pages/waitlist.tsx
+++ b/apps/backoffice/src/pages/waitlist.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Search } from "lucide-react"
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { PageHeader } from "@/components/layout/page-header"
+import { backofficeKeys, getWaitlist, type WaitlistEntry } from "@/api/backoffice"
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  })
+}
+
+/** Known statuses get a deliberate colour; anything unexpected falls back to outline. */
+const STATUS_VARIANT: Record<string, BadgeProps["variant"]> = {
+  pending: "secondary",
+  invited: "default",
+}
+
+function statusVariant(status: string): BadgeProps["variant"] {
+  return STATUS_VARIANT[status] ?? "outline"
+}
+
+function matches(entry: WaitlistEntry, q: string): boolean {
+  if (!q) return true
+  const needle = q.toLowerCase()
+  return (
+    entry.email.toLowerCase().includes(needle) ||
+    entry.status.toLowerCase().includes(needle) ||
+    (entry.source?.toLowerCase().includes(needle) ?? false)
+  )
+}
+
+export function WaitlistPage() {
+  const waitlistQ = useQuery({
+    queryKey: backofficeKeys.waitlist,
+    queryFn: getWaitlist,
+  })
+
+  const [query, setQuery] = useState("")
+  const entries = waitlistQ.data?.entries ?? []
+  const filtered = useMemo(() => entries.filter((e) => matches(e, query)), [entries, query])
+
+  const stats = waitlistQ.data?.stats
+  const truncated = waitlistQ.data?.truncated ?? false
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-8">
+      <PageHeader
+        title="Waitlist"
+        description="Everyone who signed up from the marketing site, newest first. Counts are exact; the list shows the most recent signups."
+      />
+
+      {/* Bordered band of exact counts — mirrors the Overview stat band. */}
+      <div className="grid grid-cols-1 divide-y border-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+        <Stat label="Total signups" value={stats?.total ?? null} />
+        <Stat label="Pending" value={stats?.pending ?? null} highlight={!!stats && stats.pending > 0} />
+        <Stat label="Invited" value={stats?.invited ?? null} />
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search by email, source, or status"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {waitlistQ.isLoading ? "Loading…" : `${filtered.length} of ${entries.length}`}
+        </span>
+      </div>
+
+      <WaitlistList loading={waitlistQ.isLoading} entries={filtered} query={query} />
+
+      {truncated ? (
+        <p className="text-xs text-muted-foreground">
+          Showing the {entries.length} most recent signups of {stats?.total ?? entries.length} total.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function Stat({ label, value, highlight }: { label: string; value: number | null; highlight?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1 px-1 py-5 sm:px-6">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</span>
+      <span
+        className={
+          highlight
+            ? "text-3xl font-semibold tabular-nums text-primary"
+            : "text-3xl font-semibold tabular-nums text-foreground"
+        }
+      >
+        {value == null ? <span className="text-muted-foreground">—</span> : value}
+      </span>
+    </div>
+  )
+}
+
+function WaitlistList({ loading, entries, query }: { loading: boolean; entries: WaitlistEntry[]; query: string }) {
+  if (loading) {
+    return <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">Loading signups…</div>
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="border-y px-1 py-10 text-center text-sm text-muted-foreground">
+        {query ? "No signups match that query." : "No one has joined the waitlist yet."}
+      </div>
+    )
+  }
+
+  return (
+    <ul className="divide-y border-y">
+      {entries.map((entry) => (
+        <li key={entry.id} className="flex items-center justify-between gap-4 py-4 pl-4 pr-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <span className="truncate text-sm font-medium text-foreground">{entry.email}</span>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+              <span className="truncate">{entry.source ?? "direct"}</span>
+              <span className="text-muted-foreground/50">·</span>
+              <span className="tabular-nums">{formatDate(entry.createdAt)}</span>
+            </div>
+          </div>
+          <Badge variant={statusVariant(entry.status)} className="shrink-0 capitalize">
+            {entry.status}
+          </Badge>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/backoffice/src/pages/welcome.tsx
+++ b/apps/backoffice/src/pages/welcome.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "@/components/layout/page-header"
 import { Section } from "@/components/layout/section"
 import { useUser } from "@/auth"
 import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/format"
 import {
   backofficeKeys,
   listWorkspaceOwnerInvitations,
@@ -16,14 +17,6 @@ import {
 } from "@/api/backoffice"
 
 const RECENT_LIMIT = 5
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  })
-}
 
 function countByState(
   invitations: WorkspaceOwnerInvitation[] | undefined,

--- a/apps/backoffice/src/pages/workspaces.tsx
+++ b/apps/backoffice/src/pages/workspaces.tsx
@@ -4,15 +4,8 @@ import { Link } from "react-router-dom"
 import { ChevronRight, Search } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { PageHeader } from "@/components/layout/page-header"
+import { formatDate } from "@/lib/format"
 import { backofficeKeys, listWorkspaces, type WorkspaceSummary } from "@/api/backoffice"
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  })
-}
 
 function matches(workspace: WorkspaceSummary, q: string): boolean {
   if (!q) return true

--- a/apps/backoffice/src/routes/index.tsx
+++ b/apps/backoffice/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { ProtectedRoute } from "@/components/protected-route"
 import { WelcomePage } from "@/pages/welcome"
 import { InviteWorkspaceOwnerPage } from "@/pages/invite-workspace-owner"
 import { WorkspacesPage } from "@/pages/workspaces"
+import { WaitlistPage } from "@/pages/waitlist"
 import { WorkspaceDetailLayout } from "@/pages/workspace-detail-layout"
 import { WorkspaceDetailOverviewPage } from "@/pages/workspace-detail-overview"
 import { WorkspaceDetailMembersPage } from "@/pages/workspace-detail-members"
@@ -19,6 +20,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <WelcomePage /> },
       { path: "workspaces", element: <WorkspacesPage /> },
+      { path: "waitlist", element: <WaitlistPage /> },
       {
         path: "workspaces/:id",
         element: <WorkspaceDetailLayout />,

--- a/apps/control-plane/src/features/backoffice/handlers.ts
+++ b/apps/control-plane/src/features/backoffice/handlers.ts
@@ -154,5 +154,10 @@ export function createBackofficeHandlers({ backofficeService }: Dependencies) {
     async getConfig(_req: Request, res: Response) {
       res.json({ config: backofficeService.getConfig() })
     },
+
+    async listWaitlist(_req: Request, res: Response) {
+      const waitlist = await backofficeService.listWaitlist()
+      res.json({ waitlist })
+    },
   }
 }

--- a/apps/control-plane/src/features/backoffice/index.ts
+++ b/apps/control-plane/src/features/backoffice/index.ts
@@ -8,6 +8,9 @@ export type {
   WorkspaceOwnerSummary,
   WorkspaceRef,
   BackofficeConfig,
+  WaitlistEntry,
+  WaitlistStats,
+  WaitlistOverview,
 } from "./service"
 export { createBackofficeHandlers } from "./handlers"
 export { createPlatformAdminMiddleware } from "./middleware"

--- a/apps/control-plane/src/features/backoffice/service.ts
+++ b/apps/control-plane/src/features/backoffice/service.ts
@@ -15,7 +15,16 @@ import { WorkspaceRegistryRepository } from "../workspaces"
 import { WorkosAuthzBackfill, WorkosAuthzRepository } from "../workos-authz"
 import type { WorkosAuthzOrganizationBackfillResult } from "../workos-authz"
 import { InvitationShadowRepository } from "../invitation-shadows"
+import { WaitlistRepository } from "../waitlist"
 import { CONTROL_PLANE_LISTENER_ID } from "../../lib/outbox-listeners"
+
+/**
+ * Cap on the number of waitlist rows returned to the backoffice table. The
+ * headline counts come from a separate grouped query (exact regardless of this
+ * cap), so a large waitlist degrades to "most recent N" rather than an
+ * unbounded payload.
+ */
+const WAITLIST_LIST_LIMIT = 500
 
 /** Platform roles recognised by the backoffice gate. */
 export const PLATFORM_ROLES = ["admin"] as const
@@ -129,6 +138,34 @@ export interface WorkspaceInvitationSummary {
     email: string | null
     name: string | null
   } | null
+}
+
+/** A single marketing-site waitlist signup, shaped for the backoffice table. */
+export interface WaitlistEntry {
+  id: string
+  email: string
+  /** Where the signup came from (marketing CTA id, etc.); null when unset. */
+  source: string | null
+  status: string
+  createdAt: string
+}
+
+/** Exact signup counts, computed in the database so a list cap never skews them. */
+export interface WaitlistStats {
+  total: number
+  pending: number
+  invited: number
+}
+
+/**
+ * Backoffice waitlist view: the most recent signups plus exact headline counts.
+ * `truncated` is true when there are more signups than `entries` contains, so
+ * the UI can say "showing the most recent N".
+ */
+export interface WaitlistOverview {
+  entries: WaitlistEntry[]
+  stats: WaitlistStats
+  truncated: boolean
 }
 
 /**
@@ -452,6 +489,38 @@ export class BackofficeService {
       createdAt: row.created_at.toISOString(),
       inviter: summarizeInviter(row.inviter_workos_user_id, inviterById),
     }))
+  }
+
+  /**
+   * Backoffice waitlist view. Returns the most recent signups (capped) for the
+   * table alongside exact status counts computed in the database, so the
+   * headline numbers stay accurate even when the list is truncated. The two
+   * reads run concurrently — neither depends on the other.
+   */
+  async listWaitlist(): Promise<WaitlistOverview> {
+    const [rows, counts] = await Promise.all([
+      WaitlistRepository.list(this.pool, WAITLIST_LIST_LIMIT),
+      WaitlistRepository.statusCounts(this.pool),
+    ])
+
+    const countByStatus = new Map(counts.map((c) => [c.status, c.count]))
+    const total = counts.reduce((sum, c) => sum + c.count, 0)
+
+    return {
+      entries: rows.map((row) => ({
+        id: row.id,
+        email: row.email,
+        source: row.source,
+        status: row.status,
+        createdAt: row.created_at.toISOString(),
+      })),
+      stats: {
+        total,
+        pending: countByStatus.get("pending") ?? 0,
+        invited: countByStatus.get("invited") ?? 0,
+      },
+      truncated: total > rows.length,
+    }
   }
 
   // --- private helpers -----------------------------------------------------

--- a/apps/control-plane/src/features/waitlist/repository.ts
+++ b/apps/control-plane/src/features/waitlist/repository.ts
@@ -24,4 +24,33 @@ export const WaitlistRepository = {
     )
     return (result.rowCount ?? 0) > 0
   },
+
+  /**
+   * Most recent signups first, capped at `limit`. Backs the backoffice waitlist
+   * view — the table only needs a recent window; accurate totals come from
+   * {@link statusCounts} so a capped list never skews the headline numbers.
+   */
+  async list(db: Querier, limit: number): Promise<WaitlistRow[]> {
+    const result = await db.query<WaitlistRow>(
+      `SELECT id, email, source, status, created_at, updated_at
+       FROM waitlist
+       ORDER BY created_at DESC
+       LIMIT $1`,
+      [limit]
+    )
+    return result.rows
+  },
+
+  /**
+   * Signup counts grouped by status, computed in the database so the totals are
+   * exact regardless of any list cap. Uses the `(status, created_at)` index.
+   */
+  async statusCounts(db: Querier): Promise<Array<{ status: string; count: number }>> {
+    const result = await db.query<{ status: string; count: number }>(
+      `SELECT status, COUNT(*)::int AS count
+       FROM waitlist
+       GROUP BY status`
+    )
+    return result.rows
+  },
 }

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -171,6 +171,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     backoffice.resyncWorkspaceMembers
   )
   app.get("/api/backoffice/outbox-events/status", auth, requirePlatformAdmin, backoffice.getOutboxEventsStatus)
+  app.get("/api/backoffice/waitlist", auth, requirePlatformAdmin, backoffice.listWaitlist)
   app.get("/api/backoffice/workspaces/:id/invitations", auth, requirePlatformAdmin, backoffice.listWorkspaceInvitations)
   app.get(
     "/api/backoffice/workspace-owner-invitations",

--- a/apps/control-plane/tests/e2e/backoffice.test.ts
+++ b/apps/control-plane/tests/e2e/backoffice.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from "bun:test"
 import { Pool } from "pg"
+import { waitlistId } from "@threa/backend-common"
 import { TestClient, loginAs, createWorkspace } from "../client"
 import { PlatformRoleRepository } from "../../src/features/backoffice"
+import { WaitlistRepository } from "../../src/features/waitlist"
 import { WorkosAuthzRepository } from "../../src/features/workos-authz"
 import { WorkspaceRegistryRepository } from "../../src/features/workspaces"
 import { CONTROL_PLANE_LISTENER_ID } from "../../src/lib/outbox-listeners"
@@ -54,6 +56,19 @@ async function seedMembership(input: {
       observedAt,
     })
     return { workosOrganizationId: ws.workos_organization_id, lastEventAt: observedAt }
+  } finally {
+    await pool.end()
+  }
+}
+
+/** Insert a single waitlist signup directly, mirroring the public signup path. */
+async function seedWaitlistEntry(email: string, source: string | null): Promise<void> {
+  const pool = new Pool({
+    connectionString:
+      process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_control_plane_test",
+  })
+  try {
+    await WaitlistRepository.insert(pool, { id: waitlistId(), email, source })
   } finally {
     await pool.end()
   }
@@ -405,6 +420,52 @@ describe("Backoffice", () => {
       } finally {
         await pool.end()
       }
+    })
+  })
+
+  describe("GET /api/backoffice/waitlist", () => {
+    test("returns 401 without session", async () => {
+      const client = new TestClient()
+      const res = await client.get("/api/backoffice/waitlist")
+      expect(res.status).toBe(401)
+    })
+
+    test("returns 403 when authenticated but not a platform admin", async () => {
+      const client = new TestClient()
+      await loginAs(client, "waitlist-nonadmin@example.com", "Waitlist Non Admin")
+
+      const res = await client.get<{ code: string }>("/api/backoffice/waitlist")
+      expect(res.status).toBe(403)
+      expect(res.data.code).toBe("NOT_PLATFORM_ADMIN")
+    })
+
+    test("returns recent signups and exact counts for a platform admin", async () => {
+      const client = new TestClient()
+      const user = await loginAs(client, "waitlist-admin@example.com", "Waitlist Admin")
+      await grantAdmin(user.id)
+
+      const seededEmail = `waitlist-seed-${Date.now()}@example.com`
+      await seedWaitlistEntry(seededEmail, "marketing-hero")
+
+      const res = await client.get<{
+        waitlist: {
+          entries: Array<{ id: string; email: string; source: string | null; status: string; createdAt: string }>
+          stats: { total: number; pending: number; invited: number }
+          truncated: boolean
+        }
+      }>("/api/backoffice/waitlist")
+
+      expect(res.status).toBe(200)
+      const seeded = res.data.waitlist.entries.find((e) => e.email === seededEmail)
+      expect(seeded).toBeTruthy()
+      expect(seeded?.source).toBe("marketing-hero")
+      // New signups default to pending and carry a round-trippable ISO timestamp.
+      expect(seeded?.status).toBe("pending")
+      expect(new Date(seeded!.createdAt).toISOString()).toBe(seeded!.createdAt)
+      // Counts are computed in the DB, so they cover at least the row we seeded.
+      expect(res.data.waitlist.stats.total).toBeGreaterThanOrEqual(1)
+      expect(res.data.waitlist.stats.pending).toBeGreaterThanOrEqual(1)
+      expect(typeof res.data.waitlist.truncated).toBe("boolean")
     })
   })
 


### PR DESCRIPTION
## What

Marketing-site waitlist signups (the control-plane `waitlist` table) had no admin surface — they could only be inspected by querying the database directly. This adds a read-only **Waitlist** view to the backoffice app.

## Changes

**Backend (control-plane)**
- `WaitlistRepository` gains `list` (most recent signups, capped at 500) and `statusCounts` (counts grouped in the DB, using the existing `(status, created_at)` index).
- `BackofficeService.listWaitlist` composes both via concurrent reads → `{ entries, stats, truncated }`. Counts come from the grouped query so they stay exact even when the list is capped.
- New route `GET /api/backoffice/waitlist`, gated by `requirePlatformAdmin` like every other backoffice route.

**Frontend (backoffice)**
- New Waitlist page that extends the existing backoffice design system (matches `workspaces.tsx` / `welcome.tsx`): exact-count stat band, searchable list, status badges. No new fonts/heroes/eyebrows.
- Nav item (`ClipboardList`), route wiring, typed fetcher + query key.

## Design decisions

- **Read logic lives in `BackofficeService`, not `WaitlistService`.** That service already aggregates other features' repositories for the admin surface (`WorkspaceRegistryRepository`, `InvitationShadowRepository`), importing them via feature barrels (INV-52). Keeping the waitlist read there leaves the handler wiring unchanged and matches the established pattern.
- **Exact counts come from a separate grouped query**, not from `.length` of the capped list, so a large waitlist degrades to "most recent N" without skewing the headline numbers.
- **`formatDate` consolidated into `lib/format.ts`.** Self-review caught a third copy of the date-only helper; it now lives in the existing date-formatting SSOT and the local copies in the waitlist/workspaces/welcome pages were removed (INV-35).

## Testing

- E2E (control-plane): `GET /api/backoffice/waitlist` — 401 (no session), 403 (non-admin), and the populated shape/counts.
- Vitest (backoffice): the Waitlist page mounted as a real component (INV-39) across empty / populated / search-filtered / truncated states.
- `bun run --cwd apps/backoffice test` → 11 passing; typecheck + lint clean on both apps.

> Note: the control-plane e2e suite needs Docker/Postgres, which isn't available in the authoring environment, so that suite was not executed here — it runs in CI. The new test follows the existing `backoffice.test.ts` harness exactly.

https://claude.ai/code/session_01MVMEYwdEbYMW9ALexPZGSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVMEYwdEbYMW9ALexPZGSV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783094664&installation_id=129946197&pr_number=753&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F753&signature=77d301625d5e1fed699b50f264886fa9449a5bddd2b08efa7697196c8a20d0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->