### PR TITLE
perf(timeline): drop per-write sort from cached-events read

### DIFF
--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -184,6 +184,21 @@ describe("loadStreamEvents", () => {
     expect(ids[0]).toBe("temp_low")
   })
 
+  it("returns a large floored window fully ASC without an unsent merge", async () => {
+    // Exercises the fast path: a floor is known and there are no pending/failed
+    // rows, so the result comes straight off the compound index in ASC order
+    // with no comparison sort. Insert out of order to prove the order is the
+    // index's, not insertion order.
+    const streamId = "stream_big"
+    const seqs = Array.from({ length: 250 }, (_, i) => i + 1)
+    const shuffled = [...seqs].sort(() => Math.random() - 0.5)
+    await db.events.bulkPut(shuffled.map((n) => makeRealEvent(streamId, String(n))))
+
+    const events = await loadStreamEvents(streamId, 1)
+
+    expect(events.map((e) => e._sequenceNum)).toEqual(seqs)
+  })
+
   it("excludes pending events below the floor when one is provided", async () => {
     // Floor-bounded reads must not pull in unsent events with
     // `_sequenceNum < fromSequenceNum`, or the window contract breaks.

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -191,7 +191,9 @@ describe("loadStreamEvents", () => {
     // index's, not insertion order.
     const streamId = "stream_big"
     const seqs = Array.from({ length: 250 }, (_, i) => i + 1)
-    const shuffled = [...seqs].sort(() => Math.random() - 0.5)
+    // Reverse (worst-case out-of-order) so the input order is deterministic and
+    // can never coincidentally match the expected ASC output.
+    const shuffled = [...seqs].reverse()
     await db.events.bulkPut(shuffled.map((n) => makeRealEvent(streamId, String(n))))
 
     const events = await loadStreamEvents(streamId, 1)

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -25,38 +25,47 @@ export function resetStreamStoreCache(): void {}
  * by `_sequenceNum` rather than being appended at the end of the array.
  */
 export async function loadStreamEvents(streamId: string, fromSequenceNum: number | null): Promise<CachedEvent[]> {
-  // Iterate the index in DESC so the count cap (when applied) keeps the
-  // newest events; flip to ASC at the end for rendering.
-  const lowerBound: [string, number] | [string, typeof Dexie.minKey] =
-    fromSequenceNum != null ? [streamId, fromSequenceNum] : [streamId, Dexie.minKey]
-  const collection = db.events
-    .where("[streamId+_sequenceNum]")
-    .between(lowerBound, [streamId, Dexie.maxKey], true, true)
-    .reverse()
-  const reversed =
-    fromSequenceNum != null ? await collection.toArray() : await collection.limit(DEFAULT_IDB_EVENT_LIMIT).toArray()
+  const hasFloor = fromSequenceNum != null
+  const lowerBound: [string, number] | [string, typeof Dexie.minKey] = hasFloor
+    ? [streamId, fromSequenceNum]
+    : [streamId, Dexie.minKey]
+  const range = db.events.where("[streamId+_sequenceNum]").between(lowerBound, [streamId, Dexie.maxKey], true, true)
 
-  // Merge in pending/failed optimistic events that fell outside the window
-  // (defensive — the current placeholder scheme uses `Date.now()` so they
-  // sort to the very top and are already in-window). Re-sort the full list
-  // so order is determined solely by `_sequenceNum`, not insertion path.
-  //
-  // Drive this off the `_status` index (Dexie only indexes rows where the
-  // value is present, so pending/failed is the entire keyspace here — a
-  // handful of unsent rows app-wide), then narrow to this stream in JS.
-  // The obvious `.where("streamId").equals(streamId).filter(...)` instead
-  // materialises and walks the stream's *entire* cached history on every
-  // call; `useLiveQuery` re-runs this on every write to `db.events`, so on
-  // a long chat that O(history) scan — paid repeatedly during the
-  // bootstrap/sync write burst when a chat opens — is what stalls the
-  // cached-events read past the skeleton delay.
-  const loadedIds = new Set(reversed.map((e) => e.id))
-  const unsent = (await db.events.where("_status").anyOf(["pending", "failed"]).toArray()).filter(
-    (e) =>
-      e.streamId === streamId && !loadedIds.has(e.id) && (fromSequenceNum == null || e._sequenceNum >= fromSequenceNum)
+  // The compound index already yields rows in `_sequenceNum` order, so the base
+  // window needs no comparison sort:
+  //   - With a floor: scan ASC directly — already in render order.
+  //   - Without a floor: scan DESC + cap to the newest N (memory bound on the
+  //     pre-bootstrap load), then flip to ASC with an O(n) reverse.
+  // This matters because `useLiveQuery` re-runs this on every write to
+  // `db.events`; a deep scrolled-back window must not pay an O(n log n) sort
+  // per incoming message.
+  let base: CachedEvent[]
+  if (hasFloor) {
+    base = await range.toArray()
+  } else {
+    base = await range.reverse().limit(DEFAULT_IDB_EVENT_LIMIT).toArray()
+    base.reverse()
+  }
+
+  // Pending/failed optimistic events may have placeholder sequences outside the
+  // scanned window (the current scheme uses `Date.now()`, so they sort to the
+  // very top and are usually already in `base`). Drive this off the `_status`
+  // index — Dexie only indexes rows where the value is present, so this is the
+  // handful of unsent rows app-wide, not an O(history) scan of the stream.
+  const unsentForStream = (await db.events.where("_status").anyOf(["pending", "failed"]).toArray()).filter(
+    (e) => e.streamId === streamId && (!hasFloor || e._sequenceNum >= fromSequenceNum)
   )
+  if (unsentForStream.length === 0) return base
 
-  const merged = unsent.length > 0 ? [...reversed, ...unsent] : reversed
+  // Only now pay for de-duplication: a pending row inside the scanned range is
+  // already present in `base`, so drop those before merging.
+  const loadedIds = new Set(base.map((e) => e.id))
+  const extra = unsentForStream.filter((e) => !loadedIds.has(e.id))
+  if (extra.length === 0) return base
+
+  // Re-sort the spliced list so order is determined solely by `_sequenceNum`,
+  // not by which path a row arrived on.
+  const merged = [...base, ...extra]
   merged.sort((a, b) => a._sequenceNum - b._sequenceNum)
   return merged
 }


### PR DESCRIPTION
## Problem

`loadStreamEvents` is the IndexedDB read that backs the timeline, and `useLiveQuery` re-runs it on **every** write to `db.events` — i.e. on every incoming socket message, every optimistic send, and the whole bootstrap/sync write burst when a stream opens.

On each call it scanned the `[streamId+_sequenceNum]` compound index DESC, built a `Set` over the **entire** loaded window, then ran an O(n log n) comparison sort over that whole window — even though the index already returns rows in `_sequenceNum` order. For a deep, scrolled-back stream that per-write sort grows with how far back the user has scrolled, so an active large chat pays it repeatedly.

## Solution

Lean on the index ordering instead of re-sorting:

- **With a floor:** scan ASC directly — the result is already in render order, no sort.
- **Without a floor:** scan DESC + cap to the newest N (the pre-bootstrap memory bound), then flip to ASC with an O(n) `reverse()` instead of a comparison sort.

The pending/failed optimistic merge — and the `Set` it needs for de-duplication — now only runs when there are genuinely unsent rows for the stream. The common case (no unsent rows) returns the index scan untouched.

Behavior is unchanged: rows are still ordered solely by `_sequenceNum`, optimistic rows still land in their natural slot, and below-floor pending rows are still excluded. The only difference is how much work happens per call.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/stores/stream-store.ts` | Drop the per-write full-window sort + `Set`; rely on index order, merge only when unsent rows exist |
| `apps/frontend/src/stores/stream-store.test.ts` | Add a large out-of-order floored-window test locking the no-sort fast path |

## Test plan

- [x] `bunx vitest run src/stores/stream-store.test.ts` — 8 pass (7 existing ordering cases + 1 new)
- [x] `bun run typecheck` (full monorepo, via pre-commit) — clean
- [x] Lint + OpenAPI checks (pre-commit) — clean

## Context

First small, self-contained slice of the frontend timeline performance follow-up to #810. The remaining slices (skip the IDB write→re-read hop on scroll-back; bound the scan window for very deep histories) touch render/scroll behavior and will land separately with verification in a running app.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgoRnEnf9zEfrfHSmEWfKi)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783543940&installation_id=129946197&pr_number=813&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F813&signature=9250e54231c1861460ce6297a6e777def627ba0a03c7e76e7f8f0d3e485e951e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->