### PR TITLE
feat: record enclave turn usage and cost at /complete (Phase 0.4)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -9,7 +9,8 @@ import { AgentSessionRepository, SessionStatuses } from "../agents"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { OutboxRepository } from "../../lib/outbox"
-import type { EventService } from "../messaging"
+import { MessageRepository, type EventService } from "../messaging"
+import type { AICostServiceLike } from "../ai-usage"
 import type { QueueManager } from "../../lib/queue"
 import { createEnclaveSessionHandlers } from "./session-handlers"
 
@@ -54,6 +55,10 @@ const MESSAGE_BODY = {
   envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
 }
 const COMPLETE_BODY = { messageIds: ["msg_a", "msg_b"], model: "anthropic/claude-sonnet-4.6" }
+const COMPLETE_BODY_WITH_USAGE = {
+  ...COMPLETE_BODY,
+  usage: { promptTokens: 1200, completionTokens: 340, cost: 0.0123 },
+}
 
 const STEP_BODY = {
   stepId: "step_a",
@@ -85,11 +90,24 @@ function fakeJobQueue() {
   return { jobQueue: { send } as unknown as QueueManager, send }
 }
 
+function fakeCostService() {
+  const recordUsage = mock(async (_params: Record<string, unknown>) => {})
+  return { costService: { recordUsage } as unknown as AICostServiceLike, recordUsage }
+}
+
 function makeHandlers(createMessage = mock(async (_input: Record<string, unknown>) => ({}) as never)) {
   const eventService = { createMessage } as unknown as EventService
   const { io, emit } = fakeIo()
   const { jobQueue, send } = fakeJobQueue()
-  return { handlers: createEnclaveSessionHandlers({ pool, eventService, io, jobQueue }), createMessage, io, emit, send }
+  const { costService, recordUsage } = fakeCostService()
+  return {
+    handlers: createEnclaveSessionHandlers({ pool, eventService, io, jobQueue, costService }),
+    createMessage,
+    io,
+    emit,
+    send,
+    recordUsage,
+  }
 }
 
 describe("createEnclaveSessionHandlers.message", () => {
@@ -209,13 +227,14 @@ describe("createEnclaveSessionHandlers.complete", () => {
     // No user message arrived during the turn → no follow-up dispatch.
     spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
     spyOn(StreamEventRepository, "getLatestUnseenUserMessage").mockResolvedValue(null)
-    const { handlers, createMessage, io, emit, send } = makeHandlers()
+    const { handlers, createMessage, io, emit, send, recordUsage } = makeHandlers()
     const res = fakeRes()
 
     await handlers.complete(req("session_1", COMPLETE_BODY), res)
 
     expect(res.statusCode).toBe(204)
     expect(send).not.toHaveBeenCalled() // nothing unseen → no catch-up turn
+    expect(recordUsage).not.toHaveBeenCalled() // no usage in the ack → nothing to record
     expect(createMessage).not.toHaveBeenCalled() // replies were already streamed via /messages
     expect(complete).toHaveBeenCalledTimes(1)
     // Completion + event are one atomic transaction (INV-7): completeSession runs
@@ -236,6 +255,62 @@ describe("createEnclaveSessionHandlers.complete", () => {
     // And a live-open trace dialog (session room) is transitioned to completed.
     expect(io.to).toHaveBeenCalledWith("ws:ws_1:agent_session:session_1")
     expect(emit.mock.calls.some((c) => c[0] === "agent_session:completed")).toBe(true)
+  })
+
+  it("records the turn's token + cost usage against the workspace and invoking user", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
+    spyOn(StreamEventRepository, "getLatestUnseenUserMessage").mockResolvedValue(null)
+    // The invoking user is the trigger message's author (the session stores only its id).
+    spyOn(MessageRepository, "findById").mockResolvedValue({ authorId: "usr_owner" } as never)
+    const { handlers, recordUsage } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", COMPLETE_BODY_WITH_USAGE), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(recordUsage).toHaveBeenCalledTimes(1)
+    // Same recording path companion turns use (#9): attributed to the workspace +
+    // invoking user with origin "user". Provider is re-derived from the bare
+    // OpenRouter model id; cost is OpenRouter's billed USD — accounting, never
+    // content (INV-E7).
+    expect(recordUsage.mock.calls[0]![0]).toMatchObject({
+      workspaceId: "ws_1",
+      userId: "usr_owner",
+      sessionId: "session_1",
+      functionId: "enclave-agent-loop",
+      model: "anthropic/claude-sonnet-4.6",
+      provider: "openrouter",
+      origin: "user",
+      usage: { promptTokens: 1200, completionTokens: 340, totalTokens: 1540, cost: 0.0123 },
+    })
+  })
+
+  it("does not record usage when the completion lost the RUNNING→COMPLETED race", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    // Lost the gated transition to a concurrent redelivery.
+    spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(null)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    const findMessage = spyOn(MessageRepository, "findById")
+    const { handlers, recordUsage } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", COMPLETE_BODY_WITH_USAGE), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(recordUsage).not.toHaveBeenCalled() // gated on the won transition → no double-charge
+    expect(findMessage).not.toHaveBeenCalled()
   })
 
   it("dispatches a catch-up enclave turn for a user message that arrived mid-turn", async () => {
@@ -598,6 +673,7 @@ describe("createEnclaveSessionHandlers.heartbeat", () => {
       eventService: {} as EventService,
       io: fakeIo().io,
       jobQueue: fakeJobQueue().jobQueue,
+      costService: fakeCostService().costService,
     })
     await expect(handlers.heartbeat(req(undefined, {}), fakeRes())).rejects.toBeInstanceOf(HttpError)
   })
@@ -609,6 +685,7 @@ describe("createEnclaveSessionHandlers.heartbeat", () => {
       eventService: {} as EventService,
       io: fakeIo().io,
       jobQueue: fakeJobQueue().jobQueue,
+      costService: fakeCostService().costService,
     })
     const res = fakeRes()
     await handlers.heartbeat(req("session_1", {}), res)

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -19,7 +19,9 @@ import {
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { serializeTraceStep } from "../public-api"
-import type { EventService } from "../messaging"
+import { MessageRepository, type EventService } from "../messaging"
+import type { AICostServiceLike } from "../ai-usage"
+import { parseModelId } from "@threa/agent-runtime"
 
 /**
  * Session callbacks the enclave calls while it owns an assigned turn. The enclave
@@ -67,7 +69,15 @@ const sealedNameSchema = z.object({
 const completeSchema = z.object({
   messageIds: z.array(z.string().min(1)).max(64),
   model: z.string().min(1),
-  usage: z.object({ promptTokens: z.number().optional(), completionTokens: z.number().optional() }).optional(),
+  usage: z
+    .object({
+      promptTokens: z.number().optional(),
+      completionTokens: z.number().optional(),
+      // OpenRouter's billed cost (USD) for the turn — aggregate accounting, not
+      // content. Recorded against the workspace/user like a companion turn (#9).
+      cost: z.number().optional(),
+    })
+    .optional(),
 })
 
 // The enclave's scrubbed failure classification — `errorName` is the thrown
@@ -122,6 +132,8 @@ interface Dependencies {
   io: Server
   /** Enqueues the catch-up follow-up turn on completion (enclave interjection parity). */
   jobQueue: QueueManager
+  /** Records the turn's token/cost usage at completion, same path companion turns use (#9). */
+  costService: AICostServiceLike
 }
 
 /**
@@ -164,7 +176,7 @@ function emitInlineProgress(
   })
 }
 
-export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue }: Dependencies) {
+export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue, costService }: Dependencies) {
   return {
     /**
      * POST /internal/enclave-runtimes/sessions/:id/heartbeat
@@ -515,6 +527,44 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, jobQueue 
       // stream room, so the dialog wouldn't otherwise transition until a refetch.
       if (committed && stream) {
         io.to(`ws:${stream.workspaceId}:agent_session:${id}`).emit("agent_session:completed", { sessionId: id })
+      }
+
+      // Record the turn's usage against the workspace + invoking user, the same
+      // recording path a companion turn uses (#9). The enclave runs no OTEL
+      // (egress discipline), so it reports summed token counts + OpenRouter's
+      // billed cost and we record them here — aggregate accounting, never content
+      // (INV-E7). Only after we actually won the RUNNING→COMPLETED transition, so
+      // a redelivery (handled by the already-completed no-op above) can't
+      // double-charge. Best-effort: a recording failure must not fail the ack.
+      if (committed && stream && parsed.data.usage) {
+        const usage = parsed.data.usage
+        try {
+          // The invoking user is the trigger message's author (the session row
+          // stores only the trigger message id). Origin is always "user": the
+          // enclave runs solely for user-sent E2E scratchpad messages.
+          const triggerMessage = await MessageRepository.findById(pool, session.triggerMessageId)
+          // The enclave routes exclusively through OpenRouter and reports the bare
+          // model id (the `openrouter:` prefix is stripped at dispatch), so re-derive
+          // the provider with the same parser the companion records through.
+          const parsedModel = parseModelId(`openrouter:${parsed.data.model}`)
+          await costService.recordUsage({
+            workspaceId: stream.workspaceId,
+            userId: triggerMessage?.authorId,
+            sessionId: id,
+            functionId: "enclave-agent-loop",
+            model: parsedModel.modelId,
+            provider: parsedModel.provider,
+            origin: "user",
+            usage: {
+              promptTokens: usage.promptTokens,
+              completionTokens: usage.completionTokens,
+              totalTokens: (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0),
+              cost: usage.cost,
+            },
+          })
+        } catch (err) {
+          logger.error({ err, sessionId: id, streamId: session.streamId }, "Enclave usage recording failed")
+        }
       }
 
       // Interjection catch-up (parity with the main app's `checkForUnseenMessages`,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -26,6 +26,7 @@ import { createWorkspaceSettingsHandlers } from "./features/workspace-settings"
 import { createSidebarConfigHandlers } from "./features/sidebar-config"
 import { createUserE2eKeysHandlers } from "./features/user-e2e-keys"
 import { createAIUsageHandlers } from "./features/ai-usage"
+import type { AICostServiceLike } from "./features/ai-usage"
 import type { AI } from "@threa/agent-runtime"
 import { createInvitationHandlers } from "./features/invitations"
 import { createActivityHandlers } from "./features/activity"
@@ -136,6 +137,7 @@ interface Dependencies {
   ai: AI
   controlPlaneClient: ControlPlaneClient | null
   jobQueue: QueueManager
+  costService: AICostServiceLike
 }
 
 export function registerRoutes(app: Express, deps: Dependencies) {
@@ -285,7 +287,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
     // Session callbacks: a live enclave drives an assigned turn over these
     // (liveness refresh + sealed replies on completion). Same shared-secret gate.
-    const enclaveSession = createEnclaveSessionHandlers({ pool, eventService, io: deps.io, jobQueue: deps.jobQueue })
+    const enclaveSession = createEnclaveSessionHandlers({
+      pool,
+      eventService,
+      io: deps.io,
+      jobQueue: deps.jobQueue,
+      costService: deps.costService,
+    })
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
     app.post("/internal/enclave-runtimes/sessions/:id/sealed-name", internalAuth, enclaveSession.sealedName)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -643,6 +643,7 @@ export async function startServer(): Promise<ServerInstance> {
     storage,
     ai,
     controlPlaneClient,
+    costService,
   })
 
   app.use(errorHandler)

--- a/apps/enclave/src/agent/enclave-ai.test.ts
+++ b/apps/enclave/src/agent/enclave-ai.test.ts
@@ -23,7 +23,7 @@ describe("createEnclaveAI", () => {
       model: "stub",
       usage: { prompt_tokens: 5, completion_tokens: 3 },
     })
-    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0 }
+    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0, cost: 0 }
     const ai = createEnclaveAI(chat.fn, usage)
 
     const result = await ai.generateTextWithTools({
@@ -41,7 +41,7 @@ describe("createEnclaveAI", () => {
     expect(result.text).toBe("Paris.")
     expect(result.toolCalls).toEqual([])
     expect(result.response.messages).toEqual([{ role: "assistant", content: "Paris." }])
-    expect(usage).toEqual({ promptTokens: 5, completionTokens: 3 })
+    expect(usage).toEqual({ promptTokens: 5, completionTokens: 3, cost: 0 })
   })
 
   it("maps tool calls (parsing arguments) and reconstructs the assistant message", async () => {
@@ -52,7 +52,7 @@ describe("createEnclaveAI", () => {
       },
       model: "stub",
     })
-    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0 }
+    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0, cost: 0 }
     const ai = createEnclaveAI(chat.fn, usage)
 
     const result = await ai.generateTextWithTools({
@@ -71,13 +71,17 @@ describe("createEnclaveAI", () => {
     ])
   })
 
-  it("accumulates usage across calls", async () => {
-    const chat = stub({ message: { content: "x" }, model: "stub", usage: { prompt_tokens: 4, completion_tokens: 2 } })
-    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0 }
+  it("accumulates token usage and cost across calls", async () => {
+    const chat = stub({
+      message: { content: "x" },
+      model: "stub",
+      usage: { prompt_tokens: 4, completion_tokens: 2, cost: 0.25 },
+    })
+    const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0, cost: 0 }
     const ai = createEnclaveAI(chat.fn, usage)
     const opts = { model: MODEL, modelString: "m", messages: [{ role: "user" as const, content: "hi" }] }
     await ai.generateTextWithTools(opts)
     await ai.generateTextWithTools(opts)
-    expect(usage).toEqual({ promptTokens: 8, completionTokens: 4 })
+    expect(usage).toEqual({ promptTokens: 8, completionTokens: 4, cost: 0.5 })
   })
 })

--- a/apps/enclave/src/agent/enclave-ai.ts
+++ b/apps/enclave/src/agent/enclave-ai.ts
@@ -14,6 +14,8 @@ import { buildAssistantMessage, toOpenAiMessages, toOpenAiTools } from "./openai
 export interface UsageAccumulator {
   promptTokens: number
   completionTokens: number
+  /** OpenRouter's billed cost (USD), summed across the turn's calls. */
+  cost: number
 }
 
 function parseArguments(raw: string): unknown {
@@ -39,6 +41,7 @@ export function createEnclaveAI(rawChat: RawChatFn, usage: UsageAccumulator): Ag
 
       usage.promptTokens += result.usage?.prompt_tokens ?? 0
       usage.completionTokens += result.usage?.completion_tokens ?? 0
+      usage.cost += result.usage?.cost ?? 0
 
       const toolCalls = (result.message.tool_calls ?? []).map((tc) => ({
         toolCallId: tc.id,

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -86,7 +86,11 @@ function stubChat(responses: RawChatResult | RawChatResult[]): { fn: RawChatFn; 
 }
 
 function textReply(text: string): RawChatResult {
-  return { message: { content: text }, model: "stub/model", usage: { prompt_tokens: 11, completion_tokens: 7 } }
+  return {
+    message: { content: text },
+    model: "stub/model",
+    usage: { prompt_tokens: 11, completion_tokens: 7, cost: 0.002 },
+  }
 }
 
 function sendMessageReply(...contents: string[]): RawChatResult {
@@ -165,7 +169,9 @@ describe("runEnclaveTurn", () => {
     expect(replyText).toBe("Paris.")
     expect(reply.envelope.keyGeneration).toBe(GEN)
     expect(result.model).toBe("anthropic/claude-sonnet-4.6")
-    expect(result.usage).toEqual({ promptTokens: 11, completionTokens: 7 })
+    // Token counts and OpenRouter's billed cost are summed across the turn and
+    // returned for the backend to record (#9).
+    expect(result.usage).toEqual({ promptTokens: 11, completionTokens: 7, cost: 0.002 })
 
     // The reply is also traced as a sealed message_sent step the same SSK opens,
     // linked to the reply id (its content is ciphertext on the wire).

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -164,7 +164,7 @@ export async function runEnclaveTurn(
   const replySsk = sskByGeneration.get(request.reply.keyGeneration)
   if (!replySsk) throw new InvokeError("No SSK wrap for the reply's key generation")
 
-  const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0 }
+  const usage: UsageAccumulator = { promptTokens: 0, completionTokens: 0, cost: 0 }
   const messageIds: string[] = []
   // First reply's plaintext, kept only to seed the auto-title below (never logged
   // or persisted; lives in-process for the turn like all other plaintext here).
@@ -282,7 +282,7 @@ export async function runEnclaveTurn(
   return {
     messageIds,
     model: request.model,
-    usage: { promptTokens: usage.promptTokens, completionTokens: usage.completionTokens },
+    usage: { promptTokens: usage.promptTokens, completionTokens: usage.completionTokens, cost: usage.cost },
   }
 }
 

--- a/apps/enclave/src/llm.ts
+++ b/apps/enclave/src/llm.ts
@@ -29,7 +29,12 @@ export interface RawChatResult {
     tool_calls?: Array<{ id: string; type: "function"; function: { name: string; arguments: string } }>
   }
   model: string
-  usage?: { prompt_tokens?: number; completion_tokens?: number }
+  /**
+   * Aggregate accounting for this call: token counts plus OpenRouter's billed
+   * `cost` in USD (present because the request opts into usage accounting). This
+   * is non-secret metadata, not message content — safe to surface to the backend.
+   */
+  usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
 }
 
 /** Injectable so the agent loop can be tested without network access. */
@@ -50,7 +55,7 @@ interface OpenRouterResponse {
       tool_calls?: Array<{ id?: string; type?: string; function?: { name?: string; arguments?: string } }>
     }
   }>
-  usage?: { prompt_tokens?: number; completion_tokens?: number }
+  usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
 }
 
 /**
@@ -74,6 +79,9 @@ export function createOpenRouterChat(config: EnclaveConfig): RawChatFn {
         ...(req.tools && req.tools.length > 0 ? { tools: req.tools, tool_choice: "auto" } : {}),
         ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
         ...(req.maxTokens !== undefined ? { max_tokens: req.maxTokens } : {}),
+        // Ask OpenRouter to return billed cost (USD) alongside token counts so the
+        // backend can record the turn's spend. Accounting only — no message content.
+        usage: { include: true },
         // Restrict routing to providers that do not retain request data.
         provider: { data_collection: "deny" },
       }),
@@ -102,7 +110,11 @@ export function createOpenRouterChat(config: EnclaveConfig): RawChatFn {
     return {
       message: { content: choice.content ?? null, ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}) },
       model: data.model ?? req.model,
-      usage: { prompt_tokens: data.usage?.prompt_tokens, completion_tokens: data.usage?.completion_tokens },
+      usage: {
+        prompt_tokens: data.usage?.prompt_tokens,
+        completion_tokens: data.usage?.completion_tokens,
+        cost: data.usage?.cost,
+      },
     }
   }
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -656,11 +656,15 @@ export interface EnclaveSessionAssignment {
  * this carries only the ids the enclave sent (oldest→newest, for the session's
  * `sent_message_ids`) plus non-secret model metadata. Usage is summed across
  * every model call the loop made.
+ *
+ * `usage` is aggregate accounting (token counts + the provider's billed `cost`
+ * in USD) — never message content — so it travels as plain JSON like the model
+ * id, and the backend records it against the workspace/user at completion.
  */
 export interface EnclaveSessionResult {
   messageIds: string[]
   model: string
-  usage?: { promptTokens?: number; completionTokens?: number }
+  usage?: { promptTokens?: number; completionTokens?: number; cost?: number }
 }
 
 /**


### PR DESCRIPTION
## Problem

Companion (in-process) agent turns record their token/cost usage automatically through the `createAI` wrapper's telemetry. Enclave turns don't: the enclave sums usage locally and returns it on the `/complete` ack (`EnclaveSessionResult`), but the backend handler discarded it. So E2E scratchpad turns contributed nothing to AI usage analytics or budget tracking.

This closes the **Cost/telemetry companion-only** gap — plan item 9 in `docs/plans/agent-runtimes-unification-redesign.md` (§2.3 enclave bullet, §2.4), i.e. Phase 0.4 of the agent-runtimes unification. (Not a GitHub issue — the numbering is internal to that plan's tables.)

## Solution

Record the enclave turn's usage at `/complete` through the **same** path companion turns use (`CostService.recordUsage`), attributed to the workspace + invoking user with `origin: "user"`. OTEL stays out of the enclave (egress discipline) — the enclave reports the totals and the backend records them at completion.

Cost in this codebase is never computed locally; the companion gets its billed USD straight from OpenRouter's response. The enclave is the one calling OpenRouter, so this plumbs real cost end-to-end rather than recording token volume at $0.

### How it works

1. The enclave's OpenRouter client opts into usage accounting (`usage: { include: true }`) so the response carries billed `cost` (USD) alongside token counts.
2. The turn's `UsageAccumulator` sums `cost` across every model call (the main loop + any research sub-loop), exactly as it already sums tokens.
3. `EnclaveSessionResult.usage` returns `{ promptTokens, completionTokens, cost }` on the `/complete` ack — aggregate accounting, never message content (INV-E7), so it rides as plain JSON like the model id.
4. The backend `complete` handler records via `CostService.recordUsage` **only after winning the `RUNNING→COMPLETED` transition**, best-effort.

### Key design decisions

**1. Plumb real cost, not just token volume.** Recording with no cost would store `costUsd = 0` and leave enclave turns invisible to budget alerts. Cost is non-secret aggregate metadata (a USD number), so surfacing it on the wire is consistent with the token counts already there — no plaintext leaves the enclave. `usage.cost` is recorded the same way the companion's `openrouter-cost-interceptor` records `body.usage.cost` (directly as `costUsd`), so the two paths stay consistent.

**2. Reuse the companion recording path.** Recording goes through `CostService.recordUsage` (the `AICostServiceLike` interface), with the provider re-derived from the bare OpenRouter model id via the same `parseModelId` the companion records through (the `openrouter:` prefix is stripped at dispatch, so it's reconstructed here). `functionId: "enclave-agent-loop"` distinguishes enclave turns in by-function analytics.

**3. Exactly-once, best-effort.** Gated on the won `RUNNING→COMPLETED` transition plus the existing `already_completed` no-op, so a redelivery can't double-charge. Wrapped in try/catch — a recording failure logs and still returns 204, mirroring the interjection-follow-up best-effort path. Runs after the completion transaction commits, so no DB connection is held across it (INV-41).

**4. Attribution.** Workspace from the session's stream; invoking user is the trigger message's author (the session row stores only `trigger_message_id`); `origin: "user"` per the plan — the enclave runs solely for user-sent E2E scratchpad messages.

## Modified files

| File | Change |
| --- | --- |
| `apps/enclave/src/llm.ts` | OpenRouter client opts into `usage: { include: true }`; `RawChatResult.usage` carries `cost` |
| `apps/enclave/src/agent/enclave-ai.ts` | `UsageAccumulator` sums `cost` across the turn's calls |
| `apps/enclave/src/agent/run-turn.ts` | Returns `cost` in `EnclaveSessionResult.usage` |
| `packages/types/src/api.ts` | `EnclaveSessionResult.usage` gains `cost?: number` (+ JSDoc) |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | `completeSchema` parses `cost`; `CostService` dependency; records usage on the won completion |
| `apps/backend/src/routes.ts` | Thread `costService` into `createEnclaveSessionHandlers` |
| `apps/backend/src/server.ts` | Pass the existing `costService` instance into `registerRoutes` |
| `apps/backend/.../session-handlers.test.ts` | +2 cases (records token+cost with attribution; no record on a lost race) |
| `apps/enclave/src/agent/enclave-ai.test.ts` | Asserts cost accumulation across calls |
| `apps/enclave/src/agent/run-turn.test.ts` | Asserts cost flows to the turn result |

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun run lint` — clean
- [x] Backend `session-handlers.test.ts` — 34 pass (2 new)
- [x] Backend `enclave-runtimes/` + `ai-usage/` suites — 70 pass
- [x] Enclave suite (vitest) — 60 pass
- [ ] No e2e needed — internal enclave routes aren't reachable in e2e; covered by colocated unit tests

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Phase 0.4 (plan item 9) — record enclave AI usage + cost at the `/complete` callback through the shared cost-recording path companion turns use, attributed to the workspace + invoking user with `origin: "user"`.

**What was built:**
- Enclave captures OpenRouter's billed cost: the chat client requests `usage: { include: true }`; `RawChatResult.usage`, `UsageAccumulator`, and `EnclaveSessionResult.usage` all carry `cost` (summed across the turn's model calls).
- `EnclaveSessionResult.usage` extended with `cost?: number` — aggregate accounting, never content, plain JSON on the wire.
- Backend `complete` handler: `completeSchema` parses `cost`; `CostService` injected (constructed once in `server.ts`, threaded through `routes.ts`); records via `recordUsage` on the won `RUNNING→COMPLETED` transition, best-effort. Provider re-derived from the bare OpenRouter model id via `parseModelId(\`openrouter:${model}\`)`; userId = trigger message author; `functionId: "enclave-agent-loop"`; `origin: "user"`.

**Design decisions:**
- Plumb real cost (chosen over token-only/$0) — true parity with companion; cost is metadata, not content, so the wire extension respects no-plaintext-egress (INV-E7).
- Reuse `CostService.recordUsage` (interface method, also satisfied by the no-op service); don't reimplement.
- Exactly-once via the gated transition + `already_completed` no-op; best-effort try/catch so a recording failure never fails the ack; records after the completion tx commits (INV-41).
- `CostService` constructed once and injected (INV-12/13).

**What's NOT included:** No schema/migration changes. No OTEL in the enclave (egress discipline). Bot-runtime usage recording (separate item).

**Status:** Implemented; typecheck/lint clean, relevant unit suites green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_