### PR TITLE
skill(document-feature): add explain-not-pitch register rule

### DIFF
--- a/.agents/skills/document-feature/SKILL.md
+++ b/.agents/skills/document-feature/SKILL.md
@@ -23,7 +23,8 @@ workflow for filling it in, one inventory row at a time.
 - Read `docs/features/README.md` in full: the three buckets, frontmatter schemas,
   document structure, and altitude rules. It is authoritative; this skill doesn't
   restate it.
-- Read one existing doc in the target bucket as the exemplar:
+- Read one existing doc in the target bucket as the exemplar, for its *register* and
+  altitude, not just its headings:
   `public/configurable-sidebar.md`, `concepts/subscribe-then-bootstrap.md`, or
   `architecture/sync-engine.md`.
 
@@ -56,6 +57,17 @@ workflow for filling it in, one inventory row at a time.
   smooth overclaims; an unfinished edge described accurately is a feature of the doc.
 - Tone: plain, casual, clear. Apply the deslopify skill's rules; at minimum
   `grep -c '—' <file>` must return 0, and no hype words or rhetorical flourishes.
+- Register: explain how it works, don't pitch it. These docs are for engineers and
+  agents picking the feature up (and for you later), not customers being sold to,
+  and that holds for `public/` docs too. Describe the machine: lead with the data
+  model or core mechanism, then the behavior, the way `configurable-sidebar` opens
+  on "an ordered list of sections, saved per workspace" and `sync-engine` on "the
+  engine writes server state into IndexedDB." State structure, then behavior. The
+  recurring failure (it took three passes on `ai-companions`) is the product-tour
+  register: a "what you get" capabilities list ("can search the web, read URLs,
+  run…"), benefit phrasing ("for plain capture"), imperative how-to steps, and cute
+  personification of an agent ("she keeps up"). All factually correct, still wrong.
+  Name the surface and how it behaves instead.
 - Watch markdown footguns: a `+` or `-` that wraps to line start becomes a list bullet
   and prettier will lock that in. Re-read after the pre-commit hook rewrites the file.
 


### PR DESCRIPTION
Adds a register rule to the `document-feature` skill so the next run doesn't repeat the phrasing mistake we hit on the ai-companions doc.

## Why

The skill's tone guidance caught em-dashes and hype words, but not the structural problem: the first drafts of `public/ai-companions.md` were written in a product-tour register (a "what you get" capabilities list, benefit phrasing, imperative how-to steps, agent personification). Factually correct, but pitched rather than explained. It took three passes to land the plain, mechanism-first register the other feature docs use.

## What changed

`.agents/skills/document-feature/SKILL.md`:

- **New "Register" rule (step 3):** explain how it works, don't pitch it. These docs are for engineers and agents picking the feature up (and for the author later), not customers, and that holds for `public/` docs too. Lead with the data model or core mechanism, then behavior, anchored to how `configurable-sidebar` ("an ordered list of sections, saved per workspace") and `sync-engine` ("the engine writes server state into IndexedDB") actually open. Names the specific failure mode so it's recognized before three passes.
- **Step 1 tweak:** read the exemplar for its *register and altitude*, not just its headings.

Docs/skill only. One commit, rebased onto current main.

https://claude.ai/code/session_01PUphTfSg8Yi4BuWmGuHNZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUphTfSg8Yi4BuWmGuHNZZ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783155781&installation_id=129946197&pr_number=761&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F761&signature=98be4223544ca49d388a926fb745b2385db82324d9ea92bf0d583fd5d9a1fed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->