### PR TITLE
feat: surface GAM memory capture as memos:captured timeline events (INV-62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,8 +267,8 @@ When handling variants, colocate variant config and keep shared behavior on one 
 - **Persistence and data integrity:** INV-1, INV-2, INV-3, INV-8, INV-17, INV-20, INV-30, INV-41, INV-50, INV-56, INV-57
 - **Architecture and dependencies:** INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-12, INV-13, INV-27, INV-34, INV-35, INV-37, INV-51, INV-52
 - **API and backend contracts:** INV-31, INV-32, INV-33, INV-46, INV-55, INV-58
-- **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54, INV-62
-- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61
+- **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54
+- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61, INV-62
 - **Testing:** INV-22, INV-23, INV-24, INV-26, INV-39, INV-48
 - **Code hygiene and maneuverability:** INV-25, INV-29, INV-36, INV-38, INV-43, INV-47, INV-49
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ AI component config lives next to the component in `config.ts` and is shared by 
 
 Do not make semantic decisions with language-specific heuristics or English-only literals/regexes; use model-based decisions for language-dependent behavior (INV-54).
 
+Memory capture is visible in situ (INV-62). When GAM extracts memos from a stream's conversations, the same transaction that inserts the memo rows appends a `memos:captured` broadcast timeline event to the source stream, carrying per-memo provenance (`memoId`, `title`, `knowledgeType`, `sourceMessageIds`) so the row renders and deep-links to the memory explorer (`?memo=`) without an extra fetch. Memory creation is never silent — the stream that produced the knowledge shows the capture in its own timeline. Because extraction is debounced per stream, the event lands just after the conversation it came from; the payload's source ids, not the event's position, are the authoritative link back to the messages. The event type is in `TIMELINE_BROADCAST_EVENT_TYPES`, so it consumes a dense broadcast slot and contiguity (INV-61) covers it like any other row.
+
 ### 5) Frontend Composition and UX Semantics
 
 Use Shadcn UI components from `apps/frontend/src/components/ui/` for primitives (INV-14). React components should stay UI-focused and avoid business logic or persistence access (INV-15).
@@ -265,7 +267,7 @@ When handling variants, colocate variant config and keep shared behavior on one 
 - **Persistence and data integrity:** INV-1, INV-2, INV-3, INV-8, INV-17, INV-20, INV-30, INV-41, INV-50, INV-56, INV-57
 - **Architecture and dependencies:** INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-12, INV-13, INV-27, INV-34, INV-35, INV-37, INV-51, INV-52
 - **API and backend contracts:** INV-31, INV-32, INV-33, INV-46, INV-55, INV-58
-- **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54
+- **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54, INV-62
 - **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61
 - **Testing:** INV-22, INV-23, INV-24, INV-26, INV-39, INV-48
 - **Code hygiene and maneuverability:** INV-25, INV-29, INV-36, INV-38, INV-43, INV-47, INV-49

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -98,6 +98,7 @@ function setupService(options: { memoContents: MemoContent[] }) {
   spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_1", timezone: "UTC" }] as never)
   spyOn(StreamStateRepository, "markProcessed").mockResolvedValue(undefined as never)
   const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+  const outboxInsertMany = spyOn(OutboxRepository, "insertMany").mockResolvedValue([] as never)
 
   const insertedStreamEvent: StreamEvent = {
     id: "evt_capture",
@@ -110,7 +111,7 @@ function setupService(options: { memoContents: MemoContent[] }) {
     actorType: "system",
     createdAt: new Date(),
   }
-  const streamEventInsert = spyOn(StreamEventRepository, "insert").mockResolvedValue(insertedStreamEvent)
+  const streamEventInsertMany = spyOn(StreamEventRepository, "insertMany").mockResolvedValue([insertedStreamEvent])
 
   const service = new MemoService({
     pool: {} as never,
@@ -125,22 +126,21 @@ function setupService(options: { memoContents: MemoContent[] }) {
     messageFormatter: { formatMessages: async () => "formatted conversation" } as never,
   })
 
-  return { service, streamEventInsert, outboxInsert, insertedStreamEvent }
+  return { service, streamEventInsertMany, outboxInsert, outboxInsertMany, insertedStreamEvent }
 }
 
 describe("MemoService.processBatch — memos:captured timeline event (INV-62)", () => {
   afterEach(() => mock.restore())
 
   it("appends a memos:captured stream event with memo provenance in the save transaction", async () => {
-    const { service, streamEventInsert, outboxInsert, insertedStreamEvent } = setupService({
+    const { service, streamEventInsertMany, outboxInsertMany, insertedStreamEvent } = setupService({
       memoContents: [memoContent],
     })
 
     const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
 
     expect(result.memosCreated).toBe(1)
-    expect(streamEventInsert).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(streamEventInsertMany).toHaveBeenCalledWith(expect.anything(), [
       expect.objectContaining({
         streamId: STREAM_ID,
         eventType: "memos:captured",
@@ -156,25 +156,25 @@ describe("MemoService.processBatch — memos:captured timeline event (INV-62)", 
             },
           ],
         },
-      })
-    )
+      }),
+    ])
 
     // The full stream event rides the outbox row so clients append it without a fetch
-    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "stream:memos_captured", {
-      workspaceId: WORKSPACE_ID,
-      streamId: STREAM_ID,
-      event: insertedStreamEvent,
-    })
+    expect(outboxInsertMany).toHaveBeenCalledWith(expect.anything(), [
+      {
+        eventType: "stream:memos_captured",
+        payload: { workspaceId: WORKSPACE_ID, streamId: STREAM_ID, event: insertedStreamEvent },
+      },
+    ])
   })
 
   it("does not append a capture event when the memorizer yields no memos", async () => {
-    const { service, streamEventInsert, outboxInsert } = setupService({ memoContents: [] })
+    const { service, streamEventInsertMany, outboxInsertMany } = setupService({ memoContents: [] })
 
     const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
 
     expect(result.memosCreated).toBe(0)
-    expect(streamEventInsert).not.toHaveBeenCalled()
-    const outboxTypes = outboxInsert.mock.calls.map((call) => call[1])
-    expect(outboxTypes).not.toContain("stream:memos_captured")
+    expect(streamEventInsertMany).not.toHaveBeenCalled()
+    expect(outboxInsertMany).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { PoolClient } from "pg"
+import type { Conversation } from "../conversations"
+import type { Message } from "../messaging"
+import { MemoService } from "./service"
+import { MemoRepository } from "./repository"
+import { PendingItemRepository, type PendingMemoItem } from "./pending-item-repository"
+import type { MemoContent } from "./memorizer"
+import type { ConversationClassification } from "./classifier"
+import { OutboxRepository } from "../../lib/outbox"
+import { StreamEventRepository, StreamStateRepository } from "../streams"
+import type { StreamEvent } from "../streams"
+import { ConversationRepository } from "../conversations"
+import { MessageRepository } from "../messaging"
+import { UserRepository } from "../workspaces"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_1"
+const CONVERSATION_ID = "conv_1"
+
+function fakePendingItem(): PendingMemoItem {
+  return {
+    id: "pend_1",
+    workspaceId: WORKSPACE_ID,
+    streamId: STREAM_ID,
+    itemType: "conversation",
+    itemId: CONVERSATION_ID,
+    queuedAt: new Date(),
+    processedAt: null,
+  }
+}
+
+function fakeConversation(): Conversation {
+  return {
+    id: CONVERSATION_ID,
+    streamId: STREAM_ID,
+    workspaceId: WORKSPACE_ID,
+    topicSummary: "Deciding on ID format",
+    completenessScore: 1,
+    confidence: 1,
+    status: "complete",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    messageIds: ["msg_1", "msg_2"],
+    participantIds: ["usr_1"],
+    secondaryMessageIds: [],
+  } as unknown as Conversation
+}
+
+function fakeMessages(): Map<string, Message> {
+  const base = {
+    workspaceId: WORKSPACE_ID,
+    streamId: STREAM_ID,
+    authorId: "usr_1",
+    authorType: "user",
+  }
+  return new Map<string, Message>([
+    ["msg_1", { ...base, id: "msg_1" } as unknown as Message],
+    ["msg_2", { ...base, id: "msg_2" } as unknown as Message],
+  ])
+}
+
+const memoContent: MemoContent = {
+  title: "Use prefixed ULIDs for all entities",
+  abstract: "The team decided every entity id is a prefixed ULID.",
+  knowledgeType: "decision",
+  keyPoints: ["Prefixed ULIDs everywhere"],
+  tags: ["ids"],
+  sourceMessageIds: ["msg_1", "msg_2"],
+}
+
+const classification: ConversationClassification = {
+  isKnowledgeWorthy: true,
+  shouldReviseExisting: false,
+  revisionReason: null,
+  confidence: 0.95,
+}
+
+function setupService(options: { memoContents: MemoContent[] }) {
+  const fakeClient = {} as PoolClient
+  spyOn(dbModule, "withClient").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withClient)
+  spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withTransaction)
+
+  spyOn(PendingItemRepository, "findUnprocessed").mockResolvedValue([fakePendingItem()])
+  spyOn(PendingItemRepository, "markProcessed").mockResolvedValue(undefined as never)
+  spyOn(MemoRepository, "findByStream").mockResolvedValue([])
+  spyOn(MemoRepository, "getAllTags").mockResolvedValue([])
+  spyOn(MemoRepository, "findActiveBySourceConversation").mockResolvedValue([])
+  spyOn(MemoRepository, "insert").mockResolvedValue(undefined as never)
+  spyOn(MemoRepository, "updateEmbedding").mockResolvedValue(undefined as never)
+  spyOn(ConversationRepository, "findById").mockResolvedValue(fakeConversation())
+  spyOn(MessageRepository, "findByIds").mockResolvedValue(fakeMessages())
+  spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_1", timezone: "UTC" }] as never)
+  spyOn(StreamStateRepository, "markProcessed").mockResolvedValue(undefined as never)
+  const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+  const insertedStreamEvent: StreamEvent = {
+    id: "evt_capture",
+    streamId: STREAM_ID,
+    sequence: 10n,
+    broadcastSequence: 7n,
+    eventType: "memos:captured",
+    payload: {},
+    actorId: null,
+    actorType: "system",
+    createdAt: new Date(),
+  }
+  const streamEventInsert = spyOn(StreamEventRepository, "insert").mockResolvedValue(insertedStreamEvent)
+
+  const service = new MemoService({
+    pool: {} as never,
+    classifier: { classifyConversation: async () => classification } as never,
+    memorizer: {
+      memorizeConversation: async () => options.memoContents,
+      reviseMemo: async () => [],
+    } as never,
+    embeddingService: {
+      embedBatch: async (texts: string[]) => texts.map(() => [0.1, 0.2]),
+    } as never,
+    messageFormatter: { formatMessages: async () => "formatted conversation" } as never,
+  })
+
+  return { service, streamEventInsert, outboxInsert, insertedStreamEvent }
+}
+
+describe("MemoService.processBatch — memos:captured timeline event (INV-62)", () => {
+  afterEach(() => mock.restore())
+
+  it("appends a memos:captured stream event with memo provenance in the save transaction", async () => {
+    const { service, streamEventInsert, outboxInsert, insertedStreamEvent } = setupService({
+      memoContents: [memoContent],
+    })
+
+    const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(result.memosCreated).toBe(1)
+    expect(streamEventInsert).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        streamId: STREAM_ID,
+        eventType: "memos:captured",
+        actorType: "system",
+        payload: {
+          conversationId: CONVERSATION_ID,
+          memos: [
+            {
+              memoId: expect.stringMatching(/^memo_/),
+              title: memoContent.title,
+              knowledgeType: memoContent.knowledgeType,
+              sourceMessageIds: memoContent.sourceMessageIds,
+            },
+          ],
+        },
+      })
+    )
+
+    // The full stream event rides the outbox row so clients append it without a fetch
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "stream:memos_captured", {
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      event: insertedStreamEvent,
+    })
+  })
+
+  it("does not append a capture event when the memorizer yields no memos", async () => {
+    const { service, streamEventInsert, outboxInsert } = setupService({ memoContents: [] })
+
+    const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(result.memosCreated).toBe(0)
+    expect(streamEventInsert).not.toHaveBeenCalled()
+    const outboxTypes = outboxInsert.mock.calls.map((call) => call[1])
+    expect(outboxTypes).not.toContain("stream:memos_captured")
+  })
+})

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -13,13 +13,7 @@ import { MessageFormatter } from "../../lib/ai/message-formatter"
 import type { EmbeddingServiceLike } from "./embedding-service"
 import { memoId, eventId } from "../../lib/id"
 import { logger } from "../../lib/logger"
-import {
-  MemoTypes,
-  MemoStatuses,
-  AuthorTypes,
-  type CapturedMemoSummary,
-  type MemosCapturedEventPayload,
-} from "@threa/types"
+import { MemoTypes, MemoStatuses, AuthorTypes, type MemosCapturedEventPayload } from "@threa/types"
 import { MEMO_GEM_CONFIDENCE_FLOOR, MEMO_SINGLE_MESSAGE_AGE_GATE_MS } from "./config"
 
 const MEMORY_CONTEXT_LIMIT = 20
@@ -184,9 +178,6 @@ export class MemoService implements MemoServiceLike {
     const memoryContext = fetchedData.existingMemos.map((m) => m.abstract)
     const memosToCreate: MemoToCreate[] = []
     const outboxEvents: OutboxEvent[] = []
-    // One `memos:captured` timeline event per source conversation (INV-62) —
-    // inserted in Phase 3 so the capture row commits atomically with the memos.
-    const capturedConversations: Array<{ conversationId: string; memos: CapturedMemoSummary[] }> = []
     const deferredItemIds = new Set<string>()
     let memosCreated = 0
     let itemsFailed = 0
@@ -314,7 +305,6 @@ export class MemoService implements MemoServiceLike {
           )
         }
 
-        const capturedMemos: CapturedMemoSummary[] = []
         for (let i = 0; i < contents.length; i++) {
           const content = contents[i]
 
@@ -343,16 +333,8 @@ export class MemoService implements MemoServiceLike {
               memo: this.toWireMemoFromData(memo),
             },
           })
-          capturedMemos.push({
-            memoId: memo.id,
-            title: memo.title,
-            knowledgeType: memo.knowledgeType,
-            sourceMessageIds: memo.sourceMessageIds,
-          })
           memosCreated++
         }
-
-        capturedConversations.push({ conversationId: conversation.id, memos: capturedMemos })
 
         logger.info(
           { conversationId: conversation.id, isRevision, memoCount: contents.length },
@@ -388,23 +370,45 @@ export class MemoService implements MemoServiceLike {
         await OutboxRepository.insert(client, event.eventType, event.payload)
       }
 
-      // Memory capture is visible in situ (INV-62): append a broadcast
-      // timeline event to the source stream for each conversation that
-      // yielded memos, in the same transaction as the memo rows, so memory
-      // creation is never silent. Per-stream debouncing means this lands
-      // just after the conversation it was extracted from.
-      for (const captured of capturedConversations) {
-        const event = await StreamEventRepository.insert(client, {
-          id: eventId(),
-          streamId,
-          eventType: "memos:captured",
-          payload: {
-            conversationId: captured.conversationId,
-            memos: captured.memos,
-          } satisfies MemosCapturedEventPayload,
-          actorType: AuthorTypes.SYSTEM,
-        })
-        await OutboxRepository.insert(client, "stream:memos_captured", { workspaceId, streamId, event })
+      // Memory capture is visible in situ (INV-62): append one broadcast
+      // timeline event per conversation that yielded memos, in the same
+      // transaction as the memo rows, so memory creation is never silent.
+      // Per-stream debouncing means these land just after the conversations
+      // they were extracted from. Batched (INV-56): one sequence allocation
+      // covers every capture event in the batch.
+      const memosByConversation = new Map<string, MemoToCreate[]>()
+      for (const memo of memosToCreate) {
+        if (!memo.sourceConversationId) continue
+        const group = memosByConversation.get(memo.sourceConversationId) ?? []
+        group.push(memo)
+        memosByConversation.set(memo.sourceConversationId, group)
+      }
+      if (memosByConversation.size > 0) {
+        const captureEvents = await StreamEventRepository.insertMany(
+          client,
+          Array.from(memosByConversation, ([conversationId, memos]) => ({
+            id: eventId(),
+            streamId,
+            eventType: "memos:captured" as const,
+            payload: {
+              conversationId,
+              memos: memos.map((memo) => ({
+                memoId: memo.id,
+                title: memo.title,
+                knowledgeType: memo.knowledgeType,
+                sourceMessageIds: memo.sourceMessageIds,
+              })),
+            } satisfies MemosCapturedEventPayload,
+            actorType: AuthorTypes.SYSTEM,
+          }))
+        )
+        await OutboxRepository.insertMany(
+          client,
+          captureEvents.map((event) => ({
+            eventType: "stream:memos_captured" as const,
+            payload: { workspaceId, streamId, event },
+          }))
+        )
       }
 
       // Mark processed items (excluding deferred ones that need retry).

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from "pg"
 import { withTransaction, withClient } from "../../db"
-import { StreamStateRepository } from "../streams"
+import { StreamStateRepository, StreamEventRepository } from "../streams"
 import { ConversationRepository } from "../conversations"
 import { MessageRepository, type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
@@ -11,9 +11,15 @@ import { MemoClassifier } from "./classifier"
 import { Memorizer } from "./memorizer"
 import { MessageFormatter } from "../../lib/ai/message-formatter"
 import type { EmbeddingServiceLike } from "./embedding-service"
-import { memoId } from "../../lib/id"
+import { memoId, eventId } from "../../lib/id"
 import { logger } from "../../lib/logger"
-import { MemoTypes, MemoStatuses } from "@threa/types"
+import {
+  MemoTypes,
+  MemoStatuses,
+  AuthorTypes,
+  type CapturedMemoSummary,
+  type MemosCapturedEventPayload,
+} from "@threa/types"
 import { MEMO_GEM_CONFIDENCE_FLOOR, MEMO_SINGLE_MESSAGE_AGE_GATE_MS } from "./config"
 
 const MEMORY_CONTEXT_LIMIT = 20
@@ -178,6 +184,9 @@ export class MemoService implements MemoServiceLike {
     const memoryContext = fetchedData.existingMemos.map((m) => m.abstract)
     const memosToCreate: MemoToCreate[] = []
     const outboxEvents: OutboxEvent[] = []
+    // One `memos:captured` timeline event per source conversation (INV-62) —
+    // inserted in Phase 3 so the capture row commits atomically with the memos.
+    const capturedConversations: Array<{ conversationId: string; memos: CapturedMemoSummary[] }> = []
     const deferredItemIds = new Set<string>()
     let memosCreated = 0
     let itemsFailed = 0
@@ -305,6 +314,7 @@ export class MemoService implements MemoServiceLike {
           )
         }
 
+        const capturedMemos: CapturedMemoSummary[] = []
         for (let i = 0; i < contents.length; i++) {
           const content = contents[i]
 
@@ -333,8 +343,16 @@ export class MemoService implements MemoServiceLike {
               memo: this.toWireMemoFromData(memo),
             },
           })
+          capturedMemos.push({
+            memoId: memo.id,
+            title: memo.title,
+            knowledgeType: memo.knowledgeType,
+            sourceMessageIds: memo.sourceMessageIds,
+          })
           memosCreated++
         }
+
+        capturedConversations.push({ conversationId: conversation.id, memos: capturedMemos })
 
         logger.info(
           { conversationId: conversation.id, isRevision, memoCount: contents.length },
@@ -368,6 +386,25 @@ export class MemoService implements MemoServiceLike {
       // Insert all outbox events
       for (const event of outboxEvents) {
         await OutboxRepository.insert(client, event.eventType, event.payload)
+      }
+
+      // Memory capture is visible in situ (INV-62): append a broadcast
+      // timeline event to the source stream for each conversation that
+      // yielded memos, in the same transaction as the memo rows, so memory
+      // creation is never silent. Per-stream debouncing means this lands
+      // just after the conversation it was extracted from.
+      for (const captured of capturedConversations) {
+        const event = await StreamEventRepository.insert(client, {
+          id: eventId(),
+          streamId,
+          eventType: "memos:captured",
+          payload: {
+            conversationId: captured.conversationId,
+            memos: captured.memos,
+          } satisfies MemosCapturedEventPayload,
+          actorType: AuthorTypes.SYSTEM,
+        })
+        await OutboxRepository.insert(client, "stream:memos_captured", { workspaceId, streamId, event })
       }
 
       // Mark processed items (excluding deferred ones that need retry).

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -378,7 +378,15 @@ export class MemoService implements MemoServiceLike {
       // covers every capture event in the batch.
       const memosByConversation = new Map<string, MemoToCreate[]>()
       for (const memo of memosToCreate) {
-        if (!memo.sourceConversationId) continue
+        if (!memo.sourceConversationId) {
+          // Conversation-type memos always carry sourceConversationId; a miss
+          // here is a data bug worth surfacing, not silently skipping (INV-11).
+          logger.warn(
+            { memoId: memo.id, workspaceId, streamId },
+            "Memo missing sourceConversationId — skipping capture event"
+          )
+          continue
+        }
         const group = memosByConversation.get(memo.sourceConversationId) ?? []
         group.push(memo)
         memosByConversation.set(memo.sourceConversationId, group)
@@ -408,6 +416,10 @@ export class MemoService implements MemoServiceLike {
             eventType: "stream:memos_captured" as const,
             payload: { workspaceId, streamId, event },
           }))
+        )
+        logger.info(
+          { workspaceId, streamId, conversations: memosByConversation.size, captureEvents: captureEvents.length },
+          "memos:captured timeline events inserted"
         )
       }
 

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -66,6 +66,7 @@ export type OutboxEventType =
   | "stream:member_joined"
   | "stream:member_added"
   | "stream:member_removed"
+  | "stream:memos_captured"
   | "invitation:sent"
   | "invitation:link-created"
   | "invitation:link-claimed"
@@ -109,6 +110,7 @@ export type StreamScopedEventType =
   | "stream:member_joined"
   | "stream:member_added"
   | "stream:member_removed"
+  | "stream:memos_captured"
   | "stream:activity"
   | "conversation:created"
   | "conversation:updated"
@@ -246,6 +248,15 @@ export interface StreamMemberAddedOutboxPayload extends StreamScopedPayload {
 
 export interface StreamMemberRemovedOutboxPayload extends StreamScopedPayload {
   memberId: string
+  event: StreamEvent
+}
+
+/**
+ * Carries a `memos:captured` timeline event (INV-62) to the source stream's
+ * room. Same envelope shape as the membership events: the full stream event
+ * rides along so clients append it without a fetch.
+ */
+export interface StreamMemosCapturedOutboxPayload extends StreamScopedPayload {
   event: StreamEvent
 }
 
@@ -678,6 +689,7 @@ export interface OutboxEventPayloadMap {
   "stream:member_joined": StreamMemberJoinedOutboxPayload
   "stream:member_added": StreamMemberAddedOutboxPayload
   "stream:member_removed": StreamMemberRemovedOutboxPayload
+  "stream:memos_captured": StreamMemosCapturedOutboxPayload
   "stream:read": StreamReadOutboxPayload
   "stream:read_all": StreamsReadAllOutboxPayload
   "stream:activity": StreamActivityOutboxPayload
@@ -774,6 +786,7 @@ const STREAM_SCOPED_EVENTS: StreamScopedEventType[] = [
   "stream:member_joined",
   "stream:member_added",
   "stream:member_removed",
+  "stream:memos_captured",
   "stream:activity",
   "conversation:created",
   "conversation:updated",

--- a/apps/frontend/src/components/timeline/event-item.test.tsx
+++ b/apps/frontend/src/components/timeline/event-item.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, it, expect, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import * as messageEventModule from "./message-event"
 import * as membershipEventModule from "./membership-event"
+import * as memoCapturedEventModule from "./memo-captured-event"
 import * as systemEventModule from "./system-event"
 import { EventItem } from "./event-item"
 import type { StreamEvent } from "@threa/types"
@@ -22,6 +23,9 @@ beforeEach(() => {
   vi.spyOn(systemEventModule, "SystemEvent").mockImplementation((() => (
     <div data-testid="system-event" />
   )) as unknown as typeof systemEventModule.SystemEvent)
+  vi.spyOn(memoCapturedEventModule, "MemoCapturedEvent").mockImplementation((() => (
+    <div data-testid="memo-captured-event" />
+  )) as unknown as typeof memoCapturedEventModule.MemoCapturedEvent)
 })
 
 const createMessageEvent = (messageId: string, contentMarkdown: string): StreamEvent => ({
@@ -107,6 +111,27 @@ describe("EventItem", () => {
       render(<EventItem event={event} workspaceId={workspaceId} streamId={streamId} />)
 
       expect(screen.getByTestId("message-event")).toBeInTheDocument()
+    })
+
+    it("should render MemoCapturedEvent for memos:captured events", () => {
+      const event: StreamEvent = {
+        id: "evt_capture",
+        streamId,
+        sequence: "10",
+        broadcastSequence: "7",
+        eventType: "memos:captured",
+        actorId: null,
+        actorType: "system",
+        createdAt: new Date().toISOString(),
+        payload: {
+          conversationId: "conv_1",
+          memos: [{ memoId: "memo_1", title: "A decision", knowledgeType: "decision", sourceMessageIds: ["msg_1"] }],
+        },
+      }
+
+      render(<EventItem event={event} workspaceId={workspaceId} streamId={streamId} />)
+
+      expect(screen.getByTestId("memo-captured-event")).toBeInTheDocument()
     })
   })
 })

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -4,6 +4,7 @@ import type { BatchTimelineState } from "./event-list"
 import { MessageEvent } from "./message-event"
 import { MembershipEvent } from "./membership-event"
 import { MessagesMovedEvent } from "./messages-moved-event"
+import { MemoCapturedEvent } from "./memo-captured-event"
 import { SystemEvent } from "./system-event"
 
 interface EventItemProps {
@@ -121,6 +122,13 @@ export function EventItem({
         </div>
       )
     }
+
+    case "memos:captured":
+      return (
+        <div data-event-id={event.id}>
+          <MemoCapturedEvent event={event} workspaceId={workspaceId} />
+        </div>
+      )
 
     case "reaction_added":
     case "reaction_removed":

--- a/apps/frontend/src/components/timeline/memo-captured-event.test.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { MemoCapturedEvent } from "./memo-captured-event"
+import type { MemosCapturedEventPayload, StreamEvent } from "@threa/types"
+
+function createEvent(payload: MemosCapturedEventPayload): StreamEvent {
+  return {
+    id: "evt_capture",
+    streamId: "stream_1",
+    sequence: "10",
+    broadcastSequence: "7",
+    eventType: "memos:captured",
+    actorId: null,
+    actorType: "system",
+    createdAt: new Date().toISOString(),
+    payload,
+  }
+}
+
+function renderEvent(payload: MemosCapturedEventPayload) {
+  return render(
+    <MemoryRouter>
+      <MemoCapturedEvent event={createEvent(payload)} workspaceId="ws_1" />
+    </MemoryRouter>
+  )
+}
+
+describe("MemoCapturedEvent", () => {
+  it("renders each captured memo title as a link into the memory explorer", () => {
+    renderEvent({
+      conversationId: "conv_1",
+      memos: [
+        { memoId: "memo_1", title: "Use prefixed ULIDs", knowledgeType: "decision", sourceMessageIds: ["msg_1"] },
+        { memoId: "memo_2", title: "Deploy via Railway", knowledgeType: "procedure", sourceMessageIds: ["msg_2"] },
+      ],
+    })
+
+    expect(screen.getByText(/Saved to memory:/)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Use prefixed ULIDs" })).toHaveAttribute(
+      "href",
+      "/w/ws_1/memory?memo=memo_1"
+    )
+    expect(screen.getByRole("link", { name: "Deploy via Railway" })).toHaveAttribute(
+      "href",
+      "/w/ws_1/memory?memo=memo_2"
+    )
+  })
+
+  it("renders nothing for an empty capture payload", () => {
+    const { container } = renderEvent({ conversationId: "conv_1", memos: [] })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/frontend/src/components/timeline/memo-captured-event.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.tsx
@@ -17,8 +17,8 @@ interface MemoCapturedEventProps {
  * memory explorer (`?memo=` is the canonical memo deep-link, see memo-url.ts).
  */
 export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps) {
-  const payload = event.payload as MemosCapturedEventPayload
-  if (!payload.memos?.length) return null
+  const payload = event.payload as MemosCapturedEventPayload | undefined
+  if (!payload?.memos?.length) return null
 
   return (
     <div className="py-2 px-3 sm:px-6 text-center">

--- a/apps/frontend/src/components/timeline/memo-captured-event.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom"
 import { Sparkles } from "lucide-react"
 import type { MemosCapturedEventPayload, StreamEvent } from "@threa/types"
+import { memoDeepLink } from "@/lib/memo-url"
 
 interface MemoCapturedEventProps {
   event: StreamEvent
@@ -17,7 +18,7 @@ interface MemoCapturedEventProps {
  */
 export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps) {
   const payload = event.payload as MemosCapturedEventPayload
-  if (!payload.memos || payload.memos.length === 0) return null
+  if (!payload.memos?.length) return null
 
   return (
     <div className="py-2 px-3 sm:px-6 text-center">
@@ -28,7 +29,7 @@ export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps
           <span key={memo.memoId}>
             {index > 0 && ", "}
             <Link
-              to={`/w/${workspaceId}/memory?memo=${memo.memoId}`}
+              to={memoDeepLink(workspaceId, memo.memoId)}
               className="font-medium text-foreground/80 underline-offset-2 hover:underline"
             >
               {memo.title}

--- a/apps/frontend/src/components/timeline/memo-captured-event.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom"
+import { Sparkles } from "lucide-react"
+import type { MemosCapturedEventPayload, StreamEvent } from "@threa/types"
+
+interface MemoCapturedEventProps {
+  event: StreamEvent
+  workspaceId: string
+}
+
+/**
+ * Timeline row for `memos:captured` — the visible trace of GAM extracting
+ * knowledge from this stream (INV-62). The event is appended when the memo
+ * batch commits, which per-stream debouncing places just after the source
+ * conversation, so the row reads as a small "Threa kept this" gift moment
+ * rather than an out-of-place system log line. Each title deep-links to the
+ * memory explorer (`?memo=` is the canonical memo deep-link, see memo-url.ts).
+ */
+export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps) {
+  const payload = event.payload as MemosCapturedEventPayload
+  if (!payload.memos || payload.memos.length === 0) return null
+
+  return (
+    <div className="py-2 px-3 sm:px-6 text-center">
+      <p className="text-sm text-muted-foreground">
+        <Sparkles className="inline-block h-3.5 w-3.5 mr-1.5 -mt-0.5 text-amber-500" aria-hidden="true" />
+        Saved to memory:{" "}
+        {payload.memos.map((memo, index) => (
+          <span key={memo.memoId}>
+            {index > 0 && ", "}
+            <Link
+              to={`/w/${workspaceId}/memory?memo=${memo.memoId}`}
+              className="font-medium text-foreground/80 underline-offset-2 hover:underline"
+            >
+              {memo.title}
+            </Link>
+          </span>
+        ))}
+      </p>
+    </div>
+  )
+}

--- a/apps/frontend/src/lib/memo-url.ts
+++ b/apps/frontend/src/lib/memo-url.ts
@@ -1,4 +1,12 @@
 /**
+ * Build the canonical in-app deep link to a memo in the memory explorer.
+ * Inverse of `parseMemoUrl` below — keep the two in sync.
+ */
+export function memoDeepLink(workspaceId: string, memoId: string): string {
+  return `/w/${workspaceId}/memory?memo=${memoId}`
+}
+
+/**
  * Extract a memo id from an in-app memory-explorer link
  * (`…/w/{workspaceId}/memory?memo=memo_xxx`). Returns `null` for any other
  * URL, off-origin link, or unparseable text. Used by the composer to turn a

--- a/apps/frontend/src/lib/memo-url.ts
+++ b/apps/frontend/src/lib/memo-url.ts
@@ -3,7 +3,7 @@
  * Inverse of `parseMemoUrl` below — keep the two in sync.
  */
 export function memoDeepLink(workspaceId: string, memoId: string): string {
-  return `/w/${workspaceId}/memory?memo=${memoId}`
+  return `/w/${encodeURIComponent(workspaceId)}/memory?memo=${encodeURIComponent(memoId)}`
 }
 
 /**

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -409,6 +409,12 @@ interface MemberRemovedPayload {
   event: StreamEvent
 }
 
+interface MemosCapturedPayload {
+  workspaceId: string
+  streamId: string
+  event: StreamEvent
+}
+
 interface LinkPreviewReadyPayload {
   workspaceId: string
   streamId: string
@@ -846,7 +852,9 @@ export function registerStreamSocketHandlers(
     })
   }
 
-  const handleAppendEvent = async (payload: AgentSessionEventPayload | CommandEventPayload | MemberRemovedPayload) => {
+  const handleAppendEvent = async (
+    payload: AgentSessionEventPayload | CommandEventPayload | MemberRemovedPayload | MemosCapturedPayload
+  ) => {
     if (payload.streamId !== streamId) return
     const now = Date.now()
     // Set when this event's sequence reveals missed events behind it; reported
@@ -954,6 +962,7 @@ export function registerStreamSocketHandlers(
   socket.on("agent_session:completed", handleAppendEvent)
   socket.on("agent_session:failed", handleAppendEvent)
   socket.on("agent_session:deleted", handleAppendEvent)
+  socket.on("stream:memos_captured", handleAppendEvent)
   socket.on("link_preview:ready", handleLinkPreviewReady)
   socket.on("pointer:invalidated", handlePointerInvalidated)
   socket.on("bot_runtime:presence", handleBotRuntimePresence)
@@ -977,6 +986,7 @@ export function registerStreamSocketHandlers(
     socket.off("agent_session:completed", handleAppendEvent)
     socket.off("agent_session:failed", handleAppendEvent)
     socket.off("agent_session:deleted", handleAppendEvent)
+    socket.off("stream:memos_captured", handleAppendEvent)
     socket.off("link_preview:ready", handleLinkPreviewReady)
     socket.off("pointer:invalidated", handlePointerInvalidated)
     socket.off("bot_runtime:presence", handleBotRuntimePresence)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -14,6 +14,7 @@ import type {
   ScheduledMessageStatus,
   E2eKeyWrapRecipientKind,
   AgentStepType,
+  KnowledgeType,
 } from "./constants"
 import type { WorkspaceInvitableRole } from "./workspace-permissions"
 import type { ContextBag, ContextIntent } from "./context-bag"
@@ -794,6 +795,32 @@ export interface MessagesMovedEventPayload {
    * loading placeholders.
    */
   vacatedBroadcastSequences?: string[]
+}
+
+/**
+ * One memo's worth of provenance inside a `memos:captured` event — enough
+ * to render the capture row and deep-link without fetching the memo.
+ */
+export interface CapturedMemoSummary {
+  memoId: string
+  title: string
+  knowledgeType: KnowledgeType
+  /** The exact messages this memo was derived from. */
+  sourceMessageIds: string[]
+}
+
+/**
+ * Payload for `memos:captured` timeline events (INV-62): appended to the
+ * source stream when GAM extracts memos from one of its conversations, in
+ * the same transaction as the memo rows. The event lands at the broadcast
+ * position where extraction completed — per-stream debouncing means that is
+ * normally just after the conversation that produced it — and carries the
+ * source conversation/message ids so the row can point back at the messages
+ * the knowledge came from.
+ */
+export interface MemosCapturedEventPayload {
+  conversationId: string
+  memos: CapturedMemoSummary[]
 }
 
 /**

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -79,6 +79,7 @@ export const EVENT_TYPES = [
   "agent_session:failed",
   "agent_session:deleted",
   "messages:moved",
+  "memos:captured",
 ] as const
 export type EventType = (typeof EVENT_TYPES)[number]
 
@@ -112,6 +113,7 @@ export const TIMELINE_BROADCAST_EVENT_TYPES = [
   "agent_session:failed",
   "agent_session:deleted",
   "messages:moved",
+  "memos:captured",
 ] as const
 export type TimelineBroadcastEventType = (typeof TIMELINE_BROADCAST_EVENT_TYPES)[number]
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -401,6 +401,8 @@ export type {
   MovedMessagePreview,
   MessagesMovedEventPayload,
   MovedFromProvenance,
+  CapturedMemoSummary,
+  MemosCapturedEventPayload,
   // Workspaces
   CreateWorkspaceInput,
   WorkspaceBootstrap,


### PR DESCRIPTION
## Problem

GAM is Threa's core differentiator, but memo extraction is invisible from the conversation it happens in: memos appear only in the memory explorer (`/w/…/memory`), and the stream that produced the knowledge never shows that anything was kept. Users get no in-context signal that Threa remembered something — the "gift" moment is lost, and there's no path from a conversation to the memories it produced.

## Solution

When the memo batch worker extracts memos from a stream's conversation, the same transaction that inserts the memo rows now appends a `memos:captured` broadcast timeline event to the source stream. The frontend renders it as a small centered row — ✨ **Saved to memory:** with each memo title deep-linking to the memory explorer (`?memo=`).

This is codified as a new invariant, **INV-62 — memory capture is visible in situ**: memory creation is never silent; the stream that produced the knowledge shows the capture in its own timeline.

### How it works

```
conversation goes quiet → memo batch worker (debounced per stream)
  Phase 3 transaction:
    insert memo rows
    insert memo:created outbox events            (existing)
    insert memos:captured stream event(s)        (new — one per conversation, batched)
    insert stream:memos_captured outbox event(s) (new — carries the full stream event)
        ↓ outbox dispatcher
    stream room socket emit → handleAppendEvent → IDB → timeline row
```

### Key design decisions

**1. Append at extraction time; provenance lives in the payload, not the position.**
Memos are generated asynchronously, after the messages they derive from, so the event can't sit "where the knowledge happened." Instead it consumes a broadcast slot when the batch commits — and because extraction is debounced per stream (30s quiet / 5min cap), that is naturally just after the source conversation. The payload carries `conversationId` plus per-memo `{memoId, title, knowledgeType, sourceMessageIds}`, so the exact source messages remain addressable regardless of where the row lands. The alternative (retroactively anchoring the row next to the source messages) would mean patch-style rendering and inserting rows above content already on screen, fighting the INV-61 contiguity model.

**2. Full broadcast timeline event, not a patch or workspace-only signal.**
`memos:captured` joins `TIMELINE_BROADCAST_EVENT_TYPES`, so it consumes a dense per-stream `broadcastSequence` — gap detection, scoped backfill, bootstrap, and reconnect catch-up all cover it with zero new machinery. Visibility matches the stream room, which is exactly the access boundary memos already inherit from their source stream.

**3. One event per conversation, batched per worker run (INV-56).**
A conversation can yield up to 5 memos; one capture row lists them all instead of spamming the timeline. When a batch covers several conversations, `StreamEventRepository.insertMany` allocates all sequences in a single upsert and `OutboxRepository.insertMany` writes the outbox rows in one statement.

**4. No unread/notification impact.**
Unread counts only consider `message_created` events and the memo flow emits no `stream:activity`, so the gift row never bumps badges or pings anyone.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/timeline/memo-captured-event.tsx` | Timeline row: sparkle + "Saved to memory:" with deep-linked memo titles |
| `apps/frontend/src/components/timeline/memo-captured-event.test.tsx` | Renders links/empty-payload behavior |
| `apps/backend/src/features/memos/service.test.ts` | Asserts capture event provenance + batched outbox row; absence when no memos |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | `memos:captured` added to `EVENT_TYPES` and `TIMELINE_BROADCAST_EVENT_TYPES` |
| `packages/types/src/api.ts` | `MemosCapturedEventPayload` + `CapturedMemoSummary` |
| `apps/backend/src/features/memos/service.ts` | Phase 3 transaction groups new memos by conversation and batch-inserts capture events + outbox rows |
| `apps/backend/src/lib/outbox/repository.ts` | `stream:memos_captured` outbox type (stream-scoped, generic room routing) |
| `apps/frontend/src/sync/stream-sync.ts` | Socket registration via existing generic `handleAppendEvent` |
| `apps/frontend/src/components/timeline/event-item.tsx` | Renderer case for `memos:captured` |
| `apps/frontend/src/lib/memo-url.ts` | `memoDeepLink()` helper alongside `parseMemoUrl` |
| `CLAUDE.md` | Documents INV-62 |

## Test plan

- [x] Full monorepo typecheck (14 workspaces)
- [x] Backend unit suite (1,649 tests) incl. new `MemoService.processBatch` capture-event tests
- [x] Frontend suite (2,376 tests) incl. new component + `EventItem` case tests
- [x] `/simplify` multi-angle review applied (batching per INV-56, derived grouping, `memoDeepLink` reuse)
- [ ] Manual: send a knowledge-worthy conversation on staging, wait out the debounce, confirm the capture row appears and deep-links resolve

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** When GAM generates memos for a stream's conversation, show a visible "memory captured" event in that stream's timeline, and codify the behavior as an invariant.

**What Was Built**
- New stream event type `memos:captured` (broadcast, dense-sequence) with payload `{conversationId, memos: [{memoId, title, knowledgeType, sourceMessageIds}]}`.
- Emission from `MemoService.processBatch` Phase 3: same transaction as memo inserts (INV-4/INV-7); one event per conversation that yielded memos; batched via `insertMany` (INV-56).
- Outbox type `stream:memos_captured` riding the generic stream-scoped room routing in `BroadcastHandler`.
- Frontend: generic `handleAppendEvent` ingestion (dedupe, gap detection, IDB), `MemoCapturedEvent` row with memo deep-links, INV-62 documented in CLAUDE.md.

**Design Decisions**
- Event placement: at extraction time (debounce makes it land just after the source conversation); payload provenance is the authoritative link to source messages.
- Broadcast vs patch-style: broadcast, so INV-61 contiguity/backfill covers it for free; access boundary equals the stream room, matching memo visibility.
- One event per conversation (not per memo, not per batch) to balance signal vs noise.
- No unread/notification side effects.

**What's NOT Included (follow-ups)**
- Distinct copy for memo revisions ("Updated a memory") — revisions currently emit the same row for the newly extracted memos.
- Hover affordance highlighting the source messages in the timeline.
- Copy/styling iteration on the gift moment.

**Status:** Complete; typecheck + unit suites green. Backend e2e/integration suites require a local Postgres not available in the dev session.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01SLiLySb4KXrVC14aVJ8mc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLiLySb4KXrVC14aVJ8mc7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783780581&installation_id=129946197&pr_number=839&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F839&signature=0fa88b6962db1a0680084539739dcd9fbff2a73011038f89184083cb9489fcab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->