### PR TITLE
Speed up cached app start and stop the skeleton flicker

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -12,6 +12,7 @@ import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
+import { resetRevealGate } from "@/sync/reveal-gate"
 import { useAuth } from "./hooks"
 
 const NO_ACCOUNT_KEY = "__no_account__"
@@ -68,6 +69,7 @@ function flushModuleStoreCaches(): void {
   resetDraftStoreCache()
   resetShareHandoffStoreCache()
   resetE2eSessionStoreCache()
+  resetRevealGate()
 }
 
 interface AccountScopeProviderProps {

--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -178,7 +178,7 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("phase").textContent).toBe("loading")
   })
 
-  it("transitions to skeleton after 300ms if still loading", async () => {
+  it("stays blank through a slightly-slow load and only shows the skeleton after 600ms", async () => {
     render(
       <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
         <TestConsumer />
@@ -188,8 +188,9 @@ describe("CoordinatedLoadingProvider", () => {
     await flushEffects()
     expect(screen.getByTestId("phase").textContent).toBe("loading")
 
+    // A slightly-slow load (under 600ms) must not flash a skeleton.
     act(() => {
-      vi.advanceTimersByTime(299)
+      vi.advanceTimersByTime(599)
     })
     expect(screen.getByTestId("phase").textContent).toBe("loading")
 
@@ -197,6 +198,61 @@ describe("CoordinatedLoadingProvider", () => {
       vi.advanceTimersByTime(1)
     })
     expect(screen.getByTestId("phase").textContent).toBe("skeleton")
+  })
+
+  it("holds the skeleton until ready instead of blanking when loading finishes first", async () => {
+    // Flicker regression: online, the network query can flip `isLoading` false a
+    // beat before the cached reveal settles `isReady`. The old gate reset the
+    // skeleton on that transition, producing skeleton → blank → content. The
+    // skeleton must stay up until the content is actually ready.
+    mockHasSeededWorkspaceCache = true
+    mockWorkspace = { id: "workspace_1" }
+    mockUsers = [{ id: "user_1", avatarUrl: "https://cdn.example/avatar.png" }]
+    mockStreams = [{ id: "stream_1" }]
+    mockUnreadState = { id: "workspace_1" }
+    mockMetadata = { id: "workspace_1" }
+    mockSidebarConfig = { id: "workspace_1" }
+    mockStreamsLoadState = QUERY_LOAD_STATE.READY
+    // Not primed from a prior session and avatars still preloading, so the
+    // reveal can't settle yet (revealReady stays false).
+    mockSeedCacheFromIdbResult = false
+    const preloadSpy = vi.spyOn(usePreloadImagesModule, "usePreloadImages").mockReturnValue(false)
+    // Drafts still loading keeps the initial load going so the skeleton arms.
+    mockHasSeededDraftCache = false
+
+    const { rerender } = render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(screen.getByTestId("phase").textContent).toBe("skeleton")
+
+    // Loading finishes (drafts seeded) but the reveal still can't settle
+    // (avatars not preloaded, cache not primed) — phase must hold on skeleton,
+    // never regress to the blank "loading" phase.
+    mockHasSeededDraftCache = true
+    rerender(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+    await flushEffects()
+    expect(screen.getByTestId("phase").textContent).toBe("skeleton")
+
+    // Once the reveal can settle, it goes straight to content.
+    preloadSpy.mockReturnValue(true)
+    rerender(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+    await flushEffects()
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
   })
 
   it("is ready when IDB is primed and stream record exists (no per-stream cache needed)", async () => {
@@ -594,7 +650,7 @@ describe("CoordinatedLoadingGate", () => {
 
     await flushEffects()
     act(() => {
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(600)
     })
 
     expect(screen.getByTestId("content")).toBeInTheDocument()

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/query-load-state"
 import { StreamContentSkeleton } from "@/components/loading"
 import { ApiError } from "@/api/client"
+import { markInitialRevealComplete } from "@/sync/reveal-gate"
 import { getAvatarUrl } from "@threa/types"
 
 /**
@@ -77,11 +78,20 @@ interface CoordinatedLoadingProviderProps {
 }
 
 /**
- * Delay before the loading skeleton becomes visible in the global
- * initial-load gate (`CoordinatedLoadingProvider`) so fast switches
- * never flash a skeleton.
+ * Delay before the top-bar loading indicator becomes visible in the global
+ * initial-load gate (`CoordinatedLoadingProvider`) so fast switches never
+ * flash it.
  */
 export const LOADING_DELAY_MS = 300
+
+/**
+ * Delay before the loading skeleton becomes visible. Deliberately longer than
+ * `LOADING_DELAY_MS`: a slightly-slow load that finishes within this window
+ * should go blank → content with no skeleton at all, because a skeleton that
+ * shows for a frame and is immediately replaced reads as a flicker. Only a
+ * genuinely slow load — still loading past this delay — earns a skeleton.
+ */
+export const SKELETON_DELAY_MS = 600
 
 export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }: CoordinatedLoadingProviderProps) {
   const [showSkeleton, setShowSkeleton] = useState(false)
@@ -303,6 +313,14 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
     }
   }, [isLoading, revealReady])
 
+  // Tell the background sync the cached content has painted, so its first
+  // bootstrap can commit to IndexedDB without starving the reads that gate this
+  // reveal (see reveal-gate.ts). Harmless on a cold load — the sync doesn't wait
+  // there — and idempotent across re-renders / StrictMode double-mounts.
+  useEffect(() => {
+    if (isReady) markInitialRevealComplete(workspaceId)
+  }, [isReady, workspaceId])
+
   // Once the content is revealed AND the initial background sync has gone quiet,
   // any future "syncing" is a reconnect resync — that one is worth surfacing on
   // the topbar indicator (see `isLoading`). The initial freshness pass that
@@ -311,22 +329,28 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
     if (isReady && !isAnySyncing) hasSettledInitialSyncRef.current = true
   }, [isReady, isAnySyncing])
 
-  // Show skeleton after delay if still loading during initial load
+  // Show the skeleton only if the initial load is still going after
+  // SKELETON_DELAY_MS. Once shown, it stays up until the content is ready — we
+  // deliberately do NOT drop back to blank when `isLoading` flips false ahead of
+  // `isReady` (a common race online, where the network query resolves a beat
+  // before the cached reveal settles). Blanking there produced a
+  // skeleton → blank → content flicker.
   useEffect(() => {
-    // Once ready, never show skeleton again
+    // Once ready, the content shows and the skeleton is no longer needed.
     if (isReady) {
       setShowSkeleton(false)
       return
     }
 
-    if (!isLoading) {
-      setShowSkeleton(false)
-      return
-    }
+    // Loading finished but the reveal hasn't settled yet: hold whatever we're
+    // showing (sticky) rather than blanking between skeleton and content. The
+    // cleanup below already cleared any armed timer, so a fast load that
+    // finishes before the delay never flips the skeleton on.
+    if (!isLoading) return
 
     const timer = setTimeout(() => {
       setShowSkeleton(true)
-    }, LOADING_DELAY_MS)
+    }, SKELETON_DELAY_MS)
 
     return () => clearTimeout(timer)
   }, [isLoading, isReady])

--- a/apps/frontend/src/sync/reveal-gate.test.ts
+++ b/apps/frontend/src/sync/reveal-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { markInitialRevealComplete, waitForInitialReveal, resetRevealGate } from "./reveal-gate"
+
+describe("reveal-gate", () => {
+  beforeEach(() => {
+    resetRevealGate()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("resolves the wait once the reveal is marked complete", async () => {
+    let resolved = false
+    const wait = waitForInitialReveal("ws_1").then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    markInitialRevealComplete("ws_1")
+    await wait
+    expect(resolved).toBe(true)
+  })
+
+  it("resolves immediately when the reveal already happened", async () => {
+    markInitialRevealComplete("ws_1")
+
+    let resolved = false
+    await waitForInitialReveal("ws_1").then(() => {
+      resolved = true
+    })
+    expect(resolved).toBe(true)
+  })
+
+  it("falls back to the timeout so freshness is never indefinitely delayed", async () => {
+    vi.useFakeTimers()
+
+    let resolved = false
+    const wait = waitForInitialReveal("ws_1", 2000).then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await wait
+    expect(resolved).toBe(true)
+  })
+
+  it("keeps reveal state independent per workspace", async () => {
+    markInitialRevealComplete("ws_a")
+
+    let aResolved = false
+    let bResolved = false
+    void waitForInitialReveal("ws_a").then(() => {
+      aResolved = true
+    })
+    void waitForInitialReveal("ws_b").then(() => {
+      bResolved = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(aResolved).toBe(true)
+    expect(bResolved).toBe(false)
+  })
+})

--- a/apps/frontend/src/sync/reveal-gate.ts
+++ b/apps/frontend/src/sync/reveal-gate.ts
@@ -15,6 +15,16 @@
  * indefinitely delayed, and only ever engaged on a warm first connect — a cold
  * start has nothing cached to reveal, and reconnects already have content on
  * screen.
+ *
+ * INV-9 exception: the per-workspace state lives in a module-level Map by
+ * design. The producer (`markInitialRevealComplete`, from a React effect in
+ * `CoordinatedLoadingProvider`) and the consumer (`waitForInitialReveal`, in
+ * the plain `SyncEngine` class) sit on opposite sides of the React/non-React
+ * seam, so a context would have to thread a promise from the gate into the sync
+ * engine for no benefit. Keys are globally-unique workspace ULIDs (INV-2), so
+ * there is no cross-workspace collision; `resetRevealGate` is wired into
+ * `flushModuleStoreCaches` (auth/account-scope.tsx) so an account switch clears
+ * it alongside every other module-level store cache.
  */
 
 const REVEAL_TIMEOUT_MS = 2000
@@ -72,7 +82,11 @@ export function waitForInitialReveal(workspaceId: string, timeoutMs = REVEAL_TIM
   })
 }
 
-/** Test-only: clear all reveal state between cases. */
+/**
+ * Clear all reveal state. Called on account switch via `flushModuleStoreCaches`
+ * (so a parked account's reveal flags never bleed into the next), and by tests
+ * between cases.
+ */
 export function resetRevealGate(): void {
   states.clear()
 }

--- a/apps/frontend/src/sync/reveal-gate.ts
+++ b/apps/frontend/src/sync/reveal-gate.ts
@@ -1,0 +1,78 @@
+/**
+ * Coordinates the first cached reveal with the background workspace sync so the
+ * sync's IndexedDB write doesn't starve the reads that gate that reveal.
+ *
+ * On a warm start the `CoordinatedLoadingProvider` reads the cached read model
+ * from IndexedDB to paint instantly (offline-first). The `SyncEngine`, on its
+ * first connect, fetches a fresh workspace bootstrap and writes it back to the
+ * same IndexedDB stores. IndexedDB serializes `readwrite` against `readonly` on
+ * shared stores, so an un-gated write queues the reveal's reads behind it —
+ * which is why an online start lagged an offline one (offline never writes).
+ *
+ * The fix lets the reveal win the race: the fetch still runs immediately (we do
+ * not defer freshness over the wire), but the engine waits for the cached paint
+ * before committing the write. Bounded by a timeout so freshness is never
+ * indefinitely delayed, and only ever engaged on a warm first connect — a cold
+ * start has nothing cached to reveal, and reconnects already have content on
+ * screen.
+ */
+
+const REVEAL_TIMEOUT_MS = 2000
+
+interface RevealState {
+  revealed: boolean
+  promise: Promise<void> | null
+  resolve: (() => void) | null
+}
+
+const states = new Map<string, RevealState>()
+
+function getState(workspaceId: string): RevealState {
+  let state = states.get(workspaceId)
+  if (!state) {
+    state = { revealed: false, promise: null, resolve: null }
+    states.set(workspaceId, state)
+  }
+  return state
+}
+
+/**
+ * Signal that the cached content for a workspace has painted. Idempotent —
+ * later calls (and re-renders / StrictMode double-mounts) are no-ops.
+ */
+export function markInitialRevealComplete(workspaceId: string): void {
+  const state = getState(workspaceId)
+  state.revealed = true
+  state.resolve?.()
+  state.resolve = null
+}
+
+/**
+ * Resolve once the cached reveal for a workspace has painted, or after
+ * `timeoutMs` — whichever comes first. Resolves immediately if the reveal has
+ * already happened.
+ */
+export function waitForInitialReveal(workspaceId: string, timeoutMs = REVEAL_TIMEOUT_MS): Promise<void> {
+  const state = getState(workspaceId)
+  if (state.revealed) return Promise.resolve()
+
+  if (!state.promise) {
+    state.promise = new Promise<void>((resolve) => {
+      state.resolve = resolve
+    })
+  }
+  const revealPromise = state.promise
+
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs)
+    void revealPromise.then(() => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}
+
+/** Test-only: clear all reveal state between cases. */
+export function resetRevealGate(): void {
+  states.clear()
+}

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -636,4 +636,29 @@ describe("SyncEngine.handlePageResume", () => {
 
     expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeDefined()
   })
+
+  it("does not write the bootstrap if the engine is torn down during the reveal wait", async () => {
+    // Account/workspace switch destroys the engine and repoints the shared db
+    // proxy + queryClient while bootstrapWorkspace is parked on the reveal wait.
+    // The stale bootstrap must not be committed into the now-foreign account.
+    await seedRevealableWorkspace("ws_1")
+
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    const connectPromise = engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => {
+      expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    })
+
+    // Torn down mid-wait, then the reveal fires (e.g. the timeout, or the new
+    // subtree's gate). The resumed write must bail.
+    engine.destroy()
+    markInitialRevealComplete("ws_1")
+    await connectPromise
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeUndefined()
+  })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -3,6 +3,8 @@ import type { Socket } from "socket.io-client"
 import { QueryClient } from "@tanstack/react-query"
 import { SyncEngine } from "./sync-engine"
 import { SyncStatusStore } from "./sync-status"
+import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
@@ -207,6 +209,7 @@ async function primeConnectedEngine(engine: SyncEngine, socket: MockSocket): Pro
 
 describe("SyncEngine.handlePageResume", () => {
   beforeEach(async () => {
+    resetRevealGate()
     await Promise.all([
       db.workspaces.clear(),
       db.workspaceUsers.clear(),
@@ -526,5 +529,55 @@ describe("SyncEngine.handlePageResume", () => {
       const joinedRooms = socket.emittedEvents.filter((event) => event.event === "join").map((event) => event.args[0])
       expect(joinedRooms).toContain("ws:ws_1:stream:stream_42")
     })
+  })
+
+  it("fetches immediately on the first warm connect but holds the IDB write until the cached reveal paints", async () => {
+    // Online-slower-than-offline regression: the network fetch must run right
+    // away, but applyWorkspaceBootstrap's IndexedDB write has to wait for the
+    // cached reveal so it doesn't starve the reveal's reads.
+    const now = new Date().toISOString()
+    await db.workspaces.put({
+      id: "ws_1",
+      name: "Cached",
+      slug: "cached",
+      createdAt: now,
+      updatedAt: now,
+      _cachedAt: Date.now(),
+    })
+
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    // Don't await — the write is parked behind the reveal until we signal it.
+    const connectPromise = engine.onConnect(asSocket(socket))
+
+    // The fetch fires immediately, in parallel with the (not-yet-signalled) reveal.
+    await vi.waitFor(() => {
+      expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    })
+    // ...but the bootstrap has not been committed to the query cache yet.
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeUndefined()
+
+    // Cached content painted → the write is released.
+    markInitialRevealComplete("ws_1")
+    await connectPromise
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeDefined()
+  })
+
+  it("commits the write without waiting on a cold first connect (nothing cached to reveal)", async () => {
+    // No cached workspace row: there's nothing to reveal, so the bootstrap must
+    // commit without waiting — otherwise a first-ever load would stall on the
+    // reveal timeout.
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeDefined()
   })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -207,6 +207,46 @@ async function primeConnectedEngine(engine: SyncEngine, socket: MockSocket): Pro
   await engine.onConnect(asSocket(socket))
 }
 
+/**
+ * Seed the full set of IDB rows the coordinated-loading gate requires to reveal
+ * from cache: the workspace row plus the unread / metadata / sidebar singletons.
+ * Mirrors `workspaceDataReady` in coordinated-loading-context.tsx so the engine's
+ * write-deferral check sees a complete cache.
+ */
+async function seedRevealableWorkspace(workspaceId: string): Promise<void> {
+  const now = new Date().toISOString()
+  const cachedAt = Date.now()
+  await Promise.all([
+    db.workspaces.put({
+      id: workspaceId,
+      name: "Cached",
+      slug: "cached",
+      createdAt: now,
+      updatedAt: now,
+      _cachedAt: cachedAt,
+    }),
+    db.unreadState.put({
+      id: workspaceId,
+      workspaceId,
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      mutedStreamIds: [],
+      _cachedAt: cachedAt,
+    }),
+    db.workspaceMetadata.put({
+      id: workspaceId,
+      workspaceId,
+      emojis: [],
+      emojiWeights: {},
+      commands: [],
+      _cachedAt: cachedAt,
+    }),
+    db.sidebarConfigs.put({ id: workspaceId, workspaceId, config: DEFAULT_SIDEBAR_CONFIG, _cachedAt: cachedAt }),
+  ])
+}
+
 describe("SyncEngine.handlePageResume", () => {
   beforeEach(async () => {
     resetRevealGate()
@@ -221,6 +261,7 @@ describe("SyncEngine.handlePageResume", () => {
       db.unreadState.clear(),
       db.userPreferences.clear(),
       db.workspaceMetadata.clear(),
+      db.sidebarConfigs.clear(),
       db.events.clear(),
       db.pendingMessages.clear(),
     ])
@@ -535,15 +576,7 @@ describe("SyncEngine.handlePageResume", () => {
     // Online-slower-than-offline regression: the network fetch must run right
     // away, but applyWorkspaceBootstrap's IndexedDB write has to wait for the
     // cached reveal so it doesn't starve the reveal's reads.
-    const now = new Date().toISOString()
-    await db.workspaces.put({
-      id: "ws_1",
-      name: "Cached",
-      slug: "cached",
-      createdAt: now,
-      updatedAt: now,
-      _cachedAt: Date.now(),
-    })
+    await seedRevealableWorkspace("ws_1")
 
     const deps = makeDeps()
     const engine = new SyncEngine(deps)
@@ -576,6 +609,29 @@ describe("SyncEngine.handlePageResume", () => {
     const socket = new MockSocket()
     socket.ackBehavior = "immediate"
 
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeDefined()
+  })
+
+  it("does not wait when the cache is partial (workspace row present, gating singleton missing)", async () => {
+    // Deadlock guard: the gate only reveals once the workspace row AND the
+    // unread/metadata/sidebar singletons are all cached. A partial cache (e.g.
+    // an interrupted prior session, or a schema upgrade that added a gating
+    // singleton) can only become ready once THIS write lands — so the engine
+    // must NOT wait on the reveal, or it would stall until the timeout. Here
+    // the sidebar config is missing, so the write commits immediately even
+    // though no reveal is ever signalled.
+    await seedRevealableWorkspace("ws_1")
+    await db.sidebarConfigs.delete("ws_1")
+
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    // Awaiting onConnect would hang for the full reveal timeout if the write
+    // were (incorrectly) gated — instead it resolves promptly.
     await engine.onConnect(asSocket(socket))
 
     expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeDefined()

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -385,6 +385,13 @@ export class SyncEngine {
           if (canRevealFromCache) await waitForInitialReveal(workspaceId)
         }
 
+        // An account/workspace switch tears this engine down (isDestroyed) and
+        // repoints the shared `db` proxy + queryClient before the new subtree
+        // mounts. Any await above (the fetch, the cache probe, the reveal wait)
+        // can outlive that switch, so bail before writing — otherwise this stale
+        // bootstrap lands in the newly-active account's IDB and cache.
+        if (this.isDestroyed) return
+
         // Write to IDB (source of truth)
         await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -362,12 +362,27 @@ export class SyncEngine {
         // against readonly, so an un-gated write here queues the reveal's reads
         // behind it — the reason an online start lagged an offline one. The fetch
         // above already ran in parallel with the reveal, so this only delays the
-        // write by the (bounded) time the paint needs. Skipped on a cold start
-        // (nothing cached to reveal) and on reconnects (content already on
-        // screen), where the write must land promptly. See reveal-gate.ts.
+        // write by the (bounded) time the paint needs. Skipped on reconnects
+        // (content already on screen), where the write must land promptly. See
+        // reveal-gate.ts.
         if (!_isReconnect) {
-          const hasCachedData = (await db.workspaces.get(workspaceId)) !== undefined
-          if (hasCachedData) await waitForInitialReveal(workspaceId)
+          // Only defer when the cache is complete enough for the gate to reveal
+          // WITHOUT this write. The coordinated-loading gate holds its reveal
+          // until the workspace row plus the unread / metadata / sidebar
+          // singletons are all present (see coordinated-loading-context.tsx's
+          // `workspaceDataReady`). If any are missing — a cold start, or a
+          // partial cache from an interrupted/upgraded prior session — the gate
+          // can only become ready once THIS write lands, so waiting on the
+          // reveal would deadlock until the timeout. In that case we write
+          // immediately and let the gate reveal off the fresh write.
+          const [workspace, unreadState, metadata, sidebarConfig] = await Promise.all([
+            db.workspaces.get(workspaceId),
+            db.unreadState.get(workspaceId),
+            db.workspaceMetadata.get(workspaceId),
+            db.sidebarConfigs.get(workspaceId),
+          ])
+          const canRevealFromCache = !!workspace && !!unreadState && !!metadata && !!sidebarConfig
+          if (canRevealFromCache) await waitForInitialReveal(workspaceId)
         }
 
         // Write to IDB (source of truth)

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -18,6 +18,7 @@ import {
   type CachedStreamBootstrap,
 } from "./stream-sync"
 import { processOperationQueue } from "./operation-queue"
+import { waitForInitialReveal } from "./reveal-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -352,7 +353,22 @@ export class SyncEngine {
           syncStatus.set(`stream:${streamId}`, status)
         }
       } else {
+        // Fire the fetch immediately — freshness is never deferred over the wire.
         bootstrap = await workspaceService.bootstrap(workspaceId)
+
+        // On the very first connect of a warm start, hold the IndexedDB write
+        // until the cached reveal has painted. applyWorkspaceBootstrap writes the
+        // same stores the reveal reads, and IndexedDB serializes readwrite
+        // against readonly, so an un-gated write here queues the reveal's reads
+        // behind it — the reason an online start lagged an offline one. The fetch
+        // above already ran in parallel with the reveal, so this only delays the
+        // write by the (bounded) time the paint needs. Skipped on a cold start
+        // (nothing cached to reveal) and on reconnects (content already on
+        // screen), where the write must land promptly. See reveal-gate.ts.
+        if (!_isReconnect) {
+          const hasCachedData = (await db.workspaces.get(workspaceId)) !== undefined
+          if (hasCachedData) await waitForInitialReveal(workspaceId)
+        }
 
         // Write to IDB (source of truth)
         await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -71,20 +71,21 @@ this tree. See Decisions below.
 
 ## Architecture
 
-| Doc                                                 | Covers                                                                                        | Where to look                                               |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [outbox-pattern](architecture/outbox-pattern.md) ✅ | Transactional events, dispatcher, gap-safe cursors                                            | done                                                        |
-| [sync-engine](architecture/sync-engine.md) ✅       | Client sync lifecycle, reconnect, IDB reconciliation                                          | done                                                        |
-| job-queue                                           | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                 | `apps/backend/src/lib/queue/`                               |
-| ai-wrapper                                          | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets | `packages/agent-runtime/src/ai/`                            |
-| socket-rooms                                        | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                   | `apps/backend/src/socket.ts`                                |
-| agent-runtime                                       | Persona sessions, tool execution, traces, per-stream tool privacy policies                    | `packages/agent-runtime/`, `features/agents`                |
-| bot-runtimes                                        | External bot runtime connections and session links                                            | `features/bot-runtimes`                                     |
-| e2e-encryption                                      | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                    | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
-| push-pipeline                                       | Subscriptions, device/session suppression logic, outbox-driven delivery                       | `features/push`                                             |
-| attachment-pipeline                                 | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                            | `features/attachments`, `lib/storage/`                      |
-| search-architecture                                 | Hybrid full-text and pgvector search, embedding jobs, access control                          | `features/search`                                           |
-| memo-pipeline                                       | The GAM machinery: boundary extraction, classification, memo accumulation                     | `features/memos` and its outbox handlers                    |
+| Doc                                                           | Covers                                                                                        | Where to look                                               |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [outbox-pattern](architecture/outbox-pattern.md) ✅           | Transactional events, dispatcher, gap-safe cursors                                            | done                                                        |
+| [sync-engine](architecture/sync-engine.md) ✅                 | Client sync lifecycle, reconnect, IDB reconciliation                                          | done                                                        |
+| [coordinated-loading](architecture/coordinated-loading.md) ✅ | First-paint gate: cached IDB reveal, skeleton phases, reveal-before-write                     | done                                                        |
+| job-queue                                                     | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                 | `apps/backend/src/lib/queue/`                               |
+| ai-wrapper                                                    | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets | `packages/agent-runtime/src/ai/`                            |
+| socket-rooms                                                  | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                   | `apps/backend/src/socket.ts`                                |
+| agent-runtime                                                 | Persona sessions, tool execution, traces, per-stream tool privacy policies                    | `packages/agent-runtime/`, `features/agents`                |
+| bot-runtimes                                                  | External bot runtime connections and session links                                            | `features/bot-runtimes`                                     |
+| e2e-encryption                                                | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                    | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
+| push-pipeline                                                 | Subscriptions, device/session suppression logic, outbox-driven delivery                       | `features/push`                                             |
+| attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                            | `features/attachments`, `lib/storage/`                      |
+| search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                          | `features/search`                                           |
+| memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                     | `features/memos` and its outbox handlers                    |
 
 ## Probably skip, or covered elsewhere
 

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -71,21 +71,21 @@ this tree. See Decisions below.
 
 ## Architecture
 
-| Doc                                                           | Covers                                                                                        | Where to look                                               |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [outbox-pattern](architecture/outbox-pattern.md) ✅           | Transactional events, dispatcher, gap-safe cursors                                            | done                                                        |
-| [sync-engine](architecture/sync-engine.md) ✅                 | Client sync lifecycle, reconnect, IDB reconciliation                                          | done                                                        |
-| [coordinated-loading](architecture/coordinated-loading.md) ✅ | First-paint gate: cached IDB reveal, skeleton phases, reveal-before-write                     | done                                                        |
-| job-queue                                                     | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                 | `apps/backend/src/lib/queue/`                               |
-| ai-wrapper                                                    | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets | `packages/agent-runtime/src/ai/`                            |
-| socket-rooms                                                  | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                   | `apps/backend/src/socket.ts`                                |
-| agent-runtime                                                 | Persona sessions, tool execution, traces, per-stream tool privacy policies                    | `packages/agent-runtime/`, `features/agents`                |
-| bot-runtimes                                                  | External bot runtime connections and session links                                            | `features/bot-runtimes`                                     |
-| e2e-encryption                                                | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                    | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
-| push-pipeline                                                 | Subscriptions, device/session suppression logic, outbox-driven delivery                       | `features/push`                                             |
-| attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                            | `features/attachments`, `lib/storage/`                      |
-| search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                          | `features/search`                                           |
-| memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                     | `features/memos` and its outbox handlers                    |
+| Doc                                                           | Covers                                                                                               | Where to look                                               |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [outbox-pattern](architecture/outbox-pattern.md) ✅           | Transactional events, dispatcher, gap-safe cursors                                                   | done                                                        |
+| [sync-engine](architecture/sync-engine.md) ✅                 | Client sync lifecycle, reconnect, IDB reconciliation                                                 | done                                                        |
+| [coordinated-loading](architecture/coordinated-loading.md) ✅ | First-paint gate: reveal app shell + stream content together (resolved names/avatars) off cached IDB | done                                                        |
+| job-queue                                                     | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                        | `apps/backend/src/lib/queue/`                               |
+| ai-wrapper                                                    | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets        | `packages/agent-runtime/src/ai/`                            |
+| socket-rooms                                                  | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                          | `apps/backend/src/socket.ts`                                |
+| agent-runtime                                                 | Persona sessions, tool execution, traces, per-stream tool privacy policies                           | `packages/agent-runtime/`, `features/agents`                |
+| bot-runtimes                                                  | External bot runtime connections and session links                                                   | `features/bot-runtimes`                                     |
+| e2e-encryption                                                | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                           | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
+| push-pipeline                                                 | Subscriptions, device/session suppression logic, outbox-driven delivery                              | `features/push`                                             |
+| attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                                   | `features/attachments`, `lib/storage/`                      |
+| search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                                 | `features/search`                                           |
+| memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                            | `features/memos` and its outbox handlers                    |
 
 ## Probably skip, or covered elsewhere
 

--- a/docs/features/architecture/coordinated-loading.md
+++ b/docs/features/architecture/coordinated-loading.md
@@ -6,113 +6,116 @@ kind: subsystem
 invariants: []
 entry_points:
   - apps/frontend/src/contexts/coordinated-loading-context.tsx
-  - apps/frontend/src/sync/reveal-gate.ts
   - apps/frontend/src/stores/workspace-store.ts
   - apps/frontend/src/hooks/use-coordinated-stream-queries.ts
+  - apps/frontend/src/sync/reveal-gate.ts
 public_site: false
 summary: >
-  The first-paint gate for a workspace: it reveals cached content from IndexedDB
-  in one coordinated step (blank, then skeleton, then ready) and holds the first
-  network bootstrap's IDB write until that paint lands, so an online start is as
-  fast as an offline one.
+  The single gate that reveals a workspace's app shell and its open stream
+  content together, fully resolved, so messages never paint with raw user IDs
+  and then jump to names and avatars once the shell catches up.
 related: [architecture/sync-engine.md, concepts/subscribe-then-bootstrap.md]
 ---
 
 ## The gist
 
-When you open a workspace, two sources of the same data race: the cached read model
-already in IndexedDB from your last session, and a fresh bootstrap coming over the socket.
-Coordinated loading is the gate that decides what the screen shows while that resolves, and
-in what order. It runs only during the initial load of a workspace, and once it reaches
-`ready` it never goes back.
+When you open a workspace, two things load on separate paths: the application shell (the
+sidebar and the message chrome that turn user IDs into names and avatars, and stream IDs
+into names) and the content of the stream you opened. They do not finish at the same time.
 
-It paints from IndexedDB. The cached workspace (streams, users, memberships, unread,
-metadata, sidebar config) is read into an in-memory cache and rendered immediately, so a
-returning user sees their workspace without waiting on the network. The fresh bootstrap
-then flows in reactively through live queries.
+Left uncoordinated, the stream content tends to win the race. It paints first with whatever
+it has: raw user IDs, no avatars, no resolved stream names. Then the shell's read model
+arrives and the same messages reshuffle, IDs flipping to names and blanks filling in with
+avatars. That jump looked bad, and it happened even on a fully cached load, where both
+sides are local and milliseconds apart.
 
-The gate exposes one phase to the rest of the app: `loading` (blank), `skeleton`
-(placeholder), or `ready` (real content). Two wrappers consume it. `CoordinatedLoadingGate`
-renders nothing during `loading` and the app shell from `skeleton` onward;
-`MainContentGate` shows the content skeleton until `ready`.
+Coordinated loading is the one gate that holds both back and reveals them together, in a
+single step, once the pieces that let content render correctly are in hand: the workspace
+read model (users, so names and avatars resolve; streams and DM peers, so stream names
+resolve) and the open stream's content. So the first paint of a stream already has names
+and avatars on it, with no post-hoc jump.
+
+It runs only during the initial load of a workspace, and once it reaches `ready` it never
+goes back. It paints from IndexedDB: the cached read model from your last session is read
+into an in-memory cache and rendered immediately, so a returning user gets this
+resolved-first-paint without waiting on the network. The fresh bootstrap then flows in
+reactively through live queries.
 
 ## How it works
 
-`CoordinatedLoadingProvider` owns the phase. On mount it seeds the in-memory cache from
-IndexedDB (`seedCacheFromIdb` in `workspace-store.ts`) so the store hooks return real rows
-on their first synchronous render instead of empty arrays. It then derives readiness from
-four things, all read from the cache rather than the network:
+`CoordinatedLoadingProvider` owns a single phase: `loading` (blank), `skeleton`
+(placeholder), or `ready` (real content). Two wrappers consume it, and they reveal in
+lockstep so the shell and content never paint independently. `CoordinatedLoadingGate`
+renders nothing during `loading` and the whole app shell (sidebar included) from `skeleton`
+onward; `MainContentGate` shows the content skeleton until `ready`.
 
-- workspace data is present (the workspace row plus the unread, metadata, and
-  sidebar-config singletons),
+On mount the provider seeds the in-memory cache from IndexedDB (`seedCacheFromIdb` in
+`workspace-store.ts`) so the store hooks return real rows on their first synchronous render
+instead of empty arrays. It then holds the reveal until everything needed for a correct
+first paint is present, all read from the cache rather than the network:
+
+- the workspace read model: the workspace row plus users, streams, memberships, DM peers,
+  personas, bots, and the unread, metadata, and sidebar-config singletons. This is what
+  resolves user IDs to names and avatars and stream IDs to names.
 - local drafts are seeded,
-- every visible stream has a usable local record,
+- every visible stream has a usable local record (its content),
 - and either avatars have preloaded or the cache was primed from a prior session.
 
-When all of those hold it flips to `ready` once and latches there.
+When all of those hold it flips to `ready` once and latches there. Avatar preload only
+gates a genuine cold load (nothing cached), to avoid an initials-to-avatar flash on the
+very first impression; a primed cache reveals immediately and lets avatars stream in
+through their own image loads.
 
-Phase timing is two timers. The screen stays blank for the first `SKELETON_DELAY_MS`
-(600ms); only if the load is still going past that does the skeleton appear, so a faster
-load goes straight from blank to content with no skeleton frame. Once shown, the skeleton
-is sticky: it holds until `ready` and never drops back to blank, so there is no
-skeleton-then-blank-then-content flicker. A separate `LOADING_DELAY_MS` (300ms) governs the
-top-bar sync indicator, not the skeleton.
+Phase timing keeps fast loads clean. The screen stays blank for the first
+`SKELETON_DELAY_MS` (600ms); only if the load is still going past that does the skeleton
+appear, so a quick load goes straight from blank to a fully-resolved paint with no skeleton
+frame. Once shown, the skeleton is sticky: it holds until `ready` and never drops back to
+blank, so there is no skeleton-then-blank-then-content flicker.
 
-If you only need the model, stop here: paint cached IndexedDB content in one coordinated
-step, gated on local data and never on the network. The rest is how the fresh bootstrap is
-sequenced so it does not slow that paint down.
+If you only need the model, stop here: hold the shell and the open stream behind one gate,
+reveal them together off cached IndexedDB once names, avatars, and content are all ready.
+The rest is detail about freshness and edge cases.
 
 ## Details worth knowing
 
 ### Reveal before write (the reveal-gate)
 
-On a warm start the fresh workspace bootstrap writes the same IndexedDB stores the reveal
-reads. IndexedDB serializes a read-write transaction against read-only ones on shared
-stores, so an un-gated bootstrap write queues the reveal's reads behind it. That is what
-made an online start feel slower than an offline one, where nothing writes.
+This is a refinement on top of the reveal, not its reason for existing. On a warm start the
+fresh workspace bootstrap writes the same IndexedDB stores the reveal reads. IndexedDB
+serializes a read-write transaction against read-only ones on shared stores, so an un-gated
+bootstrap write queues the reveal's reads behind it. That made an online start feel slower
+than an offline one, where nothing writes.
 
 `reveal-gate.ts` coordinates the two. The provider calls
 `markInitialRevealComplete(workspaceId)` when it reaches `ready`. The `SyncEngine`, on its
 first connect, fetches the bootstrap immediately (freshness is never deferred over the
 wire) but then calls `waitForInitialReveal(workspaceId)` before committing
 `applyWorkspaceBootstrap`. So the network fetch and the cached paint run in parallel, and
-only the write waits for the paint. The wait is bounded by a 2s timeout, so a paint that
-never completes cannot strand the write.
+only the write waits for the paint, bounded by a 2s timeout. The gate is a per-workspace
+module-level map keyed by the workspace ULID; `resetRevealGate` is called from
+`flushModuleStoreCaches` on account switch, alongside the other per-account caches.
 
-The gate is a per-workspace module-level map keyed by the workspace ULID. `resetRevealGate`
-is called from `flushModuleStoreCaches` on account switch, alongside the other per-account
-caches.
-
-### When the write is not deferred
-
-Three cases write immediately, with no wait:
-
-- Cold start: nothing is cached, so there is no paint to wait for and the bootstrap is the
-  first content.
-- Partial cache: the workspace row exists but a gating singleton (unread, metadata, or
-  sidebar config) is missing, so the gate can only become `ready` after this write. Waiting
-  would deadlock until the timeout, so the engine checks for the full set before deferring.
-- Reconnect: content is already on screen, so the refresh lands promptly.
-
-The engine also bails before the write if it was torn down during the wait (`isDestroyed`),
-so a bootstrap from a switched-away account never lands in the now-active account's
-database.
+Three cases write immediately, with no wait: a cold start (nothing cached, so the bootstrap
+is the first content), a partial cache (the workspace row exists but a gating singleton is
+missing, so the gate can only become `ready` after this write, and waiting would deadlock
+until the timeout), and a reconnect (content is already on screen). The engine also bails
+before the write if it was torn down during the wait (`isDestroyed`), so a bootstrap from a
+switched-away account never lands in the now-active account's database.
 
 ### What the reveal does not wait on
 
-The reveal is driven entirely by the cached read model. It does not wait on the network
-workspace bootstrap, nor on the per-stream bootstraps (those write the `events` store,
-which is disjoint from the workspace stores and so does not contend), nor, when the cache
-is primed, on the avatar preload. Avatar preload gates only a genuine cold load, to avoid
-an initials-to-avatar flash on first impression.
+It does not wait on the network workspace bootstrap, nor on the per-stream bootstraps (they
+write the `events` store, which is disjoint from the workspace stores and so does not
+contend), nor, when the cache is primed, on the avatar preload.
 
 ### Per-stream loading is separate
 
-After the initial load completes, opening a stream is handled by the timeline's own loading
-state (`IDB_SKELETON_DELAY_MS`, 200ms, in `use-events.ts`), not this gate. The coordinated
-gate reports every stream as idle during the initial load and only surfaces per-stream
-loading or error states once it is `ready`. The top-bar indicator stays dark for the first
-background sync that overlaps the reveal, and lights up only for a later reconnect resync.
+After the initial load completes, opening a different stream is handled by the timeline's
+own loading state (`IDB_SKELETON_DELAY_MS`, 200ms, in `use-events.ts`), not this gate. The
+coordinated gate reports every stream as idle during the initial load and only surfaces
+per-stream loading or error states once it is `ready`. The top-bar indicator stays dark for
+the first background sync that overlaps the reveal, and lights up only for a later reconnect
+resync.
 
 ## Invariants
 
@@ -124,10 +127,10 @@ coordination sits on top of the sync engine's subscribe-then-bootstrap (INV-53).
 ## Entry points
 
 - `apps/frontend/src/contexts/coordinated-loading-context.tsx`: the provider, the phase
-  machine, the two gate wrappers, and the skeleton and indicator timers.
-- `apps/frontend/src/sync/reveal-gate.ts`: `markInitialRevealComplete` /
-  `waitForInitialReveal` / `resetRevealGate`.
+  machine, the two gate wrappers, the readiness conditions, and the skeleton timer.
 - `apps/frontend/src/stores/workspace-store.ts`: `seedCacheFromIdb` and the in-memory cache
-  that lets the first render return real rows.
+  that lets the first render return real rows (resolved names and avatars).
 - `apps/frontend/src/hooks/use-coordinated-stream-queries.ts`: the parallel per-stream
   bootstrap observers the gate reads to decide visible-stream readiness.
+- `apps/frontend/src/sync/reveal-gate.ts`: `markInitialRevealComplete` /
+  `waitForInitialReveal` / `resetRevealGate`, the reveal-before-write coordination.

--- a/docs/features/architecture/coordinated-loading.md
+++ b/docs/features/architecture/coordinated-loading.md
@@ -1,0 +1,133 @@
+---
+title: Coordinated Loading
+status: shipped
+audience: internal
+kind: subsystem
+invariants: []
+entry_points:
+  - apps/frontend/src/contexts/coordinated-loading-context.tsx
+  - apps/frontend/src/sync/reveal-gate.ts
+  - apps/frontend/src/stores/workspace-store.ts
+  - apps/frontend/src/hooks/use-coordinated-stream-queries.ts
+public_site: false
+summary: >
+  The first-paint gate for a workspace: it reveals cached content from IndexedDB
+  in one coordinated step (blank, then skeleton, then ready) and holds the first
+  network bootstrap's IDB write until that paint lands, so an online start is as
+  fast as an offline one.
+related: [architecture/sync-engine.md, concepts/subscribe-then-bootstrap.md]
+---
+
+## The gist
+
+When you open a workspace, two sources of the same data race: the cached read model
+already in IndexedDB from your last session, and a fresh bootstrap coming over the socket.
+Coordinated loading is the gate that decides what the screen shows while that resolves, and
+in what order. It runs only during the initial load of a workspace, and once it reaches
+`ready` it never goes back.
+
+It paints from IndexedDB. The cached workspace (streams, users, memberships, unread,
+metadata, sidebar config) is read into an in-memory cache and rendered immediately, so a
+returning user sees their workspace without waiting on the network. The fresh bootstrap
+then flows in reactively through live queries.
+
+The gate exposes one phase to the rest of the app: `loading` (blank), `skeleton`
+(placeholder), or `ready` (real content). Two wrappers consume it. `CoordinatedLoadingGate`
+renders nothing during `loading` and the app shell from `skeleton` onward;
+`MainContentGate` shows the content skeleton until `ready`.
+
+## How it works
+
+`CoordinatedLoadingProvider` owns the phase. On mount it seeds the in-memory cache from
+IndexedDB (`seedCacheFromIdb` in `workspace-store.ts`) so the store hooks return real rows
+on their first synchronous render instead of empty arrays. It then derives readiness from
+four things, all read from the cache rather than the network:
+
+- workspace data is present (the workspace row plus the unread, metadata, and
+  sidebar-config singletons),
+- local drafts are seeded,
+- every visible stream has a usable local record,
+- and either avatars have preloaded or the cache was primed from a prior session.
+
+When all of those hold it flips to `ready` once and latches there.
+
+Phase timing is two timers. The screen stays blank for the first `SKELETON_DELAY_MS`
+(600ms); only if the load is still going past that does the skeleton appear, so a faster
+load goes straight from blank to content with no skeleton frame. Once shown, the skeleton
+is sticky: it holds until `ready` and never drops back to blank, so there is no
+skeleton-then-blank-then-content flicker. A separate `LOADING_DELAY_MS` (300ms) governs the
+top-bar sync indicator, not the skeleton.
+
+If you only need the model, stop here: paint cached IndexedDB content in one coordinated
+step, gated on local data and never on the network. The rest is how the fresh bootstrap is
+sequenced so it does not slow that paint down.
+
+## Details worth knowing
+
+### Reveal before write (the reveal-gate)
+
+On a warm start the fresh workspace bootstrap writes the same IndexedDB stores the reveal
+reads. IndexedDB serializes a read-write transaction against read-only ones on shared
+stores, so an un-gated bootstrap write queues the reveal's reads behind it. That is what
+made an online start feel slower than an offline one, where nothing writes.
+
+`reveal-gate.ts` coordinates the two. The provider calls
+`markInitialRevealComplete(workspaceId)` when it reaches `ready`. The `SyncEngine`, on its
+first connect, fetches the bootstrap immediately (freshness is never deferred over the
+wire) but then calls `waitForInitialReveal(workspaceId)` before committing
+`applyWorkspaceBootstrap`. So the network fetch and the cached paint run in parallel, and
+only the write waits for the paint. The wait is bounded by a 2s timeout, so a paint that
+never completes cannot strand the write.
+
+The gate is a per-workspace module-level map keyed by the workspace ULID. `resetRevealGate`
+is called from `flushModuleStoreCaches` on account switch, alongside the other per-account
+caches.
+
+### When the write is not deferred
+
+Three cases write immediately, with no wait:
+
+- Cold start: nothing is cached, so there is no paint to wait for and the bootstrap is the
+  first content.
+- Partial cache: the workspace row exists but a gating singleton (unread, metadata, or
+  sidebar config) is missing, so the gate can only become `ready` after this write. Waiting
+  would deadlock until the timeout, so the engine checks for the full set before deferring.
+- Reconnect: content is already on screen, so the refresh lands promptly.
+
+The engine also bails before the write if it was torn down during the wait (`isDestroyed`),
+so a bootstrap from a switched-away account never lands in the now-active account's
+database.
+
+### What the reveal does not wait on
+
+The reveal is driven entirely by the cached read model. It does not wait on the network
+workspace bootstrap, nor on the per-stream bootstraps (those write the `events` store,
+which is disjoint from the workspace stores and so does not contend), nor, when the cache
+is primed, on the avatar preload. Avatar preload gates only a genuine cold load, to avoid
+an initials-to-avatar flash on first impression.
+
+### Per-stream loading is separate
+
+After the initial load completes, opening a stream is handled by the timeline's own loading
+state (`IDB_SKELETON_DELAY_MS`, 200ms, in `use-events.ts`), not this gate. The coordinated
+gate reports every stream as idle during the initial load and only surfaces per-stream
+loading or error states once it is `ready`. The top-bar indicator stays dark for the first
+background sync that overlaps the reveal, and lights up only for a later reconnect resync.
+
+## Invariants
+
+This subsystem does not enforce a numbered invariant. It is the first-paint expression of
+the frontend pattern that IndexedDB is the client's source of truth: the UI reads cached
+IDB through live queries, and sync writes IDB rather than blocking the paint. Its bootstrap
+coordination sits on top of the sync engine's subscribe-then-bootstrap (INV-53).
+
+## Entry points
+
+- `apps/frontend/src/contexts/coordinated-loading-context.tsx`: the provider, the phase
+  machine, the two gate wrappers, and the skeleton and indicator timers.
+- `apps/frontend/src/sync/reveal-gate.ts`: `markInitialRevealComplete` /
+  `waitForInitialReveal` / `resetRevealGate`.
+- `apps/frontend/src/stores/workspace-store.ts`: `seedCacheFromIdb` and the in-memory cache
+  that lets the first render return real rows.
+- `apps/frontend/src/hooks/use-coordinated-stream-queries.ts`: the parallel per-stream
+  bootstrap observers the gate reads to decide visible-stream readiness.

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -14,7 +14,13 @@ summary: >
   One per-workspace class that owns the whole client sync lifecycle: bootstrap the
   workspace and its streams (subscribe-then-bootstrap), keep them live over the socket,
   and re-sync everything on reconnect or page resume.
-related: [concepts/subscribe-then-bootstrap.md, concepts/optimistic-then-reconcile.md, architecture/outbox-pattern.md]
+related:
+  [
+    concepts/subscribe-then-bootstrap.md,
+    concepts/optimistic-then-reconcile.md,
+    architecture/outbox-pattern.md,
+    architecture/coordinated-loading.md,
+  ]
 ---
 
 ## The gist


### PR DESCRIPTION
## Why

On a fully-cached reopen, the app took ~2s to show content and flashed a skeleton that appeared and vanished before content (blank → skeleton → blank → content). It also felt slower online than offline, which is backwards for an offline-first app.

## What was happening

**The flicker was a real bug.** In `coordinated-loading-context.tsx` two effects fought: the skeleton was turned *off* the instant `isLoading` flipped false, but content (`isReady`) only shows once loading is done *and* the cached reveal has settled (`revealReady`). Online, the network query resolves a beat before the reveal settles, so the gate fell into the blank "loading" phase between skeleton and content — and `CoordinatedLoadingGate` renders nothing there, blanking the whole shell.

**Online slower than offline was IndexedDB contention.** Both paths gate the reveal on reading the cached read model from IDB. Offline there are no writers, so reads return instantly. Online, the SyncEngine's first `applyWorkspaceBootstrap()` writes the *same* stores the reveal reads, and IndexedDB serializes `readwrite` against `readonly` — so the freshness write queued the reveal's reads behind it. Bigger cache, worse stall.

## Changes

1. **Skeleton is sticky** — once shown it holds until content is actually ready, never regressing to blank. Fast loads (under the delay) still go straight blank → content with no skeleton at all.
2. **Skeleton delay 300ms → 600ms** (`SKELETON_DELAY_MS`). A slightly-slow load that finishes inside the window shows no skeleton; only a genuinely slow load earns one. The top-bar loading indicator keeps its 300ms delay.
3. **Reveal wins the IDB race.** On a warm first connect the workspace fetch still fires immediately (freshness is **not** deferred over the wire) — only the IndexedDB *write* waits for the cached content to paint. Coordinated by the new `apps/frontend/src/sync/reveal-gate.ts`, bounded by a 2s timeout, skipped on cold starts and reconnects.

## Notes / scope

- The deferral targets the *workspace* bootstrap write, which shares stores with the reveal reads. Per-stream bootstrap writes hit the `events` store (disjoint), so they don't contend and are left alone.
- The engine only defers when the cache is complete enough for the gate to reveal *without* the write (workspace row + unread/metadata/sidebar singletons all present). A partial cache writes immediately, so it can't deadlock on a reveal that the write itself would unblock.
- `resetRevealGate()` is wired into `flushModuleStoreCaches` so an account switch clears reveal state alongside every other module-level cache.

## Tests

- Skeleton stays-until-ready (flicker regression), 600ms threshold, and the existing gate behaviors.
- Reveal-gate unit tests: mark/immediate/timeout/per-workspace isolation.
- SyncEngine: fetch-immediate-but-write-held on a warm start, no-wait on a cold start, and no-wait on a partial cache (deadlock guard).
- Full frontend suite green (2288 tests). Typecheck + lint clean across all workspaces.

https://claude.ai/code/session_018dK9tKE67k8jtqzFpaKFR1

---
_Generated by [Claude Code](https://claude.ai/code/session_018dK9tKE67k8jtqzFpaKFR1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783407185&installation_id=129946197&pr_number=805&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F805&signature=e42cfe9c2d3bd2b7088ae4a5b91fa1f38296903a050fac2fea0ba03ea2abe303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->