### PR TITLE
feat: harden the sync-log spine — exact gap classification + reconciliation sweep

### DIFF
--- a/apps/backend/src/db/migrations/20260611100000_sync_log_sweep.sql
+++ b/apps/backend/src/db/migrations/20260611100000_sync_log_sweep.sql
@@ -1,0 +1,14 @@
+-- Reconciliation sweep state (sync engine v2 step 1 hardening;
+-- docs/sync-engine-v2-exploration.md Part 6). The sweep periodically scans
+-- outbox rows in a settled time window for client-routed events that never
+-- reached sync_log (dispatcher skip or crash) and sequences + emits them.
+-- `swept_until` only advances past a window once no running transaction
+-- predates it, so the swept set is provably frozen.
+CREATE TABLE sync_log_sweep_state (
+    singleton TEXT PRIMARY KEY DEFAULT 'sweep' CHECK (singleton = 'sweep'),
+    swept_until TIMESTAMPTZ NOT NULL
+);
+
+-- The sweep scans outbox by commit-time windows (created_at = transaction
+-- start, so a frozen window stays frozen).
+CREATE INDEX idx_outbox_created_at ON outbox (created_at);

--- a/apps/backend/src/features/sync/index.ts
+++ b/apps/backend/src/features/sync/index.ts
@@ -1,3 +1,4 @@
 export { SyncLogRepository, type SyncLogEntryInput, type SyncLogEntry } from "./repository"
 export { SyncService, type CatchUpResult } from "./service"
 export { createSyncHandlers } from "./handlers"
+export { SyncLogReconciliationWorker, type SyncLogReconciliationWorkerConfig } from "./reconciliation-worker"

--- a/apps/backend/src/features/sync/reconciliation-worker.ts
+++ b/apps/backend/src/features/sync/reconciliation-worker.ts
@@ -1,0 +1,164 @@
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import { Ticker } from "@threa/backend-common"
+import { logger } from "../../lib/logger"
+import { resolveDeliveryGroups, emitToGroups, type OutboxEvent } from "../../lib/outbox"
+import { SyncLogRepository, type SyncLogEntryInput } from "./repository"
+
+export interface SyncLogReconciliationWorkerConfig {
+  intervalMs?: number
+  /** How far behind the DB clock the sweep trails — gives the dispatcher its normal head start. */
+  delayMs?: number
+  batchSize?: number
+  maxBatchesPerRun?: number
+}
+
+const DEFAULT_CONFIG = {
+  intervalMs: 30_000,
+  delayMs: 15_000,
+  batchSize: 500,
+  maxBatchesPerRun: 10,
+}
+
+/**
+ * Correctness net for the sync-log spine: the dispatcher's cursor is the
+ * latency path, this sweep is the completeness guarantee.
+ *
+ * Every tick it scans outbox rows in a provably frozen window (see
+ * SyncLogRepository.getFrozenCutoff) for client-routed events with no
+ * sync_log entry — dispatcher gap-skips, crashes between batches, DLQ'd
+ * events — then sequences them (late sync ids are safe: clients order by
+ * sync id and apply idempotently by event id) and emits them to their rooms.
+ *
+ * Finding anything is an anomaly worth alerting on: "no client-routed outbox
+ * row older than the sweep window lacks a log entry" is the invariant.
+ */
+export class SyncLogReconciliationWorker {
+  private readonly pool: Pool
+  private readonly io: Server
+  private readonly config: Required<SyncLogReconciliationWorkerConfig>
+  private readonly ticker: Ticker
+
+  constructor(deps: { pool: Pool; io: Server }, config?: SyncLogReconciliationWorkerConfig) {
+    this.pool = deps.pool
+    this.io = deps.io
+    this.config = { ...DEFAULT_CONFIG, ...config }
+    this.ticker = new Ticker({
+      name: "sync-log-reconciliation",
+      intervalMs: this.config.intervalMs,
+      maxConcurrency: 1,
+    })
+  }
+
+  async start(): Promise<void> {
+    await SyncLogRepository.ensureSweepState(this.pool)
+    this.ticker.start(() => this.sweepOnce())
+    logger.info({ ...this.config }, "SyncLogReconciliationWorker started")
+  }
+
+  async stop(): Promise<void> {
+    this.ticker.stop()
+    await this.ticker.drain()
+    logger.info("SyncLogReconciliationWorker stopped")
+  }
+
+  /** One sweep pass; the ticker calls this on its interval. */
+  async sweepOnce(): Promise<void> {
+    try {
+      const sweptUntil = await SyncLogRepository.getSweptUntil(this.pool)
+      if (!sweptUntil) {
+        // ensureSweepState ran at start(); a missing row means misconfiguration.
+        logger.error("sync_log_sweep_state row missing; skipping sweep")
+        return
+      }
+
+      const cutoff = await SyncLogRepository.getFrozenCutoff(this.pool, this.config.delayMs)
+      if (cutoff <= sweptUntil) {
+        return
+      }
+
+      let batches = 0
+      let exhausted = false
+      while (batches < this.config.maxBatchesPerRun) {
+        const stragglers = await SyncLogRepository.listUnsequencedOutboxEvents(this.pool, {
+          since: sweptUntil,
+          until: cutoff,
+          limit: this.config.batchSize,
+        })
+
+        await this.rescue(stragglers)
+
+        batches += 1
+        if (stragglers.length < this.config.batchSize) {
+          exhausted = true
+          break
+        }
+      }
+
+      // Only advance once the window came back clean — sequenced rows drop out
+      // of the anti-join, so a partially swept window is retried, not skipped.
+      if (exhausted) {
+        await SyncLogRepository.advanceSweptUntil(this.pool, cutoff)
+      }
+    } catch (err) {
+      logger.error({ err }, "sync-log reconciliation sweep failed")
+    }
+  }
+
+  private async rescue(
+    stragglers: Array<{ id: bigint; eventType: string; payload: unknown; createdAt: Date }>
+  ): Promise<void> {
+    if (stragglers.length === 0) {
+      return
+    }
+
+    const byWorkspace = new Map<string, Array<{ event: OutboxEvent; entry: SyncLogEntryInput }>>()
+    for (const straggler of stragglers) {
+      const event = {
+        id: straggler.id,
+        eventType: straggler.eventType,
+        payload: straggler.payload,
+        createdAt: straggler.createdAt,
+      } as OutboxEvent
+      const groups = resolveDeliveryGroups(event)
+      // Bot-scoped (null) and unroutable (empty) events live outside the log contract.
+      if (groups === null || groups.length === 0) {
+        continue
+      }
+      // The log is workspace-sharded; mirror the sequencer's guard.
+      const { workspaceId } = event.payload
+      if (typeof workspaceId !== "string" || workspaceId.length === 0) {
+        continue
+      }
+      let entries = byWorkspace.get(workspaceId)
+      if (!entries) {
+        entries = []
+        byWorkspace.set(workspaceId, entries)
+      }
+      entries.push({
+        event,
+        entry: { outboxEventId: event.id, eventType: event.eventType, groups, payload: event.payload },
+      })
+    }
+
+    for (const [workspaceId, entries] of byWorkspace) {
+      const assigned = await SyncLogRepository.appendForWorkspace(
+        this.pool,
+        workspaceId,
+        entries.map((e) => e.entry)
+      )
+      for (const { event, entry } of entries) {
+        emitToGroups(this.io, event, entry.groups, assigned.get(event.id))
+      }
+
+      logger.warn(
+        {
+          workspaceId,
+          count: entries.length,
+          outboxEventIds: entries.map((e) => e.event.id.toString()),
+        },
+        "sync-log sweep rescued unsequenced outbox events — the dispatcher missed these"
+      )
+    }
+  }
+}

--- a/apps/backend/src/features/sync/reconciliation-worker.ts
+++ b/apps/backend/src/features/sync/reconciliation-worker.ts
@@ -42,7 +42,17 @@ export class SyncLogReconciliationWorker {
   constructor(deps: { pool: Pool; io: Server }, config?: SyncLogReconciliationWorkerConfig) {
     this.pool = deps.pool
     this.io = deps.io
-    this.config = { ...DEFAULT_CONFIG, ...config }
+    // Per-field ?? instead of object spread: callers pass `undefined` for
+    // unset env overrides, and spreading those would clobber the defaults —
+    // an undefined delayMs turns the frozen cutoff into NOW() and an
+    // undefined intervalMs makes the ticker spin, so the sweep would race
+    // the dispatcher and double-emit every event.
+    this.config = {
+      intervalMs: config?.intervalMs ?? DEFAULT_CONFIG.intervalMs,
+      delayMs: config?.delayMs ?? DEFAULT_CONFIG.delayMs,
+      batchSize: config?.batchSize ?? DEFAULT_CONFIG.batchSize,
+      maxBatchesPerRun: config?.maxBatchesPerRun ?? DEFAULT_CONFIG.maxBatchesPerRun,
+    }
     this.ticker = new Ticker({
       name: "sync-log-reconciliation",
       intervalMs: this.config.intervalMs,

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -194,4 +194,79 @@ export const SyncLogRepository = {
     `)
     return BigInt(result.rows[0].head)
   },
+
+  /**
+   * Initializes the sweep floor at "now" — the log starts at deploy, so
+   * pre-log outbox history is never treated as missing.
+   */
+  async ensureSweepState(db: Querier): Promise<void> {
+    await db.query(sql`
+      INSERT INTO sync_log_sweep_state (singleton, swept_until)
+      VALUES ('sweep', NOW())
+      ON CONFLICT (singleton) DO NOTHING
+    `)
+  },
+
+  async getSweptUntil(db: Querier): Promise<Date | null> {
+    const result = await db.query<{ swept_until: Date }>(sql`
+      SELECT swept_until FROM sync_log_sweep_state WHERE singleton = 'sweep'
+    `)
+    return result.rows[0]?.swept_until ?? null
+  },
+
+  /** Monotone advance; concurrent sweepers are idempotent so GREATEST suffices. */
+  async advanceSweptUntil(db: Querier, until: Date): Promise<void> {
+    await db.query(sql`
+      UPDATE sync_log_sweep_state
+      SET swept_until = GREATEST(swept_until, ${until})
+      WHERE singleton = 'sweep'
+    `)
+  },
+
+  /**
+   * The latest instant the outbox is provably frozen up to: `delayMs` behind
+   * the DB clock, clamped by the oldest running transaction's start. Rows get
+   * `created_at = NOW()` = transaction start, so once every transaction that
+   * started before T has ended, the set of rows with created_at < T can never
+   * grow — a sweep over it is exhaustive, not probabilistic.
+   */
+  async getFrozenCutoff(db: Querier, delayMs: number): Promise<Date> {
+    const result = await db.query<{ cutoff: Date }>(sql`
+      SELECT LEAST(
+        NOW() - (${delayMs}::int * interval '1 millisecond'),
+        COALESCE(
+          (SELECT MIN(xact_start) FROM pg_stat_activity
+           WHERE xact_start IS NOT NULL AND datname = current_database()),
+          NOW()
+        )
+      ) AS cutoff
+    `)
+    return result.rows[0].cutoff
+  },
+
+  /**
+   * Outbox rows in [since, until) with no sync_log entry, in id order.
+   * Already-sequenced rows drop out via the anti-join, so re-running over the
+   * same window converges.
+   */
+  async listUnsequencedOutboxEvents(
+    db: Querier,
+    params: { since: Date; until: Date; limit: number }
+  ): Promise<Array<{ id: bigint; eventType: string; payload: unknown; createdAt: Date }>> {
+    const result = await db.query<{ id: string; event_type: string; payload: unknown; created_at: Date }>(sql`
+      SELECT o.id, o.event_type, o.payload, o.created_at
+      FROM outbox o
+      WHERE o.created_at >= ${params.since}
+        AND o.created_at < ${params.until}
+        AND NOT EXISTS (SELECT 1 FROM sync_log s WHERE s.outbox_event_id = o.id)
+      ORDER BY o.id
+      LIMIT ${params.limit}
+    `)
+    return result.rows.map((row) => ({
+      id: BigInt(row.id),
+      eventType: row.event_type,
+      payload: row.payload,
+      createdAt: row.created_at,
+    }))
+  },
 }

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -9,7 +9,7 @@ import {
   type BotActiveActorChangedOutboxPayload,
   type BotResyncOutboxPayload,
 } from "./repository"
-import { resolveDeliveryGroups, groupToRoom } from "./delivery-groups"
+import { resolveDeliveryGroups, emitToGroups } from "./delivery-groups"
 import { logger } from "../logger"
 import { SyncLogRepository, type SyncLogEntryInput } from "../../features/sync"
 import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
@@ -163,7 +163,12 @@ export class BroadcastHandler implements OutboxHandler {
       if (groups === null || groups.length === 0) {
         continue
       }
+      // The log is workspace-sharded; an event without a workspace can't be
+      // sequenced (and no client room would ever receive it anyway).
       const { workspaceId } = event.payload
+      if (typeof workspaceId !== "string" || workspaceId.length === 0) {
+        continue
+      }
       let entries = byWorkspace.get(workspaceId)
       if (!entries) {
         entries = []
@@ -198,19 +203,7 @@ export class BroadcastHandler implements OutboxHandler {
       return
     }
 
-    if (groups.length === 0) {
-      return
-    }
-
-    // One emit to the union of rooms — Socket.io dedupes sockets present in
-    // several of them, so an event never reaches the same connection twice.
-    // The payload carries the sync id (string, like stream sequences on the
-    // wire) so future clients can keep a sync-log cursor; current clients
-    // ignore it.
-    const { workspaceId } = event.payload
-    const rooms = groups.map((group) => groupToRoom(workspaceId, group))
-    const payload = routedEvent?.syncId ? { ...event.payload, syncId: routedEvent.syncId.toString() } : event.payload
-    this.io.to(rooms).emit(event.eventType, payload)
+    emitToGroups(this.io, event, groups, routedEvent?.syncId)
   }
 
   /**

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -1,3 +1,4 @@
+import type { Server } from "socket.io"
 import { LabelableResourceTypes, StreamTypes, Visibilities } from "@threa/types"
 import {
   isStreamScopedEvent,
@@ -51,6 +52,30 @@ export function userGroup(userId: string): string {
  */
 export function groupToRoom(workspaceId: string, group: string): string {
   return group === WORKSPACE_GROUP ? `ws:${workspaceId}` : `ws:${workspaceId}:${group}`
+}
+
+/**
+ * Emits one event to the union of its groups' rooms. Socket.io dedupes
+ * sockets present in several rooms, so an event never reaches the same
+ * connection twice. The payload carries the sync id (string, like stream
+ * sequences on the wire) when one is assigned, so future clients can keep a
+ * sync-log cursor; current clients ignore it. Shared by the BroadcastHandler
+ * (live path) and the sync-log reconciliation sweep (rescue path) so the two
+ * can never drift.
+ */
+export function emitToGroups(
+  io: Server,
+  event: Pick<OutboxEvent, "eventType" | "payload">,
+  groups: string[],
+  syncId?: bigint
+): void {
+  if (groups.length === 0) {
+    return
+  }
+  const { workspaceId } = event.payload
+  const rooms = groups.map((group) => groupToRoom(workspaceId, group))
+  const payload = syncId ? { ...event.payload, syncId: syncId.toString() } : event.payload
+  io.to(rooms).emit(event.eventType, payload)
 }
 
 /**

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -4,6 +4,14 @@ export { OutboxRetentionWorker, type OutboxRetentionWorkerConfig } from "@threa/
 
 // Domain-specific outbox code
 export { BroadcastHandler, type BroadcastHandlerConfig } from "./broadcast-handler"
+export {
+  resolveDeliveryGroups,
+  emitToGroups,
+  groupToRoom,
+  WORKSPACE_GROUP,
+  streamGroup,
+  userGroup,
+} from "./delivery-groups"
 export { parseMessagePayload, type NormalizedMessagePayload } from "./payload-parsers"
 export {
   OutboxRepository,

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -108,7 +108,7 @@ import {
 import { EmojiUsageHandler } from "./features/emoji"
 import { SystemMessageService, SystemMessageOutboxHandler } from "./features/system-messages"
 import { ActivityService, ActivityFeedHandler } from "./features/activity"
-import { SyncService } from "./features/sync"
+import { SyncService, SyncLogReconciliationWorker } from "./features/sync"
 import { BotInvocationOutboxHandler } from "./features/bot-runtimes/invocation-outbox-handler"
 import {
   BotRuntimeInstanceRepository,
@@ -1129,6 +1129,17 @@ export async function startServer(): Promise<ServerInstance> {
   await outboxDispatcher.start()
   outboxRetentionWorker.start()
 
+  // Correctness net for the sync-log spine: rescues client-routed outbox
+  // events the dispatcher missed (gap skip, crash) into sync_log + a late emit
+  const syncLogReconciliationWorker = new SyncLogReconciliationWorker(
+    { pool, io },
+    {
+      intervalMs: Number(process.env.SYNC_LOG_SWEEP_INTERVAL_MS) || undefined,
+      delayMs: Number(process.env.SYNC_LOG_SWEEP_DELAY_MS) || undefined,
+    }
+  )
+  await syncLogReconciliationWorker.start()
+
   const orphanSessionCleanup = createOrphanSessionCleanup(pools.main, io)
   orphanSessionCleanup.start()
 
@@ -1168,6 +1179,7 @@ export async function startServer(): Promise<ServerInstance> {
     await scheduleManager.stop()
     await cleanupWorker.stop()
     await outboxRetentionWorker.stop()
+    await syncLogReconciliationWorker.stop()
     await outboxDispatcher.stop()
     await jobQueue.stop()
     logger.info("Closing socket.io...")

--- a/apps/backend/tests/integration/cursor-lock.test.ts
+++ b/apps/backend/tests/integration/cursor-lock.test.ts
@@ -651,10 +651,19 @@ describe("CursorLock", () => {
         }
 
         await cursorLock.run(processor)
-        // Window expired, but transaction A still runs: the cursor must hold.
+        // Window expired while transaction A still runs. Commit ANOTHER event
+        // so the next run processes a real batch — compaction only happens on
+        // the processed path, so without this the second run would return
+        // no_events and never reach the gap guard at all (the pre-hardening
+        // window would pass a no-op run too).
         await new Promise((r) => setTimeout(r, 50))
+        const laterId = await insertTestEvent()
         await cursorLock.run(processor)
 
+        // The guard must hold the cursor below the gap even though the gap
+        // window expired — the pre-hardening compaction would have expired
+        // visibleId and pulled the cursor past gapId here.
+        expect(processed).toContain(laterId)
         let state = await getListenerState()
         expect(BigInt(state!.last_processed_id)).toBeLessThan(gapId)
 
@@ -665,7 +674,7 @@ describe("CursorLock", () => {
 
         expect(processed).toContain(gapId)
         state = await getListenerState()
-        expect(BigInt(state!.last_processed_id)).toBeGreaterThanOrEqual(visibleId)
+        expect(BigInt(state!.last_processed_id)).toBeGreaterThanOrEqual(laterId)
       } finally {
         txnClient.release()
       }

--- a/apps/backend/tests/integration/cursor-lock.test.ts
+++ b/apps/backend/tests/integration/cursor-lock.test.ts
@@ -5,6 +5,7 @@ import {
   CursorLock,
   ensureListener,
   compact,
+  hasUnfilledGaps,
   type ProcessResult,
   type CursorLockConfig,
   type ProcessedIdsMap,
@@ -519,8 +520,10 @@ describe("CursorLock", () => {
       const event2 = await insertTestEvent()
       await ensureListener(pool, testListenerId, baseId)
 
-      // gapWindowMs=0 with <= comparison means entries expire immediately
-      const cursorLock = createTestCursorLock({ gapWindowMs: 0 })
+      // gapWindowMs=0 with <= comparison means entries expire immediately;
+      // gapCeilingMs=0 bypasses the transaction-liveness hold so this test
+      // exercises the window machinery deterministically
+      const cursorLock = createTestCursorLock({ gapWindowMs: 0, gapCeilingMs: 0 })
 
       const didWork = await cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
         const events = await OutboxRepository.fetchAfterId(pool, cursor, 10, processedIds)
@@ -559,6 +562,113 @@ describe("CursorLock", () => {
       expect(processedIdsSeen[0]).toHaveLength(0)
       // Second call: event1 should be in processedIds (non-contiguous, stays in window)
       expect(processedIdsSeen[1]).toContainEqual(event1)
+    })
+  })
+
+  describe("compact - gap liveness guard (pure function)", () => {
+    test("hasUnfilledGaps detects holes between cursor and tracked ids", () => {
+      expect(hasUnfilledGaps(10n, {}, [11n, 12n, 13n])).toBe(false)
+      expect(hasUnfilledGaps(10n, {}, [12n])).toBe(true)
+      expect(hasUnfilledGaps(10n, { "11": new Date().toISOString() }, [13n])).toBe(true)
+      expect(hasUnfilledGaps(10n, { "11": new Date().toISOString() }, [12n])).toBe(false)
+      expect(hasUnfilledGaps(10n, {}, [])).toBe(false)
+    })
+
+    test("holds an expired entry above a gap while a transaction predating it runs", () => {
+      const now = new Date()
+      const readAt = new Date(now.getTime() - 5000)
+      // Entry 14 (gap at 11-13) expired by the window, but a transaction that
+      // started before it was observed is still running — could still fill 11.
+      const result = compact(10n, { "14": readAt.toISOString() }, [], now, 1000, {
+        oldestRunningTxnStart: new Date(readAt.getTime() - 1000),
+        gapCeilingMs: 60_000,
+      })
+
+      expect(result.cursor).toBe(10n)
+      expect(result.processedIds["14"]).toBeDefined()
+    })
+
+    test("skips the gap once every running transaction postdates the observation", () => {
+      const now = new Date()
+      const readAt = new Date(now.getTime() - 5000)
+      const result = compact(10n, { "14": readAt.toISOString() }, [], now, 1000, {
+        // Oldest running transaction started well after entry 14 was observed
+        // (past the clock-skew pad) — the gap's owner has provably ended.
+        oldestRunningTxnStart: new Date(readAt.getTime() + 2000),
+        gapCeilingMs: 60_000,
+      })
+
+      expect(result.cursor).toBe(14n)
+      expect(Object.keys(result.processedIds)).toHaveLength(0)
+    })
+
+    test("skips the gap when no transaction is running at all", () => {
+      const now = new Date()
+      const readAt = new Date(now.getTime() - 5000)
+      const result = compact(10n, { "14": readAt.toISOString() }, [], now, 1000, {
+        oldestRunningTxnStart: null,
+        gapCeilingMs: 60_000,
+      })
+
+      expect(result.cursor).toBe(14n)
+    })
+
+    test("the ceiling forces the skip past an abandoned long transaction", () => {
+      const now = new Date()
+      const readAt = new Date(now.getTime() - 5000)
+      const result = compact(10n, { "14": readAt.toISOString() }, [], now, 1000, {
+        oldestRunningTxnStart: new Date(now.getTime() - 600_000),
+        gapCeilingMs: 3000,
+      })
+
+      expect(result.cursor).toBe(14n)
+    })
+  })
+
+  describe("run - transaction liveness gap guard", () => {
+    test("holds a gap open while the owning transaction runs, then processes the late commit", async () => {
+      // Transaction A allocates an outbox id but stays uncommitted — the
+      // classic BIGSERIAL visibility gap, held open longer than the window.
+      const txnClient = await pool.connect()
+      try {
+        await txnClient.query("BEGIN")
+        const inFlight = await txnClient.query<{ id: string }>(
+          `INSERT INTO outbox (event_type, payload) VALUES ('test:event', '{"test": true}') RETURNING id`
+        )
+        const gapId = BigInt(inFlight.rows[0].id)
+        const visibleId = await insertTestEvent()
+        expect(visibleId).toBeGreaterThan(gapId)
+
+        await ensureListener(pool, testListenerId, gapId - 1n)
+        const cursorLock = createTestCursorLock({ gapWindowMs: 10 })
+
+        const processed: bigint[] = []
+        const processor = async (cursor: bigint, processedIds: bigint[]): Promise<ProcessResult> => {
+          const events = await OutboxRepository.fetchAfterId(pool, cursor, 10, processedIds)
+          if (events.length === 0) return { status: "no_events" }
+          processed.push(...events.map((e) => e.id))
+          return { status: "processed", processedIds: events.map((e) => e.id) }
+        }
+
+        await cursorLock.run(processor)
+        // Window expired, but transaction A still runs: the cursor must hold.
+        await new Promise((r) => setTimeout(r, 50))
+        await cursorLock.run(processor)
+
+        let state = await getListenerState()
+        expect(BigInt(state!.last_processed_id)).toBeLessThan(gapId)
+
+        // Transaction A commits after the gap window — the pre-hardening
+        // window would have skipped this event permanently.
+        await txnClient.query("COMMIT")
+        await cursorLock.run(processor)
+
+        expect(processed).toContain(gapId)
+        state = await getListenerState()
+        expect(BigInt(state!.last_processed_id)).toBeGreaterThanOrEqual(visibleId)
+      } finally {
+        txnClient.release()
+      }
     })
   })
 })

--- a/apps/backend/tests/integration/sync-reconciliation.test.ts
+++ b/apps/backend/tests/integration/sync-reconciliation.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test"
+import { Pool, type PoolClient } from "pg"
+import type { Server } from "socket.io"
+import { setupTestDatabase } from "./setup"
+import { SyncLogRepository, SyncLogReconciliationWorker } from "../../src/features/sync"
+
+describe("SyncLogReconciliationWorker", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    await SyncLogRepository.ensureSweepState(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  function uniqueId(prefix: string): string {
+    return `${prefix}_${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`
+  }
+
+  function makeWorker() {
+    const emits: Array<{ rooms: string | string[]; eventType: string; payload: Record<string, unknown> }> = []
+    const io = {
+      to: (rooms: string | string[]) => ({
+        emit: mock((eventType: string, payload: Record<string, unknown>) => {
+          emits.push({ rooms, eventType, payload })
+        }),
+      }),
+    } as unknown as Server
+    const worker = new SyncLogReconciliationWorker({ pool, io }, { delayMs: 0, intervalMs: 60_000 })
+    return { worker, emits }
+  }
+
+  async function insertOutboxEvent(db: Pool | PoolClient, eventType: string, payload: unknown): Promise<bigint> {
+    const result = await db.query<{ id: string }>(
+      `INSERT INTO outbox (event_type, payload) VALUES ($1, $2) RETURNING id`,
+      [eventType, JSON.stringify(payload)]
+    )
+    return BigInt(result.rows[0].id)
+  }
+
+  async function getLogRow(outboxEventId: bigint) {
+    const result = await pool.query<{ sync_id: string; groups: string[]; payload: unknown }>(
+      `SELECT sync_id, groups, payload FROM sync_log WHERE outbox_event_id = $1`,
+      [outboxEventId.toString()]
+    )
+    return result.rows[0] ?? null
+  }
+
+  /** Sweeps until the predicate holds — background transactions can clamp the frozen cutoff for a beat. */
+  async function sweepUntil(worker: SyncLogReconciliationWorker, predicate: () => Promise<boolean>): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      await worker.sweepOnce()
+      if (await predicate()) return
+      await new Promise((r) => setTimeout(r, 100))
+    }
+  }
+
+  test("rescues a committed client-routed event the dispatcher never sequenced", async () => {
+    const workspaceId = uniqueId("ws")
+    const streamId = uniqueId("stream")
+    const { worker, emits } = makeWorker()
+
+    // Committed outbox row with no sync_log entry — exactly what a dispatcher
+    // gap-skip or crash leaves behind.
+    const outboxEventId = await insertOutboxEvent(pool, "message:created", {
+      workspaceId,
+      streamId,
+      event: { id: "evt_1" },
+    })
+
+    await sweepUntil(worker, async () => (await getLogRow(outboxEventId)) !== null)
+
+    const row = await getLogRow(outboxEventId)
+    expect(row).not.toBeNull()
+    expect(row!.groups).toEqual([`stream:${streamId}`])
+
+    // The rescue also emits — late, but delivered — with the sync id attached.
+    const emitted = emits.find((e) => e.eventType === "message:created" && e.payload.workspaceId === workspaceId)
+    expect(emitted).toBeDefined()
+    expect(emitted!.rooms).toEqual([`ws:${workspaceId}:stream:${streamId}`])
+    expect(emitted!.payload.syncId).toBe(row!.sync_id)
+  })
+
+  test("ignores bot-scoped events — they live outside the log contract", async () => {
+    const workspaceId = uniqueId("ws")
+    const { worker } = makeWorker()
+
+    const outboxEventId = await insertOutboxEvent(pool, "bot_invocation:available", {
+      workspaceId,
+      botId: "bot_1",
+      invocationId: "inv_1",
+    })
+
+    // Sweep until the window has passed the event (swept_until > its insert).
+    await sweepUntil(worker, async () => {
+      const sweptUntil = await SyncLogRepository.getSweptUntil(pool)
+      const row = await pool.query<{ created_at: Date }>(`SELECT created_at FROM outbox WHERE id = $1`, [
+        outboxEventId.toString(),
+      ])
+      return sweptUntil !== null && sweptUntil > row.rows[0].created_at
+    })
+
+    expect(await getLogRow(outboxEventId)).toBeNull()
+  })
+
+  test("does not sweep a window an older transaction could still write into", async () => {
+    const { worker } = makeWorker()
+    const txnClient = await pool.connect()
+    try {
+      await txnClient.query("BEGIN")
+      // The open transaction holds an uncommitted outbox row; its created_at
+      // (= transaction start) pins the frozen cutoff below it.
+      const workspaceId = uniqueId("ws")
+      const streamId = uniqueId("stream")
+      const inFlightId = await insertOutboxEvent(txnClient, "message:created", {
+        workspaceId,
+        streamId,
+        event: { id: "evt_inflight" },
+      })
+
+      // While the transaction runs, the sweep can't advance past its start.
+      await worker.sweepOnce()
+      const sweptDuringTxn = await SyncLogRepository.getSweptUntil(pool)
+      const txnStart = await txnClient.query<{ xact_start: Date }>(
+        `SELECT xact_start FROM pg_stat_activity WHERE pid = pg_backend_pid()`
+      )
+      expect(sweptDuringTxn!.getTime()).toBeLessThanOrEqual(txnStart.rows[0].xact_start.getTime())
+
+      await txnClient.query("COMMIT")
+
+      // After commit the window unfreezes and the row is rescued.
+      await sweepUntil(worker, async () => (await getLogRow(inFlightId)) !== null)
+      expect(await getLogRow(inFlightId)).not.toBeNull()
+    } finally {
+      txnClient.release()
+    }
+  })
+})

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -138,6 +138,7 @@ export {
   ensureListener,
   ensureListenerFromLatest,
   compact,
+  hasUnfilledGaps,
   OUTBOX_CHANNEL,
 } from "./outbox/index"
 export type {
@@ -152,6 +153,7 @@ export type {
   ProcessResult,
   ProcessedIdsMap,
   CompactState,
+  CompactGapOptions,
 } from "./outbox/index"
 
 // CORS

--- a/packages/backend-common/src/outbox/cursor-lock.ts
+++ b/packages/backend-common/src/outbox/cursor-lock.ts
@@ -14,6 +14,7 @@ export interface CursorLockConfig {
   baseBackoffMs: number // e.g., 1000 (1s)
   batchSize: number // e.g., 100
   gapWindowMs?: number // e.g., 1000 (1s) — how long to keep processed IDs before compacting
+  gapCeilingMs?: number // e.g., 60000 (60s) — hard ceiling after which a gap is skipped without liveness proof
 }
 
 export type ProcessResult =
@@ -39,10 +40,35 @@ function generateRunId(): string {
 }
 
 const DEFAULT_GAP_WINDOW_MS = 1000
+const DEFAULT_GAP_CEILING_MS = 60_000
+// Conservative allowance for app-clock (readAt) vs DB-clock (xact_start) skew.
+// Padding only delays a skip; it can never cause one.
+const CLOCK_SKEW_PAD_MS = 1000
 
 export interface CompactState {
   cursor: bigint
   processedIds: ProcessedIdsMap
+}
+
+export interface CompactGapOptions {
+  /**
+   * Start time of the oldest transaction currently running in the database,
+   * or null when none is running. When provided, expiring an entry (which
+   * pulls the base cursor over any unfilled gaps below it) requires PROOF the
+   * gaps are dead: a gap at id N observed at time t can only be filled by a
+   * transaction that was already running at t (it allocated N from the
+   * sequence before the higher id became visible), so if every running
+   * transaction started after t, the gap's owner has ended and the missing
+   * row is either visible by now or never coming.
+   */
+  oldestRunningTxnStart: Date | null
+  /**
+   * Wall-clock fallback ceiling: entries older than this expire even without
+   * liveness proof, so an abandoned multi-minute transaction cannot stall the
+   * cursor forever. Skips at the ceiling are loud (caller logs) and, for the
+   * broadcast listener, healable by the sync-log reconciliation sweep.
+   */
+  gapCeilingMs?: number
 }
 
 /**
@@ -54,13 +80,19 @@ export interface CompactState {
  * 3. new_base = max(max(expired_ids), base_cursor)
  * 4. Remove all entries where id <= new_base
  * 5. Advance through any remaining entries contiguous with new_base
+ *
+ * Without `gapOptions`, expiry is purely time-based (the original sliding
+ * window). With `gapOptions`, expiry additionally requires the transaction
+ * liveness proof described on CompactGapOptions, with gapCeilingMs as the
+ * fallback.
  */
 export function compact(
   cursor: bigint,
   processedIds: ProcessedIdsMap,
   newIds: bigint[],
   now: Date,
-  gapWindowMs: number
+  gapWindowMs: number,
+  gapOptions?: CompactGapOptions
 ): CompactState {
   // 1. Merge new IDs
   const merged = { ...processedIds }
@@ -71,13 +103,28 @@ export function compact(
 
   // 2. Find expired entries
   const cutoff = now.getTime() - gapWindowMs
+  const ceilingCutoff = now.getTime() - (gapOptions?.gapCeilingMs ?? DEFAULT_GAP_CEILING_MS)
+  // An entry observed at `readAt` proves gaps below it are dead only if every
+  // transaction running now started after it (see CompactGapOptions).
+  const provenBefore = gapOptions
+    ? gapOptions.oldestRunningTxnStart === null
+      ? Number.POSITIVE_INFINITY
+      : gapOptions.oldestRunningTxnStart.getTime() - CLOCK_SKEW_PAD_MS
+    : Number.POSITIVE_INFINITY
   let maxExpired = cursor
   for (const [idStr, readAt] of Object.entries(merged)) {
-    if (new Date(readAt).getTime() <= cutoff) {
-      const id = BigInt(idStr)
-      if (id > maxExpired) {
-        maxExpired = id
-      }
+    const readAtMs = new Date(readAt).getTime()
+    if (readAtMs > cutoff) {
+      continue
+    }
+    if (gapOptions && readAtMs >= provenBefore && readAtMs > ceilingCutoff) {
+      // A transaction predating this observation is still running — the gap
+      // below could still fill. Hold the window open.
+      continue
+    }
+    const id = BigInt(idStr)
+    if (id > maxExpired) {
+      maxExpired = id
     }
   }
 
@@ -105,6 +152,25 @@ export function compact(
   }
 
   return { cursor: newBase, processedIds: remaining }
+}
+
+/**
+ * True when the tracked ids (window + new batch) do not form a contiguous run
+ * from the base cursor — i.e. compaction could pull the cursor over a missing
+ * id. Only then is the transaction-liveness lookup worth a query.
+ */
+export function hasUnfilledGaps(cursor: bigint, processedIds: ProcessedIdsMap, newIds: bigint[]): boolean {
+  const ids = [...Object.keys(processedIds).map(BigInt), ...newIds].sort((a, b) => Number(a - b))
+  let expected = cursor + 1n
+  for (const id of ids) {
+    if (id > expected) {
+      return true
+    }
+    if (id === expected) {
+      expected += 1n
+    }
+  }
+  return false
 }
 
 /**
@@ -138,6 +204,7 @@ export class CursorLock {
   private readonly maxRetries: number
   private readonly baseBackoffMs: number
   private readonly gapWindowMs: number
+  private readonly gapCeilingMs: number
 
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private runId: string | null = null
@@ -151,6 +218,7 @@ export class CursorLock {
     this.baseBackoffMs = config.baseBackoffMs
     this.batchSize = config.batchSize
     this.gapWindowMs = config.gapWindowMs ?? DEFAULT_GAP_WINDOW_MS
+    this.gapCeilingMs = config.gapCeilingMs ?? DEFAULT_GAP_CEILING_MS
   }
 
   /**
@@ -202,7 +270,7 @@ export class CursorLock {
             }
 
             // Compact and persist
-            const compacted = compact(cursor, processedIdsMap, result.processedIds, getNow(), this.gapWindowMs)
+            const compacted = await this.compactWithGapGuard(cursor, processedIdsMap, result.processedIds, getNow())
             await this.persistProcessedState(compacted, getNow())
             cursor = compacted.cursor
             processedIdsMap = compacted.processedIds
@@ -220,7 +288,7 @@ export class CursorLock {
           case "error": {
             // Handle partial progress if processedIds provided
             if (result.processedIds !== undefined && result.processedIds.length > 0) {
-              const compacted = compact(cursor, processedIdsMap, result.processedIds, getNow(), this.gapWindowMs)
+              const compacted = await this.compactWithGapGuard(cursor, processedIdsMap, result.processedIds, getNow())
               await this.persistProcessedState(compacted, getNow())
               cursor = compacted.cursor
               processedIdsMap = compacted.processedIds
@@ -248,6 +316,58 @@ export class CursorLock {
     }
 
     return didWork
+  }
+
+  /**
+   * Compacts the sliding window, gating gap skips on transaction liveness.
+   *
+   * When the tracked ids are contiguous from the cursor the plain compaction
+   * runs (no extra query). When a gap exists, the oldest running transaction's
+   * start time is fetched and gaps are only skipped once provably dead — or
+   * once past gapCeilingMs, which is logged loudly because it is the one path
+   * that can still lose an event for non-broadcast listeners.
+   */
+  private async compactWithGapGuard(
+    cursor: bigint,
+    processedIds: ProcessedIdsMap,
+    newIds: bigint[],
+    now: Date
+  ): Promise<CompactState> {
+    if (!hasUnfilledGaps(cursor, processedIds, newIds)) {
+      return compact(cursor, processedIds, newIds, now, this.gapWindowMs)
+    }
+
+    const oldestRunningTxnStart = await this.fetchOldestRunningTxnStart()
+    const guarded = compact(cursor, processedIds, newIds, now, this.gapWindowMs, {
+      oldestRunningTxnStart,
+      gapCeilingMs: this.gapCeilingMs,
+    })
+
+    // Compare with the unguarded result purely for observability: a held gap
+    // means a long-running transaction may still commit an event into it.
+    const unguarded = compact(cursor, processedIds, newIds, now, this.gapWindowMs)
+    if (guarded.cursor < unguarded.cursor) {
+      logger.warn(
+        {
+          listenerId: this.listenerId,
+          heldCursor: guarded.cursor.toString(),
+          wouldBeCursor: unguarded.cursor.toString(),
+          oldestRunningTxnStart: oldestRunningTxnStart?.toISOString() ?? null,
+        },
+        "Holding outbox gap open: a transaction predating the gap is still running"
+      )
+    }
+
+    return guarded
+  }
+
+  private async fetchOldestRunningTxnStart(): Promise<Date | null> {
+    const result = await this.pool.query<{ oldest: Date | null }>(sql`
+      SELECT MIN(xact_start) AS oldest
+      FROM pg_stat_activity
+      WHERE xact_start IS NOT NULL AND datname = current_database()
+    `)
+    return result.rows[0]?.oldest ?? null
   }
 
   private async isReadyToProcess(now: Date): Promise<boolean> {

--- a/packages/backend-common/src/outbox/cursor-lock.ts
+++ b/packages/backend-common/src/outbox/cursor-lock.ts
@@ -343,6 +343,27 @@ export class CursorLock {
       gapCeilingMs: this.gapCeilingMs,
     })
 
+    // The ceiling is the one path that can still lose an event for
+    // non-broadcast listeners, so a ceiling-forced skip must be loud (INV-11):
+    // re-run the guard with no ceiling — any extra cursor advance in the real
+    // result was forced by the ceiling, not proven dead by liveness.
+    const heldWithoutCeiling = compact(cursor, processedIds, newIds, now, this.gapWindowMs, {
+      oldestRunningTxnStart,
+      gapCeilingMs: Number.POSITIVE_INFINITY,
+    })
+    if (guarded.cursor > heldWithoutCeiling.cursor) {
+      logger.error(
+        {
+          listenerId: this.listenerId,
+          skippedToCursor: guarded.cursor.toString(),
+          heldCursor: heldWithoutCeiling.cursor.toString(),
+          gapCeilingMs: this.gapCeilingMs,
+          oldestRunningTxnStart: oldestRunningTxnStart?.toISOString() ?? null,
+        },
+        "Gap ceiling forced the cursor past an unproven gap — a transaction predating it is still running and its events may be skipped"
+      )
+    }
+
     // Compare with the unguarded result purely for observability: a held gap
     // means a long-running transaction may still commit an event into it.
     const unguarded = compact(cursor, processedIds, newIds, now, this.gapWindowMs)

--- a/packages/backend-common/src/outbox/index.ts
+++ b/packages/backend-common/src/outbox/index.ts
@@ -13,8 +13,10 @@ export {
   ensureListener,
   ensureListenerFromLatest,
   compact,
+  hasUnfilledGaps,
   type CursorLockConfig,
   type ProcessResult,
   type ProcessedIdsMap,
   type CompactState,
+  type CompactGapOptions,
 } from "./cursor-lock"


### PR DESCRIPTION
## Problem

The sync log (PR #830) inherits the outbox reader's gap heuristic: `CursorLock`'s sliding window skips a gap in the visible id sequence after 1 second, betting the owning transaction has committed by then. The bet can lose — a domain transaction holding its outbox INSERT open past the window (lock wait, pool saturation, batch op) commits afterward and its event is permanently skipped. Today that costs one lost emit; under the sync log it would cost a **missing log entry**, which no client catch-up can heal because the log is the thing clients trust. Relying more on the dispatcher raises the bar from "rarely loses" to "cannot lose".

Step 1 hardening from `docs/sync-engine-v2-exploration.md` Part 6 (exploration PR #826), part 3 of the stack.

## Solution

### Layer 1 — exact gap classification in CursorLock (benefits every outbox consumer)

A gap at id N observed at time t can only ever be filled by a transaction that was already running at t — it allocated N from the sequence before the higher id became visible. So a gap is provably dead once every currently-running transaction started after the observation. `compact()` now takes that proof into account: when (and only when) a hole exists in the tracked ids, the dispatcher fetches `MIN(xact_start)` from `pg_stat_activity` (one cheap lookup) and holds the gap open until the proof lands, logging while it holds. This is **stateless** — no persisted snapshots — because "oldest running transaction start" fully captures the reachable owners.

`gapCeilingMs` (default 60s) is the fallback for genuinely abandoned transactions: past it the gap is skipped without proof, loudly. The wall clock becomes the ceiling, not the decision. A 1s clock-skew pad covers app-clock (readAt) vs DB-clock (xact_start) drift; padding can only delay a skip, never cause one.

### Layer 2 — reconciliation sweep (the completeness anchor for the log)

`SyncLogReconciliationWorker` (Ticker, every 30s) anti-joins outbox against `sync_log` over **provably frozen** time windows and rescues stragglers: sequences them with late sync ids (safe — clients order by sync id and apply idempotently by event id; ids are never assigned into the past) and emits them to their rooms via the same `emitToGroups` the live path uses.

Frozen-window proof: `created_at` defaults to `NOW()` = transaction start, so once no running transaction predates T, the set of rows with `created_at < T` can never grow. The sweep's cutoff is `LEAST(now - delay, oldest running xact_start)`; `swept_until` only advances past a window that came back clean, and partially swept windows are retried (sequenced rows drop out of the anti-join). With this in place the cursor is a latency optimization and the sweep is the correctness mechanism — same philosophy as NOTIFY (fast path) + 2s polling (guarantee).

Any rescue logs a warn: **"no client-routed outbox row older than the sweep window lacks a log entry" is the alertable invariant.**

**Deploy safety:** additive (one state table + one index on `outbox(created_at)`); the CursorLock change strictly tightens when gaps may be skipped. Deploys alone (after #830/#832).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260611100000_sync_log_sweep.sql` | `sync_log_sweep_state` + `idx_outbox_created_at` |
| `apps/backend/src/features/sync/reconciliation-worker.ts` | The sweep worker |
| `apps/backend/tests/integration/sync-reconciliation.test.ts` | Rescue, bot-event exclusion, frozen-window hold |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/backend-common/src/outbox/cursor-lock.ts` | `compact()` gap liveness gate, `hasUnfilledGaps`, `gapCeilingMs`, guarded compaction in `run()` |
| `apps/backend/src/features/sync/repository.ts` | Sweep state + frozen cutoff + anti-join queries |
| `apps/backend/src/lib/outbox/delivery-groups.ts` | `emitToGroups` shared by live + rescue paths |
| `apps/backend/src/lib/outbox/broadcast-handler.ts` | Uses `emitToGroups`; events without a workspace id stay off the log |
| `apps/backend/src/server.ts` | Worker start/stop wiring |

## Test plan

- [x] The headline test from the exploration doc: an outbox row held invisible by an open transaction past the gap window is **not** skipped (cursor holds via liveness proof), then processed after the late commit — the exact scenario the old window lost
- [x] Pure compact gap-gate tests: hold while an older txn runs, skip on proof, skip on idle, ceiling override
- [x] Sweep rescues a committed-but-unsequenced event (log row + late emit with syncId); ignores bot events; refuses to advance past a window an open transaction could still write into, then rescues after commit
- [x] All 35 cursor-lock + reconciliation integration tests green; 41 outbox/sync unit tests green; 12 sync repository/catch-up integration tests green
- [x] Monorepo typecheck + lint green (pre-commit hook)

## Stack

1. #830 — the spine: log + sequencer
2. #832 — catch-up read endpoint
3. **This PR** — hardening: exact gap classification + reconciliation sweep

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783773957&installation_id=129946197&pr_number=833&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F833&signature=a3614a6ed630670fbe74902fe257d13b0ffa789d3a15155d8359d4203b9f0e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->