### PR TITLE
fix(e2e): stop spurious "Finish setup" in threads + decrypt Ariadne's thread replies

### DIFF
--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
@@ -6,6 +6,7 @@ import type { E2eKeyWrapsResponse } from "@threa/types"
 import { buildWrapAad, bytesToBase64, generateStreamKey, wrapStreamKey } from "@threa/crypto"
 import { generateUIK } from "@/lib/crypto/keys"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as streamStoreModule from "@/stores/stream-store"
 import { e2eKeysApi } from "@/api/e2e-keys"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
 import { DEFAULT_KDF_PARAMS } from "@/lib/crypto/passphrase"
@@ -58,7 +59,22 @@ beforeEach(() => {
   })
   // The affordance + provider both resolve the workspace user id via this hook.
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER_ID)
+  // The repair/revive probes resolve the stream's root from the store to scope
+  // themselves to the top-level scratchpad. Default every stream to a hydrated
+  // top-level row; thread cases override with a row carrying `rootStreamId`.
+  mockStreamRow(null)
 })
+
+/**
+ * Stub `useStreamFromStore` so a probed stream resolves to a hydrated row.
+ * `rootStreamId === null` is a top-level scratchpad (its own root); a non-null
+ * value marks a thread whose key lives on that root.
+ */
+function mockStreamRow(rootStreamId: string | null): void {
+  vi.spyOn(streamStoreModule, "useStreamFromStore").mockImplementation((id) =>
+    id ? ({ id, rootStreamId } as unknown as ReturnType<typeof streamStoreModule.useStreamFromStore>) : undefined
+  )
+}
 
 afterEach(() => {
   resetE2eSessionStoreCache()
@@ -196,6 +212,32 @@ describe("repair (unlocked stream missing its owner wrap)", () => {
     expect(screen.queryByRole("button", { name: /finish setup/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument()
   })
+
+  it("never offers Finish setup in a thread, whose empty wrap set is by design", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "pp-correct-horse", { params: FAST_PARAMS })
+    await waitFor(() => expect(getE2eSessionState(ws, USER_ID).status).toBe("unlocked"))
+
+    // A thread shares the root's SSK and carries no wraps of its own — an empty
+    // set here is expected, not a broken setup. The probe must not fire (and so
+    // must not even query the thread's wraps).
+    mockStreamRow("stream_root")
+    const getSpy = vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 1,
+      wraps: [],
+      ownerUserId: USER_ID,
+      liveActorRecipients: [],
+    })
+    const storeSpy = vi.spyOn(e2eKeyWrapsApi, "store").mockResolvedValue(undefined)
+
+    renderWithProvider(ws, <ComposerEncryptionNotice workspaceId={ws} encrypted streamId="stream_thread" />)
+
+    // Give the (disabled) query a chance to fire before asserting it didn't.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByRole("button", { name: /finish setup/i })).not.toBeInTheDocument()
+    expect(getSpy).not.toHaveBeenCalled()
+    expect(storeSpy).not.toHaveBeenCalled()
+  })
 })
 
 describe("actor wrap revive (live actor key missing its wrap)", () => {
@@ -240,6 +282,52 @@ describe("actor wrap revive (live actor key missing its wrap)", () => {
     expect(input.keyGeneration).toBe(0)
     expect(input.wraps.map((w) => w.recipientKeyId)).toEqual(["eik_fresh"])
     expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("heals against the root when the owner is viewing a thread", async () => {
+    const ws = freshWorkspaceId()
+    await setupNewKey(ws, USER_ID, "pp-correct-horse", { params: FAST_PARAMS })
+    await waitFor(() => expect(getE2eSessionState(ws, USER_ID).status).toBe("unlocked"))
+    const session = getE2eSessionState(ws, USER_ID)
+
+    const ROOT_ID = "stream_root_heal"
+    mockStreamRow(ROOT_ID)
+
+    // The owner's wrap lives on the ROOT; its AAD binds to the root id, so the
+    // heal must resolve the SSK (and re-wrap) against the root, not the thread.
+    const ssk = generateStreamKey()
+    const eik = await generateUIK()
+    const ownerWrap = await wrapStreamKey({
+      key: ssk,
+      recipientPublicKey: session.publicKey!,
+      aad: buildWrapAad({ streamId: ROOT_ID, keyGeneration: 0, recipientKeyId: session.keyId! }),
+    })
+    const getSpy = vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 0,
+      wraps: [
+        {
+          keyGeneration: 0,
+          recipientKeyId: session.keyId!,
+          recipientKind: "user",
+          wrapEnc: bytesToBase64(ownerWrap.enc),
+          wrapCt: bytesToBase64(ownerWrap.ct),
+        },
+      ],
+      ownerUserId: USER_ID,
+      liveActorRecipients: [
+        { recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: bytesToBase64(eik.publicKey) },
+      ],
+    })
+    const reviveSpy = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps").mockResolvedValue(undefined)
+
+    renderWithProvider(ws, <StreamHeaderEncryptionAction workspaceId={ws} encrypted streamId="stream_thread_heal" />)
+
+    await waitFor(() => expect(reviveSpy).toHaveBeenCalledTimes(1))
+    // Both the probe fetch and the re-wrap POST target the root id, never the thread.
+    expect(getSpy.mock.calls.every(([, streamId]) => streamId === ROOT_ID)).toBe(true)
+    const [, reviveStreamId, input] = reviveSpy.mock.calls[0]!
+    expect(reviveStreamId).toBe(ROOT_ID)
+    expect(input.wraps.map((w) => w.recipientKeyId)).toEqual(["eik_fresh"])
   })
 
   it("does not revive for a non-owner viewer", async () => {

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.test.tsx
@@ -232,8 +232,11 @@ describe("repair (unlocked stream missing its owner wrap)", () => {
 
     renderWithProvider(ws, <ComposerEncryptionNotice workspaceId={ws} encrypted streamId="stream_thread" />)
 
-    // Give the (disabled) query a chance to fire before asserting it didn't.
-    await new Promise((r) => setTimeout(r, 50))
+    // The probe gates synchronously on `isRootScratchpad`, so a disabled query
+    // never schedules its fetch — flush microtasks (deterministic, no timer
+    // race) and assert nothing fired.
+    await Promise.resolve()
+    await Promise.resolve()
     expect(screen.queryByRole("button", { name: /finish setup/i })).not.toBeInTheDocument()
     expect(getSpy).not.toHaveBeenCalled()
     expect(storeSpy).not.toHaveBeenCalled()

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
 import { provisionOwnerStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useStreamFromStore } from "@/stores/stream-store"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { useE2eUnlockOptional, type E2eUnlockContextValue } from "./e2e-unlock-provider"
 
@@ -63,18 +64,29 @@ interface OwnerWrapRepair {
  * `QueryClientProvider`. Re-provisioning is only offered when the wrap set is
  * empty: a non-empty set means ciphertext may already be sealed under an SSK we
  * must not replace.
+ *
+ * Scoped to a *top-level* scratchpad. A thread carries no wraps of its own by
+ * design — it shares the root's SSK and readers resolve the key against the
+ * root — so an empty wrap set on a thread is expected, not a broken setup.
+ * Probing the thread's (always-empty) set would surface a spurious "Finish
+ * setup", and acting on it would mint a stray thread-bound SSK that no reader
+ * resolves against (corrupting the thread). We therefore only probe once the
+ * stream row confirms this is the root (`rootStreamId == null`); while the row
+ * is unhydrated we stay silent rather than risk that false positive.
  */
 function useOwnerWrapRepair(workspaceId: string, streamId: string): OwnerWrapRepair | null {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
+  const stream = useStreamFromStore(streamId)
   const queryClient = useQueryClient()
 
+  const isRootScratchpad = stream != null && stream.rootStreamId == null
   const sessionReady = session.status === "unlocked" && !!session.keyId && !!session.publicKey
 
   const wrapsQuery = useQuery({
     queryKey: e2eKeyWrapKeys.list(workspaceId, streamId),
     queryFn: () => e2eKeyWrapsApi.get(workspaceId, streamId),
-    enabled: sessionReady,
+    enabled: sessionReady && isRootScratchpad,
     staleTime: 60_000,
   })
 
@@ -91,7 +103,7 @@ function useOwnerWrapRepair(workspaceId: string, streamId: string): OwnerWrapRep
     onSuccess: () => queryClient.invalidateQueries({ queryKey: e2eKeyWrapKeys.list(workspaceId, streamId) }),
   })
 
-  if (!sessionReady) return null
+  if (!sessionReady || !isRootScratchpad) return null
   if (repairMutation.isPending || wrapsQuery.data?.wraps.length === 0) {
     return { repair: () => repairMutation.mutate(), pending: repairMutation.isPending }
   }
@@ -109,19 +121,28 @@ function useOwnerWrapRepair(workspaceId: string, streamId: string): OwnerWrapRep
  *
  * One attempt per missing-set signature: a server reject (e.g. the key went
  * stale mid-flight) doesn't loop, and the next refetch recomputes the set.
+ *
+ * The wraps (and the SSK to re-wrap) live on the *root*, so a thread shares its
+ * root's actor wraps and carries none of its own. Resolve against the root —
+ * via the stream row's `rootStreamId`, falling back to self for a top-level
+ * stream — so the heal fires correctly even when the owner is viewing a thread.
+ * Gate on the row being hydrated so we never probe a bare thread id whose root
+ * we don't yet know.
  */
 function useActorWrapRevive(workspaceId: string, streamId: string): void {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
+  const stream = useStreamFromStore(streamId)
   const queryClient = useQueryClient()
   const attemptedRef = useRef<string | null>(null)
 
+  const rootStreamId = stream ? (stream.rootStreamId ?? streamId) : undefined
   const sessionReady = session.status === "unlocked" && !!session.keyId && !!session.privateKey
 
   const wrapsQuery = useQuery({
-    queryKey: e2eKeyWrapKeys.list(workspaceId, streamId),
-    queryFn: () => e2eKeyWrapsApi.get(workspaceId, streamId),
-    enabled: sessionReady,
+    queryKey: e2eKeyWrapKeys.list(workspaceId, rootStreamId ?? streamId),
+    queryFn: () => e2eKeyWrapsApi.get(workspaceId, rootStreamId!),
+    enabled: sessionReady && !!rootStreamId,
     staleTime: 60_000,
   })
 
@@ -130,12 +151,13 @@ function useActorWrapRevive(workspaceId: string, streamId: string): void {
   const ownerPrivateKey = session.privateKey
 
   useEffect(() => {
-    if (!sessionReady || !data || !userId || !ownerKeyId || !ownerPrivateKey) return
+    if (!sessionReady || !data || !userId || !ownerKeyId || !ownerPrivateKey || !rootStreamId) return
     if (data.ownerUserId !== userId) return
 
     const live = data.liveActorRecipients ?? []
     const missing = live.filter(
-      (r) => !data.wraps.some((w) => w.keyGeneration === data.currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
+      (r) =>
+        !data.wraps.some((w) => w.keyGeneration === data.currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
     )
     if (missing.length === 0) return
 
@@ -146,16 +168,16 @@ function useActorWrapRevive(workspaceId: string, streamId: string): void {
     if (attemptedRef.current === signature) return
     attemptedRef.current = signature
 
-    void reviveStaleActorWraps({ workspaceId, streamId, userId, ownerKeyId, ownerPrivateKey })
+    void reviveStaleActorWraps({ workspaceId, streamId: rootStreamId, userId, ownerKeyId, ownerPrivateKey })
       .then((result) => {
         if (result === "revived") {
-          queryClient.invalidateQueries({ queryKey: e2eKeyWrapKeys.list(workspaceId, streamId) })
+          queryClient.invalidateQueries({ queryKey: e2eKeyWrapKeys.list(workspaceId, rootStreamId) })
         }
       })
       .catch((err) => {
         console.error("Failed to revive stale actor key wraps", err)
       })
-  }, [sessionReady, data, userId, ownerKeyId, ownerPrivateKey, workspaceId, streamId, queryClient])
+  }, [sessionReady, data, userId, ownerKeyId, ownerPrivateKey, workspaceId, rootStreamId, queryClient])
 }
 
 /**

--- a/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
@@ -71,8 +71,11 @@ describe("useDecryptedMessageContent", () => {
 
     expect(result.current).toEqual({ status: "pending" })
     // The bug this guards: a doomed decrypt against the bare thread id, cached as
-    // a permanent failure that never retries once the root is known.
-    await new Promise((r) => setTimeout(r, 20))
+    // a permanent failure that never retries once the root is known. The decrypt
+    // effect runs synchronously on mount, so flushing microtasks (no timer race)
+    // is enough to prove it never fired.
+    await Promise.resolve()
+    await Promise.resolve()
     expect(requestSpy).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { StreamEvent } from "@threa/types"
+import * as e2eSessionModule from "@/stores/e2e-session-store"
+import * as decryptCacheModule from "@/lib/crypto/decrypt-cache"
+import * as streamStoreModule from "@/stores/stream-store"
+import { useDecryptedMessageContent } from "./use-decrypted-message-content"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_thread_1"
+const USER_ID = "usr_1"
+
+/** Stub the stream row a message's stream resolves to. `undefined` = not yet
+ *  hydrated (root unknown); `null` rootStreamId = top-level; a string = thread. */
+function mockStreamRow(row: { rootStreamId: string | null } | undefined): void {
+  vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue(
+    row as unknown as ReturnType<typeof streamStoreModule.useStreamFromStore>
+  )
+}
+
+function unlockedSession(): void {
+  vi.spyOn(e2eSessionModule, "useE2eSession").mockReturnValue({
+    status: "unlocked",
+    privateKey: {} as CryptoKey,
+    keyId: "key_1",
+  } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
+}
+
+/** A sealed `message_created` event — Ariadne's reply on the wire is exactly this. */
+function sealedEvent(): StreamEvent {
+  return {
+    id: "evt_1",
+    streamId: STREAM_ID,
+    sequence: "1",
+    eventType: "message_created",
+    payload: {
+      messageId: "msg_1",
+      ciphertext: "abc",
+      envelope: { v: 2, keyGeneration: 1, iv: "x", aad: "y" },
+      contentMarkdown: "​", // server placeholder
+    },
+    actorId: "persona_system_ariadne",
+    actorType: "persona",
+    createdAt: new Date().toISOString(),
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useDecryptedMessageContent", () => {
+  it("returns locked for a sealed message while the session is locked", () => {
+    vi.spyOn(e2eSessionModule, "useE2eSession").mockReturnValue({
+      status: "locked",
+    } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
+    mockStreamRow({ rootStreamId: "stream_root" })
+
+    const { result } = renderHook(() => useDecryptedMessageContent(sealedEvent(), WORKSPACE_ID, USER_ID))
+
+    expect(result.current).toEqual({ status: "locked" })
+  })
+
+  it("holds at pending without attempting a decrypt while the stream row is unhydrated", async () => {
+    unlockedSession()
+    mockStreamRow(undefined) // root unknown — resolving against the thread id would fail and cache forever
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue(undefined)
+    const requestSpy = vi.spyOn(decryptCacheModule, "requestDecryption").mockResolvedValue(undefined as never)
+
+    const { result } = renderHook(() => useDecryptedMessageContent(sealedEvent(), WORKSPACE_ID, USER_ID))
+
+    expect(result.current).toEqual({ status: "pending" })
+    // The bug this guards: a doomed decrypt against the bare thread id, cached as
+    // a permanent failure that never retries once the root is known.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+
+  it("resolves a thread message's key against the root once the row hydrates", async () => {
+    unlockedSession()
+    mockStreamRow({ rootStreamId: "stream_root" })
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue(undefined)
+    const requestSpy = vi.spyOn(decryptCacheModule, "requestDecryption").mockResolvedValue(undefined as never)
+
+    renderHook(() => useDecryptedMessageContent(sealedEvent(), WORKSPACE_ID, USER_ID))
+
+    await waitFor(() => expect(requestSpy).toHaveBeenCalledTimes(1))
+    const [, , opts] = requestSpy.mock.calls[0]!
+    expect(opts.streamId).toBe(STREAM_ID)
+    expect(opts.rootStreamId).toBe("stream_root")
+  })
+
+  it("returns the decrypted content from cache when available", () => {
+    unlockedSession()
+    mockStreamRow({ rootStreamId: "stream_root" })
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({
+      status: "decrypted",
+      content: { contentMarkdown: "hello from Ariadne", contentJson: { type: "doc" } as never, attachmentRefs: [] },
+    })
+
+    const { result } = renderHook(() => useDecryptedMessageContent(sealedEvent(), WORKSPACE_ID, USER_ID))
+
+    expect(result.current).toMatchObject({ status: "decrypted", contentMarkdown: "hello from Ariadne" })
+  })
+})

--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -64,9 +64,15 @@ export function useDecryptedMessageContent(
   const eventId = event.id
   // A thread shares its root scratchpad's SSK and carries no wraps of its own,
   // so the key must be resolved against the root (the wrap AAD is bound to the
-  // root id). The thread row is in IDB once it's been opened; null root means a
-  // top-level stream, which is its own root.
-  const rootStreamId = useStreamFromStore(event.streamId)?.rootStreamId ?? undefined
+  // root id). `undefined` here is ambiguous: a top-level stream (its own root,
+  // resolve against self) reads the same as a thread whose row hasn't hydrated
+  // yet (root unknown). Resolving the latter against the thread id finds no
+  // wrap and fails — and the failure is cached permanently. So gate the decrypt
+  // on the stream row being present: until then we don't know the root and hold
+  // at `pending` rather than poison the cache with a doomed attempt.
+  const stream = useStreamFromStore(event.streamId)
+  const streamHydrated = stream !== undefined
+  const rootStreamId = stream?.rootStreamId ?? undefined
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(eventId, listener),
@@ -77,7 +83,8 @@ export function useDecryptedMessageContent(
   // Memoize so useEffect deps don't churn on every render — a fresh wrapper
   // object every render would re-fire the effect even though nothing changed.
   const envelopePayload = useMemo(() => readEnvelopePayload(event), [event])
-  const canDecrypt = !!envelopePayload && session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const canDecrypt = !!envelopePayload && sessionUnlocked && streamHydrated
   const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
 
   useEffect(() => {
@@ -117,7 +124,11 @@ export function useDecryptedMessageContent(
     }
   }
 
-  if (!canDecrypt) return { status: "locked" }
+  // `locked` is specifically "session not unlocked". When the session is
+  // unlocked but the stream row hasn't hydrated (root still unknown), fall
+  // through to `pending` — the decrypt fires once the row lands and `rootStreamId`
+  // is trustworthy, never against the bare thread id.
+  if (!sessionUnlocked) return { status: "locked" }
   if (cached?.status === "decrypted" && cached.content) {
     return {
       status: "decrypted",

--- a/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
@@ -131,8 +131,11 @@ describe("useDecryptedStepContent", () => {
     )
 
     expect(result.current).toEqual({ status: "pending", content: undefined })
-    // Critically: no doomed decrypt fired against the bare thread id.
-    await new Promise((r) => setTimeout(r, 20))
+    // Critically: no doomed decrypt fired against the bare thread id. The decrypt
+    // effect runs synchronously on mount, so flushing microtasks (no timer race)
+    // is enough to prove it never fired.
+    await Promise.resolve()
+    await Promise.resolve()
     expect(requestSpy).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
@@ -1,13 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import type { AgentSessionStep } from "@threa/types"
 import * as e2eSessionModule from "@/stores/e2e-session-store"
 import * as decryptCacheModule from "@/lib/crypto/decrypt-cache"
+import * as streamStoreModule from "@/stores/stream-store"
 import { useDecryptedStepContent } from "./use-decrypted-step-content"
 
 const WORKSPACE_ID = "ws_1"
 const STREAM_ID = "stream_1"
 const USER_ID = "member_1"
+
+/** Stub the stream row a thread/top-level resolves to. `undefined` = not yet
+ *  hydrated (root unknown); `null` rootStreamId = top-level; a string = thread. */
+function mockStreamRow(row: { rootStreamId: string | null } | undefined): void {
+  vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue(
+    row as unknown as ReturnType<typeof streamStoreModule.useStreamFromStore>
+  )
+}
+
+function unlockedSession(): void {
+  vi.spyOn(e2eSessionModule, "useE2eSession").mockReturnValue({
+    status: "unlocked",
+    privateKey: {} as CryptoKey,
+    keyId: "key_1",
+  } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
+}
 
 function makeStep(overrides: Partial<AgentSessionStep>): AgentSessionStep {
   return {
@@ -96,5 +113,47 @@ describe("useDecryptedStepContent", () => {
     )
 
     expect(result.current).toEqual({ status: "failed", content: undefined })
+  })
+
+  it("holds at pending without attempting a decrypt while the stream row is unhydrated", async () => {
+    unlockedSession()
+    mockStreamRow(undefined) // root unknown — resolving against the thread id would fail and cache forever
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue(undefined)
+    const requestSpy = vi.spyOn(decryptCacheModule, "requestDecryption").mockResolvedValue(undefined as never)
+
+    const { result } = renderHook(() =>
+      useDecryptedStepContent(
+        makeStep({ contentCiphertext: "abc", contentEnvelope: { v: 2, keyGeneration: 1, iv: "x", aad: "y" } }),
+        WORKSPACE_ID,
+        STREAM_ID,
+        USER_ID
+      )
+    )
+
+    expect(result.current).toEqual({ status: "pending", content: undefined })
+    // Critically: no doomed decrypt fired against the bare thread id.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+
+  it("resolves a thread step's key against the root once the row hydrates", async () => {
+    unlockedSession()
+    mockStreamRow({ rootStreamId: "stream_root" })
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue(undefined)
+    const requestSpy = vi.spyOn(decryptCacheModule, "requestDecryption").mockResolvedValue(undefined as never)
+
+    renderHook(() =>
+      useDecryptedStepContent(
+        makeStep({ contentCiphertext: "abc", contentEnvelope: { v: 2, keyGeneration: 1, iv: "x", aad: "y" } }),
+        WORKSPACE_ID,
+        STREAM_ID,
+        USER_ID
+      )
+    )
+
+    await waitFor(() => expect(requestSpy).toHaveBeenCalledTimes(1))
+    const [, , opts] = requestSpy.mock.calls[0]!
+    expect(opts.streamId).toBe(STREAM_ID)
+    expect(opts.rootStreamId).toBe("stream_root")
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-step-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.ts
@@ -48,7 +48,14 @@ export function useDecryptedStepContent(
   const session = useE2eSession(workspaceId, userId ?? "")
   const cacheKey = step.id
   // A thread shares its root scratchpad's SSK; resolve the key against the root.
-  const rootStreamId = useStreamFromStore(streamId)?.rootStreamId ?? undefined
+  // Until the stream row hydrates the root is unknown, and `undefined` is
+  // indistinguishable from a top-level stream — resolving a thread step against
+  // the bare thread id finds no wrap, fails, and caches that failure forever. So
+  // gate on the row being present (mirrors `useDecryptedMessageContent`): hold
+  // at `pending` rather than attempt a doomed decrypt.
+  const stream = useStreamFromStore(streamId)
+  const streamHydrated = stream !== undefined
+  const rootStreamId = stream?.rootStreamId ?? undefined
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(cacheKey, listener),
@@ -60,7 +67,8 @@ export function useDecryptedStepContent(
   // `useDecryptedMessageContent`'s `readEnvelopePayload` memo, giving `sealed` a
   // stable identity it can enter the dep array with directly.
   const sealed = useMemo(() => readSealedStep(step), [step])
-  const canDecrypt = !!sealed && session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const canDecrypt = !!sealed && sessionUnlocked && streamHydrated
   const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
 
   useEffect(() => {
@@ -73,7 +81,10 @@ export function useDecryptedStepContent(
   }, [needsDecrypt, sealed, session.privateKey, session.keyId, cacheKey, workspaceId, streamId, rootStreamId])
 
   if (!sealed) return { status: "plaintext", content: step.content }
-  if (!canDecrypt) return { status: "locked", content: undefined }
+  // `locked` means the session isn't unlocked. Unlocked-but-not-yet-hydrated
+  // falls through to `pending`: the decrypt fires once the row lands and the
+  // root is known, never against the bare thread id.
+  if (!sessionUnlocked) return { status: "locked", content: undefined }
   if (cached?.status === "decrypted" && cached.content) {
     return { status: "decrypted", content: cached.content.contentMarkdown }
   }


### PR DESCRIPTION
## What

In an encrypted scratchpad, writing in a thread surfaced a spurious "Finish setup" banner, and Ariadne's messages and traces inside threads failed to decrypt.

## Why

Threads under an E2E scratchpad share the root scratchpad's symmetric key (SSK) and carry no key-wraps of their own (#793/#798) — every reader and writer must resolve the key against the **root**. Two read-side surfaces resolved against the thread instead:

1. **The repair probe** (`useOwnerWrapRepair`) queried the thread's own wraps, which are always empty by design, so it showed "This scratchpad's encryption wasn't finished. Finish setup" in every thread. Worse, clicking it ran `provisionOwnerStreamKey` against the thread id, minting a stray thread-bound SSK that no reader resolves against — corrupting the thread.

2. **The decrypt hooks** (`use-decrypted-message-content`, `use-decrypted-step-content`) derived `rootStreamId` from the cached stream row, but `undefined` (row not yet hydrated) was indistinguishable from a top-level stream. So a thread message/trace got resolved against the bare thread id, found no wrap, failed — and a failed decrypt is cached permanently (only cleared on lock). That's why Ariadne's replies and traces failed after a lock/unlock with the thread panel open: whichever decrypts fired before the thread row hydrated got stuck `failed`.

The user's own messages and the send/seal path were unaffected — #798's `sealOutgoingMessage` already resolves the root. The senderId/AAD is also not the cause: `openMessage` takes the AAD verbatim from the envelope, so a different sender can't break decryption.

## The fix

- **Scope the repair probe to the root scratchpad** (`rootStreamId == null`), and stay silent while the stream row is unhydrated rather than risk the false positive. A thread never shows "Finish setup" and never mints a thread key.
- **Gate the decrypt hooks on the stream row being hydrated.** Until the root is known, hold at `pending` instead of attempting a doomed decrypt against the thread id. `locked` now strictly means "session not unlocked"; the decrypt fires once the row lands and `rootStreamId` is trustworthy. `useStreamFromStore` is a reactive subscription, so this re-fires automatically when the row arrives.
- **Route the headless actor-wrap revive heal to the root** so it works while the owner is viewing a thread.

## Tests

- New thread-case coverage: the repair probe never fires (or fetches) in a thread; the actor-revive heal targets the root; the decrypt hooks hold at `pending` without attempting a decrypt while unhydrated, then resolve against the root once the row lands.
- 142 frontend tests across the encryption / crypto / trace / timeline / decrypt-hook suites pass; full-monorepo lint + typecheck green.

> Note: I couldn't exercise the full browser flow from this environment — worth a manual smoke test: open a thread in an encrypted scratchpad, lock/unlock with the panel open, and confirm Ariadne's messages and traces decrypt and no "Finish setup" appears.

https://claude.ai/code/session_013HKPFLkApMeD78o2gsLesU

---
_Generated by [Claude Code](https://claude.ai/code/session_013HKPFLkApMeD78o2gsLesU)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783318328&installation_id=129946197&pr_number=802&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F802&signature=63a38be22747973f9e4190af73ef3829560d5f72e10c5e806f710e8623a3567e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->