### PR TITLE
fix(e2e): unlock prompt from Quick Switcher + post-setup PIN/biometric management

### DIFF
--- a/apps/frontend/src/components/encryption/encrypted-scratchpads-section.test.tsx
+++ b/apps/frontend/src/components/encryption/encrypted-scratchpads-section.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import * as authModule from "@/auth"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import { e2eKeysApi } from "@/api/e2e-keys"
+import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
+import { getDeviceUnlockMethod, resetE2eSessionStoreCache, setupNewKey } from "@/stores/e2e-session-store"
+import { createMockUser } from "@/test/fixtures/users"
+import { E2eUnlockProvider } from "./e2e-unlock-provider"
+import { EncryptedScratchpadsSection } from "./encrypted-scratchpads-section"
+
+// Fast Argon2id preset shared with the store/crypto suites so the setup +
+// one PIN enrollment derivation stay well under a second.
+const FAST_PARAMS = { ...DEFAULT_KDF_PARAMS, m: 8 * 1024, t: 1 }
+
+const WORKSPACE_ID = "ws_settings_test"
+const USER_ID = "usr_settings_test"
+const WORKOS_ID = "workos_settings_test"
+
+interface InMemoryServerKey {
+  keyId: string
+  publicKey: string
+  encryptedPrivateBundle: string
+  kdfSalt: string
+  kdfParams: typeof FAST_PARAMS
+  createdAt: string
+}
+
+let serverKey: InMemoryServerKey | null = null
+let keyCounter = 0
+
+beforeEach(() => {
+  serverKey = null
+  keyCounter = 0
+  vi.spyOn(e2eKeysApi, "get").mockImplementation(async () => serverKey)
+  vi.spyOn(e2eKeysApi, "set").mockImplementation(async (_ws, input) => {
+    const rotated = serverKey !== null
+    serverKey = {
+      keyId: `e2ek_test_${++keyCounter}`,
+      publicKey: input.publicKey,
+      encryptedPrivateBundle: input.encryptedPrivateBundle,
+      kdfSalt: input.kdfSalt,
+      kdfParams: input.kdfParams as typeof FAST_PARAMS,
+      createdAt: new Date().toISOString(),
+    }
+    return { key: serverKey, rotated }
+  })
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER_ID)
+  vi.spyOn(authModule, "useAuth").mockReturnValue({
+    user: { id: WORKOS_ID },
+  } as unknown as ReturnType<typeof authModule.useAuth>)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([
+    createMockUser({ id: USER_ID, workosUserId: WORKOS_ID }),
+  ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>)
+})
+
+afterEach(async () => {
+  resetE2eSessionStoreCache()
+  vi.restoreAllMocks()
+})
+
+function renderSection() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}`]}>
+        <E2eUnlockProvider workspaceId={WORKSPACE_ID}>
+          <Routes>
+            <Route path="/w/:workspaceId" element={<EncryptedScratchpadsSection />} />
+          </Routes>
+        </E2eUnlockProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe("EncryptedScratchpadsSection — quick-unlock management", () => {
+  it("lets a trusted, unlocked device enroll a PIN from settings", async () => {
+    // Unlock with the device trusted so the method block renders.
+    await setupNewKey(WORKSPACE_ID, USER_ID, "correct-horse", { params: FAST_PARAMS, trustDevice: true })
+    expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("remembered")
+
+    const user = userEvent.setup()
+    renderSection()
+
+    // The method block starts on automatic unlock.
+    await screen.findByText(/Unlocks automatically on this device/i)
+
+    await user.click(screen.getByRole("button", { name: /set a pin/i }))
+    await user.type(await screen.findByLabelText("New device PIN"), "246810")
+    await user.click(screen.getByRole("button", { name: /save pin/i }))
+
+    // The displayed method flips to PIN, and the store row is now PIN-gated.
+    await screen.findByText(/Unlocks with your 6-digit PIN/i)
+    await waitFor(async () => {
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("pin")
+    })
+  })
+
+  it("hides the method block until the device is kept unlocked", async () => {
+    // Unlocked but not trusted — only the master toggle, no method block.
+    await setupNewKey(WORKSPACE_ID, USER_ID, "correct-horse", { params: FAST_PARAMS })
+
+    renderSection()
+
+    await screen.findByText("Keep me unlocked on this device")
+    expect(screen.queryByText("Unlock method on this device")).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/encryption/encrypted-scratchpads-section.tsx
+++ b/apps/frontend/src/components/encryption/encrypted-scratchpads-section.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
-import { Lock, LockOpen, ShieldAlert, ShieldCheck } from "lucide-react"
+import { Fingerprint, KeyRound, Lock, LockOpen, ShieldAlert, ShieldCheck } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/auth"
 import { Button } from "@/components/ui/button"
@@ -17,8 +17,27 @@ import {
   ResponsiveAlertDialogTitle,
 } from "@/components/ui/responsive-alert-dialog"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
-import { lock, revokeKeyForUser, setDeviceTrust, useE2eSession } from "@/stores/e2e-session-store"
+import {
+  enrollDeviceBiometric,
+  enrollDevicePin,
+  getDeviceUnlockMethod,
+  lock,
+  revokeKeyForUser,
+  setDeviceTrust,
+  useE2eSession,
+  type DeviceUnlockMethod,
+} from "@/stores/e2e-session-store"
+import { isValidPin } from "@/lib/crypto/pin-device-key"
+import { isPlatformAuthenticatorAvailable, registerDeviceBiometric } from "@/lib/crypto/webauthn-device-key"
+import { PinInput } from "./pin-input"
 import { useE2eUnlock } from "./e2e-unlock-provider"
+
+const UNLOCK_METHOD_LABEL: Record<DeviceUnlockMethod, string> = {
+  none: "You'll enter your passphrase each time on this device.",
+  remembered: "Unlocks automatically on this device — no passphrase prompt.",
+  pin: "Unlocks with your 6-digit PIN on this device.",
+  biometric: "Unlocks with this device's fingerprint or face.",
+}
 
 interface EncryptedScratchpadsSectionProps {
   workspaceId: string
@@ -31,16 +50,95 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
   const [revokeOpen, setRevokeOpen] = useState(false)
   const [revoking, setRevoking] = useState(false)
   const [trustPending, setTrustPending] = useState(false)
+  // Quick-unlock method management (only meaningful while unlocked + trusted).
+  const [unlockMethod, setUnlockMethod] = useState<DeviceUnlockMethod>("none")
+  const [biometricAvailable, setBiometricAvailable] = useState(false)
+  const [pinEditorOpen, setPinEditorOpen] = useState(false)
+  const [pin, setPin] = useState("")
+  const [methodPending, setMethodPending] = useState(false)
+
+  const isUnlocked = session.status === "unlocked"
+
+  const refreshUnlockMethod = useCallback(async () => {
+    setUnlockMethod(await getDeviceUnlockMethod(workspaceId, userId))
+  }, [workspaceId, userId])
+
+  // Load the current device method + probe biometric availability whenever the
+  // session becomes unlocked (the only state where the method block renders).
+  useEffect(() => {
+    if (!isUnlocked) return
+    let cancelled = false
+    void getDeviceUnlockMethod(workspaceId, userId).then((m) => {
+      if (!cancelled) setUnlockMethod(m)
+    })
+    void isPlatformAuthenticatorAvailable().then((ok) => {
+      if (!cancelled) setBiometricAvailable(ok)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isUnlocked, workspaceId, userId])
 
   const handleTrustChange = async (next: boolean) => {
     setTrustPending(true)
     try {
       await setDeviceTrust(workspaceId, userId, next)
+      await refreshUnlockMethod()
+      if (!next) setPinEditorOpen(false)
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to update device trust"
       toast.error(message)
     } finally {
       setTrustPending(false)
+    }
+  }
+
+  const handleSetPin = async () => {
+    if (methodPending || !isValidPin(pin)) return
+    setMethodPending(true)
+    try {
+      await enrollDevicePin(workspaceId, userId, pin)
+      toast.success("PIN set for this device")
+      setPin("")
+      setPinEditorOpen(false)
+      await refreshUnlockMethod()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't set the PIN")
+    } finally {
+      setMethodPending(false)
+    }
+  }
+
+  const handleUseBiometric = async () => {
+    if (methodPending) return
+    setMethodPending(true)
+    try {
+      const registration = await registerDeviceBiometric(userId)
+      await enrollDeviceBiometric(workspaceId, userId, registration)
+      toast.success("Biometric unlock enabled for this device")
+      setPinEditorOpen(false)
+      await refreshUnlockMethod()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't set up biometric unlock")
+    } finally {
+      setMethodPending(false)
+    }
+  }
+
+  // Drop a PIN/biometric gate back to plain auto-resume without re-entering the
+  // passphrase — the in-memory key is re-sealed under the device AES key.
+  const handleUseAutomatic = async () => {
+    if (methodPending) return
+    setMethodPending(true)
+    try {
+      await setDeviceTrust(workspaceId, userId, true)
+      toast.success("This device will unlock automatically")
+      setPinEditorOpen(false)
+      await refreshUnlockMethod()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't update the unlock method")
+    } finally {
+      setMethodPending(false)
     }
   }
 
@@ -143,6 +241,66 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
               onCheckedChange={(next) => void handleTrustChange(next)}
             />
           </div>
+
+          {session.deviceTrusted && (
+            <div className="space-y-2.5 rounded-md border border-border px-3 py-2.5">
+              <div>
+                <p className="text-sm font-medium">Unlock method on this device</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{UNLOCK_METHOD_LABEL[unlockMethod]}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="gap-1.5"
+                  disabled={methodPending}
+                  onClick={() => setPinEditorOpen((open) => !open)}
+                >
+                  <KeyRound className="h-4 w-4" />
+                  {unlockMethod === "pin" ? "Change PIN" : "Set a PIN"}
+                </Button>
+                {biometricAvailable && unlockMethod !== "biometric" && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5"
+                    disabled={methodPending}
+                    onClick={() => void handleUseBiometric()}
+                  >
+                    <Fingerprint className="h-4 w-4" />
+                    Use biometrics
+                  </Button>
+                )}
+                {unlockMethod !== "remembered" && (
+                  <Button size="sm" variant="ghost" disabled={methodPending} onClick={() => void handleUseAutomatic()}>
+                    Unlock automatically
+                  </Button>
+                )}
+              </div>
+              {pinEditorOpen && (
+                <div className="space-y-2 pt-1">
+                  <PinInput value={pin} onChange={setPin} disabled={methodPending} ariaLabel="New device PIN" />
+                  <div className="flex gap-2">
+                    <Button size="sm" disabled={methodPending || !isValidPin(pin)} onClick={() => void handleSetPin()}>
+                      {methodPending ? "Saving…" : "Save PIN"}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={methodPending}
+                      onClick={() => {
+                        setPinEditorOpen(false)
+                        setPin("")
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="flex flex-wrap gap-2">
             <Button size="sm" variant="outline" onClick={() => void lock(workspaceId, userId)}>
               <Lock className="mr-1 h-4 w-4" />

--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -18,7 +18,11 @@ import { scorePassphrase, type PassphraseScore } from "./passphrase-strength"
 import { RevealablePassphraseInput } from "./revealable-passphrase-input"
 import { PinInput, PIN_LENGTH } from "./pin-input"
 import { isValidPin } from "@/lib/crypto/pin-device-key"
-import { isPlatformAuthenticatorAvailable, registerPrfCredential, type PrfRegistration } from "@/lib/crypto/webauthn-device-key"
+import {
+  isPlatformAuthenticatorAvailable,
+  registerDeviceBiometric,
+  type PrfRegistration,
+} from "@/lib/crypto/webauthn-device-key"
 import { Fingerprint } from "lucide-react"
 
 interface PassphraseSetupModalProps {
@@ -134,12 +138,7 @@ export function PassphraseSetupModal({
     if (registeringBiometric) return
     setRegisteringBiometric(true)
     try {
-      const registration = await registerPrfCredential({
-        rpId: window.location.hostname,
-        rpName: "Threa",
-        userId: new TextEncoder().encode(userId),
-        userName: userId,
-      })
+      const registration = await registerDeviceBiometric(userId)
       setBiometric(registration)
       toast.success("Biometric unlock ready")
     } catch (err) {

--- a/apps/frontend/src/components/encryption/revealable-passphrase-input.tsx
+++ b/apps/frontend/src/components/encryption/revealable-passphrase-input.tsx
@@ -10,8 +10,9 @@ type RevealablePassphraseInputProps = Omit<React.ComponentProps<"input">, "type"
  * passphrase need to see what they're entering to avoid lockout from typos
  * they can't see — the masked default still wins on shoulder-surfing surfaces.
  *
- * The toggle is `tabIndex={-1}` so keyboard users tab straight from passphrase
- * to confirm without a detour through the reveal button.
+ * The reveal button sits in the natural tab order right after the input, so a
+ * keyboard user can Tab from the passphrase straight onto the toggle (to flip
+ * visibility) before moving on to the rest of the form.
  */
 export const RevealablePassphraseInput = forwardRef<HTMLInputElement, RevealablePassphraseInputProps>(
   ({ className, ...props }, ref) => {
@@ -21,7 +22,6 @@ export const RevealablePassphraseInput = forwardRef<HTMLInputElement, Revealable
         <Input ref={ref} type={revealed ? "text" : "password"} className={cn("pr-10", className)} {...props} />
         <button
           type="button"
-          tabIndex={-1}
           onClick={() => setRevealed((v) => !v)}
           aria-label={revealed ? "Hide passphrase" : "Show passphrase"}
           aria-pressed={revealed}

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -12,6 +12,8 @@ import { mockSearchResultsList } from "@/test/fixtures/messages"
 import * as hooksModule from "@/hooks"
 import * as mentionablesModule from "@/hooks/use-mentionables"
 import * as createEncryptedScratchpadModule from "@/hooks/use-create-encrypted-scratchpad"
+import * as e2eUnlockModule from "@/components/encryption/e2e-unlock-provider"
+import * as e2eSessionStoreModule from "@/stores/e2e-session-store"
 import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as streamsApiModule from "@/api/streams"
@@ -37,6 +39,12 @@ const mockSearchState = {
 const mockArchiveMutateAsync = vi.fn()
 const mockDeleteDraft = vi.fn()
 const mockOpenStreamSettings = vi.fn()
+
+// The encrypted-scratchpad create hook is stubbed (it reaches into the sync
+// engine). Kept at module scope so the onboarding tests can assert whether the
+// palette created the scratchpad directly or routed through the unlock modal
+// first.
+const mockCreateEncryptedScratchpad = vi.fn(async () => "stream_e2e_test")
 
 const mockWorkspaceBootstrap = {
   data: {} as {
@@ -148,7 +156,7 @@ function installSpies() {
   // outside a SyncEngineProvider. The QuickSwitcher tests don't mount one, so
   // stub the hook out instead of wiring a sync engine into the test harness.
   vi.spyOn(createEncryptedScratchpadModule, "useCreateEncryptedScratchpad").mockReturnValue(
-    vi.fn(async () => "stream_e2e_test") as unknown as ReturnType<
+    mockCreateEncryptedScratchpad as unknown as ReturnType<
       typeof createEncryptedScratchpadModule.useCreateEncryptedScratchpad
     >
   )
@@ -247,6 +255,7 @@ describe("QuickSwitcher Integration Tests", () => {
     mockArchiveMutateAsync.mockReset()
     mockDeleteDraft.mockReset()
     mockOpenStreamSettings.mockReset()
+    mockCreateEncryptedScratchpad.mockClear()
     mockWorkspaceBootstrap.data = {
       streams: mockStreamsList,
       streamMemberships: [],
@@ -1822,6 +1831,83 @@ describe("QuickSwitcher Integration Tests", () => {
       // not in QuickSwitcher. Testing that shortcut requires mounting WorkspaceLayout.
       // The test above (should not respond to cmd+f) verifies QuickSwitcher
       // doesn't intercept cmd+f - which is the important behavior to test here.
+    })
+  })
+
+  // Asking for an encrypted scratchpad from the palette IS the onboarding
+  // trigger (mirrors the sidebar): a locked / not-yet-set-up session must open
+  // the shared unlock/setup modal and finish the create afterwards — not throw
+  // the "called without an unlocked E2E session" error and dead-end on a toast.
+  describe("encrypted scratchpad onboarding", () => {
+    const mockOpenUnlock = vi.fn()
+    const mockOpenSetup = vi.fn()
+
+    const stubSession = (status: string) =>
+      vi
+        .spyOn(e2eSessionStoreModule, "getE2eSessionState")
+        .mockReturnValue({ status } as unknown as ReturnType<typeof e2eSessionStoreModule.getE2eSessionState>)
+
+    const stubUnlockProvider = () =>
+      vi.spyOn(e2eUnlockModule, "useE2eUnlockOptional").mockReturnValue({
+        openUnlock: mockOpenUnlock,
+        openSetup: mockOpenSetup,
+      })
+
+    beforeEach(() => {
+      mockOpenUnlock.mockReset()
+      mockOpenSetup.mockReset()
+    })
+
+    it("opens the unlock modal (not an error toast) when the session is locked, then creates after unlock", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      stubSession("locked")
+      stubUnlockProvider()
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" />)
+
+      await user.click(await screen.findByText("New Encrypted Scratchpad"))
+
+      // Routed through the unlock modal; the create is deferred, not thrown.
+      expect(mockOpenUnlock).toHaveBeenCalledTimes(1)
+      expect(mockOpenSetup).not.toHaveBeenCalled()
+      expect(mockCreateEncryptedScratchpad).not.toHaveBeenCalled()
+
+      // Completing the unlock runs the deferred create and navigates to it.
+      const onUnlocked = mockOpenUnlock.mock.calls[0][0]?.onUnlocked as () => void
+      onUnlocked()
+
+      await waitFor(() => {
+        expect(mockCreateEncryptedScratchpad).toHaveBeenCalledWith(true)
+        expect(mockNavigate).toHaveBeenCalledWith("/w/workspace_1/s/stream_e2e_test")
+      })
+    })
+
+    it("opens the setup modal when the user has no key yet", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      stubSession("no-key")
+      stubUnlockProvider()
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" />)
+
+      await user.click(await screen.findByText("New Encrypted Scratchpad"))
+
+      expect(mockOpenSetup).toHaveBeenCalledTimes(1)
+      expect(mockOpenUnlock).not.toHaveBeenCalled()
+      expect(mockCreateEncryptedScratchpad).not.toHaveBeenCalled()
+    })
+
+    it("creates directly when the session is already unlocked", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      stubSession("unlocked")
+      stubUnlockProvider()
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" />)
+
+      await user.click(await screen.findByText("New Encrypted Scratchpad"))
+
+      await waitFor(() => {
+        expect(mockCreateEncryptedScratchpad).toHaveBeenCalledWith(true)
+        expect(mockNavigate).toHaveBeenCalledWith("/w/workspace_1/s/stream_e2e_test")
+      })
+      expect(mockOpenUnlock).not.toHaveBeenCalled()
+      expect(mockOpenSetup).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -25,6 +25,8 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useSettings } from "@/contexts"
 import { useUser } from "@/auth"
 import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
+import { useE2eUnlockOptional } from "@/components/encryption/e2e-unlock-provider"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { useCreateChannel } from "@/components/create-channel"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
@@ -160,7 +162,35 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
     setInputValue("")
   }, [])
 
-  const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUserId)
+  const createEncryptedScratchpadRaw = useCreateEncryptedScratchpad(workspaceId, currentUserId)
+  const e2eUnlock = useE2eUnlockOptional()
+
+  // Asking for an encrypted scratchpad IS the onboarding trigger (mirrors the
+  // sidebar): if the user has no key yet, or is locked, open the shared
+  // setup/unlock modal and finish the create the moment they're unlocked —
+  // rather than letting the create hook throw "called without an unlocked E2E
+  // session" and dead-ending the command on a toast. The palette closes first
+  // so the modal isn't stacked on top of it; the command then navigates to the
+  // returned stream id. Falls back to a direct create outside the provider
+  // (unit harnesses) or when the session is already unlocked.
+  const createEncryptedScratchpad = useCallback(
+    (withAriadne: boolean): Promise<string> => {
+      const session = currentUserId ? getE2eSessionState(workspaceId, currentUserId) : null
+      if (!e2eUnlock || !session || session.status === "unlocked") {
+        return createEncryptedScratchpadRaw(withAriadne)
+      }
+      return new Promise<string>((resolve, reject) => {
+        handleClose()
+        const finish = () => createEncryptedScratchpadRaw(withAriadne).then(resolve, reject)
+        if (session.status === "no-key") {
+          e2eUnlock.openSetup({ onComplete: finish })
+        } else {
+          e2eUnlock.openUnlock({ onUnlocked: finish })
+        }
+      })
+    },
+    [workspaceId, currentUserId, e2eUnlock, createEncryptedScratchpadRaw, handleClose]
+  )
 
   const clearInputRequest = useCallback(() => {
     setInputRequest(null)

--- a/apps/frontend/src/lib/crypto/webauthn-device-key.ts
+++ b/apps/frontend/src/lib/crypto/webauthn-device-key.ts
@@ -116,6 +116,21 @@ export async function registerPrfCredential(opts: {
 }
 
 /**
+ * Convenience wrapper that fills in the relying-party fields from the current
+ * origin and the workspace user id. Both first-run setup and post-setup
+ * enrollment register biometrics the same way, so they share this rather than
+ * each repeating the `rpId` / `userId` boilerplate.
+ */
+export function registerDeviceBiometric(userId: string): Promise<PrfRegistration> {
+  return registerPrfCredential({
+    rpId: window.location.hostname,
+    rpName: "Threa",
+    userId: new TextEncoder().encode(userId),
+    userName: userId,
+  })
+}
+
+/**
  * Run a WebAuthn assertion (user verification = biometric) and read the PRF
  * secret for `prfSalt`. Throws if cancelled or the authenticator returns no PRF
  * result — callers fall back to the passphrase.

--- a/apps/frontend/src/stores/e2e-session-store.test.ts
+++ b/apps/frontend/src/stores/e2e-session-store.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
+  enrollDeviceBiometric,
+  enrollDevicePin,
+  getDeviceUnlockMethod,
   getE2eSessionState,
   loadE2eKeyForUser,
   lock,
@@ -390,6 +393,75 @@ describe("e2e session store — keep me unlocked on this device", () => {
     await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
     await lock(WORKSPACE_ID, USER_ID)
     await expect(setDeviceTrust(WORKSPACE_ID, USER_ID, true)).rejects.toThrow()
+  })
+
+  describe("post-setup quick-unlock enrollment", () => {
+    const PIN = "246810"
+    const PRF_SECRET = new Uint8Array(32).fill(5)
+    const REGISTRATION = { credentialId: "cred_enroll", prfSalt: "c2FsdHk=", prfSecret: PRF_SECRET }
+
+    it("reports the device unlock method as it changes", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("none")
+
+      await setDeviceTrust(WORKSPACE_ID, USER_ID, true)
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("remembered")
+
+      await enrollDevicePin(WORKSPACE_ID, USER_ID, PIN)
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("pin")
+
+      // Switching back to plain auto-resume drops the PIN gate.
+      await setDeviceTrust(WORKSPACE_ID, USER_ID, true)
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("remembered")
+    })
+
+    it("enrolls a PIN on an unlocked key, and a reload then needs that PIN", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
+      await enrollDevicePin(WORKSPACE_ID, USER_ID, PIN)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).deviceTrusted).toBe(true)
+
+      await reload()
+      const locked = getE2eSessionState(WORKSPACE_ID, USER_ID)
+      expect(locked.status).toBe("locked")
+      expect(locked.pinProtected).toBe(true)
+
+      await unlockWithPin(WORKSPACE_ID, USER_ID, PIN)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+    })
+
+    it("enrolls biometrics on an unlocked key, and a reload then needs the PRF secret", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
+      await enrollDeviceBiometric(WORKSPACE_ID, USER_ID, REGISTRATION)
+      const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(row!.webauthnWrappedPrivate).toBeTruthy()
+      expect(row!.pinWrappedPrivate).toBeUndefined()
+
+      await reload()
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).webauthnProtected).toBe(true)
+
+      await unlockWithWebAuthn(WORKSPACE_ID, USER_ID, PRF_SECRET)
+      expect(getE2eSessionState(WORKSPACE_ID, USER_ID).status).toBe("unlocked")
+    })
+
+    it("replaces an existing method rather than stacking (PIN then biometric)", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
+      await enrollDevicePin(WORKSPACE_ID, USER_ID, PIN)
+      await enrollDeviceBiometric(WORKSPACE_ID, USER_ID, REGISTRATION)
+
+      const row = await db.e2eDeviceKeys.get(`${WORKSPACE_ID}:${USER_ID}`)
+      expect(row!.webauthnWrappedPrivate).toBeTruthy()
+      expect(row!.pinWrappedPrivate).toBeUndefined()
+      expect(await getDeviceUnlockMethod(WORKSPACE_ID, USER_ID)).toBe("biometric")
+    })
+
+    it("rejects a malformed PIN and enrolling while locked", async () => {
+      await setupNewKey(WORKSPACE_ID, USER_ID, "pp", { params: FAST_PARAMS })
+      await expect(enrollDevicePin(WORKSPACE_ID, USER_ID, "12")).rejects.toThrow()
+
+      await lock(WORKSPACE_ID, USER_ID)
+      await expect(enrollDevicePin(WORKSPACE_ID, USER_ID, PIN)).rejects.toThrow(/Unlock/)
+      await expect(enrollDeviceBiometric(WORKSPACE_ID, USER_ID, REGISTRATION)).rejects.toThrow(/Unlock/)
+    })
   })
 
   it("a server-side rotation discards the stale device key and relocks", async () => {

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -7,12 +7,18 @@ import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
 import { generateUIK, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
 import { unwrapPrivateKeyFromDevice, wrapPrivateKeyForDevice } from "@/lib/crypto/device-wrap-key"
 import {
+  isValidPin,
   MAX_PIN_ATTEMPTS,
   unwrapPrivateKeyWithPin,
   wrapPrivateKeyWithPin,
   type PinWrappedKey,
 } from "@/lib/crypto/pin-device-key"
-import { getPrfSecret, unwrapPrivateKeyWithPrf, wrapPrivateKeyWithPrf } from "@/lib/crypto/webauthn-device-key"
+import {
+  getPrfSecret,
+  unwrapPrivateKeyWithPrf,
+  wrapPrivateKeyWithPrf,
+  type PrfRegistration,
+} from "@/lib/crypto/webauthn-device-key"
 import { DEFAULT_KDF_PARAMS, deriveKEK, generateSalt, type KdfParams } from "@/lib/crypto/passphrase"
 import { db, type CachedE2eDeviceKey, type CachedE2eKey } from "@/db"
 
@@ -943,6 +949,72 @@ export async function setDeviceTrust(workspaceId: string, userId: string, trust:
   }
   await deleteDeviceKey(workspaceId, userId)
   setState(workspaceId, userId, { deviceTrusted: false })
+}
+
+/**
+ * How this device's trusted ("keep me unlocked") key is gated, for the settings
+ * UI to render and manage without reaching into IDB itself (INV-15):
+ *   - `none`       — no device key; the passphrase is required every reload
+ *   - `remembered` — auto-resumes unlocked, no prompt
+ *   - `pin`        — resumes locked, unlocked by the 6-digit PIN
+ *   - `biometric`  — resumes locked, unlocked by a WebAuthn PRF assertion
+ */
+export type DeviceUnlockMethod = "none" | "remembered" | "pin" | "biometric"
+
+/** Classify this device's trusted-key row. Async (an IDB read) like its siblings. */
+export async function getDeviceUnlockMethod(workspaceId: string, userId: string): Promise<DeviceUnlockMethod> {
+  const row = await readDeviceKey(workspaceId, userId)
+  if (!row) return "none"
+  if (row.webauthnWrappedPrivate) return "biometric"
+  if (row.pinWrappedPrivate) return "pin"
+  if (row.deviceWrappedPrivate) return "remembered"
+  return "none"
+}
+
+/**
+ * Add (or switch to) a PIN-gated quick-unlock on this device, re-sealing the
+ * already-unlocked key under the PIN. Replaces any existing device-key method
+ * (remembered / biometric) — the single device-key row holds one method at a
+ * time. Unlike the best-effort persists during setup/unlock, an explicit
+ * settings action throws on a failed write so the UI can surface it rather than
+ * silently leaving the old method in place.
+ */
+export async function enrollDevicePin(workspaceId: string, userId: string, pin: string): Promise<void> {
+  const { status, privateKey, keyId, publicKey } = getOrCreateScope(workspaceId, userId).state
+  if (status !== "unlocked" || !privateKey || !keyId || !publicKey) {
+    throw new Error("Unlock encrypted scratchpads before setting a PIN")
+  }
+  if (!isValidPin(pin)) throw new Error("PIN must be 6–8 digits")
+  const wrapped = await wrapPrivateKeyWithPin(privateKey, pin)
+  const persisted = await tryPersistPinDeviceKey(workspaceId, userId, keyId, publicKey, wrapped)
+  if (!persisted) throw new Error("Couldn't save the PIN on this device")
+  setState(workspaceId, userId, { deviceTrusted: true })
+}
+
+/**
+ * Add (or switch to) biometric (WebAuthn PRF) quick-unlock on this device. The
+ * caller runs the registration ceremony (`registerDeviceBiometric`) and passes
+ * the result; we re-seal the already-unlocked key under its PRF secret. Replaces
+ * any existing device-key method and throws on a failed write (see
+ * `enrollDevicePin`).
+ */
+export async function enrollDeviceBiometric(
+  workspaceId: string,
+  userId: string,
+  registration: PrfRegistration
+): Promise<void> {
+  const { status, privateKey, keyId, publicKey } = getOrCreateScope(workspaceId, userId).state
+  if (status !== "unlocked" || !privateKey || !keyId || !publicKey) {
+    throw new Error("Unlock encrypted scratchpads before adding biometric unlock")
+  }
+  const wrappedPrivate = await wrapPrivateKeyWithPrf(privateKey, registration.prfSecret)
+  const persisted = await tryPersistWebAuthnDeviceKey(workspaceId, userId, keyId, publicKey, {
+    credentialId: registration.credentialId,
+    prfSalt: registration.prfSalt,
+    wrappedPrivate,
+  })
+  if (!persisted) throw new Error("Couldn't save biometric unlock on this device")
+  setState(workspaceId, userId, { deviceTrusted: true })
 }
 
 /**


### PR DESCRIPTION
## Problem

Two rough edges in the encrypted-scratchpad flow, plus a gap reported from real use:

1. **Quick Switcher dead-ended when locked.** Creating an encrypted scratchpad from the Quick Switcher called the create hook directly. If the E2E session wasn't unlocked yet, the hook threw `"createEncryptedScratchpad called without an unlocked E2E session"` and the command surfaced it as an error toast — instead of prompting the user to unlock (which is what the sidebar already does). So the only way to recover was to go unlock elsewhere first.

2. **Passphrase reveal toggle was skipped by Tab.** The eye (show/hide) button on the passphrase field was `tabIndex={-1}`, so tabbing from the passphrase jumped straight to the "keep me unlocked" checkbox — you couldn't reach the visibility toggle from the keyboard.

3. **No way to add a PIN or biometric after first-run setup.** Biometric/PIN enrollment lived *only* in the first-run setup modal. Once your key existed, the encryption settings offered just keep-me-unlocked / lock / revoke — there was no surface (and no store function) to add or change a device unlock method, and no re-prompt. Users who set up without biometrics, or whose device couldn't register one at the time (e.g. Android Chrome has no WebAuthn PRF, Chrome-on-Mac needs a passkey provider), were stuck on passphrase forever.

## Solution

### 1. Quick Switcher routes through the shared unlock/setup modal

`QuickSwitcher` now mirrors the sidebar: asking for an encrypted scratchpad *is* the onboarding trigger. It reads the session state and, when locked / no-key, closes the palette and opens the shared setup or unlock modal via `useE2eUnlockOptional()`, finishing the create (and navigating) the moment the user is unlocked. When already unlocked — or when there's no provider (unit harnesses) — it falls back to the direct create, so the command's existing close/navigate contract is unchanged.

### 2. Reveal toggle in tab order

Dropped `tabIndex={-1}` from the reveal button so it sits in the natural tab order: passphrase field → reveal toggle → "keep me unlocked".

### 3. Post-setup unlock-method management

New store functions re-seal the **already-unlocked, in-memory** key under a fresh device KEK, reusing the same wrap helpers and the single `e2eDeviceKeys` row that setup uses — so a device holds exactly one method and adding one replaces the previous:

- `enrollDevicePin(workspaceId, userId, pin)`
- `enrollDeviceBiometric(workspaceId, userId, registration)`
- `getDeviceUnlockMethod(workspaceId, userId)` → `none | remembered | pin | biometric`

A new **"Unlock method on this device"** block in the encryption settings section (shown while unlocked and kept-unlocked) lets you set/change a PIN, enable biometrics, or drop back to automatic unlock.

### Key design decisions

**1. Enrollment reuses the existing single-row device-key model.** Rather than introduce a new multi-method schema, `enroll*` write the same `e2eDeviceKeys` row shape that `setupNewKey` already produces (pin-wrapped / PRF-wrapped). Adding a method therefore *replaces* whatever was there, which matches how the unlock router already picks one method. No migration, no new persistence path.

**2. Explicit enrollment throws on a failed write.** Setup/unlock persist device trust best-effort (a failed IDB write means "not kept unlocked", never a failed unlock). An explicit settings action is different: if the write fails we throw so the UI can toast it, rather than silently leaving the old method in place.

**3. PIN is always offered; biometrics is gated on real availability.** The biometric button only appears when `isPlatformAuthenticatorAvailable()` is true, while the 6-digit PIN is always available — so devices that can't do WebAuthn PRF (Android Chrome) still get a fast unlock. This is the "PIN fallback" path.

**4. Shared `registerDeviceBiometric` helper.** Extracted the WebAuthn registration boilerplate (rpId/userId) into `registerDeviceBiometric(userId)` so the setup modal and settings register biometrics the same way instead of duplicating it.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/components/encryption/encrypted-scratchpads-section.test.tsx` | Mounts the real settings section + unlock provider; covers PIN enrollment and the method block's visibility gating |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/stores/e2e-session-store.ts` | Add `DeviceUnlockMethod`, `getDeviceUnlockMethod`, `enrollDevicePin`, `enrollDeviceBiometric` |
| `apps/frontend/src/components/encryption/encrypted-scratchpads-section.tsx` | "Unlock method on this device" management block + handlers |
| `apps/frontend/src/lib/crypto/webauthn-device-key.ts` | Add shared `registerDeviceBiometric(userId)` |
| `apps/frontend/src/components/encryption/passphrase-setup-modal.tsx` | Use the shared `registerDeviceBiometric` helper |
| `apps/frontend/src/components/quick-switcher/quick-switcher.tsx` | Route encrypted-scratchpad creation through the unlock/setup modal when locked/no-key |
| `apps/frontend/src/components/encryption/revealable-passphrase-input.tsx` | Reveal toggle back in tab order (drop `tabIndex={-1}`) |
| `apps/frontend/src/stores/e2e-session-store.test.ts` | Round-trip tests for PIN/biometric enrollment + method reporting/replacement/guards |
| `apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx` | Onboarding tests: locked → unlock modal, no-key → setup, unlocked → direct create |

## Test plan

- [x] `bun run test` for the touched suites: `e2e-session-store`, `encryption/`, `quick-switcher/`, `lib/crypto/` — all green
- [x] `bun run typecheck` (frontend) and the full monorepo lint + typecheck pre-commit gate
- [x] Store round-trip: enroll PIN/biometric on an unlocked key, reload, unlock with the new method
- [ ] Manual: from Quick Switcher with a locked session, confirm the unlock modal appears and the scratchpad is created after unlocking
- [ ] Manual: in encryption settings, set a PIN / enable biometrics / switch back to automatic; verify a reload prompts for the chosen method
- [ ] Manual (Android Chrome): confirm biometrics is hidden and PIN is offered as the fallback

Note: the WebAuthn ceremony itself isn't exercisable in jsdom, so biometric enrollment is verified at the store layer (PRF secret supplied directly) and the ceremony stays covered by the existing Playwright virtual-authenticator E2E.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRqZ4AtwsFhWZDpRfxKFw3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783289035&installation_id=129946197&pr_number=801&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F801&signature=7707cdd8461585d5cfee0eb6deefde6fa1c75dbcafffd3c70755c4217e653c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->