### PR TITLE
fix: reach save button in encryption setup drawer on mobile

### DIFF
--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -165,8 +165,8 @@ export function PassphraseSetupModal({
   }
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
-      <ResponsiveDialogContent desktopClassName="sm:max-w-md">
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange} disableSnapPoints>
+      <ResponsiveDialogContent desktopClassName="sm:max-w-md" drawerClassName="flex max-h-[92dvh] flex-col gap-0">
         <ResponsiveDialogHeader className="px-6 pt-6">
           <ResponsiveDialogTitle>Set up encrypted scratchpads</ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
@@ -174,7 +174,7 @@ export function PassphraseSetupModal({
             never sees the passphrase or the unwrapped key.
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
           <ResponsiveDialogBody className="space-y-4 py-4">
             <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
               <p className="font-medium">Save your passphrase now — there is no recovery.</p>


### PR DESCRIPTION
## Problem

On mobile, opening an encrypted scratchpad before setting up a passphrase shows the **"Set up encrypted scratchpads"** drawer. The drawer's content is tall — recovery warning, two passphrase fields, a strength meter, two checkboxes, an optional PIN, and biometric setup — and the **Enable encryption** button in the footer was pushed below the viewport with no way to scroll to it. The drawer couldn't be saved.

### Root cause

`PassphraseSetupModal` used the default snap-point drawer, and its `<form>` was a plain block rather than a flex column. With snap points, `ResponsiveDialogContent` gets `h-[100dvh]`, but because the `<form>` (which wraps the body and footer) had no flex layout, `ResponsiveDialogBody`'s `flex-1 overflow-y-auto` had no bounded height to scroll within. The body grew to its content size and the footer overflowed off-screen.

## Solution

Adopt the content-driven drawer pattern already used by the label dialogs (`labels.tsx`, `label-picker.tsx`) — the responsive-dialog docs explicitly recommend `disableSnapPoints` when the partial-snap UX "would obscure the action bar / trailing buttons":

1. `disableSnapPoints` on `ResponsiveDialog` — renders a content-driven drawer instead of a partial-snap one.
2. `drawerClassName="flex max-h-[92dvh] flex-col gap-0"` — bounds the drawer height and makes it a flex column.
3. `className="flex min-h-0 flex-1 flex-col"` on the `<form>` — so `ResponsiveDialogBody` scrolls and the footer stays pinned and reachable.

The footer already applies `pb-[max(16px,env(safe-area-inset-bottom))]` on mobile, so the button clears the home indicator.

### Why desktop is unaffected

On desktop, `ResponsiveDialogContent` renders `DialogContent` (`sm:grid`); `drawerClassName` is only applied on the mobile Drawer branch, and `flex-1`/`min-h-0` are inert on a grid item, so the form expands to content exactly as before.

### Scope

The sibling unlock drawers (passphrase / PIN / biometric) have a single field and fit within the snap, so they're left untouched per minimal-patch. They share the same latent pattern if their content ever grows.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/encryption/passphrase-setup-modal.tsx` | Switch the setup modal to the content-driven drawer pattern (`disableSnapPoints`, flex/max-height drawer, flex-column form) so the footer is reachable on mobile |

## Test plan

- [x] `tsc --noEmit` (frontend) — clean
- [x] Pre-commit hooks (full monorepo typecheck, lint, API doc check) — passed
- [ ] Manual: on a mobile viewport, open an encrypted scratchpad without a passphrase set up, fill the setup form, and confirm the **Enable encryption** button is reachable and the body scrolls
- [ ] Manual: confirm desktop dialog layout is unchanged

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2wj6Bxk24k3XQhAMpERQY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783175261&installation_id=129946197&pr_number=768&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F768&signature=b49c831d0ca807baa0b55af9decd251bdc588db43df1b91ebfbd924715163b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->