### PR TITLE
feat(e2e): share an encrypted message by decrypting it to a public quote

### DIFF
--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -176,6 +176,62 @@ describe("ShareMessageModal — picker filtering", () => {
   })
 })
 
+describe("ShareMessageModal — E2E source confirms before decrypt-to-public", () => {
+  const TARGET = [
+    {
+      id: "ch_target",
+      type: "channel",
+      visibility: "public",
+      displayName: "#general",
+      slug: "general",
+      archivedAt: null,
+      rootStreamId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+
+  it("requires confirmation, then queues the decrypted plaintext (not a pointer)", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(TARGET)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+      [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+    )
+    const queuePointer = vi.spyOn(shareHandoffStoreModule, "queueShareHandoff").mockImplementation(() => {})
+    const queuePlaintext = vi.spyOn(shareHandoffStoreModule, "queuePlaintextShareHandoff").mockImplementation(() => {})
+
+    render(
+      <MemoryRouter initialEntries={["/w/ws_1/s/current"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/s/:streamId"
+            element={
+              <ShareMessageModal
+                open
+                onOpenChange={() => {}}
+                workspaceId="ws_1"
+                attrs={SAMPLE_ATTRS}
+                sourcePlaintext="the launch codename is VELVET-OTTER"
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // Picking a target does NOT immediately queue — a confirmation appears first.
+    fireEvent.click(document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')!)
+    expect(queuePlaintext).not.toHaveBeenCalled()
+    expect(queuePointer).not.toHaveBeenCalled()
+
+    // Confirm → the decrypted plaintext is queued as a public share, never a pointer.
+    const confirm = [...document.querySelectorAll("button")].find((b) => /Share & decrypt/i.test(b.textContent ?? ""))
+    expect(confirm).toBeTruthy()
+    fireEvent.click(confirm!)
+
+    expect(queuePlaintext).toHaveBeenCalledWith("ch_target", "the launch codename is VELVET-OTTER", SAMPLE_ATTRS)
+    expect(queuePointer).not.toHaveBeenCalled()
+  })
+})
+
 describe("ShareMessageModal — surface selection", () => {
   it("renders as a centered Dialog on desktop", () => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -15,9 +15,19 @@ import { useWorkspaceStreams, useWorkspaceStreamMemberships, useWorkspaceUnreadS
 import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { compareStreamEntries, scoreStreamMatch, useStoredStreamSortMode } from "@/lib/stream-sort"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
-import { queueShareHandoff } from "@/stores/share-handoff-store"
+import { queueShareHandoff, queuePlaintextShareHandoff } from "@/stores/share-handoff-store"
 import { navigateAfterShareHandoff } from "@/lib/share-navigation"
 import { useIsMobile } from "@/hooks/use-mobile"
+import {
+  ResponsiveAlertDialog,
+  ResponsiveAlertDialogAction,
+  ResponsiveAlertDialogCancel,
+  ResponsiveAlertDialogContent,
+  ResponsiveAlertDialogDescription,
+  ResponsiveAlertDialogFooter,
+  ResponsiveAlertDialogHeader,
+  ResponsiveAlertDialogTitle,
+} from "@/components/ui/responsive-alert-dialog"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
 
 const TARGET_GROUPS: { id: "channel" | "dm" | "scratchpad"; heading: string; type: StreamType }[] = [
@@ -35,6 +45,14 @@ interface ShareMessageModalProps {
   onOpenChange: (open: boolean) => void
   workspaceId: string
   attrs: SharedMessageAttrs
+  /**
+   * Decrypted source content when the message lives in an E2E scratchpad. A
+   * sealed message can't be shared as a pointer (recipients hold no key), so
+   * sharing it decrypts it and inserts the plaintext as a public quote — gated
+   * by an explicit confirmation. Undefined/null for normal (plaintext) sources,
+   * which share as a pointer.
+   */
+  sourcePlaintext?: string | null
 }
 
 /**
@@ -57,8 +75,12 @@ interface ShareMessageModalProps {
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
  * "Share anyway / Cancel" toast (`surfacePrivacyBlockToast`).
  */
-export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: ShareMessageModalProps) {
+export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs, sourcePlaintext }: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
+  // When sharing an E2E message, the picked target waits here for confirmation
+  // (sharing decrypts it to plaintext) before the hand-off is queued.
+  const [confirmTargetId, setConfirmTargetId] = useState<string | null>(null)
+  const isE2eSource = typeof sourcePlaintext === "string"
   const [sortMode, setSortMode] = useStoredStreamSortMode()
   const navigate = useNavigate()
   const location = useLocation()
@@ -123,13 +145,30 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
     onOpenChange(next)
   }
 
-  const handleSelect = (targetStreamId: string) => {
-    queueShareHandoff(targetStreamId, attrs)
+  const goToTarget = (targetStreamId: string) => {
     handleOpenChange(false)
     // Same navigation contract as the fast-path entries in
     // `message-event.tsx` — strip search params on mobile so the panel
     // doesn't shadow the parent composer, no-op when target === current.
     navigateAfterShareHandoff({ workspaceId, targetStreamId, location, navigate, isMobile })
+  }
+
+  const handleSelect = (targetStreamId: string) => {
+    // E2E source: sharing makes it public (decrypts it), so confirm first.
+    if (isE2eSource) {
+      setConfirmTargetId(targetStreamId)
+      return
+    }
+    queueShareHandoff(targetStreamId, attrs)
+    goToTarget(targetStreamId)
+  }
+
+  const handleConfirmShare = () => {
+    if (confirmTargetId === null || !isE2eSource) return
+    queuePlaintextShareHandoff(confirmTargetId, sourcePlaintext!, attrs)
+    const target = confirmTargetId
+    setConfirmTargetId(null)
+    goToTarget(target)
   }
 
   return (
@@ -194,6 +233,27 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs }: Sh
           </CommandList>
         </Command>
       </ResponsiveDialogContent>
+
+      <ResponsiveAlertDialog
+        open={confirmTargetId !== null}
+        onOpenChange={(next) => {
+          if (!next) setConfirmTargetId(null)
+        }}
+      >
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>Share this encrypted message?</ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This message is end-to-end encrypted. Sharing it will decrypt it and post the contents as a normal message
+              — everyone in the destination will be able to read it, and it won’t be end-to-end encrypted anymore.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel onClick={() => setConfirmTargetId(null)}>Cancel</ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction onClick={handleConfirmShare}>Share &amp; decrypt</ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
     </ResponsiveDialog>
   )
 }

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -776,6 +776,12 @@ interface MessageEventInnerProps {
   attachmentRefs?: AttachmentRef[]
   /** True when the message lives in an E2E stream — hides the Edit affordance (E2EE-1). */
   e2eEnabled?: boolean
+  /**
+   * Decrypted markdown for an unlocked E2E message — set only when actually
+   * decrypted (not locked). Powers "share decrypts to public": the share modal
+   * uses it to post the plaintext instead of a sealed pointer recipients can't open.
+   */
+  e2eDecryptedMarkdown?: string
   batch?: BatchTimelineState
 }
 
@@ -818,6 +824,7 @@ function SentMessageEvent({
   isFirstMessage,
   attachmentRefs,
   e2eEnabled,
+  e2eDecryptedMarkdown,
   batch,
 }: MessageEventInnerProps) {
   const { panelId, getPanelUrl } = usePanel()
@@ -1373,6 +1380,7 @@ function SentMessageEvent({
             authorId: event.actorId ?? "",
             actorType: event.actorType ?? "user",
           }}
+          sourcePlaintext={e2eDecryptedMarkdown}
         />
       )}
       {moveDetailsOpen && movedTombstoneEvent && (
@@ -1770,6 +1778,7 @@ export function MessageEvent({
           isFirstMessage={isFirstMessage}
           attachmentRefs={decrypted.status === "decrypted" ? decrypted.attachmentRefs : undefined}
           e2eEnabled={decrypted.status !== "plaintext"}
+          e2eDecryptedMarkdown={decrypted.status === "decrypted" ? decrypted.contentMarkdown : undefined}
           batch={batch}
         />
       )

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -23,10 +23,10 @@ import { useScheduleMessage } from "@/hooks"
 import { toast } from "sonner"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { extractCommandNode } from "@/lib/commands"
-import { serializeToMarkdown } from "@threa/prosemirror"
+import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
-import { consumeShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
+import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
 import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
 import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent } from "@threa/types"
@@ -324,6 +324,15 @@ function MessageInputComponent({
           type: "sharedMessage",
           attrs: pending as unknown as Record<string, unknown>,
         })
+      }
+      // A message shared OUT of an E2E scratchpad: the decrypted plaintext was
+      // captured (behind a confirmation) and is inserted as a public blockquote,
+      // not a sealed pointer recipients couldn't open.
+      const pendingPlaintext = consumePlaintextShareHandoff(streamId)
+      if (pendingPlaintext) {
+        const parsed = parseMarkdown(pendingPlaintext.markdown)
+        const inner = parsed.content && parsed.content.length > 0 ? parsed.content : [{ type: "paragraph" }]
+        buffered.push({ type: "blockquote", content: inner })
       }
       if (buffered.length === 0) return
 

--- a/apps/frontend/src/stores/share-handoff-store.test.ts
+++ b/apps/frontend/src/stores/share-handoff-store.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   __resetShareHandoffStoreForTesting,
   consumeShareHandoff,
+  consumePlaintextShareHandoff,
   peekShareHandoff,
   queueShareHandoff,
+  queuePlaintextShareHandoff,
   subscribeShareHandoff,
 } from "./share-handoff-store"
 
@@ -29,6 +31,15 @@ describe("share handoff store", () => {
     queueShareHandoff("stream_a", sampleAttrs)
     expect(consumeShareHandoff("stream_a")).toEqual(sampleAttrs)
     expect(consumeShareHandoff("stream_a")).toBeNull()
+  })
+
+  it("queues + consumes a decrypted E2E plaintext share on its own channel", () => {
+    queuePlaintextShareHandoff("stream_a", "the secret plan", sampleAttrs)
+    // The pointer channel is untouched by a plaintext queue.
+    expect(consumeShareHandoff("stream_a")).toBeNull()
+    expect(consumePlaintextShareHandoff("stream_a")).toMatchObject({ markdown: "the secret plan", attrs: sampleAttrs })
+    // Cleared after consume.
+    expect(consumePlaintextShareHandoff("stream_a")).toBeNull()
   })
 
   it("queues independently per target stream", () => {

--- a/apps/frontend/src/stores/share-handoff-store.ts
+++ b/apps/frontend/src/stores/share-handoff-store.ts
@@ -16,9 +16,23 @@ export interface ShareHandoffEntry {
   expiresAt: number
 }
 
+/**
+ * Hand-off for a message shared OUT of an E2E scratchpad. A sealed source can't
+ * be a pointer (recipients hold no key), so the share is the decrypted plaintext
+ * itself — made public as a quote in the target — captured at share time behind
+ * an explicit confirmation. `attrs` is carried for author attribution.
+ */
+export interface PlaintextShareHandoffEntry {
+  /** The decrypted source content, to insert as a public blockquote. */
+  markdown: string
+  attrs: SharedMessageAttrs
+  expiresAt: number
+}
+
 const HANDOFF_TTL_MS = 5 * 60 * 1000
 
 const cache = new Map<string, ShareHandoffEntry>()
+const plaintextCache = new Map<string, PlaintextShareHandoffEntry>()
 const listeners = new Map<string, Set<() => void>>()
 
 /**
@@ -37,6 +51,28 @@ export function queueShareHandoff(targetStreamId: string, attrs: SharedMessageAt
   if (subs) {
     for (const listener of subs) listener()
   }
+}
+
+/**
+ * Queue a decrypted E2E message to be shared as a public plaintext quote in the
+ * target stream's composer. Same hop + TTL + subscriber notification as the
+ * pointer hand-off; consumed via {@link consumePlaintextShareHandoff}.
+ */
+export function queuePlaintextShareHandoff(targetStreamId: string, markdown: string, attrs: SharedMessageAttrs): void {
+  plaintextCache.set(targetStreamId, { markdown, attrs, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  const subs = listeners.get(targetStreamId)
+  if (subs) {
+    for (const listener of subs) listener()
+  }
+}
+
+/** Read + clear a pending plaintext (decrypted E2E) share for the stream. */
+export function consumePlaintextShareHandoff(targetStreamId: string): PlaintextShareHandoffEntry | null {
+  const entry = plaintextCache.get(targetStreamId)
+  if (!entry) return null
+  plaintextCache.delete(targetStreamId)
+  if (entry.expiresAt < Date.now()) return null
+  return entry
 }
 
 /**
@@ -95,6 +131,7 @@ export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | n
  */
 export function resetShareHandoffStoreCache(): void {
   cache.clear()
+  plaintextCache.clear()
   listeners.clear()
 }
 


### PR DESCRIPTION
Third of the encrypted-scratchpad PRs. **Stacked on #794** (auto-title) — base will retarget to `main` once #794 merges; the diff here is PR 3 only.

## Problem

Sharing a message from an E2E scratchpad was hard-blocked (`E2E_SHARING_NOT_ALLOWED`) and surfaced as a generic send error. A sealed source can't be a share *pointer* — recipients hold no key, so the pointer would render as the zero-width placeholder.

## Fix — decrypt to a public quote, behind a confirmation

Sharing an encrypted message now decrypts it and posts the contents as a normal public message, gated by an explicit confirmation (the same "you're about to expose this" intent as the private→public share confirm).

- The share **trigger already has the decrypted plaintext** (the message is rendered decrypted), so it's threaded to the share modal as `sourcePlaintext` — set **only when actually decrypted**, never for a locked message.
- **Share modal:** for an E2E source, picking a target shows a confirmation ("this will decrypt it and make it readable by everyone in the destination — it won't be end-to-end encrypted anymore"). On confirm it queues the plaintext on a new hand-off channel instead of a pointer.
- **Composer:** a plaintext hand-off is inserted as an ordinary **blockquote** (`parseMarkdown`), not a `sharedMessage` pointer — so it ships as normal plaintext with **no share-reference**, sidestepping the backend E2E block, which still guards real pointer/quote references.

## No backend change

The decrypted-to-public share carries no reference to the sealed source, so `collectShareReferences` finds nothing and the existing `E2E_SHARING_NOT_ALLOWED` guard stays intact for genuine pointer/quote shares. A **locked** (undecryptable) message still can't be shared — the backend block remains the backstop.

## Tests

- Hand-off store: the new plaintext channel queues/consumes independently of the pointer channel.
- Share modal: an E2E source requires confirmation, then queues the **decrypted plaintext** (never a pointer).
- Frontend suites (share store/modal, message-input, message-event), monorepo typecheck, lint, OpenAPI — all green.

## Notes / possible follow-ups

- The public copy is a plain blockquote with no "shared from" attribution or share-tracking row (a live pointer is impossible for E2E). Attribution could be added later, but the source scratchpad name is itself sealed, so it'd be generic.

This completes the four-part encrypted-scratchpad set: thread E2E + companion (#793, merged), auto-title (#794), and this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBYCisfdLCnagjfaHcSP7S)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783273807&installation_id=129946197&pr_number=795&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F795&signature=42f54c1f870f2d57596046c1f21e265a8f5ae5411215b7aa2e94b25e23a0887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->