### PR TITLE
fix: dock join-channel bar at the bottom instead of floating over messages

### DIFF
--- a/apps/frontend/src/components/timeline/join-channel-bar.test.tsx
+++ b/apps/frontend/src/components/timeline/join-channel-bar.test.tsx
@@ -86,4 +86,26 @@ describe("JoinChannelBar", () => {
     })
     expect(defaultProps.onJoined).not.toHaveBeenCalled()
   })
+
+  // The composer is not rendered for non-members, so the join bar must own
+  // `--composer-height` while it is mounted. Otherwise the timeline footer
+  // spacer keeps a stale height and the bar floats over the messages instead
+  // of docking flush at the bottom (the "join channel is fucked" bug).
+  it("should publish its height as --composer-height on the editor zone", () => {
+    const original = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      return { height: 96, width: 0, top: 0, left: 0, right: 0, bottom: 96, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+    }
+    try {
+      const { container } = render(
+        <div data-editor-zone="main">
+          <JoinChannelBar {...defaultProps} />
+        </div>
+      )
+      const zone = container.querySelector<HTMLElement>("[data-editor-zone]")!
+      expect(zone.style.getPropertyValue("--composer-height")).toBe("96px")
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = original
+    }
+  })
 })

--- a/apps/frontend/src/components/timeline/join-channel-bar.tsx
+++ b/apps/frontend/src/components/timeline/join-channel-bar.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { Hash } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { streamsApi } from "@/api"
+import { useComposerHeightPublish } from "@/hooks"
 import type { StreamMember } from "@threa/types"
 
 interface JoinChannelBarProps {
@@ -14,6 +15,14 @@ interface JoinChannelBarProps {
 export function JoinChannelBar({ workspaceId, streamId, channelName, onJoined }: JoinChannelBarProps) {
   const [isJoining, setIsJoining] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // The join bar stands in for the composer for non-members, so it must own
+  // `--composer-height` while it's mounted: the timeline's footer spacer sizes
+  // the gap below the last message from that variable, and the composer that
+  // would otherwise set it is not rendered for non-members. Without this the
+  // spacer keeps the stale height a prior composer left behind and the bar
+  // floats over the messages instead of docking flush at the bottom.
+  const selfRef = useRef<HTMLDivElement | null>(null)
+  useComposerHeightPublish(selfRef)
 
   const handleJoin = async () => {
     setIsJoining(true)
@@ -29,7 +38,7 @@ export function JoinChannelBar({ workspaceId, streamId, channelName, onJoined }:
   }
 
   return (
-    <div className="flex flex-col items-center gap-3 border-t px-4 py-6">
+    <div ref={selfRef} className="flex flex-col items-center gap-3 border-t bg-background px-4 py-6">
       <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
         <span>You're viewing</span>
         <span className="inline-flex items-center gap-0.5 font-medium text-foreground">

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1628,7 +1628,7 @@ export function StreamContent({
               </AlertDialogContent>
             </AlertDialog>
             {membershipResolved && !isMember && isPublicChannel && (
-              <div className="absolute inset-x-0 z-10" style={{ bottom: "var(--composer-height, 0px)" }}>
+              <div className="absolute inset-x-0 bottom-0 z-10">
                 <JoinChannelBar
                   workspaceId={workspaceId}
                   streamId={streamId}


### PR DESCRIPTION
## Problem

On a public channel you haven't joined, the "You're viewing #channel / Join Channel" bar floated in the middle of the message area, overlapping messages, with dead space beneath it.

Root cause: the `JoinChannelBar` and the message composer (`MessageInput`) are mutually exclusive — for a non-member of a public channel the composer is **not** rendered. But the bar was positioned `bottom: var(--composer-height, 0px)`, and that CSS variable is only ever maintained *by the composer* (the publish hook deliberately leaves its last value behind on unmount so stream-to-stream navigation doesn't jump).

So with no composer present, the bar floated up by a **phantom composer's height** (~100–130px left over from the last channel where you *were* a member), and the timeline's footer spacer reserved that same phantom height — letting messages scroll *behind* the bar.

## Solution

The join bar stands in for the composer for non-members, so it should behave like one:

1. **Dock it at `bottom: 0`** instead of offsetting by `--composer-height` (there is no composer to sit above).
2. **Publish its own measured height** as `--composer-height` via the same `useComposerHeightPublish` hook the composer uses, so the timeline footer spacer reserves exactly the bar's height and the last message sits cleanly above it.
3. Add `bg-background` so the docked bar is opaque and content can't bleed through behind it.

### Key design decisions

**Reuse `useComposerHeightPublish` rather than a one-off measurement.** The hook already writes the height in a `useLayoutEffect` before paint (so the spacer is correct the frame the list reveals), persists it, and leaves it on unmount for a clean handoff. When a non-member joins, the bar unmounts and the composer mounts: the composer's own hook re-seeds from the bar's value and overwrites with its real height. No new mechanism needed.

The bar doesn't pass the `onHeightChange` re-anchor callback the composer uses — it's a static element with no height transition (no attachment chips / 200ms animation), and the pre-paint layout-effect write means the spacer is already correct when the list first reveals.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/join-channel-bar.tsx` | Measure + publish the bar's height as `--composer-height`; add opaque `bg-background` |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Dock the bar wrapper at `bottom-0` instead of `bottom: var(--composer-height)` |
| `apps/frontend/src/components/timeline/join-channel-bar.test.tsx` | Add regression test: bar publishes its height onto the editor zone |

## Test plan

- [x] `join-channel-bar.test.tsx` — 6/6 pass, including the new regression test
- [x] Frontend typecheck clean (`tsc --noEmit`)
- [x] Pre-commit lint/typecheck across all workspaces passed
- [ ] Manual: open a public channel you're not a member of on mobile + web; confirm the bar docks flush at the bottom and the last message sits just above it, then join and confirm the composer takes over without a jump

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W794j2G2qaCpakgaKVJmEV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783546433&installation_id=129946197&pr_number=815&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F815&signature=65ecbf20e0131ea8c8fdb3b8975675250547b6ea57f9f284da971a7d8a1a375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->