### PR TITLE
perf(timeline): widen message overscan for smoother fast scroll

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2057,7 +2057,7 @@ function VirtuosoMessageList({
       // budget, not a row count, so the mounted-DOM ceiling stays
       // viewport + top + bottom regardless of stream length — large streams keep
       // their OOM protection. Upthread reading dominates, so top is larger.
-      increaseViewportBy={{ top: 2400, bottom: 1200 }}
+      increaseViewportBy={{ top: 4800, bottom: 2400 }}
       components={components}
       {...batchPointerHandlers}
     />

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2052,7 +2052,12 @@ function VirtuosoMessageList({
       startReached={handleStartReached}
       endReached={handleEndReached}
       atBottomThreshold={30}
-      increaseViewportBy={{ top: 600, bottom: 600 }}
+      // Overscan budget (px) of off-screen rows kept mounted so fast scrolling
+      // doesn't outrun mount+measure and flash blank rows. This is a fixed pixel
+      // budget, not a row count, so the mounted-DOM ceiling stays
+      // viewport + top + bottom regardless of stream length — large streams keep
+      // their OOM protection. Upthread reading dominates, so top is larger.
+      increaseViewportBy={{ top: 2400, bottom: 1200 }}
       components={components}
       {...batchPointerHandlers}
     />


### PR DESCRIPTION
## What

Raises the Virtuoso overscan budget on the stream message list from `{ top: 600, bottom: 600 }` to `{ top: 2400, bottom: 1200 }`.

`apps/frontend/src/components/timeline/stream-content.tsx`

## Why

Rapid scrolling (especially upthread into history) was outrunning Virtuoso's mount + measure cycle, so incoming rows flashed blank before their content rendered. The only lever for how many off-screen rows stay mounted is `increaseViewportBy` — everything else nearby governs *fetching*, not *rendering*.

## Why this is safe on large streams

`increaseViewportBy` is a **fixed pixel budget, not a row count**. The mounted-DOM ceiling stays `viewport + top + bottom` regardless of how many messages exist, so the OOM protection that motivated the virtualized list is preserved — a 50k-message stream still only mounts a bounded window. We're trading a bit of idle off-screen memory for fast-scroll smoothness, with a hard upper bound.

The split is asymmetric because reading scrolls upthread far more than down, so the top buffer gets the larger share (~4× the old budget up, 2× down).

## Verification

- Full monorepo lint + typecheck (pre-commit hook) — all green.
- No tests asserted on the previous value.

## Design notes / trade-offs

- `increaseViewportBy` is static; react-virtuoso has no built-in scroll-velocity-adaptive overscan, so this is a fixed resting point. 2400/1200 is a deliberate middle ground — noticeable improvement without unbounded mounted-node growth. Going past ~4000px would warrant profiling mounted-node count on a heavy stream first.

https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783523533&installation_id=129946197&pr_number=807&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F807&signature=7ae318310bdb34e41c33d13e1d1a217221d9fdf1904d8a36845fdf575522fa96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->