### PR TITLE
docs: e2ee/enclave audit + agent-runtime pluggability design (for remote agents)

### DIFF
--- a/docs/audits/e2ee-enclave-audit-2026-06.md
+++ b/docs/audits/e2ee-enclave-audit-2026-06.md
@@ -1,0 +1,306 @@
+# E2EE Scratchpads + Enclave Audit — June 2026
+
+- **Date:** 2026-06-05
+- **Code state:** `origin/main` @ `dce35288`, plus branch `e2e-enclave-attachment-delivery` @ `e717a5bf` (PR #778) for attachment-path findings.
+- **Method:** multi-agent audit — 6 dimension finders (sources, lifecycle, attachments, bot-api, frontend-states, server-features) → dedup → adversarial verification (2 independent refuters for high/critical findings, refute-by-default) → orthogonal completeness critic with its own verified leads. 48 agents total. Every confirmed finding survived at least one adversarial verifier that independently re-read the cited code.
+- **Scope:** Part I — security, state integrity, and missing states. **Part II (below)** — UX parity: does encrypted Ariadne *feel* like normal Ariadne?
+- **Line numbers** are as of the audited commits and will drift; treat them as starting points, the file paths and symbol names as the durable reference.
+
+Reference findings as `E2EE-<n>` in PRs and review notes.
+
+## Summary
+
+26 confirmed findings: 6 critical, 6 high, 11 medium, 3 low (two lows folded into one entry). 2 findings were refuted in verification (kept at the bottom — the refutations themselves are informative).
+
+The two big themes:
+
+1. **The plaintext-into-sealed-stream invariant is enforced only at some HTTP handlers, not at the sink.** `EventService.createMessage/editMessage` accepts plaintext for any stream, and four reachable paths exploit that — one from the normal product UI (E2EE-1..5).
+2. **Key lifecycle has unrecoverable dead ends.** Passphrase rotation strands every existing stream; a parked turn under an old key generation can never be revived (E2EE-6, E2EE-7).
+
+### Suggested fix order
+
+| Group | Findings | Theme |
+| --- | --- | --- |
+| 1 | E2EE-1, 2, 3, 4, 5 | Sink-level E2E guard in EventService + close the four plaintext leaks |
+| 2 | E2EE-6, 7 | Stranded-data criticals: rotation re-wrap, old-generation revive |
+| 3 | E2EE-8, 12, 13, 25 | "Ariadne looks dead": parked-turn visibility, DLQ hook, crash re-dispatch, fail callback |
+| 4 | E2EE-9, 14 | Sources through the sealed payload (replies + trace steps) |
+| 5 | E2EE-10, 11, 17, 18, 26b | Public bot API read gates + invocation short-circuit |
+| 6 | rest | Frontend states, push, trust-boundary hardening |
+
+---
+
+## A. Plaintext leaks into sealed streams (critical)
+
+All four leaks share one root cause, filed as its own finding (E2EE-5): the gate lives only in *some* HTTP handlers; the shared write sink does not enforce the invariant.
+
+### E2EE-1 (critical) — Editing an E2E message leaks plaintext, reachable from the normal UI
+
+The first-party message edit handler accepts plaintext `contentJson`/`contentMarkdown` with no E2E check; the frontend offers Edit on encrypted messages and submits plaintext. An edit overwrites the projection with plaintext, snapshots a plaintext version row, and broadcasts plaintext over `message:edited`.
+
+- `apps/backend/src/features/messaging/handlers.ts:403-458` — update handler: no `isE2eStream`/gate, unlike the create handler at `:288-300` which enforces the `e2eEnabled`-vs-ciphertext match.
+- `apps/backend/src/features/messaging/event-service.ts:649-744` — `editMessage` writes plaintext payload, version snapshot, projection, and outbox with no e2e awareness.
+- `apps/backend/src/features/public-api/handlers.ts:1739` — the public API *does* call `assertNotE2eStream` before its edit: proof the codebase knows edits must be blocked.
+- `apps/frontend/src/components/timeline/message-edit-form.tsx:89`, `message-event.tsx:1042` — UI submits plaintext edits for any message; Edit is offered on encrypted messages.
+
+**Fix:** reject plaintext edits on E2E streams loudly (mirror the create handler), or build a sealed-edit path (ciphertext + envelope). Frontend must gate the Edit affordance either way.
+
+### E2EE-2 (critical) — `completeBotInvocation` writes a plaintext bot reply into an E2E stream
+
+`assertNotE2eStream` guards public-API send (`handlers.ts:1659`) and update (`:1739`) but not invocation completion (`apps/backend/src/features/public-api/handlers.ts:1107-1118`), which writes plaintext via `eventService.createMessageInTransaction` into `claim.responseStreamId`. Reachable end-to-end: `inviteActor` supports `kind:"bot"` into an E2E stream (`apps/backend/src/features/streams/service.ts:763-789`, explicitly no e2eCapable gate), `message:created` outbox fires for E2E messages, and the bot-invocation outbox handler creates invocations with `responseStreamId` = the E2E stream (see E2EE-11). The completion schema (`public-api/schemas.ts:113-123`) only accepts plaintext markdown.
+
+**Fix:** run the E2E gate in `completeBotInvocation` before the insert; see also E2EE-5 (sink) and E2EE-11 (don't create the invocation in the first place).
+
+### E2EE-3 (critical) — Scheduled messages fire as server-authored plaintext into E2E streams
+
+`ensureStreamWriteAccess` checks archived/visibility/membership but never E2E (`apps/backend/src/features/scheduled-messages/service.ts:631-666`); at fire time `finalizeSendInTx` (`:510-532`) calls `createMessage` with stored plaintext. The server holds no SSK, so there is *no correct fire-time behavior* — scheduling into an E2E stream must be refused at schedule time.
+
+**Fix:** loud schedule-time rejection + frontend affordance gating for E2E streams.
+
+### E2EE-4 (critical) — Composer drafts persist plaintext to IndexedDB and survive lock
+
+Every keystroke in an E2E scratchpad composer debounce-writes plaintext `contentJson` to `db.draftMessages` (`apps/frontend/src/hooks/use-draft-composer.ts:202-208`, `use-draft-message.ts:55-64`, `db/database.ts:317`). `lock()` clears only in-memory caches (`apps/frontend/src/stores/e2e-session-store.ts:879-886`) — its comment falsely asserts the in-memory cache is the only plaintext surface. Drafts survive lock, logout, and reload, contradicting the documented lock model.
+
+**Fix:** for E2E streams, keep drafts in memory only (or seal them under the SSK before persisting) and clear them on lock.
+
+### E2EE-5 (high) — EventService has no E2E enforcement; the guarantee lives in scattered handler checks
+
+`EventService.createMessage/editMessage` accepts plaintext + optional ciphertext for any stream; its own doc comment (`event-service.ts:159-168`) says the *caller* must verify. E2EE-1/2/3 are the existing exploits; any future caller that forgets is the next one.
+
+**Fix:** enforce at the sink — plaintext write to an E2E stream throws, ciphertext write to a non-E2E stream throws. Handler-level gates stay for better error semantics; the sink is the backstop.
+
+---
+
+## B. Stuck and lost states
+
+### E2EE-6 (critical) — Passphrase rotation permanently locks every existing E2E scratchpad
+
+`rotatePassphrase` re-uploads the same keypair but the server mints a fresh `keyId` on every set (`apps/backend/src/features/user-e2e-keys/service.ts:42-69`, `apps/frontend/src/stores/e2e-session-store.ts:779-846`). Stream key resolution matches strictly on `recipientKeyId` and AAD-binds to it (`apps/frontend/src/lib/crypto/stream-key-cache.ts:323,330`). Nothing re-wraps existing stream SSKs or updates `e2e_streams.ownerUserKeyId` — no such endpoint exists. After rotation, every previously encrypted stream is silently, permanently undecryptable.
+
+**Fix:** keep the `keyId` stable across rotation (only the KEK wrap changes), or transactionally re-wrap all owned streams to the new key. At minimum refuse/warn loudly.
+
+### E2EE-7 (critical) — Parked turn under an old key generation parks forever
+
+Dispatch requires the live EIK to hold wraps for both the current *and* the trigger generation (`apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts:71-79`); revive only ever re-wraps the *current* generation (`apps/backend/src/features/streams/service.ts:1035-1040` rejects non-current with `E2E_STALE_GENERATION`; frontend computes "missing" only against current — `stream-encryption-affordance.tsx:137-139`). Enclave restart + key roll before revive ⇒ the parked turn DLQs with no API able to mint the old-generation wrap.
+
+**Fix:** revive should re-wrap every generation the owner can open (or at least any parked trigger's generation).
+
+### E2EE-8 (high) — Parked turns are invisible and DLQ exhaustion is silent
+
+No session row exists while parked, so no "Ariadne is working…" indicator for the entire backoff (~4 min over 10 retries); `ENCLAVE_INVOKE` is registered **without** an `onDLQ` hook (`apps/backend/src/server.ts:741-750`; contrast `:834,:862,:886,:900,:914`), so exhaustion is a `logger.error` and permanent user-facing silence. Contradicts the feature doc's "visible, never a silent no-reply."
+
+**Fix:** surface a pending/queued state at park time; add an `onDLQ` hook that emits a user-visible failure event with a retry affordance.
+
+### E2EE-12 (high) — Mid-turn enclave crash is terminal: orphan cleanup marks FAILED, never re-dispatches
+
+Asymmetric with the park path (which retries until a wrap appears): once RUNNING, a dead enclave means `failSessionWithLifecycle` and nothing else (`apps/backend/src/features/agents/orphan-session-cleanup.ts:108-128`); catch-up re-enqueue exists only on the *complete* path (`session-handlers.ts:467-478`).
+
+**Fix:** re-dispatch liveness-failed sessions for a live EIK instead of terminal failure.
+
+### E2EE-25 (medium) — No fail callback from the enclave; failures spin until orphan cleanup (~2 min, not the commented 60s)
+
+`runEnclaveSession` swallows every turn error into a log line (`apps/enclave/src/agent/session-runner.ts:70-80`); no `/fail` route exists. Sessions stay RUNNING with a spinning card until `ENCLAVE_RUNTIME_STALENESS_MS` (2 min — `enclave-runtimes/service.ts:11`) lets cleanup reclaim them.
+
+**Fix:** explicit fail callback so failures terminate promptly; correct the stale comment.
+
+### E2EE-13 (medium) — Orphan cleanup can race a live-but-partitioned enclave and discard its finished work
+
+Cleanup flips RUNNING→FAILED on stale heartbeat without confirming the enclave is gone (`orphan-session-cleanup.ts:39-44`); every later callback 409s (`session-handlers.ts:110-115`) and the enclave's client throws (`backend-callbacks.ts:55-63`). Replies generated after the reclaim are lost and the user sees a false failure.
+
+**Fix:** reconcile late completions idempotently (grace re-open) or verify EIK liveness before reclaiming.
+
+---
+
+## C. Sources (citation) parity
+
+### E2EE-9 (high) — Enclave replies drop all citation sources
+
+The enclave's web tools *do* return `SourceItem[]` and the shared runtime accumulates them and passes them to `sendMessage` (`packages/agent-runtime/src/runtime/agent-runtime.ts:335,396-401,719-726`) — but `run-turn.ts:214` destructures only `{ content }`. No sources field exists on `EnclaveSealedReply` (`packages/types/src/api.ts:484-488`), on `E2eSealedPayload` (`packages/crypto/src/sealed-payload.ts:14-30`), or in the backend's sealed-reply `createMessage` call (`enclave-runtimes/session-handlers.ts:177-196`). Researched E2E answers render with zero citations.
+
+**Design constraint:** sources reveal *what was researched* — they must ride **inside the sealed payload**, never the cleartext `sources` column or a plaintext wire field.
+
+### E2EE-14 (medium) — Enclave trace steps drop sources too
+
+`EnclaveTraceObserver` seals step content but discards `trace.sources` (`apps/enclave/src/agent/trace-observer.ts:116-127,160-171`); `EnclaveSealedStep` has no field; backend step writes never set the column. The E2E trace dialog shows research steps with no `SourceList`. Same sealing constraint as E2EE-9.
+
+---
+
+## D. Public bot API × E2E streams
+
+Pattern: **writes are mostly gated, reads are not** — reads degrade silently instead of failing loudly.
+
+### E2EE-10 (high) — `listMessages` returns zero-width-space placeholders for E2E streams
+
+No E2E handling on the read path (`public-api/handlers.ts:1542-1591`); `serializeMessage` (`:120-155`) maps `content = contentMarkdown` — for E2E rows that is `E2E_PLACEHOLDER_CONTENT_MARKDOWN` (U+200B, `packages/types/src/constants.ts:807`) — and the wire schema has no ciphertext field. 200 OK with lying content and no signal.
+
+**Fix:** loud `E2E_STREAM_PLAINTEXT_UNSUPPORTED`-style refusal on reads (or expose ciphertext+envelope deliberately — a design decision).
+
+### E2EE-11 (high) — Bot invocations fire on E2E streams with placeholder prompts; @-mentions silently never fire
+
+`invocation-outbox-handler.ts:82-189` has no `isE2eStream` short-circuit (contrast `agents/companion-outbox-handler.ts:114-116`). Mentions ride in ciphertext so `extractMentionSlugs` sees the placeholder ⇒ mention bots never fire (silent). Active-scratchpad bots *do* fire with a U+200B prompt, dispatching meaningless turns whose plaintext replies flow back through E2EE-2.
+
+**Fix:** `isE2eStream` short-circuit in the bot-invocation outbox handler.
+
+### E2EE-17 (medium) — `findMessagesByMetadata` mixes placeholder E2E rows into results
+
+Metadata is plaintext alongside ciphertext, so E2E rows match and serialize with placeholder content (`public-api/handlers.ts:1601-1635`). Exclude E2E streams from scope (the search service already does, via `excludedE2eStreamCount`).
+
+### E2EE-18 (medium) — Attachment endpoints serve E2E ciphertext bytes with placeholder metadata
+
+`getAttachment`/`getAttachmentDownloadUrl` (`public-api/handlers.ts:1384-1404`) hand back placeholder filename/mime and a signed URL to undecryptable bytes with no E2E flag — while upload correctly refuses with `E2E_UPLOAD_UNSUPPORTED` (`:713-718`). Mirror that refusal on reads.
+
+### E2EE-26b (low) — Public search drops `excludedE2eStreamCount`
+
+The search service returns it (`search/service.ts:55,100-115`) and the first-party handler forwards it (`search/handlers.ts:102-113`), but the public-API handler destructures only `{ results }` (`public-api/handlers.ts:1243-1269`). Automation can't tell encrypted streams were skipped.
+
+---
+
+## E. Frontend and notification states
+
+### E2EE-15 (high) — In-stream search (Cmd-F) over an unlocked E2E scratchpad silently returns zero matches
+
+Both local IDB filtering and the server ILIKE phase match the stored placeholder, never the decrypt cache (`apps/frontend/src/hooks/use-stream-search.ts:74-99,152-155`). The feature doc explicitly promises client-side keyword search works (`docs/features/public/e2e-encrypted-scratchpads.md:125`).
+
+**Fix:** search the decrypted content for unlocked streams, or show an honest "unavailable for encrypted streams" state. (Doc and code must agree.)
+
+### E2EE-16 (medium) — Saved messages from E2E streams render blank previews
+
+`resolvePreview` strips the placeholder (`apps/frontend/src/components/saved/saved-item.tsx:192-196`); the backend view ships no ciphertext (`saved-messages/view.ts:122`). The sidebar's "Encrypted message" treatment (`stream-item.tsx:165-167`) is the pattern to copy — or block saving with a reason, or ship ciphertext for client decrypt.
+
+### E2EE-19 (medium) — Saved-reminder push fires with a U+200B preview for E2E messages
+
+The activity handler deliberately suppresses E2E (`activity/outbox-handler.ts:227-230`) but the push handler consumes `saved_reminder:fired` directly with no guard (`push/outbox-handler.ts:150-157`, `push/service.ts:325-365`) — a blank notification. Render a generic "Reminder for an encrypted message" instead.
+
+### E2EE-20 (medium) — Post-key-roll history attachments vanish without a note (enclave)
+
+`run-turn.ts:128-139` skips unopenable-generation history with `continue` *before* registering `attachmentRefs` or emitting `[Attached: …]` notes, while the backend still ships those bytes (`enclave-invoke-worker.ts:250-251` has no generation filter). The model gets neither content nor a hint; the bytes are wasted. Violates the no-silent-cap discipline used everywhere else in that path.
+
+### E2EE-24 (low) — Image decrypt/network/404 failures collapse into one misleading download card
+
+Single `catch → setFailed(true)` (`apps/frontend/src/components/timeline/e2e-attachment-list.tsx:43-58`); clicking the card re-errors with a fixed "Couldn't decrypt" toast regardless of true cause; no retry for transient failures.
+
+### E2EE-26a (low) — Assign-failure flashes failed-then-started
+
+A retryable `assignSession` throw emits a terminal failed card, then the retry emits a fresh started card (`enclave-invoke-worker.ts:210-230,82-85,180-207`) — transient hiccups read as flaky. Hold the terminal card until retries are exhausted.
+
+---
+
+## F. Trust boundary (completeness-critic finds)
+
+### E2EE-21 (medium) — Session callbacks aren't bound to the owning EIK and don't validate reply generation
+
+All callbacks are gated only by the shared `INTERNAL_API_KEY` (`apps/backend/src/routes.ts:284-289`); `/messages`/`/steps` never check `session.serverId` against the caller nor that the reply envelope's `keyGeneration` is sane (`session-handlers.ts:164-198,210-279`). Any internal-key holder can inject sealed steps into any running session; a wrong-generation seal persists as a permanently undecryptable reply instead of failing loudly.
+
+### E2EE-22 (medium) — `/attestation` is decorative: registration is shared-key-only, and every "live" EIK gets SSK wraps
+
+`register.ts:13-26` carries no attestation; no backend caller verifies `/attestation` (`apps/enclave/src/index.ts:38-41`); the owner's client wraps to every live EIK (`streams/service.ts:856-865`). Any internal-key holder (e.g. the bot-runtime, which holds the same key) can register a key and become an SSK recipient. Either verify attestation at registration or document explicitly that enclave identity rests on `INTERNAL_API_KEY` secrecy.
+
+### E2EE-23 (medium) — Sealed history has no byte budget against the enclave's 48MB body cap
+
+Attachments are budgeted (16MB/file, 32MB base64 total, 64 files — `enclave-invoke-worker.ts:40-44`) but the 30 prior sealed messages + trigger are added unconditionally (`request-builder.ts:87-93,100-102`). An oversize assignment hard-fails at `express.json({limit:"48mb"})` (`apps/enclave/src/index.ts:58`) with the failure attributed to the wrong cause. Fold history into the same total budget, dropping oldest loudly.
+
+---
+
+## Refuted findings (and why the refutations matter)
+
+- **"Non-owner triggering Ariadne after enclave restart parks forever."** Refuted: the cited code is accurate (revive is owner-only at client and server), but E2E streams are owner-only by design at every layer — the harmful state is unreachable. *Becomes real if E2E streams ever gain non-owner participants.*
+- **"No operational signal for failing enclave turns."** Refuted: queue-manager-level metrics/instrumentation cover `enclave.invoke` like any queue — the finder's grep stopped at the feature folder. Ops visibility exists; *user* visibility does not (that's E2EE-8).
+
+## Provenance
+
+Full machine-readable findings (with per-finding adversarial verdicts) are in the workflow run `wf_64d57f98-2ee` output; this document is the durable summary. Verification discipline: every finding above was independently re-derived from the code by at least one adversarial verifier instructed to refute it.
+
+---
+
+# Part II — UX parity audit
+
+- **Date:** 2026-06-05
+- **Code state:** `origin/main` @ `04932986` (the working tree was branch `e2ee-plaintext-leak-closures`; none of these findings touch the Part I fixes).
+- **Method:** same harness as Part I, 71 agents. 6 UX dimension finders (Ariadne conversation parity, unlock/lock friction, composer+attachments, app-shell integration, perceived performance, copy+errors) → dedup (with the 13 confirmed Part I findings fed in as "do not re-report") → adversarial verification (2 lenses for high) → orthogonal completeness critic (mobile, a11y, onboarding, settings, cross-device).
+- **The bar (Kris's words):** *"it's crucial it feels good to use, nearly identical to how it is to use normal Ariadne."* Every finding is anchored to a concrete plaintext baseline: normal streams do X, e2e does Y, the user feels Z.
+
+Reference findings as `UX-<n>`.
+
+## Summary
+
+39 confirmed findings: **0 critical, 11 high, 18 medium, 10 low**; 2 contested, 6 refuted. No UX-critical means nothing makes the feature feel outright *broken* — but the friction is broad, and it clusters in three places.
+
+The recurring shape: **normal Ariadne is instant and local; encrypted Ariadne is gated on network round-trips and main-thread crypto, and the UI does little to mask the difference.** The three clusters:
+
+1. **Key & device lifecycle is under-built (5 of the 11 highs).** A fully-implemented, tested `rotatePassphrase()` is wired to zero UI; key management is buried at the bottom of the "AI" settings tab; there's no trusted-device list and the only revoke nukes every device; a second device always pays the full passphrase tax with no handoff. This is the biggest gap between "we shipped crypto" and "it feels like a product."
+2. **Decrypt-on-render isn't masked.** Argon2id freezes the main thread on unlock; images fetch+decrypt whole files with no thumbnail/cache; the timeline gates first paint on a wrap fetch and flashes skeletons; your own sent message and Ariadne's replies both flash a decrypt skeleton instead of appearing instantly.
+3. **The shell treats e2e streams as second-class.** No auto-title (placeholder name forever), no activity-feed row or push when Ariadne answers (nothing pulls you back), static "🔒 Encrypted message" previews even when unlocked.
+
+### Suggested UX fix order
+
+| Tier | Findings | Why |
+| --- | --- | --- |
+| **Quick wins** (code mostly exists) | UX-8 wire `rotatePassphrase` to UI · UX-30 gate biometric on `isUserVerifyingPlatformAuthenticatorAvailable()` · UX-7 system-prompt clause for Ariadne's e2e limits · UX-9 surface key mgmt under a Security tab · UX-27 drop "and sources" label (or ride E2EE-9) | High felt value, hours not days |
+| **Decrypt masking** | UX-2 Argon2 in a Web Worker · UX-22 optimistic send echo · UX-13/24 pre-warm wrap + decrypt before commit · UX-25 styled locked/failed states · UX-26 transient-vs-real decrypt failure (pairs with E2EE-15 framing) | Kills the "feels slow/janky" perception |
+| **Media** | UX-3 lightbox/gallery/copy/save for e2e images · UX-4 thumbnail tier + cross-remount blob cache · UX-17/18 reserve image box + download progress | Encrypted images currently feel like dead thumbnails |
+| **Shell first-classing** | UX-5 client-side auto-title · UX-6 out-of-stream signal (generic activity row + push) · UX-19/20 unlocked previews + name consistency | Makes e2e streams scannable and "alive" |
+| **Device story** | UX-10 trusted-device list + per-device revoke · UX-11 cross-device handoff · UX-14 cross-tab unlock · UX-15 lighter session-resume tier · UX-33 optional auto-lock | The anxiety-and-friction cluster around "my other device / my lost device" |
+
+## A. Conversation parity (does the turn feel the same)
+
+- **UX-12 (medium) — Mid-turn interjection is gone.** Plaintext Ariadne folds a message sent mid-turn into the running turn (a visible "Reconsidering…" step); enclave Ariadne ignores it and only catches up with a *new* turn afterward (`persona-agent.ts:640-755` / `agent-runtime.ts:286-303` vs `run-turn.ts:178-230`). Steering feels queued, not immediate. (This is the documented "mid-turn adaptation still missing" boundary — filed here as the felt cost.)
+- **UX-13 (medium) — Every reply flashes a gray decrypt-skeleton on arrival** where plaintext lands fully rendered (`stream-sync.ts:543-556` commits the sealed row, then the client decrypts). Decrypt before committing the row, or pre-warm, so the text is present on first paint.
+- **UX-31 (low) — The enclave loop awaits each reply's HTTP callback before continuing** (`run-turn.ts:214-226`, `backend-callbacks.ts:55-63`), so a multi-message turn stalls between bubbles.
+
+## B. Unlock / lock / device lifecycle
+
+- **UX-2 (high) — Argon2id KEK derivation runs on the main thread**, freezing the tab (and the unlock spinner can't even animate) on every unlock/setup (`passphrase.ts:40-62`, m=64MiB t=3; called inline at `e2e-session-store.ts:572,479`). Move to a Web Worker.
+- **UX-11 (high) — A second device always demands the full passphrase**, with no QR/device-link handoff and no "new device" UI (`e2e-session-store.ts:368-451`); compounded by UX-2's freeze. Plaintext Ariadne is identical on every device the instant you log in — that's the bar.
+- **UX-14 (medium) — Unlock in one tab doesn't unlock other tabs** (no BroadcastChannel/storage-event sync; `e2e-unlock-provider.tsx:66-68`).
+- **UX-15 (medium) — Without "Keep me unlocked," every reload and new tab re-prompts** for the full passphrase — no session-scoped middle tier.
+- **UX-16 (medium) — First-run setup is one long modal** (passphrase, confirm, mandatory acknowledgement, trust toggle, optional PIN/biometric) before the first message (`passphrase-setup-modal.tsx:97-290`). Progressive-disclose PIN/biometric *after* the scratchpad exists.
+- **UX-32 (low) — Abandoning the setup/unlock modal silently drops the create** the user asked for (`sidebar.tsx:363-368`) — no scratchpad, no acknowledgement.
+- **UX-33 (low) — No idle auto-lock, no lock-on-tab-hide, no quick per-stream relock** despite the security framing (`encrypted-scratchpads-section.tsx:147`, `e2e-session-store.ts:879-903`).
+
+## C. Composer & attachments
+
+- **UX-3 (high) — E2E images can't be opened, zoomed, copied, or saved.** Plaintext images open the `MediaGallery` lightbox with prev/next + mobile Save/Copy drawer (`attachment-list.tsx:175-177,251-259,817-824`); the encrypted `<img>` has no click handler at all (`e2e-attachment-list.tsx:66-73`). Wire the same lightbox off the already-decrypted blob.
+- **UX-4 (high) — Encrypted images fetch + decrypt the whole ciphertext before any pixels paint, no thumbnail tier, no cross-remount cache** (`e2e-attachment-list.tsx:21-28,40-65`) — so in a virtualized timeline, scrolling an image out and back re-downloads and re-decrypts the full file. Plaintext loads a thumbnail variant and caches URLs (`attachment-list.tsx:153,483-485`).
+- **UX-17 (medium) — Inline images shift layout on decrypt** (no reserved box — INV-21). **UX-18 (medium) — Encrypted download is a blocking two-step decrypt-on-click with no progress.** **UX-34 (low) — uploads surface no size limit and no per-file encrypt progress.**
+
+## D. App-shell integration
+
+- **UX-5 (high) — E2E scratchpads never get auto-titled.** Server auto-naming is short-circuited for e2e (`naming-outbox-handler.ts:120-125`) and no client replacement exists, so they read "New scratchpad" forever while plaintext scratchpads get an LLM title. Derive a title client-side from decrypted content.
+- **UX-6 (high) — Ariadne answering in an e2e scratchpad produces zero out-of-stream signal** — the activity handler returns `[]` for e2e (`activity/outbox-handler.ts:142`), so no activity row and no push. Navigate away and nothing brings you back. Emit a generic "New message in <stream>" activity/push (no content).
+- **UX-19 (medium) — Sidebar/switcher preview is a static "🔒 Encrypted message" even when unlocked** (`stream-item.tsx:165-167`) — decrypt it locally when unlocked. **UX-20 (medium) — sidebar displayName vs header decrypted name can drift.** **UX-21 (medium) — global content search silently returns nothing** for e2e content with no explanation (pairs with E2EE-15). **UX-35 (low) — rename pre-fills the server name, not the decrypted one.**
+
+## E. Perceived performance
+
+- **UX-22 (medium) — E2E send withholds the optimistic echo** behind async sealing (+ possible wrap fetch) (`use-stream-or-draft.ts:631`, `stream-key-cache.ts:296-307`) — your own message doesn't appear the instant you hit Enter.
+- **UX-23 (medium) — Decrypt cache is 500-entry LRU** (`decrypt-cache.ts:25`), so scroll-back in a long encrypted stream re-runs crypto where plaintext just re-renders. **UX-24 (medium) — first paint gates on a stream-key wrap fetch** (`message-envelope.ts:189-201`); prefetch at unlock/subscribe. **UX-25 (medium) — locked/failed messages render as literal placeholder strings through the markdown renderer** (`message-event.tsx:1636-1647`) instead of a styled state. **UX-36 (low) — the decrypting skeleton is a fixed single-line shape**, so resolving a multi-line message reflows (INV-21).
+
+## F. Copy, errors, accessibility
+
+- **UX-7 (high) — The enclave system prompt never tells Ariadne she lacks workspace memory/tools** (`enclave-system-prompt.ts:22-29,64-69`), so when asked to recall something from the workspace she hallucinates or refuses without naming the encryption limit. Add a clause so she voices the boundary gracefully.
+- **UX-26 (medium) — "Decryption failed" / "Couldn't decrypt this step" is shown for missing-key and network failures**, not just real crypto failures (`stream-key-cache.ts:324`, `message-envelope.ts:188-210`) — across message bodies and trace steps. A not-yet-resolvable message should show a transient loading state and self-heal.
+- **UX-27 (medium) — "Show trace and sources" is offered on enclave replies that never carry sources** (`message-actions.ts:214-218`) — resolved once E2EE-9 plumbs sources through the sealed payload, or drop the "and sources" label until then.
+- **UX-28 (medium) — Repair/heal copy leaks setup-internals** ("Finish setup", "encryption wasn't finished"; `stream-encryption-affordance.tsx:221`) — self-heal silently or explain plainly.
+- **UX-29 (medium) — Screen-reader users get silence while messages decrypt** — the skeleton is `aria-hidden` with no live region (`message-event.tsx:1662-1675`). **UX-30 (medium) — biometric is offered whenever the WebAuthn API merely exists**, not when a platform authenticator is actually available (`webauthn-device-key.ts:54-56`) — gate on `isUserVerifyingPlatformAuthenticatorAvailable()`.
+- **UX-37 (low)** generic attachment-failure toast · **UX-38 (low)** "Keep me unlocked" never says what's stored on the device · **UX-39 (low)** the full-page gate always says "Unlock with your passphrase" even on PIN/biometric-only devices.
+
+## G. Key-management discoverability (the settings cluster)
+
+- **UX-8 (high) — There is no "Change passphrase" anywhere.** `rotatePassphrase()` is fully implemented and unit-tested (`e2e-session-store.ts:779-846`, `.test.ts:126,294,395`) but no component calls it; the only escape from a compromised passphrase is "Revoke key", which destroys all content. **Wire the existing action to a UI — this is the single highest value-to-effort fix in Part II.** (Note: Part I's E2EE-6 is the deeper bug — rotation as currently written *strands* all streams because it mints a new keyId without re-wrapping; UX-8 and E2EE-6 must be fixed together.)
+- **UX-9 (high) — Key management is buried at the bottom of the "AI" settings tab**, under voice dictation, with no Security/Privacy tab and "encryption" named nowhere in the nav (`ai-settings.tsx:251`, `preferences.ts:150-159`).
+- **UX-10 (high) — No trusted-device list and no per-device revoke** — the model tracks per-device trust (`e2e-session-store.ts:323-356`) but settings shows only the current device and a single global revoke (`encrypted-scratchpads-section.tsx:61-93,151-153`). A lost laptop forces the catastrophic all-device revoke.
+
+## Cross-references to Part I
+
+- **UX-21** (search empty) ⇄ **E2EE-15** (Cmd-F returns nothing) — same root, the docs promise client-side search works.
+- **UX-27** (sources label) ⇄ **E2EE-9/14** — fixing the sealed-payload sources plumbing makes the label honest.
+- **UX-8** (no Change-passphrase UI) ⇄ **E2EE-6** (rotation strands all streams) — do not ship the UI until the re-wrap bug is fixed, or it's a footgun.
+- **UX-6** (no push/activity) is the felt-UX side of **E2EE-8** (parked-turn invisibility) — together, "Ariadne in an encrypted stream is easy to lose track of."
+
+## Contested (judgement calls, not clear-cut)
+
+- **UX-C1 (medium) — The message-action menu is plaintext-shaped, bolted onto e2e with no encryption awareness** (`message-actions.ts:221-225`). Partly addressed by Part I E2EE-1 (Edit now hidden); the remaining question is whether other entries (copy-link, quote) need e2e-aware variants. Verifiers split on whether this is one finding or a catch-all.
+- **UX-C2 (low) — Every enclave turn pays queue-poll + backend↔enclave HTTP fan-out** the in-process path doesn't, with nothing masking the dead air. Real, but verifiers disagreed on whether the added latency is perceptible enough to be a UX finding vs an architecture note.
+
+## Provenance (Part II)
+
+Workflow run `wf_8f6a8a74-33a`. Same adversarial-verification discipline as Part I.

--- a/docs/plans/agent-runtime-pluggability.md
+++ b/docs/plans/agent-runtime-pluggability.md
@@ -1,0 +1,425 @@
+---
+title: Agent Runtime Pluggability — Design Deep-Dive
+status: exploration
+audience: engineering
+created: 2026-06-05
+related: [audits/e2ee-enclave-audit-2026-06.md]
+summary: >
+  Five distinct architecture directions for making the companion, the enclave,
+  and a marketplace of external third-party agent harnesses (OpenClaw / external
+  Pi / ChatGPT / arbitrary) share as much as possible and stop drifting — plus a
+  grafted recommendation, a first-class third-party-plugin contract, and an
+  incremental 8-step migration. This is an EXPLORATION, not an approved decision.
+---
+
+> **Status: design exploration.** This document presents options and a
+> recommendation for discussion; nothing here is committed. It is grounded in the
+> code as of the cited commit and pairs with the E2EE/enclave audit
+> (`docs/audits/e2ee-enclave-audit-2026-06.md`), whose drift findings (E2EE-*,
+> UX-*) motivate it. Produced via a multi-agent design workflow (6 current-state
+> readers → 5 independent proposals → 3-lens judge panel → synthesis); every
+> `file:line` was spot-verified against the working tree.
+
+# Agent-Runtime Redesign: Five Distinct Directions for Pluggable Runtimes (incl. First-Class 3P Plugins)
+
+A design deep-dive for the product owner. Goal: make the **companion**, the **enclave**, and a **marketplace of external third-party harnesses** (OpenClaw / external Pi / ChatGPT / arbitrary) look as uniform as possible to Threa — sharing everything that *can* be shared, degrading cleanly for what cannot, and eliminating the *ability* to drift rather than just patching the drift we have.
+
+All `file:line` citations were verified against the working tree on branch `e2e-enclave-attachments`.
+
+---
+
+## 1. Current state in one page
+
+### What is genuinely shared (the one true core)
+
+`class AgentRuntime` (`packages/agent-runtime/src/runtime/agent-runtime.ts:157`, loop at `:213`) is host-agnostic and imports **zero host modules**. It is driven entirely by `AgentRuntimeConfig` (`agent-runtime.ts:43-94`), which carries `ai`, `model`/`modelString`, `systemPrompt`, `messages`, `tools`, `observers`, `telemetry`, `costContext`, and the callbacks `sendMessage`, `newMessages?`, `shouldAbort?`, `toolSignalProvider?`, `allowNoMessageOutput?`, `validateFinalResponse?`. The loop owns iteration cap, abort gate, prompt + retrieved-context assembly, message truncation, the model call, tool ordering, source dedup (`mergeSourceItems`), `systemContext` folding, multimodal-image injection, the trust-boundary wrap, the reconsider/interjection state machine, the "never end with zero messages" fallback, and the full `AgentEvent` emission.
+
+`enclave-runtime.ts` is **not a second runtime** — it is a curated re-export barrel of the *same* `AgentRuntime` with a deliberately minimal dependency surface (no `createAI`/OTEL pull), verified at `enclave-runtime.ts:1-16` (header: "the enclave runs the same loop next to decrypted plaintext, so it must keep its dependency (and egress) surface minimal"). So **for the companion and enclave, the loop is ~100% shared**; they differ only in which barrel they import and what config they hand it.
+
+Also shared: `AgentTool`/`defineAgentTool`/`AgentToolResult`, the `AgentObserver` interface, the web/research tool primitives (used by both companion and enclave), `OtelObserver`, the `TOOL_CATEGORIES_BY_NAME` privacy vocabulary, and `failSessionWithLifecycle`.
+
+### What is duplicated (parallel-but-faithful, by host)
+
+- **Two trace observers.** `SessionTraceObserver` (DB+socket) and `EnclaveTraceObserver` (`apps/enclave/src/agent/trace-observer.ts:59-247`, seal+POST) are hand-mirrored copies of the same `AgentEvent`→step state machine. The enclave file's header says it "mirrors the backend SessionTraceObserver's event→step lifecycle exactly — only the sink differs." They have already diverged on which event types they handle.
+- **Two toolset assemblers.** `buildToolSet` (companion, ~40 tools) and `buildEnclaveTools` (enclave, web-only) share no spine; a new shared tool must be added to both.
+- **Per-tool system-prompt prose** lives in a host-side prompt builder, not on the tool.
+
+### What is divergent — the parallel universe
+
+The **external-bot** path (`apps/backend/src/features/bot-runtimes/**` + `apps/backend/src/features/public-api/bot-*`) does **not use `AgentRuntime` at all**. It implements a five-verb protocol: `bot:hello` (+`supportedCapabilities`, `socket-handler.ts:132`) → bootstrap → `claim` (FOR UPDATE SKIP LOCKED) → optional `/steps` → `complete` (`finalMessageMarkdown` | `noResponse`, `schemas.ts:117-123`) | `fail`, with `renew`. It receives a `SerializedBotInvocation` (prompt + ids + trigger + `requiredCapability`) — **no history, no tools, no system prompt, no model** — and runs its own loop. `BOT_RUNTIME_KINDS = ["pi-local","hermes","openclaw","claude-code-channel","custom"]` (`constants.ts:710`) already names the intended marketplace. **It shares none of the loop.**
+
+### Concrete drift symptoms (verified)
+
+| # | Symptom | Evidence |
+|---|---------|----------|
+| E2EE-9 | Enclave drops citation sources on replies | `sendMessage: async ({ content }) =>` destructures only `content` (`run-turn.ts:203`); `AgentRuntimeConfig.sendMessage` allows `sources?` to be omitted (`agent-runtime.ts:64-67`). The shared loop threads sources to the commit; the enclave silently discards them. |
+| E2EE-14 | Enclave trace steps also drop sources | `EnclaveTraceObserver` seals step content but never `trace.sources`. |
+| UX-12 | Mid-turn interjection missing in enclave | Companion wires a full `newMessages` provider; the enclave omits `newMessages` entirely (`run-turn.ts` config has no such field). Silent because `newMessages?` is optional (`agent-runtime.ts:71`). The loop's whole reconsider path is dead code in the enclave. |
+| #4 | `CONTEXT_RECEIVED` synthesized two ways | Companion builds it inline; enclave re-synthesizes out-of-band via `traceObserver.emitContext(...)` before `runtime.run()` (`run-turn.ts:221-227`). Every host must remember to do this. |
+| #5 | Observers diverged on event types | `SessionTraceObserver` handles `response:kept`/`reconsidering`/`message:edited`; `EnclaveTraceObserver` handles none. New event types degrade silently in the enclave. |
+| #8 | Category privacy gate is **dead on companion** | `isToolAllowedByPolicy` (`tool-privacy.ts:116`) has only test call-sites + the barrel re-export (`index.ts:337`) — **zero production call-sites** (verified by grep). Companion's `allowedToolCategories` is never enforced. Three unreconciled gating models exist (companion `enabledTools`, enclave categories, external `supportedCapabilities`). |
+| #6 | Lifecycle asymmetries | Enclave has no `/fail` route; three different lifecycle machines. |
+| #9 | Cost/telemetry excludes enclave + external | Only companion records `costContext`. |
+
+**Root cause** (one sentence): the loop's *edges* are untyped opaque closures or `?optional` fields, so a host can omit or narrow a responsibility and the compiler stays silent — and the external path is a wholly separate contract nobody maps to the loop.
+
+---
+
+## 2. The five options, kept distinct
+
+The five share one inevitable common spine (every proposal independently converges on it, which is itself a strong signal it's the right first move):
+
+> **Shared spine** — make the terminal commit payload carry **required** `sources`+`multimodal`; collapse the two trace observers into one `AgentEvent→step` mapper with only the persist sink injected; route all tool gating through one path that revives the dead `isToolAllowedByPolicy`.
+
+Where they differ is the **wrapper** around that spine, and — decisively — **how the external (self-driven) host fits**, since a 3P harness can never consume `AgentRuntimeConfig` (it runs its own model and loop; there is no `generateTextWithTools` for Threa to drive).
+
+---
+
+### Option A — The Ariadne Hexagon (Ports & Adapters)
+
+**Philosophy.** `AgentRuntime` is a pure hexagonal domain core depending only on a small set of **named, total, typed ports**. Each host is a bundle of adapters; the only host-specific code that survives is the adapter fulfilling a port that genuinely cannot be shared (egress, sealing, persistence).
+
+**Shape.**
+```ts
+// Driven ports (runtime calls out)
+interface MessageSink { commit(p: CommitPayload): Promise<{ messageId: string; operation: "created" | "edited" }> }
+interface CommitPayload { content: string; sources: SourceItem[]; multimodal: MultimodalBlock[]; replacesMessageId?: string }
+interface StepSink { open(id, i): Promise<void>; finalize(id, i: StepIntent): Promise<void>; substep(...): Promise<void> }
+class    TraceMapper implements AgentObserver { constructor(sink: StepSink) }  // ONE impl, sink injected
+interface InterjectionSource { readonly supported: boolean; check(...): Promise<NewMessageInfo[]>; ... }
+interface AbortSource { fatalReason(): Promise<string|null>; toolSignal(...): AbortSignal|undefined }
+interface Toolset { resolve(policy: ToolPrivacyPolicy): AgentTool[]; readonly declaredCapabilities: AgentCapability[] }
+interface ModelPort { readonly modelString: string; generateTextWithTools: AI["generateTextWithTools"] }
+interface HostAdapters { messages; trace; interjection; abort; toolset; model }
+// Driving port (something runs a turn)
+interface TurnDispatch { dispatch(req: TurnRequest, host: HostAdapters): Promise<AgentRuntimeResult> }
+// new AgentRuntime(core: CoreConfig, ports: HostAdapters)
+```
+
+**Host plug-in.** Companion = `CompanionHost` bundle (plaintext `MessageSink`, socket `StepSink`, full `Toolset`, backend `AI`). Enclave = `EnclaveHost` bundle imported **only as port interfaces** from the curated barrel (seal-and-POST `MessageSink` now receiving `{content, sources, multimodal}`; the same shared `TraceMapper` with a sealing `StepSink`; web-only `Toolset`; OpenRouter `ModelPort`). External harness = **not** an `AgentRuntime`; a peer behind the `TurnDispatch` *driving* port — the existing bot-runtimes claim/complete protocol promoted to the canonical external contract.
+
+**Shared / per-host.** Shared: the single `TraceMapper`, the port interfaces, the capability vocabulary, the one gating path. Per-host (legitimately): egress shape (enclave `ModelPort` = one OpenRouter connection), sealing bytes (inside the enclave's `MessageSink`/`StepSink`), persistence backend, tool deps, trust identity.
+
+**Drift killed, how.** E2EE-9/14 → `CommitPayload.sources` is non-optional, so the enclave adapter cannot compile while dropping it. UX-12 → `InterjectionSource` is a *required* port; a host that can't interject passes `declaredUnsupported(reason)` — loud, not absent. Dead gate → the `Toolset.resolve(policy)` port runs the one gate for all hosts. #4 → `context:received` emitted by the loop's dispatch entry.
+
+**External-agent story.** A 3P harness sits behind `TurnDispatch` as a peer, speaking the bot-runtimes protocol, emitting into the same `CommitPayload`/`AgentEvent` vocabulary via HTTP, declaring `outputCapabilities` at `bot:hello`. **Weakness:** the in-loop ports and the external contract are two *different shapes* — the bulk of the design (6–7 driven ports) does not apply to the external tier; external uniformity is asserted, not structural.
+
+**Complexity delta.** ~7 port interfaces added; one `TraceMapper` replaces two observers; one gate replaces three. Abstraction *count* roughly flat, abstraction *quality* sharply up. Honest read: this finishes the seam the codebase was already reaching for.
+
+**Risks.** Over-abstraction — 7 ports where 3 carry real divergence (`AbortSource`/`ModelPort`/`InterjectionSource` may be ceremony). Changes the `AgentRuntime` constructor signature (wider blast radius into the live loop's entry than wrap-based options). External is a relabel, not a fit.
+
+---
+
+### Option B — Capability Kernel (the Threa Agent Substrate)
+
+**Philosophy.** A turn is a tiny host-agnostic kernel orchestrating a **registered bundle of named capability modules**, discriminated by a closed `CapabilityKind` vocabulary. Forgetting a capability is a *compile error* (required) or a *declared-disabled* value (optional) — never a silent gap.
+
+**Shape.**
+```ts
+type CapabilityKind = "transport"|"commit"|"trace"|"toolset"|"model"|"interjection"|"gating"|"cost"
+interface Capability<K extends CapabilityKind> { readonly kind: K }
+interface CommitCapability extends Capability<"commit"> { commit(p: CommitPayload): Promise<...> }  // sources/mm required
+interface TraceCapability  extends Capability<"trace">  { handle(e: AgentEvent): Promise<void> }
+interface GatingCapability extends Capability<"gating"> { admit(toolName): boolean; reason(toolName): string }
+type DeclaredDisabled<K> = { kind: K; declaredDisabled: string }
+type CapabilitySet = { [K in CapabilityKind]: Extract<Capability<K>,{kind:K}> | DeclaredDisabled<K> }
+class Kernel { static compose(bundle, req): ResolvedSet /* THROWS on missing required */; run(set, req): Promise<...> }
+```
+
+**Host plug-in.** Companion/enclave each register a `CapabilityBundle`; the kernel runs the existing loop but dispatches each side-effect to the module that owns it. External = the **external tier** — it does *not* compose a `CapabilitySet` (it runs its own loop); a backend-side `ExternalHostAdapter` implements `CommitCapability`+`TraceCapability` translating the bot wire protocol ↔ the kernel's vocabulary.
+
+**Drift killed.** Same forcing functions as A, plus the strongest *fail-loud-at-registration* mechanism: `compose()` throws if a required kind is missing, surfacing UX-12 at startup. `DeclaredDisabled<K>` makes "I can't interject and here's why" a first-class telemetry-visible value.
+
+**External-agent story.** `supportedCapabilities` (trigger-timing) extended with an output manifest `{reply, streaming?, trace?, sources?, multimodal?, toolUse?, interjection?}`. **Weakness — self-admitted:** for the two in-loop hosts that exist today the 8-kind registry is "pure tax" until a third in-loop host arrives; external participates only via a separate adapter, so the central abstraction earns nothing for the hardest case. And `CommitPayload.sources` being required can still be *willfully* defeated by `commit({...p, sources:[]})` — a type can't stop that, so it leans on review.
+
+**Complexity delta.** Most scaffolding of the five (`CapabilityKind` enum + `Capability<K>` + mapped-type `CapabilitySet` + `DeclaredDisabled` + `Bundle` + `Kernel.compose`). Net for the two real hosts: roughly flat. The most type-machinery-heavy construct in the set.
+
+**Risks.** Heaviest ceremony; brushes INV-36 (speculative abstraction justified by a future that may not arrive). Most honest proposal about its own limits — which is a point in its favor for "don't make it worse," but a point against adopting it now.
+
+---
+
+### Option C — The Turn Pipeline (named, ordered, swappable stages)
+
+**Philosophy.** A turn is a **fixed, ordered pipeline of named stages**, each with exactly one canonical default in `@threa/agent-runtime`. A host diverges only by passing a typed override, so drift requires a *visible, type-checked act of opting out*.
+
+**Shape.**
+```ts
+// Stages, in order: Hydrate → AssembleContext → SelectTools → RunLoop → OnStep → Commit → Finalize
+interface HydrateStage        { hydrate(ctx): Promise<{ messages: ModelMessage[]; promptText: string }> }
+interface AssembleContextStage{ assemble(ctx, tools): Promise<{ systemPrompt; retrievedContext? }> }  // folds tool.promptBlock
+interface SelectToolsStage    { select(ctx): Promise<AgentTool[]> }   // default = gateTools(all, ctx.policy)
+interface RunLoopStage        { run(cfg, sink: StepSink, commit: CommitAdapter): Promise<AgentRuntimeResult> }  // default = AgentRuntime; ExternalDispatchLoop = 3P variant
+interface CommitAdapter       { commit(input: { content; sources?; multimodal? }): Promise<{ messageId; operation? }> }
+interface StepSink            { startStep(s); persistStep(s: MappedStep): Promise<void> }
+interface FinalizeStage       { onSuccess(r); onFail(e); onPark(reason): Promise<void> }
+interface TurnContext         { ...; sealing: "plaintext" | "sealed"; capabilities: OutputCapabilitySet }
+function runTurn(ctx: TurnContext, overrides: Partial<StageMap>): Promise<TurnResult>
+// AgentToolConfig gains: promptBlock?: string; categories: ToolPrivacyCategory[]
+```
+
+**Host plug-in.** Companion/enclave override `Hydrate`/`Commit` and the `OnStep`/`Finalize` sinks; everything else is the default. The live loop becomes the `RunLoop` default **verbatim** (no rewrite). External plugs in via the `ExternalDispatchLoop` variant of `RunLoop` — `Hydrate`+`AssembleContext` still run on Threa's side, the bot's posted `/steps` and final message are normalized into `AgentEvent`/`CommitInput` and flow through the *same* `OnStep`/`Commit` path.
+
+**Drift killed.** Same spine. Plus the best treatment of the toolset/prompt-builder drift: per-tool `promptBlock` + `categories` move **onto the tool**, so a new tool can't be added to one host's prompt and forgotten in the other's. `sealing` marker routes sealed turns only to a sealing-capable `Commit`.
+
+**Complexity delta.** Names existing assembly structure (stages map 1:1 to steps already in `persona-agent.ts`/`run-turn.ts`). Deletes two big duplicated blocks, adds small interfaces. Best net-complexity story.
+
+**Risks.** The `RunLoopStage` interface must be "wide enough to admit both a synchronous in-process loop and an async out-of-process dispatch" — that width is where a leaky abstraction breeds drift *inside* a stage. A fixed ordered pipeline is an *in-process-host shape*; the self-driven external host runs the back half on the harness side, so the "ordered stages" framing fractures across the trust boundary. Pre-building the prompt for a self-driven harness mildly fights "it fetches its own context."
+
+---
+
+### Option D — The Turn Protocol (one verb, two tiers)
+
+**Philosophy.** Stop treating "drive the loop" as the contract. Treat **"produce a turn"** as the contract. Every host implements `TurnRunner`: a request in, a stream of typed `TurnEvent`s out, a typed result back. `AgentRuntime` becomes the *reference in-process implementation* of that contract, not the contract itself.
+
+**Shape.**
+```ts
+interface TurnRunner  { readonly capabilities: Capabilities; run(req: TurnRequest): TurnSession }
+interface TurnSession { events: AsyncIterable<TurnEvent>; result: Promise<TurnResult>; abort(reason): void }
+interface TurnOutput  { id: string; content: string; sources: SourceItem[]; multimodal: MultimodalPart[] }  // id ⇒ per-item AAD; sources required
+type TurnPayload =
+  | { delivery: "plaintext"; system; messages: ModelMessage[]; toolSpecs: ToolSpec[] }
+  | { delivery: "sealed";    wraps: SskWrap[]; history: SealedItem[]; prompt: SealedItem; reply: SealedSlot; allowedToolCategories }
+  | { delivery: "external";  promptMarkdown: string; contextRef: ContextHandle }
+interface Capabilities { delivery: ("plaintext"|"sealed"|"external")[]; emits: TurnEventKind[]; canInterject; canStream; sources; ... }
+interface TurnSink     { onEvent(e: TurnEvent): Promise<void>; finalize(r: TurnResult): Promise<void> }
+class TraceProjector   // event→step, StepStore injected — replaces both observers
+function resolveCapabilities(stream, runner): ResolvedCapabilities  // the one gating path
+```
+
+**The keystone** is the `delivery` discriminated union: a `SelfDrivenTurnRunner` can structurally only be handed `delivery:"external"`; `resolveCapabilities` refuses to mint a `delivery:"sealed"` payload for any non-attested identity. The trust gradient becomes a **type**, and the E2E-participation decision collapses to one guard.
+
+**Host plug-in.** Companion = `DrivenTurnRunner` via in-process function call (the "wire" is an async iterator). Enclave = `DrivenTurnRunner` over HTTP with `delivery:"sealed"`; `run-turn.ts` keeps doing its work but emits the canonical `TurnEvent` stream sealed before crossing back. External = `SelfDrivenTurnRunner` — `bot:hello`/claim/complete/fail/renew *are* the wire encoding of `TurnRunner`.
+
+**Drift killed.** Same spine, plus it is the **only** design where the genuinely-divergent external host is on the *same contract* without pretending it runs `AgentRuntime` — the thing all three share (emit thinking/tools/messages/sources, terminate) becomes the shared surface; the thing they don't share (who drives the model) is the two-tier `delivery` distinction.
+
+**Complexity delta.** Adds the `TurnRunner`/`TurnSession`/`TurnSink` triad + protocol types; removes one observer, the parallel-universe nature of bot-runtimes, two of three gates.
+
+**Risks.** `TurnSession` async-iterable is a real new indirection over a today-direct companion call — pure ceremony if the marketplace never arrives. The sync-`sendMessage`-returns-`messageId` vs async-`complete` mismatch is absorbed by `result: Promise` but the driven adapter's id-expectation must not leak into the protocol. `Capabilities.emits` can rot vs the union unless test-pinned.
+
+---
+
+### Option E — The Harness Contract (TAIP: Threa Agent Integration Protocol)
+
+**Philosophy.** Every agent — OpenClaw, external Pi, ChatGPT, the companion, the enclave — is the same thing: a harness that produces a turn by emitting a **declared subset of one versioned event vocabulary**. Threa is a host that negotiates capabilities, **fills the gaps** a harness can't cover, and seals/persists on its behalf.
+
+**Shape.**
+```ts
+// In @threa/types (pure data — egress-safe for the enclave)
+interface CapabilityManifest {
+  taipVersion: string                 // versioned wire contract
+  harnessId: string
+  trust: "first-party-inproc" | "first-party-attested" | "third-party"
+  output: { reply: true; stream?; trace?; sources?; multimodal?; interjection? }  // what it can EMIT
+  tools: "threa-managed" | "self" | "none"
+  e2e: boolean                        // a CLAIM; the host verifies against trust tier
+  triggers: BotInvocationCapability[] // existing supportedCapabilities, reused
+}
+type EffectiveCapabilities = CapabilityManifest["output"] & { allowedTools: AgentToolName[]; sealed: boolean }
+// In @threa/agent-runtime (interfaces only)
+interface TurnReply { content: string; sources: SourceItem[]; multimodal: Multimodal[] }  // sources/mm REQUIRED
+interface TurnSink  { commit(r: TurnReply): Promise<{messageId; operation?}>; step(e: AgentEvent): Promise<void>; meter?(u): Promise<void> }
+interface TurnDriver{ readonly manifest: CapabilityManifest; runTurn(ctx: TurnContext, sink: TurnSink, caps: EffectiveCapabilities): Promise<TurnResult> }
+function negotiateCapabilities(m: CapabilityManifest, policy: StreamPolicy): EffectiveCapabilities  // HARD RULE: trust:"third-party" ⇒ e2e forced false
+class InProcessTurnDriver implements TurnDriver  // wraps AgentRuntime; used by companion AND enclave
+class NetworkTurnDriver   implements TurnDriver  // fronts claim→complete; used by 3P
+```
+
+**The keystone** is `negotiateCapabilities`: a single function computes the gate (activating the dead `isToolAllowedByPolicy`) **and** forces `e2e:false` for `trust:"third-party"` regardless of what the manifest claims. One function owns both the gating drift and the trust-boundary drift. Plus **gap-fillers**: if a harness declares `trace:false` but `reply:true`, Threa synthesizes a minimal `context:received`+`message:sent` trace from the reply, **marked as synthesized** so the degradation is *visible* not silent.
+
+**Host plug-in.** Companion = `InProcessTurnDriver` + `PlaintextSink`. Enclave = the *same* `InProcessTurnDriver` built from the curated barrel + `SealedSink` (the only sink that can set `e2e:true`). External = `NetworkTurnDriver` fronting the upgraded bot-runtimes protocol; `bot:hello` carries the full manifest.
+
+**Drift killed.** All five §2 symptoms in one structural home each: sources (required `TurnReply` field), interjection (declared manifest field, fails loud at construction), trace parity (one `TraceStepMapper`), lifecycle (one `TurnLifecycle` with the missing `fail`/`park`), and the external parallel universe (bot-runtimes *becomes* the network half).
+
+**Complexity delta.** +4 named types, −2 large duplicated classes, −2 parallel gating paths; external stops being a parallel universe.
+
+**Risks.** Publishing a **versioned wire contract** (`taipVersion`) is the heaviest new external-facing liability: `AgentEvent` evolves freely today; under TAIP a union change can break 3P harnesses, requiring additive-only evolution forever. Gap-filler output is strictly worse than native and risks masquerading as real unless the "synthesized" marker is enforced. `negotiateCapabilities` becomes a high-stakes chokepoint that must *throw*, not downgrade.
+
+---
+
+## 3. Comparison matrix
+
+Scores are the judges' (three panels; where they split I show the range, leaning on the majority).
+
+| Proposal | Drift-elimination | Adoption-risk (higher = safer) | Net-complexity | External-agent-fit | Migration-incrementality | One-line verdict |
+|---|---|---|---|---|---|---|
+| **A. Ariadne Hexagon** | 8 — forcing functions are total/typed; root-cause fix | **8 (safest)** — pure type changes inside existing config; no wire contract; contained blast radius | ~flat count, ↑ quality | **5 (weakest)** — external is a side-attached peer; 6–7 ports don't apply to it | High — config already a degenerate `HostAdapters` | Cleanest *in-loop* design; external is a relabel. Lowest-risk to start. |
+| **B. Capability Kernel** | 7 — strong fail-loud-at-`compose()`; but `sources:[]` defeatable | 5 — heaviest scaffolding for 2 real hosts | **Heaviest** (8-kind registry) | 6 — external via separate adapter; central abstraction earns nothing for it | Medium | Most honest about being "pure tax" until a 3rd in-loop host exists. |
+| **C. Turn Pipeline** | 6–7 — kills in-loop drift; best `promptBlock`-on-tool idea | **8 (≈safest)** — names existing structure; live loop untouched; 1-file Step 1 | **Best net-complexity** | 6 — `ExternalDispatchLoop` forced into a too-wide `RunLoopStage` | **Highest** — every step independently shippable | Lowest-friction realization of the shared spine; external fit is squeezed. |
+| **D. Turn Protocol** | **9** — only design where external shares the *contract* structurally | 6.5 — async-iterable indirection; versioning liability (shared w/ E) | Moderate | **9** — `delivery` union makes trust a type; external is first-class | High — Step 1 promotes `AgentEvent`→`TurnEvent` | Inverts the contract to the one thing all 3 hosts share. Best external fit. |
+| **E. Harness Contract (TAIP)** | **9** — all 5 symptoms + trust in one home each | 6–7 — versioned wire contract is a permanent liability | +4 types, −2 classes | **9** — bot-runtimes *becomes* the network half; gap-fillers; trust-tier rule | High — Step 2 fixes bleeding before any driver refactor | Most operationally complete external story; pays with wire-versioning debt. |
+
+**Where the panels agreed:** all three ranked D and E at the top for *external-agent fit* and *drift-elimination*, and all three flagged the *versioned wire contract* as D/E's one genuine new liability. All three named **A or C as the lowest-risk thing to do first**, and all three observed that the *first PR is identical across all five* (required-sources commit type).
+
+---
+
+## 4. Recommendation & synthesis
+
+### The two-appetite answer
+
+There are two viable directions for two different appetites, and they are **not in conflict** — one is a strict prefix of the other.
+
+- **Minimal-risk now (do this regardless):** the **shared spine** (required-sources commit type, one trace mapper, one gating path), realized in the lightest-touch way — **Option C's wrap-the-loop framing + Option A's typed-port discipline at the commit/trace/interjection edges**. This needs no published wire contract, touches the live loop only to read from typed edges instead of optional fields, and fixes E2EE-9/14, UX-12, the dead gate, and the duplicated observer — all behind seams already in production.
+
+- **Ideal end-state:** **Option D (Turn Protocol) as the structural spine, grafted with Option E (TAIP)'s trust-and-negotiation machinery.** This is the only direction that makes the external marketplace a *first-class structural* citizen rather than a side adapter, which the product owner named as a **primary** requirement.
+
+### Recommended direction: "Turn Protocol spine + TAIP trust/negotiation skin"
+
+Build around **one contract — produce a turn-event stream — with two tiers (driven / self-driven)**, and graft the sharpest pieces from the other four:
+
+**Grafted, and why:**
+
+1. **From D — the `delivery` discriminated union + `TurnOutput`/`TurnEvent` stream as the core contract.** This is the load-bearing decision: it is the only one of the five where the genuinely-divergent external host shares the *contract*, not just a vocabulary, because the thing all three hosts actually have in common is "emit a turn-event stream and terminate," not "consume `AgentRuntimeConfig`." The `delivery` discriminant makes the trust gradient a *type* — a self-driven runner can only receive `delivery:"external"`.
+
+2. **From E — the `trust` tier on the manifest + the hard rule `trust:"third-party" ⇒ e2e forced false` inside one `negotiateCapabilities` function.** This is *strictly better* than D's delivery-union alone: it converts a contradictory claim (a 3P harness asking for sealed) into a **loud rejection** rather than a silent type-level absence, and it folds the dead `isToolAllowedByPolicy` gate into the same chokepoint. Carry **both**: trust tier governs *what payload variants may be minted*; the delivery discriminant governs *which one this turn uses*.
+
+3. **From E — gap-fillers with a visible "synthesized" marker.** The cleanest, fail-loud answer to graceful partial participation: a reply-only harness still gets *a* trace, explicitly labelled synthesized, so degradation is visible (INV-11), never masquerading as native.
+
+4. **From B / A — the `declaredDisabled(reason)` / `declaredUnsupported(reason)` sentinel.** A *present, loud, telemetry-visible value* for a capability a host genuinely cannot do, replacing `newMessages?:optional` everywhere. This is the cleanest UX-12 fix and pairs with D's capability declaration.
+
+5. **From C — per-tool `promptBlock` + `categories` on `AgentToolConfig`.** The single best idea for the prompt/toolset-assembler drift that none of the protocol proposals fully address: colocating a tool's prompt block and privacy categories *with the tool* means a new tool can't be added to one host's prompt and forgotten in the other's.
+
+6. **From all five — the single `TraceProjector`/`TraceMapper` + `StepSink`.** Every proposal independently converges on it; build it first.
+
+**Drop:** TAIP's `taipVersion` published wire contract **until a real external marketplace exists** (INV-36). Internally, keep the `AgentEvent`→`TurnEvent` union free to evolve; version it only at the external boundary, and only when the first non-Threa harness depends on it.
+
+### Why this is *better*, not just different
+
+Every §2 drift symptom traces to one root cause: the loop's edges are untyped/optional, so a host can narrow a responsibility and the compiler stays silent — and the external path is a contract Threa can't see into. This direction attacks the root cause on **both** fronts simultaneously:
+
+- It flips the failure mode from **silent wrong output in prod** to **compile error / construction-time throw / declared-disabled value** — exactly the INV-11 fail-loud principle the codebase already commits to. E2EE-9 becomes "you cannot construct a `TurnSink` that ignores `sources`." UX-12 becomes "you cannot construct a runner without declaring interjection." The dead gate becomes "there is one gating function and every turn flows through it."
+- It is the only direction that gives the **primary** requirement — companion, enclave, AND a marketplace of external harnesses looking uniform — a concrete shape: they share one event vocabulary, one trace projection, one gating function, one lifecycle, and differ only at the `delivery` discriminant (who drives the model) and the trust tier (who may receive a sealable sink). That is *"share everything that can be shared, degrade cleanly for what cannot,"* realized as a type, not a convention.
+- It honors every hard constraint verbatim: the shared core stays plaintext-only (`TurnOutput.content: string`); sealing lives in the enclave's `SealedSink`; the curated barrel stays the egress boundary (the protocol carries pure-data types into the enclave); per-item AAD is preserved (the `id` on `TurnOutput` is the per-item handle); and the trust gradient is *strengthened*, not collapsed.
+
+**If you want one sentence for the product owner:** adopt the Turn Protocol as the spine and the Harness Contract's trust-tier-and-negotiation as the skin; do the shared-spine PRs first (they're risk-free and fix the audit findings now), and let the protocol shape harden incrementally behind the bot-runtimes path that already exists.
+
+---
+
+## 5. Third-party plugin ecosystem (REQUIRED)
+
+This is the section the product owner cares about most. The good news: **the on-ramp already exists.** `bot-runtimes` is the embryonic external contract — `BOT_RUNTIME_KINDS` already lists `openclaw`/`custom` (`constants.ts:710`), and `bot:hello`/claim/complete/fail/renew is already a working self-driven harness protocol. The redesign *promotes* it, it does not replace it.
+
+### 5.1 The published integration contract (the thin contract a 3P harness implements)
+
+A 3P harness runs its **own model and its own agent loop**. It can never consume `AgentRuntimeConfig` — there is no `generateTextWithTools` for Threa to drive. So the contract it implements is **invocation-dispatch + result-ingestion**, i.e. the `SelfDrivenTurnRunner` tier. Concretely, the existing five verbs, upgraded:
+
+1. **Declare** — `bot:hello` carries a full `CapabilityManifest` (today it carries only `supportedCapabilities`, `socket-handler.ts:33`; that becomes `manifest.triggers`).
+2. **Receive** — it `claim`s an invocation (`FOR UPDATE SKIP LOCKED`) and gets a `TurnContext` serialized to JSON: `delivery:"external"`, `promptMarkdown`, `trigger`, allowed-tools-as-descriptions, and a `contextRef` callback handle it can use to fetch more history if it wants — **trimmed to what its manifest says it consumes and policy permits**.
+3. **Emit** — it POSTs `AgentEvent`-shaped frames to `/steps` as it works and the terminal `message` to `/complete` (today only `finalMessageMarkdown`|`noResponse`, `schemas.ts:117-123`; upgraded to also accept a `TurnOutput` with `sources`/`multimodal`).
+4. **Lifecycle** — `renew` (heartbeat), `fail`, `park` (new — bounded retry / DLQ).
+
+**Threa provides:** the trigger, the prompt, a context-fetch handle, capability-scoped permissions, lifecycle/claim TTL, sealing+persistence (on the harness's behalf), and gap-filling. **Threa requires (the floor):** at minimum a single terminal `message`. Everything else is opt-in.
+
+### 5.2 The capability manifest (what a harness declares it can do)
+
+```ts
+interface CapabilityManifest {
+  taipVersion: "1.0"
+  harnessId: string                  // "openclaw" | "pi-local" | <custom bot id>
+  trust: "third-party"               // 3P harnesses are always this tier
+  output: {                          // derived from AgentEvent / AgentToolResult / SourceItem shapes (INV-31)
+    reply: true                      // the floor — every harness must reply
+    stream?: boolean                 // interim messages before final
+    trace?: boolean                  // emits tool:* / thinking steps
+    sources?: boolean                // SourceItem[] on replies/steps
+    multimodal?: boolean
+    interjection?: boolean           // honors mid-turn newMessages
+  }
+  tools: "self"                      // a 3P harness brings its own tools/model
+  e2e: false                         // a CLAIM; negotiateCapabilities will force this false anyway
+  triggers: ("mentionable" | "active-scratchpad" | "session-control")[]  // existing BOT_INVOCATION_CAPABILITIES
+}
+```
+
+The `output` block is the **negotiation surface** for partial participation — and it is *derived from the emittable shapes* (INV-31) so it cannot drift from what's actually renderable.
+
+### 5.3 Capability negotiation + graceful degradation (Threa fills the gaps)
+
+- **Reply-only ChatGPT wrapper** declares `{ reply: true }`. Threa's gap-filler synthesizes a `context:received` + a single `message:sent` trace step from the final reply, **marked "trace synthesized (harness emits none)"** so the user sees an honest, degraded trace rather than a blank one or a fake-native one.
+- **Richer OpenClaw harness** declares `{ reply, trace, sources }` and POSTs `/steps`; those frames run through the **same** `TraceProjector` as the companion, so its trace and citations render identically.
+- **Degradation is per-feature, declared, and loud.** An undeclared capability the harness tries to use (e.g. a `/steps` POST when `trace:false`, or sources when `sources:false`) is **rejected at the normalization boundary** (INV-11), never silently accepted. This mirrors how the in-loop core already treats `observers`/`sources`/`multimodal` as optional — the manifest just makes it explicit and negotiated.
+
+### 5.4 Trust / sandbox boundary — the explicit E2E rule
+
+**The rule, stated plainly:** a third-party harness **can never touch an E2E stream.** It is plaintext-only, by hard gate, for the same reason it is today — it has no SSK and cannot seal, and it is arbitrary external code under a workspace-scoped key, not the first-party attested enclave.
+
+This is enforced as a **single typed guard**, not scattered checks:
+
+```ts
+function negotiateCapabilities(m: CapabilityManifest, policy: StreamPolicy): EffectiveCapabilities {
+  if (m.trust === "third-party" && policy.e2eEnabled) {
+    throw new ForbiddenError("third-party harnesses cannot participate in E2E streams")
+  }
+  const sealed = m.trust === "first-party-attested" && policy.e2eEnabled  // ONLY the enclave
+  // ... fold isToolAllowedByPolicy(policy.allowedToolCategories, tool) for every tool here ...
+}
+```
+
+This *consolidates* today's scattered guards — `invocation-outbox-handler.ts:97` (`if (stream.e2eEnabled === true) return`) and the four `assertNotE2eStream` call-sites (`handlers.ts:1113,1666,1746`) — into one declarative rule on the trust tier. The `delivery` union enforces it structurally too: a `SelfDrivenTurnRunner` can only ever be handed `delivery:"external"` (plaintext), never `delivery:"sealed"`. **E2E participation for anything other than the attested enclave stays the explicitly-deferred decision** — this design makes that a one-line guard to flip behind real attestation, not a refactor.
+
+> **Honest caveat to flag (not block):** callback trust today is one shared `INTERNAL_API_KEY` header, and enclave attestation is currently decorative (E2EE-21/22). Admitting less-trusted hosts strengthens the argument for **per-runner identity** (distinguish the enclave from a 3P harness at the trust check) — that is net-new work, not a pre-existing guarantee, and should land before the trust tier is load-bearing.
+
+### 5.5 Install / auth / routing (how a user adds and scopes a plugin)
+
+- **Install:** a user adds e.g. OpenClaw in workspace settings, which registers a bot with a manifest and mints a `threa_bk_*` key (the existing socket-auth path). This is the embryo today.
+- **Auth:** `threa_bk_*` workspace-scoped key + socket-auth + (future) per-runner identity + BIK registration. BIK becomes the explicit "this runner is requesting sealed-tier" signal that `negotiateCapabilities` evaluates against attestation.
+- **Routing:** a stream's "Ariadne" binding gets an optional `harnessId` (default `null` = the in-house companion). Setting it to an installed plugin routes that stream's invocations to the `NetworkTurnDriver` for that harness. Mention/active-scratchpad dispatch already routes to bots (`invocation-outbox-handler.ts:119`); this just makes "be the stream's *primary* agent" a routing option alongside "be mentionable."
+- **Bounded lifecycle:** add a `maxAttempts` cap + park-to-DLQ on the claim loop (the brief flags an unbounded `attempts` increment in the repo — confirm and bound it). The in-process hosts get this for free via the shared `TurnLifecycle.park`.
+
+### 5.6 How companion + enclave relate to this contract
+
+**Same contract, privileged internal fast-path.** Companion and enclave are `DrivenTurnRunner`s (TAIP's `InProcessTurnDriver`) — they implement the *in-process half* of the same protocol and run `AgentRuntime` internally. They do **not** pay a network hop: companion's "wire" is an async iterator / direct function call; the enclave's is the existing HTTP callback. They are privileged in exactly two ways, both typed:
+
+1. They are the only tiers handed `delivery:"plaintext"` / `delivery:"sealed"` payloads (the enclave alone gets `sealed`, gated on `trust:"first-party-attested"`).
+2. They run `AgentRuntime` directly rather than their own loop.
+
+So companion, enclave, and the marketplace all look uniform to Threa (one event vocabulary, one trace, one gate, one lifecycle), sharing everything that *can* be shared and differing only where physics forces it: who drives the model, and who may receive a sealable sink.
+
+### 5.7 Pi-specific assumptions that must be lifted first
+
+Before claiming generality, the "generic" dispatcher must shed its Pi-isms (verified):
+
+- `extractMentionSlugs` uses an **English/ASCII-only** regex `/@([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})/g` (`invocation-outbox-handler.ts:25`) — INV-54 tension.
+- The "missing link" notice and active-scratchpad path depend on `bot_runtime_session_links` that only Pi creates, and the notice hardcodes Pi-specific copy. Lift these into per-`BotRuntimeKind` config.
+
+---
+
+## 6. Migration sketch (incremental, drift reduced early, no big-bang)
+
+Each step is a shippable PR-sized change behind seams already in production. **The first PR is identical across all five proposals, so it commits you to nothing.**
+
+| Step | Change | Files | Drift fixed | Blast radius |
+|---|---|---|---|---|
+| **1** | Make `sendMessage`/commit take a payload with **required** `sources` + `multimodal`; thread sources into `EnclaveSealedReply`. | `agent-runtime.ts:64-67` (config type), `apps/enclave/src/agent/run-turn.ts:203` (stop destructuring `{ content }`), `EnclaveSealedReply` type + consume-side (partly built on this branch) | **E2EE-9** | One host's commit closure; compiler finds every caller |
+| **2** | Extract the shared `TraceProjector`/`TraceMapper` from `SessionTraceObserver`; reimplement `EnclaveTraceObserver` as the same mapper + a sealing `StepSink`. Thread `trace.sources`. Delete the mirrored state machine. | `runtime/session-trace-observer.ts`, `apps/enclave/src/agent/trace-observer.ts` | **E2EE-14**, **#5** | Two observer files; no loop change |
+| **3** | Move per-tool `promptBlock` + `categories` onto `AgentToolConfig`; make prompt-builder + toolset data-driven; **turn on `gateTools`/`isToolAllowedByPolicy` for companion**. | `agent-tool.ts`, `companion/tool-set.ts`, `companion/prompt/system-prompt.ts`, `tool-privacy.ts:116` | **#8** (dead gate), toolset/prompt drift | Tool definitions + both assemblers |
+| **4** | Emit the initial `context:received` from the loop/dispatch entry; remove the out-of-band `traceObserver.emitContext(...)` synthesis. | `agent-runtime.ts`, `run-turn.ts:221-227`, `persona-agent.ts` | **#4** | Both hosts' trace lead-in |
+| **5** | Give the enclave a real `InterjectionSource`/`newMessages` provider **or** an explicit `declaredUnsupported(reason)`; add the missing enclave `/fail` route + bounded park/DLQ. | `run-turn.ts`, enclave session-runner, `enclave-runtimes/**` | **UX-12**, **#6** | Enclave lifecycle |
+| **6** | Introduce `TurnRunner`/`TurnSession`/`TurnSink` (or `TurnDriver`); wrap `AgentRuntime.run()` to expose the event-stream shape; migrate companion `persona-agent` to build a `TurnContext` + sink (in-process, no wire change). | `packages/agent-runtime`, `persona-agent.ts` | structural spine | Companion assembly only |
+| **7** | Make the enclave dispatch implement the same `TurnRunner` over HTTP (mostly renaming its callback bundle into a sink). | `enclave-runtimes/**`, `backend-callbacks.ts` | structural spine | Enclave transport |
+| **8** | **External on-ramp:** wrap the live bot-runtimes claim→complete behind the `NetworkTurnDriver`; extend `bot:hello` with the `CapabilityManifest` `output` block; extend `/complete`+`/steps` to accept `AgentEvent`/`TurnOutput` payloads while keeping `finalMessageMarkdown` as the `{reply:true}` floor; add `negotiateCapabilities` with the trust-tier E2E rule; de-Pi-ify the dispatcher. | `bot-runtimes/socket-handler.ts:33`, `public-api/schemas.ts:117`, `public-api/handlers.ts:546`, `invocation-outbox-handler.ts:25,97` | external parallel universe; consolidates E2E guards | External path; **existing Pi/OpenClaw harnesses keep working at the reply-only tier throughout** |
+
+The live loop is touched once (Step 6) and only to expose an event stream; the live external path is never rewritten — it is wrapped (Step 8). Steps 1–3 alone clear the entire audit's high/medium findings and are worth doing immediately regardless of which end-state you commit to.
+
+**Where bot-runtimes is the on-ramp:** Step 8 is entirely additive to a working protocol. `BOT_RUNTIME_KINDS` already names `openclaw`/`custom`; `supportedCapabilities` already exists; claim/renew/complete/fail already work. The migration is "extend the manifest, accept richer payloads, add a trust-gate function, lift the Pi-isms" — not "build a plugin system."
+
+---
+
+## 7. Open questions / things to validate (spike before committing)
+
+1. **Async-iterable cost on the hot in-process path.** Does wrapping companion's today-direct call in a `TurnSession`/event-stream add measurable allocation/latency? Spike: benchmark the iterator wrapper vs the direct path under a realistic turn. If it's non-negligible, prefer the lighter Pipeline/Hexagon framing for the in-loop hosts and keep the stream contract at the *wire* boundary only.
+
+2. **Per-runner identity beyond the shared `INTERNAL_API_KEY`.** The trust-tier rule (§5.4) is only load-bearing if Threa can *distinguish* the attested enclave from a 3P harness at the gate. Spike: design per-runner credentials + real enclave attestation (closes E2EE-21/22) and prove `negotiateCapabilities` can authoritatively read `trust`.
+
+3. **`sources:[]` willful defeat.** Required-`sources` typing stops *accidental* drops but not a host passing `[]`. Spike a test that asserts: a turn whose tool results carried source-bearing output **commits non-empty sources**, so the type guarantee isn't silently defeated by review oversight.
+
+4. **`RunLoopStage`/`TurnRunner` width vs the sync-`messageId` expectation.** The driven loop expects `commit` to return a `messageId` synchronously; an async `complete` cannot. Spike: prove the driven adapter's id-expectation stays *inside* the driven runner and does not leak into the protocol surface, and that `TurnSession.result: Promise` absorbs the deferral cleanly for the external tier.
+
+5. **Capability-list ↔ union derivation.** Validate that `Capabilities.emits` / `manifest.output` can be *derived* from the `AgentEvent`/`AgentToolResult`/`SourceItem` shapes (INV-31) with a test that fails if an emittable kind is not declarable — otherwise the negotiation surface rots.
+
+6. **Gap-filler quality + visibility.** Spike the synthesized-trace UX for a reply-only harness and confirm the "synthesized" marker is rendered prominently enough that users don't mistake it for a native trace.
+
+7. **Multimodal delivery divergence.** The shared loop injects images as inline `image: url` user messages (`agent-runtime.ts:651-659`); the enclave push-inlines decrypted parts (`run-turn.ts:257-289`). Validate whether `TurnOutput.multimodal` can carry both shapes cleanly or whether a `MultimodalDelivery` capability is needed.
+
+8. **Wire-versioning trigger.** Confirm the decision to *defer* `taipVersion` until the first non-Threa harness ships — and define the additive-only evolution policy that kicks in at that moment, so internal `AgentEvent` evolution stays free until then.
+
+Key starting files for the spike: `packages/agent-runtime/src/runtime/agent-runtime.ts` (loop + config seam), `agent-tool.ts` + `agent-observer.ts` (tool/observer contracts), `apps/backend/src/features/agents/persona-agent.ts` (companion — the capability ceiling), `apps/enclave/src/agent/run-turn.ts` + `trace-observer.ts` (enclave assembly + sealing), `apps/backend/src/features/bot-runtimes/**` + `apps/backend/src/features/public-api/bot-*` (the external on-ramp), `packages/types/src/tool-privacy.ts:116` + `constants.ts:710-774` (gating + capability/runtime vocabularies), and `docs/audits/e2ee-enclave-audit-2026-06.md` (drift symptoms).


### PR DESCRIPTION
Two reference reports, docs-only, off `main` — meant to be handed to remote agents as the starting context for the e2ee hardening and the agent-runtime redesign workstreams.

## What's in here

### `docs/audits/e2ee-enclave-audit-2026-06.md`
The E2EE-scratchpad + enclave audit.
- **Part I — security & state:** 26 confirmed findings (6 critical), each with `file:line`, current-vs-expected behavior, and a suggested fix order grouped into 6 PR-sized tiers. References as `E2EE-<n>`.
- **Part II — UX parity:** 39 confirmed findings (11 high) on whether encrypted Ariadne *feels* like normal Ariadne, with a 5-tier fix order and cross-references to Part I. References as `UX-<n>`.

### `docs/plans/agent-runtime-pluggability.md`
Design deep-dive on making the **companion**, the **enclave**, and a **marketplace of external third-party harnesses** (OpenClaw / external Pi / ChatGPT / arbitrary) share as much as possible and stop drifting.
- One-page current state (what's shared / duplicated / divergent) + the root-cause analysis.
- **Five distinct architecture options, kept distinct:** Ports & Adapters, Capability Kernel, Turn Pipeline, Turn Protocol, Harness Contract (TAIP).
- Comparison matrix (judge-panel scores), a grafted recommendation ("Turn Protocol spine + TAIP trust-skin"), a dedicated **third-party-plugin ecosystem** section (capability manifest, negotiation/gap-filling, the hard E2E trust rule, install/auth/routing), and an **8-step incremental migration** (no big-bang; steps 1–3 clear the audit's high/medium findings regardless of end-state).

## Status
- The design doc is an **exploration**, not an approved decision.
- The audit's **security group 1** (sink-level E2E guards closing the four plaintext leaks) is already implemented in **#780** — that PR is now code-only; the audit doc lives here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783248330&installation_id=129946197&pr_number=781&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F781&signature=9d1f06dc1559160983a6ef2488f4d0bc7eb6ae4c5ed7ca20bc012a05a284ce22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->