### PR TITLE
fix(e2e): harden the INV-E1 sink + close the draft write-after-purge race

### DIFF
--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -794,6 +794,20 @@ describe("EventService INV-E1 sink guard", () => {
     expect(insert).not.toHaveBeenCalled()
   })
 
+  it("rejects a half-formed sealed create (ciphertext, no envelope/e2eVersion) into an E2E stream", async () => {
+    // A ciphertext row with no envelope is undecryptable — the sink must require
+    // the full E2E triple, not just the presence of ciphertext.
+    spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", e2eEnabled: true } as any)
+    const insert = spyOn(StreamEventRepository, "insert")
+    const service = new EventService({} as any)
+
+    await expect(service.createMessage({ ...baseParams, ciphertext: Buffer.from("opaque") })).rejects.toMatchObject({
+      status: 400,
+      code: "E2E_STREAM_REQUIRES_CIPHERTEXT",
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
   it("rejects a ciphertext create into a non-E2E stream (E2E_PAYLOAD_REQUIRES_E2E_STREAM)", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", e2eEnabled: false } as any)
     const insert = spyOn(StreamEventRepository, "insert")

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -318,20 +318,38 @@ class DuplicateMessageError extends Error {
 }
 
 /**
- * INV-E1: an E2E stream must carry ciphertext and a plaintext stream must not.
- * Either mismatch would persist a row that violates the encryption guarantee.
- * Throws the same error codes the messaging create handler uses so the wire
- * contract stays identical whether the check fires at the handler or the sink.
+ * INV-E1: an E2E stream must carry a *complete* E2E payload (ciphertext +
+ * envelope + e2eVersion), and a plaintext stream must carry none of them.
+ * Either mismatch would persist a row that violates the encryption guarantee —
+ * including a half-formed sealed row (ciphertext with no envelope is
+ * undecryptable). The messaging create handler's Zod schema already requires
+ * the three together; this sink backstops every other caller (scheduled-message
+ * worker, public-API bot completion, future adapters) that bypasses it. Throws
+ * the same error codes/copy the handler uses so the wire contract is identical
+ * wherever the check fires.
  */
-function assertE2eContentMatch(streamIsE2e: boolean, hasCiphertext: boolean): void {
-  if (streamIsE2e === hasCiphertext) return
+function assertE2eContentMatch(params: {
+  streamIsE2e: boolean
+  ciphertext?: Buffer
+  envelope?: unknown
+  e2eVersion?: number
+}): void {
+  const hasCiphertext = params.ciphertext !== undefined
+  const hasEnvelope = params.envelope !== undefined
+  const hasE2eVersion = params.e2eVersion !== undefined
+  const hasAnyE2ePayload = hasCiphertext || hasEnvelope || hasE2eVersion
+
+  // E2E stream: the full triple, or nothing valid. Plaintext stream: no E2E payload at all.
+  if (params.streamIsE2e && hasCiphertext && hasEnvelope && hasE2eVersion) return
+  if (!params.streamIsE2e && !hasAnyE2ePayload) return
+
   throw new HttpError(
-    streamIsE2e
+    params.streamIsE2e
       ? "Stream is end-to-end encrypted; send ciphertext, envelope, and e2eVersion"
       : "Stream is not end-to-end encrypted; send plaintext content",
     {
       status: 400,
-      code: streamIsE2e ? "E2E_STREAM_REQUIRES_CIPHERTEXT" : "E2E_PAYLOAD_REQUIRES_E2E_STREAM",
+      code: params.streamIsE2e ? "E2E_STREAM_REQUIRES_CIPHERTEXT" : "E2E_PAYLOAD_REQUIRES_E2E_STREAM",
     }
   )
 }
@@ -426,7 +444,12 @@ export class EventService {
     // future adapter — can persist plaintext into a sealed stream. `findById`
     // already LEFT JOINs `e2e_streams`, so this reads `e2eEnabled` off the row
     // we just loaded rather than issuing a second SELECT.
-    assertE2eContentMatch(stream?.e2eEnabled === true, params.ciphertext !== undefined)
+    assertE2eContentMatch({
+      streamIsE2e: stream?.e2eEnabled === true,
+      ciphertext: params.ciphertext,
+      envelope: params.envelope,
+      e2eVersion: params.e2eVersion,
+    })
 
     // 1. Validate and prepare attachments FIRST (before creating event).
     //    Two flavors are allowed:

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -187,6 +187,33 @@ describe("useDraftMessage", () => {
       expect(mockDelete).toHaveBeenCalledWith(draftKey)
     })
 
+    it("cancels a debounced plaintext save when the stream becomes encrypted mid-flight (E2EE-4 race)", async () => {
+      seededDraftCache = true
+
+      const { result, rerender } = renderHook(
+        ({ e2e }: { e2e: boolean }) => useDraftMessage(workspaceId, draftKey, e2e),
+        {
+          initialProps: { e2e: false },
+        }
+      )
+
+      // Queue a debounced save while the stream is still plaintext...
+      act(() => {
+        result.current.saveDraftDebounced(makeDoc("typed before the stream was encrypted"))
+      })
+      // ...then the stream becomes encrypted before the debounce window elapses.
+      rerender({ e2e: true })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
+
+      // The in-flight save must NOT re-persist plaintext after the purge.
+      expect(mockPut).not.toHaveBeenCalled()
+      // The encrypt transition purged any on-disk draft.
+      expect(mockDelete).toHaveBeenCalledWith(draftKey)
+    })
+
     it("should delete draft when content is empty and no attachments", async () => {
       seededDraftCache = true
       mockGet.mockResolvedValue({ attachments: [] })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -33,8 +33,22 @@ const DEBOUNCE_MS = import.meta.env.VITE_DRAFT_DEBOUNCE_MS ? Number(import.meta.
  */
 export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnabled = false) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Read inside the debounced timer so a save scheduled while the stream was
+  // plaintext can't write after the stream becomes encrypted (E2EE-4).
+  const e2eEnabledRef = useRef(e2eEnabled)
   const draftMessages = useDraftMessagesFromStore(workspaceId)
   const resolvedDraft = e2eEnabled ? undefined : draftMessages.find((draft) => draft.id === draftKey)
+
+  // When a stream becomes encrypted, cancel any debounced plaintext save still
+  // in flight — otherwise it fires after the purge below and re-persists the
+  // very plaintext we just deleted (write-after-purge race, E2EE-4).
+  useEffect(() => {
+    e2eEnabledRef.current = e2eEnabled
+    if (e2eEnabled && debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+  }, [e2eEnabled])
 
   // Purge any pre-existing on-disk draft for an E2E stream (e.g. one written
   // before this gate landed, or carried over when a stream is encrypted).
@@ -92,8 +106,11 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
       }
 
       debounceRef.current = setTimeout(() => {
-        saveDraft(contentJson)
         debounceRef.current = null
+        // The stream may have been encrypted between scheduling and firing;
+        // never write plaintext to disk in that case (E2EE-4).
+        if (e2eEnabledRef.current) return
+        saveDraft(contentJson)
       }, DEBOUNCE_MS)
     },
     [saveDraft, e2eEnabled]


### PR DESCRIPTION
Closes the two residual findings flagged during the #780 review (both now live on `main`).

## 1. Sink enforces the full E2E triple (E2EE-5)

`assertE2eContentMatch` only checked for `ciphertext`, so a caller that bypasses the messaging handler — the scheduled-message worker, public-API bot completion, a future adapter — could persist a **half-formed sealed row** (ciphertext with no `envelope`/`e2eVersion`, which is undecryptable) into an E2E stream and pass the guard.

Now the sink requires the full triple (`ciphertext` + `envelope` + `e2eVersion`) for E2E streams and **none** of it for plaintext streams, matching the messaging handler's Zod contract. Same error codes/copy (`E2E_STREAM_REQUIRES_CIPHERTEXT` / `E2E_PAYLOAD_REQUIRES_E2E_STREAM`), so the wire contract is unchanged.

## 2. Draft write-after-purge race (E2EE-4)

A `saveDraftDebounced` scheduled while a stream was plaintext captured the old `saveDraft` (with `e2eEnabled=false`). If the stream became encrypted before the timer fired, the purge effect deleted the on-disk draft but the pending timeout still fired and **re-persisted plaintext to IndexedDB** right after the purge.

Fix: track `e2eEnabled` in a ref, cancel any pending debounce on the plaintext→encrypted transition, and guard at fire time so a late timer can never write plaintext.

## Tests

- Backend: new case — a ciphertext-without-envelope create into an E2E stream is rejected before any write. Existing full-triple happy path and both prior sink cases stay green.
- Frontend: new case — queue a debounced save while plaintext, flip to encrypted, advance timers, assert nothing is written and the disk draft is purged.
- Backend + frontend suites, monorepo typecheck, lint, and OpenAPI check all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBYCisfdLCnagjfaHcSP7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783268214&installation_id=129946197&pr_number=791&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F791&signature=df84b2e397dbd47bd715e09e017db73e92934f433a80accfa89402342dc12316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->