### PR TITLE
perf(backend): compress responses + scope bootstrap thread enrichment

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -38,6 +38,7 @@
     "@types/multer-s3": "^3.0.3",
     "@workos-inc/node": "^7",
     "ai": "^5.0.113",
+    "compression": "^1.8.0",
     "cookie-parser": "^1",
     "cors": "^2",
     "express": "^5",
@@ -72,6 +73,7 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^2.2.0",
+    "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1",
     "@types/cors": "^2",
     "@types/express": "^5",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express"
+import compression from "compression"
 import cors from "cors"
 import helmet from "helmet"
 import cookieParser from "cookie-parser"
@@ -30,6 +31,12 @@ export function createApp(options: CreateAppOptions): Express {
 
   // Metrics middleware (before everything else to capture all requests)
   app.use(createMetricsMiddleware({ ignoredPaths: metricsIgnoredPaths }))
+
+  // Compress responses before they leave the origin. Event/message list payloads
+  // are large JSON (full ProseMirror docs per message) and travel an extra
+  // origin->edge hop through the Cloudflare workspace-router, which forwards our
+  // Content-Encoding unchanged. The default 1KB threshold skips tiny responses.
+  app.use(compression())
 
   app.use(
     helmet({

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -20,7 +20,6 @@ import {
 import type { Pool } from "pg"
 import { PersonaRepository, getResolver, fetchStreamBag, contextBagSchema } from "../agents"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
-import { serializeBigInt } from "@threa/backend-common"
 import { HttpError } from "../../lib/errors"
 import { streamTypeSchema, visibilitySchema, companionModeSchema, notificationLevelSchema } from "../../lib/schemas"
 
@@ -330,10 +329,6 @@ async function hydrateSharedMessagesForEvents(
   }
   if (ids.size === 0) return {}
   return hydrateSharedMessageIds(pool, workspaceId, viewerId, ids)
-}
-
-function serializeEvent(event: StreamEvent) {
-  return serializeBigInt(event)
 }
 
 function areLinkPreviewArraysEqual(current: LinkPreviewSummary[] | undefined, next: LinkPreviewSummary[]): boolean {
@@ -654,7 +649,7 @@ export function createStreamHandlers({
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(linkPreviewService, workspaceId, userId, events)
       const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
-      res.json({ events: eventsWithLinkPreviews.map(serializeEvent), sharedMessages })
+      res.json({ events: eventsWithLinkPreviews, sharedMessages })
     },
 
     async listEventsAround(req: Request, res: Response) {
@@ -690,7 +685,7 @@ export function createStreamHandlers({
       const sharedMessages = await hydrateSharedMessagesForEvents(pool, workspaceId, userId, eventsWithLinkPreviews)
 
       res.json({
-        events: eventsWithLinkPreviews.map(serializeEvent),
+        events: eventsWithLinkPreviews,
         sharedMessages,
         hasOlder: result.hasOlder,
         hasNewer: result.hasNewer,
@@ -905,7 +900,7 @@ export function createStreamHandlers({
       res.json({
         data: {
           stream,
-          events: eventsWithLinkPreviews.map(serializeEvent),
+          events: eventsWithLinkPreviews,
           sharedMessages,
           members,
           botMemberIds,

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -831,16 +831,13 @@ export function createStreamHandlers({
       // value. See `writeBootstrapEventsAndStream` in stream-sync.ts.
       const snapshotAt = new Date().toISOString()
 
-      const [members, botMemberIds, membership, threadDataMap, threadSummaryMap, latestSequence, activityCounts] =
-        await Promise.all([
-          streamService.getMembers(streamId),
-          streamService.getBotMemberIds(workspaceId, streamId),
-          streamService.getMembership(streamId, userId),
-          streamService.getThreadsWithReplyCounts(streamId),
-          streamService.getThreadSummaries(streamId),
-          eventService.getLatestSequence(streamId),
-          activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
-        ])
+      const [members, botMemberIds, membership, latestSequence, activityCounts] = await Promise.all([
+        streamService.getMembers(streamId),
+        streamService.getBotMemberIds(workspaceId, streamId),
+        streamService.getMembership(streamId, userId),
+        eventService.getLatestSequence(streamId),
+        activityService?.getUnreadCountsForStream(userId, workspaceId, streamId),
+      ])
       const botRuntimePresences = await botRuntimeService.findLatestPresences({ workspaceId, botIds: botMemberIds })
       const commands = await commandAvailabilityService.listStreamCommands({ workspaceId, userId, streamId })
       const botRuntimeLinkByBotId =
@@ -879,6 +876,19 @@ export function createStreamHandlers({
       } else if (afterSequence === undefined) {
         hasOlderEvents = events.length === EVENTS_DEFAULT_LIMIT
       }
+
+      // Thread enrichment only applies to messages in this bootstrap window, so
+      // scope the (otherwise whole-stream) thread queries to the loaded message
+      // IDs. Runs after the event window is finalized rather than in the upfront
+      // Promise.all — keeps deep streams from scanning every thread they own.
+      const parentMessageIds = events
+        .filter((e) => e.eventType === "message_created")
+        .map((e) => (e.payload as { messageId?: string }).messageId)
+        .filter((id): id is string => !!id)
+      const [threadDataMap, threadSummaryMap] = await Promise.all([
+        streamService.getThreadsWithReplyCounts(streamId, parentMessageIds),
+        streamService.getThreadSummaries(streamId, parentMessageIds),
+      ])
 
       const enrichedEvents = await eventService.enrichBootstrapEvents(events, threadDataMap, threadSummaryMap)
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -917,8 +917,13 @@ export const StreamRepository = {
    */
   async findThreadsWithReplyCounts(
     db: Querier,
-    parentStreamId: string
+    parentStreamId: string,
+    parentMessageIds?: string[]
   ): Promise<Map<string, { threadId: string; replyCount: number }>> {
+    // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
+    // list scopes the scan to those parents (bootstrap only needs summaries for
+    // the messages in its window, not every thread in the stream). An empty list
+    // matches nothing, returning an empty map without scanning.
     const result = await db.query<{ parent_message_id: string; id: string; reply_count: string }>(sql`
       SELECT
         s.parent_message_id,
@@ -928,6 +933,7 @@ export const StreamRepository = {
       LEFT JOIN messages m ON m.stream_id = s.id AND m.deleted_at IS NULL
       WHERE s.parent_stream_id = ${parentStreamId}
         AND s.parent_message_id IS NOT NULL
+        AND (${parentMessageIds === undefined} OR s.parent_message_id = ANY(${parentMessageIds ?? []}))
       GROUP BY s.id, s.parent_message_id
     `)
     const map = new Map<string, { threadId: string; replyCount: number }>()
@@ -957,7 +963,14 @@ export const StreamRepository = {
    * (`threadSummaryFromRow`) with `findThreadSummaryByParentMessage` so the
    * two entry points cannot drift on their output shape.
    */
-  async findThreadSummaries(db: Querier, parentStreamId: string): Promise<Map<string, ThreadSummary>> {
+  async findThreadSummaries(
+    db: Querier,
+    parentStreamId: string,
+    parentMessageIds?: string[]
+  ): Promise<Map<string, ThreadSummary>> {
+    // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
+    // list scopes the (potentially large) reply scan to just those parents so a
+    // bootstrap of a deep stream doesn't summarize every thread it has ever had.
     const result = await db.query<ThreadSummaryRow>(sql`
       WITH thread_messages AS (
         SELECT
@@ -972,6 +985,7 @@ export const StreamRepository = {
         WHERE s.parent_stream_id = ${parentStreamId}
           AND s.parent_message_id IS NOT NULL
           AND m.deleted_at IS NULL
+          AND (${parentMessageIds === undefined} OR s.parent_message_id = ANY(${parentMessageIds ?? []}))
       ),
       latest AS (
         SELECT DISTINCT ON (parent_message_id)

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -920,6 +920,10 @@ export const StreamRepository = {
     parentStreamId: string,
     parentMessageIds?: string[]
   ): Promise<Map<string, { threadId: string; replyCount: number }>> {
+    // An empty scope matches nothing — skip the round-trip entirely.
+    if (parentMessageIds !== undefined && parentMessageIds.length === 0) {
+      return new Map<string, { threadId: string; replyCount: number }>()
+    }
     // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
     // list scopes the scan to those parents (bootstrap only needs summaries for
     // the messages in its window, not every thread in the stream). An empty list
@@ -968,6 +972,10 @@ export const StreamRepository = {
     parentStreamId: string,
     parentMessageIds?: string[]
   ): Promise<Map<string, ThreadSummary>> {
+    // An empty scope matches nothing — skip the round-trip entirely.
+    if (parentMessageIds !== undefined && parentMessageIds.length === 0) {
+      return new Map<string, ThreadSummary>()
+    }
     // `parentMessageIds === undefined` keeps the whole-stream behavior; passing a
     // list scopes the (potentially large) reply scan to just those parents so a
     // bootstrap of a deep stream doesn't summarize every thread it has ever had.

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1626,11 +1626,15 @@ export class StreamService {
   }
 
   /**
-   * Get a map of messageId -> { threadId, replyCount } for all messages in a stream that have threads.
+   * Get a map of messageId -> { threadId, replyCount } for messages in a stream that have threads.
    * This is an optimized version that fetches threads and counts in a single query.
+   * Pass `parentMessageIds` to scope the scan to a specific bootstrap window.
    */
-  async getThreadsWithReplyCounts(streamId: string): Promise<Map<string, { threadId: string; replyCount: number }>> {
-    return StreamRepository.findThreadsWithReplyCounts(this.pool, streamId)
+  async getThreadsWithReplyCounts(
+    streamId: string,
+    parentMessageIds?: string[]
+  ): Promise<Map<string, { threadId: string; replyCount: number }>> {
+    return StreamRepository.findThreadsWithReplyCounts(this.pool, streamId, parentMessageIds)
   }
 
   /**
@@ -1643,8 +1647,10 @@ export class StreamService {
    * transaction; wrapping it in a service method would force that caller to
    * either break out of its existing `client` transaction or duplicate the
    * pool accessor, so it stays as a repository call.
+   *
+   * Pass `parentMessageIds` to scope the scan to a specific bootstrap window.
    */
-  async getThreadSummaries(streamId: string): Promise<Map<string, ThreadSummary>> {
-    return StreamRepository.findThreadSummaries(this.pool, streamId)
+  async getThreadSummaries(streamId: string, parentMessageIds?: string[]): Promise<Map<string, ThreadSummary>> {
+    return StreamRepository.findThreadSummaries(this.pool, streamId, parentMessageIds)
   }
 }

--- a/apps/backend/tests/e2e/api.test.ts
+++ b/apps/backend/tests/e2e/api.test.ts
@@ -202,6 +202,10 @@ describe("API E2E Tests", () => {
       const events = await listEvents(client, workspace.id, scratchpad.id, ["message_created"])
       expect(events.length).toBe(1)
       expect((events[0].payload as { messageId: string }).messageId).toBe(message.id)
+      // The events response no longer pre-serializes via serializeBigInt and relies
+      // on the app-level json replacer; the bigint sequence must still cross the
+      // wire as a string (a raw bigint would 500 in res.json).
+      expect(events[0].sequence).toBe("1")
     })
 
     test("should maintain message sequence", async () => {

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -225,6 +225,88 @@ describe("Thread Summary", () => {
     })
   })
 
+  describe("findThreadSummaries / findThreadsWithReplyCounts scoped to parentMessageIds", () => {
+    // Two parents with threaded replies in the SAME channel so we can assert the
+    // scoping filter narrows to a bootstrap window instead of the whole stream.
+    async function seedTwoThreadsInOneChannel() {
+      const ownerId = userId()
+      const wsId = workspaceId()
+
+      await withTestTransaction(pool, async (client) => {
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Scoped Thread Summary WS",
+          slug: `scoped-thread-${wsId}`,
+          createdBy: ownerId,
+        })
+        await addTestMember(client, wsId, ownerId)
+      })
+
+      const channel = await streamService.createChannel({
+        workspaceId: wsId,
+        slug: `scoped-thread-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        createdBy: ownerId,
+        visibility: Visibilities.PUBLIC,
+      })
+
+      async function parentWithReply(markdown: string) {
+        const parent = await eventService.createMessage({
+          workspaceId: wsId,
+          streamId: channel.id,
+          authorId: ownerId,
+          authorType: "user",
+          ...testMessageContent(markdown),
+        })
+        const thread = await streamService.createThread({
+          workspaceId: wsId,
+          parentStreamId: channel.id,
+          parentMessageId: parent.id,
+          createdBy: ownerId,
+        })
+        await eventService.createMessage({
+          workspaceId: wsId,
+          streamId: thread.id,
+          authorId: ownerId,
+          authorType: "user",
+          ...testMessageContent(`reply to ${markdown}`),
+        })
+        return parent.id
+      }
+
+      const parentA = await parentWithReply("Parent A")
+      const parentB = await parentWithReply("Parent B")
+      return { channelId: channel.id, parentA, parentB }
+    }
+
+    test("undefined scope returns every thread in the stream", async () => {
+      const { channelId, parentA, parentB } = await seedTwoThreadsInOneChannel()
+      const summaries = await StreamRepository.findThreadSummaries(pool, channelId)
+      const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId)
+      expect(summaries.has(parentA)).toBe(true)
+      expect(summaries.has(parentB)).toBe(true)
+      expect(counts.has(parentA)).toBe(true)
+      expect(counts.has(parentB)).toBe(true)
+    })
+
+    test("a scoped list returns only the requested parents", async () => {
+      const { channelId, parentA, parentB } = await seedTwoThreadsInOneChannel()
+      const summaries = await StreamRepository.findThreadSummaries(pool, channelId, [parentA])
+      const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId, [parentA])
+      expect(summaries.has(parentA)).toBe(true)
+      expect(summaries.has(parentB)).toBe(false)
+      expect(counts.has(parentA)).toBe(true)
+      expect(counts.has(parentB)).toBe(false)
+    })
+
+    test("an empty scope returns an empty map without scanning the stream", async () => {
+      const { channelId } = await seedTwoThreadsInOneChannel()
+      const summaries = await StreamRepository.findThreadSummaries(pool, channelId, [])
+      const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId, [])
+      expect(summaries.size).toBe(0)
+      expect(counts.size).toBe(0)
+    })
+  })
+
   describe("thread-summary reactivity", () => {
     test("editing the latest thread reply emits a parent-stream refresh with updated threadSummary", async () => {
       const f = await seedThread(1, 1, { markdown: "Original latest reply" })

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -282,28 +282,33 @@ describe("Thread Summary", () => {
       const { channelId, parentA, parentB } = await seedTwoThreadsInOneChannel()
       const summaries = await StreamRepository.findThreadSummaries(pool, channelId)
       const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId)
-      expect(summaries.has(parentA)).toBe(true)
-      expect(summaries.has(parentB)).toBe(true)
-      expect(counts.has(parentA)).toBe(true)
-      expect(counts.has(parentB)).toBe(true)
+      expect({
+        summaries: [...summaries.keys()].sort(),
+        counts: [...counts.keys()].sort(),
+      }).toEqual({
+        summaries: [parentA, parentB].sort(),
+        counts: [parentA, parentB].sort(),
+      })
     })
 
     test("a scoped list returns only the requested parents", async () => {
-      const { channelId, parentA, parentB } = await seedTwoThreadsInOneChannel()
+      const { channelId, parentA } = await seedTwoThreadsInOneChannel()
       const summaries = await StreamRepository.findThreadSummaries(pool, channelId, [parentA])
       const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId, [parentA])
-      expect(summaries.has(parentA)).toBe(true)
-      expect(summaries.has(parentB)).toBe(false)
-      expect(counts.has(parentA)).toBe(true)
-      expect(counts.has(parentB)).toBe(false)
+      expect({
+        summaries: [...summaries.keys()],
+        counts: [...counts.keys()],
+      }).toEqual({ summaries: [parentA], counts: [parentA] })
     })
 
     test("an empty scope returns an empty map without scanning the stream", async () => {
       const { channelId } = await seedTwoThreadsInOneChannel()
       const summaries = await StreamRepository.findThreadSummaries(pool, channelId, [])
       const counts = await StreamRepository.findThreadsWithReplyCounts(pool, channelId, [])
-      expect(summaries.size).toBe(0)
-      expect(counts.size).toBe(0)
+      expect({ summaries: [...summaries.keys()], counts: [...counts.keys()] }).toEqual({
+        summaries: [],
+        counts: [],
+      })
     })
   })
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@types/multer-s3": "^3.0.3",
         "@workos-inc/node": "^7",
         "ai": "^5.0.113",
+        "compression": "^1.8.0",
         "cookie-parser": "^1",
         "cors": "^2",
         "express": "^5",
@@ -79,6 +80,7 @@
       },
       "devDependencies": {
         "@opentelemetry/context-async-hooks": "^2.2.0",
+        "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1",
         "@types/cors": "^2",
         "@types/express": "^5",
@@ -1685,6 +1687,8 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/compression": ["@types/compression@1.8.1", "", { "dependencies": { "@types/express": "*", "@types/node": "*" } }, "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/content-disposition": ["@types/content-disposition@0.5.9", "", {}, "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ=="],
@@ -2072,6 +2076,10 @@
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
+
+    "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
+
+    "compression": ["compression@1.8.1", "", { "dependencies": { "bytes": "3.1.2", "compressible": "~2.0.18", "debug": "2.6.9", "negotiator": "~0.6.4", "on-headers": "~1.1.0", "safe-buffer": "5.2.1", "vary": "~1.1.2" } }, "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -2957,7 +2965,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -3012,6 +3020,8 @@
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -3391,7 +3401,7 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -4153,6 +4163,8 @@
 
     "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
@@ -4195,6 +4207,8 @@
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
+    "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
     "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -4204,6 +4218,8 @@
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -4238,6 +4254,10 @@
     "iron-webcrypto/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "jsdom/saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "jwa/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "jws/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "langsmith/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
@@ -4307,7 +4327,11 @@
 
     "radix-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "randombytes/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -4334,6 +4358,8 @@
     "squid/@types/pg": ["@types/pg@7.14.11", "", { "dependencies": { "@types/node": "*", "pg-protocol": "^1.2.0", "pg-types": "^2.2.0" } }, "sha512-EnZkZ1OMw9DvNfQkn2MTJrwKmhJYDEs5ujWrPfvseWNoI95N8B4HzU/Ltrq5ZfYxDX/Zg8mTzwr6UAyTjjFvXA=="],
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -4546,6 +4572,8 @@
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 


### PR DESCRIPTION
## Problem

Loading messages is already noticeable on a small dataset, which means the read path won't hold up for larger workspaces. Investigating the older-messages (`GET .../streams/:id/events?before=`) and bootstrap paths surfaced three issues, two of which are cheap, broadly-beneficial wins on the backend:

1. **Responses ship uncompressed.** Event/message payloads are large JSON (a full ProseMirror doc per message) and travel an extra origin→edge hop through the Cloudflare `workspace-router`, which is an inline `fetch`+return proxy and forwards `Content-Encoding` unchanged. Nothing in the stack compressed them.
2. **Every event response was deep-cloned for serialization.** `serializeEvent` ran `serializeBigInt` over all 50 payloads per page even though the app already configures a global `json replacer` (`bigIntReplacer`) that stringifies bigints across the whole `res.json` body — the same replacer `sharedMessages`/`members` in those responses already rely on.
3. **Bootstrap thread enrichment scanned the whole stream.** `getThreadsWithReplyCounts` and `getThreadSummaries` summarized every thread the stream has ever had, but `enrichBootstrapEvents` only consumes the entries matching the ~50 messages in the bootstrap window. The scan grows with total history while the useful output stays tiny — the clearest cliff for large/old streams.

## Solution

Three backend changes, no behavior change on the wire:

**1. Add `compression()` middleware** (`app.ts`). Default 1KB threshold skips tiny responses. No SSE/streaming endpoints exist, so there's nothing to buffer-break. Cloudflare passes the `Content-Encoding` through to the browser, and the origin→edge hop is now compressed too.

**2. Drop the redundant `serializeBigInt` clone** from the three event responses (`listEvents`, `listEventsAround`, bootstrap). They now pass the raw event array to `res.json`, letting the global replacer stringify bigints — identical bytes, one fewer full walk of every payload per page. Removed the now-dead `serializeEvent` helper and its import.

**3. Scope bootstrap thread enrichment to the loaded window.** `findThreadsWithReplyCounts` / `findThreadSummaries` (and their service wrappers) take an optional `parentMessageIds` filter, applied via the existing NULL-sentinel guard pattern already used elsewhere in the repo:

- `undefined` → whole-stream behavior (preserved for other callers and existing tests)
- a list → scan scoped to those parents
- `[]` → matches nothing, empty map, no scan

The bootstrap handler derives the parent IDs from its finalized event window and runs the two thread queries scoped, after the window is known, instead of whole-stream in the upfront `Promise.all`. `snapshotAt` is still captured before any enrichment query, so the frontend's socket-vs-bootstrap freshness watermark (INV-53) is unaffected.

### Key design decisions

**Optional filter rather than a required one / new method.** The only production caller is bootstrap, but the integration tests and the general "summaries for a stream" semantics still want the unscoped form. An optional param keeps one code path (INV-29/INV-35) and stays backward-compatible.

**Reordered, not parallelized away.** Thread queries now run after the event window is finalized (they depend on its message IDs). The upfront `Promise.all` got cheaper, so end-to-end bootstrap latency does not regress — and the scoped queries are dramatically cheaper on deep streams.

## Out of scope (follow-up)

The frontend timeline pipeline (unbounded `loadStreamEvents` IDB scan, IDB write→re-read hop on scroll-back, row memoization) is the other half of perceived latency, but those changes live in invariant-dense code (INV-53, floor ratcheting, jump-to-message) and need verification in a running app + profiler rather than reasoning alone. Markdown rendering is already memoized, so it is not a bottleneck. Tracked for a separate, app-verified PR.

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/app.ts` | Add `compression()` middleware |
| `apps/backend/src/features/streams/handlers.ts` | Drop `serializeEvent`; scope bootstrap thread queries to loaded message IDs |
| `apps/backend/src/features/streams/repository.ts` | Optional `parentMessageIds` filter on `findThreadsWithReplyCounts` / `findThreadSummaries` |
| `apps/backend/src/features/streams/service.ts` | Pass-through `parentMessageIds` on the two service wrappers |
| `apps/backend/tests/e2e/api.test.ts` | Assert `event.sequence` still serializes to a string without `serializeBigInt` |
| `apps/backend/tests/integration/thread-summary.test.ts` | Cover undefined / scoped / empty `parentMessageIds` |
| `apps/backend/package.json`, `bun.lock` | Add `compression` + `@types/compression` |

## Test plan

- [x] `bun run typecheck` (full monorepo, via pre-commit) — clean
- [x] Lint + dockerfile + OpenAPI checks (pre-commit) — clean
- [x] `bun test src/features/streams` — 43 pass
- [ ] CI: `thread-summary.test.ts` scoped cases (needs Postgres — not available in the authoring sandbox)
- [ ] CI: `api.test.ts` event-sequence assertion

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgoRnEnf9zEfrfHSmEWfKi)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539374&installation_id=129946197&pr_number=810&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F810&signature=e8361539104905b3e3ab4649b1494e69997afa0df3be2a678a27d0294b8510a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->