### PR TITLE
test(push): de-flake updated_at re-register assertion

### DIFF
--- a/apps/backend/tests/integration/push.test.ts
+++ b/apps/backend/tests/integration/push.test.ts
@@ -104,16 +104,21 @@ describe("Push Notifications", () => {
       const first = await PushSubscriptionRepository.insert(pool, params)
       expect(first.updatedAt).toBeInstanceOf(Date)
 
-      // Backdate so we can prove the re-register moves it forward.
-      await pool.query(`UPDATE push_subscriptions SET updated_at = now() - interval '40 days' WHERE id = $1`, [
-        first.id,
-      ])
+      // Backdate so we can prove the re-register moves it forward. Capture the
+      // backdated DB timestamp and assert against *that* — comparing against the
+      // original insert (also a near-now() value) races on the millisecond when
+      // both inserts land in the same ms, which getTime() then reports as equal.
+      const backdated = await pool.query<{ updated_at: Date }>(
+        `UPDATE push_subscriptions SET updated_at = now() - interval '40 days' WHERE id = $1 RETURNING updated_at`,
+        [first.id]
+      )
+      const backdatedAt = backdated.rows[0].updated_at
 
       const second = await PushSubscriptionRepository.insert(pool, params)
       expect(second.id).toBe(first.id)
-      // Compare against the prior DB timestamp (both DB-clock, monotonic) rather
-      // than the app clock, which would couple the assertion to DB/app skew.
-      expect(second.updatedAt.getTime()).toBeGreaterThan(first.updatedAt.getTime())
+      // Both DB-clock timestamps: the re-register bumps updated_at to a fresh
+      // now(), well past the 40-day-old backdated value.
+      expect(second.updatedAt.getTime()).toBeGreaterThan(backdatedAt.getTime())
     })
 
     test("deleteByEndpoint removes subscription and returns true; false for non-existent", async () => {


### PR DESCRIPTION
## What

Fixes a timing flake in the push integration test `re-registering an endpoint refreshes updated_at (its last-seen signal)`, which failed the `test:integration` CI step on [run 26936281598](https://github.com/threahq/threa/actions/runs/26936281598/job/79466731787).

## Root cause

The test backdated the subscription's `updated_at` to `now() - 40 days` to prove a re-register moves it forward — but the assertion compared the re-registered timestamp against the **original insert** timestamp, not the backdated one. Both originate from Postgres `now()` calls a fraction of a millisecond apart. `Date.getTime()` truncates to whole milliseconds, so when both inserts land in the same millisecond (likely on a fast CI runner) the values compare equal and `toBeGreaterThan` fails.

## Fix

Capture the backdated `updated_at` via `RETURNING` and assert the re-registered timestamp is greater than **that**. The re-register bumps `updated_at` to a fresh `now()`, reliably 40 days past the backdated value — which is exactly what the backdate was placed there to verify. This removes the sub-millisecond race while keeping the test's guarding intent: if a future change stopped bumping `updated_at`, the row would return the backdated value and the assertion would still fail.

## Verification

- Ran the push suite against a local Postgres: all 39 tests pass.
- Looped the previously-flaky test 8× — passed every time.
- Pre-commit hook ran full-repo lint + typecheck (incl. backend test tsconfig) with zero errors.

https://claude.ai/code/session_011K3hZSaG4gyWLZWUUmV8XG

---
_Generated by [Claude Code](https://claude.ai/code/session_011K3hZSaG4gyWLZWUUmV8XG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783152845&installation_id=129946197&pr_number=758&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F758&signature=f75b90368b75e2bfa7f17105129eca4925f868bb7fa045a1405c879572571fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->