### PR TITLE
feat: TurnDriver/TurnSink/TurnRequest spine; companion runs through InProcessTurnDriver (Phase 2.1)

### DIFF
--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -36,14 +36,16 @@ import { logger } from "../../lib/logger"
 import { buildAgentContext, buildToolSet, withCompanionSession, type WithSessionResult } from "./companion"
 import { resolveBagForStream, persistSnapshot, appendBagToSystemPrompt, type ResolvedBag } from "./context-bag"
 import { createMemoizedGithubClient, createMemoizedLinearClient, type RunGeneralResearchOptions } from "./tools"
+import { createSessionTraceProjector, OtelObserver, type AgentRuntimeConfig, type NewMessageInfo } from "./runtime"
 import {
-  AgentRuntime,
-  createSessionTraceProjector,
-  OtelObserver,
-  type AgentRuntimeConfig,
-  type NewMessageInfo,
-} from "./runtime"
-import { TurnDigestCollector, generateTurnDigest, negotiateCapabilities } from "@threa/agent-runtime"
+  InProcessTurnDriver,
+  TurnDeliveries,
+  TurnDigestCollector,
+  generateTurnDigest,
+  negotiateCapabilities,
+  type TurnRequest,
+  type TurnSink,
+} from "@threa/agent-runtime"
 import type { SessionTrace } from "./trace-emitter"
 import {
   SUPERSEDE_RESPONSE_VALIDATOR_MAX_TOKENS,
@@ -162,7 +164,16 @@ interface SupersededMessagePlan {
 }
 
 export class PersonaAgent {
-  constructor(private readonly deps: PersonaAgentDeps) {}
+  /**
+   * The plaintext TurnDriver of the turn contract. Long-lived (INV-13): each
+   * turn passes its own TurnRequest + TurnSink; the driver runs AgentRuntime
+   * in-process exactly as before.
+   */
+  private readonly turnDriver: InProcessTurnDriver
+
+  constructor(private readonly deps: PersonaAgentDeps) {
+    this.turnDriver = new InProcessTurnDriver({ ai: deps.ai })
+  }
 
   async run(input: PersonaAgentInput): Promise<PersonaAgentResult> {
     const {
@@ -401,7 +412,7 @@ export class PersonaAgent {
         const isSupersedeRerun = !!supersededMessagePlan
 
         // `sources` is required on the commit payload (empty array = none) so a
-        // caller can't silently drop citations — see AgentRuntimeConfig.sendMessage.
+        // caller can't silently drop citations — see TurnCommit.
         const doSendMessage = async (msgInput: { content: string; sources: SourceItem[] }) => {
           const latestSession = await AgentSessionRepository.findById(db, session.id)
           if (!latestSession || latestSession.status !== SessionStatuses.RUNNING) {
@@ -599,9 +610,10 @@ export class PersonaAgent {
         // turn_digest step can carry the tool work into later turns (C-1).
         const digestCollector = new TurnDigestCollector()
 
-        // Run agent runtime
-        const runtime = new AgentRuntime({
-          ai,
+        // The turn as dispatch mints it: delivery + model binding + this
+        // turn's prompt, history, toolset, and sampling params.
+        const turnRequest: TurnRequest = {
+          delivery: TurnDeliveries.PLAINTEXT,
           model,
           modelString: persona.model,
           // Origin is "user" for mention-triggered runs where we can attribute
@@ -623,7 +635,6 @@ export class PersonaAgent {
           tools,
           maxTokens: persona.maxTokens,
           temperature: persona.temperature,
-          sendMessage: doSendMessage,
           allowNoMessageOutput: isSupersedeRerun,
           validateFinalResponse: isSupersedeRerun
             ? buildSupersedeResponseValidator({
@@ -646,6 +657,13 @@ export class PersonaAgent {
               model_name: parsed.modelName,
             },
           },
+        }
+
+        // The host edges this turn runs against: the commit path, the trace
+        // observers, and the abort + interjection channels that used to be
+        // handed to the loop as raw closures.
+        const turnSink: TurnSink = {
+          commitMessage: doSendMessage,
           observers: [
             createSessionTraceProjector(trace),
             digestCollector,
@@ -797,10 +815,10 @@ export class PersonaAgent {
             personaId: persona.id,
             lastProcessedSequence: session.lastSeenSequence ?? initialSequence,
           },
-        })
+        }
 
         try {
-          const loopResult = await runtime.run()
+          const loopResult = await this.turnDriver.runTurn(turnRequest, turnSink)
           const retainedMessageIds =
             isSupersedeRerun && loopResult.sentMessageIds.length === 0
               ? [...supersededMessagePlan.messageIds]

--- a/docs/features/architecture/agent-runtime.md
+++ b/docs/features/architecture/agent-runtime.md
@@ -83,6 +83,16 @@ called no tools, the runtime treats the text as a candidate reply, validates it,
 commits it through the `sendMessage` callback or loops once more. It ends with `session:end`
 or `session:error`.
 
+**The companion reaches the loop through the plaintext turn driver.** `persona-agent.ts`
+does not construct `AgentRuntime` directly: it builds a `TurnRequest` (delivery
+`"plaintext"`, the model binding, prompt, history, toolset, and sampling params) and a
+`TurnSink` (the commit path, trace observers, and the abort + interjection edges) and hands
+them to a long-lived `InProcessTurnDriver`
+(`packages/agent-runtime/src/runtime/turn-driver.ts`), which maps them onto
+`AgentRuntimeConfig` and runs the loop. The driver is the structural seam the sealed
+(enclave) and external (bot) drivers share — each delivery gets exactly one driver, and a
+request routed to the wrong one fails loudly.
+
 **Sending a message is a callback, not a side effect the loop owns.** The runtime is handed
 a `sendMessage` function (`agent-runtime.ts:64`); the backend's implementation in
 `persona-agent.ts` writes the actual stream message, attaches the sources the agent

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -8,6 +8,16 @@ export type { AgentObserver } from "./runtime/agent-observer"
 export { OtelObserver } from "./runtime/otel-observer"
 export { AgentRuntime, mergeSourceItems } from "./runtime/agent-runtime"
 export type { AgentRuntimeConfig, AgentRuntimeResult, NewMessageAwareness } from "./runtime/agent-runtime"
+export { InProcessTurnDriver, TurnDeliveries } from "./runtime/turn-driver"
+export type {
+  TurnCommit,
+  TurnCommitReceipt,
+  TurnDelivery,
+  TurnDriver,
+  TurnRequest,
+  TurnResult,
+  TurnSink,
+} from "./runtime/turn-driver"
 export {
   TurnDigestCollector,
   generateTurnDigest,

--- a/packages/agent-runtime/src/runtime/index.ts
+++ b/packages/agent-runtime/src/runtime/index.ts
@@ -9,6 +9,16 @@ export type { AgentObserver } from "./agent-observer"
 export { OtelObserver } from "./otel-observer"
 export { AgentRuntime } from "./agent-runtime"
 export type { AgentRuntimeConfig, AgentRuntimeResult, NewMessageAwareness } from "./agent-runtime"
+export { InProcessTurnDriver, TurnDeliveries } from "./turn-driver"
+export type {
+  TurnCommit,
+  TurnCommitReceipt,
+  TurnDelivery,
+  TurnDriver,
+  TurnRequest,
+  TurnResult,
+  TurnSink,
+} from "./turn-driver"
 export {
   TurnDigestCollector,
   generateTurnDigest,

--- a/packages/agent-runtime/src/runtime/turn-driver.test.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, mock } from "bun:test"
+import { AgentToolNames } from "@threa/types"
+import type { AgentEvent } from "./agent-events"
+import { InProcessTurnDriver, TurnDeliveries, type TurnCommit, type TurnRequest } from "./turn-driver"
+
+function plaintextRequest(overrides?: Partial<TurnRequest>): TurnRequest {
+  return {
+    delivery: TurnDeliveries.PLAINTEXT,
+    model: {} as any,
+    systemPrompt: "You are helpful.",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    ...overrides,
+  }
+}
+
+describe("InProcessTurnDriver", () => {
+  it("runs a plaintext turn through the loop and commits via the sink", async () => {
+    const events: AgentEvent[] = []
+    const commits: TurnCommit[] = []
+    const driver = new InProcessTurnDriver({
+      ai: {
+        generateTextWithTools: async () => ({
+          text: "",
+          toolCalls: [
+            { toolCallId: "tool_1", toolName: AgentToolNames.SEND_MESSAGE, input: { content: "Hello there" } },
+          ],
+          response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+        }),
+      } as any,
+    })
+
+    const result = await driver.runTurn(plaintextRequest(), {
+      commitMessage: async (commit) => {
+        commits.push(commit)
+        return { messageId: "msg_1", operation: "created" }
+      },
+      observers: [
+        {
+          handle: async (event) => {
+            events.push(event)
+          },
+        },
+      ],
+    })
+
+    expect(commits).toEqual([{ content: "Hello there", sources: [] }])
+    expect(result.sentMessageIds).toEqual(["msg_1"])
+    expect(result.messagesSent).toBe(1)
+    expect(events.some((event) => event.type === "message:sent" && event.messageId === "msg_1")).toBe(true)
+    expect(events.some((event) => event.type === "session:end" && event.messagesSent === 1)).toBe(true)
+  })
+
+  it("refuses a non-plaintext delivery before any model call", async () => {
+    const generateTextWithTools = mock(async () => {
+      throw new Error("must not be called")
+    })
+    const commitMessage = mock(async () => ({ messageId: "msg_never" }))
+    const driver = new InProcessTurnDriver({ ai: { generateTextWithTools } as any })
+
+    expect(driver.delivery).toBe(TurnDeliveries.PLAINTEXT)
+    await expect(
+      driver.runTurn(plaintextRequest({ delivery: TurnDeliveries.SEALED }), { commitMessage })
+    ).rejects.toThrow('serves "plaintext" turns')
+    expect(generateTextWithTools).not.toHaveBeenCalled()
+    expect(commitMessage).not.toHaveBeenCalled()
+  })
+
+  it("forwards the sink's control edges to the loop", async () => {
+    const generateTextWithTools = mock(async () => {
+      throw new Error("must not be called")
+    })
+    const driver = new InProcessTurnDriver({ ai: { generateTextWithTools } as any })
+
+    await expect(
+      driver.runTurn(plaintextRequest(), {
+        commitMessage: async () => ({ messageId: "msg_never" }),
+        shouldAbort: async () => "session superseded",
+      })
+    ).rejects.toThrow("Agent session aborted: session superseded")
+    expect(generateTextWithTools).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agent-runtime/src/runtime/turn-driver.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.ts
@@ -1,0 +1,137 @@
+import type { LanguageModel, ModelMessage } from "ai"
+import type { SourceItem } from "@threa/types"
+import type { CostContext } from "../ai/ai"
+import {
+  AgentRuntime,
+  type AgentRuntimeAI,
+  type AgentRuntimeConfig,
+  type AgentRuntimeResult,
+  type NewMessageAwareness,
+} from "./agent-runtime"
+import type { AgentObserver } from "./agent-observer"
+import type { AgentTool } from "./agent-tool"
+
+// The turn contract's structural spine: dispatch mints a TurnRequest, routes it
+// to the driver matching its delivery, and the driver runs the turn against the
+// host's TurnSink. The request is everything a turn IS (model binding, prompt,
+// history, toolset, sampling params); the sink is everything the turn touches in
+// the host (the commit path, the trace observers, abort + interjection edges).
+// `AgentRuntimeConfig` remains the loop's own constructor shape — this module
+// types the seam in front of it without changing the loop.
+
+export const TurnDeliveries = {
+  /** First-party in-process turn next to plaintext (the companion). */
+  PLAINTEXT: "plaintext",
+  /** First-party turn behind sealed transport (the enclave). */
+  SEALED: "sealed",
+  /** Third-party harness driving its own agent over the bot wire. */
+  EXTERNAL: "external",
+} as const
+
+export type TurnDelivery = (typeof TurnDeliveries)[keyof typeof TurnDeliveries]
+
+/**
+ * The commit payload every surface converges on. `sources` is required (empty
+ * array means "none") so a host that ignores citations doesn't compile — the
+ * same contract `AgentRuntimeConfig.sendMessage` already enforces. Sealed hosts
+ * must carry the sources inside the sealed payload, never a cleartext field.
+ */
+export interface TurnCommit {
+  content: string
+  sources: SourceItem[]
+}
+
+export interface TurnCommitReceipt {
+  messageId: string
+  operation?: "created" | "edited"
+}
+
+/**
+ * The host edges a turn runs against — what persona-agent used to hand the loop
+ * as raw closures. Only the commit path is mandatory; a minimal host (no trace,
+ * no interjection) supplies just `commitMessage`.
+ */
+export interface TurnSink {
+  /** Terminal action: deliver one committed message to the conversation. */
+  commitMessage: (commit: TurnCommit) => Promise<TurnCommitReceipt>
+  /** Event sink — trace projection, digest collection, OTEL. */
+  observers?: AgentObserver[]
+  /** Mid-turn interjection (new-message awareness). Omitted → the host can't see mid-turn messages. */
+  newMessages?: NewMessageAwareness
+  /** Hard cancellation: a returned reason aborts the turn (externally deleted/superseded sessions). */
+  shouldAbort?: () => Promise<string | null>
+  /** Cooperative per-tool cancellation (graceful partial results, not session failure). */
+  toolSignalProvider?: (toolCallId: string, toolName: string) => AbortSignal | undefined
+}
+
+/**
+ * One turn, as dispatch mints it: which delivery serves it, plus the loop's
+ * inputs. The resolved `model` is host-bound (a sealed host resolves its own
+ * from `modelString`), so drivers that cross a transport boundary put only the
+ * string on the wire.
+ */
+export interface TurnRequest {
+  delivery: TurnDelivery
+  model: LanguageModel
+  /** Original provider:model string for `model` — required alongside `costContext` for usage recording. */
+  modelString?: string
+  systemPrompt: string
+  messages: ModelMessage[]
+  tools: AgentTool[]
+  maxTokens?: number | null
+  temperature?: number | null
+  maxIterations?: number
+  initialContext?: AgentRuntimeConfig["initialContext"]
+  telemetry?: AgentRuntimeConfig["telemetry"]
+  costContext?: CostContext
+  allowNoMessageOutput?: boolean
+  validateFinalResponse?: AgentRuntimeConfig["validateFinalResponse"]
+}
+
+export type TurnResult = AgentRuntimeResult
+
+export interface TurnDriver {
+  /** The single delivery this driver serves; dispatch routes requests by it. */
+  readonly delivery: TurnDelivery
+  runTurn(request: TurnRequest, sink: TurnSink): Promise<TurnResult>
+}
+
+/**
+ * The plaintext driver: runs `AgentRuntime` in-process (the companion path).
+ * Long-lived — construct once with the host's AI; each turn passes its own
+ * request and sink.
+ */
+export class InProcessTurnDriver implements TurnDriver {
+  readonly delivery: TurnDelivery = TurnDeliveries.PLAINTEXT
+
+  constructor(private readonly deps: { ai: AgentRuntimeAI }) {}
+
+  async runTurn(request: TurnRequest, sink: TurnSink): Promise<TurnResult> {
+    if (request.delivery !== this.delivery) {
+      throw new Error(`InProcessTurnDriver serves "${this.delivery}" turns; got "${request.delivery}"`)
+    }
+
+    const runtime = new AgentRuntime({
+      ai: this.deps.ai,
+      model: request.model,
+      modelString: request.modelString,
+      systemPrompt: request.systemPrompt,
+      messages: request.messages,
+      tools: request.tools,
+      maxTokens: request.maxTokens,
+      temperature: request.temperature,
+      maxIterations: request.maxIterations,
+      initialContext: request.initialContext,
+      telemetry: request.telemetry,
+      costContext: request.costContext,
+      allowNoMessageOutput: request.allowNoMessageOutput,
+      validateFinalResponse: request.validateFinalResponse,
+      sendMessage: sink.commitMessage,
+      observers: sink.observers,
+      newMessages: sink.newMessages,
+      shouldAbort: sink.shouldAbort,
+      toolSignalProvider: sink.toolSignalProvider,
+    })
+    return runtime.run()
+  }
+}


### PR DESCRIPTION
## Problem

Phase 1 unified the projector, the prompt/toolset assembly, and the per-stream tool policy across the companion and the enclave — but the seam in front of the loop is still untyped (`docs/plans/agent-runtimes-unification-redesign.md` §2.2/§2.3/§2.4):

- **The companion hands `AgentRuntime` a bag of raw closures.** `persona-agent.ts` inlines a ~200-line `AgentRuntimeConfig` literal mixing three concerns: what the turn IS (model, prompt, history, toolset, sampling params), the host edges it touches (`doSendMessage`, trace observers, abort + interjection), and the loop's own resources (`ai`).
- **There is no named place for the three drivers to meet.** The plan's spine — dispatch mints a `TurnRequest(delivery)` and routes it to exactly one driver — has no types to hang `EnclaveTurnDriver` (2.2) or `ExternalTurnDriver` (2.3) on.

## Solution

Phase 2.1 of the agent-runtimes unification plan (§2.4): the turn contract's structural spine, plus the companion wrapped as the first driver. No wire change, no behavior change.

### How it works

```
TurnRequest { delivery: "plaintext" | "sealed" | "external", model, prompt,
              history, toolset, sampling params }
        │
        ▼
TurnDriver (readonly delivery; wrong-delivery requests fail loudly, INV-11)
        │
        ├─ InProcessTurnDriver (this PR): maps request + sink onto the
        │  untouched AgentRuntime and runs it in-process
        │
        └─ EnclaveTurnDriver / ExternalTurnDriver: later phases, same seam
        │
        ▼
TurnSink { commitMessage(TurnCommit) → receipt, observers, newMessages,
           shouldAbort, toolSignalProvider }
```

`persona-agent.ts` keeps building context exactly as before; it now assembles a `TurnRequest` and a `TurnSink` and calls a long-lived `InProcessTurnDriver` instead of constructing `AgentRuntime` inline — the §2.3 "renames and edge-typing" carve.

### Key design decisions

**1. `AgentRuntimeConfig` is untouched.** The driver maps request + sink onto the existing constructor shape, so the enclave's `runEnclaveTurn` and the research sub-loop (the other two `new AgentRuntime` call sites) are unaffected. The seam is typed in front of the loop, not by rewriting it.

**2. The request/sink split follows "mintable vs host-owned".** `TurnRequest` is everything dispatch can mint for a turn (delivery, model binding, prompt, history, toolset, params — including per-turn semantics like `allowNoMessageOutput`/`validateFinalResponse` for supersede reruns). `TurnSink` is everything that touches the host: the commit path, the trace observers, and the abort + interjection edges. Only `commitMessage` is mandatory — a minimal host compiles with just that.

**3. `TurnCommit` is today's required-sources contract, without `multimodal` yet.** The plan's §2.2.1 payload eventually carries required `multimodal`; no first-party host produces outbound multimodal today and `createMessage` doesn't accept it, so adding the field now would be accept-and-drop plumbing (INV-36). It arrives with the phase that has a producer (§2.4 defers multimodal deliberately).

**4. One driver per delivery, enforced.** `TurnDriver.delivery` is the routing key; `InProcessTurnDriver` throws on a non-`plaintext` request before any model call (INV-11) — the contract is "dispatch routes by delivery", not "drivers tolerate anything".

**5. `TurnDelivery` lives in the package, not `@threa/types`.** Nothing about delivery is on a wire yet; it moves to the shared types package when 2.3 puts it there. The resolved `LanguageModel` rides the request (host-bound); drivers that cross a transport boundary send only `modelString`.

**6. The driver is long-lived (INV-13).** `PersonaAgent` constructs it once with the host AI; each turn passes its own request + sink, mirroring how dispatch will eventually hold one driver per delivery.

## New files

| File | Purpose |
| --- | --- |
| `packages/agent-runtime/src/runtime/turn-driver.ts` | `TurnDeliveries`, `TurnCommit`/`TurnCommitReceipt`, `TurnSink`, `TurnRequest`, `TurnDriver`, `InProcessTurnDriver` |
| `packages/agent-runtime/src/runtime/turn-driver.test.ts` | Driver behavior: end-to-end commit through the sink, loud wrong-delivery rejection, control-edge forwarding |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/agents/persona-agent.ts` | Builds `TurnRequest` + `TurnSink`; runs the turn through a long-lived `InProcessTurnDriver` instead of inlining `AgentRuntime` |
| `packages/agent-runtime/src/{index,runtime/index}.ts` | Export the turn-contract types + driver |
| `docs/features/architecture/agent-runtime.md` | Documents the driver seam in the companion's path to the loop |

## Test plan

- [x] `packages/agent-runtime`: 184 pass (3 new in `turn-driver.test.ts`)
- [x] backend: agents/enclave-runtimes/e2e-streams 386 pass; streams/bot-runtimes/public-api 154 pass
- [x] enclave (vitest): 68 pass — the enclave path is untouched but imports the modified barrels
- [x] `bun run typecheck` + `bun run lint` clean; OpenAPI spec unchanged (`--check` passes); no wire change anywhere

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2.1 of `docs/plans/agent-runtimes-unification-redesign.md` §2.4: define the turn contract's structural spine — `TurnDriver`/`TurnSink`/`TurnRequest(delivery)` — and wrap the companion as `InProcessTurnDriver`. No wire change. Closes the plan's "structural spine" row; `EnclaveTurnDriver` (2.2) and `ExternalTurnDriver` (2.3) build on these types.

## What Was Built

1. **`packages/agent-runtime/src/runtime/turn-driver.ts`**: `TurnDeliveries` const (`plaintext`/`sealed`/`external`) with `TurnDelivery` derived (INV-31); `TurnCommit` (content + required `sources`, the existing commit contract) and `TurnCommitReceipt`; `TurnSink` (mandatory `commitMessage`, optional `observers`/`newMessages`/`shouldAbort`/`toolSignalProvider`); `TurnRequest` (delivery + model binding + prompt/history/toolset/params/initialContext/telemetry/cost); `TurnDriver` interface with `readonly delivery`; `InProcessTurnDriver` mapping request + sink onto the untouched `AgentRuntimeConfig` and running `AgentRuntime`.
2. **Companion carve**: `PersonaAgent` constructs the driver once (INV-13); the turn body assembles `turnRequest` + `turnSink` (the former inline `AgentRuntimeConfig` literal split by concern) and calls `runTurn`. `doSendMessage` becomes `sink.commitMessage` unchanged; observers/abort/interjection move to the sink unchanged.
3. **Guard rail**: a request whose `delivery` doesn't match the driver throws before any model call (INV-11).
4. **Exports** from the `.` and `./runtime` barrels. The provider-free enclave barrel is untouched — the enclave doesn't consume the driver until 2.2 decides how to wrap its path.

## Design Decisions

- **Map onto `AgentRuntimeConfig`, don't rewrite it**: zero behavior risk; the other two `new AgentRuntime` call sites (enclave run-turn, research sub-loop) are untouched.
- **Per-turn semantics stay on the request**: `allowNoMessageOutput`/`validateFinalResponse` parameterize what THIS turn accepts (supersede reruns), so they're mintable, not host edges.
- **`TurnCommit` without `multimodal`**: deferred until a producer exists (INV-36); §2.4 defers multimodal deliberately.
- **`TurnDelivery` not in `@threa/types` yet**: no wire carries it until 2.3.
- **`model: LanguageModel` on the request**: host-bound resolution (companion resolves from the persona's model string; a sealed host resolves its own from `modelString`).

## What's NOT Included (later phases)

- `EnclaveTurnDriver` over the existing HTTP callbacks; interjection implemented-or-declared (2.2)
- `ExternalTurnDriver`, `bot:hello` manifest, context handle, reject-undeclared (2.3)
- Trust-tier rule in `negotiateCapabilities` (2.4)
- `TurnDispatch` itself — dispatch still lives in persona-agent/worker wiring; the spine types are what 2.2/2.3 consolidate it onto

## Status

Complete. Gauntlet green: monorepo typecheck + lint; agent-runtime 184; backend agents/enclave-runtimes/e2e-streams 386 + streams/bot-runtimes/public-api 154; enclave 68. OpenAPI unchanged.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01YE55PfeXPRRT1gnbHq2i5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE55PfeXPRRT1gnbHq2i5m)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783801694&installation_id=129946197&pr_number=848&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F848&signature=01eb18ff1bc81cade64ebca87db1b9577432adfff68b5eebfa9f6a396470497d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->