### PR TITLE
Fix blank link previews for bot-gated sites (Amazon) and centralize fetch identity

### DIFF
--- a/apps/backend/src/features/link-previews/config.ts
+++ b/apps/backend/src/features/link-previews/config.ts
@@ -1,3 +1,5 @@
+import { threaFetchUserAgent } from "@threa/types"
+
 /** Maximum number of link previews to extract per message */
 export const MAX_PREVIEWS_PER_MESSAGE = 5
 
@@ -7,14 +9,11 @@ export const FETCH_TIMEOUT_MS = 10_000
 /**
  * User-Agent string for metadata fetch requests.
  *
- * The `+`-prefixed contact URL is the long-standing polite-crawler convention (cf. Googlebot's
- * `+http://www.google.com/bot.html`, facebookexternalhit, Slackbot). Several large sites — Amazon
- * notably — gate their bot detection on it: a bare token like `Threa/1.0 (Link Preview)` (or even a
- * normal browser UA from a datacenter IP) is served a metadata-less captcha page, while the same
- * request carrying `(+https://…)` is served the real HTML. Keep the `+URL` form or Amazon-class
- * pages silently lose their previews.
+ * Built through the shared {@link threaFetchUserAgent} helper so the `+`-prefixed contact-URL
+ * convention is guaranteed — without it, Amazon-class sites serve a metadata-less captcha page and
+ * previews silently go blank. See `@threa/types`'s outbound-fetch module for the full rationale.
  */
-export const FETCH_USER_AGENT = "Threa/1.0 (Link Preview; +https://threa.io/bot)"
+export const FETCH_USER_AGENT = threaFetchUserAgent("Link Preview")
 
 /** Maximum HTML bytes to read before stopping (some sites like YouTube put meta tags 600KB+ in) */
 export const MAX_HTML_BYTES = 512 * 1024

--- a/apps/backend/src/features/link-previews/config.ts
+++ b/apps/backend/src/features/link-previews/config.ts
@@ -4,8 +4,17 @@ export const MAX_PREVIEWS_PER_MESSAGE = 5
 /** Timeout for fetching a single URL's metadata (ms) */
 export const FETCH_TIMEOUT_MS = 10_000
 
-/** User-Agent string for metadata fetch requests */
-export const FETCH_USER_AGENT = "Threa/1.0 (Link Preview)"
+/**
+ * User-Agent string for metadata fetch requests.
+ *
+ * The `+`-prefixed contact URL is the long-standing polite-crawler convention (cf. Googlebot's
+ * `+http://www.google.com/bot.html`, facebookexternalhit, Slackbot). Several large sites — Amazon
+ * notably — gate their bot detection on it: a bare token like `Threa/1.0 (Link Preview)` (or even a
+ * normal browser UA from a datacenter IP) is served a metadata-less captcha page, while the same
+ * request carrying `(+https://…)` is served the real HTML. Keep the `+URL` form or Amazon-class
+ * pages silently lose their previews.
+ */
+export const FETCH_USER_AGENT = "Threa/1.0 (Link Preview; +https://threa.io/bot)"
 
 /** Maximum HTML bytes to read before stopping (some sites like YouTube put meta tags 600KB+ in) */
 export const MAX_HTML_BYTES = 512 * 1024

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -456,6 +456,72 @@ describe("createLinkPreviewWorker", () => {
     expect(capturedUserAgent).toMatch(/\+https?:\/\//)
   })
 
+  test("marks non-2xx fetches as failed-and-retryable instead of caching the error page", async () => {
+    // A 503/403 hard-block returns an HTML error page; caching its URL-derived fallback as
+    // "completed" for 24h turns a transient block into a permanent miss. It must come back failed.
+    const fetchMock = mock(
+      async () =>
+        new Response("<html><head><title>Service Unavailable</title></head></html>", {
+          status: 503,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        })
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_503", url: "https://blocked.example.com/page" }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_503",
+          workspaceId: "ws_123",
+          url: "https://blocked.example.com/page",
+          normalizedUrl: "https://blocked.example.com/page",
+          title: null,
+          description: null,
+          imageUrl: null,
+          faviconUrl: null,
+          siteName: null,
+          contentType: "website",
+          status: "pending",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: null,
+          expiresAt: null,
+          createdAt: new Date("2026-05-29T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: {
+        getGithubClient: mock(async () => null),
+      } as any,
+    })
+
+    await worker({
+      id: "job_503",
+      name: "link_preview.extract",
+      data: {
+        workspaceId: "ws_123",
+        streamId: "stream_123",
+        messageId: "msg_503",
+        contentMarkdown: "https://blocked.example.com/page",
+      },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_503",
+      [expect.objectContaining({ id: "lp_503", metadata: expect.objectContaining({ status: "failed" }) })],
+      { forcePublish: undefined }
+    )
+  })
+
   test('ignores body attributes like name="descriptionField" and still captures real metadata', async () => {
     // A body attribute whose value merely starts with "description" must not flip the early-stop
     // gate: if it did, the loop would stop at </head> and drop the real og:* tags streamed after it.

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -395,6 +395,67 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  test("sends a polite-crawler User-Agent (+contact URL) so bot-gated sites serve real HTML", async () => {
+    // Amazon-class sites serve a metadata-less captcha page to bare or browser-like UAs and only
+    // return the real HTML when the UA carries the conventional `+`-prefixed contact URL. Guard the
+    // format so a future edit to FETCH_USER_AGENT can't silently break previews for those pages.
+    let capturedUserAgent: string | null = null
+    const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUserAgent = new Headers(init?.headers).get("User-Agent")
+      return new Response(
+        '<html><head><title>Product</title><meta name="description" content="A product"></head></html>',
+        { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }
+      )
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_ua", url: "https://shop.example.com/dp/ABC123" }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_ua",
+          workspaceId: "ws_123",
+          url: "https://shop.example.com/dp/ABC123",
+          normalizedUrl: "https://shop.example.com/dp/ABC123",
+          title: null,
+          description: null,
+          imageUrl: null,
+          faviconUrl: null,
+          siteName: null,
+          contentType: "website",
+          status: "pending",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: null,
+          expiresAt: null,
+          createdAt: new Date("2026-05-29T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish: mock(async () => {}),
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: {
+        getGithubClient: mock(async () => null),
+      } as any,
+    })
+
+    await worker({
+      id: "job_ua",
+      name: "link_preview.extract",
+      data: {
+        workspaceId: "ws_123",
+        streamId: "stream_123",
+        messageId: "msg_ua",
+        contentMarkdown: "https://shop.example.com/dp/ABC123",
+      },
+    })
+
+    expect(capturedUserAgent).toMatch(/\+https?:\/\//)
+  })
+
   test('ignores body attributes like name="descriptionField" and still captures real metadata', async () => {
     // A body attribute whose value merely starts with "description" must not flip the early-stop
     // gate: if it did, the loop would stop at </head> and drop the real og:* tags streamed after it.

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -222,6 +222,15 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
       return { status: "failed", expiresAt: minutesFromNow(1) }
     }
 
+    // Non-2xx responses (403/503 hard-blocks, dead links, transient 5xx) carry no usable metadata.
+    // Mark failed with a short expiry so it retries, rather than caching the error page's fallback
+    // as a "completed" preview for 24h — that silently turns a transient block into a permanent miss.
+    if (!response.ok) {
+      log.warn({ url, status: response.status }, "Link preview fetch returned non-2xx; will retry")
+      response.body?.cancel()
+      return { status: "failed", expiresAt: minutesFromNow(1) }
+    }
+
     const contentTypeHeader = response.headers.get("content-type") ?? ""
 
     // For images, we don't need to parse HTML

--- a/packages/agent-runtime/src/tools/read-url-tool.test.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.test.ts
@@ -71,7 +71,10 @@ describe("read-url-tool", () => {
     await tool.config.execute({ url: "https://example.com" }, toolOpts)
 
     expect(capturedHeaders).not.toBeNull()
-    expect(capturedHeaders!["User-Agent"]).toContain("Threa-Agent")
+    // Must carry the shared polite-crawler identity (the +-prefixed contact URL is what keeps
+    // Amazon-class bot gates from serving a captcha page instead of the real content).
+    expect(capturedHeaders!["User-Agent"]).toContain("+https://threa.io/bot")
+    expect(capturedHeaders!["User-Agent"]).toContain("Agent Reader")
   })
 
   it("should return error for non-HTML content types", async () => {

--- a/packages/agent-runtime/src/tools/read-url-tool.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 import * as dns from "dns/promises"
 import * as ipaddr from "ipaddr.js"
 import { NodeHtmlMarkdown } from "node-html-markdown"
-import { AgentStepTypes } from "@threa/types"
+import { AgentStepTypes, threaFetchUserAgent } from "@threa/types"
 import { logger } from "../logger"
 import { defineAgentTool, type AgentToolResult } from "../runtime/agent-tool"
 import { applySelect, describeShape, structuralPreview } from "./json-inspect"
@@ -172,7 +172,7 @@ async function fetchWithRedirectValidation(
   const response = await fetch(url, {
     signal,
     headers: {
-      "User-Agent": "Threa-Agent/1.0 (https://threa.app)",
+      "User-Agent": threaFetchUserAgent("Agent Reader"),
       Accept: "text/html,application/xhtml+xml,application/json;q=0.9,application/xml;q=0.8,*/*;q=0.8",
     },
     redirect: "manual", // Don't follow redirects automatically

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -326,6 +326,9 @@ export {
 } from "./slug"
 export type { BroadcastSlug } from "./slug"
 
+// Outbound fetch identity (shared User-Agent for third-party URL fetches)
+export { THREA_BOT_CONTACT_URL, threaFetchUserAgent } from "./outbound-fetch"
+
 // Attachment categories (mime → category mapping for the attachment explorer)
 export { ATTACHMENT_CATEGORIES, categoryFromMime, mimePrefixesForCategory } from "./attachment-categories"
 export type { AttachmentCategory } from "./attachment-categories"

--- a/packages/types/src/outbound-fetch.test.ts
+++ b/packages/types/src/outbound-fetch.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { THREA_BOT_CONTACT_URL, threaFetchUserAgent } from "./outbound-fetch"
+
+describe("threaFetchUserAgent", () => {
+  // The `+`-prefixed contact URL is what gets Amazon-class bot gates to serve real HTML instead of
+  // a captcha page. If a refactor ever drops it, previews silently go blank — so guard the format.
+  test("always carries the +-prefixed contact URL", () => {
+    expect(threaFetchUserAgent("Link Preview")).toMatch(/\+https?:\/\//)
+    expect(threaFetchUserAgent("Link Preview")).toContain(`+${THREA_BOT_CONTACT_URL}`)
+  })
+
+  test("tags the User-Agent with the calling component", () => {
+    expect(threaFetchUserAgent("Agent Reader")).toBe("Threa/1.0 (Agent Reader; +https://threa.io/bot)")
+  })
+})

--- a/packages/types/src/outbound-fetch.ts
+++ b/packages/types/src/outbound-fetch.ts
@@ -1,0 +1,24 @@
+/**
+ * Outbound HTTP identity shared by every Threa service that fetches third-party URLs
+ * (link-preview metadata extraction, the agent read-url tool, …).
+ *
+ * The `+`-prefixed contact URL is the load-bearing part. It is the long-standing polite-crawler
+ * convention (Googlebot's `+http://www.google.com/bot.html`, facebookexternalhit, Slackbot), and
+ * several large sites — Amazon notably — gate their bot detection on it: a bare token like
+ * `Threa/1.0`, or even a browser-like UA coming from a datacenter IP, is handed a metadata-less
+ * captcha page, while the same request carrying `(+https://…)` is served the real HTML.
+ *
+ * Every outbound fetcher must build its User-Agent through {@link threaFetchUserAgent} rather than
+ * hand-rolling a string, so a new fetch path can't silently reintroduce the bare-UA form and lose
+ * previews. This is the single source of truth (INV-33) for that identity.
+ */
+export const THREA_BOT_CONTACT_URL = "https://threa.io/bot"
+
+/**
+ * Build a polite-crawler User-Agent for outbound third-party fetches, tagged with the calling
+ * component (e.g. "Link Preview", "Agent Reader") so site operators reading their logs can tell
+ * Threa's surfaces apart. The `+`-prefixed contact URL is always present — see the module comment.
+ */
+export function threaFetchUserAgent(component: string): string {
+  return `Threa/1.0 (${component}; +${THREA_BOT_CONTACT_URL})`
+}


### PR DESCRIPTION
## Problem

Amazon product links rendered no preview. The extractor was fine — the issue was upstream: Amazon never served us the real page.

Reproduced against the reported URL (`amazon.se/dp/B0FMX5NGY9`), deterministic across repeated runs:

| User-Agent sent | Amazon response |
|---|---|
| `Threa/1.0 (Link Preview)` (old) | 5 KB **captcha page**, no `<title>`, no metadata |
| `Threa/1.0` | captcha |
| normal Chrome UA | captcha |
| `Threa/1.0 (+https://threa.io/bot)` | **1.5 MB real product page** |
| `curl/8.0`, `Twitterbot`, `facebookexternalhit` | real page |

The deterministic trigger is the **`+`-prefixed contact URL** — the long-standing polite-crawler convention (Googlebot's `+http://www.google.com/bot.html`, facebookexternalhit, Slackbot). Amazon's bot gate whitelists that format and serves everyone else a metadata-less captcha. Because the captcha page has no `<title>`, the parser fell through to the URL slug and the preview looked empty.

This was also a recurring-miss generator: the "how Threa identifies itself when fetching a URL" logic was duplicated across three fetchers that had already drifted — the agent's `read-url` tool was still on `Threa-Agent/1.0 (https://threa.app)` (no `+`), so it was being captcha'd too and getting captcha HTML *as if it were the article*.

## Changes

**Lever 1 — one source of truth for outbound fetch identity**
- Add `threaFetchUserAgent(component)` to `@threa/types` (the only package both backend and `agent-runtime` share). It builds a polite-crawler UA with the load-bearing `+`-prefixed contact URL baked in, so no future caller can reintroduce the bare form.
- Route both fetchers through it: link-preview metadata extraction (`Link Preview`) and the agent `read-url` tool (`Agent Reader`, which was the still-broken copy).
- The Twitter-image fallback keeps `Twitterbot/1.0` deliberately (it needs that specific UA to get tweet images).

**Lever 2 — stop caching blocked fetches as success**
- Non-2xx preview fetches (403/503 hard-blocks, dead links, transient 5xx) are now marked failed-and-retryable (1-min expiry) instead of caching the error page's URL-derived fallback as a "completed" preview for 24h. The main HTML path previously never checked `response.ok`.

**Tests**
- `@threa/types`: guard that the built UA always carries the `+`-prefixed contact URL.
- link-previews worker: outgoing UA carries the `+URL` convention; non-2xx → `failed`.
- `read-url` tool: UA assertion updated to the shared format.

## Notes / deliberately out of scope

- **Amazon still has no thumbnail.** Even on the real page Amazon publishes no `og:image`/`og:title`/`twitter:*` — only `<title>` + `<meta name="description">`. So previews now show title + description + favicon, but no image (Amazon's product image is a JS-driven gallery, not a meta tag). Pulling it would need brittle Amazon-specific DOM scraping.
- **No body keyword-sniffing for "200-but-empty" soft-blocks.** That would mean English-literal heuristics (INV-54) and risks reclassifying genuinely sparse-but-real pages — which today legitimately get a URL-derived fallback preview. Lever 2 is scoped to HTTP status, which is language-agnostic and false-positive-free.
- A headless-render / third-party unfurl path (for JS-only metadata and Amazon's missing image) was considered and held off — real infra cost, only worth it if misses persist.

## Verification

- Confirmed the new UA returns the real product page for the exact reported URL.
- `bun run typecheck` clean; full link-previews suite (131) + `@threa/types` + `agent-runtime` read-url tests green.

https://claude.ai/code/session_01RkzS1Pry25T7FzMzMoQGmh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkzS1Pry25T7FzMzMoQGmh)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783254753&installation_id=129946197&pr_number=789&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F789&signature=adfafb1fe234180a1da79b6bbb6b7ab1277a30efafe9b93adb650e6e72e7fec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->