### PR TITLE
Fix flaky pin-unlock-modal test from input-otp stray timer

### DIFF
--- a/apps/frontend/src/components/encryption/pin-unlock-modal.test.tsx
+++ b/apps/frontend/src/components/encryption/pin-unlock-modal.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import { e2eKeysApi } from "@/api/e2e-keys"
@@ -42,7 +42,17 @@ beforeEach(() => {
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER)
 })
 
-afterEach(() => {
+afterEach(async () => {
+  // `input-otp` (rendered via PinInput) defers a selection-sync `setState` with
+  // `setTimeout(…, 50)` and never clears it on unmount. If that timer fires after
+  // Vitest tears down the jsdom environment, React reads a `window` that's gone
+  // and throws "window is not defined" as an unhandled error — failing the whole
+  // run even though every assertion passed. Drain it here, while `window` still
+  // exists. 50ms is the library's longest deferral, and its callback only touches
+  // caret-mirror state (not the value/selection deps), so it can't re-arm itself.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 60))
+  })
   resetE2eSessionStoreCache()
   vi.restoreAllMocks()
 })
@@ -68,7 +78,14 @@ describe("PinUnlockModal", () => {
     await arrangePinLocked(ws)
     const onUnlocked = vi.fn()
     render(
-      <PinUnlockModal open workspaceId={ws} userId={USER} onOpenChange={() => {}} onUnlocked={onUnlocked} onUsePassphrase={() => {}} />
+      <PinUnlockModal
+        open
+        workspaceId={ws}
+        userId={USER}
+        onOpenChange={() => {}}
+        onUnlocked={onUnlocked}
+        onUsePassphrase={() => {}}
+      />
     )
 
     expect(await screen.findByText("Enter your PIN")).toBeInTheDocument()


### PR DESCRIPTION
## What

The frontend test run intermittently failed with an unhandled `ReferenceError: window is not defined` even though every assertion passed:

```
Test Files  200 passed (200)
Tests       2148 passed (2148)
Errors      1 error          ← this alone exited the run with code 1

ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom-client.development.js
 ❯ dispatchSetState       react-dom-client.development.js
 ❯ Timeout._onTimeout     input-otp/dist/index.mjs
This error originated in "src/components/encryption/pin-unlock-modal.test.tsx"
```

(seen on CI run 26953067049)

## Root cause

`PinInput` renders `input-otp`, whose selection-sync effect defers a `setState` through an internal helper `ht(r) = [setTimeout(r, 0), setTimeout(r, 10), setTimeout(r, 50)]` and never clears those timers on unmount. When the 50ms timer wins the race against Vitest's jsdom-environment teardown, React's `resolveUpdatePriority` reads a `window` that no longer exists and throws. Vitest reports that as an unhandled error and exits non-zero — failing the whole run on a timing race. It only surfaces when teardown lands inside that ~50ms window, which is why it was intermittent.

## Fix

Drain the deferred timers in `afterEach`, inside `act(...)`, while `window` still exists — so teardown has no pending timers. This is localized to `pin-unlock-modal.test.tsx`, the only test that renders `input-otp`. The fix is deterministic: 50ms is the library's longest deferral, and its callback only touches caret-mirror state (not the value/selection effect deps), so it cannot re-arm itself.

## Verification

- 5 consecutive runs of the file: all green, no `Errors` line, no `window is not defined`.
- Pre-commit lint + monorepo typecheck passed.

## Note

This fixes the symptom in the test. The underlying timer leak lives in `input-otp` itself, so any future test that renders `PinInput`/`InputOTP` could hit the same teardown race. If it recurs, a shared drain in `src/test/setup.ts` would be the broader fix.

https://claude.ai/code/session_01JDMevTxbYczFxZMD1SDgML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDMevTxbYczFxZMD1SDgML)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783173204&installation_id=129946197&pr_number=767&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F767&signature=31008458ac7f60e88be70eed03b74562f71de0eeb8c884401790f33b0882c19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->