### PR TITLE
[prototype] Dock the composer instead of floating it over the timeline

### DIFF
--- a/apps/frontend/src/components/composer/floating-composer-shell.tsx
+++ b/apps/frontend/src/components/composer/floating-composer-shell.tsx
@@ -1,28 +1,45 @@
 import { type ReactNode, type Ref } from "react"
 
 /**
- * Wrapper for the floating composer pill. Provides the shared shell —
- * absolute-positioned container with `pointer-events-none`, plus the inner
- * `pointer-events-auto` centered pill with the canonical padding. Used from
- * both the main stream `MessageInput` and the draft branch of `StreamPanel`
- * so visual tweaks (shadow, radius, padding, safe-area) stay in one place.
+ * Wrapper for the composer pill. Provides the shared shell plus the inner
+ * centered pill with the canonical padding. Used from both the main stream
+ * `MessageInput` and the draft branch of `StreamPanel` so visual tweaks
+ * (shadow, radius, padding, safe-area) stay in one place.
+ *
+ * Two layout modes:
+ *  - floating (default): absolute-positioned over the bottom of the scroll
+ *    area with `pointer-events-none` so content scrolls behind it. The scroll
+ *    area must reserve matching space (the `--composer-height` machinery).
+ *  - docked: a normal in-flow block. The composer is a flex sibling below the
+ *    scroll area, so the viewport simply shrinks to fit it — no reserved space,
+ *    no re-anchoring, and the last message can never sit behind the composer.
  *
  * When `hidden` is true the wrapper collapses to `display: none` — callers use
  * this while the expand-to-fullscreen overlay is mounted.
  */
 interface FloatingComposerShellProps {
   hidden?: boolean
+  /** Render in-flow (flex sibling) instead of absolutely positioned. */
+  docked?: boolean
   children: ReactNode
   ref?: Ref<HTMLDivElement>
   "data-message-composer-root"?: boolean
 }
 
-export function FloatingComposerShell({ hidden = false, children, ref, ...rest }: FloatingComposerShellProps) {
+export function FloatingComposerShell({
+  hidden = false,
+  docked = false,
+  children,
+  ref,
+  ...rest
+}: FloatingComposerShellProps) {
+  const outer = docked ? "relative w-full shrink-0 z-20" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"
+  const inner = docked
+    ? "pt-2 px-3 pb-3 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0"
+    : "pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0"
   return (
-    <div ref={ref} {...rest} className={hidden ? "hidden" : "pointer-events-none absolute inset-x-0 bottom-0 z-20"}>
-      <div className="pointer-events-auto pt-3 px-3 pb-3 sm:pt-6 sm:px-6 sm:pb-4 mx-auto max-w-[800px] w-full min-w-0">
-        {children}
-      </div>
+    <div ref={ref} {...rest} className={hidden ? "hidden" : outer}>
+      <div className={inner}>{children}</div>
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -48,6 +48,12 @@ interface MessageInputProps {
    * synchronously instead of debouncing.
    */
   onComposerHeightChange?: (px: number, opts: { initial: boolean }) => void
+  /**
+   * Render the composer in-flow (docked) as a flex sibling below the scroll
+   * area instead of floating absolutely over it. In docked mode the scroll area
+   * shrinks to fit, so no height publishing / re-anchoring is needed.
+   */
+  docked?: boolean
 }
 
 function attachmentMatchKey(attachment: Pick<PendingAttachment, "filename" | "mimeType">): string {
@@ -209,6 +215,7 @@ function MessageInputComponent({
   disabledReason,
   autoFocus,
   onComposerHeightChange,
+  docked = false,
 }: MessageInputProps) {
   const editLastCtx = useEditLastMessage()
   const triggerEditLast = editLastCtx?.triggerEditLast
@@ -432,7 +439,9 @@ function MessageInputComponent({
   // Disabled while the expanded overlay is open so the scroll area can use its
   // full height behind the overlay. `onHeightChange` lets the virtualized
   // timeline re-anchor to the bottom when the composer settles to a new height.
-  useComposerHeightPublish(selfRef, { active: !expanded, onHeightChange: onComposerHeightChange })
+  // Docked mode needs no reserved space (the scroll area is a flex sibling that
+  // shrinks to fit), so don't measure/publish the height at all.
+  useComposerHeightPublish(selfRef, { active: !expanded && !docked, onHeightChange: onComposerHeightChange })
 
   // Escape to close — only when focus is inside this expanded editor
   useEffect(() => {
@@ -595,7 +604,7 @@ function MessageInputComponent({
     // A plain in-flow div lands at the top of the absolutely-positioned stream
     // area and overlaps the first messages instead.
     return (
-      <FloatingComposerShell ref={selfRef} data-message-composer-root>
+      <FloatingComposerShell ref={selfRef} docked={docked} data-message-composer-root>
         <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
           <p className="text-sm text-muted-foreground text-center">{disabledReason}</p>
         </div>
@@ -711,7 +720,7 @@ function MessageInputComponent({
           under document.body), so the composer is hidden purely from DOM presence.
           This replaces a previous ref-counted React state mechanism that was prone to
           leaks across hydration races and virtualization cycles. */}
-      <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
+      <FloatingComposerShell ref={selfRef} hidden={expanded} docked={docked} data-message-composer-root>
         <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={!!stream?.e2eEnabled} streamId={stream?.id} />
         {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -780,49 +780,12 @@ export function StreamContent({
   const scrollToBottom = useVirtualized ? virtualScrollToBottom : plainScrollToBottom
   const disableAutoScroll = useVirtualized ? virtualDisableAutoScroll : plainDisableAutoScroll
 
-  // Re-anchor the virtualized list to the bottom when the floating composer
-  // settles to a new height. The footer spacer that keeps the last message
-  // above the composer is sized from `--composer-height`, but Virtuoso freezes
-  // its scrollTop when that spacer grows (followOutput only reacts to new
-  // items; the resize safety-net only watches the scroller's own height). So a
-  // composer that lands taller a few frames after a message arrives (its 200ms
-  // height transition, async encryption notice / attachment chips) covers the
-  // bottom of the last message until the next reload. virtualScrollToBottom
-  // self-guards on isAtBottomRef, so this is a no-op unless the user is parked
-  // at the live tail (never fires during a deep-link jump or while scrolled up
-  // reading). The plain-scroll (thread/draft) path needs none of this: its
-  // `padding-bottom` reflows the content so the bottom row is never frozen
-  // behind the composer.
-  //
-  // Two arrival paths, handled differently:
-  //  - `initial`: the composer's first measurement, fired from a layout effect
-  //    *before paint*. The list first scrolled to LAST against the approximate
-  //    persisted footer height; when the real composer differs (cold boot with
-  //    a restored draft, density/zoom change) we correct it synchronously here,
-  //    in the same frame the list reveals, so there is no visible jump.
-  //  - runtime changes: arrive async from the ResizeObserver after paint (the
-  //    200ms height transition, attachment chips settling). Debounced so the
-  //    snap lands once after the transition settles rather than fighting
-  //    Virtuoso's reflow on every intermediate frame.
-  //
-  // Called through a ref so the handler identity stays stable: virtualScrollToBottom
-  // is rebuilt on every itemCount change, and a changing prop would re-render
-  // the memoized MessageInput on every new message (the exact churn that memo
-  // exists to prevent).
-  const virtualScrollToBottomRef = useRef(virtualScrollToBottom)
-  virtualScrollToBottomRef.current = virtualScrollToBottom
-  const composerResizeTimerRef = useRef<number | undefined>(undefined)
-  const handleComposerHeightChange = useCallback((_px: number, opts: { initial: boolean }) => {
-    window.clearTimeout(composerResizeTimerRef.current)
-    if (opts.initial) {
-      virtualScrollToBottomRef.current()
-      return
-    }
-    composerResizeTimerRef.current = window.setTimeout(() => {
-      virtualScrollToBottomRef.current()
-    }, 120)
-  }, [])
-  useEffect(() => () => window.clearTimeout(composerResizeTimerRef.current), [])
+  // Docked composer (prototype): the composer is a flex sibling below the
+  // scroll area rather than floating over it, so there is no reserved space to
+  // keep in sync and no composer-height-driven re-anchor. When the composer
+  // grows the scroll area shrinks, and useVirtuosoScroll's clientHeight resize
+  // safety-net keeps the tail glued — the same path that already handles the
+  // mobile keyboard.
 
   // Scroll to a specific message and keep re-scrolling until the target
   // element is actually visible in the scroller viewport. Items rendered
@@ -1297,17 +1260,14 @@ export function StreamContent({
       <QuoteReplyProvider>
         <SharedMessagesProvider map={mergedSharedMessages}>
           <TextSelectionQuote streamId={streamId} />
-          <div className="relative h-full">
-            <div className="absolute inset-0 overflow-hidden">
+          <div className="flex h-full flex-col">
+            <div className="relative flex-1 min-h-0 overflow-hidden">
               {isSearchOpen && (
                 <StreamSearchBar search={streamSearch} onClose={handleSearchClose} onNavigate={handleSearchNavigate} />
               )}
               {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
               {isDraft && (
-                <div
-                  className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
-                  style={{ paddingBottom: "var(--composer-height, 0px)" }}
-                >
+                <div className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain">
                   {hasDraftPendingEvents ? (
                     <EventList
                       timelineItems={draftTimelineItems}
@@ -1384,11 +1344,10 @@ export function StreamContent({
                       isFetchingNewer ? "opacity-100" : "opacity-0"
                     )}
                     style={{
-                      // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
-                      bottom:
-                        isJumpMode || isScrolledFarFromBottom
-                          ? "calc(var(--composer-height, 0px) + 3.5rem)"
-                          : "calc(var(--composer-height, 0px) + 0.5rem)",
+                      // Sit above the Jump to latest button (when visible). The
+                      // docked composer is a flex sibling below this scroll area,
+                      // so offsets are relative to the scroll area's own bottom.
+                      bottom: isJumpMode || isScrolledFarFromBottom ? "3.5rem" : "0.5rem",
                     }}
                   >
                     Loading newer messages...
@@ -1403,7 +1362,6 @@ export function StreamContent({
                     (isSearchOpen || batchMode) && "pt-11",
                     batchMode && "select-none"
                   )}
-                  style={{ paddingBottom: "var(--composer-height, 0px)" }}
                   data-suppress-pull-refresh="true"
                   onScroll={plainHandleScroll}
                   {...batchPointerHandlers}
@@ -1441,25 +1399,26 @@ export function StreamContent({
                   )}
                 </div>
               )}
+              {/* Bottom fade — content dissolves into the docked composer instead
+                of ending on a hard edge, preserving the floating-pill feel. */}
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[5] h-5 bg-gradient-to-t from-background to-transparent" />
+              {/* Jump to latest — shown when scrolled far from bottom or in jump
+                mode. Floats just above the docked composer (this scroll area's
+                bottom edge). */}
+              {(isJumpMode || isScrolledFarFromBottom) && (
+                <div className="pointer-events-none absolute left-1/2 bottom-2 -translate-x-1/2 z-10">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="pointer-events-auto shadow-lg gap-1.5"
+                    onClick={handleJumpToLatest}
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" />
+                    Jump to latest
+                  </Button>
+                </div>
+              )}
             </div>
-            {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
-              Positioned above the floating composer pill. */}
-            {(isJumpMode || isScrolledFarFromBottom) && (
-              <div
-                className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
-                style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
-              >
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="pointer-events-auto shadow-lg gap-1.5"
-                  onClick={handleJumpToLatest}
-                >
-                  <ArrowDown className="h-3.5 w-3.5" />
-                  Jump to latest
-                </Button>
-              </div>
-            )}
             {dragGhost && (
               <div
                 className="pointer-events-none fixed z-50 max-w-[280px] rounded-md border bg-popover/95 px-3 py-2 text-sm shadow-lg"
@@ -1522,7 +1481,7 @@ export function StreamContent({
               </AlertDialogContent>
             </AlertDialog>
             {membershipResolved && !isMember && isPublicChannel && (
-              <div className="absolute inset-x-0 z-10" style={{ bottom: "var(--composer-height, 0px)" }}>
+              <div className="shrink-0 z-10">
                 <JoinChannelBar
                   workspaceId={workspaceId}
                   streamId={streamId}
@@ -1532,7 +1491,7 @@ export function StreamContent({
               </div>
             )}
             {showBotRuntimePresence && activeBotPresence && (
-              <div className="pointer-events-none mx-4 mb-2 mt-2 flex justify-center">
+              <div className="pointer-events-none shrink-0 mx-4 mb-2 mt-2 flex justify-center">
                 <ActiveBotStatusStrip
                   botName={activeBotPresence.bot.name}
                   runtimeDisplayName={activeBotPresence.presence?.displayName ?? null}
@@ -1548,7 +1507,7 @@ export function StreamContent({
                 disabled={isArchived || isSystem}
                 disabledReason={disabledReason}
                 autoFocus={autoFocus}
-                onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
+                docked
               />
             )}
           </div>
@@ -2008,7 +1967,10 @@ function VirtuosoMessageList({
 // for the composer's height (Virtuoso treats Footer as content).
 const StreamHeaderSpacer = () => <div className="h-3 sm:h-6" aria-hidden />
 
-const ComposerFooterSpacer = () => <div aria-hidden style={{ height: "var(--composer-height, 0px)" }} />
+// Small breathing gap below the last message. With the docked composer there is
+// no overlap to reserve space for, so this is just a little air above the
+// composer (and under the bottom fade) rather than the full composer height.
+const ComposerFooterSpacer = () => <div aria-hidden className="h-3" />
 
 // 44px scrollable spacer used as Virtuoso's Header while the search or
 // batch-selection bar is open. Both bars render `absolute top-0` outside the


### PR DESCRIPTION
**Draft / prototype — for visual A/B against the current floating composer. Not for merge as-is.**

## Idea

Every recent scroll bug (message stranded behind the composer, jumping on embed load, the ~1px-high load) exists because the composer **floats over** the scroll content, so the timeline has to manually reserve space (`--composer-height` footer spacer) and re-anchor on every resize — and with a virtualized list the browser won't keep the bottom pinned for you, so each resize source is its own fragile path.

This docks the composer: it becomes a normal **flex sibling below** the scroll area instead of an absolutely-positioned pill over it. The viewport simply shrinks to fit the composer. Result:

- No `--composer-height`, no footer spacer, no plain-scroll `padding-bottom`, no composer-height re-anchor.
- Composer grows → scroll area shrinks → `useVirtuosoScroll`'s `clientHeight` resize safety-net re-anchors (the same well-tested path that handles the mobile keyboard).
- The last message **cannot** sit behind the composer — nothing overlaps it. The embed-growth jumping and the 1px-high load both become structurally impossible.

## What changed

- **FloatingComposerShell**: new `docked` mode (in-flow `relative w-full shrink-0`) alongside the existing floating mode.
- **MessageInput**: `docked` prop; skips `useComposerHeightPublish` entirely in docked mode (nothing reads `--composer-height` anymore).
- **StreamContent**: outer → `flex flex-col`; scroll area → `relative flex-1 min-h-0`. Drops the footer spacer / padding-bottom, relocates the jump-to-latest, loading, and join-channel overlays to offsets relative to the scroll area's own bottom, adds a short bottom fade so content dissolves into the composer (keeps the floating-pill feel), and deletes the composer-height-driven `virtualScrollToBottom` re-anchor.

Scoped to the **main stream timeline**; the thread panel still uses the floating shell (`docked` defaults off) to limit blast radius. tsc + lint + the 19 existing unit tests pass.

## Why it's a draft — needs eyes in the running app

I can't visually verify layout from here. Please pull and check:
- The bottom **fade** (currently `h-5` gradient over an `h-3` footer gap) — tune or remove.
- **Mobile**: safe-area-inset-bottom under the composer, and keyboard open/close (the flex layout should behave better than the floating one, but worth confirming).
- The **expand-to-fullscreen** overlay and the **non-member join bar** (now in-flow).
- Side-by-side feel vs the floating pill — is the docked look acceptable?

If it feels right, the follow-up is to delete the now-dead `--composer-height` plumbing entirely (`useComposerHeightPublish`, `composer-height-storage`, the persisted `:root` seed) and apply the same docked treatment to the thread panel.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FyBWEwCnQT6ubG2x3NiVt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783195398&installation_id=129946197&pr_number=772&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F772&signature=e82f93b58e23940bb904fe47023ba0bb15707bd8fa398c13d33b3da9131c82c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->