### PR TITLE
fix(frontend): stop responsive dialogs orphaning a scoped DialogPortal on resize

### DIFF
--- a/apps/frontend/src/components/ui/responsive-alert-dialog.tsx
+++ b/apps/frontend/src/components/ui/responsive-alert-dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { ResponsiveModeProvider, useResponsiveMode } from "./responsive-mode"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,11 +34,11 @@ interface ResponsiveAlertDialogProps {
 function ResponsiveAlertDialog({ children, ...props }: ResponsiveAlertDialogProps) {
   const isMobile = useIsMobile()
 
-  if (isMobile) {
-    return <Drawer {...props}>{children}</Drawer>
-  }
+  // Share the decision via context so the content and sub-parts can never
+  // disagree with the root mid-resize (see responsive-mode.tsx).
+  const root = isMobile ? <Drawer {...props}>{children}</Drawer> : <AlertDialog {...props}>{children}</AlertDialog>
 
-  return <AlertDialog {...props}>{children}</AlertDialog>
+  return <ResponsiveModeProvider isMobile={isMobile}>{root}</ResponsiveModeProvider>
 }
 
 // ── Content ─────────────────────────────────────────────────────────────
@@ -46,7 +47,7 @@ const ResponsiveAlertDialogContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof AlertDialogContent>
 >(({ className, children, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     // DrawerContent already renders its own Portal + Overlay internally
@@ -72,7 +73,7 @@ ResponsiveAlertDialogContent.displayName = "ResponsiveAlertDialogContent"
 // ── Header ──────────────────────────────────────────────────────────────
 
 function ResponsiveAlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerHeader className={cn("text-left", className)} {...props} />
@@ -85,7 +86,7 @@ ResponsiveAlertDialogHeader.displayName = "ResponsiveAlertDialogHeader"
 // ── Footer ──────────────────────────────────────────────────────────────
 
 function ResponsiveAlertDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerFooter className={cn("pb-[max(16px,env(safe-area-inset-bottom))]", className)} {...props} />
@@ -101,7 +102,7 @@ const ResponsiveAlertDialogTitle = React.forwardRef<
   HTMLHeadingElement,
   React.ComponentPropsWithoutRef<typeof AlertDialogTitle>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerTitle ref={ref} className={className} {...props} />
@@ -117,7 +118,7 @@ const ResponsiveAlertDialogDescription = React.forwardRef<
   HTMLParagraphElement,
   React.ComponentPropsWithoutRef<typeof AlertDialogDescription>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerDescription ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
@@ -133,7 +134,7 @@ const ResponsiveAlertDialogAction = React.forwardRef<
   HTMLButtonElement,
   React.ComponentPropsWithoutRef<typeof AlertDialogAction>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return (
@@ -164,7 +165,7 @@ const ResponsiveAlertDialogCancel = React.forwardRef<
   HTMLButtonElement,
   React.ComponentPropsWithoutRef<typeof AlertDialogCancel>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return (

--- a/apps/frontend/src/components/ui/responsive-dialog.tsx
+++ b/apps/frontend/src/components/ui/responsive-dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { ResponsiveModeProvider, useResponsiveMode } from "./responsive-mode"
 import {
   Dialog,
   DialogClose,
@@ -64,17 +65,19 @@ function ResponsiveDialog({ children, snapPoints, disableSnapPoints, ...props }:
     [props.onOpenChange, resolvedSnaps]
   )
 
-  if (isMobile) {
-    if (disableSnapPoints) {
-      return (
-        <DisableSnapPointsContext.Provider value={true}>
-          <Drawer open={props.open} onOpenChange={props.onOpenChange}>
-            {children}
-          </Drawer>
-        </DisableSnapPointsContext.Provider>
-      )
-    }
-    return (
+  // Resolve the root once and share the decision via context so the content and
+  // sub-parts can never disagree with the root mid-resize (see responsive-mode.tsx).
+  let root: React.ReactNode
+  if (isMobile && disableSnapPoints) {
+    root = (
+      <DisableSnapPointsContext.Provider value={true}>
+        <Drawer open={props.open} onOpenChange={props.onOpenChange}>
+          {children}
+        </Drawer>
+      </DisableSnapPointsContext.Provider>
+    )
+  } else if (isMobile) {
+    root = (
       <Drawer
         open={props.open}
         onOpenChange={handleOpenChange}
@@ -86,9 +89,11 @@ function ResponsiveDialog({ children, snapPoints, disableSnapPoints, ...props }:
         {children}
       </Drawer>
     )
+  } else {
+    root = <Dialog {...props}>{children}</Dialog>
   }
 
-  return <Dialog {...props}>{children}</Dialog>
+  return <ResponsiveModeProvider isMobile={isMobile}>{root}</ResponsiveModeProvider>
 }
 
 // ── Trigger ─────────────────────────────────────────────────────────────
@@ -97,7 +102,7 @@ const ResponsiveDialogTrigger = React.forwardRef<
   HTMLButtonElement,
   React.ComponentPropsWithoutRef<typeof DialogTrigger>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
   const Comp = isMobile ? DrawerTrigger : DialogTrigger
   return <Comp ref={ref} className={className} {...props} />
 })
@@ -107,7 +112,7 @@ ResponsiveDialogTrigger.displayName = "ResponsiveDialogTrigger"
 
 const ResponsiveDialogClose = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof DialogClose>>(
   ({ className, ...props }, ref) => {
-    const isMobile = useIsMobile()
+    const isMobile = useResponsiveMode()
     const Comp = isMobile ? DrawerClose : DialogClose
     return <Comp ref={ref} className={className} {...props} />
   }
@@ -125,7 +130,7 @@ interface ResponsiveDialogContentProps extends React.ComponentPropsWithoutRef<ty
 
 const ResponsiveDialogContent = React.forwardRef<HTMLDivElement, ResponsiveDialogContentProps>(
   ({ className, desktopClassName, drawerClassName, children, hideCloseButton, ...props }, ref) => {
-    const isMobile = useIsMobile()
+    const isMobile = useResponsiveMode()
     const noSnapPoints = React.useContext(DisableSnapPointsContext)
 
     if (isMobile) {
@@ -158,7 +163,7 @@ ResponsiveDialogContent.displayName = "ResponsiveDialogContent"
 // ── Header ──────────────────────────────────────────────────────────────
 
 function ResponsiveDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     // Override DrawerHeader's default p-4 to avoid double padding — callers set their own px/pt
@@ -172,7 +177,7 @@ ResponsiveDialogHeader.displayName = "ResponsiveDialogHeader"
 // ── Footer ──────────────────────────────────────────────────────────────
 
 function ResponsiveDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerFooter className={cn("pb-[max(16px,env(safe-area-inset-bottom))]", className)} {...props} />
@@ -186,7 +191,7 @@ ResponsiveDialogFooter.displayName = "ResponsiveDialogFooter"
 
 const ResponsiveDialogTitle = React.forwardRef<HTMLHeadingElement, React.ComponentPropsWithoutRef<typeof DialogTitle>>(
   ({ className, ...props }, ref) => {
-    const isMobile = useIsMobile()
+    const isMobile = useResponsiveMode()
 
     if (isMobile) {
       return <DrawerTitle ref={ref} className={className} {...props} />
@@ -203,7 +208,7 @@ const ResponsiveDialogDescription = React.forwardRef<
   HTMLParagraphElement,
   React.ComponentPropsWithoutRef<typeof DialogDescription>
 >(({ className, ...props }, ref) => {
-  const isMobile = useIsMobile()
+  const isMobile = useResponsiveMode()
 
   if (isMobile) {
     return <DrawerDescription ref={ref} className={className} {...props} />

--- a/apps/frontend/src/components/ui/responsive-mode.test.tsx
+++ b/apps/frontend/src/components/ui/responsive-mode.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import * as mobileModule from "@/hooks/use-mobile"
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogTitle,
+} from "./responsive-alert-dialog"
+import { ResponsiveDialog, ResponsiveDialogContent, ResponsiveDialogTitle } from "./responsive-dialog"
+
+afterEach(() => vi.restoreAllMocks())
+
+/**
+ * Make `useIsMobile` report mobile to the first caller (the responsive root) and
+ * desktop to everyone after it. That is exactly the inconsistency a viewport
+ * resize crossing the breakpoint can produce for one commit: the root has
+ * already swapped to a <Drawer> while the content still thinks it's desktop.
+ *
+ * Before the context fix, the content rendered an AlertDialogContent /
+ * DialogContent (a scoped radix DialogPortal) under a vaul <Drawer>, throwing
+ * "`DialogPortal` must be used within `Dialog`" during React's concurrent
+ * render (it surfaces as a recovered concurrent-render error that fails the
+ * suite). After the fix, the content follows the root's committed mode and
+ * renders the drawer variant instead.
+ */
+function mockTornResize() {
+  let call = 0
+  vi.spyOn(mobileModule, "useIsMobile").mockImplementation(() => call++ === 0)
+}
+
+describe("ResponsiveAlertDialog mode coupling", () => {
+  beforeEach(mockTornResize)
+
+  it("does not orphan a scoped DialogPortal when root and content disagree", () => {
+    expect(() =>
+      render(
+        <ResponsiveAlertDialog open onOpenChange={() => {}}>
+          <ResponsiveAlertDialogContent>
+            <ResponsiveAlertDialogTitle>Delete?</ResponsiveAlertDialogTitle>
+          </ResponsiveAlertDialogContent>
+        </ResponsiveAlertDialog>
+      )
+    ).not.toThrow()
+
+    expect(screen.getByText("Delete?")).toBeInTheDocument()
+    // Content followed the root's mobile decision: the drawer (role "dialog")
+    // rendered, not the desktop AlertDialog (role "alertdialog").
+    expect(screen.queryByRole("alertdialog")).toBeNull()
+  })
+})
+
+describe("ResponsiveDialog mode coupling", () => {
+  beforeEach(mockTornResize)
+
+  it("does not crash when root and content disagree", () => {
+    expect(() =>
+      render(
+        <ResponsiveDialog open onOpenChange={() => {}}>
+          <ResponsiveDialogContent>
+            <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
+          </ResponsiveDialogContent>
+        </ResponsiveDialog>
+      )
+    ).not.toThrow()
+
+    expect(screen.getByText("Settings")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/ui/responsive-mode.tsx
+++ b/apps/frontend/src/components/ui/responsive-mode.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+// Carries the mobile/desktop decision the responsive root committed to, so the
+// root and its content/sub-parts can never disagree mid-resize.
+//
+// Why this exists: ResponsiveDialog / ResponsiveAlertDialog render different
+// roots per breakpoint (vaul <Drawer> on mobile, radix <Dialog>/<AlertDialog> on
+// desktop). When the root and its content each called `useIsMobile()`
+// independently, a viewport change crossing the breakpoint could leave them
+// briefly out of sync — e.g. a <Drawer> root wrapping an <AlertDialogContent>.
+// radix's AlertDialog portal is a *scoped* DialogPortal and vaul only provides
+// the *unscoped* Dialog context, so that orphan throws
+// "`DialogPortal` must be used within `Dialog`". Funnelling the decision through
+// one context makes the content follow the root's committed mode.
+const ResponsiveModeContext = React.createContext<boolean | null>(null)
+
+export function ResponsiveModeProvider({ isMobile, children }: { isMobile: boolean; children: React.ReactNode }) {
+  return <ResponsiveModeContext.Provider value={isMobile}>{children}</ResponsiveModeContext.Provider>
+}
+
+/**
+ * Read the responsive mode chosen by the enclosing responsive root. Falls back
+ * to the live media query only when a sub-part is rendered outside a root (so
+ * standalone usage still works).
+ */
+export function useResponsiveMode(): boolean {
+  const fromRoot = React.useContext(ResponsiveModeContext)
+  const live = useIsMobile()
+  return fromRoot ?? live
+}


### PR DESCRIPTION
## Problem

Resizing the desktop window across the mobile breakpoint (mobile → desktop) with a dialog open logs:

```
Error: `DialogPortal` must be used within `Dialog`
```

The app keeps working (the error is "recovered"), but it fires on every such resize.

## Root cause

`ResponsiveDialog` and `ResponsiveAlertDialog` render a vaul `<Drawer>` on mobile and a radix `<Dialog>` / `<AlertDialog>` on desktop. The catch: the **root** and **each sub-part** (`*Content`, `*Header`, `*Title`, …) called `useIsMobile()` **independently**.

During a viewport resize, `useIsMobile` is backed by `useSyncExternalStore`. React's **concurrent** render can momentarily commit a state where the root has already swapped to a `<Drawer>` while the content still renders an `<AlertDialogContent>`:

- radix `AlertDialog` is built on a **scoped** `@radix-ui/react-dialog` (`createDialogScope`), so its content is internally a scoped `DialogPortal`.
- vaul's `Drawer` provides only the **unscoped** Dialog context.
- The scoped portal can't find its provider → `` `DialogPortal` must be used within `Dialog` ``.

React recovers by re-rendering the root synchronously (a consistent tree), which is why the app survives but the error is logged. This also explains why a plain synchronous re-render in a test can't reproduce it — only the concurrent path tears.

(Note: `ResponsiveDialog` is partially masked because vaul provides the *unscoped* Dialog context that `DialogContent`'s unscoped portal happens to accept — but the split decision is still incorrect, so it's fixed too.)

## Fix

Funnel the mobile/desktop decision through a single context:

- New `responsive-mode.tsx`: `ResponsiveModeProvider` (set once by the root) + `useResponsiveMode()` (read by sub-parts, falling back to the live media query only when used standalone).
- The root keeps `useIsMobile()` as the source of truth; all sub-parts now read `useResponsiveMode()`.

Because the provider value and the chosen root element come from the **same** `isMobile` in the **same** render, they commit atomically — the content can never disagree with the root, so the orphaned portal can't happen.

## Tests

`responsive-mode.test.tsx` reproduces the torn commit (root sees mobile, content sees desktop within one render) for both `ResponsiveAlertDialog` and `ResponsiveDialog`. Before the fix the suite fails with the recovered concurrent-render error; after the fix the content follows the root to the drawer variant (asserted via `role`).

Verified: new test passes, full `apps/frontend/src/components/ui` + encryption + account-switcher suites pass (81 tests), typecheck and lint clean. The pre-commit monorepo typecheck also passed.

https://claude.ai/code/session_01BG3FMD3i2ZQeTdgQdhyByo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG3FMD3i2ZQeTdgQdhyByo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783163815&installation_id=129946197&pr_number=764&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F764&signature=50cce7eb9ff4b4f68e7eb0e09509502e0256e447a74b350f7e49367b9c9672f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->