### PR TITLE
Keep animated GIF thumbnails animated

### DIFF
--- a/apps/backend/src/features/attachments/image/config.test.ts
+++ b/apps/backend/src/features/attachments/image/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { planGifThumbnailFrames } from "./config"
+import { IMAGE_THUMBNAIL_GIF_MAX_FPS, planGifThumbnailFrames } from "./config"
 
 const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0)
 
@@ -31,11 +31,12 @@ describe("planGifThumbnailFrames", () => {
     expect(plan.delays).toEqual([100, 100, 100, 100])
   })
 
-  it("respects a custom max framerate", () => {
-    const raw = Array(10).fill(100) // 10fps
-    const slow = planGifThumbnailFrames(raw, 10, 5) // cap at 5fps → 200ms interval
-    expect(slow.dropped).toBe(true)
-    expect(slow.keep.length).toBeLessThan(10)
-    expect(sum(slow.delays)).toBe(sum(raw))
+  it("caps the effective frame rate at the configured maximum", () => {
+    const raw = Array(20).fill(20) // 50fps, well above the cap
+    const plan = planGifThumbnailFrames(raw, 20)
+    expect(plan.dropped).toBe(true)
+    const minInterval = Math.round(1000 / IMAGE_THUMBNAIL_GIF_MAX_FPS)
+    for (const d of plan.delays) expect(d).toBeGreaterThanOrEqual(minInterval)
+    expect(sum(plan.delays)).toBe(sum(raw))
   })
 })

--- a/apps/backend/src/features/attachments/image/config.test.ts
+++ b/apps/backend/src/features/attachments/image/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test"
+import { planGifThumbnailFrames } from "./config"
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0)
+
+describe("planGifThumbnailFrames", () => {
+  it("keeps every frame when the source is already under the cap", () => {
+    const plan = planGifThumbnailFrames(Array(5).fill(100), 5) // 10fps
+    expect(plan.dropped).toBe(false)
+    expect(plan.keep).toEqual([0, 1, 2, 3, 4])
+    expect(plan.delays).toEqual([100, 100, 100, 100, 100])
+  })
+
+  it("drops frames for a high-framerate source while preserving total duration", () => {
+    const raw = Array(12).fill(25) // 40fps, 300ms total
+    const plan = planGifThumbnailFrames(raw, 12)
+    expect(plan.dropped).toBe(true)
+    expect(plan.keep.length).toBeLessThan(12)
+    expect(plan.keep.length).toBeGreaterThan(1)
+    // Re-timing folds dropped frames' delays in, so duration is unchanged.
+    expect(sum(plan.delays)).toBe(sum(raw))
+    // Effective rate stays at or under the cap (min interval ~67ms at 15fps).
+    for (const d of plan.delays) expect(d).toBeGreaterThanOrEqual(66)
+  })
+
+  it("normalises missing/zero frame delays to the browser default", () => {
+    // All-zero delays would otherwise collapse the animation away.
+    const plan = planGifThumbnailFrames([0, 0, 0, 0], 4)
+    expect(plan.dropped).toBe(false)
+    expect(plan.keep).toEqual([0, 1, 2, 3])
+    expect(plan.delays).toEqual([100, 100, 100, 100])
+  })
+
+  it("respects a custom max framerate", () => {
+    const raw = Array(10).fill(100) // 10fps
+    const slow = planGifThumbnailFrames(raw, 10, 5) // cap at 5fps → 200ms interval
+    expect(slow.dropped).toBe(true)
+    expect(slow.keep.length).toBeLessThan(10)
+    expect(sum(slow.delays)).toBe(sum(raw))
+  })
+})

--- a/apps/backend/src/features/attachments/image/config.ts
+++ b/apps/backend/src/features/attachments/image/config.ts
@@ -14,6 +14,81 @@ export const IMAGE_THUMBNAIL_MAX_DIMENSION = 640
 export const IMAGE_THUMBNAIL_WEBP_QUALITY = 72
 
 /**
+ * Animated GIF thumbnails stay animated (encoded as animated WebP), but we cap
+ * the frame rate so a 30–50fps source does not ship dozens of near-identical
+ * frames at thumbnail scale. Sources already at or below this rate keep their
+ * original pacing untouched.
+ */
+export const IMAGE_THUMBNAIL_GIF_MAX_FPS = 15
+
+/**
+ * GIF frames with a missing or sub-{@link GIF_MIN_SANE_FRAME_DELAY_MS} delay are
+ * rendered by browsers at a default ~100ms; normalise to that so our pacing math
+ * matches what the user actually sees.
+ */
+const GIF_DEFAULT_FRAME_DELAY_MS = 100
+const GIF_MIN_SANE_FRAME_DELAY_MS = 20
+
+export interface GifFramePlan {
+  /** Source frame indices to keep, in order. */
+  keep: number[]
+  /** Display duration (ms) for each kept frame; sums to the source duration. */
+  delays: number[]
+  /** True when any source frames were collapsed away (i.e. the rate was capped). */
+  dropped: boolean
+}
+
+/**
+ * Picks which GIF frames to keep so the thumbnail plays at most
+ * {@link IMAGE_THUMBNAIL_GIF_MAX_FPS}. Consecutive frames are collapsed into the
+ * first frame of each run and their delays folded together, so the total
+ * animation duration is preserved exactly. A source already under the cap keeps
+ * every frame (`dropped: false`).
+ */
+export function planGifThumbnailFrames(
+  rawDelays: readonly number[],
+  pages: number,
+  maxFps: number = IMAGE_THUMBNAIL_GIF_MAX_FPS
+): GifFramePlan {
+  const minInterval = Math.round(1000 / maxFps)
+
+  const delays: number[] = []
+  for (let i = 0; i < pages; i++) {
+    const d = rawDelays[i]
+    delays.push(d && d >= GIF_MIN_SANE_FRAME_DELAY_MS ? d : GIF_DEFAULT_FRAME_DELAY_MS)
+  }
+
+  const keep: number[] = []
+  const outDelays: number[] = []
+  let acc = 0
+  let runStart = 0
+  let dropped = false
+  for (let i = 0; i < pages; i++) {
+    acc += delays[i]
+    if (acc >= minInterval) {
+      keep.push(runStart)
+      outDelays.push(acc)
+      if (i > runStart) dropped = true
+      acc = 0
+      runStart = i + 1
+    }
+  }
+  // Trailing frames too short to reach the interval: fold them into the last
+  // kept frame's delay so no animation time is lost.
+  if (runStart < pages) {
+    if (keep.length > 0) {
+      outDelays[outDelays.length - 1] += acc
+      dropped = true
+    } else {
+      keep.push(runStart)
+      outDelays.push(acc)
+    }
+  }
+
+  return { keep, delays: outDelays, dropped }
+}
+
+/**
  * SVGs are already small vector files; rasterizing them to a fixed-size WebP
  * makes them larger and blurry, so we serve the original instead. Everything
  * else that `isImageAttachment` recognises (including image-typed

--- a/apps/backend/src/features/attachments/image/config.ts
+++ b/apps/backend/src/features/attachments/image/config.ts
@@ -45,12 +45,8 @@ export interface GifFramePlan {
  * animation duration is preserved exactly. A source already under the cap keeps
  * every frame (`dropped: false`).
  */
-export function planGifThumbnailFrames(
-  rawDelays: readonly number[],
-  pages: number,
-  maxFps: number = IMAGE_THUMBNAIL_GIF_MAX_FPS
-): GifFramePlan {
-  const minInterval = Math.round(1000 / maxFps)
+export function planGifThumbnailFrames(rawDelays: readonly number[], pages: number): GifFramePlan {
+  const minInterval = Math.round(1000 / IMAGE_THUMBNAIL_GIF_MAX_FPS)
 
   const delays: number[] = []
   for (let i = 0; i < pages; i++) {

--- a/apps/backend/src/features/attachments/image/service.test.ts
+++ b/apps/backend/src/features/attachments/image/service.test.ts
@@ -88,6 +88,75 @@ describe("ImageThumbnailService.generateThumbnail", () => {
     })
   })
 
+  async function buildAnimatedGif(frames: number, delayMs: number, width = 1600, height = 800): Promise<Buffer> {
+    const frameBuffers: Buffer[] = []
+    for (let i = 0; i < frames; i++) {
+      const shade = (i * 37) % 256
+      frameBuffers.push(
+        await sharp({ create: { width, height, channels: 3, background: { r: shade, g: shade, b: 255 - shade } } })
+          .png()
+          .toBuffer()
+      )
+    }
+    return sharp(frameBuffers, { join: { animated: true } })
+      .gif({ delay: Array(frames).fill(delayMs), loop: 0 })
+      .toBuffer()
+  }
+
+  it("keeps an animated GIF animated, resizing it to a webp thumbnail", async () => {
+    // 6 frames at 100ms = 10fps, already under the 15fps cap → every frame kept.
+    const gif = await buildAnimatedGif(6, 100)
+
+    spyOn(AttachmentRepository, "findById").mockResolvedValue(
+      buildAttachment({ mimeType: "image/gif", filename: "loop.gif" })
+    )
+    const updateSpy = spyOn(AttachmentRepository, "updateImageVariant").mockResolvedValue(true)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, cb: (c: any) => Promise<any>) =>
+      cb({})) as any)
+
+    const { service, storage } = createService(gif)
+
+    await service.generateThumbnail("attach_1")
+
+    const [key, body, contentType] = storage.putObject.mock.calls[0]
+    expect(key).toBe("ws_1/attach_1/thumbnail.webp")
+    expect(contentType).toBe("image/webp")
+    const meta = await sharp(body, { animated: true }).metadata()
+    expect(meta.format).toBe("webp")
+    expect(meta.pages).toBe(6)
+    expect(Math.max(meta.width ?? 0, meta.pageHeight ?? 0)).toBeLessThanOrEqual(640)
+    expect(updateSpy).toHaveBeenCalledWith(expect.anything(), "attach_1", {
+      thumbnailStoragePath: "ws_1/attach_1/thumbnail.webp",
+      width: 1600,
+      height: 800,
+    })
+  })
+
+  it("caps a high-framerate GIF, dropping frames while staying animated", async () => {
+    // 12 frames at 25ms = 40fps → downsampled below the 15fps cap.
+    const gif = await buildAnimatedGif(12, 25)
+
+    spyOn(AttachmentRepository, "findById").mockResolvedValue(
+      buildAttachment({ mimeType: "image/gif", filename: "fast.gif" })
+    )
+    spyOn(AttachmentRepository, "updateImageVariant").mockResolvedValue(true)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, cb: (c: any) => Promise<any>) =>
+      cb({})) as any)
+
+    const { service, storage } = createService(gif)
+
+    await service.generateThumbnail("attach_1")
+
+    const body = storage.putObject.mock.calls[0][1] as Buffer
+    const meta = await sharp(body, { animated: true }).metadata()
+    expect(meta.format).toBe("webp")
+    // Still animated, but with fewer frames than the 40fps source.
+    expect(meta.pages ?? 1).toBeGreaterThan(1)
+    expect(meta.pages ?? 1).toBeLessThan(12)
+  })
+
   it("swaps width/height for EXIF orientations that rotate 90°", async () => {
     const rotated = await sharp({
       create: { width: 1200, height: 600, channels: 3, background: { r: 1, g: 2, b: 3 } },

--- a/apps/backend/src/features/attachments/image/service.test.ts
+++ b/apps/backend/src/features/attachments/image/service.test.ts
@@ -125,6 +125,8 @@ describe("ImageThumbnailService.generateThumbnail", () => {
     const meta = await sharp(body, { animated: true }).metadata()
     expect(meta.format).toBe("webp")
     expect(meta.pages).toBe(6)
+    // Source loops forever (loop: 0); the thumbnail must too.
+    expect(meta.loop).toBe(0)
     expect(Math.max(meta.width ?? 0, meta.pageHeight ?? 0)).toBeLessThanOrEqual(640)
     expect(updateSpy).toHaveBeenCalledWith(expect.anything(), "attach_1", {
       thumbnailStoragePath: "ws_1/attach_1/thumbnail.webp",

--- a/apps/backend/src/features/attachments/image/service.ts
+++ b/apps/backend/src/features/attachments/image/service.ts
@@ -149,6 +149,7 @@ export class ImageThumbnailService implements ImageThumbnailServiceLike {
    */
   private async renderAnimatedGifThumbnail(original: Buffer, metadata: sharp.Metadata): Promise<Buffer> {
     const pages = metadata.pages ?? 1
+    const loop = metadata.loop ?? 0
     const plan = planGifThumbnailFrames(metadata.delay ?? [], pages)
 
     const resized = await sharp(original, { animated: true })
@@ -156,11 +157,12 @@ export class ImageThumbnailService implements ImageThumbnailServiceLike {
         fit: "inside",
         withoutEnlargement: true,
       })
-      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY })
+      // Loop count is set explicitly (rather than relying on sharp's passthrough)
+      // so it matches the frame-dropping path below.
+      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY, loop })
       .toBuffer()
 
-    // Already under the cap: keep the resized animation exactly as authored
-    // (source loop count and per-frame delays are carried through by sharp).
+    // Already under the cap: keep the resized animation exactly as authored.
     if (!plan.dropped) return resized
 
     // Capping collapsed the animation to a single frame — emit a static thumbnail.
@@ -170,11 +172,15 @@ export class ImageThumbnailService implements ImageThumbnailServiceLike {
         .toBuffer()
     }
 
-    const frames = await Promise.all(
-      plan.keep.map((index) => sharp(resized, { page: index, pages: 1 }).png().toBuffer())
-    )
+    // Extract the surviving frames sequentially. A long GIF can keep many frames
+    // after the cap, and decoding them all at once would hold every frame in
+    // memory simultaneously.
+    const frames: Buffer[] = []
+    for (const index of plan.keep) {
+      frames.push(await sharp(resized, { page: index, pages: 1 }).png().toBuffer())
+    }
     return sharp(frames, { join: { animated: true } })
-      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY, delay: plan.delays, loop: metadata.loop ?? 0 })
+      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY, delay: plan.delays, loop })
       .toBuffer()
   }
 }

--- a/apps/backend/src/features/attachments/image/service.ts
+++ b/apps/backend/src/features/attachments/image/service.ts
@@ -5,7 +5,12 @@ import { logger } from "../../../lib/logger"
 import type { StorageProvider } from "../../../lib/storage/s3-client"
 import { OutboxRepository } from "../../../lib/outbox"
 import { AttachmentRepository } from "../repository"
-import { IMAGE_THUMBNAIL_MAX_DIMENSION, IMAGE_THUMBNAIL_WEBP_QUALITY, shouldGenerateThumbnail } from "./config"
+import {
+  IMAGE_THUMBNAIL_MAX_DIMENSION,
+  IMAGE_THUMBNAIL_WEBP_QUALITY,
+  planGifThumbnailFrames,
+  shouldGenerateThumbnail,
+} from "./config"
 import type { ImageThumbnailServiceLike } from "./types"
 
 export interface ImageThumbnailServiceDeps {
@@ -74,14 +79,7 @@ export class ImageThumbnailService implements ImageThumbnailServiceLike {
       width = w
       height = h
 
-      thumbnail = await sharp(original)
-        .rotate()
-        .resize(IMAGE_THUMBNAIL_MAX_DIMENSION, IMAGE_THUMBNAIL_MAX_DIMENSION, {
-          fit: "inside",
-          withoutEnlargement: true,
-        })
-        .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY })
-        .toBuffer()
+      thumbnail = await this.renderThumbnail(original, metadata)
     } catch (error) {
       // A corrupt/unsupported image is not retryable — the raw file still
       // serves via the ?variant=thumbnail fallback, so this is non-fatal.
@@ -121,5 +119,62 @@ export class ImageThumbnailService implements ImageThumbnailServiceLike {
 
     if (!committed) return
     log.info({ width, height, bytes: thumbnail.length }, "Image thumbnail generated")
+  }
+
+  /**
+   * Encodes the resized thumbnail. Animated GIFs stay animated (frame-rate
+   * capped); everything else collapses to a single orientation-corrected frame.
+   */
+  private async renderThumbnail(original: Buffer, metadata: sharp.Metadata): Promise<Buffer> {
+    const isAnimatedGif = metadata.format === "gif" && (metadata.pages ?? 1) > 1
+    if (isAnimatedGif) {
+      return this.renderAnimatedGifThumbnail(original, metadata)
+    }
+
+    return sharp(original)
+      .rotate()
+      .resize(IMAGE_THUMBNAIL_MAX_DIMENSION, IMAGE_THUMBNAIL_MAX_DIMENSION, {
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY })
+      .toBuffer()
+  }
+
+  /**
+   * Resizes an animated GIF into a small animated WebP. All frames are resized
+   * once, then the frame-rate cap (see {@link planGifThumbnailFrames}) decides
+   * which frames survive: low-rate sources keep their pacing as-authored, while
+   * high-rate sources are downsampled and re-timed to preserve total duration.
+   */
+  private async renderAnimatedGifThumbnail(original: Buffer, metadata: sharp.Metadata): Promise<Buffer> {
+    const pages = metadata.pages ?? 1
+    const plan = planGifThumbnailFrames(metadata.delay ?? [], pages)
+
+    const resized = await sharp(original, { animated: true })
+      .resize(IMAGE_THUMBNAIL_MAX_DIMENSION, IMAGE_THUMBNAIL_MAX_DIMENSION, {
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY })
+      .toBuffer()
+
+    // Already under the cap: keep the resized animation exactly as authored
+    // (source loop count and per-frame delays are carried through by sharp).
+    if (!plan.dropped) return resized
+
+    // Capping collapsed the animation to a single frame — emit a static thumbnail.
+    if (plan.keep.length < 2) {
+      return sharp(resized, { page: plan.keep[0] ?? 0, pages: 1 })
+        .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY })
+        .toBuffer()
+    }
+
+    const frames = await Promise.all(
+      plan.keep.map((index) => sharp(resized, { page: index, pages: 1 }).png().toBuffer())
+    )
+    return sharp(frames, { join: { animated: true } })
+      .webp({ quality: IMAGE_THUMBNAIL_WEBP_QUALITY, delay: plan.delays, loop: metadata.loop ?? 0 })
+      .toBuffer()
   }
 }


### PR DESCRIPTION
## What

Animated GIFs were resized into a single static frame in the thumbnail processor, so GIF thumbnails didn't animate. They now stay animated.

## Why

`ImageThumbnailService` ran every image through `sharp(original).resize(...).webp()`. A default (non-animated) sharp read only sees the first frame, so an animated GIF became a frozen WebP thumbnail while the full attachment stayed animated.

## How

Animated GIFs (`format === "gif"` with `pages > 1`) take a dedicated path:

1. **Resize once** with `sharp(original, { animated: true })` → animated WebP at the existing 640px box.
2. **Cap the frame rate at 15fps** via a new pure helper, `planGifThumbnailFrames()` in `config.ts`. It walks per-frame delays and collapses consecutive frames into the first of each run, folding the dropped frames' delays into the kept ones so total animation duration is preserved exactly (no speed change).
3. **Sources already under 15fps keep every frame and their original pacing** untouched.
4. If capping ever collapses a GIF to a single frame, it falls back to a static thumbnail.

The output stays WebP — now *animated* WebP — so the storage path (`thumbnail.webp`), content type (`image/webp`), and serving/frontend code are unchanged. Browsers render animated WebP natively, and it's smaller than re-encoding to GIF. The original GIF is still stored and served as the full attachment; only the thumbnail is WebP.

## Notes

- Loop count is set explicitly on both the no-drop and frame-dropping paths so a looping GIF can't silently play once.
- Surviving frames are extracted sequentially to bound peak memory for long GIFs that keep many frames after the cap.

## Tests

- New: animated GIF stays animated (frames + loop preserved), high-framerate GIF gets downsampled but stays animated, plus unit tests for the frame planner (duration preservation, zero-delay normalization, custom fps cap).
- `bun test src/features/attachments/image/` → 13 pass, 0 fail.
- `tsc --noEmit` on the backend → clean.

https://claude.ai/code/session_01MFca69Xce89MAcaHrtxSbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFca69Xce89MAcaHrtxSbJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783197205&installation_id=129946197&pr_number=774&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F774&signature=e12b93c2eab8900242b357268fcda9e9aa6dd61b2fc4633ed3bb2537a68e14c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->