### PR TITLE
Retry Giphy GIF loads on transient CDN errors

### DIFF
--- a/apps/frontend/src/components/giphy/giphy-image.test.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.test.tsx
@@ -5,9 +5,19 @@ import { GiphyImage } from "./giphy-image"
 const GIF_URL = "https://media.giphy.com/media/abc123/giphy.gif"
 
 function getImg(): HTMLImageElement {
-  const img = document.querySelector('img[data-type], [data-type="giphy-embed"] img') as HTMLImageElement | null
+  const img = document.querySelector('[data-type="giphy-embed"] img') as HTMLImageElement | null
   if (!img) throw new Error("GIF image not rendered")
   return img
+}
+
+/** Drive every automatic retry until the manual-retry fallback appears. */
+function exhaustRetries() {
+  for (let i = 0; i <= 5; i++) {
+    act(() => {
+      fireEvent.error(getImg())
+      vi.advanceTimersByTime(500 * 2 ** i)
+    })
+  }
 }
 
 describe("GiphyImage — load reliability", () => {
@@ -38,29 +48,39 @@ describe("GiphyImage — load reliability", () => {
       vi.advanceTimersByTime(500)
     })
     const retried = getImg().getAttribute("src") ?? ""
-    expect(retried).toContain("_threaRetry=1")
+    expect(retried).toContain("_threaReload=1")
     expect(retried).toContain(GIF_URL)
   })
 
-  it("shows a manual retry affordance once retries are exhausted, then recovers on tap", () => {
+  it("shows a manual retry affordance once retries are exhausted", () => {
     render(<GiphyImage url={GIF_URL} title="dance" />)
+    exhaustRetries()
 
-    // Exhaust every retry: each error schedules the next attempt after backoff.
-    for (let i = 0; i <= 5; i++) {
-      act(() => {
-        fireEvent.error(getImg())
-        vi.advanceTimersByTime(500 * 2 ** i)
-      })
-    }
+    expect(screen.getByRole("button", { name: /tap to retry/i })).toBeInTheDocument()
+    expect(document.querySelector('[data-type="giphy-embed"] img')).toBeNull()
+  })
 
-    const retryButton = screen.getByRole("button", { name: /tap to retry/i })
-    expect(retryButton).toBeInTheDocument()
+  it("starts a fresh backoff cycle when the user taps retry (not an instant re-fail)", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" />)
+    exhaustRetries()
 
     act(() => {
-      fireEvent.click(retryButton)
+      fireEvent.click(screen.getByRole("button", { name: /tap to retry/i }))
     })
-    // The image is back, attempting a fresh cache-busted load.
-    expect(getImg().getAttribute("src")).toContain("_threaRetry")
+    // The image is back with a fresh cache-busted load.
+    expect(getImg().getAttribute("src")).toContain("_threaReload")
+
+    // A subsequent error must schedule another backoff retry rather than
+    // immediately falling back to the broken state.
+    act(() => {
+      fireEvent.error(getImg())
+    })
+    expect(screen.queryByRole("button", { name: /tap to retry/i })).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(getImg()).toBeTruthy()
   })
 
   it("resets retry state when the GIF URL changes", () => {
@@ -70,7 +90,7 @@ describe("GiphyImage — load reliability", () => {
       fireEvent.error(getImg())
       vi.advanceTimersByTime(500)
     })
-    expect(getImg().getAttribute("src")).toContain("_threaRetry=1")
+    expect(getImg().getAttribute("src")).toContain("_threaReload=1")
 
     const nextUrl = "https://media.giphy.com/media/xyz789/giphy.gif"
     rerender(<GiphyImage url={nextUrl} title="wave" />)

--- a/apps/frontend/src/components/giphy/giphy-image.test.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { GiphyImage } from "./giphy-image"
+
+const GIF_URL = "https://media.giphy.com/media/abc123/giphy.gif"
+
+function getImg(): HTMLImageElement {
+  const img = document.querySelector('img[data-type], [data-type="giphy-embed"] img') as HTMLImageElement | null
+  if (!img) throw new Error("GIF image not rendered")
+  return img
+}
+
+describe("GiphyImage — load reliability", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("loads the pristine URL on the first attempt (no cache-bust param)", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" />)
+    expect(getImg().getAttribute("src")).toBe(GIF_URL)
+  })
+
+  it("retries with a cache-busting param after a transient load error", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" />)
+
+    act(() => {
+      fireEvent.error(getImg())
+    })
+    // Backoff hasn't elapsed yet — still on the original src.
+    expect(getImg().getAttribute("src")).toBe(GIF_URL)
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    const retried = getImg().getAttribute("src") ?? ""
+    expect(retried).toContain("_threaRetry=1")
+    expect(retried).toContain(GIF_URL)
+  })
+
+  it("shows a manual retry affordance once retries are exhausted, then recovers on tap", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" />)
+
+    // Exhaust every retry: each error schedules the next attempt after backoff.
+    for (let i = 0; i <= 5; i++) {
+      act(() => {
+        fireEvent.error(getImg())
+        vi.advanceTimersByTime(500 * 2 ** i)
+      })
+    }
+
+    const retryButton = screen.getByRole("button", { name: /tap to retry/i })
+    expect(retryButton).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(retryButton)
+    })
+    // The image is back, attempting a fresh cache-busted load.
+    expect(getImg().getAttribute("src")).toContain("_threaRetry")
+  })
+
+  it("resets retry state when the GIF URL changes", () => {
+    const { rerender } = render(<GiphyImage url={GIF_URL} title="dance" />)
+
+    act(() => {
+      fireEvent.error(getImg())
+      vi.advanceTimersByTime(500)
+    })
+    expect(getImg().getAttribute("src")).toContain("_threaRetry=1")
+
+    const nextUrl = "https://media.giphy.com/media/xyz789/giphy.gif"
+    rerender(<GiphyImage url={nextUrl} title="wave" />)
+    expect(getImg().getAttribute("src")).toBe(nextUrl)
+  })
+})

--- a/apps/frontend/src/components/giphy/giphy-image.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { ImageOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 interface GiphyImageProps {
@@ -14,16 +15,16 @@ interface GiphyImageProps {
 // backoff, cache-busting each attempt so the browser issues a fresh request
 // instead of reusing the failed response. After the attempts are exhausted we
 // show a manual retry affordance, and we retry automatically when connectivity
-// returns.
+// returns — both of which start a fresh backoff cycle.
 const MAX_RETRIES = 5
 const RETRY_BASE_MS = 500
 
-/** Append a cache-busting param so a retry forces a fresh CDN fetch. */
-function withRetryParam(url: string, attempt: number): string {
-  if (attempt === 0) return url
+/** Append a cache-busting param so a reload forces a fresh CDN fetch. */
+function withReloadParam(url: string, token: number): string {
+  if (token === 0) return url
   try {
     const next = new URL(url)
-    next.searchParams.set("_threaRetry", String(attempt))
+    next.searchParams.set("_threaReload", String(token))
     return next.toString()
   } catch {
     return url
@@ -37,7 +38,12 @@ function withRetryParam(url: string, attempt: number): string {
  * transient CDN hiccup doesn't drop the asset until the next page refresh.
  */
 export function GiphyImage({ url, title, className }: GiphyImageProps) {
-  const [attempt, setAttempt] = useState(0)
+  // Monotonic token: drives the <img> key and cache-bust param so every reload
+  // is a genuinely fresh request rather than a reuse of the failed response.
+  const [reloadToken, setReloadToken] = useState(0)
+  // Auto-retries used in the current cycle, capped at MAX_RETRIES. Reset to 0
+  // when the user taps retry or connectivity returns, so each is a full cycle.
+  const [retries, setRetries] = useState(0)
   const [failed, setFailed] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -51,60 +57,66 @@ export function GiphyImage({ url, title, className }: GiphyImageProps) {
   // Reset retry state whenever the GIF source changes, and clear any pending
   // retry on unmount.
   useEffect(() => {
-    setAttempt(0)
+    setReloadToken(0)
+    setRetries(0)
     setFailed(false)
     return clearTimer
   }, [url])
 
-  // When connectivity returns, give an exhausted GIF a fresh attempt.
+  // When connectivity returns, give an exhausted GIF a fresh backoff cycle.
   useEffect(() => {
     if (!failed) return
     const onOnline = () => {
+      clearTimer()
       setFailed(false)
-      setAttempt((current) => current + 1)
+      setRetries(0)
+      setReloadToken((token) => token + 1)
     }
     window.addEventListener("online", onOnline)
     return () => window.removeEventListener("online", onOnline)
   }, [failed])
 
   const handleError = () => {
-    if (attempt >= MAX_RETRIES) {
+    if (retries >= MAX_RETRIES) {
       setFailed(true)
       return
     }
-    const delay = RETRY_BASE_MS * 2 ** attempt
+    const delay = RETRY_BASE_MS * 2 ** retries
     clearTimer()
-    timerRef.current = setTimeout(() => setAttempt((current) => current + 1), delay)
+    timerRef.current = setTimeout(() => {
+      setRetries((current) => current + 1)
+      setReloadToken((token) => token + 1)
+    }, delay)
   }
 
   const handleRetryClick = () => {
     clearTimer()
     setFailed(false)
-    setAttempt((current) => current + 1)
+    setRetries(0)
+    setReloadToken((token) => token + 1)
   }
 
   if (failed) {
     return (
-      <button
+      <Button
         type="button"
+        variant="outline"
+        size="sm"
         onClick={handleRetryClick}
-        className={cn(
-          "flex items-center gap-2 rounded-item border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/70",
-          className
-        )}
+        className={cn("h-auto gap-2 px-3 py-2 text-xs font-normal text-muted-foreground", className)}
         data-type="giphy-embed"
       >
         <ImageOff className="h-4 w-4 shrink-0" />
         <span>Couldn&apos;t load GIF — tap to retry</span>
-      </button>
+      </Button>
     )
   }
 
   return (
     <span className={cn("relative inline-block max-w-full align-bottom", className)} data-type="giphy-embed">
       <img
-        key={attempt}
-        src={withRetryParam(url, attempt)}
+        key={reloadToken}
+        src={withReloadParam(url, reloadToken)}
         alt={title || "GIF"}
         loading="lazy"
         onError={handleError}

--- a/apps/frontend/src/components/giphy/giphy-image.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react"
+import { ImageOff } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 interface GiphyImageProps {
@@ -7,15 +9,107 @@ interface GiphyImageProps {
   className?: string
 }
 
+// A transient CDN/network blip must not leave a GIF permanently broken until the
+// user reloads the page. On error we refetch a few times with exponential
+// backoff, cache-busting each attempt so the browser issues a fresh request
+// instead of reusing the failed response. After the attempts are exhausted we
+// show a manual retry affordance, and we retry automatically when connectivity
+// returns.
+const MAX_RETRIES = 5
+const RETRY_BASE_MS = 500
+
+/** Append a cache-busting param so a retry forces a fresh CDN fetch. */
+function withRetryParam(url: string, attempt: number): string {
+  if (attempt === 0) return url
+  try {
+    const next = new URL(url)
+    next.searchParams.set("_threaRetry", String(attempt))
+    return next.toString()
+  } catch {
+    return url
+  }
+}
+
 /**
  * Renders a GIF straight from Giphy's CDN with the required GIPHY attribution
  * mark. Shared by the composer node view and the timeline renderer so the embed
- * looks the same wherever it appears.
+ * looks the same wherever it appears. Failed loads are retried with backoff so a
+ * transient CDN hiccup doesn't drop the asset until the next page refresh.
  */
 export function GiphyImage({ url, title, className }: GiphyImageProps) {
+  const [attempt, setAttempt] = useState(0)
+  const [failed, setFailed] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Reset retry state whenever the GIF source changes, and clear any pending
+  // retry on unmount.
+  useEffect(() => {
+    setAttempt(0)
+    setFailed(false)
+    return clearTimer
+  }, [url])
+
+  // When connectivity returns, give an exhausted GIF a fresh attempt.
+  useEffect(() => {
+    if (!failed) return
+    const onOnline = () => {
+      setFailed(false)
+      setAttempt((current) => current + 1)
+    }
+    window.addEventListener("online", onOnline)
+    return () => window.removeEventListener("online", onOnline)
+  }, [failed])
+
+  const handleError = () => {
+    if (attempt >= MAX_RETRIES) {
+      setFailed(true)
+      return
+    }
+    const delay = RETRY_BASE_MS * 2 ** attempt
+    clearTimer()
+    timerRef.current = setTimeout(() => setAttempt((current) => current + 1), delay)
+  }
+
+  const handleRetryClick = () => {
+    clearTimer()
+    setFailed(false)
+    setAttempt((current) => current + 1)
+  }
+
+  if (failed) {
+    return (
+      <button
+        type="button"
+        onClick={handleRetryClick}
+        className={cn(
+          "flex items-center gap-2 rounded-item border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/70",
+          className
+        )}
+        data-type="giphy-embed"
+      >
+        <ImageOff className="h-4 w-4 shrink-0" />
+        <span>Couldn&apos;t load GIF — tap to retry</span>
+      </button>
+    )
+  }
+
   return (
     <span className={cn("relative inline-block max-w-full align-bottom", className)} data-type="giphy-embed">
-      <img src={url} alt={title || "GIF"} loading="lazy" className="block max-h-64 w-auto max-w-full rounded-item" />
+      <img
+        key={attempt}
+        src={withRetryParam(url, attempt)}
+        alt={title || "GIF"}
+        loading="lazy"
+        onError={handleError}
+        className="block max-h-64 w-auto max-w-full rounded-item"
+      />
       <span className="pointer-events-none absolute bottom-1.5 right-1.5 rounded-md bg-black/55 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-white/85 backdrop-blur-sm">
         GIPHY
       </span>


### PR DESCRIPTION
## Problem

A Giphy GIF on a sent message could fail to load after a transient CDN/network blip and stay broken until a full page refresh (see the bottom message in the reported screenshot — a broken-image placeholder while other GIFs rendered fine).

The shared renderer `apps/frontend/src/components/giphy/giphy-image.tsx` rendered a bare ``&lt;img src={url} loading="lazy"&gt;`` with no `onError` handling. The browser does not retry a failed image load on its own, so a single failed request left that GIF permanently broken until a fresh page load created a new `<img>` element.

## Fix

`GiphyImage` is the single component both the composer node view and the timeline preview use, so the fix covers every GIF surface. It now:

- **Retries on error with exponential backoff** — up to 5 attempts (500ms → 8s).
- **Cache-busts each retry** (`_threaRetry=N` query param) so the browser issues a genuinely fresh request instead of reusing the failed/negatively-cached response. The first load still uses the pristine Giphy URL, so the normal path is unchanged.
- **Recovers when connectivity returns** — listens for the `online` event and re-attempts an exhausted GIF.
- **Falls back to a "tap to retry" affordance** only after automatic retries are exhausted, instead of silently showing a broken image.

This follows the existing `onError` fallback pattern in `link-preview-card.tsx` / `attachment-list.tsx`, but goes further since GIFs are content we can't afford to drop — it actively recovers rather than just swapping in a placeholder.

## Tests

Added `giphy-image.test.tsx` (4 tests):
- First load uses the clean URL (no cache-bust param).
- A transient error triggers a cache-busted retry after backoff.
- Exhausting retries shows the retry button, which recovers the image on tap.
- Changing the GIF URL resets retry state.

All giphy tests pass (11) and `tsc --noEmit` on the frontend is clean.

## Note / follow-up

This is the client-side render path; the GIF URL is stored inline pointing at `media.giphy.com`, so reliability still ultimately depends on Giphy's CDN being reachable. Full independence from Giphy uptime would mean proxying/caching the GIF bytes through our own storage at send time — out of scope here, can be scoped separately if it matters.

https://claude.ai/code/session_01UbZGxUHofZJMRBuHeDmghw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbZGxUHofZJMRBuHeDmghw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783286851&installation_id=129946197&pr_number=799&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F799&signature=74d198fa090f08eb9945623ba4c97c071a769078be16c4fd937668ca9a99de35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->