### PR TITLE
feat(e2e): enclave Ariadne reads encrypted attachments (Slice C)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -9,6 +9,8 @@ import { OutboxRepository } from "../../../lib/outbox"
 import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
 import type { E2eStream, E2eStreamActor, StreamE2eKeyWrap } from "../../e2e-streams"
 import { MessageRepository } from "../../messaging"
+import { AttachmentRepository } from "../../attachments"
+import type { StorageProvider } from "../../../lib/storage/s3-client"
 import type { Message } from "../../messaging"
 import { UserRepository } from "../../workspaces"
 import { UserPreferencesService } from "../../user-preferences"
@@ -57,6 +59,8 @@ const TRIGGER = {
 
 afterEach(() => mock.restore())
 
+const FAKE_STORAGE = { getObject: async () => Buffer.from("") } as unknown as StorageProvider
+
 function fakeIo() {
   const emit = mock((_event: string, _payload: unknown) => {})
   const io = { to: mock((_room: string) => ({ emit })) } as unknown as Server
@@ -72,6 +76,7 @@ function arrangeDispatch() {
   spyOn(EnclaveRuntimesRepository, "listLive").mockResolvedValue([EIK])
   spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([WRAP])
   spyOn(MessageRepository, "findSurrounding").mockResolvedValue([])
+  spyOn(AttachmentRepository, "findByMessageId").mockResolvedValue([])
   spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
   spyOn(UserPreferencesService.prototype, "getPreferences").mockResolvedValue({} as never)
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ name: "Kris" }] as never)
@@ -99,6 +104,7 @@ describe("createEnclaveInvokeWorker", () => {
       pool,
       io,
       enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: FAKE_STORAGE,
     })
     await worker(JOB)
 
@@ -128,6 +134,7 @@ describe("createEnclaveInvokeWorker", () => {
       pool,
       io,
       enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: FAKE_STORAGE,
     })
     await worker(JOB)
 
@@ -155,6 +162,7 @@ describe("createEnclaveInvokeWorker", () => {
       pool,
       io,
       enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: FAKE_STORAGE,
     })
     // The original assign error still propagates so the job retries.
     await expect(worker(JOB)).rejects.toThrow("enclave unreachable")

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -10,6 +10,8 @@ import { UserPreferencesService } from "../../user-preferences"
 import type { EnclaveInvokeJobData, JobHandler } from "../../../lib/queue/job-queue"
 import { E2eStreamActorsRepository, E2eStreamsRepository, StreamE2eKeyWrapsRepository } from "../../e2e-streams"
 import { MessageRepository } from "../../messaging"
+import { AttachmentRepository } from "../../attachments"
+import type { StorageProvider } from "../../../lib/storage/s3-client"
 import {
   AgentSessionRepository,
   SessionStatuses,
@@ -31,6 +33,13 @@ export interface EnclaveInvokeWorkerDeps {
   pool: Pool
   io: Server
   enclaveForwarder: EnclaveForwarder
+  /**
+   * Reads attachment ciphertext from S3 to ship inline to the enclave. The
+   * backend can't decrypt it (the per-file key is sealed in the prompt) — it only
+   * relays the opaque bytes so the enclave's egress stays pinned to backend +
+   * OpenRouter.
+   */
+  storage: StorageProvider
 }
 
 /**
@@ -41,7 +50,7 @@ export interface EnclaveInvokeWorkerDeps {
  * Ariadne's replies are written by the `/complete` callback, not here.
  */
 export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHandler<EnclaveInvokeJobData> {
-  const { pool, io, enclaveForwarder } = deps
+  const { pool, io, enclaveForwarder, storage } = deps
   const userPreferencesService = new UserPreferencesService(pool)
 
   return async (job) => {
@@ -91,6 +100,14 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     // content stays ciphertext.
     const systemPrompt = await buildEnclaveSystemPrompt({ pool, stream, preferences, persona })
 
+    // Ship the trigger message's attachment ciphertext inline so the enclave can
+    // read files (it can't reach S3 — egress is backend + OpenRouter only). We
+    // can't know which attachmentIds the sealed payload references, so we ship
+    // every E2E row bound to the trigger; the enclave matches them by id to the
+    // refs it decrypts. Best-effort per file: a read failure drops that one
+    // attachment rather than failing the turn.
+    const triggerAttachmentCiphertexts = await loadTriggerAttachmentCiphertexts(pool, storage, triggerId)
+
     const sid = newSessionId()
     const built = buildEnclaveSessionAssignment({
       e2e,
@@ -108,6 +125,7 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       },
       replySenderId: ARIADNE_AGENT_ID,
       sessionId: sid,
+      triggerAttachmentCiphertexts,
     })
     if (!built) {
       logger.info({ workspaceId, streamId }, "enclave dispatch: no live enclave can serve this stream; skipping")
@@ -181,4 +199,33 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
 
     logger.info({ workspaceId, streamId, sessionId: sid, keyId: built.keyId }, "Enclave session assigned")
   }
+}
+
+/**
+ * Read the opaque ciphertext for every E2E attachment bound to the trigger
+ * message and base64-encode it for inline shipping. The backend never decrypts:
+ * the per-file key is sealed inside the prompt and recovered only in the enclave.
+ * Best-effort — a single unreadable object is dropped (the enclave then notes the
+ * file as unavailable) rather than failing the whole turn.
+ */
+async function loadTriggerAttachmentCiphertexts(
+  pool: Pool,
+  storage: StorageProvider,
+  triggerId: string
+): Promise<{ attachmentId: string; ciphertext: string }[]> {
+  const rows = await AttachmentRepository.findByMessageId(pool, triggerId)
+  const e2eRows = rows.filter((a) => a.e2eOnly)
+  if (e2eRows.length === 0) return []
+  const results = await Promise.all(
+    e2eRows.map(async (a) => {
+      try {
+        const bytes = await storage.getObject(a.storagePath)
+        return { attachmentId: a.id, ciphertext: bytes.toString("base64") }
+      } catch (err) {
+        logger.warn({ err, attachmentId: a.id }, "enclave dispatch: failed to read attachment ciphertext; skipping")
+        return null
+      }
+    })
+  )
+  return results.filter((r): r is { attachmentId: string; ciphertext: string } => r !== null)
 }

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -103,6 +103,15 @@ describe("buildEnclaveSessionAssignment", () => {
     expect(built!.assignment).not.toHaveProperty("trigger")
   })
 
+  it("ships the trigger's attachment ciphertext inline, and omits it when there's none", () => {
+    expect(buildEnclaveSessionAssignment(inputs())!.assignment).not.toHaveProperty("attachmentCiphertexts")
+
+    const withFiles = buildEnclaveSessionAssignment(
+      inputs({ triggerAttachmentCiphertexts: [{ attachmentId: "attach_1", ciphertext: "Y2lwaGVy" }] })
+    )
+    expect(withFiles!.assignment.attachmentCiphertexts).toEqual([{ attachmentId: "attach_1", ciphertext: "Y2lwaGVy" }])
+  })
+
   it("returns null when no enclave actor is invited", () => {
     expect(
       buildEnclaveSessionAssignment(inputs({ actors: [{ kind: "bot", actorId: "bot_x", keyId: null }] }))

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -43,6 +43,13 @@ export interface BuildInvokeInputs {
   replySenderId: string
   /** The server-created agent_sessions id the enclave drives this turn under. */
   sessionId: string
+  /**
+   * Opaque ciphertext for each E2E attachment bound to the trigger message,
+   * base64-encoded. The worker reads these from S3 (the backend can't decrypt
+   * them); the enclave matches them to the decrypted `attachmentRefs` by id and
+   * opens them with the sealed per-file key. Empty/omitted → no attachments.
+   */
+  triggerAttachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
 }
 
 export interface BuiltEnclaveInvoke {
@@ -104,6 +111,11 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     // NULL = unrestricted → omit the field (the enclave then builds its full
     // web surface, today's behavior).
     ...(e2e.allowedToolCategories ? { allowedToolCategories: e2e.allowedToolCategories } : {}),
+    // Trigger-message attachment ciphertext, shipped inline so the enclave reads
+    // files without an S3 egress. Omitted when there are none.
+    ...(inputs.triggerAttachmentCiphertexts && inputs.triggerAttachmentCiphertexts.length > 0
+      ? { attachmentCiphertexts: inputs.triggerAttachmentCiphertexts }
+      : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
     // Clear metadata for the enclave's "Triggered by" CONTEXT step; the body is
     // the decrypted prompt, sealed enclave-side. Omitted when the author name

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -705,7 +705,7 @@ export async function startServer(): Promise<ServerInstance> {
   // is configured — the forwarder authenticates to the enclave with it, and the
   // enclave rejects callers that don't present it.
   if (enclaveForwarder) {
-    const enclaveInvokeWorker = createEnclaveInvokeWorker({ pool, io, enclaveForwarder })
+    const enclaveInvokeWorker = createEnclaveInvokeWorker({ pool, io, enclaveForwarder, storage })
     jobQueue.registerHandler(JobQueues.ENCLAVE_INVOKE, enclaveInvokeWorker, {
       tier: QueueTiers.INTERACTIVE,
       fairness: QueueFairness.NONE,

--- a/apps/enclave/src/agent/openai-format.ts
+++ b/apps/enclave/src/agent/openai-format.ts
@@ -19,9 +19,20 @@ export interface OpenAiToolCall {
   function: { name: string; arguments: string }
 }
 
+/**
+ * OpenAI/OpenRouter multimodal content parts. OpenRouter passes `image_url`
+ * (data URL) and `file` (base64 `file_data`) parts through to vision/PDF-capable
+ * models like Claude — that's how the enclave feeds decrypted attachments to the
+ * model without ever giving the server the plaintext.
+ */
+export type OpenAiContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }
+  | { type: "file"; file: { filename: string; file_data: string } }
+
 export interface OpenAiMessage {
   role: "system" | "user" | "assistant" | "tool"
-  content: string | null
+  content: string | OpenAiContentPart[] | null
   tool_calls?: OpenAiToolCall[]
   tool_call_id?: string
 }
@@ -39,6 +50,42 @@ function contentToText(content: ModelMessage["content"]): string {
     .filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
     .map((part) => part.text)
     .join("")
+}
+
+/** AI-SDK user content part shapes the enclave produces for attachment turns. */
+type UserModelPart =
+  | { type: "text"; text: string }
+  | { type: "image"; image: string }
+  | { type: "file"; data: string; mediaType: string; filename: string }
+
+/**
+ * Convert a user `ModelMessage` content to OpenAI form. A plain string (or a
+ * parts array with only text) stays a string — byte-identical to the old
+ * text-only path. Once an image/file part is present, emit the multimodal parts
+ * array OpenRouter forwards to the model.
+ */
+function toUserContent(content: ModelMessage["content"]): string | OpenAiContentPart[] {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  const parts: OpenAiContentPart[] = []
+  let hasMedia = false
+  for (const raw of content) {
+    const part = raw as UserModelPart
+    if (part.type === "text" && typeof part.text === "string") {
+      parts.push({ type: "text", text: part.text })
+    } else if (part.type === "image" && typeof part.image === "string") {
+      parts.push({ type: "image_url", image_url: { url: part.image } })
+      hasMedia = true
+    } else if (part.type === "file" && typeof part.data === "string") {
+      parts.push({
+        type: "file",
+        file: { filename: part.filename, file_data: `data:${part.mediaType};base64,${part.data}` },
+      })
+      hasMedia = true
+    }
+  }
+  if (!hasMedia) return parts.map((p) => (p.type === "text" ? p.text : "")).join("")
+  return parts
 }
 
 /** Split an assistant message into its text and any tool-call parts. */
@@ -86,7 +133,7 @@ export function toOpenAiMessages(system: string | undefined, messages: ModelMess
         out.push({ role: "system", content: contentToText(m.content) })
         break
       case "user":
-        out.push({ role: "user", content: contentToText(m.content) })
+        out.push({ role: "user", content: toUserContent(m.content) })
         break
       case "assistant": {
         const { text, toolCalls } = splitAssistant(m.content)

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest"
 import {
+  ATTACHMENT_AAD,
+  ATTACHMENT_KEY_GENERATION,
   buildMessageAad,
   buildWrapAad,
   bytesToBase64,
   generateStreamKey,
   openMessageAsString,
   sealMessage,
+  serializeSealedPayload,
+  utf8Encode,
   wrapStreamKey,
+  type AttachmentRef,
 } from "@threa/crypto"
 import type {
   EnclaveSealedReply,
@@ -275,6 +280,99 @@ describe("runEnclaveTurn", () => {
     // The turn still produced its reply, streamed and reported under the same id.
     expect(result.messageIds[0]).toMatch(/^msg_/)
     expect(sent.find((m) => m.messageId === result.messageIds[0])).toBeDefined()
+  })
+
+  it("decrypts the trigger's attachments and feeds them as multimodal content", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+
+    // Encrypt two files exactly as the browser does: a fresh per-file key, the
+    // single-key attachment envelope (gen 0, the domain-separation AAD).
+    const encryptFile = async (bytes: Uint8Array, mimeType: string, filename: string, attachmentId: string) => {
+      const fileKey = generateStreamKey()
+      const sealed = await sealMessage({
+        key: fileKey,
+        keyGeneration: ATTACHMENT_KEY_GENERATION,
+        payload: bytes,
+        aad: ATTACHMENT_AAD,
+      })
+      const ref: AttachmentRef = {
+        attachmentId,
+        key: bytesToBase64(fileKey),
+        iv: sealed.envelope.iv,
+        filename,
+        mimeType,
+        sizeBytes: bytes.length,
+      }
+      return { ref, ciphertext: bytesToBase64(sealed.ciphertext) }
+    }
+
+    const img = await encryptFile(utf8Encode("fake-png-bytes"), "image/png", "shot.png", "attach_img")
+    const pdf = await encryptFile(utf8Encode("fake-pdf-bytes"), "application/pdf", "contract.pdf", "attach_pdf")
+
+    // The prompt seals the versioned wrapper carrying both refs (the per-file keys
+    // ride here, inside the SSK ciphertext — never on the wire).
+    const prompt = await sealUnder(
+      ssk,
+      serializeSealedPayload("review these", [img.ref, pdf.ref]),
+      "msg_user",
+      "usr_owner"
+    )
+    const chat = stubChat(textReply("On it."))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({
+        wraps: [wrap],
+        prompt,
+        // The backend shipped the opaque ciphertext inline (the enclave can't reach S3).
+        attachmentCiphertexts: [
+          { attachmentId: "attach_img", ciphertext: img.ciphertext },
+          { attachmentId: "attach_pdf", ciphertext: pdf.ciphertext },
+        ],
+      })
+    )
+
+    // The model received the clean markdown (not the JSON wrapper) plus the
+    // decrypted image as an image_url data URL and the PDF as a file part —
+    // exactly what OpenRouter forwards to a vision/PDF-capable model.
+    const userMsg = chat.seen[0]?.messages.find((m) => m.role === "user")
+    expect(userMsg?.content).toEqual([
+      { type: "text", text: "review these" },
+      { type: "image_url", image_url: { url: `data:image/png;base64,${bytesToBase64(utf8Encode("fake-png-bytes"))}` } },
+      {
+        type: "file",
+        file: { filename: "contract.pdf", file_data: `data:application/pdf;base64,${bytesToBase64(utf8Encode("fake-pdf-bytes"))}` },
+      },
+    ])
+  })
+
+  it("notes an attachment whose ciphertext the backend couldn't ship, without failing the turn", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const ref: AttachmentRef = {
+      attachmentId: "attach_missing",
+      key: bytesToBase64(generateStreamKey()),
+      iv: "aXY=",
+      filename: "lost.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 10,
+    }
+    const prompt = await sealUnder(ssk, serializeSealedPayload("see file", [ref]), "msg_user", "usr_owner")
+    const chat = stubChat(textReply("ok"))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    // No attachmentCiphertexts shipped → the file degrades to a text note.
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({ wraps: [wrap], prompt })
+    )
+
+    const userMsg = chat.seen[0]?.messages.find((m) => m.role === "user")
+    expect(userMsg?.content).toBe('see file\n\n[Attachment "lost.pdf" is unavailable]')
   })
 
   it("rejects when the prompt's generation has no wrap (can't read the trigger)", async () => {

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -5,9 +5,12 @@ import {
   buildMessageAad,
   buildWrapAad,
   bytesToBase64,
+  decryptAttachmentBytes,
   openMessageAsString,
+  parseSealedPayload,
   sealMessage,
   unwrapStreamKey,
+  type AttachmentRef,
 } from "@threa/crypto"
 import { AgentToolNames } from "@threa/types"
 import type {
@@ -105,28 +108,39 @@ export async function runEnclaveTurn(
     sskByGeneration.set(wrap.keyGeneration, await unwrap(keyPair, request.streamId, wrap))
   }
 
+  // Inline attachment ciphertext for the trigger, keyed by id. The backend
+  // shipped these because the enclave can't reach S3; the per-file key lives in
+  // the decrypted payload, not here.
+  const ciphertextById = new Map((request.attachmentCiphertexts ?? []).map((a) => [a.attachmentId, a.ciphertext]))
+
   // Open the history this enclave is entitled to. Generations predating our
-  // invite have no wrap; that history is skipped rather than fatal.
+  // invite have no wrap; that history is skipped rather than fatal. Strip the
+  // sealed-payload wrapper so the model sees clean markdown (not the JSON
+  // envelope) for any message that carried attachments; note the filenames so
+  // the model has context, but we only fetch+feed bytes for the trigger.
   const messages: ModelMessage[] = []
   for (const item of request.history) {
     const ssk = sskByGeneration.get(item.envelope.keyGeneration)
     if (!ssk) continue
-    const content = await openMessageAsString({
+    const raw = await openMessageAsString({
       key: ssk,
       envelope: item.envelope,
       ciphertext: base64ToBytes(item.ciphertext),
     })
-    messages.push({ role: item.role, content })
+    const { contentMarkdown, attachmentRefs } = parseSealedPayload(raw)
+    messages.push({ role: item.role, content: withAttachmentNote(contentMarkdown, attachmentRefs) })
   }
 
   const promptSsk = sskByGeneration.get(request.prompt.envelope.keyGeneration)
   if (!promptSsk) throw new InvokeError("No SSK wrap for the prompt's key generation")
-  const promptText = await openMessageAsString({
+  const promptRaw = await openMessageAsString({
     key: promptSsk,
     envelope: request.prompt.envelope,
     ciphertext: base64ToBytes(request.prompt.ciphertext),
   })
-  messages.push({ role: "user", content: promptText })
+  const { contentMarkdown: promptText, attachmentRefs: promptRefs } = parseSealedPayload(promptRaw)
+  const promptContent = await buildUserContent(promptText, promptRefs, ciphertextById)
+  messages.push({ role: "user", content: promptContent } as ModelMessage)
 
   const replySsk = sskByGeneration.get(request.reply.keyGeneration)
   if (!replySsk) throw new InvokeError("No SSK wrap for the reply's key generation")
@@ -219,6 +233,69 @@ export async function runEnclaveTurn(
     model: request.model,
     usage: { promptTokens: usage.promptTokens, completionTokens: usage.completionTokens },
   }
+}
+
+/**
+ * AI-SDK user content parts the enclave builds for an attachment-bearing turn.
+ * Structurally match the SDK's `UserContent` part shapes; the whole content is
+ * asserted onto `ModelMessage` (the role↔content union needs the cast) and the
+ * enclave's `openai-format` maps these to OpenRouter image_url / file parts.
+ */
+type EnclaveUserPart =
+  | { type: "text"; text: string }
+  | { type: "image"; image: string }
+  | { type: "file"; data: string; mediaType: string; filename: string }
+
+/**
+ * Build the trigger user message: clean markdown plus a decrypted multimodal
+ * part per attachment, so the (vision/PDF-capable) model reads the actual file —
+ * parity with the non-E2E path, which feeds extracted text/images. The per-file
+ * key/iv come from the decrypted ref; the ciphertext was shipped inline by the
+ * backend. A missing or undecryptable file degrades to a text note rather than
+ * failing the turn. No attachments → a plain string (byte-identical to before).
+ */
+async function buildUserContent(
+  contentMarkdown: string,
+  refs: AttachmentRef[],
+  ciphertextById: Map<string, string>
+): Promise<string | EnclaveUserPart[]> {
+  if (refs.length === 0) return contentMarkdown
+  const media: EnclaveUserPart[] = []
+  const notes: string[] = []
+  for (const ref of refs) {
+    const ct = ciphertextById.get(ref.attachmentId)
+    if (!ct) {
+      notes.push(`[Attachment "${ref.filename}" is unavailable]`)
+      continue
+    }
+    try {
+      const bytes = await decryptAttachmentBytes({ ciphertext: base64ToBytes(ct), key: ref.key, iv: ref.iv })
+      const b64 = bytesToBase64(bytes)
+      if (ref.mimeType.startsWith("image/")) {
+        media.push({ type: "image", image: `data:${ref.mimeType};base64,${b64}` })
+      } else {
+        media.push({ type: "file", data: b64, mediaType: ref.mimeType, filename: ref.filename })
+      }
+    } catch {
+      notes.push(`[Attachment "${ref.filename}" could not be decrypted]`)
+    }
+  }
+  // Fold any "unavailable/undecryptable" notes into the leading text so the model
+  // still knows a file was meant to be there.
+  const text = [contentMarkdown, ...notes].filter((s) => s.length > 0).join("\n\n")
+  // No decryptable media → a plain string (byte-identical to the no-attachment path).
+  if (media.length === 0) return text
+  return [{ type: "text", text }, ...media]
+}
+
+/**
+ * History attachments aren't fetched (trigger-only this slice), but the model
+ * should still know a file was shared — append the filenames as a text note.
+ */
+function withAttachmentNote(contentMarkdown: string, refs: AttachmentRef[]): string {
+  if (refs.length === 0) return contentMarkdown
+  const note = `[Attached: ${refs.map((r) => r.filename).join(", ")}]`
+  return contentMarkdown.length > 0 ? `${contentMarkdown}\n\n${note}` : note
 }
 
 async function unwrap(keyPair: EnclaveKeyPair, streamId: string, wrap: EnclaveSskWrap): Promise<Uint8Array> {

--- a/apps/frontend/src/lib/crypto/attachment-crypto.ts
+++ b/apps/frontend/src/lib/crypto/attachment-crypto.ts
@@ -1,39 +1,16 @@
 import {
-  base64ToBytes,
+  ATTACHMENT_AAD,
+  ATTACHMENT_KEY_GENERATION,
   bytesToBase64,
   generateStreamKey,
-  openMessage,
   sealMessage,
-  STREAM_ENVELOPE_VERSION,
-  utf8Encode,
+  type AttachmentRef,
 } from "@threa/crypto"
 
-/**
- * One end-to-end-encrypted attachment, carried inside the SSK-sealed message
- * payload (its `attachmentRefs`) and never on the wire in clear. `key`/`iv`
- * open the opaque S3 ciphertext; `filename`/`mimeType`/`sizeBytes` are the real
- * values the server's placeholder row deliberately hides. See
- * `.claude/plans/e2e-attachments.md`.
- */
-export interface AttachmentRef {
-  attachmentId: string
-  /** Base64 of the 32-byte single-use AES-256-GCM key for this attachment. */
-  key: string
-  /** Base64 12-byte GCM IV (from the seal envelope). */
-  iv: string
-  filename: string
-  mimeType: string
-  sizeBytes: number
-}
-
-// Domain-separation label bound as GCM AAD. The per-attachment key is random
-// and used exactly once, so relocation/confusion attacks gain nothing and the
-// AAD's only job is to satisfy the AEAD interface and pin the ciphertext to
-// this scheme. It carries no secret and is reconstructed verbatim by the
-// decrypt path (Slice B2).
-const ATTACHMENT_AAD = utf8Encode("threa-attachment-v1")
-/** Single-key scheme: attachment keys are per-file, never rotated. */
-const ATTACHMENT_KEY_GENERATION = 0
+// The `AttachmentRef` type and the `decryptAttachmentBytes` open primitive are
+// canonical in @threa/crypto so the enclave shares them (INV-35). Re-export them
+// here so existing call sites that import from this module keep working.
+export { decryptAttachmentBytes, type AttachmentRef } from "@threa/crypto"
 
 export interface EncryptedAttachment {
   /** Ciphertext bytes to upload as the opaque file body (a valid `BlobPart`). */
@@ -59,30 +36,6 @@ export async function encryptAttachmentBytes(plaintext: Uint8Array): Promise<Enc
     aad: ATTACHMENT_AAD,
   })
   return { ciphertext, key: bytesToBase64(key), iv: envelope.iv }
-}
-
-/**
- * Decrypt the opaque S3 ciphertext of an E2E attachment back to its bytes, using
- * the `key`/`iv` carried in the message's `attachmentRef`. Inverse of
- * `encryptAttachmentBytes` — reconstructs the same single-key envelope (gen 0,
- * the domain-separation AAD) and opens it. Throws if the key/iv don't match or
- * the bytes were tampered (AES-GCM tag check).
- */
-export async function decryptAttachmentBytes(input: {
-  ciphertext: Uint8Array
-  key: string
-  iv: string
-}): Promise<Uint8Array<ArrayBuffer>> {
-  return openMessage({
-    key: base64ToBytes(input.key),
-    envelope: {
-      v: STREAM_ENVELOPE_VERSION,
-      keyGeneration: ATTACHMENT_KEY_GENERATION,
-      iv: input.iv,
-      aad: bytesToBase64(ATTACHMENT_AAD),
-    },
-    ciphertext: input.ciphertext,
-  })
 }
 
 // In-memory bridge from upload time (where the per-attachment key/iv are

--- a/apps/frontend/src/lib/crypto/message-envelope.ts
+++ b/apps/frontend/src/lib/crypto/message-envelope.ts
@@ -8,13 +8,20 @@ import {
   decryptPayloadAsString,
   ENVELOPE_VERSION,
   openMessageAsString,
+  parseSealedPayload,
   sealMessage,
+  serializeSealedPayload,
   STREAM_ENVELOPE_VERSION,
+  type AttachmentRef,
   type Envelope,
   type StreamEnvelope,
 } from "@threa/crypto"
 import { resolveStreamKey } from "./stream-key-cache"
-import type { AttachmentRef } from "./attachment-crypto"
+
+// Parsing/serializing the sealed payload (and the AttachmentRef shape) is shared
+// crypto so the enclave strips the same wrapper (INV-35). Re-export the parser
+// and its result type for callers that import them from this module.
+export { parseSealedPayload, type ParsedSealedPayload } from "@threa/crypto"
 
 // The placeholder text the backend stores in `contentMarkdown` / `contentJson`
 // for E2E messages is the single source of truth in @threa/types so the
@@ -37,83 +44,6 @@ export interface SealStreamMessageInput {
    * wire — the server only holds opaque bytes and a placeholder row.
    */
   attachmentRefs?: AttachmentRef[]
-}
-
-/**
- * The structured E2E message payload. Messages with no attachments seal the
- * bare markdown string (byte-identical to every E2E message already written),
- * so this wrapper only appears once attachments ride along. The `__e2ePayload`
- * marker + version lets the decrypt path tell a wrapper apart from a user's
- * markdown that merely happens to start with `{` — the same structurally-
- * disjoint discrimination the backend's envelope union uses.
- */
-interface E2eSealedPayload {
-  __e2ePayload: typeof E2E_PAYLOAD_VERSION
-  contentMarkdown: string
-  attachmentRefs: AttachmentRef[]
-}
-
-const E2E_PAYLOAD_VERSION = 1
-
-/** Build the bytes to seal: bare markdown, or the wrapper when refs ride along. */
-function serializeSealedPayload(contentMarkdown: string, attachmentRefs?: AttachmentRef[]): string {
-  if (!attachmentRefs || attachmentRefs.length === 0) return contentMarkdown
-  return JSON.stringify({
-    __e2ePayload: E2E_PAYLOAD_VERSION,
-    contentMarkdown,
-    attachmentRefs,
-  } satisfies E2eSealedPayload)
-}
-
-export interface ParsedSealedPayload {
-  contentMarkdown: string
-  attachmentRefs: AttachmentRef[]
-}
-
-/**
- * Validate one decrypted `attachmentRefs` element before it reaches the viewer.
- * The refs are decrypted text we authored, but a malformed or mixed-version
- * payload could carry objects missing `key`/`iv`/`filename`/etc. — those must
- * not flow to the timeline (it would try to fetch/decrypt with `undefined`).
- */
-function isAttachmentRef(value: unknown): value is AttachmentRef {
-  if (typeof value !== "object" || value === null) return false
-  const r = value as Record<string, unknown>
-  return (
-    typeof r.attachmentId === "string" &&
-    typeof r.key === "string" &&
-    typeof r.iv === "string" &&
-    typeof r.filename === "string" &&
-    typeof r.mimeType === "string" &&
-    typeof r.sizeBytes === "number"
-  )
-}
-
-/**
- * Inverse of `serializeSealedPayload`. A decrypted string is either the bare
- * markdown body (the legacy/no-attachment shape) or the versioned wrapper;
- * anything that doesn't parse as our wrapper is treated as raw markdown so old
- * messages keep opening unchanged.
- */
-export function parseSealedPayload(raw: string): ParsedSealedPayload {
-  if (raw.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(raw) as Partial<E2eSealedPayload>
-      if (parsed.__e2ePayload === E2E_PAYLOAD_VERSION && typeof parsed.contentMarkdown === "string") {
-        // attachmentRefs comes from decrypted text we authored, but guard the
-        // shape anyway so a malformed wrapper degrades to "no attachments" and
-        // any malformed element is dropped, rather than handing junk to the
-        // timeline.
-        const attachmentRefs = Array.isArray(parsed.attachmentRefs)
-          ? parsed.attachmentRefs.filter(isAttachmentRef)
-          : []
-        return { contentMarkdown: parsed.contentMarkdown, attachmentRefs }
-      }
-    } catch {
-      // Not our wrapper — fall through and treat the whole string as markdown.
-    }
-  }
-  return { contentMarkdown: raw, attachmentRefs: [] }
 }
 
 export interface SealStreamMessageResult {

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -92,8 +92,13 @@ known-missing tally, kept current as gaps close:
   filename/mime/size ride sealed inside the message payload. The timeline decrypts
   on view: images preview inline and other files decrypt on click, using the
   per-file key recovered from the message — never the server's placeholder row.
-  Server-side processing (image captioning, PDF text, transcoding) stays off for
-  these by design (the server can't read the content).
+  **Ariadne reads them too:** the backend relays the opaque ciphertext to the
+  enclave (which can't reach S3), the enclave decrypts in memory with the sealed
+  per-file key, and feeds images/PDFs straight to the (vision-capable) model — so
+  asking Ariadne about an attached PDF or screenshot works, the same as a plaintext
+  scratchpad. Today this covers the attachments on the message you send (not files
+  shared several turns earlier). Server-side processing (image captioning, PDF text,
+  transcoding) stays off by design — the *server* still can't read the content.
 - **Interjections are picked up after the current turn, not folded into it.** If you
   send a message while Ariadne is mid-turn, it isn't ignored: when the running turn
   finishes, a follow-up turn automatically runs for the message(s) that arrived

--- a/packages/crypto/src/attachment.ts
+++ b/packages/crypto/src/attachment.ts
@@ -1,0 +1,55 @@
+import { base64ToBytes, bytesToBase64, utf8Encode } from "./encoding"
+import { openMessage, STREAM_ENVELOPE_VERSION } from "./stream-key"
+
+/**
+ * One end-to-end-encrypted attachment, carried inside the SSK-sealed message
+ * payload (its `attachmentRefs`) and never on the wire in clear. `key`/`iv`
+ * open the opaque S3 ciphertext; `filename`/`mimeType`/`sizeBytes` are the real
+ * values the server's placeholder row deliberately hides. See
+ * `.claude/plans/e2e-attachments.md`.
+ *
+ * Lives in the shared crypto package so both the browser (encrypt on upload,
+ * decrypt on view) and the enclave (decrypt to feed the model) use one
+ * definition and one open primitive — no parallel implementation (INV-35).
+ */
+export interface AttachmentRef {
+  attachmentId: string
+  /** Base64 of the 32-byte single-use AES-256-GCM key for this attachment. */
+  key: string
+  /** Base64 12-byte GCM IV (from the seal envelope). */
+  iv: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+}
+
+// Domain-separation label bound as GCM AAD. The per-attachment key is random
+// and used exactly once, so relocation/confusion attacks gain nothing and the
+// AAD's only job is to satisfy the AEAD interface and pin the ciphertext to
+// this scheme. It carries no secret and is reconstructed verbatim on decrypt.
+export const ATTACHMENT_AAD = utf8Encode("threa-attachment-v1")
+/** Single-key scheme: attachment keys are per-file, never rotated. */
+export const ATTACHMENT_KEY_GENERATION = 0
+
+/**
+ * Decrypt the opaque S3 ciphertext of an E2E attachment back to its bytes, using
+ * the `key`/`iv` carried in the message's `attachmentRef`. Reconstructs the
+ * single-key envelope (gen 0, the domain-separation AAD) and opens it. Throws if
+ * the key/iv don't match or the bytes were tampered (AES-GCM tag check).
+ */
+export async function decryptAttachmentBytes(input: {
+  ciphertext: Uint8Array
+  key: string
+  iv: string
+}): Promise<Uint8Array<ArrayBuffer>> {
+  return openMessage({
+    key: base64ToBytes(input.key),
+    envelope: {
+      v: STREAM_ENVELOPE_VERSION,
+      keyGeneration: ATTACHMENT_KEY_GENERATION,
+      iv: input.iv,
+      aad: bytesToBase64(ATTACHMENT_AAD),
+    },
+    ciphertext: input.ciphertext,
+  })
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -44,3 +44,19 @@ export {
   type WrapStreamKeyInput,
   type UnwrapStreamKeyInput,
 } from "./stream-key"
+
+export {
+  ATTACHMENT_AAD,
+  ATTACHMENT_KEY_GENERATION,
+  decryptAttachmentBytes,
+  type AttachmentRef,
+} from "./attachment"
+
+export {
+  E2E_PAYLOAD_VERSION,
+  serializeSealedPayload,
+  parseSealedPayload,
+  isAttachmentRef,
+  type E2eSealedPayload,
+  type ParsedSealedPayload,
+} from "./sealed-payload"

--- a/packages/crypto/src/sealed-payload.ts
+++ b/packages/crypto/src/sealed-payload.ts
@@ -1,0 +1,77 @@
+import type { AttachmentRef } from "./attachment"
+
+/**
+ * The structured E2E message payload. Messages with no attachments seal the
+ * bare markdown string (byte-identical to every E2E message already written),
+ * so this wrapper only appears once attachments ride along. The `__e2ePayload`
+ * marker + version lets the open path tell a wrapper apart from a user's
+ * markdown that merely happens to start with `{` — the same structurally-
+ * disjoint discrimination the backend's envelope union uses.
+ *
+ * Shared so the browser (seal on send, strip on view) and the enclave (strip
+ * to feed the model clean markdown + read attachmentRefs) use one parser.
+ */
+export interface E2eSealedPayload {
+  __e2ePayload: typeof E2E_PAYLOAD_VERSION
+  contentMarkdown: string
+  attachmentRefs: AttachmentRef[]
+}
+
+export const E2E_PAYLOAD_VERSION = 1
+
+/** Build the bytes to seal: bare markdown, or the wrapper when refs ride along. */
+export function serializeSealedPayload(contentMarkdown: string, attachmentRefs?: AttachmentRef[]): string {
+  if (!attachmentRefs || attachmentRefs.length === 0) return contentMarkdown
+  return JSON.stringify({
+    __e2ePayload: E2E_PAYLOAD_VERSION,
+    contentMarkdown,
+    attachmentRefs,
+  } satisfies E2eSealedPayload)
+}
+
+export interface ParsedSealedPayload {
+  contentMarkdown: string
+  attachmentRefs: AttachmentRef[]
+}
+
+/**
+ * Validate one decrypted `attachmentRefs` element before it's surfaced. The
+ * refs are decrypted text we authored, but a malformed or mixed-version payload
+ * could carry objects missing `key`/`iv`/`filename`/etc. — those must not flow
+ * onward (a viewer would fetch/decrypt with `undefined`).
+ */
+export function isAttachmentRef(value: unknown): value is AttachmentRef {
+  if (typeof value !== "object" || value === null) return false
+  const r = value as Record<string, unknown>
+  return (
+    typeof r.attachmentId === "string" &&
+    typeof r.key === "string" &&
+    typeof r.iv === "string" &&
+    typeof r.filename === "string" &&
+    typeof r.mimeType === "string" &&
+    typeof r.sizeBytes === "number"
+  )
+}
+
+/**
+ * Inverse of `serializeSealedPayload`. A decrypted string is either the bare
+ * markdown body (the legacy/no-attachment shape) or the versioned wrapper;
+ * anything that doesn't parse as our wrapper is treated as raw markdown so old
+ * messages keep opening unchanged. Malformed ref elements are dropped.
+ */
+export function parseSealedPayload(raw: string): ParsedSealedPayload {
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<E2eSealedPayload>
+      if (parsed.__e2ePayload === E2E_PAYLOAD_VERSION && typeof parsed.contentMarkdown === "string") {
+        const attachmentRefs = Array.isArray(parsed.attachmentRefs)
+          ? parsed.attachmentRefs.filter(isAttachmentRef)
+          : []
+        return { contentMarkdown: parsed.contentMarkdown, attachmentRefs }
+      }
+    } catch {
+      // Not our wrapper — fall through and treat the whole string as markdown.
+    }
+  }
+  return { contentMarkdown: raw, attachmentRefs: [] }
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -573,6 +573,16 @@ export interface EnclaveSessionAssignment {
    * all. `messaging` (replies) is always allowed regardless.
    */
   allowedToolCategories?: ToolPrivacyCategory[]
+  /**
+   * Opaque ciphertext for the trigger message's attachments, shipped INLINE so
+   * the enclave can read files without widening its egress to S3 (it stays pinned
+   * to the backend + OpenRouter). The backend can't read the per-file key — it's
+   * sealed inside the prompt — so it ships every E2E attachment row bound to the
+   * trigger; the enclave matches `attachmentId` to the decrypted `attachmentRefs`,
+   * decrypts with the sealed key/iv, and feeds the bytes to the (vision/PDF-capable)
+   * model. Omitted when the trigger has no attachments.
+   */
+  attachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
 }
 
 /**


### PR DESCRIPTION
## What

Closes the last attachment gap in E2E scratchpads. Before this, Ariadne in an encrypted stream could see an attachment's *filename* but none of its content, so it replied "paste the sections as text". Now it **reads the file** — parity with the non-E2E path (which feeds extracted text / vision images).

This is **Slice C** from `.claude/plans/e2e-attachments.md` (A = backend foundation, B = produce + viewer, both merged; C = enclave consume).

## How — without widening the enclave's egress

The enclave's egress is pinned to **backend + OpenRouter only**, so it can't fetch S3. The data path keeps the server blind:

1. **Backend (worker)** can't read the per-file key — it's sealed inside the prompt — so it ships *every* E2E attachment row bound to the trigger message as **opaque ciphertext, inline** on the assignment (new `attachmentCiphertexts`). It reads bytes from S3 and relays them; it never decrypts. Best-effort per file (an unreadable object is dropped, the turn still runs).
2. **Enclave** parses the sealed-payload wrapper with the **shared `@threa/crypto` parser** (also fixes a latent bug: attachment-bearing messages used to feed the model the raw JSON wrapper instead of clean markdown), matches each `attachmentRef` to its ciphertext by id, decrypts in memory with the sealed key/iv, and builds a **multimodal user message**: images as `image_url` data URLs, other files (PDFs, …) as `file` parts. Missing/undecryptable → a text note, never a failed turn.
3. **`openai-format`** emits those parts to OpenRouter (Ariadne is `claude-sonnet-4.6` — vision/PDF-capable). Text-only turns stay byte-identical strings.

## Foundation refactor

`AttachmentRef`, the per-file decrypt primitive, and the sealed-payload parser/serializer were frontend-only. Moved the canonical definitions into `@threa/crypto` (`attachment.ts` + `sealed-payload.ts`) so the enclave shares them — no parallel implementation (INV-35). The frontend modules re-export them, so no call site changed.

## Scope

The trigger message's attachments. History attachment messages are stripped to clean markdown with a filename note (their bytes aren't fetched — that's the natural follow-up). Inline base64 is fine for bounded turn attachments; a backend-proxy fetch for very large files is the next iteration.

## Tests

- `run-turn` end-to-end: encrypt → seal wrapper → `runEnclaveTurn` parses, decrypts, and builds the multimodal model request (image + PDF); plus the unavailable-file degradation note.
- `request-builder`: inline `attachmentCiphertexts` shipped / omitted.
- `openai-format` + worker storage wiring covered.
- Green: enclave 45, backend enclave/attachments 225, crypto 33, frontend crypto 20. Full-monorepo typecheck clean (except the pre-existing local `@astrojs/sitemap` public-site issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783164639&installation_id=129946197&pr_number=765&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F765&signature=fe281f62223c2531df6a800a67eed0616b1365398fc38f91dc5298631352671b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->