### PR TITLE
fix(conversations): resolve a conversation emptied by a correction, reactivate on undo

### DIFF
--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -1,5 +1,5 @@
 import { sql, type Querier } from "../../db"
-import type { ConversationStatus } from "@threa/types"
+import { ConversationStatuses, type ConversationStatus } from "@threa/types"
 
 interface ConversationRow {
   id: string
@@ -457,6 +457,37 @@ export const ConversationRepository = {
       SET message_ids = array_remove(message_ids, ${messageId}),
           updated_at = NOW()
       WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
+    `)
+  },
+
+  /**
+   * Resolve a conversation that no longer owns any primary messages. The
+   * emptiness check runs inside the UPDATE (INV-20): a concurrent extraction
+   * appending to `message_ids` between the caller's read and this write makes
+   * the condition fail under the row lock instead of resolving a conversation
+   * that just gained a message. Workspace-scoped (INV-8).
+   */
+  async resolveIfEmpty(db: Querier, workspaceId: string, conversationId: string): Promise<void> {
+    await db.query(sql`
+      UPDATE conversations
+      SET status = ${ConversationStatuses.RESOLVED}, updated_at = NOW()
+      WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
+        AND cardinality(message_ids) = 0
+    `)
+  },
+
+  /**
+   * Flip a resolved conversation back to active. Used when a message moves
+   * into a conversation that was resolved — in particular one auto-resolved
+   * on becoming empty, which keeps it usable as an undo target. Conditional
+   * in SQL (INV-20), so it no-ops for active/stalled conversations.
+   */
+  async reactivateIfResolved(db: Querier, workspaceId: string, conversationId: string): Promise<void> {
+    await db.query(sql`
+      UPDATE conversations
+      SET status = ${ConversationStatuses.ACTIVE}, updated_at = NOW()
+      WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
+        AND status = ${ConversationStatuses.RESOLVED}
     `)
   },
 

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -477,10 +477,12 @@ export const ConversationRepository = {
   },
 
   /**
-   * Flip a resolved conversation back to active. Used when a message moves
-   * into a conversation that was resolved — in particular one auto-resolved
-   * on becoming empty, which keeps it usable as an undo target. Conditional
-   * in SQL (INV-20), so it no-ops for active/stalled conversations.
+   * Flip a resolved conversation back to active. Applied whenever a message
+   * moves into a resolved conversation — gaining a message means it has
+   * activity again, whether it was resolved by a normal workflow or
+   * auto-resolved on becoming empty (which keeps the emptied conversation
+   * usable as an undo target). Conditional in SQL (INV-20), so it no-ops for
+   * active/stalled conversations.
    */
   async reactivateIfResolved(db: Querier, workspaceId: string, conversationId: string): Promise<void> {
     await db.query(sql`

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -119,6 +119,9 @@ export class ConversationService {
         await ConversationRepository.resolveIfEmpty(client, workspaceId, previous.id)
       }
       await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, messageId, message.authorId)
+      // Deliberately unconditional, not just for the undo path: a user moving
+      // a message into ANY resolved conversation is declaring it has activity
+      // again, so it returns to the active lifecycle.
       await ConversationRepository.reactivateIfResolved(client, workspaceId, target.id)
 
       await ConversationFeedbackRepository.insert(client, {

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -113,8 +113,13 @@ export class ConversationService {
 
       if (previous) {
         await ConversationRepository.removePrimaryMessage(client, workspaceId, previous.id, messageId)
+        // Moving a conversation's only message out leaves an empty shell that
+        // would otherwise stay "active" forever; resolve it. Moving a message
+        // back into it (the undo path) reactivates it below.
+        await ConversationRepository.resolveIfEmpty(client, workspaceId, previous.id)
       }
       await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, messageId, message.authorId)
+      await ConversationRepository.reactivateIfResolved(client, workspaceId, target.id)
 
       await ConversationFeedbackRepository.insert(client, {
         id: conversationFeedbackId(),

--- a/apps/backend/tests/integration/conversation-reassign.test.ts
+++ b/apps/backend/tests/integration/conversation-reassign.test.ts
@@ -251,7 +251,7 @@ describe("ConversationService.reassignMessage", () => {
   })
 
   test("reactivates a resolved-empty conversation when a message moves back into it", async () => {
-    const { convAId, convBId, msg0Id } = await seedTwoConversations()
+    const { convAId, convBId, msg0Id, msg1Id, msg2Id } = await seedTwoConversations()
 
     // Empty conversation B (auto-resolves), then undo: move the message back.
     await service.reassignMessage({
@@ -268,6 +268,13 @@ describe("ConversationService.reassignMessage", () => {
     })
 
     expect(result.conversation).toMatchObject({ id: convBId, messageIds: [msg0Id], status: "active" })
+    // Conversation A still owns msg1+msg2 after the undo: resolve-on-empty
+    // must NOT fire for a previous conversation that has messages left.
+    expect(result.previousConversation).toMatchObject({
+      id: convAId,
+      messageIds: [msg1Id, msg2Id],
+      status: "active",
+    })
 
     const convB = await withTransaction(pool, (client) => ConversationRepository.findById(client, convBId))
     expect(convB?.status).toBe("active")

--- a/apps/backend/tests/integration/conversation-reassign.test.ts
+++ b/apps/backend/tests/integration/conversation-reassign.test.ts
@@ -223,6 +223,56 @@ describe("ConversationService.reassignMessage", () => {
     })
   })
 
+  test("resolves the previous conversation when its only message moves out", async () => {
+    const { convAId, convBId, msg0Id } = await seedTwoConversations()
+
+    // Conversation B owns only msg0; moving it out empties B.
+    const result = await service.reassignMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convAId,
+      messageId: msg0Id,
+      userId: testUserId,
+    })
+
+    expect(result.previousConversation).toMatchObject({ id: convBId, messageIds: [], status: "resolved" })
+
+    const convB = await withTransaction(pool, (client) => ConversationRepository.findById(client, convBId))
+    expect(convB?.status).toBe("resolved")
+
+    // The conversation:updated payload must carry the new status (INV-4, INV-7).
+    const events = await withTransaction(pool, async (client) => {
+      const res = await client.query<{ payload: { conversationId: string; conversation: { status: string } } }>(
+        `SELECT payload FROM outbox WHERE event_type = 'conversation:updated'`
+      )
+      return res.rows
+    })
+    const updatedB = events.find((e) => e.payload.conversationId === convBId)
+    expect(updatedB?.payload.conversation).toMatchObject({ id: convBId, status: "resolved" })
+  })
+
+  test("reactivates a resolved-empty conversation when a message moves back into it", async () => {
+    const { convAId, convBId, msg0Id } = await seedTwoConversations()
+
+    // Empty conversation B (auto-resolves), then undo: move the message back.
+    await service.reassignMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convAId,
+      messageId: msg0Id,
+      userId: testUserId,
+    })
+    const result = await service.reassignMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convBId,
+      messageId: msg0Id,
+      userId: testUserId,
+    })
+
+    expect(result.conversation).toMatchObject({ id: convBId, messageIds: [msg0Id], status: "active" })
+
+    const convB = await withTransaction(pool, (client) => ConversationRepository.findById(client, convBId))
+    expect(convB?.status).toBe("active")
+  })
+
   test("no-ops when the message is already primary in the target conversation", async () => {
     const { convAId, msg2Id } = await seedTwoConversations()
 


### PR DESCRIPTION
First of a five-PR stack for the conversation-overlay follow-ups in #849. Closes item 1 of #849.

## Problem

`ConversationService.reassignMessage` could leave the previous conversation with `message_ids = {}` when a correction moved its only message out. The empty conversation lingered as `active` forever — still surfacing in the conversations list and the correction picker.

## Change

- **`ConversationRepository.resolveIfEmpty`**: sets `status = 'resolved'` when the conversation owns no primary messages. The emptiness check lives inside the `UPDATE` (INV-20), so a concurrent extraction appending to `message_ids` makes the condition fail under the row lock instead of resolving a conversation that just gained a message.
- **`ConversationRepository.reactivateIfResolved`**: flips a resolved conversation back to `active`; also conditional in SQL, no-op for active/stalled.
- **`reassignMessage`** calls `resolveIfEmpty` on the previous conversation right after `removePrimaryMessage`, and `reactivateIfResolved` on the target right after `addPrimaryMessage` — the undo path (moving the message back) reactivates the emptied conversation. Both run inside the existing `withTransaction` block and before the final `findByIds` re-read, so the `conversation:updated` outbox payloads carry the new status (INV-4, INV-7).

Statuses use `ConversationStatuses` from `@threa/types` (`active | stalled | resolved` — no separate "archived" state; INV-33).

## Tests

Extended `apps/backend/tests/integration/conversation-reassign.test.ts`:
- moving the only message out → previous conversation returned with `status: 'resolved'`, DB row resolved, and the `conversation:updated` outbox payload reflects it
- moving the message back into the resolved-empty conversation → back to `'active'`

Ran: backend integration (480 pass / 0 fail), backend unit (1677 pass / 0 fail), repo-wide `bun run typecheck` — all green.

https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804138&installation_id=129946197&pr_number=852&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F852&signature=d573ea19c998d2aef8c2a2965285cc4dd7845b1f26139a5214e244f12a982535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->