### PR TITLE
perf(frontend): memoize the timeline row tree and stagger hydration

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -8,7 +8,10 @@ import {
   getTimelineItemKey,
   groupTimelineItems,
   injectGapItems,
+  timelineItemEqual,
+  timelineRowPropsEqual,
   type TimelineItem,
+  type TimelineItemRenderContext,
 } from "./event-list"
 
 interface CreateEventParams {
@@ -459,5 +462,140 @@ describe("injectGapItems", () => {
     const items = injectGapItems([messageItem("evt_1")], [{ afterEventId: "evt_1", missingCount: 1 }])
     const visible = filterVisibleItems(items)
     expect(visible.some((item) => item.type === "gap")).toBe(true)
+  })
+})
+
+describe("timelineRowPropsEqual (memoized row comparator)", () => {
+  function makeCtx(overrides: Partial<TimelineItemRenderContext> = {}): TimelineItemRenderContext {
+    return {
+      workspaceId: "ws_1",
+      streamId: "stream_123",
+      sessionLiveCounts: new Map(),
+      sessionLiveSubsteps: new Map(),
+      sessionCanAbort: new Map(),
+      ...overrides,
+    }
+  }
+
+  function messageItem(event: StreamEvent): TimelineItem {
+    return { type: "event", event }
+  }
+
+  const msgA = createEvent({
+    id: "evt_a",
+    sequence: "100",
+    eventType: "message_created",
+    payload: { messageId: "msg_a", contentMarkdown: "a" },
+  })
+  const msgB = createEvent({
+    id: "evt_b",
+    sequence: "200",
+    eventType: "message_created",
+    payload: { messageId: "msg_b", contentMarkdown: "b" },
+  })
+
+  it("equal when ctx is rebuilt with fresh containers but same per-item content", () => {
+    // Simulates a data tick: new ctx object, new Set/Map identities, same content.
+    const prev = {
+      item: messageItem(msgA),
+      ctx: makeCtx({ newMessageIds: new Set(["evt_x"]) }),
+      deferSecondaryHydration: false,
+    }
+    const next = {
+      item: { ...prev.item } as TimelineItem,
+      ctx: makeCtx({ newMessageIds: new Set(["evt_x"]) }),
+      deferSecondaryHydration: false,
+    }
+    expect(timelineRowPropsEqual(prev, next)).toBe(true)
+  })
+
+  it("not equal when the contained event identity changed (the row's own data changed)", () => {
+    const patched = { ...msgA, payload: { ...(msgA.payload as object), reactions: [{ emoji: "👍" }] } }
+    const prev = { item: messageItem(msgA), ctx: makeCtx(), deferSecondaryHydration: false }
+    const next = { item: messageItem(patched), ctx: makeCtx(), deferSecondaryHydration: false }
+    expect(timelineRowPropsEqual(prev, next)).toBe(false)
+  })
+
+  it("newMessageIds membership change invalidates only the member row", () => {
+    const before = makeCtx({ newMessageIds: new Set<string>() })
+    const after = makeCtx({ newMessageIds: new Set(["evt_a"]) })
+    const rowA = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgA), ctx, deferSecondaryHydration: false })
+    const rowB = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgB), ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(rowA(before), rowA(after))).toBe(false)
+    expect(timelineRowPropsEqual(rowB(before), rowB(after))).toBe(true)
+  })
+
+  it("highlight change invalidates only the highlighted row (both directions)", () => {
+    const off = makeCtx()
+    const on = makeCtx({ highlightMessageId: "msg_a" })
+    const rowA = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgA), ctx, deferSecondaryHydration: false })
+    const rowB = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgB), ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(rowA(off), rowA(on))).toBe(false)
+    expect(timelineRowPropsEqual(rowA(on), rowA(off))).toBe(false)
+    expect(timelineRowPropsEqual(rowB(off), rowB(on))).toBe(true)
+  })
+
+  it("unread divider position change invalidates the rows gaining/losing the divider", () => {
+    const before = makeCtx({ firstUnreadEventId: "evt_a" })
+    const after = makeCtx({ firstUnreadEventId: "evt_b" })
+    const rowA = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgA), ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(rowA(before), rowA(after))).toBe(false)
+  })
+
+  it("deferSecondaryHydration flip invalidates the row", () => {
+    const prev = { item: messageItem(msgA), ctx: makeCtx(), deferSecondaryHydration: true }
+    const next = { item: messageItem(msgA), ctx: makeCtx(), deferSecondaryHydration: false }
+    expect(timelineRowPropsEqual(prev, next)).toBe(false)
+  })
+
+  it("batch selection membership invalidates only the toggled message", () => {
+    const onToggleMessage = () => {}
+    const batchWith = (selected: string[]) => ({
+      enabled: true,
+      selectedMessageIds: new Set(selected),
+      invalidTargetIds: new Set<string>(),
+      hoveredTargetId: null,
+      onToggleMessage,
+    })
+    const before = makeCtx({ batch: batchWith([]) })
+    const after = makeCtx({ batch: batchWith(["msg_a"]) })
+    const rowA = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgA), ctx, deferSecondaryHydration: false })
+    const rowB = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgB), ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(rowA(before), rowA(after))).toBe(false)
+    expect(timelineRowPropsEqual(rowB(before), rowB(after))).toBe(true)
+  })
+
+  it("agent activity for the row's message invalidates it; other rows stay equal", () => {
+    const activity = {
+      sessionId: "sess_1",
+      personaName: "Ariadne",
+      stepCount: 1,
+      messageCount: 0,
+      substep: null,
+      currentStepType: null,
+    }
+    const before = makeCtx({ agentActivity: new Map() })
+    const after = makeCtx({ agentActivity: new Map([["msg_a", activity]]) })
+    const rowA = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgA), ctx, deferSecondaryHydration: false })
+    const rowB = (ctx: TimelineItemRenderContext) => ({ item: messageItem(msgB), ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(rowA(before), rowA(after))).toBe(false)
+    expect(timelineRowPropsEqual(rowB(before), rowB(after))).toBe(true)
+  })
+
+  it("session group: live count value change invalidates; rebuilt-but-equal maps do not", () => {
+    const started = createSessionStartedEvent("evt_s", "300", "sess_1", "msg_a")
+    const item: TimelineItem = { type: "session_group", sessionId: "sess_1", sessionVersion: 1, events: [started] }
+    const counts = (stepCount: number) =>
+      makeCtx({ sessionLiveCounts: new Map([["sess_1", { stepCount, messageCount: 0 }]]) })
+    const row = (ctx: TimelineItemRenderContext) => ({ item, ctx, deferSecondaryHydration: false })
+    expect(timelineRowPropsEqual(row(counts(1)), row(counts(1)))).toBe(true)
+    expect(timelineRowPropsEqual(row(counts(1)), row(counts(2)))).toBe(false)
+  })
+
+  it("timelineItemEqual: rebuilt wrapper with same event identities is equal; changed groupContinuation is not", () => {
+    const a: TimelineItem = { type: "event", event: msgA }
+    expect(timelineItemEqual(a, { type: "event", event: msgA })).toBe(true)
+    expect(timelineItemEqual(a, { type: "event", event: msgA, groupContinuation: true })).toBe(false)
+    expect(timelineItemEqual(a, { type: "event", event: { ...msgA } })).toBe(false)
   })
 })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import {
   COMMAND_EVENT_TYPES,
   AGENT_SESSION_EVENT_TYPES,
@@ -403,7 +403,6 @@ export interface TimelineItemRenderContext {
   sessionCanAbort: Map<string, boolean>
   /** Click handler for the Stop research button. */
   onAbortResearch?: (sessionId: string) => void
-  phase: string
   batch?: BatchTimelineState
 }
 
@@ -416,8 +415,15 @@ function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean
   return item.event.id === firstUnreadEventId
 }
 
-/** Renders a single timeline item. Used by Virtuoso's itemContent and non-virtualized lists. */
-export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: TimelineItemRenderContext }) {
+interface TimelineItemContentProps {
+  item: TimelineItem
+  ctx: TimelineItemRenderContext
+  /** Defer non-critical per-message hydration (presigns, previews, embeds). */
+  deferSecondaryHydration: boolean
+}
+
+/** Renders a single timeline item. Used by virtua's row mapping and non-virtualized lists. */
+function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: TimelineItemContentProps) {
   const showUnreadDivider = isFirstUnread(item, ctx.firstUnreadEventId)
   return (
     <>
@@ -460,7 +466,7 @@ export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: Ti
           highlightMessageId={ctx.highlightMessageId}
           agentActivity={ctx.hideSessionCards ? ctx.agentActivity : undefined}
           isNew={ctx.newMessageIds?.has(item.event.id)}
-          deferSecondaryHydration={ctx.phase !== "ready"}
+          deferSecondaryHydration={deferSecondaryHydration}
           batch={ctx.batch}
           // Continuations directly under an UnreadDivider promote back to head so
           // the first unread message in a run still reads as a fresh turn for the
@@ -475,6 +481,125 @@ export function TimelineItemContent({ item, ctx }: { item: TimelineItem; ctx: Ti
     </>
   )
 }
+
+function getEventMessageId(event: StreamEvent): string | undefined {
+  return (event.payload as { messageId?: string })?.messageId
+}
+
+function eventsArrayEqual(a: StreamEvent[], b: StreamEvent[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/**
+ * Whether two TimelineItems would render identically. `groupTimelineItems`
+ * rebuilds every wrapper object on each run, but the underlying StreamEvent
+ * objects keep identity when unchanged (structural sharing in
+ * `useStreamEvents`), so identity of the contained events is the real signal.
+ */
+function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
+  if (a === b) return true
+  if (a.type !== b.type) return false
+  switch (a.type) {
+    case "event": {
+      const other = b as Extract<TimelineItem, { type: "event" }>
+      return a.event === other.event && (a.groupContinuation ?? false) === (other.groupContinuation ?? false)
+    }
+    case "command_group": {
+      const other = b as Extract<TimelineItem, { type: "command_group" }>
+      return a.commandId === other.commandId && eventsArrayEqual(a.events, other.events)
+    }
+    case "session_group": {
+      const other = b as Extract<TimelineItem, { type: "session_group" }>
+      return (
+        a.sessionId === other.sessionId &&
+        a.sessionVersion === other.sessionVersion &&
+        eventsArrayEqual(a.events, other.events)
+      )
+    }
+    case "gap": {
+      const other = b as Extract<TimelineItem, { type: "gap" }>
+      return a.afterEventId === other.afterEventId && a.missingCount === other.missingCount
+    }
+  }
+}
+
+/**
+ * Per-item props equality for the memoized row. `ctx` is rebuilt (new object,
+ * new Maps/Sets) on every message arrival, agent-activity tick, or batch
+ * interaction, so comparing ctx by identity would defeat the memo. Instead we
+ * compare only what this *item* actually reads out of ctx — set membership
+ * and map lookups rather than container identity.
+ *
+ * IMPORTANT: when adding a field to TimelineItemRenderContext that affects
+ * row rendering, it must be compared here, or rows will render stale.
+ */
+function timelineRowPropsEqual(prev: TimelineItemContentProps, next: TimelineItemContentProps): boolean {
+  if (!timelineItemEqual(prev.item, next.item)) return false
+  if (prev.deferSecondaryHydration !== next.deferSecondaryHydration) return false
+  const p = prev.ctx
+  const n = next.ctx
+  if (
+    p.workspaceId !== n.workspaceId ||
+    p.streamId !== n.streamId ||
+    p.hideSessionCards !== n.hideSessionCards ||
+    p.isDividerFading !== n.isDividerFading ||
+    p.onAbortResearch !== n.onAbortResearch
+  ) {
+    return false
+  }
+  const item = next.item
+  if (isFirstUnread(item, p.firstUnreadEventId) !== isFirstUnread(item, n.firstUnreadEventId)) return false
+
+  if (item.type === "session_group") {
+    const prevCounts = p.sessionLiveCounts.get(item.sessionId)
+    const nextCounts = n.sessionLiveCounts.get(item.sessionId)
+    if (prevCounts?.stepCount !== nextCounts?.stepCount || prevCounts?.messageCount !== nextCounts?.messageCount) {
+      return false
+    }
+    if (p.sessionLiveSubsteps.get(item.sessionId) !== n.sessionLiveSubsteps.get(item.sessionId)) return false
+    if ((p.sessionCanAbort.get(item.sessionId) ?? false) !== (n.sessionCanAbort.get(item.sessionId) ?? false)) {
+      return false
+    }
+    return true
+  }
+
+  if (item.type !== "event") return true
+
+  const messageId = getEventMessageId(item.event)
+  if ((p.highlightMessageId === messageId) !== (n.highlightMessageId === messageId)) return false
+  if ((p.firstMessageId === messageId) !== (n.firstMessageId === messageId)) return false
+  if ((p.newMessageIds?.has(item.event.id) ?? false) !== (n.newMessageIds?.has(item.event.id) ?? false)) return false
+  if (messageId !== undefined && p.agentActivity?.get(messageId) !== n.agentActivity?.get(messageId)) return false
+
+  const pb = p.batch
+  const nb = n.batch
+  if ((pb === undefined) !== (nb === undefined)) return false
+  if (pb && nb && messageId !== undefined) {
+    if (
+      pb.enabled !== nb.enabled ||
+      pb.onToggleMessage !== nb.onToggleMessage ||
+      pb.selectedMessageIds.has(messageId) !== nb.selectedMessageIds.has(messageId) ||
+      pb.invalidTargetIds.has(messageId) !== nb.invalidTargetIds.has(messageId) ||
+      (pb.hoveredTargetId === messageId) !== (nb.hoveredTargetId === messageId)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Memoized timeline row. The timeline's inputs churn identity constantly
+ * (Dexie liveQuery re-emits all-new arrays on any events write; ctx is
+ * rebuilt per tick), so the memo uses a per-item comparator instead of
+ * shallow props equality — a data tick re-renders only the rows whose own
+ * inputs changed instead of the full window.
+ */
+export const TimelineItemContent = memo(TimelineItemContentImpl, timelineRowPropsEqual)
 
 /**
  * Non-virtualized event list for threads and other cases where all items are rendered.
@@ -573,7 +698,6 @@ export function EventList({
     sessionLiveSubsteps,
     sessionCanAbort,
     onAbortResearch: handleAbortResearch,
-    phase,
     batch,
   }
 
@@ -583,7 +707,7 @@ export function EventList({
         const itemKey = getTimelineItemKey(item)
         return (
           <div key={itemKey} className={isFirstUnread(item, firstUnreadEventId) ? "relative" : undefined}>
-            <TimelineItemContent item={item} ctx={ctx} />
+            <TimelineItemContent item={item} ctx={ctx} deferSecondaryHydration={phase !== "ready"} />
           </div>
         )
       })}

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -415,7 +415,7 @@ function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean
   return item.event.id === firstUnreadEventId
 }
 
-interface TimelineItemContentProps {
+export interface TimelineItemContentProps {
   item: TimelineItem
   ctx: TimelineItemRenderContext
   /** Defer non-critical per-message hydration (presigns, previews, embeds). */
@@ -500,7 +500,7 @@ function eventsArrayEqual(a: StreamEvent[], b: StreamEvent[]): boolean {
  * objects keep identity when unchanged (structural sharing in
  * `useStreamEvents`), so identity of the contained events is the real signal.
  */
-function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
+export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
   if (a === b) return true
   if (a.type !== b.type) return false
   switch (a.type) {
@@ -536,8 +536,11 @@ function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
  *
  * IMPORTANT: when adding a field to TimelineItemRenderContext that affects
  * row rendering, it must be compared here, or rows will render stale.
+ *
+ * Exported for isolated coverage (see event-list.test.ts); production callers
+ * go through the memoized TimelineItemContent.
  */
-function timelineRowPropsEqual(prev: TimelineItemContentProps, next: TimelineItemContentProps): boolean {
+export function timelineRowPropsEqual(prev: TimelineItemContentProps, next: TimelineItemContentProps): boolean {
   if (!timelineItemEqual(prev.item, next.item)) return false
   if (prev.deferSecondaryHydration !== next.deferSecondaryHydration) return false
   const p = prev.ctx

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1795,7 +1795,6 @@ function TimelineMessageList({
       sessionLiveSubsteps,
       sessionCanAbort,
       onAbortResearch: handleAbortResearch,
-      phase,
       batch,
     }),
     [
@@ -1812,10 +1811,37 @@ function TimelineMessageList({
       sessionLiveSubsteps,
       sessionCanAbort,
       handleAbortResearch,
-      phase,
       batch,
     ]
   )
+
+  // Stagger the post-reveal hydration burst (INV-21 adjacent): when the
+  // coordinated-loading phase flips to "ready", releasing every row's
+  // deferSecondaryHydration at once fires all presigns/link previews/embeds
+  // in one frame — a long task right at reveal. Instead release rows in
+  // batches from the bottom (the viewport on a chat) upward, one batch per
+  // frame. Once every row present at release time is hydrated, latch open so
+  // later prepends/appends hydrate immediately.
+  const HYDRATION_RELEASE_BATCH = 8
+  const [hydrationWave, setHydrationWave] = useState(0)
+  const fullyHydratedRef = useRef(false)
+  const lastHydrationStreamRef = useRef(streamId)
+  if (lastHydrationStreamRef.current !== streamId) {
+    lastHydrationStreamRef.current = streamId
+    fullyHydratedRef.current = false
+    setHydrationWave(0)
+  }
+  const itemCount = visibleItems.length
+  useEffect(() => {
+    if (phase !== "ready" || fullyHydratedRef.current) return
+    if (hydrationWave * HYDRATION_RELEASE_BATCH >= itemCount) {
+      fullyHydratedRef.current = true
+      return
+    }
+    const id = requestAnimationFrame(() => setHydrationWave((wave) => wave + 1))
+    return () => cancelAnimationFrame(id)
+  }, [phase, hydrationWave, itemCount])
+  const releasedFromBottom = hydrationWave * HYDRATION_RELEASE_BATCH
 
   // Fetch guards to prevent rapid re-firing
   const olderFetchCooldownRef = useRef(0)
@@ -2011,14 +2037,22 @@ function TimelineMessageList({
             // viewport doesn't move — the core reverse-infinite-scroll fix.
             shift={shift}
             // Off-screen px kept mounted so fast scrolling doesn't outrun
-            // mount+measure and flash blank rows. Deliberately modest: heavy
-            // message DOM (ProseMirror, link previews) janks with a large window;
-            // smooth fast-scroll comes from prefetching pages early, not overscan.
-            bufferSize={1000}
+            // mount+measure and flash blank rows. Was 1000 when every data tick
+            // re-rendered the whole window; with memoized rows the steady-state
+            // cost of extra mounted rows is near zero, so a larger buffer buys
+            // fling headroom. Mount cost still bounds it — don't raise further
+            // without profiling on a low-end device.
+            bufferSize={2000}
           >
-            {visibleItems.map((item) => (
+            {visibleItems.map((item, index) => (
               <div key={getTimelineItemKey(item)} className="relative mx-auto max-w-[800px]">
-                <TimelineItemContent item={item} ctx={renderCtx} />
+                <TimelineItemContent
+                  item={item}
+                  ctx={renderCtx}
+                  deferSecondaryHydration={
+                    !fullyHydratedRef.current && (phase !== "ready" || index < visibleItems.length - releasedFromBottom)
+                  }
+                />
               </div>
             ))}
           </Virtualizer>

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { loadStreamEvents } from "./stream-store"
+import { loadStreamEvents, shareEventIdentities } from "./stream-store"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -217,5 +217,70 @@ describe("loadStreamEvents", () => {
     const events = await loadStreamEvents(streamId, 100)
 
     expect(events.map((e) => e.id)).toEqual(["evt_stream_floored_100", "evt_stream_floored_101", "temp_above"])
+  })
+})
+
+describe("shareEventIdentities", () => {
+  function reEmit(rows: CachedEvent[]): CachedEvent[] {
+    // Simulate a liveQuery re-run: same stored bytes, all-new object identities.
+    return rows.map((row) => ({ ...row, payload: { ...(row.payload as Record<string, unknown>) } }))
+  }
+
+  it("returns the previous array identity when nothing changed", () => {
+    const prev = [makeRealEvent("stream_1", "100"), makeRealEvent("stream_1", "200")]
+    expect(shareEventIdentities(prev, reEmit(prev))).toBe(prev)
+  })
+
+  it("reuses unchanged row identities when one row changed", () => {
+    const a = makeRealEvent("stream_1", "100")
+    const b = makeRealEvent("stream_1", "200")
+    const next = reEmit([a, b])
+    next[1]._patchedAt = Date.now() // a socket patch landed on b
+
+    const shared = shareEventIdentities([a, b], next)
+    expect(shared).not.toBe(next)
+    expect(shared[0]).toBe(a)
+    expect(shared[1]).toBe(next[1])
+  })
+
+  it("produces a new row identity when each write marker changes", () => {
+    const base = makeRealEvent("stream_1", "100")
+    const markers: Array<Partial<CachedEvent>> = [
+      { _cachedAt: base._cachedAt + 1 },
+      { _patchedAt: 123 },
+      { _status: "pending" },
+      { sequence: "999", _sequenceNum: 999 },
+    ]
+    for (const marker of markers) {
+      const next = { ...reEmit([base])[0], ...marker }
+      const shared = shareEventIdentities([base], [next])
+      expect(shared[0]).toBe(next)
+    }
+  })
+
+  it("keeps unchanged identities when a new row is appended (live message arrival)", () => {
+    const a = makeRealEvent("stream_1", "100")
+    const c = makeRealEvent("stream_1", "300")
+    const next = [...reEmit([a]), c]
+
+    const shared = shareEventIdentities([a], next)
+    expect(shared).not.toBe(next.slice(0, 1))
+    expect(shared[0]).toBe(a)
+    expect(shared[1]).toBe(c)
+    expect(shared).toHaveLength(2)
+  })
+
+  it("keeps unchanged identities when an older page is prepended", () => {
+    const b = makeRealEvent("stream_1", "200")
+    const olderPage = [makeRealEvent("stream_1", "50"), makeRealEvent("stream_1", "100")]
+    const next = [...olderPage, ...reEmit([b])]
+
+    const shared = shareEventIdentities([b], next)
+    expect(shared[2]).toBe(b)
+  })
+
+  it("passes the array through when there is no previous emission", () => {
+    const next = [makeRealEvent("stream_1", "100")]
+    expect(shareEventIdentities(null, next)).toBe(next)
   })
 })

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -101,45 +101,57 @@ export function useStreamEvents(
   // the previous stream's array. Our stamp lets us detect that regardless of
   // whether the previous result happened to be non-empty or empty.
   const resultStreamId = (result as (CachedEvent[] & { __streamId?: string }) | undefined)?.__streamId
-  const prevRef = useRef<{ streamId: string; array: CachedEvent[]; byId: Map<string, CachedEvent> } | null>(null)
+  const prevRef = useRef<{ streamId: string; array: CachedEvent[] } | null>(null)
   if (streamId && resultStreamId !== streamId) {
     return undefined
   }
   if (!result || !streamId) return result
 
-  // Structural sharing: `useLiveQuery` re-runs on ANY write to db.events and
-  // materializes all-new row objects, even for rows whose stored bytes did
-  // not change. Downstream memoization (timeline rows) keys off row identity,
-  // so without sharing a single-message write invalidates every visible row.
-  // A row is considered unchanged when its write markers match: every
-  // payload-mutating write path bumps `_patchedAt` (socket patches),
-  // `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
-  // lifecycle), so matching markers imply an identical row.
   const prev = prevRef.current
-  let shared = result
-  if (prev && prev.streamId === streamId) {
-    let allSame = prev.array.length === result.length
-    shared = result.map((row, i) => {
-      const old = prev.byId.get(row.id)
-      if (
-        old &&
-        old._cachedAt === row._cachedAt &&
-        old._patchedAt === row._patchedAt &&
-        old._status === row._status &&
-        old.sequence === row.sequence
-      ) {
-        if (allSame && prev.array[i] !== old) allSame = false
-        return old
-      }
-      allSame = false
-      return row
-    })
-    if (allSame) shared = prev.array
-  }
+  const shared = shareEventIdentities(prev?.streamId === streamId ? prev.array : null, result)
   if (shared !== prev?.array) {
-    prevRef.current = { streamId, array: shared, byId: new Map(shared.map((row) => [row.id, row])) }
+    prevRef.current = { streamId, array: shared }
   }
   return shared
+}
+
+/**
+ * Structural sharing across liveQuery emissions: `useLiveQuery` re-runs on
+ * ANY write to db.events and materializes all-new row objects, even for rows
+ * whose stored bytes did not change. Downstream memoization (timeline rows)
+ * keys off row identity, so without sharing a single-message write would
+ * invalidate every visible row.
+ *
+ * A row from `prev` is reused when its write markers match: every
+ * payload-mutating write path bumps `_patchedAt` (socket patches),
+ * `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
+ * lifecycle), so matching markers imply an identical row. When every position
+ * is unchanged, the previous array itself is returned so array-level memo
+ * chains bail out too.
+ *
+ * Exported for isolated coverage; production callers go through
+ * `useStreamEvents`.
+ */
+export function shareEventIdentities(prev: CachedEvent[] | null, next: CachedEvent[]): CachedEvent[] {
+  if (!prev) return next
+  const prevById = new Map(prev.map((row) => [row.id, row]))
+  let allSame = prev.length === next.length
+  const shared = next.map((row, i) => {
+    const old = prevById.get(row.id)
+    if (
+      old &&
+      old._cachedAt === row._cachedAt &&
+      old._patchedAt === row._patchedAt &&
+      old._status === row._status &&
+      old.sequence === row.sequence
+    ) {
+      if (allSame && prev[i] !== old) allSame = false
+      return old
+    }
+    allSame = false
+    return row
+  })
+  return allSame ? prev : shared
 }
 
 /**

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -1,5 +1,6 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
+import { useRef } from "react"
 import { db, type CachedEvent, type CachedStream } from "@/db"
 
 /**
@@ -100,11 +101,45 @@ export function useStreamEvents(
   // the previous stream's array. Our stamp lets us detect that regardless of
   // whether the previous result happened to be non-empty or empty.
   const resultStreamId = (result as (CachedEvent[] & { __streamId?: string }) | undefined)?.__streamId
+  const prevRef = useRef<{ streamId: string; array: CachedEvent[]; byId: Map<string, CachedEvent> } | null>(null)
   if (streamId && resultStreamId !== streamId) {
     return undefined
   }
+  if (!result || !streamId) return result
 
-  return result
+  // Structural sharing: `useLiveQuery` re-runs on ANY write to db.events and
+  // materializes all-new row objects, even for rows whose stored bytes did
+  // not change. Downstream memoization (timeline rows) keys off row identity,
+  // so without sharing a single-message write invalidates every visible row.
+  // A row is considered unchanged when its write markers match: every
+  // payload-mutating write path bumps `_patchedAt` (socket patches),
+  // `_cachedAt` (bootstrap apply / cache updates), or `_status` (optimistic
+  // lifecycle), so matching markers imply an identical row.
+  const prev = prevRef.current
+  let shared = result
+  if (prev && prev.streamId === streamId) {
+    let allSame = prev.array.length === result.length
+    shared = result.map((row, i) => {
+      const old = prev.byId.get(row.id)
+      if (
+        old &&
+        old._cachedAt === row._cachedAt &&
+        old._patchedAt === row._patchedAt &&
+        old._status === row._status &&
+        old.sequence === row.sequence
+      ) {
+        if (allSame && prev.array[i] !== old) allSame = false
+        return old
+      }
+      allSame = false
+      return row
+    })
+    if (allSame) shared = prev.array
+  }
+  if (shared !== prev?.array) {
+    prevRef.current = { streamId, array: shared, byId: new Map(shared.map((row) => [row.id, row])) }
+  }
+  return shared
 }
 
 /**

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1446,3 +1446,78 @@ describe("getPersistedTail", () => {
     expect(await getPersistedTail("stream_tail_empty")).toEqual({ latestSequence: null, latestBroadcastSequence: null })
   })
 })
+
+describe("bootstrap no-op rewrite skip (perceived-perf: silence spurious liveQuery emissions)", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("does not rewrite a row when a second identical bootstrap applies (unchanged _cachedAt)", async () => {
+    const streamId = "stream_noop"
+    const events = [
+      makeEvent({ id: "evt_1", streamId, sequence: "100" }),
+      makeEvent({ id: "evt_2", streamId, sequence: "200" }),
+    ]
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap(events, streamId))
+    // Sentinel: if the second apply rewrites the row, _cachedAt jumps to "now"
+    // and the assertion below catches it even when both applies share a ms.
+    await db.events.update("evt_1", { _cachedAt: 12345 })
+    const first = await db.events.get("evt_1")
+
+    // Same content arrives again (cold open re-bootstrap). Without the skip,
+    // every row would be re-put with a fresh _cachedAt.
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap(events, streamId))
+    const second = await db.events.get("evt_1")
+
+    expect(second).toEqual(first)
+    expect(second?._cachedAt).toBe(12345)
+  })
+
+  it("still rewrites a row whose payload changed", async () => {
+    const streamId = "stream_changed"
+    const original = makeEvent({ id: "evt_1", streamId, sequence: "100" })
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([original], streamId))
+
+    const edited = {
+      ...original,
+      payload: { messageId: "evt_1", contentMarkdown: "edited content" },
+    }
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([edited], streamId))
+
+    const row = await db.events.get("evt_1")
+    expect((row?.payload as { contentMarkdown?: string }).contentMarkdown).toBe("edited content")
+  })
+
+  it("never skips a row carrying optimistic _status (the put intentionally clears it)", async () => {
+    const streamId = "stream_status"
+    const event = makeEvent({ id: "evt_1", streamId, sequence: "100" })
+    await db.events.put({
+      ...event,
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+      _status: "sent",
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([event], streamId))
+
+    const row = await db.events.get("evt_1")
+    expect(row?._status).toBeUndefined()
+  })
+
+  it("skips no-op rewrites for non-message event types too", async () => {
+    const streamId = "stream_member"
+    const joined = makeEvent({ id: "evt_join", streamId, sequence: "100", eventType: "member_joined" })
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([joined], streamId))
+    await db.events.update("evt_join", { _cachedAt: 12345 })
+    const first = await db.events.get("evt_join")
+
+    await applyStreamBootstrap("ws_1", streamId, makeBootstrap([joined], streamId))
+    const second = await db.events.get("evt_join")
+
+    expect(second).toEqual(first)
+    expect(second?._cachedAt).toBe(12345)
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -182,6 +182,33 @@ async function pruneBootstrapReplaceWindow(streamId: string, bootstrap: StreamBo
   }
 }
 
+/**
+ * Whether putting `candidate` over `existing` would change nothing the app
+ * can observe. Skipping these puts matters for perceived performance: every
+ * write to `db.events` re-runs the timeline's `useLiveQuery`, and a bootstrap
+ * that rewrites byte-identical rows forces a full-window re-render for no
+ * user-visible change. `_cachedAt` is bookkeeping (nothing reads it for
+ * eviction or rendering), so a row that differs only by `_cachedAt` is a
+ * no-op. Rows carrying optimistic `_status` are never skipped — the put
+ * intentionally clears that flag on confirm.
+ */
+function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
+  if (existing._status !== undefined) return false
+  return (
+    existing.streamId === candidate.streamId &&
+    existing.workspaceId === candidate.workspaceId &&
+    existing.sequence === candidate.sequence &&
+    existing.broadcastSequence === candidate.broadcastSequence &&
+    existing._clientId === candidate._clientId &&
+    existing._sequenceNum === candidate._sequenceNum &&
+    existing.eventType === candidate.eventType &&
+    existing.actorId === candidate.actorId &&
+    existing.actorType === candidate.actorType &&
+    existing.createdAt === candidate.createdAt &&
+    JSON.stringify(existing.payload) === JSON.stringify(candidate.payload)
+  )
+}
+
 async function writeBootstrapEventsAndStream(
   workspaceId: string,
   streamId: string,
@@ -225,11 +252,13 @@ async function writeBootstrapEventsAndStream(
     const toWrite: CachedEvent[] = []
     for (const e of bootstrap.events) {
       const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+      const existing = existingById.get(e.id)
       if (e.eventType !== "message_created") {
-        toWrite.push(base)
+        if (existing === undefined || !isNoOpRewrite(existing, base)) {
+          toWrite.push(base)
+        }
         continue
       }
-      const existing = existingById.get(e.id)
       if (!existing) {
         toWrite.push(base)
         continue
@@ -238,7 +267,7 @@ async function writeBootstrapEventsAndStream(
         // Skip the put — existing row is fresher than this snapshot.
         continue
       }
-      toWrite.push({
+      const merged: CachedEvent = {
         ...base,
         payload: {
           ...(existing.payload as Record<string, unknown>),
@@ -247,7 +276,10 @@ async function writeBootstrapEventsAndStream(
         // Preserve the patch watermark so subsequent bootstraps still see
         // that this row has been touched by socket activity.
         _patchedAt: existing._patchedAt,
-      })
+      }
+      if (!isNoOpRewrite(existing, merged)) {
+        toWrite.push(merged)
+      }
     }
 
     if (toWrite.length > 0) {


### PR DESCRIPTION
## Problem

`TimelineItemContent` (and everything under it) is a plain function component, and its `ctx` prop is rebuilt with fresh Maps/Sets on every message arrival, agent-activity tick, or phase change — so any data tick re-renders every visible row. On a low-end phone that's the difference between a 2ms and a 60ms+ frame, and it's root cause 1 for all four symptoms in `docs/stream-timeline-perceived-performance.md` (#828). The phase flip to `ready` also releases `deferSecondaryHydration` for every row at once, firing all presigns/link previews/embeds in a single frame right at reveal.

## Solution

**Memoized row with a per-item comparator** (`timelineRowPropsEqual`): comparing `ctx` by identity would defeat the memo, so the comparator checks only what *this item* reads out of it — set membership (`newMessageIds`, batch selection), map lookups by the item's own messageId/sessionId (agent activity, session live counts by value), and derived booleans (highlight, first-message badge, unread-divider position). Item equality keys off contained `StreamEvent` identities (stable thanks to #834), since `groupTimelineItems` rebuilds the wrapper objects every run.

**`phase` removed from `TimelineItemRenderContext`**; `deferSecondaryHydration` is an explicit prop, so phase transitions between non-ready phases no longer invalidate rows.

**Staggered hydration release**: after the phase flips to `ready`, rows release `deferSecondaryHydration` in batches of 8 per frame from the bottom (the viewport on a chat) up, then latch open so later prepends/appends hydrate immediately.

**`bufferSize` 1000 → 2000**: the old value was trapped between blank rows on fling and jank from expensive re-renders; with memoized rows the steady-state cost of extra mounted rows is near zero.

⚠️ Maintenance note for reviewers: the comparator must be updated when a new field is added to `TimelineItemRenderContext` that affects row rendering — there's a prominent comment on it saying so.

## Stack

Part 2/4, stacked on #834. Next: #836 (media), #837 (composer).

## Test plan

- [x] `src/components/timeline` suites pass (part of the 449 tests run across all touched areas)
- [x] Full monorepo lint + typecheck via pre-commit hooks
- [ ] Manual: React Profiler on bootstrap apply — rows re-rendered should drop from "all visible" to "only changed"

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774070&installation_id=129946197&pr_number=835&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F835&signature=8a6f97b85eb6b5b88074fdac4a1970f9f38adc736fadb9e1c5cfadf83e1044a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
