### PR TITLE
fix: status picker shows stale state after changing status

### DIFF
--- a/apps/frontend/src/hooks/use-workspaces.ts
+++ b/apps/frontend/src/hooks/use-workspaces.ts
@@ -8,7 +8,7 @@ import { getQueryLoadState, isTerminalBootstrapError } from "@/lib/query-load-st
 import { db } from "@/db"
 import { joinRoomBestEffort } from "@/lib/socket-room"
 import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
-import { useWorkspaceUsers } from "@/stores/workspace-store"
+import { useWorkspaceUsers, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import type { WorkspaceBootstrap, User } from "@threa/types"
 import type { WorkspaceListResult } from "@/api/workspaces"
 
@@ -206,7 +206,9 @@ function updateUserInBootstrap(queryClient: ReturnType<typeof useQueryClient>, w
     }
   })
 
-  db.workspaceUsers.put({ ...updatedUser, _cachedAt: Date.now() })
+  const cachedUser = { ...updatedUser, _cachedAt: Date.now() }
+  db.workspaceUsers.put(cachedUser)
+  upsertWorkspaceUserInCache(workspaceId, cachedUser)
 }
 
 export function useUpdateProfile(workspaceId: string) {

--- a/apps/frontend/src/stores/workspace-store.test.tsx
+++ b/apps/frontend/src/stores/workspace-store.test.tsx
@@ -1,14 +1,63 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { LabelableResourceTypes } from "@threa/types"
-import { db, type CachedLabelAssignment } from "@/db"
+import { db, type CachedLabelAssignment, type CachedWorkspaceUser } from "@/db"
 import {
   resetWorkspaceStoreCache,
   seedWorkspaceCache,
+  upsertWorkspaceUserInCache,
   useWorkspaceLabelAssignments,
   useWorkspaceMetadata,
   useWorkspaceUsers,
 } from "./workspace-store"
+
+function makeUser(overrides: Partial<CachedWorkspaceUser> = {}): CachedWorkspaceUser {
+  return {
+    id: "user_1",
+    workspaceId: "workspace_1",
+    workosUserId: "workos_1",
+    email: "kris@example.com",
+    role: "owner",
+    slug: "kris",
+    name: "Kris",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+function seedWithUsers(users: CachedWorkspaceUser[]): void {
+  seedWorkspaceCache("workspace_1", {
+    workspace: {
+      id: "workspace_1",
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-03-01T10:00:00Z",
+      updatedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users,
+    streams: [],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
 
 describe("workspace store cache subscriptions", () => {
   beforeEach(() => {
@@ -101,6 +150,33 @@ describe("workspace store cache subscriptions", () => {
     })
 
     expect(result.current?.emojis.map((emoji) => emoji.shortcode)).toEqual(["wave"])
+  })
+
+  it("patches the in-memory cache so a freshly-mounted reader sees a status change on its first render", () => {
+    act(() => seedWithUsers([makeUser({ statusEmoji: null, statusText: null })]))
+
+    act(() => {
+      upsertWorkspaceUserInCache("workspace_1", makeUser({ statusEmoji: "dart", statusText: "Focus" }))
+    })
+
+    // A fresh mount (the status picker remounts every time it opens) reads the
+    // in-memory cache synchronously before useLiveQuery resolves. Without the
+    // patch it would seed its editor from the stale pre-change snapshot.
+    const { result } = renderHook(() => useWorkspaceUsers("workspace_1"))
+    expect(result.current.map((u) => ({ emoji: u.statusEmoji, text: u.statusText }))).toEqual([
+      { emoji: "dart", text: "Focus" },
+    ])
+  })
+
+  it("does not seed the in-memory cache before the workspace bootstrap has", () => {
+    const { result } = renderHook(() => useWorkspaceUsers("workspace_1"))
+    expect(result.current).toEqual([])
+
+    act(() => {
+      upsertWorkspaceUserInCache("workspace_1", makeUser({ statusEmoji: "dart" }))
+    })
+
+    expect(result.current).toEqual([])
   })
 
   it("follows an emptied IDB rather than stranding the stale bootstrap cache", async () => {

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -243,6 +243,28 @@ export function seedWorkspaceCache(
   emitWorkspaceCacheChange(workspaceId)
 }
 
+/**
+ * Patch a single user into the in-memory cache after an out-of-band write to
+ * IDB (a local status/profile mutation or a socket-pushed update).
+ *
+ * The in-memory cache otherwise only refreshes on a full bootstrap, while
+ * useLiveQuery is undefined on a component's first synchronous render — so a
+ * freshly-mounted reader (e.g. the status picker, which remounts each time it
+ * opens and seeds its editor once from `currentUser`) would read a stale row
+ * until the next page load. Keeping the cache in step with IDB closes that gap.
+ *
+ * No-op when the workspace's users aren't cached yet: the pending bootstrap/seed
+ * will carry the fresh row, and we must not partially populate the cache.
+ */
+export function upsertWorkspaceUserInCache(workspaceId: string, user: CachedWorkspaceUser): void {
+  const current = cache.users.get(workspaceId)
+  if (!current) return
+  const exists = current.some((u) => u.id === user.id)
+  cache.users.set(workspaceId, exists ? current.map((u) => (u.id === user.id ? user : u)) : [...current, user])
+  cacheVersion.set(workspaceId, (cacheVersion.get(workspaceId) ?? 0) + 1)
+  emitWorkspaceCacheChange(workspaceId)
+}
+
 // =============================================================================
 // Store hooks — useLiveQuery for reactivity, in-memory cache for first render
 // =============================================================================

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1,5 +1,5 @@
 import { db, type CachedStream, type CachedStreamMembership, type CachedUnreadState } from "@/db"
-import { seedWorkspaceCache } from "@/stores/workspace-store"
+import { seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import type { Socket } from "socket.io-client"
 import type { QueryClient } from "@tanstack/react-query"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
@@ -726,11 +726,11 @@ export function registerWorkspaceSocketHandlers(
       return withWorkspaceUsers(bootstrap, updatedUsers)
     })
 
-    // Update IndexedDB
-    db.workspaceUsers.put({
-      ...toWorkspaceUser(user),
-      _cachedAt: now,
-    })
+    // Update IndexedDB and the in-memory cache so a freshly-mounted reader's
+    // first synchronous render (before useLiveQuery resolves) sees this update.
+    const cachedUser = { ...toWorkspaceUser(user), _cachedAt: now }
+    db.workspaceUsers.put(cachedUser)
+    upsertWorkspaceUserInCache(workspaceId, cachedUser)
   }
 
   // Handle stream read (from other sessions of the same user)


### PR DESCRIPTION
## Problem

Changing your status and reopening the picker showed an empty editor — as if no status were set — until a full page refresh, after which it populated correctly.

Root cause is a stale in-memory cache read on remount:

- The status picker is conditionally mounted (`{statusOpen && <StatusPicker open .../>}` in `sidebar-footer.tsx` and `profile-settings.tsx`), so it **remounts every time it opens** and seeds its editor once from `currentUser` in a `useEffect([open])`.
- On a fresh mount, `useWorkspaceUsers` → `useArrayStoreHook` returns `live ?? cached`, and `useLiveQuery` is `undefined` for the first synchronous render. So the render the seed effect reads falls back to the in-memory `cache.users` map, not IDB.
- `updateUserInBootstrap` (local mutations) and the socket `handleWorkspaceUserUpdated` wrote the updated user to IDB and the React Query bootstrap cache, but **never to the in-memory store cache**. A page refresh re-seeded `cache.users` from bootstrap, which is why it only looked right after refresh.

## Solution

Keep the in-memory store cache in step with IDB on these out-of-band single-user writes.

### Key design decisions

**1. New `upsertWorkspaceUserInCache` helper in the store**

The in-memory cache is private to `workspace-store.ts`. Rather than reach into it from callers, the store exposes a focused helper that patches one user, bumps the cache version (so a concurrent `seedCacheFromIdb` defers to it), and emits the change signal so already-mounted readers re-render. It is a no-op before the workspace's users are seeded, so it never partially populates the cache (the pending bootstrap carries the fresh row).

**2. Wire it into both write paths, not the picker**

Fixing the picker's seed effect to re-read `currentUser` was rejected: the existing comment there is explicit that re-seeding mid-edit would clobber the user's draft when a socket update lands. The correct fix is upstream — make the cache the picker reads on mount actually current. Both the local mutation path (`updateUserInBootstrap`, which also backs profile edits and DND pause/resume) and the socket `handleWorkspaceUserUpdated` now call the helper.

### Scope note

`handleWorkspaceUserAdded` / `handleWorkspaceUserRemoved` share the same latent cache-staleness shape but affect member-list rows, not the reported status bug, so they are intentionally left out of this minimal patch.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/stores/workspace-store.ts` | Add exported `upsertWorkspaceUserInCache(workspaceId, user)` |
| `apps/frontend/src/hooks/use-workspaces.ts` | `updateUserInBootstrap` patches the in-memory cache alongside its IDB put |
| `apps/frontend/src/sync/workspace-sync.ts` | `handleWorkspaceUserUpdated` patches the in-memory cache alongside its IDB put |
| `apps/frontend/src/stores/workspace-store.test.tsx` | Tests: freshly-mounted reader sees the change on first render; no-op before seeding |

## Test plan

- [x] `bun run test src/stores/workspace-store.test.tsx` — 5 passing (2 new)
- [x] `bun run test src/sync/workspace-sync.test.ts` — 13 passing (no regressions)
- [x] Monorepo lint + typecheck (pre-commit hook) clean
- [ ] Manual: set a status, reopen the picker without refreshing — editor reflects the current status

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015NyPYxgdRqy8su8hHJYfi5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783267867&installation_id=129946197&pr_number=790&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F790&signature=39e732ab46a899c5fd1f208a4ce0fcfd3831a3d6161d27ae7490ebfae04c66cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->