### PR TITLE
fix: keep dictation chunk popover open while cursor crosses the hover gap

### DIFF
--- a/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
+++ b/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
@@ -85,6 +85,29 @@ describe("DictationChunkInspector hover lifecycle", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
+  it("ignores pointerout from unrelated elements: the grace timer is not restarted", () => {
+    const { chunkEl } = setup()
+    const elsewhere = document.createElement("div")
+    document.body.appendChild(elsewhere)
+
+    hoverChunk(chunkEl)
+    fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: document.body })
+
+    // Mid-grace, the cursor crosses other UI on the page. Those departures
+    // must not reschedule the close, or the popover would stay open for as
+    // long as the mouse keeps moving.
+    act(() => {
+      vi.advanceTimersByTime(HOVER_CLOSE_GRACE_MS / 2)
+    })
+    fireEvent.pointerOut(elsewhere, { pointerType: "mouse", relatedTarget: document.body })
+    act(() => {
+      vi.advanceTimersByTime(HOVER_CLOSE_GRACE_MS / 2 + 1)
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    elsewhere.remove()
+  })
+
   it("closes after leaving the popover itself", () => {
     const { chunkEl } = setup()
     hoverChunk(chunkEl)
@@ -110,7 +133,7 @@ describe("DictationChunkInspector hover lifecycle", () => {
     fireEvent.pointerOver(popover, { pointerType: "mouse" })
     fireEvent.click(screen.getByRole("button", { name: "Show original" }))
 
-    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalled()
     // The popover stays open after the flip so the user can read the swap.
     expect(screen.getByRole("dialog", { name: "Dictation polish comparison" })).toBeInTheDocument()
   })

--- a/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
+++ b/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, act, fireEvent } from "@testing-library/react"
+import type { DictationChunkRecord } from "@/hooks/use-voice-dictation"
+import { DictationChunkInspector, HOVER_CLOSE_GRACE_MS } from "./dictation-chunk-inspector"
+
+function makeChunks(overrides: Partial<DictationChunkRecord> = {}): Map<string, DictationChunkRecord> {
+  return new Map([
+    [
+      "chunk-1",
+      {
+        raw: "helo wrld",
+        polished: "Hello world",
+        currentlyShowing: "polished" as const,
+        locked: false,
+        ...overrides,
+      },
+    ],
+  ])
+}
+
+/** Mounts the inspector plus a decoration-style chunk element it can anchor to. */
+function setup(chunks = makeChunks()) {
+  const chunkEl = document.createElement("span")
+  chunkEl.dataset.chunkId = "chunk-1"
+  chunkEl.textContent = "Hello world"
+  document.body.appendChild(chunkEl)
+
+  const onToggle = vi.fn()
+  render(<DictationChunkInspector chunks={chunks} onToggle={onToggle} />)
+  return { chunkEl, onToggle }
+}
+
+function hoverChunk(chunkEl: HTMLElement) {
+  fireEvent.pointerOver(chunkEl, { pointerType: "mouse" })
+}
+
+describe("DictationChunkInspector hover lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.querySelectorAll("[data-chunk-id]").forEach((el) => el.remove())
+  })
+
+  it("opens on hover and shows both versions", () => {
+    const { chunkEl } = setup()
+    hoverChunk(chunkEl)
+
+    const popover = screen.getByRole("dialog", { name: "Dictation polish comparison" })
+    expect(popover).toHaveTextContent("Hello world")
+    expect(popover).toHaveTextContent("helo wrld")
+  })
+
+  it("stays open while the cursor crosses the gap to the popover", () => {
+    const { chunkEl } = setup()
+    hoverChunk(chunkEl)
+
+    // Cursor leaves the chunk into the gap between chunk and popover
+    // (relatedTarget is neither the chunk nor the popover).
+    fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: document.body })
+
+    // Still open during the grace window...
+    const popover = screen.getByRole("dialog", { name: "Dictation polish comparison" })
+
+    // ...and landing on the popover cancels the pending close for good.
+    fireEvent.pointerOver(popover, { pointerType: "mouse" })
+    act(() => {
+      vi.advanceTimersByTime(HOVER_CLOSE_GRACE_MS * 2)
+    })
+
+    expect(screen.getByRole("dialog", { name: "Dictation polish comparison" })).toBeInTheDocument()
+  })
+
+  it("closes after the grace period when the cursor leaves for good", () => {
+    const { chunkEl } = setup()
+    hoverChunk(chunkEl)
+    fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: document.body })
+
+    act(() => {
+      vi.advanceTimersByTime(HOVER_CLOSE_GRACE_MS + 1)
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("closes after leaving the popover itself", () => {
+    const { chunkEl } = setup()
+    hoverChunk(chunkEl)
+    const popover = screen.getByRole("dialog", { name: "Dictation polish comparison" })
+
+    fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: popover })
+    fireEvent.pointerOver(popover, { pointerType: "mouse" })
+    fireEvent.pointerOut(popover, { pointerType: "mouse", relatedTarget: document.body })
+
+    act(() => {
+      vi.advanceTimersByTime(HOVER_CLOSE_GRACE_MS + 1)
+    })
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("keeps the popover interactive: Switch stays clickable after crossing the gap", () => {
+    const { chunkEl, onToggle } = setup()
+    hoverChunk(chunkEl)
+    fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: document.body })
+
+    const popover = screen.getByRole("dialog", { name: "Dictation polish comparison" })
+    fireEvent.pointerOver(popover, { pointerType: "mouse" })
+    fireEvent.click(screen.getByRole("button", { name: "Show original" }))
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    // The popover stays open after the flip so the user can read the swap.
+    expect(screen.getByRole("dialog", { name: "Dictation polish comparison" })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
+++ b/apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, act, fireEvent } from "@testing-library/react"
 import type { DictationChunkRecord } from "@/hooks/use-voice-dictation"
@@ -18,16 +19,36 @@ function makeChunks(overrides: Partial<DictationChunkRecord> = {}): Map<string, 
   ])
 }
 
-/** Mounts the inspector plus a decoration-style chunk element it can anchor to. */
-function setup(chunks = makeChunks()) {
+/** Appends a decoration-style chunk element the inspector can anchor to. */
+function appendChunkEl() {
   const chunkEl = document.createElement("span")
   chunkEl.dataset.chunkId = "chunk-1"
   chunkEl.textContent = "Hello world"
   document.body.appendChild(chunkEl)
+  return chunkEl
+}
 
+/** Mounts the inspector plus a chunk element it can anchor to. */
+function setup(chunks = makeChunks()) {
+  const chunkEl = appendChunkEl()
   const onToggle = vi.fn()
   render(<DictationChunkInspector chunks={chunks} onToggle={onToggle} />)
   return { chunkEl, onToggle }
+}
+
+/**
+ * Harness that mimics the dictation hook's session toggle: onToggle flips
+ * which version every chunk shows, so the test can assert the user-visible
+ * label swap instead of inspecting the mock.
+ */
+function ToggleHarness() {
+  const [showing, setShowing] = useState<"polished" | "raw">("polished")
+  return (
+    <DictationChunkInspector
+      chunks={makeChunks({ currentlyShowing: showing })}
+      onToggle={() => setShowing((prev) => (prev === "polished" ? "raw" : "polished"))}
+    />
+  )
 }
 
 function hoverChunk(chunkEl: HTMLElement) {
@@ -125,7 +146,8 @@ describe("DictationChunkInspector hover lifecycle", () => {
   })
 
   it("keeps the popover interactive: Switch stays clickable after crossing the gap", () => {
-    const { chunkEl, onToggle } = setup()
+    const chunkEl = appendChunkEl()
+    render(<ToggleHarness />)
     hoverChunk(chunkEl)
     fireEvent.pointerOut(chunkEl, { pointerType: "mouse", relatedTarget: document.body })
 
@@ -133,8 +155,9 @@ describe("DictationChunkInspector hover lifecycle", () => {
     fireEvent.pointerOver(popover, { pointerType: "mouse" })
     fireEvent.click(screen.getByRole("button", { name: "Show original" }))
 
-    expect(onToggle).toHaveBeenCalled()
-    // The popover stays open after the flip so the user can read the swap.
+    // The popover stays open after the flip so the user can read the swap,
+    // and the switch label reflects that the editor now shows the raw take.
     expect(screen.getByRole("dialog", { name: "Dictation polish comparison" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Show polished" })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/composer/dictation-chunk-inspector.tsx
+++ b/apps/frontend/src/components/composer/dictation-chunk-inspector.tsx
@@ -12,6 +12,14 @@ interface DictationChunkInspectorProps {
 }
 
 /**
+ * How long the popover survives after the cursor leaves the chunk. The popover
+ * is offset 8px from the chunk, so the cursor must cross a gap where it hovers
+ * neither element; closing immediately on pointerout would make the popover
+ * unreachable with a mouse.
+ */
+export const HOVER_CLOSE_GRACE_MS = 200
+
+/**
  * Hover/tap inspector for the just-landed polished dictation chunk(s). The
  * editor decoration tags each chunk with a `[data-chunk-id]` attribute; this
  * component watches the document for hover/click on those elements and floats
@@ -19,7 +27,9 @@ interface DictationChunkInspectorProps {
  * raw versions, with a one-tap switch.
  *
  * Two interaction models, one component:
- *   - Mouse: hover opens, leaving both the chunk and the popover closes.
+ *   - Mouse: hover opens; leaving both the chunk and the popover closes after
+ *     a short grace period (the popover is offset from the chunk, so the
+ *     cursor needs time to travel across the gap without dismissing it).
  *   - Touch / click: tap the chunk to open, tap outside (or Escape) to close.
  *
  * Positioning uses `@floating-ui/react` (same stack as the editor's other
@@ -69,6 +79,25 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
     [refs.floating]
   )
 
+  const closeTimerRef = useRef<number | null>(null)
+
+  const cancelScheduledClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleClose = useCallback(() => {
+    cancelScheduledClose()
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null
+      setAnchor(null)
+    }, HOVER_CLOSE_GRACE_MS)
+  }, [cancelScheduledClose])
+
+  useEffect(() => cancelScheduledClose, [cancelScheduledClose])
+
   useEffect(() => {
     function findChunkElement(target: EventTarget | null): HTMLElement | null {
       if (!(target instanceof Element)) return null
@@ -80,12 +109,18 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
       // Touch devices emulate hover-ish events on first tap; ignore them so
       // the click handler is the sole source of truth on mobile.
       if (e.pointerType === "touch") return
+      // The cursor made it onto the popover: keep it open.
+      if (isInsidePopover(e.target instanceof Node ? e.target : null)) {
+        cancelScheduledClose()
+        return
+      }
       const el = findChunkElement(e.target)
       if (!el) return
       const chunkId = el.dataset.chunkId
       if (!chunkId) return
       const record = chunksRef.current.get(chunkId)
       if (!record || record.locked) return
+      cancelScheduledClose()
       setAnchor({ chunkId, el })
     }
 
@@ -97,7 +132,11 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
       // element (the next pointerover handles the re-anchor).
       if (next && isInsidePopover(next)) return
       if (next instanceof Element && next.closest("[data-chunk-id]")) return
-      setAnchor(null)
+      // The popover floats with a gap from the chunk, so the cursor passes
+      // over neither on its way there. Defer the close so the traversal
+      // doesn't dismiss the popover before it can be reached; pointerover on
+      // the popover (or a chunk) cancels the pending close.
+      scheduleClose()
     }
 
     function onClick(e: MouseEvent) {
@@ -109,7 +148,9 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
         const record = chunksRef.current.get(chunkId)
         if (!record || record.locked) return
         // Tapping the same chunk toggles closed; tapping a different one
-        // re-anchors to it.
+        // re-anchors to it. A pending hover-close must not fire after the
+        // re-anchor, or it would dismiss the freshly opened popover.
+        cancelScheduledClose()
         setAnchor((prev) => (prev?.chunkId === chunkId ? null : { chunkId, el }))
         return
       }
@@ -130,7 +171,7 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
       document.removeEventListener("click", onClick)
       document.removeEventListener("keydown", onKey)
     }
-  }, [isInsidePopover])
+  }, [isInsidePopover, scheduleClose, cancelScheduledClose])
 
   if (typeof document === "undefined" || !anchor) return null
   const record = chunks.get(anchor.chunkId)

--- a/apps/frontend/src/components/composer/dictation-chunk-inspector.tsx
+++ b/apps/frontend/src/components/composer/dictation-chunk-inspector.tsx
@@ -126,6 +126,13 @@ export function DictationChunkInspector({ chunks, onToggle }: DictationChunkInsp
 
     function onPointerOut(e: PointerEvent) {
       if (e.pointerType === "touch") return
+      // Only departures from a chunk or the popover can close it. Without
+      // this origin guard, every element boundary the cursor crosses
+      // elsewhere on the page would restart the grace timer below and keep
+      // the popover alive long past HOVER_CLOSE_GRACE_MS.
+      const from = e.target instanceof Node ? e.target : null
+      const fromChunk = from instanceof Element && from.closest("[data-chunk-id]") !== null
+      if (!fromChunk && !isInsidePopover(from)) return
       const next = e.relatedTarget instanceof Node ? e.relatedTarget : null
       // Don't dismiss when the cursor moves onto the popover itself (so the
       // user can hover inside it to click Switch) or onto another chunk


### PR DESCRIPTION
## Problem

On desktop, hovering a just-dictated chunk opens the polished/raw comparison popover, but the popover was unreachable by mouse: it floats 8px above the chunk (`offset(8)`), and the `pointerout` handler closed it the instant the cursor left the chunk unless `relatedTarget` was already the popover. Crossing the 8px gap means the cursor momentarily hovers neither element, so the popover unmounted before it could be reached — making the comparison and the "Show original"/"Show polished" switch unusable on desktop.

## Solution

Defer the hover-close with a short grace period instead of closing immediately:

- `pointerout` from the chunk (or popover) now schedules the close 200ms out (`HOVER_CLOSE_GRACE_MS`) rather than calling `setAnchor(null)` directly.
- `pointerover` landing on the popover — or on a chunk — cancels the pending close, so the cursor can travel across the gap and interact with the popover.
- Leaving the popover for good still closes it after the same grace period; Escape and outside-click still close immediately.

### Key design decisions

**1. Grace-period timer over floating-ui's `safePolygon`**

`useHover` + `safePolygon` is floating-ui's canonical fix, but it requires routing open/close through `useInteractions` on a React-managed reference. Here the anchor is a ProseMirror decoration DOM node (`[data-chunk-id]`) discovered via document-level listeners, with custom multi-chunk re-anchoring logic. A scheduled-close timer fits the existing event architecture without restructuring it, and 200ms is ample for an 8px traversal.

**2. Cancel pending close on click re-anchor**

A click that re-anchors to a different chunk also cancels any pending hover-close — otherwise a stale timer from a prior `pointerout` would dismiss the freshly opened popover.

Touch behavior is unchanged: tap to open, tap outside or Escape to close.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/composer/dictation-chunk-inspector.test.tsx` | Hover lifecycle tests: opens on hover, survives the gap traversal, closes after the grace period, closes after leaving the popover, switch button stays clickable |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/composer/dictation-chunk-inspector.tsx` | Scheduled close with `HOVER_CLOSE_GRACE_MS` grace period; cancel on popover/chunk pointerover and on click re-anchor |

## Test plan

- [x] New tests pass, including "stays open while the cursor crosses the gap" (fails against the old immediate-close behavior)
- [x] All 45 composer tests pass
- [x] Frontend typecheck clean; pre-commit full monorepo lint + typecheck passed
- [ ] Manual verification on desktop: hover a dictated chunk, move cursor into the popover, click the switch

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01Qqr4pzbby56nYpvsSpz4Af

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqr4pzbby56nYpvsSpz4Af)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783790945&installation_id=129946197&pr_number=844&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F844&signature=705360bde73008d6943c8e5442408209f07d46bf3ef937d0c9dcf00fa163ae46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->