### PR TITLE
fix(e2e): Encrypted-message placeholder for saved E2E messages (E2EE-16)

### DIFF
--- a/apps/frontend/src/components/saved/saved-item.test.tsx
+++ b/apps/frontend/src/components/saved/saved-item.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
-import type { SavedMessageView } from "@threa/types"
+import { E2E_PLACEHOLDER_CONTENT_MARKDOWN, type SavedMessageView } from "@threa/types"
 import { SavedItem } from "./saved-item"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as useMobileModule from "@/hooks/use-mobile"
@@ -122,5 +122,24 @@ describe("SavedItem stream label", () => {
     )
 
     expect(getByText("Unknown")).toBeTruthy()
+  })
+})
+
+describe("SavedItem preview (E2EE-16)", () => {
+  it("renders an 'Encrypted message' placeholder for a saved E2E message", () => {
+    mockStore()
+    const { getByText, queryByText } = mount(
+      makeView({ message: { ...makeView().message!, contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN } })
+    )
+
+    expect(getByText("🔒 Encrypted message")).toBeTruthy()
+    // The invisible zero-width placeholder is never rendered as the body.
+    expect(queryByText(E2E_PLACEHOLDER_CONTENT_MARKDOWN)).toBeNull()
+  })
+
+  it("renders the plaintext body for a normal saved message", () => {
+    mockStore()
+    const { getByText } = mount(makeView({ message: { ...makeView().message!, contentMarkdown: "hello there" } }))
+    expect(getByText("hello there")).toBeTruthy()
   })
 })

--- a/apps/frontend/src/components/saved/saved-item.tsx
+++ b/apps/frontend/src/components/saved/saved-item.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Archive, Bell, Check, CircleAlert, Trash2, Undo2 } from "lucide-react"
-import type { SavedMessageView, SavedStatus } from "@threa/types"
+import { E2E_PLACEHOLDER_CONTENT_MARKDOWN, type SavedMessageView, type SavedStatus } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
@@ -190,7 +190,14 @@ function SavedRowActions({ workspaceId, saved, onMarkDone, onArchive, onRestore,
 }
 
 function resolvePreview(saved: SavedMessageView): string {
-  if (saved.message) return stripMarkdownToInline(saved.message.contentMarkdown)
+  if (saved.message) {
+    // E2E messages store a zero-width placeholder on the wire and ship no
+    // ciphertext to the Saved surface, so there's nothing to decrypt here —
+    // render the same "Encrypted message" treatment the sidebar uses (E2EE-16)
+    // rather than a blank/invisible preview.
+    if (saved.message.contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return "🔒 Encrypted message"
+    return stripMarkdownToInline(saved.message.contentMarkdown)
+  }
   if (saved.unavailableReason === "deleted") return "Original message was deleted"
   return "You no longer have access to this message"
 }


### PR DESCRIPTION
**Stacked on #784** (→ #783 → #782 → main).

## E2EE-16 (medium)
Saving a message from an E2E stream then viewing it on the Saved page rendered a **blank** preview row — the Saved view ships the zero-width placeholder (U+200B) and no ciphertext, so `resolvePreview` stripped it to nothing.

## Fix
Detect the placeholder sentinel (`E2E_PLACEHOLDER_CONTENT_MARKDOWN`) in `resolvePreview` and render the same `🔒 Encrypted message` treatment the sidebar uses. Plaintext previews unchanged. (The Saved surface has no key material to decrypt, so a placeholder is the correct treatment — matching the sidebar.)

## Testing
- `saved-item.test.tsx`: E2E saved message renders the placeholder (and never the invisible U+200B); a normal message still renders its body.
- Frontend typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252927&installation_id=129946197&pr_number=785&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F785&signature=89f84ea3228fc3d820cc9c402c46cabf8a6c670f2e97e706134d6fa09863e72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->