### PR TITLE
feat(sync): verifiable timeline contiguity via a dense broadcast sequence (INV-61)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,8 @@ Multi-view pages (tabs, sub-sections, filter states) must derive their active vi
 
 Preview surfaces must strip markdown before rendering. Any UI that shows a preview of user-authored message content (thread cards, sidebar stream previews, activity feed snippets, notification text, quoted snippets, search results) must route `contentMarkdown` through `stripMarkdownToInline()` in `apps/frontend/src/lib/markdown/strip.ts` or `truncateContent()` in `apps/frontend/src/components/layout/sidebar/utils.ts` — never pass raw markdown into a plain `<span>`, or literal syntax (`**bold**`, fenced code, `[text](url)`, `:emoji:` shortcodes) ships to users as characters (INV-60). Backend sends raw markdown on the wire; frontend strips at render time. Reference surfaces that already do this correctly: `StreamItemPreview` (sidebar stream list) and `ActivityPreview` (activity feed).
 
+The rendered timeline window is verifiably contiguous over the viewer-visible ordering (INV-61). Events every member receives as timeline rows (`TIMELINE_BROADCAST_EVENT_TYPES` in `packages/types`) consume a dense per-stream `broadcastSequence` allocated by `StreamEventRepository` alongside the global `sequence`; author-scoped command events and patch-style rows (edits, reactions, deletes) do not, so for any viewer a missing broadcast number is ALWAYS a real gap — never another user's invisible event. The message-move flow, the one operation that vacates slots, declares them on its source tombstone (`vacatedBroadcastSequences`). On the frontend, `computeTimelineHoles` (`apps/frontend/src/sync/contiguity.ts`) is the single read-side authority: a detected hole renders as an in-place loading placeholder (never a silent gap) and triggers a scoped backfill, so a missed message resolves the placeholder where it belongs instead of popping in above rows already on screen. The catch-up cursor has exactly one owner — `SyncEngine.joinStreamForCatchUp` reads the cursor BEFORE joining the room; never re-derive it at call sites.
+
 ### 6) Testing and Reliability Expectations
 
 Always resolve failing tests; do not dismiss failures as pre-existing (INV-22).
@@ -264,7 +266,7 @@ When handling variants, colocate variant config and keep shared behavior on one 
 - **Architecture and dependencies:** INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-12, INV-13, INV-27, INV-34, INV-35, INV-37, INV-51, INV-52
 - **API and backend contracts:** INV-31, INV-32, INV-33, INV-46, INV-55, INV-58
 - **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54
-- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60
+- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61
 - **Testing:** INV-22, INV-23, INV-24, INV-26, INV-39, INV-48
 - **Code hygiene and maneuverability:** INV-25, INV-29, INV-36, INV-38, INV-43, INV-47, INV-49
 

--- a/apps/backend/src/db/migrations/20260611075601_add_broadcast_sequence.sql
+++ b/apps/backend/src/db/migrations/20260611075601_add_broadcast_sequence.sql
@@ -1,0 +1,57 @@
+-- Dense per-stream ordering over viewer-visible timeline events (INV-61).
+--
+-- The global `sequence` counter is shared by ALL event types, including
+-- author-scoped command events and patch-style rows (edits, reactions) that
+-- are never delivered to other viewers as timeline rows — so a viewer's
+-- persisted sequence set has legitimate, unfillable holes and clients cannot
+-- distinguish "missed message" from "someone else's /command". The
+-- `broadcast_sequence` counter increments only for TIMELINE_BROADCAST_EVENT_TYPES
+-- (events every member receives as appended rows), making the chain dense for
+-- every viewer: a missing broadcast_sequence is always a real gap that a
+-- backfill fetch can close.
+
+ALTER TABLE stream_events
+ADD COLUMN IF NOT EXISTS broadcast_sequence BIGINT;
+
+ALTER TABLE stream_sequences
+ADD COLUMN IF NOT EXISTS next_broadcast_sequence BIGINT NOT NULL DEFAULT 1;
+
+-- Backfill: number existing broadcast-type rows densely per stream in
+-- `sequence` order. Rows that vanished from a stream before this migration
+-- (the message-move flow reassigns rows to the destination thread) simply
+-- don't participate, so the historical numbering is dense over what remains.
+UPDATE stream_events e
+SET broadcast_sequence = numbered.rn
+FROM (
+    SELECT id, row_number() OVER (PARTITION BY stream_id ORDER BY sequence) AS rn
+    FROM stream_events
+    WHERE event_type IN (
+        'message_created',
+        'member_joined',
+        'member_added',
+        'member_left',
+        'agent_session:started',
+        'agent_session:completed',
+        'agent_session:failed',
+        'agent_session:deleted',
+        'messages:moved'
+    )
+) numbered
+WHERE e.id = numbered.id
+  AND e.broadcast_sequence IS NULL;
+
+-- Seed each stream's counter just past its highest assigned slot. Streams
+-- with no broadcast events keep the column default of 1.
+UPDATE stream_sequences ss
+SET next_broadcast_sequence = GREATEST(
+    ss.next_broadcast_sequence,
+    COALESCE(
+        (SELECT MAX(e.broadcast_sequence) + 1 FROM stream_events e WHERE e.stream_id = ss.stream_id),
+        1
+    )
+);
+
+-- Density is a correctness invariant — enforce uniqueness at the source.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stream_events_stream_broadcast_seq
+    ON stream_events (stream_id, broadcast_sequence)
+    WHERE broadcast_sequence IS NOT NULL;

--- a/apps/backend/src/db/migrations/20260611075601_add_broadcast_sequence.sql
+++ b/apps/backend/src/db/migrations/20260611075601_add_broadcast_sequence.sql
@@ -10,6 +10,18 @@
 -- every viewer: a missing broadcast_sequence is always a real gap that a
 -- backfill fetch can close.
 
+BEGIN;
+
+-- Serialize against in-flight event writers for the duration of the backfill.
+-- Lock order matches the writers' order (every insert upserts stream_sequences
+-- first, then writes stream_events) so the migration cannot deadlock against
+-- them; once both locks are held the backfill snapshot is stable. Events
+-- written by not-yet-redeployed old code AFTER this commits simply carry a
+-- NULL broadcast_sequence — clients skip unstamped rows in the chain, so the
+-- deploy window degrades coverage, never correctness.
+LOCK TABLE stream_sequences IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE stream_events IN ACCESS EXCLUSIVE MODE;
+
 ALTER TABLE stream_events
 ADD COLUMN IF NOT EXISTS broadcast_sequence BIGINT;
 
@@ -40,18 +52,22 @@ FROM (
 WHERE e.id = numbered.id
   AND e.broadcast_sequence IS NULL;
 
--- Seed each stream's counter just past its highest assigned slot. Streams
--- with no broadcast events keep the column default of 1.
+-- Seed each stream's counter just past its highest assigned slot, in one
+-- set-based pass (INV-56). Streams with no broadcast events aren't in the
+-- aggregate and keep the column default of 1.
 UPDATE stream_sequences ss
-SET next_broadcast_sequence = GREATEST(
-    ss.next_broadcast_sequence,
-    COALESCE(
-        (SELECT MAX(e.broadcast_sequence) + 1 FROM stream_events e WHERE e.stream_id = ss.stream_id),
-        1
-    )
-);
+SET next_broadcast_sequence = GREATEST(ss.next_broadcast_sequence, agg.max_assigned + 1)
+FROM (
+    SELECT stream_id, MAX(broadcast_sequence) AS max_assigned
+    FROM stream_events
+    WHERE broadcast_sequence IS NOT NULL
+    GROUP BY stream_id
+) agg
+WHERE ss.stream_id = agg.stream_id;
 
 -- Density is a correctness invariant — enforce uniqueness at the source.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_stream_events_stream_broadcast_seq
     ON stream_events (stream_id, broadcast_sequence)
     WHERE broadcast_sequence IS NOT NULL;
+
+COMMIT;

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1087,7 +1087,10 @@ export class EventService {
         return left.event.id.localeCompare(right.event.id)
       })
 
-      const nextSequences = await StreamEventRepository.getNextSequences(
+      // Every movable event is a broadcast timeline type (message_created /
+      // agent_session:*), so each gets a fresh (sequence, broadcastSequence)
+      // pair at the destination — the destination chain stays dense (INV-61).
+      const nextSequencePairs = await StreamEventRepository.getNextSequencePairs(
         client,
         destinationThread.id,
         movableEvents.length
@@ -1095,12 +1098,31 @@ export class EventService {
       const updates: MoveMessageSequenceUpdate[] = []
       const agentSessionEventUpdates: MoveEventIdSequenceUpdate[] = []
       movableEvents.forEach((entry, index) => {
+        const pair = nextSequencePairs[index]
         if (entry.kind === "message") {
-          updates.push({ messageId: entry.messageId, sequence: nextSequences[index] })
+          updates.push({
+            messageId: entry.messageId,
+            sequence: pair.sequence,
+            broadcastSequence: pair.broadcastSequence,
+          })
         } else {
-          agentSessionEventUpdates.push({ eventId: entry.event.id, sequence: nextSequences[index] })
+          agentSessionEventUpdates.push({
+            eventId: entry.event.id,
+            sequence: pair.sequence,
+            broadcastSequence: pair.broadcastSequence,
+          })
         }
       })
+
+      // The slots these events occupied in the SOURCE stream's broadcast
+      // chain are vacated by the move. Declare them on the source tombstone
+      // so clients can tell "moved away" apart from "missed" (INV-61).
+      // movableEvents is already in ascending source-sequence order, and
+      // broadcast order matches global order, so no re-sort is needed.
+      const vacatedBroadcastSequences = movableEvents
+        .map((entry) => entry.event.broadcastSequence)
+        .filter((value): value is bigint => value !== null)
+        .map((value) => value.toString())
 
       // Pre-generate the destination tombstone's event ID so it can be
       // stamped onto each relocated `message_created` payload via
@@ -1215,11 +1237,13 @@ export class EventService {
       // same `movedAt` value so the badge tooltip and the tombstone summary
       // line render identical timestamps for the same move (otherwise app
       // clock vs DB NOW() can drift visibly under slow transactions).
+      // Only the source side carries `vacatedBroadcastSequences` — the
+      // destination gained dense fresh slots and has nothing to account for.
       const sourceTombstone = await StreamEventRepository.insert(client, {
         id: eventId(),
         streamId: params.sourceStreamId,
         eventType: "messages:moved",
-        payload: tombstonePayload,
+        payload: { ...tombstonePayload, vacatedBroadcastSequences } satisfies MessagesMovedEventPayload,
         actorId: params.actorId,
         actorType: AuthorTypes.USER,
         createdAt: movedAt,

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -1,12 +1,19 @@
 import type { Querier } from "../../db"
 import { sql } from "../../db"
-import { COMMAND_EVENT_TYPES, type AgentSessionRerunContext, type AuthorType, type EventType } from "@threa/types"
+import {
+  COMMAND_EVENT_TYPES,
+  isTimelineBroadcastEventType,
+  type AgentSessionRerunContext,
+  type AuthorType,
+  type EventType,
+} from "@threa/types"
 
 // Internal row type (snake_case, not exported)
 interface StreamEventRow {
   id: string
   stream_id: string
   sequence: string // bigint comes as string from pg
+  broadcast_sequence: string | null
   event_type: string
   payload: unknown
   actor_id: string | null
@@ -23,6 +30,15 @@ export interface StreamEvent {
   id: string
   streamId: string
   sequence: bigint
+  /**
+   * Dense per-stream counter over TIMELINE_BROADCAST_EVENT_TYPES only —
+   * the events every member receives as appended timeline rows. Unlike
+   * `sequence` (which all event types consume, including author-scoped
+   * command events), a viewer's broadcast chain has no legitimate holes,
+   * so clients can treat a missing number as a real gap (INV-61).
+   * `null` for non-broadcast event types.
+   */
+  broadcastSequence: bigint | null
   eventType: EventType
   payload: unknown
   actorId: string | null
@@ -49,11 +65,13 @@ export interface InsertEventParams {
 export interface MoveEventSequenceUpdate {
   messageId: string
   sequence: bigint
+  broadcastSequence: bigint
 }
 
 export interface MoveEventIdSequenceUpdate {
   eventId: string
   sequence: bigint
+  broadcastSequence: bigint
 }
 
 function mapRowToEvent(row: StreamEventRow): StreamEvent {
@@ -61,6 +79,7 @@ function mapRowToEvent(row: StreamEventRow): StreamEvent {
     id: row.id,
     streamId: row.stream_id,
     sequence: BigInt(row.sequence),
+    broadcastSequence: row.broadcast_sequence === null ? null : BigInt(row.broadcast_sequence),
     eventType: row.event_type as EventType,
     payload: row.payload,
     actorId: row.actor_id,
@@ -87,48 +106,79 @@ function parseAgentSessionRerunContext(value: unknown): AgentSessionRerunContext
 }
 
 export const StreamEventRepository = {
-  async getNextSequence(db: Querier, streamId: string): Promise<bigint> {
-    // Upsert and return next sequence atomically
-    const result = await db.query<{ next_sequence: string }>(sql`
-      INSERT INTO stream_sequences (stream_id, next_sequence)
-      VALUES (${streamId}, 2)
+  /**
+   * Atomically bump the stream's global counter by `total` and its dense
+   * broadcast counter (INV-61) by `broadcast` in one upsert, returning the
+   * first value of each allocated range. A single statement keeps the two
+   * counters race-safe under concurrent writers (INV-20) — the broadcast
+   * order always matches the global order because both ranges are claimed
+   * together.
+   */
+  async allocateSequences(
+    db: Querier,
+    streamId: string,
+    counts: { total: number; broadcast: number }
+  ): Promise<{ firstSequence: bigint; firstBroadcastSequence: bigint }> {
+    const { total, broadcast } = counts
+    const result = await db.query<{ first_sequence: string; first_broadcast_sequence: string }>(sql`
+      INSERT INTO stream_sequences (stream_id, next_sequence, next_broadcast_sequence)
+      VALUES (${streamId}, ${total + 1}, ${broadcast + 1})
       ON CONFLICT (stream_id) DO UPDATE
-        SET next_sequence = stream_sequences.next_sequence + 1
-      RETURNING next_sequence - 1 AS next_sequence
+        SET next_sequence = stream_sequences.next_sequence + ${total},
+            next_broadcast_sequence = stream_sequences.next_broadcast_sequence + ${broadcast}
+      RETURNING next_sequence - ${total} AS first_sequence,
+                next_broadcast_sequence - ${broadcast} AS first_broadcast_sequence
     `)
-    return BigInt(result.rows[0].next_sequence)
+    return {
+      firstSequence: BigInt(result.rows[0].first_sequence),
+      firstBroadcastSequence: BigInt(result.rows[0].first_broadcast_sequence),
+    }
   },
 
-  async getNextSequences(db: Querier, streamId: string, count: number): Promise<bigint[]> {
+  /**
+   * Allocate `count` (sequence, broadcastSequence) pairs for events that are
+   * all broadcast timeline types — used by the move flow when relocating
+   * message/agent-session events into a destination stream.
+   */
+  async getNextSequencePairs(
+    db: Querier,
+    streamId: string,
+    count: number
+  ): Promise<Array<{ sequence: bigint; broadcastSequence: bigint }>> {
     if (count <= 0) return []
-    const result = await db.query<{ start_sequence: string }>(sql`
-      INSERT INTO stream_sequences (stream_id, next_sequence)
-      VALUES (${streamId}, ${count + 1})
-      ON CONFLICT (stream_id) DO UPDATE
-        SET next_sequence = stream_sequences.next_sequence + ${count}
-      RETURNING next_sequence - ${count} AS start_sequence
-    `)
-    const start = BigInt(result.rows[0].start_sequence)
-    return Array.from({ length: count }, (_, i) => start + BigInt(i))
+    const { firstSequence, firstBroadcastSequence } = await this.allocateSequences(db, streamId, {
+      total: count,
+      broadcast: count,
+    })
+    return Array.from({ length: count }, (_, i) => ({
+      sequence: firstSequence + BigInt(i),
+      broadcastSequence: firstBroadcastSequence + BigInt(i),
+    }))
   },
 
   async insert(db: Querier, params: InsertEventParams): Promise<StreamEvent> {
-    const sequence = await this.getNextSequence(db, params.streamId)
+    const isBroadcast = isTimelineBroadcastEventType(params.eventType)
+    const { firstSequence, firstBroadcastSequence } = await this.allocateSequences(db, params.streamId, {
+      total: 1,
+      broadcast: isBroadcast ? 1 : 0,
+    })
+    const broadcastSequence = isBroadcast ? firstBroadcastSequence : null
     const createdAt = params.createdAt ?? new Date()
 
     const result = await db.query<StreamEventRow>(sql`
-      INSERT INTO stream_events (id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at)
+      INSERT INTO stream_events (id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at)
       VALUES (
         ${params.id},
         ${params.streamId},
-        ${sequence.toString()},
+        ${firstSequence.toString()},
+        ${broadcastSequence === null ? null : broadcastSequence.toString()},
         ${params.eventType},
         ${JSON.stringify(params.payload)},
         ${params.actorId ?? null},
         ${params.actorType ?? null},
         ${createdAt}
       )
-      RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      RETURNING id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
     `)
     return mapRowToEvent(result.rows[0])
   },
@@ -139,21 +189,36 @@ export const StreamEventRepository = {
     if (paramsList.some((p) => p.streamId !== streamId)) {
       throw new Error("insertMany requires all events to belong to the same stream")
     }
-    const sequences = await this.getNextSequences(db, streamId, paramsList.length)
+    const broadcastFlags = paramsList.map((p) => isTimelineBroadcastEventType(p.eventType))
+    const broadcastCount = broadcastFlags.filter(Boolean).length
+    const { firstSequence, firstBroadcastSequence } = await this.allocateSequences(db, streamId, {
+      total: paramsList.length,
+      broadcast: broadcastCount,
+    })
+
+    // Broadcast slots are handed out in list order so the broadcast chain's
+    // order always matches the global sequence order.
+    let broadcastOffset = 0n
+    const broadcastSeqs = broadcastFlags.map((isBroadcast) => {
+      if (!isBroadcast) return null
+      const value = firstBroadcastSequence + broadcastOffset
+      broadcastOffset += 1n
+      return value.toString()
+    })
 
     const ids = paramsList.map((p) => p.id)
     const streamIds = paramsList.map(() => streamId)
-    const seqs = sequences.map((s) => s.toString())
+    const seqs = paramsList.map((_, i) => (firstSequence + BigInt(i)).toString())
     const eventTypes = paramsList.map((p) => p.eventType)
     const payloads = paramsList.map((p) => JSON.stringify(p.payload))
     const actorIds = paramsList.map((p) => p.actorId ?? null)
     const actorTypes = paramsList.map((p) => p.actorType ?? null)
 
     const result = await db.query<StreamEventRow>(
-      `INSERT INTO stream_events (id, stream_id, sequence, event_type, payload, actor_id, actor_type)
-       SELECT * FROM unnest($1::text[], $2::text[], $3::bigint[], $4::text[], $5::jsonb[], $6::text[], $7::text[])
-       RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
-      [ids, streamIds, seqs, eventTypes, payloads, actorIds, actorTypes]
+      `INSERT INTO stream_events (id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type)
+       SELECT * FROM unnest($1::text[], $2::text[], $3::bigint[], $4::bigint[], $5::text[], $6::jsonb[], $7::text[], $8::text[])
+       RETURNING id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at`,
+      [ids, streamIds, seqs, broadcastSeqs, eventTypes, payloads, actorIds, actorTypes]
     )
     return result.rows.map(mapRowToEvent)
   },
@@ -215,7 +280,7 @@ export const StreamEventRepository = {
     const orderDirection = afterSequence !== undefined ? "ASC" : "DESC"
 
     const query = `
-      SELECT id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
       FROM stream_events
       WHERE ${conditions.join(" AND ")}
       ORDER BY sequence ${orderDirection}
@@ -282,7 +347,7 @@ export const StreamEventRepository = {
 
   async findById(db: Querier, id: string): Promise<StreamEvent | null> {
     const result = await db.query<StreamEventRow>(sql`
-      SELECT id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
       FROM stream_events
       WHERE id = ${id}
     `)
@@ -292,7 +357,7 @@ export const StreamEventRepository = {
   /** Find the message_created event for a given message ID within a stream. */
   async findByMessageId(db: Querier, streamId: string, messageId: string): Promise<StreamEvent | null> {
     const result = await db.query<StreamEventRow>(sql`
-      SELECT id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
       FROM stream_events
       WHERE stream_id = ${streamId}
         AND event_type = 'message_created'
@@ -310,7 +375,7 @@ export const StreamEventRepository = {
     if (messageIds.length === 0) return []
 
     const result = await db.query<StreamEventRow>(sql`
-      SELECT id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
       FROM stream_events
       WHERE stream_id = ${streamId}
         AND event_type = 'message_created'
@@ -355,33 +420,36 @@ export const StreamEventRepository = {
 
     const messageIds = params.updates.map((update) => update.messageId)
     const sequences = params.updates.map((update) => update.sequence.toString())
+    const broadcastSequences = params.updates.map((update) => update.broadcastSequence.toString())
 
     const result = await db.query<StreamEventRow>(
       `UPDATE stream_events e
        SET stream_id = $1,
            sequence = updates.new_sequence,
+           broadcast_sequence = updates.new_broadcast_sequence,
            payload = e.payload || jsonb_build_object(
              'movedFrom', jsonb_build_object(
-               'sourceStreamId', $4::text,
-               'sourceStreamSlug', $5::text,
-               'sourceStreamDisplayName', $6::text,
-               'movedAt', $7::text,
-               'movedBy', $8::text,
-               'movedByType', $9::text,
-               'moveTombstoneId', $10::text
+               'sourceStreamId', $5::text,
+               'sourceStreamSlug', $6::text,
+               'sourceStreamDisplayName', $7::text,
+               'movedAt', $8::text,
+               'movedBy', $9::text,
+               'movedByType', $10::text,
+               'moveTombstoneId', $11::text
              )
            )
        FROM (
-         SELECT * FROM unnest($2::text[], $3::bigint[]) AS u(message_id, new_sequence)
+         SELECT * FROM unnest($2::text[], $3::bigint[], $4::bigint[]) AS u(message_id, new_sequence, new_broadcast_sequence)
        ) updates
-       WHERE e.stream_id = $4
+       WHERE e.stream_id = $5
          AND e.event_type = 'message_created'
          AND e.payload->>'messageId' = updates.message_id
-       RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
+       RETURNING id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at`,
       [
         params.destinationStreamId,
         messageIds,
         sequences,
+        broadcastSequences,
         params.sourceStreamId,
         params.movedFrom.sourceStreamSlug,
         params.movedFrom.sourceStreamDisplayName,
@@ -402,7 +470,7 @@ export const StreamEventRepository = {
     if (sessionIds.length === 0) return []
 
     const result = await db.query<StreamEventRow>(sql`
-      SELECT id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
       FROM stream_events
       WHERE stream_id = ${streamId}
         AND event_type = ANY(${["agent_session:started", "agent_session:completed", "agent_session:failed", "agent_session:deleted"]})
@@ -421,17 +489,18 @@ export const StreamEventRepository = {
 
     const eventIds = params.updates.map((update) => update.eventId)
     const sequences = params.updates.map((update) => update.sequence.toString())
+    const broadcastSequences = params.updates.map((update) => update.broadcastSequence.toString())
 
     const result = await db.query<StreamEventRow>(
       `UPDATE stream_events e
-       SET stream_id = $1, sequence = updates.new_sequence
+       SET stream_id = $1, sequence = updates.new_sequence, broadcast_sequence = updates.new_broadcast_sequence
        FROM (
-         SELECT * FROM unnest($2::text[], $3::bigint[]) AS u(event_id, new_sequence)
+         SELECT * FROM unnest($2::text[], $3::bigint[], $4::bigint[]) AS u(event_id, new_sequence, new_broadcast_sequence)
        ) updates
-       WHERE e.stream_id = $4
+       WHERE e.stream_id = $5
          AND e.id = updates.event_id
-       RETURNING id, stream_id, sequence, event_type, payload, actor_id, actor_type, created_at`,
-      [params.destinationStreamId, eventIds, sequences, params.sourceStreamId]
+       RETURNING id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at`,
+      [params.destinationStreamId, eventIds, sequences, broadcastSequences, params.sourceStreamId]
     )
     return result.rows.map(mapRowToEvent)
   },

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -8,6 +8,7 @@ function createMessageEvent(messageId: string): StreamEvent {
     id: `evt_${messageId}`,
     streamId: "stream_1",
     sequence: 1n,
+    broadcastSequence: 1n,
     eventType: "message_created",
     actorId: "user_1",
     actorType: "user",

--- a/apps/backend/tests/integration/event-sourcing.test.ts
+++ b/apps/backend/tests/integration/event-sourcing.test.ts
@@ -4,7 +4,7 @@ import { withTransaction, withTestTransaction } from "./setup"
 import { EventService, MessageRepository } from "../../src/features/messaging"
 import { StreamEventRepository } from "../../src/features/streams"
 import { OutboxRepository } from "../../src/lib/outbox"
-import { streamId, userId, workspaceId } from "../../src/lib/id"
+import { eventId, streamId, userId, workspaceId } from "../../src/lib/id"
 import { setupTestDatabase, testMessageContent } from "./setup"
 
 describe("Event Sourcing", () => {
@@ -737,6 +737,156 @@ describe("Event Sourcing", () => {
       const events = await eventService.listEvents(testStreamId, { limit: 3 })
 
       expect(events).toHaveLength(3)
+    })
+  })
+
+  describe("Broadcast sequence (INV-61)", () => {
+    test("messages consume dense broadcast slots; edits, deletes, and reactions do not", async () => {
+      const testStreamId = streamId()
+      const testWorkspaceId = workspaceId()
+      const testUserId = userId()
+
+      const msg1 = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("first"),
+      })
+      await eventService.editMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        messageId: msg1.id,
+        actorId: testUserId,
+        ...testMessageContent("first (edited)"),
+      })
+      await eventService.addReaction({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        messageId: msg1.id,
+        userId: testUserId,
+        emoji: "👍",
+      })
+      const msg2 = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("second"),
+      })
+      await eventService.deleteMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        messageId: msg2.id,
+        actorId: testUserId,
+      })
+
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      const byType = new Map(events.map((event) => [event.eventType, event]))
+
+      // Edits/deletes/reactions arrive at clients as payload patches, not
+      // appended rows — a broadcast slot for them would never be filled.
+      expect(byType.get("message_edited")?.broadcastSequence).toBeNull()
+      expect(byType.get("message_deleted")?.broadcastSequence).toBeNull()
+      expect(byType.get("reaction_added")?.broadcastSequence).toBeNull()
+
+      // The two messages hold consecutive slots despite the global counter
+      // having advanced past them in between.
+      const messageEvents = events.filter((event) => event.eventType === "message_created")
+      expect(messageEvents.map((event) => event.broadcastSequence)).toEqual([1n, 2n])
+      expect(messageEvents[1].sequence > 2n).toBe(true)
+    })
+
+    test("another viewer's command events leave the visible broadcast chain dense", async () => {
+      const testStreamId = streamId()
+      const testWorkspaceId = workspaceId()
+      const viewerA = userId()
+      const viewerB = userId()
+
+      await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId: viewerA,
+        authorType: "user",
+        ...testMessageContent("before"),
+      })
+      // Viewer B's author-scoped command lifecycle punches holes in the
+      // GLOBAL sequence that viewer A never receives.
+      await StreamEventRepository.insert(pool, {
+        id: eventId(),
+        streamId: testStreamId,
+        eventType: "command_dispatched",
+        payload: { commandId: "cmd_1", command: "/recap" },
+        actorId: viewerB,
+        actorType: "user",
+      })
+      await StreamEventRepository.insert(pool, {
+        id: eventId(),
+        streamId: testStreamId,
+        eventType: "command_completed",
+        payload: { commandId: "cmd_1" },
+        actorId: viewerB,
+        actorType: "user",
+      })
+      await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId: viewerB,
+        authorType: "user",
+        ...testMessageContent("after"),
+      })
+
+      const viewerAEvents = await StreamEventRepository.list(pool, testStreamId, { viewerId: viewerA })
+      // Global sequences have a hole for viewer A (the command events), but
+      // the broadcast chain is dense — exactly what lets the client treat
+      // any missing broadcast number as a real gap.
+      expect(viewerAEvents.map((event) => event.eventType)).toEqual(["message_created", "message_created"])
+      expect(viewerAEvents.map((event) => event.broadcastSequence)).toEqual([1n, 2n])
+      expect(viewerAEvents[1].sequence - viewerAEvents[0].sequence > 1n).toBe(true)
+
+      // Command events themselves never consume broadcast slots.
+      const viewerBEvents = await StreamEventRepository.list(pool, testStreamId, { viewerId: viewerB })
+      const commandEvents = viewerBEvents.filter((event) => event.eventType === "command_dispatched")
+      expect(commandEvents.map((event) => event.broadcastSequence)).toEqual([null])
+    })
+
+    test("insertMany assigns broadcast slots in list order, skipping non-broadcast types", async () => {
+      const testStreamId = streamId()
+      const memberA = userId()
+      const memberB = userId()
+
+      const events = await StreamEventRepository.insertMany(pool, [
+        {
+          id: eventId(),
+          streamId: testStreamId,
+          eventType: "member_added",
+          payload: {},
+          actorId: memberA,
+          actorType: "user",
+        },
+        {
+          id: eventId(),
+          streamId: testStreamId,
+          eventType: "reaction_added",
+          payload: {},
+          actorId: memberA,
+          actorType: "user",
+        },
+        {
+          id: eventId(),
+          streamId: testStreamId,
+          eventType: "member_added",
+          payload: {},
+          actorId: memberB,
+          actorType: "user",
+        },
+      ])
+
+      expect(events.map((event) => [event.sequence, event.broadcastSequence])).toEqual([
+        [1n, 1n],
+        [2n, null],
+        [3n, 2n],
+      ])
     })
   })
 

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -206,6 +206,7 @@ describe("message move integration", () => {
       sourceStreamId: string
       destinationStreamId: string
       messages: Array<{ id: string; authorId: string | null; contentMarkdown: string }>
+      vacatedBroadcastSequences?: string[]
     }
     expect(sourceTombstonePayload.sourceStreamId).toBe(sourceStreamId)
     expect(sourceTombstonePayload.destinationStreamId).toBe(result.thread.id)
@@ -214,6 +215,15 @@ describe("message move integration", () => {
     // passed `[movedB, movedA]` deliberately to verify this.
     expect(sourceTombstonePayload.messages.map((message) => message.id)).toEqual([movedA.id, movedB.id])
 
+    // INV-61: the source tombstone declares the broadcast slots the move
+    // vacated, so clients don't mistake them for missed events. Source
+    // broadcast order here: target=1, keep=2, movedA=3, movedB=4,
+    // session started=5, session completed=6 — the move relocates 3..6.
+    expect(sourceTombstonePayload.vacatedBroadcastSequences).toEqual(["3", "4", "5", "6"])
+    // The tombstone's own slot is the next dense value, above everything it
+    // declares — any window that can see the hole also sees the declaration.
+    expect(sourceTombstone.broadcastSequence).toBe(7n)
+
     const destinationTombstoneRows = await StreamEventRepository.list(pool, result.thread.id, {
       types: ["messages:moved"],
     })
@@ -221,7 +231,28 @@ describe("message move integration", () => {
       (event) => (event.payload as { destinationStreamId: string }).destinationStreamId === result.thread.id
     )
     expect(destinationTombstone).toBeDefined()
-    expect(destinationTombstone?.payload).toEqual(sourceTombstonePayload)
+    // Destination side gained dense fresh slots — nothing to declare, so its
+    // payload is the shared base WITHOUT the source-only vacated list.
+    const { vacatedBroadcastSequences: _vacated, ...sharedTombstonePayload } = sourceTombstonePayload
+    expect(destinationTombstone?.payload).toEqual(sharedTombstonePayload)
+
+    // The destination's broadcast chain is dense over the relocated events
+    // (in source chronological order) plus the destination tombstone (INV-61).
+    const destinationEvents = await StreamEventRepository.list(pool, result.thread.id)
+    expect(destinationEvents.map((event) => [event.eventType, event.broadcastSequence])).toEqual([
+      ["message_created", 1n],
+      ["message_created", 2n],
+      ["agent_session:started", 3n],
+      ["agent_session:completed", 4n],
+      ["messages:moved", 5n],
+    ])
+
+    // Wire shape: bigint fields cross as strings (sourceTombstoneEvent is the
+    // pre-serialized outbox payload).
+    expect(result.sourceTombstoneEvent.broadcastSequence).toBe("7")
+    expect(
+      (result.sourceTombstoneEvent.payload as { vacatedBroadcastSequences?: string[] }).vacatedBroadcastSequences
+    ).toEqual(["3", "4", "5", "6"])
 
     // The outbox payload carries the source tombstone separately so source
     // clients can append it after applying `removedEventIds` (the tombstone

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -421,6 +421,30 @@ describe("injectGapItems", () => {
     expect(result[1]).toEqual({ type: "gap", afterEventId: "evt_s1", missingCount: 1 })
   })
 
+  it("emits a placeholder for every hole anchored inside the same group", () => {
+    const items: TimelineItem[] = [
+      {
+        type: "session_group",
+        sessionId: "sess_1",
+        sessionVersion: 1,
+        events: [
+          createSessionStartedEvent("evt_s1", "1", "sess_1", "msg_t"),
+          createSessionCompletedEvent("evt_s2", "2", "sess_1"),
+        ],
+      },
+      messageItem("evt_3"),
+    ]
+    const result = injectGapItems(items, [
+      { afterEventId: "evt_s1", missingCount: 1 },
+      { afterEventId: "evt_s2", missingCount: 2 },
+    ])
+
+    expect(result.slice(1, 3)).toEqual([
+      { type: "gap", afterEventId: "evt_s1", missingCount: 1 },
+      { type: "gap", afterEventId: "evt_s2", missingCount: 2 },
+    ])
+  })
+
   it("skips holes whose anchor is not in the item list and is a no-op without holes", () => {
     const items = [messageItem("evt_1")]
     expect(injectGapItems(items, [{ afterEventId: "evt_unknown", missingCount: 1 }])).toEqual(items)

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from "vitest"
 import type { StreamEvent } from "@threa/types"
 import {
   annotateAuthorGroups,
+  filterVisibleItems,
   findFirstMessageId,
   findMessageItemIndex,
+  getTimelineItemKey,
   groupTimelineItems,
+  injectGapItems,
   type TimelineItem,
 } from "./event-list"
 
@@ -385,5 +388,52 @@ describe("findMessageItemIndex", () => {
       eventItem("evt_2", "msg_real"),
     ]
     expect(findMessageItemIndex(items, "msg_real")).toBe(1)
+  })
+})
+
+describe("injectGapItems", () => {
+  function messageItem(id: string): TimelineItem {
+    return {
+      type: "event",
+      event: createEvent({ id, sequence: "1", eventType: "message_created", payload: { messageId: `msg_${id}` } }),
+    }
+  }
+
+  it("inserts a gap placeholder directly after its anchor row", () => {
+    const items = [messageItem("evt_1"), messageItem("evt_2")]
+    const result = injectGapItems(items, [{ afterEventId: "evt_1", missingCount: 2 }])
+
+    expect(result).toEqual([items[0], { type: "gap", afterEventId: "evt_1", missingCount: 2 }, items[1]])
+  })
+
+  it("anchors a gap after a group that contains the anchor event", () => {
+    const items: TimelineItem[] = [
+      {
+        type: "session_group",
+        sessionId: "sess_1",
+        sessionVersion: 1,
+        events: [createSessionStartedEvent("evt_s1", "1", "sess_1", "msg_t")],
+      },
+      messageItem("evt_2"),
+    ]
+    const result = injectGapItems(items, [{ afterEventId: "evt_s1", missingCount: 1 }])
+
+    expect(result[1]).toEqual({ type: "gap", afterEventId: "evt_s1", missingCount: 1 })
+  })
+
+  it("skips holes whose anchor is not in the item list and is a no-op without holes", () => {
+    const items = [messageItem("evt_1")]
+    expect(injectGapItems(items, [{ afterEventId: "evt_unknown", missingCount: 1 }])).toEqual(items)
+    expect(injectGapItems(items, [])).toBe(items)
+  })
+
+  it("gives gap items a stable key distinct from event keys", () => {
+    expect(getTimelineItemKey({ type: "gap", afterEventId: "evt_1", missingCount: 2 })).toBe("gap:evt_1")
+  })
+
+  it("keeps gap items visible through filterVisibleItems", () => {
+    const items = injectGapItems([messageItem("evt_1")], [{ afterEventId: "evt_1", missingCount: 1 }])
+    const visible = filterVisibleItems(items)
+    expect(visible.some((item) => item.type === "gap")).toBe(true)
   })
 })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -14,6 +14,7 @@ import type { MessageAgentActivity } from "@/hooks"
 import { useSocket, useCoordinatedLoading } from "@/contexts"
 import { useAbortResearch } from "@/hooks"
 import { isAbortableStepType } from "@/lib/step-config"
+import { Loader2 } from "lucide-react"
 import { EventItem } from "./event-item"
 import { AgentSessionEvent } from "./agent-session-event"
 import { CommandEvent } from "./command-event"
@@ -107,6 +108,14 @@ export type TimelineItem =
     }
   | { type: "command_group"; commandId: string; events: StreamEvent[] }
   | { type: "session_group"; sessionId: string; sessionVersion: number; events: StreamEvent[] }
+  /**
+   * An in-place loading placeholder for a detected hole in the broadcast
+   * chain (INV-61): events are known to be missing right after
+   * `afterEventId` and a scoped backfill is in flight. Rendering the
+   * placeholder where the events belong means the backfill resolves it in
+   * place — a missed message never pops in above rows already on screen.
+   */
+  | { type: "gap"; afterEventId: string; missingCount: number }
 
 /** Event types that participate in author-grouping (render as message bodies). */
 const MESSAGE_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["message_created", "companion_response"])
@@ -225,9 +234,50 @@ export function getTimelineItemKey(item: TimelineItem): string {
       return item.commandId
     case "session_group":
       return item.sessionId
+    case "gap":
+      return `gap:${item.afterEventId}`
     default:
       return item.event.id
   }
+}
+
+/** Whether a timeline item renders (or contains) the given event id. */
+function itemContainsEvent(item: TimelineItem, eventId: string): boolean {
+  switch (item.type) {
+    case "command_group":
+    case "session_group":
+      return item.events.some((event) => event.id === eventId)
+    case "gap":
+      return false
+    default:
+      return item.event.id === eventId
+  }
+}
+
+/**
+ * Insert a `gap` placeholder item directly after the timeline item that
+ * renders each hole's `afterEventId` (INV-61). Holes whose anchor row isn't
+ * in the item list (e.g. the anchor was filtered out of this view) are
+ * skipped — the backfill still runs; there is just no position to mark.
+ */
+export function injectGapItems(
+  items: TimelineItem[],
+  holes: Array<{ afterEventId: string; missingCount: number }>
+): TimelineItem[] {
+  if (holes.length === 0) return items
+  const result: TimelineItem[] = []
+  const holesByAnchor = new Map(holes.map((hole) => [hole.afterEventId, hole]))
+  for (const item of items) {
+    result.push(item)
+    for (const [anchorId, hole] of holesByAnchor) {
+      if (itemContainsEvent(item, anchorId)) {
+        result.push({ type: "gap", afterEventId: hole.afterEventId, missingCount: hole.missingCount })
+        holesByAnchor.delete(anchorId)
+        break
+      }
+    }
+  }
+  return result
 }
 
 /**
@@ -356,6 +406,7 @@ export interface TimelineItemRenderContext {
 
 function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean {
   if (!firstUnreadEventId) return false
+  if (item.type === "gap") return false
   if (item.type === "command_group" || item.type === "session_group") {
     return item.events[0]?.id === firstUnreadEventId
   }
@@ -371,6 +422,19 @@ export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: Ti
       {item.type === "command_group" && (
         <div className="px-3 sm:px-6">
           <CommandEvent events={item.events} />
+        </div>
+      )}
+      {item.type === "gap" && (
+        // Fixed-height single row: the placeholder reserves the hole's spot
+        // and is replaced in place when the backfill lands — no content ever
+        // inserts above rows the user is already reading (INV-61, INV-21).
+        <div
+          role="status"
+          aria-label="Loading missed messages"
+          className="flex h-8 items-center gap-2 px-3 sm:px-6 text-xs text-muted-foreground"
+        >
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <span>Loading {item.missingCount === 1 ? "a missed message" : `${item.missingCount} missed messages`}…</span>
         </div>
       )}
       {item.type === "session_group" && !ctx.hideSessionCards && (

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -269,11 +269,14 @@ export function injectGapItems(
   const holesByAnchor = new Map(holes.map((hole) => [hole.afterEventId, hole]))
   for (const item of items) {
     result.push(item)
+    // An item can anchor MORE than one hole: a command/session group renders
+    // several events as one card, and distinct holes can sit behind distinct
+    // events inside it — emit a placeholder for each (map order preserves the
+    // holes' ascending order). Deleting while iterating a Map is safe in JS.
     for (const [anchorId, hole] of holesByAnchor) {
       if (itemContainsEvent(item, anchorId)) {
         result.push({ type: "gap", afterEventId: hole.afterEventId, missingCount: hole.missingCount })
         holesByAnchor.delete(anchorId)
-        break
       }
     }
   }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -55,6 +55,7 @@ import {
   TimelineItemContent,
   groupTimelineItems,
   annotateAuthorGroups,
+  injectGapItems,
   findFirstMessageId,
   findMessageItemIndex,
   getTimelineItemKey,
@@ -343,6 +344,7 @@ export function StreamContent({
 
   const {
     events,
+    holes,
     isLoading,
     isConfirmedEmpty,
     error,
@@ -465,9 +467,16 @@ export function StreamContent({
       })
   }, [events, isThread])
 
+  // Gap placeholders are injected AFTER grouping/annotation so a hole in the
+  // broadcast chain (INV-61) renders as its own in-place loading row — see
+  // useEvents' contiguity gate for how holes are detected and backfilled.
   const timelineItems = useMemo(
-    () => annotateAuthorGroups(groupTimelineItems(displayEvents, currentWorkspaceUserId ?? undefined)),
-    [displayEvents, currentWorkspaceUserId]
+    () =>
+      injectGapItems(
+        annotateAuthorGroups(groupTimelineItems(displayEvents, currentWorkspaceUserId ?? undefined)),
+        holes
+      ),
+    [displayEvents, currentWorkspaceUserId, holes]
   )
 
   // `order` is the position in the rendered timeline. Non-thread streams

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -137,6 +137,13 @@ export interface CachedEvent {
   sequence: string // bigint as string
   /** Numeric mirror of sequence for IDB index ordering (string indexes sort lexicographically). */
   _sequenceNum: number
+  /**
+   * Dense per-stream position over viewer-visible timeline rows (INV-61),
+   * mirrored from the wire. `null` for non-broadcast event types (own command
+   * events, patch-style rows), `undefined` for rows cached before the field
+   * existed — both are simply skipped by the contiguity chain.
+   */
+  broadcastSequence?: string | null
   eventType: EventType
   payload: unknown
   actorId: string | null

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -6,6 +6,8 @@ import { db, sequenceToNum } from "@/db"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
 import { isTerminalBootstrapError, shouldSuppressBootstrapError } from "@/lib/query-load-state"
+import { computeTimelineHoles, holesSignature, type TimelineHole } from "@/sync/contiguity"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import type { StreamEvent, EventsAroundResponse, SharedMessageHydration } from "@threa/types"
 
 export const eventKeys = {
@@ -13,6 +15,10 @@ export const eventKeys = {
   list: (workspaceId: string, streamId: string) => [...eventKeys.all, "list", workspaceId, streamId] as const,
   newer: (workspaceId: string, streamId: string) => [...eventKeys.all, "newer", workspaceId, streamId] as const,
 }
+
+/** Spacing/cap for re-requesting a backfill while the same holes persist. */
+const HOLE_BACKFILL_RETRY_MS = 15_000
+const HOLE_BACKFILL_MAX_ATTEMPTS = 3
 
 interface JumpState {
   events: StreamEvent[]
@@ -460,6 +466,47 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     return getRenderableEvents(effectiveEvents, displayFloor) as unknown as StreamEvent[]
   }, [effectiveEvents, olderData, newerData, jumpState, displayFloor])
 
+  // Contiguity gate (INV-61): detect holes in the broadcast chain of the
+  // rendered window. Each hole renders as an in-place loading placeholder
+  // (see injectGapItems in event-list) and is backfilled via the engine's
+  // single-flighted gap fetch, so the missed message resolves the
+  // placeholder where it belongs instead of popping in above rows already
+  // on screen. Jump mode is exempt — its window is a single contiguous
+  // server response, and holes against the live tail are expected there.
+  const syncEngine = useOptionalSyncEngine()
+  const holes = useMemo<TimelineHole[]>(() => (jumpState ? [] : computeTimelineHoles(events)), [events, jumpState])
+  const holesKey = holesSignature(holes)
+  const holesRef = useRef(holes)
+  holesRef.current = holes
+
+  useEffect(() => {
+    if (!syncEngine || holesKey === "") return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let attempt = 0
+
+    // Re-request a few times while the SAME holes persist (transient fetch
+    // failures, server lag), then leave the placeholder to the next
+    // reconnect/navigation refresh. A filled hole changes holesKey, which
+    // cancels the retry chain via cleanup.
+    const request = () => {
+      if (cancelled) return
+      attempt++
+      for (const hole of holesRef.current) {
+        void syncEngine.backfillStreamGap(streamId, hole.afterSequence)
+      }
+      if (attempt < HOLE_BACKFILL_MAX_ATTEMPTS) {
+        timer = setTimeout(request, HOLE_BACKFILL_RETRY_MS)
+      }
+    }
+    request()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [holesKey, syncEngine, streamId])
+
   // When IDB has been unresolved long enough that a user would notice, flip
   // the timeline to the skeleton instead of leaving it blank. Fast switches
   // clear the timer before it fires, so the flicker-free path is preserved
@@ -635,6 +682,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
 
   return {
     events,
+    holes,
     isLoading,
     isConfirmedEmpty,
     error: suppressBootstrapError ? null : error,

--- a/apps/frontend/src/sync/contiguity.test.ts
+++ b/apps/frontend/src/sync/contiguity.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+import { computeTimelineHoles, holesSignature, type ContiguityCheckEvent } from "./contiguity"
+
+function event(overrides: Partial<ContiguityCheckEvent> & { id: string; sequence: string }): ContiguityCheckEvent {
+  return {
+    eventType: "message_created",
+    payload: { messageId: overrides.id },
+    broadcastSequence: null,
+    ...overrides,
+  }
+}
+
+describe("computeTimelineHoles", () => {
+  it("returns no holes for a contiguous broadcast chain", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({ id: "e2", sequence: "11", broadcastSequence: "6" }),
+      event({ id: "e3", sequence: "14", broadcastSequence: "7" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([])
+  })
+
+  it("detects a mid-window hole and anchors it on the row below", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({ id: "e2", sequence: "20", broadcastSequence: "8" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([{ afterEventId: "e1", afterSequence: "10", missingCount: 2 }])
+  })
+
+  it("reports multiple distinct holes", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "1" }),
+      event({ id: "e2", sequence: "12", broadcastSequence: "3" }),
+      event({ id: "e3", sequence: "15", broadcastSequence: "4" }),
+      event({ id: "e4", sequence: "19", broadcastSequence: "6" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([
+      { afterEventId: "e1", afterSequence: "10", missingCount: 1 },
+      { afterEventId: "e3", afterSequence: "15", missingCount: 1 },
+    ])
+  })
+
+  it("never flags rows without a broadcast sequence (other viewers' commands, pre-deploy cache)", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      // Own command event: consumes a global slot but no broadcast slot.
+      event({ id: "cmd", sequence: "11", broadcastSequence: null, eventType: "command_dispatched" }),
+      // Pre-deploy cached row: no stamp at all.
+      event({ id: "old", sequence: "12", broadcastSequence: undefined }),
+      event({ id: "e2", sequence: "13", broadcastSequence: "6" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([])
+  })
+
+  it("skips pending and failed optimistic rows", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({ id: "tmp", sequence: "999", broadcastSequence: "999", _status: "pending" }),
+      event({ id: "e2", sequence: "11", broadcastSequence: "6" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([])
+  })
+
+  it("does not flag slots a move tombstone declares vacated", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({
+        id: "tomb",
+        sequence: "20",
+        broadcastSequence: "9",
+        eventType: "messages:moved",
+        payload: { vacatedBroadcastSequences: ["6", "7", "8"] },
+      }),
+      event({ id: "e2", sequence: "21", broadcastSequence: "10" }),
+    ]
+    expect(computeTimelineHoles(events)).toEqual([])
+  })
+
+  it("still reports the real gap inside a partially vacated range", () => {
+    const events = [
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({
+        id: "tomb",
+        sequence: "20",
+        broadcastSequence: "9",
+        eventType: "messages:moved",
+        payload: { vacatedBroadcastSequences: ["6", "8"] },
+      }),
+    ]
+    // Slot 7 is neither present nor vacated — a real missed event.
+    expect(computeTimelineHoles(events)).toEqual([{ afterEventId: "e1", afterSequence: "10", missingCount: 1 }])
+  })
+
+  it("returns no holes for empty or single-row windows", () => {
+    expect(computeTimelineHoles([])).toEqual([])
+    expect(computeTimelineHoles([event({ id: "e1", sequence: "10", broadcastSequence: "5" })])).toEqual([])
+  })
+})
+
+describe("holesSignature", () => {
+  it("is stable for equal holes and distinguishes different ones", () => {
+    const holes = computeTimelineHoles([
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({ id: "e2", sequence: "20", broadcastSequence: "8" }),
+    ])
+    const sameHoles = computeTimelineHoles([
+      event({ id: "e1", sequence: "10", broadcastSequence: "5" }),
+      event({ id: "e2", sequence: "20", broadcastSequence: "8" }),
+    ])
+    expect(holesSignature(holes)).toBe(holesSignature(sameHoles))
+    expect(holesSignature([])).toBe("")
+    expect(holesSignature(holes)).not.toBe(holesSignature([]))
+  })
+})

--- a/apps/frontend/src/sync/contiguity.ts
+++ b/apps/frontend/src/sync/contiguity.ts
@@ -1,0 +1,110 @@
+import type { MessagesMovedEventPayload } from "@threa/types"
+
+/**
+ * Read-side contiguity over the viewer-visible broadcast chain (INV-61).
+ *
+ * Every stream member receives the broadcast timeline events (messages,
+ * membership, agent sessions, move tombstones) with a dense per-stream
+ * `broadcastSequence`. Because the chain is dense for every viewer, a missing
+ * number inside the rendered window is ALWAYS a real gap — never another
+ * user's author-scoped command event (those don't consume broadcast slots).
+ *
+ * The one legitimate way slots disappear is the message-move flow, which
+ * relocates rows to a destination thread. The move's source-side tombstone
+ * declares the vacated slots in its payload (`vacatedBroadcastSequences`),
+ * and the tombstone's own broadcastSequence is always above every slot it
+ * declares — so any window that can see the hole also contains the
+ * declaration.
+ *
+ * This module is pure; `useEvents` renders detected holes as in-place
+ * loading placeholders and asks the SyncEngine for a scoped backfill, so a
+ * missed message resolves a visible placeholder where it belongs instead of
+ * popping in above rows that are already on screen.
+ */
+
+/** Minimal shape the hole scan needs — satisfied by StreamEvent and CachedEvent. */
+export interface ContiguityCheckEvent {
+  id: string
+  sequence: string
+  broadcastSequence?: string | null
+  eventType: string
+  payload: unknown
+  _status?: string | null
+}
+
+export interface TimelineHole {
+  /** Event id of the row immediately below the hole — the placeholder renders right after it. */
+  afterEventId: string
+  /** Global sequence of that row — the `bootstrap?after=` cursor that closes the hole. */
+  afterSequence: string
+  /** Missing broadcast slots in the hole, net of declared vacated slots. */
+  missingCount: number
+}
+
+function collectVacatedBroadcastSlots(events: ContiguityCheckEvent[]): Set<number> {
+  const vacated = new Set<number>()
+  for (const event of events) {
+    if (event.eventType !== "messages:moved") continue
+    const declared = (event.payload as Partial<MessagesMovedEventPayload> | undefined)?.vacatedBroadcastSequences
+    if (!Array.isArray(declared)) continue
+    for (const slot of declared) {
+      const num = Number(slot)
+      if (Number.isFinite(num)) vacated.add(num)
+    }
+  }
+  return vacated
+}
+
+/**
+ * Detect holes in the broadcast chain of a rendered timeline window.
+ *
+ * `events` must be in render order (ascending global sequence — the order
+ * `useEvents` produces). Pending/failed optimistic rows and rows without a
+ * `broadcastSequence` (non-broadcast types, pre-deploy cached rows) don't
+ * participate in the chain; they can never create a phantom hole, only
+ * reduce coverage. Contiguity is asserted strictly *between* adjacent chain
+ * rows — history below the window floor is the server's (already
+ * contiguous) pagination responses, and the area above the newest row is
+ * covered by the write-path tail-gap check in stream-sync.
+ */
+export function computeTimelineHoles(events: ContiguityCheckEvent[]): TimelineHole[] {
+  const chain: ContiguityCheckEvent[] = []
+  for (const event of events) {
+    if (event._status === "pending" || event._status === "failed") continue
+    if (event.broadcastSequence == null) continue
+    chain.push(event)
+  }
+  if (chain.length < 2) return []
+
+  const vacated = collectVacatedBroadcastSlots(events)
+  const holes: TimelineHole[] = []
+
+  for (let i = 1; i < chain.length; i++) {
+    const previous = chain[i - 1]
+    const current = chain[i]
+    const previousSlot = Number(previous.broadcastSequence)
+    const currentSlot = Number(current.broadcastSequence)
+    let missingCount = 0
+    for (let slot = previousSlot + 1; slot < currentSlot; slot++) {
+      if (!vacated.has(slot)) missingCount++
+    }
+    if (missingCount > 0) {
+      holes.push({
+        afterEventId: previous.id,
+        afterSequence: previous.sequence,
+        missingCount,
+      })
+    }
+  }
+
+  return holes
+}
+
+/**
+ * Stable identity for a set of holes — used as an effect dependency so the
+ * backfill request fires when the holes actually change, not on every
+ * re-render of the same (still unfilled) window.
+ */
+export function holesSignature(holes: TimelineHole[]): string {
+  return holes.map((hole) => `${hole.afterEventId}:${hole.missingCount}`).join("|")
+}

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -4,7 +4,9 @@ import type { Socket } from "socket.io-client"
 import { db } from "@/db"
 import {
   applyStreamBootstrap,
+  detectSequenceGap,
   getLatestPersistedSequence,
+  getPersistedTail,
   registerStreamSocketHandlers,
   toCachedStreamBootstrap,
   updateMessageEvent,
@@ -1271,5 +1273,176 @@ describe("registerStreamSocketHandlers — sequence gap detection (INV-53)", () 
 
     expect(onSequenceGap).not.toHaveBeenCalled()
     cleanup()
+  })
+
+  // -------------------------------------------------------------------------
+  // Broadcast-chain detection (INV-61) — exact, no command-event phantoms
+  // -------------------------------------------------------------------------
+
+  async function seedStamped(streamId: string, id: string, sequence: number, broadcastSequence: string | null) {
+    await db.events.put({
+      ...makeEvent({ id, streamId, sequence: String(sequence) }),
+      broadcastSequence,
+      workspaceId: "ws_1",
+      _sequenceNum: sequence,
+      _cachedAt: Date.now(),
+    })
+  }
+
+  it("does not report a gap when skipped global slots belong to viewer-invisible events (INV-61)", async () => {
+    const streamId = "stream_bcast_clean"
+    // Persisted tail: message at global 100, broadcast 50. Another user's
+    // command events consumed global 101-102 but were never delivered here.
+    await seedStamped(streamId, "evt_100", 100, "50")
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: { ...makeWireEvent("evt_103", streamId, "103"), broadcastSequence: "51" },
+    })
+
+    // The pre-INV-61 global heuristic would have flagged this as a gap and
+    // fired a futile backfill; the dense broadcast chain proves it's contiguous.
+    expect(onSequenceGap).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it("reports a broadcast-chain gap with the latest GLOBAL sequence as cursor", async () => {
+    const streamId = "stream_bcast_gap"
+    await seedStamped(streamId, "evt_100", 100, "50")
+    // Own command event sits on the global tail without a broadcast slot —
+    // the cursor must still be the global latest so `bootstrap?after=`
+    // fetches everything missed.
+    await seedStamped(streamId, "cmd_101", 101, null)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: { ...makeWireEvent("evt_105", streamId, "105"), broadcastSequence: "52" },
+    })
+
+    expect(onSequenceGap).toHaveBeenCalledWith({ streamId, afterSequence: "101" })
+    cleanup()
+  })
+
+  it("compares on the broadcast chain even when an unstamped row is the global tail", async () => {
+    const streamId = "stream_bcast_cmd_tail"
+    await seedStamped(streamId, "evt_100", 100, "50")
+    await seedStamped(streamId, "cmd_101", 101, null)
+    const onSequenceGap = vi.fn()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), { onSequenceGap })
+
+    // Global 103 > 101 + 1 would false-positive on the old heuristic, but
+    // broadcast 51 is exactly contiguous with the persisted 50.
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: { ...makeWireEvent("evt_103", streamId, "103"), broadcastSequence: "51" },
+    })
+
+    expect(onSequenceGap).not.toHaveBeenCalled()
+    cleanup()
+  })
+})
+
+describe("detectSequenceGap (unit)", () => {
+  it("uses the dense broadcast chain when both sides are stamped", () => {
+    const tail = { latestSequence: "100", latestBroadcastSequence: "50" }
+    expect(detectSequenceGap(tail, { sequence: "105", broadcastSequence: "51" })).toBeNull()
+    expect(detectSequenceGap(tail, { sequence: "105", broadcastSequence: "52" })).toBe("100")
+    expect(detectSequenceGap(tail, { sequence: "105", broadcastSequence: "50" })).toBeNull()
+  })
+
+  it("falls back to the global heuristic when either side is unstamped", () => {
+    expect(
+      detectSequenceGap(
+        { latestSequence: "100", latestBroadcastSequence: null },
+        { sequence: "102", broadcastSequence: "51" }
+      )
+    ).toBe("100")
+    expect(
+      detectSequenceGap(
+        { latestSequence: "100", latestBroadcastSequence: "50" },
+        { sequence: "102", broadcastSequence: null }
+      )
+    ).toBe("100")
+    expect(
+      detectSequenceGap(
+        { latestSequence: "100", latestBroadcastSequence: null },
+        { sequence: "101", broadcastSequence: null }
+      )
+    ).toBeNull()
+  })
+
+  it("never reports a gap against an empty cache", () => {
+    expect(
+      detectSequenceGap(
+        { latestSequence: null, latestBroadcastSequence: null },
+        { sequence: "5", broadcastSequence: "3" }
+      )
+    ).toBeNull()
+  })
+})
+
+describe("getPersistedTail", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("finds the highest broadcast stamp below an unstamped global tail", async () => {
+    const streamId = "stream_tail_scan"
+    await db.events.bulkPut([
+      {
+        ...makeEvent({ id: "evt_a", streamId, sequence: "100" }),
+        broadcastSequence: "50",
+        workspaceId: "ws_1",
+        _sequenceNum: 100,
+        _cachedAt: Date.now(),
+      },
+      {
+        ...makeEvent({ id: "cmd_b", streamId, sequence: "101" }),
+        broadcastSequence: null,
+        workspaceId: "ws_1",
+        _sequenceNum: 101,
+        _cachedAt: Date.now(),
+      },
+    ])
+
+    expect(await getPersistedTail(streamId)).toEqual({ latestSequence: "101", latestBroadcastSequence: "50" })
+  })
+
+  it("excludes pending/failed optimistic rows from both cursors", async () => {
+    const streamId = "stream_tail_pending"
+    const placeholder = Date.now()
+    await db.events.bulkPut([
+      {
+        ...makeEvent({ id: "evt_a", streamId, sequence: "100" }),
+        broadcastSequence: "50",
+        workspaceId: "ws_1",
+        _sequenceNum: 100,
+        _cachedAt: Date.now(),
+      },
+      {
+        ...makeEvent({ id: "temp_x", streamId, sequence: String(placeholder) }),
+        broadcastSequence: null,
+        workspaceId: "ws_1",
+        _sequenceNum: placeholder,
+        _status: "pending",
+        _cachedAt: Date.now(),
+      },
+    ])
+
+    expect(await getPersistedTail(streamId)).toEqual({ latestSequence: "100", latestBroadcastSequence: "50" })
+  })
+
+  it("returns nulls for an empty stream", async () => {
+    expect(await getPersistedTail("stream_tail_empty")).toEqual({ latestSequence: null, latestBroadcastSequence: null })
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -83,6 +83,39 @@ export async function getLatestPersistedSequence(streamId: string): Promise<stri
   return latestEvent?.sequence ?? null
 }
 
+export interface PersistedTail {
+  /** Global sequence of the newest persisted row — the `bootstrap?after=` catch-up cursor. */
+  latestSequence: string | null
+  /**
+   * Highest `broadcastSequence` among recent persisted rows (broadcast order
+   * matches global order, so the first stamped row scanning downward holds
+   * the max). `null` when the cache predates the broadcast counter.
+   */
+  latestBroadcastSequence: string | null
+}
+
+/**
+ * Bound on the downward scan for a stamped row. Unstamped rows above the
+ * last stamped one only occur transitionally (pre-INV-61 cached rows);
+ * past the bound we fall back to the global-sequence gap heuristic.
+ */
+const TAIL_SCAN_LIMIT = 50
+
+export async function getPersistedTail(streamId: string): Promise<PersistedTail> {
+  const recent = await db.events
+    .where("[streamId+_sequenceNum]")
+    .between([streamId, 0], [streamId, Number.MAX_SAFE_INTEGER], true, true)
+    .reverse()
+    .filter((event) => event._status !== "pending" && event._status !== "failed")
+    .limit(TAIL_SCAN_LIMIT)
+    .toArray()
+
+  return {
+    latestSequence: recent[0]?.sequence ?? null,
+    latestBroadcastSequence: recent.find((event) => event.broadcastSequence != null)?.broadcastSequence ?? null,
+  }
+}
+
 function getBootstrapWindowFloor(events: StreamEvent[]): bigint | null {
   if (events.length === 0) return null
   return events.reduce((min, event) => {
@@ -505,22 +538,33 @@ export interface StreamSocketHandlerOptions {
    * client wasn't receiving (zombie socket, server bounce, a catch-up fetch
    * that raced live delivery). `afterSequence` is the pre-write latest, so a
    * `bootstrap?after=` fetch from it closes the hole (INV-53: overlap is safe,
-   * gaps are not). Other users' command events legitimately occupy sequence
-   * slots that are never delivered to this viewer, so a reported gap may turn
-   * out to be empty — the backfill is idempotent and self-quiets because the
-   * next live event sits contiguously on the new tail.
+   * gaps are not). When both sides carry a `broadcastSequence` the check is
+   * exact (INV-61: the broadcast chain is dense for every viewer). Only the
+   * transitional global-sequence fallback can report a gap that turns out to
+   * be empty — the backfill is idempotent and self-quiets.
    */
   onSequenceGap?: (gap: { streamId: string; afterSequence: string }) => void
 }
 
 /**
- * Pre-write tail-gap check: returns the latest persisted sequence when the
- * incoming event skips past it (a hole exists behind the new tail), null when
- * contiguous, older-than-tail, or the stream has nothing cached to gap against.
+ * Pre-write tail-gap check: returns the catch-up cursor (latest persisted
+ * global sequence) when the incoming event skips past the persisted tail,
+ * null when contiguous, older-than-tail, or there is nothing to gap against.
+ *
+ * The comparison runs on the dense broadcast chain when both sides are
+ * stamped — exact, no false positives from other viewers' command events.
+ * Unstamped events (own command echoes, pre-INV-61 caches) fall back to the
+ * conservative global-sequence heuristic.
  */
-function detectSequenceGap(latestPersisted: string | null, incomingSequence: string): string | null {
-  if (latestPersisted === null) return null
-  return sequenceToNum(incomingSequence) > sequenceToNum(latestPersisted) + 1 ? latestPersisted : null
+export function detectSequenceGap(
+  tail: PersistedTail,
+  incoming: Pick<StreamEvent, "sequence" | "broadcastSequence">
+): string | null {
+  if (tail.latestSequence === null) return null
+  if (incoming.broadcastSequence != null && tail.latestBroadcastSequence != null) {
+    return Number(incoming.broadcastSequence) > Number(tail.latestBroadcastSequence) + 1 ? tail.latestSequence : null
+  }
+  return sequenceToNum(incoming.sequence) > sequenceToNum(tail.latestSequence) + 1 ? tail.latestSequence : null
 }
 
 export function registerStreamSocketHandlers(
@@ -568,7 +612,7 @@ export function registerStreamSocketHandlers(
 
       // Tail-gap check must read the latest BEFORE this write advances it.
       if (onSequenceGap) {
-        gapAfterSequence = detectSequenceGap(await getLatestPersistedSequence(streamId), newEvent.sequence)
+        gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), newEvent)
       }
 
       // Add the real event BEFORE deleting the optimistic one so that
@@ -817,7 +861,7 @@ export function registerStreamSocketHandlers(
       if (existing) return
       // Tail-gap check must read the latest BEFORE this write advances it.
       if (onSequenceGap) {
-        gapAfterSequence = detectSequenceGap(await getLatestPersistedSequence(streamId), payload.event.sequence)
+        gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), payload.event)
       }
       await db.events.put({
         ...payload.event,

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -341,22 +341,13 @@ export class SyncEngine {
       let bootstrap: WorkspaceBootstrap
 
       if (_isReconnect && visibleStreamIds.length > 0) {
-        // Read each stream's catch-up cursor BEFORE re-joining its room. The
-        // re-join below starts delivering live events into IndexedDB
-        // immediately, and a message landing before the cursor read advances
-        // the cursor past the disconnect gap — the `after` fetch then
-        // permanently skips everything missed while offline (the "older
-        // message never appears while newer ones do" bug). Overlap is safe
-        // (writes dedupe by event id); gaps are not (INV-53).
+        // Cursor-before-join per stream is owned by joinStreamForCatchUp —
+        // see its doc for why the order is load-bearing (INV-53).
         const catchupCursors = new Map<string, string | null>()
         await Promise.all(
           visibleStreamIds.map(async (streamId) => {
-            catchupCursors.set(streamId, await getLatestPersistedSequence(streamId))
+            catchupCursors.set(streamId, await this.joinStreamForCatchUp(streamId))
           })
-        )
-
-        await Promise.all(
-          visibleStreamIds.map((streamId) => this.ensureStreamSubscription(streamId, { awaitJoin: true }))
         )
 
         const [workspaceBootstrap, streamResults] = await Promise.all([
@@ -581,6 +572,27 @@ export class SyncEngine {
     return memberships.map((membership) => membership.streamId)
   }
 
+  /**
+   * The single owner of catch-up-cursor derivation (INV-53, INV-61): read
+   * the stream's latest persisted sequence, THEN join its room — in that
+   * order. Once subscribed, live events land in IndexedDB immediately, and a
+   * message landing before the cursor read would advance the cursor past the
+   * disconnect gap, making the subsequent `bootstrap?after=` fetch
+   * permanently skip everything missed while offline (the "older message
+   * never appears while newer ones do" bug). Overlap is safe (writes dedupe
+   * by event id); gaps are not.
+   *
+   * Callers must never read `getLatestPersistedSequence` and order it
+   * against a room join themselves. The one other cursor source is
+   * `backfillStreamGap`, which intentionally uses an explicit PRE-GAP cursor
+   * (the current latest would skip the very hole it fills).
+   */
+  private async joinStreamForCatchUp(streamId: string): Promise<string | null> {
+    const after = await getLatestPersistedSequence(streamId)
+    await this.ensureStreamSubscription(streamId, { awaitJoin: true })
+    return after
+  }
+
   private async ensureStreamSubscription(streamId: string, options?: { awaitJoin?: boolean }): Promise<void> {
     if (!this.socket || this.isDestroyed) return
 
@@ -641,13 +653,11 @@ export class SyncEngine {
     try {
       const queryKey = streamKeys.bootstrap(workspaceId, streamId)
       const previousBootstrap = queryClient.getQueryData<CachedStreamBootstrap>(queryKey)
-      // Cursor BEFORE the room join — once subscribed, live events land in
-      // IndexedDB and would advance the cursor past any gap this refresh is
-      // meant to close (INV-53: overlap is safe, gaps are not).
-      const after = previousBootstrap ? await getLatestPersistedSequence(streamId) : null
-
-      await this.ensureStreamSubscription(streamId, { awaitJoin: true })
+      const cursor = await this.joinStreamForCatchUp(streamId)
       if (this.isDestroyed) return
+      // Without a cached bootstrap this is a fresh open, not a catch-up —
+      // fetch the full latest window instead of an append from the cursor.
+      const after = previousBootstrap ? cursor : null
 
       const bootstrap = await streamService.bootstrap(workspaceId, streamId, after ? { after } : undefined)
       await applyStreamBootstrap(workspaceId, streamId, bootstrap)

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -3,17 +3,19 @@ title: Sync Engine
 status: shipped
 audience: internal
 kind: subsystem
-invariants: [INV-53]
+invariants: [INV-53, INV-61]
 entry_points:
   - apps/frontend/src/sync/sync-engine.ts
   - apps/frontend/src/sync/stream-sync.ts
   - apps/frontend/src/sync/workspace-sync.ts
+  - apps/frontend/src/sync/contiguity.ts
   - apps/frontend/src/lib/socket-room.ts
 public_site: false
 summary: >
   One per-workspace class that owns the whole client sync lifecycle: bootstrap the
   workspace and its streams (subscribe-then-bootstrap), keep them live over the socket,
-  and re-sync everything on reconnect or page resume.
+  re-sync everything on reconnect or page resume, and verify the rendered timeline is
+  contiguous — detected gaps render as in-place placeholders and backfill themselves.
 related:
   [
     concepts/subscribe-then-bootstrap.md,
@@ -53,9 +55,10 @@ its room. The handlers (`registerStreamSocketHandlers`, `registerWorkspaceSocket
 write incoming events straight to IDB.
 
 **Navigation triggers a targeted refresh.** When the route changes, `setCurrentStreamId`
-kicks `refreshStreamAfterNavigation` → `performStreamRefresh`: confirm the subscription,
-then fetch a **delta** bootstrap (`after` = the latest persisted sequence) and merge it.
-So opening a stream you've seen before fetches only what you missed, not its whole history.
+kicks `refreshStreamAfterNavigation` → `performStreamRefresh`: derive the catch-up cursor
+and confirm the subscription (via `joinStreamForCatchUp`, see below), then fetch a
+**delta** bootstrap (`after` = the latest persisted sequence) and merge it. So opening a
+stream you've seen before fetches only what you missed, not its whole history.
 
 If you only need the mental model, stop here. The rest is the behavior that makes it
 correct under reconnects and races.
@@ -65,14 +68,58 @@ correct under reconnects and races.
 ### Reconnect re-bootstraps everything, as a delta
 
 On reconnect, the engine marks all state stale, tears down and re-registers handlers, and
-re-bootstraps. For the streams the user can currently see, it `awaitJoin`s each room, then
-fetches the workspace bootstrap and per-stream **delta** bootstraps in parallel: `after` =
-latest persisted sequence, which the backend serves as `syncMode: "append"` (or falls back
-to `replace` when the gap is too large to append). It applies them in one batch
-(`applyReconnectBootstrapBatch`). Per-stream failures are classified: 403/404 are terminal
-(the stream is gone or forbidden), everything else is transient and left "stale" to retry.
-This is subscribe-then-bootstrap again: the reconnect path is exactly where the old naive
-"just refetch" loses the events that arrived mid-reconnect.
+re-bootstraps. For the streams the user can currently see, it runs `joinStreamForCatchUp`
+per stream, then fetches the workspace bootstrap and per-stream **delta** bootstraps in
+parallel: `after` = latest persisted sequence, which the backend serves as
+`syncMode: "append"` (or falls back to `replace` when the gap is too large to append). It
+applies them in one batch (`applyReconnectBootstrapBatch`). Per-stream failures are
+classified: 403/404 are terminal (the stream is gone or forbidden), everything else is
+transient and left "stale" to retry. This is subscribe-then-bootstrap again: the reconnect
+path is exactly where the old naive "just refetch" loses the events that arrived
+mid-reconnect.
+
+### The catch-up cursor has exactly one owner
+
+`SyncEngine.joinStreamForCatchUp` is the only place that derives a stream's catch-up
+cursor, and it hard-codes the load-bearing order: **read the cursor, then join the room.**
+Once subscribed, live events land in IDB immediately, and a message landing before the
+cursor read would advance the cursor past the disconnect gap — the `after` fetch then
+permanently skips everything missed while offline ("an older message never appears while
+newer ones do"). Overlap is safe (writes dedupe by event id); gaps are not. Both the
+reconnect path and the navigation refresh go through it; call sites never read
+`getLatestPersistedSequence` and order it against a join themselves. The one intentional
+exception is `backfillStreamGap`, which takes an explicit **pre-gap** cursor — the current
+latest would skip the very hole it exists to fill.
+
+### Timeline contiguity is verified, not assumed (INV-61)
+
+The global per-stream `sequence` is consumed by every event type, including author-scoped
+command events other viewers never receive and patch-style rows (edits, reactions,
+deletes) that arrive as payload patches rather than rows — so a viewer's persisted
+sequence set has legitimate holes and "seq N requires N−1" is unsound. The backend
+therefore allocates a second, **dense** `broadcastSequence` for exactly the row-delivered
+broadcast types (`TIMELINE_BROADCAST_EVENT_TYPES`): for any viewer, a missing broadcast
+number is always a real gap.
+
+The client checks that chain in two places:
+
+- **Write path** (`detectSequenceGap` in `stream-sync.ts`): when a live event's broadcast
+  position skips past the persisted tail (`getPersistedTail`), the handler reports the
+  pre-write latest as a gap cursor and the engine's `backfillStreamGap` fetches
+  `bootstrap?after=` from it — single-flighted per stream, with a queued lowest-cursor
+  follow-up. Exact when both sides are stamped; pre-deploy rows fall back to the global
+  heuristic (which can over-report; the backfill is idempotent and self-quiets).
+- **Read path** (`computeTimelineHoles` in `sync/contiguity.ts`, driven by `useEvents`):
+  the single authority over the rendered window. A hole between two visible rows renders
+  as a fixed-height in-place "loading missed messages" placeholder and triggers a scoped
+  backfill, so the missed message resolves the placeholder where it belongs instead of
+  popping in above rows already on screen.
+
+The one operation that legitimately vacates broadcast slots is the message-move flow: it
+re-allocates moved rows densely in the destination and declares the vacated source slots
+on its source tombstone (`vacatedBroadcastSequences`). The tombstone's own slot is always
+above everything it declares, so any window that can see the hole also contains the
+declaration — moves never produce phantom placeholders.
 
 ### In-flight dedup and queued reconnects
 
@@ -124,13 +171,21 @@ retry affordances.
   [subscribe-then-bootstrap](../concepts/subscribe-then-bootstrap.md): subscriptions are
   confirmed before fetches, and snapshots merge rather than replace live events, on first
   load and on every reconnect.
+- **INV-61.** The rendered timeline window is verifiably contiguous over the
+  viewer-visible ordering. The dense `broadcastSequence` chain makes a missing event
+  detectable for any viewer; holes render as in-place placeholders and backfill via
+  `backfillStreamGap`; the catch-up cursor is owned solely by `joinStreamForCatchUp`.
 
 ## Entry points
 
 - `apps/frontend/src/sync/sync-engine.ts`: the `SyncEngine` class. Lifecycle, bootstrap
-  cycle, reconnect, navigation refresh, page resume.
+  cycle, reconnect, navigation refresh, page resume, gap backfill, the catch-up cursor
+  owner.
 - `apps/frontend/src/sync/stream-sync.ts`: `applyStreamBootstrap` and the merge / window
-  prune / two-tier reconciliation; the per-stream socket handlers.
+  prune / two-tier reconciliation; the per-stream socket handlers; write-path gap
+  detection (`getPersistedTail`, `detectSequenceGap`).
+- `apps/frontend/src/sync/contiguity.ts`: `computeTimelineHoles`, the read-side authority
+  for INV-61 (consumed by `useEvents` / the timeline's gap placeholders).
 - `apps/frontend/src/sync/workspace-sync.ts`: workspace bootstrap apply, workspace socket
   handlers, the batched reconnect apply.
 - `apps/frontend/src/lib/socket-room.ts`: `joinRoomWithAck` / `joinRoomBestEffort`, the

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -768,6 +768,17 @@ export interface MessagesMovedEventPayload {
    * `messages.length` is the canonical count.
    */
   messages: MovedMessagePreview[]
+  /**
+   * Present only on the SOURCE-side tombstone: the `broadcastSequence`
+   * values the relocated events vacated in the source stream. Moving is the
+   * one operation that removes rows from a stream's otherwise-dense
+   * broadcast chain (INV-61); the tombstone — whose own broadcastSequence is
+   * always above every vacated slot, so any window that can see the hole
+   * also contains the tombstone — declares those slots accounted-for so
+   * clients don't mistake them for missed messages and render phantom
+   * loading placeholders.
+   */
+  vacatedBroadcastSequences?: string[]
 }
 
 /**

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -86,6 +86,39 @@ export type EventType = (typeof EVENT_TYPES)[number]
 export const COMMAND_EVENT_TYPES = ["command_dispatched", "command_completed", "command_failed"] as const
 export type CommandEventType = (typeof COMMAND_EVENT_TYPES)[number]
 
+/**
+ * Timeline broadcast event types (subset of EVENT_TYPES): events that every
+ * stream member receives as individually delivered timeline rows — via a
+ * stream-room socket append AND bootstrap/list responses. These, and only
+ * these, consume the per-stream dense `broadcastSequence` counter that lets
+ * clients verify their visible timeline window is contiguous (INV-61).
+ *
+ * Excluded on purpose:
+ * - Command events are author-scoped — other viewers never receive them, so
+ *   giving them broadcast slots would create permanent holes for everyone else.
+ * - Edits / deletes / reactions are delivered live as payload *patches* onto
+ *   the original message row, not as appended rows, so a broadcast slot for
+ *   them would never be filled by live delivery.
+ * - Legacy/no-longer-emitted types (thread_created, companion_response,
+ *   stream_archived/unarchived) ride along in bootstrap windows without slots.
+ */
+export const TIMELINE_BROADCAST_EVENT_TYPES = [
+  "message_created",
+  "member_joined",
+  "member_added",
+  "member_left",
+  "agent_session:started",
+  "agent_session:completed",
+  "agent_session:failed",
+  "agent_session:deleted",
+  "messages:moved",
+] as const
+export type TimelineBroadcastEventType = (typeof TIMELINE_BROADCAST_EVENT_TYPES)[number]
+
+export function isTimelineBroadcastEventType(eventType: string): eventType is TimelineBroadcastEventType {
+  return (TIMELINE_BROADCAST_EVENT_TYPES as readonly string[]).includes(eventType)
+}
+
 // Workspace user roles — re-exported from workspace-permissions so the catalog
 // (`WORKSPACE_ROLE_DEFINITIONS`) and the User.role union cannot drift.
 export { WORKSPACE_USER_ROLES, type WorkspaceRoleSlug } from "./workspace-permissions"

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -447,6 +447,16 @@ export interface StreamEvent {
   id: string
   streamId: string
   sequence: string
+  /**
+   * Dense per-stream position over viewer-visible timeline rows
+   * (TIMELINE_BROADCAST_EVENT_TYPES), serialized as a string like `sequence`.
+   * For any viewer the broadcast chain has no legitimate holes — a missing
+   * number is always a real gap the client can backfill (INV-61). `null` for
+   * event types outside the broadcast set (author-scoped command events,
+   * patch-style edit/reaction rows) and for rows written before the counter
+   * existed.
+   */
+  broadcastSequence?: string | null
   eventType: EventType
   payload: unknown
   actorId: string | null

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,9 @@ export {
   type EventType,
   COMMAND_EVENT_TYPES,
   type CommandEventType,
+  TIMELINE_BROADCAST_EVENT_TYPES,
+  type TimelineBroadcastEventType,
+  isTimelineBroadcastEventType,
   // Workspace roles
   WORKSPACE_USER_ROLES,
   // Invitation statuses


### PR DESCRIPTION
## Problem

PR #820 fixed a reconnect race that permanently dropped missed messages and added a reactive backfill — "eventually handled", not "impossible". Two structural problems remained:

1. **The artifact users hate:** a gap-revealing message (seq 3502) renders at the tail, then the missed message (3501) **pops in above it** one round-trip later. Reads as "messages arriving out of order".
2. **The client cannot prove contiguity.** The global per-stream `sequence` is consumed by ALL event types — including author-scoped command events other viewers never receive, and patch-style rows (edits/reactions/deletes) that arrive live as payload patches, not rows. Every viewer's persisted set has legitimate, unfillable holes, so "seq N requires N−1" is unsound and gap handling could only ever be best-effort (with futile backfills fired at phantom gaps from other users' `/command`s).

## Solution

Give the client an ordering signal that is **dense for every viewer**, then gate rendering on it.

**Backend:** a new `broadcast_sequence` counter on `stream_events`, bumped atomically with the global counter in one upsert, but **only** for `TIMELINE_BROADCAST_EVENT_TYPES` — the events every member receives as appended timeline rows (messages, membership, agent sessions, move tombstones). For any viewer the broadcast chain has no legitimate holes: **a missing number is always a real gap.** The field rides every existing wire surface automatically (`bigIntReplacer` on HTTP responses and outbox writes).

**Frontend:** `computeTimelineHoles` (`sync/contiguity.ts`) is the single read-side authority. A hole in the rendered window surfaces as a fixed-height in-place "Loading missed messages…" row injected exactly where the events belong, and triggers the engine's single-flighted scoped backfill — so the missed message **resolves a visible placeholder in place** instead of popping in above rows already on screen.

### How it works

- **Allocation** (`StreamEventRepository.allocateSequences`): one race-safe upsert bumps `next_sequence` by N and `next_broadcast_sequence` by M, so broadcast order always matches global order (INV-20).
- **Moves** — the one operation that vacates slots — allocate fresh `(sequence, broadcastSequence)` pairs at the destination (its chain stays dense) and declare the vacated source slots on the source tombstone (`vacatedBroadcastSequences`). The tombstone's own slot is always above everything it declares, so **any window that can see the hole also contains the declaration** — moves never produce phantom placeholders.
- **Write-path tail-gap detection** (`detectSequenceGap`) compares on the broadcast chain when both sides are stamped — exact, no false positives from other viewers' commands — and falls back to the global heuristic for unstamped transitional rows.
- **One cursor owner:** `SyncEngine.joinStreamForCatchUp` reads the catch-up cursor strictly before joining the room (INV-53), replacing the three call-site orderings from #820. `grep getLatestPersistedSequence` now shows exactly one production read site.

### Key design decisions

**1. Dense set = row-delivered events, not "all non-command events".**
Exploration showed edits/deletes/reactions create `stream_events` rows but are delivered live as payload *patches* — broadcast slots for them would never fill and live delivery itself would mint phantom holes. The counter covers exactly the types whose socket handlers append rows.

**2. Vacated-slot declaration on the move tombstone, not filler rows.**
Filler marker events would keep the chain dense but consume bootstrap-window slots forever (a 50-message move would fill an entire page with invisible rows). The declaration is one payload field on an event that already exists, and the suffix-window property guarantees visibility.

**3. Read-side gate over a pre-IDB hold-back buffer.**
IndexedDB stays the complete offline source of truth — everything is written on arrival, including out-of-order events. Contiguity is enforced over what's *displayed*. Unstamped pre-deploy cached rows simply don't participate in the chain (they can't create phantom holes, only reduce coverage until the next bootstrap re-stamps them), making rollout transition-safe.

**4. Migration locks in writer order inside one explicit transaction.**
`LOCK TABLE stream_sequences, stream_events` (the order every insert acquires them) serializes the backfill against in-flight writes without deadlock; a partial unique index on `(stream_id, broadcast_sequence)` enforces density at the source. Events written by old code during the deploy window carry NULL and degrade coverage, never correctness.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/db/migrations/20260611075601_add_broadcast_sequence.sql` | Column + counter, dense backfill per stream, set-based counter seeding, partial unique index |
| `apps/frontend/src/sync/contiguity.ts` | Read-side authority: `computeTimelineHoles` (chain scan + vacated-slot accounting), `holesSignature` |
| `apps/frontend/src/sync/contiguity.test.ts` | Hole detection, vacated declarations, unstamped/pending row exemptions |

## Modified files

| File | Change |
| --- | --- |
| `packages/types` (constants/domain/api/index) | `TIMELINE_BROADCAST_EVENT_TYPES`, `StreamEvent.broadcastSequence`, `MessagesMovedEventPayload.vacatedBroadcastSequences` |
| `apps/backend/.../streams/event-repository.ts` | Atomic dual-counter allocator, broadcast-aware `insert`/`insertMany`, pairs for moves, `broadcast_sequence` in all reads |
| `apps/backend/.../messaging/event-service.ts` | Move flow: dest pairs + vacated declaration on the source tombstone |
| `apps/frontend/src/sync/stream-sync.ts` | `getPersistedTail`, broadcast-aware `detectSequenceGap` with global fallback |
| `apps/frontend/src/sync/sync-engine.ts` | `joinStreamForCatchUp` — the single catch-up-cursor owner |
| `apps/frontend/src/hooks/use-events.ts` | Contiguity gate: holes memo + bounded backfill-request effect; returns `holes` |
| `apps/frontend/src/components/timeline/event-list.tsx` | `gap` TimelineItem + `injectGapItems` + placeholder row renderer |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Injects gap items after grouping/annotation |
| `apps/frontend/src/db/database.ts` | `CachedEvent.broadcastSequence` (unindexed; no version bump) |
| `CLAUDE.md` | INV-61 documented + quick-lookup entry |

## Test plan

- [x] `bun run test` — backend unit (1,626) + backend e2e (308), all green
- [x] `bun run test:integration` — 447 green against a real Postgres, including: dense allocation while edits/reactions/commands punch global holes; viewer-filtered chains dense across other users' command events; `insertMany` slot assignment; move flow vacated-declaration + destination density; migration executed from scratch (post-rework)
- [x] Frontend suite — 2,370+ green, including: phantom-gap regression tests (other viewers' commands no longer trigger backfills), broadcast-vs-global detection fallbacks, `getPersistedTail` scanning past unstamped tails, hole detection with vacated slots, multi-hole placeholder injection
- [x] Full monorepo typecheck (14 workspaces)
- [x] Self-review (3-perspective): both surviving findings fixed in `ddcf6b0` (migration locking/set-based seeding; multi-hole injection)
- [ ] Staging verification: suspend/resume with concurrent sends; move messages and confirm no placeholder appears at the source

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make out-of-order / gap-fill rendering structurally impossible in the stream sync engine: a message can never appear inserted above messages already on screen, and a hole in the visible window can never render as two adjacent-but-non-consecutive messages. Follow-up to #820, which closed the concrete reconnect data-loss race but left gap handling reactive and best-effort.

## What Was Built

1. **Backend ordering signal (the gating decision):** dense per-stream `broadcast_sequence` over `TIMELINE_BROADCAST_EVENT_TYPES` (message_created, member_joined/added/left, agent_session:*, messages:moved) — the exact set of events delivered to every member as appended timeline rows. Command events (author-scoped) and patch-delivered rows (edits, deletes, reactions) consume no slots. Allocated atomically with the global sequence in `StreamEventRepository.allocateSequences`; threaded over every wire surface via the existing bigint replacers; backfilled for historical rows by migration with a partial unique index enforcing density.
2. **Move-flow accounting:** moves relocate rows out of the source stream — the only operation that vacates slots. Destination gets fresh dense pairs; the source tombstone declares `vacatedBroadcastSequences`. Suffix-window property: the tombstone always sits above its declared slots, so any window exposing the hole contains the declaration.
3. **Frontend contiguity gate:** `computeTimelineHoles` scans the rendered window's broadcast chain (skipping pending/failed/unstamped rows, netting out declared vacated slots); `useEvents` renders holes via `injectGapItems` as in-place fixed-height placeholders and requests `backfillStreamGap` with bounded retries (3 × 15s, cancelled when the hole fills). Jump mode exempt (single contiguous server response).
4. **Exact write-path detection:** `detectSequenceGap(getPersistedTail(...), incoming)` compares broadcast positions when both sides are stamped; global-sequence fallback only for transitional unstamped rows. Eliminates phantom backfills from other users' command events (regression-tested).
5. **One cursor owner:** `SyncEngine.joinStreamForCatchUp` (cursor read → room join, in that order, INV-53) used by both the reconnect batch path and `performStreamRefresh`; `backfillStreamGap` remains the one intentional explicit-cursor caller (pre-gap cursor).
6. **INV-61** documented in CLAUDE.md with tests enforcing it on both sides.

## Design Decisions

- **Dense broadcast sequence over per-event `prevVisibleSequence` links:** one counter, no per-payload chaining to preserve across bootstrap/list/socket/move surfaces.
- **Contiguity domain = row-delivered events:** discovered during exploration that bootstrap returns ALL event types (including reaction/edit rows) while live delivery appends only a subset — the dense set must match live row delivery exactly or the gate would starve at the tail.
- **Tombstone vacancy declaration over filler events:** no bootstrap-window pollution; one payload field.
- **Read-side gate, IDB stays complete:** writes never held back; offline durability unchanged; placeholders are a render-layer concept.
- **Transition safety:** unstamped rows (pre-deploy cache, old-code writes during deploy) are chain-exempt — degraded coverage, zero false placeholders; next bootstrap re-stamps.

## What's NOT Included

- Subsuming the bootstrap-floor/`windowVersion` machinery in `use-events.ts` — orthogonal (pre-session windowing), composes with the gate; folding it in is a high-risk refactor with no behavioral gain.
- Tail-silence detection when no signal arrives at all (dead socket with nothing delivered) — covered by the existing page-resume probe + reconnect bootstrap (INV-53), which this PR's cursor owner makes race-free.

## Status

Complete; all suites green (unit, integration, e2e, typecheck). Self-reviewed (3-perspective, ≥80 threshold); both surviving findings fixed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GBH4x3YSje7C3PuyPoEvXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBH4x3YSje7C3PuyPoEvXW)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783759668&installation_id=129946197&pr_number=824&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F824&signature=77799abacb3b9df91218bc5e395cd272590848b1ec1b0ce69df6b43c51a196cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->