### PR TITLE
feat: bound bot claim attempts with park/DLQ (Phase 0.5)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, mock } from "bun:test"
 import type { QueryConfig, QueryResult } from "pg"
 import type { Querier } from "../../db"
-import { BotRuntimeInstanceRepository } from "./repository"
+import { BOT_CLAIM_MAX_ATTEMPTS, BotInvocationRepository, BotRuntimeInstanceRepository } from "./repository"
 
 interface Captured {
   text: string | null
@@ -139,5 +139,120 @@ describe("BotRuntimeInstanceRepository.findLiveWithKeyForBot", () => {
     expect(captured.values).toContain(120_000)
     expect(result[0]?.publicKey).toBe(publicKey)
     expect(result[0]?.publicKeyId).toBe("bik_live")
+  })
+})
+
+// A complete invocation row so `mapInvocation` (which asserts known
+// actor_type/trigger/capability/status) doesn't throw.
+function makeInvocationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "inv_1",
+    workspace_id: "ws_1",
+    root_stream_id: "stream_root",
+    active_stream_id: "stream_active",
+    source_message_id: "msg_src",
+    response_stream_id: "stream_resp",
+    actor_type: "bot",
+    actor_id: "bot_alice",
+    trigger: "active-scratchpad",
+    required_capability: "active-scratchpad",
+    prompt_markdown: "do a thing",
+    author_user_id: "usr_owner",
+    mentioned_actor_slugs: [],
+    status: "claimed",
+    target_instance_id: null,
+    target_runtime_session_id: null,
+    claimed_by_instance_id: "inst_42",
+    claim_token: "tok_1",
+    claim_expires_at: new Date(),
+    attempts: 1,
+    error_message: null,
+    metadata: {},
+    created_at: new Date(),
+    updated_at: new Date(),
+    completed_at: null,
+    ...overrides,
+  }
+}
+
+describe("BotInvocationRepository.claimOne", () => {
+  afterEach(() => mock.restore())
+
+  it("only claims invocations under the attempt budget and increments attempts", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeInvocationRow()])
+
+    await BotInvocationRepository.claimOne(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      instanceId: "inst_42",
+      runtimeKind: "pi-local",
+      claimToken: "tok_1",
+      supportedCapabilities: ["active-scratchpad"],
+      claimTtlSeconds: 60,
+      maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+    })
+
+    // Bounded re-claim: a wedged invocation can't be picked up forever.
+    expect(captured.text).toContain("attempts < ")
+    expect(captured.text).toContain("attempts = attempts + 1")
+    expect(captured.values).toContain(BOT_CLAIM_MAX_ATTEMPTS)
+  })
+})
+
+describe("BotInvocationRepository.parkExhausted", () => {
+  afterEach(() => mock.restore())
+
+  it("dead-letters expired claims at the attempt ceiling, preserving any reported error", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeInvocationRow({ status: "parked", attempts: BOT_CLAIM_MAX_ATTEMPTS })])
+
+    const parked = await BotInvocationRepository.parkExhausted(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+    })
+
+    expect(captured.text).toContain("status = 'parked'")
+    expect(captured.text).toContain("claim_expires_at < NOW()")
+    expect(captured.text).toContain("attempts >= ")
+    // Keep the runtime's own failure message if it reported one.
+    expect(captured.text).toContain("COALESCE(error_message,")
+    expect(captured.values).toContain(BOT_CLAIM_MAX_ATTEMPTS)
+    expect(parked[0]?.status).toBe("parked")
+  })
+})
+
+describe("BotInvocationRepository.findBootstrapInvocations", () => {
+  afterEach(() => mock.restore())
+
+  it("excludes attempt-exhausted rows from the available list (mirrors claimOne)", async () => {
+    // Two queries run via Promise.all (available + ownedClaims); capture every
+    // text so the assertion targets the available query specifically.
+    const texts: string[] = []
+    const db: Querier = {
+      query: mock(async (q) => {
+        texts.push((q as QueryConfig).text)
+        return { rows: [], rowCount: 0 } as unknown as QueryResult
+      }),
+    }
+
+    await BotInvocationRepository.findBootstrapInvocations(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      instanceId: "inst_42",
+      runtimeSessionId: null,
+      supportedCapabilities: ["active-scratchpad"],
+      since: null,
+      maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+    })
+
+    const availableQuery = texts.find((t) => t.includes("attempts < "))
+    expect(availableQuery).toBeDefined()
+    // The owned-claims query must NOT be attempt-bounded: a runtime keeps its
+    // own in-flight claim regardless of how many times it's been re-dispatched.
+    const ownedClaimsQuery = texts.find((t) => t.includes("claimed_by_instance_id ="))
+    expect(ownedClaimsQuery).toBeDefined()
+    expect(ownedClaimsQuery).not.toContain("attempts < ")
   })
 })

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -23,6 +23,16 @@ export type RuntimeSessionLinkStatus = BotRuntimeSessionLinkStatus
  */
 export const BOT_RUNTIME_BIK_STALENESS_MS = 2 * 60 * 1000
 
+/**
+ * How many times the claim loop will re-dispatch a single invocation before it
+ * is parked (dead-lettered). Each claim increments `attempts`; a claim only
+ * comes back up for grabs when its TTL expires without a `/complete` or
+ * `/fail`, i.e. the runtime took the work and went silent. Bounding this
+ * matches the retry discipline every first-party queue job already has — a
+ * wedged runtime can't pin one invocation in an infinite re-claim loop.
+ */
+export const BOT_CLAIM_MAX_ATTEMPTS = 5
+
 export interface StreamActiveActor {
   id: string
   workspaceId: string
@@ -561,6 +571,7 @@ export const BotInvocationRepository = {
       claimToken: string
       supportedCapabilities: BotInvocationCapability[]
       claimTtlSeconds: number
+      maxAttempts: number
     }
   ): Promise<BotInvocation | null> {
     const result = await db.query<BotInvocationRow>(sql`WITH candidate AS (
@@ -579,6 +590,7 @@ export const BotInvocationRepository = {
           AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
           AND (target_runtime_session_id IS NULL OR target_runtime_session_id = ${params.runtimeSessionId ?? null})
           AND (status = 'pending' OR (status = 'claimed' AND claim_expires_at < NOW()))
+          AND attempts < ${params.maxAttempts}
         ORDER BY created_at ASC, id ASC
         FOR UPDATE SKIP LOCKED
         LIMIT 1
@@ -658,11 +670,40 @@ export const BotInvocationRepository = {
   },
 
   /**
+   * Dead-letter every invocation for this bot that has exhausted its claim
+   * budget — `claimed` with an expired claim and `attempts >= maxAttempts`, so
+   * `claimOne` will never pick it up again. Moves them to terminal `parked`
+   * with an explanatory `error_message` (preserving any failure the runtime
+   * already reported). Run on the claim loop so a wedged invocation is reaped
+   * at the same cadence the work is polled. Returns the rows it parked so the
+   * caller can log them. Idempotent under concurrent claimers: the
+   * `status = 'claimed'` predicate means a second runner's UPDATE no-ops once
+   * the first has flipped the row to `parked` (INV-20).
+   */
+  async parkExhausted(
+    db: Querier,
+    params: { workspaceId: string; botId: string; maxAttempts: number }
+  ): Promise<BotInvocation[]> {
+    const result = await db.query<BotInvocationRow>(sql`UPDATE bot_invocations
+      SET status = 'parked', error_message = COALESCE(error_message, 'Claim attempts exhausted without completion'), updated_at = NOW()
+      WHERE workspace_id = ${params.workspaceId}
+        AND actor_type = 'bot'
+        AND actor_id = ${params.botId}
+        AND status = 'claimed'
+        AND claim_expires_at < NOW()
+        AND attempts >= ${params.maxAttempts}
+      RETURNING *`)
+    return result.rows.map(mapInvocation)
+  },
+
+  /**
    * Snapshot for `/bot` namespace bootstrap. Returns two disjoint lists:
    *  - `available`: rows this runtime could claim right now (pending, or
-   *    `claimed` with an expired claim) filtered to its capabilities and the
-   *    steering target. Used to replay anything that piled up while the
-   *    socket was offline.
+   *    `claimed` with an expired claim, and not yet attempt-exhausted)
+   *    filtered to its capabilities and the steering target. Mirrors
+   *    `claimOne`'s claimability predicate so a row advertised here is one a
+   *    follow-up claim can actually win. Used to replay anything that piled
+   *    up while the socket was offline.
    *  - `ownedClaims`: live `claimed` rows already owned by this instance.
    *    Returned regardless of `since` so a reconnect cannot drop work that
    *    is in flight.
@@ -681,6 +722,7 @@ export const BotInvocationRepository = {
       runtimeSessionId: string | null
       supportedCapabilities: BotInvocationCapability[]
       since: Date | null
+      maxAttempts: number
     }
   ): Promise<{ available: BotInvocation[]; ownedClaims: BotInvocation[] }> {
     const [availableResult, ownedClaimsResult] = await Promise.all([
@@ -692,6 +734,7 @@ export const BotInvocationRepository = {
           AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
           AND (target_runtime_session_id IS NULL OR target_runtime_session_id = ${params.runtimeSessionId})
           AND (status = 'pending' OR (status = 'claimed' AND claim_expires_at < NOW()))
+          AND attempts < ${params.maxAttempts}
           AND (${params.since}::timestamptz IS NULL OR created_at >= ${params.since})
         ORDER BY created_at ASC, id ASC
         LIMIT 200`),

--- a/apps/backend/src/features/bot-runtimes/service.test.ts
+++ b/apps/backend/src/features/bot-runtimes/service.test.ts
@@ -185,9 +185,11 @@ describe("BotRuntimeService outbox emission", () => {
         botId: "bot_alice",
         maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
       })
-      // Each parked invocation is logged for operational visibility.
-      expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy.mock.calls[0]?.[0]).toMatchObject({ invocationId: "inv_dead" })
+      // Each parked invocation is logged for operational visibility. Assert on
+      // the logged content, not the call count — parkExhausted can return any
+      // number of rows (INV-23).
+      const warnedInvocationIds = warnSpy.mock.calls.map((call) => (call[0] as { invocationId?: string }).invocationId)
+      expect(warnedInvocationIds).toContain("inv_dead")
     })
 
     it("does not emit when no row was available to claim", async () => {
@@ -372,7 +374,7 @@ describe("BotRuntimeService outbox emission", () => {
         createdAt: new Date("2026-05-26T11:00:00Z"),
         updatedAt: new Date("2026-05-26T11:45:00Z"),
       }
-      spyOn(BotInvocationRepository, "findBootstrapInvocations").mockResolvedValue({
+      const findSpy = spyOn(BotInvocationRepository, "findBootstrapInvocations").mockResolvedValue({
         available: [makeInvocation()],
         ownedClaims: [],
       })
@@ -390,6 +392,10 @@ describe("BotRuntimeService outbox emission", () => {
       expect(result.available).toHaveLength(1)
       expect(result.activeActorByStream).toEqual([actor])
       expect(result.activeSessionLinks).toEqual([link])
+      // Bootstrap must apply the same attempt ceiling as the claim path, or it
+      // would re-advertise exhausted invocations even though claimOne refuses
+      // them. Pin the plumbing here so a dropped arg fails at the service layer.
+      expect(findSpy.mock.calls[0]?.[1]).toMatchObject({ maxAttempts: BOT_CLAIM_MAX_ATTEMPTS })
     })
 
     it("opens a REPEATABLE READ READ ONLY transaction so all reads share a snapshot", async () => {

--- a/apps/backend/src/features/bot-runtimes/service.test.ts
+++ b/apps/backend/src/features/bot-runtimes/service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { BotRuntimeService } from "./service"
 import {
+  BOT_CLAIM_MAX_ATTEMPTS,
   BotInvocationRepository,
   BotRuntimeSessionLinkRepository,
   StreamActiveActorRepository,
@@ -9,6 +10,7 @@ import {
   type StreamActiveActor,
 } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
+import { logger } from "../../lib/logger"
 import * as db from "../../db"
 
 const fakeQuerier = { query: mock(async () => ({ rows: [], rowCount: 0 })) }
@@ -128,7 +130,10 @@ describe("BotRuntimeService outbox emission", () => {
   describe("claimNextInvocation", () => {
     it("emits bot_invocation:claimed when a row is locked", async () => {
       patchWithTransaction()
-      spyOn(BotInvocationRepository, "claimOne").mockResolvedValue(makeInvocation({ status: "claimed" }))
+      spyOn(BotInvocationRepository, "parkExhausted").mockResolvedValue([])
+      const claimSpy = spyOn(BotInvocationRepository, "claimOne").mockResolvedValue(
+        makeInvocation({ status: "claimed" })
+      )
       const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
 
       const service = new BotRuntimeService({ pool: fakePool })
@@ -142,6 +147,8 @@ describe("BotRuntimeService outbox emission", () => {
         claimTtlSeconds: 60,
       })
 
+      // The claim is bounded by the attempt ceiling.
+      expect(claimSpy.mock.calls[0]?.[1]).toMatchObject({ maxAttempts: BOT_CLAIM_MAX_ATTEMPTS })
       expect(insertSpy).toHaveBeenCalledTimes(1)
       expect(insertSpy.mock.calls[0]?.[1]).toBe("bot_invocation:claimed")
       const payload = insertSpy.mock.calls[0]?.[2] as unknown as Record<string, unknown>
@@ -150,6 +157,37 @@ describe("BotRuntimeService outbox emission", () => {
         botId: "bot_alice",
         invocationId: "inv_1",
       })
+    })
+
+    it("parks invocations that exhausted their claim budget before handing out fresh work", async () => {
+      patchWithTransaction()
+      const exhausted = makeInvocation({ id: "inv_dead", status: "parked", attempts: BOT_CLAIM_MAX_ATTEMPTS })
+      const parkSpy = spyOn(BotInvocationRepository, "parkExhausted").mockResolvedValue([exhausted])
+      spyOn(BotInvocationRepository, "claimOne").mockResolvedValue(null)
+      spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+      const warnSpy = spyOn(logger, "warn").mockReturnValue(undefined as never)
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const result = await service.claimNextInvocation({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        instanceId: "inst_42",
+        runtimeKind: "pi-local",
+        claimToken: "tok_1",
+        supportedCapabilities: ["active-scratchpad"],
+        claimTtlSeconds: 60,
+      })
+
+      expect(result).toBeNull()
+      expect(parkSpy).toHaveBeenCalledTimes(1)
+      expect(parkSpy.mock.calls[0]?.[1]).toMatchObject({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+      })
+      // Each parked invocation is logged for operational visibility.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0]?.[0]).toMatchObject({ invocationId: "inv_dead" })
     })
 
     it("does not emit when no row was available to claim", async () => {

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -11,7 +11,9 @@ import { withClient, withTransaction } from "../../db"
 import { OutboxRepository } from "../../lib/outbox"
 import { BotRepository, type Bot } from "../public-api/bot-repository"
 import { botInvocationId, botRuntimeInstanceId, botRuntimeSessionLinkId, streamActiveActorId } from "../../lib/id"
+import { logger } from "../../lib/logger"
 import {
+  BOT_CLAIM_MAX_ATTEMPTS,
   BotInvocationRepository,
   BotRuntimeInstanceRepository,
   BotRuntimeSessionLinkRepository,
@@ -400,6 +402,7 @@ export class BotRuntimeService {
             runtimeSessionId: params.runtimeSessionId ?? null,
             supportedCapabilities: params.supportedCapabilities,
             since,
+            maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
           }),
           StreamActiveActorRepository.findActiveForBot(db, {
             workspaceId: params.workspaceId,
@@ -437,7 +440,30 @@ export class BotRuntimeService {
     claimTtlSeconds: number
   }): Promise<BotInvocation | null> {
     return withTransaction(this.pool, async (db) => {
-      const claimed = await BotInvocationRepository.claimOne(db, params)
+      // Reap invocations this bot has re-claimed to exhaustion before handing
+      // out fresh work, so a wedged runtime can't keep one pinned in an
+      // infinite re-claim loop. Parking is bot-wide (not instance-scoped):
+      // whichever instance polls next clears the backlog for the bot.
+      const parked = await BotInvocationRepository.parkExhausted(db, {
+        workspaceId: params.workspaceId,
+        botId: params.botId,
+        maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+      })
+      for (const invocation of parked) {
+        logger.warn(
+          {
+            invocationId: invocation.id,
+            workspaceId: invocation.workspaceId,
+            botId: invocation.actorId,
+            attempts: invocation.attempts,
+          },
+          "Parked bot invocation after exhausting claim attempts"
+        )
+      }
+      const claimed = await BotInvocationRepository.claimOne(db, {
+        ...params,
+        maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+      })
       if (!claimed) return null
       // Siblings on the same bot need to stop racing this invocation. The
       // narrow payload deliberately omits the winning instance — see

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -760,7 +760,15 @@ export const BotRuntimeStatuses = {
   ERROR: "error",
 } as const satisfies Record<string, BotRuntimeStatus>
 
-export const BOT_INVOCATION_STATUSES = ["pending", "claimed", "completed", "failed", "cancelled", "expired"] as const
+export const BOT_INVOCATION_STATUSES = [
+  "pending",
+  "claimed",
+  "completed",
+  "failed",
+  "cancelled",
+  "expired",
+  "parked",
+] as const
 export type BotInvocationStatus = (typeof BOT_INVOCATION_STATUSES)[number]
 
 export const BotInvocationStatuses = {
@@ -770,6 +778,11 @@ export const BotInvocationStatuses = {
   FAILED: "failed",
   CANCELLED: "cancelled",
   EXPIRED: "expired",
+  // Terminal dead-letter state: the claim loop re-dispatched this invocation
+  // `BOT_CLAIM_MAX_ATTEMPTS` times without it ever completing (a runtime that
+  // keeps claiming and going silent), so it is parked instead of retried
+  // forever. No longer claimable; kept for inspection.
+  PARKED: "parked",
 } as const satisfies Record<string, BotInvocationStatus>
 
 export const BOT_INVOCATION_TRIGGERS = ["mention", "active-scratchpad", "session-control"] as const


### PR DESCRIPTION
## Problem

External bot invocations were re-dispatched **without limit**. The claim loop hands an invocation to a runtime with a short TTL; the runtime is expected to `/complete` or `/fail` (or `/renew` for long work). If a runtime claims an invocation and then goes silent — crashes, wedges, loses the socket mid-turn — the claim TTL simply expires and the next poll re-claims the same row, incrementing `attempts` forever. There was no ceiling and no dead-letter state, so one wedged runtime could pin an invocation in an infinite re-claim loop, and a permanently-stuck invocation stayed indistinguishable from one that's legitimately in flight.

This closes the **`unbounded-attempts`** finding — plan item 0.5 in `docs/plans/agent-runtimes-unification-redesign.md` (§2.3 External bullet "Bounded lifecycle", §2.4 table). The drift matrix (§1.3, line 153) flagged it directly: bots have `/fail` but *"attempts unbounded, no park/DLQ"*.

## Solution

Bound the claim loop and dead-letter what it can't make progress on, matching the retry discipline every first-party queue job already has (the queue manager moves a message to DLQ once `failedCount >= maxRetries`).

### How it works

1. **`claimOne` only grants invocations under the ceiling** (`BOT_CLAIM_MAX_ATTEMPTS = 5`): the candidate predicate gains `AND attempts < maxAttempts`. Each claim still does `attempts = attempts + 1`, so a row is dispatched at most `maxAttempts` times before it stops being claimable.
2. **`findBootstrapInvocations` applies the same guard** to its `available` list, so a row advertised on socket reconnect as claimable is one a follow-up claim can actually win — the two claimability predicates stay in lockstep. (The `ownedClaims` list is *not* bounded: a runtime keeps its own in-flight claim regardless of attempt count.)
3. **`parkExhausted` dead-letters the stragglers**: expired `claimed` rows at the ceiling move to a new terminal `parked` status with an explanatory `error_message`. It runs at the head of `claimNextInvocation` (the claim loop), so a wedged invocation is reaped at the same cadence the work is polled — no new worker or cron. Each parked invocation is logged.

### Key design decisions

**1. Park on the claim loop, not a periodic reaper.** Bot claims expire passively (there is no reaper for `bot_invocations`), and §2.4 names the fix as *"park/DLQ on the claim loop"*. Folding the park into the claim transaction keeps the mechanism where the re-dispatch happens and avoids introducing a background sweep. Trade-off: a fully-gone bot (nothing ever polls again) leaves its straggler in `claimed`/expired rather than `parked` — harmless, since nothing re-claims it once it's over the ceiling, and the queue's own DLQ rows are likewise inert.

**2. New terminal `parked` status (not reuse of `expired`/`cancelled`).** The plan's lifecycle is explicitly `complete / fail / park` (§2.2 diagram), and §2.3/§2.6 talk in terms of "parked" work. `parked` names the dead-letter state precisely; the pre-existing unused `expired`/`cancelled` values are left for their own future semantics.

**3. Race-safe park, no double-park.** `parkExhausted` filters on `status = 'claimed'`, so under concurrent claimers the second runner's UPDATE no-ops once the first has flipped the row (INV-20). `COALESCE(error_message, …)` preserves any failure the runtime had already reported.

**4. No migration.** `status` is `TEXT` validated in code (INV-3), and the `attempts` column already exists — adding the `parked` value and the ceiling needs no schema change.

## Modified files

| File | Change |
| --- | --- |
| `packages/types/src/constants.ts` | `BOT_INVOCATION_STATUSES` / `BotInvocationStatuses` gain `parked` (+ doc) |
| `apps/backend/src/features/bot-runtimes/repository.ts` | `BOT_CLAIM_MAX_ATTEMPTS`; `claimOne` + bootstrap `available` bounded by attempts; new `parkExhausted` |
| `apps/backend/src/features/bot-runtimes/service.ts` | `claimNextInvocation` parks exhausted rows then claims; thread the ceiling into both claimable paths; log parked rows |
| `apps/backend/src/features/bot-runtimes/repository.test.ts` | SQL-shape tests for the `claimOne`/bootstrap guard and `parkExhausted` |
| `apps/backend/src/features/bot-runtimes/service.test.ts` | `claimNextInvocation` parks before claiming and bounds the claim |

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun run lint` — clean
- [x] `bun test src/features/bot-runtimes/` — 52 pass (5 new across repository/service)
- [x] Pre-commit gauntlet (typecheck, lint, `generate-api-docs --check`) — green
- [ ] No e2e: internal `/bot` claim flow isn't reachable in e2e; covered by colocated unit tests
- Note: 4 failures in `packages/types/src/tool-privacy.test.ts` are **pre-existing on main** (verified via `git stash`) and unrelated to this change — left for a separate follow-up (INV-22 isolation).

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Phase 0.5 (`unbounded-attempts`) — bound the external bot claim loop and dead-letter invocations that exhaust their claim budget, matching first-party queue retry/DLQ discipline.

**What was built:**
- `BOT_CLAIM_MAX_ATTEMPTS = 5` constant colocated with the claim SQL in the bot-runtimes repository.
- `claimOne`: candidate selection gains `AND attempts < maxAttempts`; each claim still increments `attempts`, so an invocation is dispatched at most `maxAttempts` times.
- `findBootstrapInvocations`: same `attempts < maxAttempts` guard on the `available` list only (owned in-flight claims stay unbounded) — keeps advertised-claimable in lockstep with actually-claimable.
- `parkExhausted(workspaceId, botId, maxAttempts)`: UPDATE expired `claimed` rows at the ceiling → terminal `parked` status, `COALESCE`-preserving any reported error; returns parked rows for logging. Race-safe via the `status = 'claimed'` predicate (INV-20).
- `claimNextInvocation`: parks exhausted rows (bot-wide) inside the existing claim transaction before `claimOne`, logging each; threads the ceiling into both repo calls.
- `BotInvocationStatuses.PARKED` added to the shared types.

**Design decisions:**
- Park on the claim loop (where re-dispatch happens), not a new reaper — §2.4 "park/DLQ on the claim loop".
- New terminal `parked` status matching the plan's `complete/fail/park` lifecycle; left `expired`/`cancelled` untouched.
- No migration — `status` is TEXT (INV-3) and `attempts` already exists.

**What's NOT included:** No user-facing notification on park (out of scope for 0.5). No change to the explicit `/fail` path (already terminal). No new outbox/socket event — the `parked` row + log is the observable record.

**Status:** Implemented; typecheck/lint/relevant suites green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY18BbKdn3GCeWNaXBLqTu)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783760066&installation_id=129946197&pr_number=825&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F825&signature=3d6ab977f83eb7bb1136db8c2b173e33cf87a7e552ce24146b0745783ac62154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->