### PR TITLE
Restore pre-#769 stream composer baseline

### DIFF
--- a/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
+++ b/apps/frontend/src/hooks/use-composer-height-publish.test.tsx
@@ -163,36 +163,6 @@ describe("useComposerHeightPublish", () => {
     }
   })
 
-  it("keeps the last good height when the composer is hidden (measures 0)", () => {
-    const ro = installManualResizeObserver()
-    try {
-      const onHeightChange = vi.fn()
-      const { container } = render(<Harness onHeightChange={onHeightChange} />)
-      const zone = container.querySelector<HTMLElement>("[data-editor-zone]")!
-
-      // Composer settles at a real height.
-      ro.fire(120)
-      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
-      expect(onHeightChange).toHaveBeenCalledTimes(1)
-
-      // Inline message-edit opens on mobile → [data-message-composer-root] is
-      // `display:none`, so the ResizeObserver reports 0. The footer spacer must
-      // NOT collapse to 0 (that drops the last message behind the composer with
-      // no scroll slack); keep the last good height and don't notify.
-      ro.fire(0)
-      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
-      expect(onHeightChange).toHaveBeenCalledTimes(1)
-
-      // Edit closes → composer returns at its real height. Already correct, so
-      // still no spurious re-notify.
-      ro.fire(120)
-      expect(zone.style.getPropertyValue("--composer-height")).toBe("120px")
-      expect(onHeightChange).toHaveBeenCalledTimes(1)
-    } finally {
-      ro.restore()
-    }
-  })
-
   it("flags only the first measurement as initial, even when it drifts", () => {
     const ro = installManualResizeObserver()
     try {

--- a/apps/frontend/src/hooks/use-composer-height-publish.ts
+++ b/apps/frontend/src/hooks/use-composer-height-publish.ts
@@ -82,18 +82,6 @@ export function useComposerHeightPublish(
 
     const write = (h: number) => {
       const px = Math.ceil(h)
-      // The composer is sometimes hidden without unmounting: on mobile the
-      // inline message-edit form hides [data-message-composer-root] via
-      // `display:none` (see index.css). A hidden element measures 0, and
-      // writing that would collapse the footer spacer / padding-bottom that
-      // holds the last message above the floating composer — dropping the last
-      // message behind the pill with no scroll slack left to recover it (you
-      // are already at the bottom of the scroll range). Ignore non-positive
-      // measurements and keep the last good height (the same reason cleanup
-      // leaves the variable set), so the reserved space survives the hide and
-      // is already correct the instant the composer returns. Virtuoso guards
-      // its own header/footer measurement the same way (`offsetParent !== null`).
-      if (px <= 0) return
       zone.style.setProperty("--composer-height", `${px}px`)
       persistComposerHeight(px)
       // Notify on any change from the height the footer was last sized for —


### PR DESCRIPTION
## What

Restores the stream view's composer-height publishing to its **pre-#769 baseline**.

After #771, the only change still live on `main` from the whole #769/#771 cycle was the `px<=0` hidden-composer guard in `useComposerHeightPublish` (commit `ed16287`). This reverts that one file (and its test) to the exact state it had before any of this work, removing the positional weirdness that appeared in the stream view.

After this merges, nothing from the composer-padding effort remains on `main` — it's back to known-good.

## Notes

- 2-file diff (the hook + its test), rebased on current `main`. tsc + lint + tests pass.
- The frosted-glass composer experiment was dropped (doesn't fit the current styling yet — parked, not deleted; easy to revisit later).
- If positional issues somehow persist after this, they aren't from our work (nothing of ours is left), and I'd look at other recently-merged PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)