### PR TITLE
fix(e2e): in-stream search over unlocked E2E streams (E2EE-15 / UX-21)

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -331,7 +331,14 @@ export function StreamContent({
   const agentActivity = useAgentActivity(events, socket, workspaceId, currentWorkspaceUserId)
 
   // --- In-stream search ---
-  const streamSearch = useStreamSearch({ workspaceId, streamId })
+  // E2E streams search decrypted bodies client-side (the server only holds
+  // ciphertext); pass the flag + viewer id so the hook can resolve the session.
+  const streamSearch = useStreamSearch({
+    workspaceId,
+    streamId,
+    e2eEnabled: stream?.e2eEnabled === true,
+    userId: currentWorkspaceUserId,
+  })
   const clearSearch = streamSearch.clear
   const openOrFocusSearch = useCallback(() => {
     if (isSearchOpen) {

--- a/apps/frontend/src/hooks/use-stream-search.test.ts
+++ b/apps/frontend/src/hooks/use-stream-search.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest"
+import { collectLocalMatches, type SearchContentResolver } from "./use-stream-search"
+import type { CachedEvent } from "@/db"
+
+function event(overrides: Partial<CachedEvent> & { id: string; _sequenceNum: number }): CachedEvent {
+  return {
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    sequence: String(overrides._sequenceNum),
+    eventType: "message_created",
+    payload: {},
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt: new Date(overrides._sequenceNum * 1000).toISOString(),
+    _cachedAt: 0,
+    ...overrides,
+  } as CachedEvent
+}
+
+/** Plaintext resolver: bare contentMarkdown off the payload. */
+const plaintext: SearchContentResolver = (e) => {
+  const p = e.payload as { contentMarkdown?: string }
+  return Promise.resolve(typeof p.contentMarkdown === "string" ? p.contentMarkdown : null)
+}
+
+describe("collectLocalMatches", () => {
+  it("matches plaintext bodies case-insensitively and returns chronological order", async () => {
+    const events = [
+      event({ id: "e2", _sequenceNum: 2, payload: { messageId: "m2", contentMarkdown: "the Quick brown fox" } }),
+      event({ id: "e1", _sequenceNum: 1, payload: { messageId: "m1", contentMarkdown: "a quick note" } }),
+      event({ id: "e3", _sequenceNum: 3, payload: { messageId: "m3", contentMarkdown: "nothing here" } }),
+    ]
+
+    const matches = await collectLocalMatches(events, "QUICK", plaintext)
+
+    expect(matches.map((m) => m.id)).toEqual(["m1", "m2"]) // sorted by _sequenceNum, m3 excluded
+    expect(matches[0]).toMatchObject({ id: "m1", streamId: "stream_1", content: "a quick note", authorType: "user" })
+  })
+
+  it("matches DECRYPTED bodies for sealed rows (the E2E path)", async () => {
+    // Sealed rows carry only a zero-width placeholder on the wire; the resolver
+    // returns the decrypted body, which is what search must match against.
+    const plain = "​" // E2E placeholder
+    const events = [
+      event({
+        id: "e1",
+        _sequenceNum: 1,
+        payload: { messageId: "m1", contentMarkdown: plain, ciphertext: "ct", envelope: { v: 2 } },
+      }),
+    ]
+    const decrypted: Record<string, string> = { e1: "the launch codename is VELVET-OTTER" }
+    const resolver: SearchContentResolver = (e) => Promise.resolve(decrypted[e.id] ?? null)
+
+    const matches = await collectLocalMatches(events, "velvet-otter", resolver)
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({ id: "m1", content: "the launch codename is VELVET-OTTER" })
+  })
+
+  it("never matches the placeholder when a sealed row can't be decrypted (locked → null)", async () => {
+    const placeholder = "​"
+    const events = [
+      event({
+        id: "e1",
+        _sequenceNum: 1,
+        payload: { messageId: "m1", contentMarkdown: placeholder, ciphertext: "ct", envelope: { v: 2 } },
+      }),
+    ]
+    // Locked/undecryptable rows resolve to null and are skipped entirely.
+    const lockedResolver: SearchContentResolver = () => Promise.resolve(null)
+
+    // Even searching for the placeholder character yields nothing — we never
+    // match server-side ciphertext/placeholder, only decrypted content.
+    expect(await collectLocalMatches(events, placeholder, lockedResolver)).toEqual([])
+    expect(await collectLocalMatches(events, "anything", lockedResolver)).toEqual([])
+  })
+
+  it("falls back to the event id when the payload has no messageId", async () => {
+    const events = [event({ id: "evt_x", _sequenceNum: 1, payload: { contentMarkdown: "findme" } })]
+    const matches = await collectLocalMatches(events, "findme", plaintext)
+    expect(matches[0].id).toBe("evt_x")
+  })
+})

--- a/apps/frontend/src/hooks/use-stream-search.test.ts
+++ b/apps/frontend/src/hooks/use-stream-search.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from "vitest"
-import { collectLocalMatches, type SearchContentResolver } from "./use-stream-search"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { collectLocalMatches, useStreamSearch, type SearchContentResolver } from "./use-stream-search"
 import type { CachedEvent } from "@/db"
+import * as dbModule from "@/db"
+import * as decryptCache from "@/lib/crypto/decrypt-cache"
+import * as e2eStore from "@/stores/e2e-session-store"
+import * as api from "@/api"
 
 function event(overrides: Partial<CachedEvent> & { id: string; _sequenceNum: number }): CachedEvent {
   return {
@@ -79,5 +84,96 @@ describe("collectLocalMatches", () => {
     const events = [event({ id: "evt_x", _sequenceNum: 1, payload: { contentMarkdown: "findme" } })]
     const matches = await collectLocalMatches(events, "findme", plaintext)
     expect(matches[0].id).toBe("evt_x")
+  })
+})
+
+// Integration: exercise the real hook wiring (session → resolver →
+// requestDecryption → search orchestration → e2e server-phase skip), mocking
+// only the boundaries (IDB, decrypt cache, session, server search).
+describe("useStreamSearch hook integration", () => {
+  let fakeEvents: CachedEvent[]
+  let searchMessagesSpy: ReturnType<typeof vi.spyOn>
+
+  function mockEventsTable(events: CachedEvent[]) {
+    // db.events.where(...).equals(...).filter(pred).toArray()
+    const chain = {
+      equals: () => chain,
+      filter: (pred: (e: CachedEvent) => boolean) => ({ toArray: async () => events.filter(pred) }),
+    }
+    vi.spyOn(dbModule.db.events, "where").mockReturnValue(chain as never)
+  }
+
+  beforeEach(() => {
+    fakeEvents = []
+    vi.spyOn(e2eStore, "useE2eSession").mockReturnValue({
+      status: "unlocked",
+      privateKey: {} as CryptoKey,
+      keyId: "e2ek_self",
+    } as never)
+    searchMessagesSpy = vi
+      .spyOn(api, "searchMessages")
+      .mockResolvedValue({ results: [] } as never)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("decrypts sealed rows on demand and matches their plaintext; skips the server phase", async () => {
+    fakeEvents = [
+      event({
+        id: "e1",
+        _sequenceNum: 1,
+        payload: { messageId: "m1", contentMarkdown: "​", ciphertext: "ct1", envelope: { v: 2 } },
+      }),
+      event({
+        id: "e2",
+        _sequenceNum: 2,
+        payload: { messageId: "m2", contentMarkdown: "​", ciphertext: "ct2", envelope: { v: 2 } },
+      }),
+    ]
+    mockEventsTable(fakeEvents)
+    const decryptedById: Record<string, string> = {
+      e1: "the codename is VELVET-OTTER",
+      e2: "unrelated chatter",
+    }
+    vi.spyOn(decryptCache, "requestDecryption").mockImplementation(
+      async (eventId: string) =>
+        ({ status: "decrypted", content: { contentMarkdown: decryptedById[eventId] ?? "" } }) as never
+    )
+
+    const { result } = renderHook(() =>
+      useStreamSearch({ workspaceId: "ws_1", streamId: "stream_1", e2eEnabled: true, userId: "usr_self" })
+    )
+
+    await act(async () => {
+      result.current.setQuery("velvet-otter")
+    })
+    await act(async () => {
+      await result.current.search()
+    })
+
+    // Matched the DECRYPTED body of the sealed row…
+    expect(result.current.results.map((r) => r.id)).toEqual(["m1"])
+    expect(result.current.results[0].content).toContain("VELVET-OTTER")
+    // …and never hit the server ILIKE phase (it can only match the placeholder).
+    expect(searchMessagesSpy).not.toHaveBeenCalled()
+  })
+
+  it("plaintext stream still calls the server phase (no behavior change)", async () => {
+    fakeEvents = [event({ id: "e1", _sequenceNum: 1, payload: { messageId: "m1", contentMarkdown: "hello plaintext" } })]
+    mockEventsTable(fakeEvents)
+
+    const { result } = renderHook(() =>
+      useStreamSearch({ workspaceId: "ws_1", streamId: "stream_1", e2eEnabled: false })
+    )
+
+    await act(async () => {
+      result.current.setQuery("plaintext")
+    })
+    await act(async () => {
+      await result.current.search()
+    })
+
+    expect(result.current.results.map((r) => r.id)).toEqual(["m1"])
+    expect(searchMessagesSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/hooks/use-stream-search.test.ts
+++ b/apps/frontend/src/hooks/use-stream-search.test.ts
@@ -58,8 +58,7 @@ describe("collectLocalMatches", () => {
 
     const matches = await collectLocalMatches(events, "velvet-otter", resolver)
 
-    expect(matches).toHaveLength(1)
-    expect(matches[0]).toMatchObject({ id: "m1", content: "the launch codename is VELVET-OTTER" })
+    expect(matches).toEqual([expect.objectContaining({ id: "m1", content: "the launch codename is VELVET-OTTER" })])
   })
 
   it("never matches the placeholder when a sealed row can't be decrypted (locked → null)", async () => {
@@ -110,9 +109,7 @@ describe("useStreamSearch hook integration", () => {
       privateKey: {} as CryptoKey,
       keyId: "e2ek_self",
     } as never)
-    searchMessagesSpy = vi
-      .spyOn(api, "searchMessages")
-      .mockResolvedValue({ results: [] } as never)
+    searchMessagesSpy = vi.spyOn(api, "searchMessages").mockResolvedValue({ results: [] } as never)
   })
 
   afterEach(() => vi.restoreAllMocks())
@@ -159,7 +156,9 @@ describe("useStreamSearch hook integration", () => {
   })
 
   it("plaintext stream still calls the server phase (no behavior change)", async () => {
-    fakeEvents = [event({ id: "e1", _sequenceNum: 1, payload: { messageId: "m1", contentMarkdown: "hello plaintext" } })]
+    fakeEvents = [
+      event({ id: "e1", _sequenceNum: 1, payload: { messageId: "m1", contentMarkdown: "hello plaintext" } }),
+    ]
     mockEventsTable(fakeEvents)
 
     const { result } = renderHook(() =>

--- a/apps/frontend/src/hooks/use-stream-search.ts
+++ b/apps/frontend/src/hooks/use-stream-search.ts
@@ -1,10 +1,74 @@
 import { useState, useCallback, useRef, useMemo } from "react"
 import { searchMessages, type SearchFilters, type SearchResultItem } from "@/api"
-import { db } from "@/db"
+import { db, type CachedEvent } from "@/db"
+import { requestDecryption } from "@/lib/crypto/decrypt-cache"
+import { useE2eSession } from "@/stores/e2e-session-store"
 
 interface UseStreamSearchOptions {
   workspaceId: string
   streamId: string
+  /**
+   * When the stream is end-to-end encrypted, in-stream search matches against
+   * the *decrypted* message bodies (the server only stores ciphertext + a
+   * zero-width placeholder), and the server-side ILIKE phase is skipped because
+   * it can only ever match the placeholder. Plaintext streams are unaffected.
+   */
+  e2eEnabled?: boolean
+  /** Current workspace user id — needed to resolve the E2E session for decryption. */
+  userId?: string | null
+}
+
+/**
+ * Resolve an event's searchable plaintext body: the bare `contentMarkdown` for
+ * a plaintext row, or the decrypted markdown for a sealed row. Returns `null`
+ * when a sealed row can't be read (locked session / decrypt failure) so it is
+ * simply skipped rather than matched against its zero-width placeholder.
+ */
+export type SearchContentResolver = (event: CachedEvent) => Promise<string | null>
+
+/** Extract the sealed payload off a cached event, or null when it's plaintext. */
+function readSealedEventPayload(
+  event: CachedEvent
+): { ciphertext: string; envelope: unknown; contentMarkdown?: string } | null {
+  if (event.eventType !== "message_created") return null
+  const payload = event.payload as Record<string, unknown> | undefined
+  if (!payload || typeof payload.ciphertext !== "string" || !payload.envelope) return null
+  return {
+    ciphertext: payload.ciphertext,
+    envelope: payload.envelope,
+    contentMarkdown: typeof payload.contentMarkdown === "string" ? payload.contentMarkdown : undefined,
+  }
+}
+
+/**
+ * Pure matcher: given loaded events (any order) and a content resolver, return
+ * the chronologically-ordered `SearchResultItem`s whose resolved body contains
+ * `query` (case-insensitive). Shared by the plaintext and E2E search paths and
+ * unit-tested directly.
+ */
+export async function collectLocalMatches(
+  events: CachedEvent[],
+  query: string,
+  resolve: SearchContentResolver
+): Promise<SearchResultItem[]> {
+  const lowerQuery = query.toLowerCase()
+  const sorted = [...events].sort((a, b) => a._sequenceNum - b._sequenceNum)
+  const resolved = await Promise.all(sorted.map(async (e) => ({ e, content: await resolve(e) })))
+  const out: SearchResultItem[] = []
+  for (const { e, content } of resolved) {
+    if (!content || !content.toLowerCase().includes(lowerQuery)) continue
+    const payload = e.payload as { messageId?: string }
+    out.push({
+      id: payload.messageId ?? e.id,
+      streamId: e.streamId,
+      content,
+      authorId: e.actorId ?? "",
+      authorType: (e.actorType ?? "user") as "user" | "persona",
+      createdAt: e.createdAt,
+      rank: 0,
+    })
+  }
+  return out
 }
 
 /** A single navigable match: one text occurrence within one message */
@@ -70,33 +134,22 @@ function buildFlatMatches(results: SearchResultItem[], query: string): FlatMatch
   return matches
 }
 
-/** Search local IDB events for a text match (case-insensitive substring) */
-async function searchLocalEvents(streamId: string, query: string): Promise<SearchResultItem[]> {
-  const lowerQuery = query.toLowerCase()
+/**
+ * Search local IDB events for a text match (case-insensitive substring),
+ * resolving each event's body through `resolve` — bare markdown for plaintext
+ * streams, decrypted markdown for E2E streams.
+ */
+async function searchLocalEvents(
+  streamId: string,
+  query: string,
+  resolve: SearchContentResolver
+): Promise<SearchResultItem[]> {
   const events = await db.events
     .where("streamId")
     .equals(streamId)
-    .filter((e) => {
-      if (e.eventType !== "message_created" && e.eventType !== "companion_response") return false
-      const payload = e.payload as { contentMarkdown?: string }
-      return !!payload.contentMarkdown && payload.contentMarkdown.toLowerCase().includes(lowerQuery)
-    })
+    .filter((e) => e.eventType === "message_created" || e.eventType === "companion_response")
     .toArray()
-
-  return events
-    .sort((a, b) => a._sequenceNum - b._sequenceNum)
-    .map((e) => {
-      const payload = e.payload as { messageId?: string; contentMarkdown?: string }
-      return {
-        id: payload.messageId ?? e.id,
-        streamId: e.streamId,
-        content: payload.contentMarkdown ?? "",
-        authorId: e.actorId ?? "",
-        authorType: (e.actorType ?? "user") as "user" | "persona",
-        createdAt: e.createdAt,
-        rank: 0,
-      }
-    })
+  return collectLocalMatches(events, query, resolve)
 }
 
 /** Merge local and server results, dedup by id, sort chronologically (oldest first) */
@@ -107,7 +160,12 @@ function mergeAndSort(local: SearchResultItem[], server: SearchResultItem[]): Se
   return Array.from(seen.values()).sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
 }
 
-export function useStreamSearch({ workspaceId, streamId }: UseStreamSearchOptions): UseStreamSearchReturn {
+export function useStreamSearch({
+  workspaceId,
+  streamId,
+  e2eEnabled = false,
+  userId = null,
+}: UseStreamSearchOptions): UseStreamSearchReturn {
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<SearchResultItem[]>([])
   const [isSearching, setIsSearching] = useState(false)
@@ -120,6 +178,37 @@ export function useStreamSearch({ workspaceId, streamId }: UseStreamSearchOption
   const inputRef = useRef<HTMLInputElement>(null)
   const activeMatchIndexRef = useRef(activeMatchIndex)
   activeMatchIndexRef.current = activeMatchIndex
+
+  // E2E search reads decrypted bodies on demand. For a plaintext stream the
+  // session is irrelevant (sealed-payload resolution returns null and the row
+  // falls through to its plaintext `contentMarkdown`), so this is a no-op there.
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const sessionRef = useRef(session)
+  sessionRef.current = session
+
+  // Resolve an event's searchable body. Sealed rows decrypt on demand (warming
+  // the shared decrypt cache the timeline also reads); plaintext rows return
+  // their stored markdown. A sealed row that can't be opened resolves to null
+  // and is skipped — matching the documented "search over already-decrypted
+  // content" behavior rather than matching the zero-width placeholder.
+  const resolveContent = useCallback<SearchContentResolver>(
+    async (event) => {
+      const sealed = readSealedEventPayload(event)
+      if (!sealed) {
+        const payload = event.payload as { contentMarkdown?: string }
+        return typeof payload.contentMarkdown === "string" ? payload.contentMarkdown : null
+      }
+      const s = sessionRef.current
+      if (s.status !== "unlocked" || !s.privateKey || !s.keyId) return null
+      const entry = await requestDecryption(
+        event.id,
+        { contentMarkdown: sealed.contentMarkdown ?? "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
+        { privateKey: s.privateKey, recipientKeyId: s.keyId, workspaceId, streamId: event.streamId }
+      )
+      return entry.status === "decrypted" && entry.content ? entry.content.contentMarkdown : null
+    },
+    [workspaceId]
+  )
 
   // Build flat matches from results + current query
   const flatMatches = useMemo(() => buildFlatMatches(results, query), [results, query])
@@ -138,8 +227,9 @@ export function useStreamSearch({ workspaceId, streamId }: UseStreamSearchOption
     let localResults: SearchResultItem[] = []
 
     try {
-      // Phase 1: instant local IDB substring search
-      localResults = await searchLocalEvents(streamId, trimmed)
+      // Phase 1: instant local IDB substring search (decrypting sealed rows on
+      // demand for E2E streams).
+      localResults = await searchLocalEvents(streamId, trimmed, resolveContent)
       if (searchId !== searchIdRef.current) return
 
       if (localResults.length > 0) {
@@ -147,6 +237,17 @@ export function useStreamSearch({ workspaceId, streamId }: UseStreamSearchOption
         const localFlat = buildFlatMatches(localResults, trimmed)
         setActiveMatchIndex(localFlat.length > 0 ? localFlat.length - 1 : 0)
         setHasSearched(true)
+      }
+
+      // E2E streams: the server only holds ciphertext + a zero-width placeholder,
+      // so the ILIKE phase can never match the real body. The local decrypted
+      // search above is authoritative — finalize (even when empty) and stop.
+      if (e2eEnabled) {
+        const localFlat = buildFlatMatches(localResults, trimmed)
+        setResults(localResults)
+        setActiveMatchIndex(localFlat.length > 0 ? localFlat.length - 1 : -1)
+        setHasSearched(true)
+        return
       }
 
       // Phase 2: server exact search (ILIKE) — covers events not in IDB.
@@ -190,7 +291,7 @@ export function useStreamSearch({ workspaceId, streamId }: UseStreamSearchOption
         setIsSearching(false)
       }
     }
-  }, [workspaceId, streamId])
+  }, [workspaceId, streamId, e2eEnabled, resolveContent])
 
   const prevResult = useCallback(() => {
     if (flatMatches.length === 0) return

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -56,7 +56,10 @@ test.describe("E2E encrypted scratchpads", () => {
     await expect(page.getByRole("button", { name: /^Unlock$/ }).first()).toBeVisible()
 
     // Unlock from the gate → the gate clears and the timeline returns.
-    await page.getByRole("button", { name: /^Unlock$/ }).first().click()
+    await page
+      .getByRole("button", { name: /^Unlock$/ })
+      .first()
+      .click()
     const unlock = page.getByRole("dialog")
     await expect(unlock.getByText("Unlock encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
     await unlock.locator("input[type='password'], input[type='text']").first().fill(PASSPHRASE)
@@ -159,5 +162,48 @@ test.describe("E2E encrypted scratchpads", () => {
     const image = page.locator('img[alt="pasted-image-1.png"]')
     await expect(image).toBeVisible({ timeout: 30_000 })
     expect(await image.getAttribute("src")).toMatch(/^blob:/)
+  })
+
+  test("in-stream search matches the DECRYPTED body of an unlocked encrypted message (E2EE-15)", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "e2e-enc-search")
+
+    // Create an encrypted scratchpad and stay unlocked (we search within the
+    // same session, so the body is decryptable on demand).
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+    const setup = page.getByRole("dialog")
+    await expect(setup.getByText("Set up encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await setup.locator("#e2e-passphrase").fill(PASSPHRASE)
+    await setup.locator("#e2e-passphrase-confirm").fill(PASSPHRASE)
+    await setup.locator("#e2e-acknowledged").check()
+    const trustDevice = setup.locator("#e2e-setup-trust-device")
+    if (await trustDevice.isChecked()) await trustDevice.uncheck()
+    await setup.getByRole("button", { name: "Enable encryption" }).click()
+    await expect(page.getByText("Encrypted", { exact: true })).toBeVisible({ timeout: 15_000 })
+
+    // Send a message. On the wire this is sealed — the server stores ciphertext
+    // plus a zero-width placeholder, never this token — so any later search hit
+    // can ONLY come from decrypting locally. That's the documented promise the
+    // old code broke (Cmd-F returned zero matches because both phases saw the
+    // placeholder): E2EE-15 / UX-21.
+    const token = "VELVET-OTTER-SEARCHME"
+    const editor = page.locator("[contenteditable='true']")
+    await editor.click()
+    await page.keyboard.type(`the launch codename is ${token}`)
+    await page.getByRole("button", { name: "Send", exact: true }).first().click()
+    // The row renders decrypted in the timeline (composer clears on send).
+    await expect(page.getByText(token).first()).toBeVisible({ timeout: 20_000 })
+
+    // Open in-stream search via the same DOM event the header search button
+    // dispatches — deterministic across Cmd/Ctrl platforms — and query the token
+    // in lowercase to also prove the match is case-insensitive.
+    await page.evaluate(() => document.dispatchEvent(new Event("threa:open-stream-search")))
+    const searchInput = page.getByPlaceholder("Search in conversation...")
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+    await searchInput.fill(token.toLowerCase())
+
+    // The match counter (activeMatchIndex+1 / matchCount) only renders once the
+    // local decrypted search found the body. One message, one occurrence → 1/1.
+    await expect(page.getByText("1/1")).toBeVisible({ timeout: 10_000 })
   })
 })


### PR DESCRIPTION
Autonomous build while you were out — picked the highest-value, **lowest-regret, decision-independent** item from the audit so it can't be "the wrong way": it's frontend-only, additive, and unrelated to the agent-runtime redesign direction.

## Problem (E2EE-15, high · UX-21)
Cmd-F in an **unlocked** encrypted scratchpad returned **zero matches**. Both search phases matched the server-stored zero-width placeholder, never the real body:
- local IDB scan filtered on `payload.contentMarkdown` (the U+200B placeholder for E2E rows),
- the server ILIKE phase can only see ciphertext/placeholder.

This directly contradicts the documented promise (`docs/.../e2e-encrypted-scratchpads.md`): *"Client-side keyword search over already-decrypted content still works."*

## Fix
- Local search resolves each event's body through the **shared decrypt cache**: plaintext rows return their markdown unchanged; **sealed rows decrypt on demand** via `requestDecryption` — the exact same path + session opts the timeline already uses, so searching also *warms* the render cache.
- The **server ILIKE phase is skipped for E2E streams** (it can never match the sealed body).
- A sealed row that can't be opened (locked session / decrypt failure) resolves to `null` and is **skipped** — we never match the placeholder/ciphertext.
- **Plaintext search is byte-for-byte unchanged** (same results, same order); the core matcher was extracted as the pure `collectLocalMatches`.

## Testing
- New `use-stream-search.test.ts` (4 tests) on `collectLocalMatches`: plaintext case-insensitive + chronological order, decrypted-body matching (E2E path), locked-row → never matches placeholder, event-id fallback.
- Frontend typecheck clean; eslint clean; adjacent crypto + timeline suites green (108).
- **Not yet browser-verified** end-to-end (dev:test + real unlock + Cmd-F) — the logic reuses the production decrypt path, but a live click-through is the recommended last check before merge. Happy to run it on confirmation.

## Scope notes
- Coverage is "already-loaded events," decrypted on demand — exactly the documented "already-decrypted content" behavior. Messages never synced to IDB aren't searched (same limit as today's local phase; the server can't help for E2E by design).
- Pairs with the audit in #781 (this addresses **E2EE-15 / UX-21**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250553&installation_id=129946197&pr_number=782&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F782&signature=58eebcb405ed699d729ecda21dab371f21c237535cb0cfceb17b7e5dcb55c158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->