### PR TITLE
fix: wrap long source URLs in trace UI to stop horizontal overflow

### DIFF
--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -870,7 +870,7 @@ function SubstepTimeline({
                   }}
                 />
               </span>
-              <span className={cn("flex-1 min-w-0 text-foreground/90", isLast && isLive && "font-medium")}>
+              <span className={cn("flex-1 min-w-0 break-words text-foreground/90", isLast && isLive && "font-medium")}>
                 {substep.text}
               </span>
               {offset && (
@@ -1027,10 +1027,10 @@ function SourceItem({ source, workspaceId, isLast }: { source: TraceSource; work
 
   return (
     <div className={cn("px-2.5 py-1.5 mx-[-1px]", !isLast && "border-b border-border")}>
-      <div className="font-semibold mb-1 text-xs">
+      <div className="font-semibold mb-1 text-xs break-words">
         <SourceTitle source={source} internalLink={internalLink} />
       </div>
-      {source.domain && <div className="text-[11px] text-muted-foreground mb-1">{source.domain}</div>}
+      {source.domain && <div className="text-[11px] text-muted-foreground mb-1 break-words">{source.domain}</div>}
       {source.authorName && source.type === "workspace_message" && (
         <div className="text-[11px] text-muted-foreground mb-1">
           by {source.authorName}


### PR DESCRIPTION
## Problem

In the Agent Session Trace dialog, long unbreakable URLs ran off the right edge of the panel and got clipped. This is visible in the substep timeline (`Reading https://www.reddit.com/r/alphaandbetausers/comments/...`, `https://www.producthunt.com/search?q=threa`) where the URL has no whitespace break opportunities.

The text spans were constrained with `flex-1 min-w-0`, but without a word-breaking rule a long token simply overflows its container. The trace body uses `overflow-x-hidden`, so instead of wrapping, the overflowing URL was clipped at the panel edge.

## Solution

Add `break-words` (`overflow-wrap: break-word`) to the text containers that render URL-bearing content so long URLs wrap inside the panel instead of overflowing. `break-words` only breaks a token when it would otherwise overflow, so ordinary text still wraps on spaces.

### Key design decisions

**1. `break-words` over `break-all`**

`break-words` only inserts a break when a token would otherwise overflow the line; normal prose still wraps on whitespace. `break-all` would break mid-word even when not needed, which reads worse for the mixed prose + URL substep text (e.g. `Reading https://...`).

**2. Harden the Sources list too, not just the visible substep**

The screenshot shows the substep timeline overflowing, but the collapsible **Sources** list renders raw web titles and domains that carry the same risk. Added `break-words` to the source title and domain so the whole trace surface is consistent.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-step.tsx` | Add `break-words` to the `SubstepTimeline` phase text and to the `SourceItem` title/domain so long URLs wrap instead of overflowing |

## Test plan

- [x] `apps/frontend/src/components/trace/trace-step.test.tsx` — 17/17 pass
- [x] `apps/frontend/src/components/trace/trace-dialog.test.tsx` — 3/3 pass
- [ ] Manual: open a trace with web-research steps and confirm long Reddit/ProductHunt URLs wrap within the panel on a narrow (mobile) viewport

Note: the change is className-only; CSS wrap behavior isn't observable in jsdom, so it's verified by the existing behavior suites plus the reasoning above rather than an automated layout assertion.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFnv7qKcmxgqjo383CTR3R)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783785939&installation_id=129946197&pr_number=843&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F843&signature=9ee3d3dabaed453225a210bbc606c925bbbaffe83e10606f0b72fc03d53bf867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->