### PR TITLE
feat: sync-log catch-up endpoint (GET /api/workspaces/:workspaceId/sync)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -93,6 +93,13 @@ reviews:
         dedicated client. (INV-30)
         Validate API inputs (body, query, params) with Zod schemas, not manual typeof
         checks. (INV-55)
+        Stream access is inherited through root_stream_id: threads never carry their own
+        access, and public root streams grant read access without a stream_members row.
+        Any new query or filter gating rows on stream membership/visibility must reuse
+        checkStreamAccess / listAccessibleStreamIds (features/streams/access.ts) or
+        replicate the thread-to-root rule. Flag audience/visibility predicates built on
+        direct stream_members rows alone — they drop thread content for root-stream
+        members. (INV-62)
     - path: "apps/frontend/src/**/*.tsx"
       instructions: |
         Do not define React components inside other React components. Extract to separate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ Relational integrity is enforced in application code, not in PostgreSQL schema d
 - Use `UserId` for workspace-scoped identity.
   `MemberId` is reserved for stream membership surfaces (`stream_members` and stream member APIs/events) (INV-50)
 
+Stream access is inherited, never direct (INV-62): a thread carries no access of its own — visibility resolves through `root_stream_id` to the nearest non-thread ancestor, and public root streams grant read access without a `stream_members` row. `checkStreamAccess` and `listAccessibleStreamIds` in `apps/backend/src/features/streams/access.ts` are the canonical predicates. Any query or filter that gates rows on stream membership or visibility (search, feeds, sync catch-up, attachments, notifications) must reuse those helpers or replicate the thread→root rule and pair it with a test for the non-member-thread-inside-a-member-channel case. Filtering by direct `stream_members` rows alone is the recurring footgun: it silently drops thread content for root-stream members (membership ≠ access).
+
 Migrations are append-only (INV-17). Never edit existing migration files.
 
 Write paths must be race-safe:
@@ -262,7 +264,7 @@ When handling variants, colocate variant config and keep shared behavior on one 
 
 ## Quick Invariant Lookup
 
-- **Persistence and data integrity:** INV-1, INV-2, INV-3, INV-8, INV-17, INV-20, INV-30, INV-41, INV-50, INV-56, INV-57
+- **Persistence and data integrity:** INV-1, INV-2, INV-3, INV-8, INV-17, INV-20, INV-30, INV-41, INV-50, INV-56, INV-57, INV-62
 - **Architecture and dependencies:** INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-12, INV-13, INV-27, INV-34, INV-35, INV-37, INV-51, INV-52
 - **API and backend contracts:** INV-31, INV-32, INV-33, INV-46, INV-55, INV-58
 - **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -61,7 +61,7 @@ export async function resolveEffectiveAccessStream<T extends AccessResolvable>(
  * Use this from any feature that needs to gate on stream access. Inlining
  * `StreamMemberRepository.isMember` plus visibility logic is a recurring
  * footgun (membership ≠ access) — route everything through here so the
- * three cases above stay consistent.
+ * three cases above stay consistent (INV-62).
  *
  * Takes a `Querier` so it composes with existing transactions (`withClient`
  * / `withTransaction` blocks) without acquiring an extra connection. The

--- a/apps/backend/src/features/sync/handlers.test.ts
+++ b/apps/backend/src/features/sync/handlers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { Request, Response } from "express"
+import { createSyncHandlers } from "./handlers"
+import { HttpError } from "../../lib/errors"
+import type { SyncService } from "./service"
+
+function makeReqRes(query: Record<string, string>) {
+  const req = {
+    user: { id: "usr_alice" },
+    workspaceId: "ws_1",
+    query,
+  } as unknown as Request
+  const json = mock((_body: unknown) => {})
+  const res = { json } as unknown as Response
+  return { req, res, json }
+}
+
+describe("createSyncHandlers.catchUp", () => {
+  it("returns entries and head as wire strings", async () => {
+    const catchUp = mock(async (_params: Parameters<SyncService["catchUp"]>[0]) => ({
+      entries: [
+        {
+          syncId: 7n,
+          eventType: "message:created",
+          payload: { workspaceId: "ws_1" },
+          createdAt: new Date("2026-06-11T08:00:00Z"),
+        },
+      ],
+      head: 9n,
+    }))
+    const handlers = createSyncHandlers({ syncService: { catchUp } as unknown as SyncService })
+
+    const { req, res, json } = makeReqRes({ after: "5", limit: "50" })
+    await handlers.catchUp(req, res)
+
+    expect(catchUp.mock.calls[0][0]).toEqual({ workspaceId: "ws_1", userId: "usr_alice", after: 5n, limit: 50 })
+    expect(json.mock.calls[0][0]).toEqual({
+      entries: [
+        {
+          syncId: "7",
+          eventType: "message:created",
+          payload: { workspaceId: "ws_1" },
+          createdAt: "2026-06-11T08:00:00.000Z",
+        },
+      ],
+      head: "9",
+    })
+  })
+
+  it("defaults after to 0 and limit to 200", async () => {
+    const catchUp = mock(async (_params: Parameters<SyncService["catchUp"]>[0]) => ({ entries: [], head: 0n }))
+    const handlers = createSyncHandlers({ syncService: { catchUp } as unknown as SyncService })
+
+    const { req, res } = makeReqRes({})
+    await handlers.catchUp(req, res)
+
+    expect(catchUp.mock.calls[0][0]).toEqual({ workspaceId: "ws_1", userId: "usr_alice", after: 0n, limit: 200 })
+  })
+
+  it("rejects a non-numeric cursor with a 400", async () => {
+    const catchUp = mock(async (_params: Parameters<SyncService["catchUp"]>[0]) => ({ entries: [], head: 0n }))
+    const handlers = createSyncHandlers({ syncService: { catchUp } as unknown as SyncService })
+
+    const { req, res } = makeReqRes({ after: "abc" })
+    await expect(handlers.catchUp(req, res)).rejects.toThrow(HttpError)
+    expect(catchUp.mock.calls).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/features/sync/handlers.ts
+++ b/apps/backend/src/features/sync/handlers.ts
@@ -1,0 +1,44 @@
+import type { Request, Response } from "express"
+import { z } from "zod"
+import { HttpError } from "../../lib/errors"
+import type { SyncService } from "./service"
+
+const catchUpQuerySchema = z.object({
+  after: z.string().regex(/^\d+$/, "after must be a non-negative integer sync id").default("0"),
+  limit: z.coerce.number().int().min(1).max(500).default(200),
+})
+
+interface Dependencies {
+  syncService: SyncService
+}
+
+export function createSyncHandlers({ syncService }: Dependencies) {
+  return {
+    async catchUp(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const parsed = catchUpQuerySchema.safeParse(req.query)
+      if (!parsed.success) {
+        throw new HttpError("Invalid sync catch-up query", { status: 400, code: "VALIDATION_ERROR" })
+      }
+
+      const { entries, head } = await syncService.catchUp({
+        workspaceId,
+        userId,
+        after: BigInt(parsed.data.after),
+        limit: parsed.data.limit,
+      })
+
+      res.json({
+        entries: entries.map((entry) => ({
+          syncId: entry.syncId.toString(),
+          eventType: entry.eventType,
+          payload: entry.payload,
+          createdAt: entry.createdAt.toISOString(),
+        })),
+        head: head.toString(),
+      })
+    },
+  }
+}

--- a/apps/backend/src/features/sync/index.ts
+++ b/apps/backend/src/features/sync/index.ts
@@ -1,1 +1,3 @@
-export { SyncLogRepository, type SyncLogEntryInput } from "./repository"
+export { SyncLogRepository, type SyncLogEntryInput, type SyncLogEntry } from "./repository"
+export { SyncService, type CatchUpResult } from "./service"
+export { createSyncHandlers } from "./handlers"

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -120,15 +120,24 @@ export const SyncLogRepository = {
   /**
    * Lists log entries after a cursor, filtered to what the requesting user is
    * allowed to see: workspace-group entries, their own user-group entries, and
-   * stream-group entries for streams they are currently a member of.
+   * stream-group entries for streams they can read.
    *
-   * Each stream group is additionally bounded below by the user's join
-   * position — the sync id of their latest `stream:member_added` entry — so
-   * joining a stream never replays its pre-join history through the log
-   * (over-delivery would leak no-history private streams). Memberships with no
-   * member_added entry predate the log itself, so every log entry postdates
-   * the join and no bound is needed. The member_added entry itself reaches the
-   * joiner through their user group.
+   * A stream is readable when the user is a member of it OR a member of its
+   * root stream — threads never carry their own access; `checkStreamAccess`
+   * resolves a thread's visibility entirely through `root_stream_id`, so a
+   * channel member must receive thread events (previews, replies by others)
+   * for threads they haven't participated in. The log filter mirrors that
+   * exact rule to keep catch-up delivery congruent with live delivery.
+   *
+   * Each visibility grant is bounded below by its membership's join position —
+   * the sync id of the user's latest `stream:member_added` entry for the
+   * member stream (threads inherit the ROOT membership's bound) — so joining a
+   * stream never replays its pre-join history through the log (over-delivery
+   * would leak no-history private streams). Memberships with no member_added
+   * entry predate the log itself, so every log entry postdates the join and no
+   * bound is needed. The member_added entry itself reaches the joiner through
+   * their user group. When several grants cover one stream (direct thread
+   * member AND root member), any grant whose bound passes admits the entry.
    */
   async listEntriesForUser(
     db: Querier,
@@ -136,16 +145,27 @@ export const SyncLogRepository = {
   ): Promise<SyncLogEntry[]> {
     const { workspaceId, userId, after, limit } = params
     const result = await db.query<SyncLogEntryRow>(sql`
-      WITH member_streams AS (
-        SELECT stream_id FROM stream_members WHERE member_id = ${userId}
-      ),
-      join_bounds AS (
+      WITH join_bounds AS (
         SELECT DISTINCT ON (payload->>'streamId') payload->>'streamId' AS stream_id, sync_id AS join_sync_id
         FROM sync_log
         WHERE workspace_id = ${workspaceId}
           AND event_type = 'stream:member_added'
           AND groups @> ARRAY['user:' || ${userId}]
         ORDER BY payload->>'streamId', sync_id DESC
+      ),
+      memberships AS (
+        SELECT sm.stream_id, COALESCE(jb.join_sync_id, 0) AS bound
+        FROM stream_members sm
+        LEFT JOIN join_bounds jb ON jb.stream_id = sm.stream_id
+        WHERE sm.member_id = ${userId}
+      ),
+      visible_streams AS (
+        SELECT stream_id, bound FROM memberships
+        UNION ALL
+        SELECT s.id, m.bound
+        FROM streams s
+        JOIN memberships m ON m.stream_id = s.root_stream_id
+        WHERE s.workspace_id = ${workspaceId}
       )
       SELECT l.sync_id, l.event_type, l.payload, l.created_at
       FROM sync_log l
@@ -155,10 +175,9 @@ export const SyncLogRepository = {
           l.groups && ARRAY['workspace', 'user:' || ${userId}]
           OR EXISTS (
             SELECT 1
-            FROM member_streams ms
-            LEFT JOIN join_bounds jb ON jb.stream_id = ms.stream_id
-            WHERE l.groups @> ARRAY['stream:' || ms.stream_id]
-              AND l.sync_id > COALESCE(jb.join_sync_id, 0)
+            FROM visible_streams vs
+            WHERE l.groups @> ARRAY['stream:' || vs.stream_id]
+              AND l.sync_id > vs.bound
           )
         )
       ORDER BY l.sync_id

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -123,11 +123,12 @@ export const SyncLogRepository = {
    * stream-group entries for streams they can read.
    *
    * A stream is readable when the user is a member of it OR a member of its
-   * root stream — threads never carry their own access; `checkStreamAccess`
-   * resolves a thread's visibility entirely through `root_stream_id`, so a
-   * channel member must receive thread events (previews, replies by others)
-   * for threads they haven't participated in. The log filter mirrors that
-   * exact rule to keep catch-up delivery congruent with live delivery.
+   * root stream (INV-62) — threads never carry their own access;
+   * `checkStreamAccess` resolves a thread's visibility entirely through
+   * `root_stream_id`, so a channel member must receive thread events
+   * (previews, replies by others) for threads they haven't participated in.
+   * The log filter mirrors that exact rule to keep catch-up delivery
+   * congruent with live delivery.
    *
    * Each visibility grant is bounded below by its membership's join position —
    * the sync id of the user's latest `stream:member_added` entry for the

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -1,5 +1,5 @@
 import type { Pool } from "pg"
-import { sql, withTransaction } from "../../db"
+import { sql, withTransaction, type Querier } from "../../db"
 
 /** One client-routed outbox event headed for the sync log. */
 export interface SyncLogEntryInput {
@@ -7,6 +7,30 @@ export interface SyncLogEntryInput {
   eventType: string
   groups: string[]
   payload: unknown
+}
+
+/** A sync-log entry as returned by catch-up reads. */
+export interface SyncLogEntry {
+  syncId: bigint
+  eventType: string
+  payload: unknown
+  createdAt: Date
+}
+
+interface SyncLogEntryRow {
+  sync_id: string
+  event_type: string
+  payload: unknown
+  created_at: Date
+}
+
+function mapRowToEntry(row: SyncLogEntryRow): SyncLogEntry {
+  return {
+    syncId: BigInt(row.sync_id),
+    eventType: row.event_type,
+    payload: row.payload,
+    createdAt: row.created_at,
+  }
 }
 
 export const SyncLogRepository = {
@@ -91,5 +115,63 @@ export const SyncLogRepository = {
 
       return assigned
     })
+  },
+
+  /**
+   * Lists log entries after a cursor, filtered to what the requesting user is
+   * allowed to see: workspace-group entries, their own user-group entries, and
+   * stream-group entries for streams they are currently a member of.
+   *
+   * Each stream group is additionally bounded below by the user's join
+   * position — the sync id of their latest `stream:member_added` entry — so
+   * joining a stream never replays its pre-join history through the log
+   * (over-delivery would leak no-history private streams). Memberships with no
+   * member_added entry predate the log itself, so every log entry postdates
+   * the join and no bound is needed. The member_added entry itself reaches the
+   * joiner through their user group.
+   */
+  async listEntriesForUser(
+    db: Querier,
+    params: { workspaceId: string; userId: string; after: bigint; limit: number }
+  ): Promise<SyncLogEntry[]> {
+    const { workspaceId, userId, after, limit } = params
+    const result = await db.query<SyncLogEntryRow>(sql`
+      WITH member_streams AS (
+        SELECT stream_id FROM stream_members WHERE member_id = ${userId}
+      ),
+      join_bounds AS (
+        SELECT DISTINCT ON (payload->>'streamId') payload->>'streamId' AS stream_id, sync_id AS join_sync_id
+        FROM sync_log
+        WHERE workspace_id = ${workspaceId}
+          AND event_type = 'stream:member_added'
+          AND groups @> ARRAY['user:' || ${userId}]
+        ORDER BY payload->>'streamId', sync_id DESC
+      )
+      SELECT l.sync_id, l.event_type, l.payload, l.created_at
+      FROM sync_log l
+      WHERE l.workspace_id = ${workspaceId}
+        AND l.sync_id > ${after.toString()}
+        AND (
+          l.groups && ARRAY['workspace', 'user:' || ${userId}]
+          OR EXISTS (
+            SELECT 1
+            FROM member_streams ms
+            LEFT JOIN join_bounds jb ON jb.stream_id = ms.stream_id
+            WHERE l.groups @> ARRAY['stream:' || ms.stream_id]
+              AND l.sync_id > COALESCE(jb.join_sync_id, 0)
+          )
+        )
+      ORDER BY l.sync_id
+      LIMIT ${limit}
+    `)
+    return result.rows.map(mapRowToEntry)
+  },
+
+  /** Max visible sync id for a workspace (0 when the log is empty). */
+  async getHead(db: Querier, workspaceId: string): Promise<bigint> {
+    const result = await db.query<{ head: string }>(sql`
+      SELECT COALESCE(MAX(sync_id), 0) AS head FROM sync_log WHERE workspace_id = ${workspaceId}
+    `)
+    return BigInt(result.rows[0].head)
   },
 }

--- a/apps/backend/src/features/sync/service.ts
+++ b/apps/backend/src/features/sync/service.ts
@@ -1,0 +1,32 @@
+import type { Pool } from "pg"
+import { withClient } from "../../db"
+import { SyncLogRepository, type SyncLogEntry } from "./repository"
+
+export interface CatchUpResult {
+  entries: SyncLogEntry[]
+  head: bigint
+}
+
+export class SyncService {
+  private readonly pool: Pool
+
+  constructor(deps: { pool: Pool }) {
+    this.pool = deps.pool
+  }
+
+  /**
+   * Returns log entries after the client's cursor plus the workspace head.
+   *
+   * `head` is read AFTER the entries query, so it is always ≥ the last
+   * returned entry. Clients advance their cursor only by applied entries
+   * (never by jumping to `head`) and page until a fetch comes back empty —
+   * `head` is a freshness hint, not a cursor target.
+   */
+  async catchUp(params: { workspaceId: string; userId: string; after: bigint; limit: number }): Promise<CatchUpResult> {
+    return withClient(this.pool, async (client) => {
+      const entries = await SyncLogRepository.listEntriesForUser(client, params)
+      const head = await SyncLogRepository.getHead(client, params.workspaceId)
+      return { entries, head }
+    })
+  }
+}

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -30,6 +30,7 @@ import type { AICostServiceLike } from "./features/ai-usage"
 import type { AI } from "@threa/agent-runtime"
 import { createInvitationHandlers } from "./features/invitations"
 import { createActivityHandlers } from "./features/activity"
+import { createSyncHandlers } from "./features/sync"
 import { createSavedMessagesHandlers } from "./features/saved-messages"
 import { createScheduledMessagesHandlers } from "./features/scheduled-messages"
 import { createLabelHandlers } from "./features/labels"
@@ -68,6 +69,7 @@ import type { MemoExplorerService } from "./features/memos"
 import type { ConversationService } from "./features/conversations"
 import type { InvitationService } from "./features/invitations"
 import type { ActivityService } from "./features/activity"
+import type { SyncService } from "./features/sync"
 import type { SavedMessagesService } from "./features/saved-messages"
 import type { ScheduledMessagesService } from "./features/scheduled-messages"
 import type { LabelService, LabelAssignmentService } from "./features/labels"
@@ -108,6 +110,7 @@ interface Dependencies {
   userE2eKeysService: UserE2eKeysService
   invitationService: InvitationService
   activityService: ActivityService
+  syncService: SyncService
   savedMessagesService: SavedMessagesService
   scheduledMessagesService: ScheduledMessagesService
   labelService: LabelService
@@ -158,6 +161,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     userE2eKeysService,
     invitationService,
     activityService,
+    syncService,
     savedMessagesService,
     scheduledMessagesService,
     labelService,
@@ -247,6 +251,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const debug = createDebugHandlers({ pool, poolMonitor })
   const invitation = createInvitationHandlers({ invitationService })
   const activity = createActivityHandlers({ activityService })
+  const sync = createSyncHandlers({ syncService })
   const savedMessages = createSavedMessagesHandlers({ savedMessagesService })
   const scheduledMessages = createScheduledMessagesHandlers({ scheduledMessagesService })
   const label = createLabelHandlers({ labelService, labelAssignmentService })
@@ -504,6 +509,10 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   )
 
   // Activity feed
+  // Sync-log catch-up (sync engine v2 step 1): ordered entries after a cursor,
+  // ACL-filtered to the requester's delivery groups.
+  app.get("/api/workspaces/:workspaceId/sync", ...authed, sync.catchUp)
+
   app.get("/api/workspaces/:workspaceId/activity", ...authed, activity.list)
   app.post("/api/workspaces/:workspaceId/activity/read", ...authed, activity.markAllAsRead)
   app.post("/api/workspaces/:workspaceId/activity/:id/read", ...authed, activity.markOneAsRead)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -108,6 +108,7 @@ import {
 import { EmojiUsageHandler } from "./features/emoji"
 import { SystemMessageService, SystemMessageOutboxHandler } from "./features/system-messages"
 import { ActivityService, ActivityFeedHandler } from "./features/activity"
+import { SyncService } from "./features/sync"
 import { BotInvocationOutboxHandler } from "./features/bot-runtimes/invocation-outbox-handler"
 import {
   BotRuntimeInstanceRepository,
@@ -479,6 +480,7 @@ export async function startServer(): Promise<ServerInstance> {
   const createThread = (params: Parameters<typeof streamService.createThread>[0]) => streamService.createThread(params)
 
   const activityService = new ActivityService({ pool })
+  const syncService = new SyncService({ pool })
   const savedMessagesService = new SavedMessagesService({ pool })
   const scheduledMessagesService = new ScheduledMessagesService({ pool, eventService })
   const labelService = new LabelService({ pool })
@@ -615,6 +617,7 @@ export async function startServer(): Promise<ServerInstance> {
     userE2eKeysService,
     invitationService,
     activityService,
+    syncService,
     savedMessagesService,
     scheduledMessagesService,
     labelService,

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -95,7 +95,8 @@ describe("SyncLogRepository catch-up reads", () => {
     const joiner = uniqueId("usr")
     const streamId = uniqueId("stream")
 
-    const preJoin = await appendEntry(workspaceId, {
+    // Pre-join history: appended before the join, must never surface.
+    await appendEntry(workspaceId, {
       eventType: "message:created",
       groups: [`stream:${streamId}`],
       payload: { workspaceId, kind: "pre-join" },
@@ -113,11 +114,10 @@ describe("SyncLogRepository catch-up reads", () => {
     })
 
     const entries = await listFor(workspaceId, joiner)
-    const syncIds = entries.map((e) => e.syncId)
-    // The join entry itself arrives via the user group; pre-join stream
-    // history stays out of the log path (windowed snapshots cover it).
-    expect(syncIds).toEqual([joinEntry, postJoin])
-    expect(syncIds).not.toContain(preJoin)
+    // Exactly the join entry (via the user group) and post-join content —
+    // the exact-array compare proves the pre-join entry stays hidden
+    // (windowed snapshots cover that history instead).
+    expect(entries.map((e) => e.syncId)).toEqual([joinEntry, postJoin])
   })
 
   test("a membership predating the log (no member_added entry) is unbounded", async () => {
@@ -188,7 +188,8 @@ describe("SyncLogRepository catch-up reads", () => {
     const thread = uniqueId("stream")
     await addThread(workspaceId, thread, channel, channel)
 
-    const preJoinThreadMessage = await appendEntry(workspaceId, {
+    // Thread content from before the channel join, must never surface.
+    await appendEntry(workspaceId, {
       eventType: "message:created",
       groups: [`stream:${thread}`],
       payload: { workspaceId, kind: "thread-pre-join" },
@@ -207,7 +208,6 @@ describe("SyncLogRepository catch-up reads", () => {
 
     const syncIds = (await listFor(workspaceId, joiner)).map((e) => e.syncId)
     expect(syncIds).toEqual([joinEntry, postJoinThreadMessage])
-    expect(syncIds).not.toContain(preJoinThreadMessage)
   })
 
   test("a rejoin moves the bound forward — entries from the left period stay hidden", async () => {
@@ -215,12 +215,13 @@ describe("SyncLogRepository catch-up reads", () => {
     const userId = uniqueId("usr")
     const streamId = uniqueId("stream")
 
-    await appendEntry(workspaceId, {
+    const firstJoin = await appendEntry(workspaceId, {
       eventType: "stream:member_added",
       groups: [`stream:${streamId}`, `user:${userId}`],
       payload: { workspaceId, streamId, memberId: userId },
     })
-    const whileGone = await appendEntry(workspaceId, {
+    // Posted while the user was gone — hidden behind the rejoin bound.
+    await appendEntry(workspaceId, {
       eventType: "message:created",
       groups: [`stream:${streamId}`],
       payload: { workspaceId, kind: "while-gone" },
@@ -237,10 +238,10 @@ describe("SyncLogRepository catch-up reads", () => {
       payload: { workspaceId, kind: "after-rejoin" },
     })
 
+    // Both member_added entries reach the user via their user group (which
+    // the join bound never gates); the while-gone stream entry stays hidden.
     const syncIds = (await listFor(workspaceId, userId)).map((e) => e.syncId)
-    expect(syncIds).not.toContain(whileGone)
-    expect(syncIds).toContain(rejoin)
-    expect(syncIds).toContain(afterRejoin)
+    expect(syncIds).toEqual([firstJoin, rejoin, afterRejoin])
   })
 
   test("pages by cursor and respects the limit", async () => {

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -33,6 +33,15 @@ describe("SyncLogRepository catch-up reads", () => {
     )
   }
 
+  /** Inserts a thread stream whose visibility inherits from `rootStreamId`. */
+  async function addThread(workspaceId: string, threadId: string, rootStreamId: string, parentStreamId: string) {
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, parent_stream_id, root_stream_id, created_by)
+       VALUES ($1, $2, 'thread', 'private', $3, $4, $5)`,
+      [threadId, workspaceId, parentStreamId, rootStreamId, uniqueId("usr")]
+    )
+  }
+
   /** Appends one entry and returns its sync id. */
   async function appendEntry(workspaceId: string, entry: Omit<SyncLogEntryInput, "outboxEventId">): Promise<bigint> {
     const [outboxEventId] = await reserveOutboxIds(1)
@@ -125,6 +134,78 @@ describe("SyncLogRepository catch-up reads", () => {
 
     const entries = await listFor(workspaceId, veteran)
     expect(entries.map((e) => e.syncId)).toEqual([entry])
+  })
+
+  test("thread entries are visible to root-stream members who never joined the thread", async () => {
+    const workspaceId = uniqueId("ws")
+    const me = uniqueId("usr")
+    const outsider = uniqueId("usr")
+    const channel = uniqueId("stream")
+    const thread = uniqueId("stream")
+    await addMembership(channel, me)
+    await addThread(workspaceId, thread, channel, channel)
+
+    const threadMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${thread}`],
+      payload: { workspaceId, kind: "pierres-thread-reply" },
+    })
+
+    // Member of the root channel: sees the thread's content without being a
+    // thread member (access inherits from the root, mirroring checkStreamAccess).
+    const mine = await listFor(workspaceId, me)
+    expect(mine.map((e) => e.syncId)).toEqual([threadMessage])
+
+    // Not a member of the root: sees nothing.
+    expect(await listFor(workspaceId, outsider)).toEqual([])
+  })
+
+  test("a depth-2 thread inherits visibility from the root, not the immediate parent", async () => {
+    const workspaceId = uniqueId("ws")
+    const me = uniqueId("usr")
+    const channel = uniqueId("stream")
+    const thread = uniqueId("stream")
+    const subThread = uniqueId("stream")
+    await addMembership(channel, me)
+    await addThread(workspaceId, thread, channel, channel)
+    await addThread(workspaceId, subThread, channel, thread)
+
+    const deepMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${subThread}`],
+      payload: { workspaceId, kind: "thread-of-thread" },
+    })
+
+    expect((await listFor(workspaceId, me)).map((e) => e.syncId)).toEqual([deepMessage])
+  })
+
+  test("inherited thread visibility is bounded by the root membership's join position", async () => {
+    const workspaceId = uniqueId("ws")
+    const joiner = uniqueId("usr")
+    const channel = uniqueId("stream")
+    const thread = uniqueId("stream")
+    await addThread(workspaceId, thread, channel, channel)
+
+    const preJoinThreadMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${thread}`],
+      payload: { workspaceId, kind: "thread-pre-join" },
+    })
+    const joinEntry = await appendEntry(workspaceId, {
+      eventType: "stream:member_added",
+      groups: [`stream:${channel}`, `user:${joiner}`],
+      payload: { workspaceId, streamId: channel, memberId: joiner },
+    })
+    await addMembership(channel, joiner)
+    const postJoinThreadMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${thread}`],
+      payload: { workspaceId, kind: "thread-post-join" },
+    })
+
+    const syncIds = (await listFor(workspaceId, joiner)).map((e) => e.syncId)
+    expect(syncIds).toEqual([joinEntry, postJoinThreadMessage])
+    expect(syncIds).not.toContain(preJoinThreadMessage)
   })
 
   test("a rejoin moves the bound forward — entries from the left period stay hidden", async () => {

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase } from "./setup"
+import { SyncLogRepository, type SyncLogEntryInput } from "../../src/features/sync"
+
+describe("SyncLogRepository catch-up reads", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function reserveOutboxIds(count: number): Promise<bigint[]> {
+    const result = await pool.query<{ id: string }>(
+      `SELECT nextval('outbox_id_seq') AS id FROM generate_series(1, $1)`,
+      [count]
+    )
+    return result.rows.map((r) => BigInt(r.id))
+  }
+
+  function uniqueId(prefix: string): string {
+    return `${prefix}_${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`
+  }
+
+  async function addMembership(streamId: string, userId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO stream_members (stream_id, member_id) VALUES ($1, $2) ON CONFLICT (stream_id, member_id) DO NOTHING`,
+      [streamId, userId]
+    )
+  }
+
+  /** Appends one entry and returns its sync id. */
+  async function appendEntry(workspaceId: string, entry: Omit<SyncLogEntryInput, "outboxEventId">): Promise<bigint> {
+    const [outboxEventId] = await reserveOutboxIds(1)
+    const assigned = await SyncLogRepository.appendForWorkspace(pool, workspaceId, [{ ...entry, outboxEventId }])
+    return assigned.get(outboxEventId)!
+  }
+
+  function listFor(workspaceId: string, userId: string, after = 0n, limit = 100) {
+    return SyncLogRepository.listEntriesForUser(pool, { workspaceId, userId, after, limit })
+  }
+
+  test("filters entries to the requester's groups: workspace, own user, member streams", async () => {
+    const workspaceId = uniqueId("ws")
+    const alice = uniqueId("usr")
+    const bob = uniqueId("usr")
+    const aliceStream = uniqueId("stream")
+    const bobStream = uniqueId("stream")
+    await addMembership(aliceStream, alice)
+    await addMembership(bobStream, bob)
+
+    const workspaceWide = await appendEntry(workspaceId, {
+      eventType: "stream:created",
+      groups: ["workspace"],
+      payload: { workspaceId, kind: "workspace-wide" },
+    })
+    const aliceOnly = await appendEntry(workspaceId, {
+      eventType: "activity:created",
+      groups: [`user:${alice}`],
+      payload: { workspaceId, kind: "alice-only" },
+    })
+    const aliceStreamEntry = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${aliceStream}`],
+      payload: { workspaceId, kind: "alice-stream" },
+    })
+    const bobStreamEntry = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${bobStream}`],
+      payload: { workspaceId, kind: "bob-stream" },
+    })
+
+    const aliceEntries = await listFor(workspaceId, alice)
+    expect(aliceEntries.map((e) => e.syncId)).toEqual([workspaceWide, aliceOnly, aliceStreamEntry])
+
+    const bobEntries = await listFor(workspaceId, bob)
+    expect(bobEntries.map((e) => e.syncId)).toEqual([workspaceWide, bobStreamEntry])
+  })
+
+  test("bounds stream groups by the member_added join position — no pre-join history", async () => {
+    const workspaceId = uniqueId("ws")
+    const joiner = uniqueId("usr")
+    const streamId = uniqueId("stream")
+
+    const preJoin = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${streamId}`],
+      payload: { workspaceId, kind: "pre-join" },
+    })
+    const joinEntry = await appendEntry(workspaceId, {
+      eventType: "stream:member_added",
+      groups: [`stream:${streamId}`, `user:${joiner}`],
+      payload: { workspaceId, streamId, memberId: joiner },
+    })
+    await addMembership(streamId, joiner)
+    const postJoin = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${streamId}`],
+      payload: { workspaceId, kind: "post-join" },
+    })
+
+    const entries = await listFor(workspaceId, joiner)
+    const syncIds = entries.map((e) => e.syncId)
+    // The join entry itself arrives via the user group; pre-join stream
+    // history stays out of the log path (windowed snapshots cover it).
+    expect(syncIds).toEqual([joinEntry, postJoin])
+    expect(syncIds).not.toContain(preJoin)
+  })
+
+  test("a membership predating the log (no member_added entry) is unbounded", async () => {
+    const workspaceId = uniqueId("ws")
+    const veteran = uniqueId("usr")
+    const streamId = uniqueId("stream")
+    await addMembership(streamId, veteran)
+
+    const entry = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${streamId}`],
+      payload: { workspaceId, kind: "any" },
+    })
+
+    const entries = await listFor(workspaceId, veteran)
+    expect(entries.map((e) => e.syncId)).toEqual([entry])
+  })
+
+  test("a rejoin moves the bound forward — entries from the left period stay hidden", async () => {
+    const workspaceId = uniqueId("ws")
+    const userId = uniqueId("usr")
+    const streamId = uniqueId("stream")
+
+    await appendEntry(workspaceId, {
+      eventType: "stream:member_added",
+      groups: [`stream:${streamId}`, `user:${userId}`],
+      payload: { workspaceId, streamId, memberId: userId },
+    })
+    const whileGone = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${streamId}`],
+      payload: { workspaceId, kind: "while-gone" },
+    })
+    const rejoin = await appendEntry(workspaceId, {
+      eventType: "stream:member_added",
+      groups: [`stream:${streamId}`, `user:${userId}`],
+      payload: { workspaceId, streamId, memberId: userId },
+    })
+    await addMembership(streamId, userId)
+    const afterRejoin = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${streamId}`],
+      payload: { workspaceId, kind: "after-rejoin" },
+    })
+
+    const syncIds = (await listFor(workspaceId, userId)).map((e) => e.syncId)
+    expect(syncIds).not.toContain(whileGone)
+    expect(syncIds).toContain(rejoin)
+    expect(syncIds).toContain(afterRejoin)
+  })
+
+  test("pages by cursor and respects the limit", async () => {
+    const workspaceId = uniqueId("ws")
+    const userId = uniqueId("usr")
+
+    const ids: bigint[] = []
+    for (let i = 0; i < 5; i++) {
+      ids.push(
+        await appendEntry(workspaceId, {
+          eventType: "stream:created",
+          groups: ["workspace"],
+          payload: { workspaceId, i },
+        })
+      )
+    }
+
+    const firstPage = await listFor(workspaceId, userId, 0n, 2)
+    expect(firstPage.map((e) => e.syncId)).toEqual(ids.slice(0, 2))
+
+    const secondPage = await listFor(workspaceId, userId, firstPage[1].syncId, 2)
+    expect(secondPage.map((e) => e.syncId)).toEqual(ids.slice(2, 4))
+  })
+
+  test("head is the workspace's max sync id, 0 for an empty log", async () => {
+    const workspaceId = uniqueId("ws")
+    expect(await SyncLogRepository.getHead(pool, workspaceId)).toBe(0n)
+
+    const last = await appendEntry(workspaceId, {
+      eventType: "stream:created",
+      groups: ["workspace"],
+      payload: { workspaceId },
+    })
+    expect(await SyncLogRepository.getHead(pool, workspaceId)).toBe(last)
+  })
+
+  test("entries are isolated per workspace", async () => {
+    const workspaceA = uniqueId("ws")
+    const workspaceB = uniqueId("ws")
+    const userId = uniqueId("usr")
+
+    await appendEntry(workspaceA, {
+      eventType: "stream:created",
+      groups: ["workspace"],
+      payload: { workspaceId: workspaceA },
+    })
+
+    expect(await listFor(workspaceB, userId)).toEqual([])
+  })
+})

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -136,6 +136,8 @@ describe("SyncLogRepository catch-up reads", () => {
     expect(entries.map((e) => e.syncId)).toEqual([entry])
   })
 
+  // INV-62: threads inherit access from their root stream; a membership-only
+  // filter would silently drop thread content for root-stream members.
   test("thread entries are visible to root-stream members who never joined the thread", async () => {
     const workspaceId = uniqueId("ws")
     const me = uniqueId("usr")


### PR DESCRIPTION
## Problem

PR #830 makes the dispatcher persist every client-routed event into a per-workspace `sync_log`, but nothing can read it back. The log only becomes a recovery path once a client (or service worker) can ask "give me everything after my cursor that I am allowed to see".

Step 1 of the sync engine v2 plan, part 2 of the stack (see exploration PR #826, Part 6).

## Solution

`GET /api/workspaces/:workspaceId/sync?after=<syncId>&limit=<n>` → `{ entries, head }`, in a new `features/sync` read path (Zod-validated INV-55, repository-backed INV-5, feature-colocated INV-51).

### Key design decisions

**1. ACL filtering by delivery groups.** One set-based query: an entry is visible if its groups overlap `workspace` / `user:<requester>`, or hit a `stream:<id>` group for a stream the requester is currently a member of.

**2. Stream groups are bounded below by the join position.** Each stream group is additionally constrained to entries after the requester's latest `stream:member_added` log entry (resolved in-query via the GIN groups index). Joining a stream therefore never replays pre-join history through the log — the no-history-leak guard from exploration pressure test 1. Memberships with no member_added entry predate the log itself, so every entry postdates the join and no bound is needed; a rejoin moves the bound forward, hiding the left period.

**3. `head` is a freshness hint, not a cursor target.** It is read after the entries query (always ≥ the last returned entry); clients advance cursors only by applied entries and page until an empty fetch. This is the read-side of the read-before-stamp rule from the exploration doc.

**Deploy safety:** additive endpoint, no callers yet, no behavior change anywhere else. Merges and deploys alone (after #830).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/sync/service.ts` | `SyncService.catchUp` — entries + head under one client |
| `apps/backend/src/features/sync/handlers.ts` | Zod-validated handler, bigints as wire strings |
| `apps/backend/src/features/sync/handlers.test.ts` | Validation + wire-mapping unit tests |
| `apps/backend/tests/integration/sync-catch-up.test.ts` | ACL, join-bound, rejoin, paging, head, workspace isolation |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/sync/repository.ts` | `listEntriesForUser` + `getHead` |
| `apps/backend/src/routes.ts` | Route + handler wiring |
| `apps/backend/src/server.ts` | `SyncService` construction |

## Test plan

- [x] 7 integration tests against real Postgres: group filtering per user, pre-join exclusion (join entry still arrives via user group), pre-log membership unbounded, rejoin bound, cursor paging, head semantics, workspace isolation
- [x] 3 handler unit tests: wire mapping, defaults, 400 on bad cursor
- [x] Monorepo typecheck + lint green (pre-commit hook)

## Stack

1. #830 — the spine: log + sequencer
2. **This PR** — catch-up read endpoint
3. PR 3 (stacked) — hardening: exact gap classification + reconciliation sweep

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783773044&installation_id=129946197&pr_number=832&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F832&signature=46bcf155702bb20841672bb8f4abcc24e1cc64660b4b880add8a74744f5a80f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->