### PR TITLE
feat: sync-v2 client cursor in shadow mode (phase 2a)

### DIFF
--- a/apps/backend/src/features/sync/handlers.ts
+++ b/apps/backend/src/features/sync/handlers.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express"
 import { z } from "zod"
+import type { SyncCatchUpResponse } from "@threa/types"
 import { HttpError } from "../../lib/errors"
 import type { SyncService } from "./service"
 
@@ -38,7 +39,7 @@ export function createSyncHandlers({ syncService }: Dependencies) {
           createdAt: entry.createdAt.toISOString(),
         })),
         head: head.toString(),
-      })
+      } satisfies SyncCatchUpResponse)
     },
   }
 }

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -34,6 +34,7 @@ export {
   type MemoDetailResponse,
 } from "./memos"
 export { conversationsApi, type ListConversationsParams } from "./conversations"
+export { syncApi } from "./sync"
 export { preferencesApi } from "./preferences"
 export { workspaceSettingsApi } from "./workspace-settings"
 export { sidebarConfigApi } from "./sidebar-config"

--- a/apps/frontend/src/api/sync.ts
+++ b/apps/frontend/src/api/sync.ts
@@ -1,0 +1,19 @@
+import { api } from "./client"
+import type { SyncCatchUpResponse } from "@threa/types"
+
+export const syncApi = {
+  /**
+   * One page of sync-log entries after the cursor, filtered server-side to
+   * what this user may see. Page until `entries` comes back empty — `head`
+   * is a workspace-global freshness hint, never a cursor target.
+   */
+  async catchUp(
+    workspaceId: string,
+    params: { after: string; limit?: number },
+    signal?: AbortSignal
+  ): Promise<SyncCatchUpResponse> {
+    const query = new URLSearchParams({ after: params.after })
+    if (params.limit !== undefined) query.set("limit", String(params.limit))
+    return api.get<SyncCatchUpResponse>(`/api/workspaces/${workspaceId}/sync?${query.toString()}`, { signal })
+  },
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -58,7 +58,7 @@ import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext } from "@/sync/sync-engine"
-import { messagesApi } from "@/api"
+import { messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { SettingsDialog } from "@/components/settings"
 import { WorkspaceSettingsDialog } from "@/components/workspace-settings/workspace-settings-dialog"
@@ -206,6 +206,7 @@ function WorkspaceSyncHandler({
         delete: scheduledService.delete,
         sendNow: scheduledService.sendNow,
       },
+      syncService: syncApi,
     })
   }
   const syncEngine = syncEngineRef.current

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SIDEBAR_CONFIG,
   type WorkspaceBootstrap,
   type StreamBootstrap,
+  type SyncCatchUpResponse,
 } from "@threa/types"
 
 type EventHandler = (...args: unknown[]) => void
@@ -28,6 +29,7 @@ class MockSocket {
    *  while the room join is in flight. */
   joinInterceptor: ((room: string) => Promise<void>) | null = null
   private listeners = new Map<string, Set<EventHandler>>()
+  private anyListeners = new Set<(event: string, ...args: unknown[]) => void>()
 
   on(event: string, handler: EventHandler) {
     const handlers = this.listeners.get(event)
@@ -38,6 +40,17 @@ class MockSocket {
 
   off(event: string, handler: EventHandler) {
     this.listeners.get(event)?.delete(handler)
+    return this
+  }
+
+  onAny(listener: (event: string, ...args: unknown[]) => void) {
+    this.anyListeners.add(listener)
+    return this
+  }
+
+  offAny(listener?: (event: string, ...args: unknown[]) => void) {
+    if (listener) this.anyListeners.delete(listener)
+    else this.anyListeners.clear()
     return this
   }
 
@@ -75,6 +88,7 @@ class MockSocket {
   }
 
   trigger(event: string, ...args: unknown[]) {
+    for (const listener of this.anyListeners) listener(event, ...args)
     const handlers = this.listeners.get(event)
     if (!handlers) return
     for (const handler of handlers) handler(...args)
@@ -868,5 +882,106 @@ describe("SyncEngine.backfillStreamGap", () => {
     await vi.waitFor(() => {
       expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_7", { after: "1" })
     })
+  })
+})
+
+describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([db.workspaces.clear(), db.syncCursors.clear()])
+  })
+
+  function makeShadowDeps(catchUp: ReturnType<typeof vi.fn>) {
+    return {
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      syncCursorShadowEnabled: true,
+    }
+  }
+
+  function emptyPage(head: string): SyncCatchUpResponse {
+    return { entries: [], head }
+  }
+
+  function entry(syncId: string, eventType = "message:created"): SyncCatchUpResponse["entries"][number] {
+    return { syncId, eventType, payload: {}, createdAt: new Date().toISOString() }
+  }
+
+  it("seeds the cursor from head on first run instead of replaying the log", async () => {
+    const catchUp = vi.fn(async () => emptyPage("42"))
+    const engine = new SyncEngine(makeShadowDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("42"))
+    expect(catchUp).toHaveBeenCalledTimes(1)
+    expect(catchUp).toHaveBeenCalledWith("ws_1", { after: "0", limit: 1 })
+    engine.destroy()
+  })
+
+  it("advances the cursor only from this workspace's live payloads carrying syncId", async () => {
+    const catchUp = vi.fn(async () => emptyPage("5"))
+    const engine = new SyncEngine(makeShadowDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("5"))
+
+    socket.trigger("message:created", { workspaceId: "ws_1", syncId: "7" })
+    expect(engine.getSyncCursor()).toBe("7")
+
+    // Lower id, other workspace, missing syncId: none move the cursor
+    socket.trigger("message:created", { workspaceId: "ws_1", syncId: "6" })
+    socket.trigger("message:created", { workspaceId: "ws_other", syncId: "9" })
+    socket.trigger("stream:read", { workspaceId: "ws_1" })
+    expect(engine.getSyncCursor()).toBe("7")
+    engine.destroy()
+  })
+
+  it("pages catch-up from the persisted cursor until an empty page, advancing by fetched entries", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi
+      .fn()
+      .mockResolvedValueOnce({ entries: [entry("11"), entry("12", "stream:read")], head: "12" })
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeShadowDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("12"))
+    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", { after: "10", limit: 500 })
+    expect(catchUp).toHaveBeenNthCalledWith(2, "ws_1", { after: "12", limit: 500 })
+    engine.destroy()
+  })
+
+  it("single-flights concurrent shadow catch-ups", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirst: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi.fn(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirst ??= resolve)))
+    const engine = new SyncEngine(makeShadowDeps(catchUp))
+    const socket = new MockSocket()
+    await engine.onConnect(asSocket(socket))
+
+    await engine.refreshAfterConnectivityResume()
+    await engine.refreshAfterConnectivityResume()
+    await vi.waitFor(() => expect(catchUp).toHaveBeenCalled())
+    expect(catchUp).toHaveBeenCalledTimes(1)
+
+    resolveFirst?.(emptyPage("10"))
+    engine.destroy()
+  })
+
+  it("does nothing when the shadow flag is off", async () => {
+    const catchUp = vi.fn(async () => emptyPage("42"))
+    const deps = { ...makeShadowDeps(catchUp), syncCursorShadowEnabled: false }
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    socket.trigger("message:created", { workspaceId: "ws_1", syncId: "7" })
+
+    expect(catchUp).not.toHaveBeenCalled()
+    expect(engine.getSyncCursor()).toBeNull()
+    engine.destroy()
   })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -915,7 +915,7 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
 
     await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("42"))
     expect(catchUp).toHaveBeenCalledTimes(1)
-    expect(catchUp).toHaveBeenCalledWith("ws_1", { after: "0", limit: 1 })
+    expect(catchUp).toHaveBeenCalledWith("ws_1", { after: "0", limit: 1 }, expect.any(AbortSignal))
     engine.destroy()
   })
 
@@ -949,8 +949,8 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
     await engine.onConnect(asSocket(new MockSocket()))
 
     await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("12"))
-    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", { after: "10", limit: 500 })
-    expect(catchUp).toHaveBeenNthCalledWith(2, "ws_1", { after: "12", limit: 500 })
+    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", { after: "10", limit: 500 }, expect.any(AbortSignal))
+    expect(catchUp).toHaveBeenNthCalledWith(2, "ws_1", { after: "12", limit: 500 }, expect.any(AbortSignal))
     engine.destroy()
   })
 
@@ -969,6 +969,23 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
 
     resolveFirst?.(emptyPage("10"))
     engine.destroy()
+  })
+
+  it("aborts an in-flight shadow catch-up on destroy", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let capturedSignal: AbortSignal | undefined
+    const catchUp = vi.fn((_workspaceId: unknown, _params: unknown, signal?: AbortSignal) => {
+      capturedSignal = signal
+      return new Promise<SyncCatchUpResponse>(() => {})
+    })
+    const engine = new SyncEngine(makeShadowDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+    await vi.waitFor(() => expect(catchUp).toHaveBeenCalled())
+    expect(capturedSignal?.aborted).toBe(false)
+
+    engine.destroy()
+    expect(capturedSignal?.aborted).toBe(true)
   })
 
   it("does nothing when the shadow flag is off", async () => {

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -19,6 +19,7 @@ import {
 } from "./stream-sync"
 import { processOperationQueue } from "./operation-queue"
 import { waitForInitialReveal } from "./reveal-gate"
+import { SyncLogCursor, SYNC_V2_CURSOR_SHADOW_DEFAULT } from "./sync-log-cursor"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -52,7 +53,19 @@ interface SyncEngineDeps {
     delete: (workspaceId: string, id: string) => Promise<void>
     sendNow: (workspaceId: string, id: string) => Promise<import("@threa/types").ScheduledMessageView>
   }
+  syncService?: {
+    catchUp: (
+      workspaceId: string,
+      params: { after: string; limit?: number }
+    ) => Promise<import("@threa/types").SyncCatchUpResponse>
+  }
+  /** Test override for the VITE_SYNC_V2_CURSOR flag. */
+  syncCursorShadowEnabled?: boolean
 }
+
+/** Safety valve for shadow catch-up paging (20 pages × 500 entries). */
+const MAX_SHADOW_CATCHUP_PAGES = 20
+const SHADOW_CATCHUP_PAGE_LIMIT = 500
 
 /**
  * Owns the full sync lifecycle for a workspace:
@@ -81,6 +94,14 @@ export class SyncEngine {
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
 
+  // Sync-engine v2 cursor (shadow mode): one lastSyncId per workspace,
+  // advanced by live events and exercised against the catch-up endpoint
+  // without owning any healing yet. See sync-log-cursor.ts.
+  private readonly syncCursorShadowEnabled: boolean
+  private syncLogCursor: SyncLogCursor | null = null
+  private syncCursorCleanup: (() => void) | null = null
+  private activeShadowCatchUp: Promise<void> | null = null
+
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
   private visibleStreamIds: string[] = []
@@ -92,6 +113,7 @@ export class SyncEngine {
 
   constructor(private deps: SyncEngineDeps) {
     this.workspaceId = deps.workspaceId
+    this.syncCursorShadowEnabled = (deps.syncCursorShadowEnabled ?? SYNC_V2_CURSOR_SHADOW_DEFAULT) && !!deps.syncService
   }
 
   /** Update the current stream ID (called from React when route changes). */
@@ -129,6 +151,10 @@ export class SyncEngine {
       this.cleanupStreamHandlers()
     }
 
+    if (this.syncCursorShadowEnabled) {
+      this.trackSyncCursor(socket)
+    }
+
     // Register workspace-level socket handlers (stream:created, stream:updated, etc.)
     this.workspaceHandlerCleanup = registerWorkspaceSocketHandlers(
       socket,
@@ -145,6 +171,10 @@ export class SyncEngine {
 
     // Process pending offline operations (edits, deletes, reactions)
     this.kickOperationQueue()
+
+    // Shadow only — runs after bootstrap so it never competes for the
+    // connection setup window, and applies nothing.
+    void this.runShadowCatchUp(isReconnect ? "reconnect" : "connect")
   }
 
   /**
@@ -155,6 +185,7 @@ export class SyncEngine {
   async refreshAfterConnectivityResume(): Promise<void> {
     if (this.isDestroyed) return
     await this.runBootstrap(true)
+    void this.runShadowCatchUp("resume")
   }
 
   /**
@@ -226,6 +257,11 @@ export class SyncEngine {
       this.deps.scheduledService,
       () => this.socket !== null && !this.isDestroyed
     )
+  }
+
+  /** Current sync-log cursor (v2 shadow), or null when none is tracked yet. */
+  getSyncCursor(): string | null {
+    return this.syncLogCursor?.get() ?? null
   }
 
   /**
@@ -312,6 +348,11 @@ export class SyncEngine {
     this.cleanupAllHandlers()
     this.subscribedStreams.clear()
     this.socket = null
+    // Dispose without flushing — destroy can be an account switch that
+    // repoints the shared db proxy, and the cursor must not leak across
+    // accounts. See SyncLogCursor.
+    this.syncLogCursor?.dispose()
+    this.syncLogCursor = null
   }
 
   // =========================================================================
@@ -684,6 +725,120 @@ export class SyncEngine {
     this.deps.syncStatus.setError(key, null)
   }
 
+  /**
+   * Shadow-mode half of the v2 live path: every socket event whose payload
+   * carries a `syncId` for this workspace advances the cursor. Events
+   * without one are bot-scoped or pre-deploy and stay invisible to the
+   * cursor. Registered with `onAny` so all 40+ event types hit one
+   * chokepoint instead of 40 handler edits.
+   */
+  private trackSyncCursor(socket: Socket): void {
+    this.syncLogCursor ??= new SyncLogCursor(this.workspaceId)
+    void this.syncLogCursor.load()
+
+    this.cleanupSyncCursorTracking()
+    const listener = (_event: string, ...args: unknown[]) => {
+      const payload = args[0] as { workspaceId?: unknown; syncId?: unknown } | undefined
+      if (!payload || payload.workspaceId !== this.workspaceId || typeof payload.syncId !== "string") return
+      this.syncLogCursor?.advance(payload.syncId)
+    }
+    socket.onAny(listener)
+    this.syncCursorCleanup = () => socket.offAny(listener)
+  }
+
+  /**
+   * Shadow-mode catch-up: pages the sync endpoint from the cursor and logs
+   * what active mode WOULD have applied, applying nothing. Entries fetched
+   * here are events the live path never advanced past — after a disconnect
+   * that count is the healing the cursor will own; on a healthy resume it
+   * should be ~zero. Single-flighted; never throws into callers.
+   */
+  private runShadowCatchUp(trigger: string): Promise<void> {
+    if (!this.syncCursorShadowEnabled || this.isDestroyed) return Promise.resolve()
+    if (this.activeShadowCatchUp) return this.activeShadowCatchUp
+
+    const promise = this.performShadowCatchUp(trigger)
+      .catch((error) => {
+        console.error("Sync-v2 shadow catch-up failed", { workspaceId: this.workspaceId, trigger, error })
+      })
+      .finally(() => {
+        if (this.activeShadowCatchUp === promise) {
+          this.activeShadowCatchUp = null
+        }
+      })
+    this.activeShadowCatchUp = promise
+    return promise
+  }
+
+  private async performShadowCatchUp(trigger: string): Promise<void> {
+    const syncService = this.deps.syncService!
+    const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
+    await cursorStore.load()
+
+    const cursorBefore = cursorStore.get()
+    if (cursorBefore === null) {
+      // No cursor yet (first run on this device): seed from head instead of
+      // replaying the whole retained log — everything at or below head is
+      // covered by the bootstrap snapshot path. NOTE: this jump is legal
+      // only because shadow mode owns no healing. Active mode must read
+      // head BEFORE the bootstrap data fetch (read-before-stamp rule) so
+      // the race falls on the duplicate side, never the gap side.
+      const { head } = await syncService.catchUp(this.workspaceId, { after: "0", limit: 1 })
+      if (this.isDestroyed) return
+      cursorStore.advance(head)
+      console.info("Sync-v2 shadow cursor seeded from head", { workspaceId: this.workspaceId, trigger, head })
+      return
+    }
+
+    let cursor = cursorBefore
+    let head = cursorBefore
+    let pages = 0
+    let fetched = 0
+    const byEventType: Record<string, number> = {}
+
+    while (pages < MAX_SHADOW_CATCHUP_PAGES) {
+      const response = await syncService.catchUp(this.workspaceId, {
+        after: cursor,
+        limit: SHADOW_CATCHUP_PAGE_LIMIT,
+      })
+      if (this.isDestroyed) return
+      head = response.head
+      if (response.entries.length === 0) break
+
+      pages += 1
+      fetched += response.entries.length
+      for (const entry of response.entries) {
+        byEventType[entry.eventType] = (byEventType[entry.eventType] ?? 0) + 1
+      }
+      // Shadow advances by fetched entries — "applied" is a no-op here. The
+      // live onAny path may concurrently advance past this; monotonic max
+      // makes the race converge.
+      cursor = response.entries[response.entries.length - 1].syncId
+      cursorStore.advance(cursor)
+    }
+
+    if (fetched > 0 || trigger !== "connect") {
+      console.info("Sync-v2 shadow catch-up", {
+        workspaceId: this.workspaceId,
+        trigger,
+        cursorBefore,
+        cursorAfter: cursor,
+        head,
+        fetched,
+        pages,
+        byEventType,
+        truncated: pages >= MAX_SHADOW_CATCHUP_PAGES,
+      })
+    }
+  }
+
+  private cleanupSyncCursorTracking(): void {
+    if (this.syncCursorCleanup) {
+      this.syncCursorCleanup()
+      this.syncCursorCleanup = null
+    }
+  }
+
   private cleanupWorkspaceHandlers(): void {
     if (this.workspaceHandlerCleanup) {
       this.workspaceHandlerCleanup()
@@ -700,6 +855,7 @@ export class SyncEngine {
   private cleanupAllHandlers(): void {
     this.cleanupWorkspaceHandlers()
     this.cleanupStreamHandlers()
+    this.cleanupSyncCursorTracking()
   }
 }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -56,7 +56,8 @@ interface SyncEngineDeps {
   syncService?: {
     catchUp: (
       workspaceId: string,
-      params: { after: string; limit?: number }
+      params: { after: string; limit?: number },
+      signal?: AbortSignal
     ) => Promise<import("@threa/types").SyncCatchUpResponse>
   }
   /** Test override for the VITE_SYNC_V2_CURSOR flag. */
@@ -101,6 +102,7 @@ export class SyncEngine {
   private syncLogCursor: SyncLogCursor | null = null
   private syncCursorCleanup: (() => void) | null = null
   private activeShadowCatchUp: Promise<void> | null = null
+  private shadowCatchUpAbort: AbortController | null = null
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
@@ -351,6 +353,8 @@ export class SyncEngine {
     // Dispose without flushing — destroy can be an account switch that
     // repoints the shared db proxy, and the cursor must not leak across
     // accounts. See SyncLogCursor.
+    this.shadowCatchUpAbort?.abort()
+    this.shadowCatchUpAbort = null
     this.syncLogCursor?.dispose()
     this.syncLogCursor = null
   }
@@ -757,20 +761,27 @@ export class SyncEngine {
     if (!this.syncCursorShadowEnabled || this.isDestroyed) return Promise.resolve()
     if (this.activeShadowCatchUp) return this.activeShadowCatchUp
 
-    const promise = this.performShadowCatchUp(trigger)
+    const abort = new AbortController()
+    this.shadowCatchUpAbort = abort
+    const promise = this.performShadowCatchUp(trigger, abort.signal)
       .catch((error) => {
+        // A destroy-triggered abort is expected teardown, not a failure.
+        if (this.isDestroyed) return
         console.error("Sync-v2 shadow catch-up failed", { workspaceId: this.workspaceId, trigger, error })
       })
       .finally(() => {
         if (this.activeShadowCatchUp === promise) {
           this.activeShadowCatchUp = null
         }
+        if (this.shadowCatchUpAbort === abort) {
+          this.shadowCatchUpAbort = null
+        }
       })
     this.activeShadowCatchUp = promise
     return promise
   }
 
-  private async performShadowCatchUp(trigger: string): Promise<void> {
+  private async performShadowCatchUp(trigger: string, signal: AbortSignal): Promise<void> {
     const syncService = this.deps.syncService!
     const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
     await cursorStore.load()
@@ -783,7 +794,7 @@ export class SyncEngine {
       // only because shadow mode owns no healing. Active mode must read
       // head BEFORE the bootstrap data fetch (read-before-stamp rule) so
       // the race falls on the duplicate side, never the gap side.
-      const { head } = await syncService.catchUp(this.workspaceId, { after: "0", limit: 1 })
+      const { head } = await syncService.catchUp(this.workspaceId, { after: "0", limit: 1 }, signal)
       if (this.isDestroyed) return
       cursorStore.advance(head)
       console.info("Sync-v2 shadow cursor seeded from head", { workspaceId: this.workspaceId, trigger, head })
@@ -797,10 +808,11 @@ export class SyncEngine {
     const byEventType: Record<string, number> = {}
 
     while (pages < MAX_SHADOW_CATCHUP_PAGES) {
-      const response = await syncService.catchUp(this.workspaceId, {
-        after: cursor,
-        limit: SHADOW_CATCHUP_PAGE_LIMIT,
-      })
+      const response = await syncService.catchUp(
+        this.workspaceId,
+        { after: cursor, limit: SHADOW_CATCHUP_PAGE_LIMIT },
+        signal
+      )
       if (this.isDestroyed) return
       head = response.head
       if (response.entries.length === 0) break

--- a/apps/frontend/src/sync/sync-log-cursor.test.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { db } from "@/db"
+import { SyncLogCursor, syncLogCursorKey } from "./sync-log-cursor"
+
+const WORKSPACE_ID = "ws_cursor_test"
+const KEY = syncLogCursorKey(WORKSPACE_ID)
+
+async function persistedCursor(): Promise<string | undefined> {
+  return (await db.syncCursors.get(KEY))?.cursor
+}
+
+describe("SyncLogCursor", () => {
+  beforeEach(async () => {
+    await db.syncCursors.clear()
+  })
+
+  it("advances monotonically by BigInt comparison", () => {
+    const cursor = new SyncLogCursor(WORKSPACE_ID)
+
+    expect(cursor.get()).toBeNull()
+    cursor.advance("10")
+    expect(cursor.get()).toBe("10")
+    // Lower and equal ids never move the cursor back
+    cursor.advance("9")
+    cursor.advance("10")
+    expect(cursor.get()).toBe("10")
+    // String comparison would put "9" > "10"; BigInt must win
+    cursor.advance("100")
+    expect(cursor.get()).toBe("100")
+    cursor.dispose()
+  })
+
+  it("loads the persisted cursor and merges with in-memory advances by max", async () => {
+    await db.syncCursors.put({ key: KEY, cursor: "50", updatedAt: Date.now() })
+
+    const behind = new SyncLogCursor(WORKSPACE_ID)
+    behind.advance("20")
+    await behind.load()
+    expect(behind.get()).toBe("50")
+    behind.dispose()
+
+    const ahead = new SyncLogCursor(WORKSPACE_ID)
+    ahead.advance("80")
+    await ahead.load()
+    expect(ahead.get()).toBe("80")
+    ahead.dispose()
+  })
+
+  it("persists pending advances on flush", async () => {
+    const cursor = new SyncLogCursor(WORKSPACE_ID)
+    cursor.advance("7")
+    await cursor.flush()
+
+    expect(await persistedCursor()).toBe("7")
+    cursor.dispose()
+  })
+
+  it("persists on the debounce timer without an explicit flush", async () => {
+    const cursor = new SyncLogCursor(WORKSPACE_ID, 5)
+    cursor.advance("3")
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(await persistedCursor()).toBe("3")
+    cursor.dispose()
+  })
+
+  it("never moves the persisted cursor backwards (multi-tab convergence)", async () => {
+    const tabA = new SyncLogCursor(WORKSPACE_ID)
+    tabA.advance("100")
+    await tabA.flush()
+
+    const tabB = new SyncLogCursor(WORKSPACE_ID)
+    tabB.advance("40")
+    await tabB.flush()
+
+    expect(await persistedCursor()).toBe("100")
+    tabA.dispose()
+    tabB.dispose()
+  })
+
+  it("dispose cancels pending writes and blocks later ones (account-switch safety)", async () => {
+    const cursor = new SyncLogCursor(WORKSPACE_ID, 5)
+    cursor.advance("12")
+    cursor.dispose()
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(await persistedCursor()).toBeUndefined()
+
+    cursor.advance("13")
+    await cursor.flush()
+    expect(await persistedCursor()).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/sync/sync-log-cursor.test.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.test.ts
@@ -30,6 +30,24 @@ describe("SyncLogCursor", () => {
     cursor.dispose()
   })
 
+  it("ignores malformed sync ids instead of throwing (hot onAny path)", async () => {
+    const cursor = new SyncLogCursor(WORKSPACE_ID)
+    cursor.advance("10")
+
+    cursor.advance("")
+    cursor.advance("1.5")
+    cursor.advance("abc")
+    expect(cursor.get()).toBe("10")
+    cursor.dispose()
+
+    // A corrupted persisted row must not poison the load either
+    await db.syncCursors.put({ key: KEY, cursor: "not-a-number", updatedAt: Date.now() })
+    const reloaded = new SyncLogCursor(WORKSPACE_ID)
+    await reloaded.load()
+    expect(reloaded.get()).toBeNull()
+    reloaded.dispose()
+  })
+
   it("loads the persisted cursor and merges with in-memory advances by max", async () => {
     await db.syncCursors.put({ key: KEY, cursor: "50", updatedAt: Date.now() })
 

--- a/apps/frontend/src/sync/sync-log-cursor.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.ts
@@ -1,0 +1,105 @@
+import { db } from "@/db"
+
+/**
+ * Kill switch for the sync-engine v2 cursor shadow path (cursor tracking +
+ * shadow catch-up in SyncEngine). Shadow mode observes and logs only — it
+ * never applies catch-up entries — so it defaults on; set
+ * VITE_SYNC_V2_CURSOR=off to disable.
+ */
+export const SYNC_V2_CURSOR_SHADOW_DEFAULT = import.meta.env.VITE_SYNC_V2_CURSOR !== "off"
+
+const PERSIST_DEBOUNCE_MS = 1_000
+
+export function syncLogCursorKey(workspaceId: string): string {
+  return `${workspaceId}:sync-log`
+}
+
+/**
+ * The client's single sync-log position for one workspace (`lastSyncId`),
+ * persisted in the `syncCursors` IDB table.
+ *
+ * Advancement is a monotonic BigInt max: live events and catch-up pages can
+ * race in any order (sweep-rescued events arrive late, two tabs sync
+ * concurrently) and still converge. Persistence is debounced — live events
+ * advance the cursor on every message — and the write itself is a
+ * read-max-write inside one IDB transaction so concurrent tabs never move
+ * the persisted cursor backwards.
+ *
+ * `dispose()` cancels any pending write WITHOUT flushing: the engine is
+ * destroyed on account switch, which repoints the shared `db` proxy, and a
+ * cursor is per-user state (the server filters the log per user) that must
+ * never leak into another account's database. Losing the last debounce
+ * window is harmless — entries are re-fetched and applied idempotently.
+ */
+export class SyncLogCursor {
+  private readonly key: string
+  private value: bigint | null = null
+  private loadPromise: Promise<void> | null = null
+  private persistTimer: ReturnType<typeof setTimeout> | null = null
+  private disposed = false
+
+  constructor(
+    workspaceId: string,
+    private readonly debounceMs: number = PERSIST_DEBOUNCE_MS
+  ) {
+    this.key = syncLogCursorKey(workspaceId)
+  }
+
+  /** Loads the persisted cursor once; concurrent callers share the load. */
+  load(): Promise<void> {
+    this.loadPromise ??= (async () => {
+      const row = await db.syncCursors.get(this.key)
+      if (row) {
+        const persisted = BigInt(row.cursor)
+        if (this.value === null || persisted > this.value) {
+          this.value = persisted
+        }
+      }
+    })()
+    return this.loadPromise
+  }
+
+  /** Current cursor, or null when nothing is known yet. Call `load()` first. */
+  get(): string | null {
+    return this.value?.toString() ?? null
+  }
+
+  /** Monotonic max advance; schedules a debounced persist. */
+  advance(syncId: string): void {
+    if (this.disposed) return
+    const candidate = BigInt(syncId)
+    if (this.value !== null && candidate <= this.value) return
+    this.value = candidate
+    this.persistTimer ??= setTimeout(() => {
+      this.persistTimer = null
+      void this.persist()
+    }, this.debounceMs)
+  }
+
+  /** Persists any pending advance immediately. */
+  async flush(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer)
+      this.persistTimer = null
+    }
+    await this.persist()
+  }
+
+  dispose(): void {
+    this.disposed = true
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer)
+      this.persistTimer = null
+    }
+  }
+
+  private async persist(): Promise<void> {
+    if (this.disposed || this.value === null) return
+    const value = this.value
+    await db.transaction("rw", db.syncCursors, async () => {
+      const existing = await db.syncCursors.get(this.key)
+      if (existing && BigInt(existing.cursor) >= value) return
+      await db.syncCursors.put({ key: this.key, cursor: value.toString(), updatedAt: Date.now() })
+    })
+  }
+}

--- a/apps/frontend/src/sync/sync-log-cursor.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.ts
@@ -15,6 +15,20 @@ export function syncLogCursorKey(workspaceId: string): string {
 }
 
 /**
+ * Parses a sync id off the wire or out of IDB. Malformed input (a rogue
+ * payload, a corrupted row) is ignored loudly instead of throwing — a throw
+ * here would crash the hot onAny listener or poison the cursor load.
+ */
+function parseSyncId(value: string, context: string): bigint | null {
+  try {
+    return BigInt(value)
+  } catch {
+    console.warn(`Sync-v2: ignoring malformed sync id (${context})`, { value })
+    return null
+  }
+}
+
+/**
  * The client's single sync-log position for one workspace (`lastSyncId`),
  * persisted in the `syncCursors` IDB table.
  *
@@ -50,8 +64,8 @@ export class SyncLogCursor {
     this.loadPromise ??= (async () => {
       const row = await db.syncCursors.get(this.key)
       if (row) {
-        const persisted = BigInt(row.cursor)
-        if (this.value === null || persisted > this.value) {
+        const persisted = parseSyncId(row.cursor, "load")
+        if (persisted !== null && (this.value === null || persisted > this.value)) {
           this.value = persisted
         }
       }
@@ -67,7 +81,8 @@ export class SyncLogCursor {
   /** Monotonic max advance; schedules a debounced persist. */
   advance(syncId: string): void {
     if (this.disposed) return
-    const candidate = BigInt(syncId)
+    const candidate = parseSyncId(syncId, "advance")
+    if (candidate === null) return
     if (this.value !== null && candidate <= this.value) return
     this.value = candidate
     this.persistTimer ??= setTimeout(() => {
@@ -78,6 +93,7 @@ export class SyncLogCursor {
 
   /** Persists any pending advance immediately. */
   async flush(): Promise<void> {
+    if (this.disposed) return
     if (this.persistTimer) {
       clearTimeout(this.persistTimer)
       this.persistTimer = null

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -249,7 +249,8 @@ export interface SyncCatchUpEntry {
  * Catch-up page. Clients advance their cursor only by applied entries and
  * page until a fetch comes back empty — `head` is a workspace-global
  * freshness hint, NOT a cursor target: the per-user filtered view can sit
- * permanently below it.
+ * permanently below it. (Shadow mode, which applies nothing, deliberately
+ * advances by fetched entries instead — see SyncEngine.performShadowCatchUp.)
  */
 export interface SyncCatchUpResponse {
   entries: SyncCatchUpEntry[]

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -229,6 +229,34 @@ export interface EventsAroundResponse {
 }
 
 // ============================================================================
+// Sync log catch-up (GET /api/workspaces/:workspaceId/sync)
+// ============================================================================
+
+/**
+ * One sync-log entry. `payload` is the exact outbox payload the live socket
+ * emits for `eventType` — applying a catch-up entry reuses the same handler
+ * the live event uses. `syncId` is a stringified BIGINT, like stream
+ * sequences on the wire.
+ */
+export interface SyncCatchUpEntry {
+  syncId: string
+  eventType: string
+  payload: unknown
+  createdAt: string
+}
+
+/**
+ * Catch-up page. Clients advance their cursor only by applied entries and
+ * page until a fetch comes back empty — `head` is a workspace-global
+ * freshness hint, NOT a cursor target: the per-user filtered view can sit
+ * permanently below it.
+ */
+export interface SyncCatchUpResponse {
+  entries: SyncCatchUpEntry[]
+  head: string
+}
+
+// ============================================================================
 // Messages API
 // ============================================================================
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -387,6 +387,9 @@ export type {
   StreamContextRefSource,
   EventsAroundResponse,
   SharedMessageHydration,
+  // Sync log catch-up
+  SyncCatchUpEntry,
+  SyncCatchUpResponse,
   // Messages
   CreateMessageInput,
   CreateMessageInputJson,


### PR DESCRIPTION
## Problem

Phase 1 of sync-engine v2 (#830, #832, #833) built the server spine: every client-routed outbox event is sequenced into a per-workspace dense `sync_log`, live emits carry `syncId`, and `GET /api/workspaces/:workspaceId/sync` serves ACL-filtered catch-up pages. The client ignores all of it. Phase 2 is client adoption: one cursor per workspace, advanced on the live path, healed by catch-up on reconnect — replacing "hope + bootstrap invalidation" for the workspace tier.

Adopting that in one step would put an unproven cursor in charge of healing. This PR is phase 2a: build the cursor mechanics and run them in **shadow mode** — track, fetch, log, change nothing — so production data can show the cursor is trustworthy before it owns anything.

## Solution

The `SyncEngine` now (behind `VITE_SYNC_V2_CURSOR`, default on, `off` to kill):

1. **Tracks one `lastSyncId` per workspace** (`SyncLogCursor`), persisted in the previously-unused `syncCursors` IDB table. Advancement is a monotonic BigInt max — live events, catch-up pages, and concurrent tabs converge regardless of arrival order (sweep-rescued events arrive late by design). Persistence is debounced and the write is read-max-write in one IDB transaction, so the persisted cursor never moves backwards across tabs.
2. **Advances the cursor from live events** via one `socket.onAny` chokepoint: any payload carrying `syncId` for this workspace advances it. Events without `syncId` (bot-scoped, pre-deploy) are invisible to the cursor. No changes to the 40+ per-event handlers.
3. **Runs shadow catch-up** on connect/reconnect/resume: pages the endpoint from the cursor (single-flighted, 500/page, until an empty page), advances the cursor by fetched entries, and logs a structured summary — entries fetched, pages, event-type histogram, head. **It applies nothing.** Entries fetched after a disconnect are exactly the events active mode would have healed; on a healthy resume the count should be ~zero. That log line is the shadow-mode divergence signal.
4. **First run on a device seeds the cursor from `head`** instead of replaying the whole retained log — everything ≤ head is covered by the bootstrap snapshot path. The page-resume/visibility hooks now exercise the cheap head check, the phase 2 starting point for the heartbeat.

### Key design decisions

**1. `onAny` instead of per-handler wiring.** The cursor needs every sync-logged event type; touching 40+ registrations would be churn with no signal. One listener filters on `payload.workspaceId` + `payload.syncId`.

**2. Cursor advance on the live path is optimistic and that's acceptable here.** A dropped emit followed by a later live event jumps the cursor past the dropped entry. That is exactly today's loss mode for the workspace tier, the existing healing (INV-53 bootstrap invalidation, per-stream contiguity INV-61) still covers it in this PR, and the durable log means a future heartbeat/replay layer can close it structurally. Shadow mode quantifies how often it happens.

**3. Dispose-without-flush on engine destroy.** Engine destroy can be an account switch, which repoints the shared `db` proxy. The cursor is per-user state (the server filters the log per user), so a post-destroy flush could leak one account's position into another account's database — for a workspace both accounts are members of, that would skip entries the second user never applied. Losing the last debounce window instead is harmless: monotonic, idempotent re-fetch.

**4. No INV-61-style contiguity math on sync ids — ever.** The workspace log is not per-viewer dense (other users' entries occupy ids), so a missing sync id is meaningless to the client. The cursor is a position, not a gap detector. Per-stream `broadcastSequence` + `computeTimelineHoles` remain the only contiguity authority.

**5. Shadow advances by fetched (not applied) entries.** "Applied" is a no-op in shadow; advancing by the page tail keeps deltas small and exercises the real paging loop. Active mode will advance only by applied entries, per the protocol contract in `apps/backend/src/features/sync/service.ts`.

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/sync/sync-log-cursor.ts` | `SyncLogCursor` (persisted monotonic cursor) + feature flag |
| `apps/frontend/src/sync/sync-log-cursor.test.ts` | Monotonicity, load-merge, debounce, multi-tab convergence, dispose safety |
| `apps/frontend/src/api/sync.ts` | `syncApi.catchUp` client for the phase 1 endpoint |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/sync/sync-engine.ts` | Cursor tracking (`onAny`), single-flighted shadow catch-up, head seeding, `getSyncCursor()` accessor |
| `apps/frontend/src/sync/sync-engine.test.ts` | MockSocket `onAny`/`offAny`; 5 shadow-mode tests |
| `apps/frontend/src/pages/workspace-layout.tsx` | Pass `syncService: syncApi` to the engine |
| `apps/frontend/src/api/index.ts` | Export `syncApi` |
| `packages/types/src/api.ts`, `packages/types/src/index.ts` | `SyncCatchUpEntry` / `SyncCatchUpResponse` wire types (INV-31) |
| `apps/backend/src/features/sync/handlers.ts` | Response `satisfies SyncCatchUpResponse` so the contract can't drift |

## Test plan

- [x] `sync-log-cursor.test.ts` — 6 tests (monotonic BigInt advance, persisted/in-memory max merge, debounce persist, flush, multi-tab no-backwards write, dispose cancels and blocks writes)
- [x] `sync-engine.test.ts` — 5 new tests (head seeding with `{after:"0",limit:1}`, live-payload advance filtered by workspace/syncId presence, paging from persisted cursor until empty page, single-flight, flag off = fully inert)
- [x] Full frontend suite: 2389 passing
- [x] Backend sync unit tests + monorepo typecheck + lint (pre-commit)
- [ ] Backend integration suite needs Postgres on :5454 — not runnable in this environment (no Docker); backend change is type-only

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2 of sync-engine v2 (exploration doc Part 6, step 2): the client holds exactly one sync-log cursor per workspace and uses server-side catch-up — not bootstrap-shaped hope — to heal delivery gaps. Split into increments so the cursor proves itself before it owns healing.

## Phase 2a (this PR): shadow mode

- One `lastSyncId` per workspace in IDB (`syncCursors` table, key `<workspaceId>:sync-log`).
- Live socket payloads carrying `syncId` advance it (monotonic max; events without `syncId` are bot-scoped or pre-deploy and ignored).
- On connect/reconnect/resume, page `GET /sync?after=<cursor>` (single-flighted), advance by fetched entries, log a structured divergence summary. Apply nothing.
- First run seeds the cursor from `head` (legal only because shadow owns no healing).
- Kill switch: `VITE_SYNC_V2_CURSOR=off`.

## Phase 2b (next): active catch-up

- Apply catch-up entries through the SAME apply path the live socket events use (protocol: `payload` is the exact outbox payload). Plan: dispatch each entry to the socket's registered listeners for `entry.eventType` so live and catch-up can never drift.
- Order by `syncId`, apply idempotently by domain event id; duplicates are by design (sweep + dispatcher can both emit; snapshot/log overlap is the safe side of the read-before-stamp rule).
- Buffer live events while catch-up pages, then apply buffered entries with `syncId` greater than the catch-up position (doc Part 5 pressure-test 7) — no `_patchedAt`/wall-clock heuristics.
- Cursor initialization must move to BEFORE the workspace bootstrap data fetch (read-before-stamp: read position P first so races fall on the duplicate side, never the gap side).
- Advance the cursor ONLY by applied entries; never jump to `head` (the per-user filtered view can sit permanently below it).
- Audit which apply handlers are duplicate-safe (e.g. unread-count increments) before flipping; add idempotency where needed.

## Phase 2c (after 2b is proven): narrow INV-53

- Delete only the reconnect invalidations that catch-up provably replaces, each with a test. Candidates: `savedKeys`/`scheduledKeys` invalidation in `registerWorkspaceSocketHandlers`, parts of the reconnect re-bootstrap fan-out.
- Keep: per-stream windowed bootstrap (history is never replayed through the log), the public-stream non-member backfill path (catch-up is membership-scoped, live rooms are access-scoped — deliberate phase 1 decision), per-stream contiguity (INV-61).
- Heartbeat: promote the resume-time head check to a periodic per-connection signal if shadow data shows silent-loss windows that page-resume misses.

## Hard constraints carried from phase 1 (do not regress)

- The workspace log is NOT per-viewer dense — no contiguity math on sync ids, ever.
- Duplicates are normal; sweep-rescued events get LATE sync ids. Timeline display order comes from stream sequence + timestamps, never sync id.
- Catch-up is membership-scoped; threads inherit the ROOT membership with join-position bounds (INV-62).
- The catch-up cursor for per-stream backfill has one owner (`SyncEngine.joinStreamForCatchUp`); the sync-log cursor is a separate, workspace-level concept and must not be conflated with stream sequences.

## What's NOT included (tracked, deliberate)

- No retention/pruning for `sync_log` (phase 1 deferral; needs a tracking issue).
- No alerting on the reconciliation sweep WARN / `gapCeilingMs` ERROR (good adjacent task).
- No derived server-side subscriptions or per-connection replay (explicitly later than phase 2).

## Status

- Phase 2a: this PR.
- Phase 2b/2c: follow-up PRs on top, stacked per the repo's squash-merge workflow.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01MtvkQTqUWVauErSPk6Kces

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtvkQTqUWVauErSPk6Kces)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783799262&installation_id=129946197&pr_number=846&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F846&signature=53206c35c62eceb5346400c04e335932be84f520b1bc1d03402e251f27c93744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->