### PR TITLE
fix(push): stop the service worker silencing notifications you can't actually see

### DIFF
--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -7,6 +7,7 @@ import {
   PrefNotificationLevels,
   ActivityTypes,
   StreamTypes,
+  PRESENCE_INTERACTION_WINDOW_MS,
   type PrefNotificationLevel,
   type StreamType,
 } from "@threa/types"
@@ -36,7 +37,9 @@ const CURRENTLY_FOCUSED_WINDOW_MS = 60_000
  * fall through to fanout so the user gets notified on whichever device they
  * pick up next.
  */
-const RECENT_INTERACTION_WINDOW_MS = 2 * 60 * 1_000 // 2 minutes
+// Shared with the frontend SW's push-suppression check so the two layers agree
+// on what "present" means (@threa/types).
+const RECENT_INTERACTION_WINDOW_MS = PRESENCE_INTERACTION_WINDOW_MS
 
 /**
  * Per-device session expiry window. If a specific device has not sent a heartbeat

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -5,21 +5,13 @@ import { api } from "@/api/client"
 import { getCachedWsConfig, setCachedWsConfig } from "@/lib/cached-ws-config"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
-import { recordInteractionPresence } from "@/lib/sw-presence"
+import { useSwPresence } from "@/hooks/use-sw-presence"
 
 /** Periodic heartbeat tick for session liveness — must be < ACTIVE_SESSION_WINDOW_MS on the backend (60s). */
 const PERIODIC_HEARTBEAT_INTERVAL_MS = 30_000
 
 /** Throttle for focus-change-driven heartbeats so a flicker of blur/focus events doesn't flood the socket. */
 const FOCUS_CHANGE_HEARTBEAT_THROTTLE_MS = 10_000
-
-/**
- * Throttle for writing the device-presence timestamp the service worker reads
- * to gate push suppression. A single write captures "last interaction" accurate
- * to within this interval — well under the SW's 2-minute presence window — so
- * we don't touch Cache Storage on every pointer move.
- */
-const PRESENCE_WRITE_THROTTLE_MS = 10_000
 
 /**
  * Socket connection status.
@@ -254,23 +246,9 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
     }
   }, [socket, status, pageInteraction])
 
-  // Record this device's recent interaction so the service worker can gate push
-  // suppression on activity, not focus alone (a focused-but-abandoned tab should
-  // stop silencing notifications). Independent of socket status — push delivery
-  // matters even when the socket is down (flaky mobile). Seeded immediately when
-  // the window is focused so the stream you just opened is treated as watched.
-  useEffect(() => {
-    if (typeof window === "undefined" || !("caches" in window)) return
-    let lastWriteAt = 0
-    const write = () => {
-      const now = Date.now()
-      if (now - lastWriteAt < PRESENCE_WRITE_THROTTLE_MS) return
-      lastWriteAt = now
-      void recordInteractionPresence(now)
-    }
-    if (document.hasFocus()) write()
-    return pageInteraction.subscribe(write)
-  }, [pageInteraction])
+  // Record recent interaction so the SW can gate push suppression on activity,
+  // not focus alone (see useSwPresence). Reuses the tracker the heartbeats use.
+  useSwPresence(pageInteraction)
 
   useEffect(() => {
     const previousPageActivity = previousPageActivityRef.current

--- a/apps/frontend/src/contexts/socket-context.tsx
+++ b/apps/frontend/src/contexts/socket-context.tsx
@@ -5,12 +5,21 @@ import { api } from "@/api/client"
 import { getCachedWsConfig, setCachedWsConfig } from "@/lib/cached-ws-config"
 import { usePageActivity } from "@/hooks/use-page-activity"
 import { usePageInteraction } from "@/hooks/use-page-interaction"
+import { recordInteractionPresence } from "@/lib/sw-presence"
 
 /** Periodic heartbeat tick for session liveness — must be < ACTIVE_SESSION_WINDOW_MS on the backend (60s). */
 const PERIODIC_HEARTBEAT_INTERVAL_MS = 30_000
 
 /** Throttle for focus-change-driven heartbeats so a flicker of blur/focus events doesn't flood the socket. */
 const FOCUS_CHANGE_HEARTBEAT_THROTTLE_MS = 10_000
+
+/**
+ * Throttle for writing the device-presence timestamp the service worker reads
+ * to gate push suppression. A single write captures "last interaction" accurate
+ * to within this interval — well under the SW's 2-minute presence window — so
+ * we don't touch Cache Storage on every pointer move.
+ */
+const PRESENCE_WRITE_THROTTLE_MS = 10_000
 
 /**
  * Socket connection status.
@@ -244,6 +253,24 @@ export function SocketProvider({ workspaceId, children }: SocketProviderProps) {
       unsubscribe()
     }
   }, [socket, status, pageInteraction])
+
+  // Record this device's recent interaction so the service worker can gate push
+  // suppression on activity, not focus alone (a focused-but-abandoned tab should
+  // stop silencing notifications). Independent of socket status — push delivery
+  // matters even when the socket is down (flaky mobile). Seeded immediately when
+  // the window is focused so the stream you just opened is treated as watched.
+  useEffect(() => {
+    if (typeof window === "undefined" || !("caches" in window)) return
+    let lastWriteAt = 0
+    const write = () => {
+      const now = Date.now()
+      if (now - lastWriteAt < PRESENCE_WRITE_THROTTLE_MS) return
+      lastWriteAt = now
+      void recordInteractionPresence(now)
+    }
+    if (document.hasFocus()) write()
+    return pageInteraction.subscribe(write)
+  }, [pageInteraction])
 
   useEffect(() => {
     const previousPageActivity = previousPageActivityRef.current

--- a/apps/frontend/src/hooks/use-sw-presence.ts
+++ b/apps/frontend/src/hooks/use-sw-presence.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react"
+import { recordInteractionPresence } from "@/lib/sw-presence"
+import type { PageInteractionTracker } from "@/hooks/use-page-interaction"
+
+/**
+ * Throttle for writing the device-presence timestamp the service worker reads
+ * to gate push suppression. A single write captures "last interaction" accurate
+ * to within this interval — well under the SW's presence window — so we don't
+ * touch Cache Storage on every pointer move.
+ */
+const PRESENCE_WRITE_THROTTLE_MS = 10_000
+
+/**
+ * Records this device's recent interaction (via the shared page interaction
+ * tracker) so the service worker can gate push suppression on activity, not
+ * focus alone — a focused-but-abandoned tab stops silencing notifications.
+ *
+ * Independent of socket/connection state: push delivery matters even when the
+ * socket is down (flaky mobile). Seeded immediately when the window is focused
+ * so the stream you just opened is treated as watched right away.
+ */
+export function useSwPresence(pageInteraction: PageInteractionTracker): void {
+  useEffect(() => {
+    if (typeof window === "undefined" || !("caches" in window)) return
+    let lastWriteAt = 0
+    const write = () => {
+      const now = Date.now()
+      if (now - lastWriteAt < PRESENCE_WRITE_THROTTLE_MS) return
+      lastWriteAt = now
+      void recordInteractionPresence(now)
+    }
+    if (document.hasFocus()) write()
+    return pageInteraction.subscribe(write)
+  }, [pageInteraction])
+}

--- a/apps/frontend/src/lib/sw-notification-format.test.ts
+++ b/apps/frontend/src/lib/sw-notification-format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { appendMessage, resolveTag, formatTitle, formatBody, type NotificationMessage } from "./sw-notification-format"
+import {
+  appendMessage,
+  resolveTag,
+  formatTitle,
+  formatBody,
+  isViewingStream,
+  type NotificationMessage,
+} from "./sw-notification-format"
 
 describe("resolveTag", () => {
   it("returns streamId for message activity", () => {
@@ -12,6 +19,41 @@ describe("resolveTag", () => {
 
   it("returns streamId when activityType is undefined", () => {
     expect(resolveTag("stream_123")).toBe("stream_123")
+  })
+})
+
+describe("isViewingStream", () => {
+  const ORIGIN = "https://app.threa.io"
+
+  it("matches a window viewing the same workspace + stream", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/s/stream_1`, "ws_1", "stream_1")).toBe(true)
+  })
+
+  it("ignores a query string (open thread still counts as the stream)", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/s/stream_1?m=msg_9`, "ws_1", "stream_1")).toBe(true)
+  })
+
+  it("does not match a different stream in the same workspace", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/s/stream_2`, "ws_1", "stream_1")).toBe(false)
+  })
+
+  it("does not match the same stream id in a different workspace", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_2/s/stream_1`, "ws_1", "stream_1")).toBe(false)
+  })
+
+  it("does not match a non-stream view", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/saved`, "ws_1", "stream_1")).toBe(false)
+    expect(isViewingStream(`${ORIGIN}/w/ws_1`, "ws_1", "stream_1")).toBe(false)
+    expect(isViewingStream(`${ORIGIN}/workspaces`, "ws_1", "stream_1")).toBe(false)
+  })
+
+  it("returns false when the push has no stream/workspace id (cannot confirm the view)", () => {
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/s/stream_1`, undefined, "stream_1")).toBe(false)
+    expect(isViewingStream(`${ORIGIN}/w/ws_1/s/stream_1`, "ws_1", undefined)).toBe(false)
+  })
+
+  it("returns false for a malformed url", () => {
+    expect(isViewingStream("not a url", "ws_1", "stream_1")).toBe(false)
   })
 })
 

--- a/apps/frontend/src/lib/sw-notification-format.ts
+++ b/apps/frontend/src/lib/sw-notification-format.ts
@@ -26,6 +26,38 @@ export function appendMessage(existing: NotificationMessage[], incoming: Notific
   return updated
 }
 
+/**
+ * Parse a Threa stream-view URL into its workspace + stream ids, or null when
+ * the URL isn't a stream view. The route is `/w/{workspaceId}/s/{streamId}`;
+ * an open thread is a `?m=…` query (not a path segment), so it still resolves
+ * to the underlying stream. Non-stream surfaces (sidebar root, settings,
+ * activity, saved) return null and never match.
+ */
+function parseStreamRoute(url: string): { workspaceId: string; streamId: string } | null {
+  let pathname: string
+  try {
+    pathname = new URL(url).pathname
+  } catch {
+    return null
+  }
+  const match = pathname.match(/^\/w\/([^/]+)\/s\/([^/]+)/)
+  if (!match) return null
+  return { workspaceId: match[1], streamId: match[2] }
+}
+
+/**
+ * True when `url` is a window already viewing the given stream. Used by the
+ * service worker to suppress a push the user can already see: a push for the
+ * stream on screen is dropped, but a push for any *other* stream (or a
+ * non-stream view) still surfaces even while the app is focused. Absent ids
+ * never match — we can't confirm the view, so we err toward showing.
+ */
+export function isViewingStream(url: string, workspaceId: string | undefined, streamId: string | undefined): boolean {
+  if (!workspaceId || !streamId) return false
+  const route = parseStreamRoute(url)
+  return route !== null && route.workspaceId === workspaceId && route.streamId === streamId
+}
+
 /** Resolve the notification tag — mentions get a distinct tag so they stay visually separate. */
 export function resolveTag(streamId: string, activityType?: string): string {
   if (activityType === ActivityTypes.MENTION) {

--- a/apps/frontend/src/lib/sw-presence.test.ts
+++ b/apps/frontend/src/lib/sw-presence.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { isWithinPresenceWindow, PRESENCE_INTERACTION_WINDOW_MS } from "./sw-presence"
+
+describe("isWithinPresenceWindow", () => {
+  const now = 1_000_000_000_000
+
+  it("is present right after an interaction", () => {
+    expect(isWithinPresenceWindow(now, now)).toBe(true)
+  })
+
+  it("is present just inside the window", () => {
+    expect(isWithinPresenceWindow(now - (PRESENCE_INTERACTION_WINDOW_MS - 1), now)).toBe(true)
+  })
+
+  it("is not present at exactly the window boundary", () => {
+    expect(isWithinPresenceWindow(now - PRESENCE_INTERACTION_WINDOW_MS, now)).toBe(false)
+  })
+
+  it("is not present once the window has elapsed (walked-away focused tab)", () => {
+    expect(isWithinPresenceWindow(now - (PRESENCE_INTERACTION_WINDOW_MS + 1), now)).toBe(false)
+  })
+
+  it("is not present when no interaction was ever recorded", () => {
+    expect(isWithinPresenceWindow(null, now)).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/sw-presence.ts
+++ b/apps/frontend/src/lib/sw-presence.ts
@@ -1,3 +1,5 @@
+import { PRESENCE_INTERACTION_WINDOW_MS } from "@threa/types"
+
 /**
  * Device-presence signal shared between the page and the service worker.
  *
@@ -7,43 +9,59 @@
  * origin (window + worker) and survives the SW's frequent restarts, so this
  * needs no message round-trip and no in-memory state.
  *
- * "Present" deliberately mirrors the backend's attended-device rule
- * (RECENT_INTERACTION_WINDOW_MS in features/push/service.ts): a focused window
- * only counts as actively watched if it was interacted with within this window.
- * A tab the user left focused and walked away from ages out and stops
- * suppressing notifications — so both layers agree on what "present" means.
+ * "Present" uses PRESENCE_INTERACTION_WINDOW_MS — the same window the backend's
+ * attended-device routing uses (features/push/service.ts) — so both layers
+ * agree on what "present" means: a focused window only counts as actively
+ * watched if it was interacted with within this window. A tab the user left
+ * focused and walked away from ages out and stops suppressing notifications.
  */
-export const PRESENCE_INTERACTION_WINDOW_MS = 2 * 60_000
+
+/** Cache name holding the presence signal. Exported so the SW activate sweep keeps it. */
+export const PRESENCE_CACHE = "threa-presence"
+// Synthetic request key — never hits the network; just a stable Cache lookup key.
+const PRESENCE_KEY = "https://threa.local/__presence__/last-interaction"
 
 /** Pure: is `lastInteractionAt` within the presence window relative to `now`? */
 export function isWithinPresenceWindow(lastInteractionAt: number | null, now: number): boolean {
   return lastInteractionAt !== null && now - lastInteractionAt < PRESENCE_INTERACTION_WINDOW_MS
 }
 
-const PRESENCE_CACHE = "threa-presence"
-// Synthetic request key — never hits the network; just a stable Cache lookup key.
-const PRESENCE_KEY = "https://threa.local/__presence__/last-interaction"
-
-/** Record "the user just interacted with this device." Called by the page (throttled). */
+/**
+ * Record "the user just interacted with this device." Called by the page
+ * (throttled). Best-effort: Cache Storage can be unavailable (private mode,
+ * quota) — a failed write just means the SW won't see this interaction, which
+ * fails open to showing notifications.
+ */
 export async function recordInteractionPresence(now: number = Date.now()): Promise<void> {
-  const cache = await caches.open(PRESENCE_CACHE)
-  await cache.put(PRESENCE_KEY, new Response(String(now)))
+  try {
+    const cache = await caches.open(PRESENCE_CACHE)
+    await cache.put(PRESENCE_KEY, new Response(String(now)))
+  } catch {
+    // ignore — see doc comment
+  }
 }
 
-/** Last-interaction timestamp (ms epoch), or null if never recorded. */
+/** Last-interaction timestamp (ms epoch), or null if never recorded or unreadable. */
 async function readInteractionPresence(): Promise<number | null> {
-  const cache = await caches.open(PRESENCE_CACHE)
-  const res = await cache.match(PRESENCE_KEY)
-  if (!res) return null
-  const value = Number(await res.text())
-  return Number.isFinite(value) ? value : null
+  try {
+    const cache = await caches.open(PRESENCE_CACHE)
+    const res = await cache.match(PRESENCE_KEY)
+    if (!res) return null
+    const value = Number(await res.text())
+    return Number.isFinite(value) ? value : null
+  } catch {
+    return null
+  }
 }
 
 /**
  * True when this device saw a direct interaction within the presence window.
  * Read by the service worker to gate push suppression on recent activity rather
- * than focus alone. Fails open (false) when nothing was ever recorded.
+ * than focus alone. Fails open (false) when nothing was recorded or Cache
+ * Storage is unreadable, so an error never silently swallows a notification.
  */
 export async function isDevicePresent(now: number = Date.now()): Promise<boolean> {
   return isWithinPresenceWindow(await readInteractionPresence(), now)
 }
+
+export { PRESENCE_INTERACTION_WINDOW_MS }

--- a/apps/frontend/src/lib/sw-presence.ts
+++ b/apps/frontend/src/lib/sw-presence.ts
@@ -1,0 +1,49 @@
+/**
+ * Device-presence signal shared between the page and the service worker.
+ *
+ * The page records its most recent direct interaction (pointer/key/touch) into
+ * a Cache entry; the service worker reads it when deciding whether to suppress a
+ * push for the stream currently on screen. Cache Storage is shared across the
+ * origin (window + worker) and survives the SW's frequent restarts, so this
+ * needs no message round-trip and no in-memory state.
+ *
+ * "Present" deliberately mirrors the backend's attended-device rule
+ * (RECENT_INTERACTION_WINDOW_MS in features/push/service.ts): a focused window
+ * only counts as actively watched if it was interacted with within this window.
+ * A tab the user left focused and walked away from ages out and stops
+ * suppressing notifications — so both layers agree on what "present" means.
+ */
+export const PRESENCE_INTERACTION_WINDOW_MS = 2 * 60_000
+
+/** Pure: is `lastInteractionAt` within the presence window relative to `now`? */
+export function isWithinPresenceWindow(lastInteractionAt: number | null, now: number): boolean {
+  return lastInteractionAt !== null && now - lastInteractionAt < PRESENCE_INTERACTION_WINDOW_MS
+}
+
+const PRESENCE_CACHE = "threa-presence"
+// Synthetic request key — never hits the network; just a stable Cache lookup key.
+const PRESENCE_KEY = "https://threa.local/__presence__/last-interaction"
+
+/** Record "the user just interacted with this device." Called by the page (throttled). */
+export async function recordInteractionPresence(now: number = Date.now()): Promise<void> {
+  const cache = await caches.open(PRESENCE_CACHE)
+  await cache.put(PRESENCE_KEY, new Response(String(now)))
+}
+
+/** Last-interaction timestamp (ms epoch), or null if never recorded. */
+async function readInteractionPresence(): Promise<number | null> {
+  const cache = await caches.open(PRESENCE_CACHE)
+  const res = await cache.match(PRESENCE_KEY)
+  if (!res) return null
+  const value = Number(await res.text())
+  return Number.isFinite(value) ? value : null
+}
+
+/**
+ * True when this device saw a direct interaction within the presence window.
+ * Read by the service worker to gate push suppression on recent activity rather
+ * than focus alone. Fails open (false) when nothing was ever recorded.
+ */
+export async function isDevicePresent(now: number = Date.now()): Promise<boolean> {
+  return isWithinPresenceWindow(await readInteractionPresence(), now)
+}

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -632,13 +632,23 @@ self.addEventListener("push", (event) => {
   // Tag by stream, with mentions on a separate tag so they stay visually distinct.
   const tag = data.streamId ? resolveTag(data.streamId, data.activityType) : "threa-notification"
 
-  // Suppress notification if the user has a focused app window — they can already see the message.
-  // Backend always sends the push; the SW decides whether to display it.
+  // Suppress only when a focused window is already viewing THIS stream — the user
+  // can see the message there. A push for any other stream still shows even with
+  // the app focused, so you're alerted to conversations you aren't looking at
+  // (e.g. viewing the DM with Pierre doesn't mute a new message in #general).
+  // Backend always sends the push; the SW decides whether to display it. Skipping
+  // only the on-screen stream (vs. every focused push) also keeps us off the
+  // userVisibleOnly silent-push budget that browsers penalize on mobile.
   event.waitUntil(
     Promise.all([fmt, self.clients.matchAll({ type: "window", includeUncontrolled: true })]).then(
-      async ([{ appendMessage, formatTitle, formatBody }, clients]) => {
-        const hasFocusedWindow = clients.some((c) => c.focused && new URL(c.url).origin === self.location.origin)
-        if (hasFocusedWindow) return
+      async ([{ appendMessage, formatTitle, formatBody, isViewingStream }, clients]) => {
+        const viewingThisStream = clients.some(
+          (c) =>
+            c.focused &&
+            new URL(c.url).origin === self.location.origin &&
+            isViewingStream(c.url, data.workspaceId, data.streamId)
+        )
+        if (viewingThisStream) return
 
         // Accumulate a rolling list of recent messages from the existing notification
         const existing = await self.registration.getNotifications({ tag })

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -2,7 +2,7 @@
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import { resolveTag } from "./lib/sw-notification-format"
-import { isDevicePresent } from "./lib/sw-presence"
+import { isDevicePresent, PRESENCE_CACHE } from "./lib/sw-presence"
 import {
   SW_MSG_NOTIFICATION_CLICK,
   SW_MSG_SUBSCRIPTION_CHANGED,
@@ -69,7 +69,13 @@ self.addEventListener("activate", (event) => {
       // Clean stale caches from previous SW versions. Keep only the current
       // workbox precache, push-bootstrap, and share-target caches. Without this,
       // old precache buckets linger and can serve stale HTML/CSS after an update.
-      const currentCaches = new Set([PUSH_BOOTSTRAP_CACHE, SHARE_TARGET_CACHE, PENDING_SYNC_CACHE, AVATAR_CACHE])
+      const currentCaches = new Set([
+        PUSH_BOOTSTRAP_CACHE,
+        SHARE_TARGET_CACHE,
+        PENDING_SYNC_CACHE,
+        AVATAR_CACHE,
+        PRESENCE_CACHE,
+      ])
       const allCaches = await caches.keys()
       await Promise.all(
         allCaches

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -2,6 +2,7 @@
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import { resolveTag } from "./lib/sw-notification-format"
+import { isDevicePresent } from "./lib/sw-presence"
 import {
   SW_MSG_NOTIFICATION_CLICK,
   SW_MSG_SUBSCRIPTION_CHANGED,
@@ -632,13 +633,16 @@ self.addEventListener("push", (event) => {
   // Tag by stream, with mentions on a separate tag so they stay visually distinct.
   const tag = data.streamId ? resolveTag(data.streamId, data.activityType) : "threa-notification"
 
-  // Suppress only when a focused window is already viewing THIS stream — the user
-  // can see the message there. A push for any other stream still shows even with
-  // the app focused, so you're alerted to conversations you aren't looking at
-  // (e.g. viewing the DM with Pierre doesn't mute a new message in #general).
-  // Backend always sends the push; the SW decides whether to display it. Skipping
-  // only the on-screen stream (vs. every focused push) also keeps us off the
-  // userVisibleOnly silent-push budget that browsers penalize on mobile.
+  // Suppress only when a focused window is already viewing THIS stream AND the
+  // device was interacted with recently — the user can actually see the message
+  // there. A push for any other stream still shows even with the app focused, so
+  // you're alerted to conversations you aren't looking at (e.g. viewing the DM
+  // with Pierre doesn't mute a new message in #general). Requiring recent
+  // interaction (not focus alone) means a tab left focused and walked away from
+  // ages out and stops eating notifications — matching the backend's attended
+  // rule. Backend always sends the push; the SW decides whether to display it.
+  // Skipping only the on-screen stream also keeps us off the userVisibleOnly
+  // silent-push budget that browsers penalize on mobile.
   event.waitUntil(
     Promise.all([fmt, self.clients.matchAll({ type: "window", includeUncontrolled: true })]).then(
       async ([{ appendMessage, formatTitle, formatBody, isViewingStream }, clients]) => {
@@ -648,7 +652,7 @@ self.addEventListener("push", (event) => {
             new URL(c.url).origin === self.location.origin &&
             isViewingStream(c.url, data.workspaceId, data.streamId)
         )
-        if (viewingThisStream) return
+        if (viewingThisStream && (await isDevicePresent())) return
 
         // Accumulate a rolling list of recent messages from the existing notification
         const existing = await self.registration.getNotifications({ tag })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -659,6 +659,16 @@ export const E2eKeyWrapRecipientKinds = {
  */
 export const HEARTBEAT_INTERACTION_THROTTLE_MS = 15_000
 
+/**
+ * How recently a device must have seen a direct interaction (pointer/key/touch)
+ * to count as "the device the user is actively on." Shared across the push
+ * presence boundary: the backend uses it to decide which device is attended for
+ * notification routing, and the frontend service worker uses the same window to
+ * decide whether to suppress a push for the stream on screen. Shared so the two
+ * sides cannot drift on what "present" means.
+ */
+export const PRESENCE_INTERACTION_WINDOW_MS = 2 * 60 * 1_000
+
 // Bot kind: shared (admin-managed, workspace-wide) vs personal (owned by one user)
 export const BOT_TYPES = ["shared", "personal"] as const
 export type BotType = (typeof BOT_TYPES)[number]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -169,6 +169,8 @@ export {
   INTERNAL_API_KEY_HEADER,
   // Socket heartbeat
   HEARTBEAT_INTERACTION_THROTTLE_MS,
+  // Push presence (attended-device interaction window)
+  PRESENCE_INTERACTION_WINDOW_MS,
   // Bots
   BOT_TYPES,
   type BotType,


### PR DESCRIPTION
## Problem

Push notifications were intermittently not showing on mobile. I checked production first to rule out the server side: the user's Android subscription was fresh (re-registered ~2.7h prior), the `push-notifications` outbox listener was fully caught up (cursor = max id, 0 retries, 0 dead-letters), and the notification level was `all`. So events were flowing and delivery was being attempted without error — the gap was on the device.

Two service-worker behaviors were dropping notifications:

1. **Blanket focus suppression.** The SW suppressed *every* notification whenever any Threa window was focused, regardless of which stream you were looking at. A message in another stream produced nothing while the app was open. And because the backend deliberately routes a push to the focused/attended device expecting the SW to drop it, each of those was a `userVisibleOnly` silent push — which mobile browsers penalize against the push-display budget, degrading later delivery.

2. **Focus treated as presence.** Suppression keyed on `client.focused` alone, with no check that you were actually *there*. A tab left focused and walked away from kept eating notifications for the stream on screen — even though the backend's attended-device routing already requires a real interaction within 2 minutes. The two layers disagreed on what "present" means.

## Change

- **Stream-aware suppression** (`3d3f02a`): suppress only when a focused window is viewing *that* stream (read from the client URL, `/w/{ws}/s/{stream}`; an open thread `?m=…` still resolves to its stream). A push for any other stream now shows even with the app focused, and only the on-screen stream is ever skipped — which also drastically cuts the silent-push budget burn.

- **Interaction-gated presence** (`c6d802e`): suppress only when the focused window viewing that stream was also interacted with (pointer/key/touch) in the last 2 minutes. The page records its last interaction into a shared Cache entry (throttled); the SW reads it in the push handler. Cache Storage is shared across the origin and survives the SW's frequent restarts, so this needs no message round-trip — and it fails open to *showing* when presence is unknown.

- **Self-review hardening** (`6abd2c0`): guard Cache Storage access so an error can't reject the push handler and silently drop a notification; register the presence cache in the SW activate-cleanup allowlist; hoist the 2-minute window to `@threa/types` (`PRESENCE_INTERACTION_WINDOW_MS`) so the backend routing and the SW share one source of truth; extract the presence writer into a `useSwPresence` hook.

## Notes

- Behavior change confirmed with the user: when you're actively at your laptop, notifications surface on the laptop and the phone stays quiet (no desk double-buzz); the phone fans back in automatically once the laptop isn't actively attended.
- "Interaction" matches the backend exactly (`pointerdown`/`keydown`/`touchstart`). Passive reading via mouse-wheel for >2 min then a message *in that same stream* can now notify — the intended consequence of "interacted, not just focused."
- Takes effect per device once the new SW installs and claims (next app load).

## Testing

- New unit tests: `isViewingStream` (stream/workspace match, query strings, non-stream routes, missing ids, malformed URLs) and `isWithinPresenceWindow` (window boundaries, never-recorded).
- `bun run test` for the touched suites (format, presence, contexts) — green. Full monorepo lint + typecheck green via pre-commit.

🤖 Self-reviewed with the multi-perspective code-review skill (3× Sonnet) before opening; findings addressed in `6abd2c0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012hboNRpoVYgcMg3Fg3fQz3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783107014&installation_id=129946197&pr_number=755&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F755&signature=6a4fe9df0dd2cc011ab1a546812ff57140cbc68126d5aaff7af7b62880c63ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->