### PR TITLE
Copy link to stream from menus and a keyboard shortcut

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
-import { Bell, FileEdit, FolderPlus, Hash, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
+import { Bell, FileEdit, FolderPlus, Hash, Link2, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { SectionPicker } from "./section-picker"
@@ -13,6 +13,7 @@ import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { cn } from "@/lib/utils"
 import { streamLabel } from "@/lib/streams"
+import { copyStreamLink } from "@/lib/stream-links"
 import { BADGE_CONFIG, URGENCY_COLORS } from "./config"
 import {
   SidebarActionDrawer,
@@ -280,13 +281,19 @@ export function StreamItem({
               onSelect: () => setLabelPickerOpen(true),
             },
             {
+              id: "copy-link",
+              label: "Copy link",
+              icon: Link2,
+              onSelect: () => void copyStreamLink(workspaceId, stream.id),
+            },
+            {
               id: "add-to-section",
               label: "Add to section…",
               icon: FolderPlus,
               onSelect: () => setSectionPickerOpen(true),
             },
           ],
-    [isVirtualDraft, openStreamSettings, stream.id]
+    [isVirtualDraft, openStreamSettings, stream.id, workspaceId]
   )
 
   let drawerPreview: SidebarActionPreview | null = null

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -1,7 +1,16 @@
 import { useSearchParams, useParams } from "react-router-dom"
 import { useMemo, useCallback, useEffect, useState, useRef } from "react"
 import { createPortal } from "react-dom"
-import { MessageSquare, ChevronLeft, MoreHorizontal, CornerDownRight, Paperclip, Settings, Tag } from "lucide-react"
+import {
+  MessageSquare,
+  ChevronLeft,
+  MoreHorizontal,
+  CornerDownRight,
+  Paperclip,
+  Settings,
+  Tag,
+  Link2,
+} from "lucide-react"
 import {
   SidePanel,
   SidePanelHeader,
@@ -51,6 +60,7 @@ import { ResponsiveBreadcrumbs } from "./responsive-breadcrumbs"
 import { LabelableResourceTypes, StreamTypes } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import { streamLabel } from "@/lib/streams"
+import { copyStreamLink } from "@/lib/stream-links"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 
@@ -64,7 +74,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const { getStreamState } = useCoordinatedLoading()
   const [searchParams] = useSearchParams()
   const highlightMessageId = searchParams.get("m")
-  const { panelId, openPanel, getPanelUrl, closePanel } = usePanel()
+  const { panelId, openPanel, getPanelUrl, closePanel, setFocusedPane } = usePanel()
   const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
@@ -216,6 +226,14 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     label: "Labels…",
     icon: Tag,
     onSelect: () => setLabelPickerOpen(true),
+  })
+  panelMenuActions.push({
+    id: "copy-link",
+    label: "Copy link",
+    icon: Link2,
+    onSelect: () => {
+      if (panelId) void copyStreamLink(workspaceId, panelId)
+    },
   })
   panelMenuActions.push({
     id: "move-messages",
@@ -398,7 +416,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   }
 
   return (
-    <SidePanel data-editor-zone="panel">
+    <SidePanel
+      data-editor-zone="panel"
+      onPointerDownCapture={() => setFocusedPane("panel")}
+      onFocusCapture={() => setFocusedPane("panel")}
+    >
       <SidePanelHeader className="relative">
         <StreamLoadingIndicator isLoading={showLoadingIndicator} />
         {/* Mobile: thread view takes over the full screen, so the sidebar

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -17,6 +17,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
+import { buildStreamLink } from "@/lib/stream-links"
 
 /**
  * Context available to message actions.
@@ -373,7 +374,9 @@ export const messageActions: MessageAction[] = [
     when: (ctx) => !!ctx.messageId && !!ctx.workspaceId && !!ctx.streamId,
     action: async (ctx) => {
       try {
-        const url = `${window.location.origin}/w/${ctx.workspaceId}/s/${ctx.streamId}?m=${ctx.messageId}`
+        // `when` above guarantees these are present; compose on the shared
+        // builder so the route shape lives in one place (stream-links.ts).
+        const url = `${buildStreamLink(ctx.workspaceId!, ctx.streamId!)}?m=${ctx.messageId}`
         await copyToClipboard(url)
         toast.success("Link copied")
       } catch {

--- a/apps/frontend/src/contexts/panel-context.tsx
+++ b/apps/frontend/src/contexts/panel-context.tsx
@@ -1,5 +1,8 @@
-import { createContext, useContext, useCallback, useMemo, type ReactNode } from "react"
+import { createContext, useContext, useCallback, useEffect, useMemo, useRef, type ReactNode } from "react"
 import { useSearchParams, useLocation } from "react-router-dom"
+
+/** Which pane the user most recently interacted with — drives "copy current link" (mod+L). */
+export type FocusedPane = "main" | "panel"
 
 /**
  * Check if a panel ID represents a draft thread
@@ -40,6 +43,11 @@ interface PanelContextValue {
   openPanel: (streamId: string) => void
   /** Close the current panel */
   closePanel: () => void
+
+  /** Record which pane the user is interacting with (main view vs thread panel). */
+  setFocusedPane: (pane: FocusedPane) => void
+  /** Read the most recently focused pane. Defaults to "main". */
+  getFocusedPane: () => FocusedPane
 }
 
 const PanelContext = createContext<PanelContextValue | null>(null)
@@ -93,6 +101,19 @@ export function PanelProvider({ children }: PanelProviderProps) {
     )
   }, [setSearchParams])
 
+  // Tracked via a ref, not state: only the mod+L handler reads it (on keypress),
+  // so updating it on every click/focus must not re-render panel consumers.
+  const focusedPaneRef = useRef<FocusedPane>("main")
+  const setFocusedPane = useCallback((pane: FocusedPane) => {
+    focusedPaneRef.current = pane
+  }, [])
+  const getFocusedPane = useCallback(() => focusedPaneRef.current, [])
+
+  // When the panel closes, focus belongs to the main pane again.
+  useEffect(() => {
+    if (panelId === null) focusedPaneRef.current = "main"
+  }, [panelId])
+
   const value = useMemo<PanelContextValue>(
     () => ({
       panelId,
@@ -100,8 +121,10 @@ export function PanelProvider({ children }: PanelProviderProps) {
       getPanelUrl,
       openPanel,
       closePanel,
+      setFocusedPane,
+      getFocusedPane,
     }),
-    [panelId, isPanelOpen, getPanelUrl, openPanel, closePanel]
+    [panelId, isPanelOpen, getPanelUrl, openPanel, closePanel, setFocusedPane, getFocusedPane]
   )
 
   return <PanelContext.Provider value={value}>{children}</PanelContext.Provider>

--- a/apps/frontend/src/contexts/panel-context.tsx
+++ b/apps/frontend/src/contexts/panel-context.tsx
@@ -101,9 +101,11 @@ export function PanelProvider({ children }: PanelProviderProps) {
     )
   }, [setSearchParams])
 
-  // Tracked via a ref, not state: only the mod+L handler reads it (on keypress),
-  // so updating it on every click/focus must not re-render panel consumers.
-  const focusedPaneRef = useRef<FocusedPane>("main")
+  // Tracked via a ref, not state: only the copy-link shortcut reads it (on
+  // keypress), so updating it on every click/focus must not re-render panel
+  // consumers. Seed from the initial URL so a deep link that opens a panel
+  // (which then autofocuses) reports the panel before any pointer interaction.
+  const focusedPaneRef = useRef<FocusedPane>(panelId !== null ? "panel" : "main")
   const setFocusedPane = useCallback((pane: FocusedPane) => {
     focusedPaneRef.current = pane
   }, [])

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -79,8 +79,10 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   {
     id: "copyStreamLink",
     label: "Copy Link",
+    // Default avoids plain mod+L — browsers reserve that to focus the address
+    // bar and won't surrender it. Rebindable in keyboard settings like the rest.
     description: "Copy a link to the focused stream or thread",
-    defaultKey: "mod+l",
+    defaultKey: "mod+shift+l",
     category: "navigation",
     global: true,
   },

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -76,6 +76,14 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
     category: "navigation",
     global: true,
   },
+  {
+    id: "copyStreamLink",
+    label: "Copy Link",
+    description: "Copy a link to the focused stream or thread",
+    defaultKey: "mod+l",
+    category: "navigation",
+    global: true,
+  },
   // Editor formatting shortcuts (not global — only active when editor is focused)
   {
     id: "formatBold",

--- a/apps/frontend/src/lib/stream-links.test.ts
+++ b/apps/frontend/src/lib/stream-links.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { toast } from "sonner"
+import { buildStreamLink, copyStreamLink } from "./stream-links"
+
+describe("buildStreamLink", () => {
+  it("builds an absolute main-view URL from workspace and stream ids", () => {
+    expect(buildStreamLink("ws_1", "stream_abc")).toBe(`${window.location.origin}/w/ws_1/s/stream_abc`)
+  })
+})
+
+describe("copyStreamLink", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("writes the stream link to the clipboard and reports success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const success = vi.spyOn(toast, "success").mockReturnValue("" as ReturnType<typeof toast.success>)
+
+    await copyStreamLink("ws_1", "stream_abc")
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/ws_1/s/stream_abc`)
+    expect(success).toHaveBeenCalledWith("Link copied")
+  })
+
+  it("reports an error toast when the clipboard write fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"))
+    Object.assign(navigator, { clipboard: { writeText } })
+    const error = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+
+    await copyStreamLink("ws_1", "stream_abc")
+
+    expect(error).toHaveBeenCalledWith("Failed to copy link")
+  })
+})

--- a/apps/frontend/src/lib/stream-links.ts
+++ b/apps/frontend/src/lib/stream-links.ts
@@ -1,0 +1,25 @@
+import { toast } from "sonner"
+
+/**
+ * Absolute, shareable URL for a stream's main view. The "copy link" affordances
+ * (sidebar/top-bar context menus and the mod+L shortcut) all point here so a
+ * thread, channel, DM, or scratchpad opens as the main view when the link is
+ * followed.
+ */
+export function buildStreamLink(workspaceId: string, streamId: string): string {
+  return `${window.location.origin}/w/${workspaceId}/s/${streamId}`
+}
+
+/**
+ * Copy a stream link to the clipboard with user feedback. Centralized so every
+ * copy-link surface reports success/failure the same way (mirrors the message
+ * permalink action in message-actions.ts).
+ */
+export async function copyStreamLink(workspaceId: string, streamId: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(buildStreamLink(workspaceId, streamId))
+    toast.success("Link copied")
+  } catch {
+    toast.error("Failed to copy link")
+  }
+}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -15,6 +15,7 @@ import {
   Moon,
   Lock,
   Tag,
+  Link2,
 } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
@@ -45,6 +46,7 @@ import { StreamErrorView } from "@/components/stream-error-view"
 import { InviteActorButton } from "@/components/encryption"
 import { CompanionModes, LabelableResourceTypes, StreamTypes, type StreamType } from "@threa/types"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { copyStreamLink } from "@/lib/stream-links"
 import { setPageStreamName } from "@/lib/page-title"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
 
@@ -68,7 +70,7 @@ export function StreamPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const { stream, isDraft, error, rename, archive, unarchive } = useStreamOrDraft(workspaceId!, streamId!)
   const { isMobile } = useSidebar()
-  const { panelId, isPanelOpen, closePanel } = usePanel()
+  const { panelId, isPanelOpen, closePanel, setFocusedPane } = usePanel()
   const {
     containerRef,
     panelWidth,
@@ -194,6 +196,12 @@ export function StreamPage() {
     label: "Labels…",
     icon: Tag,
     onSelect: () => setLabelPickerOpen(true),
+  })
+  streamMenuActions.push({
+    id: "copy-link",
+    label: "Copy link",
+    icon: Link2,
+    onSelect: () => void copyStreamLink(workspaceId, streamId),
   })
   if (!isArchived && !isSystem) {
     streamMenuActions.push({
@@ -535,7 +543,13 @@ export function StreamPage() {
   return (
     <>
       <div ref={containerRef} className="flex h-full">
-        <div className="flex-1 min-w-0 overflow-hidden">{mainStreamContent}</div>
+        <div
+          className="flex-1 min-w-0 overflow-hidden"
+          onPointerDownCapture={() => setFocusedPane("main")}
+          onFocusCapture={() => setFocusedPane("main")}
+        >
+          {mainStreamContent}
+        </div>
 
         <ThreadPanelSlot
           displayWidth={displayWidth}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -40,6 +40,8 @@ import {
   TraceProvider,
   useTrace,
   MediaGalleryProvider,
+  usePanel,
+  isDraftPanel,
 } from "@/contexts"
 import {
   useKeyboardShortcuts,
@@ -68,6 +70,7 @@ import { E2eUnlockProvider } from "@/components/encryption/e2e-unlock-provider"
 import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
 import { SyncStatusStore, SyncStatusContext } from "@/sync/sync-status"
+import { copyStreamLink } from "@/lib/stream-links"
 import { useResolveOrBounce } from "./use-resolve-or-bounce"
 import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 
@@ -108,6 +111,32 @@ function useOnlineStatus(): boolean {
     () => navigator.onLine,
     () => true
   )
+}
+
+/**
+ * Registers the mod+L "copy link" shortcut. Must be rendered inside
+ * PanelProvider so it can read which pane (main view vs thread panel) the user
+ * last interacted with. Copies the thread link when the panel is focused and
+ * shows a real (non-draft) thread; otherwise copies the main stream link.
+ */
+function StreamLinkKeyboardHandler({
+  workspaceId,
+  mainStreamId,
+}: {
+  workspaceId: string
+  mainStreamId: string | undefined
+}) {
+  const { panelId, getFocusedPane } = usePanel()
+
+  useKeyboardShortcuts({
+    copyStreamLink: () => {
+      const targetStreamId = getFocusedPane() === "panel" && panelId && !isDraftPanel(panelId) ? panelId : mainStreamId
+      if (!targetStreamId) return
+      void copyStreamLink(workspaceId, targetStreamId)
+    },
+  })
+
+  return null
 }
 
 /**
@@ -370,6 +399,7 @@ export function WorkspaceLayout() {
                             <E2eUnlockProvider workspaceId={workspaceId}>
                               <QuickSwitcherProvider openSwitcher={openSwitcher}>
                                 <PanelProvider>
+                                  <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
                                   <MediaGalleryProvider>
                                     <TraceProvider>
                                       <SidebarProvider>

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -114,10 +114,10 @@ function useOnlineStatus(): boolean {
 }
 
 /**
- * Registers the mod+L "copy link" shortcut. Must be rendered inside
- * PanelProvider so it can read which pane (main view vs thread panel) the user
- * last interacted with. Copies the thread link when the panel is focused and
- * shows a real (non-draft) thread; otherwise copies the main stream link.
+ * Registers the "copy link" shortcut. Must be rendered inside PanelProvider so
+ * it can read which pane (main view vs thread panel) the user last interacted
+ * with. Copies the thread link when the panel is focused and shows a real
+ * (non-draft) thread; otherwise copies the main stream link.
  */
 function StreamLinkKeyboardHandler({
   workspaceId,


### PR DESCRIPTION
## What

Adds a "copy link to stream" affordance, reachable three ways:

- **Sidebar context menu** — "Copy link" on each stream item.
- **Top-bar overflow menus** — on both the main stream view and the thread panel header.
- **Keyboard shortcut** (`mod+shift+L`) — copies the *focused* pane's link: the thread when the thread panel is focused (and showing a real, non-draft thread), otherwise the main stream.

All four entry points route through one helper, `apps/frontend/src/lib/stream-links.ts`:
- `buildStreamLink(workspaceId, streamId)` → `${origin}/w/{workspaceId}/s/{streamId}` (opens the stream/thread as the main view when followed)
- `copyStreamLink(...)` — writes to the clipboard and toasts `Link copied` / `Failed to copy link`, mirroring the existing message-permalink action.

## Focused-pane tracking

`PanelContext` gains `getFocusedPane()` / `setFocusedPane()`, backed by a **ref** rather than state — only the shortcut handler reads it (on keypress), so marking focus on every click/focus never re-renders `usePanel` consumers. Pane roots set it via `onPointerDownCapture` / `onFocusCapture` (main view in `stream.tsx`, thread panel on `<SidePanel>` in `stream-panel.tsx`). It resets to `"main"` when the panel closes and is seeded from the initial URL so a deep link that opens a panel reports the panel link on the first press.

## Keyboard shortcut default

Default is **`mod+shift+L`**, not plain `mod+L`: browsers reserve `Cmd/Ctrl+L` to focus the address bar and won't surrender it, so plain `mod+L` would never fire on the web. `mod+shift+L` is unclaimed and collides with no existing binding. It's a normal registry entry, so it's fully rebindable (or disable-able) from **Settings → Keyboard** like every other shortcut — including back to `mod+L` on the desktop app.

## Notes

- Drafts (virtual sidebar drafts, draft thread panels) have no shareable URL, so the copy-link action is omitted there.
- Refactored the existing message-permalink action to compose on `buildStreamLink`, so the `/w/:ws/s/:stream` route shape lives in one place.

## Tests

- New `apps/frontend/src/lib/stream-links.test.ts` covers URL building and clipboard success/failure toasts.
- Existing keyboard-shortcut and message-action suites still green.
- Frontend typecheck + full-monorepo lint/typecheck (pre-commit hook) clean.

## Self-review

Ran a multi-perspective review (spec-compliance, correctness, design) before opening. Spec-compliance came back clean; the two surfaced findings (reuse `buildStreamLink` in the message action; seed the focused-pane ref on deep-link) are both addressed in this branch.

https://claude.ai/code/session_01SdEDJ7ezvSrMhZN5LnoN7L

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdEDJ7ezvSrMhZN5LnoN7L)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783202390&installation_id=129946197&pr_number=777&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F777&signature=418ea14266531b2fe671570753dee10894d79977468b1d6c2592d8ae2adcc254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->