### PR TITLE
fix(timeline): don't prefetch older history while parked at the live tail

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest"
-import { classifyDeepLinkScrollTick, shouldStartHighlightClear, computePaginationEdges } from "./stream-content"
+import {
+  classifyDeepLinkScrollTick,
+  shouldStartHighlightClear,
+  computePaginationEdges,
+  shouldPrefetchOlderHistory,
+} from "./stream-content"
 
 const DEADLINE = 4000
 
@@ -204,5 +209,35 @@ describe("computePaginationEdges", () => {
         prefetchDistance: DISTANCE,
       })
     ).toEqual({ reachedStart: false, reachedEnd: true })
+  })
+})
+
+describe("shouldPrefetchOlderHistory", () => {
+  const base = { followingLiveTail: false, scrollerScrollable: true, hasOlderEvents: true, isFetchingOlder: false }
+
+  it("does not prefetch while parked at the live tail of a scrollable viewport", () => {
+    // Regression guard: on load the viewport sits at the tail and the whole
+    // loaded window can fit inside the overscan, so reachedStart fires with no
+    // user scroll. Prefetching there prepends history above a scrolled anchor
+    // and jumps the scroll on load — the cascade this gate exists to prevent.
+    expect(shouldPrefetchOlderHistory({ ...base, followingLiveTail: true, scrollerScrollable: true })).toBe(false)
+  })
+
+  it("still pages in history at the tail when the window fits the viewport (not scrollable)", () => {
+    // The user can't scroll off the tail to unlock pagination, and a non-
+    // scrollable prepend is bottom-pinned and jump-free — so it must load.
+    expect(shouldPrefetchOlderHistory({ ...base, followingLiveTail: true, scrollerScrollable: false })).toBe(true)
+  })
+
+  it("prefetches once scrolled off the tail with older events not already loading", () => {
+    expect(shouldPrefetchOlderHistory({ ...base, followingLiveTail: false })).toBe(true)
+  })
+
+  it("does not prefetch when there is no older history", () => {
+    expect(shouldPrefetchOlderHistory({ ...base, hasOlderEvents: false })).toBe(false)
+  })
+
+  it("does not stack a second fetch while one is already in flight", () => {
+    expect(shouldPrefetchOlderHistory({ ...base, isFetchingOlder: true })).toBe(false)
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -181,6 +181,32 @@ export function computePaginationEdges(args: {
   }
 }
 
+/**
+ * Whether to prefetch older history given the reached-start signal.
+ *
+ * The jump-prone case is being parked at the live tail of a *scrollable*
+ * viewport: the loaded window can sit entirely inside the top overscan, so
+ * `reachedStart` is satisfied with zero user scrolling, and prefetching then
+ * prepends variable-height history above a scrolled anchor — jumping the scroll
+ * on load and cascading as each jump re-satisfies the trigger. So block older
+ * prefetch only while `followingLiveTail && scrollerScrollable`.
+ *
+ * When the whole window fits the viewport (`scrollerScrollable` false), the user
+ * cannot scroll off the tail to unlock pagination, and prepending is bottom-
+ * pinned and jump-free — so allow it; it fills history until the viewport
+ * scrolls, then the scrollable gate takes over. Once the user scrolls up off the
+ * tail (`followingLiveTail` false), prefetch leads normally.
+ */
+export function shouldPrefetchOlderHistory(args: {
+  followingLiveTail: boolean
+  scrollerScrollable: boolean
+  hasOlderEvents: boolean
+  isFetchingOlder: boolean
+}): boolean {
+  if (!args.hasOlderEvents || args.isFetchingOlder) return false
+  return !(args.followingLiveTail && args.scrollerScrollable)
+}
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -1828,14 +1854,22 @@ function VirtuosoMessageList({
   const FETCH_COOLDOWN_MS = 500
 
   const handleStartReached = useCallback(() => {
-    if (!hasOlderEvents || isFetchingOlder) return
+    // shouldFollowRef is true while parked at the live tail. Reading
+    // scrollHeight forces layout, so only measure in that case (see
+    // shouldPrefetchOlderHistory): block the on-load prepend-jump when the
+    // viewport is scrollable, but still let a window that fits the viewport
+    // page in history the user can't scroll to.
+    const followingLiveTail = shouldFollowRef.current
+    const el = virtuosoScrollerRef.current
+    const scrollerScrollable = followingLiveTail && el ? el.scrollHeight > el.clientHeight + 1 : false
+    if (!shouldPrefetchOlderHistory({ followingLiveTail, scrollerScrollable, hasOlderEvents, isFetchingOlder })) return
     const now = performance.now()
     if (now < olderFetchCooldownRef.current) return
     const started = fetchOlderEvents()
     if (started !== false) {
       olderFetchCooldownRef.current = now + FETCH_COOLDOWN_MS
     }
-  }, [hasOlderEvents, isFetchingOlder, fetchOlderEvents])
+  }, [hasOlderEvents, isFetchingOlder, fetchOlderEvents, virtuosoScrollerRef])
 
   const handleEndReached = useCallback(() => {
     if (!hasNewerEvents || isFetchingNewer) return


### PR DESCRIPTION
## What

Stops the timeline from prefetching older history while parked at the live tail, fixing an on-load scroll-jump cascade.

`apps/frontend/src/components/timeline/stream-content.tsx`

## The bug

Opening a stream with short messages (a DM) loaded the previous page with **zero scrolling** and jumped the viewport up on load, which re-satisfied the trigger and cascaded into bigger jumps.

**Cause:** at the live tail, a short-message stream's entire 50-event bootstrap window can sit inside the 2400px top overscan. Virtuoso then mounts all of it, so the rendered range reaches index 0 and `distFromStart` hits 0 — satisfying the `EVENT_PREFETCH_DISTANCE` (15) trigger with no user scroll. Prefetching prepends variable-height history above a scrolled anchor; the re-measure jumps the scroll, and since the window still reaches the top it fires again. The previous hardcoded distance of `3` only dodged this by luck of the older 600px overscan mounting fewer items.

## The fix

Older history is only needed once the user has scrolled *up* off the tail — there's no reason to preload it while sitting on the newest messages. Gate older prefetch on `followingLiveTail && scrollerScrollable`:

- **`followingLiveTail`** reuses `shouldFollowRef` (already tracked for `followOutput`). Because `followOutput` keeps the user pinned at the bottom *after* a prepend, the gate blocks the whole cascade, not just the first fetch.
- **`scrollerScrollable`** (measured only when at the tail) keeps a window that *fits the viewport* — no scroll room, common on large screens — able to page in history: the user can't scroll off the tail to unlock it, and a non-scrollable prepend is bottom-pinned and jump-free. This was caught in self-review: gating on the tail alone would permanently strand short-stream history on large screens.

Covers both trigger paths (`rangeChanged` and Virtuoso's native `startReached`). Newer/forward prefetch (jump mode) is unaffected. Gate extracted as the pure `shouldPrefetchOlderHistory` helper.

## Verification

- 19/19 stream-content tests (5 new for the gate, including the fits-the-viewport case), frontend typecheck clean, full pre-commit hook green.
- Self-reviewed via 3-perspective review (correctness/spec/design): the fits-the-viewport permanent-block was found and fixed before this PR; re-derived gate is otherwise clean.

## Test on staging

Open a long DM (e.g. the Pierre DM) — it should land at the bottom with **no** jump-up on load, and scrolling up should page in history smoothly without the cascade.

https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNqB8VYqiAaXp8WGow3ZbG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783544522&installation_id=129946197&pr_number=814&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F814&signature=8d78c8c83671f75dea89a42f0dc7aa0ac42a54b0aff1ff087caa62062e23a083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->