### PR TITLE
fix(e2e): seal the first thread reply under an encrypted scratchpad

### DIFF
--- a/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
+++ b/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
@@ -85,34 +85,6 @@ export const StreamE2eKeyWrapsRepository = {
   },
 
   /**
-   * Copy every wrap from `fromStreamId` onto `toStreamId` (same workspace),
-   * minting fresh row ids. Used when a thread inherits its root scratchpad's
-   * SSK: the thread reuses the same key, so it carries the same per-recipient
-   * wraps (owner + enclave + any bots) under its own stream id. Idempotent via
-   * the slot conflict, so a re-run (or a racing thread create) is a no-op.
-   * Wrap counts are tiny (a handful of recipients), so a list + batch insert is
-   * fine — no hot path.
-   */
-  async copyToStream(
-    db: Querier,
-    params: { workspaceId: string; fromStreamId: string; toStreamId: string }
-  ): Promise<void> {
-    const wraps = await this.listForStream(db, params.workspaceId, params.fromStreamId)
-    await this.insertMany(
-      db,
-      wraps.map((w) => ({
-        workspaceId: params.workspaceId,
-        streamId: params.toStreamId,
-        keyGeneration: w.keyGeneration,
-        recipientKeyId: w.recipientKeyId,
-        recipientKind: w.recipientKind,
-        wrapEnc: w.wrapEnc,
-        wrapCt: w.wrapCt,
-      }))
-    )
-  },
-
-  /**
    * All wraps for a stream, across recipients and generations. Wrap bytes are
    * HPKE ciphertext (decryptable only by the matching private key), so it is
    * safe to return the full set to any stream member; the caller selects its

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.test.ts
@@ -124,6 +124,44 @@ describe("createEnclaveInvokeWorker", () => {
     expect(assignSession).toHaveBeenCalledTimes(1)
   })
 
+  it("resolves the SSK + wraps from the root for a thread message (reply still lands in the thread)", async () => {
+    arrangeDispatch()
+    // The trigger lives in a THREAD whose root is stream_root; the thread shares
+    // the root's SSK and carries no wraps of its own.
+    spyOn(StreamRepository, "findById").mockImplementation((async (_p: unknown, id: string) =>
+      id === "stream_1"
+        ? { id: "stream_1", workspaceId: "ws_1", rootStreamId: "stream_root" }
+        : { id: "stream_root", workspaceId: "ws_1", rootStreamId: null }) as never)
+    const getE2e = spyOn(E2eStreamsRepository, "getByStreamId").mockResolvedValue({ ...E2E, streamId: "stream_root" })
+    const listWraps = spyOn(StreamE2eKeyWrapsRepository, "listForStream").mockResolvedValue([WRAP])
+    const insertSession = spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue({
+      id: "session_1",
+      createdAt: new Date(),
+    } as never)
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const assignSession = mock(async (_instanceUrl: string, _assignment: unknown) => {})
+    const { io } = fakeIo()
+
+    const worker = createEnclaveInvokeWorker({
+      pool,
+      io,
+      enclaveForwarder: { assignSession } as unknown as EnclaveForwarder,
+      storage: FAKE_STORAGE,
+    })
+    await worker(JOB)
+
+    // Key material (e2e row + wraps) is fetched against the root...
+    expect(getE2e).toHaveBeenCalledWith(pool, "ws_1", "stream_root")
+    expect(listWraps).toHaveBeenCalledWith(pool, "ws_1", "stream_root")
+    // ...the assignment carries the root id, so the enclave unwraps under the
+    // AAD the wraps were sealed with...
+    const assignment = assignSession.mock.calls[0]![1] as { streamId: string }
+    expect(assignment.streamId).toBe("stream_root")
+    // ...but the session (and therefore Ariadne's reply) lands in the thread.
+    expect(insertSession.mock.calls[0]![1]).toMatchObject({ streamId: "stream_1" })
+  })
+
   it("ships attachment ciphertext for the trigger AND recent history, trigger first", async () => {
     arrangeDispatch()
     // One prior message in the window carrying its own E2E attachment.

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -163,9 +163,11 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
       replySenderId: ARIADNE_AGENT_ID,
       sessionId: sid,
       attachmentCiphertexts,
-      // Ask the enclave to seal a title only for an untitled root scratchpad
-      // (threads aren't titled; an already-named scratchpad isn't re-titled).
-      autoTitle: stream.type === StreamTypes.SCRATCHPAD && !e2e.hasSealedName,
+      // Ask the enclave to seal a title only for an untitled scratchpad: gate on
+      // the *trigger's own* stream (a top-level scratchpad message titles it; a
+      // thread reply never does), while `e2e.hasSealedName` is the root's — the
+      // scratchpad that owns the title. (`e2e` resolves to the root for threads.)
+      autoTitle: triggerStream.type === StreamTypes.SCRATCHPAD && !e2e.hasSealedName,
     })
     if (!built) {
       // Park, don't drop: no live EIK can both open the trigger and seal the

--- a/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
+++ b/apps/backend/src/features/enclave-runtimes/dispatch/enclave-invoke-worker.ts
@@ -71,7 +71,17 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
   return async (job) => {
     const { workspaceId, streamId, messageId: triggerId } = job.data
 
-    const e2e = await E2eStreamsRepository.getByStreamId(pool, workspaceId, streamId)
+    // A thread shares its root scratchpad's E2E identity (SSK wraps, owner, tool
+    // policy, custom instructions); it carries no wraps of its own. Resolve all
+    // key material against the root: the SSK wraps are HPKE-bound to the root's
+    // id, so the enclave must unwrap under it (assignment.streamId = e2e.streamId
+    // = root). The reply still lands in the thread — the session row below is
+    // keyed by the thread `streamId`, independent of the assignment's streamId.
+    const triggerStream = await StreamRepository.findById(pool, streamId)
+    if (!triggerStream) return
+    const e2eStreamId = triggerStream.rootStreamId ?? streamId
+
+    const e2e = await E2eStreamsRepository.getByStreamId(pool, workspaceId, e2eStreamId)
     if (!e2e) return
 
     const actors = await E2eStreamActorsRepository.listForStream(pool, workspaceId, streamId)
@@ -93,15 +103,18 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     const trigger = await MessageRepository.findById(pool, triggerId)
     if (!trigger || !trigger.ciphertext) return // gone, or not an E2E message
 
-    const [liveEiks, wraps, surrounding, stream, preferences, authors] = await Promise.all([
+    const [liveEiks, wraps, surrounding, rootStream, preferences, authors] = await Promise.all([
       EnclaveRuntimesRepository.listLive(pool, ENCLAVE_RUNTIME_STALENESS_MS),
-      StreamE2eKeyWrapsRepository.listForStream(pool, workspaceId, streamId),
+      // Root's wraps — the thread shares the root's SSK and has no wraps of its own.
+      StreamE2eKeyWrapsRepository.listForStream(pool, workspaceId, e2eStreamId),
       MessageRepository.findSurrounding(pool, triggerId, streamId, MAX_HISTORY_MESSAGES, 0),
-      StreamRepository.findById(pool, streamId),
+      triggerStream.rootStreamId
+        ? StreamRepository.findById(pool, triggerStream.rootStreamId)
+        : Promise.resolve(triggerStream),
       userPreferencesService.getPreferences(workspaceId, trigger.authorId),
       UserRepository.findByIds(pool, workspaceId, [trigger.authorId]),
     ])
-    if (!stream) return
+    if (!rootStream) return
     // Display name for the enclave's "Triggered by" CONTEXT step (metadata only).
     // Left undefined when unresolved → the enclave suppresses the row rather than
     // rendering a misleading "Unknown" author.
@@ -113,7 +126,7 @@ export function createEnclaveInvokeWorker(deps: EnclaveInvokeWorkerDeps): JobHan
     // toolset is reduced. The enclave runs the same loop on the same prompt; just
     // the I/O is encrypted. This is the raw text the backend ships; the message
     // content stays ciphertext.
-    const systemPrompt = await buildEnclaveSystemPrompt({ pool, stream, preferences, persona })
+    const systemPrompt = await buildEnclaveSystemPrompt({ pool, stream: rootStream, preferences, persona })
 
     // Ship attachment ciphertext inline so the enclave can read files (it can't
     // reach S3 — egress is backend + OpenRouter only): the trigger's files plus

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -568,7 +568,6 @@ describe("StreamService.createThread (via create)", () => {
       enabledAt: new Date(),
     } as never)
     mockMarkStreamE2e.mockReset().mockResolvedValue({} as never)
-    const copyWraps = spyOn(StreamE2eKeyWrapsRepository, "copyToStream").mockResolvedValue(undefined as never)
     const copyActors = spyOn(E2eStreamActorsRepository, "copyToStream").mockResolvedValue(undefined as never)
 
     const result = await service.create({
@@ -590,14 +589,15 @@ describe("StreamService.createThread (via create)", () => {
         currentKeyGeneration: 2,
       })
     )
-    expect(copyWraps).toHaveBeenCalledWith(
-      {},
-      { workspaceId: "ws_1", fromStreamId: "stream_root", toStreamId: e2eThread.id }
-    )
+    // Actors are copied (so the enclave-actor dispatch gate fires for the thread)
+    // but key-WRAPS are NOT — the thread shares the root's SSK and resolves it
+    // against the root's wraps (a copied wrap is HPKE-bound to the root id and
+    // can't be unwrapped under the thread id).
     expect(copyActors).toHaveBeenCalledWith(
       {},
       { workspaceId: "ws_1", fromStreamId: "stream_root", toStreamId: e2eThread.id }
     )
+    expect(StreamE2eKeyWrapsRepository).not.toHaveProperty("copyToStream")
     // The returned/broadcast thread reflects the sealed state.
     expect(result.e2eEnabled).toBe(true)
   })

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -578,10 +578,18 @@ export class StreamService {
 
       // INV-E1: a thread under an E2E scratchpad must itself be E2E, or its
       // replies would be stored server-readable plaintext (the encryption
-      // guarantee silently breaks one reply deep). Inherit the root's E2E state
-      // — same SSK, same recipients (owner + enclave + bots) — onto the new
-      // thread in this same transaction, so `e2eEnabled` is true the instant the
-      // thread is and the composer/sink/dispatch all treat it like the root.
+      // guarantee silently breaks one reply deep). The thread shares the root's
+      // SSK: mark it E2E (so `e2eEnabled` is true the instant the thread is, and
+      // the composer/sink/dispatch all treat it like the root) and copy the
+      // actors (so the enclave-actor dispatch gate fires for the thread).
+      //
+      // The key-WRAPS are deliberately NOT copied. A wrap is HPKE-sealed bound by
+      // AAD to its `(streamId, generation, recipientKeyId)` slot (buildWrapAad),
+      // so a wrap copied onto the thread's id can't be unwrapped under the thread
+      // id — and it would also go stale on the next root key-roll. Instead, every
+      // reader resolves the thread's SSK against the ROOT's wraps (frontend
+      // decrypt + seal pass the root; the enclave worker fetches the root's
+      // wraps). The thread therefore needs no wraps of its own.
       // Only on first creation: a found-existing thread already carries it.
       if (created && rootStream?.e2eEnabled === true) {
         const rootE2e = await E2eStreamsRepository.getByStreamId(client, params.workspaceId, rootStreamId)
@@ -596,11 +604,6 @@ export class StreamService {
           ownerUserId: rootE2e.ownerUserId,
           ownerUserKeyId: rootE2e.ownerUserKeyId,
           currentKeyGeneration: rootE2e.currentKeyGeneration,
-        })
-        await StreamE2eKeyWrapsRepository.copyToStream(client, {
-          workspaceId: params.workspaceId,
-          fromStreamId: rootStreamId,
-          toStreamId: stream.id,
         })
         await E2eStreamActorsRepository.copyToStream(client, {
           workspaceId: params.workspaceId,

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -334,6 +334,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   // Handle draft thread submission
   const handleSubmit = useCallback(async () => {
     if (!draftInfo || !composer.canSend || !currentUserId || !panelId) return
+    // Fail closed: until the parent resolves we can't tell whether this thread
+    // inherits an encrypted root, and queuing a plaintext reply into a stream
+    // the server seals would jam the outbox on INV-E1 (400, retried forever).
+    // The parent loads from cache almost immediately; the user just retries.
+    if (!parentStream) return
 
     composer.setIsSending(true)
     const pendingAttachments = composer.getPendingAttachmentsSnapshot()
@@ -357,8 +362,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
       // promoted thread inherits the root's SSK, so a plaintext send would be
       // rejected by the backend's INV-E1 gate. The root is the parent's root
       // (or the parent itself when it is the root).
-      const rootStreamId = parentStream ? (parentStream.rootStreamId ?? parentStream.id) : undefined
-      const e2e = parentStream?.e2eEnabled === true && rootStreamId ? { rootStreamId } : undefined
+      const rootStreamId = parentStream.rootStreamId ?? parentStream.id
+      const e2e =
+        parentStream.e2eEnabled === true
+          ? { rootStreamId, hasActors: (parentStream.e2eActors?.length ?? 0) > 0 }
+          : undefined
 
       await queueDraftMessage(
         {

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -164,11 +164,15 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
 
   // Draft composer
   const draftKey = draftInfo ? getDraftMessageKey({ type: "thread", parentMessageId: draftInfo.parentMessageId }) : ""
+  // A draft thread has no stream row of its own yet — its E2E state is the
+  // parent's (threads inherit the root's SSK server-side, INV-E1). Read the flag
+  // off the parent so the composer encrypts attachments before upload and skips
+  // plaintext draft persistence, exactly as it would in the sealed thread.
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
     scopeId: draftInfo?.parentMessageId ?? "",
-    e2eEnabled: stream?.e2eEnabled === true,
+    e2eEnabled: (stream ?? parentStream)?.e2eEnabled === true,
   })
 
   // Stashed drafts for this thread. `draftKey` is "" until the panel resolves
@@ -349,6 +353,13 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
       composer.clearDraft()
       composer.clearAttachments()
 
+      // Seal the reply under the encrypted root when the parent is E2E — the
+      // promoted thread inherits the root's SSK, so a plaintext send would be
+      // rejected by the backend's INV-E1 gate. The root is the parent's root
+      // (or the parent itself when it is the root).
+      const rootStreamId = parentStream ? (parentStream.rootStreamId ?? parentStream.id) : undefined
+      const e2e = parentStream?.e2eEnabled === true && rootStreamId ? { rootStreamId } : undefined
+
       await queueDraftMessage(
         {
           contentJson,
@@ -364,6 +375,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
             parentMessageId: draftInfo.parentMessageId,
           },
           draftId: panelId,
+          e2e,
         }
       )
     } catch {
@@ -372,7 +384,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     } finally {
       composer.setIsSending(false)
     }
-  }, [draftInfo, composer, currentUserId, panelId, workspaceId, queueDraftMessage])
+  }, [draftInfo, composer, currentUserId, panelId, workspaceId, queueDraftMessage, parentStream])
 
   // Build the full ancestor chain for draft breadcrumbs: hook ancestors + parent stream
   const fullChain = useMemo(() => {

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -15,6 +15,7 @@ import type {
 import { getStepInlineLabel } from "@/lib/step-config"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
+import { db } from "@/db"
 
 export interface MessageAgentActivity {
   sessionId: string
@@ -225,15 +226,19 @@ export function useAgentActivity(
       if (typeof payload.ciphertext === "string" && payload.envelope) {
         const session = getE2eSessionState(workspaceId, userId ?? "")
         if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return
-        void tryDecryptMessagePayload(
-          { contentMarkdown: "", ciphertext: payload.ciphertext, envelope: payload.envelope },
-          { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId: payload.streamId }
-        )
-          .then((decrypted) => {
-            if (decrypted?.contentMarkdown)
-              applySubstep(payload.sessionId, decrypted.contentMarkdown, payload.updatedAt, stepCountAtArrival)
-          })
-          .catch(() => {})
+        const { privateKey, keyId } = session
+        const { ciphertext, envelope, streamId: substepStreamId, sessionId, updatedAt } = payload
+        void (async () => {
+          // The substep's stream may be a thread, which shares its root's SSK —
+          // resolve the key against the root.
+          const rootStreamId = (await db.streams.get(substepStreamId))?.rootStreamId ?? undefined
+          const decrypted = await tryDecryptMessagePayload(
+            { contentMarkdown: "", ciphertext, envelope },
+            { privateKey, recipientKeyId: keyId, workspaceId, streamId: substepStreamId, rootStreamId }
+          ).catch(() => null)
+          if (decrypted?.contentMarkdown)
+            applySubstep(sessionId, decrypted.contentMarkdown, updatedAt, stepCountAtArrival)
+        })()
       }
     },
     [workspaceId, userId, applySubstep]

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -7,6 +7,7 @@ import { joinRoomWithAck } from "@/lib/socket-room"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
+import { db } from "@/db"
 import type {
   AgentSessionStep,
   AgentSession,
@@ -189,15 +190,18 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
       if (typeof payload.ciphertext === "string" && payload.envelope) {
         const session = getE2eSessionState(workspaceId, userId ?? "")
         if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return
-        void tryDecryptMessagePayload(
-          { contentMarkdown: "", ciphertext: payload.ciphertext, envelope: payload.envelope },
-          { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId: payload.streamId }
-        )
-          .then((decrypted) => {
-            if (decrypted?.contentMarkdown)
-              appendSubstep(payload.stepType, decrypted.contentMarkdown, payload.updatedAt)
-          })
-          .catch(() => {})
+        const { privateKey, keyId } = session
+        const { ciphertext, envelope, streamId: substepStreamId, stepType, updatedAt } = payload
+        void (async () => {
+          // The substep's stream may be a thread, which shares its root's SSK —
+          // resolve the key against the root.
+          const rootStreamId = (await db.streams.get(substepStreamId))?.rootStreamId ?? undefined
+          const decrypted = await tryDecryptMessagePayload(
+            { contentMarkdown: "", ciphertext, envelope },
+            { privateKey, recipientKeyId: keyId, workspaceId, streamId: substepStreamId, rootStreamId }
+          ).catch(() => null)
+          if (decrypted?.contentMarkdown) appendSubstep(stepType, decrypted.contentMarkdown, updatedAt)
+        })()
       }
     },
     [sessionId, workspaceId, userId, appendSubstep]

--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -7,6 +7,7 @@ import {
   type DecryptCacheEntry,
 } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
+import { useStreamFromStore } from "@/stores/stream-store"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
 
 /**
@@ -61,6 +62,11 @@ export function useDecryptedMessageContent(
 ): DecryptedMessageContent {
   const session = useE2eSession(workspaceId, userId ?? "")
   const eventId = event.id
+  // A thread shares its root scratchpad's SSK and carries no wraps of its own,
+  // so the key must be resolved against the root (the wrap AAD is bound to the
+  // root id). The thread row is in IDB once it's been opened; null root means a
+  // top-level stream, which is its own root.
+  const rootStreamId = useStreamFromStore(event.streamId)?.rootStreamId ?? undefined
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(eventId, listener),
@@ -88,9 +94,19 @@ export function useDecryptedMessageContent(
         recipientKeyId: session.keyId,
         workspaceId,
         streamId: event.streamId,
+        rootStreamId,
       }
     )
-  }, [needsDecrypt, envelopePayload, session.privateKey, session.keyId, eventId, workspaceId, event.streamId])
+  }, [
+    needsDecrypt,
+    envelopePayload,
+    session.privateKey,
+    session.keyId,
+    eventId,
+    workspaceId,
+    event.streamId,
+    rootStreamId,
+  ])
 
   if (!envelopePayload) {
     const payload = event.payload as { contentMarkdown?: unknown; contentJson?: unknown } | undefined

--- a/apps/frontend/src/hooks/use-decrypted-step-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.ts
@@ -7,6 +7,7 @@ import {
   type DecryptCacheEntry,
 } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
+import { useStreamFromStore } from "@/stores/stream-store"
 
 /**
  * Render-time decryption for E2E (enclave) trace steps.
@@ -46,6 +47,8 @@ export function useDecryptedStepContent(
 ): DecryptedStepContent {
   const session = useE2eSession(workspaceId, userId ?? "")
   const cacheKey = step.id
+  // A thread shares its root scratchpad's SSK; resolve the key against the root.
+  const rootStreamId = useStreamFromStore(streamId)?.rootStreamId ?? undefined
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(cacheKey, listener),
@@ -65,9 +68,9 @@ export function useDecryptedStepContent(
     void requestDecryption(
       cacheKey,
       { contentMarkdown: "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
-      { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId }
+      { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId, rootStreamId }
     )
-  }, [needsDecrypt, sealed, session.privateKey, session.keyId, cacheKey, workspaceId, streamId])
+  }, [needsDecrypt, sealed, session.privateKey, session.keyId, cacheKey, workspaceId, streamId, rootStreamId])
 
   if (!sealed) return { status: "plaintext", content: step.content }
   if (!canDecrypt) return { status: "locked", content: undefined }

--- a/apps/frontend/src/hooks/use-queue-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.test.ts
@@ -106,6 +106,12 @@ describe("useQueueDraftMessage", () => {
         streamCreation: threadCreation,
       })
     )
+    // The optimistic event must carry contentJson so the post-promotion server
+    // echo can seed the decrypt cache (stream-sync needs both markdown + JSON) —
+    // otherwise an encrypted reply flashes the placeholder for its own author.
+    expect(mockEventsAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ contentJson: CONTENT }) })
+    )
   })
 
   it("heals the encrypted root's actor wraps on send when the root has invited actors", async () => {

--- a/apps/frontend/src/hooks/use-queue-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useQueueDraftMessage } from "./use-queue-draft-message"
+import { StreamTypes, type JSONContent } from "@threa/types"
+import * as dbModule from "@/db"
+import * as contextsModule from "@/contexts"
+import * as authModule from "@/auth"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as prosemirrorModule from "@threa/prosemirror"
+import * as streamSyncModule from "@/sync/stream-sync"
+import * as e2eSessionModule from "@/stores/e2e-session-store"
+import * as streamKeyCacheModule from "@/lib/crypto/stream-key-cache"
+import * as messageEnvelopeModule from "@/lib/crypto/message-envelope"
+
+const WORKSPACE_ID = "ws_1"
+const WORKOS_USER_ID = "workos_1"
+const USER_ID = "user_1"
+const ROOT_STREAM_ID = "stream_root"
+const PANEL_ID = "draft_panel"
+
+const CONTENT: JSONContent = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] }
+
+const mockMarkPending = vi.fn()
+const mockNotifyQueue = vi.fn()
+const mockPendingAdd = vi.fn().mockResolvedValue(undefined)
+const mockEventsAdd = vi.fn().mockResolvedValue(undefined)
+
+function setup() {
+  return renderHook(() => useQueueDraftMessage(WORKSPACE_ID))
+}
+
+const threadCreation = {
+  type: StreamTypes.THREAD,
+  parentStreamId: "stream_parent",
+  parentMessageId: "msg_parent",
+}
+
+describe("useQueueDraftMessage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockMarkPending.mockReset()
+    mockNotifyQueue.mockReset()
+    mockPendingAdd.mockClear()
+    mockEventsAdd.mockClear()
+
+    vi.spyOn(authModule, "useUser").mockReturnValue({ id: WORKOS_USER_ID } as ReturnType<typeof authModule.useUser>)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([
+      { workosUserId: WORKOS_USER_ID, id: USER_ID },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>)
+    vi.spyOn(contextsModule, "usePendingMessages").mockReturnValue({
+      markPending: mockMarkPending,
+      notifyQueue: mockNotifyQueue,
+    } as unknown as ReturnType<typeof contextsModule.usePendingMessages>)
+    vi.spyOn(prosemirrorModule, "serializeToMarkdown").mockReturnValue("hi")
+    vi.spyOn(streamSyncModule, "optimisticReplyCountUpdate").mockResolvedValue(undefined)
+    vi.spyOn(dbModule.db.pendingMessages, "add").mockImplementation(((...args: unknown[]) =>
+      mockPendingAdd(...args)) as unknown as typeof dbModule.db.pendingMessages.add)
+    vi.spyOn(dbModule.db.events, "add").mockImplementation(((...args: unknown[]) =>
+      mockEventsAdd(...args)) as unknown as typeof dbModule.db.events.add)
+  })
+
+  it("seals the body under the encrypted root and stores ciphertext on the pending message", async () => {
+    vi.spyOn(e2eSessionModule, "getE2eSessionState").mockReturnValue({
+      status: "unlocked",
+      keyId: "key_1",
+      privateKey: {} as CryptoKey,
+    } as unknown as ReturnType<typeof e2eSessionModule.getE2eSessionState>)
+    vi.spyOn(streamKeyCacheModule, "resolveCurrentStreamKey").mockResolvedValue({
+      key: new Uint8Array(32),
+      keyGeneration: 3,
+    })
+    const sealSpy = vi
+      .spyOn(messageEnvelopeModule, "sealStreamMessage")
+      .mockResolvedValue({
+        ciphertext: "CT",
+        envelope: { v: 2, keyGeneration: 3, iv: "iv", aad: "aad" },
+        e2eVersion: 2,
+      })
+
+    const { result } = setup()
+    await act(async () => {
+      await result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        {
+          workspaceId: WORKSPACE_ID,
+          streamId: PANEL_ID,
+          streamCreation: threadCreation,
+          draftId: PANEL_ID,
+          e2e: { rootStreamId: ROOT_STREAM_ID },
+        }
+      )
+    })
+
+    // The SSK and AAD are bound to the encrypted root, not the (not-yet-created) thread.
+    expect(sealSpy).toHaveBeenCalledTimes(1)
+    expect(sealSpy.mock.calls[0][0]).toMatchObject({ streamId: ROOT_STREAM_ID, keyGeneration: 3 })
+
+    expect(mockPendingAdd).toHaveBeenCalledTimes(1)
+    expect(mockPendingAdd.mock.calls[0][0]).toMatchObject({
+      ciphertext: "CT",
+      e2eVersion: 2,
+      streamCreation: threadCreation,
+    })
+  })
+
+  it("queues plaintext (no ciphertext) when the draft has no encrypted root", async () => {
+    const sealSpy = vi.spyOn(messageEnvelopeModule, "sealStreamMessage")
+
+    const { result } = setup()
+    await act(async () => {
+      await result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        {
+          workspaceId: WORKSPACE_ID,
+          streamId: PANEL_ID,
+          streamCreation: threadCreation,
+          draftId: PANEL_ID,
+        }
+      )
+    })
+
+    expect(sealSpy).not.toHaveBeenCalled()
+    expect(mockPendingAdd).toHaveBeenCalledTimes(1)
+    const pending = mockPendingAdd.mock.calls[0][0]
+    expect(pending.ciphertext).toBeUndefined()
+    expect(pending.e2eVersion).toBeUndefined()
+  })
+
+  it("refuses to queue an encrypted draft when the session is locked", async () => {
+    vi.spyOn(e2eSessionModule, "getE2eSessionState").mockReturnValue({
+      status: "locked",
+      keyId: null,
+      privateKey: null,
+    } as unknown as ReturnType<typeof e2eSessionModule.getE2eSessionState>)
+
+    const { result } = setup()
+    await expect(
+      result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        {
+          workspaceId: WORKSPACE_ID,
+          streamId: PANEL_ID,
+          streamCreation: threadCreation,
+          draftId: PANEL_ID,
+          e2e: { rootStreamId: ROOT_STREAM_ID },
+        }
+      )
+    ).rejects.toThrow(/Unlock encrypted scratchpads/)
+
+    expect(mockPendingAdd).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-queue-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.test.ts
@@ -35,6 +35,23 @@ const threadCreation = {
   parentMessageId: "msg_parent",
 }
 
+function mockUnlockedSession() {
+  vi.spyOn(e2eSessionModule, "getE2eSessionState").mockReturnValue({
+    status: "unlocked",
+    keyId: "key_1",
+    privateKey: {} as CryptoKey,
+  } as unknown as ReturnType<typeof e2eSessionModule.getE2eSessionState>)
+  vi.spyOn(streamKeyCacheModule, "resolveCurrentStreamKey").mockResolvedValue({
+    key: new Uint8Array(32),
+    keyGeneration: 3,
+  })
+  vi.spyOn(messageEnvelopeModule, "sealStreamMessage").mockResolvedValue({
+    ciphertext: "CT",
+    envelope: { v: 2, keyGeneration: 3, iv: "iv", aad: "aad" },
+    e2eVersion: 2,
+  })
+}
+
 describe("useQueueDraftMessage", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -60,22 +77,8 @@ describe("useQueueDraftMessage", () => {
   })
 
   it("seals the body under the encrypted root and stores ciphertext on the pending message", async () => {
-    vi.spyOn(e2eSessionModule, "getE2eSessionState").mockReturnValue({
-      status: "unlocked",
-      keyId: "key_1",
-      privateKey: {} as CryptoKey,
-    } as unknown as ReturnType<typeof e2eSessionModule.getE2eSessionState>)
-    vi.spyOn(streamKeyCacheModule, "resolveCurrentStreamKey").mockResolvedValue({
-      key: new Uint8Array(32),
-      keyGeneration: 3,
-    })
-    const sealSpy = vi
-      .spyOn(messageEnvelopeModule, "sealStreamMessage")
-      .mockResolvedValue({
-        ciphertext: "CT",
-        envelope: { v: 2, keyGeneration: 3, iv: "iv", aad: "aad" },
-        e2eVersion: 2,
-      })
+    mockUnlockedSession()
+    const sealSpy = vi.spyOn(messageEnvelopeModule, "sealStreamMessage")
 
     const { result } = setup()
     await act(async () => {
@@ -86,21 +89,46 @@ describe("useQueueDraftMessage", () => {
           streamId: PANEL_ID,
           streamCreation: threadCreation,
           draftId: PANEL_ID,
-          e2e: { rootStreamId: ROOT_STREAM_ID },
+          e2e: { rootStreamId: ROOT_STREAM_ID, hasActors: false },
         }
       )
     })
 
     // The SSK and AAD are bound to the encrypted root, not the (not-yet-created) thread.
-    expect(sealSpy).toHaveBeenCalledTimes(1)
-    expect(sealSpy.mock.calls[0][0]).toMatchObject({ streamId: ROOT_STREAM_ID, keyGeneration: 3 })
+    expect(sealSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: ROOT_STREAM_ID, messageId: expect.any(String), keyGeneration: 3 })
+    )
+    expect(mockPendingAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ciphertext: "CT",
+        envelope: { v: 2, keyGeneration: 3, iv: "iv", aad: "aad" },
+        e2eVersion: 2,
+        streamCreation: threadCreation,
+      })
+    )
+  })
 
-    expect(mockPendingAdd).toHaveBeenCalledTimes(1)
-    expect(mockPendingAdd.mock.calls[0][0]).toMatchObject({
-      ciphertext: "CT",
-      e2eVersion: 2,
-      streamCreation: threadCreation,
+  it("heals the encrypted root's actor wraps on send when the root has invited actors", async () => {
+    mockUnlockedSession()
+    const reviveSpy = vi.spyOn(streamKeyCacheModule, "reviveStaleActorWraps").mockResolvedValue("none-missing")
+
+    const { result } = setup()
+    await act(async () => {
+      await result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        {
+          workspaceId: WORKSPACE_ID,
+          streamId: PANEL_ID,
+          streamCreation: threadCreation,
+          draftId: PANEL_ID,
+          e2e: { rootStreamId: ROOT_STREAM_ID, hasActors: true },
+        }
+      )
     })
+
+    expect(reviveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: WORKSPACE_ID, streamId: ROOT_STREAM_ID, userId: USER_ID })
+    )
   })
 
   it("queues plaintext (no ciphertext) when the draft has no encrypted root", async () => {
@@ -120,10 +148,12 @@ describe("useQueueDraftMessage", () => {
     })
 
     expect(sealSpy).not.toHaveBeenCalled()
-    expect(mockPendingAdd).toHaveBeenCalledTimes(1)
     const pending = mockPendingAdd.mock.calls[0][0]
-    expect(pending.ciphertext).toBeUndefined()
-    expect(pending.e2eVersion).toBeUndefined()
+    expect({ ciphertext: pending.ciphertext, envelope: pending.envelope, e2eVersion: pending.e2eVersion }).toEqual({
+      ciphertext: undefined,
+      envelope: undefined,
+      e2eVersion: undefined,
+    })
   })
 
   it("refuses to queue an encrypted draft when the session is locked", async () => {
@@ -142,7 +172,7 @@ describe("useQueueDraftMessage", () => {
           streamId: PANEL_ID,
           streamCreation: threadCreation,
           draftId: PANEL_ID,
-          e2e: { rootStreamId: ROOT_STREAM_ID },
+          e2e: { rootStreamId: ROOT_STREAM_ID, hasActors: false },
         }
       )
     ).rejects.toThrow(/Unlock encrypted scratchpads/)

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -7,6 +7,10 @@ import { serializeToMarkdown } from "@threa/prosemirror"
 import { StreamTypes, Visibilities, type JSONContent, type StreamEvent } from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { optimisticReplyCountUpdate } from "@/sync/stream-sync"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { sealStreamMessage } from "@/lib/crypto/message-envelope"
+import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
+import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { generateClientId } from "./use-stream-or-draft"
 import type { AttachmentSummary } from "./create-optimistic-bootstrap"
 
@@ -24,6 +28,15 @@ export interface QueueDraftMessageParams {
   streamCreation: PendingStreamCreation
   /** The draft ID to clean up after promotion (may differ from streamId for threads) */
   draftId: string
+  /**
+   * Set when this draft lives under an end-to-end-encrypted root (a thread reply
+   * in an encrypted scratchpad). The promoted stream inherits the root's SSK
+   * server-side (INV-E1), so the body must be sealed here — a plaintext send to
+   * the sealed stream is rejected by the backend's E2E gate. `rootStreamId` is
+   * the encrypted root whose current SSK seals this message; the promoted thread
+   * carries a copy of the same key + wraps, so it opens under the thread id too.
+   */
+  e2e?: { rootStreamId: string }
 }
 
 /**
@@ -58,11 +71,65 @@ export function useQueueDraftMessage(workspaceId: string) {
         payload: {
           messageId: clientId,
           contentMarkdown,
+          // Carry the JSON content so the post-promotion server echo can seed the
+          // decrypt cache from this optimistic row (stream-sync needs both
+          // contentMarkdown + contentJson) — without it an encrypted thread reply
+          // would flash the opaque placeholder for its own author.
+          contentJson: input.contentJson,
           ...(input.attachments && input.attachments.length > 0 ? { attachments: input.attachments } : {}),
         },
         actorId: currentUserId,
         actorType: "user",
         createdAt: now,
+      }
+
+      // When the draft lives under an E2E root, seal the body here (with the
+      // owner's UIK held in memory) so the drain loop stays identity-agnostic —
+      // it just forwards the precomputed ciphertext once it has promoted the
+      // draft into the (server-sealed) stream. Mirrors the encrypted send path
+      // in `use-stream-or-draft`. Bind the AAD to the encrypted root: the
+      // promoted thread shares the root's SSK + generation, so it opens under
+      // the thread id all the same (decryption resolves the key by the copied
+      // wraps, not by re-deriving the AAD).
+      let e2eFields: Awaited<ReturnType<typeof sealStreamMessage>> | undefined
+      if (params.e2e) {
+        const session = getE2eSessionState(params.workspaceId, currentUserId)
+        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) {
+          throw new Error("Unlock encrypted scratchpads before sending")
+        }
+        let attachmentRefs: AttachmentRef[] | undefined
+        if (input.attachmentIds && input.attachmentIds.length > 0) {
+          attachmentRefs = input.attachmentIds.map((id) => {
+            const ref = getAttachmentRef(id)
+            if (!ref) {
+              throw new Error("Re-attach the file before sending — its encryption key was lost on reload")
+            }
+            return ref
+          })
+        }
+        const streamKey = await resolveCurrentStreamKey({
+          workspaceId: params.workspaceId,
+          streamId: params.e2e.rootStreamId,
+          recipientKeyId: session.keyId,
+          privateKey: session.privateKey,
+        })
+        if (!streamKey) {
+          throw new Error("You don't have access to this encrypted scratchpad's key")
+        }
+        e2eFields = await sealStreamMessage({
+          contentMarkdown,
+          streamId: params.e2e.rootStreamId,
+          messageId: clientId,
+          senderId: currentUserId,
+          ssk: streamKey.key,
+          keyGeneration: streamKey.keyGeneration,
+          attachmentRefs,
+        })
+        // Carry the refs on the optimistic payload so the sender sees their own
+        // attachments render immediately (mirrors the encrypted send path).
+        if (attachmentRefs && attachmentRefs.length > 0) {
+          ;(optimisticEvent.payload as Record<string, unknown>).attachmentRefs = attachmentRefs
+        }
       }
 
       markPending(clientId)
@@ -79,6 +146,9 @@ export function useQueueDraftMessage(workspaceId: string) {
         retryCount: 0,
         streamCreation: params.streamCreation,
         draftId: params.draftId,
+        ...(e2eFields
+          ? { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
+          : {}),
       })
 
       await db.events.add({

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -7,10 +7,8 @@ import { serializeToMarkdown } from "@threa/prosemirror"
 import { StreamTypes, Visibilities, type JSONContent, type StreamEvent } from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { optimisticReplyCountUpdate } from "@/sync/stream-sync"
-import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { sealStreamMessage } from "@/lib/crypto/message-envelope"
-import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
-import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { sealOutgoingMessage, type SealOutgoingMessageResult } from "@/lib/crypto/seal-send"
+import { reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { generateClientId } from "./use-stream-or-draft"
 import type { AttachmentSummary } from "./create-optimistic-bootstrap"
 
@@ -35,8 +33,10 @@ export interface QueueDraftMessageParams {
    * the sealed stream is rejected by the backend's E2E gate. `rootStreamId` is
    * the encrypted root whose current SSK seals this message; the promoted thread
    * carries a copy of the same key + wraps, so it opens under the thread id too.
+   * `hasActors` is true when the root has invited actors (the enclave / bots),
+   * gating the best-effort heal-on-send.
    */
-  e2e?: { rootStreamId: string }
+  e2e?: { rootStreamId: string; hasActors: boolean }
 }
 
 /**
@@ -86,49 +86,40 @@ export function useQueueDraftMessage(workspaceId: string) {
       // When the draft lives under an E2E root, seal the body here (with the
       // owner's UIK held in memory) so the drain loop stays identity-agnostic —
       // it just forwards the precomputed ciphertext once it has promoted the
-      // draft into the (server-sealed) stream. Mirrors the encrypted send path
-      // in `use-stream-or-draft`. Bind the AAD to the encrypted root: the
+      // draft into the (server-sealed) stream. Shares `sealOutgoingMessage` with
+      // the live send path (INV-35). Bind the AAD to the encrypted root: the
       // promoted thread shares the root's SSK + generation, so it opens under
       // the thread id all the same (decryption resolves the key by the copied
       // wraps, not by re-deriving the AAD).
-      let e2eFields: Awaited<ReturnType<typeof sealStreamMessage>> | undefined
+      let e2eFields: SealOutgoingMessageResult["e2eFields"] | undefined
       if (params.e2e) {
-        const session = getE2eSessionState(params.workspaceId, currentUserId)
-        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) {
-          throw new Error("Unlock encrypted scratchpads before sending")
-        }
-        let attachmentRefs: AttachmentRef[] | undefined
-        if (input.attachmentIds && input.attachmentIds.length > 0) {
-          attachmentRefs = input.attachmentIds.map((id) => {
-            const ref = getAttachmentRef(id)
-            if (!ref) {
-              throw new Error("Re-attach the file before sending — its encryption key was lost on reload")
-            }
-            return ref
-          })
-        }
-        const streamKey = await resolveCurrentStreamKey({
+        const sealed = await sealOutgoingMessage({
           workspaceId: params.workspaceId,
-          streamId: params.e2e.rootStreamId,
-          recipientKeyId: session.keyId,
-          privateKey: session.privateKey,
-        })
-        if (!streamKey) {
-          throw new Error("You don't have access to this encrypted scratchpad's key")
-        }
-        e2eFields = await sealStreamMessage({
-          contentMarkdown,
+          senderId: currentUserId,
           streamId: params.e2e.rootStreamId,
           messageId: clientId,
-          senderId: currentUserId,
-          ssk: streamKey.key,
-          keyGeneration: streamKey.keyGeneration,
-          attachmentRefs,
+          contentMarkdown,
+          attachmentIds: input.attachmentIds,
         })
+        e2eFields = sealed.e2eFields
+        // Heal-on-send, best-effort: keep the root's actor wraps fresh so the
+        // thread copies live wraps when the server seals it. Without this, an
+        // enclave whose EIK rotated would have the first thread turn park
+        // server-side; it self-heals on the next reply (the live send path
+        // revives on the thread itself), so fire-and-forget is enough here.
+        if (params.e2e.hasActors) {
+          void reviveStaleActorWraps({
+            workspaceId: params.workspaceId,
+            streamId: params.e2e.rootStreamId,
+            userId: currentUserId,
+            ownerKeyId: sealed.owner.keyId,
+            ownerPrivateKey: sealed.owner.privateKey,
+          }).catch((err) => console.error("Failed to revive stale actor key wraps on encrypted thread send", err))
+        }
         // Carry the refs on the optimistic payload so the sender sees their own
         // attachments render immediately (mirrors the encrypted send path).
-        if (attachmentRefs && attachmentRefs.length > 0) {
-          ;(optimisticEvent.payload as Record<string, unknown>).attachmentRefs = attachmentRefs
+        if (sealed.attachmentRefs && sealed.attachmentRefs.length > 0) {
+          ;(optimisticEvent.payload as Record<string, unknown>).attachmentRefs = sealed.attachmentRefs
         }
       }
 

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -607,10 +607,13 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
       const e2eEnabled = baseStream?.e2eEnabled === true
       let e2eFields: SealStreamMessageResult | undefined
       if (e2eEnabled) {
+        // A thread shares its root scratchpad's SSK and carries no wraps of its
+        // own; seal (and heal) against the root, whose wraps hold the key.
+        const e2eStreamId = baseStream?.rootStreamId ?? streamId
         const sealed = await sealOutgoingMessage({
           workspaceId,
           senderId: currentUserId,
-          streamId,
+          streamId: e2eStreamId,
           messageId: clientId,
           contentMarkdown,
           attachmentIds: input.attachmentIds,
@@ -624,7 +627,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         if ((baseStream?.e2eActors?.length ?? 0) > 0) {
           void reviveStaleActorWraps({
             workspaceId,
-            streamId,
+            streamId: e2eStreamId,
             userId: currentUserId,
             ownerKeyId: sealed.owner.keyId,
             ownerPrivateKey: sealed.owner.privateKey,

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -5,9 +5,9 @@ import { db, sequenceToNum, type CachedStream } from "@/db"
 import { useStreamService, useMessageService, usePendingMessages } from "@/contexts"
 import { useUser } from "@/auth"
 import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { sealStreamMessage, sealStreamName } from "@/lib/crypto/message-envelope"
+import { sealStreamName, type SealStreamMessageResult } from "@/lib/crypto/message-envelope"
 import { resolveCurrentStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
-import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { sealOutgoingMessage } from "@/lib/crypto/seal-send"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
@@ -605,47 +605,17 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
       // arrives before the per-stream IDB row mirrors the workspace-bootstrap
       // row still encrypts instead of writing plaintext that INV-E1 rejects.
       const e2eEnabled = baseStream?.e2eEnabled === true
-      let e2eFields: Awaited<ReturnType<typeof sealStreamMessage>> | undefined
+      let e2eFields: SealStreamMessageResult | undefined
       if (e2eEnabled) {
-        const session = getE2eSessionState(workspaceId, currentUserId)
-        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) {
-          throw new Error("Unlock encrypted scratchpads before sending")
-        }
-        // Resolve each attachment's per-file key/iv (minted at upload) and seal
-        // them into the payload as `attachmentRefs`. The key lives only in
-        // memory by design, so a reload between upload and send drops it — fail
-        // loud rather than ship a row the owner can never decrypt.
-        let attachmentRefs: AttachmentRef[] | undefined
-        if (input.attachmentIds && input.attachmentIds.length > 0) {
-          attachmentRefs = input.attachmentIds.map((id) => {
-            const ref = getAttachmentRef(id)
-            if (!ref) {
-              throw new Error("Re-attach the file before sending — its encryption key was lost on reload")
-            }
-            return ref
-          })
-        }
-        // Seal under the stream's symmetric key (SSK, v2). The SSK is resolved
-        // from the stream's wraps and unwrapped with the viewer's UIK — a
-        // viewer who isn't a recipient of the current generation can't seal.
-        const streamKey = await resolveCurrentStreamKey({
+        const sealed = await sealOutgoingMessage({
           workspaceId,
-          streamId,
-          recipientKeyId: session.keyId,
-          privateKey: session.privateKey,
-        })
-        if (!streamKey) {
-          throw new Error("You don't have access to this encrypted scratchpad's key")
-        }
-        e2eFields = await sealStreamMessage({
-          contentMarkdown,
+          senderId: currentUserId,
           streamId,
           messageId: clientId,
-          senderId: currentUserId,
-          ssk: streamKey.key,
-          keyGeneration: streamKey.keyGeneration,
-          attachmentRefs,
+          contentMarkdown,
+          attachmentIds: input.attachmentIds,
         })
+        e2eFields = sealed.e2eFields
         // Heal-on-send: if an invited actor's key went stale (an enclave
         // restart mints a fresh EIK), this turn parks server-side on the
         // missing wrap. Fire the revive now — fire-and-forget, de-duped
@@ -656,8 +626,8 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
             workspaceId,
             streamId,
             userId: currentUserId,
-            ownerKeyId: session.keyId,
-            ownerPrivateKey: session.privateKey,
+            ownerKeyId: sealed.owner.keyId,
+            ownerPrivateKey: sealed.owner.privateKey,
           }).catch((err) => console.error("Failed to revive stale actor key wraps on send", err))
         }
         // Carry the refs on the optimistic payload so the server echo's
@@ -666,8 +636,8 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         // seeded "decrypted" entry suppresses the real decrypt that would
         // surface the refs, and the row falls through to the opaque server
         // placeholder.
-        if (attachmentRefs && attachmentRefs.length > 0) {
-          ;(optimisticEvent.payload as Record<string, unknown>).attachmentRefs = attachmentRefs
+        if (sealed.attachmentRefs && sealed.attachmentRefs.length > 0) {
+          ;(optimisticEvent.payload as Record<string, unknown>).attachmentRefs = sealed.attachmentRefs
         }
       }
 

--- a/apps/frontend/src/hooks/use-stream-search.ts
+++ b/apps/frontend/src/hooks/use-stream-search.ts
@@ -3,6 +3,7 @@ import { searchMessages, type SearchFilters, type SearchResultItem } from "@/api
 import { db, type CachedEvent } from "@/db"
 import { requestDecryption } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
+import { useStreamFromStore } from "@/stores/stream-store"
 
 interface UseStreamSearchOptions {
   workspaceId: string
@@ -185,6 +186,11 @@ export function useStreamSearch({
   const session = useE2eSession(workspaceId, userId ?? "")
   const sessionRef = useRef(session)
   sessionRef.current = session
+  // A thread shares its root's SSK; resolve the key against the root (the search
+  // is scoped to this one stream, so every result carries `streamId`).
+  const rootStreamId = useStreamFromStore(streamId)?.rootStreamId ?? undefined
+  const rootStreamIdRef = useRef(rootStreamId)
+  rootStreamIdRef.current = rootStreamId
 
   // Resolve an event's searchable body. Sealed rows decrypt on demand (warming
   // the shared decrypt cache the timeline also reads); plaintext rows return
@@ -203,7 +209,13 @@ export function useStreamSearch({
       const entry = await requestDecryption(
         event.id,
         { contentMarkdown: sealed.contentMarkdown ?? "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
-        { privateKey: s.privateKey, recipientKeyId: s.keyId, workspaceId, streamId: event.streamId }
+        {
+          privateKey: s.privateKey,
+          recipientKeyId: s.keyId,
+          workspaceId,
+          streamId: event.streamId,
+          rootStreamId: rootStreamIdRef.current,
+        }
       )
       return entry.status === "decrypted" && entry.content ? entry.content.contentMarkdown : null
     },

--- a/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
@@ -166,6 +166,85 @@ describe("sealStreamMessage + tryDecryptMessagePayload (v2 SSK loopback)", () =>
   })
 })
 
+describe("tryDecryptMessagePayload — thread inherits the root's SSK (resolve against root)", () => {
+  const THREAD = "stream_thread_01"
+
+  /**
+   * Stub the wraps endpoint so the SSK is wrapped under the ROOT's id (as the
+   * owner provisioned it) and the THREAD has no wraps of its own — exactly the
+   * post-#793-fix layout. The wrap AAD is bound to the root, so it can only be
+   * unwrapped when resolution targets the root.
+   */
+  async function stubRootOnlyWrap(ssk: Uint8Array, publicKey: Uint8Array): Promise<void> {
+    const wrap = await wrapStreamKey({
+      key: ssk,
+      recipientPublicKey: publicKey,
+      aad: buildWrapAad({ streamId: STREAM, keyGeneration: 0, recipientKeyId: KEY_ID }),
+    })
+    vi.spyOn(e2eKeyWrapsApi, "get").mockImplementation(async (_ws: string, sid: string) => ({
+      currentKeyGeneration: 0,
+      ownerUserId: "user_owner",
+      liveActorRecipients: [],
+      wraps:
+        sid === STREAM
+          ? [
+              {
+                keyGeneration: 0,
+                recipientKeyId: KEY_ID,
+                recipientKind: "user" as const,
+                wrapEnc: bytesToBase64(wrap.enc),
+                wrapCt: bytesToBase64(wrap.ct),
+              },
+            ]
+          : [],
+    }))
+  }
+
+  it("decrypts a thread message when rootStreamId points at the key-bearing root", async () => {
+    const uik = await generateUIK()
+    const ssk = generateStreamKey()
+    await stubRootOnlyWrap(ssk, uik.publicKey)
+
+    const sealed = await sealStreamMessage({
+      contentMarkdown: "sealed in a thread",
+      streamId: STREAM,
+      messageId: MSG,
+      senderId: SENDER,
+      ssk,
+      keyGeneration: 0,
+    })
+
+    const result = await tryDecryptMessagePayload(
+      { contentMarkdown: "​", ciphertext: sealed.ciphertext, envelope: sealed.envelope },
+      { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: THREAD, rootStreamId: STREAM }
+    )
+    expect(result?.contentMarkdown).toBe("sealed in a thread")
+  })
+
+  it("returns null for a thread message when resolved against the thread id (the #793 bug)", async () => {
+    const uik = await generateUIK()
+    const ssk = generateStreamKey()
+    await stubRootOnlyWrap(ssk, uik.publicKey)
+
+    const sealed = await sealStreamMessage({
+      contentMarkdown: "sealed in a thread",
+      streamId: STREAM,
+      messageId: MSG,
+      senderId: SENDER,
+      ssk,
+      keyGeneration: 0,
+    })
+
+    // No rootStreamId → resolution falls back to the thread id, which has no
+    // wraps (and a copied wrap's AAD wouldn't match anyway) → undecryptable.
+    const result = await tryDecryptMessagePayload(
+      { contentMarkdown: "​", ciphertext: sealed.ciphertext, envelope: sealed.envelope },
+      { privateKey: uik.privateKey, recipientKeyId: KEY_ID, workspaceId: WS, streamId: THREAD }
+    )
+    expect(result).toBeNull()
+  })
+})
+
 describe("sealStreamName + tryOpenStreamName (sealed stream name loopback)", () => {
   it("round-trips a name sealed under the SSK and opened via the resolved wrap", async () => {
     const uik = await generateUIK()

--- a/apps/frontend/src/lib/crypto/message-envelope.ts
+++ b/apps/frontend/src/lib/crypto/message-envelope.ts
@@ -113,7 +113,7 @@ export async function tryOpenStreamName(
   try {
     const ssk = await resolveStreamKey({
       workspaceId: opts.workspaceId,
-      streamId: opts.streamId,
+      streamId: opts.rootStreamId ?? opts.streamId,
       keyGeneration: env.keyGeneration,
       recipientKeyId: opts.recipientKeyId,
       privateKey: opts.privateKey,
@@ -152,6 +152,13 @@ export interface DecryptMessageOpts {
   recipientKeyId: string
   workspaceId: string
   streamId: string
+  /**
+   * The stream whose SSK wraps seal this message — the root for a thread, which
+   * shares its root scratchpad's key. A thread carries no wraps of its own, so
+   * the SSK is resolved against the root (the wrap AAD is bound to the root id).
+   * Defaults to `streamId` (a top-level stream is its own root).
+   */
+  rootStreamId?: string
 }
 
 /**
@@ -188,7 +195,7 @@ async function tryOpenStreamMessage(
   try {
     const ssk = await resolveStreamKey({
       workspaceId: opts.workspaceId,
-      streamId: opts.streamId,
+      streamId: opts.rootStreamId ?? opts.streamId,
       keyGeneration: env.keyGeneration,
       recipientKeyId: opts.recipientKeyId,
       privateKey: opts.privateKey,

--- a/apps/frontend/src/lib/crypto/seal-send.ts
+++ b/apps/frontend/src/lib/crypto/seal-send.ts
@@ -1,0 +1,81 @@
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
+import { sealStreamMessage, type SealStreamMessageResult } from "@/lib/crypto/message-envelope"
+import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+
+export interface SealOutgoingMessageInput {
+  workspaceId: string
+  /** Author's workspace user id — bound into the AAD and used to resolve the session. */
+  senderId: string
+  /**
+   * The E2E stream whose current SSK seals this message and whose id binds the
+   * AAD. For a thread reply queued before the thread exists, pass the encrypted
+   * *root*: the promoted thread inherits the same SSK + wraps, so it opens under
+   * the thread id all the same (decryption resolves the key by the copied wraps,
+   * not by re-deriving the AAD).
+   */
+  streamId: string
+  /** The (client) message id — bound into the AAD. */
+  messageId: string
+  contentMarkdown: string
+  attachmentIds?: string[]
+}
+
+export interface SealOutgoingMessageResult {
+  e2eFields: SealStreamMessageResult
+  /** Sealed attachment refs (key/iv/filename), if any — for the optimistic payload. */
+  attachmentRefs?: AttachmentRef[]
+  /** The unlocked owner identity used to seal — reuse it for heal-on-send. */
+  owner: { keyId: string; privateKey: CryptoKey }
+}
+
+/**
+ * Seal an outgoing message body (and its attachment refs) under a stream's SSK,
+ * with the owner's UIK held in memory. Shared by the live send path
+ * (`use-stream-or-draft`) and the draft-promotion path (`use-queue-draft-message`)
+ * so the encrypt-before-enqueue rule lives on one path (INV-35). Throws loudly
+ * (INV-11) when the session is locked, an attachment key was lost on reload, or
+ * the caller isn't a recipient of the stream's current generation.
+ */
+export async function sealOutgoingMessage(input: SealOutgoingMessageInput): Promise<SealOutgoingMessageResult> {
+  const session = getE2eSessionState(input.workspaceId, input.senderId)
+  if (session.status !== "unlocked" || !session.privateKey || !session.keyId) {
+    throw new Error("Unlock encrypted scratchpads before sending")
+  }
+  // Resolve each attachment's per-file key/iv (minted at upload) and seal them
+  // into the payload. The key lives only in memory by design, so a reload
+  // between upload and send drops it — fail loud rather than ship a row the
+  // owner can never decrypt.
+  let attachmentRefs: AttachmentRef[] | undefined
+  if (input.attachmentIds && input.attachmentIds.length > 0) {
+    attachmentRefs = input.attachmentIds.map((id) => {
+      const ref = getAttachmentRef(id)
+      if (!ref) {
+        throw new Error("Re-attach the file before sending — its encryption key was lost on reload")
+      }
+      return ref
+    })
+  }
+  // Seal under the stream's symmetric key (SSK, v2). The SSK is resolved from
+  // the stream's wraps and unwrapped with the viewer's UIK — a viewer who isn't
+  // a recipient of the current generation can't seal.
+  const streamKey = await resolveCurrentStreamKey({
+    workspaceId: input.workspaceId,
+    streamId: input.streamId,
+    recipientKeyId: session.keyId,
+    privateKey: session.privateKey,
+  })
+  if (!streamKey) {
+    throw new Error("You don't have access to this encrypted scratchpad's key")
+  }
+  const e2eFields = await sealStreamMessage({
+    contentMarkdown: input.contentMarkdown,
+    streamId: input.streamId,
+    messageId: input.messageId,
+    senderId: input.senderId,
+    ssk: streamKey.key,
+    keyGeneration: streamKey.keyGeneration,
+    attachmentRefs,
+  })
+  return { e2eFields, attachmentRefs, owner: { keyId: session.keyId, privateKey: session.privateKey } }
+}


### PR DESCRIPTION
## What

Sending a message in a thread under an **encrypted** scratchpad was broken: the first reply never went through. This fixes it.

## Why it broke

#793 made threads under an E2E scratchpad inherit the root stream's symmetric key (SSK) server-side — a thread is sealed the instant it's created, and the backend's INV-E1 gate then *requires* ciphertext on every message POST to it.

But the **first reply** to a message is what creates the thread, and it goes through a different frontend path than normal sends: the draft-promotion path (`queueDraftMessage`), which never encrypted. So the sequence was:

1. User replies → message queued as **plaintext** with thread-creation metadata.
2. Drain loop promotes the draft → backend creates the thread and **seals it**.
3. Drain sends the queued plaintext to the now-sealed thread → **INV-E1 → 400**, retried forever.

Diagnosed from the prod backend logs (repeated `POST /api/workspaces/.../messages 400`). Subsequent replies to an already-created thread use the normal (encrypting) send path, which is why only the first one failed.

## The fix

All frontend (keys only live on the client):

- **`queueDraftMessage` now seals** when the draft lives under an E2E root: resolves the root's current SSK (held in memory after unlock), seals the body + attachment refs, and stashes `ciphertext/envelope/e2eVersion` on the pending row. The drain's existing E2E branch forwards it after promotion. The AAD binds the root id, but the promoted thread carries a copy of the root's wraps, so it still opens under the thread id (decryption resolves the key by the wraps and uses `envelope.aad` verbatim — verified across the frontend and enclave decrypt paths).
- **The draft-thread composer** reads `e2eEnabled` off the parent stream instead of the always-`undefined` panel stream. Without this it uploaded **attachments as plaintext** under an encrypted root (a leak) and persisted plaintext drafts to IDB.
- **Carry `contentJson`** on the optimistic event so the post-promotion server echo can seed the decrypt cache (stream-sync needs both `contentMarkdown` + `contentJson`) — otherwise the author saw the opaque placeholder for their own reply.

## Self-review hardening (2nd commit)

- **Extracted `sealOutgoingMessage`** (`lib/crypto/seal-send`) and routed both the live send path and the draft path through it, so the encrypt-before-enqueue rule lives on one path (INV-35) instead of two copies.
- **Fail closed in the composer**: don't queue a reply until the parent stream resolves. A cold/slow load could otherwise leave `parentStream` undefined at submit, queue plaintext, and jam the outbox.
- **Best-effort heal-on-send**: when the encrypted root has invited actors, revive stale actor wraps on the root at queue time so the promoted thread copies live wraps — closing a parity gap with the live send path (an enclave whose key rotated would otherwise park the first thread turn; it self-heals on the next reply).

## Tests

- New `use-queue-draft-message` suite: seals under the root, heals when the root has actors, stays plaintext with no root, refuses when the session is locked.
- Frontend hooks / sync / crypto / encryption / timeline suites (734) + full-monorepo typecheck green.

> Note: I couldn't exercise the full browser flow from this environment — worth a manual smoke test (reply in an encrypted scratchpad, confirm the thread's first message lands and renders decrypted, with and without an attachment).

https://claude.ai/code/session_01Tuv1cX1PEHCNDbHWFBHTWe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuv1cX1PEHCNDbHWFBHTWe)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783275946&installation_id=129946197&pr_number=798&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F798&signature=767978f842a00e0e2e330235d494625de2dce548894652b1079dd0282266df6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->