### PR TITLE
fix(e2e): rename pre-fills the decrypted stream name (UX-35)

### DIFF
--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -154,8 +154,14 @@ export function StreamPage() {
     streamName = streamFallbackLabel(isDmDraft ? "dm" : "scratchpad", "sidebar")
   }
 
+  // Pre-fill (and no-op-guard) the rename against the name the header actually
+  // shows: for an encrypted stream that's the client-decrypted name, which can
+  // differ from the server-stored `displayName`. Seeding with `displayName`
+  // would surprise the user with a stale/placeholder value (UX-35).
+  const currentDisplayedName = decryptedStreamName ?? stream?.displayName ?? ""
+
   const handleStartRename = () => {
-    setEditValue(stream?.displayName ?? "")
+    setEditValue(currentDisplayedName)
     setIsEditing(true)
   }
 
@@ -163,7 +169,7 @@ export function StreamPage() {
     const trimmed = editValue.trim()
     setIsEditing(false)
 
-    if (!trimmed || trimmed === stream?.displayName) return
+    if (!trimmed || trimmed === currentDisplayedName) return
 
     await rename(trimmed)
   }


### PR DESCRIPTION
**Stacked on #786** (→ #785 → #784 → #783 → #782 → main).

## UX-35 (low)
Renaming an encrypted stream seeded the edit box with the server-stored `displayName`, which can differ from the **client-decrypted** name the header actually shows (encrypted streams seal their name). The user saw a stale/placeholder value to edit.

## Fix
Pre-fill — and no-op-guard — the rename against `decryptedStreamName ?? displayName`, the same decrypted-preferred name the header renders.

## Testing
Typecheck + eslint clean. (No existing test harness for the stream page; this is a 2-line render-time consistency fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783253270&installation_id=129946197&pr_number=787&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F787&signature=ba63468cf9462dfbbb0973a7bc5209631b9ba78c266a895a59a0c499ea748113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->