### PR TITLE
fix(giphy): focus search field when GIF picker opens

### DIFF
--- a/apps/frontend/src/components/editor/giphy-picker-dialog.tsx
+++ b/apps/frontend/src/components/editor/giphy-picker-dialog.tsx
@@ -40,6 +40,7 @@ interface GiphyPickerDialogProps {
 const SEARCH_DEBOUNCE_MS = 350
 
 export function GiphyPickerDialog({ open, onOpenChange, workspaceId, onSelect }: GiphyPickerDialogProps) {
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
   const [items, setItems] = useState<GiphyGif[]>([])
@@ -215,6 +216,17 @@ export function GiphyPickerDialog({ open, onOpenChange, workspaceId, onSelect }:
         desktopClassName="max-w-2xl max-h-[85vh] sm:flex flex-col gap-0 p-0"
         drawerClassName="flex flex-col"
         aria-describedby={undefined}
+        onOpenAutoFocus={(e) => {
+          // The picker opens from the slash palette, whose command handler
+          // focuses the editor (`.focus().deleteRange(...)`) just before we
+          // open. That focus grab races with the input's `autoFocus` and wins,
+          // leaving the search field unfocused. Take over: focus the input
+          // ourselves once the dialog has settled.
+          e.preventDefault()
+          requestAnimationFrame(() => {
+            searchInputRef.current?.focus()
+          })
+        }}
       >
         <ResponsiveDialogHeader className="border-b px-4 py-3 sm:px-6">
           <ResponsiveDialogTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
@@ -224,7 +236,7 @@ export function GiphyPickerDialog({ open, onOpenChange, workspaceId, onSelect }:
           <div className="relative mt-2.5">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
-              autoFocus
+              ref={searchInputRef}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search GIPHY"

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -400,18 +400,6 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
           desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[20%] sm:!translate-y-0 sm:max-w-[600px] sm:rounded-2xl sm:border"
           drawerClassName="overflow-hidden p-0"
           hideCloseButton
-          onOpenAutoFocus={(e) => {
-            // Radix's FocusScope runs its own mount auto-focus, which races
-            // with — and overrides — TipTap's lazily-created contenteditable,
-            // leaving the search field unfocused. Take over: focus the rich
-            // input ourselves once it's mounted. Skip on mobile, where opening
-            // the keyboard shifts the drawer layout.
-            if (isMobile) return
-            e.preventDefault()
-            requestAnimationFrame(() => {
-              richInputRef.current?.focus()
-            })
-          }}
           onPointerDownOutside={(e) => {
             // Prevent closing when clicking on suggestion popover (rendered via portal)
             const target = e.target as HTMLElement

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -400,6 +400,18 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
           desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[20%] sm:!translate-y-0 sm:max-w-[600px] sm:rounded-2xl sm:border"
           drawerClassName="overflow-hidden p-0"
           hideCloseButton
+          onOpenAutoFocus={(e) => {
+            // Radix's FocusScope runs its own mount auto-focus, which races
+            // with — and overrides — TipTap's lazily-created contenteditable,
+            // leaving the search field unfocused. Take over: focus the rich
+            // input ourselves once it's mounted. Skip on mobile, where opening
+            // the keyboard shifts the drawer layout.
+            if (isMobile) return
+            e.preventDefault()
+            requestAnimationFrame(() => {
+              richInputRef.current?.focus()
+            })
+          }}
           onPointerDownOutside={(e) => {
             // Prevent closing when clicking on suggestion popover (rendered via portal)
             const target = e.target as HTMLElement


### PR DESCRIPTION
## What

Auto-focus the search field when the Giphy GIF picker opens, so you can start typing immediately.

## Why it wasn't focused

The picker opens from the editor's slash palette. The shared slash-command handler runs `editor.chain().focus().deleteRange(range).run()` (`command-extension.ts`) to strip the typed `/giphy` — which **focuses the editor** — and *then* opens the dialog. That focus grab races with the input's plain `autoFocus` attribute and wins, so the "Search GIPHY" field comes up unfocused.

## Fix

Take over the dialog's `onOpenAutoFocus`: `preventDefault()` Radix's default mount-focus, then focus the input via a ref inside `requestAnimationFrame` so it lands after the open settles and the editor's synchronous focus grab is done. Dropped the now-superseded `autoFocus` attribute on the input.

Only `giphy-picker-dialog.tsx` changes. (An earlier commit on this branch mistakenly touched the quick-switcher — "Jiffy" was a voice-mode mishearing of "Giphy" — and has been reverted within the branch, so it has no net change here.)

## Test

- `giphy-picker-dialog.test.tsx`: 2/2 pass.
- Frontend typecheck clean; full pre-commit lint + monorepo typecheck sweep passed.

https://claude.ai/code/session_0112QRVGXjrSYCoTu4Pu8vAo

---
_Generated by [Claude Code](https://claude.ai/code/session_0112QRVGXjrSYCoTu4Pu8vAo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269109&installation_id=129946197&pr_number=792&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F792&signature=96542f9f556d300c5e90e14078dc448e2d60adce6276b8287becb9ebde693f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->