### PR TITLE
feat(e2e): wrap-revive + park enclave turns (no silent drop)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -123,6 +123,31 @@ describe("createEnclaveInvokeWorker", () => {
     expect(assignSession).toHaveBeenCalledTimes(1)
   })
 
+  it("parks the turn (throws for queue retry) when no live EIK holds the stream's wrap", async () => {
+    arrangeDispatch()
+    // The enclave restarted: the only wrap on file addresses a dead EIK, so the
+    // live one can't open the trigger. The turn must park on the queue's
+    // retry/backoff (the owner's client revives the wrap meanwhile) — never a
+    // silent skip, and no session row before a servable enclave exists.
+    spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([
+      { ...WRAP, recipientKeyId: "eik_dead" },
+    ])
+    const insertSession = spyOn(AgentSessionRepository, "insertRunningOrSkip")
+    const assignSession = mock(async () => {})
+    const { io } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: FAKE_STORAGE,
+    })
+    await expect(worker(JOB)).rejects.toThrow(/parking turn for retry/)
+
+    expect(insertSession).not.toHaveBeenCalled()
+    expect(assignSession).not.toHaveBeenCalled()
+  })
+
   it("emits no started event when the one-running guard skips the session", async () => {
     arrangeDispatch()
     spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue(null)

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -128,8 +128,17 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       triggerAttachmentCiphertexts,
     })
     if (!built) {
-      logger.info({ workspaceId, streamId }, "enclave dispatch: no live enclave can serve this stream; skipping")
-      return
+      // Park, don't drop: no live EIK can both open the trigger and seal the
+      // reply — either no enclave is running, or every live EIK is missing this
+      // stream's wrap (an enclave restart mints a fresh EIK, orphaning streams
+      // wrapped to the old one). Throwing hands the job to the queue's
+      // retry/backoff; meanwhile the owner's unlocked client — which just sent
+      // the message, so it's looking at the stream — auto-revives the wrap via
+      // `POST …/e2e/actor-key-wraps`, and the next retry succeeds. Exhausted
+      // retries land in the DLQ: visible, never a silent no-reply.
+      throw new Error(
+        `No live enclave key can serve stream ${streamId} (live EIKs: ${liveEiks.length}); parking turn for retry`
+      )
     }
 
     // Create the session row owned by the chosen EIK — skip if another session is

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -205,6 +205,27 @@ const rollKeySchema = z.object({
     .max(64),
 })
 
+/**
+ * Actor-wrap revive body: re-wraps of the *current* SSK (generation 0 is
+ * valid — an owner-only stream that never rolled) to invited actors' live
+ * keys. Same per-wrap caps as `rollKeySchema`; the service rejects `user`
+ * recipients and keys that aren't live actor keys.
+ */
+const actorRewrapSchema = z.object({
+  keyGeneration: z.number().int().min(0),
+  wraps: z
+    .array(
+      z.object({
+        recipientKeyId: z.string().min(1).max(128),
+        recipientKind: z.enum(E2E_KEY_WRAP_RECIPIENT_KINDS),
+        wrapEnc: z.string().min(1).max(1024),
+        wrapCt: z.string().min(1).max(1024),
+      })
+    )
+    .min(1)
+    .max(64),
+})
+
 /** Default number of events returned in bootstrap and event list queries. */
 const EVENTS_DEFAULT_LIMIT = 50
 
@@ -1009,9 +1030,23 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const { currentKeyGeneration, wraps } = await streamService.listE2eKeyWraps(workspaceId, streamId)
-      const body: E2eKeyWrapsResponse = { currentKeyGeneration, wraps }
+      const { currentKeyGeneration, wraps, ownerUserId, liveActorRecipients } = await streamService.listE2eKeyWraps(
+        workspaceId,
+        streamId
+      )
+      const body: E2eKeyWrapsResponse = { currentKeyGeneration, wraps, ownerUserId, liveActorRecipients }
       res.json(body)
+    },
+
+    async reviveE2eActorKeyWraps(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { streamId } = req.params
+      const input = actorRewrapSchema.parse(req.body)
+
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
+      await streamService.reviveActorKeyWraps(workspaceId, streamId, userId, input)
+      res.status(204).send()
     },
 
     async storeE2eKeyWrap(req: Request, res: Response) {

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -797,6 +797,114 @@ describe("StreamService.rollStreamKey", () => {
   })
 })
 
+describe("StreamService.reviveActorKeyWraps", () => {
+  let service: StreamService
+
+  const mockGetByStreamId = spyOn(E2eStreamsRepository, "getByStreamId")
+  const mockInsertManyWraps = spyOn(StreamE2eKeyWrapsRepository, "insertMany")
+  const mockListActors = spyOn(E2eStreamActorsRepository, "listForStream")
+  const mockListLiveEiks = spyOn(EnclaveRuntimesRepository, "listLive")
+
+  // A transaction client that answers the advisory-lock query the revive
+  // issues before any repo call (same serialization as rollStreamKey).
+  const lockClient = { query: mock(async () => ({ rows: [], rowCount: 0 })) } as never
+
+  const ownedStream = {
+    streamId: "stream_e2e",
+    workspaceId: "ws_1",
+    ownerUserId: "usr_owner",
+    ownerUserKeyId: "e2ek_owner",
+    currentKeyGeneration: 1,
+  } as never
+
+  const enclaveWrap = { recipientKeyId: "eik_fresh", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" }
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    spyOn(db, "withTransaction").mockImplementation((_pool, fn) => fn(lockClient))
+    mockGetByStreamId.mockReset().mockResolvedValue(ownedStream)
+    mockInsertManyWraps.mockReset().mockResolvedValue(undefined as never)
+    mockListActors.mockReset().mockResolvedValue([{ kind: "enclave", actorId: "enclave", keyId: null }])
+    mockListLiveEiks.mockReset().mockResolvedValue([{ keyId: "eik_fresh", publicKey: new Uint8Array([1]) }] as never)
+  })
+
+  afterAll(() => {
+    spyOn(db, "withTransaction").mockImplementation((_pool, fn) => fn({} as PoolClient))
+  })
+
+  test("stores re-wraps for live actor keys at the current generation, with no generation bump", async () => {
+    // `spyOn` returns the suite-shared spy (rollStreamKey's tests already called
+    // it) — clear so the assertion below sees only this test's calls.
+    const mockBumpGeneration = spyOn(E2eStreamsRepository, "bumpKeyGeneration")
+    mockBumpGeneration.mockClear()
+
+    await service.reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+      keyGeneration: 1,
+      wraps: [enclaveWrap] as never,
+    })
+
+    expect(mockInsertManyWraps).toHaveBeenCalledWith(lockClient, [
+      {
+        workspaceId: "ws_1",
+        streamId: "stream_e2e",
+        keyGeneration: 1,
+        recipientKeyId: "eik_fresh",
+        recipientKind: "enclave",
+        wrapEnc: "ZW5j",
+        wrapCt: "Y3Q=",
+      },
+    ])
+    expect(mockBumpGeneration).not.toHaveBeenCalled()
+  })
+
+  test("throws 403 when the caller is not the owner", async () => {
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_intruder", { keyGeneration: 1, wraps: [enclaveWrap] as never })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(403)
+    expect((error as HttpError).code).toBe("NOT_STREAM_OWNER")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 409 when the generation is not exactly current", async () => {
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", { keyGeneration: 0, wraps: [enclaveWrap] as never })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(409)
+    expect((error as HttpError).code).toBe("E2E_STALE_GENERATION")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 400 when a wrap targets a key that is not live for an invited actor", async () => {
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        wraps: [{ ...enclaveWrap, recipientKeyId: "eik_dead" }] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_RECIPIENT_NOT_LIVE_ACTOR")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 400 when a wrap targets a user key (revive can't add readers)", async () => {
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        // Even a key id that happens to be in the live set must be rejected by kind.
+        wraps: [{ ...enclaveWrap, recipientKind: "user" }] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_RECIPIENT_NOT_LIVE_ACTOR")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+})
+
 describe("StreamService.createScratchpad (E2E)", () => {
   let service: StreamService
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -35,6 +35,7 @@ import {
   type E2eKeyRoll,
   type E2eKeyRollRecipient,
   type E2eKeyRollInput,
+  type E2eActorRewrapInput,
 } from "@threa/types"
 import { ContextBagRepository } from "../agents"
 import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepository } from "../e2e-streams"
@@ -973,14 +974,97 @@ export class StreamService {
   async listE2eKeyWraps(
     workspaceId: string,
     streamId: string
-  ): Promise<{ currentKeyGeneration: number; wraps: StreamE2eKeyWrap[] }> {
+  ): Promise<{
+    currentKeyGeneration: number
+    wraps: StreamE2eKeyWrap[]
+    ownerUserId: string
+    liveActorRecipients: E2eKeyRollRecipient[]
+  }> {
     return withClient(this.pool, async (client) => {
       const e2e = await E2eStreamsRepository.getByStreamId(client, workspaceId, streamId)
       if (!e2e) {
         throw new HttpError("Stream is not end-to-end encrypted", { status: 400, code: "STREAM_NOT_E2E" })
       }
       const wraps = await StreamE2eKeyWrapsRepository.listForStream(client, workspaceId, streamId)
-      return { currentKeyGeneration: e2e.currentKeyGeneration, wraps }
+      // Live actor keys ride along so the owner's client can spot a stale
+      // recipient — a live key with no wrap at `currentKeyGeneration` (e.g.
+      // the enclave restarted with a fresh EIK) — and revive it via
+      // `reviveActorKeyWraps` without a second round-trip.
+      const liveActorRecipients = await this.resolveActorRecipients(client, e2e)
+      return { currentKeyGeneration: e2e.currentKeyGeneration, wraps, ownerUserId: e2e.ownerUserId, liveActorRecipients }
+    })
+  }
+
+  /**
+   * Re-wrap the *current* SSK to invited actors' live keys that lost their
+   * wrap — the revive path for an actor whose key changed after the invite
+   * (an enclave restart mints a fresh EIK, orphaning every stream wrapped to
+   * the old one; until revived, enclave turns for the stream park in the
+   * queue). No fresh SSK and no generation bump: the actor already held this
+   * generation, so re-addressing the same key to its new instance restores
+   * exactly the prior access — and keeps a parked turn (sealed under the
+   * current generation) decryptable, which a roll would strand.
+   *
+   * Owner-only, generation must be exactly current (same advisory lock as
+   * `rollStreamKey` so a concurrent roll can't slip a stale-generation wrap
+   * in), and every wrap must address a currently-live key of a currently-
+   * invited actor — never a `user` wrap, so this can't become a side door
+   * for adding readers.
+   */
+  async reviveActorKeyWraps(
+    workspaceId: string,
+    streamId: string,
+    userId: string,
+    input: E2eActorRewrapInput
+  ): Promise<void> {
+    await withTransaction(this.pool, async (client) => {
+      await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+        `e2e_key_roll:${workspaceId}:${streamId}`,
+      ])
+
+      const e2e = await E2eStreamsRepository.getByStreamId(client, workspaceId, streamId)
+      if (!e2e) {
+        throw new HttpError("Stream is not end-to-end encrypted", { status: 400, code: "STREAM_NOT_E2E" })
+      }
+      if (e2e.ownerUserId !== userId) {
+        throw new HttpError("Only the stream owner can revive actor key wraps", {
+          status: 403,
+          code: "NOT_STREAM_OWNER",
+        })
+      }
+      if (input.keyGeneration !== e2e.currentKeyGeneration) {
+        throw new HttpError("Key generation is stale; refetch before re-wrapping", {
+          status: 409,
+          code: "E2E_STALE_GENERATION",
+        })
+      }
+
+      const live = await this.resolveActorRecipients(client, e2e)
+      const liveKeyIds = new Set(live.map((r) => r.recipientKeyId))
+      for (const wrap of input.wraps) {
+        if (wrap.recipientKind === E2eKeyWrapRecipientKinds.USER || !liveKeyIds.has(wrap.recipientKeyId)) {
+          throw new HttpError("Wrap recipient is not a live key of an invited actor", {
+            status: 400,
+            code: "E2E_RECIPIENT_NOT_LIVE_ACTOR",
+          })
+        }
+      }
+
+      // Idempotent under retries/races: the slot has `ON CONFLICT DO NOTHING`,
+      // so a wrap that already exists (or a concurrent duplicate revive) is a
+      // no-op rather than a displacement.
+      await StreamE2eKeyWrapsRepository.insertMany(
+        client,
+        input.wraps.map((w) => ({
+          workspaceId,
+          streamId,
+          keyGeneration: input.keyGeneration,
+          recipientKeyId: w.recipientKeyId,
+          recipientKind: w.recipientKind,
+          wrapEnc: w.wrapEnc,
+          wrapCt: w.wrapCt,
+        }))
+      )
     })
   }
 

--- a/apps/backend/src/lib/queue/job-queue.ts
+++ b/apps/backend/src/lib/queue/job-queue.ts
@@ -366,4 +366,12 @@ export interface HandlerOptions<T> {
   tier?: QueueTier
   /** Fairness policy for leasing tokens (default: none). */
   fairness?: QueueFairnessMode
+  /**
+   * Per-queue retry budget before a failing job moves to the DLQ, overriding
+   * the manager-wide default. Raise it for queues whose failures are expected
+   * to heal on their own — e.g. an enclave turn parked until the owner's
+   * client revives a stale key wrap — where the default budget (~8s of
+   * exponential backoff) gives the healer no time to act.
+   */
+  maxRetries?: number
 }

--- a/apps/backend/src/lib/queue/manager.test.ts
+++ b/apps/backend/src/lib/queue/manager.test.ts
@@ -125,3 +125,65 @@ describe("QueueManager stuck token warning", () => {
     expect(deleteToken).toHaveBeenCalledTimes(1)
   })
 })
+
+describe("QueueManager per-queue maxRetries override", () => {
+  function createFailureManager() {
+    const fail = mock(async () => {})
+    const failDlq = mock(async () => {})
+    const manager = new QueueManager({
+      pool: {} as any,
+      queueRepository: { fail, failDlq } as any,
+      tokenPoolRepository: {} as any,
+      // Manager-wide default budget.
+      maxRetries: 5,
+    })
+    return { manager, fail, failDlq }
+  }
+
+  const failingHandler = mock(async () => {
+    throw new Error("park me")
+  })
+
+  it("keeps retrying past the manager default when the queue declares a larger budget", async () => {
+    const { manager, fail, failDlq } = createFailureManager()
+    manager.registerHandler("enclave.invoke" as any, failingHandler as any, { maxRetries: 10 })
+
+    // failedCount 5 would DLQ under the default (6 >= 5) but must retry under 10.
+    await (manager as any).processMessage(
+      {
+        id: "qm_1",
+        queueName: "enclave.invoke",
+        workspaceId: "ws_1",
+        payload: {},
+        failedCount: 5,
+        insertedAt: new Date(),
+      },
+      "worker_1",
+      new Set<string>()
+    )
+
+    expect(fail).toHaveBeenCalledTimes(1)
+    expect(failDlq).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the manager default for queues without an override", async () => {
+    const { manager, fail, failDlq } = createFailureManager()
+    manager.registerHandler("persona.agent" as any, failingHandler as any)
+
+    await (manager as any).processMessage(
+      {
+        id: "qm_2",
+        queueName: "persona.agent",
+        workspaceId: "ws_1",
+        payload: {},
+        failedCount: 5,
+        insertedAt: new Date(),
+      },
+      "worker_1",
+      new Set<string>()
+    )
+
+    expect(failDlq).toHaveBeenCalledTimes(1)
+    expect(fail).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/lib/queue/manager.ts
+++ b/apps/backend/src/lib/queue/manager.ts
@@ -133,6 +133,7 @@ export class QueueManager {
   private readonly handlerHooks = new Map<string, HandlerHooks<unknown>>()
   private readonly handlerTiers = new Map<string, QueueTier>()
   private readonly handlerFairness = new Map<string, QueueFairnessMode>()
+  private readonly handlerMaxRetries = new Map<string, number>()
   private readonly managerId: string
   private isStarted = false
   private isStopping = false
@@ -211,6 +212,9 @@ export class QueueManager {
     this.handlers.set(queueName, handler as JobHandler<unknown>)
     this.handlerTiers.set(queueName, options?.tier ?? DEFAULT_TIER)
     this.handlerFairness.set(queueName, options?.fairness ?? QueueFairness.NONE)
+    if (options?.maxRetries !== undefined) {
+      this.handlerMaxRetries.set(queueName, options.maxRetries)
+    }
     if (options?.hooks) {
       this.handlerHooks.set(queueName, options.hooks as HandlerHooks<unknown>)
     }
@@ -835,8 +839,9 @@ export class QueueManager {
 
       // Calculate new failed_count
       const newFailedCount = message.failedCount + 1
+      const maxRetries = this.handlerMaxRetries.get(message.queueName) ?? this.maxRetries
 
-      if (newFailedCount >= this.maxRetries) {
+      if (newFailedCount >= maxRetries) {
         // Move to DLQ
         await this.moveMessageToDlq(message, workerId, error)
         completedMessageIds.add(message.id)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -369,6 +369,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/actors", ...authed, stream.inviteActor)
   app.get("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps", ...authed, stream.getE2eKeyWraps)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-wraps", ...authed, stream.storeE2eKeyWrap)
+  app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/actor-key-wraps", ...authed, stream.reviveE2eActorKeyWraps)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/key-generations", ...authed, stream.rollE2eKey)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/read", ...authed, stream.markAsRead)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/archive", ...authed, stream.archive)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -709,6 +709,12 @@ export async function startServer(): Promise<ServerInstance> {
     jobQueue.registerHandler(JobQueues.ENCLAVE_INVOKE, enclaveInvokeWorker, {
       tier: QueueTiers.INTERACTIVE,
       fairness: QueueFairness.NONE,
+      // A turn with no servable enclave key *parks* (the worker throws) until
+      // the owner's client revives the stream's wrap for a freshly-registered
+      // EIK, or an enclave finishes (re)deploying. The default budget DLQs in
+      // ~8s of backoff — far too short for either healer — so give parked
+      // turns a few minutes (exponential backoff, ~4 min across 10 attempts).
+      maxRetries: 10,
     })
   }
 

--- a/apps/frontend/src/api/e2e-key-wraps.ts
+++ b/apps/frontend/src/api/e2e-key-wraps.ts
@@ -1,4 +1,4 @@
-import type { E2eKeyWrapsResponse, E2eOwnerKeyWrapInput, E2eKeyRollInput } from "@threa/types"
+import type { E2eKeyWrapsResponse, E2eOwnerKeyWrapInput, E2eKeyRollInput, E2eActorRewrapInput } from "@threa/types"
 import { api } from "./client"
 
 /**
@@ -30,5 +30,15 @@ export const e2eKeyWrapsApi = {
    */
   async roll(workspaceId: string, streamId: string, input: E2eKeyRollInput): Promise<void> {
     await api.post<void>(`/api/workspaces/${workspaceId}/streams/${streamId}/e2e/key-generations`, input)
+  },
+
+  /**
+   * Re-wrap the *current* SSK to invited actors' live keys that lost their
+   * wrap (an enclave restart mints a fresh EIK). No generation bump — the
+   * actor already held this generation, so the new instance gets exactly the
+   * prior access, and a turn parked on the missing wrap revives.
+   */
+  async reviveActorWraps(workspaceId: string, streamId: string, input: E2eActorRewrapInput): Promise<void> {
+    await api.post<void>(`/api/workspaces/${workspaceId}/streams/${streamId}/e2e/actor-key-wraps`, input)
   },
 }

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { E2eKeyWrapsResponse } from "@threa/types"
+import { buildWrapAad, bytesToBase64, generateStreamKey, wrapStreamKey } from "@threa/crypto"
+import { generateUIK } from "@/lib/crypto/keys"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import { e2eKeysApi } from "@/api/e2e-keys"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
@@ -81,6 +83,8 @@ function nonEmptyWraps(): E2eKeyWrapsResponse {
   return {
     currentKeyGeneration: 0,
     wraps: [{ keyGeneration: 0, recipientKeyId: "e2ek_owner", recipientKind: "user", wrapEnc: "ZW5j", wrapCt: "Y3Q=" }],
+    ownerUserId: USER_ID,
+    liveActorRecipients: [],
   }
 }
 
@@ -163,7 +167,7 @@ describe("repair (unlocked stream missing its owner wrap)", () => {
     // After repair stores one, the refetch returns a non-empty set.
     let stored = false
     vi.spyOn(e2eKeyWrapsApi, "get").mockImplementation(async () =>
-      stored ? nonEmptyWraps() : { currentKeyGeneration: 0, wraps: [] }
+      stored ? nonEmptyWraps() : { currentKeyGeneration: 0, wraps: [], ownerUserId: USER_ID, liveActorRecipients: [] }
     )
     const storeSpy = vi.spyOn(e2eKeyWrapsApi, "store").mockImplementation(async () => {
       stored = true
@@ -191,5 +195,69 @@ describe("repair (unlocked stream missing its owner wrap)", () => {
     await waitFor(() => expect(getSpy).toHaveBeenCalled())
     expect(screen.queryByRole("button", { name: /finish setup/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument()
+  })
+})
+
+describe("actor wrap revive (live actor key missing its wrap)", () => {
+  it("silently re-wraps the current SSK to the stale actor key when the unlocked owner views the stream", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "pp-correct-horse", { params: FAST_PARAMS })
+    await waitFor(() => expect(getE2eSessionState(ws, USER_ID).status).toBe("unlocked"))
+    const session = getE2eSessionState(ws, USER_ID)
+
+    // The owner holds the only wrap; the enclave restarted, so its live EIK
+    // (a fresh X25519 key) has no wrap at the current generation.
+    const ssk = generateStreamKey()
+    const eik = await generateUIK()
+    const ownerWrap = await wrapStreamKey({
+      key: ssk,
+      recipientPublicKey: session.publicKey!,
+      aad: buildWrapAad({ streamId: STREAM_ID, keyGeneration: 0, recipientKeyId: session.keyId! }),
+    })
+    vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [
+        {
+          keyGeneration: 0,
+          recipientKeyId: session.keyId!,
+          recipientKind: "user",
+          wrapEnc: bytesToBase64(ownerWrap.enc),
+          wrapCt: bytesToBase64(ownerWrap.ct),
+        },
+      ],
+      ownerUserId: USER_ID,
+      liveActorRecipients: [
+        { recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: bytesToBase64(eik.publicKey) },
+      ],
+    })
+    const reviveSpy = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps").mockResolvedValue(undefined)
+
+    renderWithProvider(ws, <StreamHeaderEncryptionAction workspaceId={ws} encrypted streamId={STREAM_ID} />)
+
+    // Headless heal: no CTA, no dialog — just the re-wrap POST for the live key.
+    await waitFor(() => expect(reviveSpy).toHaveBeenCalledTimes(1))
+    const [, , input] = reviveSpy.mock.calls[0]!
+    expect(input.keyGeneration).toBe(0)
+    expect(input.wraps.map((w) => w.recipientKeyId)).toEqual(["eik_fresh"])
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("does not revive for a non-owner viewer", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "pp-correct-horse", { params: FAST_PARAMS })
+    await waitFor(() => expect(getE2eSessionState(ws, USER_ID).status).toBe("unlocked"))
+
+    const getSpy = vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [],
+      ownerUserId: "usr_someone_else",
+      liveActorRecipients: [{ recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: "AA==" }],
+    })
+    const reviveSpy = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps")
+
+    renderWithProvider(ws, <StreamHeaderEncryptionAction workspaceId={ws} encrypted streamId={STREAM_ID} />)
+
+    await waitFor(() => expect(getSpy).toHaveBeenCalled())
+    expect(reviveSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useRef } from "react"
 import { Lock, LockOpen, ShieldPlus, Wrench } from "lucide-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
-import { provisionOwnerStreamKey } from "@/lib/crypto/stream-key-cache"
+import { provisionOwnerStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { useE2eUnlockOptional, type E2eUnlockContextValue } from "./e2e-unlock-provider"
@@ -98,6 +99,66 @@ function useOwnerWrapRepair(workspaceId: string, streamId: string): OwnerWrapRep
 }
 
 /**
+ * Headless self-heal for stale actor wraps: when the unlocked *owner* views an
+ * encrypted stream whose invited actor has a live key with no wrap at the
+ * current generation — an enclave restart minted a fresh EIK after the invite
+ * — silently re-wrap the current SSK to it. Server-side, the turn that hit the
+ * missing wrap is parked on the queue's retry/backoff, so this heal is what
+ * revives it; no dialog, no CTA, the user never learns it happened (a "you
+ * need to fix encryption" prompt would be the UX failure here).
+ *
+ * One attempt per missing-set signature: a server reject (e.g. the key went
+ * stale mid-flight) doesn't loop, and the next refetch recomputes the set.
+ */
+function useActorWrapRevive(workspaceId: string, streamId: string): void {
+  const userId = useWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const queryClient = useQueryClient()
+  const attemptedRef = useRef<string | null>(null)
+
+  const sessionReady = session.status === "unlocked" && !!session.keyId && !!session.privateKey
+
+  const wrapsQuery = useQuery({
+    queryKey: e2eKeyWrapKeys.list(workspaceId, streamId),
+    queryFn: () => e2eKeyWrapsApi.get(workspaceId, streamId),
+    enabled: sessionReady,
+    staleTime: 60_000,
+  })
+
+  const data = wrapsQuery.data
+  const ownerKeyId = session.keyId
+  const ownerPrivateKey = session.privateKey
+
+  useEffect(() => {
+    if (!sessionReady || !data || !userId || !ownerKeyId || !ownerPrivateKey) return
+    if (data.ownerUserId !== userId) return
+
+    const live = data.liveActorRecipients ?? []
+    const missing = live.filter(
+      (r) => !data.wraps.some((w) => w.keyGeneration === data.currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
+    )
+    if (missing.length === 0) return
+
+    const signature = `${data.currentKeyGeneration}:${missing
+      .map((r) => r.recipientKeyId)
+      .sort()
+      .join(",")}`
+    if (attemptedRef.current === signature) return
+    attemptedRef.current = signature
+
+    void reviveStaleActorWraps({ workspaceId, streamId, userId, ownerKeyId, ownerPrivateKey })
+      .then((result) => {
+        if (result === "revived") {
+          queryClient.invalidateQueries({ queryKey: e2eKeyWrapKeys.list(workspaceId, streamId) })
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to revive stale actor key wraps", err)
+      })
+  }, [sessionReady, data, userId, ownerKeyId, ownerPrivateKey, workspaceId, streamId, queryClient])
+}
+
+/**
  * Inline unlock affordance for the stream header — sits beside the "Encrypted"
  * pill so a locked stream can be unlocked in place, without detouring through
  * Settings. Renders nothing for unencrypted or already-unlocked streams; an
@@ -144,6 +205,9 @@ export function StreamHeaderEncryptionAction({
 
 function StreamHeaderRepairAction({ workspaceId, streamId }: { workspaceId: string; streamId: string }) {
   const repair = useOwnerWrapRepair(workspaceId, streamId)
+  // Piggybacks on this mount point (every unlocked encrypted stream view) —
+  // the heal is headless, so it renders nothing of its own.
+  useActorWrapRevive(workspaceId, streamId)
   if (!repair) return null
   return (
     <Button

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -6,7 +6,7 @@ import { useStreamService, useMessageService, usePendingMessages } from "@/conte
 import { useUser } from "@/auth"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { sealStreamMessage, sealStreamName } from "@/lib/crypto/message-envelope"
-import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
+import { resolveCurrentStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
@@ -646,6 +646,20 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
           keyGeneration: streamKey.keyGeneration,
           attachmentRefs,
         })
+        // Heal-on-send: if an invited actor's key went stale (an enclave
+        // restart mints a fresh EIK), this turn parks server-side on the
+        // missing wrap. Fire the revive now — fire-and-forget, de-duped
+        // in-flight — so the re-wrap lands within the queue's retry window
+        // and the parked turn proceeds. No-ops when nothing is missing.
+        if ((baseStream?.e2eActors?.length ?? 0) > 0) {
+          void reviveStaleActorWraps({
+            workspaceId,
+            streamId,
+            userId: currentUserId,
+            ownerKeyId: session.keyId,
+            ownerPrivateKey: session.privateKey,
+          }).catch((err) => console.error("Failed to revive stale actor key wraps on send", err))
+        }
         // Carry the refs on the optimistic payload so the server echo's
         // decrypt-cache seed (stream-sync) can render the sender's own
         // attachments via `<E2eAttachmentList>` immediately — otherwise the

--- a/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
@@ -42,6 +42,8 @@ async function stubOwnerWrap(ssk: Uint8Array, publicKey: Uint8Array, recipientKe
   })
   vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
     currentKeyGeneration: 0,
+    ownerUserId: "user_owner",
+    liveActorRecipients: [],
     wraps: [
       {
         keyGeneration: 0,

--- a/apps/frontend/src/lib/crypto/__tests__/stream-key-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-key-cache.test.ts
@@ -14,6 +14,7 @@ import {
   rekeyStream,
   resolveCurrentStreamKey,
   resolveStreamKey,
+  reviveStaleActorWraps,
 } from "../stream-key-cache"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
 
@@ -38,6 +39,8 @@ async function stubWrap(uik: UserIdentityKey, ssk: Uint8Array, currentKeyGenerat
         wrapCt: bytesToBase64(wrap.ct),
       },
     ],
+    ownerUserId: "user_owner",
+    liveActorRecipients: [],
   })
 }
 
@@ -225,7 +228,7 @@ describe("putStreamKey + resolveCurrentStreamKey", () => {
 
     putStreamKey(WS, STREAM, 0, ssk)
     clearStreamKeyCache()
-    spy.mockResolvedValue({ currentKeyGeneration: 0, wraps: [] })
+    spy.mockResolvedValue({ currentKeyGeneration: 0, wraps: [], ownerUserId: "user_owner", liveActorRecipients: [] })
 
     const current = await resolveCurrentStreamKey({
       workspaceId: WS,
@@ -236,5 +239,105 @@ describe("putStreamKey + resolveCurrentStreamKey", () => {
     // Cache was cleared, so it must fetch — and the empty wrap set yields null.
     expect(spy).toHaveBeenCalledTimes(1)
     expect(current).toBeNull()
+  })
+})
+
+describe("reviveStaleActorWraps", () => {
+  it("re-wraps the current SSK to a live actor key that is missing its wrap (enclave restart)", async () => {
+    const owner = await generateUIK()
+    const enclave = await generateUIK() // stands in for the fresh EIK's X25519 pair
+    const ssk = generateStreamKey()
+    const ownerWrap = await wrapStreamKey({
+      key: ssk,
+      recipientPublicKey: owner.publicKey,
+      aad: buildWrapAad({ streamId: STREAM, keyGeneration: 0, recipientKeyId: KEY_ID }),
+    })
+    vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [
+        {
+          keyGeneration: 0,
+          recipientKeyId: KEY_ID,
+          recipientKind: "user",
+          wrapEnc: bytesToBase64(ownerWrap.enc),
+          wrapCt: bytesToBase64(ownerWrap.ct),
+        },
+        // The dead EIK's wrap is still on file — it must not mask the missing one.
+        { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+      ],
+      ownerUserId: "user_owner",
+      liveActorRecipients: [
+        { recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: bytesToBase64(enclave.publicKey) },
+      ],
+    })
+    const revive = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps").mockResolvedValue(undefined)
+
+    const result = await reviveStaleActorWraps({
+      workspaceId: WS,
+      streamId: STREAM,
+      userId: "user_owner",
+      ownerKeyId: KEY_ID,
+      ownerPrivateKey: owner.privateKey,
+    })
+
+    expect(result).toBe("revived")
+    const [, , input] = revive.mock.calls[0]!
+    expect(input.keyGeneration).toBe(0)
+    expect(input.wraps.map((w) => `${w.recipientKind}:${w.recipientKeyId}`)).toEqual(["enclave:eik_fresh"])
+
+    // The posted wrap must open to the SAME current SSK under the fresh EIK's
+    // key, bound to (stream, generation, recipient) — i.e. the new enclave
+    // instance gets exactly the access the old one had.
+    const revived = await unwrapStreamKey({
+      enc: base64ToBytes(input.wraps[0]!.wrapEnc),
+      ct: base64ToBytes(input.wraps[0]!.wrapCt),
+      recipientPrivateKey: enclave.privateKey,
+      aad: buildWrapAad({ streamId: STREAM, keyGeneration: 0, recipientKeyId: "eik_fresh" }),
+    })
+    expect(revived).toEqual(ssk)
+  })
+
+  it("no-ops when every live actor key already has its current-generation wrap", async () => {
+    const owner = await generateUIK()
+    vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [{ keyGeneration: 0, recipientKeyId: "eik_live", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" }],
+      ownerUserId: "user_owner",
+      liveActorRecipients: [{ recipientKeyId: "eik_live", recipientKind: "enclave", publicKey: "AA==" }],
+    })
+    const revive = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps")
+
+    const result = await reviveStaleActorWraps({
+      workspaceId: WS,
+      streamId: STREAM,
+      userId: "user_owner",
+      ownerKeyId: KEY_ID,
+      ownerPrivateKey: owner.privateKey,
+    })
+
+    expect(result).toBe("none-missing")
+    expect(revive).not.toHaveBeenCalled()
+  })
+
+  it("short-circuits for a non-owner without touching the SSK", async () => {
+    const viewer = await generateUIK()
+    vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [],
+      ownerUserId: "user_owner",
+      liveActorRecipients: [{ recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: "AA==" }],
+    })
+    const revive = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps")
+
+    const result = await reviveStaleActorWraps({
+      workspaceId: WS,
+      streamId: STREAM,
+      userId: "user_viewer",
+      ownerKeyId: KEY_ID,
+      ownerPrivateKey: viewer.privateKey,
+    })
+
+    expect(result).toBe("not-owner")
+    expect(revive).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/lib/crypto/stream-key-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-key-cache.ts
@@ -165,6 +165,103 @@ export async function rekeyStream(input: RekeyStreamInput): Promise<void> {
   putStreamKey(input.workspaceId, input.streamId, input.nextGeneration, ssk)
 }
 
+export interface ReviveActorWrapsInput {
+  workspaceId: string
+  streamId: string
+  /** The caller's workspace user id — only the stream owner may revive. */
+  userId: string
+  /** The owner's UIK key id — selects the wrap to recover the SSK from. */
+  ownerKeyId: string
+  /** The owner's unwrapped UIK private key. */
+  ownerPrivateKey: CryptoKey
+}
+
+export type ReviveActorWrapsResult = "revived" | "none-missing" | "not-owner" | "no-key"
+
+/** De-dupes concurrent revives per stream (header probe + send firing together). */
+const reviveInflight = new Map<string, Promise<ReviveActorWrapsResult>>()
+
+/**
+ * Re-wrap the *current* SSK to invited actors' live keys that are missing a
+ * wrap at the current generation — the heal for an enclave restart, whose
+ * fresh EIK orphans every stream wrapped to its predecessor (parking enclave
+ * turns server-side until this runs). Unlike `rekeyStream`, no fresh SSK and
+ * no generation bump: the actor already held this generation, so the new
+ * instance gets exactly the prior access — and a parked turn (sealed under
+ * the current generation) stays decryptable, which a roll would strand.
+ *
+ * Owner-only (the server enforces it; `"not-owner"` short-circuits everyone
+ * else). Returns `"none-missing"` when every live actor key already has its
+ * wrap, `"no-key"` when the owner's own wrap can't be recovered (nothing to
+ * re-wrap), `"revived"` after storing the missing wraps.
+ */
+export async function reviveStaleActorWraps(input: ReviveActorWrapsInput): Promise<ReviveActorWrapsResult> {
+  const slot = streamSlot(input.workspaceId, input.streamId)
+  const pending = reviveInflight.get(slot)
+  if (pending) return pending
+
+  const promise = doReviveStaleActorWraps(input).finally(() => {
+    reviveInflight.delete(slot)
+  })
+  reviveInflight.set(slot, promise)
+  return promise
+}
+
+async function doReviveStaleActorWraps(input: ReviveActorWrapsInput): Promise<ReviveActorWrapsResult> {
+  // Always a fresh fetch: the point is to see an EIK that registered after
+  // whatever the UI has cached.
+  const { currentKeyGeneration, wraps, liveActorRecipients, ownerUserId } = await e2eKeyWrapsApi.get(
+    input.workspaceId,
+    input.streamId
+  )
+  currentGenerations.set(streamSlot(input.workspaceId, input.streamId), currentKeyGeneration)
+
+  if (ownerUserId !== input.userId) return "not-owner"
+
+  // `?? []` tolerates a not-yet-redeployed backend that omits the field.
+  const missing = (liveActorRecipients ?? []).filter(
+    (r) => !wraps.some((w) => w.keyGeneration === currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
+  )
+  if (missing.length === 0) return "none-missing"
+
+  // At send time the seal path has already cached this generation's SSK, so
+  // this is normally a cache hit; on a cold open it unwraps the owner's slot.
+  const ssk = await resolveStreamKey({
+    workspaceId: input.workspaceId,
+    streamId: input.streamId,
+    keyGeneration: currentKeyGeneration,
+    recipientKeyId: input.ownerKeyId,
+    privateKey: input.ownerPrivateKey,
+  })
+  if (!ssk) return "no-key"
+
+  const rewraps = await Promise.all(
+    missing.map(async (r) => {
+      const wrap = await wrapStreamKey({
+        key: ssk,
+        recipientPublicKey: base64ToBytes(r.publicKey),
+        aad: buildWrapAad({
+          streamId: input.streamId,
+          keyGeneration: currentKeyGeneration,
+          recipientKeyId: r.recipientKeyId,
+        }),
+      })
+      return {
+        recipientKeyId: r.recipientKeyId,
+        recipientKind: r.recipientKind,
+        wrapEnc: bytesToBase64(wrap.enc),
+        wrapCt: bytesToBase64(wrap.ct),
+      }
+    })
+  )
+
+  await e2eKeyWrapsApi.reviveActorWraps(input.workspaceId, input.streamId, {
+    keyGeneration: currentKeyGeneration,
+    wraps: rewraps,
+  })
+  return "revived"
+}
+
 /**
  * Resolve the SSK for a specific `(stream, keyGeneration)`. Returns the cached
  * key, or fetches the stream's wraps, unwraps the slot addressed to

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -36,9 +36,15 @@ The key model, in plain terms:
   so only invited identities can open it. Inviting or removing a participant
   rolls the key generation forward; history stays sealed under the old generation.
 - The built-in **Ariadne** assistant participates as its own encrypted recipient:
-  the SSK is wrapped to a fresh **enclave instance key** at invocation time, the
-  enclave unwraps it in memory, runs the same agent loop the rest of the app uses,
-  and seals each reply (and each AI trace step) back under the SSK.
+  when invited, the SSK is wrapped to the enclave's **instance key** (a fresh
+  keypair each enclave boot, private half memory-only); the enclave unwraps it in
+  memory, runs the same agent loop the rest of the app uses, and seals each reply
+  (and each AI trace step) back under the SSK. When the enclave restarts (every
+  deploy), its new instance key has no wrap yet — the turn **parks** on the
+  queue's retry backoff instead of dropping, and the owner's unlocked client
+  silently re-wraps the current SSK to the new key (on viewing the stream and on
+  every send), at which point the parked turn proceeds. No prompt, no dialog —
+  the heal is invisible.
 
 ## How a user experiences it
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -358,6 +358,16 @@ export interface E2eKeyWrapsResponse {
   /** All wrap rows for the stream. The caller selects the one matching its
    *  own `recipientKeyId` and the message's `keyGeneration`. */
   wraps: E2eKeyWrap[]
+  /** The stream's E2E owner — only this user may revive actor wraps. */
+  ownerUserId: string
+  /**
+   * Invited actors' currently-live keys (same shape an invite's key roll
+   * carries). A live key with no `wraps` row at `currentKeyGeneration` is
+   * stale — e.g. the enclave restarted with a fresh EIK after the invite —
+   * and the owner's unlocked client heals it by re-wrapping the current SSK
+   * to that key (`POST …/e2e/actor-key-wraps`).
+   */
+  liveActorRecipients: E2eKeyRollRecipient[]
 }
 
 /**
@@ -407,6 +417,24 @@ export interface E2eKeyWrapInput {
  * present (no self-lockout), and no wrap addresses an unauthorized key id.
  */
 export interface E2eKeyRollInput {
+  keyGeneration: number
+  wraps: E2eKeyWrapInput[]
+}
+
+/**
+ * Body for `POST …/e2e/actor-key-wraps`: re-wraps of the *current* SSK to
+ * invited actors' live keys that are missing a wrap at that generation —
+ * the revive path for an actor whose key changed after the invite (an
+ * enclave restart mints a fresh EIK, orphaning every stream wrapped to the
+ * old one). Unlike a key roll, no fresh SSK is minted and the generation
+ * does not advance: the actor was already granted this generation, so
+ * re-addressing the same key to its new instance preserves exactly the
+ * prior access — and keeps a pending turn (sealed under the current
+ * generation) decryptable, which a roll would strand. `keyGeneration` must
+ * equal the stream's current generation; recipients must be live keys of
+ * currently-invited actors (never `user` wraps).
+ */
+export interface E2eActorRewrapInput {
   keyGeneration: number
   wraps: E2eKeyWrapInput[]
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -350,6 +350,7 @@ export type {
   InviteActorResponse,
   E2eKeyWrapInput,
   E2eKeyRollInput,
+  E2eActorRewrapInput,
   EnclaveStreamEnvelope,
   EnclaveSealedMessage,
   EnclaveSskWrap,


### PR DESCRIPTION
## Why

Every enclave restart mints a fresh EIK, orphaning every encrypted stream whose SSK was wrapped to the old one. The dispatch worker then **silently skipped** the turn — Ariadne just never replied. This is live in prod right now: the only enclave wrap on file targets a revoked EIK (`eik_01KT9F8R…`, dead since 14:15 UTC), so no enclave turn has run since, including the Slice C attachment test.

## What

**Park, don't drop (backend)**
- `enclave-invoke-worker`: when no live EIK can both open the trigger and seal the reply, throw instead of skipping — the queue's retry/backoff holds the turn while the heal lands. Exhausted retries go to the DLQ: visible, never a silent no-reply.
- New per-queue `maxRetries` override on `HandlerOptions`; `enclave.invoke` gets 10 attempts (~4 min of exponential backoff) instead of the manager default (~8 s), covering both a mid-deploy enclave gap and the client-side re-wrap round trip.

**Revive (frontend + API)**
- `GET …/e2e/key-wraps` now also returns `ownerUserId` + `liveActorRecipients` (the invited actors' currently-live keys, same shape as an invite's key roll) so a client can spot a live key with no current-generation wrap in one fetch.
- New owner-only `POST …/e2e/actor-key-wraps` (`reviveActorKeyWraps`): stores re-wraps of the **current** SSK to live actor keys. Validated against the live recipient set of currently-invited actors — never `user` wraps, so it can't become a side door for adding readers (the SSK itself never transits; INV-20 advisory lock shared with `rollStreamKey` so a concurrent roll can't slip a stale-generation wrap in; idempotent `ON CONFLICT DO NOTHING` slot).
- `reviveStaleActorWraps` (stream-key-cache): fresh wrap fetch → compute missing → unwrap own SSK → HPKE-wrap to each missing live key → POST. In-flight de-duped per stream.
- Two silent triggers, no dialogs (a "you must fix encryption" prompt would be the UX failure): a headless probe when the unlocked owner views the stream, and a fire-and-forget call on every send in an actor stream — the sender is by definition unlocked with the SSK cached, and a send is exactly the event that parks a turn.

**Why re-wrap instead of roll:** a roll mints a fresh SSK at generation+1 — but the parked trigger is sealed under the *current* generation, and the dispatch requires the chosen EIK to open both the trigger and the reply generation. A roll would strand the parked turn forever; re-addressing the same key to the actor's new instance restores exactly the prior access and revives it.

## Tests

- `StreamService.reviveActorKeyWraps`: stores at current generation with no bump; 403 non-owner; 409 stale generation; 400 non-live key; 400 `user`-kind wrap.
- Invoke worker: parks (throws) when only a dead EIK's wrap is on file — no session row, no assignment.
- QueueManager: per-queue `maxRetries` override honored; default unchanged for other queues.
- `reviveStaleActorWraps`: posted wrap unwraps to the **same** SSK under the fresh EIK's key with the right AAD; no-op when nothing is missing; non-owner short-circuit.
- Affordance probe: unlocked owner viewing a stream with a stale live key POSTs the re-wrap headlessly (no button rendered); non-owner doesn't.

`bun test` (backend streams + enclave-runtimes + queue: 139 pass), frontend crypto + encryption suites (94 pass), typecheck clean across types/backend/frontend. Lint clean except the pre-existing public-site `@astrojs/sitemap` local-install issue (unrelated).

## After merge

Backend + enclave redeploy from main; the frontend (Cloudflare Pages) ships the heal. First time Kris opens the encrypted scratchpad unlocked (or sends a message), the stale wrap revives and enclave turns — including attachment reads — work again, and keep working across future enclave deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783193626&installation_id=129946197&pr_number=770&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F770&signature=0a3daac65e163eb7a764e4af50ffc6dc20415f3aa201e8b4a7e3240f903141d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->