### PR TITLE
fix(e2e): deliver attachment ciphertext to the enclave + load_attachment tool

### DIFF
--- a/apps/backend/src/features/agents/enclave-system-prompt.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.ts
@@ -23,6 +23,9 @@ const ENCLAVE_ENABLED_TOOLS: string[] = [
   AgentToolNames.WEB_SEARCH,
   AgentToolNames.READ_URL,
   AgentToolNames.GENERAL_RESEARCH,
+  // Conversation-local file reads: the enclave's in-process variant decrypts
+  // inline-shipped ciphertext (no S3, no backend callback).
+  AgentToolNames.LOAD_ATTACHMENT,
 ]
 
 export async function buildEnclaveSystemPrompt(params: {

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -76,7 +76,7 @@ function arrangeDispatch() {
   spyOn(EnclaveRuntimesRepository, "listLive").mockResolvedValue([EIK])
   spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([WRAP])
   spyOn(MessageRepository, "findSurrounding").mockResolvedValue([])
-  spyOn(AttachmentRepository, "findByMessageId").mockResolvedValue([])
+  spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
   spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
   spyOn(UserPreferencesService.prototype, "getPreferences").mockResolvedValue({} as never)
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ name: "Kris" }] as never)
@@ -121,6 +121,49 @@ describe("createEnclaveInvokeWorker", () => {
     expect(insertOutbox.mock.calls[0]![0]).toBe(tx)
     expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:started")
     expect(assignSession).toHaveBeenCalledTimes(1)
+  })
+
+  it("ships attachment ciphertext for the trigger AND recent history, trigger first", async () => {
+    arrangeDispatch()
+    // One prior message in the window carrying its own E2E attachment.
+    spyOn(MessageRepository, "findSurrounding").mockResolvedValue([
+      {
+        id: "msg_history",
+        authorType: "user",
+        ciphertext: Buffer.from("cipher:earlier"),
+        envelope: { v: 2, keyGeneration: 1, iv: "aXY=", aad: "YWFk" },
+      },
+      TRIGGER,
+    ] as never)
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        ["msg_trigger", [{ id: "attach_t", e2eOnly: true, sizeBytes: 10, storagePath: "p/t" }]],
+        ["msg_history", [{ id: "attach_h", e2eOnly: true, sizeBytes: 10, storagePath: "p/h" }]],
+      ]) as never
+    )
+    const getObject = mock(async (path: string) => Buffer.from(`bytes:${path}`))
+    spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue({
+      id: "session_1",
+      createdAt: new Date(),
+    } as never)
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const assignSession = mock(async (_instanceUrl: string, _assignment: unknown) => {})
+    const { io } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: { getObject } as unknown as StorageProvider,
+    })
+    await worker(JOB)
+
+    const assignment = assignSession.mock.calls[0]![1] as { attachmentCiphertexts?: unknown }
+    expect(assignment.attachmentCiphertexts).toEqual([
+      { attachmentId: "attach_t", ciphertext: Buffer.from("bytes:p/t").toString("base64") },
+      { attachmentId: "attach_h", ciphertext: Buffer.from("bytes:p/h").toString("base64") },
+    ])
   })
 
   it("parks the turn (throws for queue retry) when no live EIK holds the stream's wrap", async () => {

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -29,6 +29,20 @@ import { buildEnclaveSessionAssignment } from "./request-builder"
 /** How many prior messages of context to forward. */
 const MAX_HISTORY_MESSAGES = 30
 
+/**
+ * Caps on inline attachment shipping (the enclave can't fetch from S3, so
+ * ciphertext rides the assignment as base64). Per-file: ~16MB ciphertext
+ * (≈21MB base64) — past that no model reads it anyway. Total: ~32MB of
+ * base64 across all files, inside the enclave's 48mb `/sessions` body limit
+ * with room for history + system prompt. Files over the cap are dropped with
+ * a warn (no silent cap) and surface to the model as an "unavailable" note.
+ */
+const MAX_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
+const MAX_INLINE_TOTAL_BASE64_CHARS = 32 * 1024 * 1024
+/** Count cap, mirrored by the enclave schema's `MAX_INLINE_ATTACHMENTS` — a
+ *  flood of tiny files must not push the assignment past what it accepts. */
+const MAX_INLINE_ATTACHMENT_COUNT = 64
+
 export interface EnclaveInvokeWorkerDeps {
   pool: Pool
   io: Server
@@ -100,13 +114,22 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     // content stays ciphertext.
     const systemPrompt = await buildEnclaveSystemPrompt({ pool, stream, preferences, persona })
 
-    // Ship the trigger message's attachment ciphertext inline so the enclave can
-    // read files (it can't reach S3 — egress is backend + OpenRouter only). We
-    // can't know which attachmentIds the sealed payload references, so we ship
-    // every E2E row bound to the trigger; the enclave matches them by id to the
-    // refs it decrypts. Best-effort per file: a read failure drops that one
-    // attachment rather than failing the turn.
-    const triggerAttachmentCiphertexts = await loadTriggerAttachmentCiphertexts(pool, storage, triggerId)
+    // Ship attachment ciphertext inline so the enclave can read files (it can't
+    // reach S3 — egress is backend + OpenRouter only): the trigger's files plus
+    // recent history's, so a follow-up like "what does the file say?" still has
+    // the bytes of a file shared a few turns earlier. We can't know which
+    // attachmentIds the sealed payloads reference, so we ship every E2E row
+    // bound to those messages; the enclave matches them by id to the refs it
+    // decrypts. Budget-bounded newest-first (trigger wins), and best-effort per
+    // file: a read failure drops that one attachment rather than failing the turn.
+    const attachmentCiphertextIds = [
+      triggerId,
+      ...surrounding
+        .filter((m) => m.id !== triggerId)
+        .map((m) => m.id)
+        .reverse(),
+    ]
+    const attachmentCiphertexts = await loadAttachmentCiphertexts(pool, storage, attachmentCiphertextIds)
 
     const sid = newSessionId()
     const built = buildEnclaveSessionAssignment({
@@ -125,7 +148,7 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       },
       replySenderId: ARIADNE_AGENT_ID,
       sessionId: sid,
-      triggerAttachmentCiphertexts,
+      attachmentCiphertexts,
     })
     if (!built) {
       // Park, don't drop: no live EIK can both open the trigger and seal the
@@ -211,22 +234,32 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
 }
 
 /**
- * Read the opaque ciphertext for every E2E attachment bound to the trigger
- * message and base64-encode it for inline shipping. The backend never decrypts:
- * the per-file key is sealed inside the prompt and recovered only in the enclave.
- * Best-effort — a single unreadable object is dropped (the enclave then notes the
- * file as unavailable) rather than failing the whole turn.
+ * Read the opaque ciphertext for every E2E attachment bound to the given
+ * messages (trigger first, then newest history) and base64-encode it for
+ * inline shipping. The backend never decrypts: the per-file keys are sealed
+ * inside the messages and recovered only in the enclave. Best-effort — a
+ * single unreadable object is dropped (the enclave then notes the file as
+ * unavailable) rather than failing the whole turn.
  */
-async function loadTriggerAttachmentCiphertexts(
+async function loadAttachmentCiphertexts(
   pool: Pool,
   storage: StorageProvider,
-  triggerId: string
+  /** Message ids in shipping priority order (trigger first, then newest history). */
+  messageIds: string[]
 ): Promise<{ attachmentId: string; ciphertext: string }[]> {
-  const rows = await AttachmentRepository.findByMessageId(pool, triggerId)
-  const e2eRows = rows.filter((a) => a.e2eOnly)
+  const byMessage = await AttachmentRepository.findByMessageIds(pool, messageIds)
+  const e2eRows = messageIds.flatMap((id) => (byMessage.get(id) ?? []).filter((a) => a.e2eOnly))
   if (e2eRows.length === 0) return []
+
   const results = await Promise.all(
     e2eRows.map(async (a) => {
+      if (a.sizeBytes > MAX_INLINE_ATTACHMENT_BYTES) {
+        logger.warn(
+          { attachmentId: a.id, sizeBytes: a.sizeBytes, cap: MAX_INLINE_ATTACHMENT_BYTES },
+          "enclave dispatch: attachment exceeds inline cap; skipping"
+        )
+        return null
+      }
       try {
         const bytes = await storage.getObject(a.storagePath)
         return { attachmentId: a.id, ciphertext: bytes.toString("base64") }
@@ -236,5 +269,31 @@ async function loadTriggerAttachmentCiphertexts(
       }
     })
   )
-  return results.filter((r): r is { attachmentId: string; ciphertext: string } => r !== null)
+  const loaded = results.filter((r): r is { attachmentId: string; ciphertext: string } => r !== null)
+
+  // Total cap: keep the assignment inside the enclave's body limit. `loaded`
+  // preserves priority order (trigger first, then newest history), so when the
+  // budget runs out it's the oldest files that drop — with a warn, never
+  // silently. A dropped file surfaces to the model as an "unavailable" note.
+  const shipped: { attachmentId: string; ciphertext: string }[] = []
+  let totalChars = 0
+  for (const item of loaded) {
+    if (shipped.length >= MAX_INLINE_ATTACHMENT_COUNT) {
+      logger.warn(
+        { attachmentId: item.attachmentId, cap: MAX_INLINE_ATTACHMENT_COUNT },
+        "enclave dispatch: inline attachment count cap reached; skipping remaining file"
+      )
+      continue
+    }
+    if (totalChars + item.ciphertext.length > MAX_INLINE_TOTAL_BASE64_CHARS) {
+      logger.warn(
+        { attachmentId: item.attachmentId, totalChars, cap: MAX_INLINE_TOTAL_BASE64_CHARS },
+        "enclave dispatch: inline attachment budget exhausted; skipping remaining file"
+      )
+      continue
+    }
+    shipped.push(item)
+    totalChars += item.ciphertext.length
+  }
+  return shipped
 }

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -107,7 +107,7 @@ describe("buildEnclaveSessionAssignment", () => {
     expect(buildEnclaveSessionAssignment(inputs())!.assignment).not.toHaveProperty("attachmentCiphertexts")
 
     const withFiles = buildEnclaveSessionAssignment(
-      inputs({ triggerAttachmentCiphertexts: [{ attachmentId: "attach_1", ciphertext: "Y2lwaGVy" }] })
+      inputs({ attachmentCiphertexts: [{ attachmentId: "attach_1", ciphertext: "Y2lwaGVy" }] })
     )
     expect(withFiles!.assignment.attachmentCiphertexts).toEqual([{ attachmentId: "attach_1", ciphertext: "Y2lwaGVy" }])
   })

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -49,7 +49,7 @@ export interface BuildInvokeInputs {
    * them); the enclave matches them to the decrypted `attachmentRefs` by id and
    * opens them with the sealed per-file key. Empty/omitted → no attachments.
    */
-  triggerAttachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
+  attachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
 }
 
 export interface BuiltEnclaveInvoke {
@@ -111,10 +111,10 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     // NULL = unrestricted → omit the field (the enclave then builds its full
     // web surface, today's behavior).
     ...(e2e.allowedToolCategories ? { allowedToolCategories: e2e.allowedToolCategories } : {}),
-    // Trigger-message attachment ciphertext, shipped inline so the enclave reads
-    // files without an S3 egress. Omitted when there are none.
-    ...(inputs.triggerAttachmentCiphertexts && inputs.triggerAttachmentCiphertexts.length > 0
-      ? { attachmentCiphertexts: inputs.triggerAttachmentCiphertexts }
+    // Attachment ciphertext (trigger + recent history), shipped inline so the
+    // enclave reads files without an S3 egress. Omitted when there are none.
+    ...(inputs.attachmentCiphertexts && inputs.attachmentCiphertexts.length > 0
+      ? { attachmentCiphertexts: inputs.attachmentCiphertexts }
       : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
     // Clear metadata for the enclave's "Triggered by" CONTEXT step; the body is

--- a/apps/enclave/src/agent/attachment-tool.ts
+++ b/apps/enclave/src/agent/attachment-tool.ts
@@ -1,0 +1,112 @@
+import { z } from "zod"
+import { AgentStepTypes } from "@threa/types"
+import { base64ToBytes, bytesToBase64, decryptAttachmentBytes, type AttachmentRef } from "@threa/crypto"
+import { defineAgentTool, type AgentTool, type AgentToolResult } from "@threa/agent-runtime/runtime"
+
+/**
+ * Everything the enclave holds about this turn's attachments: the refs
+ * (per-file key/iv/filename/mime, decrypted out of each message's sealed
+ * payload) and the opaque ciphertext the backend shipped inline (the enclave
+ * can't reach S3 — egress is backend + OpenRouter only).
+ */
+export interface EnclaveAttachmentStore {
+  refsById: Map<string, AttachmentRef>
+  ciphertextById: Map<string, string>
+}
+
+const LoadAttachmentSchema = z.object({
+  attachmentId: z.string().describe("The attachment id from an [Attached: …] note in the conversation"),
+})
+
+/**
+ * The enclave's `load_attachment`: same tool name the main-app agent has, but
+ * sourced entirely in-process — ref + ciphertext travel with the turn, and the
+ * decrypt happens next to the model call, so plaintext never leaves the
+ * enclave. History messages carry `[Attached: "name" (id)]` notes instead of
+ * auto-fed bytes; the model calls this when it actually needs a file, which
+ * keeps multi-turn token cost proportional to use.
+ *
+ * Deliberately NOT gated by the stream's tool-privacy policy: these files are
+ * the conversation's own content (their refs already ride the messages the
+ * model reads), not workspace reads or web egress.
+ */
+export function createEnclaveLoadAttachmentTool(store: EnclaveAttachmentStore): AgentTool {
+  return defineAgentTool({
+    name: "load_attachment",
+    description: `Load a file attached to this conversation so you can read it. Use the attachment id from the [Attached: "filename" (attachment id)] note on the message that shared it.
+
+Works for any attached file: images and PDFs are loaded for direct viewing; text files (markdown, code, CSV, logs) return their contents.`,
+    inputSchema: LoadAttachmentSchema,
+
+    execute: async (input): Promise<AgentToolResult> => {
+      const ref = store.refsById.get(input.attachmentId)
+      const ciphertext = store.ciphertextById.get(input.attachmentId)
+      if (!ref || !ciphertext) {
+        return {
+          output: JSON.stringify({
+            error: "Attachment not available in this conversation (unknown id, or the file was too large to ship)",
+            attachmentId: input.attachmentId,
+          }),
+        }
+      }
+
+      let bytes: Uint8Array
+      try {
+        bytes = await decryptAttachmentBytes({ ciphertext: base64ToBytes(ciphertext), key: ref.key, iv: ref.iv })
+      } catch {
+        return {
+          output: JSON.stringify({ error: "Attachment could not be decrypted", attachmentId: input.attachmentId }),
+        }
+      }
+
+      if (ref.mimeType.startsWith("image/")) {
+        return {
+          output: `Image loaded: ${ref.filename} (${ref.mimeType})`,
+          multimodal: [{ type: "image", url: `data:${ref.mimeType};base64,${bytesToBase64(bytes)}` }],
+        }
+      }
+      if (ref.mimeType === "application/pdf") {
+        return {
+          output: `File loaded: ${ref.filename} (${ref.mimeType})`,
+          multimodal: [
+            { type: "file", data: bytesToBase64(bytes), mediaType: ref.mimeType, filename: ref.filename },
+          ],
+        }
+      }
+
+      // Anything else: valid UTF-8 (markdown, code, CSV — browsers report no
+      // MIME for most of these, so the ref often says octet-stream) returns its
+      // contents; true binary is an honest error instead of a request the
+      // provider would reject.
+      const text = decodeUtf8(bytes)
+      if (text !== null) {
+        return { output: `Contents of "${ref.filename}":\n\n${text}` }
+      }
+      return {
+        output: JSON.stringify({
+          error: `Attachment is a binary format (${ref.mimeType}) that can't be read directly`,
+          attachmentId: input.attachmentId,
+        }),
+      }
+    },
+
+    trace: {
+      stepType: AgentStepTypes.TOOL_CALL,
+      formatContent: (input, result) => {
+        if (result.multimodal && result.multimodal.length > 0) {
+          return `Loaded attachment: ${(input as { attachmentId: string }).attachmentId}`
+        }
+        return result.output
+      },
+    },
+  })
+}
+
+/** Strict UTF-8 decode: returns null for bytes that aren't valid UTF-8 (binary). */
+export function decodeUtf8(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+  } catch {
+    return null
+  }
+}

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -349,6 +349,118 @@ describe("runEnclaveTurn", () => {
     ])
   })
 
+  it("loads a HISTORY attachment on demand via load_attachment (note → tool call → contents)", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+
+    // A file shared two turns ago: its ref rides the history message's sealed
+    // payload; the backend shipped its ciphertext inline alongside the trigger's.
+    const fileKey = generateStreamKey()
+    const sealed = await sealMessage({
+      key: fileKey,
+      keyGeneration: ATTACHMENT_KEY_GENERATION,
+      payload: utf8Encode("# Plan\n\nship it"),
+      aad: ATTACHMENT_AAD,
+    })
+    const ref: AttachmentRef = {
+      attachmentId: "attach_hist",
+      key: bytesToBase64(fileKey),
+      iv: sealed.envelope.iv,
+      filename: "plan.md",
+      mimeType: "application/octet-stream",
+      sizeBytes: 16,
+    }
+    const history = [
+      await sealUnder(ssk, serializeSealedPayload("here's the plan", [ref]), "msg_old", "usr_owner"),
+    ].map((m) => ({ ...m, role: "user" as const }))
+    const prompt = await sealUnder(ssk, "what does the plan file say?", "msg_user", "usr_owner")
+
+    // Turn script: the model asks for the file, then replies.
+    const chat = stubChat([
+      toolCallReply("load_attachment", { attachmentId: "attach_hist" }),
+      textReply("It says: ship it."),
+    ])
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({
+        wraps: [wrap],
+        prompt,
+        history,
+        attachmentCiphertexts: [{ attachmentId: "attach_hist", ciphertext: bytesToBase64(sealed.ciphertext) }],
+      })
+    )
+
+    // First call: the history message carries the id-bearing note (not the bytes),
+    // and load_attachment is offered even with no web tools configured.
+    const first = chat.seen[0]!
+    const historyMsg = first.messages.find((m) => m.role === "user" && typeof m.content === "string" && m.content.includes("plan"))
+    expect(historyMsg?.content).toBe('here\'s the plan\n\n[Attached: "plan.md" (attach_hist)]')
+    expect(first.tools?.map((t) => t.function.name)).toEqual(expect.arrayContaining(["load_attachment"]))
+
+    // Second call: the tool result carries the decrypted contents (inside the
+    // runtime's untrusted-output trust boundary wrapper).
+    const second = chat.seen[1]!
+    const toolMsg = second.messages.find((m) => m.role === "tool")
+    expect(toolMsg?.content).toContain('Contents of "plan.md":\n\n# Plan\n\nship it')
+  })
+
+  it("inlines a UTF-8 text file as contents and degrades a binary blob to a note", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+
+    const encryptFile = async (bytes: Uint8Array, mimeType: string, filename: string, attachmentId: string) => {
+      const fileKey = generateStreamKey()
+      const sealed = await sealMessage({
+        key: fileKey,
+        keyGeneration: ATTACHMENT_KEY_GENERATION,
+        payload: bytes,
+        aad: ATTACHMENT_AAD,
+      })
+      const ref: AttachmentRef = {
+        attachmentId,
+        key: bytesToBase64(fileKey),
+        iv: sealed.envelope.iv,
+        filename,
+        mimeType,
+        sizeBytes: bytes.length,
+      }
+      return { ref, ciphertext: bytesToBase64(sealed.ciphertext) }
+    }
+
+    // Browsers report no MIME for .md, so the ref says octet-stream — the
+    // enclave must still recognize valid UTF-8 and inline it as text.
+    const md = await encryptFile(utf8Encode("# Notes\n\nremember the milk"), "application/octet-stream", "notes.md", "attach_md")
+    // 0xFF 0xFE… is not valid UTF-8 → genuinely binary, no model-readable form.
+    const bin = await encryptFile(new Uint8Array([0xff, 0xfe, 0x00, 0x01]), "application/octet-stream", "blob.bin", "attach_bin")
+
+    const prompt = await sealUnder(ssk, serializeSealedPayload("read these", [md.ref, bin.ref]), "msg_user", "usr_owner")
+    const chat = stubChat(textReply("done"))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep },
+      baseRequest({
+        wraps: [wrap],
+        prompt,
+        attachmentCiphertexts: [
+          { attachmentId: "attach_md", ciphertext: md.ciphertext },
+          { attachmentId: "attach_bin", ciphertext: bin.ciphertext },
+        ],
+      })
+    )
+
+    // No media parts → the whole turn collapses to one plain string: the user
+    // text, the inlined file contents, and the binary note.
+    const userMsg = chat.seen[0]?.messages.find((m) => m.role === "user")
+    expect(userMsg?.content).toBe(
+      'read these\n\nContents of attached file "notes.md":\n\n# Notes\n\nremember the milk\n\n[Attachment "blob.bin" (application/octet-stream) is a binary format I can\'t read directly]'
+    )
+  })
+
   it("notes an attachment whose ciphertext the backend couldn't ship, without failing the turn", async () => {
     const keyPair = await createEnclaveKeyPair()
     const ssk = generateStreamKey()

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -28,6 +28,7 @@ import type { RawChatFn } from "../llm"
 import { createEnclaveAI, type UsageAccumulator } from "./enclave-ai"
 import { EnclaveTraceObserver } from "./trace-observer"
 import { buildEnclaveTools } from "./tools"
+import { decodeUtf8 } from "./attachment-tool"
 
 /**
  * The agent turn, run entirely inside the enclave next to decrypted plaintext.
@@ -108,16 +109,21 @@ export async function runEnclaveTurn(
     sskByGeneration.set(wrap.keyGeneration, await unwrap(keyPair, request.streamId, wrap))
   }
 
-  // Inline attachment ciphertext for the trigger, keyed by id. The backend
-  // shipped these because the enclave can't reach S3; the per-file key lives in
-  // the decrypted payload, not here.
+  // Inline attachment ciphertext (trigger + recent history), keyed by id. The
+  // backend shipped these because the enclave can't reach S3; the per-file key
+  // lives in the decrypted payloads, not here.
   const ciphertextById = new Map((request.attachmentCiphertexts ?? []).map((a) => [a.attachmentId, a.ciphertext]))
+  // Every ref the conversation mentions, decrypted out of the sealed payloads —
+  // together with `ciphertextById` this powers the `load_attachment` tool.
+  const refsById = new Map<string, AttachmentRef>()
 
   // Open the history this enclave is entitled to. Generations predating our
   // invite have no wrap; that history is skipped rather than fatal. Strip the
   // sealed-payload wrapper so the model sees clean markdown (not the JSON
-  // envelope) for any message that carried attachments; note the filenames so
-  // the model has context, but we only fetch+feed bytes for the trigger.
+  // envelope) for any message that carried attachments; an `[Attached: …]`
+  // note (with the attachment id) tells the model what's there, and it pulls
+  // the actual bytes on demand via `load_attachment` — only the trigger's
+  // files are fed eagerly.
   const messages: ModelMessage[] = []
   for (const item of request.history) {
     const ssk = sskByGeneration.get(item.envelope.keyGeneration)
@@ -128,6 +134,7 @@ export async function runEnclaveTurn(
       ciphertext: base64ToBytes(item.ciphertext),
     })
     const { contentMarkdown, attachmentRefs } = parseSealedPayload(raw)
+    for (const ref of attachmentRefs) refsById.set(ref.attachmentId, ref)
     messages.push({ role: item.role, content: withAttachmentNote(contentMarkdown, attachmentRefs) })
   }
 
@@ -139,6 +146,7 @@ export async function runEnclaveTurn(
     ciphertext: base64ToBytes(request.prompt.ciphertext),
   })
   const { contentMarkdown: promptText, attachmentRefs: promptRefs } = parseSealedPayload(promptRaw)
+  for (const ref of promptRefs) refsById.set(ref.attachmentId, ref)
   const promptContent = await buildUserContent(promptText, promptRefs, ciphertextById)
   messages.push({ role: "user", content: promptContent } as ModelMessage)
 
@@ -183,6 +191,9 @@ export async function runEnclaveTurn(
       // Per-stream policy travels on the assignment, not in `deps.tools` (which
       // is the enclave's own capability config, e.g. whether it has a Tavily key).
       allowedCategories: request.allowedToolCategories,
+      // Conversation-local file access for `load_attachment` (ungated; the
+      // refs already ride the messages the model reads).
+      attachments: { refsById, ciphertextById },
     }),
     observers: [traceObserver],
     maxTokens: request.maxTokens,
@@ -270,11 +281,23 @@ async function buildUserContent(
     }
     try {
       const bytes = await decryptAttachmentBytes({ ciphertext: base64ToBytes(ct), key: ref.key, iv: ref.iv })
-      const b64 = bytesToBase64(bytes)
       if (ref.mimeType.startsWith("image/")) {
-        media.push({ type: "image", image: `data:${ref.mimeType};base64,${b64}` })
+        media.push({ type: "image", image: `data:${ref.mimeType};base64,${bytesToBase64(bytes)}` })
+      } else if (ref.mimeType === "application/pdf") {
+        // The one non-image format models read natively as a `file` part.
+        media.push({ type: "file", data: bytesToBase64(bytes), mediaType: ref.mimeType, filename: ref.filename })
       } else {
-        media.push({ type: "file", data: b64, mediaType: ref.mimeType, filename: ref.filename })
+        // Everything else: if it's valid UTF-8 (markdown, code, CSV, logs —
+        // browsers report no MIME for most of these, so the ref often says
+        // `application/octet-stream`), inline it as text. A binary blob the
+        // model can't read degrades to a note instead of a request the
+        // provider would reject.
+        const text = decodeUtf8(bytes)
+        if (text !== null) {
+          notes.push(`Contents of attached file "${ref.filename}":\n\n${text}`)
+        } else {
+          notes.push(`[Attachment "${ref.filename}" (${ref.mimeType}) is a binary format I can't read directly]`)
+        }
       }
     } catch {
       notes.push(`[Attachment "${ref.filename}" could not be decrypted]`)
@@ -289,12 +312,12 @@ async function buildUserContent(
 }
 
 /**
- * History attachments aren't fetched (trigger-only this slice), but the model
- * should still know a file was shared — append the filenames as a text note.
+ * History attachments aren't auto-fed — the model should know a file is there
+ * and pull it on demand: note each filename with the id `load_attachment` takes.
  */
 function withAttachmentNote(contentMarkdown: string, refs: AttachmentRef[]): string {
   if (refs.length === 0) return contentMarkdown
-  const note = `[Attached: ${refs.map((r) => r.filename).join(", ")}]`
+  const note = refs.map((r) => `[Attached: "${r.filename}" (${r.attachmentId})]`).join("\n")
   return contentMarkdown.length > 0 ? `${contentMarkdown}\n\n${note}` : note
 }
 

--- a/apps/enclave/src/agent/tools.ts
+++ b/apps/enclave/src/agent/tools.ts
@@ -8,6 +8,7 @@ import {
 import type { AgentRuntimeAI } from "@threa/agent-runtime/runtime"
 import { isToolCategoryAllowed, type ToolPrivacyCategory } from "@threa/types"
 import type { LanguageModel } from "ai"
+import { createEnclaveLoadAttachmentTool, type EnclaveAttachmentStore } from "./attachment-tool"
 
 /**
  * The enclave-safe tool surface for an E2E turn.
@@ -41,13 +42,24 @@ export interface EnclaveToolDeps {
    * — a pure model turn that can still reply (`send_message` is never gated).
    */
   allowedCategories?: ToolPrivacyCategory[]
+  /**
+   * This turn's attachment refs + inline ciphertext, powering `load_attachment`.
+   * The tool is NOT behind the privacy gate: the files are the conversation's
+   * own content (their refs already ride the messages the model reads), not
+   * workspace reads or web egress.
+   */
+  attachments?: EnclaveAttachmentStore
 }
 
 export function buildEnclaveTools(deps: EnclaveToolDeps): AgentTool[] {
-  // The owner's policy may forbid web egress for this scratchpad. Since the
-  // enclave's entire surface (web_search, read_url, general_research) is web,
-  // that collapses to "no tools" — honest about the privacy the stream keeps.
-  if (!isToolCategoryAllowed(deps.allowedCategories, "web")) return []
+  // Conversation-local tools live outside the privacy gate (see `attachments`).
+  const localTools: AgentTool[] = deps.attachments ? [createEnclaveLoadAttachmentTool(deps.attachments)] : []
+
+  // The owner's policy may forbid web egress for this scratchpad. The enclave's
+  // entire *web* surface (web_search, read_url, general_research) then drops,
+  // leaving only the conversation-local tools — honest about the privacy the
+  // stream keeps without crippling files the model was already shown.
+  if (!isToolCategoryAllowed(deps.allowedCategories, "web")) return localTools
 
   // The web primitives, built fresh on demand. The top-level loop and the
   // research sub-loop each get their OWN instances (the sub-loop runs the same
@@ -74,5 +86,5 @@ export function buildEnclaveTools(deps: EnclaveToolDeps): AgentTool[] {
       ),
   })
 
-  return [...webTools(), research]
+  return [...localTools, ...webTools(), research]
 }

--- a/apps/enclave/src/index.ts
+++ b/apps/enclave/src/index.ts
@@ -52,7 +52,10 @@ async function main() {
   app.post(
     "/sessions",
     requireInternalKey(config.internalApiKey),
-    express.json({ limit: "4mb" }),
+    // Sized for inline attachment ciphertext: the dispatch worker caps what it
+    // ships at ~32MB of base64 (per-file + total caps in
+    // `loadAttachmentCiphertexts`), plus history + system prompt.
+    express.json({ limit: "48mb" }),
     createSessionsHandler({
       keyPair,
       rawChat,

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -18,7 +18,7 @@ import {
 import { createEnclaveKeyPair, type EnclaveKeyPair } from "./keystore"
 import type { BackendCallbacks } from "./agent/backend-callbacks"
 import type { RawChatFn } from "./llm"
-import { createCancelHandler, createSessionsHandler, requireInternalKey } from "./sessions"
+import { createCancelHandler, createSessionsHandler, requireInternalKey, sessionAssignmentSchema } from "./sessions"
 
 const STREAM_ID = "stream_x"
 const GEN = 0
@@ -258,5 +258,23 @@ describe("createCancelHandler validation", () => {
     const res = fakeRes()
     handler({ params: {} } as unknown as Request, res)
     expect(res.statusCode).toBe(400)
+  })
+})
+
+describe("sessionAssignmentSchema", () => {
+  it("preserves attachmentCiphertexts through parse (zod strips undeclared keys)", async () => {
+    // Regression: the first attachment slice shipped with this field missing
+    // from the schema — the backend sent the bytes and this parse silently
+    // deleted them, so every file reached the model as "unavailable".
+    const keyPair = await createEnclaveKeyPair()
+    const assignment = await assignmentFor(keyPair, generateStreamKey(), "read the file")
+    const withAttachments = {
+      ...assignment,
+      attachmentCiphertexts: [{ attachmentId: "attach_1", ciphertext: "b64bytes" }],
+    }
+
+    const parsed = sessionAssignmentSchema.parse(withAttachments)
+
+    expect(parsed.attachmentCiphertexts).toEqual([{ attachmentId: "attach_1", ciphertext: "b64bytes" }])
   })
 })

--- a/apps/enclave/src/sessions.ts
+++ b/apps/enclave/src/sessions.ts
@@ -29,6 +29,13 @@ const MAX_WRAP_RECIPIENTS = 64
 const MAX_SYSTEM_PROMPT_CHARS = 100_000
 const MAX_MODEL_ID_CHARS = 200
 const MAX_COMPLETION_TOKENS = 32_000
+/**
+ * Upper bound on inline-shipped files per assignment (trigger + recent
+ * history). Matches the dispatch worker's own count cap — the byte budget
+ * usually binds first, but a flood of tiny files must not reject the whole
+ * assignment.
+ */
+const MAX_INLINE_ATTACHMENTS = 64
 
 const streamEnvelopeSchema = z.object({
   v: z.number(),
@@ -93,6 +100,20 @@ export const sessionAssignmentSchema = z.object({
       authorType: z.enum(AUTHOR_TYPES),
       createdAt: z.string().min(1),
     })
+    .optional(),
+  /**
+   * Inline ciphertext for the conversation's attachments (base64; the
+   * trigger's plus recent history's), keyed by attachment id — the enclave
+   * can't reach S3 (egress is backend + OpenRouter only), so the backend
+   * relays the opaque bytes and the per-file keys arrive sealed inside the
+   * messages. MUST be declared here: Zod strips unknown keys, and omitting
+   * this is exactly how the first attachment slice shipped broken — the
+   * backend sent the bytes and this parse silently deleted them, so every
+   * file showed up as "unavailable".
+   */
+  attachmentCiphertexts: z
+    .array(z.object({ attachmentId: z.string().min(1), ciphertext: z.string().min(1) }))
+    .max(MAX_INLINE_ATTACHMENTS)
     .optional(),
 })
 

--- a/docs/features/public/e2e-encrypted-scratchpads.md
+++ b/docs/features/public/e2e-encrypted-scratchpads.md
@@ -100,11 +100,14 @@ known-missing tally, kept current as gaps close:
   per-file key recovered from the message — never the server's placeholder row.
   **Ariadne reads them too:** the backend relays the opaque ciphertext to the
   enclave (which can't reach S3), the enclave decrypts in memory with the sealed
-  per-file key, and feeds images/PDFs straight to the (vision-capable) model — so
-  asking Ariadne about an attached PDF or screenshot works, the same as a plaintext
-  scratchpad. Today this covers the attachments on the message you send (not files
-  shared several turns earlier). Server-side processing (image captioning, PDF text,
-  transcoding) stays off by design — the *server* still can't read the content.
+  per-file key, and feeds images/PDFs straight to the (vision-capable) model;
+  text-ish files (markdown, code, CSV — anything valid UTF-8) are inlined as
+  text. The message you send feeds its files eagerly; files from earlier turns
+  surface as `[Attached: …]` notes the model pulls on demand through its
+  in-enclave `load_attachment` tool (same name as the main app's, but sourced
+  from the inline-shipped ciphertext — never S3, never a backend callback).
+  Server-side processing (image captioning, PDF text, transcoding) stays off by
+  design — the *server* still can't read the content.
 - **Interjections are picked up after the current turn, not folded into it.** If you
   send a message while Ariadne is mid-turn, it isn't ignored: when the running turn
   finishes, a follow-up turn automatically runs for the message(s) that arrived

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -647,14 +647,21 @@ export class AgentRuntime {
         // Tool result → LLM
         resultParts.push(makeToolResult(tc, protectToolOutputText(toolResult.output)))
 
-        // Multimodal images → injected as user messages
+        // Multimodal media → injected as user messages (tool results are
+        // text-only on the wire; images/files must ride a user turn).
         if (toolResult.multimodal && toolResult.multimodal.length > 0) {
           extraMessages.push({
             role: "user",
-            content: toolResult.multimodal.map((img) => ({
-              type: "image" as const,
-              image: img.url,
-            })),
+            content: toolResult.multimodal.map((m) =>
+              m.type === "image"
+                ? { type: "image" as const, image: m.url }
+                : {
+                    type: "file" as const,
+                    data: m.data,
+                    mediaType: m.mediaType,
+                    ...(m.filename ? { filename: m.filename } : {}),
+                  }
+            ),
           })
         }
       } catch (error) {

--- a/packages/agent-runtime/src/runtime/agent-tool.ts
+++ b/packages/agent-runtime/src/runtime/agent-tool.ts
@@ -9,8 +9,16 @@ import type { AgentStepType, TraceSource, SourceItem } from "@threa/types"
 export interface AgentToolResult {
   /** What the LLM sees as the tool result */
   output: string
-  /** Images for vision models — injected as user messages */
-  multimodal?: Array<{ type: "image"; url: string }>
+  /**
+   * Media for vision/file-capable models — injected as user messages, since
+   * tool results themselves are text-only on the chat-completions wire.
+   * `image` carries a data URL (or https URL); `file` carries raw base64 +
+   * media type (e.g. a PDF the model reads natively).
+   */
+  multimodal?: Array<
+    | { type: "image"; url: string }
+    | { type: "file"; data: string; mediaType: string; filename?: string }
+  >
   /** Citation sources accumulated and attached to sent messages */
   sources?: SourceItem[]
   /** Injected into system prompt on next iteration (workspace research context) */

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -602,13 +602,16 @@ export interface EnclaveSessionAssignment {
    */
   allowedToolCategories?: ToolPrivacyCategory[]
   /**
-   * Opaque ciphertext for the trigger message's attachments, shipped INLINE so
-   * the enclave can read files without widening its egress to S3 (it stays pinned
-   * to the backend + OpenRouter). The backend can't read the per-file key — it's
-   * sealed inside the prompt — so it ships every E2E attachment row bound to the
-   * trigger; the enclave matches `attachmentId` to the decrypted `attachmentRefs`,
-   * decrypts with the sealed key/iv, and feeds the bytes to the (vision/PDF-capable)
-   * model. Omitted when the trigger has no attachments.
+   * Opaque ciphertext for the conversation's attachments (the trigger's plus
+   * recent history's, budget-bounded newest-first), shipped INLINE so the
+   * enclave can read files without widening its egress to S3 (it stays pinned
+   * to the backend + OpenRouter). The backend can't read the per-file keys —
+   * they're sealed inside the messages — so it ships every E2E attachment row
+   * bound to those messages; the enclave matches `attachmentId` to the
+   * decrypted `attachmentRefs`, decrypts with the sealed key/iv, and feeds the
+   * trigger's files to the (vision/PDF-capable) model eagerly while history
+   * files load on demand via its `load_attachment` tool. Omitted when there
+   * are none.
    */
   attachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
 }

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -229,6 +229,11 @@ async function main() {
         `CONTROL_PLANE_URL:http://localhost:${controlPlanePort}`,
         "--var",
         `REGIONS:${regionsJson}`,
+        // Without this the router's `resolveRegion` control-plane lookup is
+        // skipped entirely and EVERY uncached workspace 404s ("Workspace not
+        // found") — the same shared secret the backend + control-plane get.
+        "--var",
+        `INTERNAL_API_KEY:${backendEnv.INTERNAL_API_KEY ?? "dev-internal-key"}`,
       ],
       {
         cwd: routerDir,


### PR DESCRIPTION
## The bug (why Ariadne couldn't read any encrypted attachment)

The enclave attachment slice (#765) **never worked in integration**: `sessionAssignmentSchema` in `apps/enclave/src/sessions.ts` was missing `attachmentCiphertexts`, and **Zod strips unknown keys** — the backend shipped the bytes, the enclave's request parse silently deleted them, and every file reached the model as `[Attachment "…" is unavailable]`. (The schema's own doc comments warn about exactly this failure mode for two other fields.)

The slice's 45 tests were green because they called `runEnclaveTurn` directly, bypassing the HTTP parse that broke it. Confirmed live with debug taps in dev: backend logged `loaded … bytes: 17668`, enclave logged `shipped: []`.

A second finding from Kris's testing ("it's not PDFs, it's all files"): browsers report **no MIME type** for `.md`/code/CSV files, so their refs say `application/octet-stream` — which no model accepts as a `file` part even once the bytes arrive.

## What this PR does

**Delivery (the root-cause fix)**
- Declare `attachmentCiphertexts` in the enclave schema + a regression test that round-trips the assignment through `sessionAssignmentSchema.parse` so the next undeclared field can't ship silently.
- `/sessions` body limit 4mb → 48mb, with matching worker-side budgets: 16MB/file, ~32MB base64 + 64-file total, dropped files always `logger.warn`'d (no silent caps) and surfaced to the model as "unavailable" notes.

**Trigger files feed eagerly** (as before, plus):
- images → image parts, PDFs → file parts (unchanged)
- **new:** anything valid UTF-8 (strict `TextDecoder`) is inlined as text contents — covers the no-MIME reality of markdown/code/CSV; true binary degrades to an honest note instead of a request the provider would reject.

**History files load on demand — `load_attachment` (Kris's call)**
- The worker now ships ciphertext for the trigger **plus recent history** (newest-first priority within the budget).
- History messages carry `[Attached: "name" (attachment id)]` notes instead of auto-fed bytes (token cost proportional to use), and a new **in-enclave `load_attachment` tool** decrypts the inline-shipped ciphertext next to the model call — never S3, never a backend callback. Same tool name as the main app's, added to `ENCLAVE_ENABLED_TOOLS` for prompt parity.
- Deliberately **outside the stream's tool-privacy gate**: the files are the conversation's own content (their refs already ride the messages the model reads), not workspace reads or web egress — so a web-restricted scratchpad can still read its own files.
- `AgentToolResult.multimodal` gains a `file` variant (runtime injection maps it to an AI-SDK file part) so a tool can hand the model a PDF, not just images. The main app's image-only `load_attachment` is unaffected.

**Test-infra fix**
- `scripts/dev-test.ts` never passed `INTERNAL_API_KEY` to the wrangler workspace-router, so `resolveRegion` was skipped and every uncached workspace 404'd ("Workspace not found"). One `--var` fixes dev:test for everyone.

## Verification

Beyond units (enclave 48, backend enclave-runtimes 56, agent-runtime 141, all typechecks):

**Live end-to-end via dev:test + Playwright + real OpenRouter inference** —
1. Fresh user → workspace → **New Encrypted Scratchpad** → passphrase setup.
2. Uploaded a `.md` file (ref mime: `application/octet-stream`) + asked for specifics → Ariadne replied: *"The launch codename is **VELVET-OTTER-99**, and the most important rule is: 'never deploy on a Friday.'"* — exact file contents, sealed end-to-end.
3. Follow-up turn (**no attachment on the trigger**): "What were the two key dates listed in that file?" → *"Code freeze: June 12, Launch: June 19"* — facts that appear in no message text, and the session trace shows the `tool_call` step where she loaded the history file.

Debug taps used for diagnosis were removed before commit.

## Notes for review

- The enclave's `load_attachment` being ungated by tool privacy is a deliberate judgment call (reasoning above + in code comments) — flag if you disagree.
- Known follow-ups (unchanged scope): very large files fall back to "unavailable" notes rather than a backend-proxy fetch; mid-turn reconsideration; PR9 workspace tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783203981&installation_id=129946197&pr_number=778&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F778&signature=8fa09c638508533532b1518760e50b44a23a69123c2b036d8d753c7f3a0660e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->