### PR TITLE
feat: sync-log spine — sequence client-routed outbox events at the dispatcher

### DIFF
--- a/apps/backend/eslint.config.js
+++ b/apps/backend/eslint.config.js
@@ -60,7 +60,8 @@ export default [
   // Exceptions:
   //   static-config-resolver.ts — aggregates AI configs from all features
   //   message-formatter — AI utility that resolves author names from member/persona repos
-  //   outbox/broadcast-handler — resolves memberId→userId for socket routing
+  //   outbox/broadcast-handler — resolves memberId→userId for socket routing and
+  //     sequences client-routed events into the sync log (features/sync)
   //   outbox/repository — outbox payload types reference domain types (type-only, no runtime dep)
   {
     files: ["src/lib/**/*.ts"],
@@ -70,6 +71,7 @@ export default [
       "src/lib/ai/message-formatter.ts",
       "src/lib/ai/message-formatter.test.ts",
       "src/lib/outbox/broadcast-handler.ts",
+      "src/lib/outbox/broadcast-handler.test.ts",
       "src/lib/outbox/repository.ts",
     ],
     rules: {

--- a/apps/backend/src/db/migrations/20260611080000_sync_log.sql
+++ b/apps/backend/src/db/migrations/20260611080000_sync_log.sql
@@ -1,0 +1,34 @@
+-- Sync-log spine (sync engine v2, step 1; docs/sync-engine-v2-exploration.md Part 6).
+-- A per-workspace ordered log of every client-routed outbox event, written by the
+-- BroadcastHandler (single-writer sequencer under its exclusive cursor lock) before
+-- the socket emit. `sync_id` is dense per workspace; `groups` carries the delivery
+-- groups the broadcast router already computes ("workspace", "stream:<id>",
+-- "user:<id>") so catch-up reads can be ACL-filtered. `payload` is the outbox
+-- payload verbatim — sealed E2EE envelopes pass through untouched.
+-- No FKs (INV-1); workspace-scoped (INV-8).
+CREATE TABLE sync_log (
+    workspace_id TEXT NOT NULL,
+    sync_id BIGINT NOT NULL,
+    outbox_event_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    groups TEXT[] NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, sync_id)
+);
+
+-- Idempotency anchor: crash-retry of the sequencer (and the reconciliation sweep)
+-- must converge on one row per outbox event.
+CREATE UNIQUE INDEX idx_sync_log_outbox_event ON sync_log (outbox_event_id);
+
+-- Catch-up reads filter by group membership.
+CREATE INDEX idx_sync_log_groups ON sync_log USING GIN (groups);
+
+-- Per-workspace sync-id allocator, same shape as stream_sequences. The allocator
+-- row doubles as the serialization lock between the sequencer and the
+-- reconciliation sweep: writers lock it FIRST, then check for existing entries,
+-- so allocated ids are never burned into gaps (INV-20).
+CREATE TABLE workspace_sync_sequences (
+    workspace_id TEXT PRIMARY KEY,
+    next_sequence BIGINT NOT NULL DEFAULT 1
+);

--- a/apps/backend/src/features/sync/index.ts
+++ b/apps/backend/src/features/sync/index.ts
@@ -1,0 +1,1 @@
+export { SyncLogRepository, type SyncLogEntryInput } from "./repository"

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -49,7 +49,8 @@ export const SyncLogRepository = {
       const existingResult = await client.query<{ outbox_event_id: string; sync_id: string }>(sql`
         SELECT outbox_event_id, sync_id
         FROM sync_log
-        WHERE outbox_event_id = ANY(${outboxEventIds}::bigint[])
+        WHERE workspace_id = ${workspaceId}
+          AND outbox_event_id = ANY(${outboxEventIds}::bigint[])
       `)
 
       const assigned = new Map<bigint, bigint>()
@@ -57,9 +58,7 @@ export const SyncLogRepository = {
         assigned.set(BigInt(row.outbox_event_id), BigInt(row.sync_id))
       }
 
-      const missing = entries
-        .filter((e) => !assigned.has(e.outboxEventId))
-        .sort((a, b) => Number(a.outboxEventId - b.outboxEventId))
+      const missing = entries.filter((e) => !assigned.has(e.outboxEventId))
 
       if (missing.length > 0) {
         const rows = missing.map((e, i) => {

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -1,0 +1,96 @@
+import type { Pool } from "pg"
+import { sql, withTransaction } from "../../db"
+
+/** One client-routed outbox event headed for the sync log. */
+export interface SyncLogEntryInput {
+  outboxEventId: bigint
+  eventType: string
+  groups: string[]
+  payload: unknown
+}
+
+export const SyncLogRepository = {
+  /**
+   * Appends a batch of outbox events to one workspace's sync log, allocating
+   * dense, gapless sync ids in input order. Idempotent: events that already
+   * have a log entry (sequencer crash-retry, reconciliation-sweep overlap)
+   * keep their existing sync id and are not re-inserted.
+   *
+   * Returns outboxEventId → syncId for every input entry.
+   *
+   * Concurrency protocol (INV-20): writers lock the workspace's allocator row
+   * FIRST (no-op upsert), then read existing entries on a fresh snapshot, then
+   * insert only the missing ones. Checking before locking would let two
+   * writers both see an event as missing and burn an allocated id into a
+   * permanent gap — so any unique-index violation here means a writer broke
+   * the lock-first protocol, and the transaction fails loudly instead of
+   * absorbing it.
+   */
+  async appendForWorkspace(
+    pool: Pool,
+    workspaceId: string,
+    entries: SyncLogEntryInput[]
+  ): Promise<Map<bigint, bigint>> {
+    if (entries.length === 0) {
+      return new Map()
+    }
+
+    return withTransaction(pool, async (client) => {
+      const lockResult = await client.query<{ next_sequence: string }>(sql`
+        INSERT INTO workspace_sync_sequences (workspace_id, next_sequence)
+        VALUES (${workspaceId}, 1)
+        ON CONFLICT (workspace_id) DO UPDATE
+          SET next_sequence = workspace_sync_sequences.next_sequence
+        RETURNING next_sequence
+      `)
+      const start = BigInt(lockResult.rows[0].next_sequence)
+
+      const outboxEventIds = entries.map((e) => e.outboxEventId.toString())
+      const existingResult = await client.query<{ outbox_event_id: string; sync_id: string }>(sql`
+        SELECT outbox_event_id, sync_id
+        FROM sync_log
+        WHERE outbox_event_id = ANY(${outboxEventIds}::bigint[])
+      `)
+
+      const assigned = new Map<bigint, bigint>()
+      for (const row of existingResult.rows) {
+        assigned.set(BigInt(row.outbox_event_id), BigInt(row.sync_id))
+      }
+
+      const missing = entries
+        .filter((e) => !assigned.has(e.outboxEventId))
+        .sort((a, b) => Number(a.outboxEventId - b.outboxEventId))
+
+      if (missing.length > 0) {
+        const rows = missing.map((e, i) => {
+          const syncId = start + BigInt(i)
+          assigned.set(e.outboxEventId, syncId)
+          return {
+            sync_id: syncId.toString(),
+            outbox_event_id: e.outboxEventId.toString(),
+            event_type: e.eventType,
+            groups: e.groups,
+            payload: e.payload,
+          }
+        })
+
+        await client.query(sql`
+          INSERT INTO sync_log (workspace_id, sync_id, outbox_event_id, event_type, groups, payload)
+          SELECT ${workspaceId}, r.sync_id::bigint, r.outbox_event_id::bigint, r.event_type,
+                 ARRAY(SELECT g FROM jsonb_array_elements_text(r.groups) AS g),
+                 r.payload
+          FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb)
+            AS r(sync_id text, outbox_event_id text, event_type text, groups jsonb, payload jsonb)
+        `)
+
+        await client.query(sql`
+          UPDATE workspace_sync_sequences
+          SET next_sequence = ${(start + BigInt(missing.length)).toString()}
+          WHERE workspace_id = ${workspaceId}
+        `)
+      }
+
+      return assigned
+    })
+  },
+}

--- a/apps/backend/src/lib/outbox/broadcast-handler.test.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { OutboxRepository } from "./repository"
 import * as cursorLockModule from "@threa/backend-common"
 import { BroadcastHandler } from "./broadcast-handler"
+import { SyncLogRepository } from "../../features/sync"
 import type { ProcessResult } from "@threa/backend-common"
 import type { OutboxEvent } from "./repository"
 
@@ -31,9 +32,22 @@ function createMockIo() {
     }),
   })
 
+  // The handler emits once to the union of rooms (string[]); record one chain
+  // entry per room so assertions stay per-room.
+  const makeRoomsChain = (rooms: string | string[]): MockEmitChain => {
+    const roomList = Array.isArray(rooms) ? rooms : [rooms]
+    return {
+      emit: mock((eventType: string, payload: unknown) => {
+        for (const room of roomList) {
+          emitChains.push({ room, eventType, payload })
+        }
+      }),
+    }
+  }
+
   const namespaceCache = new Map<string, { to: (room: string) => MockEmitChain }>()
   const io = {
-    to: mock((room: string): MockEmitChain => makeRoomChain(room)),
+    to: mock((rooms: string | string[]): MockEmitChain => makeRoomsChain(rooms)),
     of: mock((namespace: string) => {
       let ns = namespaceCache.get(namespace)
       if (!ns) {
@@ -60,6 +74,13 @@ function makeEvent(id: bigint, eventType: string, payload: Record<string, unknow
 }
 
 describe("BroadcastHandler", () => {
+  beforeEach(() => {
+    // The handler sequences each batch into the sync log before emitting;
+    // routing tests don't exercise the DB, so resolve with no assigned sync
+    // ids (payloads pass through unchanged).
+    spyOn(SyncLogRepository, "appendForWorkspace").mockResolvedValue(new Map())
+  })
+
   afterEach(() => {
     mock.restore()
   })
@@ -681,5 +702,85 @@ describe("BroadcastHandler", () => {
       eventType: "label:unassigned",
       payload: event.payload,
     })
+  })
+
+  it("sequences the batch into the sync log per workspace, in outbox order, before emitting", async () => {
+    const event1 = makeEvent(1n, "message:created", { workspaceId: "ws_1", streamId: "stream_1", event: { id: "e1" } })
+    const event2 = makeEvent(2n, "message:created", { workspaceId: "ws_2", streamId: "stream_9", event: { id: "e2" } })
+    const event3 = makeEvent(3n, "stream:activity", { workspaceId: "ws_1", streamId: "stream_1" })
+
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event1, event2, event3])
+    const appendSpy = spyOn(SyncLogRepository, "appendForWorkspace").mockImplementation(
+      async (_pool, _workspaceId, entries) => new Map(entries.map((e, i) => [e.outboxEventId, BigInt(100 + i)]))
+    )
+
+    const { handler, emitChains } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    const callsByWorkspace = new Map(appendSpy.mock.calls.map((call) => [call[1], call[2]]))
+    expect(callsByWorkspace.get("ws_1")).toEqual([
+      { outboxEventId: 1n, eventType: "message:created", groups: ["stream:stream_1"], payload: event1.payload },
+      { outboxEventId: 3n, eventType: "stream:activity", groups: ["stream:stream_1"], payload: event3.payload },
+    ])
+    expect(callsByWorkspace.get("ws_2")).toEqual([
+      { outboxEventId: 2n, eventType: "message:created", groups: ["stream:stream_9"], payload: event2.payload },
+    ])
+
+    // Emitted payloads carry the assigned sync id as a wire string
+    expect(emitChains).toContainEqual({
+      room: "ws:ws_1:stream:stream_1",
+      eventType: "message:created",
+      payload: { ...event1.payload, syncId: "100" },
+    })
+    expect(emitChains).toContainEqual({
+      room: "ws:ws_1:stream:stream_1",
+      eventType: "stream:activity",
+      payload: { ...event3.payload, syncId: "101" },
+    })
+  })
+
+  it("keeps bot-scoped events off the sync log", async () => {
+    const event = makeEvent(1n, "bot_invocation:available", {
+      workspaceId: "ws_1",
+      botId: "bot_1",
+      invocationId: "inv_1",
+    })
+
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
+    const appendSpy = spyOn(SyncLogRepository, "appendForWorkspace").mockResolvedValue(new Map())
+
+    const { handler, emitChains } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(appendSpy.mock.calls).toHaveLength(0)
+    expect(emitChains).toContainEqual({
+      room: "bot:ws_1:bot:bot_1",
+      eventType: "bot_invocation:available",
+      payload: event.payload,
+      namespace: "/bot",
+    })
+  })
+
+  it("returns an error without emitting when sequencing fails, so the batch is retried", async () => {
+    const event = makeEvent(1n, "message:created", { workspaceId: "ws_1", streamId: "stream_1", event: { id: "e1" } })
+
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
+    spyOn(SyncLogRepository, "appendForWorkspace").mockRejectedValue(new Error("sync log unavailable"))
+
+    let result: ProcessResult | undefined
+    mockCursorLock((r) => {
+      result = r
+    })
+
+    const { io, emitChains } = createMockIo()
+    const botNamespace = io.of("/bot")
+    const handler = new BroadcastHandler({} as any, io as any, botNamespace as any)
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(result?.status).toBe("error")
+    expect(emitChains).toHaveLength(0)
   })
 })

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -186,7 +186,9 @@ export class BroadcastHandler implements OutboxHandler {
   }
 
   private broadcastEvent(event: OutboxEvent, routedEvent: RoutedEvent | undefined): void {
-    const groups = routedEvent?.groups ?? resolveDeliveryGroups(event)
+    // Explicit undefined check, not `??`: bot-scoped events carry groups ===
+    // null, which must pass through without re-resolving routing.
+    const groups = routedEvent !== undefined ? routedEvent.groups : resolveDeliveryGroups(event)
 
     // Bot-scoped events ride the `/bot` namespace and use bot/instance/session
     // rooms so siblings on the same bot can stop racing each other (claimed,

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -1,34 +1,17 @@
 import { Server, type Namespace } from "socket.io"
 import type { Pool } from "pg"
-import { LabelableResourceTypes, StreamTypes, Visibilities } from "@threa/types"
 import {
   OutboxRepository,
-  isStreamScopedEvent,
   isOutboxEventType,
-  isOneOfOutboxEventType,
-  isAuthorScopedEvent,
-  isUserScopedEvent,
-  isBotScopedEvent,
   type OutboxEvent,
-  type StreamCreatedOutboxPayload,
-  type StreamMemberAddedOutboxPayload,
-  type ActivityCreatedOutboxPayload,
-  type StreamDisplayNameUpdatedPayload,
-  type AttachmentTranscodedOutboxPayload,
-  type AttachmentThumbnailedOutboxPayload,
-  type MessagesMovedOutboxPayload,
   type BotInvocationAvailableOutboxPayload,
   type BotInvocationClaimedOutboxPayload,
   type BotActiveActorChangedOutboxPayload,
   type BotResyncOutboxPayload,
-  type LabelUpsertedOutboxPayload,
-  type LabelDeletedOutboxPayload,
-  type LabelMemberJoinedOutboxPayload,
-  type LabelMemberLeftOutboxPayload,
-  type LabelAssignedOutboxPayload,
-  type LabelUnassignedOutboxPayload,
 } from "./repository"
+import { resolveDeliveryGroups, groupToRoom } from "./delivery-groups"
 import { logger } from "../logger"
+import { SyncLogRepository, type SyncLogEntryInput } from "../../features/sync"
 import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import type { OutboxHandler } from "@threa/backend-common"
 import { invalidatePointersForEvent } from "../../features/messaging/sharing"
@@ -41,6 +24,12 @@ export interface BroadcastHandlerConfig {
   refreshIntervalMs?: number
   maxRetries?: number
   baseBackoffMs?: number
+}
+
+/** Per-event routing computed once per batch: delivery groups + assigned sync id. */
+interface RoutedEvent {
+  groups: string[] | null
+  syncId?: bigint
 }
 
 const DEFAULT_CONFIG = {
@@ -120,11 +109,23 @@ export class BroadcastHandler implements OutboxHandler {
         return { status: "no_events" }
       }
 
+      // Sequence the whole batch into the sync log BEFORE any emit: the log
+      // entry is the durable record, the socket emit is best-effort delivery.
+      // A failure here retries the batch via the cursor; appendForWorkspace is
+      // idempotent, so retried events keep their already-assigned sync ids.
+      let routed: Map<bigint, RoutedEvent>
+      try {
+        routed = await this.sequenceEvents(events)
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+        return { status: "error", error }
+      }
+
       const seen: bigint[] = []
 
       try {
         for (const event of events) {
-          this.broadcastEvent(event)
+          this.broadcastEvent(event, routed.get(event.id))
           // After the normal per-event emit, fan out any pointer-invalidated
           // hints so clients subscribed to target streams refresh their
           // hydrated pointer content (see features/messaging/sharing, D7).
@@ -145,187 +146,69 @@ export class BroadcastHandler implements OutboxHandler {
     })
   }
 
-  private broadcastEvent(event: OutboxEvent): void {
-    const { workspaceId } = event.payload
+  /**
+   * Resolves every event's delivery groups once and appends client-routed
+   * events to their workspace's sync log, in outbox-visibility order.
+   * Bot-scoped events (groups === null) stay off the log; events with no
+   * resolvable audience (groups === []) are logged by the resolver and
+   * dropped.
+   */
+  private async sequenceEvents(events: OutboxEvent[]): Promise<Map<bigint, RoutedEvent>> {
+    const routed = new Map<bigint, RoutedEvent>()
+    const byWorkspace = new Map<string, SyncLogEntryInput[]>()
+
+    for (const event of events) {
+      const groups = resolveDeliveryGroups(event)
+      routed.set(event.id, { groups })
+      if (groups === null || groups.length === 0) {
+        continue
+      }
+      const { workspaceId } = event.payload
+      let entries = byWorkspace.get(workspaceId)
+      if (!entries) {
+        entries = []
+        byWorkspace.set(workspaceId, entries)
+      }
+      entries.push({ outboxEventId: event.id, eventType: event.eventType, groups, payload: event.payload })
+    }
+
+    for (const [workspaceId, entries] of byWorkspace) {
+      const syncIds = await SyncLogRepository.appendForWorkspace(this.db, workspaceId, entries)
+      for (const [outboxEventId, syncId] of syncIds) {
+        const entry = routed.get(outboxEventId)
+        if (entry) {
+          entry.syncId = syncId
+        }
+      }
+    }
+
+    return routed
+  }
+
+  private broadcastEvent(event: OutboxEvent, routedEvent: RoutedEvent | undefined): void {
+    const groups = routedEvent?.groups ?? resolveDeliveryGroups(event)
 
     // Bot-scoped events ride the `/bot` namespace and use bot/instance/session
     // rooms so siblings on the same bot can stop racing each other (claimed,
     // cancelled) and steered work reaches exactly one instance/session.
-    if (isBotScopedEvent(event)) {
+    if (groups === null) {
       this.dispatchBotEvent(event)
       return
     }
 
-    // User-scoped events: emit to the target user's room
-    if (isUserScopedEvent(event)) {
-      const { targetUserId } = event.payload as ActivityCreatedOutboxPayload
-      this.io.to(`ws:${workspaceId}:user:${targetUserId}`).emit(event.eventType, event.payload)
+    if (groups.length === 0) {
       return
     }
 
-    // Author-scoped events: emit to the author's user room
-    if (isAuthorScopedEvent(event)) {
-      const { authorId } = event.payload as { authorId: string }
-      this.io.to(`ws:${workspaceId}:user:${authorId}`).emit(event.eventType, event.payload)
-      return
-    }
-
-    // Special handling for stream:created - route threads to parent stream room
-    if (isOutboxEventType(event, "stream:created")) {
-      const payload = event.payload as StreamCreatedOutboxPayload
-      if (payload.stream.parentMessageId) {
-        this.io.to(`ws:${workspaceId}:stream:${payload.streamId}`).emit(event.eventType, event.payload)
-      } else if (payload.stream.type === StreamTypes.DM && payload.dmUserIds?.length === 2) {
-        for (const userId of new Set(payload.dmUserIds)) {
-          this.io.to(`ws:${workspaceId}:user:${userId}`).emit(event.eventType, event.payload)
-        }
-      } else if (payload.stream.visibility === Visibilities.PRIVATE) {
-        // Private streams (scratchpads, private channels) — only notify the creator.
-        // Additional members are notified via stream:member_added events.
-        this.io.to(`ws:${workspaceId}:user:${payload.stream.createdBy}`).emit(event.eventType, event.payload)
-      } else {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, event.payload)
-      }
-      return
-    }
-
-    // stream:member_added: emit to stream room (existing members) AND the added
-    // user's room directly — they haven't joined the stream room yet.
-    if (isOutboxEventType(event, "stream:member_added")) {
-      const { streamId, memberId } = event.payload as StreamMemberAddedOutboxPayload
-      this.io.to(`ws:${workspaceId}:stream:${streamId}`).emit(event.eventType, event.payload)
-      this.io.to(`ws:${workspaceId}:user:${memberId}`).emit(event.eventType, event.payload)
-      return
-    }
-
-    // Conversation events broadcast to stream + optionally parent stream for discoverability.
-    // `conversation:message_assigned` rides the same fan-out so thread-message membership
-    // updates reach parent-channel subscribers; `conversation:message_reassigned` has no
-    // parent dimension (it's keyed to the moved message's own stream).
-    if (
-      isOneOfOutboxEventType(event, ["conversation:created", "conversation:updated", "conversation:message_assigned"])
-    ) {
-      const payload = event.payload as { streamId: string; parentStreamId?: string }
-      this.io.to(`ws:${workspaceId}:stream:${payload.streamId}`).emit(event.eventType, event.payload)
-      if (payload.parentStreamId) {
-        this.io.to(`ws:${workspaceId}:stream:${payload.parentStreamId}`).emit(event.eventType, event.payload)
-      }
-      return
-    }
-
-    if (isOutboxEventType(event, "messages:moved")) {
-      const payload = event.payload as MessagesMovedOutboxPayload
-      this.io
-        .to(`ws:${workspaceId}:stream:${payload.sourceStreamId}`)
-        .to(`ws:${workspaceId}:stream:${payload.destinationStreamId}`)
-        .emit(event.eventType, event.payload)
-      return
-    }
-
-    // Display name updates for public streams go to the workspace room so all
-    // workspace users can update their bootstrap cache (e.g. for activity/search
-    // name resolution on streams the user isn't a member of). Private stream names
-    // stay stream-scoped to avoid leaking DM/scratchpad thread names.
-    if (isOutboxEventType(event, "stream:display_name_updated")) {
-      const payload = event.payload as StreamDisplayNameUpdatedPayload
-      if (payload.visibility === "public") {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, event.payload)
-      } else {
-        this.io.to(`ws:${workspaceId}:stream:${payload.streamId}`).emit(event.eventType, event.payload)
-      }
-      return
-    }
-
-    // attachment:transcoded — stream-scoped when attached to a message, workspace-scoped otherwise
-    if (isOutboxEventType(event, "attachment:transcoded")) {
-      const payload = event.payload as AttachmentTranscodedOutboxPayload
-      if (payload.streamId) {
-        this.io.to(`ws:${workspaceId}:stream:${payload.streamId}`).emit(event.eventType, event.payload)
-      } else {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, event.payload)
-      }
-      return
-    }
-
-    // attachment:thumbnailed — same scoping as transcoded
-    if (isOutboxEventType(event, "attachment:thumbnailed")) {
-      const payload = event.payload as AttachmentThumbnailedOutboxPayload
-      if (payload.streamId) {
-        this.io.to(`ws:${workspaceId}:stream:${payload.streamId}`).emit(event.eventType, event.payload)
-      } else {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, event.payload)
-      }
-      return
-    }
-
-    // Labels: `targetUserId` is the routing discriminator. Private-label
-    // events ship to the creator's user room only; public-label events go
-    // workspace-wide. Membership events ship to the affected member only —
-    // memberships are viewer-scoped on the wire (bootstrap/list), so no other
-    // user needs them in Phase 1.
-    if (isOneOfOutboxEventType(event, ["label:created", "label:updated"])) {
-      const payload = event.payload as LabelUpsertedOutboxPayload
-      if (payload.targetUserId) {
-        this.io.to(`ws:${workspaceId}:user:${payload.targetUserId}`).emit(event.eventType, payload)
-      } else {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, payload)
-      }
-      return
-    }
-
-    if (isOutboxEventType(event, "label:deleted")) {
-      const payload = event.payload as LabelDeletedOutboxPayload
-      if (payload.targetUserId) {
-        this.io.to(`ws:${workspaceId}:user:${payload.targetUserId}`).emit(event.eventType, payload)
-      } else {
-        this.io.to(`ws:${workspaceId}`).emit(event.eventType, payload)
-      }
-      return
-    }
-
-    if (isOneOfOutboxEventType(event, ["label:member_joined", "label:member_left"])) {
-      const payload = event.payload as LabelMemberJoinedOutboxPayload | LabelMemberLeftOutboxPayload
-      this.io.to(`ws:${workspaceId}:user:${payload.targetUserId}`).emit(event.eventType, payload)
-      return
-    }
-
-    // Assignment routing follows the label's visibility (carried as
-    // `targetUserId`). Private-label rows are viewer-scoped — deliver to the
-    // creator's room. Public-label rows (`targetUserId === null`) are a shared
-    // pool scoped to the resource: reuse the stream room so a public label on a
-    // private channel reaches exactly its members, identical to a message.
-    if (isOneOfOutboxEventType(event, ["label:assigned", "label:unassigned"])) {
-      const payload = event.payload as LabelAssignedOutboxPayload | LabelUnassignedOutboxPayload
-      if (payload.targetUserId) {
-        this.io.to(`ws:${workspaceId}:user:${payload.targetUserId}`).emit(event.eventType, payload)
-        return
-      }
-      const { resourceType, resourceId } = "assignment" in payload ? payload.assignment : payload
-      if (resourceType === LabelableResourceTypes.STREAM) {
-        this.io.to(`ws:${workspaceId}:stream:${resourceId}`).emit(event.eventType, payload)
-      } else {
-        // Every labelable resource type must map to an access scope (room) here,
-        // or its public assignments would never broadcast and clients go stale.
-        // The `never` assignment enforces that at build time — adding a type
-        // without wiring a room is a compile error, the safe place to fail.
-        // We log rather than throw because this runs in the background outbox
-        // dispatcher: a throw never marks the event processed, so the cursor
-        // stalls and retries it forever, blocking every later event.
-        const unmapped: never = resourceType
-        logger.error(
-          { eventType: event.eventType, resourceType: unmapped, workspaceId, resourceId },
-          "label assignment: no room mapping for public-label resource type"
-        )
-      }
-      return
-    }
-
-    if (isStreamScopedEvent(event)) {
-      const { streamId } = event.payload
-      this.io.to(`ws:${workspaceId}:stream:${streamId}`).emit(event.eventType, event.payload)
-    } else {
-      this.io.to(`ws:${workspaceId}`).emit(event.eventType, event.payload)
-    }
+    // One emit to the union of rooms — Socket.io dedupes sockets present in
+    // several of them, so an event never reaches the same connection twice.
+    // The payload carries the sync id (string, like stream sequences on the
+    // wire) so future clients can keep a sync-log cursor; current clients
+    // ignore it.
+    const { workspaceId } = event.payload
+    const rooms = groups.map((group) => groupToRoom(workspaceId, group))
+    const payload = routedEvent?.syncId ? { ...event.payload, syncId: routedEvent.syncId.toString() } : event.payload
+    this.io.to(rooms).emit(event.eventType, payload)
   }
 
   /**

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -1,0 +1,193 @@
+import { LabelableResourceTypes, StreamTypes, Visibilities } from "@threa/types"
+import {
+  isStreamScopedEvent,
+  isOutboxEventType,
+  isOneOfOutboxEventType,
+  isAuthorScopedEvent,
+  isUserScopedEvent,
+  isBotScopedEvent,
+  type OutboxEvent,
+  type StreamCreatedOutboxPayload,
+  type StreamMemberAddedOutboxPayload,
+  type ActivityCreatedOutboxPayload,
+  type StreamDisplayNameUpdatedPayload,
+  type AttachmentTranscodedOutboxPayload,
+  type AttachmentThumbnailedOutboxPayload,
+  type MessagesMovedOutboxPayload,
+  type LabelUpsertedOutboxPayload,
+  type LabelDeletedOutboxPayload,
+  type LabelMemberJoinedOutboxPayload,
+  type LabelMemberLeftOutboxPayload,
+  type LabelAssignedOutboxPayload,
+  type LabelUnassignedOutboxPayload,
+} from "./repository"
+import { logger } from "../logger"
+
+/**
+ * A delivery group names the audience of a client-routed outbox event,
+ * independent of any one socket connection:
+ *
+ *   "workspace"     — every member of the workspace
+ *   "stream:<id>"   — members of one stream
+ *   "user:<id>"     — one user
+ *
+ * Groups are the single source of truth for routing: the BroadcastHandler
+ * persists them to `sync_log` and derives the Socket.io rooms from them, so
+ * what the log records and what gets emitted can never drift apart.
+ */
+export const WORKSPACE_GROUP = "workspace"
+
+export function streamGroup(streamId: string): string {
+  return `stream:${streamId}`
+}
+
+export function userGroup(userId: string): string {
+  return `user:${userId}`
+}
+
+/**
+ * Socket.io room for a delivery group. Rooms are the group name prefixed with
+ * the workspace scope: `ws:<wsId>`, `ws:<wsId>:stream:<id>`, `ws:<wsId>:user:<id>`.
+ */
+export function groupToRoom(workspaceId: string, group: string): string {
+  return group === WORKSPACE_GROUP ? `ws:${workspaceId}` : `ws:${workspaceId}:${group}`
+}
+
+/**
+ * Resolves a client-routed outbox event to its delivery groups.
+ *
+ * Returns `null` for bot-scoped events — they ride the `/bot` namespace and
+ * stay off the sync log. Returns `[]` when an event has no resolvable
+ * audience (a routing bug, logged here); such events are neither logged nor
+ * emitted.
+ */
+export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
+  if (isBotScopedEvent(event)) {
+    return null
+  }
+
+  // User-scoped events: deliver to the target user only
+  if (isUserScopedEvent(event)) {
+    const { targetUserId } = event.payload as ActivityCreatedOutboxPayload
+    return [userGroup(targetUserId)]
+  }
+
+  // Author-scoped events: deliver to the author only
+  if (isAuthorScopedEvent(event)) {
+    const { authorId } = event.payload as { authorId: string }
+    return [userGroup(authorId)]
+  }
+
+  // stream:created — threads go to the parent stream's audience; DMs to the
+  // two participants; private streams (scratchpads, private channels) to the
+  // creator only (additional members learn via stream:member_added); public
+  // streams to the whole workspace.
+  if (isOutboxEventType(event, "stream:created")) {
+    const payload = event.payload as StreamCreatedOutboxPayload
+    if (payload.stream.parentMessageId) {
+      return [streamGroup(payload.streamId)]
+    }
+    if (payload.stream.type === StreamTypes.DM && payload.dmUserIds?.length === 2) {
+      return [...new Set(payload.dmUserIds)].map(userGroup)
+    }
+    if (payload.stream.visibility === Visibilities.PRIVATE) {
+      return [userGroup(payload.stream.createdBy)]
+    }
+    return [WORKSPACE_GROUP]
+  }
+
+  // stream:member_added — existing members (stream group) AND the added user,
+  // who isn't in the stream group yet.
+  if (isOutboxEventType(event, "stream:member_added")) {
+    const { streamId, memberId } = event.payload as StreamMemberAddedOutboxPayload
+    return [streamGroup(streamId), userGroup(memberId)]
+  }
+
+  // Conversation events reach the stream + optionally its parent for
+  // discoverability. `conversation:message_reassigned` has no parent dimension
+  // and falls through to the generic stream-scoped branch below.
+  if (
+    isOneOfOutboxEventType(event, ["conversation:created", "conversation:updated", "conversation:message_assigned"])
+  ) {
+    const payload = event.payload as { streamId: string; parentStreamId?: string }
+    const groups = [streamGroup(payload.streamId)]
+    if (payload.parentStreamId) {
+      groups.push(streamGroup(payload.parentStreamId))
+    }
+    return groups
+  }
+
+  if (isOutboxEventType(event, "messages:moved")) {
+    const payload = event.payload as MessagesMovedOutboxPayload
+    return [streamGroup(payload.sourceStreamId), streamGroup(payload.destinationStreamId)]
+  }
+
+  // Public stream names go workspace-wide (activity/search name resolution on
+  // streams the user isn't a member of); private names stay stream-scoped to
+  // avoid leaking DM/scratchpad thread names.
+  if (isOutboxEventType(event, "stream:display_name_updated")) {
+    const payload = event.payload as StreamDisplayNameUpdatedPayload
+    return payload.visibility === "public" ? [WORKSPACE_GROUP] : [streamGroup(payload.streamId)]
+  }
+
+  // Attachment lifecycle — stream-scoped when attached to a message,
+  // workspace-scoped otherwise.
+  if (isOutboxEventType(event, "attachment:transcoded")) {
+    const payload = event.payload as AttachmentTranscodedOutboxPayload
+    return payload.streamId ? [streamGroup(payload.streamId)] : [WORKSPACE_GROUP]
+  }
+
+  if (isOutboxEventType(event, "attachment:thumbnailed")) {
+    const payload = event.payload as AttachmentThumbnailedOutboxPayload
+    return payload.streamId ? [streamGroup(payload.streamId)] : [WORKSPACE_GROUP]
+  }
+
+  // Labels: `targetUserId` is the visibility discriminator — private-label
+  // events are viewer-scoped, public-label events go workspace-wide.
+  if (isOneOfOutboxEventType(event, ["label:created", "label:updated"])) {
+    const payload = event.payload as LabelUpsertedOutboxPayload
+    return payload.targetUserId ? [userGroup(payload.targetUserId)] : [WORKSPACE_GROUP]
+  }
+
+  if (isOutboxEventType(event, "label:deleted")) {
+    const payload = event.payload as LabelDeletedOutboxPayload
+    return payload.targetUserId ? [userGroup(payload.targetUserId)] : [WORKSPACE_GROUP]
+  }
+
+  if (isOneOfOutboxEventType(event, ["label:member_joined", "label:member_left"])) {
+    const payload = event.payload as LabelMemberJoinedOutboxPayload | LabelMemberLeftOutboxPayload
+    return [userGroup(payload.targetUserId)]
+  }
+
+  // Assignments follow the label's visibility: private rows to the creator;
+  // public rows scoped to the resource's own audience (a public label on a
+  // private channel reaches exactly its members, identical to a message).
+  if (isOneOfOutboxEventType(event, ["label:assigned", "label:unassigned"])) {
+    const payload = event.payload as LabelAssignedOutboxPayload | LabelUnassignedOutboxPayload
+    if (payload.targetUserId) {
+      return [userGroup(payload.targetUserId)]
+    }
+    const { resourceType, resourceId } = "assignment" in payload ? payload.assignment : payload
+    if (resourceType === LabelableResourceTypes.STREAM) {
+      return [streamGroup(resourceId)]
+    }
+    // Every labelable resource type must map to a delivery group here, or its
+    // public assignments would neither broadcast nor reach the sync log. The
+    // `never` assignment enforces that at build time; we log rather than throw
+    // because this runs in the outbox dispatcher, where a throw stalls the
+    // cursor and blocks every later event.
+    const unmapped: never = resourceType
+    logger.error(
+      { eventType: event.eventType, resourceType: unmapped, resourceId },
+      "delivery groups: no mapping for public-label resource type"
+    )
+    return []
+  }
+
+  if (isStreamScopedEvent(event)) {
+    const { streamId } = event.payload
+    return [streamGroup(streamId)]
+  }
+
+  return [WORKSPACE_GROUP]
+}

--- a/apps/backend/tests/integration/sync-log-repository.test.ts
+++ b/apps/backend/tests/integration/sync-log-repository.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase } from "./setup"
+import { SyncLogRepository, type SyncLogEntryInput } from "../../src/features/sync"
+
+describe("SyncLogRepository", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  // Outbox event ids in the real system come from one global BIGSERIAL; tests
+  // reserve unique ids the same way so parallel test files can't collide on
+  // the sync_log unique index.
+  async function reserveOutboxIds(count: number): Promise<bigint[]> {
+    const result = await pool.query<{ id: string }>(
+      `SELECT nextval('outbox_id_seq') AS id FROM generate_series(1, $1)`,
+      [count]
+    )
+    return result.rows.map((r) => BigInt(r.id))
+  }
+
+  function makeEntry(outboxEventId: bigint, overrides?: Partial<SyncLogEntryInput>): SyncLogEntryInput {
+    return {
+      outboxEventId,
+      eventType: "message:created",
+      groups: ["stream:stream_test"],
+      payload: { workspaceId: "ws_x", event: { id: `evt_${outboxEventId}` } },
+      ...overrides,
+    }
+  }
+
+  function uniqueWorkspaceId(): string {
+    return `ws_test_${crypto.randomUUID().replaceAll("-", "")}`
+  }
+
+  async function fetchLog(workspaceId: string) {
+    const result = await pool.query<{
+      sync_id: string
+      outbox_event_id: string
+      event_type: string
+      groups: string[]
+      payload: unknown
+    }>(
+      `SELECT sync_id, outbox_event_id, event_type, groups, payload FROM sync_log WHERE workspace_id = $1 ORDER BY sync_id`,
+      [workspaceId]
+    )
+    return result.rows
+  }
+
+  test("allocates dense sync ids from 1 in input order and round-trips groups + payload", async () => {
+    const workspaceId = uniqueWorkspaceId()
+    const ids = await reserveOutboxIds(3)
+    const sealedPayload = { workspaceId, sealed: { v: 1, ciphertext: "bRq+aGVsbG8=", nonce: "AAAA" } }
+    const entries = [
+      makeEntry(ids[0]),
+      makeEntry(ids[1], { eventType: "stream:activity", groups: ["stream:stream_a", "stream:stream_b"] }),
+      makeEntry(ids[2], { eventType: "message:created", payload: sealedPayload }),
+    ]
+
+    const assigned = await SyncLogRepository.appendForWorkspace(pool, workspaceId, entries)
+
+    expect([...assigned.entries()]).toEqual([
+      [ids[0], 1n],
+      [ids[1], 2n],
+      [ids[2], 3n],
+    ])
+
+    const rows = await fetchLog(workspaceId)
+    expect(rows).toEqual([
+      expect.objectContaining({
+        sync_id: "1",
+        outbox_event_id: ids[0].toString(),
+        event_type: "message:created",
+        groups: ["stream:stream_test"],
+      }),
+      expect.objectContaining({
+        sync_id: "2",
+        groups: ["stream:stream_a", "stream:stream_b"],
+      }),
+      // E2EE passthrough: sealed payloads land in the log untouched
+      expect.objectContaining({
+        sync_id: "3",
+        payload: sealedPayload,
+      }),
+    ])
+  })
+
+  test("is idempotent: re-appending the same events returns the original sync ids without new rows", async () => {
+    const workspaceId = uniqueWorkspaceId()
+    const ids = await reserveOutboxIds(2)
+    const entries = [makeEntry(ids[0]), makeEntry(ids[1])]
+
+    const first = await SyncLogRepository.appendForWorkspace(pool, workspaceId, entries)
+    const retry = await SyncLogRepository.appendForWorkspace(pool, workspaceId, entries)
+
+    expect(retry).toEqual(first)
+    expect(await fetchLog(workspaceId)).toHaveLength(2)
+  })
+
+  test("a partially-sequenced batch (crash retry) keeps existing ids and extends densely", async () => {
+    const workspaceId = uniqueWorkspaceId()
+    const ids = await reserveOutboxIds(3)
+
+    const first = await SyncLogRepository.appendForWorkspace(pool, workspaceId, [makeEntry(ids[0]), makeEntry(ids[1])])
+    const retry = await SyncLogRepository.appendForWorkspace(pool, workspaceId, [
+      makeEntry(ids[0]),
+      makeEntry(ids[1]),
+      makeEntry(ids[2]),
+    ])
+
+    expect(retry.get(ids[0])).toBe(first.get(ids[0])!)
+    expect(retry.get(ids[1])).toBe(first.get(ids[1])!)
+    expect(retry.get(ids[2])).toBe(3n)
+  })
+
+  test("sequences are independent per workspace", async () => {
+    const workspaceA = uniqueWorkspaceId()
+    const workspaceB = uniqueWorkspaceId()
+    const ids = await reserveOutboxIds(2)
+
+    const a = await SyncLogRepository.appendForWorkspace(pool, workspaceA, [makeEntry(ids[0])])
+    const b = await SyncLogRepository.appendForWorkspace(pool, workspaceB, [makeEntry(ids[1])])
+
+    expect(a.get(ids[0])).toBe(1n)
+    expect(b.get(ids[1])).toBe(1n)
+  })
+
+  test("concurrent appends to one workspace stay dense and gapless", async () => {
+    const workspaceId = uniqueWorkspaceId()
+    const batches = 8
+    const perBatch = 5
+    const ids = await reserveOutboxIds(batches * perBatch)
+
+    const results = await Promise.all(
+      Array.from({ length: batches }, (_, b) =>
+        SyncLogRepository.appendForWorkspace(
+          pool,
+          workspaceId,
+          ids.slice(b * perBatch, (b + 1) * perBatch).map((id) => makeEntry(id))
+        )
+      )
+    )
+
+    const allAssigned = results.flatMap((m) => [...m.values()]).sort((a, b) => (a < b ? -1 : 1))
+    expect(allAssigned).toEqual(Array.from({ length: batches * perBatch }, (_, i) => BigInt(i + 1)))
+
+    const rows = await fetchLog(workspaceId)
+    expect(rows.map((r) => r.sync_id)).toEqual(Array.from({ length: batches * perBatch }, (_, i) => String(i + 1)))
+  })
+})


### PR DESCRIPTION
## Problem

Today a client-routed outbox event exists only for the instant it transits `io.to(room).emit()`. If the emit is dropped — disconnect blip, the "availability > guaranteed delivery" per-event skip in `broadcast-handler-event-loss.md`, a crashed dispatcher — the event is gone permanently; nothing server-side records what a client should have received. This is the root cause behind the recurring "shoddy internet" drift bugs: there is no ordered, durable log a client could ever catch up from.

This is **step 1 of the sync engine v2 plan** (see exploration PR #826, `docs/sync-engine-v2-exploration.md` Part 6). Decision recorded there: sequence at the dispatcher (option b).

## Solution

The `BroadcastHandler` becomes the single-writer sequencer. It already holds an exclusive `CursorLock` and processes outbox events in visibility order — now, before emitting a batch, it appends every client-routed event to a new per-workspace `sync_log` with a dense `sync_id`, then emits with `syncId` attached to the payload.

**Deploy safety:** purely additive. Two new tables, one new write inside the existing dispatcher, one extra field on emitted payloads (clients ignore unknown fields). No domain write path changes, no client changes, no read path yet. Can merge and deploy alone.

### Key design decisions

**1. Delivery groups become the single source of truth for routing.** The routing branches in `broadcastEvent` are extracted into a pure `resolveDeliveryGroups(event)` (`lib/outbox/delivery-groups.ts`) returning `workspace` / `stream:<id>` / `user:<id>` groups. The handler persists those groups to the log and derives the Socket.io rooms from them (`groupToRoom`), so what the log records and what gets emitted cannot drift. Bot-namespace events return `null` and stay off the log.

**2. Lock-first allocation instead of `ON CONFLICT DO NOTHING`.** The exploration doc sketched conflict-absorbing inserts, but a conflict would burn a pre-allocated sync id into a permanent gap. `SyncLogRepository.appendForWorkspace` instead locks the workspace allocator row FIRST (no-op upsert), then reads already-sequenced events on a fresh snapshot, then inserts only the missing ones (INV-20). Idempotent on crash-retry, gapless under concurrency, and a unique-index violation now means a protocol bug and fails loudly (INV-11) instead of being silently absorbed.

**3. Sequence before emit.** The log append happens before any socket emit, so the durable record always precedes best-effort delivery. A sequencing failure returns an error to the cursor lock (batch retried, idempotent); an emit failure after sequencing can no longer lose the event for future catch-up.

**4. One union emit per event.** `io.to(rooms).emit(...)` with the room array replaces per-room emit chains; Socket.io dedupes sockets present in several rooms, so e.g. `stream:member_added` no longer double-delivers to a socket that is in both the stream room and the user room.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260611080000_sync_log.sql` | `sync_log` + `workspace_sync_sequences` (append-only, INV-17; no FKs, INV-1; workspace-scoped, INV-8) |
| `apps/backend/src/lib/outbox/delivery-groups.ts` | Pure delivery-group resolver + group→room mapping |
| `apps/backend/src/features/sync/repository.ts` | `SyncLogRepository.appendForWorkspace` — transactional, idempotent, gapless allocation |
| `apps/backend/src/features/sync/index.ts` | Feature barrel (INV-52) |
| `apps/backend/tests/integration/sync-log-repository.test.ts` | Density, idempotency, crash-retry, per-workspace isolation, concurrency, E2EE passthrough |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/outbox/broadcast-handler.ts` | Routing branches → resolver; sequence batch before emit; `syncId` on payloads |
| `apps/backend/src/lib/outbox/broadcast-handler.test.ts` | Mock io accepts room arrays; 3 new sequencing tests |
| `apps/backend/eslint.config.js` | INV-51 exemption for the handler test (precedent: `message-formatter.test.ts`) |

## Test plan

- [x] 28 unit tests pass (`broadcast-handler.test.ts` — all 25 existing routing tests unchanged in intent, 3 new sequencing tests)
- [x] 5 integration tests pass against real Postgres, incl. dense gapless ids under 8 concurrent appends and sealed-payload round-trip
- [x] Full backend unit suite green (except pre-existing local-env `loadConfig` failures, unrelated)
- [x] Monorepo-wide typecheck + lint green (pre-commit hook)

## Stack

1. **This PR** — the spine: log + sequencer
2. PR 2 (stacked) — catch-up read endpoint `GET /api/workspaces/:id/sync`
3. PR 3 (stacked) — hardening: exact gap classification + reconciliation sweep

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772553&installation_id=129946197&pr_number=830&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F830&signature=8c22b88c5d506bf104653c700539cad63cfa2f34bbfa32585316a6f2046f36c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->