### PR TITLE
fix(e2e): 'Keep me unlocked' explains what's stored on the device (UX-38)

### DIFF
--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -252,7 +252,8 @@ export function PassphraseSetupModal({
               <Label htmlFor="e2e-setup-trust-device" className="cursor-pointer font-normal leading-snug">
                 Keep me unlocked on this device
                 <span className="mt-0.5 block text-xs text-muted-foreground">
-                  Skips the passphrase next time on this device. Don't use on shared or public computers.
+                  Stores an encrypted copy of your key on this device so it skips the passphrase next time — it never
+                  leaves this device. Don't use on shared or public computers.
                 </span>
               </Label>
             </div>

--- a/apps/frontend/src/components/encryption/passphrase-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-unlock-modal.tsx
@@ -140,7 +140,8 @@ export function PassphraseUnlockModal({
               <Label htmlFor="e2e-unlock-trust-device" className="cursor-pointer font-normal leading-snug">
                 Keep me unlocked on this device
                 <span className="mt-0.5 block text-xs text-muted-foreground">
-                  Skips the passphrase next time on this device. Don't use on shared or public computers.
+                  Stores an encrypted copy of your key on this device so it skips the passphrase next time — it never
+                  leaves this device. Don't use on shared or public computers.
                 </span>
               </Label>
             </div>


### PR DESCRIPTION
**Stacked on #787** (→ #786 → #785 → #784 → #783 → #782 → main).

## UX-38 (low)
The "Keep me unlocked on this device" toggle never said what enabling it actually stores — leaving the security trade-off implicit.

## Fix
Add the honest clause ("Stores an encrypted copy of your key on this device … it never leaves this device") to both the setup and unlock modals, mirroring the PIN copy's "never leaves this device" honesty.

## Testing
Typecheck + eslint clean; no test asserts the old copy string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783253339&installation_id=129946197&pr_number=788&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F788&signature=19e78671e97117ac3614f30159c3982a911c802e84943e67943ce9dc6cca2e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->