### PR TITLE
fix(enclave): copy agent-runtime source into Docker build

### DIFF
--- a/Dockerfile.enclave
+++ b/Dockerfile.enclave
@@ -29,6 +29,7 @@ RUN sed -i '/"prepare"/d' package.json && bun install --frozen-lockfile --produc
 # Copy source and bundle to a single Node-targeted ESM file.
 COPY packages/types/ packages/types/
 COPY packages/crypto/ packages/crypto/
+COPY packages/agent-runtime/ packages/agent-runtime/
 COPY apps/enclave/ apps/enclave/
 RUN bun build apps/enclave/src/index.ts --target=node --format=esm --outfile /app/dist/index.mjs
 

--- a/apps/enclave/railway.toml
+++ b/apps/enclave/railway.toml
@@ -1,7 +1,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile.enclave"
-watchPatterns = ["apps/enclave/**", "packages/types/**", "packages/crypto/**", "Dockerfile.enclave", "bun.lock"]
+watchPatterns = ["apps/enclave/**", "packages/types/**", "packages/crypto/**", "packages/agent-runtime/**", "Dockerfile.enclave", "bun.lock"]
 
 [deploy]
 healthcheckPath = "/healthz"


### PR DESCRIPTION
PR #727 added imports from @threa/agent-runtime (/logger and /runtime)
to the enclave, but Dockerfile.enclave only copied packages/types and
packages/crypto into the build stage. The `bun build` bundle step could
not resolve "@threa/agent-runtime/logger" and the production build failed.

Copy packages/agent-runtime/ into the build stage so the bundler can
inline it (its only workspace dep, @threa/types, is already present).
Also add packages/agent-runtime/** to the enclave railway.toml
watchPatterns so changes to it trigger an enclave rebuild.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783171800&installation_id=129946197&pr_number=766&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F766&signature=1b17735c49ccb7abe275458a8932bf4d6700a30bfc00ab9488693f8a0268dc4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->