### PR TITLE
fix(frontend): evict immutable-cached bad assets during SW recovery

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -189,6 +189,29 @@
               )
             })
           )
+          // Missing styles can also mean an immutable-cached bad /assets/*.css
+          // (the SPA index.html fallback served as text/html and pinned for a
+          // year — see public/_headers). That lives in the browser HTTP cache,
+          // which the unregister + caches.delete above can't evict and
+          // location.reload() won't revalidate. Re-fetch the shell and its
+          // asset URLs with `cache: "reload"` to bypass and overwrite them.
+          tasks.push(
+            fetch("/index.html", { cache: "reload" })
+              .then(function (res) {
+                return res.text()
+              })
+              .then(function (html) {
+                var urls = (html.match(/\/assets\/[^"')\s]+/g) || []).filter(function (u, i, a) {
+                  return a.indexOf(u) === i
+                })
+                return Promise.all(
+                  urls.map(function (u) {
+                    return fetch(u, { cache: "reload" }).catch(function () {})
+                  })
+                )
+              })
+              .catch(function () {})
+          )
           Promise.all(tasks).then(function () {
             location.reload()
           })

--- a/apps/frontend/public/recover.html
+++ b/apps/frontend/public/recover.html
@@ -173,6 +173,33 @@
               setStatus("Cache Storage not supported — skipped.")
             }
 
+            // The poison is usually in the *browser HTTP cache*, not the SW
+            // caches above: a hashed /assets/* URL fetched mid-deploy gets the
+            // index.html SPA fallback stamped `immutable, max-age=1yr`, which
+            // never revalidates and survives the unregister + clear above.
+            // Re-fetch the shell and its asset URLs with `cache: "reload"` to
+            // bypass and overwrite those entries. (A lazily-imported chunk that
+            // isn't referenced in index.html is handled on the next load: the
+            // counter reset below restores the app's auto-recovery budget so its
+            // error boundary can bust that chunk too.)
+            try {
+              var shell = await fetch("/index.html", { cache: "reload" })
+              var html = await shell.text()
+              var assetUrls = (html.match(/\/assets\/[^"')\s]+/g) || []).filter(function (u, i, a) {
+                return a.indexOf(u) === i
+              })
+              await Promise.all(
+                assetUrls.map(function (u) {
+                  return fetch(u, { cache: "reload" }).catch(function () {})
+                })
+              )
+              setStatus("Re-fetched shell + " + assetUrls.length + " asset(s) from network.")
+            } catch (e) {
+              // Offline or fetch unsupported — the unregister/clear above still
+              // helps, and the next load's error boundary will retry.
+              setStatus("Could not force-refetch assets — continuing anyway.")
+            }
+
             // Reset the in-app auto-recovery counter so if something goes
             // wrong again, the app gets its full quota of auto-retries.
             try {

--- a/apps/frontend/src/components/error-boundary.tsx
+++ b/apps/frontend/src/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from "@/components/ui/empty"
 import { ErrorDetails } from "./error-details"
-import { isChunkLoadError, runSwRecovery } from "@/lib/sw-recovery"
+import { chunkUrlFromError, isChunkLoadError, runSwRecovery } from "@/lib/sw-recovery"
 
 function formatError(error: unknown): string | null {
   if (error instanceof Error) {
@@ -41,10 +41,14 @@ export function ErrorBoundary() {
   // (see lib/sw-recovery.ts) so we can't loop past the cap.
   useEffect(() => {
     if (!chunkLoadFailed) return
-    void runSwRecovery().then((triggered) => {
+    // Pass the failing chunk URL so recovery force-refetches it past the
+    // browser HTTP cache — an immutable-cached bad response (HTML served as JS
+    // at an /assets/* URL) is what unregister + caches.delete can't evict.
+    const bustUrl = chunkUrlFromError(error)
+    void runSwRecovery({ bustUrls: bustUrl ? [bustUrl] : undefined }).then((triggered) => {
       if (!triggered) setRecoveryDeclined(true)
     })
-  }, [chunkLoadFailed])
+  }, [chunkLoadFailed, error])
 
   let title = "Something Went Wrong"
   let description = "The labyrinth has shifted unexpectedly. We encountered an error while navigating your path."

--- a/apps/frontend/src/lib/sw-recovery.test.ts
+++ b/apps/frontend/src/lib/sw-recovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { isChunkLoadError, runSwRecovery } from "./sw-recovery"
+import { chunkUrlFromError, isChunkLoadError, runSwRecovery } from "./sw-recovery"
 
 describe("isChunkLoadError", () => {
   it("detects Chromium/Firefox dynamic-import failures", () => {
@@ -32,6 +32,26 @@ describe("isChunkLoadError", () => {
   })
 })
 
+describe("chunkUrlFromError", () => {
+  it("extracts the asset URL from a Chromium/Firefox import failure", () => {
+    const err = new TypeError(
+      "Failed to fetch dynamically imported module: https://app.threa.io/assets/workspace-layout-D6MDsthX.js"
+    )
+    expect(chunkUrlFromError(err)).toBe("https://app.threa.io/assets/workspace-layout-D6MDsthX.js")
+  })
+
+  it("extracts a .css asset URL", () => {
+    expect(chunkUrlFromError("error loading module https://app.threa.io/assets/index-AbC123.css")).toBe(
+      "https://app.threa.io/assets/index-AbC123.css"
+    )
+  })
+
+  it("returns null when the message carries no URL", () => {
+    expect(chunkUrlFromError(new TypeError("error loading dynamically imported module"))).toBeNull()
+    expect(chunkUrlFromError(null)).toBeNull()
+  })
+})
+
 describe("runSwRecovery", () => {
   const originalLocation = window.location
 
@@ -42,11 +62,16 @@ describe("runSwRecovery", () => {
       configurable: true,
       value: { ...originalLocation, reload: vi.fn() },
     })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("")))
+    )
   })
 
   afterEach(() => {
     Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
     sessionStorage.clear()
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -85,6 +110,28 @@ describe("runSwRecovery", () => {
     const result = await runSwRecovery({ force: true })
     expect(result).toBe(true)
     expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("2")
+    expect(window.location.reload).toHaveBeenCalledOnce()
+  })
+
+  it("force-refetches the app shell past the browser HTTP cache", async () => {
+    await runSwRecovery({ force: true })
+    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload" })
+  })
+
+  it("force-refetches the failing chunk URL so an immutable-cached bad response is overwritten", async () => {
+    const bad = "https://app.threa.io/assets/workspace-layout-D6MDsthX.js"
+    await runSwRecovery({ force: true, bustUrls: [bad] })
+    expect(fetch).toHaveBeenCalledWith(bad, { cache: "reload" })
+    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload" })
+  })
+
+  it("reloads even if the cache-busting refetch rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline")))
+    )
+    const result = await runSwRecovery({ force: true })
+    expect(result).toBe(true)
     expect(window.location.reload).toHaveBeenCalledOnce()
   })
 })

--- a/apps/frontend/src/lib/sw-recovery.ts
+++ b/apps/frontend/src/lib/sw-recovery.ts
@@ -43,6 +43,23 @@ export function isChunkLoadError(error: unknown): boolean {
 }
 
 /**
+ * Pull the asset URL out of a dynamic-import failure message, e.g.
+ *   "Failed to fetch dynamically imported module: https://app.threa.io/assets/x-AbC123.js"
+ * Returns null when the message carries no URL (some Safari variants).
+ *
+ * The URL is what recovery force-refetches with `cache: "reload"` — see the
+ * `bustUrls` rationale in runSwRecovery.
+ */
+export function chunkUrlFromError(error: unknown): string | null {
+  let message = ""
+  if (error instanceof Error) message = error.message
+  else if (typeof error === "string") message = error
+  if (!message) return null
+  const match = message.match(/https?:\/\/[^\s"')]+\.(?:m?js|css)/)
+  return match ? match[0] : null
+}
+
+/**
  * Unregister the service worker, clear all Cache Storage buckets, then
  * hard-reload. Returns true if recovery was kicked off (a reload will
  * follow), false if the per-session cap has been reached and the caller
@@ -51,8 +68,16 @@ export function isChunkLoadError(error: unknown): boolean {
  * Pass `force: true` for user-initiated clicks — the attempt cap only
  * exists to prevent auto-recovery loops when recovery itself is broken,
  * not to limit the user's ability to ask for a clean reload.
+ *
+ * `bustUrls` are force-refetched with `cache: "reload"` before the reload.
+ * The poison this recovers from often lives in the *browser HTTP cache*, not
+ * CacheStorage: a hashed `/assets/*.js` URL requested while the edge was
+ * mid-deploy gets the SPA `index.html` fallback (200 text/html) stamped with
+ * our `immutable, max-age=1yr` header (see public/_headers). That entry never
+ * revalidates, so unregister + caches.delete + location.reload() can't shift
+ * it — only a `cache: "reload"` fetch bypasses and overwrites it.
  */
-export async function runSwRecovery(options?: { force?: boolean }): Promise<boolean> {
+export async function runSwRecovery(options?: { force?: boolean; bustUrls?: string[] }): Promise<boolean> {
   if (!options?.force) {
     const attempts = Number.parseInt(sessionStorage.getItem(ATTEMPTS_KEY) ?? "0", 10)
     if (attempts >= MAX_ATTEMPTS) return false
@@ -66,6 +91,12 @@ export async function runSwRecovery(options?: { force?: boolean }): Promise<bool
   }
   if ("caches" in window) {
     tasks.push(caches.keys().then((names) => Promise.all(names.map((n) => caches.delete(n)))))
+  }
+  // Overwrite any immutable-cached bad responses in the browser HTTP cache.
+  // Always bust the app shell; bust the specific failing chunk when we have it.
+  const bustUrls = new Set(["/index.html", ...(options?.bustUrls ?? [])])
+  for (const url of bustUrls) {
+    tasks.push(fetch(url, { cache: "reload" }).catch(() => {}))
   }
   await Promise.all(tasks).catch(() => {})
   window.location.reload()


### PR DESCRIPTION
## Problem

`/recover` and the in-app recovery paths reported success ("service worker is deleted") but the app kept failing with:

```
TypeError: Failed to fetch dynamically imported module: https://app.threa.io/assets/workspace-layout-D6MDsthX.js
```

even though the chunk existed on the server. The poisoned response lived in a cache layer none of the recovery code touched: the **browser HTTP disk cache**, marked `immutable`.

## Root cause

From `public/_headers` + `public/_redirects`:

- `/assets/*` is served `Cache-Control: public, max-age=31536000, immutable`
- `_redirects` has the SPA fallback `/* /index.html 200`

When a hashed `/assets/*.js` URL is requested while the Cloudflare Pages edge is mid-deploy (or an old precached SW imports a chunk before that edge has it), the SPA fallback returns **`index.html` as `200 text/html`**. Because the request path matches `/assets/*`, the browser stores that HTML document under the chunk URL **immutable for a year**.

`immutable` means the browser never revalidates it. So `serviceWorker.unregister()` + `caches.delete()` + `location.reload()` — everything the recovery surfaces did — genuinely cleared the SW and CacheStorage but the reload still read the poisoned entry straight from disk cache.

## Fix

The only way to evict an `immutable` HTTP-cache entry from JS is `fetch(url, { cache: "reload" })`, which bypasses on read and overwrites the stored response. Wired into all three recovery surfaces:

- **`src/lib/sw-recovery.ts`** — `runSwRecovery` gains a `bustUrls` option; always force-refetches `/index.html`, plus the specific failing chunk. New `chunkUrlFromError()` extracts the URL from the dynamic-import error message.
- **`src/components/error-boundary.tsx`** — passes the failing chunk URL through so the exact poisoned chunk gets overwritten before reload.
- **`public/recover.html`** and the **`index.html`** CSS watchdog — after clearing SW + caches, re-fetch the shell and every `/assets/*` URL it references with `cache: "reload"`. A lazily-imported chunk not referenced in `index.html` is caught on the next load: the existing counter reset restores the app's auto-recovery budget so the error boundary busts that chunk.

The chunk bust is the load-bearing part and works because the failing chunk isn't in the SW precache (that's why the import hit the network and failed), so the SW is transparent to it and `cache: "reload"` reaches the network. Each bust is `.catch(() => {})` so an offline refetch never blocks the reload.

## Tests

`src/lib/sw-recovery.test.ts` — added coverage for `chunkUrlFromError` (js/css URLs, no-URL messages), the shell + chunk `cache: "reload"` busts, and reload-on-fetch-rejection. 16 tests pass; lint + monorepo typecheck green.

## Not in scope

The durable CDN-side fix would be making a missing `/assets/*` return a real 404 instead of the `index.html` fallback, so the `immutable` header never lands on HTML-as-JS. That touches Cloudflare Pages routing behavior I couldn't verify from the dev environment; the client-side bust makes the app self-healing for already-stuck users regardless. Happy to do the `_redirects`/`_headers` hardening as a follow-up.

https://claude.ai/code/session_01Miuwzb6vHyXcED3a6C9Y2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Miuwzb6vHyXcED3a6C9Y2V)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783543866&installation_id=129946197&pr_number=812&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F812&signature=ed1d3bac9d629d79fcc16f489e002c3fa87f0b8455ad32b2798513233400bfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->