### PR TITLE
Drag streams onto label sections to tag them

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -11,6 +11,7 @@ import {
   FONT_FAMILY_OPTIONS,
   MESSAGE_SEND_MODE_OPTIONS,
   LINK_PREVIEW_DEFAULT_OPTIONS,
+  LABEL_REMOVE_ON_MOVE_OPTIONS,
   VOICE_POLISH_LEVEL_OPTIONS,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MIN,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MAX,
@@ -30,6 +31,7 @@ const updatePreferencesSchema = z.object({
   sidebarCollapsed: z.boolean().optional(),
   messageSendMode: z.enum(MESSAGE_SEND_MODE_OPTIONS).optional(),
   linkPreviewDefault: z.enum(LINK_PREVIEW_DEFAULT_OPTIONS).optional(),
+  labelRemoveOnMove: z.enum(LABEL_REMOVE_ON_MOVE_OPTIONS).optional(),
   scratchpadCustomPrompt: z.string().max(8000).nullable().optional(),
   codeBlockCollapseThreshold: z
     .number()

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -83,6 +83,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "sidebarCollapsed",
     "messageSendMode",
     "linkPreviewDefault",
+    "labelRemoveOnMove",
     "scratchpadCustomPrompt",
     "codeBlockCollapseThreshold",
     "blockquoteCollapseThreshold",

--- a/apps/frontend/src/components/layout/sidebar/remove-label-dialog.tsx
+++ b/apps/frontend/src/components/layout/sidebar/remove-label-dialog.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react"
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@/components/ui/responsive-alert-dialog"
+import { Checkbox } from "@/components/ui/checkbox"
+
+interface RemoveLabelDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  labelName: string
+  streamName: string
+  /** Called with the choice and whether to persist it as the default behavior. */
+  onResolve: (remove: boolean, remember: boolean) => void
+}
+
+/**
+ * Asked when a labeled stream is dragged out of its label section into a custom
+ * section or a different label: keep the old label (it still shows under that
+ * label everywhere) or strip it. The "remember" checkbox flips the
+ * `labelRemoveOnMove` preference to always/never so the question stops. Mounted
+ * conditionally by the parent, so its local checkbox state resets per prompt.
+ */
+export function RemoveLabelDialog({ open, onOpenChange, labelName, streamName, onResolve }: RemoveLabelDialogProps) {
+  const [remember, setRemember] = useState(false)
+
+  return (
+    <ResponsiveAlertDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveAlertDialogContent>
+        <ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogTitle>Remove the “{labelName}” label?</ResponsiveAlertDialogTitle>
+          <ResponsiveAlertDialogDescription>
+            {streamName} still carries the “{labelName}” label, so it keeps showing under that label. Remove the label,
+            or keep it on this stream?
+          </ResponsiveAlertDialogDescription>
+        </ResponsiveAlertDialogHeader>
+
+        <label className="flex items-center gap-2 px-1 text-sm text-muted-foreground">
+          <Checkbox checked={remember} onCheckedChange={(value) => setRemember(value === true)} />
+          Remember my choice
+        </label>
+
+        <ResponsiveAlertDialogFooter>
+          <ResponsiveAlertDialogCancel onClick={() => onResolve(false, remember)}>
+            Keep label
+          </ResponsiveAlertDialogCancel>
+          <ResponsiveAlertDialogAction onClick={() => onResolve(true, remember)}>
+            Remove label
+          </ResponsiveAlertDialogAction>
+        </ResponsiveAlertDialogFooter>
+      </ResponsiveAlertDialogContent>
+    </ResponsiveAlertDialog>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -6,7 +6,7 @@ import {
   SMART_SIDEBAR_CONFIG,
   SIDEBAR_CONFIG_VERSION,
 } from "@threa/types"
-import { resolveSections, type ResolveSectionsInput } from "./resolve-sections"
+import { resolveSections, findSourceLabelId, type ResolveSectionsInput } from "./resolve-sections"
 import { customSectionId, labelSectionId } from "./sidebar-config"
 import type { SectionKey, StreamItemData, UrgencyLevel } from "./types"
 
@@ -355,5 +355,35 @@ describe("resolveSections — custom sections", () => {
       { id: customSectionId("sec_a"), items: ["s_x"] },
       { id: customSectionId("sec_b"), items: [] },
     ])
+  })
+})
+
+describe("findSourceLabelId", () => {
+  const config = {
+    version: SIDEBAR_CONFIG_VERSION,
+    basePreset: "smart" as const,
+    sections: [
+      { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+      { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+    ],
+    quickLinks: [],
+  }
+
+  it("returns the label id of the label section a stream is shown under", () => {
+    const processedStreams = [
+      makeItem({ id: "s_lab", section: "recent", activity: 5 }),
+      makeItem({ id: "s_plain", section: "recent", activity: 3 }),
+    ]
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["s_lab"])]])
+    const resolved = resolveSections(config, makeInput({ processedStreams, streamIdsByLabel }))
+
+    expect(findSourceLabelId("s_lab", resolved)).toBe("lbl_1")
+  })
+
+  it("returns null for a stream shown in a non-label section", () => {
+    const processedStreams = [makeItem({ id: "s_plain", section: "recent", activity: 3 })]
+    const resolved = resolveSections(config, makeInput({ processedStreams }))
+
+    expect(findSourceLabelId("s_plain", resolved)).toBeNull()
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -187,7 +187,7 @@ describe("resolveSections — label sections", () => {
     ])
   })
 
-  it("keeps a stream in the bucket above and drops it from the label section below", () => {
+  it("a pinned label lens trumps a bucket above it: labeled streams leave the bucket", () => {
     const recentFirst = {
       version: SIDEBAR_CONFIG_VERSION,
       basePreset: "smart" as const,
@@ -210,10 +210,40 @@ describe("resolveSections — label sections", () => {
     }))
 
     expect(result).toEqual([
-      // Recent (topmost) keeps s_new; s_old is read but within the cap.
-      { id: "recent", items: ["s_new", "s_old"] },
-      // Label section only keeps s_other; s_new was claimed by Recent above.
-      { id: labelSectionId("lbl_1"), items: ["s_other"] },
+      // Recent loses s_new to the label lens even though it is ordered above —
+      // a pinned label claims its streams out of the automatic buckets.
+      { id: "recent", items: ["s_old"] },
+      // Label lens shows both labeled streams, by activity.
+      { id: labelSectionId("lbl_1"), items: ["s_new", "s_other"] },
+    ])
+  })
+
+  it("surfaces a labeled thread under its label instead of its smart bucket", () => {
+    const recentFirst = {
+      version: SIDEBAR_CONFIG_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+      ],
+      quickLinks: [],
+    }
+    // A thread is just another stream: it lands in a smart bucket by activity,
+    // but a pinned label claims it the same as any other type.
+    const processedStreams = [
+      makeItem({ id: "thr_1", type: StreamTypes.THREAD, section: "recent", activity: 7 }),
+      makeItem({ id: "ch_1", type: StreamTypes.CHANNEL, section: "recent", activity: 3 }),
+    ]
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["thr_1"])]])
+
+    const result = resolveSections(recentFirst, makeInput({ processedStreams, streamIdsByLabel })).map((r) => ({
+      id: r.section.id,
+      items: r.items.map((i) => i.id),
+    }))
+
+    expect(result).toEqual([
+      { id: "recent", items: ["ch_1"] },
+      { id: labelSectionId("lbl_1"), items: ["thr_1"] },
     ])
   })
 

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -30,6 +30,20 @@ export interface ResolvedSection {
 }
 
 /**
+ * The label id of the label section a stream is currently rendered under, or
+ * null when it isn't shown in a label section. Drives the "remove the old
+ * label?" prompt when a stream is dragged out of its label lens — the stream is
+ * placed in exactly one section, so the first match is its visible home.
+ */
+export function findSourceLabelId(streamId: string, resolved: ResolvedSection[]): string | null {
+  for (const { section, items } of resolved) {
+    if (section.spec.kind !== "label") continue
+    if (items.some((item) => item.id === streamId)) return section.spec.labelId
+  }
+  return null
+}
+
+/**
  * Turn a {@link SidebarConfig} into the ordered, capped, sorted stream lists the
  * sidebar renders. Pure — no React, no IO — so it is exercised directly in tests
  * and reused by every view. Each stream appears in the topmost section that

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -41,22 +41,33 @@ export interface ResolvedSection {
  * before each section's caps, so a capped bucket (e.g. Recent) backfills the
  * slots freed by streams claimed above it.
  *
- * Custom sections are the exception to topmost-wins: a stream filed into one
- * shows **only** there, even when a smart/label/type section ordered above it
- * would also match. Their membership is collected up front and excluded from
- * every non-custom section regardless of order — so a custom section "trumps"
- * the layout order rather than competing for the topmost claim.
+ * Custom sections and pinned label sections are the exception to topmost-wins:
+ * a stream filed into a custom section, or carrying a pinned label, shows under
+ * that section **only**, even when a smart/type bucket ordered above it would
+ * also match. Both memberships are collected up front and excluded from the
+ * automatic buckets regardless of order — so an explicit "filing" trumps the
+ * layout order rather than competing for the topmost claim. Custom sections
+ * out-rank label sections (a stream filed into a custom section is withheld
+ * from the label lens too); among label sections, the topmost one wins.
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
   const claimed = new Set<string>()
   // Streams pinned to any custom section, gathered before resolving so they can
-  // be withheld from non-custom sections wherever those sit in the order.
+  // be withheld from every other section wherever those sit in the order.
   const customClaimed = new Set<string>()
+  // Streams carrying a label that is pinned as a section, gathered the same way
+  // so the label lens claims them out of the smart/type buckets — a labeled
+  // stream lives under its label, not its automatic bucket, regardless of order.
+  const labeledClaimed = new Set<string>()
   for (const section of config.sections) {
     if (section.spec.kind === "custom") for (const id of section.spec.streamIds) customClaimed.add(id)
+    if (section.spec.kind === "label") {
+      const ids = input.streamIdsByLabel.get(section.spec.labelId)
+      if (ids) for (const id of ids) labeledClaimed.add(id)
+    }
   }
   return config.sections.map((section) => {
-    const items = resolveItems(section.spec, input, claimed, customClaimed)
+    const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed)
     for (const item of items) claimed.add(item.id)
     return { section, items }
   })
@@ -66,17 +77,28 @@ function resolveItems(
   spec: SidebarSectionSpec,
   input: ResolveSectionsInput,
   claimed: ReadonlySet<string>,
-  customClaimed: ReadonlySet<string>
+  customClaimed: ReadonlySet<string>,
+  labeledClaimed: ReadonlySet<string>
 ): StreamItemData[] {
   // A custom section draws only its own membership, minus anything an earlier
   // custom section already took (single-membership; topmost custom wins).
   if (spec.kind === "custom") return resolveCustomSection(spec.streamIds, input, claimed)
-  // Non-custom sections never show a stream filed into a custom section, so fold
-  // the custom membership into their exclusion set on top of the running claims.
-  const exclude = customClaimed.size === 0 ? claimed : new Set([...claimed, ...customClaimed])
+  // A label lens shows its streams out of the buckets, but a stream filed into a
+  // custom section still trumps the label — fold custom membership into the
+  // exclusion. Topmost label wins via the running `claimed` set.
+  if (spec.kind === "label") {
+    const exclude = customClaimed.size === 0 ? claimed : new Set([...claimed, ...customClaimed])
+    return resolveLabelSection(spec.labelId, input, exclude)
+  }
+  // Smart/type buckets never show a stream that was filed into a custom section
+  // or that carries a pinned label, so fold both memberships into their
+  // exclusion set on top of the running claims.
+  const exclude =
+    customClaimed.size === 0 && labeledClaimed.size === 0
+      ? claimed
+      : new Set([...claimed, ...customClaimed, ...labeledClaimed])
   if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input, exclude)
   if (spec.kind === "type") return resolveTypeSection(spec.streamType, input, exclude)
-  if (spec.kind === "label") return resolveLabelSection(spec.labelId, input, exclude)
   // Quick links draw no streams — the block renders its own link list, so the
   // resolved section is a positional placeholder the stream list renders specially.
   return []

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -19,6 +19,7 @@ import {
   type SidebarActionPreview,
 } from "./sidebar-actions"
 import { UrgencyStrip, StreamItemAvatar, StreamItemPreview } from "./stream-item"
+import { StreamLabelDots } from "./sidebar-labels"
 import { useSidebarItemDrawer } from "./use-sidebar-item-drawer"
 import { truncateContent } from "./utils"
 import type { StreamItemData } from "./types"
@@ -180,7 +181,10 @@ export function ScratchpadItem({
                   {name}
                   {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
                 </span>
-                <MentionIndicator count={mentionCount} className="ml-auto" />
+                <div className="ml-auto flex items-center gap-1.5">
+                  <StreamLabelDots streamId={streamWithPreview.id} />
+                  <MentionIndicator count={mentionCount} />
+                </div>
               </div>
               <StreamItemPreview
                 preview={preview}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-dnd.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from "react"
 import { useDraggable, useDroppable } from "@dnd-kit/core"
 import { cn } from "@/lib/utils"
-import { customSectionId } from "./sidebar-config"
+import { customSectionId, labelSectionId } from "./sidebar-config"
 
 /**
- * Drag-and-drop wiring for filing streams into custom sidebar sections. A stream
- * row is the drag source; a custom section is the drop target. The data payloads
- * (not the ids) carry the resolved ids, so the drop handler reads them directly
- * without parsing prefixes. Desktop-only — mobile files streams through the
- * action drawer's section picker instead, so dragging is `disabled` there to
- * leave touch scrolling and long-press untouched.
+ * Drag-and-drop wiring for filing streams into sidebar sections. A stream row is
+ * the drag source; a custom section or a pinned label section is the drop
+ * target. Dropping onto a custom section files the stream there; dropping onto a
+ * label section applies that label to the stream (and unfiles it from any custom
+ * section). The data payloads (not the ids) carry the resolved ids, so the drop
+ * handler reads them directly without parsing prefixes. Desktop-only — mobile
+ * files streams through the action drawer's section picker instead, so dragging
+ * is `disabled` there to leave touch scrolling and long-press untouched.
  */
 
 interface StreamDragData {
@@ -22,6 +24,11 @@ interface CustomSectionDropData {
   customSectionId: string
 }
 
+interface LabelSectionDropData {
+  type: "label-section"
+  labelId: string
+}
+
 /** The stream id of an in-flight drag, or null when the drag isn't a stream. */
 export function streamIdFromDragData(data: unknown): string | null {
   const d = data as StreamDragData | undefined
@@ -32,6 +39,12 @@ export function streamIdFromDragData(data: unknown): string | null {
 export function customSectionIdFromDropData(data: unknown): string | null {
   const d = data as CustomSectionDropData | undefined
   return d?.type === "custom-section" ? d.customSectionId : null
+}
+
+/** The target label id under the pointer, or null when not over a label section. */
+export function labelIdFromDropData(data: unknown): string | null {
+  const d = data as LabelSectionDropData | undefined
+  return d?.type === "label-section" ? d.labelId : null
 }
 
 /**
@@ -71,6 +84,35 @@ export function CustomSectionDropZone({
 }) {
   const data: CustomSectionDropData = { type: "custom-section", customSectionId: sectionId }
   const { setNodeRef, isOver } = useDroppable({ id: customSectionId(sectionId), data, disabled: !enabled })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn("rounded-lg transition-colors", isOver && "bg-primary/5 ring-2 ring-primary/40 ring-inset")}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * A droppable wrapper that highlights a pinned label section while a stream
+ * hovers it. Dropping applies the label to the stream. The droppable id reuses
+ * the label section's stable id ({@link labelSectionId}) so the `label:`-prefix
+ * convention lives in one place; the handler reads the label id from the data
+ * payload, not by parsing the id.
+ */
+export function LabelSectionDropZone({
+  labelId,
+  enabled,
+  children,
+}: {
+  labelId: string
+  enabled: boolean
+  children: ReactNode
+}) {
+  const data: LabelSectionDropData = { type: "label-section", labelId }
+  const { setNodeRef, isOver } = useDroppable({ id: labelSectionId(labelId), data, disabled: !enabled })
 
   return (
     <div

--- a/apps/frontend/src/components/layout/sidebar/sidebar-labels.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-labels.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react"
+import { LabelableResourceTypes } from "@threa/types"
+import { useWorkspaceLabels, useWorkspaceLabelAssignments } from "@/stores/workspace-store"
+import { LabelGlyph } from "@/components/labels/label-chip"
+import type { CachedLabel } from "@/hooks"
+
+/**
+ * Per-stream label lookup for the sidebar. Built once from the workspace store
+ * (labels + assignments) and shared via context so each row reads its labels
+ * with a single map lookup instead of its own `useResourceLabelAssignments`
+ * hook — one derivation for the whole list rather than one per row.
+ */
+const EMPTY: CachedLabel[] = []
+const SidebarLabelsContext = createContext<Map<string, CachedLabel[]>>(new Map())
+
+export function SidebarLabelsProvider({ workspaceId, children }: { workspaceId: string; children: ReactNode }) {
+  const labels = useWorkspaceLabels(workspaceId)
+  const assignments = useWorkspaceLabelAssignments(workspaceId)
+
+  const byStreamId = useMemo(() => {
+    const labelById = new Map<string, CachedLabel>()
+    for (const label of labels) if (!label.archivedAt) labelById.set(label.id, label)
+
+    const map = new Map<string, CachedLabel[]>()
+    for (const assignment of assignments) {
+      if (assignment.resourceType !== LabelableResourceTypes.STREAM) continue
+      const label = labelById.get(assignment.labelId)
+      if (!label) continue
+      const list = map.get(assignment.resourceId)
+      if (list) {
+        if (!list.some((existing) => existing.id === label.id)) list.push(label)
+      } else {
+        map.set(assignment.resourceId, [label])
+      }
+    }
+    for (const list of map.values()) list.sort((a, b) => a.name.localeCompare(b.name))
+    return map
+  }, [labels, assignments])
+
+  return <SidebarLabelsContext.Provider value={byStreamId}>{children}</SidebarLabelsContext.Provider>
+}
+
+/** Active labels applied to a stream, sorted by name. Empty array when none. */
+export function useStreamLabels(streamId: string): CachedLabel[] {
+  return useContext(SidebarLabelsContext).get(streamId) ?? EMPTY
+}
+
+/**
+ * Compact label indicator for a stream row: the first label's color dot, with a
+ * "+N" when the stream carries more. Sits on the right of the title so a stream
+ * reads as labeled even when it's parked in a custom section (away from its
+ * label lens). Returns null when the stream has no labels, so it adds nothing to
+ * the layout in the common case (INV-21).
+ */
+export function StreamLabelDots({ streamId }: { streamId: string }) {
+  const labels = useStreamLabels(streamId)
+  if (labels.length === 0) return null
+
+  const extra = labels.length - 1
+  const aria = labels.length === 1 ? `Label: ${labels[0].name}` : `${labels.length} labels`
+
+  return (
+    <span className="flex shrink-0 items-center gap-0.5" role="img" aria-label={aria}>
+      <LabelGlyph label={labels[0]} className="h-3.5 w-3.5" />
+      {extra > 0 && <span className="text-[10px] font-medium leading-none text-muted-foreground">+{extra}</span>}
+    </span>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -16,7 +16,13 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { streamLabel } from "@/lib/streams"
 import type { CachedLabel } from "@/hooks"
 import { StreamSection, TieredStreamSection } from "./sections"
-import { CustomSectionDropZone, customSectionIdFromDropData, streamIdFromDragData } from "./sidebar-dnd"
+import {
+  CustomSectionDropZone,
+  LabelSectionDropZone,
+  customSectionIdFromDropData,
+  labelIdFromDropData,
+  streamIdFromDragData,
+} from "./sidebar-dnd"
 import { sectionPresentation, type SidebarSectionSpec } from "./sidebar-config"
 import type { ResolvedSection } from "./resolve-sections"
 import type { SidebarActionItem } from "./sidebar-actions"
@@ -70,6 +76,11 @@ interface SidebarStreamListProps {
    * parent owns the sidebar config, so the membership write lives there.
    */
   onFileStreamToSection: (streamId: string, customSectionId: string) => void
+  /**
+   * Apply a label to a stream dragged onto its label section (drag-and-drop
+   * drop). The parent owns the label mutation and the unfile-from-custom write.
+   */
+  onAssignStreamLabel: (streamId: string, labelId: string) => void
   scrollContainerRef: RefObject<HTMLDivElement | null>
 }
 
@@ -90,6 +101,7 @@ export function SidebarStreamList({
   scratchpadAddMenuActions,
   quickLinksSlot,
   onFileStreamToSection,
+  onAssignStreamLabel,
   scrollContainerRef,
 }: SidebarStreamListProps) {
   // Dragging streams into sections is a desktop interaction; on mobile the same
@@ -112,8 +124,16 @@ export function SidebarStreamList({
   const handleDragEnd = (event: DragEndEvent) => {
     setDraggingStreamId(null)
     const streamId = streamIdFromDragData(event.active.data.current)
+    if (!streamId) return
+    // A drop lands on exactly one zone; file into a custom section or, when the
+    // target is a label section, apply that label instead.
     const customSectionId = customSectionIdFromDropData(event.over?.data.current)
-    if (streamId && customSectionId) onFileStreamToSection(streamId, customSectionId)
+    if (customSectionId) {
+      onFileStreamToSection(streamId, customSectionId)
+      return
+    }
+    const labelId = labelIdFromDropData(event.over?.data.current)
+    if (labelId) onAssignStreamLabel(streamId, labelId)
   }
 
   if (hasError) {
@@ -235,13 +255,21 @@ export function SidebarStreamList({
           />
         )
 
-        // Custom sections are drop targets — a stream dragged onto one is filed
-        // there. Other section kinds render as-is.
+        // Custom and label sections are drop targets — a stream dragged onto a
+        // custom section is filed there; one dragged onto a label section is
+        // tagged with that label. Other section kinds render as-is.
         if (section.spec.kind === "custom") {
           return (
             <CustomSectionDropZone key={section.id} sectionId={section.spec.sectionId} enabled={streamDragEnabled}>
               {sectionEl}
             </CustomSectionDropZone>
+          )
+        }
+        if (section.spec.kind === "label") {
+          return (
+            <LabelSectionDropZone key={section.id} labelId={section.spec.labelId} enabled={streamDragEnabled}>
+              {sectionEl}
+            </LabelSectionDropZone>
           )
         }
         return <Fragment key={section.id}>{sectionEl}</Fragment>

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -24,7 +24,8 @@ import {
   streamIdFromDragData,
 } from "./sidebar-dnd"
 import { sectionPresentation, type SidebarSectionSpec } from "./sidebar-config"
-import type { ResolvedSection } from "./resolve-sections"
+import { findSourceLabelId, type ResolvedSection } from "./resolve-sections"
+import { SidebarLabelsProvider } from "./sidebar-labels"
 import type { SidebarActionItem } from "./sidebar-actions"
 import type { StreamItemData } from "./types"
 
@@ -81,6 +82,13 @@ interface SidebarStreamListProps {
    * drop). The parent owns the label mutation and the unfile-from-custom write.
    */
   onAssignStreamLabel: (streamId: string, labelId: string) => void
+  /**
+   * A stream was dragged out of the label section it was sitting under (into a
+   * custom section or a different label). The parent decides — per the user's
+   * `labelRemoveOnMove` preference — whether to strip the old label, prompting
+   * when set to "ask".
+   */
+  onStreamMovedFromLabel: (streamId: string, sourceLabelId: string) => void
   scrollContainerRef: RefObject<HTMLDivElement | null>
 }
 
@@ -102,6 +110,7 @@ export function SidebarStreamList({
   quickLinksSlot,
   onFileStreamToSection,
   onAssignStreamLabel,
+  onStreamMovedFromLabel,
   scrollContainerRef,
 }: SidebarStreamListProps) {
   // Dragging streams into sections is a desktop interaction; on mobile the same
@@ -125,15 +134,22 @@ export function SidebarStreamList({
     setDraggingStreamId(null)
     const streamId = streamIdFromDragData(event.active.data.current)
     if (!streamId) return
+    // The label section the stream is currently shown under (if any) — dropping
+    // it elsewhere may strip this label, per the user's preference.
+    const sourceLabelId = findSourceLabelId(streamId, resolvedSections)
     // A drop lands on exactly one zone; file into a custom section or, when the
     // target is a label section, apply that label instead.
     const customSectionId = customSectionIdFromDropData(event.over?.data.current)
     if (customSectionId) {
       onFileStreamToSection(streamId, customSectionId)
+      if (sourceLabelId) onStreamMovedFromLabel(streamId, sourceLabelId)
       return
     }
     const labelId = labelIdFromDropData(event.over?.data.current)
-    if (labelId) onAssignStreamLabel(streamId, labelId)
+    if (labelId) {
+      onAssignStreamLabel(streamId, labelId)
+      if (sourceLabelId && sourceLabelId !== labelId) onStreamMovedFromLabel(streamId, sourceLabelId)
+    }
   }
 
   if (hasError) {
@@ -176,114 +192,116 @@ export function SidebarStreamList({
   const draggingStream = draggingStreamId ? processedStreams.find((s) => s.id === draggingStreamId) : null
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={pointerWithin}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={() => setDraggingStreamId(null)}
-    >
-      {resolvedSections.map(({ section, items }) => {
-        // The Quick Links block renders its own link list at this position. The
-        // slot owns its spacing (and may render null when every link is hidden),
-        // so it's not wrapped — a wrapper would leave a stray margin when empty.
-        if (section.spec.kind === "quicklinks") {
-          return quickLinksSlot ? <Fragment key={section.id}>{quickLinksSlot}</Fragment> : null
-        }
+    <SidebarLabelsProvider workspaceId={workspaceId}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setDraggingStreamId(null)}
+      >
+        {resolvedSections.map(({ section, items }) => {
+          // The Quick Links block renders its own link list at this position. The
+          // slot owns its spacing (and may render null when every link is hidden),
+          // so it's not wrapped — a wrapper would leave a stray margin when empty.
+          if (section.spec.kind === "quicklinks") {
+            return quickLinksSlot ? <Fragment key={section.id}>{quickLinksSlot}</Fragment> : null
+          }
 
-        const presentation = sectionPresentation(section.spec)
-        if (presentation.hideWhenEmpty && items.length === 0) return null
+          const presentation = sectionPresentation(section.spec)
+          if (presentation.hideWhenEmpty && items.length === 0) return null
 
-        // Label sections render a tinted chip header resolved from the labels
-        // cache; a section whose label was archived/deleted is an orphan — skip it.
-        const label = section.spec.kind === "label" ? labelsById.get(section.spec.labelId) : undefined
-        if (section.spec.kind === "label" && !label) return null
-        const titleContent = label ? <LabelChip label={label} /> : undefined
-        // Label sections get an "open" affordance to their landing page.
-        const titleHref = label ? `/w/${workspaceId}/labels/${label.id}` : undefined
-        const headerLabel = label ? label.name : presentation.label
+          // Label sections render a tinted chip header resolved from the labels
+          // cache; a section whose label was archived/deleted is an orphan — skip it.
+          const label = section.spec.kind === "label" ? labelsById.get(section.spec.labelId) : undefined
+          if (section.spec.kind === "label" && !label) return null
+          const titleContent = label ? <LabelChip label={label} /> : undefined
+          // Label sections get an "open" affordance to their landing page.
+          const titleHref = label ? `/w/${workspaceId}/labels/${label.id}` : undefined
+          const headerLabel = label ? label.name : presentation.label
 
-        const state = getSectionState(section.id, presentation.defaultCollapse)
-        const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
-        const add = addWiringFor(section.spec)
+          const state = getSectionState(section.id, presentation.defaultCollapse)
+          const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
+          const add = addWiringFor(section.spec)
 
-        const sectionEl = presentation.tiered ? (
-          <TieredStreamSection
-            sectionKey={section.id}
-            label={headerLabel}
-            titleContent={titleContent}
-            titleHref={titleHref}
-            onTitleNavigate={collapseOnMobile}
-            icon={presentation.icon}
-            items={items}
-            allStreams={processedStreams}
-            workspaceId={workspaceId}
-            activeStreamId={activeStreamId}
-            getUnreadCount={getUnreadCount}
-            getMentionCount={getMentionCount}
-            state={state}
-            onToggle={onToggle}
-            moreState={getSectionState(moreKey(section.id), MORE_DEFAULT)}
-            onToggleMore={() => toggleSectionState(moreKey(section.id), MORE_DEFAULT)}
-            compact={presentation.compact}
-            showPreviewOnHover={presentation.showPreviewOnHover}
-            scrollContainerRef={scrollContainerRef}
-            onAdd={add?.onAdd}
-            addTooltip={add?.addTooltip}
-            addMenuActions={add?.addMenuActions}
-            streamDragEnabled={streamDragEnabled}
-          />
-        ) : (
-          <StreamSection
-            label={headerLabel}
-            titleContent={titleContent}
-            titleHref={titleHref}
-            onTitleNavigate={collapseOnMobile}
-            icon={presentation.icon}
-            items={items}
-            allStreams={processedStreams}
-            workspaceId={workspaceId}
-            activeStreamId={activeStreamId}
-            getUnreadCount={getUnreadCount}
-            getMentionCount={getMentionCount}
-            state={state}
-            onToggle={onToggle}
-            compact={presentation.compact}
-            showPreviewOnHover={presentation.showPreviewOnHover}
-            scrollContainerRef={scrollContainerRef}
-            streamDragEnabled={streamDragEnabled}
-          />
-        )
-
-        // Custom and label sections are drop targets — a stream dragged onto a
-        // custom section is filed there; one dragged onto a label section is
-        // tagged with that label. Other section kinds render as-is.
-        if (section.spec.kind === "custom") {
-          return (
-            <CustomSectionDropZone key={section.id} sectionId={section.spec.sectionId} enabled={streamDragEnabled}>
-              {sectionEl}
-            </CustomSectionDropZone>
+          const sectionEl = presentation.tiered ? (
+            <TieredStreamSection
+              sectionKey={section.id}
+              label={headerLabel}
+              titleContent={titleContent}
+              titleHref={titleHref}
+              onTitleNavigate={collapseOnMobile}
+              icon={presentation.icon}
+              items={items}
+              allStreams={processedStreams}
+              workspaceId={workspaceId}
+              activeStreamId={activeStreamId}
+              getUnreadCount={getUnreadCount}
+              getMentionCount={getMentionCount}
+              state={state}
+              onToggle={onToggle}
+              moreState={getSectionState(moreKey(section.id), MORE_DEFAULT)}
+              onToggleMore={() => toggleSectionState(moreKey(section.id), MORE_DEFAULT)}
+              compact={presentation.compact}
+              showPreviewOnHover={presentation.showPreviewOnHover}
+              scrollContainerRef={scrollContainerRef}
+              onAdd={add?.onAdd}
+              addTooltip={add?.addTooltip}
+              addMenuActions={add?.addMenuActions}
+              streamDragEnabled={streamDragEnabled}
+            />
+          ) : (
+            <StreamSection
+              label={headerLabel}
+              titleContent={titleContent}
+              titleHref={titleHref}
+              onTitleNavigate={collapseOnMobile}
+              icon={presentation.icon}
+              items={items}
+              allStreams={processedStreams}
+              workspaceId={workspaceId}
+              activeStreamId={activeStreamId}
+              getUnreadCount={getUnreadCount}
+              getMentionCount={getMentionCount}
+              state={state}
+              onToggle={onToggle}
+              compact={presentation.compact}
+              showPreviewOnHover={presentation.showPreviewOnHover}
+              scrollContainerRef={scrollContainerRef}
+              streamDragEnabled={streamDragEnabled}
+            />
           )
-        }
-        if (section.spec.kind === "label") {
-          return (
-            <LabelSectionDropZone key={section.id} labelId={section.spec.labelId} enabled={streamDragEnabled}>
-              {sectionEl}
-            </LabelSectionDropZone>
-          )
-        }
-        return <Fragment key={section.id}>{sectionEl}</Fragment>
-      })}
 
-      {/* A small chip trails the cursor while filing a stream, so the drag reads
+          // Custom and label sections are drop targets — a stream dragged onto a
+          // custom section is filed there; one dragged onto a label section is
+          // tagged with that label. Other section kinds render as-is.
+          if (section.spec.kind === "custom") {
+            return (
+              <CustomSectionDropZone key={section.id} sectionId={section.spec.sectionId} enabled={streamDragEnabled}>
+                {sectionEl}
+              </CustomSectionDropZone>
+            )
+          }
+          if (section.spec.kind === "label") {
+            return (
+              <LabelSectionDropZone key={section.id} labelId={section.spec.labelId} enabled={streamDragEnabled}>
+                {sectionEl}
+              </LabelSectionDropZone>
+            )
+          }
+          return <Fragment key={section.id}>{sectionEl}</Fragment>
+        })}
+
+        {/* A small chip trails the cursor while filing a stream, so the drag reads
           as intentional even though the source row stays put (dimmed). */}
-      <DragOverlay dropAnimation={null}>
-        {draggingStream ? (
-          <div className="pointer-events-none rounded-md border bg-card px-2.5 py-1.5 text-sm font-medium shadow-md">
-            {streamLabel(draggingStream, "sidebar")}
-          </div>
-        ) : null}
-      </DragOverlay>
-    </DndContext>
+        <DragOverlay dropAnimation={null}>
+          {draggingStream ? (
+            <div className="pointer-events-none rounded-md border bg-card px-2.5 py-1.5 text-sm font-medium shadow-md">
+              {streamLabel(draggingStream, "sidebar")}
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </SidebarLabelsProvider>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -440,7 +440,14 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // A stream was dragged out of the label lens it was under. Whether that strips
   // the old label follows the user's `labelRemoveOnMove` preference: act silently
   // for "always"/"never", otherwise prompt (and let the prompt persist a choice).
+  //
+  // Public labels are shared org-wide and unassign broadcasts to everyone, so a
+  // casual drag must never strip one — that would yank the stream out of the
+  // shared lens for the whole workspace. Only private labels (the dragger's own)
+  // are removable this way; the label picker stays the explicit path for public.
   const handleStreamMovedFromLabel = (streamId: string, sourceLabelId: string) => {
+    const label = labelsById.get(sourceLabelId)
+    if (!label || label.visibility !== Visibilities.PRIVATE) return
     const behavior = preferencesContext?.preferences?.labelRemoveOnMove ?? "ask"
     if (behavior === "never") return
     if (behavior === "always") {

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   useSidebarConfig,
   useUnreadCounts,
   useAssignLabel,
+  useUnassignLabel,
 } from "@/hooks"
 import { useSyncStatus } from "@/sync/sync-status"
 import { useSyncEngine } from "@/sync/sync-engine"
@@ -29,7 +30,7 @@ import {
   useWorkspaceLabels,
   useWorkspaceLabelAssignments,
 } from "@/stores/workspace-store"
-import { useCoordinatedLoading, useSidebar } from "@/contexts"
+import { useCoordinatedLoading, useSidebar, usePreferencesOptional } from "@/contexts"
 import { useCreateChannel } from "@/components/create-channel"
 import { Button } from "@/components/ui/button"
 import { SidebarShell } from "./sidebar-shell"
@@ -41,10 +42,11 @@ import { SidebarFooter } from "./sidebar-footer"
 import { SidebarEditorDialog } from "./sidebar-editor"
 import { resolveSections } from "./resolve-sections"
 import { setStreamCustomSection } from "./sidebar-config"
+import { RemoveLabelDialog } from "./remove-label-dialog"
 import type { SidebarActionItem } from "./sidebar-actions"
 import { calculateUrgency, categorizeStream } from "./utils"
 import type { StreamItemData } from "./types"
-import { resolveDmDisplayName } from "@/lib/streams"
+import { resolveDmDisplayName, streamLabel } from "@/lib/streams"
 import type { CachedLabel } from "@/hooks"
 import { StreamTypes, Visibilities, LabelableResourceTypes } from "@threa/types"
 
@@ -84,6 +86,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const { openCreateChannel } = useCreateChannel()
   const { user } = useAuth()
   const assignLabel = useAssignLabel(workspaceId)
+  const unassignLabel = useUnassignLabel(workspaceId)
+  const preferencesContext = usePreferencesOptional()
+  const [labelRemovePrompt, setLabelRemovePrompt] = useState<{ streamId: string; labelId: string } | null>(null)
   const navigate = useNavigate()
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
   const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
@@ -428,6 +433,38 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     )
   }
 
+  const removeStreamLabel = (streamId: string, labelId: string) => {
+    unassignLabel.mutate({ labelId, resourceType: LabelableResourceTypes.STREAM, resourceId: streamId })
+  }
+
+  // A stream was dragged out of the label lens it was under. Whether that strips
+  // the old label follows the user's `labelRemoveOnMove` preference: act silently
+  // for "always"/"never", otherwise prompt (and let the prompt persist a choice).
+  const handleStreamMovedFromLabel = (streamId: string, sourceLabelId: string) => {
+    const behavior = preferencesContext?.preferences?.labelRemoveOnMove ?? "ask"
+    if (behavior === "never") return
+    if (behavior === "always") {
+      removeStreamLabel(streamId, sourceLabelId)
+      return
+    }
+    setLabelRemovePrompt({ streamId, labelId: sourceLabelId })
+  }
+
+  const resolveLabelRemovePrompt = (remove: boolean, remember: boolean) => {
+    const prompt = labelRemovePrompt
+    setLabelRemovePrompt(null)
+    if (!prompt) return
+    if (remove) removeStreamLabel(prompt.streamId, prompt.labelId)
+    if (remember && preferencesContext) {
+      void preferencesContext.updatePreference("labelRemoveOnMove", remove ? "always" : "never")
+    }
+  }
+
+  const promptStream = labelRemovePrompt
+    ? (processedStreams.find((s) => s.id === labelRemovePrompt.streamId) ?? null)
+    : null
+  const promptStreamName = promptStream ? streamLabel(promptStream, "sidebar") : "This stream"
+
   return (
     <>
       <SidebarShell
@@ -458,6 +495,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             scratchpadAddMenuActions={scratchpadAddMenuActions}
             onFileStreamToSection={handleFileStreamToSection}
             onAssignStreamLabel={handleAssignStreamLabel}
+            onStreamMovedFromLabel={handleStreamMovedFromLabel}
             quickLinksSlot={
               hasQuickLinksSection ? (
                 <SidebarQuickLinks
@@ -491,6 +529,17 @@ export function Sidebar({ workspaceId }: SidebarProps) {
         }
       />
       <SidebarEditorDialog workspaceId={workspaceId} open={isEditorOpen} onOpenChange={setIsEditorOpen} />
+      {labelRemovePrompt && (
+        <RemoveLabelDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setLabelRemovePrompt(null)
+          }}
+          labelName={labelsById.get(labelRemovePrompt.labelId)?.name ?? "this label"}
+          streamName={promptStreamName}
+          onResolve={resolveLabelRemovePrompt}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -411,12 +411,21 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   // Drag-and-drop drop onto a label section: tag the stream with that label.
   // A labeled stream lives under its label lens (which trumps the smart/type
-  // buckets), so first unfile it from any custom section — the custom-section
-  // trump would otherwise hide it from the very lens the drop just targeted.
+  // buckets), so once the label lands we unfile it from any custom section — the
+  // custom-section trump would otherwise hide it from the very lens the drop
+  // targeted. The unfile runs in `onSuccess` (not before `mutate`) so a failed
+  // assignment doesn't strand the stream out of the section it was filed into;
+  // `setStreamCustomSection` is a no-op when the stream isn't filed anywhere.
   const handleAssignStreamLabel = (streamId: string, labelId: string) => {
-    const unfiled = setStreamCustomSection(sidebarConfig, streamId, null)
-    if (unfiled !== sidebarConfig) setSidebarConfig(unfiled)
-    assignLabel.mutate({ labelId, resourceType: LabelableResourceTypes.STREAM, resourceId: streamId })
+    assignLabel.mutate(
+      { labelId, resourceType: LabelableResourceTypes.STREAM, resourceId: streamId },
+      {
+        onSuccess: () => {
+          const unfiled = setStreamCustomSection(sidebarConfig, streamId, null)
+          if (unfiled !== sidebarConfig) setSidebarConfig(unfiled)
+        },
+      }
+    )
   }
 
   return (

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   useLiveScheduledCount,
   useSidebarConfig,
   useUnreadCounts,
+  useAssignLabel,
 } from "@/hooks"
 import { useSyncStatus } from "@/sync/sync-status"
 import { useSyncEngine } from "@/sync/sync-engine"
@@ -82,6 +83,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const { drafts: allDrafts } = useAllDrafts(workspaceId)
   const { openCreateChannel } = useCreateChannel()
   const { user } = useAuth()
+  const assignLabel = useAssignLabel(workspaceId)
   const navigate = useNavigate()
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
   const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
@@ -407,6 +409,16 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     setSidebarConfig(setStreamCustomSection(sidebarConfig, streamId, customSectionId))
   }
 
+  // Drag-and-drop drop onto a label section: tag the stream with that label.
+  // A labeled stream lives under its label lens (which trumps the smart/type
+  // buckets), so first unfile it from any custom section — the custom-section
+  // trump would otherwise hide it from the very lens the drop just targeted.
+  const handleAssignStreamLabel = (streamId: string, labelId: string) => {
+    const unfiled = setStreamCustomSection(sidebarConfig, streamId, null)
+    if (unfiled !== sidebarConfig) setSidebarConfig(unfiled)
+    assignLabel.mutate({ labelId, resourceType: LabelableResourceTypes.STREAM, resourceId: streamId })
+  }
+
   return (
     <>
       <SidebarShell
@@ -436,6 +448,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             onCreateChannel={handleCreateChannel}
             scratchpadAddMenuActions={scratchpadAddMenuActions}
             onFileStreamToSection={handleFileStreamToSection}
+            onAssignStreamLabel={handleAssignStreamLabel}
             quickLinksSlot={
               hasQuickLinksSection ? (
                 <SidebarQuickLinks

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -22,6 +22,7 @@ import {
 } from "./sidebar-actions"
 import { useSidebarItemDrawer } from "./use-sidebar-item-drawer"
 import { useUrgencyTracking } from "./use-urgency-tracking"
+import { StreamLabelDots } from "./sidebar-labels"
 import { truncateContent } from "./utils"
 import {
   LabelableResourceTypes,
@@ -383,7 +384,10 @@ export function StreamItem({
                 {stream.type === StreamTypes.CHANNEL && stream.visibility === Visibilities.PRIVATE && (
                   <Lock className="h-3 w-3 shrink-0 text-muted-foreground/60" />
                 )}
-                <MentionIndicator count={mentionCount} className="ml-auto" />
+                <div className="ml-auto flex items-center gap-1.5">
+                  <StreamLabelDots streamId={stream.id} />
+                  <MentionIndicator count={mentionCount} />
+                </div>
               </div>
               <StreamItemPreview
                 preview={preview}

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -7,6 +7,7 @@ import { usePreferences } from "@/contexts"
 import {
   THEME_OPTIONS,
   MESSAGE_DISPLAY_OPTIONS,
+  LABEL_REMOVE_ON_MOVE_OPTIONS,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MIN,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MAX,
   DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
@@ -15,6 +16,7 @@ import {
   DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
   type Theme,
   type MessageDisplay,
+  type LabelRemoveOnMove,
 } from "@threa/types"
 
 const THEME_LABELS: Record<Theme, string> = {
@@ -33,11 +35,24 @@ const MESSAGE_DISPLAY_DESCRIPTIONS: Record<MessageDisplay, string> = {
   comfortable: "More spacing between messages",
 }
 
+const LABEL_REMOVE_LABELS: Record<LabelRemoveOnMove, string> = {
+  ask: "Ask each time",
+  always: "Remove the old label",
+  never: "Keep the old label",
+}
+
+const LABEL_REMOVE_DESCRIPTIONS: Record<LabelRemoveOnMove, string> = {
+  ask: "Prompt when you drag a labeled stream into a custom section or another label",
+  always: "Drop the label it was sitting under whenever you move it elsewhere",
+  never: "Leave labels alone — a moved stream keeps every label it had",
+}
+
 export function AppearanceSettings() {
   const { preferences, updatePreference } = usePreferences()
 
   const theme = preferences?.theme ?? "system"
   const messageDisplay = preferences?.messageDisplay ?? "comfortable"
+  const labelRemoveOnMove = preferences?.labelRemoveOnMove ?? "ask"
   const codeBlockThreshold = preferences?.codeBlockCollapseThreshold ?? DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD
   const blockquoteThreshold = preferences?.blockquoteCollapseThreshold ?? DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD
 
@@ -209,6 +224,35 @@ export function AppearanceSettings() {
             className="w-24"
           />
         </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Moving labeled streams</h3>
+          <p className="text-sm text-muted-foreground">
+            When you drag a labeled stream into a custom section or a different label, decide what happens to the label
+            it was under
+          </p>
+        </div>
+        <RadioGroup
+          value={labelRemoveOnMove}
+          onValueChange={(value) => updatePreference("labelRemoveOnMove", value as LabelRemoveOnMove)}
+          className="space-y-3"
+        >
+          {LABEL_REMOVE_ON_MOVE_OPTIONS.map((option) => (
+            <div key={option} className="flex items-start space-x-3">
+              <RadioGroupItem value={option} id={`label-remove-${option}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`label-remove-${option}`} className="cursor-pointer">
+                  {LABEL_REMOVE_LABELS[option]}
+                </Label>
+                <p className="text-sm text-muted-foreground">{LABEL_REMOVE_DESCRIPTIONS[option]}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
       </section>
     </div>
   )

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -72,6 +72,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       notificationLevel: "all",
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
+      labelRemoveOnMove: "ask",
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -85,6 +85,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       notificationLevel: "all",
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
+      labelRemoveOnMove: "ask",
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -558,6 +558,10 @@ export {
   LINK_PREVIEW_DEFAULT_OPTIONS,
   type LinkPreviewDefault,
   LinkPreviewDefaults,
+  // Label-remove-on-move behavior
+  LABEL_REMOVE_ON_MOVE_OPTIONS,
+  type LabelRemoveOnMove,
+  LabelRemoveOnMoveOptions,
   // Code block collapse threshold
   CODE_BLOCK_COLLAPSE_THRESHOLD_MIN,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MAX,

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -91,6 +91,19 @@ export const MessageSendModes = {
   CMD_ENTER: "cmdEnter",
 } as const satisfies Record<string, MessageSendMode>
 
+// Label-remove-on-move behavior — when a labeled stream is dragged out of its
+// label section in the sidebar (into a custom section or a different label),
+// whether to also strip the label it was sitting under. "ask" prompts each time
+// (with a remember-my-choice option that flips this preference to always/never).
+export const LABEL_REMOVE_ON_MOVE_OPTIONS = ["ask", "always", "never"] as const
+export type LabelRemoveOnMove = (typeof LABEL_REMOVE_ON_MOVE_OPTIONS)[number]
+
+export const LabelRemoveOnMoveOptions = {
+  ASK: "ask",
+  ALWAYS: "always",
+  NEVER: "never",
+} as const satisfies Record<string, LabelRemoveOnMove>
+
 // Code block collapse threshold - line count above which blocks start collapsed.
 // Blocks with fewer lines render expanded by default. A user can always toggle
 // an individual block; this preference only controls the initial state.
@@ -209,6 +222,11 @@ export interface UserPreferences {
   sidebarCollapsed: boolean
   messageSendMode: MessageSendMode
   linkPreviewDefault: LinkPreviewDefault
+  /**
+   * What dragging a labeled stream out of its sidebar label section does to that
+   * label. "ask" prompts each time; "always"/"never" act without prompting.
+   */
+  labelRemoveOnMove: LabelRemoveOnMove
   scratchpadCustomPrompt: string | null
   codeBlockCollapseThreshold: number
   blockquoteCollapseThreshold: number
@@ -252,6 +270,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   sidebarCollapsed: false,
   messageSendMode: "enter",
   linkPreviewDefault: "open",
+  labelRemoveOnMove: "ask",
   scratchpadCustomPrompt: null,
   codeBlockCollapseThreshold: DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
@@ -280,6 +299,7 @@ export interface UpdateUserPreferencesInput {
   sidebarCollapsed?: boolean
   messageSendMode?: MessageSendMode
   linkPreviewDefault?: LinkPreviewDefault
+  labelRemoveOnMove?: LabelRemoveOnMove
   scratchpadCustomPrompt?: string | null
   codeBlockCollapseThreshold?: number
   blockquoteCollapseThreshold?: number


### PR DESCRIPTION
Desktop sidebar drag-and-drop could only file streams into custom sections. This lets you drag a stream onto a pinned **label** section to apply that label — and makes labels behave as a real lens in the sidebar.

## What changed

- **Label sections are drop targets.** Dropping a stream onto a pinned label applies that label (`LabelSectionDropZone` / `labelIdFromDropData`, mirroring the existing custom-section wiring). On a successful assignment the stream is also unfiled from any custom section it was in, so the custom-section trump doesn't shadow the lens it was just dropped into.
- **A pinned label now trumps the smart/type buckets**, the same way custom sections already do. A labeled stream lives under its label lens regardless of layout order, with the topmost pinned label winning — so a stream still shows in exactly one place. Custom sections continue to out-rank labels.

## Why the trump

Two things pointed at the same fix:

1. For the drop to feel right, a stream has to land where you dropped it. Pinned labels are appended at the bottom of the layout, so under the old order-based rule a dropped stream would stay in its bucket above and the gesture would look like a no-op.
2. Labeled **thread** streams weren't surfacing under their label — in the Smart preset a thread lands in Important/Recent/Other (above the label section), so order-based topmost-wins kept it in the bucket. Threads you've participated in are already in the sidebar's stream set, so once the label claims them out of the buckets they show up under the lens.

The tradeoff (chosen deliberately): a labeled stream that's also urgent now lives under its label section rather than **Important**. Reorder the label section above the buckets to keep it higher.

## Resolution precedence

`custom section` > `label lens (topmost pinned label)` > `smart/type bucket`. Implemented in `resolve-sections.ts` by gathering a `labeledClaimed` set up front and withholding those streams from the automatic buckets — the same mechanism as the existing `customClaimed`.

## Scope notes

- Drag is desktop-only by design; mobile assigns labels through the existing per-row label picker, so there's no mobile gap.
- Multi-label streams are intentionally additive on the data side (a stream can carry many labels); only the *sidebar placement* is single, via topmost-pinned-label.

## Tests

`resolve-sections.test.ts` updated for the new label-trumps-buckets semantics, plus an explicit labeled-thread case. All 106 sidebar tests pass; full monorepo lint + typecheck green via pre-commit.

## Self-review

Ran a multi-perspective self-review before opening. It caught a partial-failure bug — the custom-section unfile originally ran before the non-optimistic label mutation, so a failed assignment could strand the stream out of its custom section. Fixed by moving the unfile into the mutation's `onSuccess` (second commit).

https://claude.ai/code/session_01YAT9qDYg1n1BgL41MgwJhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAT9qDYg1n1BgL41MgwJhn)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783196530&installation_id=129946197&pr_number=773&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F773&signature=2766e9370b81e986fd47693c918ed724e44e7d57debf90444cb37ee221dc64b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->