### PR TITLE
fix(ci): deploy staging backoffice router via Cloudflare custom domain

### DIFF
--- a/apps/backoffice-router/wrangler.staging.toml
+++ b/apps/backoffice-router/wrangler.staging.toml
@@ -2,13 +2,18 @@ name = "backoffice-router-staging"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
-# Route binding for the staging backoffice. The DNS record `admin-staging.threa.io`
-# must exist as a Cloudflare-proxied record in the `threa.io` zone for traffic
-# to actually hit the edge; the route just tells Cloudflare "when a request
-# matching this pattern arrives, hand it to this worker".
+# Custom-domain binding for the staging backoffice. Unlike a plain route
+# (`pattern` + `zone_name`), a custom domain makes wrangler provision the
+# proxied DNS record for `admin-staging.threa.io` itself on every deploy, so
+# the deploy is self-contained and idempotent. A plain route instead requires
+# the DNS record to already exist in the zone — it never did for staging, so
+# the routes API rejected the assignment (surfaced as the opaque Cloudflare
+# error 10013) even though the script uploaded fine. A custom domain covers
+# the whole hostname, which matches this worker owning every path on
+# `admin-staging.threa.io`.
 [[routes]]
-pattern = "admin-staging.threa.io/*"
-zone_name = "threa.io"
+pattern = "admin-staging.threa.io"
+custom_domain = true
 
 [vars]
 # Staging control-plane (separate Railway project from prod).


### PR DESCRIPTION
## What

Switch the staging backoffice router's hostname binding from a plain Cloudflare route to a wrangler-managed custom domain in `apps/backoffice-router/wrangler.staging.toml`.

```diff
-pattern = "admin-staging.threa.io/*"
-zone_name = "threa.io"
+pattern = "admin-staging.threa.io"
+custom_domain = true
```

## Why

The **Deploy Backoffice Router (Staging)** job has been failing. The worker uploaded fine, then the route-assignment API call failed:

```
A request to the Cloudflare API (/accounts/***/workers/scripts/backoffice-router-staging/routes) failed.
An unknown error has occurred. [code: 10013]
```

Comparing against the jobs that pass isolates the cause to the hostname:

| Job | Binding | Result |
|---|---|---|
| Deploy Backoffice Router (prod) | route `admin.threa.io/*`, same zone + token | ✅ |
| Deploy Backoffice Router (Staging) | route `admin-staging.threa.io/*` | ❌ |
| Deploy Workspace Router (Staging) | no `[[routes]]` block | ✅ |

A plain wrangler **route** (`pattern` + `zone_name`) requires a pre-existing proxied DNS record for its hostname — the old config comment said exactly this. `admin.threa.io` has that record (prod deploys); `admin-staging.threa.io` never did, so Cloudflare rejected the route assignment. `10013` is the opaque wrapper Cloudflare returns for this class of routes-API failure.

A **custom domain** (`custom_domain = true`) makes wrangler provision the proxied DNS record itself on deploy, so the binding is self-contained and idempotent — no manual dashboard step. A custom domain covers the whole hostname, which matches this worker owning every path on `admin-staging.threa.io` (it proxies `/api/*` → control-plane and everything else → the `threa-backoffice-staging` Pages project).

## Scope / safety

- Prod (`wrangler.production.toml`) is left untouched — its route already works against the existing `admin.threa.io` DNS record.
- Safe to switch: the route failed *because* no DNS record exists for the staging hostname, so there's nothing for custom-domain provisioning to collide with.
- The worker→Pages hop is an internal `fetch` proxy, not DNS, so the custom domain doesn't conflict with the Pages project.

## Verification

- `bunx wrangler deploy --config wrangler.staging.toml --dry-run` parses cleanly.
- Pre-commit lint + monorepo typecheck passed.
- Real confirmation is the next `Deploy Cloudflare` run on `main` after merge.

## Note for reviewer

Custom-domain provisioning needs Zone → DNS edit on the CI Cloudflare API token. The token already manages a hostname in the `threa.io` zone for the prod route, so it most likely has it; if the next deploy errors on DNS rather than the routes endpoint, that token scope is where to look.

https://claude.ai/code/session_01ASvnEjWNsgRm79K5mi3uC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASvnEjWNsgRm79K5mi3uC8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783274316&installation_id=129946197&pr_number=796&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F796&signature=589b335d4f1ec8fc90244aed5fdb9a55e0c81ec56a741c47f1d3dbee5825d2c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->