### PR TITLE
Fix last message getting stranded behind the floating composer

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   classifyDeepLinkScrollTick,
   classifyTailFollowOnAtBottomChange,
-  TAIL_FOLLOW_USER_SCROLL_WINDOW_MS,
+  TAIL_FOLLOW_SCROLL_AWAY_WINDOW_MS,
 } from "./stream-content"
 
 const DEADLINE = 4000
@@ -110,35 +110,37 @@ describe("classifyDeepLinkScrollTick", () => {
 describe("classifyTailFollowOnAtBottomChange", () => {
   const NOW = 100_000
 
-  it("re-pins when a row grows under a stationary reader at the tail (no recent gesture)", () => {
+  it("re-pins when a row grows under a stationary reader at the tail (no recent scroll-away)", () => {
     // The bug: an async embed/image in the last message finishes loading several
-    // seconds after the user last touched anything, growing the row past
-    // atBottomThreshold. Virtuoso reports atBottom=false; without re-pinning the
+    // seconds after the reader last moved the scroll, growing the row past
+    // atBottomThreshold. The scroll position never moved, so the scroll-away
+    // stamp is stale. Virtuoso reports atBottom=false; without re-pinning the
     // last message is stranded behind the floating composer.
     expect(
       classifyTailFollowOnAtBottomChange({
         atBottom: false,
         isJumpMode: false,
         nowMs: NOW,
-        userInteractedAtMs: NOW - 5_000,
+        scrolledAwayAtMs: NOW - 5_000,
       })
     ).toBe("repin")
 
-    // Never interacted at all (stamp 0) is also content-driven.
+    // Never scrolled up at all (stamp 0) is also content-driven.
     expect(
-      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: false, nowMs: NOW, userInteractedAtMs: 0 })
+      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: false, nowMs: NOW, scrolledAwayAtMs: 0 })
     ).toBe("repin")
   })
 
   it("propagates a genuine scroll-away so follow is disabled and the reader isn't yanked back", () => {
     // The threshold crossing fires at the onset of the scroll, right after the
-    // gesture, so a fresh stamp marks the user-driven case.
+    // position last moved up, so a fresh stamp marks the user-driven case. This
+    // holds for any input that decreases scrollTop, including a scrollbar drag.
     expect(
       classifyTailFollowOnAtBottomChange({
         atBottom: false,
         isJumpMode: false,
         nowMs: NOW,
-        userInteractedAtMs: NOW - 50,
+        scrolledAwayAtMs: NOW - 50,
       })
     ).toBe("propagate")
   })
@@ -149,7 +151,7 @@ describe("classifyTailFollowOnAtBottomChange", () => {
         atBottom: false,
         isJumpMode: false,
         nowMs: NOW,
-        userInteractedAtMs: NOW - TAIL_FOLLOW_USER_SCROLL_WINDOW_MS,
+        scrolledAwayAtMs: NOW - TAIL_FOLLOW_SCROLL_AWAY_WINDOW_MS,
       })
     ).toBe("repin")
     // One ms inside the window is still an active scroll.
@@ -158,7 +160,7 @@ describe("classifyTailFollowOnAtBottomChange", () => {
         atBottom: false,
         isJumpMode: false,
         nowMs: NOW,
-        userInteractedAtMs: NOW - (TAIL_FOLLOW_USER_SCROLL_WINDOW_MS - 1),
+        scrolledAwayAtMs: NOW - (TAIL_FOLLOW_SCROLL_AWAY_WINDOW_MS - 1),
       })
     ).toBe("propagate")
   })
@@ -166,12 +168,12 @@ describe("classifyTailFollowOnAtBottomChange", () => {
   it("always propagates atBottom=true and never re-pins in jump mode", () => {
     // atBottom=true settles at the tail regardless of timing.
     expect(
-      classifyTailFollowOnAtBottomChange({ atBottom: true, isJumpMode: false, nowMs: NOW, userInteractedAtMs: 0 })
+      classifyTailFollowOnAtBottomChange({ atBottom: true, isJumpMode: false, nowMs: NOW, scrolledAwayAtMs: 0 })
     ).toBe("propagate")
     // Deep-link / search reading window: a transient atBottom=false from reflow
     // must not yank the reader to the live tail.
     expect(
-      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: true, nowMs: NOW, userInteractedAtMs: 0 })
+      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: true, nowMs: NOW, scrolledAwayAtMs: 0 })
     ).toBe("propagate")
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest"
-import { classifyDeepLinkScrollTick } from "./stream-content"
+import {
+  classifyDeepLinkScrollTick,
+  classifyTailFollowOnAtBottomChange,
+  TAIL_FOLLOW_USER_SCROLL_WINDOW_MS,
+} from "./stream-content"
 
 const DEADLINE = 4000
 
@@ -100,5 +104,74 @@ describe("classifyDeepLinkScrollTick", () => {
         deadlineMs: DEADLINE,
       })
     ).toBe("user-abort")
+  })
+})
+
+describe("classifyTailFollowOnAtBottomChange", () => {
+  const NOW = 100_000
+
+  it("re-pins when a row grows under a stationary reader at the tail (no recent gesture)", () => {
+    // The bug: an async embed/image in the last message finishes loading several
+    // seconds after the user last touched anything, growing the row past
+    // atBottomThreshold. Virtuoso reports atBottom=false; without re-pinning the
+    // last message is stranded behind the floating composer.
+    expect(
+      classifyTailFollowOnAtBottomChange({
+        atBottom: false,
+        isJumpMode: false,
+        nowMs: NOW,
+        userInteractedAtMs: NOW - 5_000,
+      })
+    ).toBe("repin")
+
+    // Never interacted at all (stamp 0) is also content-driven.
+    expect(
+      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: false, nowMs: NOW, userInteractedAtMs: 0 })
+    ).toBe("repin")
+  })
+
+  it("propagates a genuine scroll-away so follow is disabled and the reader isn't yanked back", () => {
+    // The threshold crossing fires at the onset of the scroll, right after the
+    // gesture, so a fresh stamp marks the user-driven case.
+    expect(
+      classifyTailFollowOnAtBottomChange({
+        atBottom: false,
+        isJumpMode: false,
+        nowMs: NOW,
+        userInteractedAtMs: NOW - 50,
+      })
+    ).toBe("propagate")
+  })
+
+  it("treats the window edge as content-driven (just past the active-scroll window)", () => {
+    expect(
+      classifyTailFollowOnAtBottomChange({
+        atBottom: false,
+        isJumpMode: false,
+        nowMs: NOW,
+        userInteractedAtMs: NOW - TAIL_FOLLOW_USER_SCROLL_WINDOW_MS,
+      })
+    ).toBe("repin")
+    // One ms inside the window is still an active scroll.
+    expect(
+      classifyTailFollowOnAtBottomChange({
+        atBottom: false,
+        isJumpMode: false,
+        nowMs: NOW,
+        userInteractedAtMs: NOW - (TAIL_FOLLOW_USER_SCROLL_WINDOW_MS - 1),
+      })
+    ).toBe("propagate")
+  })
+
+  it("always propagates atBottom=true and never re-pins in jump mode", () => {
+    // atBottom=true settles at the tail regardless of timing.
+    expect(
+      classifyTailFollowOnAtBottomChange({ atBottom: true, isJumpMode: false, nowMs: NOW, userInteractedAtMs: 0 })
+    ).toBe("propagate")
+    // Deep-link / search reading window: a transient atBottom=false from reflow
+    // must not yank the reader to the live tail.
+    expect(
+      classifyTailFollowOnAtBottomChange({ atBottom: false, isJumpMode: true, nowMs: NOW, userInteractedAtMs: 0 })
+    ).toBe("propagate")
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -131,15 +131,14 @@ export function classifyDeepLinkScrollTick(args: {
 }
 
 /**
- * Window (ms) within which a wheel/touch/keydown stamp counts as "the user is
- * actively scrolling right now". Virtuoso crosses `atBottomThreshold` at the
- * *onset* of a scroll — right after the gesture — so the freshest stamp marks a
- * genuine scroll-away; content that grows under a stationary reader crosses it
- * with no recent gesture. Sized to absorb the small latency between the gesture
- * and Virtuoso's throttled atBottom callback, not the (much longer) momentum tail
- * — by the time momentum is coasting, the false transition has already fired.
+ * Window (ms) within which an upward scroll counts as "the user is scrolling
+ * away right now". Virtuoso crosses `atBottomThreshold` at the *onset* of a
+ * scroll, so a fresh scroll-away stamp marks a genuine scroll-away; content that
+ * grows under a stationary reader crosses the threshold with the scroll position
+ * unchanged (no scroll event, stale stamp). Sized to absorb the small latency
+ * between the scroll and Virtuoso's throttled atBottom callback.
  */
-export const TAIL_FOLLOW_USER_SCROLL_WINDOW_MS = 300
+export const TAIL_FOLLOW_SCROLL_AWAY_WINDOW_MS = 300
 
 /**
  * Decide what to do when Virtuoso reports an `atBottomStateChange` for the live
@@ -154,21 +153,28 @@ export const TAIL_FOLLOW_USER_SCROLL_WINDOW_MS = 300
  *                 message or manual scroll. Re-pin to the tail and keep
  *                 following instead.
  *  - `propagate`  forward to the scroll hook unchanged: atBottom=true (settled
- *                 at the tail) or a genuine user scroll-away (fresh gesture
- *                 stamp) that must disable follow so we never yank the reader
+ *                 at the tail) or a genuine user scroll-away (a recent upward
+ *                 scroll) that must disable follow so we never yank the reader
  *                 back down.
  *
- * `nowMs` / `userInteractedAtMs` are `performance.now()` readings.
+ * The scroll-away signal is the scroll *position* moving up, not an input
+ * event, so it is device-independent: wheel, touch, keyboard, and dragging the
+ * native scrollbar all decrease scrollTop and stamp it, while a row growing
+ * under a stationary reader does not move scrollTop and so never fires a scroll.
+ * Its error modes are one-sided: a missed scroll-away stamp degrades to the old
+ * behavior (a brief non-re-pin), never a wrong yank.
+ *
+ * `nowMs` / `scrolledAwayAtMs` are `performance.now()` readings.
  */
 export function classifyTailFollowOnAtBottomChange(args: {
   atBottom: boolean
   isJumpMode: boolean
   nowMs: number
-  userInteractedAtMs: number
+  scrolledAwayAtMs: number
 }): "repin" | "propagate" {
   if (args.atBottom || args.isJumpMode) return "propagate"
-  const userDriven = args.nowMs - args.userInteractedAtMs < TAIL_FOLLOW_USER_SCROLL_WINDOW_MS
-  return userDriven ? "propagate" : "repin"
+  const userScrolledAway = args.nowMs - args.scrolledAwayAtMs < TAIL_FOLLOW_SCROLL_AWAY_WINDOW_MS
+  return userScrolledAway ? "propagate" : "repin"
 }
 
 interface StreamContentProps {
@@ -852,6 +858,13 @@ export function StreamContent({
   // exactly the "I scroll up to read context, then get yanked back to the
   // linked message" deep-link bug.
   const userInteractedAtRef = useRef(0)
+  // Timestamp of the last time the scroll position moved *up* (scrollTop
+  // decreased) on the live timeline. Stamped by a passive scroll listener on
+  // the Virtuoso scroller (attached in handleVirtuosoScrollerRef). Read by the
+  // atBottom classifier to tell a genuine scroll-away from a row growing under a
+  // stationary reader — see classifyTailFollowOnAtBottomChange. Position-based
+  // (not input-based) so it covers dragging the native scrollbar too.
+  const scrolledAwayAtRef = useRef(0)
   const scrollToMessage = useCallback(
     (messageId: string) => {
       if (!useVirtualized) {
@@ -1345,6 +1358,7 @@ export function StreamContent({
                     virtuosoScrollerRef={virtuosoScrollerRef}
                     handleScrollerRef={handleScrollerRef}
                     userInteractedAtRef={userInteractedAtRef}
+                    scrolledAwayAtRef={scrolledAwayAtRef}
                     scrollAbortRef={scrollAbortRef}
                     isJumpMode={isJumpMode}
                     firstItemIndex={firstItemIndex}
@@ -1573,6 +1587,7 @@ function VirtuosoMessageList({
   virtuosoScrollerRef,
   handleScrollerRef,
   userInteractedAtRef,
+  scrolledAwayAtRef,
   scrollAbortRef,
   isJumpMode,
   firstItemIndex,
@@ -1613,6 +1628,9 @@ function VirtuosoMessageList({
   /** Stamp set by long-lived scroller input listeners; read by the outer
    *  scrollToMessage refine loop so manual scroll always wins. */
   userInteractedAtRef: React.MutableRefObject<number>
+  /** Stamp set when the scroll position last moved up; read by the atBottom
+   *  classifier to tell a scroll-away from a row growing under the reader. */
+  scrolledAwayAtRef: React.MutableRefObject<number>
   /** Non-null while a scrollToMessage refine loop is in flight. Programmatic
    *  scroll-into-view must not trigger edge pagination. */
   scrollAbortRef: React.MutableRefObject<(() => void) | null>
@@ -1812,11 +1830,27 @@ function VirtuosoMessageList({
         el.addEventListener("touchstart", mark, { passive: true })
         el.addEventListener("touchmove", mark, { passive: true })
         el.addEventListener("keydown", mark)
+        // Device-independent scroll-away stamp: any upward movement of the
+        // scroll position (wheel, touch, keyboard, or dragging the native
+        // scrollbar — none of which the input listeners above fully cover)
+        // decreases scrollTop and fires `scroll`. A row growing under a
+        // stationary reader does not move scrollTop, so it never stamps. The
+        // atBottom classifier uses this to avoid re-pinning a reader who is
+        // genuinely scrolling up. Programmatic snaps to the tail only ever
+        // increase scrollTop, so they never register as a scroll-away.
+        let prevScrollTop = el.scrollTop
+        const onScroll = () => {
+          const next = el.scrollTop
+          if (next < prevScrollTop - 1) scrolledAwayAtRef.current = performance.now()
+          prevScrollTop = next
+        }
+        el.addEventListener("scroll", onScroll, { passive: true })
         userInteractionCleanupRef.current = () => {
           el.removeEventListener("wheel", mark)
           el.removeEventListener("touchstart", mark)
           el.removeEventListener("touchmove", mark)
           el.removeEventListener("keydown", mark)
+          el.removeEventListener("scroll", onScroll)
         }
       }
     },
@@ -1853,7 +1887,7 @@ function VirtuosoMessageList({
         atBottom,
         isJumpMode,
         nowMs: performance.now(),
-        userInteractedAtMs: userInteractedAtRef.current,
+        scrolledAwayAtMs: scrolledAwayAtRef.current,
       })
       if (decision === "repin") {
         virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" })
@@ -1868,7 +1902,7 @@ function VirtuosoMessageList({
       // still propagates so a real scroll-away keeps follow disabled.
       handleAtBottomChange(isJumpMode ? false : atBottom)
     },
-    [handleAtBottomChange, visibleItems.length, isJumpMode, userInteractedAtRef, virtuosoRef]
+    [handleAtBottomChange, visibleItems.length, isJumpMode, scrolledAwayAtRef, virtuosoRef]
   )
 
   const wrappedHandleRangeChanged = useCallback(

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -743,6 +743,7 @@ export function StreamContent({
     shouldFollowOutput,
     scrollToBottom: virtualScrollToBottom,
     disableAutoScroll: virtualDisableAutoScroll,
+    handleReservedSpaceChange,
     handleAtBottomChange,
     handleRangeChanged,
     handleScrollerRef,
@@ -780,49 +781,12 @@ export function StreamContent({
   const scrollToBottom = useVirtualized ? virtualScrollToBottom : plainScrollToBottom
   const disableAutoScroll = useVirtualized ? virtualDisableAutoScroll : plainDisableAutoScroll
 
-  // Re-anchor the virtualized list to the bottom when the floating composer
-  // settles to a new height. The footer spacer that keeps the last message
-  // above the composer is sized from `--composer-height`, but Virtuoso freezes
-  // its scrollTop when that spacer grows (followOutput only reacts to new
-  // items; the resize safety-net only watches the scroller's own height). So a
-  // composer that lands taller a few frames after a message arrives (its 200ms
-  // height transition, async encryption notice / attachment chips) covers the
-  // bottom of the last message until the next reload. virtualScrollToBottom
-  // self-guards on isAtBottomRef, so this is a no-op unless the user is parked
-  // at the live tail (never fires during a deep-link jump or while scrolled up
-  // reading). The plain-scroll (thread/draft) path needs none of this: its
-  // `padding-bottom` reflows the content so the bottom row is never frozen
-  // behind the composer.
-  //
-  // Two arrival paths, handled differently:
-  //  - `initial`: the composer's first measurement, fired from a layout effect
-  //    *before paint*. The list first scrolled to LAST against the approximate
-  //    persisted footer height; when the real composer differs (cold boot with
-  //    a restored draft, density/zoom change) we correct it synchronously here,
-  //    in the same frame the list reveals, so there is no visible jump.
-  //  - runtime changes: arrive async from the ResizeObserver after paint (the
-  //    200ms height transition, attachment chips settling). Debounced so the
-  //    snap lands once after the transition settles rather than fighting
-  //    Virtuoso's reflow on every intermediate frame.
-  //
-  // Called through a ref so the handler identity stays stable: virtualScrollToBottom
-  // is rebuilt on every itemCount change, and a changing prop would re-render
-  // the memoized MessageInput on every new message (the exact churn that memo
-  // exists to prevent).
-  const virtualScrollToBottomRef = useRef(virtualScrollToBottom)
-  virtualScrollToBottomRef.current = virtualScrollToBottom
-  const composerResizeTimerRef = useRef<number | undefined>(undefined)
-  const handleComposerHeightChange = useCallback((_px: number, opts: { initial: boolean }) => {
-    window.clearTimeout(composerResizeTimerRef.current)
-    if (opts.initial) {
-      virtualScrollToBottomRef.current()
-      return
-    }
-    composerResizeTimerRef.current = window.setTimeout(() => {
-      virtualScrollToBottomRef.current()
-    }, 120)
-  }, [])
-  useEffect(() => () => window.clearTimeout(composerResizeTimerRef.current), [])
+  // The plain-scroll (thread/draft) path keeps the last message above the
+  // floating composer with `padding-bottom: var(--composer-height)`, which
+  // reflows the content so the bottom row is never frozen behind the composer.
+  // The virtualized path needs an active re-anchor instead — see
+  // `handleReservedSpaceChange` in useVirtuosoScroll — and wires it to
+  // MessageInput's `onComposerHeightChange` below.
 
   // Scroll to a specific message and keep re-scrolling until the target
   // element is actually visible in the scroller viewport. Items rendered
@@ -1548,7 +1512,7 @@ export function StreamContent({
                 disabled={isArchived || isSystem}
                 disabledReason={disabledReason}
                 autoFocus={autoFocus}
-                onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
+                onComposerHeightChange={useVirtualized ? handleReservedSpaceChange : undefined}
               />
             )}
           </div>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -130,6 +130,47 @@ export function classifyDeepLinkScrollTick(args: {
   return "active"
 }
 
+/**
+ * Window (ms) within which a wheel/touch/keydown stamp counts as "the user is
+ * actively scrolling right now". Virtuoso crosses `atBottomThreshold` at the
+ * *onset* of a scroll — right after the gesture — so the freshest stamp marks a
+ * genuine scroll-away; content that grows under a stationary reader crosses it
+ * with no recent gesture. Sized to absorb the small latency between the gesture
+ * and Virtuoso's throttled atBottom callback, not the (much longer) momentum tail
+ * — by the time momentum is coasting, the false transition has already fired.
+ */
+export const TAIL_FOLLOW_USER_SCROLL_WINDOW_MS = 300
+
+/**
+ * Decide what to do when Virtuoso reports an `atBottomStateChange` for the live
+ * (non-jump) timeline.
+ *
+ *  - `repin`      a row grew under a reader parked at the tail — most often an
+ *                 async embed / image in the last message finishing load over
+ *                 the next few seconds, which grows the row past
+ *                 `atBottomThreshold`. Virtuoso reports atBottom=false, and the
+ *                 default handling would disable followOutput and strand the
+ *                 last message behind the floating composer until the next
+ *                 message or manual scroll. Re-pin to the tail and keep
+ *                 following instead.
+ *  - `propagate`  forward to the scroll hook unchanged: atBottom=true (settled
+ *                 at the tail) or a genuine user scroll-away (fresh gesture
+ *                 stamp) that must disable follow so we never yank the reader
+ *                 back down.
+ *
+ * `nowMs` / `userInteractedAtMs` are `performance.now()` readings.
+ */
+export function classifyTailFollowOnAtBottomChange(args: {
+  atBottom: boolean
+  isJumpMode: boolean
+  nowMs: number
+  userInteractedAtMs: number
+}): "repin" | "propagate" {
+  if (args.atBottom || args.isJumpMode) return "propagate"
+  const userDriven = args.nowMs - args.userInteractedAtMs < TAIL_FOLLOW_USER_SCROLL_WINDOW_MS
+  return userDriven ? "propagate" : "repin"
+}
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -1801,6 +1842,23 @@ function VirtuosoMessageList({
   const wrappedHandleAtBottomChange = useCallback(
     (atBottom: boolean) => {
       if (visibleItems.length > 0) hasRangeSettledRef.current = true
+      // Tell a genuine scroll-away apart from a row growing under a stationary
+      // reader at the live tail (an async embed/image in the last message
+      // finishing load, which grows it past atBottomThreshold over a few
+      // seconds). Both surface as atBottom=false, but only the user-driven one
+      // should disable follow; the content-driven one must re-pin so the last
+      // message doesn't sit stranded behind the floating composer. See
+      // classifyTailFollowOnAtBottomChange.
+      const decision = classifyTailFollowOnAtBottomChange({
+        atBottom,
+        isJumpMode,
+        nowMs: performance.now(),
+        userInteractedAtMs: userInteractedAtRef.current,
+      })
+      if (decision === "repin") {
+        virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" })
+        return
+      }
       // In jump mode the user is reading a deep-linked / searched history
       // window. Prepend/append reflow and size measurement make Virtuoso
       // transiently report atBottom; letting that arm followOutput (and the
@@ -1810,7 +1868,7 @@ function VirtuosoMessageList({
       // still propagates so a real scroll-away keeps follow disabled.
       handleAtBottomChange(isJumpMode ? false : atBottom)
     },
-    [handleAtBottomChange, visibleItems.length, isJumpMode]
+    [handleAtBottomChange, visibleItems.length, isJumpMode, userInteractedAtRef, virtuosoRef]
   )
 
   const wrappedHandleRangeChanged = useCallback(

--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -163,6 +163,36 @@ describe("useComposerHeightPublish", () => {
     }
   })
 
+  it("keeps the last good height when the composer is hidden (measures 0)", () => {
+    const ro = installManualResizeObserver()
+    try {
+      const onHeightChange = vi.fn()
+      const { container } = render(<Harness onHeightChange={onHeightChange} />)
+      const zone = container.querySelector<HTMLElement>("[data-editor-zone]")!
+
+      // Composer settles at a real height.
+      ro.fire(120)
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+
+      // Inline message-edit opens on mobile → [data-message-composer-root] is
+      // `display:none`, so the ResizeObserver reports 0. The footer spacer must
+      // NOT collapse to 0 (that drops the last message behind the composer with
+      // no scroll slack); keep the last good height and don't notify.
+      ro.fire(0)
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+
+      // Edit closes → composer returns at its real height. Already correct, so
+      // still no spurious re-notify.
+      ro.fire(120)
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
+      expect(onHeightChange).toHaveBeenCalledTimes(1)
+    } finally {
+      ro.restore()
+    }
+  })
+
   it("flags only the first measurement as initial, even when it drifts", () => {
     const ro = installManualResizeObserver()
     try {

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -82,6 +82,18 @@ export function useComposerHeightPublish(
 
     const write = (h: number) => {
       const px = Math.ceil(h)
+      // The composer is sometimes hidden without unmounting: on mobile the
+      // inline message-edit form hides [data-message-composer-root] via
+      // `display:none` (see index.css). A hidden element measures 0, and
+      // writing that would collapse the footer spacer / padding-bottom that
+      // holds the last message above the floating composer — dropping the last
+      // message behind the pill with no scroll slack left to recover it (you
+      // are already at the bottom of the scroll range). Ignore non-positive
+      // measurements and keep the last good height (the same reason cleanup
+      // leaves the variable set), so the reserved space survives the hide and
+      // is already correct the instant the composer returns. Virtuoso guards
+      // its own header/footer measurement the same way (`offsetParent !== null`).
+      if (px <= 0) return
       zone.style.setProperty("--composer-height", `${px}px`)
       persistComposerHeight(px)
       // Notify on any change from the height the footer was last sized for —

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.test.tsx
@@ -243,6 +243,99 @@ describe("useVirtuosoScroll", () => {
     }
   })
 
+  it("forces a re-anchor to the tail when the composer grows after atBottom has flipped false", async () => {
+    // Regression: a message arrives, the list scrolls to LAST, then the floating
+    // composer settles taller a few frames later (200ms height transition, async
+    // encryption notice, attachment chips). The growing footer spacer pushes the
+    // viewport off the bottom by more than atBottomThreshold, so Virtuoso reports
+    // atBottom=false BEFORE the debounced re-anchor fires. A trailing-edge
+    // isAtBottom read would bail and leave the last message covered. The
+    // leading-edge snapshot must win and force the re-scroll.
+    const { restore } = installManualResizeObserver()
+    try {
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        makeScrollableDiv({ clientHeight: 800 }).el,
+        virtuosoHandle
+      )
+
+      // User is glued to the live tail.
+      act(() => apiRef.current.handleAtBottomChange(true))
+
+      // Composer starts growing — leading edge of the resize burst fires while we
+      // are still at the bottom (the growth hasn't flipped the state yet).
+      act(() => apiRef.current.handleReservedSpaceChange(120, { initial: false }))
+      // ...then the grown footer spacer flips Virtuoso off the bottom.
+      act(() => apiRef.current.handleAtBottomChange(false))
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 150))
+      })
+
+      expect(scrollToIndex).toHaveBeenCalledWith({ index: "LAST", align: "end", behavior: "auto" })
+    } finally {
+      restore()
+    }
+  })
+
+  it("does NOT re-anchor on composer growth when the user was scrolled up reading history", async () => {
+    const { restore } = installManualResizeObserver()
+    try {
+      const scrollToIndex = vi.fn()
+      const virtuosoHandle = { scrollToIndex } as unknown as VirtuosoHandle
+
+      const apiRef = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        makeScrollableDiv({ clientHeight: 800 }).el,
+        virtuosoHandle
+      )
+
+      // User has scrolled up away from the tail before the composer grows.
+      act(() => apiRef.current.handleAtBottomChange(false))
+      act(() => apiRef.current.handleReservedSpaceChange(120, { initial: false }))
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 150))
+      })
+
+      expect(scrollToIndex).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it("re-anchors synchronously on the initial composer measurement only when at the tail", () => {
+    // The initial measurement fires pre-paint from a layout effect. At the live
+    // tail (skipInitialScroll=false) it must correct the approximate persisted
+    // footer height immediately; on a deep-link landing (skipInitialScroll=true)
+    // it must NOT yank the user to the tail.
+    const { restore } = installManualResizeObserver()
+    try {
+      const atTailScroll = vi.fn()
+      const atTail = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_1", skipInitialScroll: false },
+        makeScrollableDiv({ clientHeight: 800 }).el,
+        { scrollToIndex: atTailScroll } as unknown as VirtuosoHandle
+      )
+      act(() => atTail.current.handleReservedSpaceChange(120, { initial: true }))
+      expect(atTailScroll).toHaveBeenCalledWith({ index: "LAST", align: "end", behavior: "auto" })
+
+      const deepLinkScroll = vi.fn()
+      const deepLink = renderHookWithScroller(
+        { itemCount: 50, getItemKey: (i) => String(i), resetKey: "stream_2", skipInitialScroll: true },
+        makeScrollableDiv({ clientHeight: 800 }).el,
+        { scrollToIndex: deepLinkScroll } as unknown as VirtuosoHandle
+      )
+      act(() => deepLink.current.handleReservedSpaceChange(120, { initial: true }))
+      expect(deepLinkScroll).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
   it("shifts scrollTop by the delta when scrolled away from the bottom (keyboard open)", () => {
     const { trigger, restore } = installManualResizeObserver()
     try {

--- a/apps/frontend/src/hooks/use-virtuoso-scroll.ts
+++ b/apps/frontend/src/hooks/use-virtuoso-scroll.ts
@@ -40,6 +40,16 @@ interface UseVirtuosoScrollReturn {
   scrollToBottom: (options?: { behavior?: "auto" | "smooth"; force?: boolean }) => void
   /** Disable auto-scroll (e.g. when navigating to a specific message via jump mode) */
   disableAutoScroll: () => void
+  /**
+   * Re-anchor to the tail when the floating composer's reserved space changes.
+   * Wire this to `MessageInput`'s `onComposerHeightChange`: the footer spacer
+   * that keeps the last message above the composer is sized from
+   * `--composer-height`, but Virtuoso freezes its scrollTop when that spacer
+   * grows, so a composer that settles to a taller height a few frames after a
+   * message arrives covers the bottom of the last message. See the
+   * implementation for why the trailing-edge `isAtBottom` read is unreliable.
+   */
+  handleReservedSpaceChange: (px: number, opts: { initial: boolean }) => void
   /** Called by Virtuoso's atBottomStateChange */
   handleAtBottomChange: (atBottom: boolean) => void
   /** Called by Virtuoso's rangeChanged to track distance from bottom */
@@ -198,6 +208,56 @@ export function useVirtuosoScroll({
     setShouldFollowOutput(false)
   }, [])
 
+  // Re-anchor to the tail when the floating composer reserves a new amount of
+  // space below the timeline. The composer publishes its measured height as
+  // `--composer-height`, which sizes the ComposerFooterSpacer; scrollToIndex
+  // LAST and followOutput both land the last message above that spacer. But
+  // when the composer *grows* after the message is already positioned (its
+  // 200ms height transition, an async encryption notice, attachment chips
+  // settling), Virtuoso freezes scrollTop while the spacer grows under it,
+  // leaving the last message covered by the composer until the next reload.
+  //
+  // We cannot re-anchor by reading isAtBottomRef on the trailing edge of the
+  // resize: the spacer growth itself pushes the viewport off the bottom by more
+  // than atBottomThreshold, so atBottomStateChange flips isAtBottomRef false
+  // before the debounce fires and scrollToBottom's self-guard bails — the exact
+  // failure this re-anchor exists to fix. Instead we snapshot whether the user
+  // was glued to the tail on the LEADING edge of the resize burst (before the
+  // growth flips the state) and force the re-scroll only when they were. A user
+  // scrolled up reading history snapshots false and is left where they are.
+  const reservedSpaceBurstRef = useRef(false)
+  const reservedSpaceWasAtBottomRef = useRef(false)
+  const reservedSpaceTimerRef = useRef<number | undefined>(undefined)
+  // Held in a ref so the handler identity stays stable: scrollToBottom is
+  // rebuilt on every itemCount change, and a changing handler prop would
+  // re-render the memoized MessageInput on every new message.
+  const scrollToBottomRef = useRef(scrollToBottom)
+  scrollToBottomRef.current = scrollToBottom
+
+  const handleReservedSpaceChange = useCallback((_px: number, opts: { initial: boolean }) => {
+    if (opts.initial) {
+      // First composer measurement, fired pre-paint from a layout effect: the
+      // list already scrolled to LAST against the approximate persisted footer
+      // height, so correct it synchronously now that the real composer is
+      // measured. isAtBottomRef still holds the mount default here (true for the
+      // live tail, false for a deep-link jump), so the self-guarded scroll is
+      // correct — no force, so a deep-link landing is never yanked to the tail.
+      scrollToBottomRef.current()
+      return
+    }
+    if (!reservedSpaceBurstRef.current) {
+      reservedSpaceBurstRef.current = true
+      reservedSpaceWasAtBottomRef.current = isAtBottomRef.current
+    }
+    window.clearTimeout(reservedSpaceTimerRef.current)
+    reservedSpaceTimerRef.current = window.setTimeout(() => {
+      reservedSpaceBurstRef.current = false
+      if (reservedSpaceWasAtBottomRef.current) scrollToBottomRef.current({ force: true })
+    }, 120)
+  }, [])
+
+  useEffect(() => () => window.clearTimeout(reservedSpaceTimerRef.current), [])
+
   const handleAtBottomChange = useCallback(
     (atBottom: boolean) => {
       // Ignore atBottomStateChange while the list is empty — Virtuoso reports
@@ -321,6 +381,7 @@ export function useVirtuosoScroll({
     shouldFollowOutput: resetKeyChanged ? !skipInitialScroll : shouldFollowOutput,
     scrollToBottom,
     disableAutoScroll,
+    handleReservedSpaceChange,
     handleAtBottomChange,
     handleRangeChanged,
     handleScrollerRef,


### PR DESCRIPTION
## Problem

The last message in a stream sometimes ends up behind the floating composer with no way to scroll it into view — you're already at the bottom of the scroll range. This has been a recurring "fix it, then it's broken another way" bug.

The reason it keeps coming back is **architectural**: the composer is absolutely positioned and *overlaps* the scroll content, so the timeline has to manually reserve space for it (a footer spacer sized from `--composer-height`) and re-anchor the scroll position whenever *anything* resizes. Every resize source is a separate code path that can get the reservation or the scroll position wrong. This PR fixes the three distinct failure modes that were live, and I've written up the durable alternative at the bottom.

## The three bugs (three independent causes)

**1. Composer settles taller after a message arrives** (`923f644`)
`scrollToIndex({index:"LAST", align:"end"})` lands at *max* scrollTop with the footer spacer reserving the composer's height. When the composer grows a few frames later (200ms height transition, async encryption notice, attachment chips), the footer grows under Virtuoso's frozen scrollTop and covers the last message. The existing re-anchor read `isAtBottom` on the trailing edge of a debounce — but the footer growth itself flips `isAtBottom` false (it exceeds `atBottomThreshold`) before the debounce fires, so the re-scroll's self-guard bailed. Fix: snapshot "glued to the tail" on the *leading* edge of the resize burst and force the re-scroll. Moved into `useVirtuosoScroll` (`handleReservedSpaceChange`) where `isAtBottomRef` lives, so it's unit-testable.

**2. `--composer-height` collapses to 0 when the composer is hidden** (`ed16287`)
On mobile the inline message-edit form hides `[data-message-composer-root]` via `display:none` (index.css). A hidden element measures 0, and `useComposerHeightPublish` wrote `--composer-height: 0px`, collapsing the footer spacer / padding-bottom that holds the last message above the composer — with zero reserved space the message has no scroll slack to recover it. Fix: ignore non-positive measurements and keep the last good height (mirrors how Virtuoso guards its own header/footer measurement with `offsetParent !== null`).

**3. A row grows under a reader parked at the tail** (`bd072a8`, refined in `b8fbed2`) — most likely the case in the original screenshot
Streams full of link-unfurl cards (e.g. `#gh-notifications`) load their embeds/images asynchronously over several seconds. When the last message's embed finishes loading while you're at the tail, the row grows past `atBottomThreshold`; Virtuoso reports `atBottom=false`, and our handler treated that identically to a user scroll-away — disabling follow and stranding the message behind the composer for several seconds. Fix: distinguish "user scrolled away" from "content grew under a stationary reader." 

The self-review commit (`b8fbed2`) is worth calling out: the first attempt used the wheel/touch/keydown gesture stamp, which **misses dragging the native scrollbar** (fires `scroll` but none of those) — a desktop scrollbar-drag would have been yanked back to the bottom. So the discriminator is now the scroll *position* moving up (device-independent: wheel, touch, keyboard, and scrollbar drag all decrease scrollTop; a growing row does not). Its error modes are one-sided — a missed re-pin degrades to the old behavior, never a wrong yank.

## Tests

26 unit tests across the three suites (pure classifiers + hook behavior with a manual ResizeObserver/scroller harness). Full-monorepo lint + typecheck green via the pre-commit hook.

- `classifyTailFollowOnAtBottomChange` — re-pin vs propagate, scrollbar-safe window, jump-mode/atBottom guards
- `useVirtuosoScroll` — forced re-anchor after atBottom flips false, no re-anchor when scrolled up, initial pre-paint correction only at the tail
- `useComposerHeightPublish` — hidden composer (measures 0) holds the last good height

## The durable fix (proposal, not in this PR)

All of the above are compensating for the composer **overlapping** the scroll content. The fragility goes away if the composer stops overlapping — make it a normal flex sibling (`flex-1 min-h-0` scroller above, composer below):

- No `--composer-height`, no publish hook, no footer spacer, no plain-scroll `padding-bottom`, no composer-resize re-anchor, no tail-follow classifier — i.e. this entire PR plus the original mechanism, deleted.
- Composer grows → flex shrinks the scroller → Virtuoso's existing, well-tested `clientHeight`-resize handling re-anchors (the keyboard path, the one path with passing tests).
- Composer hidden → scroller gets full height. No special case.
- Last message grows → nothing overlaps, so the message is always visible above the composer; `followOutput` sticks. Bug 3 becomes structurally impossible.

The cost is purely visual: the floating-pill-over-content look becomes a docked composer (most of the aesthetic can be kept with a gradient mask above an in-flow bar). It's a design call, so I didn't make it unilaterally — happy to prototype it as a follow-up spike if you want to see it side by side.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FyBWEwCnQT6ubG2x3NiVt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185097&installation_id=129946197&pr_number=769&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F769&signature=f7260f2fa922f466e450bc97e1a4ecc957fcdc7dca94e9dc45c14b9e3bb54184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->