### PR TITLE
fix(e2e): gate biometric unlock on real platform-authenticator availability (UX-30)

### DIFF
--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -18,7 +18,7 @@ import { scorePassphrase, type PassphraseScore } from "./passphrase-strength"
 import { RevealablePassphraseInput } from "./revealable-passphrase-input"
 import { PinInput, PIN_LENGTH } from "./pin-input"
 import { isValidPin } from "@/lib/crypto/pin-device-key"
-import { isWebAuthnAvailable, registerPrfCredential, type PrfRegistration } from "@/lib/crypto/webauthn-device-key"
+import { isPlatformAuthenticatorAvailable, registerPrfCredential, type PrfRegistration } from "@/lib/crypto/webauthn-device-key"
 import { Fingerprint } from "lucide-react"
 
 interface PassphraseSetupModalProps {
@@ -82,11 +82,27 @@ export function PassphraseSetupModal({
   const [biometric, setBiometric] = useState<PrfRegistration | null>(null)
   const [registeringBiometric, setRegisteringBiometric] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  // Offer biometric only when a real platform authenticator exists (UX-30) —
+  // probed async on open, so the option never appears as a button that can
+  // only fail on devices that merely expose the WebAuthn API.
+  const [biometricAvailable, setBiometricAvailable] = useState(false)
 
   // Reset the toggle to the caller's default each time the modal opens.
   useEffect(() => {
     if (open) setTrustDevice(defaultTrustDevice)
   }, [open, defaultTrustDevice])
+
+  // Probe platform-authenticator availability when the modal opens.
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void isPlatformAuthenticatorAvailable().then((ok) => {
+      if (!cancelled) setBiometricAvailable(ok)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
 
   const passphraseTooShort = passphrase.length > 0 && passphrase.length < MIN_PASSPHRASE_LENGTH
   const mismatched = confirm.length > 0 && passphrase !== confirm
@@ -258,7 +274,7 @@ export function PassphraseSetupModal({
                     )}
                   </div>
                 )}
-                {isWebAuthnAvailable() && (
+                {biometricAvailable && (
                   <div className="space-y-1.5 border-t border-border pt-3 first:border-t-0 first:pt-0">
                     <Label className="font-normal">
                       Biometric unlock <span className="text-muted-foreground">(optional)</span>

--- a/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { generateUIK } from "../keys"
-import { unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "../webauthn-device-key"
+import { isPlatformAuthenticatorAvailable, unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "../webauthn-device-key"
 
 // The PRF secret is a uniformly-random 32 bytes the authenticator would return;
 // the ceremony itself (navigator.credentials) is covered by the Playwright
@@ -32,5 +32,44 @@ describe("wrapPrivateKeyWithPrf / unwrapPrivateKeyWithPrf", () => {
   it("rejects a too-short PRF secret", async () => {
     const uik = await generateUIK()
     await expect(wrapPrivateKeyWithPrf(uik.privateKey, new Uint8Array(16))).rejects.toThrow(/at least 32/)
+  })
+})
+
+describe("isPlatformAuthenticatorAvailable (UX-30)", () => {
+  const originalPkc = Object.getOwnPropertyDescriptor(window, "PublicKeyCredential")
+  const originalCreds = Object.getOwnPropertyDescriptor(navigator, "credentials")
+
+  function setGlobals(pkc: unknown, hasCredentialsCreate: boolean) {
+    Object.defineProperty(window, "PublicKeyCredential", { value: pkc, configurable: true, writable: true })
+    Object.defineProperty(navigator, "credentials", {
+      value: hasCredentialsCreate ? { create: () => Promise.resolve(null) } : undefined,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  afterEach(() => {
+    if (originalPkc) Object.defineProperty(window, "PublicKeyCredential", originalPkc)
+    else Reflect.deleteProperty(window, "PublicKeyCredential")
+    if (originalCreds) Object.defineProperty(navigator, "credentials", originalCreds)
+    else Reflect.deleteProperty(navigator, "credentials")
+  })
+
+  it("is false when the WebAuthn API is absent", async () => {
+    setGlobals(undefined, false)
+    expect(await isPlatformAuthenticatorAvailable()).toBe(false)
+  })
+
+  it("reflects the platform-authenticator probe when the API exists", async () => {
+    setGlobals({ isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true) }, true)
+    expect(await isPlatformAuthenticatorAvailable()).toBe(true)
+
+    setGlobals({ isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(false) }, true)
+    expect(await isPlatformAuthenticatorAvailable()).toBe(false)
+  })
+
+  it("is false (never throws) when the probe rejects", async () => {
+    setGlobals({ isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.reject(new Error("nope")) }, true)
+    expect(await isPlatformAuthenticatorAvailable()).toBe(false)
   })
 })

--- a/apps/frontend/src/lib/crypto/webauthn-device-key.ts
+++ b/apps/frontend/src/lib/crypto/webauthn-device-key.ts
@@ -55,6 +55,23 @@ export function isWebAuthnAvailable(): boolean {
   return typeof window !== "undefined" && !!window.PublicKeyCredential && !!navigator.credentials?.create
 }
 
+/**
+ * True only when a *platform* authenticator (Touch ID / Face / Windows Hello /
+ * Android biometrics) is actually present and usable. `isWebAuthnAvailable()`
+ * only proves the WebAuthn API exists — which many desktop browsers expose with
+ * no platform authenticator attached, so gating the biometric affordance on it
+ * offers a button that can only fail (UX-30). This is async (a browser probe)
+ * and resolves false on any error or where the API is absent.
+ */
+export async function isPlatformAuthenticatorAvailable(): Promise<boolean> {
+  if (!isWebAuthnAvailable()) return false
+  try {
+    return await window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+  } catch {
+    return false
+  }
+}
+
 export interface PrfRegistration {
   /** base64 of the credential's raw id — stored to address it on unlock. */
   credentialId: string


### PR DESCRIPTION
**Stacked on #782** (base branch `e2ee-search-unlocked-content`).

## UX-30 (medium)
The passphrase setup modal offered "Set up biometric unlock" whenever `isWebAuthnAvailable()` was true — but that only checks the **WebAuthn API exists**, which many desktop browsers expose with **no platform authenticator** attached. Users got a button that could only fail.

## Fix
- New `isPlatformAuthenticatorAvailable()` — async probe via `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()`, degrades to `false` on absence or any error.
- The setup modal probes it on open (state) and only renders the biometric option when a platform authenticator is actually present. The passphrase + PIN paths are unchanged.

## Testing
- `webauthn-device-key.test.ts`: API-absent → false, UVPAA true/false reflected, probe-rejects → false (never throws).
- Frontend typecheck + eslint clean.

> Note: full browser click-through of the E2E flows is currently blocked by a local dev:test infra issue (Vite 431 on the bloated stub-auth cookie under bun, which ignores `--max-http-header-size`); verified at unit + integration level instead. Details in the session report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252539&installation_id=129946197&pr_number=783&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F783&signature=a865aade39cf8e25ec8e63e8fae6fc864682f0b6dbfaf35df6b269630e61ae88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->