### PR TITLE
feat(e2e): enclave-generated auto-title for encrypted scratchpads

### DIFF
--- a/apps/backend/src/features/e2e-streams/repository.test.ts
+++ b/apps/backend/src/features/e2e-streams/repository.test.ts
@@ -85,6 +85,7 @@ describe("E2eStreamsRepository.getByStreamId", () => {
       ownerUserKeyId: "e2ek_01",
       currentKeyGeneration: 0,
       allowedToolCategories: ["web"],
+      hasSealedName: false,
     })
   })
 

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -10,6 +10,8 @@ interface E2eStreamRow {
   owner_user_key_id: string
   current_key_generation: number
   allowed_tool_categories: string[] | null
+  /** Computed in getByStreamId only; absent (→ false) on RETURNING rows. */
+  has_sealed_name?: boolean
 }
 
 export interface E2eStream {
@@ -26,6 +28,12 @@ export interface E2eStream {
    * assignment and enforced there (the server never builds the tools itself).
    */
   allowedToolCategories: ToolPrivacyPolicy
+  /**
+   * Whether a sealed display name is already stored. Lets the enclave dispatch
+   * decide whether to ask the enclave to auto-title this scratchpad (only when
+   * it has no name yet). Populated by `getByStreamId`; false elsewhere.
+   */
+  hasSealedName: boolean
 }
 
 export interface MarkStreamE2eParams {
@@ -54,6 +62,7 @@ function mapRow(row: E2eStreamRow): E2eStream {
     ownerUserKeyId: row.owner_user_key_id,
     currentKeyGeneration: row.current_key_generation,
     allowedToolCategories: (row.allowed_tool_categories as ToolPrivacyPolicy) ?? null,
+    hasSealedName: row.has_sealed_name ?? false,
   }
 }
 
@@ -117,12 +126,38 @@ export const E2eStreamsRepository = {
 
   async getByStreamId(db: Querier, workspaceId: string, streamId: string): Promise<E2eStream | null> {
     const result = await db.query<E2eStreamRow>(sql`
-      SELECT ${sql.raw(COLUMNS)}
+      SELECT ${sql.raw(COLUMNS)}, (name_ciphertext IS NOT NULL) AS has_sealed_name
       FROM e2e_streams
       WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
       LIMIT 1
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /**
+   * Store a sealed display name only if the stream doesn't already have one
+   * (race-safe first-write-wins, INV-20). Used by the enclave auto-title path:
+   * the enclave only generates a title for an untitled scratchpad, and the
+   * `name_ciphertext IS NULL` guard means a second concurrent first-turn can't
+   * clobber the title the first one set. Returns true when this call set it.
+   * No-op (false) for a plaintext stream or one already named.
+   */
+  async setSealedNameIfAbsent(
+    db: Querier,
+    workspaceId: string,
+    streamId: string,
+    sealed: { ciphertext: string; envelope: unknown }
+  ): Promise<boolean> {
+    if (Buffer.from(sealed.ciphertext, "base64").toString("base64") !== sealed.ciphertext) {
+      throw new Error("setSealedNameIfAbsent: ciphertext is not canonical base64")
+    }
+    const result = await db.query(sql`
+      UPDATE e2e_streams
+      SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
+          name_envelope = ${JSON.stringify(sealed.envelope)}
+      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId} AND name_ciphertext IS NULL
+    `)
+    return (result.rowCount ?? 0) > 0
   },
 
   /**

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -29,6 +29,7 @@ const E2E: E2eStream = {
   ownerUserKeyId: "e2ek_owner",
   currentKeyGeneration: 1,
   allowedToolCategories: null,
+  hasSealedName: false,
 }
 const ENCLAVE_ACTOR: E2eStreamActor = { kind: "enclave", actorId: "enclave", keyId: null }
 const EIK: EnclaveRuntime = {
@@ -172,9 +173,7 @@ describe("createEnclaveInvokeWorker", () => {
     // live one can't open the trigger. The turn must park on the queue's
     // retry/backoff (the owner's client revives the wrap meanwhile) — never a
     // silent skip, and no session row before a servable enclave exists.
-    spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([
-      { ...WRAP, recipientKeyId: "eik_dead" },
-    ])
+    spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([{ ...WRAP, recipientKeyId: "eik_dead" }])
     const insertSession = spyOn(AgentSessionRepository, "insertRunningOrSkip")
     const assignSession = mock(async () => {})
     const { io } = fakeIo()

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -25,6 +25,7 @@ import { EnclaveRuntimesRepository } from "../repository"
 import { ENCLAVE_RUNTIME_STALENESS_MS } from "../service"
 import type { EnclaveForwarder } from "../forwarder"
 import { buildEnclaveSessionAssignment } from "./request-builder"
+import { StreamTypes } from "@threa/types"
 
 /** How many prior messages of context to forward. */
 const MAX_HISTORY_MESSAGES = 30
@@ -149,6 +150,9 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       replySenderId: ARIADNE_AGENT_ID,
       sessionId: sid,
       attachmentCiphertexts,
+      // Ask the enclave to seal a title only for an untitled root scratchpad
+      // (threads aren't titled; an already-named scratchpad isn't re-titled).
+      autoTitle: stream.type === StreamTypes.SCRATCHPAD && !e2e.hasSealedName,
     })
     if (!built) {
       // Park, don't drop: no live EIK can both open the trigger and seal the

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.test.ts
@@ -12,6 +12,7 @@ const E2E: E2eStream = {
   ownerUserKeyId: "e2ek_owner",
   currentKeyGeneration: 1,
   allowedToolCategories: null,
+  hasSealedName: false,
 }
 
 const ENCLAVE_ACTOR: E2eStreamActor = { kind: "enclave", actorId: "enclave", keyId: null }

--- a/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/request-builder.ts
@@ -50,6 +50,8 @@ export interface BuildInvokeInputs {
    * opens them with the sealed per-file key. Empty/omitted → no attachments.
    */
   attachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
+  /** Ask the enclave to generate + seal a title for this (untitled) scratchpad. */
+  autoTitle?: boolean
 }
 
 export interface BuiltEnclaveInvoke {
@@ -116,6 +118,7 @@ export function buildEnclaveSessionAssignment(inputs: BuildInvokeInputs): BuiltE
     ...(inputs.attachmentCiphertexts && inputs.attachmentCiphertexts.length > 0
       ? { attachmentCiphertexts: inputs.attachmentCiphertexts }
       : {}),
+    ...(inputs.autoTitle ? { autoTitle: true } : {}),
     reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
     // Clear metadata for the enclave's "Triggered by" CONTEXT step; the body is
     // the decrypted prompt, sealed enclave-side. Omitted when the author name

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -7,6 +7,7 @@ import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
 import { AgentSessionRepository, SessionStatuses } from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
+import { E2eStreamsRepository } from "../e2e-streams"
 import { OutboxRepository } from "../../lib/outbox"
 import type { EventService } from "../messaging"
 import type { QueueManager } from "../../lib/queue"
@@ -125,6 +126,47 @@ describe("createEnclaveSessionHandlers.message", () => {
       accessibleStreamIds: ["stream_1"],
       clientMessageId: "enclave-reply:session_1:msg_a",
     })
+  })
+})
+
+describe("createEnclaveSessionHandlers.sealedName", () => {
+  const NAME_BODY = { ciphertext: "Y3Q=", envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" } }
+
+  it("stores the sealed title (first-write-wins) and broadcasts stream:updated", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
+    spyOn(db, "withTransaction").mockImplementation(((_pool: unknown, cb: (c: unknown) => unknown) => cb({})) as never)
+    const setName = spyOn(E2eStreamsRepository, "setSealedNameIfAbsent").mockResolvedValue(true)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const { handlers } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.sealedName(req("session_1", NAME_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(setName).toHaveBeenCalledWith({}, "ws_1", "stream_1", expect.objectContaining({ ciphertext: "Y3Q=" }))
+    expect(insert).toHaveBeenCalledWith({}, "stream:updated", expect.objectContaining({ streamId: "stream_1" }))
+  })
+
+  it("does not broadcast when the scratchpad is already named (no-op)", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
+    spyOn(db, "withTransaction").mockImplementation(((_pool: unknown, cb: (c: unknown) => unknown) => cb({})) as never)
+    spyOn(E2eStreamsRepository, "setSealedNameIfAbsent").mockResolvedValue(false)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const { handlers } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.sealedName(req("session_1", NAME_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("409s when the session is no longer running", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...SESSION!, status: SessionStatuses.FAILED })
+    const { handlers } = makeHandlers()
+    await expect(handlers.sealedName(req("session_1", NAME_BODY), fakeRes())).rejects.toMatchObject({ status: 409 })
   })
 })
 

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -11,6 +11,7 @@ import { JobQueues, type QueueManager } from "../../lib/queue"
 import { HttpError } from "../../lib/errors"
 import { AgentSessionRepository, SessionStatuses, getBuiltInAgentConfig, type AgentSession } from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
+import { E2eStreamsRepository } from "../e2e-streams"
 import { serializeTraceStep } from "../public-api"
 import type { EventService } from "../messaging"
 
@@ -45,6 +46,13 @@ const streamEnvelopeSchema = z.object({
 
 const messageSchema = z.object({
   messageId: z.string().min(1),
+  ciphertext: z.base64().min(1),
+  envelope: streamEnvelopeSchema,
+})
+
+// A sealed auto-generated stream name. Like a reply but without a messageId — a
+// name is a single per-stream slot, not a message. Same base64 validation.
+const sealedNameSchema = z.object({
   ciphertext: z.base64().min(1),
   envelope: streamEnvelopeSchema,
 })
@@ -193,6 +201,44 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue 
         // stream so a reply can't post twice (keyed by the enclave-minted id).
         accessibleStreamIds: [session.streamId],
         clientMessageId: `enclave-reply:${id}:${reply.messageId}`,
+      })
+
+      res.status(204).end()
+    },
+
+    /**
+     * POST /internal/enclave-runtimes/sessions/:id/sealed-name
+     * Persist the enclave's sealed auto-title for an untitled E2E scratchpad
+     * (the server can't title it — it only holds ciphertext). First-write-wins
+     * (`setSealedNameIfAbsent`), and on a real change we re-read the e2e-joined
+     * stream and broadcast `stream:updated` so the sidebar/header pick up the
+     * name and decrypt it live. We never set a plaintext display name — the
+     * title exists only as ciphertext.
+     */
+    async sealedName(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
+
+      const parsed = sealedNameSchema.safeParse(req.body)
+      if (!parsed.success) throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+
+      const session = await AgentSessionRepository.findById(pool, id)
+      assertRunning(session)
+      const stream = await StreamRepository.findById(pool, session.streamId)
+      if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+
+      await withTransaction(pool, async (client) => {
+        const set = await E2eStreamsRepository.setSealedNameIfAbsent(client, stream.workspaceId, session.streamId, {
+          ciphertext: parsed.data.ciphertext,
+          envelope: parsed.data.envelope,
+        })
+        if (!set) return
+        const updated = (await StreamRepository.findById(client, session.streamId)) ?? stream
+        await OutboxRepository.insert(client, "stream:updated", {
+          workspaceId: updated.workspaceId,
+          streamId: updated.id,
+          stream: updated,
+        })
       })
 
       res.status(204).end()

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -288,6 +288,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     const enclaveSession = createEnclaveSessionHandlers({ pool, eventService, io: deps.io, jobQueue: deps.jobQueue })
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
+    app.post("/internal/enclave-runtimes/sessions/:id/sealed-name", internalAuth, enclaveSession.sealedName)
     app.post("/internal/enclave-runtimes/sessions/:id/steps/started", internalAuth, enclaveSession.stepStarted)
     app.post("/internal/enclave-runtimes/sessions/:id/steps", internalAuth, enclaveSession.steps)
     app.post("/internal/enclave-runtimes/sessions/:id/substeps", internalAuth, enclaveSession.substep)

--- a/apps/enclave/src/agent/auto-title.test.ts
+++ b/apps/enclave/src/agent/auto-title.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { sanitizeTitle } from "./auto-title"
+
+describe("sanitizeTitle", () => {
+  it("returns a trimmed single-line title", () => {
+    expect(sanitizeTitle("  Trip planning to France  ")).toBe("Trip planning to France")
+  })
+
+  it("strips surrounding quotes and a trailing period the model tends to add", () => {
+    expect(sanitizeTitle('"Quarterly budget review."')).toBe("Quarterly budget review")
+    expect(sanitizeTitle("“Launch checklist”")).toBe("Launch checklist")
+  })
+
+  it("collapses to the first non-empty line and normalizes whitespace", () => {
+    expect(sanitizeTitle("\n\n  Onboarding   notes \nignored second line")).toBe("Onboarding notes")
+  })
+
+  it("caps overly long titles", () => {
+    const long = "a".repeat(200)
+    expect(sanitizeTitle(long)!.length).toBe(60)
+  })
+
+  it("returns null for empty / missing input", () => {
+    expect(sanitizeTitle("")).toBeNull()
+    expect(sanitizeTitle("   \n  ")).toBeNull()
+    expect(sanitizeTitle(null)).toBeNull()
+    expect(sanitizeTitle(undefined)).toBeNull()
+  })
+})

--- a/apps/enclave/src/agent/auto-title.ts
+++ b/apps/enclave/src/agent/auto-title.ts
@@ -1,0 +1,64 @@
+import type { RawChatFn } from "../llm"
+
+/** Hard cap on a generated title's length (characters), matching a sensible UI width. */
+const MAX_TITLE_CHARS = 60
+/** Plenty for a handful of words; keeps the extra call cheap. */
+const TITLE_MAX_TOKENS = 24
+
+/**
+ * Normalize a model-produced title into a single clean line, or null if there's
+ * nothing usable. Strips surrounding quotes the model often adds, flattens to
+ * the first line, collapses whitespace, and caps length. Language-agnostic — no
+ * locale heuristics (INV-54); phrasing is the model's job.
+ */
+export function sanitizeTitle(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const firstLine = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0)
+  if (!firstLine) return null
+  // Drop matching surrounding quotes (straight or curly) and trailing period.
+  const unquoted = firstLine
+    .replace(/^["'“”‘’]+/, "")
+    .replace(/["'“”‘’]+$/, "")
+    .replace(/\.+$/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (unquoted.length === 0) return null
+  return unquoted.length > MAX_TITLE_CHARS ? unquoted.slice(0, MAX_TITLE_CHARS).trim() : unquoted
+}
+
+/**
+ * Generate a short title for an encrypted scratchpad from its decrypted opening
+ * turn. Runs inside the enclave (the only place this plaintext exists) as one
+ * cheap completion over the same model the turn used. Best-effort: any failure
+ * or empty result returns null and the caller simply skips titling — never
+ * blocks or fails the turn.
+ */
+export async function generateTitle(params: {
+  rawChat: RawChatFn
+  model: string
+  promptText: string
+  replyText: string
+}): Promise<string | null> {
+  const conversation = `User:\n${params.promptText}\n\nAssistant:\n${params.replyText}`.slice(0, 4000)
+  try {
+    const result = await params.rawChat({
+      model: params.model,
+      maxTokens: TITLE_MAX_TOKENS,
+      temperature: 0.3,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You name a conversation. Reply with ONLY a short, specific title of 3 to 6 words — no quotes, no surrounding punctuation, no preamble. Use the same language as the conversation.",
+        },
+        { role: "user", content: conversation },
+      ],
+    })
+    return sanitizeTitle(result.message.content)
+  } catch {
+    return null
+  }
+}

--- a/apps/enclave/src/agent/backend-callbacks.ts
+++ b/apps/enclave/src/agent/backend-callbacks.ts
@@ -1,6 +1,7 @@
 import {
   INTERNAL_API_KEY_HEADER,
   type EnclaveSealedReply,
+  type EnclaveSealedName,
   type EnclaveSealedStep,
   type EnclaveSealedStepStart,
   type EnclaveSealedSubstep,
@@ -28,6 +29,8 @@ export interface BackendCallbacks {
   substep(sessionId: string, substep: EnclaveSealedSubstep): Promise<void>
   /** Mark the session complete once the loop finishes (replies already streamed). */
   complete(sessionId: string, result: EnclaveSessionResult): Promise<void>
+  /** Persist a sealed auto-generated stream title (best-effort; for untitled E2E scratchpads). */
+  sealedName(sessionId: string, sealed: EnclaveSealedName): Promise<void>
 }
 
 const HEARTBEAT_TIMEOUT_MS = 10_000
@@ -100,6 +103,16 @@ export function createBackendCallbacks(config: EnclaveConfig): BackendCallbacks 
         signal: AbortSignal.timeout(COMPLETE_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`session complete failed: ${res.status}`)
+    },
+
+    async sealedName(sessionId, sealed) {
+      const res = await fetch(`${base}/internal/enclave-runtimes/sessions/${sessionId}/sealed-name`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(sealed),
+        signal: AbortSignal.timeout(MESSAGE_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`session sealed-name failed: ${res.status}`)
     },
   }
 }

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -180,6 +180,65 @@ describe("runEnclaveTurn", () => {
     expect(stepText).toBe("Paris.")
   })
 
+  it("seals an auto-title the owner's SSK can recover when autoTitle is set", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "Help me plan a trip to France.", "msg_user", "usr_owner")
+    // First chat = the turn's reply; second = the title generation call.
+    const chat = stubChat([textReply("Sure, where to?"), textReply('"Trip planning to France."')])
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    let sealedName: { ciphertext: string; envelope: { keyGeneration: number } } | null = null
+    await runEnclaveTurn(
+      {
+        keyPair,
+        rawChat: chat.fn,
+        onMessage,
+        onStepStarted,
+        onStep,
+        onSubstep,
+        onSealedName: async (s) => void (sealedName = s),
+      },
+      baseRequest({ wraps: [wrap], prompt, autoTitle: true })
+    )
+
+    expect(sealedName).not.toBeNull()
+    expect(sealedName!.envelope.keyGeneration).toBe(GEN)
+    // The sealed title decrypts under the same SSK (quotes/period stripped).
+    const title = await openMessageAsString({
+      key: ssk,
+      envelope: sealedName!.envelope as never,
+      ciphertext: Buffer.from(sealedName!.ciphertext, "base64"),
+    })
+    expect(title).toBe("Trip planning to France")
+  })
+
+  it("does not title when autoTitle is unset", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "Just a note.", "msg_user", "usr_owner")
+    const chat = stubChat(textReply("Noted."))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    let titled = false
+    await runEnclaveTurn(
+      {
+        keyPair,
+        rawChat: chat.fn,
+        onMessage,
+        onStepStarted,
+        onStep,
+        onSubstep,
+        onSealedName: async () => void (titled = true),
+      },
+      baseRequest({ wraps: [wrap], prompt })
+    )
+
+    expect(titled).toBe(false)
+  })
+
   it("seals every message when the loop sends more than one", async () => {
     const keyPair = await createEnclaveKeyPair()
     const ssk = generateStreamKey()
@@ -344,7 +403,10 @@ describe("runEnclaveTurn", () => {
       { type: "image_url", image_url: { url: `data:image/png;base64,${bytesToBase64(utf8Encode("fake-png-bytes"))}` } },
       {
         type: "file",
-        file: { filename: "contract.pdf", file_data: `data:application/pdf;base64,${bytesToBase64(utf8Encode("fake-pdf-bytes"))}` },
+        file: {
+          filename: "contract.pdf",
+          file_data: `data:application/pdf;base64,${bytesToBase64(utf8Encode("fake-pdf-bytes"))}`,
+        },
       },
     ])
   })
@@ -396,7 +458,9 @@ describe("runEnclaveTurn", () => {
     // First call: the history message carries the id-bearing note (not the bytes),
     // and load_attachment is offered even with no web tools configured.
     const first = chat.seen[0]!
-    const historyMsg = first.messages.find((m) => m.role === "user" && typeof m.content === "string" && m.content.includes("plan"))
+    const historyMsg = first.messages.find(
+      (m) => m.role === "user" && typeof m.content === "string" && m.content.includes("plan")
+    )
     expect(historyMsg?.content).toBe('here\'s the plan\n\n[Attached: "plan.md" (attach_hist)]')
     expect(first.tools?.map((t) => t.function.name)).toEqual(expect.arrayContaining(["load_attachment"]))
 
@@ -433,11 +497,26 @@ describe("runEnclaveTurn", () => {
 
     // Browsers report no MIME for .md, so the ref says octet-stream — the
     // enclave must still recognize valid UTF-8 and inline it as text.
-    const md = await encryptFile(utf8Encode("# Notes\n\nremember the milk"), "application/octet-stream", "notes.md", "attach_md")
+    const md = await encryptFile(
+      utf8Encode("# Notes\n\nremember the milk"),
+      "application/octet-stream",
+      "notes.md",
+      "attach_md"
+    )
     // 0xFF 0xFE… is not valid UTF-8 → genuinely binary, no model-readable form.
-    const bin = await encryptFile(new Uint8Array([0xff, 0xfe, 0x00, 0x01]), "application/octet-stream", "blob.bin", "attach_bin")
+    const bin = await encryptFile(
+      new Uint8Array([0xff, 0xfe, 0x00, 0x01]),
+      "application/octet-stream",
+      "blob.bin",
+      "attach_bin"
+    )
 
-    const prompt = await sealUnder(ssk, serializeSealedPayload("read these", [md.ref, bin.ref]), "msg_user", "usr_owner")
+    const prompt = await sealUnder(
+      ssk,
+      serializeSealedPayload("read these", [md.ref, bin.ref]),
+      "msg_user",
+      "usr_owner"
+    )
     const chat = stubChat(textReply("done"))
     const { onMessage, onStepStarted, onStep, onSubstep } = collector()
 

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -3,6 +3,7 @@ import { ulid } from "ulid"
 import {
   base64ToBytes,
   buildMessageAad,
+  buildNameAad,
   buildWrapAad,
   bytesToBase64,
   decryptAttachmentBytes,
@@ -20,6 +21,7 @@ import type {
   EnclaveSealedStep,
   EnclaveSealedStepStart,
   EnclaveSealedSubstep,
+  EnclaveSealedName,
   EnclaveSskWrap,
 } from "@threa/types"
 import { AgentRuntime } from "@threa/agent-runtime/runtime"
@@ -29,6 +31,7 @@ import { createEnclaveAI, type UsageAccumulator } from "./enclave-ai"
 import { EnclaveTraceObserver } from "./trace-observer"
 import { buildEnclaveTools } from "./tools"
 import { decodeUtf8 } from "./attachment-tool"
+import { generateTitle } from "./auto-title"
 
 /**
  * The agent turn, run entirely inside the enclave next to decrypted plaintext.
@@ -78,6 +81,13 @@ export interface EnclaveTurnDeps {
   /** Stream a sealed substep — ephemeral mid-run phase text (e.g. research progress). */
   onSubstep: (substep: EnclaveSealedSubstep) => Promise<void>
   /**
+   * Persist a sealed auto-generated title for the scratchpad. Called best-effort
+   * after the turn when `request.autoTitle` is set and the turn produced a reply;
+   * a throw here is swallowed (titling never blocks or fails the turn). Omitted →
+   * no titling.
+   */
+  onSealedName?: (sealed: EnclaveSealedName) => Promise<void>
+  /**
    * Cooperative cancellation for long-running tools (research). Wired to the
    * runtime's `toolSignalProvider`, so the user's "Stop research" aborts the web
    * sub-loop gracefully — it returns partial findings and the turn still replies,
@@ -100,7 +110,7 @@ export async function runEnclaveTurn(
   deps: EnclaveTurnDeps,
   request: EnclaveSessionAssignment
 ): Promise<EnclaveSessionResult> {
-  const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, tools, abortSignal } = deps
+  const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, onSealedName, tools, abortSignal } = deps
 
   // Recover the SSK for every generation the backend wrapped to us. The wrap AAD
   // binds to our own keyId — a wrap addressed elsewhere simply won't open.
@@ -155,6 +165,9 @@ export async function runEnclaveTurn(
 
   const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0 }
   const messageIds: string[] = []
+  // First reply's plaintext, kept only to seed the auto-title below (never logged
+  // or persisted; lives in-process for the turn like all other plaintext here).
+  let firstReplyText: string | null = null
 
   // Construct the enclave AI once so the turn loop and any in-process research
   // sub-loop accumulate token usage into the same total. The enclave AI keys off
@@ -212,6 +225,7 @@ export async function runEnclaveTurn(
     // to that id, and stream it back now (awaited, so it's delivered before the
     // loop moves on). The backend stores ciphertext under this id.
     sendMessage: async ({ content }) => {
+      if (firstReplyText === null) firstReplyText = content
       const messageId = `msg_${ulid()}`
       const sealed = await sealMessage({
         key: replySsk,
@@ -238,6 +252,28 @@ export async function runEnclaveTurn(
   }
 
   await runtime.run()
+
+  // Auto-title an untitled encrypted scratchpad from the decrypted turn. The
+  // server can't do this (it only holds ciphertext), so the enclave generates a
+  // short title here, seals it under the reply SSK bound to the name slot
+  // (`buildNameAad`), and hands the ciphertext back. Best-effort and last —
+  // never block or fail the turn over a title.
+  if (request.autoTitle && firstReplyText && onSealedName) {
+    try {
+      const title = await generateTitle({ rawChat, model: request.model, promptText, replyText: firstReplyText })
+      if (title) {
+        const sealed = await sealMessage({
+          key: replySsk,
+          keyGeneration: request.reply.keyGeneration,
+          payload: title,
+          aad: buildNameAad({ streamId: request.streamId, keyGeneration: request.reply.keyGeneration }),
+        })
+        await onSealedName({ ciphertext: bytesToBase64(sealed.ciphertext), envelope: sealed.envelope })
+      }
+    } catch {
+      // Titling is non-essential; a failure must never affect the reply.
+    }
+  }
 
   return {
     messageIds,

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -60,6 +60,8 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
         onStepStarted: (step) => deps.callbacks.stepStarted(sessionId, step),
         onStep: (step) => deps.callbacks.step(sessionId, step),
         onSubstep: (substep) => deps.callbacks.substep(sessionId, substep),
+        // Persist a sealed auto-title when the backend flagged this turn for it.
+        onSealedName: (sealed) => deps.callbacks.sealedName(sessionId, sealed),
         tools: deps.toolConfig ? { tavilyApiKey: deps.toolConfig.tavilyApiKey } : undefined,
         abortSignal: abortController.signal,
       },

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -140,6 +140,7 @@ describe("createSessionsHandler", () => {
       stepStarted: async () => {},
       step: async () => {},
       substep: async () => {},
+      sealedName: async () => {},
       complete: async (sessionId, result) => {
         completed = { sessionId, result }
       },
@@ -184,6 +185,7 @@ describe("createSessionsHandler", () => {
       stepStarted: async () => {},
       step: async () => {},
       substep: async () => {},
+      sealedName: async () => {},
       complete: async () => {
         completed = true
       },
@@ -217,6 +219,7 @@ describe("createSessionsHandler", () => {
         stepStarted: async () => {},
         step: async () => {},
         substep: async () => {},
+        sealedName: async () => {},
         complete: async () => {},
       },
       inFlight: new Set([assignment.sessionId]), // already running

--- a/apps/enclave/src/sessions.ts
+++ b/apps/enclave/src/sessions.ts
@@ -115,6 +115,9 @@ export const sessionAssignmentSchema = z.object({
     .array(z.object({ attachmentId: z.string().min(1), ciphertext: z.string().min(1) }))
     .max(MAX_INLINE_ATTACHMENTS)
     .optional(),
+  // Whether to auto-title this scratchpad (declared so Zod doesn't strip it —
+  // the same failure mode the attachment slice hit).
+  autoTitle: z.boolean().optional(),
 })
 
 export interface SessionsDeps {

--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -176,6 +176,62 @@ describe("ShareMessageModal — picker filtering", () => {
   })
 })
 
+describe("ShareMessageModal — E2E source confirms before decrypt-to-public", () => {
+  const TARGET = [
+    {
+      id: "ch_target",
+      type: "channel",
+      visibility: "public",
+      displayName: "#general",
+      slug: "general",
+      archivedAt: null,
+      rootStreamId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+
+  it("requires confirmation, then queues the decrypted plaintext (not a pointer)", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(TARGET)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+    )
+    const queuePointer = vi.spyOn(shareHandoffStoreModule, "queueShareHandoff").mockImplementation(() => {})
+    const queuePlaintext = vi.spyOn(shareHandoffStoreModule, "queuePlaintextShareHandoff").mockImplementation(() => {})
+
+    render(
+      <MemoryRouter initialEntries={["/w/ws_1/s/current"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/s/:streamId"
+            element={
+              <ShareMessageModal
+                open
+                onOpenChange={() => {}}
+                workspaceId="ws_1"
+                attrs={SAMPLE_ATTRS}
+                sourcePlaintext="the launch codename is VELVET-OTTER"
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // Picking a target does NOT immediately queue — a confirmation appears first.
+    fireEvent.click(document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')!)
+    expect(queuePlaintext).not.toHaveBeenCalled()
+    expect(queuePointer).not.toHaveBeenCalled()
+
+    // Confirm → the decrypted plaintext is queued as a public share, never a pointer.
+    const confirm = [...document.querySelectorAll("button")].find((b) => /Share & decrypt/i.test(b.textContent ?? ""))
+    expect(confirm).toBeTruthy()
+    fireEvent.click(confirm!)
+
+    expect(queuePlaintext).toHaveBeenCalledWith("ch_target", "the launch codename is VELVET-OTTER", SAMPLE_ATTRS)
+    expect(queuePointer).not.toHaveBeenCalled()
+  })
+})
+
 describe("ShareMessageModal — surface selection", () => {
   it("renders as a centered Dialog on desktop", () => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -15,9 +15,19 @@ import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceUnreadS
 import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { compareStreamEntries, scoreStreamMatch, useStoredStreamSortMode } from "@/lib/stream-sort"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
-import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { queueShareHandoff, queuePlaintextShareHandoff } from "@/stores/share-handoff-store"
 import { navigateAfterShareHandoff } from "@/lib/share-navigation"
 import { useIsMobile } from "@/hooks/use-mobile"
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@/components/ui/responsive-alert-dialog"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
 
 const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; type: StreamType }[] = [
@@ -35,6 +45,14 @@ interface ShareMessageModalProps {
   onOpenChange: (open: boolean) => void
   workspaceId: string
   attrs: SharedMessageAttrs
+  /**
+   * Decrypted source content when the message lives in an E2E scratchpad. A
+   * sealed message can't be shared as a pointer (recipients hold no key), so
+   * sharing it decrypts it and inserts the plaintext as a public quote — gated
+   * by an explicit confirmation. Undefined/null for normal (plaintext) sources,
+   * which share as a pointer.
+   */
+  sourcePlaintext?: string | null
 }
 
 /**
@@ -57,8 +75,12 @@ interface ShareMessageModalProps {
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
  * "Share anyway / Cancel" toast (`surfacePrivacyBlockToast`).
  */
-export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
+export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs, sourcePlaintext }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
+  // When sharing an E2E message, the picked target waits here for confirmation
+  // (sharing decrypts it to plaintext) before the hand-off is queued.
+  const [confirmTargetId, setConfirmTargetId] = useState<string | null>(null)
+  const isE2eSource = typeof sourcePlaintext === "string"
   const [sortMode, setSortMode] = useStoredStreamSortMode()
   const navigate = useNavigate()
   const location = useLocation()
@@ -123,13 +145,30 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
     onOpenChange(next)
   }
 
-  const handleSelect = (targetStreamId: string) => {
-    queueShareHandoff(targetStreamId, attrs)
+  const goToTarget = (targetStreamId: string) => {
     handleOpenChange(false)
     // Same navigation contract as the fast-path entries in
     // `message-event.tsx` — strip search params on mobile so the panel
     // doesn't shadow the parent composer, no-op when target === current.
     navigateAfterShareHandoff({ workspaceId, targetStreamId, location, navigate, isMobile })
+  }
+
+  const handleSelect = (targetStreamId: string) => {
+    // E2E source: sharing makes it public (decrypts it), so confirm first.
+    if (isE2eSource) {
+      setConfirmTargetId(targetStreamId)
+      return
+    }
+    queueShareHandoff(targetStreamId, attrs)
+    goToTarget(targetStreamId)
+  }
+
+  const handleConfirmShare = () => {
+    if (confirmTargetId === null || !isE2eSource) return
+    queuePlaintextShareHandoff(confirmTargetId, sourcePlaintext!, attrs)
+    const target = confirmTargetId
+    setConfirmTargetId(null)
+    goToTarget(target)
   }
 
   return (
@@ -194,6 +233,27 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
           </CommandList>
         </Command>
       </ResponsiveDialogContent>
+
+      <ResponsiveAlertDialog
+        open={confirmTargetId !== null}
+        onOpenChange={(next) => {
+          if (!next) setConfirmTargetId(null)
+        }}
+      >
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>Share this encrypted message?</ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This message is end-to-end encrypted. Sharing it will decrypt it and post the contents as a normal message
+              — everyone in the destination will be able to read it, and it won’t be end-to-end encrypted anymore.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel onClick={() => setConfirmTargetId(null)}>Cancel</ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction onClick={handleConfirmShare}>Share &amp; decrypt</ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
     </ResponsiveDialog>
   )
 }

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -776,6 +776,12 @@ interface MessageEventInnerProps {
   attachmentRefs?: AttachmentRef[]
   /** True when the message lives in an E2E stream — hides the Edit affordance (E2EE-1). */
   e2eEnabled?: boolean
+  /**
+   * Decrypted markdown for an unlocked E2E message — set only when actually
+   * decrypted (not locked). Powers "share decrypts to public": the share modal
+   * uses it to post the plaintext instead of a sealed pointer recipients can't open.
+   */
+  e2eDecryptedMarkdown?: string
   batch?: BatchTimelineState
 }
 
@@ -818,6 +824,7 @@ function SentMessageEvent({
   isFirstMessage,
   attachmentRefs,
   e2eEnabled,
+  e2eDecryptedMarkdown,
   batch,
 }: MessageEventInnerProps) {
   const { panelId, getPanelUrl } = usePanel()
@@ -1373,6 +1380,7 @@ function SentMessageEvent({
             authorId: event.actorId ?? "",
             actorType: event.actorType ?? "user",
           }}
+          sourcePlaintext={e2eDecryptedMarkdown}
         />
       )}
       {moveDetailsOpen && movedTombstoneEvent && (
@@ -1770,6 +1778,7 @@ export function MessageEvent({
           isFirstMessage={isFirstMessage}
           attachmentRefs={decrypted.status === "decrypted" ? decrypted.attachmentRefs : undefined}
           e2eEnabled={decrypted.status !== "plaintext"}
+          e2eDecryptedMarkdown={decrypted.status === "decrypted" ? decrypted.contentMarkdown : undefined}
           batch={batch}
         />
       )

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -23,10 +23,10 @@ import { useScheduleMessage } from "@/hooks"
 import { toast } from "sonner"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { extractCommandNode } from "@/lib/commands"
-import { serializeToMarkdown } from "@threa/prosemirror"
+import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
-import { consumeShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
+import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
 import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
 import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent } from "@threa/types"
@@ -324,6 +324,15 @@ function MessageInputComponent({
           type: "sharedMessage",
           attrs: pending as unknown as Record<string, unknown>,
         })
+      }
+      // A message shared OUT of an E2E scratchpad: the decrypted plaintext was
+      // captured (behind a confirmation) and is inserted as a public blockquote,
+      // not a sealed pointer recipients couldn't open.
+      const pendingPlaintext = consumePlaintextShareHandoff(streamId)
+      if (pendingPlaintext) {
+        const parsed = parseMarkdown(pendingPlaintext.markdown)
+        const inner = parsed.content && parsed.content.length > 0 ? parsed.content : [{ type: "paragraph" }]
+        buffered.push({ type: "blockquote", content: inner })
       }
       if (buffered.length === 0) return
 

--- a/apps/frontend/src/stores/share-handoff-store.test.ts
+++ b/apps/frontend/src/stores/share-handoff-store.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   __resetShareHandoffStoreForTesting,
   consumeShareHandoff,
+  consumePlaintextShareHandoff,
   peekShareHandoff,
   queueShareHandoff,
+  queuePlaintextShareHandoff,
   subscribeShareHandoff,
 } from "./share-handoff-store"
 
@@ -29,6 +31,15 @@ describe("share handoff store", () => {
     queueShareHandoff("stream_a", sampleAttrs)
     expect(consumeShareHandoff("stream_a")).toEqual(sampleAttrs)
     expect(consumeShareHandoff("stream_a")).toBeNull()
+  })
+
+  it("queues + consumes a decrypted E2E plaintext share on its own channel", () => {
+    queuePlaintextShareHandoff("stream_a", "the secret plan", sampleAttrs)
+    // The pointer channel is untouched by a plaintext queue.
+    expect(consumeShareHandoff("stream_a")).toBeNull()
+    expect(consumePlaintextShareHandoff("stream_a")).toMatchObject({ markdown: "the secret plan", attrs: sampleAttrs })
+    // Cleared after consume.
+    expect(consumePlaintextShareHandoff("stream_a")).toBeNull()
   })
 
   it("queues independently per target stream", () => {

--- a/apps/frontend/src/stores/share-handoff-store.ts
+++ b/apps/frontend/src/stores/share-handoff-store.ts
@@ -16,9 +16,23 @@ export interface ShareHandoffEntry {
   expiresAt: number
 }
 
+/**
+ * Hand-off for a message shared OUT of an E2E scratchpad. A sealed source can't
+ * be a pointer (recipients hold no key), so the share is the decrypted plaintext
+ * itself — made public as a quote in the target — captured at share time behind
+ * an explicit confirmation. `attrs` is carried for author attribution.
+ */
+export interface PlaintextShareHandoffEntry {
+  /** The decrypted source content, to insert as a public blockquote. */
+  markdown: string
+  attrs: SharedMessageAttrs
+  expiresAt: number
+}
+
 const HANDOFF_TTL_MS = 5 * 60 * 1000
 
 const cache = new Map<string, ShareHandoffEntry>()
+const plaintextCache = new Map<string, PlaintextShareHandoffEntry>()
 const listeners = new Map<string, Set<() => void>>()
 
 /**
@@ -37,6 +51,28 @@ export function queueShareHandoff(targetStreamId: string, attrs: SharedMessageAt
   if (subs) {
     for (const listener of subs) listener()
   }
+}
+
+/**
+ * Queue a decrypted E2E message to be shared as a public plaintext quote in the
+ * target stream's composer. Same hop + TTL + subscriber notification as the
+ * pointer hand-off; consumed via {@link consumePlaintextShareHandoff}.
+ */
+export function queuePlaintextShareHandoff(targetStreamId: string, markdown: string, attrs: SharedMessageAttrs): void {
+  plaintextCache.set(targetStreamId, { markdown, attrs, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  const subs = listeners.get(targetStreamId)
+  if (subs) {
+    for (const listener of subs) listener()
+  }
+}
+
+/** Read + clear a pending plaintext (decrypted E2E) share for the stream. */
+export function consumePlaintextShareHandoff(targetStreamId: string): PlaintextShareHandoffEntry | null {
+  const entry = plaintextCache.get(targetStreamId)
+  if (!entry) return null
+  plaintextCache.delete(targetStreamId)
+  if (entry.expiresAt < Date.now()) return null
+  return entry
 }
 
 /**
@@ -95,6 +131,7 @@ export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | n
  */
 export function resetShareHandoffStoreCache(): void {
   cache.clear()
+  plaintextCache.clear()
   listeners.clear()
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -488,6 +488,20 @@ export interface EnclaveSealedReply {
 }
 
 /**
+ * A sealed auto-generated stream title the enclave produced this turn, POSTed to
+ * `POST .../sessions/:id/sealed-name`. The server can't read message content, so
+ * it can't title an encrypted scratchpad — the enclave (which sees plaintext)
+ * generates a short title, seals it under the stream SSK bound by AAD to
+ * `streamId|name|generation` (`buildNameAad`), and the backend stores the
+ * ciphertext as the stream's sealed name (`e2e_streams.name_ciphertext`). No
+ * `messageId`: a stream name occupies a single per-stream slot, not a message.
+ */
+export interface EnclaveSealedName {
+  ciphertext: string
+  envelope: EnclaveStreamEnvelope
+}
+
+/**
  * One sealed trace step the enclave produced this turn, POSTed to
  * `POST .../sessions/:id/steps` the moment the agent loop emits it (the LLM's
  * reasoning, each reply it sends, …). Only the step's *type*, optional reply
@@ -614,6 +628,15 @@ export interface EnclaveSessionAssignment {
    * are none.
    */
   attachmentCiphertexts?: { attachmentId: string; ciphertext: string }[]
+  /**
+   * When true, this scratchpad has no sealed name yet, so the enclave should
+   * generate a short title from the decrypted turn, seal it under the SSK
+   * (`buildNameAad`), and POST it back via the sealed-name callback. The server
+   * can't title an encrypted scratchpad itself (it only holds ciphertext).
+   * Set only for the root scratchpad's first untitled turn; omitted/false
+   * otherwise (threads and already-titled scratchpads).
+   */
+  autoTitle?: boolean
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -363,6 +363,7 @@ export type {
   EnclaveSealedMessage,
   EnclaveSskWrap,
   EnclaveSealedReply,
+  EnclaveSealedName,
   EnclaveSealedStep,
   EnclaveSealedStepStart,
   EnclaveSealedSubstep,


### PR DESCRIPTION
Second of the encrypted-scratchpad PRs (PR 1 = #793, merged). Closes audit **UX-5**.

## Problem

The server only holds ciphertext for an encrypted scratchpad, so server-side auto-naming is skipped — they read "New scratchpad" forever, while plaintext scratchpads get an LLM title.

## Fix — title in the enclave, sealed

The enclave already runs Ariadne on the decrypted turn, so it's the one place that can title an encrypted scratchpad without the server ever seeing plaintext:

- **Enclave:** after the turn, when the assignment is flagged `autoTitle` and a reply was produced, it generates a short (3–6 word) title via one cheap `rawChat` call, sanitizes it (language-agnostic — no locale heuristics), seals it under the stream SSK bound to the name slot (`buildNameAad`), and POSTs it to a new sealed-name callback. Best-effort and last — a titling failure never blocks or fails the turn.
- **Dispatch** flags `autoTitle` only for an **untitled root scratchpad** (`hasSealedName` false; threads and already-titled streams are skipped). The enclave's Zod schema declares the new field so it isn't silently stripped (the #778 lesson).
- **Backend:** new internal route `POST /sessions/:id/sealed-name` → `setSealedNameIfAbsent` (race-safe, first-write-wins) → re-read the e2e-joined stream and broadcast `stream:updated` so the title decrypts and appears live. **No plaintext `displayName` is ever set** — the title exists only as ciphertext, shown when unlocked (same model as a manual encrypted rename).

## Tests

- `sanitizeTitle` units (quote/period stripping, first-line, length cap, empty → null).
- Enclave turn seals a title the owner's SSK recovers when flagged, and skips titling when not.
- Backend sealed-name handler stores first-write-wins and broadcasts; no-op (no broadcast) when already named; 409 when the session isn't running.
- Backend + enclave suites, monorepo typecheck, lint, OpenAPI all green.

## Notes

- Quiet (companion off) encrypted scratchpads don't run the enclave, so they aren't auto-titled — consistent with "Quiet = no AI work"; manual rename still works.

Next: PR 3 — decrypt-to-public message sharing with confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBYCisfdLCnagjfaHcSP7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783272988&installation_id=129946197&pr_number=794&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F794&signature=29e932dc8dcfada6f502620f08a64d25820f1af83c3c8ac73caa3d02c224642f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->