### PR TITLE
fix(e2e): seal threads under encrypted scratchpads + make the companion toggle honest

### DIFF
--- a/apps/backend/src/db/migrations/20260605190000_e2e_companion_mode_honest.sql
+++ b/apps/backend/src/db/migrations/20260605190000_e2e_companion_mode_honest.sql
@@ -1,0 +1,15 @@
+-- Encrypted scratchpads used to have companion_mode force-set to 'off' at
+-- creation while Ariadne replied anyway through the enclave -- the Companion/
+-- Quiet toggle "lied". Companion mode now genuinely gates the enclave
+-- auto-reply (EnclaveDispatchHandler). Preserve current behavior for existing
+-- encrypted scratchpads that have the enclave invited by flipping their stored
+-- 'off' to 'on', so Ariadne keeps replying where she already does; owners who
+-- want a silent encrypted dump can switch to Quiet, which now actually works.
+UPDATE streams s
+SET companion_mode = 'on'
+WHERE s.companion_mode = 'off'
+  AND EXISTS (SELECT 1 FROM e2e_streams e WHERE e.stream_id = s.id)
+  AND EXISTS (
+    SELECT 1 FROM e2e_stream_actors a
+    WHERE a.stream_id = s.id AND a.kind = 'enclave'
+  );

--- a/apps/backend/src/features/e2e-streams/actor-repository.ts
+++ b/apps/backend/src/features/e2e-streams/actor-repository.ts
@@ -52,6 +52,25 @@ export const E2eStreamActorsRepository = {
     return (result.rowCount ?? 0) > 0
   },
 
+  /**
+   * Copy every actor (enclave + bots) from `fromStreamId` onto `toStreamId` in
+   * one set-based, idempotent insert (INV-56). Used when a thread inherits its
+   * root scratchpad's E2E state so the enclave (and any invited bots) are
+   * present on the thread and its turns dispatch the same way the root's do.
+   */
+  async copyToStream(
+    db: Querier,
+    params: { workspaceId: string; fromStreamId: string; toStreamId: string }
+  ): Promise<void> {
+    await db.query(sql`
+      INSERT INTO e2e_stream_actors (workspace_id, stream_id, kind, actor_id, key_id, added_at)
+      SELECT workspace_id, ${params.toStreamId}, kind, actor_id, key_id, added_at
+      FROM e2e_stream_actors
+      WHERE workspace_id = ${params.workspaceId} AND stream_id = ${params.fromStreamId}
+      ON CONFLICT (workspace_id, stream_id, kind, actor_id) DO NOTHING
+    `)
+  },
+
   async remove(db: Querier, workspaceId: string, streamId: string, kind: E2eActorKind, actorId: string): Promise<void> {
     await db.query(sql`
       DELETE FROM e2e_stream_actors

--- a/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
+++ b/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
@@ -85,6 +85,34 @@ export const StreamE2eKeyWrapsRepository = {
   },
 
   /**
+   * Copy every wrap from `fromStreamId` onto `toStreamId` (same workspace),
+   * minting fresh row ids. Used when a thread inherits its root scratchpad's
+   * SSK: the thread reuses the same key, so it carries the same per-recipient
+   * wraps (owner + enclave + any bots) under its own stream id. Idempotent via
+   * the slot conflict, so a re-run (or a racing thread create) is a no-op.
+   * Wrap counts are tiny (a handful of recipients), so a list + batch insert is
+   * fine — no hot path.
+   */
+  async copyToStream(
+    db: Querier,
+    params: { workspaceId: string; fromStreamId: string; toStreamId: string }
+  ): Promise<void> {
+    const wraps = await this.listForStream(db, params.workspaceId, params.fromStreamId)
+    await this.insertMany(
+      db,
+      wraps.map((w) => ({
+        workspaceId: params.workspaceId,
+        streamId: params.toStreamId,
+        keyGeneration: w.keyGeneration,
+        recipientKeyId: w.recipientKeyId,
+        recipientKind: w.recipientKind,
+        wrapEnc: w.wrapEnc,
+        wrapCt: w.wrapCt,
+      }))
+    )
+  },
+
+  /**
    * All wraps for a stream, across recipients and generations. Wrap bytes are
    * HPKE ciphertext (decryptable only by the matching private key), so it is
    * safe to return the full set to any stream member; the caller selects its

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -33,6 +33,13 @@ export interface MarkStreamE2eParams {
   workspaceId: string
   ownerUserId: string
   ownerUserKeyId: string
+  /**
+   * SSK generation the stream starts at. Defaults to 0 (a fresh owner-only
+   * stream). A thread that inherits its root's key passes the root's current
+   * generation so new thread messages seal under the same generation the
+   * copied wraps cover.
+   */
+  currentKeyGeneration?: number
 }
 
 const COLUMNS =
@@ -144,13 +151,14 @@ export const E2eStreamsRepository = {
   async markStreamE2e(db: Querier, params: MarkStreamE2eParams): Promise<E2eStream> {
     const result = await db.query<E2eStreamRow>(sql`
       INSERT INTO e2e_streams (
-        stream_id, workspace_id, owner_user_id, owner_user_key_id
+        stream_id, workspace_id, owner_user_id, owner_user_key_id, current_key_generation
       )
       VALUES (
         ${params.streamId},
         ${params.workspaceId},
         ${params.ownerUserId},
-        ${params.ownerUserKeyId}
+        ${params.ownerUserKeyId},
+        ${params.currentKeyGeneration ?? 0}
       )
       RETURNING ${sql.raw(COLUMNS)}
     `)

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-dispatch-handler.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-dispatch-handler.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool } from "pg"
+import { CursorLock } from "@threa/backend-common"
+import * as outbox from "../../../lib/outbox"
+import { OutboxRepository } from "../../../lib/outbox"
+import { E2eStreamActorsRepository, E2eStreamsRepository } from "../../e2e-streams"
+import { StreamRepository } from "../../streams"
+import { JobQueues, type QueueManager } from "../../../lib/queue"
+import { EnclaveDispatchHandler } from "./enclave-dispatch-handler"
+
+// The enclave only auto-replies when companion mode is ON. "Quiet" (off) keeps
+// the encrypted scratchpad a silent dump — the enclave actor stays invited but
+// no turn is dispatched. Threads inherit the root scratchpad's mode live.
+
+const EVENT = { id: 1n, eventType: "message:created", payload: {} }
+
+function arrange(streamById: Record<string, unknown>) {
+  spyOn(CursorLock.prototype, "run").mockImplementation((async (
+    processor: (c: bigint, p: bigint[]) => Promise<unknown>
+  ) => {
+    await processor(0n, [])
+    return true
+  }) as never)
+  spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([EVENT] as never)
+  spyOn(outbox, "parseMessagePayload").mockReturnValue({
+    streamId: "stream_target",
+    workspaceId: "ws_1",
+    event: { actorType: "user", actorId: "usr_1", payload: { messageId: "msg_1" } },
+  } as never)
+  spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
+  spyOn(E2eStreamActorsRepository, "listForStream").mockResolvedValue([
+    { kind: "enclave", actorId: "enclave", keyId: null },
+  ] as never)
+  spyOn(StreamRepository, "findById").mockImplementation(((_db: unknown, id: string) =>
+    Promise.resolve(streamById[id] ?? null)) as never)
+}
+
+describe("EnclaveDispatchHandler companion-mode gate", () => {
+  let send: ReturnType<typeof mock>
+
+  beforeEach(() => {
+    send = mock(() => Promise.resolve())
+  })
+  afterEach(() => mock.restore())
+
+  const run = async () => {
+    const handler = new EnclaveDispatchHandler({} as Pool, { send } as unknown as QueueManager)
+    await (handler as unknown as { processEvents(): Promise<void> }).processEvents()
+  }
+
+  it("does NOT dispatch when the scratchpad's companion mode is OFF (Quiet)", async () => {
+    arrange({ stream_target: { id: "stream_target", type: "scratchpad", companionMode: "off", rootStreamId: null } })
+    await run()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("dispatches an enclave invoke when companion mode is ON", async () => {
+    arrange({ stream_target: { id: "stream_target", type: "scratchpad", companionMode: "on", rootStreamId: null } })
+    await run()
+    expect(send).toHaveBeenCalledWith(
+      JobQueues.ENCLAVE_INVOKE,
+      expect.objectContaining({ workspaceId: "ws_1", streamId: "stream_target", messageId: "msg_1" })
+    )
+  })
+
+  it("dispatches for a thread whose own mode is off but whose root scratchpad is ON", async () => {
+    arrange({
+      stream_target: { id: "stream_target", type: "thread", companionMode: "off", rootStreamId: "stream_root" },
+      stream_root: { id: "stream_root", type: "scratchpad", companionMode: "on", rootStreamId: null },
+    })
+    await run()
+    expect(send).toHaveBeenCalledWith(JobQueues.ENCLAVE_INVOKE, expect.objectContaining({ streamId: "stream_target" }))
+  })
+})

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-dispatch-handler.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-dispatch-handler.ts
@@ -1,9 +1,10 @@
 import type { Pool } from "pg"
-import { AuthorTypes } from "@threa/types"
+import { AuthorTypes, CompanionModes, StreamTypes } from "@threa/types"
 import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
 import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../../lib/outbox"
 import { JobQueues, type QueueManager } from "../../../lib/queue"
 import { E2eStreamActorsRepository, E2eStreamsRepository } from "../../e2e-streams"
+import { StreamRepository } from "../../streams"
 import { logger } from "../../../lib/logger"
 
 const DEFAULT_CONFIG = {
@@ -92,6 +93,33 @@ export class EnclaveDispatchHandler implements OutboxHandler {
           }
           const actors = await E2eStreamActorsRepository.listForStream(this.db, workspaceId, streamId)
           if (!actors.some((a) => a.kind === "enclave")) {
+            seen.push(event.id)
+            continue
+          }
+
+          // Honest companion toggle: the enclave only auto-replies when the
+          // scratchpad's companion mode is ON. "Quiet" means a silent encrypted
+          // dump — the enclave actor stays invited (so flipping to Companion
+          // works instantly) but no turn is dispatched. Threads inherit the
+          // root scratchpad's mode live, mirroring CompanionHandler, so a root
+          // toggled after the thread was created is still respected.
+          const stream = await StreamRepository.findById(this.db, streamId)
+          if (!stream) {
+            seen.push(event.id)
+            continue
+          }
+          let companionSource = stream
+          if (stream.companionMode !== CompanionModes.ON && stream.rootStreamId) {
+            const rootStream = await StreamRepository.findById(this.db, stream.rootStreamId)
+            if (
+              rootStream &&
+              rootStream.type === StreamTypes.SCRATCHPAD &&
+              rootStream.companionMode === CompanionModes.ON
+            ) {
+              companionSource = rootStream
+            }
+          }
+          if (companionSource.companionMode !== CompanionModes.ON) {
             seen.push(event.id)
             continue
           }

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -522,11 +522,14 @@ export function createStreamHandlers({
       let resolvedCompanionMode = companionMode
       let resolvedPersonaId = companionPersonaId
       if (e2eEnabled) {
-        // INV-E1: companion mode would broadcast plaintext from Ariadne into
-        // an encrypted stream. Force-off rather than rejecting so the
-        // Quickswitcher entry point doesn't have to coordinate with whatever
-        // companion default the workspace ships with.
-        resolvedCompanionMode = CompanionModes.OFF
+        // Encrypted scratchpads run Ariadne in the *enclave* (sealed), never the
+        // plaintext companion path — CompanionHandler skips E2E, so companion
+        // mode here can't leak plaintext. It's a real setting: it gates the
+        // enclave auto-reply (EnclaveDispatchHandler). Default ON so encrypted
+        // Ariadne works out of the box; an explicit "off" means a silent
+        // encrypted dump. Persona stays unset — the enclave always runs the
+        // built-in Ariadne regardless of `companionPersonaId`.
+        resolvedCompanionMode = companionMode ?? CompanionModes.ON
         resolvedPersonaId = undefined
       }
       if (contextBag) {

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -528,6 +528,79 @@ describe("StreamService.createThread (via create)", () => {
       })
     )
   })
+
+  test("seals a thread created under an E2E scratchpad root (INV-E1: inherit key, wraps, actors)", async () => {
+    // Root scratchpad is E2E; the thread must inherit its E2E state in the same
+    // transaction so replies can't land as server-readable plaintext.
+    const e2eRoot = {
+      id: "stream_root",
+      workspaceId: "ws_1",
+      type: "scratchpad",
+      visibility: "private",
+      rootStreamId: null,
+      companionMode: "on",
+      companionPersonaId: null,
+      e2eEnabled: true,
+    }
+    const e2eThread = { ...thread, parentStreamId: "stream_root", rootStreamId: "stream_root" }
+    const sealedThread = { ...e2eThread, e2eEnabled: true, e2eOwnerKeyId: "uik_owner" }
+
+    mockMessageFindById.mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_root",
+      authorType: "user",
+      authorId: "member_author",
+    } as never)
+    // findById: parent/root → e2eRoot; the post-copy re-read of the thread → sealed.
+    mockFindById
+      .mockReset()
+      .mockImplementation(((_c: unknown, id: string) =>
+        Promise.resolve(id === e2eThread.id ? sealedThread : e2eRoot)) as never)
+    mockInsertThreadOrFind.mockResolvedValue({ stream: { ...e2eThread }, created: true } as never)
+
+    const getByStreamId = spyOn(E2eStreamsRepository, "getByStreamId").mockResolvedValue({
+      streamId: "stream_root",
+      workspaceId: "ws_1",
+      ownerUserId: "usr_owner",
+      ownerUserKeyId: "uik_owner",
+      currentKeyGeneration: 2,
+      allowedToolCategories: null,
+      enabledAt: new Date(),
+    } as never)
+    mockMarkStreamE2e.mockReset().mockResolvedValue({} as never)
+    const copyWraps = spyOn(StreamE2eKeyWrapsRepository, "copyToStream").mockResolvedValue(undefined as never)
+    const copyActors = spyOn(E2eStreamActorsRepository, "copyToStream").mockResolvedValue(undefined as never)
+
+    const result = await service.create({
+      workspaceId: "ws_1",
+      type: "thread",
+      parentStreamId: "stream_root",
+      parentMessageId: "msg_1",
+      createdBy: "member_creator",
+    })
+
+    expect(getByStreamId).toHaveBeenCalledWith({}, "ws_1", "stream_root")
+    expect(mockMarkStreamE2e).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        streamId: e2eThread.id,
+        workspaceId: "ws_1",
+        ownerUserId: "usr_owner",
+        ownerUserKeyId: "uik_owner",
+        currentKeyGeneration: 2,
+      })
+    )
+    expect(copyWraps).toHaveBeenCalledWith(
+      {},
+      { workspaceId: "ws_1", fromStreamId: "stream_root", toStreamId: e2eThread.id }
+    )
+    expect(copyActors).toHaveBeenCalledWith(
+      {},
+      { workspaceId: "ws_1", fromStreamId: "stream_root", toStreamId: e2eThread.id }
+    )
+    // The returned/broadcast thread reflects the sealed state.
+    expect(result.e2eEnabled).toBe(true)
+  })
 })
 
 describe("StreamService.inviteActor", () => {

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -576,6 +576,43 @@ export class StreamService {
         createdBy: params.createdBy,
       })
 
+      // INV-E1: a thread under an E2E scratchpad must itself be E2E, or its
+      // replies would be stored server-readable plaintext (the encryption
+      // guarantee silently breaks one reply deep). Inherit the root's E2E state
+      // — same SSK, same recipients (owner + enclave + bots) — onto the new
+      // thread in this same transaction, so `e2eEnabled` is true the instant the
+      // thread is and the composer/sink/dispatch all treat it like the root.
+      // Only on first creation: a found-existing thread already carries it.
+      if (created && rootStream?.e2eEnabled === true) {
+        const rootE2e = await E2eStreamsRepository.getByStreamId(client, params.workspaceId, rootStreamId)
+        if (!rootE2e) {
+          // The stream row says e2eEnabled but the e2e_streams row is gone:
+          // refuse rather than create a plaintext thread under a sealed root.
+          throw new Error(`E2E root ${rootStreamId} has no e2e_streams row; cannot seal thread ${stream.id}`)
+        }
+        await E2eStreamsRepository.markStreamE2e(client, {
+          streamId: stream.id,
+          workspaceId: params.workspaceId,
+          ownerUserId: rootE2e.ownerUserId,
+          ownerUserKeyId: rootE2e.ownerUserKeyId,
+          currentKeyGeneration: rootE2e.currentKeyGeneration,
+        })
+        await StreamE2eKeyWrapsRepository.copyToStream(client, {
+          workspaceId: params.workspaceId,
+          fromStreamId: rootStreamId,
+          toStreamId: stream.id,
+        })
+        await E2eStreamActorsRepository.copyToStream(client, {
+          workspaceId: params.workspaceId,
+          fromStreamId: rootStreamId,
+          toStreamId: stream.id,
+        })
+        // Re-read so the returned/broadcast stream carries e2eEnabled + actors
+        // in the canonical shape (StreamRepository LEFT JOINs e2e_streams).
+        const sealed = await StreamRepository.findById(client, stream.id)
+        if (sealed) Object.assign(stream, sealed)
+      }
+
       // Add creator as member (idempotent - handles existing membership)
       const isMember = await StreamMemberRepository.isMember(client, stream.id, params.createdBy)
       if (!isMember) {
@@ -991,7 +1028,12 @@ export class StreamService {
       // the enclave restarted with a fresh EIK) — and revive it via
       // `reviveActorKeyWraps` without a second round-trip.
       const liveActorRecipients = await this.resolveActorRecipients(client, e2e)
-      return { currentKeyGeneration: e2e.currentKeyGeneration, wraps, ownerUserId: e2e.ownerUserId, liveActorRecipients }
+      return {
+        currentKeyGeneration: e2e.currentKeyGeneration,
+        wraps,
+        ownerUserId: e2e.ownerUserId,
+        liveActorRecipients,
+      }
     })
   }
 

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -13,10 +13,11 @@ interface CompanionTabProps {
 export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
   const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
 
-  // INV-E1: E2E streams can't speak plaintext through the companion, so this
-  // surface is purely informational for them.
+  // On encrypted scratchpads Ariadne runs in the enclave (never the plaintext
+  // companion path), so the toggle is a real control here too: Companion =
+  // she replies via the enclave, Quiet = silent encrypted storage.
   const isE2e = stream.e2eEnabled === true
-  const disabled = isPending || isE2e
+  const disabled = isPending
 
   const handleChange = async (next: CompanionMode) => {
     if (next === stream.companionMode) return
@@ -64,8 +65,8 @@ export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
 
       {isE2e && (
         <p className="text-xs text-muted-foreground">
-          Companion mode stays off on encrypted scratchpads — it would reply in plaintext. Ariadne still replies here,
-          running in the encryption enclave so your content stays end-to-end encrypted.
+          On encrypted scratchpads Ariadne replies from inside the encryption enclave, so your content stays end-to-end
+          encrypted either way. Companion lets her reply; Quiet keeps this a silent, encrypted dump.
         </p>
       )}
     </div>


### PR DESCRIPTION
First of three PRs from the encrypted-scratchpad review. Fixes the confidentiality leak (plaintext threads) and the lying companion toggle.

## 1. Threads under an E2E scratchpad were plaintext (the leak)

Replying in a thread under an encrypted scratchpad created a **plaintext** child stream — `createThread` inherited visibility/companion mode from the root but not its E2E state — so thread replies were stored server-readable. The encryption guarantee broke one reply deep.

**Fix (Option B — thread is a first-class E2E stream sharing the root's key):** on thread creation under an E2E root, in the same transaction, copy the root's `e2e_streams` row (same owner key + key generation), its key wraps, and its actors onto the thread. The thread then reuses the root's SSK, so every existing path works unchanged and fail-closed: the composer encrypts, the INV-E1 sink requires ciphertext, the enclave dispatches, and external bots short-circuit.

- New repo helpers: `StreamE2eKeyWrapsRepository.copyToStream`, `E2eStreamActorsRepository.copyToStream`; `markStreamE2e` accepts a starting key generation.
- *Note:* threads created **before** this change remain plaintext (the data already leaked) — a backfill/cleanup of legacy plaintext threads under E2E roots is a possible follow-up.

## 2. Agent runtime continues in E2E threads

Because the thread carries the enclave actor (copied), the enclave dispatch fires for thread turns exactly as at the top level, and external bot invocations stay short-circuited — same behavior as the root scratchpad.

## 3. The Companion/Quiet toggle lied

Companion mode was force-set **off** on encrypted scratchpads while Ariadne replied anyway through the enclave (the enclave dispatch ignored companion mode). So "Quiet — no AI replies" was false.

**Fix:** the enclave auto-reply now gates on the scratchpad's companion mode (root-resolved for threads, mirroring `CompanionHandler`). Companion = Ariadne replies via the enclave; Quiet = silent encrypted storage. The plaintext companion path still skips E2E, so no plaintext can leak. Creation no longer force-sets off — it defaults **on** (encrypted Ariadne on out of the box) and honors an explicit Quiet. A migration flips existing encrypted scratchpads that have the enclave invited to **on**, so they keep replying under the now-honest gate. Settings copy fixed and the toggle is live for E2E.

## Tests

- `service.test.ts`: a thread created under an E2E root inherits the e2e row + wraps + actors and comes back `e2eEnabled`.
- `enclave-dispatch-handler.test.ts` (new): no dispatch when Quiet, dispatch when Companion, and dispatch for a thread whose root is Companion.
- Full backend + frontend suites, monorepo typecheck, lint, OpenAPI check all green.

Follow-ups (separate PRs, already scoped): enclave-generated auto-title for encrypted scratchpads; decrypt-to-public message sharing with confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBYCisfdLCnagjfaHcSP7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783271511&installation_id=129946197&pr_number=793&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F793&signature=7633276e4ce6d29a65fccdc78a122c06c845595cc6642b84bb4d0a6438a8cb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->