### PR TITLE
fix(sync): close the reconnect catch-up gap that dropped live messages

### DIFF
--- a/apps/frontend/src/hooks/use-stream-socket.ts
+++ b/apps/frontend/src/hooks/use-stream-socket.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useSocket } from "@/contexts"
 import { joinRoomFireAndForget } from "@/lib/socket-room"
 import { registerStreamSocketHandlers } from "@/sync/stream-sync"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
 
 /**
  * Hook to handle real-time message/reaction events for a specific stream.
@@ -16,6 +17,8 @@ export function useStreamSocket(workspaceId: string, streamId: string, options?:
   const shouldSubscribe = options?.enabled ?? true
   const queryClient = useQueryClient()
   const socket = useSocket()
+  // Optional: draft panels can mount outside the workspace SyncEngine provider.
+  const syncEngine = useOptionalSyncEngine()
 
   useEffect(() => {
     if (!socket || !workspaceId || !streamId || !shouldSubscribe) return
@@ -29,7 +32,14 @@ export function useStreamSocket(workspaceId: string, streamId: string, options?:
     // Register all stream-level socket handlers — they write to IDB only.
     // queryClient is passed for transitional workspace bootstrap preview updates
     // (will be removed in Phase 3).
-    const cleanupHandlers = registerStreamSocketHandlers(socket, workspaceId, streamId, queryClient)
+    const cleanupHandlers = registerStreamSocketHandlers(socket, workspaceId, streamId, queryClient, {
+      // A live event that skips past the cached tail means events were missed
+      // (zombie socket, server bounce). Route to the engine's single-flighted
+      // backfill so the hole is fetched instead of persisting until reload.
+      onSequenceGap: syncEngine
+        ? ({ streamId: gapStreamId, afterSequence }) => void syncEngine.backfillStreamGap(gapStreamId, afterSequence)
+        : undefined,
+    })
 
     return () => {
       abortController.abort()
@@ -38,5 +48,5 @@ export function useStreamSocket(workspaceId: string, streamId: string, options?:
       // a single leave undoes ALL joins. The SyncEngine also joins this room
       // for stream:activity delivery — leaving here would break sidebar updates.
     }
-  }, [socket, workspaceId, streamId, shouldSubscribe, queryClient])
+  }, [socket, workspaceId, streamId, shouldSubscribe, queryClient, syncEngine])
 }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach, vi } from "vitest"
 import { QueryClient } from "@tanstack/react-query"
 import type { Socket } from "socket.io-client"
 import { db } from "@/db"
@@ -1099,6 +1099,177 @@ describe("registerStreamSocketHandlers — E2E send reconciliation seeds the dec
     // Plaintext events render straight from their payload; the cache stays empty.
     expect(getCachedDecryption("evt_plain")).toBeUndefined()
 
+    cleanup()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sequence gap detection — live events that skip past the cached tail
+// ---------------------------------------------------------------------------
+
+describe("registerStreamSocketHandlers — sequence gap detection (INV-53)", () => {
+  // A live event whose sequence leaves a hole behind the latest persisted one
+  // means events were missed (zombie socket, server bounce, failed catch-up).
+  // The handler must report the pre-write latest sequence so the caller can
+  // fetch the hole — without it the gap is permanent until a full reload.
+
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function makeWireEvent(id: string, streamId: string, sequence: string): StreamEvent {
+    return {
+      id,
+      streamId,
+      sequence,
+      eventType: "message_created",
+      payload: { messageId: id, contentMarkdown: "hi", contentJson: { type: "doc", content: [] } },
+      actorId: "user_2",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  async function seedPersisted(streamId: string, id: string, sequence: number): Promise<void> {
+    await db.events.put({
+      ...makeEvent({ id, streamId, sequence: String(sequence) }),
+      workspaceId: "ws_1",
+      _sequenceNum: sequence,
+      _cachedAt: Date.now(),
+    })
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("reports a gap when a live message skips past the latest persisted event", async () => {
+    const streamId = "stream_gap"
+    await seedPersisted(streamId, "evt_100", 100)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_102", streamId, "102") })
+
+    expect(onSequenceGap).toHaveBeenCalledWith({ streamId, afterSequence: "100" })
+    // The gap-revealing event itself is still written.
+    expect(await db.events.get("evt_102")).toBeDefined()
+    cleanup()
+  })
+
+  it("does not report a gap for the contiguous next event", async () => {
+    const streamId = "stream_contiguous"
+    await seedPersisted(streamId, "evt_100", 100)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_101", streamId, "101") })
+
+    expect(onSequenceGap).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it("does not report a gap when the stream has no cached events yet", async () => {
+    const streamId = "stream_cold"
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_5", streamId, "5") })
+
+    expect(onSequenceGap).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it("does not report a gap for an event at or below the cached tail", async () => {
+    const streamId = "stream_old_event"
+    await seedPersisted(streamId, "evt_100", 100)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_95", streamId, "95") })
+
+    expect(onSequenceGap).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it("ignores pending optimistic placeholder rows when computing the gap baseline", async () => {
+    const streamId = "stream_gap_pending"
+    await seedPersisted(streamId, "evt_100", 100)
+    // Pending optimistic row with a Date.now() placeholder sequence must not
+    // mask the real tail — it would make every gap invisible.
+    const placeholder = Date.now()
+    await db.events.put({
+      ...makeEvent({ id: "temp_x", streamId, sequence: String(placeholder) }),
+      workspaceId: "ws_1",
+      _sequenceNum: placeholder,
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_102", streamId, "102") })
+
+    expect(onSequenceGap).toHaveBeenCalledWith({ streamId, afterSequence: "100" })
+    cleanup()
+  })
+
+  it("detects gaps on append-style events (membership, sessions) too", async () => {
+    const streamId = "stream_gap_member"
+    await seedPersisted(streamId, "evt_100", 100)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("stream:member_joined", {
+      workspaceId: "ws_1",
+      streamId,
+      event: { ...makeWireEvent("evt_103", streamId, "103"), eventType: "member_joined", payload: {} },
+    })
+
+    expect(onSequenceGap).toHaveBeenCalledWith({ streamId, afterSequence: "100" })
+    expect(await db.events.get("evt_103")).toBeDefined()
+    cleanup()
+  })
+
+  it("does not report duplicate gaps for an event already in IDB", async () => {
+    const streamId = "stream_gap_dupe"
+    await seedPersisted(streamId, "evt_100", 100)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_102", streamId, "102") })
+    onSequenceGap.mockClear()
+    // Redelivery of the same event (handler re-registration overlap) — deduped.
+    await emit("message:created", { workspaceId: "ws_1", streamId, event: makeWireEvent("evt_102", streamId, "102") })
+
+    expect(onSequenceGap).not.toHaveBeenCalled()
     cleanup()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -805,18 +805,26 @@ export function registerStreamSocketHandlers(
   const handleAppendEvent = async (payload: AgentSessionEventPayload | CommandEventPayload | MemberRemovedPayload) => {
     if (payload.streamId !== streamId) return
     const now = Date.now()
-    // Dedupe by event ID
-    const existing = await db.events.get(payload.event.id)
-    if (existing) return
-    // Tail-gap check must read the latest BEFORE this write advances it.
-    const gapAfterSequence = onSequenceGap
-      ? detectSequenceGap(await getLatestPersistedSequence(streamId), payload.event.sequence)
-      : null
-    await db.events.put({
-      ...payload.event,
-      workspaceId,
-      _sequenceNum: sequenceToNum(payload.event.sequence),
-      _cachedAt: now,
+    // Set when this event's sequence reveals missed events behind it; reported
+    // after the transaction commits so the backfill never runs inside it.
+    let gapAfterSequence: string | null = null
+    // Same transactional shape as handleMessageCreated: dedupe, gap-read, and
+    // put must be atomic, or a concurrent append can land between the gap read
+    // and this write and make the cursor lie in either direction.
+    await db.transaction("rw", [db.events], async () => {
+      // Dedupe by event ID
+      const existing = await db.events.get(payload.event.id)
+      if (existing) return
+      // Tail-gap check must read the latest BEFORE this write advances it.
+      if (onSequenceGap) {
+        gapAfterSequence = detectSequenceGap(await getLatestPersistedSequence(streamId), payload.event.sequence)
+      }
+      await db.events.put({
+        ...payload.event,
+        workspaceId,
+        _sequenceNum: sequenceToNum(payload.event.sequence),
+        _cachedAt: now,
+      })
     })
     if (gapAfterSequence !== null) {
       onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -498,12 +498,40 @@ function isEncryptedPayload(payload: unknown): boolean {
   return !!p && typeof p.ciphertext === "string" && !!p.envelope
 }
 
+export interface StreamSocketHandlerOptions {
+  /**
+   * Called after a live event was written whose sequence leaves a hole behind
+   * the previously-latest persisted event — i.e. events were missed while this
+   * client wasn't receiving (zombie socket, server bounce, a catch-up fetch
+   * that raced live delivery). `afterSequence` is the pre-write latest, so a
+   * `bootstrap?after=` fetch from it closes the hole (INV-53: overlap is safe,
+   * gaps are not). Other users' command events legitimately occupy sequence
+   * slots that are never delivered to this viewer, so a reported gap may turn
+   * out to be empty — the backfill is idempotent and self-quiets because the
+   * next live event sits contiguously on the new tail.
+   */
+  onSequenceGap?: (gap: { streamId: string; afterSequence: string }) => void
+}
+
+/**
+ * Pre-write tail-gap check: returns the latest persisted sequence when the
+ * incoming event skips past it (a hole exists behind the new tail), null when
+ * contiguous, older-than-tail, or the stream has nothing cached to gap against.
+ */
+function detectSequenceGap(latestPersisted: string | null, incomingSequence: string): string | null {
+  if (latestPersisted === null) return null
+  return sequenceToNum(incomingSequence) > sequenceToNum(latestPersisted) + 1 ? latestPersisted : null
+}
+
 export function registerStreamSocketHandlers(
   socket: Socket,
   workspaceId: string,
   streamId: string,
-  queryClient: QueryClient
+  queryClient: QueryClient,
+  options?: StreamSocketHandlerOptions
 ): () => void {
+  const onSequenceGap = options?.onSequenceGap
+
   const handleMessageCreated = async (payload: MessageEventPayload) => {
     if (payload.streamId !== streamId) return
 
@@ -529,10 +557,19 @@ export function registerStreamSocketHandlers(
       attachmentRefs: AttachmentRef[]
     } | null = null
 
+    // Set when this event's sequence reveals missed events behind it; reported
+    // after the transaction commits so the backfill never runs inside it.
+    let gapAfterSequence: string | null = null
+
     await db.transaction("rw", [db.events, db.pendingMessages], async () => {
       // Dedupe by event ID
       const existing = await db.events.get(newEvent.id)
       if (existing) return
+
+      // Tail-gap check must read the latest BEFORE this write advances it.
+      if (onSequenceGap) {
+        gapAfterSequence = detectSequenceGap(await getLatestPersistedSequence(streamId), newEvent.sequence)
+      }
 
       // Add the real event BEFORE deleting the optimistic one so that
       // Dexie live-query observers never see a frame with neither event.
@@ -546,6 +583,10 @@ export function registerStreamSocketHandlers(
         await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
       }
     })
+
+    if (gapAfterSequence !== null) {
+      onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+    }
 
     // Seed the decrypt cache so the encrypted server event renders its content
     // immediately. Only meaningful for E2E events (the wire payload carries a
@@ -767,12 +808,19 @@ export function registerStreamSocketHandlers(
     // Dedupe by event ID
     const existing = await db.events.get(payload.event.id)
     if (existing) return
+    // Tail-gap check must read the latest BEFORE this write advances it.
+    const gapAfterSequence = onSequenceGap
+      ? detectSequenceGap(await getLatestPersistedSequence(streamId), payload.event.sequence)
+      : null
     await db.events.put({
       ...payload.event,
       workspaceId,
       _sequenceNum: sequenceToNum(payload.event.sequence),
       _cachedAt: now,
     })
+    if (gapAfterSequence !== null) {
+      onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+    }
   }
 
   const handleLinkPreviewReady = async (payload: LinkPreviewReadyPayload) => {

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -61,7 +61,10 @@ class MockSocket {
       const room = args[0] as string
       const callback = args[1] as ((result?: { ok: boolean }) => void) | undefined
       if (this.joinInterceptor) {
-        void this.joinInterceptor(room).then(() => callback?.({ ok: true }))
+        // Ack on both paths so a rejecting interceptor can't hang an awaited join.
+        void this.joinInterceptor(room)
+          .then(() => callback?.({ ok: true }))
+          .catch(() => callback?.({ ok: false }))
       } else {
         callback?.({ ok: true })
       }

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -24,6 +24,9 @@ class MockSocket {
   disconnectCalls = 0
   connectCalls = 0
   emittedEvents: Array<{ event: string; args: unknown[] }> = []
+  /** Runs before a join is acked — lets tests simulate live events landing
+   *  while the room join is in flight. */
+  joinInterceptor: ((room: string) => Promise<void>) | null = null
   private listeners = new Map<string, Set<EventHandler>>()
 
   on(event: string, handler: EventHandler) {
@@ -55,8 +58,13 @@ class MockSocket {
 
     // join ack: reply ok so onConnect's workspace join succeeds in tests
     if (event === "join") {
+      const room = args[0] as string
       const callback = args[1] as ((result?: { ok: boolean }) => void) | undefined
-      callback?.({ ok: true })
+      if (this.joinInterceptor) {
+        void this.joinInterceptor(room).then(() => callback?.({ ok: true }))
+      } else {
+        callback?.({ ok: true })
+      }
       return this
     }
 
@@ -654,5 +662,176 @@ describe("SyncEngine.handlePageResume", () => {
     await connectPromise
 
     expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBeUndefined()
+  })
+})
+
+describe("SyncEngine reconnect catch-up cursor (INV-53 gap safety)", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([db.workspaces.clear(), db.events.clear(), db.streams.clear(), db.streamMemberships.clear()])
+  })
+
+  async function seedEvent(streamId: string, sequence: number): Promise<void> {
+    await db.events.put({
+      id: `evt_${sequence}`,
+      workspaceId: "ws_1",
+      streamId,
+      sequence: String(sequence),
+      eventType: "message_created",
+      payload: {
+        messageId: `msg_${sequence}`,
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: sequence,
+      _cachedAt: Date.now(),
+    })
+  }
+
+  it("reads the reconnect catch-up cursor before re-joining the stream room", async () => {
+    // A live message can land the moment the room is re-joined — before the
+    // catch-up fetch runs. Reading the cursor after the join lets that message
+    // advance it past the disconnect gap, permanently skipping everything
+    // missed while offline. The cursor must reflect the pre-join tail.
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    engine.setVisibleStreamIds(["stream_1"])
+    deps.streamService.bootstrap.mockClear()
+
+    // Live event arrives through the freshly-joined room, mid-reconnect.
+    socket.joinInterceptor = async (room) => {
+      if (room === "ws:ws_1:stream:stream_1") {
+        await seedEvent("stream_1", 3)
+      }
+    }
+
+    await engine.onConnect(asSocket(socket)) // second connect → reconnect
+
+    expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+  })
+
+  it("reads the navigation refresh cursor before the room join can deliver live events", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    deps.streamService.bootstrap.mockClear()
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "stream_1"], makeStreamBootstrap("stream_1", "1"))
+    await seedEvent("stream_1", 1)
+
+    socket.joinInterceptor = async (room) => {
+      if (room === "ws:ws_1:stream:stream_1") {
+        await seedEvent("stream_1", 3)
+      }
+    }
+
+    engine.setCurrentStreamId("stream_1")
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+    })
+  })
+})
+
+describe("SyncEngine.backfillStreamGap", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([db.workspaces.clear(), db.events.clear(), db.streams.clear(), db.streamMemberships.clear()])
+  })
+
+  it("fetches events after the provided pre-gap cursor and applies them", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    deps.streamService.bootstrap.mockClear()
+
+    await engine.backfillStreamGap("stream_1", "1")
+
+    expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+    expect(await db.events.get("evt_2")).toBeTruthy()
+  })
+
+  it("single-flights concurrent backfills for the same stream", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    deps.streamService.bootstrap.mockClear()
+
+    await Promise.all([engine.backfillStreamGap("stream_1", "1"), engine.backfillStreamGap("stream_1", "1")])
+
+    expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(1)
+  })
+
+  it("backfills when a live socket event skips past the cached tail (end to end)", async () => {
+    const deps = makeDeps()
+    const workspaceBootstrap = makeWorkspaceBootstrap()
+    workspaceBootstrap.streamMemberships = [
+      {
+        streamId: "stream_7",
+        memberId: "user_1",
+        notificationLevel: null,
+        lastReadEventId: null,
+        lastReadAt: null,
+        joinedAt: new Date().toISOString(),
+      },
+    ]
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(workspaceBootstrap)
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await db.events.put({
+      id: "evt_1",
+      workspaceId: "ws_1",
+      streamId: "stream_7",
+      sequence: "1",
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_1",
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+
+    await engine.onConnect(asSocket(socket))
+    deps.streamService.bootstrap.mockClear()
+
+    // Sequence 2 was missed (e.g. server bounce); 3 arrives live.
+    socket.trigger("message:created", {
+      workspaceId: "ws_1",
+      streamId: "stream_7",
+      event: {
+        id: "evt_3",
+        streamId: "stream_7",
+        sequence: "3",
+        eventType: "message_created",
+        payload: {
+          messageId: "msg_3",
+          contentMarkdown: "new",
+          contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+        },
+        actorId: "user_2",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_7", { after: "1" })
+    })
   })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -772,6 +772,38 @@ describe("SyncEngine.backfillStreamGap", () => {
     expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(1)
   })
 
+  it("queues a distinct gap reported mid-flight and backfills it after the active one settles", async () => {
+    // A second gap with a different cursor may cover events that committed
+    // after the in-flight fetch's server read — dropping it would leave the
+    // hole until the next reconnect. It must chain one follow-up fetch.
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    deps.streamService.bootstrap.mockClear()
+
+    let resolveFirst: (bootstrap: StreamBootstrap) => void = () => {}
+    deps.streamService.bootstrap.mockImplementationOnce(
+      () =>
+        new Promise<StreamBootstrap>((resolve) => {
+          resolveFirst = resolve
+        })
+    )
+
+    const first = engine.backfillStreamGap("stream_1", "1")
+    // Distinct gap arrives while the first backfill is in flight.
+    void engine.backfillStreamGap("stream_1", "3")
+
+    resolveFirst(makeStreamBootstrap("stream_1", "2"))
+    await first
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(2)
+      expect(deps.streamService.bootstrap).toHaveBeenNthCalledWith(1, "ws_1", "stream_1", { after: "1" })
+      expect(deps.streamService.bootstrap).toHaveBeenNthCalledWith(2, "ws_1", "stream_1", { after: "3" })
+    })
+  })
+
   it("backfills when a live socket event skips past the cached tail (end to end)", async () => {
     const deps = makeDeps()
     const workspaceBootstrap = makeWorkspaceBootstrap()

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -73,7 +73,10 @@ export class SyncEngine {
   private activeBootstrap: Promise<void> | null = null
   private queuedReconnectBootstrap: Promise<void> | null = null
   private activeStreamRefreshes = new Map<string, Promise<void>>()
-  private activeGapBackfills = new Map<string, Promise<void>>()
+  private activeGapBackfills = new Map<string, { cursor: string; promise: Promise<void> }>()
+  /** Lowest gap cursor reported per stream while a backfill was in flight —
+   *  drained into one follow-up backfill when the active one settles. */
+  private queuedGapCursors = new Map<string, string>()
   private hasEverConnected = false
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
@@ -233,17 +236,29 @@ export class SyncEngine {
    * after the PRE-GAP cursor — the current latest would skip the very hole
    * this is meant to fill — and applies them append-style (INV-53).
    *
-   * Single-flighted per stream: a burst of gap reports while a backfill is in
-   * flight collapses onto the same fetch; the applied response closes the gap
-   * they all observed.
+   * Single-flighted per stream: duplicate reports of the SAME gap (the engine
+   * and the stream-view hook both register handlers, so each gap fires twice)
+   * collapse onto the in-flight fetch. A report with a DIFFERENT cursor while
+   * one is in flight is a distinct gap whose events may have committed after
+   * the active fetch's server read — it is queued (lowest cursor wins) and
+   * drained into one follow-up backfill when the active one settles, instead
+   * of being silently dropped.
    */
   backfillStreamGap(streamId: string, afterSequence: string): Promise<void> {
     if (this.isDestroyed) return Promise.resolve()
-    const existing = this.activeGapBackfills.get(streamId)
-    if (existing) return existing
+    const active = this.activeGapBackfills.get(streamId)
+    if (active) {
+      if (active.cursor !== afterSequence) {
+        const queued = this.queuedGapCursors.get(streamId)
+        if (queued === undefined || BigInt(afterSequence) < BigInt(queued)) {
+          this.queuedGapCursors.set(streamId, afterSequence)
+        }
+      }
+      return active.promise
+    }
 
     const { workspaceId, streamService, queryClient } = this.deps
-    const backfill = (async () => {
+    const promise = (async () => {
       try {
         const bootstrap = await streamService.bootstrap(workspaceId, streamId, { after: afterSequence })
         if (this.isDestroyed) return
@@ -263,12 +278,17 @@ export class SyncEngine {
         console.error("Sequence-gap backfill failed", { streamId, afterSequence, error })
       }
     })().finally(() => {
-      if (this.activeGapBackfills.get(streamId) === backfill) {
+      if (this.activeGapBackfills.get(streamId)?.promise === promise) {
         this.activeGapBackfills.delete(streamId)
       }
+      const queued = this.queuedGapCursors.get(streamId)
+      if (queued !== undefined) {
+        this.queuedGapCursors.delete(streamId)
+        void this.backfillStreamGap(streamId, queued)
+      }
     })
-    this.activeGapBackfills.set(streamId, backfill)
-    return backfill
+    this.activeGapBackfills.set(streamId, { cursor: afterSequence, promise })
+    return promise
   }
 
   /**

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -73,6 +73,7 @@ export class SyncEngine {
   private activeBootstrap: Promise<void> | null = null
   private queuedReconnectBootstrap: Promise<void> | null = null
   private activeStreamRefreshes = new Map<string, Promise<void>>()
+  private activeGapBackfills = new Map<string, Promise<void>>()
   private hasEverConnected = false
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
@@ -225,6 +226,52 @@ export class SyncEngine {
   }
 
   /**
+   * Close a detected sequence gap: a live socket event arrived whose sequence
+   * leaves a hole behind the previously-latest persisted event, meaning events
+   * were missed while this client wasn't receiving (zombie socket, server
+   * bounce, a reconnect catch-up that raced live delivery). Fetches events
+   * after the PRE-GAP cursor — the current latest would skip the very hole
+   * this is meant to fill — and applies them append-style (INV-53).
+   *
+   * Single-flighted per stream: a burst of gap reports while a backfill is in
+   * flight collapses onto the same fetch; the applied response closes the gap
+   * they all observed.
+   */
+  backfillStreamGap(streamId: string, afterSequence: string): Promise<void> {
+    if (this.isDestroyed) return Promise.resolve()
+    const existing = this.activeGapBackfills.get(streamId)
+    if (existing) return existing
+
+    const { workspaceId, streamService, queryClient } = this.deps
+    const backfill = (async () => {
+      try {
+        const bootstrap = await streamService.bootstrap(workspaceId, streamId, { after: afterSequence })
+        if (this.isDestroyed) return
+        await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+        queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (current) =>
+          current
+            ? toCachedStreamBootstrap(bootstrap, current, {
+                incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
+              })
+            : current
+        )
+      } catch (error) {
+        // Best-effort: the gap stays in the local cache and the next
+        // reconnect/navigation bootstrap closes it. Mark the stream stale so
+        // the sync indicator reflects the known divergence.
+        this.deps.syncStatus.set(`stream:${streamId}`, "stale")
+        console.error("Sequence-gap backfill failed", { streamId, afterSequence, error })
+      }
+    })().finally(() => {
+      if (this.activeGapBackfills.get(streamId) === backfill) {
+        this.activeGapBackfills.delete(streamId)
+      }
+    })
+    this.activeGapBackfills.set(streamId, backfill)
+    return backfill
+  }
+
+  /**
    * Re-trigger workspace bootstrap (e.g., user clicks "Retry" in sidebar error).
    */
   retryWorkspace(): void {
@@ -270,6 +317,20 @@ export class SyncEngine {
       let bootstrap: WorkspaceBootstrap
 
       if (_isReconnect && visibleStreamIds.length > 0) {
+        // Read each stream's catch-up cursor BEFORE re-joining its room. The
+        // re-join below starts delivering live events into IndexedDB
+        // immediately, and a message landing before the cursor read advances
+        // the cursor past the disconnect gap — the `after` fetch then
+        // permanently skips everything missed while offline (the "older
+        // message never appears while newer ones do" bug). Overlap is safe
+        // (writes dedupe by event id); gaps are not (INV-53).
+        const catchupCursors = new Map<string, string | null>()
+        await Promise.all(
+          visibleStreamIds.map(async (streamId) => {
+            catchupCursors.set(streamId, await getLatestPersistedSequence(streamId))
+          })
+        )
+
         await Promise.all(
           visibleStreamIds.map((streamId) => this.ensureStreamSubscription(streamId, { awaitJoin: true }))
         )
@@ -279,7 +340,7 @@ export class SyncEngine {
           Promise.all(
             visibleStreamIds.map(async (streamId) => {
               try {
-                const after = await getLatestPersistedSequence(streamId)
+                const after = catchupCursors.get(streamId) ?? null
                 const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
                 return { streamId, bootstrap }
               } catch (error) {
@@ -501,7 +562,16 @@ export class SyncEngine {
 
     if (!this.subscribedStreams.has(streamId)) {
       this.subscribedStreams.add(streamId)
-      const cleanup = registerStreamSocketHandlers(this.socket, this.deps.workspaceId, streamId, this.deps.queryClient)
+      const cleanup = registerStreamSocketHandlers(
+        this.socket,
+        this.deps.workspaceId,
+        streamId,
+        this.deps.queryClient,
+        {
+          onSequenceGap: ({ streamId: gapStreamId, afterSequence }) =>
+            void this.backfillStreamGap(gapStreamId, afterSequence),
+        }
+      )
       this.streamHandlerCleanups.set(streamId, cleanup)
     }
 
@@ -545,12 +615,16 @@ export class SyncEngine {
     syncStatus.setError(key, null)
 
     try {
+      const queryKey = streamKeys.bootstrap(workspaceId, streamId)
+      const previousBootstrap = queryClient.getQueryData<CachedStreamBootstrap>(queryKey)
+      // Cursor BEFORE the room join — once subscribed, live events land in
+      // IndexedDB and would advance the cursor past any gap this refresh is
+      // meant to close (INV-53: overlap is safe, gaps are not).
+      const after = previousBootstrap ? await getLatestPersistedSequence(streamId) : null
+
       await this.ensureStreamSubscription(streamId, { awaitJoin: true })
       if (this.isDestroyed) return
 
-      const queryKey = streamKeys.bootstrap(workspaceId, streamId)
-      const previousBootstrap = queryClient.getQueryData<CachedStreamBootstrap>(queryKey)
-      const after = previousBootstrap ? await getLatestPersistedSequence(streamId) : null
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
       await applyStreamBootstrap(workspaceId, streamId, bootstrap)
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -270,6 +270,10 @@ export class SyncEngine {
               })
             : current
         )
+        // Clear any stale marker a prior failed backfill (or a degraded
+        // reconnect) left behind — the gap is closed and the stream is current.
+        this.deps.syncStatus.setError(`stream:${streamId}`, null)
+        this.deps.syncStatus.set(`stream:${streamId}`, "synced")
       } catch (error) {
         // Best-effort: the gap stays in the local cache and the next
         // reconnect/navigation bootstrap closes it. Mark the stream stale so


### PR DESCRIPTION
## Problem

A message sent while a client was briefly disconnected (deploy bounce, phone sleep) could stay missing from the timeline until a full reload, while newer messages kept arriving fine.

Verified against prod for the reported incident (DM `stream_01KJMS776MNP2Q382MJ639Y2JD`):

- seq **3501** created 18:55:11Z while the viewer's device was suspended (its `stream:read` events stop at 18:53:31 and resume 18:55:36) → broadcast missed
- seq **3502** arrived live at 18:55:34, exactly mid-resume
- 3501 never backfilled — visible in the screenshots that triggered this investigation

## Root cause

`SyncEngine.bootstrapWorkspace`'s reconnect path re-joined stream rooms (re-registering socket handlers) **before** reading the per-stream catch-up cursor from `getLatestPersistedSequence`. A live message landing in that window (3502) is written to IndexedDB and advances the cursor past the disconnect gap, so the `bootstrap?after=3502` fetch returns nothing and 3501 is permanently skipped. Since stream bootstrap queries run with `staleTime: Infinity` and all refetch triggers disabled, nothing ever heals the hole short of a reload. `performStreamRefresh` had the same ordering flaw.

INV-53's subscribe-then-fetch makes *overlap* safe (writes dedupe by event id) — but this ordering created *gaps*, which nothing tolerated.

## Fix (two layers)

1. **Root cause:** read each visible stream's catch-up cursor before re-joining its room, in both the reconnect path and `performStreamRefresh`. The regression test fails against the old ordering with the exact production symptom (`after: "3"` instead of `after: "1"`).
2. **Safety net:** tail sequence-gap detection on the live socket write path. When an incoming event's sequence skips past the latest persisted one, the handler reports the pre-write tail via a new `onSequenceGap` callback and `SyncEngine.backfillStreamGap` runs a single-flighted `bootstrap?after=` fetch. This heals *any* missed-event scenario (zombie socket, server bounce, failed catch-up) instead of leaving the hole until the next full-replace bootstrap. A distinct gap reported mid-flight is queued and drained into one follow-up fetch; duplicate reports of the same gap (both handler registration sites observe it) collapse onto the in-flight fetch.

Note: other users' command events legitimately occupy sequence slots that are never delivered to this viewer, so a reported gap can come back empty — the backfill is idempotent and self-quiets because the next live event sits contiguously on the new tail.

## Design decisions

- `backfillStreamGap` deliberately does not coordinate with `activeStreamRefreshes`: concurrent applies are idempotent by design (append-mode merges, writes dedupe by id), so the worst case of an overlapping navigation refresh is one redundant fetch — not worth coupling the two flight guards.
- Gap detection runs inside the same Dexie transaction as the dedupe + put in both `handleMessageCreated` and `handleAppendEvent`, so a concurrent write can't make the reported cursor lie; the backfill itself fires only after commit.

## Testing

- Gap detection: contiguous events, cold cache, older-than-tail events, pending optimistic placeholder rows, duplicate redelivery, append-style (membership/session) events
- Pre-join cursor regression tests for both the reconnect path and navigation refresh (verified to fail with the old ordering)
- Backfill single-flighting + queued mid-flight cursor drain
- Full frontend suite: 2338 tests green; monorepo typecheck + lint green via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7PKnoGy94kset59mDPyYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7PKnoGy94kset59mDPyYw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713556&installation_id=129946197&pr_number=820&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F820&signature=1a658ccd69df36b9062d8e1e6fded1e8bb5500b2a0c197da1fbfe3626e1fc01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->