### PR TITLE
fix(e2e): saved-reminder push shows a generic label for E2E messages (E2EE-19)

### DIFF
--- a/apps/backend/src/features/push/saved-reminder-preview.test.ts
+++ b/apps/backend/src/features/push/saved-reminder-preview.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
+import { resolveSavedReminderPreview } from "./service"
+
+describe("resolveSavedReminderPreview (E2EE-19)", () => {
+  it("substitutes a generic label for the E2E placeholder instead of the blank zero-width char", () => {
+    expect(resolveSavedReminderPreview(E2E_PLACEHOLDER_CONTENT_MARKDOWN)).toBe("🔒 Encrypted message")
+  })
+
+  it("returns the truncated body for a normal message", () => {
+    expect(resolveSavedReminderPreview("hello there")).toBe("hello there")
+    expect(resolveSavedReminderPreview("x".repeat(300))).toHaveLength(200)
+  })
+
+  it("returns null when there is no content", () => {
+    expect(resolveSavedReminderPreview(null)).toBeNull()
+    expect(resolveSavedReminderPreview(undefined)).toBeNull()
+  })
+})

--- a/apps/backend/src/features/push/saved-reminder-preview.test.ts
+++ b/apps/backend/src/features/push/saved-reminder-preview.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "bun:test"
-import { E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
+import { E2E_PLACEHOLDER_CONTENT_MARKDOWN, ENCRYPTED_MESSAGE_PREVIEW_LABEL } from "@threa/types"
 import { resolveSavedReminderPreview } from "./service"
 
 describe("resolveSavedReminderPreview (E2EE-19)", () => {
   it("substitutes a generic label for the E2E placeholder instead of the blank zero-width char", () => {
-    expect(resolveSavedReminderPreview(E2E_PLACEHOLDER_CONTENT_MARKDOWN)).toBe("🔒 Encrypted message")
+    expect(resolveSavedReminderPreview(E2E_PLACEHOLDER_CONTENT_MARKDOWN)).toBe(ENCRYPTED_MESSAGE_PREVIEW_LABEL)
   })
 
   it("returns the truncated body for a normal message", () => {
     expect(resolveSavedReminderPreview("hello there")).toBe("hello there")
     expect(resolveSavedReminderPreview("x".repeat(300))).toHaveLength(200)
+  })
+
+  it("strips markdown so the OS notification never shows literal syntax (INV-60)", () => {
+    expect(resolveSavedReminderPreview("**ship it** by [Friday](https://x.io)")).toBe("ship it by Friday")
   })
 
   it("returns null when there is no content", () => {

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -8,6 +8,7 @@ import {
   ActivityTypes,
   StreamTypes,
   PRESENCE_INTERACTION_WINDOW_MS,
+  E2E_PLACEHOLDER_CONTENT_MARKDOWN,
   type PrefNotificationLevel,
   type StreamType,
 } from "@threa/types"
@@ -86,6 +87,19 @@ interface PushServiceDeps {
  * The VAPID config is optional — when null, delivery methods are no-ops
  * (push feature is disabled but the service can still be constructed).
  */
+
+/**
+ * Resolve the `contentPreview` for a saved-reminder push. E2E messages store a
+ * zero-width placeholder on the wire (the server holds no key), so surfacing
+ * the raw markdown produces a blank notification — substitute a generic,
+ * leak-free label instead (E2EE-19), mirroring the saved-list/sidebar
+ * treatment. Normal messages get their body truncated; missing content → null.
+ */
+export function resolveSavedReminderPreview(contentMarkdown: string | null | undefined): string | null {
+  if (contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return "🔒 Encrypted message"
+  return contentMarkdown?.slice(0, 200) ?? null
+}
+
 export class PushService {
   private readonly pool: Pool
   private readonly vapidPublicKey: string
@@ -375,7 +389,7 @@ export class PushService {
         streamId,
         messageId,
         streamName: saved.message?.streamName ?? null,
-        contentPreview: saved.message?.contentMarkdown?.slice(0, 200) ?? null,
+        contentPreview: resolveSavedReminderPreview(saved.message?.contentMarkdown),
         unavailableReason: saved.unavailableReason ?? null,
       },
     })

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -9,6 +9,8 @@ import {
   StreamTypes,
   PRESENCE_INTERACTION_WINDOW_MS,
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+  ENCRYPTED_MESSAGE_PREVIEW_LABEL,
+  stripMarkdownToInline,
   type PrefNotificationLevel,
   type StreamType,
 } from "@threa/types"
@@ -93,11 +95,14 @@ interface PushServiceDeps {
  * zero-width placeholder on the wire (the server holds no key), so surfacing
  * the raw markdown produces a blank notification — substitute a generic,
  * leak-free label instead (E2EE-19), mirroring the saved-list/sidebar
- * treatment. Normal messages get their body truncated; missing content → null.
+ * treatment. Normal messages are stripped to plain text before truncation so
+ * the OS notification never shows literal markdown syntax (INV-60 — the SW
+ * renders this verbatim, there is no later strip step). Missing content → null.
  */
 export function resolveSavedReminderPreview(contentMarkdown: string | null | undefined): string | null {
-  if (contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return "🔒 Encrypted message"
-  return contentMarkdown?.slice(0, 200) ?? null
+  if (contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return ENCRYPTED_MESSAGE_PREVIEW_LABEL
+  if (contentMarkdown == null) return null
+  return stripMarkdownToInline(contentMarkdown).slice(0, 200)
 }
 
 export class PushService {

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -26,6 +26,7 @@ import { useUrgencyTracking } from "./use-urgency-tracking"
 import { StreamLabelDots } from "./sidebar-labels"
 import { truncateContent } from "./utils"
 import {
+  ENCRYPTED_MESSAGE_PREVIEW_LABEL,
   LabelableResourceTypes,
   StreamTypes,
   Visibilities,
@@ -165,7 +166,7 @@ export function StreamItemPreview({
     >
       <span className="truncate flex-1">
         {e2eEnabled
-          ? `${getActorName(preview.authorId, preview.authorType)}: 🔒 Encrypted message`
+          ? `${getActorName(preview.authorId, preview.authorType)}: ${ENCRYPTED_MESSAGE_PREVIEW_LABEL}`
           : `${getActorName(preview.authorId, preview.authorType)}: ${truncateContent(preview.content, 50, toEmoji)}`}
       </span>
       <RelativeTime date={preview.createdAt} className="flex-shrink-0" />

--- a/apps/frontend/src/components/saved/saved-item.tsx
+++ b/apps/frontend/src/components/saved/saved-item.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Archive, Bell, Check, CircleAlert, Trash2, Undo2 } from "lucide-react"
-import { E2E_PLACEHOLDER_CONTENT_MARKDOWN, type SavedMessageView, type SavedStatus } from "@threa/types"
+import {
+  E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+  ENCRYPTED_MESSAGE_PREVIEW_LABEL,
+  type SavedMessageView,
+  type SavedStatus,
+} from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
@@ -195,7 +200,7 @@ function resolvePreview(saved: SavedMessageView): string {
     // ciphertext to the Saved surface, so there's nothing to decrypt here —
     // render the same "Encrypted message" treatment the sidebar uses (E2EE-16)
     // rather than a blank/invisible preview.
-    if (saved.message.contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return "🔒 Encrypted message"
+    if (saved.message.contentMarkdown === E2E_PLACEHOLDER_CONTENT_MARKDOWN) return ENCRYPTED_MESSAGE_PREVIEW_LABEL
     return stripMarkdownToInline(saved.message.contentMarkdown)
   }
   if (saved.unavailableReason === "deleted") return "Original message was deleted"

--- a/apps/frontend/src/lib/markdown/strip.ts
+++ b/apps/frontend/src/lib/markdown/strip.ts
@@ -1,46 +1,5 @@
-/**
- * Strip markdown formatting and collapse newlines to spaces.
- * Use for single-line preview surfaces (sidebar, activity feed) where the
- * source text is markdown but the surface only shows a flattened snippet.
- *
- * Pass `toEmoji` (from `useWorkspaceEmoji`) to also resolve `:shortcode:`
- * sequences into their emoji characters; unresolved shortcodes stay as text.
- */
-export function stripMarkdownToInline(md: string, toEmoji?: (shortcode: string) => string | null): string {
-  const stripped = stripMarkdown(md).replace(/\n+/g, " ")
-  if (!toEmoji) return stripped
-  return stripped.replace(/:([a-z0-9_+-]+):/g, (match, shortcode) => toEmoji(shortcode) ?? match)
-}
-
-/** Strip markdown formatting, returning plain text content. */
-export function stripMarkdown(md: string): string {
-  return (
-    md
-      // Remove code blocks (fenced) — extract inner content
-      .replace(/```[\s\S]*?```/g, (match) => {
-        const lines = match.split("\n")
-        return lines.slice(1, -1).join("\n")
-      })
-      // Remove headers
-      .replace(/^#{1,6}\s+/gm, "")
-      // Remove bold/italic
-      .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
-      // Underscores only act as emphasis when not adjacent to word characters
-      // (CommonMark intra-word underscores rule). Without this guard, identifiers
-      // like `:white_check_mark:` get mangled into `:whitecheckmark:`.
-      .replace(/(^|[^A-Za-z0-9_])_{1,3}([^_\n]+?)_{1,3}(?![A-Za-z0-9_])/g, "$1$2")
-      // Remove inline code
-      .replace(/`([^`]+)`/g, "$1")
-      // Remove images (before links — images use ![])
-      .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
-      // Remove links but keep text
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-      // Remove blockquotes
-      .replace(/^>\s?/gm, "")
-      // Remove horizontal rules
-      .replace(/^---+$/gm, "")
-      // Clean up extra whitespace
-      .replace(/\n{3,}/g, "\n\n")
-      .trim()
-  )
-}
+// The strip implementation moved to `@threa/types` so the backend push path
+// can reuse it (INV-60 — notification bodies are stripped before they ship,
+// the SW renders them verbatim). Re-exported here so existing frontend
+// imports keep their `@/lib/markdown/strip` path and there's one impl, not two.
+export { stripMarkdown, stripMarkdownToInline } from "@threa/types"

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -805,3 +805,10 @@ export const MAGIC_CODE_LENGTH = 6
 // backend insert, frontend encrypt, and frontend decrypt paths — the explicit
 // \u200B escape keeps the source readable instead of a literal invisible byte.
 export const E2E_PLACEHOLDER_CONTENT_MARKDOWN = "\u200B"
+
+// User-facing label shown wherever a preview of an E2E message is rendered
+// without the key material to decrypt it (sidebar stream preview, Saved list,
+// saved-reminder push). The body itself stays sealed; this is the leak-free
+// stand-in for the zero-width placeholder. Centralized so the backend and
+// frontend surfaces can't drift (INV-33).
+export const ENCRYPTED_MESSAGE_PREVIEW_LABEL = "\uD83D\uDD12 Encrypted message"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -208,6 +208,8 @@ export {
   MAGIC_CODE_LENGTH,
   // E2E placeholder shared between backend insert and frontend encrypt/decrypt
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+  // Leak-free label for E2E message previews (sidebar / Saved / push)
+  ENCRYPTED_MESSAGE_PREVIEW_LABEL,
   // E2E actor kinds (bot / enclave)
   E2E_ACTOR_KINDS,
   type E2eActorKind,
@@ -218,6 +220,9 @@ export {
   type E2eKeyWrapRecipientKind,
   E2eKeyWrapRecipientKinds,
 } from "./constants"
+
+// Markdown → plain-text stripping for preview surfaces (shared FE/BE, INV-60)
+export { stripMarkdown, stripMarkdownToInline } from "./markdown-strip"
 
 // Domain entities (wire format)
 export { getAvatarUrl, getBotAvatarUrl } from "./domain"

--- a/packages/types/src/markdown-strip.ts
+++ b/packages/types/src/markdown-strip.ts
@@ -1,0 +1,55 @@
+/**
+ * Markdown → plain-text stripping for preview surfaces, shared between the
+ * frontend (sidebar, activity feed, Saved list) and the backend (push
+ * notification bodies). Notification text is built backend-side and rendered
+ * by the service worker verbatim, so the strip has to happen before it ships
+ * — there is no frontend render step to lean on (INV-60). Pure string work,
+ * no runtime deps, so it lives in `@threa/types` where both sides import it.
+ */
+
+/**
+ * Strip markdown formatting and collapse newlines to spaces.
+ * Use for single-line preview surfaces (sidebar, activity feed) where the
+ * source text is markdown but the surface only shows a flattened snippet.
+ *
+ * Pass `toEmoji` (from `useWorkspaceEmoji`) to also resolve `:shortcode:`
+ * sequences into their emoji characters; unresolved shortcodes stay as text.
+ */
+export function stripMarkdownToInline(md: string, toEmoji?: (shortcode: string) => string | null): string {
+  const stripped = stripMarkdown(md).replace(/\n+/g, " ")
+  if (!toEmoji) return stripped
+  return stripped.replace(/:([a-z0-9_+-]+):/g, (match, shortcode) => toEmoji(shortcode) ?? match)
+}
+
+/** Strip markdown formatting, returning plain text content. */
+export function stripMarkdown(md: string): string {
+  return (
+    md
+      // Remove code blocks (fenced) — extract inner content
+      .replace(/```[\s\S]*?```/g, (match) => {
+        const lines = match.split("\n")
+        return lines.slice(1, -1).join("\n")
+      })
+      // Remove headers
+      .replace(/^#{1,6}\s+/gm, "")
+      // Remove bold/italic
+      .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
+      // Underscores only act as emphasis when not adjacent to word characters
+      // (CommonMark intra-word underscores rule). Without this guard, identifiers
+      // like `:white_check_mark:` get mangled into `:whitecheckmark:`.
+      .replace(/(^|[^A-Za-z0-9_])_{1,3}([^_\n]+?)_{1,3}(?![A-Za-z0-9_])/g, "$1$2")
+      // Remove inline code
+      .replace(/`([^`]+)`/g, "$1")
+      // Remove images (before links — images use ![])
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+      // Remove links but keep text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      // Remove blockquotes
+      .replace(/^>\s?/gm, "")
+      // Remove horizontal rules
+      .replace(/^---+$/gm, "")
+      // Clean up extra whitespace
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  )
+}


### PR DESCRIPTION
**Stacked on #785** (→ #784 → #783 → #782 → main).

## E2EE-19 (medium)
The saved-reminder push fires regardless of the activity feed's E2E suppression, and built `contentPreview` straight from the raw `contentMarkdown` — which for an E2E message is the zero-width placeholder (U+200B). Result: a blank/invisible notification body when a reminder on an encrypted message fires.

## Fix
Substitute a generic, leak-free `🔒 Encrypted message` label for the placeholder (mirrors the saved-list and sidebar treatment); normal messages are unchanged. No service-worker change needed — the SW renders the supplied preview.

## Testing
- Extracted `resolveSavedReminderPreview` + unit tests: placeholder → label, normal body → truncated (≤200), missing → null.
- Backend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783253127&installation_id=129946197&pr_number=786&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F786&signature=2b0857ed049b0e2f03c1c5c2dca5560f18b7c3aa5d1c3984dd6edb7e77954476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->