### PR TITLE
Fix "keep me unlocked" not persisting across app restarts

### DIFF
--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -593,10 +593,10 @@ export interface CachedLabelAssignment {
  * sign-out delete it. `keyId` is stored so a server-side key rotation can be
  * detected and the now-stale device key discarded.
  *
- * We previously stored the X25519 private key directly as a `CryptoKey`, but
- * some browsers (Android Chrome) drop newer X25519 keys when IndexedDB is
- * flushed to disk, so it never survived a cold start. The AES-GCM device key
- * round-trips reliably; see `device-wrap-key.ts` for the full rationale.
+ * The X25519 private key is sealed under the AES key rather than stored as a
+ * `CryptoKey` because some browsers (Android Chrome) drop newer X25519 keys
+ * when IndexedDB is flushed to disk; AES-GCM keys round-trip reliably. See
+ * `device-wrap-key.ts` for the full rationale.
  */
 export interface CachedE2eDeviceKey {
   id: string // `${workspaceId}:${userId}` — deterministic, one trusted key per user

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -581,17 +581,22 @@ export interface CachedLabelAssignment {
 }
 
 /**
- * "Keep me unlocked on this device" record. Persists the UNWRAPPED X25519
- * private key as a NON-EXTRACTABLE `CryptoKey` (structured-clone-serializable
- * native key) so a page reload can resume the unlocked session without the
- * passphrase / Argon2id step.
+ * "Keep me unlocked on this device" record. Persists the UIK private key sealed
+ * for at-rest storage so a cold start can resume the unlocked session without
+ * the passphrase / Argon2id step.
  *
- * Security note: the key is non-extractable — even an attacker with this IDB
- * record cannot read the raw private bytes back out (`crypto.subtle.exportKey`
- * rejects); it stays usable only for in-process HPKE decryption. The presence
- * of a row here IS the "this device is trusted" state. `lock()` / sign-out
- * delete it. `keyId` is stored so a server-side key rotation can be detected
- * and the now-stale device key discarded.
+ * Security note: the private key is never stored in the clear. For the plain
+ * (no PIN/biometric) case it's sealed under a NON-EXTRACTABLE AES-GCM device
+ * key (see `device-wrap-key.ts`) — even an attacker with this IDB record cannot
+ * recover the raw private bytes, because that AES key can't be exported. The
+ * presence of a row here IS the "this device is trusted" state. `lock()` /
+ * sign-out delete it. `keyId` is stored so a server-side key rotation can be
+ * detected and the now-stale device key discarded.
+ *
+ * We previously stored the X25519 private key directly as a `CryptoKey`, but
+ * some browsers (Android Chrome) drop newer X25519 keys when IndexedDB is
+ * flushed to disk, so it never survived a cold start. The AES-GCM device key
+ * round-trips reliably; see `device-wrap-key.ts` for the full rationale.
  */
 export interface CachedE2eDeviceKey {
   id: string // `${workspaceId}:${userId}` — deterministic, one trusted key per user
@@ -600,12 +605,15 @@ export interface CachedE2eDeviceKey {
   keyId: string
   publicKey: string // base64 — matched against the server key to detect rotation
   /**
-   * Auto-resume key for plain "keep me unlocked": a non-extractable CryptoKey
-   * stored via structured clone. Present only when the device is trusted
-   * WITHOUT a PIN — a reload resumes `unlocked` directly. Mutually exclusive
-   * with the `pin*` fields below.
+   * Auto-resume material for plain "keep me unlocked": a non-extractable
+   * AES-GCM `CryptoKey` (`deviceWrapKey`) plus the X25519 private key sealed
+   * under it (`deviceWrappedPrivate`, base64 `iv || ciphertext`). Present only
+   * when the device is trusted WITHOUT a PIN/biometric — a cold start unwraps
+   * these and resumes `unlocked` directly. Mutually exclusive with the
+   * `pin*` / `webauthn*` fields below.
    */
-  privateKey?: CryptoKey
+  deviceWrapKey?: CryptoKey
+  deviceWrappedPrivate?: string
   /**
    * PIN-gated quick-unlock: the UIK private key wrapped under a PIN-derived KEK
    * (base64 `wrapPrivate` bundle) + its Argon2id salt/params, plus a local
@@ -1046,9 +1054,9 @@ export async function clearAllCachedData(): Promise<void> {
       db.labelMemberships.clear(),
       db.labelAssignments.clear(),
       db.sidebarConfigs.clear(),
-      // The persisted device key IS the unwrapped (non-extractable) private
-      // key — sign-out must drop it so the next account can't resume this
-      // identity's unlocked session.
+      // The persisted device key seals this identity's private key for
+      // auto-resume — sign-out must drop it so the next account can't resume
+      // this identity's unlocked session.
       db.e2eDeviceKeys.clear(),
       // Note: we keep pendingMessages to retry sending after re-login
     ])

--- a/apps/frontend/src/lib/crypto/__tests__/device-wrap-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/device-wrap-key.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { decryptPayloadAsString, encryptPayload } from "@threa/crypto"
+import { generateUIK } from "../keys"
+import { unwrapPrivateKeyFromDevice, wrapPrivateKeyForDevice } from "../device-wrap-key"
+
+describe("wrapPrivateKeyForDevice / unwrapPrivateKeyFromDevice", () => {
+  it("round-trips the UIK private key so the recovered key still decrypts", async () => {
+    const uik = await generateUIK()
+    const wrapped = await wrapPrivateKeyForDevice(uik.privateKey)
+    expect(wrapped.deviceWrappedPrivate.length).toBeGreaterThan(0)
+
+    const recovered = await unwrapPrivateKeyFromDevice(wrapped)
+    const { envelope } = await encryptPayload({
+      payload: "secret",
+      recipients: [{ recipientKeyId: "e2ek_self", publicKey: uik.publicKey }],
+    })
+    expect(await decryptPayloadAsString({ envelope, privateKey: recovered, recipientKeyId: "e2ek_self" })).toBe(
+      "secret"
+    )
+  })
+
+  it("seals under a non-extractable AES-GCM key that can never be exported", async () => {
+    const uik = await generateUIK()
+    const { deviceWrapKey } = await wrapPrivateKeyForDevice(uik.privateKey)
+    expect(deviceWrapKey.algorithm.name).toBe("AES-GCM")
+    expect(deviceWrapKey.extractable).toBe(false)
+    await expect(crypto.subtle.exportKey("raw", deviceWrapKey)).rejects.toThrow()
+  })
+
+  it("fails to unwrap when the sealed bytes are tampered with", async () => {
+    const uik = await generateUIK()
+    const wrapped = await wrapPrivateKeyForDevice(uik.privateKey)
+    const tampered = { ...wrapped, deviceWrappedPrivate: "AAAA" + wrapped.deviceWrappedPrivate.slice(4) }
+    await expect(unwrapPrivateKeyFromDevice(tampered)).rejects.toThrow()
+  })
+
+  it("fails to unwrap with a different device key (the AES-GCM tag check)", async () => {
+    const uik = await generateUIK()
+    const a = await wrapPrivateKeyForDevice(uik.privateKey)
+    const b = await wrapPrivateKeyForDevice(uik.privateKey)
+    // Pair A's ciphertext with B's key — the GCM tag must reject it.
+    await expect(
+      unwrapPrivateKeyFromDevice({ deviceWrapKey: b.deviceWrapKey, deviceWrappedPrivate: a.deviceWrappedPrivate })
+    ).rejects.toThrow()
+  })
+})

--- a/apps/frontend/src/lib/crypto/__tests__/keys.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { fingerprintPublicKey, generateUIK, toNonExtractable, unwrapPrivate, wrapPrivate } from "../keys"
+import { fingerprintPublicKey, generateUIK, unwrapPrivate, wrapPrivate } from "../keys"
 import { deriveKEK, generateSalt, DEFAULT_KDF_PARAMS } from "../passphrase"
 import { encryptPayload, decryptPayloadAsString } from "@threa/crypto"
 
@@ -53,51 +53,23 @@ describe("UIK lifecycle", () => {
     await expect(unwrapPrivate(tampered, kek)).rejects.toThrow(/Unsupported private bundle version/)
   })
 
-  it("unwraps a non-extractable key by default that still decrypts but cannot be exported", async () => {
+  it("unwraps an extractable key that decrypts and can be re-wrapped", async () => {
     const uik = await generateUIK()
     const salt = generateSalt()
     const kek = await deriveKEK("pp", salt, FAST_PARAMS)
     const wrapped = await wrapPrivate(uik.privateKey, kek)
 
     const priv = await unwrapPrivate(wrapped, await deriveKEK("pp", salt, FAST_PARAMS))
-    expect(priv.extractable).toBe(false)
-    await expect(crypto.subtle.exportKey("pkcs8", priv)).rejects.toThrow()
+    // Extractable so the rotation / device-trust paths can re-export the bytes.
+    expect(priv.extractable).toBe(true)
+    const rewrapped = await wrapPrivate(priv, kek)
+    expect(rewrapped[0]).toBe(1)
 
     const { envelope } = await encryptPayload({
       payload: "secret",
       recipients: [{ recipientKeyId: "e2ek_self", publicKey: uik.publicKey }],
     })
     expect(await decryptPayloadAsString({ envelope, privateKey: priv, recipientKeyId: "e2ek_self" })).toBe("secret")
-  })
-
-  it("unwraps an extractable key when asked (the rotation path needs the raw bytes)", async () => {
-    const uik = await generateUIK()
-    const salt = generateSalt()
-    const kek = await deriveKEK("pp", salt, FAST_PARAMS)
-    const wrapped = await wrapPrivate(uik.privateKey, kek)
-
-    const priv = await unwrapPrivate(wrapped, await deriveKEK("pp", salt, FAST_PARAMS), { extractable: true })
-    expect(priv.extractable).toBe(true)
-    // Re-wrapping (what rotation does) requires the bytes to be exportable.
-    const rewrapped = await wrapPrivate(priv, kek)
-    expect(rewrapped[0]).toBe(1)
-  })
-
-  it("toNonExtractable hardens an extractable key while preserving decryption", async () => {
-    const uik = await generateUIK()
-    expect(uik.privateKey.extractable).toBe(true)
-
-    const hardened = await toNonExtractable(uik.privateKey)
-    expect(hardened.extractable).toBe(false)
-    await expect(crypto.subtle.exportKey("pkcs8", hardened)).rejects.toThrow()
-
-    const { envelope } = await encryptPayload({
-      payload: "still-decodes",
-      recipients: [{ recipientKeyId: "e2ek_self", publicKey: uik.publicKey }],
-    })
-    expect(await decryptPayloadAsString({ envelope, privateKey: hardened, recipientKeyId: "e2ek_self" })).toBe(
-      "still-decodes"
-    )
   })
 })
 

--- a/apps/frontend/src/lib/crypto/__tests__/pin-device-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/pin-device-key.test.ts
@@ -40,10 +40,10 @@ describe("wrapPrivateKeyWithPin / unwrapPrivateKeyWithPin", () => {
     expect(wrapped.pinSalt.length).toBeGreaterThan(0)
 
     // The recovered key opens HPKE for our own public key — i.e. it's the same
-    // private key, usable for decryption (non-extractable is fine for that).
+    // private key, usable for decryption.
     const recovered = await unwrapPrivateKeyWithPin(wrapped, "135790")
     expect(recovered).toBeDefined()
-    expect(recovered.extractable).toBe(false)
+    expect(recovered.extractable).toBe(true)
   })
 
   it("rejects the wrong PIN (AES-GCM tag check fails)", async () => {

--- a/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/webauthn-device-key.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { generateUIK } from "../keys"
-import { isPlatformAuthenticatorAvailable, unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "../webauthn-device-key"
+import {
+  isPlatformAuthenticatorAvailable,
+  unwrapPrivateKeyWithPrf,
+  wrapPrivateKeyWithPrf,
+} from "../webauthn-device-key"
 
 // The PRF secret is a uniformly-random 32 bytes the authenticator would return;
 // the ceremony itself (navigator.credentials) is covered by the Playwright
@@ -20,7 +24,7 @@ describe("wrapPrivateKeyWithPrf / unwrapPrivateKeyWithPrf", () => {
 
     const recovered = await unwrapPrivateKeyWithPrf(bundle, secret)
     expect(recovered).toBeDefined()
-    expect(recovered.extractable).toBe(false)
+    expect(recovered.extractable).toBe(true)
   })
 
   it("fails to unwrap under a different PRF secret (AES-GCM tag check)", async () => {

--- a/apps/frontend/src/lib/crypto/device-wrap-key.ts
+++ b/apps/frontend/src/lib/crypto/device-wrap-key.ts
@@ -1,4 +1,5 @@
-import { base64ToBytes, bytesToBase64, exportPrivateKey, importRecipientPrivateKey } from "@threa/crypto"
+import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
+import { unwrapPrivate, wrapPrivate } from "./keys"
 
 /**
  * "Keep me unlocked on this device" at-rest sealing.
@@ -11,52 +12,45 @@ import { base64ToBytes, bytesToBase64, exportPrivateKey, importRecipientPrivateK
  * start reads the row back without the key and forces a re-unlock. That made
  * "keep me unlocked" effectively a no-op across app restarts.
  *
- * Instead we seal the raw X25519 private bytes under a freshly generated,
- * NON-EXTRACTABLE AES-GCM key. AES-GCM keys have round-tripped through on-disk
- * IndexedDB on every engine for a decade, so this survives a cold start.
+ * Instead we seal the private key under a freshly generated, NON-EXTRACTABLE
+ * AES-GCM key, reusing the same `wrapPrivate` / `unwrapPrivate` primitives the
+ * PIN and biometric device-unlock paths use — here the generated AES key is
+ * itself the KEK. AES-GCM keys round-trip through on-disk IndexedDB on every
+ * engine, so this survives a cold start.
  *
- * Security posture is unchanged from the previous design: the AES key is
- * non-extractable (`crypto.subtle.exportKey` rejects), so an attacker with the
- * IDB record alone still cannot recover the raw private bytes — the row's mere
- * presence IS the "this device is trusted" state, exactly as before.
+ * Security posture is unchanged: the AES key is non-extractable
+ * (`crypto.subtle.exportKey` rejects), so an attacker with the IDB record alone
+ * still cannot recover the raw private bytes — the row's mere presence IS the
+ * "this device is trusted" state.
  */
 
-const IV_LENGTH = 12
-
 export interface DeviceWrappedKey {
-  /** Non-extractable AES-GCM key. Lives only in IndexedDB; never exportable. */
+  /** Non-extractable AES-GCM KEK. Lives only in IndexedDB; never exportable. */
   deviceWrapKey: CryptoKey
-  /** base64 of `iv || AES-GCM(ciphertext)` over the raw X25519 private bytes. */
+  /** base64 `wrapPrivate` bundle (version + iv + AES-GCM ciphertext). */
   deviceWrappedPrivate: string
+}
+
+/** A non-extractable AES-GCM key used as the KEK that seals the private key. */
+function generateDeviceKek(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"])
 }
 
 /**
  * Seal a private key for device persistence. The caller must hold an
- * EXTRACTABLE key — we export the raw bytes to seal them under the generated
- * AES-GCM key.
+ * EXTRACTABLE key — `wrapPrivate` exports the raw bytes to seal them.
  */
 export async function wrapPrivateKeyForDevice(privateKey: CryptoKey): Promise<DeviceWrappedKey> {
-  const privBytes = await exportPrivateKey(privateKey)
-  const deviceWrapKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"])
-  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
-  const ciphertext = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv }, deviceWrapKey, privBytes))
-  const blob = new Uint8Array(IV_LENGTH + ciphertext.length)
-  blob.set(iv, 0)
-  blob.set(ciphertext, IV_LENGTH)
-  return { deviceWrapKey, deviceWrappedPrivate: bytesToBase64(blob) }
+  const deviceWrapKey = await generateDeviceKek()
+  const bundle = await wrapPrivate(privateKey, deviceWrapKey)
+  return { deviceWrapKey, deviceWrappedPrivate: bytesToBase64(bundle) }
 }
 
 /**
  * Recover the UIK private key from a device-wrapped bundle on cold start. Throws
- * if the AES key and ciphertext don't match (corruption / tampering) so the
- * caller can fall back to the unlock prompt.
+ * if the AES key and bundle don't match (corruption / tampering) so the caller
+ * can fall back to the unlock prompt.
  */
 export async function unwrapPrivateKeyFromDevice(wrapped: DeviceWrappedKey): Promise<CryptoKey> {
-  const blob = base64ToBytes(wrapped.deviceWrappedPrivate)
-  const iv = blob.slice(0, IV_LENGTH)
-  const ciphertext = blob.slice(IV_LENGTH)
-  const privBytes = new Uint8Array(
-    await crypto.subtle.decrypt({ name: "AES-GCM", iv }, wrapped.deviceWrapKey, ciphertext)
-  )
-  return importRecipientPrivateKey(privBytes, { extractable: true })
+  return unwrapPrivate(base64ToBytes(wrapped.deviceWrappedPrivate), wrapped.deviceWrapKey)
 }

--- a/apps/frontend/src/lib/crypto/device-wrap-key.ts
+++ b/apps/frontend/src/lib/crypto/device-wrap-key.ts
@@ -1,0 +1,62 @@
+import { base64ToBytes, bytesToBase64, exportPrivateKey, importRecipientPrivateKey } from "@threa/crypto"
+
+/**
+ * "Keep me unlocked on this device" at-rest sealing.
+ *
+ * We deliberately do NOT persist the UIK's X25519 private key as a `CryptoKey`.
+ * Some browsers (observed on Android Chrome) resolve the IndexedDB write — so
+ * the caller sees success — but silently drop the newer X25519/Ed25519
+ * `CryptoKey` when the database is flushed to disk. A page reload within the
+ * same session still finds it (it's in the in-memory IDB), but a true cold
+ * start reads the row back without the key and forces a re-unlock. That made
+ * "keep me unlocked" effectively a no-op across app restarts.
+ *
+ * Instead we seal the raw X25519 private bytes under a freshly generated,
+ * NON-EXTRACTABLE AES-GCM key. AES-GCM keys have round-tripped through on-disk
+ * IndexedDB on every engine for a decade, so this survives a cold start.
+ *
+ * Security posture is unchanged from the previous design: the AES key is
+ * non-extractable (`crypto.subtle.exportKey` rejects), so an attacker with the
+ * IDB record alone still cannot recover the raw private bytes — the row's mere
+ * presence IS the "this device is trusted" state, exactly as before.
+ */
+
+const IV_LENGTH = 12
+
+export interface DeviceWrappedKey {
+  /** Non-extractable AES-GCM key. Lives only in IndexedDB; never exportable. */
+  deviceWrapKey: CryptoKey
+  /** base64 of `iv || AES-GCM(ciphertext)` over the raw X25519 private bytes. */
+  deviceWrappedPrivate: string
+}
+
+/**
+ * Seal a private key for device persistence. The caller must hold an
+ * EXTRACTABLE key — we export the raw bytes to seal them under the generated
+ * AES-GCM key.
+ */
+export async function wrapPrivateKeyForDevice(privateKey: CryptoKey): Promise<DeviceWrappedKey> {
+  const privBytes = await exportPrivateKey(privateKey)
+  const deviceWrapKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"])
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv }, deviceWrapKey, privBytes))
+  const blob = new Uint8Array(IV_LENGTH + ciphertext.length)
+  blob.set(iv, 0)
+  blob.set(ciphertext, IV_LENGTH)
+  return { deviceWrapKey, deviceWrappedPrivate: bytesToBase64(blob) }
+}
+
+/**
+ * Recover the UIK private key from a device-wrapped bundle on cold start. Throws
+ * if the AES key and ciphertext don't match (corruption / tampering) so the
+ * caller can fall back to the unlock prompt.
+ */
+export async function unwrapPrivateKeyFromDevice(wrapped: DeviceWrappedKey): Promise<CryptoKey> {
+  const blob = base64ToBytes(wrapped.deviceWrappedPrivate)
+  const iv = blob.slice(0, IV_LENGTH)
+  const ciphertext = blob.slice(IV_LENGTH)
+  const privBytes = new Uint8Array(
+    await crypto.subtle.decrypt({ name: "AES-GCM", iv }, wrapped.deviceWrapKey, ciphertext)
+  )
+  return importRecipientPrivateKey(privBytes, { extractable: true })
+}

--- a/apps/frontend/src/lib/crypto/keys.ts
+++ b/apps/frontend/src/lib/crypto/keys.ts
@@ -58,16 +58,12 @@ export async function wrapPrivate(privateKey: CryptoKey, kek: CryptoKey): Promis
  * `hpke.open`. Throws if the bundle was tampered with (GCM tag mismatch) or
  * the KEK is wrong.
  *
- * Defaults to a NON-EXTRACTABLE key: the unlock path never needs the raw bytes
- * again, and a non-extractable key is what we persist for "keep me unlocked on
- * this device". Rotation passes `{ extractable: true }` because it must
- * re-export the bytes to wrap them under the new passphrase.
+ * Returns an EXTRACTABLE key. The in-memory session key never needs to be
+ * non-extractable: at-rest protection comes from wrapping (the server bundle,
+ * the device key — see `device-wrap-key.ts`), not from the live key's flag, and
+ * the rotation / device-trust paths must be able to re-export the raw bytes.
  */
-export async function unwrapPrivate(
-  bundle: Uint8Array,
-  kek: CryptoKey,
-  opts?: { extractable?: boolean }
-): Promise<CryptoKey> {
+export async function unwrapPrivate(bundle: Uint8Array, kek: CryptoKey): Promise<CryptoKey> {
   if (bundle.length < 1 + IV_LENGTH + 1) {
     throw new Error("Wrapped private bundle is too short")
   }
@@ -78,17 +74,7 @@ export async function unwrapPrivate(
   const iv = bundle.slice(1, 1 + IV_LENGTH)
   const ciphertext = bundle.slice(1 + IV_LENGTH)
   const privBytes = new Uint8Array(await crypto.subtle.decrypt({ name: "AES-GCM", iv }, kek, ciphertext))
-  return importRecipientPrivateKey(privBytes, { extractable: opts?.extractable ?? false })
-}
-
-/**
- * Re-import a private key as a non-extractable CryptoKey. Used when we hold an
- * extractable key (e.g. straight from `generateUIK` during first-time setup)
- * but want to persist the hardened, non-extractable form to the device store.
- */
-export async function toNonExtractable(privateKey: CryptoKey): Promise<CryptoKey> {
-  const raw = await exportPrivateKey(privateKey)
-  return importRecipientPrivateKey(raw, { extractable: false })
+  return importRecipientPrivateKey(privBytes, { extractable: true })
 }
 
 /**

--- a/apps/frontend/src/lib/crypto/pin-device-key.ts
+++ b/apps/frontend/src/lib/crypto/pin-device-key.ts
@@ -40,9 +40,9 @@ export interface PinWrappedKey {
 }
 
 /**
- * Wrap the UIK private key under a PIN-derived KEK. The caller must hold an
- * *extractable* private key (e.g. straight from setup, or `unwrapPrivate(...,
- * { extractable: true })`) — `wrapPrivate` exports the raw bytes to seal them.
+ * Wrap the UIK private key under a PIN-derived KEK. `wrapPrivate` exports the
+ * raw bytes to seal them, so the caller must hold an extractable private key —
+ * which is what setup and `unwrapPrivate` both return.
  */
 export async function wrapPrivateKeyWithPin(
   privateKey: CryptoKey,
@@ -57,10 +57,9 @@ export async function wrapPrivateKeyWithPin(
 }
 
 /**
- * Recover the UIK private key from a PIN-wrapped bundle. Returns a
- * NON-EXTRACTABLE key (the unlock path never needs the raw bytes again).
- * Throws on the wrong PIN — the AES-GCM tag check fails — so callers can count
- * the failure toward the lockout.
+ * Recover the UIK private key from a PIN-wrapped bundle. Throws on the wrong
+ * PIN — the AES-GCM tag check fails — so callers can count the failure toward
+ * the lockout.
  */
 export async function unwrapPrivateKeyWithPin(wrapped: PinWrappedKey, pin: string): Promise<CryptoKey> {
   const kek = await deriveKEK(pin, base64ToBytes(wrapped.pinSalt), wrapped.pinKdfParams)

--- a/apps/frontend/src/lib/crypto/webauthn-device-key.ts
+++ b/apps/frontend/src/lib/crypto/webauthn-device-key.ts
@@ -44,7 +44,7 @@ export async function wrapPrivateKeyWithPrf(privateKey: CryptoKey, prfSecret: Ui
   return bytesToBase64(await wrapPrivate(privateKey, kek))
 }
 
-/** Recover the (non-extractable) UIK private key from a PRF-wrapped bundle. */
+/** Recover the UIK private key from a PRF-wrapped bundle. */
 export async function unwrapPrivateKeyWithPrf(bundleB64: string, prfSecret: Uint8Array): Promise<CryptoKey> {
   const kek = await importPrfKek(prfSecret)
   return unwrapPrivate(base64ToBytes(bundleB64), kek)

--- a/apps/frontend/src/stores/e2e-session-store.test.ts
+++ b/apps/frontend/src/stores/e2e-session-store.test.ts
@@ -228,15 +228,22 @@ describe("e2e session store — keep me unlocked on this device", () => {
     expect(await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)).toBeUndefined()
   })
 
-  it("setupNewKey with trustDevice persists a usable, non-extractable device key", async () => {
+  it("setupNewKey with trustDevice seals the key under a non-extractable AES device key", async () => {
     await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, trustDevice: true })
     const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
     expect(row).toBeDefined()
-    const privateKey = row!.privateKey!
-    expect(privateKey).toBeInstanceOf(CryptoKey)
-    expect(privateKey.extractable).toBe(false)
-    // Non-extractable means the raw bytes can never be read back out.
-    await expect(crypto.subtle.exportKey("pkcs8", privateKey)).rejects.toThrow()
+    // We must NOT persist the X25519 CryptoKey directly — some browsers drop it
+    // on disk, which is the bug this design avoids. Store the sealed bytes plus
+    // a non-extractable AES key instead. (The row type no longer carries a
+    // `privateKey` field at all, so that regression can't recur.)
+    expect(row!.deviceWrappedPrivate).toBeTruthy()
+    const wrapKey = row!.deviceWrapKey!
+    expect(wrapKey).toBeInstanceOf(CryptoKey)
+    expect(wrapKey.algorithm.name).toBe("AES-GCM")
+    expect(wrapKey.extractable).toBe(false)
+    // The non-extractable AES key can never be read back out — so the IDB row
+    // alone can't yield the raw private bytes.
+    await expect(crypto.subtle.exportKey("raw", wrapKey)).rejects.toThrow()
   })
 
   it("lock forgets the device key so a reload requires the passphrase again", async () => {
@@ -251,16 +258,28 @@ describe("e2e session store — keep me unlocked on this device", () => {
     expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("locked")
   })
 
+  it("a corrupt device key falls back to the passphrase prompt and is forgotten", async () => {
+    await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS, trustDevice: true })
+    // Tamper with the sealed bytes so the AES-GCM unwrap fails on the next load.
+    await db.e2eDeviceKeys.update(`${WORKSPACE_ID}:${USER_ID}`, { deviceWrappedPrivate: "not-valid-base64-ciphertext" })
+
+    await reload()
+    expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("locked")
+    // The unreadable device key is dropped so it can't wedge future loads.
+    expect(await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)).toBeUndefined()
+  })
+
   describe("device PIN quick-unlock", () => {
     const PIN = "135790"
 
     it("setup with a PIN resumes pin-locked, and the right PIN unlocks", async () => {
       await setupNewKey(WORKSPACE_ID, USER_ID, "pp-correct", { params: FAST_PARAMS, pin: PIN })
       expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
-      // PIN mode stores the sealed bundle, not an auto-resume CryptoKey.
+      // PIN mode stores the sealed bundle, not auto-resume device material.
       const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
       expect(row!.pinWrappedPrivate).toBeTruthy()
-      expect(row!.privateKey).toBeUndefined()
+      expect(row!.deviceWrapKey).toBeUndefined()
+      expect(row!.deviceWrappedPrivate).toBeUndefined()
 
       await reload()
       const locked = getE2eSessionState(WORKSPACE_ID, USER_ID)
@@ -331,7 +350,8 @@ describe("e2e session store — keep me unlocked on this device", () => {
       expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
       const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
       expect(row!.webauthnWrappedPrivate).toBeTruthy()
-      expect(row!.privateKey).toBeUndefined()
+      expect(row!.deviceWrapKey).toBeUndefined()
+      expect(row!.deviceWrappedPrivate).toBeUndefined()
 
       await reload()
       const locked = getE2eSessionState(WORKSPACE_ID, USER_ID)

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -4,7 +4,8 @@ import { clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import { clearStreamKeyCache } from "@/lib/crypto/stream-key-cache"
 import { clearAttachmentRefCache } from "@/lib/crypto/attachment-crypto"
 import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
-import { generateUIK, toNonExtractable, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
+import { generateUIK, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
+import { unwrapPrivateKeyFromDevice, wrapPrivateKeyForDevice } from "@/lib/crypto/device-wrap-key"
 import {
   MAX_PIN_ATTEMPTS,
   unwrapPrivateKeyWithPin,
@@ -18,11 +19,12 @@ import { db, type CachedE2eDeviceKey, type CachedE2eKey } from "@/db"
 /**
  * In-memory session store for the user's unwrapped E2E identity key.
  *
- * The unwrapped private key never leaves this module: it's held as a
- * non-extractable `CryptoKey` for the life of the session and discarded on
- * lock / sign-out. The wrapped bundle (encrypted by the passphrase-derived
- * KEK) lives in IDB for offline unlock and on the server for cross-device
- * recovery; the bare private key never persists anywhere.
+ * The unwrapped private key never leaves this module: it's held as a live
+ * `CryptoKey` for the life of the session and discarded on lock / sign-out.
+ * The wrapped bundle (encrypted by the passphrase-derived KEK) lives in IDB
+ * for offline unlock and on the server for cross-device recovery; the bare
+ * private key is never persisted in the clear (the "keep me unlocked" device
+ * key seals it under a non-extractable AES key — see `device-wrap-key.ts`).
  *
  * The status machine:
  *   - `unknown`   — initial state before we've checked for a cached key
@@ -177,10 +179,11 @@ function readDeviceKey(workspaceId: string, userId: string): Promise<CachedE2eDe
 }
 
 /**
- * Persist the unwrapped private key for "keep me unlocked on this device".
- * The key MUST already be non-extractable — we never write extractable key
- * material to disk. Callers holding an extractable key (fresh from setup)
- * convert it via `toNonExtractable` first.
+ * Persist the private key for "keep me unlocked on this device". The key is
+ * sealed under a freshly generated, non-extractable AES-GCM device key before
+ * it touches disk — see `device-wrap-key.ts` for why we don't store the X25519
+ * `CryptoKey` directly. `privateKey` must be extractable so its bytes can be
+ * exported for sealing; all in-memory session keys are.
  */
 async function persistDeviceKey(
   workspaceId: string,
@@ -189,13 +192,15 @@ async function persistDeviceKey(
   publicKey: Uint8Array,
   privateKey: CryptoKey
 ): Promise<void> {
+  const { deviceWrapKey, deviceWrappedPrivate } = await wrapPrivateKeyForDevice(privateKey)
   const row: CachedE2eDeviceKey = {
     id: `${workspaceId}:${userId}`,
     workspaceId,
     userId,
     keyId,
     publicKey: bytesToBase64(publicKey),
-    privateKey,
+    deviceWrapKey,
+    deviceWrappedPrivate,
     trustedAt: new Date().toISOString(),
   }
   await db.e2eDeviceKeys.put(row)
@@ -204,10 +209,9 @@ async function persistDeviceKey(
 /**
  * Best-effort variant of `persistDeviceKey` that never throws. Returns `true`
  * when the key was written, `false` when the IDB put failed (e.g. private
- * browsing, quota, or a browser that won't structured-clone a non-extractable
- * CryptoKey). A failure here means "unlocked for this session but not kept
- * unlocked" — never a failed unlock — so callers must not surface it as a
- * wrong-passphrase error.
+ * browsing, quota, or a blocked database). A failure here means "unlocked for
+ * this session but not kept unlocked" — never a failed unlock — so callers must
+ * not surface it as a wrong-passphrase error.
  */
 async function tryPersistDeviceKey(
   workspaceId: string,
@@ -309,9 +313,10 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
   // Already unlocked — bootstrap is a no-op once we're holding the key.
   if (scope.state.status === "unlocked") return
 
-  // "Keep me unlocked on this device": if a persisted private key exists, jump
-  // straight to `unlocked` (no passphrase, no Argon2id). The stored key is
-  // non-extractable, so even reading it from IDB doesn't leak raw bytes.
+  // "Keep me unlocked on this device": if a persisted device key exists, jump
+  // straight to `unlocked` (no passphrase, no Argon2id) by unwrapping the
+  // sealed private bytes with the non-extractable AES device key. Reading the
+  // row doesn't leak raw bytes — that AES key can't be exported.
   const [deviceKey, cachedRow] = await Promise.all([
     readDeviceKey(workspaceId, userId),
     db.e2eKeys.get(`${workspaceId}:${userId}`),
@@ -320,16 +325,39 @@ export async function loadE2eKeyForUser(workspaceId: string, userId: string): Pr
   if (cachedRow) {
     scope.cachedKey = toCachedKeyView(cachedRow)
   }
-  if (deviceKey?.privateKey) {
-    setState(workspaceId, userId, {
-      status: "unlocked",
-      keyId: deviceKey.keyId,
-      publicKey: base64ToBytes(deviceKey.publicKey),
-      privateKey: deviceKey.privateKey,
-      deviceTrusted: true,
-      ...NO_UNLOCK_PROMPT,
-      error: null,
-    })
+  if (deviceKey?.deviceWrapKey && deviceKey.deviceWrappedPrivate) {
+    let privateKey: CryptoKey | null = null
+    try {
+      privateKey = await unwrapPrivateKeyFromDevice({
+        deviceWrapKey: deviceKey.deviceWrapKey,
+        deviceWrappedPrivate: deviceKey.deviceWrappedPrivate,
+      })
+    } catch {
+      // Corrupt / unreadable device key — forget it and fall through to the
+      // passphrase prompt rather than wedging in a half-resumed state.
+      await deleteDeviceKey(workspaceId, userId).catch(() => {})
+    }
+    if (scope.loadGeneration !== generation) return
+    if (privateKey) {
+      setState(workspaceId, userId, {
+        status: "unlocked",
+        keyId: deviceKey.keyId,
+        publicKey: base64ToBytes(deviceKey.publicKey),
+        privateKey,
+        deviceTrusted: true,
+        ...NO_UNLOCK_PROMPT,
+        error: null,
+      })
+    } else if (cachedRow) {
+      setState(workspaceId, userId, {
+        status: "locked",
+        ...NO_UNLOCK_PROMPT,
+        keyId: scope.cachedKey!.keyId,
+        publicKey: scope.cachedKey!.publicKey,
+        deviceTrusted: false,
+        error: null,
+      })
+    }
   } else if (deviceKey?.pinWrappedPrivate) {
     // PIN-gated: the key is here but sealed under the PIN, so resume `locked`
     // and flag `pinProtected` so the unlock surface prompts for the PIN.
@@ -519,12 +547,11 @@ export async function setupNewKey(
     trustPersisted = await tryPersistPinDeviceKey(workspaceId, userId, view.keyId, view.publicKey, wrapped)
     if (scope.loadGeneration !== generation) return
   } else if (trustDevice) {
-    // The freshly generated key is extractable; persist the hardened
-    // non-extractable form so the raw bytes never touch disk. Best-effort: a
-    // failed device-key write must not fail setup — the key is already on the
-    // server and cached, the user is just not kept unlocked on this device.
-    const hardened = await toNonExtractable(uik.privateKey)
-    trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, hardened)
+    // Seal the fresh key under a non-extractable AES device key so the raw
+    // bytes never touch disk. Best-effort: a failed device-key write must not
+    // fail setup — the key is already on the server and cached, the user is
+    // just not kept unlocked on this device.
+    trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, uik.privateKey)
     if (scope.loadGeneration !== generation) return
   }
   scope.cachedKey = view
@@ -570,10 +597,7 @@ export async function unlock(
   let privateKey: CryptoKey
   try {
     const kek = await deriveKEK(passphrase, cached.kdfSalt, cached.kdfParams)
-    // Non-extractable by default — the session never needs the raw bytes back.
-    // Setting a device PIN or biometric is the exception: it must re-seal the
-    // private key under the new KEK, which requires an extractable key to export.
-    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek, { extractable: !!pin || !!webauthn })
+    privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, kek)
   } catch (err) {
     // Only a derive/unwrap failure is the wrong-passphrase (or tampered-bundle)
     // case — the one condition the modal surfaces as "try again". Failures in
@@ -790,8 +814,7 @@ export async function rotatePassphrase(
   const generation = ++scope.loadGeneration
 
   const oldKek = await deriveKEK(oldPassphrase, cached.kdfSalt, cached.kdfParams)
-  // Extractable: rotation re-exports the raw bytes to re-wrap under the new KEK.
-  const privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, oldKek, { extractable: true })
+  const privateKey = await unwrapPrivate(cached.encryptedPrivateBundle, oldKek)
 
   const newSalt = generateSalt()
   const newKek = await deriveKEK(newPassphrase, newSalt, params)
@@ -828,8 +851,7 @@ export async function rotatePassphrase(
     if (existing?.pinWrappedPrivate || existing?.webauthnWrappedPrivate) {
       await deleteDeviceKey(workspaceId, userId).catch(() => {})
     } else {
-      const hardened = await toNonExtractable(privateKey)
-      trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, hardened)
+      trustPersisted = await tryPersistDeviceKey(workspaceId, userId, view.keyId, view.publicKey, privateKey)
     }
     if (scope.loadGeneration !== generation) return
   }
@@ -904,9 +926,9 @@ export async function lock(workspaceId: string, userId: string): Promise<void> {
 
 /**
  * Toggle "keep me unlocked on this device" from settings without re-entering
- * the passphrase. Enabling persists the current (already unwrapped) private
- * key as a non-extractable device key; disabling forgets it. Only meaningful
- * while `unlocked`.
+ * the passphrase. Enabling seals the current (already unwrapped) private key
+ * under a non-extractable AES device key and persists it; disabling forgets it.
+ * Only meaningful while `unlocked`.
  */
 export async function setDeviceTrust(workspaceId: string, userId: string, trust: boolean): Promise<void> {
   const scope = getOrCreateScope(workspaceId, userId)
@@ -915,8 +937,7 @@ export async function setDeviceTrust(workspaceId: string, userId: string, trust:
     if (status !== "unlocked" || !privateKey || !keyId || !publicKey) {
       throw new Error("Unlock encrypted scratchpads before trusting this device")
     }
-    // The in-memory key may be extractable (e.g. right after setup); harden it.
-    await persistDeviceKey(workspaceId, userId, keyId, publicKey, await toNonExtractable(privateKey))
+    await persistDeviceKey(workspaceId, userId, keyId, publicKey, privateKey)
     setState(workspaceId, userId, { deviceTrusted: true })
     return
   }


### PR DESCRIPTION
"Keep me unlocked on this device" stored the UIK's X25519 private key
directly as a non-extractable CryptoKey in IndexedDB. Some browsers
(observed on Android Chrome) resolve the IndexedDB write — so the unlock
reports success — but silently drop newer X25519/Ed25519 CryptoKeys when
the database is flushed to disk. A reload within the same session still
found it, but a true cold start read the row back without the key and fell
through to the passphrase prompt, so the device was never actually kept
unlocked across app restarts.

Seal the private bytes under a freshly generated, non-extractable AES-GCM
device key instead, and store that AES key plus the sealed bytes. AES-GCM
keys round-trip through on-disk IndexedDB reliably on every engine. The
security posture is unchanged: the AES key is non-extractable, so the IDB
row alone still cannot yield the raw private bytes — its presence remains
the "this device is trusted" signal.

The in-memory session key is now always extractable (it already was after
setup/rotation); at-rest protection comes entirely from wrapping, which
lets the settings "keep me unlocked" toggle re-seal without re-deriving.

Cold start unwraps the sealed bytes to resume unlocked; a corrupt device
key is forgotten and falls back to the passphrase prompt. Existing trusted
devices that did persist (e.g. desktop) re-unlock once, after which the new
format takes over.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783275395&installation_id=129946197&pr_number=797&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F797&signature=b319c320f010993cbaf38bf243bdf93e7245d09e757d03760f777220e0e439c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->