### PR TITLE
feat(dev): auto-detect the Tailscale hostname in LAN mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev": "bun scripts/dev.ts",
-    "dev:lan": "LAN_MODE=true bun scripts/dev.ts",
+    "dev:mobile": "LAN_MODE=true bun scripts/dev.ts",
     "dev:test": "bun scripts/dev-test.ts",
     "dev:backend": "bun --hot apps/backend/src/index.ts",
     "dev:frontend": "bun run --cwd apps/frontend dev",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -501,6 +501,11 @@ async function main() {
     stdout: "inherit",
     stderr: "inherit",
     env: {
+      // The enclave requires OPENROUTER_API_KEY. In the main checkout Bun
+      // auto-loads it from the root `.env`, but worktrees only get
+      // `apps/backend/.env` (ensureWorktreeEnv / setup-worktree copy that
+      // one), so fall back to it — listed first so real process env wins.
+      ...(backendEnv.OPENROUTER_API_KEY ? { OPENROUTER_API_KEY: backendEnv.OPENROUTER_API_KEY } : {}),
       ...process.env,
       PORT: "3011",
       ENCLAVE_SELF_URL: "http://localhost:3011",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -108,6 +108,31 @@ function getDefaultLanHost(): string | undefined {
     .find((i) => i && i.family === "IPv4" && !i.internal)?.address
 }
 
+/**
+ * Best-effort Tailscale MagicDNS hostname so LAN mode also serves devices on
+ * the tailnet (e.g. a phone off the home WiFi). Tries the CLI on PATH first,
+ * then the macOS app-bundle binary. Returns undefined when Tailscale is
+ * absent or not running — LAN mode then behaves exactly as before.
+ */
+async function getTailscaleHost(): Promise<string | undefined> {
+  const candidates = ["tailscale", "/Applications/Tailscale.app/Contents/MacOS/Tailscale"]
+  for (const bin of candidates) {
+    const result = await $`${bin} status --json`.quiet().nothrow()
+    if (result.exitCode !== 0) continue
+    try {
+      const status = JSON.parse(result.stdout.toString())
+      const dnsName: unknown = status?.Self?.DNSName
+      if (status?.BackendState === "Running" && typeof dnsName === "string" && dnsName.length > 0) {
+        // MagicDNS names come back fully qualified with a trailing dot.
+        return dnsName.replace(/\.$/, "")
+      }
+    } catch {
+      // Unparseable output — try the next candidate.
+    }
+  }
+  return undefined
+}
+
 async function ensureWorktreeEnv(): Promise<void> {
   const cwd = process.cwd()
   const backendEnvPath = path.join(cwd, "apps/backend/.env")
@@ -336,20 +361,30 @@ async function main() {
     }
   }
 
-  // LAN mode: bind to WiFi IP so the app is reachable from phones
+  // LAN mode: make the app reachable from phones. Every detected host gets
+  // CORS + Vite allowedHosts coverage; auth callbacks can only bind to ONE
+  // host (WORKOS_REDIRECT_URI is a single value), so an explicit LAN_HOST
+  // wins, then the Tailscale MagicDNS name (works away from the home
+  // network), then the WiFi IP.
   const explicitLanHost = getExplicitLanHost()
   const lanMode = process.env.LAN_MODE === "true" || process.argv.includes("--lan") || !!explicitLanHost
-  let lanIp: string | undefined
+  let lanHosts: string[] = []
+  let primaryLanHost: string | undefined
 
   if (lanMode) {
-    lanIp = explicitLanHost ?? getDefaultLanHost()
+    const tailscaleHost = await getTailscaleHost()
+    const defaultLanIp = getDefaultLanHost()
+    lanHosts = [...new Set([explicitLanHost, tailscaleHost, defaultLanIp].filter((h): h is string => !!h))]
 
-    if (!lanIp) {
-      console.error("LAN_MODE enabled but no LAN IP found — are you connected to WiFi?")
+    if (lanHosts.length === 0) {
+      console.error("LAN_MODE enabled but no LAN IP or Tailscale host found — are you connected to WiFi?")
       process.exit(1)
     }
 
-    console.log(`LAN mode: http://${lanIp}:3000`)
+    primaryLanHost = explicitLanHost ?? tailscaleHost ?? defaultLanIp
+    for (const host of lanHosts) {
+      console.log(`LAN mode: http://${host}:3000${host === primaryLanHost ? "  (auth callbacks)" : ""}`)
+    }
   }
 
   const corsOrigins = [
@@ -358,11 +393,11 @@ async function main() {
     "http://localhost:5173",
     "http://127.0.0.1:5173",
   ]
-  if (lanIp) corsOrigins.push(`http://${lanIp}:3000`)
+  for (const host of lanHosts) corsOrigins.push(`http://${host}:3000`)
 
   const cpEnvOverrides: Record<string, string> = {}
-  if (lanIp && cpEnv.WORKOS_REDIRECT_URI) {
-    cpEnvOverrides.WORKOS_REDIRECT_URI = cpEnv.WORKOS_REDIRECT_URI.replace("localhost", lanIp)
+  if (primaryLanHost && cpEnv.WORKOS_REDIRECT_URI) {
+    cpEnvOverrides.WORKOS_REDIRECT_URI = cpEnv.WORKOS_REDIRECT_URI.replace("localhost", primaryLanHost)
   }
 
   // Dev convenience: auto-seed a platform admin for the default stub email so
@@ -426,6 +461,16 @@ async function main() {
   const frontend = Bun.spawn(["bun", "run", "--cwd", "apps/frontend", "dev"], {
     stdout: "inherit",
     stderr: "inherit",
+    env: {
+      ...process.env,
+      // Vite rejects unknown Host headers for non-IP hostnames, so every
+      // LAN-mode host (Tailscale name included) must be allowlisted or the
+      // phone's request bounces with "Blocked request".
+      VITE_ALLOWED_HOSTS: [...new Set([...(process.env.VITE_ALLOWED_HOSTS?.split(",") ?? []), ...lanHosts])]
+        .map((host) => host.trim())
+        .filter(Boolean)
+        .join(","),
+    },
   })
 
   const backoffice = Bun.spawn(["bun", "run", "--cwd", "apps/backoffice", "dev"], {


### PR DESCRIPTION
## Problem

Testing on a phone over Tailscale required hand-assembling the invocation every time: `LAN_HOST=<magic-dns-fqdn> VITE_ALLOWED_HOSTS=<same> bun scripts/dev.ts`, and knowing that the FQDN (not the short hostname) is what the WorkOS redirect URI needs. Forgetting any piece produced a confusing failure (Vite "Blocked request", CORS rejection, or an auth callback bouncing).

## Solution

LAN mode now detects every host the machine is reachable on and wires all of them up, best-effort:

- **`getTailscaleHost()`** asks the Tailscale CLI (`tailscale status --json`, falling back to the macOS app-bundle binary) for the MagicDNS FQDN. If Tailscale is absent or not running, LAN mode behaves exactly as before — no new requirements.
- All detected hosts (explicit `LAN_HOST` → Tailscale FQDN → WiFi IPv4) go into backend/control-plane CORS origins and Vite `allowedHosts`. `dev.ts` now passes `VITE_ALLOWED_HOSTS` to the frontend itself (merged with any caller-provided value) instead of relying on the caller to export it.
- Auth callbacks (`WORKOS_REDIRECT_URI`) can only bind to one host; priority is explicit `LAN_HOST` > Tailscale FQDN > WiFi IP, and the startup banner marks which host got it:

  ```
  LAN mode: http://kristoffers-macbook-pro.dwelf-tone.ts.net:3000  (auth callbacks)
  LAN mode: http://192.168.86.129:3000
  ```

- **`dev:lan` renamed to `dev:mobile`** — it now covers both LAN and tailnet access, and the name says what it's for. No alias kept (INV-49).

`LAN_HOST`/`LAN_IP` still work as explicit overrides and win over detection.

## Modified files

| File | Change |
| --- | --- |
| `scripts/dev.ts` | `getTailscaleHost()`; multi-host LAN mode (CORS, allowedHosts, redirect-URI priority); pass `VITE_ALLOWED_HOSTS` to the frontend spawn |
| `package.json` | `dev:lan` → `dev:mobile` |

## Test plan

- [x] `bun run dev:mobile` with no env vars: banner shows both the Tailscale FQDN (marked for auth callbacks) and the WiFi IP; frontend serves `200` for a request with the FQDN `Host` header (Vite allowlist working); full stack boots
- [x] Fallback path is by construction: CLI missing/not running → `getTailscaleHost()` returns undefined → identical behavior to the previous LAN mode
- [ ] Phone over Tailscale: open the FQDN URL, log in (auth callback), send a message (socket CORS)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783802821&installation_id=129946197&pr_number=850&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F850&signature=a997842fa4045a9a0928269bd262fd9d18b7e1eda749dacdd0c8852a415f75ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->