### PR TITLE
feat: terminate enclave sessions promptly on turn failure (E2EE-25)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -311,6 +311,82 @@ describe("createEnclaveSessionHandlers.complete", () => {
   })
 })
 
+describe("createEnclaveSessionHandlers.fail", () => {
+  const FAIL_BODY = { errorName: "AbortError" }
+
+  it("400s an invalid body", async () => {
+    const { handlers } = makeHandlers()
+    await expect(handlers.fail(req("session_1", { bad: true }), fakeRes())).rejects.toMatchObject({ status: 400 })
+  })
+
+  it("404s when the session is gone", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(null)
+    const { handlers } = makeHandlers()
+    await expect(handlers.fail(req("session_1", FAIL_BODY), fakeRes())).rejects.toMatchObject({ status: 404 })
+  })
+
+  it("409s when the session already terminated", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...SESSION!, status: SessionStatuses.FAILED })
+    const { handlers } = makeHandlers()
+    await expect(handlers.fail(req("session_1", FAIL_BODY), fakeRes())).rejects.toMatchObject({ status: 409 })
+  })
+
+  it("marks the session FAILED with the scrubbed classification and emits the failed lifecycle", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const updateStatus = spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue(SESSION)
+    const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const { handlers, io, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.fail(req("session_1", FAIL_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    // FAILED is gated on the RUNNING→FAILED transition and carries the scrubbed
+    // classification — the error's class name, never plaintext content (INV-E7).
+    expect(updateStatus.mock.calls[0]![2]).toBe(SessionStatuses.FAILED)
+    expect(updateStatus.mock.calls[0]![3]).toMatchObject({
+      error: "Enclave session failed: AbortError",
+      onlyIfStatus: SessionStatuses.RUNNING,
+    })
+    // The failed lifecycle event/outbox is what clears the inline indicator.
+    expect(insertEvent.mock.calls[0]![1]).toMatchObject({
+      streamId: "stream_1",
+      eventType: "agent_session:failed",
+      payload: { sessionId: "session_1", error: "Enclave session failed: AbortError" },
+    })
+    expect(insertOutbox.mock.calls[0]![1]).toBe("agent_session:failed")
+    // And a live-open trace dialog (session room) is transitioned to failed.
+    expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
+    expect(emit.mock.calls.some((c) => c[0] === "agent_session:failed")).toBe(true)
+  })
+
+  it("204s without emitting when the session raced to a terminal state under us", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    // Lost the RUNNING→FAILED transition (completed concurrently between
+    // assertRunning and the gated update).
+    spyOn(AgentSessionRepository, "updateStatus").mockResolvedValue(null)
+    const insertEvent = spyOn(StreamEventRepository, "insert")
+    const { handlers, emit } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.fail(req("session_1", FAIL_BODY), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(insertEvent).not.toHaveBeenCalled() // no double-emit
+    expect(emit).not.toHaveBeenCalled()
+  })
+})
+
 describe("createEnclaveSessionHandlers.stepStarted", () => {
   it("400s an invalid body", async () => {
     const { handlers } = makeHandlers()

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -9,7 +9,13 @@ import { logger } from "../../lib/logger"
 import { OutboxRepository } from "../../lib/outbox"
 import { JobQueues, type QueueManager } from "../../lib/queue"
 import { HttpError } from "../../lib/errors"
-import { AgentSessionRepository, SessionStatuses, getBuiltInAgentConfig, type AgentSession } from "../agents"
+import {
+  AgentSessionRepository,
+  SessionStatuses,
+  getBuiltInAgentConfig,
+  failSessionWithLifecycle,
+  type AgentSession,
+} from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { serializeTraceStep } from "../public-api"
@@ -25,6 +31,7 @@ import type { EventService } from "../messaging"
  *   POST /internal/enclave-runtimes/sessions/:id/messages   — one sealed reply, streamed
  *   POST /internal/enclave-runtimes/sessions/:id/steps      — one sealed trace step, streamed
  *   POST /internal/enclave-runtimes/sessions/:id/complete   — ack (ids + metadata)
+ *   POST /internal/enclave-runtimes/sessions/:id/fail       — terminate on loop error
  */
 
 // Same opaque placeholder the user-send path stores for E2E rows (INV-E1: the
@@ -61,6 +68,14 @@ const completeSchema = z.object({
   messageIds: z.array(z.string().min(1)).max(64),
   model: z.string().min(1),
   usage: z.object({ promptTokens: z.number().optional(), completionTokens: z.number().optional() }).optional(),
+})
+
+// The enclave's scrubbed failure classification — `errorName` is the thrown
+// error's class name (e.g. "AbortError"), never plaintext content (INV-E7): the
+// loop runs after the prompt/history are decrypted, so the raw error is withheld.
+// Bounded so a misbehaving caller can't persist an unbounded string on the row.
+const failSchema = z.object({
+  errorName: z.string().min(1).max(200),
 })
 
 // One sealed trace step. `stepType` + `messageId` + timing are clear; the step's
@@ -535,6 +550,33 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue 
           )
         }
       }
+
+      res.status(204).end()
+    },
+
+    /**
+     * POST /internal/enclave-runtimes/sessions/:id/fail
+     * The enclave's turn loop threw, so terminate the session promptly instead of
+     * waiting for orphan-cleanup's stale-heartbeat backstop. Drives the same
+     * `failSessionWithLifecycle` path the dispatch worker and orphan cleanup use
+     * (FAILED + an `agent_session:failed` stream event/outbox + session-room
+     * socket), so the inline indicator and an open trace dialog stop spinning at
+     * once. The body is a scrubbed error *classification* only — the enclave never
+     * sends plaintext (the raw error could carry decrypted payload bytes, INV-E7).
+     * `failSessionWithLifecycle` gates on winning the RUNNING→FAILED transition, so
+     * a redelivery that raced a concurrent terminal transition no-ops (still 204).
+     */
+    async fail(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
+
+      const parsed = failSchema.safeParse(req.body)
+      if (!parsed.success) throw new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" })
+
+      const session = await AgentSessionRepository.findById(pool, id)
+      assertRunning(session)
+
+      await failSessionWithLifecycle(pool, io, session, `Enclave session failed: ${parsed.data.errorName}`)
 
       res.status(204).end()
     },

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -293,6 +293,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app.post("/internal/enclave-runtimes/sessions/:id/steps", internalAuth, enclaveSession.steps)
     app.post("/internal/enclave-runtimes/sessions/:id/substeps", internalAuth, enclaveSession.substep)
     app.post("/internal/enclave-runtimes/sessions/:id/complete", internalAuth, enclaveSession.complete)
+    app.post("/internal/enclave-runtimes/sessions/:id/fail", internalAuth, enclaveSession.fail)
   }
 
   // Global baseline rate limit

--- a/apps/enclave/src/agent/backend-callbacks.ts
+++ b/apps/enclave/src/agent/backend-callbacks.ts
@@ -6,6 +6,7 @@ import {
   type SealedStepStart,
   type EnclaveSealedSubstep,
   type EnclaveSessionResult,
+  type EnclaveSessionFailure,
 } from "@threa/types"
 import type { EnclaveConfig } from "../config"
 
@@ -29,6 +30,8 @@ export interface BackendCallbacks {
   substep(sessionId: string, substep: EnclaveSealedSubstep): Promise<void>
   /** Mark the session complete once the loop finishes (replies already streamed). */
   complete(sessionId: string, result: EnclaveSessionResult): Promise<void>
+  /** Terminate the session promptly when the loop throws — scrubbed error metadata only, never plaintext. */
+  fail(sessionId: string, failure: EnclaveSessionFailure): Promise<void>
   /** Persist a sealed auto-generated stream title (best-effort; for untitled E2E scratchpads). */
   sealedName(sessionId: string, sealed: EnclaveSealedName): Promise<void>
 }
@@ -103,6 +106,16 @@ export function createBackendCallbacks(config: EnclaveConfig): BackendCallbacks 
         signal: AbortSignal.timeout(COMPLETE_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`session complete failed: ${res.status}`)
+    },
+
+    async fail(sessionId, failure) {
+      const res = await fetch(`${base}/internal/enclave-runtimes/sessions/${sessionId}/fail`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(failure),
+        signal: AbortSignal.timeout(COMPLETE_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`session fail failed: ${res.status}`)
     },
 
     async sealedName(sessionId, sealed) {

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -75,6 +75,10 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
     // populate with request/response content (the enclave never logs payloads).
     const errorName = err instanceof Error ? err.name : typeof err
     logger.error({ errorName, sessionId }, "Enclave session failed")
+    // Stop liveness refresh now, before the (awaited) fail ack — otherwise a
+    // hanging/slow `/fail` would keep beating `heartbeat_at` forward and push
+    // back the orphan-cleanup backstop. (`finally` clears it again; idempotent.)
+    clearInterval(heartbeat)
     // Ack the failure so the backend terminates the session now (clears the
     // inline indicator + open trace dialog) instead of waiting for orphan-cleanup.
     // Best-effort + scrubbed metadata only: if this can't land, heartbeats have

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -30,9 +30,9 @@ export interface SessionRunnerDeps {
 /**
  * Owns one assigned turn end to end: keeps the session's heartbeat fresh while
  * the agent loop runs, then hands the sealed replies back via `complete`. On
- * failure it stops heartbeating and lets the backend's orphan-cleanup reclaim
- * the session (an explicit fail callback + resume are later slices). Plaintext
- * lives only in `runEnclaveTurn`, for the duration of the loop.
+ * failure it acks the backend via `fail` so the session terminates promptly
+ * (orphan-cleanup stays the backstop if that ack can't land). Plaintext lives
+ * only in `runEnclaveTurn`, for the duration of the loop.
  */
 export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: EnclaveSessionAssignment): Promise<void> {
   const { sessionId } = assignment
@@ -70,12 +70,19 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
     await deps.callbacks.complete(sessionId, result)
     logger.info({ sessionId, messages: result.messageIds.length }, "Enclave session completed")
   } catch (err) {
-    // This runs after the prompt/history were decrypted, so log only a scrubbed
+    // This runs after the prompt/history were decrypted, so derive only a scrubbed
     // classification — never the raw error object, which an upstream SDK might
     // populate with request/response content (the enclave never logs payloads).
-    // Nothing to ack — the backend reclaims the session when heartbeats stop.
     const errorName = err instanceof Error ? err.name : typeof err
     logger.error({ errorName, sessionId }, "Enclave session failed")
+    // Ack the failure so the backend terminates the session now (clears the
+    // inline indicator + open trace dialog) instead of waiting for orphan-cleanup.
+    // Best-effort + scrubbed metadata only: if this can't land, heartbeats have
+    // already stopped, so orphan-cleanup still reclaims the session as a backstop.
+    await deps.callbacks.fail(sessionId, { errorName }).catch((failErr) => {
+      const failErrorName = failErr instanceof Error ? failErr.name : typeof failErr
+      logger.warn({ errorName: failErrorName, sessionId }, "Enclave session fail callback failed")
+    })
   } finally {
     clearInterval(heartbeat)
     deps.aborts?.delete(sessionId)

--- a/apps/enclave/src/sessions.test.ts
+++ b/apps/enclave/src/sessions.test.ts
@@ -144,6 +144,7 @@ describe("createSessionsHandler", () => {
       complete: async (sessionId, result) => {
         completed = { sessionId, result }
       },
+      fail: async () => {},
     }
     const inFlight = new Set<string>()
     const handler = createSessionsHandler({ keyPair, rawChat, callbacks, inFlight, aborts: new Map() })
@@ -179,6 +180,7 @@ describe("createSessionsHandler", () => {
       throw new Error("model exploded")
     }
     let completed = false
+    const failed: { sessionId: string; errorName: string }[] = []
     const callbacks: BackendCallbacks = {
       heartbeat: async () => {},
       message: async () => {},
@@ -188,6 +190,9 @@ describe("createSessionsHandler", () => {
       sealedName: async () => {},
       complete: async () => {
         completed = true
+      },
+      fail: async (sessionId, failure) => {
+        failed.push({ sessionId, errorName: failure.errorName })
       },
     }
     const inFlight = new Set<string>()
@@ -199,6 +204,9 @@ describe("createSessionsHandler", () => {
 
     await vi.waitFor(() => expect(inFlight.size).toBe(0))
     expect(completed).toBe(false) // the failed turn never acked completion
+    // It acked the failure instead, with scrubbed metadata only (the error's class
+    // name, never the thrown message — which could carry decrypted payload bytes).
+    expect(failed).toEqual([{ sessionId: "session_test", errorName: "Error" }])
   })
 
   it("acks 202 without re-running when the session is already in flight", async () => {
@@ -221,6 +229,7 @@ describe("createSessionsHandler", () => {
         substep: async () => {},
         sealedName: async () => {},
         complete: async () => {},
+        fail: async () => {},
       },
       inFlight: new Set([assignment.sessionId]), // already running
       aborts: new Map(),

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -663,6 +663,19 @@ export interface EnclaveSessionResult {
   usage?: { promptTokens?: number; completionTokens?: number }
 }
 
+/**
+ * The failure ack, posted to `POST .../sessions/:id/fail` when the enclave's turn
+ * loop throws. Carries only a scrubbed error *classification* — never plaintext
+ * content. The loop runs after the prompt/history are decrypted, so the raw error
+ * could carry payload bytes; the enclave sends just the thrown error's class name
+ * (e.g. `"AbortError"`). The backend maps it onto the session's failure lifecycle
+ * (`failSessionWithLifecycle`), terminating the session promptly instead of
+ * waiting for orphan-cleanup's stale-heartbeat backstop.
+ */
+export interface EnclaveSessionFailure {
+  errorName: string
+}
+
 export type CreateDmMessageInput = CreateDmMessageInputJson | CreateDmMessageInputMarkdown
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -371,6 +371,7 @@ export type {
   EnclaveSealedSubstep,
   EnclaveSessionAssignment,
   EnclaveSessionResult,
+  EnclaveSessionFailure,
   UpdateStreamInput,
   UpdateCompanionModeInput,
   StreamBootstrap,


### PR DESCRIPTION
## Problem

When the enclave's turn loop throws, `runEnclaveSession`'s catch path only logged a scrubbed classification and stopped heartbeating (`apps/enclave/src/agent/session-runner.ts`). The session stayed `RUNNING` until orphan-cleanup reclaimed it on a stale heartbeat (~60s) — so the inline "Ariadne is working…" indicator and any open trace dialog spun for up to a minute after the turn had already failed.

This is Phase 0.3 of the agent-runtimes unification (`docs/plans/agent-runtimes-unification-redesign.md` §2.4), closing **E2EE-25 / #6**.

## Solution

Add an explicit `/fail` callback so the enclave acks a failed turn and the backend terminates the session at once, driving the same failure lifecycle the dispatch worker and orphan cleanup already use. Orphan-cleanup stays the backstop, not the mechanism.

### How it works

1. The enclave's turn loop throws → `runEnclaveSession`'s catch derives the scrubbed `errorName` (as before) and now also calls `callbacks.fail(sessionId, { errorName })`.
2. `BackendCallbacks.fail` POSTs to `/internal/enclave-runtimes/sessions/:id/fail` under the same internal-api-key as the other callbacks.
3. The backend handler validates the metadata, asserts the session is running (404 missing / 409 terminal, like the sibling callbacks), and delegates to the shared `failSessionWithLifecycle` — FAILED status + `agent_session:failed` stream event/outbox + session-room socket, gated on winning the RUNNING→FAILED transition.

### Key design decisions

**1. Error *metadata* only, never plaintext.** The loop runs after the prompt/history are decrypted, so the raw error object could carry decrypted payload bytes. `EnclaveSessionFailure` carries only `errorName` (the thrown error's class name, e.g. `"AbortError"`), bounded (`max(200)`) at the Zod boundary. This mirrors what the enclave already logs and matches the no-plaintext-egress discipline (INV-E7).

**2. Reuse `failSessionWithLifecycle`, don't reimplement.** The dispatch worker (assign-failure) and orphan cleanup already share this path; the new callback is a third caller. It owns the gated RUNNING→FAILED transition and lifecycle emission, so a redelivery that raced a concurrent terminal transition no-ops and still returns 204 — no double-emit.

**3. Best-effort ack, orphan-cleanup as backstop.** The `fail()` call is wrapped in `.catch()` in the runner: if it can't land, heartbeats have already stopped, so orphan-cleanup still reclaims the session. Cancellation ("Stop research") is unaffected — the abort signal only reaches the research sub-loop tool, so a cancelled turn completes through `complete`, not the catch path.

## New types

| Symbol | Purpose |
| --- | --- |
| `EnclaveSessionFailure` (`packages/types/src/api.ts`) | Scrubbed failure metadata (`errorName`) for the `/fail` ack |

## Modified files

| File | Change |
| --- | --- |
| `apps/enclave/src/agent/backend-callbacks.ts` | Add `fail()` to `BackendCallbacks` + POST implementation |
| `apps/enclave/src/agent/session-runner.ts` | Catch path acks via `fail()` (best-effort); updated JSDoc |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | Add `fail` handler + `failSchema`; import `failSessionWithLifecycle` |
| `apps/backend/src/routes.ts` | Register `POST /internal/enclave-runtimes/sessions/:id/fail` |
| `packages/types/src/{api,index}.ts` | Export `EnclaveSessionFailure` |
| `apps/enclave/src/sessions.test.ts` | Add `fail` to callback mocks; assert it's acked with scrubbed metadata on a thrown turn |
| `apps/backend/src/features/enclave-runtimes/session-handlers.test.ts` | New `fail` describe block (400/404/409, FAILED+lifecycle, raced-terminal no-op) |

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun run lint` — clean
- [x] Backend `session-handlers.test.ts` — 32 pass (4 new `fail` cases)
- [x] Backend `enclave-runtimes/` feature suite — 68 pass
- [x] Enclave suite — no new failures vs. base (pre-existing HPKE `EncapError`s are environmental, identical on `main`; the new enclave-side assertion runs in CI)

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Phase 0.3 (E2EE-25 / #6) — give the enclave an explicit `/fail` callback so a failed turn terminates its session promptly instead of waiting for orphan-cleanup's stale-heartbeat backstop.

**What was built:**
- `EnclaveSessionFailure` type (`{ errorName: string }`) — scrubbed metadata, no plaintext.
- `BackendCallbacks.fail` + POST to `/internal/enclave-runtimes/sessions/:id/fail` (same internal-api-key auth as the other callbacks, `COMPLETE_TIMEOUT_MS`).
- `runEnclaveSession` catch path acks via `fail()` best-effort (logs + falls back to orphan-cleanup on failure).
- Backend handler: validate `failSchema`, `assertRunning` (404/409), delegate to `failSessionWithLifecycle`; route registered in `routes.ts`.

**Design decisions:**
- Sources/fields never leave the ciphertext on E2E paths — but the fail body is *metadata*, not content, so it travels as plain JSON (error class name only, INV-E7). Backend constructs the persisted error string `Enclave session failed: <errorName>`.
- Reuse the shared `failSessionWithLifecycle` (third caller alongside dispatch-worker and orphan-cleanup); the gated RUNNING→FAILED transition handles redelivery races.
- Orphan-cleanup stays the backstop, not the mechanism.

**What's NOT included:** Session resume after failure (later slice). No schema/migration changes.

**Status:** Implemented, typecheck/lint/relevant unit tests green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019JGqWDjUTxrLDizyXbUSpz)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753855&installation_id=129946197&pr_number=822&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F822&signature=05b2e28c1d320d1468ed831cd33feff2e750ecf03f8fd67e5702b2603f0a4eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->