### PR TITLE
perf(timeline): narrow overscan, prefetch older pages earlier

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { classifyDeepLinkScrollTick, shouldStartHighlightClear } from "./stream-content"
+import { classifyDeepLinkScrollTick, shouldStartHighlightClear, computePaginationEdges } from "./stream-content"
 
 const DEADLINE = 4000
 
@@ -148,5 +148,61 @@ describe("shouldStartHighlightClear", () => {
         deepLinkGaveUp: true,
       })
     ).toBe(true)
+  })
+})
+
+describe("computePaginationEdges", () => {
+  // Virtuoso assigns data[0] a high virtual index that decrements as older
+  // pages prepend. Model a 100-item window: indices FIRST..FIRST+99.
+  const FIRST = 1_000_000
+  const COUNT = 100
+  const DISTANCE = 15
+
+  it("stays idle while the rendered range sits in the middle of the loaded window", () => {
+    expect(
+      computePaginationEdges({
+        range: { startIndex: FIRST + 40, endIndex: FIRST + 60 },
+        firstItemIndex: FIRST,
+        itemCount: COUNT,
+        prefetchDistance: DISTANCE,
+      })
+    ).toEqual({ reachedStart: false, reachedEnd: false })
+  })
+
+  it("leads the older fetch by prefetchDistance — fires before the range reaches index 0", () => {
+    // This is the regression guard for the "loading older messages" thrash:
+    // the older page must start loading while DISTANCE items still remain above
+    // the rendered range, not only when it lands on the boundary.
+    expect(
+      computePaginationEdges({
+        range: { startIndex: FIRST + DISTANCE, endIndex: FIRST + DISTANCE + 20 },
+        firstItemIndex: FIRST,
+        itemCount: COUNT,
+        prefetchDistance: DISTANCE,
+      })
+    ).toEqual({ reachedStart: true, reachedEnd: false })
+  })
+
+  it("does not fire the older fetch while the range is still beyond the lead distance", () => {
+    expect(
+      computePaginationEdges({
+        range: { startIndex: FIRST + DISTANCE + 1, endIndex: FIRST + DISTANCE + 21 },
+        firstItemIndex: FIRST,
+        itemCount: COUNT,
+        prefetchDistance: DISTANCE,
+      }).reachedStart
+    ).toBe(false)
+  })
+
+  it("leads the newer fetch by prefetchDistance near the bottom of the loaded window", () => {
+    const lastIndex = FIRST + COUNT - 1
+    expect(
+      computePaginationEdges({
+        range: { startIndex: lastIndex - 20, endIndex: lastIndex - DISTANCE },
+        firstItemIndex: FIRST,
+        itemCount: COUNT,
+        prefetchDistance: DISTANCE,
+      })
+    ).toEqual({ reachedStart: false, reachedEnd: true })
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -50,6 +50,7 @@ import {
   type StreamBootstrap,
 } from "@threa/types"
 import { isAbortableStepType } from "@/lib/step-config"
+import { EVENT_PREFETCH_DISTANCE } from "@/lib/constants"
 import {
   EventList,
   TimelineItemContent,
@@ -155,6 +156,29 @@ export function shouldStartHighlightClear(args: {
 }): boolean {
   if (!args.highlightMessageId) return false
   return args.deepLinkTargetLoaded || args.deepLinkGaveUp
+}
+
+/**
+ * Decide whether the rendered range is close enough to either edge of the
+ * loaded window to prefetch the next page. `range` indices and `firstItemIndex`
+ * are Virtuoso's virtual indices (firstItemIndex decrements as older pages are
+ * prepended). `prefetchDistance` is the lead in items — a larger value starts
+ * the fetch sooner so the page lands before a fast scroll reaches the boundary.
+ */
+export function computePaginationEdges(args: {
+  range: { startIndex: number; endIndex: number }
+  firstItemIndex: number
+  itemCount: number
+  prefetchDistance: number
+}): { reachedStart: boolean; reachedEnd: boolean } {
+  const { range, firstItemIndex, itemCount, prefetchDistance } = args
+  const distFromStart = range.startIndex - firstItemIndex
+  const lastVirtualIndex = firstItemIndex + itemCount - 1
+  const distFromEnd = lastVirtualIndex - range.endIndex
+  return {
+    reachedStart: distFromStart <= prefetchDistance,
+    reachedEnd: distFromEnd <= prefetchDistance,
+  }
 }
 
 interface StreamContentProps {
@@ -1917,11 +1941,14 @@ function VirtuosoMessageList({
       // be user-scroll driven; the loop aborts on real interaction, after
       // which these fire normally.
       if (scrollAbortRef.current !== null) return
-      const distFromStart = range.startIndex - firstItemIndex
-      if (distFromStart <= 3) handleStartReached()
-      const lastVirtualIndex = firstItemIndex + visibleItems.length - 1
-      const distFromEnd = lastVirtualIndex - range.endIndex
-      if (distFromEnd <= 3) handleEndReached()
+      const { reachedStart, reachedEnd } = computePaginationEdges({
+        range,
+        firstItemIndex,
+        itemCount: visibleItems.length,
+        prefetchDistance: EVENT_PREFETCH_DISTANCE,
+      })
+      if (reachedStart) handleStartReached()
+      if (reachedEnd) handleEndReached()
     },
     [handleRangeChanged, firstItemIndex, visibleItems.length, handleStartReached, handleEndReached]
   )
@@ -2057,7 +2084,11 @@ function VirtuosoMessageList({
       // budget, not a row count, so the mounted-DOM ceiling stays
       // viewport + top + bottom regardless of stream length — large streams keep
       // their OOM protection. Upthread reading dominates, so top is larger.
-      increaseViewportBy={{ top: 4800, bottom: 2400 }}
+      // Deliberately small: a larger window mounts more heavy message DOM
+      // (ProseMirror content, link previews) than fast scrolling can absorb and
+      // janks on real-world data. Smooth fast-scroll comes from prefetching
+      // older pages early (EVENT_PREFETCH_DISTANCE), not a huge mounted window.
+      increaseViewportBy={{ top: 2400, bottom: 1200 }}
       components={components}
       {...batchPointerHandlers}
     />

--- a/apps/frontend/src/lib/constants.ts
+++ b/apps/frontend/src/lib/constants.ts
@@ -1,5 +1,20 @@
 /** Number of events fetched per page (bootstrap and pagination). */
 export const EVENT_PAGE_SIZE = 50
 
-/** Fetch next page when this fraction of the current page remains ahead. */
+/**
+ * Fetch next page when this fraction of the current page remains ahead.
+ * Used by the non-virtualized scroll path (threads); the virtualized timeline
+ * uses EVENT_PREFETCH_DISTANCE instead.
+ */
 export const SCROLL_FETCH_RATIO = 0.75
+
+/**
+ * Prefetch lead for the virtualized timeline: how many loaded items may remain
+ * beyond the rendered range before the next page fetch fires. Sits below
+ * EVENT_PAGE_SIZE so a freshly prepended page pushes the trigger back out of
+ * range (no runaway loop), and high enough that a page round-trip usually lands
+ * before a fast scroll reaches the boundary — without it the user sees the
+ * "loading older messages" indicator on every fling. The non-virtualized thread
+ * path uses SCROLL_FETCH_RATIO for the equivalent trigger.
+ */
+export const EVENT_PREFETCH_DISTANCE = 15


### PR DESCRIPTION
## What

Follow-up to #807. Two changes to the timeline message list:

1. **Reverted the overscan window** from `{ top: 4800, bottom: 2400 }` back to `{ top: 2400, bottom: 1200 }`.
2. **Lead the older/newer page fetch by `EVENT_PREFETCH_DISTANCE` (15 items)** instead of a hardcoded 3, so pagination starts well before a fast scroll reaches the loaded boundary.

`apps/frontend/src/components/timeline/stream-content.tsx`, `apps/frontend/src/lib/constants.ts`

## Why

The doubled `4800/2400` window from #807 janked badly on real-world prod streams: a larger overscan mounts more heavy message DOM (ProseMirror content, link previews) than fast scrolling can absorb. Overscan was the wrong lever.

The actual cause of the constant **"loading older messages"** indicator was the *prefetch lead*, not the window. The older-page fetch only fired when the rendered range was within **3 items** of the loaded boundary, so a fast scroll through heavy data reached the edge before the 50-event page landed — indicator on every fling. The big window had been *masking* this (it rendered further up, firing the trigger slightly earlier), which is why narrowing it alone would have made the thrash worse. Both levers had to move together.

Now the fetch leads by 15 items — kept well under `EVENT_PAGE_SIZE` (50) so a fresh page's prepend pushes the trigger back out of range (no runaway loop).

## Changes

- `EVENT_PREFETCH_DISTANCE = 15` added to `constants.ts`, cross-referenced with the non-virtualized path's `SCROLL_FETCH_RATIO`.
- Edge decision extracted into a pure `computePaginationEdges` helper (same pattern as the existing `classifyDeepLinkScrollTick` / `shouldStartHighlightClear` helpers in this file).
- 4 regression tests pinning the lead behavior at both edges.

## Verification

- `computePaginationEdges` reproduces the original trigger semantics exactly (verified); leading by 15 with a 50-item page and the existing 500 ms fetch cooldown does not cause a runaway loop — a 50-item prepend pushes `distFromStart` back to ~52, well above the threshold.
- 14/14 stream-content tests, 22/22 use-events tests pass.
- Full monorepo lint + typecheck (pre-commit hook) green.
- Self-reviewed via 3-perspective review (correctness/spec/design): no correctness or security findings; comment nits addressed.

## Tuning notes

`EVENT_PREFETCH_DISTANCE = 15` is a conservative start. If prod still flashes the indicator on very fast flings, bump toward ~25; if individual page loads are themselves slow on heavy data, raising `EVENT_PAGE_SIZE` buys more runway per fetch (trade-off: slower individual fetches).

https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783532517&installation_id=129946197&pr_number=809&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F809&signature=6b2135cb49ecabf80a6d684fb23b88df8cd3389b765f0d8490050185b49ba078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->