### PR TITLE
perf(frontend): stop identity churn at the events data layer

### DIFF
--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { loadStreamEvents } from "./stream-store"
+import { loadStreamEvents, shareEventIdentities } from "./stream-store"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -217,5 +217,70 @@ describe("loadStreamEvents", () => {
     const events = await loadStreamEvents(streamId, 100)
 
     expect(events.map((e) => e.id)).toEqual(["evt_stream_floored_100", "evt_stream_floored_101", "temp_above"])
+  })
+})
+
+describe("shareEventIdentities", () => {
+  function reEmit(rows: CachedEvent[]): CachedEvent[] {
+    // Simulate a liveQuery re-run: same stored bytes, all-new object identities.
+    return rows.map((row) => ({ ...row, payload: { ...(row.payload as Record<string, unknown>) } }))
+  }
+
+  it("returns the previous array identity when nothing changed", () => {
+    const prev = [makeRealEvent("stream_1", "100"), makeRealEvent("stream_1", "200")]
+    expect(shareEventIdentities(prev, reEmit(prev))).toBe(prev)
+  })
+
+  it("reuses unchanged row identities when one row changed", () => {
+    const a = makeRealEvent("stream_1", "100")
+    const b = makeRealEvent("stream_1", "200")
+    const next = reEmit([a, b])
+    next[1]._patchedAt = Date.now() // a socket patch landed on b
+
+    const shared = shareEventIdentities([a, b], next)
+    expect(shared).not.toBe(next)
+    expect(shared[0]).toBe(a)
+    expect(shared[1]).toBe(next[1])
+  })
+
+  it("produces a new row identity when each write marker changes", () => {
+    const base = makeRealEvent("stream_1", "100")
+    const markers: Array<Partial<CachedEvent>> = [
+      { _cachedAt: base._cachedAt + 1 },
+      { _patchedAt: 123 },
+      { _status: "pending" },
+      { sequence: "999", _sequenceNum: 999 },
+    ]
+    for (const marker of markers) {
+      const next = { ...reEmit([base])[0], ...marker }
+      const shared = shareEventIdentities([base], [next])
+      expect(shared[0]).toBe(next)
+    }
+  })
+
+  it("keeps unchanged identities when a new row is appended (live message arrival)", () => {
+    const a = makeRealEvent("stream_1", "100")
+    const c = makeRealEvent("stream_1", "300")
+    const next = [...reEmit([a]), c]
+
+    const shared = shareEventIdentities([a], next)
+    expect(shared).not.toBe(next.slice(0, 1))
+    expect(shared[0]).toBe(a)
+    expect(shared[1]).toBe(c)
+    expect(shared).toHaveLength(2)
+  })
+
+  it("keeps unchanged identities when an older page is prepended", () => {
+    const b = makeRealEvent("stream_1", "200")
+    const olderPage = [makeRealEvent("stream_1", "50"), makeRealEvent("stream_1", "100")]
+    const next = [...olderPage, ...reEmit([b])]
+
+    const shared = shareEventIdentities([b], next)
+    expect(shared[2]).toBe(b)
+  })
+
+  it("passes the array through when there is no previous emission", () => {
+    const next = [makeRealEvent("stream_1", "100")]
+    expect(shareEventIdentities(null, next)).toBe(next)
   })
 })

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -101,45 +101,57 @@ export function useStreamEvents(
   // the previous stream's array. Our stamp lets us detect that regardless of
   // whether the previous result happened to be non-empty or empty.
   const resultStreamId = (result as (CachedEvent[] & { __streamId?: string }) | undefined)?.__streamId
-  const prevRef = useRef<{ streamId: string; array: CachedEvent[]; byId: Map<string, CachedEvent> } | null>(null)
+  const prevRef = useRef<{ streamId: string; array: CachedEvent[] } | null>(null)
   if (streamId && resultStreamId !== streamId) {
     return undefined
   }
   if (!result || !streamId) return result
 
-  // Structural sharing: `useLiveQuery` re-runs on ANY write to db.events and
-  // materializes all-new row objects, even for rows whose stored bytes did
-  // not change. Downstream memoization (timeline rows) keys off row identity,
-  // so without sharing a single-message write invalidates every visible row.
-  // A row is considered unchanged when its write markers match: every
-  // payload-mutating write path bumps `_patchedAt` (socket patches),
-  // `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
-  // lifecycle), so matching markers imply an identical row.
   const prev = prevRef.current
-  let shared = result
-  if (prev && prev.streamId === streamId) {
-    let allSame = prev.array.length === result.length
-    shared = result.map((row, i) => {
-      const old = prev.byId.get(row.id)
-      if (
-        old &&
-        old._cachedAt === row._cachedAt &&
-        old._patchedAt === row._patchedAt &&
-        old._status === row._status &&
-        old.sequence === row.sequence
-      ) {
-        if (allSame && prev.array[i] !== old) allSame = false
-        return old
-      }
-      allSame = false
-      return row
-    })
-    if (allSame) shared = prev.array
-  }
+  const shared = shareEventIdentities(prev?.streamId === streamId ? prev.array : null, result)
   if (shared !== prev?.array) {
-    prevRef.current = { streamId, array: shared, byId: new Map(shared.map((row) => [row.id, row])) }
+    prevRef.current = { streamId, array: shared }
   }
   return shared
+}
+
+/**
+ * Structural sharing across liveQuery emissions: `useLiveQuery` re-runs on
+ * ANY write to db.events and materializes all-new row objects, even for rows
+ * whose stored bytes did not change. Downstream memoization (timeline rows)
+ * keys off row identity, so without sharing a single-message write would
+ * invalidate every visible row.
+ *
+ * A row from `prev` is reused when its write markers match: every
+ * payload-mutating write path bumps `_patchedAt` (socket patches),
+ * `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
+ * lifecycle), so matching markers imply an identical row. When every position
+ * is unchanged, the previous array itself is returned so array-level memo
+ * chains bail out too.
+ *
+ * Exported for isolated coverage; production callers go through
+ * `useStreamEvents`.
+ */
+export function shareEventIdentities(prev: CachedEvent[] | null, next: CachedEvent[]): CachedEvent[] {
+  if (!prev) return next
+  const prevById = new Map(prev.map((row) => [row.id, row]))
+  let allSame = prev.length === next.length
+  const shared = next.map((row, i) => {
+    const old = prevById.get(row.id)
+    if (
+      old &&
+      old._cachedAt === row._cachedAt &&
+      old._patchedAt === row._patchedAt &&
+      old._status === row._status &&
+      old.sequence === row.sequence
+    ) {
+      if (allSame && prev[i] !== old) allSame = false
+      return old
+    }
+    allSame = false
+    return row
+  })
+  return allSame ? prev : shared
 }
 
 /**

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -1,5 +1,6 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
+import { useRef } from "react"
 import { db, type CachedEvent, type CachedStream } from "@/db"
 
 /**
@@ -100,11 +101,45 @@ export function useStreamEvents(
   // the previous stream's array. Our stamp lets us detect that regardless of
   // whether the previous result happened to be non-empty or empty.
   const resultStreamId = (result as (CachedEvent[] & { __streamId?: string }) | undefined)?.__streamId
+  const prevRef = useRef<{ streamId: string; array: CachedEvent[]; byId: Map<string, CachedEvent> } | null>(null)
   if (streamId && resultStreamId !== streamId) {
     return undefined
   }
+  if (!result || !streamId) return result
 
-  return result
+  // Structural sharing: `useLiveQuery` re-runs on ANY write to db.events and
+  // materializes all-new row objects, even for rows whose stored bytes did
+  // not change. Downstream memoization (timeline rows) keys off row identity,
+  // so without sharing a single-message write invalidates every visible row.
+  // A row is considered unchanged when its write markers match: every
+  // payload-mutating write path bumps `_patchedAt` (socket patches),
+  // `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
+  // lifecycle), so matching markers imply an identical row.
+  const prev = prevRef.current
+  let shared = result
+  if (prev && prev.streamId === streamId) {
+    let allSame = prev.array.length === result.length
+    shared = result.map((row, i) => {
+      const old = prev.byId.get(row.id)
+      if (
+        old &&
+        old._cachedAt === row._cachedAt &&
+        old._patchedAt === row._patchedAt &&
+        old._status === row._status &&
+        old.sequence === row.sequence
+      ) {
+        if (allSame && prev.array[i] !== old) allSame = false
+        return old
+      }
+      allSame = false
+      return row
+    })
+    if (allSame) shared = prev.array
+  }
+  if (shared !== prev?.array) {
+    prevRef.current = { streamId, array: shared, byId: new Map(shared.map((row) => [row.id, row])) }
+  }
+  return shared
 }
 
 /**

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1446,3 +1446,78 @@ describe("getPersistedTail", () => {
     expect(await getPersistedTail("stream_tail_empty")).toEqual({ latestSequence: null, latestBroadcastSequence: null })
   })
 })
+
+describe("bootstrap no-op rewrite skip (perceived-perf: silence spurious liveQuery emissions)", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("does not rewrite a row when a second identical bootstrap applies (unchanged _cachedAt)", async () => {
+    const streamId = "stream_noop"
+    const events = [
+      makeEvent({ id: "evt_1", streamId, sequence: "100" }),
+      makeEvent({ id: "evt_2", streamId, sequence: "200" }),
+    ]
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap(events, streamId))
+    // Sentinel: if the second apply rewrites the row, _cachedAt jumps to "now"
+    // and the assertion below catches it even when both applies share a ms.
+    await db.events.update("evt_1", { _cachedAt: 12345 })
+    const first = await db.events.get("evt_1")
+
+    // Same content arrives again (cold open re-bootstrap). Without the skip,
+    // every row would be re-put with a fresh _cachedAt.
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap(events, streamId))
+    const second = await db.events.get("evt_1")
+
+    expect(second).toEqual(first)
+    expect(second?._cachedAt).toBe(12345)
+  })
+
+  it("still rewrites a row whose payload changed", async () => {
+    const streamId = "stream_changed"
+    const original = makeEvent({ id: "evt_1", streamId, sequence: "100" })
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([original], streamId))
+
+    const edited = {
+      ...original,
+      payload: { messageId: "evt_1", contentMarkdown: "edited content" },
+    }
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([edited], streamId))
+
+    const row = await db.events.get("evt_1")
+    expect((row?.payload as { contentMarkdown?: string }).contentMarkdown).toBe("edited content")
+  })
+
+  it("never skips a row carrying optimistic _status (the put intentionally clears it)", async () => {
+    const streamId = "stream_status"
+    const event = makeEvent({ id: "evt_1", streamId, sequence: "100" })
+    await db.events.put({
+      ...event,
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+      _status: "sent",
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([event], streamId))
+
+    const row = await db.events.get("evt_1")
+    expect(row?._status).toBeUndefined()
+  })
+
+  it("skips no-op rewrites for non-message event types too", async () => {
+    const streamId = "stream_member"
+    const joined = makeEvent({ id: "evt_join", streamId, sequence: "100", eventType: "member_joined" })
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([joined], streamId))
+    await db.events.update("evt_join", { _cachedAt: 12345 })
+    const first = await db.events.get("evt_join")
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([joined], streamId))
+    const second = await db.events.get("evt_join")
+
+    expect(second).toEqual(first)
+    expect(second?._cachedAt).toBe(12345)
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -182,6 +182,33 @@ async function pruneBootstrapReplaceWindow(streamId: string, bootstrap: StreamBo
   }
 }
 
+/**
+ * Whether putting `candidate` over `existing` would change nothing the app
+ * can observe. Skipping these puts matters for perceived performance: every
+ * write to `db.events` re-runs the timeline's `useLiveQuery`, and a bootstrap
+ * that rewrites byte-identical rows forces a full-window re-render for no
+ * user-visible change. `_cachedAt` is bookkeeping (nothing reads it for
+ * eviction or rendering), so a row that differs only by `_cachedAt` is a
+ * no-op. Rows carrying optimistic `_status` are never skipped — the put
+ * intentionally clears that flag on confirm.
+ */
+function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
+  if (existing._status !== undefined) return false
+  return (
+    existing.streamId === candidate.streamId &&
+    existing.workspaceId === candidate.workspaceId &&
+    existing.sequence === candidate.sequence &&
+    existing.broadcastSequence === candidate.broadcastSequence &&
+    existing._clientId === candidate._clientId &&
+    existing._sequenceNum === candidate._sequenceNum &&
+    existing.eventType === candidate.eventType &&
+    existing.actorId === candidate.actorId &&
+    existing.actorType === candidate.actorType &&
+    existing.createdAt === candidate.createdAt &&
+    JSON.stringify(existing.payload) === JSON.stringify(candidate.payload)
+  )
+}
+
 async function writeBootstrapEventsAndStream(
   workspaceId: string,
   streamId: string,
@@ -225,11 +252,13 @@ async function writeBootstrapEventsAndStream(
     const toWrite: CachedEvent[] = []
     for (const e of bootstrap.events) {
       const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+      const existing = existingById.get(e.id)
       if (e.eventType !== "message_created") {
-        toWrite.push(base)
+        if (existing === undefined || !isNoOpRewrite(existing, base)) {
+          toWrite.push(base)
+        }
         continue
       }
-      const existing = existingById.get(e.id)
       if (!existing) {
         toWrite.push(base)
         continue
@@ -238,7 +267,7 @@ async function writeBootstrapEventsAndStream(
         // Skip the put — existing row is fresher than this snapshot.
         continue
       }
-      toWrite.push({
+      const merged: CachedEvent = {
         ...base,
         payload: {
           ...(existing.payload as Record<string, unknown>),
@@ -247,7 +276,10 @@ async function writeBootstrapEventsAndStream(
         // Preserve the patch watermark so subsequent bootstraps still see
         // that this row has been touched by socket activity.
         _patchedAt: existing._patchedAt,
-      })
+      }
+      if (!isNoOpRewrite(existing, merged)) {
+        toWrite.push(merged)
+      }
     }
 
     if (toWrite.length > 0) {


### PR DESCRIPTION
## Problem

Dexie `useLiveQuery` re-runs on ANY write to `db.events` and materializes all-new row objects — and the stream bootstrap rewrites byte-identical rows into IDB on every apply, so every cold open / reconnect triggers a full-window identity churn that re-renders every visible timeline row. This is the data-layer half of root cause 1 in `docs/stream-timeline-perceived-performance.md` (#828): cold-start lag and the "some but not all messages flicker" symptom.

## Solution

**Structural sharing in `useStreamEvents`** (`stores/stream-store.ts`): reuse the previous row object when its write markers match (`_cachedAt`, `_patchedAt`, `_status`, `sequence` — every payload-mutating write path bumps one of them), and return the previous *array* identity when nothing changed at all, so the downstream memo chain (`events → displayEvents → timelineItems`) bails out entirely.

**Skip no-op IDB rewrites in the bootstrap merge** (`isNoOpRewrite` in `sync/stream-sync.ts`): rows whose merged result is byte-identical to the stored row (ignoring `_cachedAt`, which nothing reads) are not re-put — the spurious liveQuery emission stops at the source. Rows carrying optimistic `_status` are never skipped (the put intentionally clears the flag on confirm).

This skip is the one piece sync v2 (#826) eventually subsumes structurally; it's ~20 lines of interim relief until then.

## Stack

Part 1/4 of the timeline perceived-performance stack (from #828's "Proposed work"):
1. **this PR** — data-layer identity stability
2. #835 — row-tree memoization + staggered hydration
3. #836 — media fast paths
4. #837 — composer snap + keyboard reconcile tolerance

## Test plan

- [x] `src/stores` + `src/sync` suites pass (part of the 449 tests run across all touched areas)
- [x] Full monorepo lint + typecheck via pre-commit hooks

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774050&installation_id=129946197&pr_number=834&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F834&signature=a3fb5ca41b4a0b30ce70348bc42b265fd4144db367b84f4983098173765d3d2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
