### PR TITLE
fix(e2e): enclave Ariadne explains her encrypted-scratchpad limits (UX-7)

### DIFF
--- a/apps/backend/src/features/agents/enclave-system-prompt.test.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import * as contextBuilder from "./context-builder"
+import * as systemPrompt from "./companion/prompt/system-prompt"
+import { buildEnclaveSystemPrompt } from "./enclave-system-prompt"
+import type { Stream } from "../streams"
+import type { BuiltInAgentConfig } from "./built-in-agents"
+
+afterEach(() => mock.restore())
+
+const STREAM = { id: "stream_1", workspaceId: "ws_1", type: "scratchpad" } as Stream
+const PERSONA = { id: "ariadne", name: "Ariadne", systemPrompt: "You are Ariadne." } as BuiltInAgentConfig
+const PREFS = { scratchpadCustomPrompt: null } as never
+
+describe("buildEnclaveSystemPrompt", () => {
+  it("appends the encrypted-scratchpad limits clause after the shared prompt (UX-7)", async () => {
+    spyOn(contextBuilder, "buildStreamContext").mockResolvedValue({} as never)
+    spyOn(systemPrompt, "buildSystemPrompt").mockReturnValue("BASE_PROMPT_BODY")
+
+    const result = await buildEnclaveSystemPrompt({
+      pool: {} as Pool,
+      stream: STREAM,
+      preferences: PREFS,
+      persona: PERSONA,
+    })
+
+    // The shared prompt is preserved verbatim and leads…
+    expect(result.startsWith("BASE_PROMPT_BODY")).toBe(true)
+    // …followed by the limits section that names the boundary and the guidance.
+    expect(result).toContain("## Encrypted scratchpad limits")
+    expect(result).toContain("workspace memory (GAM)")
+    expect(result).toMatch(/do not guess or invent/i)
+  })
+
+  it("builds the prompt with the enclave-reduced toolset and workspace_research disabled", async () => {
+    spyOn(contextBuilder, "buildStreamContext").mockResolvedValue({} as never)
+    const build = spyOn(systemPrompt, "buildSystemPrompt").mockReturnValue("BASE")
+
+    await buildEnclaveSystemPrompt({ pool: {} as Pool, stream: STREAM, preferences: PREFS, persona: PERSONA })
+
+    const [personaArg, , , , , rollingSummary, workspaceResearch] = build.mock.calls[0]!
+    expect((personaArg as { enabledTools: string[] }).enabledTools).toEqual(["web_search", "read_url", "general_research"])
+    expect(rollingSummary).toBeNull() // no plaintext history to summarize
+    expect(workspaceResearch).toBe(false) // no DB in the enclave
+  })
+})

--- a/apps/backend/src/features/agents/enclave-system-prompt.test.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.test.ts
@@ -39,7 +39,12 @@ describe("buildEnclaveSystemPrompt", () => {
     await buildEnclaveSystemPrompt({ pool: {} as Pool, stream: STREAM, preferences: PREFS, persona: PERSONA })
 
     const [personaArg, , , , , rollingSummary, workspaceResearch] = build.mock.calls[0]!
-    expect((personaArg as { enabledTools: string[] }).enabledTools).toEqual(["web_search", "read_url", "general_research"])
+    expect((personaArg as { enabledTools: string[] }).enabledTools).toEqual([
+      "web_search",
+      "read_url",
+      "general_research",
+      "load_attachment",
+    ])
     expect(rollingSummary).toBeNull() // no plaintext history to summarize
     expect(workspaceResearch).toBe(false) // no DB in the enclave
   })

--- a/apps/backend/src/features/agents/enclave-system-prompt.ts
+++ b/apps/backend/src/features/agents/enclave-system-prompt.ts
@@ -55,7 +55,7 @@ export async function buildEnclaveSystemPrompt(params: {
     updatedAt: new Date(),
   }
 
-  return buildSystemPrompt(
+  const prompt = buildSystemPrompt(
     enclavePersona,
     context,
     preferences.scratchpadCustomPrompt,
@@ -67,4 +67,18 @@ export async function buildEnclaveSystemPrompt(params: {
     // workspace_research needs the DB; the enclave has none.
     false
   )
+
+  // The shared prompt advertises the reduced toolset but never explains *why*
+  // capabilities are missing. Without this, asked to recall something from the
+  // workspace, Ariadne either hallucinates or refuses confusingly (UX-7). Tell
+  // her plainly so she can voice the boundary gracefully — kept as a
+  // natural-language instruction (the model handles phrasing/locale), not a
+  // code-level heuristic.
+  return `${prompt}
+
+## Encrypted scratchpad limits
+
+You are running inside an end-to-end-encrypted scratchpad. You can read this conversation and do web research, but the rest of the workspace never enters this encrypted context: you have no access to workspace memory (GAM), other channels or scratchpads, saved knowledge, or any cross-stream search. This is a deliberate privacy boundary, not an error.
+
+If the user asks you to recall, summarize, or look something up from their workspace or another conversation, do not guess or invent it. Briefly explain that you can't see anything outside this encrypted scratchpad, and offer what you *can* do here (work with what's in this conversation, or research the web).`
 }


### PR DESCRIPTION
**Stacked on #783** (→ #782 → main).

## UX-7 (high)
In an E2E scratchpad Ariadne loses workspace memory (GAM), other channels, saved knowledge, and cross-stream search — but the system prompt only advertises the reduced toolset, never explaining the boundary. Asked to recall something from the workspace, she hallucinates or gives a confusing refusal.

## Fix
Append an "Encrypted scratchpad limits" section to the enclave system prompt that names the privacy boundary and instructs her to explain it plainly (and offer what she *can* do) rather than guess. Kept as a natural-language instruction (model handles phrasing/locale — no code-level language heuristic, INV-54). **Enclave-only**: the shared `buildSystemPrompt` the companion uses is untouched.

## Testing
- New `enclave-system-prompt.test.ts`: the limits clause is appended after the shared prompt and names the boundary + guidance; the enclave-reduced toolset + `workspace_research=false` + null rolling summary are passed through.
- Full enclave-runtimes + new suite green (57); backend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252667&installation_id=129946197&pr_number=784&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F784&signature=4c38955ba917814c7debf5a51fbad8b352a022ad59053d5504707d42f34ea4e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->