### PR TITLE
feat: de-Pi-ify mention extraction and session-link policy (Phase 0.6)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -2,17 +2,59 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Pool } from "pg"
 import { BotInvocationOutboxHandler } from "./invocation-outbox-handler"
 import { BotRuntimeService } from "./service"
+import {
+  BotRuntimeInstanceRepository,
+  BotRuntimeSessionLinkRepository,
+  StreamActiveActorRepository,
+} from "./repository"
 import { StreamRepository } from "../streams"
+import { BotRepository } from "../public-api/bot-repository"
+import { PersonaRepository } from "../agents"
+import { EventService } from "../messaging"
 import * as outbox from "../../lib/outbox"
 import { E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
 
-// E2EE-11: external bot invocations must never fire for E2E streams. The outbox
-// payload carries the ciphertext placeholder (mentions ride sealed, not in the
-// cleartext markdown), so dispatching would either silently no-op (@mention) or
-// send an empty-prompt turn to an external bot whose plaintext reply would then
-// violate INV-E1. The handler short-circuits the moment it sees an E2E stream.
-
 afterEach(() => mock.restore())
+
+const runProcessMessageCreated = async (payload: unknown): Promise<void> => {
+  const handler = new BotInvocationOutboxHandler({} as Pool)
+  // processMessageCreated is private; exercise it directly with a raw payload.
+  await (handler as unknown as { processMessageCreated(p: unknown): Promise<void> }).processMessageCreated(payload)
+}
+
+const userMessagePayload = (params: { contentMarkdown: string; contentJson?: unknown }) => ({
+  workspaceId: "ws_1",
+  streamId: "stream_1",
+  event: {
+    id: "evt_1",
+    sequence: "1",
+    actorType: "user",
+    actorId: "usr_1",
+    payload: {
+      messageId: "msg_1",
+      contentMarkdown: params.contentMarkdown,
+      ...(params.contentJson !== undefined && { contentJson: params.contentJson }),
+    },
+  },
+})
+
+const docWithText = (text: string) => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+const docWithMention = (slug: string) => ({
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "mention", attrs: { id: slug, slug, mentionType: "bot" } },
+        { type: "text", text: " hi" },
+      ],
+    },
+  ],
+})
 
 describe("BotInvocationOutboxHandler E2E short-circuit", () => {
   it("does not create any invocation for a message in an E2E stream", async () => {
@@ -22,7 +64,7 @@ describe("BotInvocationOutboxHandler E2E short-circuit", () => {
       event: {
         actorId: "usr_1",
         actorType: "user",
-        payload: { messageId: "msg_1", contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN },
+        payload: { messageId: "msg_1", contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN, contentJson: null },
       },
     } as never)
     const findById = spyOn(StreamRepository, "findById").mockResolvedValue({
@@ -32,14 +74,150 @@ describe("BotInvocationOutboxHandler E2E short-circuit", () => {
       rootStreamId: null,
       e2eEnabled: true,
     } as never)
-    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(undefined as never)
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
+      undefined as never
+    )
 
-    const handler = new BotInvocationOutboxHandler({} as Pool)
-    // processMessageCreated is private; exercise it directly with a parsed payload.
-    await (handler as unknown as { processMessageCreated(p: unknown): Promise<void> }).processMessageCreated({})
+    await runProcessMessageCreated({})
 
     expect(createInvocation).not.toHaveBeenCalled()
     // Returned at the E2E gate — never resolved the root stream (the next lookup).
     expect(findById).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => {
+  const channelStream = {
+    id: "stream_1",
+    workspaceId: "ws_1",
+    archivedAt: null,
+    rootStreamId: null,
+    type: "channel",
+    e2eEnabled: false,
+  }
+
+  it("dispatches a mention invocation from a contentJson mention node with a non-ASCII slug", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
+    const findVisibleBySlugs = spyOn(BotRepository, "findVisibleBySlugs").mockResolvedValue([
+      { id: "bot_1", slug: "аріадна", name: "Аріадна", archivedAt: null, traits: ["mentionable"] },
+    ] as never)
+    spyOn(PersonaRepository, "findBySlug").mockResolvedValue(null as never)
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
+      undefined as never
+    )
+
+    // The retired ASCII regex could never match this mention; the node can.
+    await runProcessMessageCreated(
+      userMessagePayload({ contentMarkdown: "@аріадна hi", contentJson: docWithMention("аріадна") })
+    )
+
+    expect(findVisibleBySlugs).toHaveBeenCalledWith({} as Pool, "ws_1", "usr_1", ["аріадна"])
+    expect(createInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "bot_1",
+        trigger: "mention",
+        mentionedActorSlugs: ["аріадна"],
+      })
+    )
+  })
+
+  it("ignores @-shaped plain text that has no mention node", async () => {
+    spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
+    const findVisibleBySlugs = spyOn(BotRepository, "findVisibleBySlugs").mockResolvedValue([] as never)
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
+      undefined as never
+    )
+
+    await runProcessMessageCreated(
+      userMessagePayload({ contentMarkdown: "ping @scout", contentJson: docWithText("ping @scout") })
+    )
+
+    expect(findVisibleBySlugs).not.toHaveBeenCalled()
+    expect(createInvocation).not.toHaveBeenCalled()
+  })
+})
+
+describe("BotInvocationOutboxHandler active-scratchpad session-link policy", () => {
+  const scratchpadStream = {
+    id: "stream_1",
+    workspaceId: "ws_1",
+    archivedAt: null,
+    rootStreamId: null,
+    type: "scratchpad",
+    e2eEnabled: false,
+  }
+
+  const activeBot = {
+    id: "bot_1",
+    slug: "scout",
+    name: "Scout",
+    archivedAt: null,
+    traits: ["active-scratchpad"],
+  }
+
+  const setupActiveScratchpad = (params: {
+    instance: { runtimeKind: string } | null
+  }): {
+    createInvocation: ReturnType<typeof spyOn>
+    createMessage: ReturnType<typeof spyOn>
+  } => {
+    spyOn(StreamRepository, "findById").mockResolvedValue(scratchpadStream as never)
+    spyOn(StreamActiveActorRepository, "findByRootStream").mockResolvedValue({
+      actorType: "bot",
+      actorId: "bot_1",
+    } as never)
+    spyOn(BotRepository, "findById").mockResolvedValue(activeBot as never)
+    spyOn(BotRuntimeSessionLinkRepository, "findActiveByStream").mockResolvedValue(null)
+    spyOn(BotRuntimeInstanceRepository, "findLatestForBots").mockResolvedValue(
+      (params.instance ? new Map([["bot_1", params.instance]]) : new Map()) as never
+    )
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
+      undefined as never
+    )
+    const createMessage = spyOn(EventService.prototype, "createMessage").mockResolvedValue(undefined as never)
+    return { createInvocation, createMessage }
+  }
+
+  const plainUserMessage = userMessagePayload({ contentMarkdown: "hello", contentJson: docWithText("hello") })
+
+  it("posts the Pi notice and skips dispatch when an unlinked pi-local bot is active", async () => {
+    const { createInvocation, createMessage } = setupActiveScratchpad({ instance: { runtimeKind: "pi-local" } })
+
+    await runProcessMessageCreated(plainUserMessage)
+
+    expect(createInvocation).not.toHaveBeenCalled()
+    expect(createMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentMarkdown: "**Scout is not linked to this scratchpad.** Run `/remote-control` in Pi to link a session.",
+        metadata: { "bot_runtime.notice": "missing_session_link" },
+      })
+    )
+  })
+
+  it("defaults to the pi-local policy when the bot has no runtime instance", async () => {
+    const { createInvocation, createMessage } = setupActiveScratchpad({ instance: null })
+
+    await runProcessMessageCreated(plainUserMessage)
+
+    expect(createInvocation).not.toHaveBeenCalled()
+    expect(createMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { "bot_runtime.notice": "missing_session_link" } })
+    )
+  })
+
+  it("dispatches an untargeted invocation without a notice for a link-free runtime kind", async () => {
+    const { createInvocation, createMessage } = setupActiveScratchpad({ instance: { runtimeKind: "openclaw" } })
+
+    await runProcessMessageCreated(plainUserMessage)
+
+    expect(createMessage).not.toHaveBeenCalled()
+    expect(createInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "bot_1",
+        trigger: "active-scratchpad",
+        targetInstanceId: null,
+        targetRuntimeSessionId: null,
+      })
+    )
   })
 })

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -1,13 +1,18 @@
 import type { Pool } from "pg"
 import { AuthorTypes, StreamTypes, botHasCapability } from "@threa/types"
-import { parseMarkdown } from "@threa/prosemirror"
+import { collectMentionSlugs, parseMarkdown } from "@threa/prosemirror"
 import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
 import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { StreamRepository } from "../streams"
 import { BotRepository } from "../public-api/bot-repository"
 import { BotRuntimeService } from "./service"
-import { BotRuntimeSessionLinkRepository, StreamActiveActorRepository } from "./repository"
+import {
+  BotRuntimeInstanceRepository,
+  BotRuntimeSessionLinkRepository,
+  StreamActiveActorRepository,
+} from "./repository"
+import { resolveRuntimeKindConfig } from "./runtime-kind-config"
 import { EventService } from "../messaging"
 import { PersonaRepository } from "../agents"
 
@@ -19,10 +24,6 @@ const DEFAULT_CONFIG = {
   refreshIntervalMs: 5_000,
   maxRetries: 5,
   baseBackoffMs: 1_000,
-}
-
-function extractMentionSlugs(markdown: string): string[] {
-  return Array.from(markdown.matchAll(/@([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})/g), (match) => match[1]!.toLowerCase())
 }
 
 export class BotInvocationOutboxHandler implements OutboxHandler {
@@ -100,7 +101,12 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(this.pool, rootStreamId)
     const invocationRootStreamId = rootStream?.id ?? stream.id
     const isUserAuthored = message.event.actorType === AuthorTypes.USER
-    const mentionedSlugs = isUserAuthored ? extractMentionSlugs(message.event.payload.contentMarkdown) : []
+    // Mentions come from the canonical contentJson mention nodes (INV-58) —
+    // produced by the editor's mention picker and by parseMarkdown on the API
+    // path — not from a pattern over serialized markdown, so non-Latin slugs
+    // dispatch the same as ASCII ones (INV-54).
+    const contentJson = message.event.payload.contentJson
+    const mentionedSlugs = isUserAuthored && contentJson ? collectMentionSlugs(contentJson) : []
     const uniqueMentionedSlugs = Array.from(new Set(mentionedSlugs))
     const [mentionedBots, mentionedPersonas] =
       uniqueMentionedSlugs.length > 0
@@ -163,14 +169,21 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
       })
     }
     if (!link) {
-      await this.createMissingLinkNotice({
-        workspaceId: message.workspaceId,
-        streamId: stream.id,
-        botName: bot.name,
-        rootStreamId: rootStream.id,
-        sourceMessageId: message.event.payload.messageId,
-      })
-      return
+      // No link: whether that blocks dispatch is a per-runtime-kind policy.
+      // Resolve the kind from the bot's latest runtime instance; link-free
+      // kinds fall through to an untargeted invocation below.
+      const instances = await BotRuntimeInstanceRepository.findLatestForBots(this.pool, message.workspaceId, [bot.id])
+      const kindConfig = resolveRuntimeKindConfig(instances.get(bot.id)?.runtimeKind ?? null)
+      if (kindConfig.sessionLinking === "required") {
+        await this.createMissingLinkNotice({
+          workspaceId: message.workspaceId,
+          streamId: stream.id,
+          contentMarkdown: kindConfig.missingSessionLinkNotice(bot.name),
+          rootStreamId: rootStream.id,
+          sourceMessageId: message.event.payload.messageId,
+        })
+        return
+      }
     }
 
     await this.service.createInvocation({
@@ -192,8 +205,8 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
           ].join("\n"),
       authorUserId: message.event.actorId,
       mentionedActorSlugs: mentionedSlugs,
-      targetInstanceId: link.instanceId,
-      targetRuntimeSessionId: link.runtimeSessionId,
+      targetInstanceId: link?.instanceId ?? null,
+      targetRuntimeSessionId: link?.runtimeSessionId ?? null,
       metadata: {},
     })
   }
@@ -201,18 +214,17 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
   private async createMissingLinkNotice(params: {
     workspaceId: string
     streamId: string
-    botName: string
+    contentMarkdown: string
     rootStreamId: string
     sourceMessageId: string
   }): Promise<void> {
-    const contentMarkdown = `**${params.botName} is not linked to this scratchpad.** Run \`/remote-control\` in Pi to link a session.`
     await this.eventService.createMessage({
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       authorId: AuthorTypes.SYSTEM,
       authorType: AuthorTypes.SYSTEM,
-      contentJson: parseMarkdown(contentMarkdown),
-      contentMarkdown,
+      contentJson: parseMarkdown(params.contentMarkdown),
+      contentMarkdown: params.contentMarkdown,
       clientMessageId: `bot-runtime-unlinked:${params.rootStreamId}:${params.sourceMessageId}`,
       metadata: { "bot_runtime.notice": "missing_session_link" },
     })

--- a/apps/backend/src/features/bot-runtimes/runtime-kind-config.ts
+++ b/apps/backend/src/features/bot-runtimes/runtime-kind-config.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-runtime-kind dispatch policy for the active-scratchpad path.
+ *
+ * Pi drives long-lived local sessions, so its active-scratchpad turns must be
+ * pinned to an explicit session link (created via Pi's `/remote-control`
+ * flow) — without one we post a notice telling the user how to link. Other
+ * kinds never create session links; their invocations dispatch untargeted and
+ * any live instance of the bot may claim them.
+ */
+
+import type { BotRuntimeKind } from "@threa/types"
+
+export type BotRuntimeKindConfig =
+  | {
+      sessionLinking: "required"
+      /** Markdown for the system notice posted when no active session link exists. */
+      missingSessionLinkNotice: (botName: string) => string
+    }
+  | { sessionLinking: "none" }
+
+const BOT_RUNTIME_KIND_CONFIGS: Record<BotRuntimeKind, BotRuntimeKindConfig> = {
+  "pi-local": {
+    sessionLinking: "required",
+    missingSessionLinkNotice: (botName) =>
+      `**${botName} is not linked to this scratchpad.** Run \`/remote-control\` in Pi to link a session.`,
+  },
+  hermes: { sessionLinking: "none" },
+  openclaw: { sessionLinking: "none" },
+  "claude-code-channel": { sessionLinking: "none" },
+  custom: { sessionLinking: "none" },
+}
+
+/**
+ * Null kind (no runtime instance ever seen for the bot) resolves to the
+ * pi-local config: only Pi's link flow can make a bot the active scratchpad
+ * actor today, so a presence-less active actor is a Pi straggler. Matches the
+ * `runtimeKind ?? PI_LOCAL` default the public API already uses.
+ */
+export function resolveRuntimeKindConfig(kind: BotRuntimeKind | null): BotRuntimeKindConfig {
+  return BOT_RUNTIME_KIND_CONFIGS[kind ?? "pi-local"]
+}

--- a/apps/backend/src/lib/outbox/payload-parsers.test.ts
+++ b/apps/backend/src/lib/outbox/payload-parsers.test.ts
@@ -5,6 +5,10 @@ import { AuthorTypes } from "@threa/types"
 describe("parseMessagePayload", () => {
   describe("modern format", () => {
     test("should parse valid modern payload", () => {
+      const contentJson = {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Hello world" }] }],
+      }
       const payload = {
         workspaceId: "ws_123",
         streamId: "stream_456",
@@ -16,6 +20,7 @@ describe("parseMessagePayload", () => {
           payload: {
             messageId: "msg_def",
             contentMarkdown: "Hello world",
+            contentJson,
           },
         },
       }
@@ -33,6 +38,7 @@ describe("parseMessagePayload", () => {
           payload: {
             messageId: "msg_def",
             contentMarkdown: "Hello world",
+            contentJson,
           },
         },
       })
@@ -84,9 +90,28 @@ describe("parseMessagePayload", () => {
           payload: {
             messageId: "msg_def",
             contentMarkdown: "",
+            contentJson: null,
           },
         },
       })
+    })
+
+    test("should null out non-object contentJson", () => {
+      const payload = {
+        workspaceId: "ws_123",
+        streamId: "stream_456",
+        event: {
+          payload: {
+            messageId: "msg_def",
+            contentMarkdown: "Hello",
+            contentJson: "not-a-doc",
+          },
+        },
+      }
+
+      const result = parseMessagePayload(payload)
+
+      expect(result?.event.payload.contentJson).toBeNull()
     })
   })
 

--- a/apps/backend/src/lib/outbox/payload-parsers.test.ts
+++ b/apps/backend/src/lib/outbox/payload-parsers.test.ts
@@ -96,6 +96,24 @@ describe("parseMessagePayload", () => {
       })
     })
 
+    test("should null out array contentJson", () => {
+      const payload = {
+        workspaceId: "ws_123",
+        streamId: "stream_456",
+        event: {
+          payload: {
+            messageId: "msg_def",
+            contentMarkdown: "Hello",
+            contentJson: [],
+          },
+        },
+      }
+
+      const result = parseMessagePayload(payload)
+
+      expect(result?.event.payload.contentJson).toBeNull()
+    })
+
     test("should null out non-object contentJson", () => {
       const payload = {
         workspaceId: "ws_123",

--- a/apps/backend/src/lib/outbox/payload-parsers.ts
+++ b/apps/backend/src/lib/outbox/payload-parsers.ts
@@ -5,7 +5,7 @@
  * raw type casts to ensure consistent handling across all listeners.
  */
 
-import type { AuthorType } from "@threa/types"
+import type { AuthorType, JSONContent } from "@threa/types"
 import { AuthorTypes } from "@threa/types"
 
 /**
@@ -23,6 +23,12 @@ export interface NormalizedMessagePayload {
     payload: {
       messageId: string
       contentMarkdown: string
+      /**
+       * Canonical ProseMirror content (INV-58). Null only when the event
+       * payload predates contentJson or is malformed — consumers that read
+       * structural nodes (mentions, shares) treat null as "none present".
+       */
+      contentJson: JSONContent | null
     }
   }
 }
@@ -64,6 +70,10 @@ export function parseMessagePayload(payload: unknown): NormalizedMessagePayload 
           payload: {
             messageId: eventPayload.messageId,
             contentMarkdown: (eventPayload.contentMarkdown as string) ?? "",
+            contentJson:
+              eventPayload.contentJson && typeof eventPayload.contentJson === "object"
+                ? (eventPayload.contentJson as JSONContent)
+                : null,
           },
         },
       }

--- a/apps/backend/src/lib/outbox/payload-parsers.ts
+++ b/apps/backend/src/lib/outbox/payload-parsers.ts
@@ -71,7 +71,9 @@ export function parseMessagePayload(payload: unknown): NormalizedMessagePayload 
             messageId: eventPayload.messageId,
             contentMarkdown: (eventPayload.contentMarkdown as string) ?? "",
             contentJson:
-              eventPayload.contentJson && typeof eventPayload.contentJson === "object"
+              eventPayload.contentJson &&
+              typeof eventPayload.contentJson === "object" &&
+              !Array.isArray(eventPayload.contentJson)
                 ? (eventPayload.contentJson as JSONContent)
                 : null,
           },

--- a/packages/prosemirror/src/extractors.test.ts
+++ b/packages/prosemirror/src/extractors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import type { JSONContent } from "@threa/types"
-import { collectAttachmentReferenceIds } from "./extractors"
+import { collectAttachmentReferenceIds, collectMentionSlugs } from "./extractors"
+
+const mention = (slug: string): JSONContent => ({
+  type: "mention",
+  attrs: { id: slug, slug, mentionType: "bot" },
+})
 
 const reference = (id: string, status: string = "uploaded"): JSONContent => ({
   type: "attachmentReference",
@@ -101,5 +106,85 @@ describe("collectAttachmentReferenceIds", () => {
     }
 
     expect(collectAttachmentReferenceIds(doc)).toEqual(["attach_real"])
+  })
+})
+
+describe("collectMentionSlugs", () => {
+  it("returns slugs in document order across nested blocks, keeping duplicates", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "hey " },
+            mention("ariadne"),
+            { type: "text", text: " and " },
+            mention("scout"),
+          ],
+        },
+        {
+          type: "blockquote",
+          content: [{ type: "paragraph", content: [mention("ariadne")] }],
+        },
+      ],
+    }
+
+    expect(collectMentionSlugs(doc)).toEqual(["ariadne", "scout", "ariadne"])
+  })
+
+  it("collects non-ASCII slugs the editor produced (no ASCII pattern involved)", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [mention("аріадна"), mention("研究員")],
+        },
+      ],
+    }
+
+    expect(collectMentionSlugs(doc)).toEqual(["аріадна", "研究員"])
+  })
+
+  it("lowercases slugs", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [mention("Ariadne")] }],
+    }
+
+    expect(collectMentionSlugs(doc)).toEqual(["ariadne"])
+  })
+
+  it("ignores plain text that merely looks like a mention", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "email test@example.com mentions @nobody as text" }],
+        },
+      ],
+    }
+
+    expect(collectMentionSlugs(doc)).toEqual([])
+  })
+
+  it("ignores mention nodes with missing or empty slug", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "mention", attrs: { id: "x", mentionType: "bot" } },
+            { type: "mention", attrs: { id: "y", slug: "", mentionType: "bot" } },
+            mention("real"),
+          ],
+        },
+      ],
+    }
+
+    expect(collectMentionSlugs(doc)).toEqual(["real"])
   })
 })

--- a/packages/prosemirror/src/extractors.ts
+++ b/packages/prosemirror/src/extractors.ts
@@ -16,6 +16,36 @@ import type { JSONContent } from "@threa/types"
  * result straight to access-check / projection code that already accepts
  * an ordered ID list.
  */
+/**
+ * Collect mention slugs from `mention` nodes, in document order, keeping
+ * duplicate occurrences. Slugs come from the node attrs the editor (or
+ * `parseMarkdown`) produced, so this works for any script the slug is
+ * written in — no ASCII pattern matching over serialized markdown (INV-54).
+ *
+ * Slugs are lowercased to match how mention targets are stored and looked
+ * up. Callers that need a unique set dedupe on their side.
+ */
+export function collectMentionSlugs(content: JSONContent): string[] {
+  const slugs: string[] = []
+
+  const walk = (node: JSONContent): void => {
+    if (node.type === "mention") {
+      const slug = node.attrs?.slug
+      if (typeof slug === "string" && slug.length > 0) {
+        slugs.push(slug.toLowerCase())
+      }
+    }
+    if (node.content) {
+      for (const child of node.content) {
+        walk(child)
+      }
+    }
+  }
+
+  walk(content)
+  return slugs
+}
+
 export function collectAttachmentReferenceIds(content: JSONContent): string[] {
   const seen = new Set<string>()
   const ordered: string[] = []

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -38,7 +38,7 @@ export {
   type MemoHref,
   type GiphyHref,
 } from "./pointer-urls"
-export { collectAttachmentReferenceIds } from "./extractors"
+export { collectAttachmentReferenceIds, collectMentionSlugs } from "./extractors"
 
 // Re-export types for convenience
 export type { JSONContent, JSONContentMark, ThreaDocument } from "@threa/types"


### PR DESCRIPTION
## Problem

Phase 0.6 of the agent-runtimes unification plan (`docs/plans/agent-runtimes-unification-redesign.md` §2.4, §5.7). The "generic" bot dispatcher carried two Pi-isms:

1. **ASCII-only mention regex.** `invocation-outbox-handler.ts` scanned serialized markdown with `/@([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})/g` — an English/ASCII heuristic over a wire format. A bot whose slug isn't Latin script could never be mentioned, and `test@example.com` false-matched as a mention of `example` (INV-54, INV-58).
2. **Pi-hardcoded session-link behavior.** The active-scratchpad path assumed every runtime works like Pi: it required a `bot_runtime_session_links` row (which only Pi's `/remote-control` flow creates) and, when missing, posted a notice hardcoding Pi copy — "Run `/remote-control` in Pi to link a session" — regardless of the bot's actual runtime kind.

## Solution

**Mentions come from `contentJson` mention nodes, not a markdown pattern.** New `collectMentionSlugs()` walker in `@threa/prosemirror` (next to `collectAttachmentReferenceIds`) reads the `mention` nodes the editor's mention picker — and `parseMarkdown` on the public-API path — already produce. `parseMessagePayload` now threads `contentJson` through the normalized outbox payload so the dispatcher can read it. Works for any script; plain text that merely looks like a mention no longer dispatches.

**Session-link policy is per-`BotRuntimeKind` config.** New `runtime-kind-config.ts` colocated in `bot-runtimes`: `pi-local` requires a session link and owns its notice copy; the other kinds (`hermes`, `openclaw`, `claude-code-channel`, `custom`) are link-free — their active-scratchpad invocations dispatch untargeted (`targetInstanceId`/`targetRuntimeSessionId` null), claimable by any live instance of the bot, instead of receiving Pi instructions they can't follow.

### Key design decisions

**1. Kind is resolved lazily, only on the no-link path.** If a link exists, dispatch is pinned to it regardless of kind (no extra query on the happy path). Only when no link is found does the handler look up the bot's latest runtime instance (`BotRuntimeInstanceRepository.findLatestForBots`) to decide notice-vs-untargeted-dispatch.

**2. Unknown kind defaults to the pi-local policy.** Only Pi's link flow can make a bot the active scratchpad actor today, so an active actor with no instance row is a Pi straggler. This matches the `runtimeKind ?? PI_LOCAL` default the public API already uses (`public-api/handlers.ts`), and means **no reachable behavior changes for Pi** — pure seam-building, which is what Phase 0 is.

**3. No markdown fallback when `contentJson` is absent.** A fallback regex would keep the INV-54 violation alive. `contentJson` is required on every `message_created` event payload (`satisfies MessageCreatedPayload`), so null only occurs for malformed/ancient payloads, which the handler already tolerates by doing less.

**4. Duplicate slugs preserved in document order.** Mirrors the regex's output shape exactly; the handler keeps its existing dedup for lookups, so `mentionedActorSlugs` on the invocation row is unchanged in shape.

**5. Pi's link-creation flow is untouched.** `createOrLinkPiRemoteSession` and the `z.literal("pi-local")` schema stay as-is — lifting link *creation* to other kinds is Phase 2.3 (manifest) territory. 0.6 only de-Pi-ifies the dispatcher.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/runtime-kind-config.ts` | Per-`BotRuntimeKind` active-scratchpad dispatch policy: `sessionLinking: "required"` (+ notice copy) vs `"none"` |

## Modified files

| File | Change |
| --- | --- |
| `packages/prosemirror/src/extractors.ts` | New `collectMentionSlugs()` JSONContent walker |
| `packages/prosemirror/src/index.ts` | Export it |
| `apps/backend/src/lib/outbox/payload-parsers.ts` | `NormalizedMessagePayload` gains `contentJson: JSONContent \| null` |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | Mention extraction from contentJson nodes; session-link branch driven by kind config; notice copy injected |
| `packages/prosemirror/src/extractors.test.ts` | `collectMentionSlugs` cases incl. non-ASCII slugs, text-that-looks-like-a-mention |
| `apps/backend/src/lib/outbox/payload-parsers.test.ts` | contentJson threading + non-object guard |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts` | Non-ASCII mention dispatches; plain-text `@` does not; per-kind notice vs untargeted dispatch; no-instance default |

## Test plan

- [x] `bun test src/features/bot-runtimes/ src/lib/outbox/` — 91 pass
- [x] `bun test` in `packages/prosemirror` — 63 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Phase 0.6 of `docs/plans/agent-runtimes-unification-redesign.md` — lift the two dispatcher Pi-isms named in §5.7 so the external bot path stops assuming Pi: ASCII mention regex → contentJson mention entities (INV-54/INV-58), and session-link behavior + missing-link notice → per-`BotRuntimeKind` config.

**What was built:**
1. `collectMentionSlugs(content)` in `@threa/prosemirror/extractors` — walks `mention` nodes, collects `attrs.slug` (lowercased) in document order with duplicates, ignoring text that merely looks like a mention.
2. `parseMessagePayload` threads `contentJson` (`JSONContent | null`) through the normalized payload; consumers reading structural nodes treat null as "none present".
3. `runtime-kind-config.ts`: discriminated union `{ sessionLinking: "required", missingSessionLinkNotice } | { sessionLinking: "none" }` over all `BOT_RUNTIME_KINDS` (Record-typed so a new kind fails the build without a policy). `resolveRuntimeKindConfig(null)` → pi-local (matches the public API's existing default).
4. Handler: mention slugs from contentJson; on the no-link active-scratchpad path, resolve kind from the bot's latest runtime instance — `required` posts the kind's notice and returns, `none` dispatches with null targets. `createMissingLinkNotice` takes the copy as a param.

**Design decisions:** lazy kind lookup only when no link; unknown kind = Pi straggler (only Pi sets active actors today → no reachable behavior change); no markdown fallback regex; duplicates preserved to keep `mentionedActorSlugs` shape; Pi's link-creation API untouched (Phase 2.3).

**What's NOT included:** the persona mention path (`agents/mention-extractor`) and activity service still use the shared markdown regex — separate surfaces, out of 0.6's scope (§5.7 names the bot dispatcher only). Link creation for non-Pi kinds (Phase 2.3 manifest work). Turn digests (0.7, next).

**Status:** complete; all suites green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdiRYoBP7qD8oNgu81z22K)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783768182&installation_id=129946197&pr_number=827&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F827&signature=d2d8c3b3af447840f8b2ba0ad6f139246d4b62cae21998fc0216c5285b5f445b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->