### PR TITLE
docs(features): add public/ai-companions

### DIFF
--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -44,7 +44,7 @@ Two rules for using it:
 | public-api                                                           | REST API for integrations, user API keys                                         | `features/public-api`, `docs/public-api/openapi.json`               |
 | share-target                                                         | OS-level share into a workspace (PWA), destination picker                        | `pages/share-target.tsx`                                            |
 | offline                                                              | Composing offline, queued operations, connection status                          | `sw.ts`, `sync/operation-queue.ts`                                  |
-| ai-companions                                                        | Personas, companion mode, bot status strip, agent traces                         | `features/agents`, `docs/core-concepts.md`                          |
+| [ai-companions](public/ai-companions.md) ✅                          | Personas, companion mode, mentions, in-timeline activity card, agent traces      | `features/agents`, `docs/core-concepts.md`                          |
 
 ## Concepts
 

--- a/docs/features/public/ai-companions.md
+++ b/docs/features/public/ai-companions.md
@@ -1,0 +1,80 @@
+---
+title: AI Companions
+status: shipped
+audience: public
+since: 2026-05
+surfaces: [scratchpads, stream-settings, message-timeline, trace-view]
+public_site: true
+summary: >
+  Turn on a companion for a stream and Ariadne reads new messages and replies in
+  the thread, with a live activity card and a full trace of every step she took.
+---
+
+## What it does
+
+A companion is an AI participant in a stream. Turn it on for a scratchpad and
+Ariadne, Threa's built-in companion, reads each new message and replies in the
+thread. Turn it off and the same stream is silent storage with no AI and no
+inference cost.
+
+Ariadne is a thinking companion, not just a chat bot. She can search your
+workspace (messages, streams, people, attachments), look things up on the web,
+read URLs, run longer research, and pull from connected GitHub and Linear. She
+answers in the stream like any other participant, so her replies live alongside
+your own messages and stay part of the thread's history.
+
+Two ways to reach her:
+
+- **Companion mode.** Switch a stream to "Companion" and she responds to every
+  new message you post there: you think out loud, she keeps up. A new scratchpad
+  starts this way; a plain "quick note" starts quiet.
+- **By mention.** Type `@ariadne` in any message and she replies to that one
+  message, whether or not companion mode is on.
+
+When a thread is opened off a scratchpad that has companion mode on, the thread
+inherits it, so Ariadne keeps responding inside nested threads without you
+turning it on again.
+
+## How you use it
+
+- **Start with or without her.** "New Scratchpad" creates a stream with the
+  companion on; "New Quick Note" creates the same kind of stream with it off, for
+  plain capture. You can flip either one later.
+- **Companion mode toggle.** Open a stream's settings and pick Companion or
+  Quiet. Companion means Ariadne reads new messages and replies; Quiet means the
+  stream is just storage. The change saves right away.
+- **Spot which streams have her.** A scratchpad with the companion on shows a
+  sparkle marker in the sidebar and a companion indicator in its header.
+- **Watch her work.** While Ariadne is running, an activity card appears in the
+  timeline: "Ariadne is working…" with a live count of steps and messages and a
+  short line describing the current phase (for example "Planning queries…"). When
+  she finishes it settles into "Session complete" with the step count, duration,
+  and how many messages she sent.
+- **Open the trace.** Click that card to see the full trace: every step she took,
+  the tools she called, her reasoning, and the sources she pulled from. The trace
+  streams in live as she works and stays available after she's done.
+- **Stop a long run.** During a long research step the activity card shows a Stop
+  button so you can cut it short.
+
+## Boundaries
+
+- **Ariadne is the only companion today.** The persona model is data-driven (a
+  persona carries its own name, avatar, model, system prompt, and tool list), and
+  the schema supports workspace-specific personas, but there is no UI to create
+  them or to pick a different one. Companion mode always uses Ariadne. There is
+  also an internal "Empty Agent" shell that is not a product-facing companion.
+- **No persona picker.** A stream stores which persona its companion uses, and the
+  update API accepts one, but the settings screen only offers on/off. Choosing a
+  persona per stream is not exposed.
+- **End-to-end encrypted streams keep the companion off.** Ariadne can't read
+  ciphertext, so the toggle is informational there and replies never happen.
+  (The separate enclave path that lets a companion serve an encrypted stream is
+  documented under e2e-encrypted-scratchpads, not here.)
+- **External bots are a different feature.** The "bot status strip" that shows
+  Available / Working / Not connected is for third-party bot runtimes, not for
+  Ariadne. Her status shows as the in-timeline activity card described above.
+
+## Related
+
+- [`docs/core-concepts.md`](../../core-concepts.md) describes personas as data at
+  the domain level.

--- a/docs/features/public/ai-companions.md
+++ b/docs/features/public/ai-companions.md
@@ -7,54 +7,51 @@ surfaces: [scratchpads, stream-settings, message-timeline, trace-view]
 public_site: true
 summary: >
   Turn on a companion for a stream and Ariadne reads new messages and replies in
-  the thread, with a live activity card and a full trace of every step she took.
+  the thread. A live activity card and a step-by-step trace show what it did.
 ---
 
 ## What it does
 
 A companion is an AI participant in a stream. Turn it on for a scratchpad and
 Ariadne, Threa's built-in companion, reads each new message and replies in the
-thread. Turn it off and the same stream is silent storage with no AI and no
-inference cost.
+thread. Turn it off and the stream is storage only, with no AI replies.
 
-Ariadne is a thinking companion, not just a chat bot. She can search your
-workspace (messages, streams, people, attachments), look things up on the web,
-read URLs, run longer research, and pull from connected GitHub and Linear. She
-answers in the stream like any other participant, so her replies live alongside
-your own messages and stay part of the thread's history.
+Ariadne can search your workspace (messages, streams, people, attachments),
+search the web, read URLs, run longer research, and read from connected GitHub
+and Linear. Replies post into the stream like any other message, so they sit
+alongside yours and stay in the thread's history.
 
-Two ways to reach her:
+Two ways to invoke it:
 
-- **Companion mode.** Switch a stream to "Companion" and she responds to every
-  new message you post there: you think out loud, she keeps up. A new scratchpad
-  starts this way; a plain "quick note" starts quiet.
-- **By mention.** Type `@ariadne` in any message and she replies to that one
-  message, whether or not companion mode is on.
+- **Companion mode.** Switch a stream to "Companion" and Ariadne replies to every
+  new message you post there. A new scratchpad starts this way; a plain quick note
+  starts quiet.
+- **By mention.** Type `@ariadne` in a message and it replies to that one message,
+  whether or not companion mode is on.
 
-When a thread is opened off a scratchpad that has companion mode on, the thread
-inherits it, so Ariadne keeps responding inside nested threads without you
-turning it on again.
+When you open a thread off a scratchpad that has companion mode on, the thread
+inherits it, so Ariadne keeps replying in the thread without you turning it on
+again.
 
 ## How you use it
 
-- **Start with or without her.** "New Scratchpad" creates a stream with the
+- **Start with or without it.** "New Scratchpad" creates a stream with the
   companion on; "New Quick Note" creates the same kind of stream with it off, for
-  plain capture. You can flip either one later.
-- **Companion mode toggle.** Open a stream's settings and pick Companion or
-  Quiet. Companion means Ariadne reads new messages and replies; Quiet means the
-  stream is just storage. The change saves right away.
-- **Spot which streams have her.** A scratchpad with the companion on shows a
-  sparkle marker in the sidebar and a companion indicator in its header.
-- **Watch her work.** While Ariadne is running, an activity card appears in the
-  timeline: "Ariadne is working…" with a live count of steps and messages and a
-  short line describing the current phase (for example "Planning queries…"). When
-  she finishes it settles into "Session complete" with the step count, duration,
-  and how many messages she sent.
-- **Open the trace.** Click that card to see the full trace: every step she took,
-  the tools she called, her reasoning, and the sources she pulled from. The trace
-  streams in live as she works and stays available after she's done.
-- **Stop a long run.** During a long research step the activity card shows a Stop
-  button so you can cut it short.
+  plain capture. You can change either one later.
+- **Companion mode toggle.** In a stream's settings, pick Companion or Quiet.
+  Companion means Ariadne reads new messages and replies; Quiet means the stream is
+  storage only. The change saves right away.
+- **See which streams have it.** A scratchpad with the companion on shows a sparkle
+  marker in the sidebar and a companion indicator in its header.
+- **Activity card.** While Ariadne is running, an activity card in the timeline
+  reads "Ariadne is working…" with a running count of steps and messages and a line
+  for the current phase (for example "Planning queries…"). When it finishes the
+  card reads "Session complete" with the step count, duration, and number of
+  messages sent.
+- **Trace.** Click the card to open the trace: each step, the tools called, the
+  reasoning, and the sources used. It streams in as Ariadne works and stays
+  available afterward.
+- **Stop a long run.** During a long research step the card shows a Stop button.
 
 ## Boundaries
 
@@ -67,12 +64,12 @@ turning it on again.
   update API accepts one, but the settings screen only offers on/off. Choosing a
   persona per stream is not exposed.
 - **End-to-end encrypted streams keep the companion off.** Ariadne can't read
-  ciphertext, so the toggle is informational there and replies never happen.
-  (The separate enclave path that lets a companion serve an encrypted stream is
-  documented under e2e-encrypted-scratchpads, not here.)
+  ciphertext, so the toggle is informational there and replies never happen. The
+  separate enclave path that lets a companion serve an encrypted stream is
+  documented under e2e-encrypted-scratchpads, not here.
 - **External bots are a different feature.** The "bot status strip" that shows
   Available / Working / Not connected is for third-party bot runtimes, not for
-  Ariadne. Her status shows as the in-timeline activity card described above.
+  Ariadne. Companion status shows as the in-timeline activity card described above.
 
 ## Related
 

--- a/docs/features/public/ai-companions.md
+++ b/docs/features/public/ai-companions.md
@@ -6,52 +6,51 @@ since: 2026-05
 surfaces: [scratchpads, stream-settings, message-timeline, trace-view]
 public_site: true
 summary: >
-  Turn on a companion for a stream and Ariadne reads new messages and replies in
-  the thread. A live activity card and a step-by-step trace show what it did.
+  A per-stream on/off setting; when it's on, Ariadne reads each new message and
+  replies in the thread. An activity card and a step-by-step trace show what it did.
 ---
 
 ## What it does
 
-A companion is an AI participant in a stream. Turn it on for a scratchpad and
-Ariadne, Threa's built-in companion, reads each new message and replies in the
-thread. Turn it off and the stream is storage only, with no AI replies.
+A companion is an AI agent attached to a stream. Each stream carries a companion
+mode that is either on or off. With it on, Ariadne (Threa's built-in companion)
+reads each new message in the stream and replies in the thread. With it off, the
+stream is storage only and nothing runs.
 
-Ariadne can search your workspace (messages, streams, people, attachments),
-search the web, read URLs, run longer research, and read from connected GitHub
-and Linear. Replies post into the stream like any other message, so they sit
-alongside yours and stay in the thread's history.
+Ariadne replies as a normal participant: its messages land in the stream next to
+yours and stay in the thread's history. It has a set of tools it can call while it
+works: searching the workspace (messages, streams, people, attachments), searching
+the web and reading URLs, a longer research mode, and reading from GitHub and
+Linear when those integrations are connected.
 
-Two ways to invoke it:
+A companion runs in two cases:
 
-- **Companion mode.** Switch a stream to "Companion" and Ariadne replies to every
-  new message you post there. A new scratchpad starts this way; a plain quick note
-  starts quiet.
-- **By mention.** Type `@ariadne` in a message and it replies to that one message,
-  whether or not companion mode is on.
+- **Companion mode on.** Ariadne responds to every new message in the stream. A
+  new scratchpad starts with companion mode on; a quick note starts with it off.
+- **A mention.** Writing `@ariadne` in a message invokes Ariadne for that one
+  message, regardless of the stream's companion mode.
 
-When you open a thread off a scratchpad that has companion mode on, the thread
-inherits it, so Ariadne keeps replying in the thread without you turning it on
-again.
+Companion mode is inherited down a scratchpad: a thread opened under a scratchpad
+that has it on runs the companion too, without being switched on per thread.
 
-## How you use it
+## How it surfaces
 
-- **Start with or without it.** "New Scratchpad" creates a stream with the
-  companion on; "New Quick Note" creates the same kind of stream with it off, for
-  plain capture. You can change either one later.
-- **Companion mode toggle.** In a stream's settings, pick Companion or Quiet.
-  Companion means Ariadne reads new messages and replies; Quiet means the stream is
-  storage only. The change saves right away.
-- **See which streams have it.** A scratchpad with the companion on shows a sparkle
-  marker in the sidebar and a companion indicator in its header.
-- **Activity card.** While Ariadne is running, an activity card in the timeline
-  reads "Ariadne is working…" with a running count of steps and messages and a line
-  for the current phase (for example "Planning queries…"). When it finishes the
-  card reads "Session complete" with the step count, duration, and number of
-  messages sent.
-- **Trace.** Click the card to open the trace: each step, the tools called, the
-  reasoning, and the sources used. It streams in as Ariadne works and stays
-  available afterward.
-- **Stop a long run.** During a long research step the card shows a Stop button.
+- **Creating one.** "New Scratchpad" makes a stream with companion mode on; "New
+  Quick Note" makes the same kind of stream with it off. Either can be changed
+  later.
+- **The toggle.** A stream's settings has a Companion / Quiet switch. Companion
+  means Ariadne reads new messages and replies; Quiet means storage only. It saves
+  immediately.
+- **Indicators.** A scratchpad with companion mode on shows a sparkle marker in the
+  sidebar and a companion indicator in its header.
+- **The activity card.** While a run is in progress, a card in the timeline shows
+  "Ariadne is working…" with a running count of steps and messages and the current
+  phase (for example "Planning queries…"). When the run ends the card shows
+  "Session complete" with the step count, duration, and number of messages sent.
+- **The trace.** Opening the card shows the trace of the run: each step, the tools
+  called, the reasoning, and the sources used. It streams in while the run is going
+  and stays available afterward.
+- **Stopping a run.** During a long research step the card shows a Stop button.
 
 ## Boundaries
 


### PR DESCRIPTION
One feature doc, verified against the code: `docs/features/public/ai-companions.md` (status `shipped`).

## What I verified (file:line)

- **Personas are data.** `built-in-agents.ts` defines two system personas: Ariadne (`persona_system_ariadne`, visible, Sonnet 4.6, 24 tools incl. web/research/GitHub/Linear/`describe_memo`, e2e-capable) and an internal "Empty Agent" (no tools, `visibility: internal`). Schema supports workspace personas + per-workspace overrides, but nothing in the frontend creates or picks one.
- **Companion mode.** `companion-tab.tsx` is on/off only (no persona picker); E2E streams disable it (informational). `companion-outbox-handler.ts` dispatches a `PERSONA_AGENT` job for each USER message in a companion-on stream, skips E2E and persona-authored messages, and inherits the root scratchpad's companion settings into threads.
- **Create-time default.** `quick-switcher/commands.ts`: "New Scratchpad" creates companion **on**, "New Quick Note" creates it **off** (backend service default is off, `streams/service.ts:398`).
- **Mentions.** `mention-invoke-outbox-handler.ts` resolves `@slug` to an active persona and dispatches, independent of companion mode.
- **Activity card + traces.** `agent-session-event.tsx` renders the live "Ariadne is working…" card (step/message counts, live substep, Stop button) linking to the trace; `use-agent-trace.ts` subscribes to real `agent_session:*` socket events, so the trace view is real data, not a stub.

## Status call

`shipped`, `public_site: true`. The companion works end to end in code (toggle → response → live card → trace → tools), and nothing user-visible is stubbed. The unfinished parts (persona picker, custom workspace personas) are *absent* rather than rendered-but-empty, so they live in `## Boundaries` instead of dropping the status to `building`.

## Drift fixed

The INVENTORY one-liner attributed the **"bot status strip"** to AI companions. That component (`ActiveBotStatusStrip`) actually belongs to the separate external **bot-runtimes** feature; Ariadne's status surfaces as the in-timeline agent-session card. Corrected the row and called it out in the doc's Boundaries.

## Out of scope (one doc per run)

The `architecture/agent-runtime` subsystem doc (sessions, tool execution, access specs, trace persistence) is where the mechanics belong; it'll pair back to this doc via `related:` when written. Left `related:` pointing only at existing targets to avoid dead links.

https://claude.ai/code/session_01PUphTfSg8Yi4BuWmGuHNZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUphTfSg8Yi4BuWmGuHNZZ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783152599&installation_id=129946197&pr_number=757&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F757&signature=9009e832fa3627b40bec8c24fba8e932ba502e9f73f36267305e09974c870192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->