### PR TITLE
Fix push-notification deep-link scroll jump + Giphy load reflow

### DIFF
--- a/apps/frontend/src/components/editor/giphy-embed-extension.ts
+++ b/apps/frontend/src/components/editor/giphy-embed-extension.ts
@@ -7,15 +7,26 @@ export interface GiphyEmbedAttrs {
   giphyUrl: string
   /** Cached Giphy title; cosmetic fallback label. */
   title: string
+  /** Intrinsic pixel size of the rendition, so the renderer reserves an
+   *  aspect-ratio box before the GIF loads (no layout shift). */
+  width: number | null
+  height: number | null
 }
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     giphyEmbed: {
       /** Insert an inline GIF embed rendered straight from Giphy's CDN. */
-      insertGiphyEmbed: (attrs: { giphyUrl: string; title?: string }) => ReturnType
+      insertGiphyEmbed: (attrs: { giphyUrl: string; title?: string; width?: number; height?: number }) => ReturnType
     }
   }
+}
+
+/** Coerce a `data-*` attribute to a positive integer, or null when absent/invalid. */
+function parseDimensionAttr(raw: string | null): number | null {
+  if (raw === null) return null
+  const value = Number(raw)
+  return Number.isInteger(value) && value > 0 ? value : null
 }
 
 /**
@@ -43,6 +54,16 @@ export const GiphyEmbedExtension = Node.create({
         default: "",
         parseHTML: (element) => element.getAttribute("data-title"),
         renderHTML: (attrs) => ({ "data-title": attrs.title }),
+      },
+      width: {
+        default: null,
+        parseHTML: (element) => parseDimensionAttr(element.getAttribute("data-width")),
+        renderHTML: (attrs) => (attrs.width ? { "data-width": String(attrs.width) } : {}),
+      },
+      height: {
+        default: null,
+        parseHTML: (element) => parseDimensionAttr(element.getAttribute("data-height")),
+        renderHTML: (attrs) => (attrs.height ? { "data-height": String(attrs.height) } : {}),
       },
     }
   },
@@ -73,7 +94,16 @@ export const GiphyEmbedExtension = Node.create({
           const marks = currentMarks.map((mark) => ({ type: mark.type.name, attrs: mark.attrs }))
           return chain()
             .insertContent([
-              { type: this.name, attrs: { giphyUrl: attrs.giphyUrl, title: attrs.title ?? "" }, marks },
+              {
+                type: this.name,
+                attrs: {
+                  giphyUrl: attrs.giphyUrl,
+                  title: attrs.title ?? "",
+                  width: attrs.width ?? null,
+                  height: attrs.height ?? null,
+                },
+                marks,
+              },
               { type: "text", text: " ", marks },
             ])
             .run()

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -448,7 +448,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const handleGifSelect = useCallback((gif: GiphyGif) => {
     const editorInstance = editorRef.current
     if (!editorInstance || editorInstance.isDestroyed) return
-    editorInstance.chain().focus().insertGiphyEmbed({ giphyUrl: gif.previewUrl, title: gif.title }).run()
+    editorInstance
+      .chain()
+      .focus()
+      .insertGiphyEmbed({ giphyUrl: gif.previewUrl, title: gif.title, width: gif.width, height: gif.height })
+      .run()
   }, [])
 
   const editor = useEditor({

--- a/apps/frontend/src/components/giphy/giphy-image.test.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.test.tsx
@@ -96,4 +96,20 @@ describe("GiphyImage — load reliability", () => {
     rerender(<GiphyImage url={nextUrl} title="wave" />)
     expect(getImg().getAttribute("src")).toBe(nextUrl)
   })
+
+  it("reserves an aspect-ratio box from intrinsic dimensions to avoid load reflow", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" width={480} height={270} />)
+    const img = getImg()
+    expect(img.getAttribute("width")).toBe("480")
+    expect(img.getAttribute("height")).toBe("270")
+    expect(img.style.aspectRatio).toBe("480 / 270")
+  })
+
+  it("omits dimension hints when none are known (legacy embeds) so nothing distorts", () => {
+    render(<GiphyImage url={GIF_URL} title="dance" />)
+    const img = getImg()
+    expect(img.getAttribute("width")).toBeNull()
+    expect(img.getAttribute("height")).toBeNull()
+    expect(img.style.aspectRatio).toBe("")
+  })
 })

--- a/apps/frontend/src/components/giphy/giphy-image.tsx
+++ b/apps/frontend/src/components/giphy/giphy-image.tsx
@@ -8,6 +8,10 @@ interface GiphyImageProps {
   url: string
   title?: string
   className?: string
+  /** Intrinsic pixel size of the rendition, when known. Used to reserve an
+   *  aspect-ratio box before the GIF decodes so the timeline doesn't reflow. */
+  width?: number
+  height?: number
 }
 
 // A transient CDN/network blip must not leave a GIF permanently broken until the
@@ -37,7 +41,13 @@ function withReloadParam(url: string, token: number): string {
  * looks the same wherever it appears. Failed loads are retried with backoff so a
  * transient CDN hiccup doesn't drop the asset until the next page refresh.
  */
-export function GiphyImage({ url, title, className }: GiphyImageProps) {
+export function GiphyImage({ url, title, className, width, height }: GiphyImageProps) {
+  // Reserve the GIF's box before its bytes decode. Without intrinsic dimensions
+  // the <img> lays out at ~0 height and grows to the decoded height on load,
+  // shifting every message below it — the "timeline jumps on load" report. With
+  // the width/height attributes plus an explicit aspect-ratio the browser
+  // reserves the (height-capped) box up front, so load is a no-reflow swap.
+  const hasDimensions = typeof width === "number" && typeof height === "number" && width > 0 && height > 0
   // Monotonic token: drives the <img> key and cache-bust param so every reload
   // is a genuinely fresh request rather than a reuse of the failed response.
   const [reloadToken, setReloadToken] = useState(0)
@@ -119,8 +129,11 @@ export function GiphyImage({ url, title, className }: GiphyImageProps) {
         src={withReloadParam(url, reloadToken)}
         alt={title || "GIF"}
         loading="lazy"
+        width={hasDimensions ? width : undefined}
+        height={hasDimensions ? height : undefined}
         onError={handleError}
         className="block max-h-64 w-auto max-w-full rounded-item"
+        style={hasDimensions ? { aspectRatio: `${width} / ${height}` } : undefined}
       />
       <span className="pointer-events-none absolute bottom-1.5 right-1.5 rounded-md bg-black/55 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-white/85 backdrop-blur-sm">
         GIPHY

--- a/apps/frontend/src/components/timeline/giphy-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/giphy-preview-list.tsx
@@ -15,7 +15,13 @@ export function GiphyPreviewList({ contentMarkdown }: { contentMarkdown: string 
   return (
     <div className="mt-2 flex flex-col items-start gap-2">
       {refs.map((ref) => (
-        <GiphyEmbedBlock key={ref.giphyUrl} giphyUrl={ref.giphyUrl} title={ref.title} />
+        <GiphyEmbedBlock
+          key={ref.giphyUrl}
+          giphyUrl={ref.giphyUrl}
+          title={ref.title}
+          width={ref.width}
+          height={ref.height}
+        />
       ))}
     </div>
   )

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { classifyDeepLinkScrollTick } from "./stream-content"
+import { classifyDeepLinkScrollTick, shouldStartHighlightClear } from "./stream-content"
 
 const DEADLINE = 4000
 
@@ -100,5 +100,53 @@ describe("classifyDeepLinkScrollTick", () => {
         deadlineMs: DEADLINE,
       })
     ).toBe("user-abort")
+  })
+})
+
+describe("shouldStartHighlightClear", () => {
+  it("never starts the countdown without a highlight target", () => {
+    for (const highlightMessageId of [null, undefined, ""] as const) {
+      expect(
+        shouldStartHighlightClear({
+          highlightMessageId,
+          deepLinkTargetLoaded: true,
+          deepLinkGaveUp: true,
+        })
+      ).toBe(false)
+    }
+  })
+
+  it("holds the param while a slow (cold push-notification) jump is still loading", () => {
+    // This is the regression guard: the old timer fired 3s from mount, so a
+    // cold boot whose jump window loads after that window cleared `?m=` before
+    // <Virtuoso> mounted, dropping the anchor and dumping the user at the top.
+    // The countdown must NOT start until the target is in the loaded window.
+    expect(
+      shouldStartHighlightClear({
+        highlightMessageId: "msg_1",
+        deepLinkTargetLoaded: false,
+        deepLinkGaveUp: false,
+      })
+    ).toBe(false)
+  })
+
+  it("starts the countdown once the deep-link target is in the loaded window", () => {
+    expect(
+      shouldStartHighlightClear({
+        highlightMessageId: "msg_1",
+        deepLinkTargetLoaded: true,
+        deepLinkGaveUp: false,
+      })
+    ).toBe(true)
+  })
+
+  it("starts the countdown once the jump conclusively fails so the param can't hang", () => {
+    expect(
+      shouldStartHighlightClear({
+        highlightMessageId: "msg_1",
+        deepLinkTargetLoaded: false,
+        deepLinkGaveUp: true,
+      })
+    ).toBe(true)
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1102,6 +1102,12 @@ export function StreamContent({
       if (phase === "deadline") {
         deepLinkDebug("post-jump: deadline exceeded, giving up", target)
         pendingScrollTarget.current = null
+        // The jump window loaded but the target never became placeable (e.g. a
+        // mid-flight window swap). Mark the deep-link as conclusively failed so
+        // the holdForDeepLink skeleton releases and the gated ?m= clear can
+        // fire — without this the skeleton/param would hang now that the clear
+        // no longer runs on a blind mount timer.
+        setDeepLinkGaveUp(true)
         return
       }
 
@@ -1126,7 +1132,7 @@ export function StreamContent({
         pendingScrollRafRef.current = 0
       }
     }
-  }, [events, isLoading, scrollToMessage, useVirtualized])
+  }, [events, isLoading, scrollToMessage, useVirtualized, setDeepLinkGaveUp])
 
   // Jump to highlighted message if it's not in the current event window.
   // The guard uses location.key so repeat clicks on the same message link
@@ -1265,16 +1271,6 @@ export function StreamContent({
     }
   }, [isJumpMode, exitJumpMode, resetPrependState, scrollToBottom])
 
-  if (error && !isDraft && events.length === 0 && !idbStream) {
-    return (
-      <ErrorView
-        className="h-full border-0"
-        title="Failed to Load Messages"
-        description="We couldn't load the messages for this stream. Please refresh the page or try again later."
-      />
-    )
-  }
-
   const editLastMessageCtxWithScroll = useMemo(
     () => ({ ...editLastMessageCtx, scrollToMessage }),
     [editLastMessageCtx, scrollToMessage]
@@ -1336,6 +1332,21 @@ export function StreamContent({
     }, 3000)
     return () => clearTimeout(timer)
   }, [canStartHighlightClear, setSearchParams])
+
+  // Hard load error with nothing cached to fall back on. Placed after every
+  // hook so the hook order stays stable: `error`/`idbStream` can toggle (a
+  // failed fetch that later succeeds, or IDB resolving a beat after first
+  // paint), and an early return above the hooks would change the hook count
+  // between renders and crash the route.
+  if (error && !isDraft && events.length === 0 && !idbStream) {
+    return (
+      <ErrorView
+        className="h-full border-0"
+        title="Failed to Load Messages"
+        description="We couldn't load the messages for this stream. Please refresh the page or try again later."
+      />
+    )
+  }
 
   return (
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -130,6 +130,33 @@ export function classifyDeepLinkScrollTick(args: {
   return "active"
 }
 
+/**
+ * Whether the `?m=` highlight fade-out countdown may start.
+ *
+ * The highlight param is stripped from the URL a few seconds after a deep-link
+ * lands, fading the highlight ring and returning the URL to its canonical form.
+ * The countdown must NOT start at mount. On a cold push-notification open the
+ * jump window (auth + workspace bootstrap + the events-around fetch) can take
+ * longer than the fade delay to load. If the param clears before <Virtuoso>
+ * mounts, the mount loses its `highlightMessageId` anchor
+ * (`effectiveInitialTopMostItemIndex` falls back to the hook's `undefined`) and
+ * the list mounts at index 0 — the *top* of the loaded window — leaving the
+ * user "dumped way up high" instead of centered on the linked message.
+ *
+ * Gate the countdown on the deep-link having actually landed (the target is in
+ * the loaded window) or conclusively failed (`deepLinkGaveUp`), so a slow load
+ * keeps the param — and thus the mount anchor — alive until the message is
+ * really there.
+ */
+export function shouldStartHighlightClear(args: {
+  highlightMessageId: string | null | undefined
+  deepLinkTargetLoaded: boolean
+  deepLinkGaveUp: boolean
+}): boolean {
+  if (!args.highlightMessageId) return false
+  return args.deepLinkTargetLoaded || args.deepLinkGaveUp
+}
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -194,22 +221,6 @@ export function StreamContent({
     dragging: boolean
     wasSelected: boolean
   } | null>(null)
-
-  // Clear highlight param after delay (works for both main view and panels)
-  useEffect(() => {
-    if (highlightMessageId) {
-      const timer = setTimeout(() => {
-        setSearchParams(
-          (prev) => {
-            prev.delete("m")
-            return prev
-          },
-          { replace: true }
-        )
-      }, 3000)
-      return () => clearTimeout(timer)
-    }
-  }, [highlightMessageId, setSearchParams])
 
   const idbStreams = useWorkspaceStreams(workspaceId)
   const idbMemberships = useWorkspaceStreamMemberships(workspaceId)
@@ -1278,7 +1289,8 @@ export function StreamContent({
   // to hell"). Holding the skeleton until the target is actually in the loaded
   // window makes the single keyed mount land already-anchored on it. Uses the
   // raw ?m= id (not the search-active id) so in-stream search is unaffected,
-  // and releases via deepLinkGaveUp / the 3s ?m= clear so it never hangs.
+  // and releases when the target loads (deepLinkTargetLoaded) or the jump
+  // conclusively fails (deepLinkGaveUp) so it never hangs.
   const deepLinkTargetLoaded = useMemo(
     () =>
       !highlightMessageId ||
@@ -1298,6 +1310,32 @@ export function StreamContent({
     prevHoldForDeepLinkRef.current = holdForDeepLink
     deepLinkDebug("holdForDeepLink ->", holdForDeepLink, "for", highlightMessageId)
   }
+
+  // Strip the `?m=` highlight param a few seconds after the deep-link lands,
+  // fading the highlight and restoring the canonical URL. Works for both the
+  // main view and panels. The countdown is gated on the deep-link having
+  // actually landed (or given up) rather than firing blindly from mount —
+  // otherwise a slow cold-boot (push-notification) open clears the param
+  // before <Virtuoso> mounts, dropping the mount anchor and dumping the user at
+  // the top of the window. See shouldStartHighlightClear.
+  const canStartHighlightClear = shouldStartHighlightClear({
+    highlightMessageId,
+    deepLinkTargetLoaded,
+    deepLinkGaveUp,
+  })
+  useEffect(() => {
+    if (!canStartHighlightClear) return
+    const timer = setTimeout(() => {
+      setSearchParams(
+        (prev) => {
+          prev.delete("m")
+          return prev
+        },
+        { replace: true }
+      )
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [canStartHighlightClear, setSearchParams])
 
   return (
     <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>

--- a/apps/frontend/src/lib/markdown/giphy-embed-block.tsx
+++ b/apps/frontend/src/lib/markdown/giphy-embed-block.tsx
@@ -5,6 +5,9 @@ interface GiphyEmbedBlockProps {
   giphyUrl: string
   /** Pre-render label parsed from the markdown link text. */
   title: string
+  /** Intrinsic pixel size of the rendition, when known, to reserve space. */
+  width?: number
+  height?: number
 }
 
 /**
@@ -13,7 +16,7 @@ interface GiphyEmbedBlockProps {
  * stays in the rendered markdown; this surfaces the actual GIF (from Giphy's
  * CDN), highlighted on hover the way attachment cards are.
  */
-export function GiphyEmbedBlock({ giphyUrl, title }: GiphyEmbedBlockProps) {
+export function GiphyEmbedBlock({ giphyUrl, title, width, height }: GiphyEmbedBlockProps) {
   return (
     <div
       className={cn(
@@ -22,7 +25,7 @@ export function GiphyEmbedBlock({ giphyUrl, title }: GiphyEmbedBlockProps) {
       )}
       data-type="giphy-embed"
     >
-      <GiphyImage url={giphyUrl} title={title} />
+      <GiphyImage url={giphyUrl} title={title} width={width} height={height} />
     </div>
   )
 }

--- a/apps/frontend/src/lib/markdown/giphy-refs.test.ts
+++ b/apps/frontend/src/lib/markdown/giphy-refs.test.ts
@@ -39,4 +39,17 @@ describe("extractGiphyRefs", () => {
   it("skips non-Giphy hosts", () => {
     expect(extractGiphyRefs("[evil](giphy:https%3A%2F%2Fevil.example.com%2Fx.gif)")).toEqual([])
   })
+
+  it("carries intrinsic dimensions through so the card can reserve its box", () => {
+    const md = serializeToMarkdown({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "giphyEmbed", attrs: { giphyUrl: GIF_URL, title: "cat", width: 480, height: 270 } }],
+        },
+      ],
+    })
+    expect(extractGiphyRefs(md)).toEqual([{ giphyUrl: GIF_URL, title: "cat", width: 480, height: 270 }])
+  })
 })

--- a/apps/frontend/src/lib/markdown/giphy-refs.ts
+++ b/apps/frontend/src/lib/markdown/giphy-refs.ts
@@ -8,6 +8,10 @@ import { parseGiphyHref } from "@threa/prosemirror"
 export interface GiphyRef {
   giphyUrl: string
   title: string
+  /** Intrinsic pixel size of the rendition, when the wire carried it, so the
+   *  preview card reserves an aspect-ratio box before the GIF loads. */
+  width?: number
+  height?: number
 }
 
 // Mirrors the giphy branch of the serializer: `[title](giphy:<encoded-url>)`.
@@ -28,7 +32,7 @@ export function extractGiphyRefs(markdown: string): GiphyRef[] {
     if (!parsed || seen.has(parsed.giphyUrl)) continue
     seen.add(parsed.giphyUrl)
     const title = match[1].replace(/\\([\]\\])/g, "$1")
-    refs.push({ giphyUrl: parsed.giphyUrl, title })
+    refs.push({ giphyUrl: parsed.giphyUrl, title, width: parsed.width, height: parsed.height })
   }
   return refs
 }

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -585,6 +585,33 @@ describe("@threa/prosemirror giphy embed round-trip", () => {
     const para = parsed.content?.[0]
     expect(para?.content?.some((n) => n.type === "giphyEmbed")).toBe(false)
   })
+
+  it("round-trips intrinsic dimensions so the renderer can reserve the box", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "giphyEmbed", attrs: { giphyUrl: GIF_URL, title: "cat", width: 480, height: 270 } }],
+        },
+      ],
+    }
+    const parsed = parseMarkdown(serializeToMarkdown(doc))
+    expect(parsed.content?.[0]).toEqual({
+      type: "paragraph",
+      content: [{ type: "giphyEmbed", attrs: { giphyUrl: GIF_URL, title: "cat", width: 480, height: 270 } }],
+    })
+  })
+
+  it("omits the dimension suffix when dimensions are absent (no width/height keys)", () => {
+    const markdown = serializeToMarkdown({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "giphyEmbed", attrs: { giphyUrl: GIF_URL, title: "cat" } }] }],
+    })
+    expect(markdown).not.toContain("?w=")
+    const node = parseMarkdown(markdown).content?.[0]?.content?.[0]
+    expect(node).toEqual({ type: "giphyEmbed", attrs: { giphyUrl: GIF_URL, title: "cat" } })
+  })
 })
 
 describe("mention/channel whitespace boundary", () => {

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -299,7 +299,9 @@ function getNodeText(node: JSONContent): string {
     const title = node.attrs?.title as string | undefined
     const rawTitle = title && title.length > 0 ? title : "GIF"
     const safeTitle = rawTitle.replace(/[[\]\\\n]/g, " ").trim() || "GIF"
-    return `[${safeTitle}](${buildGiphyHref({ giphyUrl })})`
+    const width = node.attrs?.width as number | undefined
+    const height = node.attrs?.height as number | undefined
+    return `[${safeTitle}](${buildGiphyHref({ giphyUrl, width, height })})`
   }
   if (node.type === "text") return node.text ?? ""
   return ""
@@ -960,7 +962,15 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
       // dedicated regex group is needed; the encoded URL never contains a `)`.
       const giphyHref = parseGiphyHref(linkUrl)
       if (giphyHref) {
-        result.push({ type: "giphyEmbed", attrs: { giphyUrl: giphyHref.giphyUrl, title: linkText } })
+        const attrs: { giphyUrl: string; title: string; width?: number; height?: number } = {
+          giphyUrl: giphyHref.giphyUrl,
+          title: linkText,
+        }
+        if (giphyHref.width && giphyHref.height) {
+          attrs.width = giphyHref.width
+          attrs.height = giphyHref.height
+        }
+        result.push({ type: "giphyEmbed", attrs })
         lastIndex = match.index + match[0].length
         continue
       }

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -101,6 +101,12 @@ export interface GiphyHref {
  * cached title rides on the link text. Intrinsic dimensions ride as a trailing
  * `?w=&h=` query: `encodeURIComponent` escapes `?`/`&`/`=`, so the encoded URL
  * can never contain those literally and the suffix is unambiguous on parse.
+ *
+ * Unlike attachments — whose metadata rides the markdown link *title* slot
+ * (`[text](attachment:id "threa-attachment:...")`, see `attachment-markdown.ts`)
+ * via a dedicated regex group — a `giphy:` link is detected inside the generic
+ * link branch, which has no title capture. Keeping the dimensions on the
+ * pseudo-URI that `parseGiphyHref` already owns is the cohesive fit here.
  */
 export function buildGiphyHref(params: GiphyHref): string {
   const encoded = encodeURIComponent(params.giphyUrl).replace(/\(/g, "%28").replace(/\)/g, "%29")

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -88,24 +88,38 @@ export function parseMemoHref(href: string): MemoHref | null {
 
 export interface GiphyHref {
   giphyUrl: string
+  /** Intrinsic pixel size of the rendition, when known, so the renderer can
+   *  reserve an aspect-ratio box before the GIF loads. */
+  width?: number
+  height?: number
 }
 
 /**
- * `giphy:<encoded CDN url>` — the inline pointer a `giphyEmbed` node serialises
- * to. The URL is percent-encoded (parens included) so it can't contain a `)`
- * that would truncate the surrounding markdown link, and the cached title rides
- * on the link text.
+ * `giphy:<encoded CDN url>[?w=<n>&h=<n>]` — the inline pointer a `giphyEmbed`
+ * node serialises to. The URL is percent-encoded (parens included) so it can't
+ * contain a `)` that would truncate the surrounding markdown link, and the
+ * cached title rides on the link text. Intrinsic dimensions ride as a trailing
+ * `?w=&h=` query: `encodeURIComponent` escapes `?`/`&`/`=`, so the encoded URL
+ * can never contain those literally and the suffix is unambiguous on parse.
  */
 export function buildGiphyHref(params: GiphyHref): string {
   const encoded = encodeURIComponent(params.giphyUrl).replace(/\(/g, "%28").replace(/\)/g, "%29")
+  if (isPositiveInt(params.width) && isPositiveInt(params.height)) {
+    return `giphy:${encoded}?w=${params.width}&h=${params.height}`
+  }
   return `giphy:${encoded}`
 }
 
 export function parseGiphyHref(href: string): GiphyHref | null {
   if (!href.startsWith("giphy:")) return null
+  const body = href.slice("giphy:".length)
+  // The encoded CDN url can't contain a literal `?` (encodeURIComponent escapes
+  // it), so the first `?` cleanly separates the url from the dimension query.
+  const queryIndex = body.indexOf("?")
+  const encodedUrl = queryIndex >= 0 ? body.slice(0, queryIndex) : body
   let giphyUrl: string
   try {
-    giphyUrl = decodeURIComponent(href.slice("giphy:".length))
+    giphyUrl = decodeURIComponent(encodedUrl)
   } catch {
     return null
   }
@@ -119,5 +133,21 @@ export function parseGiphyHref(href: string): GiphyHref | null {
   }
   if (parsed.protocol !== "https:") return null
   if (parsed.hostname !== "giphy.com" && !parsed.hostname.endsWith(".giphy.com")) return null
-  return { giphyUrl }
+
+  const dims = queryIndex >= 0 ? parseGiphyDimensions(body.slice(queryIndex + 1)) : undefined
+  return dims ? { giphyUrl, ...dims } : { giphyUrl }
+}
+
+function isPositiveInt(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+}
+
+/** Parse the `w=<n>&h=<n>` dimension suffix; returns undefined unless both are
+ *  present as positive integers, so a malformed suffix degrades to "no dims". */
+function parseGiphyDimensions(query: string): { width: number; height: number } | undefined {
+  const params = new URLSearchParams(query)
+  const width = Number(params.get("w"))
+  const height = Number(params.get("h"))
+  if (!isPositiveInt(width) || !isPositiveInt(height)) return undefined
+  return { width, height }
 }

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -292,6 +292,13 @@ export interface ThreaGiphyEmbed {
     giphyUrl: string
     /** Cached Giphy title; cosmetic fallback for markdown/preview text. */
     title?: string
+    /**
+     * Intrinsic pixel size of the rendition, carried so the renderer can
+     * reserve an aspect-ratio box before the GIF loads — without it the row
+     * grows from ~0 to the decoded height and shifts the timeline.
+     */
+    width?: number
+    height?: number
   }
 }
 
@@ -448,6 +455,8 @@ const giphyEmbedNodeSchema = z.object({
   attrs: z.object({
     giphyUrl: z.string().refine(isGiphyMediaUrl, "giphyUrl must be an https URL on a *.giphy.com host"),
     title: z.string().optional(),
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional(),
   }),
 })
 


### PR DESCRIPTION
## What

Two scroll-position bugs in the stream timeline.

### 1. Opening a chat from a push notification dumps you at the top of the window

The `?m=` highlight param was stripped from the URL on a fixed **3-second timer that started the moment the param appeared at mount** — not when the deep-link actually landed.

The deep-link mount is anchored entirely on `highlightMessageId` being present: `effectiveInitialTopMostItemIndex` reads the target's index to mount `<Virtuoso>` centered on it. On a cold push-notification open the path is slow (auth → workspace bootstrap → `jumpToEvent` fetches the events-around window → `holdForDeepLink` skeleton → keyed mount). When that crossed the 3s boundary, `?m=` was already gone, so the anchor fell back to the scroll hook's `undefined` and the list mounted at **index 0 — the top of the window**, with `scrollToMessage` having nothing to converge on. That's why it hit cold-boot push opens far more than warm in-app navigation.

**Fix:** gate the fade-out countdown on the deep-link having actually landed (target is in the loaded window) or conclusively failed (`deepLinkGaveUp`), via a pure `shouldStartHighlightClear` helper. A slow load now keeps the param — and the mount anchor — alive until the message is really there.

### 2. The timeline jumps when the app loads anew (Giphy)

`GiphyImage` rendered an `<img>` with no reserved size (`max-h-64 w-auto`), so it laid out at ~0 height and grew to the decoded height on load, shifting every message below it — and feeding Virtuoso wrong row heights during its hidden measure pass.

**Fix:** carry the rendition's intrinsic `width`/`height` (already returned by the Giphy API and used by the picker grid) end-to-end so the renderer reserves an aspect-ratio box up front:
- `giphyEmbed` node attrs gain optional `width`/`height` (types Zod schema + tiptap extension), captured at pick time.
- The `giphy:` pointer URL carries them as a trailing `?w=&h=` query (the percent-encoded CDN url can't contain a literal `?`/`&`/`=`, so it's unambiguous); `build/parseGiphyHref` + markdown serialize/parse round-trip losslessly.
- `extractGiphyRefs` → `GiphyPreviewList` → `GiphyEmbedBlock` → `GiphyImage`, which sets the `<img>` dimension attrs + explicit `aspect-ratio` (the CLS-prevention pattern the picker already uses).

As a bonus, the reserved box lets Virtuoso measure correct heights before GIFs decode, which also stabilizes rows *above* a deep-linked target.

## Design decisions

- **`?w=&h=` on the giphy pointer vs the attachment title-slot pattern:** attachments carry metadata in the markdown link *title* slot via a dedicated regex group; a `giphy:` link is detected inside the generic link branch, which has no title capture. Keeping the dimensions on the pseudo-URI that `parseGiphyHref` already owns is the cohesive fit, and it round-trips losslessly. Documented inline.
- **Legacy GIFs** (already on the wire without `?w=&h=`) fall back to the prior behavior — there's no stored dimension to recover without re-querying Giphy. Newly sent GIFs are stable.

## Self-review

Ran a multi-perspective review (spec/CLAUDE.md, correctness/security, design) before opening. It caught two real issues, now fixed in `515c1a1`:
- **Never-hang:** the convergent post-jump driver's deadline branch now sets `deepLinkGaveUp(true)`. The old unconditional timer always released the `holdForDeepLink` skeleton by deleting `?m=`; the new gated clear releases only on land/give-up, so a `jumpToEvent` that succeeds but whose target never becomes placeable (a mid-flight window swap) hitting the 4s deadline would otherwise hang the skeleton/param forever.
- **Hook order:** moved the hard load-error early return below every hook so the `?m=` clear effect always runs — `error`/`idbStream` can toggle and an early return above the hooks would change the hook count between renders and crash the route.

## Testing

- `shouldStartHighlightClear` unit tests (gate stays closed during a slow load, opens on land/give-up).
- Giphy dimension round-trip tests in `@threa/prosemirror` (markdown + pointer-url) and `extractGiphyRefs`; `GiphyImage` reserves the aspect-ratio box and falls back cleanly for legacy embeds.
- Frontend editor/markdown/giphy/timeline suites (440) + prosemirror suite green; types/prosemirror/frontend typecheck clean; all three commits passed the full-monorepo lint+typecheck pre-commit hook.

https://claude.ai/code/session_01L9qZRXTDZu2jrtzhtfF2yB

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9qZRXTDZu2jrtzhtfF2yB)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783372323&installation_id=129946197&pr_number=804&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F804&signature=d5153e7d4f600c3f68a1bcfae9ce725d187ae00fcfa26926a2cf0178014a09d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->