### PR TITLE
perf(frontend): interim relief for stream timeline perceived performance

### DIFF
--- a/apps/frontend/src/api/attachments.ts
+++ b/apps/frontend/src/api/attachments.ts
@@ -48,6 +48,23 @@ export function resetAttachmentUrlCache(): void {
   resolvedDownloadUrlCache.clear()
 }
 
+/**
+ * Synchronous peek at an already-resolved download URL. Lets remounting
+ * components (virtualized rows) seed their initial state with the cached URL
+ * instead of rendering a skeleton for the frame(s) the async `getDownloadUrl`
+ * resolution takes, even on a warm cache.
+ */
+export function peekDownloadUrl(
+  workspaceId: string,
+  attachmentId: string,
+  options?: { download?: boolean; variant?: "raw" | "processed" | "thumbnail" }
+): string | null {
+  const key = `${workspaceId}:${attachmentId}:${options?.download ? "download" : "inline"}:${options?.variant ?? "raw"}`
+  const cached = resolvedDownloadUrlCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.url
+  return null
+}
+
 export const attachmentsApi = {
   /**
    * Upload a file to the workspace.

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -4,7 +4,7 @@ export { workspacesApi, type WorkspaceBootstrap } from "./workspaces"
 export { streamsApi, type StreamBootstrap, type CreateStreamInput, type UpdateStreamInput } from "./streams"
 export { e2eKeyWrapsApi } from "./e2e-key-wraps"
 export { messagesApi, type CreateMessageInput, type UpdateMessageInput } from "./messages"
-export { attachmentsApi } from "./attachments"
+export { attachmentsApi, peekDownloadUrl } from "./attachments"
 export {
   commandsApi,
   type DispatchCommandInput,

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -961,7 +961,13 @@ export function MessageComposer({
       <div
         ref={mobileRootRef}
         className={cn(
-          "flex flex-col transition-[max-height,min-height] duration-200 ease-out",
+          // No transition on max/min-height: animating the shell's layout box
+          // re-runs layout every frame, and the timeline scroller above resizes
+          // with it — each frame fires its ResizeObserver, re-pins to bottom,
+          // and forces a virtua re-measure (~10fps on low-end Android, see
+          // docs/stream-timeline-perceived-performance.md). Snap instead, same
+          // as the keyboard choreography.
+          "flex flex-col",
           mobileExpanded ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
           className
         )}

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { Skeleton } from "@/components/ui/skeleton"
-import { attachmentsApi } from "@/api"
+import { attachmentsApi, peekDownloadUrl } from "@/api"
 import { cn } from "@/lib/utils"
 import { downloadImage, copyImage, triggerDownload } from "@/lib/image-utils"
 import { formatFileSize } from "@/lib/file-size"
@@ -135,7 +135,12 @@ function ImageAttachment({
   isHighlighted,
   deferHydration = false,
 }: AttachmentItemProps) {
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
+  // Seed from the resolved-presign cache so a warm remount (virtua
+  // unmount/remount, bootstrap rewrite) renders the <img> on the very first
+  // frame instead of replaying skeleton → async presign → fade.
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(() =>
+    peekDownloadUrl(workspaceId, attachment.id, { variant: "thumbnail" })
+  )
   const [imgDecoded, setImgDecoded] = useState(false)
   const [error, setError] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -237,6 +242,14 @@ function ImageAttachment({
         {!imgDecoded && <Skeleton className="absolute inset-0 rounded-none" />}
         {thumbnailUrl && (
           <img
+            // Cache fast path: when the browser already has the bytes (warm
+            // remount — virtua unmount/remount, bootstrap rewrite), the image
+            // is complete before onLoad ever fires. Flip imgDecoded during
+            // commit so the row paints at full opacity instead of replaying
+            // the skeleton → fade-in cycle on content that never left cache.
+            ref={(node) => {
+              if (node?.complete && node.naturalWidth > 0) setImgDecoded(true)
+            }}
             src={thumbnailUrl}
             alt={attachment.filename}
             onLoad={() => setImgDecoded(true)}

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import {
   COMMAND_EVENT_TYPES,
   AGENT_SESSION_EVENT_TYPES,
@@ -403,7 +403,6 @@ export interface TimelineItemRenderContext {
   sessionCanAbort: Map<string, boolean>
   /** Click handler for the Stop research button. */
   onAbortResearch?: (sessionId: string) => void
-  phase: string
   batch?: BatchTimelineState
 }
 
@@ -416,8 +415,15 @@ function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean
   return item.event.id === firstUnreadEventId
 }
 
-/** Renders a single timeline item. Used by Virtuoso's itemContent and non-virtualized lists. */
-export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: TimelineItemRenderContext }) {
+interface TimelineItemContentProps {
+  item: TimelineItem
+  ctx: TimelineItemRenderContext
+  /** Defer non-critical per-message hydration (presigns, previews, embeds). */
+  deferSecondaryHydration: boolean
+}
+
+/** Renders a single timeline item. Used by virtua's row mapping and non-virtualized lists. */
+function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: TimelineItemContentProps) {
   const showUnreadDivider = isFirstUnread(item, ctx.firstUnreadEventId)
   return (
     <>
@@ -460,7 +466,7 @@ export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: Ti
           highlightMessageId={ctx.highlightMessageId}
           agentActivity={ctx.hideSessionCards ? ctx.agentActivity : undefined}
           isNew={ctx.newMessageIds?.has(item.event.id)}
-          deferSecondaryHydration={ctx.phase !== "ready"}
+          deferSecondaryHydration={deferSecondaryHydration}
           batch={ctx.batch}
           // Continuations directly under an UnreadDivider promote back to head so
           // the first unread message in a run still reads as a fresh turn for the
@@ -475,6 +481,125 @@ export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: Ti
     </>
   )
 }
+
+function getEventMessageId(event: StreamEvent): string | undefined {
+  return (event.payload as { messageId?: string })?.messageId
+}
+
+function eventsArrayEqual(a: StreamEvent[], b: StreamEvent[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/**
+ * Whether two TimelineItems would render identically. `groupTimelineItems`
+ * rebuilds every wrapper object on each run, but the underlying StreamEvent
+ * objects keep identity when unchanged (structural sharing in
+ * `useStreamEvents`), so identity of the contained events is the real signal.
+ */
+function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
+  if (a === b) return true
+  if (a.type !== b.type) return false
+  switch (a.type) {
+    case "event": {
+      const other = b as Extract<TimelineItem, { type: "event" }>
+      return a.event === other.event && (a.groupContinuation ?? false) === (other.groupContinuation ?? false)
+    }
+    case "command_group": {
+      const other = b as Extract<TimelineItem, { type: "command_group" }>
+      return a.commandId === other.commandId && eventsArrayEqual(a.events, other.events)
+    }
+    case "session_group": {
+      const other = b as Extract<TimelineItem, { type: "session_group" }>
+      return (
+        a.sessionId === other.sessionId &&
+        a.sessionVersion === other.sessionVersion &&
+        eventsArrayEqual(a.events, other.events)
+      )
+    }
+    case "gap": {
+      const other = b as Extract<TimelineItem, { type: "gap" }>
+      return a.afterEventId === other.afterEventId && a.missingCount === other.missingCount
+    }
+  }
+}
+
+/**
+ * Per-item props equality for the memoized row. `ctx` is rebuilt (new object,
+ * new Maps/Sets) on every message arrival, agent-activity tick, or batch
+ * interaction, so comparing ctx by identity would defeat the memo. Instead we
+ * compare only what this *item* actually reads out of ctx — set membership
+ * and map lookups rather than container identity.
+ *
+ * IMPORTANT: when adding a field to TimelineItemRenderContext that affects
+ * row rendering, it must be compared here, or rows will render stale.
+ */
+function timelineRowPropsEqual(prev: TimelineItemContentProps, next: TimelineItemContentProps): boolean {
+  if (!timelineItemEqual(prev.item, next.item)) return false
+  if (prev.deferSecondaryHydration !== next.deferSecondaryHydration) return false
+  const p = prev.ctx
+  const n = next.ctx
+  if (
+    p.workspaceId !== n.workspaceId ||
+    p.streamId !== n.streamId ||
+    p.hideSessionCards !== n.hideSessionCards ||
+    p.isDividerFading !== n.isDividerFading ||
+    p.onAbortResearch !== n.onAbortResearch
+  ) {
+    return false
+  }
+  const item = next.item
+  if (isFirstUnread(item, p.firstUnreadEventId) !== isFirstUnread(item, n.firstUnreadEventId)) return false
+
+  if (item.type === "session_group") {
+    const prevCounts = p.sessionLiveCounts.get(item.sessionId)
+    const nextCounts = n.sessionLiveCounts.get(item.sessionId)
+    if (prevCounts?.stepCount !== nextCounts?.stepCount || prevCounts?.messageCount !== nextCounts?.messageCount) {
+      return false
+    }
+    if (p.sessionLiveSubsteps.get(item.sessionId) !== n.sessionLiveSubsteps.get(item.sessionId)) return false
+    if ((p.sessionCanAbort.get(item.sessionId) ?? false) !== (n.sessionCanAbort.get(item.sessionId) ?? false)) {
+      return false
+    }
+    return true
+  }
+
+  if (item.type !== "event") return true
+
+  const messageId = getEventMessageId(item.event)
+  if ((p.highlightMessageId === messageId) !== (n.highlightMessageId === messageId)) return false
+  if ((p.firstMessageId === messageId) !== (n.firstMessageId === messageId)) return false
+  if ((p.newMessageIds?.has(item.event.id) ?? false) !== (n.newMessageIds?.has(item.event.id) ?? false)) return false
+  if (messageId !== undefined && p.agentActivity?.get(messageId) !== n.agentActivity?.get(messageId)) return false
+
+  const pb = p.batch
+  const nb = n.batch
+  if ((pb === undefined) !== (nb === undefined)) return false
+  if (pb && nb && messageId !== undefined) {
+    if (
+      pb.enabled !== nb.enabled ||
+      pb.onToggleMessage !== nb.onToggleMessage ||
+      pb.selectedMessageIds.has(messageId) !== nb.selectedMessageIds.has(messageId) ||
+      pb.invalidTargetIds.has(messageId) !== nb.invalidTargetIds.has(messageId) ||
+      (pb.hoveredTargetId === messageId) !== (nb.hoveredTargetId === messageId)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Memoized timeline row. The timeline's inputs churn identity constantly
+ * (Dexie liveQuery re-emits all-new arrays on any events write; ctx is
+ * rebuilt per tick), so the memo uses a per-item comparator instead of
+ * shallow props equality — a data tick re-renders only the rows whose own
+ * inputs changed instead of the full window.
+ */
+export const TimelineItemContent = memo(TimelineItemContentImpl, timelineRowPropsEqual)
 
 /**
  * Non-virtualized event list for threads and other cases where all items are rendered.
@@ -573,7 +698,6 @@ export function EventList({
     sessionLiveSubsteps,
     sessionCanAbort,
     onAbortResearch: handleAbortResearch,
-    phase,
     batch,
   }
 
@@ -583,7 +707,7 @@ export function EventList({
         const itemKey = getTimelineItemKey(item)
         return (
           <div key={itemKey} className={isFirstUnread(item, firstUnreadEventId) ? "relative" : undefined}>
-            <TimelineItemContent item={item} ctx={ctx} />
+            <TimelineItemContent item={item} ctx={ctx} deferSecondaryHydration={phase !== "ready"} />
           </div>
         )
       })}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1795,7 +1795,6 @@ function TimelineMessageList({
       sessionLiveSubsteps,
       sessionCanAbort,
       onAbortResearch: handleAbortResearch,
-      phase,
       batch,
     }),
     [
@@ -1812,10 +1811,37 @@ function TimelineMessageList({
       sessionLiveSubsteps,
       sessionCanAbort,
       handleAbortResearch,
-      phase,
       batch,
     ]
   )
+
+  // Stagger the post-reveal hydration burst (INV-21 adjacent): when the
+  // coordinated-loading phase flips to "ready", releasing every row's
+  // deferSecondaryHydration at once fires all presigns/link previews/embeds
+  // in one frame — a long task right at reveal. Instead release rows in
+  // batches from the bottom (the viewport on a chat) upward, one batch per
+  // frame. Once every row present at release time is hydrated, latch open so
+  // later prepends/appends hydrate immediately.
+  const HYDRATION_RELEASE_BATCH = 8
+  const [hydrationWave, setHydrationWave] = useState(0)
+  const fullyHydratedRef = useRef(false)
+  const lastHydrationStreamRef = useRef(streamId)
+  if (lastHydrationStreamRef.current !== streamId) {
+    lastHydrationStreamRef.current = streamId
+    fullyHydratedRef.current = false
+    setHydrationWave(0)
+  }
+  const itemCount = visibleItems.length
+  useEffect(() => {
+    if (phase !== "ready" || fullyHydratedRef.current) return
+    if (hydrationWave * HYDRATION_RELEASE_BATCH >= itemCount) {
+      fullyHydratedRef.current = true
+      return
+    }
+    const id = requestAnimationFrame(() => setHydrationWave((wave) => wave + 1))
+    return () => cancelAnimationFrame(id)
+  }, [phase, hydrationWave, itemCount])
+  const releasedFromBottom = hydrationWave * HYDRATION_RELEASE_BATCH
 
   // Fetch guards to prevent rapid re-firing
   const olderFetchCooldownRef = useRef(0)
@@ -2011,14 +2037,22 @@ function TimelineMessageList({
             // viewport doesn't move — the core reverse-infinite-scroll fix.
             shift={shift}
             // Off-screen px kept mounted so fast scrolling doesn't outrun
-            // mount+measure and flash blank rows. Deliberately modest: heavy
-            // message DOM (ProseMirror, link previews) janks with a large window;
-            // smooth fast-scroll comes from prefetching pages early, not overscan.
-            bufferSize={1000}
+            // mount+measure and flash blank rows. Was 1000 when every data tick
+            // re-rendered the whole window; with memoized rows the steady-state
+            // cost of extra mounted rows is near zero, so a larger buffer buys
+            // fling headroom. Mount cost still bounds it — don't raise further
+            // without profiling on a low-end device.
+            bufferSize={2000}
           >
-            {visibleItems.map((item) => (
+            {visibleItems.map((item, index) => (
               <div key={getTimelineItemKey(item)} className="relative mx-auto max-w-[800px]">
-                <TimelineItemContent item={item} ctx={renderCtx} />
+                <TimelineItemContent
+                  item={item}
+                  ctx={renderCtx}
+                  deferSecondaryHydration={
+                    !fullyHydratedRef.current && (phase !== "ready" || index < visibleItems.length - releasedFromBottom)
+                  }
+                />
               </div>
             ))}
           </Virtualizer>

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -35,6 +35,16 @@ const GROWTH_DEBOUNCE_MS = 150
  */
 const OPTIMISTIC_CLOSE_SUPPRESS_MS = 500
 
+/**
+ * Max px difference between the optimistic-close baseline and the reconcile
+ * measurement that we silently accept. Browsers report the settled viewport a
+ * few px off the baseline (URL-bar rounding, inset rounding); re-snapping for
+ * that triggers a second resize → re-pin → re-measure cycle the user sees as
+ * content "loading in again" after the keyboard closed. Genuine settles (URL
+ * bar moved: tens of px) still apply.
+ */
+const RECONCILE_TOLERANCE_PX = 8
+
 /** CSS custom property AppShell reads to size the app to the visible viewport */
 const VIEWPORT_HEIGHT_VAR = "--viewport-height"
 
@@ -268,7 +278,11 @@ export function useVisualViewport(enabled: boolean): boolean {
             clearTimeout(reconcileTimeoutId)
             reconcileTimeoutId = window.setTimeout(() => {
               const settled = measureEffectiveHeight()
-              if (settled !== lastWrittenHeight) applyHeight(settled)
+              // Tolerate small deltas: a few px of URL-bar/inset noise in the
+              // settled measurement is not worth a second resize → re-pin →
+              // virtua re-measure cycle right after the optimistic snap (the
+              // visible "content loads in again" double-snap on close).
+              if (Math.abs(settled - lastWrittenHeight) > RECONCILE_TOLERANCE_PX) applyHeight(settled)
             }, OPTIMISTIC_CLOSE_SUPPRESS_MS)
           }
         }, 0)

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -1,5 +1,6 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
+import { useRef } from "react"
 import { db, type CachedEvent, type CachedStream } from "@/db"
 
 /**
@@ -100,11 +101,45 @@ export function useStreamEvents(
   // the previous stream's array. Our stamp lets us detect that regardless of
   // whether the previous result happened to be non-empty or empty.
   const resultStreamId = (result as (CachedEvent[] & { __streamId?: string }) | undefined)?.__streamId
+  const prevRef = useRef<{ streamId: string; array: CachedEvent[]; byId: Map<string, CachedEvent> } | null>(null)
   if (streamId && resultStreamId !== streamId) {
     return undefined
   }
+  if (!result || !streamId) return result
 
-  return result
+  // Structural sharing: `useLiveQuery` re-runs on ANY write to db.events and
+  // materializes all-new row objects, even for rows whose stored bytes did
+  // not change. Downstream memoization (timeline rows) keys off row identity,
+  // so without sharing a single-message write invalidates every visible row.
+  // A row is considered unchanged when its write markers match: every
+  // payload-mutating write path bumps `_patchedAt` (socket patches),
+  // `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
+  // lifecycle), so matching markers imply an identical row.
+  const prev = prevRef.current
+  let shared = result
+  if (prev && prev.streamId === streamId) {
+    let allSame = prev.array.length === result.length
+    shared = result.map((row, i) => {
+      const old = prev.byId.get(row.id)
+      if (
+        old &&
+        old._cachedAt === row._cachedAt &&
+        old._patchedAt === row._patchedAt &&
+        old._status === row._status &&
+        old.sequence === row.sequence
+      ) {
+        if (allSame && prev.array[i] !== old) allSame = false
+        return old
+      }
+      allSame = false
+      return row
+    })
+    if (allSame) shared = prev.array
+  }
+  if (shared !== prev?.array) {
+    prevRef.current = { streamId, array: shared, byId: new Map(shared.map((row) => [row.id, row])) }
+  }
+  return shared
 }
 
 /**

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -182,6 +182,33 @@ async function pruneBootstrapReplaceWindow(streamId: string, bootstrap: StreamBo
   }
 }
 
+/**
+ * Whether putting `candidate` over `existing` would change nothing the app
+ * can observe. Skipping these puts matters for perceived performance: every
+ * write to `db.events` re-runs the timeline's `useLiveQuery`, and a bootstrap
+ * that rewrites byte-identical rows forces a full-window re-render for no
+ * user-visible change. `_cachedAt` is bookkeeping (nothing reads it for
+ * eviction or rendering), so a row that differs only by `_cachedAt` is a
+ * no-op. Rows carrying optimistic `_status` are never skipped — the put
+ * intentionally clears that flag on confirm.
+ */
+function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
+  if (existing._status !== undefined) return false
+  return (
+    existing.streamId === candidate.streamId &&
+    existing.workspaceId === candidate.workspaceId &&
+    existing.sequence === candidate.sequence &&
+    existing.broadcastSequence === candidate.broadcastSequence &&
+    existing._clientId === candidate._clientId &&
+    existing._sequenceNum === candidate._sequenceNum &&
+    existing.eventType === candidate.eventType &&
+    existing.actorId === candidate.actorId &&
+    existing.actorType === candidate.actorType &&
+    existing.createdAt === candidate.createdAt &&
+    JSON.stringify(existing.payload) === JSON.stringify(candidate.payload)
+  )
+}
+
 async function writeBootstrapEventsAndStream(
   workspaceId: string,
   streamId: string,
@@ -225,11 +252,13 @@ async function writeBootstrapEventsAndStream(
     const toWrite: CachedEvent[] = []
     for (const e of bootstrap.events) {
       const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+      const existing = existingById.get(e.id)
       if (e.eventType !== "message_created") {
-        toWrite.push(base)
+        if (existing === undefined || !isNoOpRewrite(existing, base)) {
+          toWrite.push(base)
+        }
         continue
       }
-      const existing = existingById.get(e.id)
       if (!existing) {
         toWrite.push(base)
         continue
@@ -238,7 +267,7 @@ async function writeBootstrapEventsAndStream(
         // Skip the put — existing row is fresher than this snapshot.
         continue
       }
-      toWrite.push({
+      const merged: CachedEvent = {
         ...base,
         payload: {
           ...(existing.payload as Record<string, unknown>),
@@ -247,7 +276,10 @@ async function writeBootstrapEventsAndStream(
         // Preserve the patch watermark so subsequent bootstraps still see
         // that this row has been touched by socket activity.
         _patchedAt: existing._patchedAt,
-      })
+      }
+      if (!isNoOpRewrite(existing, merged)) {
+        toWrite.push(merged)
+      }
     }
 
     if (toWrite.length > 0) {


### PR DESCRIPTION
## Problem

The stream timeline feels sluggish on mobile: cold opens get laggy as content loads in, the composer open/close blanks content, fast scrolling outruns row rendering, and rows/media flicker as if replaced. `docs/stream-timeline-perceived-performance.md` (#828) traced all four symptoms to two root causes: an unmemoized row tree fed by identity-churning inputs, and media with no stable identity across remounts.

This PR is the interim relief from that doc: the render-layer fixes that pay off immediately and do not conflict with the sync v2 direction (#826).

## Solution

### 1. Memoize the timeline row tree (root cause 1)

`TimelineItemContent` is now wrapped in `React.memo` with a per-item comparator (`timelineRowPropsEqual`). The comparator does not compare `ctx` by identity (it is rebuilt with fresh Maps/Sets on every tick) — it compares what *this item* actually reads: set membership (`newMessageIds.has(id)`, batch selection), map lookups (`agentActivity.get(messageId)`, session live counts by value), and derived booleans (`isHighlighted`, `isFirstMessage`, unread-divider position). `TimelineItem` wrappers are rebuilt every run by `groupTimelineItems`, so item equality keys off the contained `StreamEvent` identities.

`phase` was removed from `TimelineItemRenderContext`; `deferSecondaryHydration` is now an explicit prop, so phase changes between non-ready phases no longer invalidate rows.

### 2. Stabilize the inputs so the memo actually fires

- **Structural sharing in `useStreamEvents`**: Dexie `liveQuery` re-runs on any write to `db.events` and materializes all-new row objects. The hook now reuses the previous row object when write markers match (`_cachedAt`, `_patchedAt`, `_status`, `sequence` — every payload-mutating write path bumps one of them), and returns the previous *array* identity when nothing changed at all, so the whole downstream memo chain bails.
- **Skip no-op IDB rewrites in the bootstrap merge** (`isNoOpRewrite` in `stream-sync.ts`): rows whose merged result is byte-identical to the stored row (ignoring `_cachedAt`, which nothing reads) are not re-put, silencing spurious liveQuery emissions at the source. This is the one item sync v2 eventually subsumes; it is cheap relief until then.

### 3. Stable media on remount (frontend half of doc item 3)

- `ImageAttachment` seeds its thumbnail URL synchronously from the resolved-presign cache (new `peekDownloadUrl`), so warm remounts render the `<img>` on the first frame instead of skeleton → async presign → fade.
- `img.complete` fast path: when the browser already has the bytes, `imgDecoded` flips during commit, skipping the opacity fade replay.

The backend half (deterministic cookie-authed attachment URLs so the HTTP cache works across sessions) is deliberately left out — it is an API change worth its own PR.

### 4. Composer: snap, don't animate layout

The mobile composer no longer transitions `max-height`/`min-height` (200ms layout animation → per-frame ResizeObserver → re-pin → virtua re-measure; the PR #816 lesson). The keyboard-close reconcile pass now tolerates an 8px delta before re-snapping, removing the visible double-snap on close.

### 5. Staggered hydration release + overscan raise

- After the coordinated-loading phase flips to `ready`, `deferSecondaryHydration` is released in batches of 8 rows per frame from the bottom (viewport) up, instead of firing every presign/link-preview/embed in one frame. Once caught up it latches open so new rows hydrate immediately.
- virtua `bufferSize` raised 1000 → 2000 now that keeping rows mounted is cheap.

### Not included (deliberately)

- Backend stable-URL endpoint (item 3's other half) — separate PR.
- Skeleton rows while fetching older pages — inserting real elements above the virtualizer interacts with scroll anchoring; needs its own careful change.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/timeline/event-list.tsx` | Memoized `TimelineItemContent` with per-item comparator; `deferSecondaryHydration` prop; `phase` removed from ctx |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Staggered hydration release; per-item defer; `bufferSize` 2000; ctx without `phase` |
| `apps/frontend/src/stores/stream-store.ts` | Structural sharing in `useStreamEvents` |
| `apps/frontend/src/sync/stream-sync.ts` | `isNoOpRewrite` skip in bootstrap merge |
| `apps/frontend/src/api/attachments.ts` | `peekDownloadUrl` sync cache peek |
| `apps/frontend/src/api/index.ts` | Export `peekDownloadUrl` |
| `apps/frontend/src/components/timeline/attachment-list.tsx` | Seed thumbnail from cache; `img.complete` fast path |
| `apps/frontend/src/components/composer/message-composer.tsx` | Remove max/min-height transition |
| `apps/frontend/src/hooks/use-visual-viewport.ts` | 8px tolerance on keyboard-close reconcile |

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 38 test files / 449 tests covering the touched areas pass (`src/stores`, `src/sync`, `src/components/timeline`, `src/components/composer`, `src/hooks/use-visual-viewport`)
- [x] Full-monorepo lint + typecheck via pre-commit hooks
- [ ] Manual: cold-open a media-heavy stream on a throttled device — rows should not flicker on bootstrap apply, images should not replay skeleton/fade on scroll remounts
- [ ] Manual: open/close the mobile composer — no layout animation jank, no double snap on keyboard close

Note: 11 unrelated test files fail locally with `localStorage.setItem is not a function` — reproduced identically on a clean `origin/main` checkout (local environment issue, not introduced here).

Exploration doc: #828. Sync-layer sibling: #826.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772140&installation_id=129946197&pr_number=829&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F829&signature=8bb36c7149d46d691ea52b50342f7e3e3dd3f06f2a0e6f7c6b900846c67537c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->