### PR TITLE
fix(timeline): stop "New" unread divider overlapping the previous message

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1776,7 +1776,7 @@ function VirtuosoMessageList({
 
   const itemContent = useCallback(
     (_index: number, item: TimelineItem) => (
-      <div className="mx-auto max-w-[800px]">
+      <div className="relative mx-auto max-w-[800px]">
         <TimelineItemContent item={item} ctx={renderCtx} />
       </div>
     ),

--- a/apps/frontend/src/components/timeline/unread-divider.tsx
+++ b/apps/frontend/src/components/timeline/unread-divider.tsx
@@ -5,7 +5,13 @@ interface UnreadDividerProps {
 export function UnreadDivider({ isFading }: UnreadDividerProps) {
   return (
     <div
-      className={`absolute left-0 right-0 -top-2 -translate-y-1/2 z-10 flex items-center gap-3 pointer-events-none transition-opacity duration-500 ${
+      // The line sits in the gap *above* the first-unread item. With
+      // `-translate-y-1/2` the line's center lands exactly at the `top` value,
+      // so a small positive offset places it inside that item's own top-padding
+      // gap (heads `pt-3`, agent cards `py-3` — both 12px). A negative offset
+      // would push the line up into the previous message's last line, since the
+      // only clearance above the wrapper edge is the previous row's 2px `pb-0.5`.
+      className={`absolute left-0 right-0 top-1.5 -translate-y-1/2 z-10 flex items-center gap-3 pointer-events-none transition-opacity duration-500 ${
         isFading ? "opacity-0" : "opacity-100"
       }`}
     >


### PR DESCRIPTION
## What

The "New" unread divider was drawing its line over the bottom of the message *above* it (most visible in threads), instead of sitting in the gap between rows.

## Why

The divider was positioned with `-top-2 -translate-y-1/2`. Because `-translate-y-1/2` makes the line's center land exactly at the `top` value, `-top-2` placed the line ~8px **above** the first-unread row's wrapper edge.

But this timeline's spacing is asymmetric — nearly all of it lives in each row's *own top padding* (`pt-3` for message heads, `py-3` for agent-session cards — both 12px), which sits **below** that wrapper edge. The only clearance *above* the edge is the previous row's 2px `pb-0.5`. So the line floated up into the previous message's last line of text.

## Fix

- `unread-divider.tsx`: `-top-2` → `top-1.5`, dropping the line (+6px) into the unread row's own top-padding gap — clear of both the previous row's content and the unread row's content. Added a comment explaining the positioning math.
- `stream-content.tsx`: made the virtualized item wrapper `relative` so the divider anchors to its own row (and spans the 800px content width) in channels, matching the non-virtualized thread path, which already wraps the first-unread item in `relative`.

## Notes / risk

- The divider stays `absolute` + `pointer-events-none`, so there's still no layout shift when it appears/fades (INV-21).
- Adding `relative` to the virtualized wrapper is a no-op for position (the `mx-auto` div already fills the Virtuoso item) — it just establishes the containing block explicitly.
- Verified the +6px line clears the top-padding gap for every first-unread item type: heads (`pt-3`), agent cards (`py-3`), membership/system/moved rows (`py-2`). Command groups (`py-1.5`) coincide but the `bg-background` label covers and they're author-dispatched.

## Testing

CSS-positioning change — not measurable in jsdom. Existing `useUnreadDivider` hook tests pass; lint clean; full monorepo typecheck (pre-push hook) passed.

https://claude.ai/code/session_019kitzgbnCssJ9M26yHRQw3

---
_Generated by [Claude Code](https://claude.ai/code/session_019kitzgbnCssJ9M26yHRQw3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783371751&installation_id=129946197&pr_number=803&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F803&signature=ddb74f55f5a3815ed2a76c4995414bb1fe04b8e85a381c15d4a5fbf72731faf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->