### PR TITLE
feat: sync-v2 active catch-up — apply log entries through live handlers (phase 2b)

### DIFF
--- a/apps/frontend/src/hooks/use-stream-socket.ts
+++ b/apps/frontend/src/hooks/use-stream-socket.ts
@@ -32,7 +32,13 @@ export function useStreamSocket(workspaceId: string, streamId: string, options?:
     // Register all stream-level socket handlers — they write to IDB only.
     // queryClient is passed for transitional workspace bootstrap preview updates
     // (will be removed in Phase 3).
-    const cleanupHandlers = registerStreamSocketHandlers(socket, workspaceId, streamId, queryClient, {
+    //
+    // In active sync-v2 mode, register through the engine's event gate so
+    // these handlers receive catch-up entries and respect buffer-and-splice
+    // exactly like engine-owned handlers; a raw-socket registration here
+    // would apply live events out of order while catch-up replays the log.
+    const eventSource = syncEngine?.getLiveEventSource() ?? socket
+    const cleanupHandlers = registerStreamSocketHandlers(eventSource, workspaceId, streamId, queryClient, {
       // A live event that skips past the cached tail means events were missed
       // (zombie socket, server bounce). Route to the engine's single-flighted
       // backfill so the hole is fetched instead of persisting until reload.

--- a/apps/frontend/src/sync/socket-event-gate.test.ts
+++ b/apps/frontend/src/sync/socket-event-gate.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from "vitest"
+import type { Socket } from "socket.io-client"
+import { SocketEventGate } from "./socket-event-gate"
+
+type Handler = (...args: unknown[]) => void
+
+class FakeSocket {
+  private listeners = new Map<string, Set<Handler>>()
+
+  on(event: string, handler: Handler) {
+    const set = this.listeners.get(event) ?? new Set()
+    set.add(handler)
+    this.listeners.set(event, set)
+    return this
+  }
+
+  off(event: string, handler: Handler) {
+    this.listeners.get(event)?.delete(handler)
+    return this
+  }
+
+  trigger(event: string, ...args: unknown[]) {
+    for (const handler of this.listeners.get(event) ?? []) handler(...args)
+  }
+
+  listenerCount(event: string): number {
+    return this.listeners.get(event)?.size ?? 0
+  }
+}
+
+function asSocket(fake: FakeSocket): Socket {
+  return fake as unknown as Socket
+}
+
+const WS = "ws_1"
+
+describe("SocketEventGate", () => {
+  it("forwards live socket events to every registered handler when open", () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const workspaceHandler = vi.fn()
+    const streamHandler = vi.fn()
+    gate.on("stream:member_added", workspaceHandler)
+    gate.on("stream:member_added", streamHandler)
+    gate.attach(asSocket(socket))
+
+    const payload = { workspaceId: WS, syncId: "5" }
+    socket.trigger("stream:member_added", payload)
+
+    expect(workspaceHandler).toHaveBeenCalledWith(payload)
+    expect(streamHandler).toHaveBeenCalledWith(payload)
+  })
+
+  it("reports applied syncIds for this workspace's live events and ignores the rest", () => {
+    const applied: string[] = []
+    const gate = new SocketEventGate(WS, { onApplied: (syncId) => applied.push(syncId) })
+    const socket = new FakeSocket()
+    gate.on("message:created", vi.fn())
+    gate.attach(asSocket(socket))
+
+    socket.trigger("message:created", { workspaceId: WS, syncId: "7" })
+    socket.trigger("message:created", { workspaceId: "ws_other", syncId: "9" })
+    socket.trigger("message:created", { workspaceId: WS })
+
+    expect(applied).toEqual(["7"])
+  })
+
+  it("buffers this workspace's syncId-bearing events while paused and passes others through", () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const handler = vi.fn()
+    gate.on("message:created", handler)
+    gate.on("bot_runtime:presence", handler)
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("message:created", { workspaceId: WS, syncId: "5" })
+    socket.trigger("bot_runtime:presence", { workspaceId: WS, botId: "bot_1" })
+    socket.trigger("message:created", { workspaceId: "ws_other", syncId: "6" })
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenCalledWith({ workspaceId: WS, botId: "bot_1" })
+    expect(handler).toHaveBeenCalledWith({ workspaceId: "ws_other", syncId: "6" })
+  })
+
+  it("splices buffered events in ascending syncId order, applying only those the predicate admits", async () => {
+    const applied: string[] = []
+    const gate = new SocketEventGate(WS, { onApplied: (syncId) => applied.push(syncId) })
+    const socket = new FakeSocket()
+    const seen: string[] = []
+    gate.on("message:created", (payload: unknown) => {
+      seen.push((payload as { syncId: string }).syncId)
+    })
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("message:created", { workspaceId: WS, syncId: "12" })
+    socket.trigger("message:created", { workspaceId: WS, syncId: "9" })
+    socket.trigger("message:created", { workspaceId: WS, syncId: "11" })
+    expect(seen).toEqual([])
+
+    await gate.resume((_eventType, syncId) => syncId > 10n)
+
+    expect(seen).toEqual(["11", "12"])
+    expect(applied).toEqual(["11", "12"])
+
+    // Gate is open again: live events apply immediately.
+    socket.trigger("message:created", { workspaceId: WS, syncId: "13" })
+    expect(seen).toEqual(["11", "12", "13"])
+  })
+
+  it("lets the predicate admit skipped-type events below the position during the splice", async () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const handler = vi.fn()
+    gate.on("stream:activity", handler)
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("stream:activity", { workspaceId: WS, syncId: "3" })
+    await gate.resume((eventType, syncId) => syncId > 10n || eventType === "stream:activity")
+
+    expect(handler).toHaveBeenCalledWith({ workspaceId: WS, syncId: "3" })
+  })
+
+  it("keeps draining events that arrive while the splice is running", async () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const seen: string[] = []
+    let injected = false
+    gate.on("message:created", async (payload: unknown) => {
+      seen.push((payload as { syncId: string }).syncId)
+      if (!injected) {
+        injected = true
+        // Still paused mid-splice: this buffers and is drained by the same loop.
+        socket.trigger("message:created", { workspaceId: WS, syncId: "20" })
+      }
+    })
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("message:created", { workspaceId: WS, syncId: "15" })
+    await gate.resume(() => true)
+
+    expect(seen).toEqual(["15", "20"])
+  })
+
+  it("dispatch awaits all handlers and survives a rejecting one", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const gate = new SocketEventGate(WS)
+      let settled = false
+      gate.on("saved:upserted", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        settled = true
+      })
+      gate.on("saved:upserted", async () => {
+        throw new Error("boom")
+      })
+
+      await gate.dispatch("saved:upserted", { workspaceId: WS })
+
+      expect(settled).toBe(true)
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it("falls back to immediate application when the pause buffer overflows", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const gate = new SocketEventGate(WS, { bufferLimit: 1 })
+      const socket = new FakeSocket()
+      const handler = vi.fn()
+      gate.on("message:created", handler)
+      gate.attach(asSocket(socket))
+
+      gate.pause()
+      socket.trigger("message:created", { workspaceId: WS, syncId: "1" })
+      socket.trigger("message:created", { workspaceId: WS, syncId: "2" })
+
+      // First buffered, second passed through live.
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler).toHaveBeenCalledWith({ workspaceId: WS, syncId: "2" })
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("removes the socket forwarder when the last handler for a type unregisters", () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const a = vi.fn()
+    const b = vi.fn()
+    gate.attach(asSocket(socket))
+    gate.on("message:created", a)
+    gate.on("message:created", b)
+    expect(socket.listenerCount("message:created")).toBe(1)
+
+    gate.off("message:created", a)
+    expect(socket.listenerCount("message:created")).toBe(1)
+    gate.off("message:created", b)
+    expect(socket.listenerCount("message:created")).toBe(0)
+  })
+
+  it("moves registrations to a newly attached socket and survives reconnects on the same socket", () => {
+    const gate = new SocketEventGate(WS)
+    const first = new FakeSocket()
+    const second = new FakeSocket()
+    const handler = vi.fn()
+    gate.on("message:created", handler)
+    gate.attach(asSocket(first))
+    gate.attach(asSocket(first)) // reconnect with same instance: no duplicate forwarders
+    expect(first.listenerCount("message:created")).toBe(1)
+
+    gate.attach(asSocket(second))
+    expect(first.listenerCount("message:created")).toBe(0)
+
+    second.trigger("message:created", { workspaceId: WS, syncId: "4" })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it("dispose drops buffered events without applying them", async () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const handler = vi.fn()
+    gate.on("message:created", handler)
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("message:created", { workspaceId: WS, syncId: "5" })
+    gate.dispose()
+    await gate.resume(() => true)
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(socket.listenerCount("message:created")).toBe(0)
+  })
+})

--- a/apps/frontend/src/sync/socket-event-gate.test.ts
+++ b/apps/frontend/src/sync/socket-event-gate.test.ts
@@ -78,9 +78,11 @@ describe("SocketEventGate", () => {
     socket.trigger("bot_runtime:presence", { workspaceId: WS, botId: "bot_1" })
     socket.trigger("message:created", { workspaceId: "ws_other", syncId: "6" })
 
-    expect(handler).toHaveBeenCalledTimes(2)
-    expect(handler).toHaveBeenCalledWith({ workspaceId: WS, botId: "bot_1" })
-    expect(handler).toHaveBeenCalledWith({ workspaceId: "ws_other", syncId: "6" })
+    // The syncId-bearing event for this workspace is absent: buffered.
+    expect(handler.mock.calls).toEqual([
+      [{ workspaceId: WS, botId: "bot_1" }],
+      [{ workspaceId: "ws_other", syncId: "6" }],
+    ])
   })
 
   it("splices buffered events in ascending syncId order, applying only those the predicate admits", async () => {
@@ -121,6 +123,34 @@ describe("SocketEventGate", () => {
     await gate.resume((eventType, syncId) => syncId > 10n || eventType === "stream:activity")
 
     expect(handler).toHaveBeenCalledWith({ workspaceId: WS, syncId: "3" })
+  })
+
+  it("stops the splice and stays paused when a new pause lands mid-drain", async () => {
+    const gate = new SocketEventGate(WS)
+    const socket = new FakeSocket()
+    const seen: string[] = []
+    gate.on("message:created", (payload: unknown) => {
+      const syncId = (payload as { syncId: string }).syncId
+      seen.push(syncId)
+      // A reconnect cycle starts while the splice is draining.
+      if (syncId === "15") gate.pause()
+    })
+    gate.attach(asSocket(socket))
+
+    gate.pause()
+    socket.trigger("message:created", { workspaceId: WS, syncId: "15" })
+    socket.trigger("message:created", { workspaceId: WS, syncId: "20" })
+    await gate.resume(() => true)
+
+    // The drain stopped at the new pause: "20" stays buffered, gate stays
+    // paused (a live event buffers instead of applying)...
+    expect(seen).toEqual(["15"])
+    socket.trigger("message:created", { workspaceId: WS, syncId: "25" })
+    expect(seen).toEqual(["15"])
+
+    // ...and the new cycle's own resume drains the remainder in order.
+    await gate.resume(() => true)
+    expect(seen).toEqual(["15", "20", "25"])
   })
 
   it("keeps draining events that arrive while the splice is running", async () => {
@@ -181,8 +211,7 @@ describe("SocketEventGate", () => {
       socket.trigger("message:created", { workspaceId: WS, syncId: "2" })
 
       // First buffered, second passed through live.
-      expect(handler).toHaveBeenCalledTimes(1)
-      expect(handler).toHaveBeenCalledWith({ workspaceId: WS, syncId: "2" })
+      expect(handler.mock.calls).toEqual([[{ workspaceId: WS, syncId: "2" }]])
       expect(warnSpy).toHaveBeenCalled()
     } finally {
       warnSpy.mockRestore()
@@ -218,8 +247,9 @@ describe("SocketEventGate", () => {
     gate.attach(asSocket(second))
     expect(first.listenerCount("message:created")).toBe(0)
 
+    // Exactly one delivery — a duplicated forwarder would produce two.
     second.trigger("message:created", { workspaceId: WS, syncId: "4" })
-    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls).toEqual([[{ workspaceId: WS, syncId: "4" }]])
   })
 
   it("dispose drops buffered events without applying them", async () => {

--- a/apps/frontend/src/sync/socket-event-gate.ts
+++ b/apps/frontend/src/sync/socket-event-gate.ts
@@ -54,6 +54,9 @@ export class SocketEventGate implements SyncEventSource {
   private readonly forwarders = new Map<string, SyncEventHandler>()
   private socket: Socket | null = null
   private paused = false
+  /** Bumped on every pause so an in-flight resume from an older cycle can
+   *  detect that a newer pause owns the gate and must not reopen it. */
+  private pauseEpoch = 0
   private buffer: BufferedEvent[] = []
   private overflowWarned = false
   private disposed = false
@@ -124,6 +127,7 @@ export class SocketEventGate implements SyncEventSource {
   pause(): void {
     if (this.disposed) return
     this.paused = true
+    this.pauseEpoch += 1
   }
 
   /**
@@ -132,8 +136,15 @@ export class SocketEventGate implements SyncEventSource {
    * reopens live flow. Events arriving while the splice is draining keep
    * buffering and are drained by the same loop, so nothing applies out of
    * order during the handoff back to live.
+   *
+   * If a NEW pause lands while this splice is draining (a reconnect/resume
+   * cycle started), the drain stops, the remaining events go back to the
+   * buffer, and the gate stays paused — the new cycle's own resume owns the
+   * splice from there. Reopening here would let live events flow into the
+   * new cycle's bootstrap window.
    */
   async resume(applyIf: (eventType: string, syncId: bigint) => boolean): Promise<void> {
+    const epoch = this.pauseEpoch
     while (this.buffer.length > 0) {
       if (this.disposed) return
       const batch = this.buffer
@@ -143,13 +154,19 @@ export class SocketEventGate implements SyncEventSource {
         if (a.syncId > b.syncId) return 1
         return 0
       })
-      for (const event of batch) {
+      for (let i = 0; i < batch.length; i++) {
         if (this.disposed) return
+        if (this.pauseEpoch !== epoch) {
+          this.buffer = [...batch.slice(i), ...this.buffer]
+          return
+        }
+        const event = batch[i]
         if (!applyIf(event.eventType, event.syncId)) continue
         await this.dispatch(event.eventType, event.payload)
         this.opts.onApplied?.(event.syncId.toString())
       }
     }
+    if (this.pauseEpoch !== epoch) return
     this.paused = false
     this.overflowWarned = false
   }

--- a/apps/frontend/src/sync/socket-event-gate.ts
+++ b/apps/frontend/src/sync/socket-event-gate.ts
@@ -1,0 +1,222 @@
+import type { Socket } from "socket.io-client"
+
+/**
+ * Minimal registration surface shared by the raw socket and the gate. Handler
+ * registration code (workspace-sync, stream-sync, useStreamSocket) is written
+ * against this so the SyncEngine can interpose the gate in active sync-v2
+ * mode without the handlers knowing.
+ */
+export interface SyncEventSource {
+  // `any[]` (not `unknown[]`) so the raw socket.io `Socket` stays structurally
+  // assignable — its listener types are `(...args: any[]) => void` and the
+  // strict contravariant check rejects narrower parameter types.
+  on(event: string, listener: (...args: any[]) => void): unknown
+  off(event: string, listener: (...args: any[]) => void): unknown
+}
+
+type SyncEventHandler = (...args: unknown[]) => unknown
+
+interface BufferedEvent {
+  eventType: string
+  payload: unknown
+  syncId: bigint
+}
+
+/**
+ * Soft cap on the pause buffer. Catch-up pauses for seconds at most; a
+ * workspace producing this many live events in that window is far outside
+ * normal load, and falling back to immediate (live) application there merely
+ * reverts to today's delivery semantics for the overflow.
+ */
+const DEFAULT_BUFFER_LIMIT = 2_000
+
+/**
+ * The single delivery chokepoint for sync-v2 active mode. Live socket events
+ * and catch-up log entries must apply through the SAME registered handlers
+ * (the protocol guarantees `entry.payload` is the exact payload the socket
+ * emits), so handlers register here instead of on the raw socket and the
+ * gate forwards real socket events into them.
+ *
+ * While catch-up pages the sync log, the gate is paused: live events that
+ * carry a `syncId` for this workspace are buffered instead of applied, then
+ * spliced in syncId order once catch-up lands (doc Part 5, pressure test 7 —
+ * exact integer reconciliation, no wall-clock heuristics). Events without a
+ * syncId (ephemeral presence, pre-deploy emits) and other workspaces' events
+ * pass through untouched — they are not in the log, so there is no splice
+ * position to order them against.
+ *
+ * `onApplied` fires with the syncId after the gate applies a live or spliced
+ * event — the engine advances the workspace cursor there, so the cursor only
+ * ever moves past entries that were actually handed to handlers.
+ */
+export class SocketEventGate implements SyncEventSource {
+  private readonly handlers = new Map<string, Set<SyncEventHandler>>()
+  private readonly forwarders = new Map<string, SyncEventHandler>()
+  private socket: Socket | null = null
+  private paused = false
+  private buffer: BufferedEvent[] = []
+  private overflowWarned = false
+  private disposed = false
+
+  constructor(
+    private readonly workspaceId: string,
+    private readonly opts: {
+      onApplied?: (syncId: string) => void
+      bufferLimit?: number
+    } = {}
+  ) {}
+
+  /**
+   * Points the gate at the engine's current socket, moving every event-type
+   * forwarder over. Idempotent for the same socket instance (reconnects reuse
+   * the socket.io client), so handler registrations survive reconnect cycles
+   * exactly like raw `socket.on` registrations do today.
+   */
+  attach(socket: Socket): void {
+    if (this.disposed || this.socket === socket) return
+    this.detach()
+    this.socket = socket
+    for (const [eventType, forwarder] of this.forwarders) {
+      socket.on(eventType, forwarder)
+    }
+  }
+
+  detach(): void {
+    if (!this.socket) return
+    for (const [eventType, forwarder] of this.forwarders) {
+      this.socket.off(eventType, forwarder)
+    }
+    this.socket = null
+  }
+
+  on(event: string, listener: SyncEventHandler): this {
+    if (this.disposed) return this
+    let set = this.handlers.get(event)
+    if (!set) {
+      set = new Set()
+      this.handlers.set(event, set)
+    }
+    set.add(listener)
+    if (!this.forwarders.has(event)) {
+      const forwarder = (...args: unknown[]) => this.handleIncoming(event, args)
+      this.forwarders.set(event, forwarder)
+      this.socket?.on(event, forwarder)
+    }
+    return this
+  }
+
+  off(event: string, listener: SyncEventHandler): this {
+    const set = this.handlers.get(event)
+    if (!set) return this
+    set.delete(listener)
+    if (set.size === 0) {
+      this.handlers.delete(event)
+      const forwarder = this.forwarders.get(event)
+      if (forwarder) {
+        this.forwarders.delete(event)
+        this.socket?.off(event, forwarder)
+      }
+    }
+    return this
+  }
+
+  /** Start buffering this workspace's syncId-bearing live events. */
+  pause(): void {
+    if (this.disposed) return
+    this.paused = true
+  }
+
+  /**
+   * Applies buffered events that pass `applyIf` in ascending syncId order
+   * (awaiting each event's handlers, so applies cannot interleave), then
+   * reopens live flow. Events arriving while the splice is draining keep
+   * buffering and are drained by the same loop, so nothing applies out of
+   * order during the handoff back to live.
+   */
+  async resume(applyIf: (eventType: string, syncId: bigint) => boolean): Promise<void> {
+    while (this.buffer.length > 0) {
+      if (this.disposed) return
+      const batch = this.buffer
+      this.buffer = []
+      batch.sort((a, b) => {
+        if (a.syncId < b.syncId) return -1
+        if (a.syncId > b.syncId) return 1
+        return 0
+      })
+      for (const event of batch) {
+        if (this.disposed) return
+        if (!applyIf(event.eventType, event.syncId)) continue
+        await this.dispatch(event.eventType, event.payload)
+        this.opts.onApplied?.(event.syncId.toString())
+      }
+    }
+    this.paused = false
+    this.overflowWarned = false
+  }
+
+  /**
+   * Invokes every registered handler for `eventType` with `payload`, awaiting
+   * them all. Used by the catch-up loop (log entries) and the resume splice;
+   * a rejecting handler is logged and skipped — same net effect as a live
+   * handler throwing today, and the entry is not redelivered either way.
+   */
+  async dispatch(eventType: string, payload: unknown): Promise<void> {
+    const set = this.handlers.get(eventType)
+    if (!set || set.size === 0) return
+    const snapshot = Array.from(set)
+    const results = await Promise.allSettled(snapshot.map(async (handler) => handler(payload)))
+    for (const result of results) {
+      if (result.status === "rejected") {
+        console.error("Sync-v2 catch-up handler failed", { eventType, error: result.reason })
+      }
+    }
+  }
+
+  /** Drops the buffer and all socket forwarders. Never applies on dispose —
+   *  engine destroy can be an account switch, and a post-destroy apply would
+   *  write one account's events into another account's database. */
+  dispose(): void {
+    this.disposed = true
+    this.detach()
+    this.buffer = []
+    this.handlers.clear()
+    this.forwarders.clear()
+  }
+
+  private handleIncoming(eventType: string, args: unknown[]): void {
+    if (this.disposed) return
+    const payload = args[0] as { workspaceId?: unknown; syncId?: unknown } | undefined
+
+    if (this.paused && payload && payload.workspaceId === this.workspaceId && typeof payload.syncId === "string") {
+      const syncId = parseBufferSyncId(payload.syncId)
+      if (syncId !== null) {
+        if (this.buffer.length < (this.opts.bufferLimit ?? DEFAULT_BUFFER_LIMIT)) {
+          this.buffer.push({ eventType, payload, syncId })
+          return
+        }
+        if (!this.overflowWarned) {
+          this.overflowWarned = true
+          console.warn("Sync-v2 gate buffer overflow — applying live events immediately", {
+            workspaceId: this.workspaceId,
+          })
+        }
+        // Fall through: overflow reverts to live (immediate) application.
+      }
+    }
+
+    // Live path: apply immediately without awaiting (matches raw socket
+    // delivery), advancing the cursor for syncId-bearing payloads.
+    void this.dispatch(eventType, args[0])
+    if (payload && payload.workspaceId === this.workspaceId && typeof payload.syncId === "string") {
+      this.opts.onApplied?.(payload.syncId)
+    }
+  }
+}
+
+function parseBufferSyncId(value: string): bigint | null {
+  try {
+    return BigInt(value)
+  } catch {
+    return null
+  }
+}

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -13,7 +13,7 @@ import {
 } from "@threa/types"
 import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
-import type { Socket } from "socket.io-client"
+import type { SyncEventSource } from "./socket-event-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import type { QueryClient } from "@tanstack/react-query"
@@ -606,7 +606,7 @@ export function detectSequenceGap(
 }
 
 export function registerStreamSocketHandlers(
-  socket: Socket,
+  socket: SyncEventSource,
   workspaceId: string,
   streamId: string,
   queryClient: QueryClient,

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -895,7 +895,7 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
     return {
       ...makeDeps(),
       syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
-      syncCursorShadowEnabled: true,
+      syncCursorMode: "shadow" as const,
     }
   }
 
@@ -990,7 +990,7 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
 
   it("does nothing when the shadow flag is off", async () => {
     const catchUp = vi.fn(async () => emptyPage("42"))
-    const deps = { ...makeShadowDeps(catchUp), syncCursorShadowEnabled: false }
+    const deps = { ...makeShadowDeps(catchUp), syncCursorMode: "off" as const }
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
 
@@ -1000,5 +1000,206 @@ describe("SyncEngine sync-v2 cursor (shadow mode)", () => {
     expect(catchUp).not.toHaveBeenCalled()
     expect(engine.getSyncCursor()).toBeNull()
     engine.destroy()
+  })
+})
+
+describe("SyncEngine sync-v2 cursor (active mode)", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([
+      db.workspaces.clear(),
+      db.syncCursors.clear(),
+      db.workspaceUsers.clear(),
+      db.unreadState.clear(),
+    ])
+  })
+
+  function makeActiveDeps(catchUp: ReturnType<typeof vi.fn>) {
+    return {
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      syncCursorMode: "active" as const,
+    }
+  }
+
+  function emptyPage(head: string): SyncCatchUpResponse {
+    return { entries: [], head }
+  }
+
+  function userAddedEntry(syncId: string, userId: string): SyncCatchUpResponse["entries"][number] {
+    return {
+      syncId,
+      eventType: "workspace_user:added",
+      payload: { workspaceId: "ws_1", user: { id: userId, workspaceId: "ws_1", name: `User ${userId}` } },
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  function userAddedLivePayload(syncId: string, userId: string) {
+    return {
+      workspaceId: "ws_1",
+      syncId,
+      user: { id: userId, workspaceId: "ws_1", name: `User ${userId}` },
+    }
+  }
+
+  it("seeds the cursor from head BEFORE the workspace bootstrap data fetch on first run", async () => {
+    const order: string[] = []
+    const catchUp = vi.fn(async () => {
+      order.push("catchUp")
+      return emptyPage("42")
+    })
+    const deps = makeActiveDeps(catchUp)
+    const innerBootstrap = deps.workspaceService.bootstrap
+    deps.workspaceService.bootstrap = vi.fn(async () => {
+      order.push("bootstrap")
+      return innerBootstrap()
+    })
+    const engine = new SyncEngine(deps)
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    expect(order[0]).toBe("catchUp")
+    expect(order).toContain("bootstrap")
+    expect(catchUp).toHaveBeenNthCalledWith(1, "ws_1", { after: "0", limit: 1 }, expect.any(AbortSignal))
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("42"))
+    engine.destroy()
+  })
+
+  it("applies catch-up entries through the registered live handlers and advances the cursor by applied entries", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi
+      .fn()
+      .mockResolvedValueOnce({ entries: [userAddedEntry("11", "user_a"), userAddedEntry("12", "user_b")], head: "12" })
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(async () => {
+      expect(await db.workspaceUsers.get("user_a")).toBeDefined()
+      expect(await db.workspaceUsers.get("user_b")).toBeDefined()
+    })
+    expect(engine.getSyncCursor()).toBe("12")
+    engine.destroy()
+  })
+
+  it("skips unread-counter entries from the log but still advances the cursor past them", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi
+      .fn()
+      .mockResolvedValueOnce({
+        entries: [
+          {
+            syncId: "11",
+            eventType: "activity:created",
+            payload: {
+              workspaceId: "ws_1",
+              activity: { id: "act_1", streamId: "stream_x", activityType: "message", isSelf: false },
+            },
+            createdAt: new Date().toISOString(),
+          },
+          userAddedEntry("12", "user_a"),
+        ],
+        head: "12",
+      })
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("user_a")).toBeDefined())
+    expect(engine.getSyncCursor()).toBe("12")
+    // The bootstrap wrote zeroed unread state; the skipped log entry must not
+    // have incremented it (bootstrap stays the counter authority in 2b).
+    const unread = await db.unreadState.get("ws_1")
+    expect(unread?.unreadActivityCount).toBe(0)
+    engine.destroy()
+  })
+
+  it("buffers live events while catch-up runs and splices those above the catch-up position afterwards", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
+      .mockResolvedValue(emptyPage("11"))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
+
+    // Lands while catch-up pages: buffered, not applied.
+    socket.trigger("workspace_user:added", userAddedLivePayload("12", "user_live"))
+    expect(await db.workspaceUsers.get("user_live")).toBeUndefined()
+
+    resolveFirstPage!({ entries: [userAddedEntry("11", "user_log")], head: "11" })
+
+    await vi.waitFor(async () => {
+      expect(await db.workspaceUsers.get("user_log")).toBeDefined()
+      expect(await db.workspaceUsers.get("user_live")).toBeDefined()
+    })
+    expect(engine.getSyncCursor()).toBe("12")
+    engine.destroy()
+  })
+
+  it("applies buffered counter events at the splice even when at or below the catch-up position", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
+    // Bootstrap has applied by now (onConnect awaited it) with zeroed counts.
+    expect((await db.unreadState.get("ws_1"))?.unreadActivityCount).toBe(0)
+
+    const activityPayload = {
+      workspaceId: "ws_1",
+      syncId: "11",
+      activity: { id: "act_1", streamId: "stream_x", activityType: "message", isSelf: false },
+    }
+    socket.trigger("activity:created", activityPayload)
+
+    // The same event is also in the log (duplicate by design) — catch-up
+    // skips it there; the buffered live copy applies exactly once at splice.
+    resolveFirstPage!({
+      entries: [
+        {
+          syncId: "11",
+          eventType: "activity:created",
+          payload: activityPayload,
+          createdAt: new Date().toISOString(),
+        },
+        userAddedEntry("12", "user_a"),
+      ],
+      head: "12",
+    })
+
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadActivityCount).toBe(1)
+    })
+    expect((await db.unreadState.get("ws_1"))?.activityCounts["stream_x"]).toBe(1)
+    engine.destroy()
+  })
+
+  it("never applies buffered events after destroy (account-switch safety)", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi.fn(() => new Promise<SyncCatchUpResponse>(() => {}))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    socket.trigger("workspace_user:added", userAddedLivePayload("12", "user_live"))
+
+    engine.destroy()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(await db.workspaceUsers.get("user_live")).toBeUndefined()
   })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1188,6 +1188,74 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     engine.destroy()
   })
 
+  it("does not let a stale catch-up run reopen live flow for a newer reconnect cycle", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
+      .mockResolvedValue(emptyPage("11"))
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
+
+    // Reconnect while the first cycle's catch-up is still paging: a new
+    // cycle pauses the gate and must own the eventual splice.
+    await engine.onConnect(asSocket(socket))
+    socket.trigger("workspace_user:added", userAddedLivePayload("20", "user_live"))
+
+    // The stale run completes — it applies its log entry but must NOT
+    // resume the gate (the buffered live event stays unapplied until the
+    // new cycle's chained run splices it).
+    resolveFirstPage!({ entries: [userAddedEntry("11", "user_log")], head: "11" })
+
+    await vi.waitFor(async () => {
+      expect(await db.workspaceUsers.get("user_log")).toBeDefined()
+      expect(await db.workspaceUsers.get("user_live")).toBeDefined()
+    })
+    expect(engine.getSyncCursor()).toBe("20")
+    // The new cycle ran its own catch-up from the stale run's end position
+    // (one such fetch belongs to the stale run's paging, one to the rerun).
+    const fetchesFromEleven = catchUp.mock.calls.filter((call) => (call[1] as { after: string }).after === "11")
+    expect(fetchesFromEleven.length).toBeGreaterThanOrEqual(2)
+    engine.destroy()
+  })
+
+  it("applies all buffered events when the cursor seed only succeeds after bootstrap", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      let resolveRetrySeed: ((value: SyncCatchUpResponse) => void) | undefined
+      const catchUp = vi
+        .fn()
+        // Pre-bootstrap seed fails (offline first run)...
+        .mockRejectedValueOnce(new Error("offline"))
+        // ...the catch-up run's fallback retry succeeds with a head read
+        // AFTER the bootstrap snapshot.
+        .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveRetrySeed = resolve)))
+        .mockResolvedValue(emptyPage("42"))
+      const engine = new SyncEngine(makeActiveDeps(catchUp))
+      const socket = new MockSocket()
+
+      await engine.onConnect(asSocket(socket))
+      await vi.waitFor(() => expect(resolveRetrySeed).toBeDefined())
+
+      // Buffered during the window the snapshot does not provably cover —
+      // its syncId is below the late-read head, and it must still apply.
+      socket.trigger("workspace_user:added", userAddedLivePayload("5", "user_live"))
+      resolveRetrySeed!(emptyPage("42"))
+
+      await vi.waitFor(async () => {
+        expect(await db.workspaceUsers.get("user_live")).toBeDefined()
+      })
+      expect(engine.getSyncCursor()).toBe("42")
+      engine.destroy()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
   it("never applies buffered events after destroy (account-switch safety)", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     const catchUp = vi.fn(() => new Promise<SyncCatchUpResponse>(() => {}))

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -128,6 +128,12 @@ export class SyncEngine {
   private syncCursorCleanup: (() => void) | null = null
   private activeCatchUp: Promise<void> | null = null
   private catchUpAbort: AbortController | null = null
+  /** Bumped on every gate pause (connect/resume trigger). A catch-up run
+   *  belongs to the cycle it started in; a stale run must not reopen the
+   *  gate for a newer cycle's bootstrap window. */
+  private catchUpCycle = 0
+  private activeCatchUpCycle = 0
+  private queuedCatchUp: Promise<void> | null = null
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
@@ -182,9 +188,9 @@ export class SyncEngine {
     // keeps the catch-up position honest: an applied live event advances the
     // cursor optimistically, and a cursor that jumps during the bootstrap
     // window would make catch-up skip the very disconnect gap it heals.
-    // The catch-up run's finally-splice always reopens live flow.
+    // This cycle's catch-up run reopens live flow when it completes.
     this.eventGate?.attach(socket)
-    this.eventGate?.pause()
+    this.beginCatchUpCycle()
 
     if (isReconnect) {
       this.deps.syncStatus.setAllStale()
@@ -236,7 +242,7 @@ export class SyncEngine {
     if (this.isDestroyed) return
     // Same pause-before-bootstrap rule as onConnect: the catch-up position
     // must not move between this trigger and the catch-up fetch.
-    this.eventGate?.pause()
+    this.beginCatchUpCycle()
     await this.runBootstrap(true)
     void this.runCatchUp("resume")
   }
@@ -817,6 +823,16 @@ export class SyncEngine {
     return this.eventGate ?? socket
   }
 
+  /** Active mode: pause the gate and open a new catch-up cycle. Each
+   *  connect/resume trigger gets its own cycle so a catch-up run that was
+   *  already in flight cannot reopen live delivery inside the new trigger's
+   *  bootstrap window (its finally checks the cycle before resuming). */
+  private beginCatchUpCycle(): void {
+    if (!this.eventGate) return
+    this.eventGate.pause()
+    this.catchUpCycle += 1
+  }
+
   /**
    * Active mode, on connect: load the persisted cursor and, on a first run,
    * seed it from head — BEFORE the workspace bootstrap data fetch, so the
@@ -850,13 +866,32 @@ export class SyncEngine {
    */
   private runCatchUp(trigger: string): Promise<void> {
     if (this.syncCursorMode === "off" || this.isDestroyed) return Promise.resolve()
-    if (this.activeCatchUp) return this.activeCatchUp
+    if (this.activeCatchUp) {
+      // Same cycle: share the in-flight run. An OLDER cycle's run, though,
+      // started from a position read before this trigger's gap — its applies
+      // are still valid, but it must not stand in for this cycle's healing.
+      // Its finally leaves the gate paused (cycle mismatch) and we chain ONE
+      // fresh run after it settles, mirroring runBootstrap's queued
+      // reconnect chaining (INV-53).
+      if (this.activeCatchUpCycle === this.catchUpCycle) return this.activeCatchUp
+      this.queuedCatchUp ??= this.activeCatchUp
+        .catch(() => {
+          // Swallow — the follow-up run retries whatever failed.
+        })
+        .then(() => {
+          this.queuedCatchUp = null
+          return this.runCatchUp(trigger)
+        })
+      return this.queuedCatchUp
+    }
 
+    const cycle = this.catchUpCycle
+    this.activeCatchUpCycle = cycle
     const abort = new AbortController()
     this.catchUpAbort = abort
     const run =
       this.syncCursorMode === "active"
-        ? this.performActiveCatchUp(trigger, abort.signal)
+        ? this.performActiveCatchUp(trigger, abort.signal, cycle)
         : this.performShadowCatchUp(trigger, abort.signal)
     const promise = run
       .catch((error) => {
@@ -897,14 +932,15 @@ export class SyncEngine {
    * and reopens live flow. The cursor advances only past entries that were
    * handed to handlers (or policy-skipped), never by jumping to head.
    */
-  private async performActiveCatchUp(trigger: string, signal: AbortSignal): Promise<void> {
+  private async performActiveCatchUp(trigger: string, signal: AbortSignal, cycle: number): Promise<void> {
     const syncService = this.deps.syncService!
     const gate = this.eventGate!
     const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
-    // The position everything at or below which the log already applied (or
-    // the bootstrap snapshot covers). Buffered live events above it splice in
-    // after catch-up; null means no position is known (first run that failed
-    // to seed) and the splice applies everything buffered — live behavior.
+    // The position everything at or below which this run applied from the
+    // log (starting from the cursor, whose coverage the bootstrap snapshot
+    // owns). Buffered live events above it splice in after catch-up; null
+    // means no position is known and the splice applies everything buffered
+    // — live behavior.
     let appliedThrough: bigint | null = null
 
     try {
@@ -913,11 +949,12 @@ export class SyncEngine {
       if (cursorBefore === null) {
         // Normally seeded in initializeActiveCursor before bootstrap;
         // reaching here means that failed (offline first run). Retry the
-        // seed — the bootstrap that just ran covers everything at or below
-        // the seeded head.
+        // seed so future cycles have a position — but this head is read
+        // AFTER the bootstrap snapshot, so it must NOT bound the splice: a
+        // buffered live event at or below it is not guaranteed to be in the
+        // snapshot (read-before-stamp). appliedThrough stays null and the
+        // splice applies everything buffered.
         await this.initializeActiveCursor()
-        const seeded = cursorStore.get()
-        appliedThrough = seeded === null ? null : BigInt(seeded)
         return
       }
 
@@ -976,12 +1013,16 @@ export class SyncEngine {
         })
       }
     } finally {
-      // Always reopen live flow, even on a failed fetch or early return (the
-      // buffer must never strand). Buffered events at or below the applied
-      // position were already applied from the log — except skipped-type
-      // events, which only ever apply via live delivery and so splice
-      // regardless of position.
-      if (!this.isDestroyed) {
+      // Reopen live flow, even on a failed fetch or early return (the buffer
+      // must never strand) — but only when this run still belongs to the
+      // CURRENT pause cycle. If a newer connect/resume paused the gate while
+      // this run was in flight, its bootstrap window is still open; leave the
+      // gate paused and let that cycle's own run (chained by runCatchUp) do
+      // the splice. Buffered events at or below the applied position were
+      // already applied from the log — except skipped-type events, which
+      // only ever apply via live delivery and so splice regardless of
+      // position.
+      if (!this.isDestroyed && this.catchUpCycle === cycle) {
         const through = appliedThrough
         await gate.resume(
           (eventType, syncId) =>

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -19,7 +19,8 @@ import {
 } from "./stream-sync"
 import { processOperationQueue } from "./operation-queue"
 import { waitForInitialReveal } from "./reveal-gate"
-import { SyncLogCursor, SYNC_V2_CURSOR_SHADOW_DEFAULT } from "./sync-log-cursor"
+import { SyncLogCursor, SYNC_V2_CURSOR_MODE, type SyncV2CursorMode } from "./sync-log-cursor"
+import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -61,12 +62,34 @@ interface SyncEngineDeps {
     ) => Promise<import("@threa/types").SyncCatchUpResponse>
   }
   /** Test override for the VITE_SYNC_V2_CURSOR flag. */
-  syncCursorShadowEnabled?: boolean
+  syncCursorMode?: SyncV2CursorMode
 }
 
-/** Safety valve for shadow catch-up paging (20 pages × 500 entries). */
-const MAX_SHADOW_CATCHUP_PAGES = 20
-const SHADOW_CATCHUP_PAGE_LIMIT = 500
+/** Safety valve for catch-up paging (20 pages × 500 entries). */
+const MAX_CATCHUP_PAGES = 20
+const CATCHUP_PAGE_LIMIT = 500
+
+/**
+ * Unread/read-state event types that active catch-up SKIPS (the cursor still
+ * advances past them). Their handlers are the only duplicate-unsafe ones in
+ * the apply surface: `stream:activity` and `activity:created` increment
+ * counters, so replaying a log entry already reflected in the bootstrap's
+ * absolute counts double-counts; and replaying `stream:read`/`stream:read_all`
+ * would zero counts whose causing increments were skipped. In phase 2b the
+ * workspace bootstrap stays the sole authority for unread state (INV-53
+ * healing is untouched), and live delivery of these types — including events
+ * buffered while catch-up pages — keeps applying exactly as today. A dropped
+ * live emit of these types heals on the next bootstrap, the same loss mode
+ * as before the log existed. Phase 2c can lift them into the log properly by
+ * converting their payloads to absolute values (LWW), at which point they
+ * leave this set.
+ */
+const CATCHUP_SKIPPED_UNREAD_EVENT_TYPES = new Set([
+  "stream:activity",
+  "activity:created",
+  "stream:read",
+  "stream:read_all",
+])
 
 /**
  * Owns the full sync lifecycle for a workspace:
@@ -95,14 +118,16 @@ export class SyncEngine {
   /** Whether the engine has been destroyed. Public for ref-check re-creation. */
   isDestroyed = false
 
-  // Sync-engine v2 cursor (shadow mode): one lastSyncId per workspace,
+  // Sync-engine v2 cursor: one lastSyncId per workspace. In shadow mode it is
   // advanced by live events and exercised against the catch-up endpoint
-  // without owning any healing yet. See sync-log-cursor.ts.
-  private readonly syncCursorShadowEnabled: boolean
+  // without owning any healing; in active mode catch-up entries are applied
+  // through the live handlers via the event gate. See sync-log-cursor.ts.
+  private readonly syncCursorMode: SyncV2CursorMode
+  private readonly eventGate: SocketEventGate | null
   private syncLogCursor: SyncLogCursor | null = null
   private syncCursorCleanup: (() => void) | null = null
-  private activeShadowCatchUp: Promise<void> | null = null
-  private shadowCatchUpAbort: AbortController | null = null
+  private activeCatchUp: Promise<void> | null = null
+  private catchUpAbort: AbortController | null = null
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
@@ -115,7 +140,13 @@ export class SyncEngine {
 
   constructor(private deps: SyncEngineDeps) {
     this.workspaceId = deps.workspaceId
-    this.syncCursorShadowEnabled = (deps.syncCursorShadowEnabled ?? SYNC_V2_CURSOR_SHADOW_DEFAULT) && !!deps.syncService
+    this.syncCursorMode = deps.syncService ? (deps.syncCursorMode ?? SYNC_V2_CURSOR_MODE) : "off"
+    this.eventGate =
+      this.syncCursorMode === "active"
+        ? new SocketEventGate(this.workspaceId, {
+            onApplied: (syncId) => this.syncLogCursor?.advance(syncId),
+          })
+        : null
   }
 
   /** Update the current stream ID (called from React when route changes). */
@@ -145,6 +176,15 @@ export class SyncEngine {
     const isReconnect = this.hasEverConnected
     this.hasEverConnected = true
     this.socket = socket
+    // Synchronously, before any await: events arriving right after the
+    // connect ack must already flow through the gate's forwarders — and be
+    // buffered, not applied. Pausing here (not at catch-up start) is what
+    // keeps the catch-up position honest: an applied live event advances the
+    // cursor optimistically, and a cursor that jumps during the bootstrap
+    // window would make catch-up skip the very disconnect gap it heals.
+    // The catch-up run's finally-splice always reopens live flow.
+    this.eventGate?.attach(socket)
+    this.eventGate?.pause()
 
     if (isReconnect) {
       this.deps.syncStatus.setAllStale()
@@ -153,13 +193,21 @@ export class SyncEngine {
       this.cleanupStreamHandlers()
     }
 
-    if (this.syncCursorShadowEnabled) {
+    if (this.syncCursorMode === "shadow") {
       this.trackSyncCursor(socket)
+    } else if (this.syncCursorMode === "active") {
+      // Read-before-stamp: the cursor position (head, on a first run) must be
+      // read BEFORE the bootstrap data fetch so any race falls on the
+      // duplicate side (entry also present in the snapshot — idempotent),
+      // never the gap side (entry stamped below a position read after the
+      // snapshot — permanent loss).
+      await this.initializeActiveCursor()
+      if (this.isDestroyed) return
     }
 
     // Register workspace-level socket handlers (stream:created, stream:updated, etc.)
     this.workspaceHandlerCleanup = registerWorkspaceSocketHandlers(
-      socket,
+      this.liveEventSource(socket),
       this.deps.workspaceId,
       this.deps.queryClient,
       {
@@ -174,9 +222,9 @@ export class SyncEngine {
     // Process pending offline operations (edits, deletes, reactions)
     this.kickOperationQueue()
 
-    // Shadow only — runs after bootstrap so it never competes for the
-    // connection setup window, and applies nothing.
-    void this.runShadowCatchUp(isReconnect ? "reconnect" : "connect")
+    // Runs after bootstrap so it never competes for the connection setup
+    // window. Shadow logs only; active applies through the gate.
+    void this.runCatchUp(isReconnect ? "reconnect" : "connect")
   }
 
   /**
@@ -186,8 +234,11 @@ export class SyncEngine {
    */
   async refreshAfterConnectivityResume(): Promise<void> {
     if (this.isDestroyed) return
+    // Same pause-before-bootstrap rule as onConnect: the catch-up position
+    // must not move between this trigger and the catch-up fetch.
+    this.eventGate?.pause()
     await this.runBootstrap(true)
-    void this.runShadowCatchUp("resume")
+    void this.runCatchUp("resume")
   }
 
   /**
@@ -261,9 +312,19 @@ export class SyncEngine {
     )
   }
 
-  /** Current sync-log cursor (v2 shadow), or null when none is tracked yet. */
+  /** Current sync-log cursor (v2), or null when none is tracked yet. */
   getSyncCursor(): string | null {
     return this.syncLogCursor?.get() ?? null
+  }
+
+  /**
+   * Registration surface for live stream handlers mounted outside the engine
+   * (useStreamSocket). In active mode this is the event gate, so hook-mounted
+   * handlers participate in catch-up dispatch and buffer-and-splice exactly
+   * like engine-owned ones; otherwise callers fall back to the raw socket.
+   */
+  getLiveEventSource(): SyncEventSource | null {
+    return this.eventGate
   }
 
   /**
@@ -350,11 +411,12 @@ export class SyncEngine {
     this.cleanupAllHandlers()
     this.subscribedStreams.clear()
     this.socket = null
-    // Dispose without flushing — destroy can be an account switch that
-    // repoints the shared db proxy, and the cursor must not leak across
-    // accounts. See SyncLogCursor.
-    this.shadowCatchUpAbort?.abort()
-    this.shadowCatchUpAbort = null
+    // Dispose without flushing or splicing — destroy can be an account switch
+    // that repoints the shared db proxy, and neither the cursor nor buffered
+    // events may leak across accounts. See SyncLogCursor / SocketEventGate.
+    this.catchUpAbort?.abort()
+    this.catchUpAbort = null
+    this.eventGate?.dispose()
     this.syncLogCursor?.dispose()
     this.syncLogCursor = null
   }
@@ -644,7 +706,7 @@ export class SyncEngine {
     if (!this.subscribedStreams.has(streamId)) {
       this.subscribedStreams.add(streamId)
       const cleanup = registerStreamSocketHandlers(
-        this.socket,
+        this.liveEventSource(this.socket),
         this.deps.workspaceId,
         streamId,
         this.deps.queryClient,
@@ -750,35 +812,183 @@ export class SyncEngine {
     this.syncCursorCleanup = () => socket.offAny(listener)
   }
 
+  /** Handler registration target: the gate in active mode, the socket otherwise. */
+  private liveEventSource(socket: Socket): SyncEventSource {
+    return this.eventGate ?? socket
+  }
+
   /**
-   * Shadow-mode catch-up: pages the sync endpoint from the cursor and logs
-   * what active mode WOULD have applied, applying nothing. Entries fetched
-   * here are events the live path never advanced past — after a disconnect
-   * that count is the healing the cursor will own; on a healthy resume it
-   * should be ~zero. Single-flighted; never throws into callers.
+   * Active mode, on connect: load the persisted cursor and, on a first run,
+   * seed it from head — BEFORE the workspace bootstrap data fetch, so the
+   * position is a lower bound of the snapshot (read-before-stamp). Errors are
+   * non-fatal: catch-up retries seeding later, and the bootstrap healing this
+   * phase keeps (INV-53) covers the rare first-run-plus-network-failure gap.
    */
-  private runShadowCatchUp(trigger: string): Promise<void> {
-    if (!this.syncCursorShadowEnabled || this.isDestroyed) return Promise.resolve()
-    if (this.activeShadowCatchUp) return this.activeShadowCatchUp
+  private async initializeActiveCursor(): Promise<void> {
+    const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
+    try {
+      await cursorStore.load()
+      if (cursorStore.get() !== null || this.isDestroyed) return
+      const abort = (this.catchUpAbort ??= new AbortController())
+      const { head } = await this.deps.syncService!.catchUp(this.workspaceId, { after: "0", limit: 1 }, abort.signal)
+      if (this.isDestroyed) return
+      cursorStore.advance(head)
+      console.info("Sync-v2 cursor seeded from head", { workspaceId: this.workspaceId, head })
+    } catch (error) {
+      if (this.isDestroyed) return
+      console.error("Sync-v2 cursor initialization failed", { workspaceId: this.workspaceId, error })
+    }
+  }
+
+  /**
+   * Catch-up after connect/reconnect/resume: pages the sync endpoint from the
+   * cursor. Shadow mode logs what active mode WOULD have applied; active mode
+   * applies entries through the gate. Entries fetched here are events the
+   * live path never advanced past — after a disconnect that is the healing
+   * the cursor owns; on a healthy resume it should be ~zero.
+   * Single-flighted; never throws into callers.
+   */
+  private runCatchUp(trigger: string): Promise<void> {
+    if (this.syncCursorMode === "off" || this.isDestroyed) return Promise.resolve()
+    if (this.activeCatchUp) return this.activeCatchUp
 
     const abort = new AbortController()
-    this.shadowCatchUpAbort = abort
-    const promise = this.performShadowCatchUp(trigger, abort.signal)
+    this.catchUpAbort = abort
+    const run =
+      this.syncCursorMode === "active"
+        ? this.performActiveCatchUp(trigger, abort.signal)
+        : this.performShadowCatchUp(trigger, abort.signal)
+    const promise = run
       .catch((error) => {
         // A destroy-triggered abort is expected teardown, not a failure.
         if (this.isDestroyed) return
-        console.error("Sync-v2 shadow catch-up failed", { workspaceId: this.workspaceId, trigger, error })
+        console.error("Sync-v2 catch-up failed", {
+          workspaceId: this.workspaceId,
+          mode: this.syncCursorMode,
+          trigger,
+          error,
+        })
       })
       .finally(() => {
-        if (this.activeShadowCatchUp === promise) {
-          this.activeShadowCatchUp = null
+        if (this.activeCatchUp === promise) {
+          this.activeCatchUp = null
         }
-        if (this.shadowCatchUpAbort === abort) {
-          this.shadowCatchUpAbort = null
+        if (this.catchUpAbort === abort) {
+          this.catchUpAbort = null
         }
       })
-    this.activeShadowCatchUp = promise
+    this.activeCatchUp = promise
     return promise
+  }
+
+  /**
+   * Active catch-up: applies log entries through the SAME registered handlers
+   * live socket events use (the protocol guarantees `entry.payload` is the
+   * exact payload the socket emits — see the sync service doc), in syncId
+   * order, awaiting each entry so applies cannot interleave. Duplicates are
+   * by design (sweep + dispatcher can both emit; snapshot/log overlap is the
+   * safe side of read-before-stamp) and are absorbed by the handlers'
+   * idempotency — except the unread counter family, which is skipped (see
+   * CATCHUP_SKIPPED_UNREAD_EVENT_TYPES).
+   *
+   * While catch-up pages, the gate buffers live syncId-bearing events; the
+   * finally-splice applies buffered events above the catch-up position (plus
+   * skipped-type events at any position, since catch-up never applies those)
+   * and reopens live flow. The cursor advances only past entries that were
+   * handed to handlers (or policy-skipped), never by jumping to head.
+   */
+  private async performActiveCatchUp(trigger: string, signal: AbortSignal): Promise<void> {
+    const syncService = this.deps.syncService!
+    const gate = this.eventGate!
+    const cursorStore = (this.syncLogCursor ??= new SyncLogCursor(this.workspaceId))
+    // The position everything at or below which the log already applied (or
+    // the bootstrap snapshot covers). Buffered live events above it splice in
+    // after catch-up; null means no position is known (first run that failed
+    // to seed) and the splice applies everything buffered — live behavior.
+    let appliedThrough: bigint | null = null
+
+    try {
+      await cursorStore.load()
+      const cursorBefore = cursorStore.get()
+      if (cursorBefore === null) {
+        // Normally seeded in initializeActiveCursor before bootstrap;
+        // reaching here means that failed (offline first run). Retry the
+        // seed — the bootstrap that just ran covers everything at or below
+        // the seeded head.
+        await this.initializeActiveCursor()
+        const seeded = cursorStore.get()
+        appliedThrough = seeded === null ? null : BigInt(seeded)
+        return
+      }
+
+      let cursor = cursorBefore
+      appliedThrough = BigInt(cursorBefore)
+      let head = cursorBefore
+      let pages = 0
+      let fetched = 0
+      let skipped = 0
+      const byEventType: Record<string, number> = {}
+
+      while (pages < MAX_CATCHUP_PAGES) {
+        const response = await syncService.catchUp(
+          this.workspaceId,
+          { after: cursor, limit: CATCHUP_PAGE_LIMIT },
+          signal
+        )
+        if (this.isDestroyed) return
+        head = response.head
+        if (response.entries.length === 0) break
+
+        pages += 1
+        fetched += response.entries.length
+        for (const entry of response.entries) {
+          if (this.isDestroyed) return
+          byEventType[entry.eventType] = (byEventType[entry.eventType] ?? 0) + 1
+          if (CATCHUP_SKIPPED_UNREAD_EVENT_TYPES.has(entry.eventType)) {
+            skipped += 1
+          } else {
+            // Mirror the live wire shape exactly: emits carry the syncId
+            // spread onto the outbox payload (see emitToGroups).
+            const payload =
+              typeof entry.payload === "object" && entry.payload !== null
+                ? { ...entry.payload, syncId: entry.syncId }
+                : entry.payload
+            await gate.dispatch(entry.eventType, payload)
+          }
+          cursorStore.advance(entry.syncId)
+          appliedThrough = BigInt(entry.syncId)
+          cursor = entry.syncId
+        }
+      }
+
+      if (fetched > 0 || trigger !== "connect") {
+        console.info("Sync-v2 active catch-up", {
+          workspaceId: this.workspaceId,
+          trigger,
+          cursorBefore,
+          cursorAfter: cursor,
+          head,
+          fetched,
+          skipped,
+          pages,
+          byEventType,
+          truncated: pages >= MAX_CATCHUP_PAGES,
+        })
+      }
+    } finally {
+      // Always reopen live flow, even on a failed fetch or early return (the
+      // buffer must never strand). Buffered events at or below the applied
+      // position were already applied from the log — except skipped-type
+      // events, which only ever apply via live delivery and so splice
+      // regardless of position.
+      if (!this.isDestroyed) {
+        const through = appliedThrough
+        await gate.resume(
+          (eventType, syncId) =>
+            through === null || syncId > through || CATCHUP_SKIPPED_UNREAD_EVENT_TYPES.has(eventType)
+        )
+      }
+    }
   }
 
   private async performShadowCatchUp(trigger: string, signal: AbortSignal): Promise<void> {
@@ -791,9 +1001,10 @@ export class SyncEngine {
       // No cursor yet (first run on this device): seed from head instead of
       // replaying the whole retained log — everything at or below head is
       // covered by the bootstrap snapshot path. NOTE: this jump is legal
-      // only because shadow mode owns no healing. Active mode must read
-      // head BEFORE the bootstrap data fetch (read-before-stamp rule) so
-      // the race falls on the duplicate side, never the gap side.
+      // only because shadow mode owns no healing. Active mode reads head
+      // BEFORE the bootstrap data fetch (read-before-stamp rule) so the
+      // race falls on the duplicate side, never the gap side — see
+      // initializeActiveCursor.
       const { head } = await syncService.catchUp(this.workspaceId, { after: "0", limit: 1 }, signal)
       if (this.isDestroyed) return
       cursorStore.advance(head)
@@ -807,12 +1018,8 @@ export class SyncEngine {
     let fetched = 0
     const byEventType: Record<string, number> = {}
 
-    while (pages < MAX_SHADOW_CATCHUP_PAGES) {
-      const response = await syncService.catchUp(
-        this.workspaceId,
-        { after: cursor, limit: SHADOW_CATCHUP_PAGE_LIMIT },
-        signal
-      )
+    while (pages < MAX_CATCHUP_PAGES) {
+      const response = await syncService.catchUp(this.workspaceId, { after: cursor, limit: CATCHUP_PAGE_LIMIT }, signal)
       if (this.isDestroyed) return
       head = response.head
       if (response.entries.length === 0) break
@@ -839,7 +1046,7 @@ export class SyncEngine {
         fetched,
         pages,
         byEventType,
-        truncated: pages >= MAX_SHADOW_CATCHUP_PAGES,
+        truncated: pages >= MAX_CATCHUP_PAGES,
       })
     }
   }

--- a/apps/frontend/src/sync/sync-log-cursor.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.ts
@@ -1,12 +1,24 @@
 import { db } from "@/db"
 
 /**
- * Kill switch for the sync-engine v2 cursor shadow path (cursor tracking +
- * shadow catch-up in SyncEngine). Shadow mode observes and logs only — it
- * never applies catch-up entries — so it defaults on; set
- * VITE_SYNC_V2_CURSOR=off to disable.
+ * Sync-engine v2 cursor rollout stage (VITE_SYNC_V2_CURSOR):
+ *
+ * - "off"    — cursor fully inert (kill switch).
+ * - "shadow" — track the cursor and page catch-up, log what active mode
+ *              WOULD apply, apply nothing. The default: production shadow
+ *              logs must show the cursor heals correctly (fetched > 0 after
+ *              disconnects, ~0 on healthy resumes) before "active" ships.
+ * - "active" — apply catch-up entries through the live handlers and buffer-
+ *              and-splice live events while catch-up pages.
  */
-export const SYNC_V2_CURSOR_SHADOW_DEFAULT = import.meta.env.VITE_SYNC_V2_CURSOR !== "off"
+export type SyncV2CursorMode = "off" | "shadow" | "active"
+
+function parseSyncV2CursorMode(raw: string | undefined): SyncV2CursorMode {
+  if (raw === "off" || raw === "active") return raw
+  return "shadow"
+}
+
+export const SYNC_V2_CURSOR_MODE: SyncV2CursorMode = parseSyncV2CursorMode(import.meta.env.VITE_SYNC_V2_CURSOR)
 
 const PERSIST_DEBOUNCE_MS = 1_000
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1,6 +1,6 @@
 import { db, type CachedStream, type CachedStreamMembership, type CachedUnreadState } from "@/db"
 import { seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
-import type { Socket } from "socket.io-client"
+import type { SyncEventSource } from "./socket-event-gate"
 import type { QueryClient } from "@tanstack/react-query"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
 import { streamKeys } from "@/hooks/use-streams"
@@ -401,7 +401,7 @@ function resolveDmPeerUserId(dmUserIds: [string, string] | undefined, currentUse
  * independently of component mount/unmount cycles.
  */
 export function registerWorkspaceSocketHandlers(
-  socket: Socket,
+  socket: SyncEventSource,
   workspaceId: string,
   queryClient: QueryClient,
   refs: {


### PR DESCRIPTION
## Problem

Phase 2a (#846) put a shadow cursor in production: it tracks `lastSyncId` per workspace and pages the catch-up endpoint on reconnect, but applies nothing. Phase 2b makes the cursor own healing: catch-up entries must be **applied**, and they must apply through the exact same code paths live socket events use — any second apply path would drift from the live one, which is the failure mode that produced today's 43 cache-patch sites.

Two correctness problems stand between shadow and active, and both are ordering problems, not fetch problems:

1. **Live events race the replay.** While catch-up pages the log, live events keep arriving. An older log entry applied after a newer live patch to the same row (e.g. two `message:updated` replyCount sets) regresses the row permanently. The design doc (Part 5, pressure test 7) prescribes buffer-and-splice: buffer live entries while catch-up runs, then apply buffered entries with syncId greater than the catch-up position. No `_patchedAt` wall-clock heuristics.
2. **The optimistic cursor can jump the gap.** The live path advances the cursor by monotonic max. If live events apply during the reconnect bootstrap window, the cursor jumps past the disconnect gap before catch-up reads it — and catch-up would then skip the very entries it exists to heal.

## Handler duplicate-safety audit

Duplicates are by design (sweep + dispatcher can both emit; snapshot/log overlap is the safe side of read-before-stamp), so every handler that catch-up dispatches to must absorb a re-apply. Audit of all ~35 client-routed event handlers in `workspace-sync.ts` / `stream-sync.ts`:

| Safety class | Handlers | Verdict |
| --- | --- | --- |
| Dedupe by event id (txn-guarded) | `message:created`, all append events (`stream:member_*`, `command:*`, `agent_session:*`, `stream:memos_captured`) | safe |
| LWW set from payload | `message:edited`/`deleted`/`updated`, `messages:moved` (sets authoritative counts, documented idempotent), `link_preview:ready`, `attachment:*`, `stream:updated`/`archived`/`unarchived`/`display_name_updated`, `user_preferences:updated`, `sidebar_config:updated`, `workspace_settings:updated`, `workspace_user:updated`, `bot_runtime:presence` | safe |
| Exists-checked insert / filter delete | `stream:created`, `workspace_user:added`/`removed`, `reaction:added`/`removed`, `bot:*`, `label:*` (all 7), `saved:*`, `scheduled_message:*` | safe |
| **Counter increment / read-state** | **`stream:activity`** (unread +1), **`activity:created`** (mention/activity +1), **`stream:read`/`stream:read_all`** (zeroing races the skipped increments) | **NOT safe from the log** |

The unread family is the entire unsafe surface, and it's also the state the workspace bootstrap already carries as **absolute values**. So: catch-up skips those four event types (cursor still advances past them); the bootstrap stays the sole counter authority in 2b, exactly as INV-53 already guarantees. Live delivery of these types — including events buffered during catch-up — applies exactly as today, so a counter event that exists both in the log and the buffer lands exactly once. Phase 2c can lift counters into the log properly by converting their payloads to absolute values (LWW).

## Solution

Behind a new flag stage (`VITE_SYNC_V2_CURSOR=active`; **default remains `shadow`** — prod shadow logs must show `fetched > 0` only after disconnects before this flips):

1. **`SocketEventGate`** — the single delivery chokepoint. In active mode, all live handlers (engine-owned and `useStreamSocket`-mounted) register on the gate instead of the raw socket; the gate forwards real socket events into them. Catch-up entries dispatch to the same registry, with the syncId spread onto the payload exactly as `emitToGroups` does on the wire — live and catch-up apply paths are literally the same functions, including event types registered in both workspace-sync and stream-sync (all listeners fire, matching live fan-out).
2. **Buffer-and-splice.** The gate pauses at trigger time — connect (synchronously, before any await) and connectivity resume — not at catch-up start. That single placement decision solves both ordering problems: no live event can apply (and optimistically advance the cursor) between the trigger-time cursor read and the catch-up fetch, so the catch-up position is honest; and no older log entry can apply after a newer live one, because live events buffer until the splice. Events without a `syncId` (ephemeral presence, pre-deploy emits) and other workspaces' events pass through untouched — they aren't in the log, so there is no position to order them against. The splice applies buffered events above the catch-up position in ascending syncId order (awaiting each, so applies can't interleave), plus skipped-type events at any position, then reopens live flow. The drain loop re-collects events that arrive mid-splice. `finally`-guaranteed: the buffer never strands, even on a failed fetch.
3. **Read-before-stamp.** Active mode loads the cursor — and head-seeds it on first run — **before** the workspace bootstrap data fetch, so the position is a lower bound of the snapshot and races fall on the duplicate side (absorbed by idempotency), never the gap side. This replaces shadow's lazy post-bootstrap seeding, which the 2a code explicitly marked as wrong for active mode.
4. **Advance only by applied entries.** The catch-up loop advances the cursor per entry after its handlers settle (policy-skipped counter entries advance too — they only ever apply via live delivery). Active mode has no `onAny` advance; the gate reports applied syncIds instead, so a persisted cursor never moves past an entry that wasn't handed to handlers. Shadow keeps its documented advance-by-fetched deviation, unchanged.
5. **Account-switch safety.** `dispose()` drops the buffer without applying and detaches all forwarders — a post-destroy splice would write one account's events into another account's IndexedDB, the same hazard class the cursor's no-flush dispose already guards.

### What active catch-up heals that bootstrap doesn't

The reconnect bootstrap delta-fetches only **visible** streams. Catch-up applies missed events for every member stream — messages, edits, reactions, saved/scheduled rows, labels, members — straight through the live handlers into IDB. Entries for streams with no registered handlers (e.g. unopened threads, which inherit root membership per INV-62) dispatch to zero listeners, matching live behavior for rooms the client hasn't joined; navigation-time stream bootstrap covers them as today.

### Explicitly unchanged

- Shadow mode behavior (byte-for-byte path, only plumbing renames).
- INV-53 bootstrap healing and invalidations — narrowing them is phase 2c, one deletion per proven replacement.
- Per-stream contiguity (INV-61): no contiguity math on sync ids, ever — the workspace log is not per-viewer dense.
- The per-stream catch-up cursor owner (`joinStreamForCatchUp`).

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/sync/socket-event-gate.ts` | `SocketEventGate` + `SyncEventSource` registration interface |
| `apps/frontend/src/sync/socket-event-gate.test.ts` | 11 tests: forwarding, buffering, splice order/predicate, mid-splice drain, overflow fallback, handler failure isolation, attach/detach, dispose safety |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/sync/sync-engine.ts` | Active catch-up (`performActiveCatchUp`), cursor init before bootstrap, gate lifecycle (attach/pause on connect+resume, dispose on destroy), skip-set, `getLiveEventSource()`; shadow runner unchanged behind a mode dispatch |
| `apps/frontend/src/sync/sync-log-cursor.ts` | Flag becomes three-stage `SyncV2CursorMode` (`off` \| `shadow` \| `active`), default `shadow` |
| `apps/frontend/src/sync/workspace-sync.ts`, `stream-sync.ts` | Handler registration accepts `SyncEventSource` (structural; raw `Socket` still satisfies it) |
| `apps/frontend/src/hooks/use-stream-socket.ts` | Registers through the engine gate in active mode so hook-mounted handlers respect buffering and catch-up dispatch |
| `apps/frontend/src/sync/sync-engine.test.ts` | Shadow tests moved to `syncCursorMode`; new active-mode describe (6 tests) |

## Test plan

- [x] `socket-event-gate.test.ts` — 11 tests (see above)
- [x] `sync-engine.test.ts` — 6 new active-mode tests: head-seed ordered before the bootstrap fetch, entries applied through real registered handlers with cursor advanced by applied entries, counter entries skipped from the log while the cursor advances past them, live events buffered during catch-up and spliced above the position, buffered counter event applied exactly once when duplicated in the log, destroy drops buffered events without applying
- [x] Existing shadow + cursor tests pass unchanged (13)
- [x] Full frontend suite: 2434 passing; monorepo typecheck + lint + prettier clean (pre-commit)
- [ ] `bun run test:e2e` needs Postgres on :5454 (Docker) — not available in this environment, same constraint as 2a; this PR is frontend-only and active mode is off by default
- [ ] Before flipping `VITE_SYNC_V2_CURSOR=active` anywhere: verify prod `"Sync-v2 shadow catch-up"` logs show `fetched > 0` after disconnects and ~0 on healthy resumes (`fetched > 0` on healthy resumes means a live-advance bug)

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2b of sync-engine v2 (doc Part 6 step 3 / #846 plan): the client cursor stops shadowing and owns workspace-tier healing — catch-up entries apply through the same handlers live events use, ordered by syncId, idempotent by domain event id.

## What Was Built

- `SocketEventGate`: handler registry + socket forwarders + pause buffer + ordered splice + awaited dispatch. One instance per engine, active mode only; shadow/off keep raw-socket registration.
- Active catch-up in `SyncEngine`: pages `GET /sync` from the cursor (20 × 500 safety valve, single-flighted, abortable), dispatches each entry through the gate with the live wire shape (`{ ...payload, syncId }`), advances the cursor per applied entry, logs a structured `"Sync-v2 active catch-up"` summary with a `skipped` count.
- Trigger-time pause: `onConnect` (synchronous, pre-await) and `refreshAfterConnectivityResume` pause the gate before the bootstrap so the catch-up position cannot move between trigger and fetch; the catch-up `finally` always resumes.
- Read-before-stamp cursor init: `initializeActiveCursor` loads + head-seeds before the bootstrap data fetch; seed failure is non-fatal (catch-up retries; INV-53 covers the rare first-run-offline gap).
- Unread-counter skip set (`stream:activity`, `activity:created`, `stream:read`, `stream:read_all`): skipped from log replay, advanced past, still applied from the live buffer at splice regardless of position.
- Flag staging: `VITE_SYNC_V2_CURSOR` = `off` | `shadow` (default) | `active`.

## Design Decisions

1. **Pause at trigger, not at catch-up start.** An applied live event advances the cursor optimistically; during the reconnect window that jump would move the catch-up position past the disconnect gap (permanent skip). Pausing before the bootstrap freezes the position and simultaneously provides the buffer-and-splice ordering. Cost: live application is deferred for bootstrap + catch-up duration on reconnect; bounded, and the bootstrap window already gates fresh content today.
2. **Skip counters instead of building an applied-id ledger.** True counter idempotency needs per-event applied tracking; the bootstrap already carries absolute counts and 2b keeps INV-53 intact, so a ledger would be speculative machinery (INV-36). 2c converts counter payloads to absolute values instead.
3. **Gate owns cursor advance in active mode (no `onAny`).** Advancing on arrival would let the debounced persist move past buffered-but-unapplied events; a crash in that window turns into a real gap. The gate reports syncIds only when events are handed to handlers.
4. **`useStreamSocket` registers through the gate.** The stream-view hook is a second registration path for the currently-viewed stream — exactly the stream most likely to regress if its handlers bypassed buffering. Draft panels without an engine keep the raw socket (draft streams have no log entries).
5. **Zero-listener dispatch is applied-as-noop.** Catch-up returns entries for streams the client never registered handlers for (unopened threads via INV-62 root inheritance). Live delivery wouldn't have reached them either (no room); navigation bootstrap heals them, so the cursor may advance past.
6. **Buffer overflow (2000) falls back to live application with a warn** — bounded memory, and the fallback is exactly today's delivery semantics.

## What's NOT Included (deliberate)

- No INV-53 invalidation deletions (phase 2c, one per proven replacement with a test).
- No flag default flip to `active` — gated on prod shadow-log verification.
- No `sync_log` retention/pruning, no sweep alerting (phase 1 deferrals, still open).
- No per-connection heartbeat (later; resume-time head check remains the liveness probe).

## Status

- Phase 2a: merged (#846). Phase 2b: this PR. Phase 2c: follow-up after active mode proves out in prod.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01K9cnUA9KjgshVHVCZMcrEa

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9cnUA9KjgshVHVCZMcrEa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783805055&installation_id=129946197&pr_number=851&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F851&signature=4cdd2cefa00b1d741ddab64292fca1657a92a9cd1178b86a2551082ec673822b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->