### PR TITLE
feat: EnclaveTurnDriver runs the sealed loop through the turn contract; interjection declared unsupported (Phase 2.2)

### DIFF
--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -26,13 +26,17 @@ import type {
   EnclaveSskWrap,
 } from "@threa/types"
 import {
-  AgentRuntime,
+  EnclaveTurnDriver,
+  TurnDeliveries,
+  declaredUnsupported,
   TurnDigestCollector,
   buildToolPromptSections,
   formatTurnDigestsForPrompt,
   generateTurnDigest,
   parseTurnDigestStepContent,
   type TurnDigestPromptEntry,
+  type TurnRequest,
+  type TurnSink,
 } from "@threa/agent-runtime/runtime"
 import type { EnclaveKeyPair } from "../keystore"
 import type { RawChatFn } from "../llm"
@@ -251,14 +255,21 @@ export async function runEnclaveTurn(
     .filter((block): block is string => Boolean(block))
     .join("\n\n")
 
-  const runtime = new AgentRuntime({
-    ai,
+  // Split the turn into what it IS (the request: model binding, prompt, history,
+  // toolset, sampling) and what it touches in the host (the sink: the sealing
+  // commit + trace observers, cooperative cancel, and the declared-unsupported
+  // interjection edge). The EnclaveTurnDriver maps both onto the same
+  // `AgentRuntime` the in-process companion runs — the enclave differs only by
+  // delivery and by sealing, never by a forked loop.
+  const turnRequest: TurnRequest = {
+    delivery: TurnDeliveries.SEALED,
     model,
     modelString: request.model,
     systemPrompt,
     messages,
     tools: turnTools,
-    observers: [traceObserver, digestCollector],
+    maxTokens: request.maxTokens,
+    temperature: request.temperature,
     // Lead the trace with the CONTEXT step ("Triggered by: …"): the runtime
     // emits it as a `context:received` event at run start and the observer
     // seals it like any other step. The body is the decrypted prompt;
@@ -267,25 +278,16 @@ export async function runEnclaveTurn(
     ...(request.trigger
       ? { initialContext: { messages: [{ ...request.trigger, content: promptText, isTrigger: true }] } }
       : {}),
-    maxTokens: request.maxTokens,
-    temperature: request.temperature,
-    // Hand ONLY the long-running research sub-loop the session's cancel signal so
-    // a user "Stop research" aborts it gracefully (partial findings, the turn
-    // still replies). Gated by tool name exactly like the in-process path, so a
-    // short/uninterruptible tool never receives an already-aborted signal.
-    ...(abortSignal
-      ? {
-          toolSignalProvider: (_toolCallId: string, toolName: string) =>
-            toolName === AgentToolNames.GENERAL_RESEARCH ? abortSignal : undefined,
-        }
-      : {}),
+  }
+
+  const turnSink: TurnSink = {
     // Terminal action: mint each reply's id, seal it under the current SSK bound
     // to that id, and stream it back now (awaited, so it's delivered before the
     // loop moves on). The backend stores ciphertext under this id. Citation
     // sources ride INSIDE the sealed payload — they reveal what was researched,
     // so they must never travel as a cleartext column or wire field (E2EE-9). A
     // sourceless reply seals the bare string, byte-identical to before.
-    sendMessage: async ({ content, sources }) => {
+    commitMessage: async ({ content, sources }) => {
       if (firstReplyText === null) firstReplyText = content
       lastReplyText = content
       const messageId = `msg_${ulid()}`
@@ -303,9 +305,27 @@ export async function runEnclaveTurn(
       messageIds.push(messageId)
       return { messageId }
     },
-  })
+    observers: [traceObserver, digestCollector],
+    // Interjection is declared unsupported, not silently omitted (UX-12 / §2.2.4):
+    // the enclave reads sealed history once at assignment time and has no channel
+    // to see messages that land mid-turn, so the loop's reconsider path has no
+    // provider here. The reason rides the seam for rendering; the sealed mid-turn
+    // pull (§2.7) is the future "implement" alternative.
+    newMessages: declaredUnsupported("Ariadne can't see mid-turn messages in encrypted scratchpads"),
+    // Hand ONLY the long-running research sub-loop the session's cancel signal so
+    // a user "Stop research" aborts it gracefully (partial findings, the turn
+    // still replies). Gated by tool name exactly like the in-process path, so a
+    // short/uninterruptible tool never receives an already-aborted signal.
+    ...(abortSignal
+      ? {
+          toolSignalProvider: (_toolCallId: string, toolName: string) =>
+            toolName === AgentToolNames.GENERAL_RESEARCH ? abortSignal : undefined,
+        }
+      : {}),
+  }
 
-  await runtime.run()
+  // Per turn because the enclave AI is per turn (it accumulates THIS turn's usage).
+  await new EnclaveTurnDriver({ ai }).runTurn(turnRequest, turnSink)
 
   // Turn digest (C-1): condense the turn's tool work with one cheap completion
   // over the same pinned model, seal it as a trailing turn_digest step (the

--- a/docs/features/architecture/agent-runtime.md
+++ b/docs/features/architecture/agent-runtime.md
@@ -204,6 +204,19 @@ transport. Only personas flagged `e2eCapable` (Ariadne, `built-in-agents.ts:95`)
 enclave actor; the dispatch gate refuses a non-capable one (`isE2eCapablePersona`). The
 enclave-side wiring lives in the enclave service, not here. See e2e-encrypted-scratchpads.
 
+**The enclave reaches the loop through the sealed turn driver.** `run-turn.ts` mirrors the
+companion's seam: it builds a `TurnRequest` (delivery `"sealed"`) and a `TurnSink` whose
+`commitMessage` seals each reply under the stream SSK and whose observers seal each trace
+step, then hands both to an `EnclaveTurnDriver` — the same `runTurnOnAgentRuntime` mapping
+the plaintext driver uses, differing only by delivery and sealing. The driver is exported
+from the curated barrel (no OTEL, no `createAI`) and is constructed per turn because the
+enclave's `AgentRuntimeAI` is per turn (it accumulates that turn's token usage). The enclave
+cannot see messages that arrive mid-turn — it reads sealed history once at assignment time —
+so its sink passes `declaredUnsupported("…")` for the interjection edge rather than omitting
+it: the gap (UX-12) is a named, renderable product decision, not a silent hole. Implementing
+a sealed mid-turn pull is a later option (`docs/plans/agent-runtimes-unification-redesign.md`
+§2.7).
+
 ## Boundaries
 
 What does not exist today, stated plainly:

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -8,7 +8,13 @@ export type { AgentObserver } from "./runtime/agent-observer"
 export { OtelObserver } from "./runtime/otel-observer"
 export { AgentRuntime, mergeSourceItems } from "./runtime/agent-runtime"
 export type { AgentRuntimeConfig, AgentRuntimeResult, NewMessageAwareness } from "./runtime/agent-runtime"
-export { InProcessTurnDriver, TurnDeliveries } from "./runtime/turn-driver"
+export {
+  InProcessTurnDriver,
+  EnclaveTurnDriver,
+  TurnDeliveries,
+  declaredUnsupported,
+  isDeclaredUnsupported,
+} from "./runtime/turn-driver"
 export type {
   TurnCommit,
   TurnCommitReceipt,
@@ -17,6 +23,7 @@ export type {
   TurnRequest,
   TurnResult,
   TurnSink,
+  DeclaredUnsupported,
 } from "./runtime/turn-driver"
 export {
   TurnDigestCollector,

--- a/packages/agent-runtime/src/runtime/enclave-runtime.ts
+++ b/packages/agent-runtime/src/runtime/enclave-runtime.ts
@@ -11,6 +11,22 @@ export { defineAgentTool, toVercelToolDefs, buildToolPromptSections } from "./ag
 export type { AgentTool, AgentToolConfig, AgentToolResult, ExecutionPhase } from "./agent-tool"
 export { negotiateCapabilities } from "./negotiate-capabilities"
 export type { NegotiateCapabilitiesParams, NegotiatedCapabilities } from "./negotiate-capabilities"
+// The turn contract's sealed driver: the enclave runs the same AgentRuntime loop
+// behind a sealing sink. Provider-free (no createAI / OTEL), so it belongs in the
+// curated barrel; the companion's InProcessTurnDriver stays out — the enclave only
+// ever serves "sealed" delivery. `declaredUnsupported` lets it name the gaps it
+// can't fill (interjection, UX-12) instead of silently omitting them.
+export { EnclaveTurnDriver, TurnDeliveries, declaredUnsupported, isDeclaredUnsupported } from "./turn-driver"
+export type {
+  TurnCommit,
+  TurnCommitReceipt,
+  TurnDelivery,
+  TurnDriver,
+  TurnRequest,
+  TurnResult,
+  TurnSink,
+  DeclaredUnsupported,
+} from "./turn-driver"
 export type { AgentEvent, NewMessageInfo, TraceContextMessage } from "./agent-events"
 export type { AgentObserver } from "./agent-observer"
 export { MAX_MESSAGE_CHARS, truncateMessages } from "./truncation"

--- a/packages/agent-runtime/src/runtime/index.ts
+++ b/packages/agent-runtime/src/runtime/index.ts
@@ -9,7 +9,13 @@ export type { AgentObserver } from "./agent-observer"
 export { OtelObserver } from "./otel-observer"
 export { AgentRuntime } from "./agent-runtime"
 export type { AgentRuntimeConfig, AgentRuntimeResult, NewMessageAwareness } from "./agent-runtime"
-export { InProcessTurnDriver, TurnDeliveries } from "./turn-driver"
+export {
+  InProcessTurnDriver,
+  EnclaveTurnDriver,
+  TurnDeliveries,
+  declaredUnsupported,
+  isDeclaredUnsupported,
+} from "./turn-driver"
 export type {
   TurnCommit,
   TurnCommitReceipt,
@@ -18,6 +24,7 @@ export type {
   TurnRequest,
   TurnResult,
   TurnSink,
+  DeclaredUnsupported,
 } from "./turn-driver"
 export {
   TurnDigestCollector,

--- a/packages/agent-runtime/src/runtime/turn-driver.test.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, mock } from "bun:test"
 import { AgentToolNames } from "@threa/types"
 import type { AgentEvent } from "./agent-events"
-import { InProcessTurnDriver, TurnDeliveries, type TurnCommit, type TurnRequest } from "./turn-driver"
+import {
+  EnclaveTurnDriver,
+  InProcessTurnDriver,
+  TurnDeliveries,
+  declaredUnsupported,
+  isDeclaredUnsupported,
+  type TurnCommit,
+  type TurnRequest,
+} from "./turn-driver"
 
 function plaintextRequest(overrides?: Partial<TurnRequest>): TurnRequest {
   return {
@@ -12,6 +20,20 @@ function plaintextRequest(overrides?: Partial<TurnRequest>): TurnRequest {
     tools: [],
     ...overrides,
   }
+}
+
+function sealedRequest(overrides?: Partial<TurnRequest>): TurnRequest {
+  return { ...plaintextRequest(), delivery: TurnDeliveries.SEALED, ...overrides }
+}
+
+function commitOnceAI(content: string) {
+  return {
+    generateTextWithTools: async () => ({
+      text: "",
+      toolCalls: [{ toolCallId: "tool_1", toolName: AgentToolNames.SEND_MESSAGE, input: { content } }],
+      response: { messages: [{ role: "assistant", content: "Sending." } as any] },
+    }),
+  } as any
 }
 
 describe("InProcessTurnDriver", () => {
@@ -79,5 +101,56 @@ describe("InProcessTurnDriver", () => {
       })
     ).rejects.toThrow("Agent session aborted: session superseded")
     expect(generateTextWithTools).not.toHaveBeenCalled()
+  })
+})
+
+describe("EnclaveTurnDriver", () => {
+  it("runs a sealed turn through the SAME loop and commits via the sealing sink", async () => {
+    const commits: TurnCommit[] = []
+    const driver = new EnclaveTurnDriver({ ai: commitOnceAI("Sealed reply") })
+
+    expect(driver.delivery).toBe(TurnDeliveries.SEALED)
+    const result = await driver.runTurn(sealedRequest(), {
+      commitMessage: async (commit) => {
+        commits.push(commit)
+        return { messageId: "msg_sealed_1" }
+      },
+      // The enclave declares interjection unsupported rather than omitting it; the
+      // turn must still run and commit, proving the driver folds the sentinel to
+      // "no provider" instead of handing it to the loop as an awareness object.
+      newMessages: declaredUnsupported("encrypted scratchpads"),
+    })
+
+    expect(commits).toEqual([{ content: "Sealed reply", sources: [] }])
+    expect(result.sentMessageIds).toEqual(["msg_sealed_1"])
+    expect(result.messagesSent).toBe(1)
+  })
+
+  it("refuses a non-sealed delivery before any model call", async () => {
+    const generateTextWithTools = mock(async () => {
+      throw new Error("must not be called")
+    })
+    const commitMessage = mock(async () => ({ messageId: "msg_never" }))
+    const driver = new EnclaveTurnDriver({ ai: { generateTextWithTools } as any })
+
+    await expect(
+      driver.runTurn(sealedRequest({ delivery: TurnDeliveries.PLAINTEXT }), { commitMessage })
+    ).rejects.toThrow('serves "sealed" turns')
+    expect(generateTextWithTools).not.toHaveBeenCalled()
+    expect(commitMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe("declaredUnsupported", () => {
+  it("builds a renderable sentinel that narrows true and carries its reason", () => {
+    const declared = declaredUnsupported("encrypted scratchpads")
+    expect(declared).toEqual({ unsupported: true, reason: "encrypted scratchpads" })
+    expect(isDeclaredUnsupported(declared)).toBe(true)
+  })
+
+  it("does not mistake a real awareness provider or nullish for the sentinel", () => {
+    expect(isDeclaredUnsupported(undefined)).toBe(false)
+    expect(isDeclaredUnsupported(null)).toBe(false)
+    expect(isDeclaredUnsupported({ check: async () => [] })).toBe(false)
   })
 })

--- a/packages/agent-runtime/src/runtime/turn-driver.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.ts
@@ -47,6 +47,29 @@ export interface TurnCommitReceipt {
 }
 
 /**
+ * A capability a driver structurally cannot provide, declared with a user-facing
+ * `reason` instead of being silently omitted (§2.2.4). A sink that passes this
+ * for an optional edge is saying "I considered this and can't here" — so a gap
+ * like the enclave's missing mid-turn interjection (UX-12) is a loud, renderable
+ * product decision, not an `undefined` field. Drivers fold it to "no provider"
+ * for the loop while the reason stays available to telemetry and the trace UI.
+ */
+export interface DeclaredUnsupported {
+  readonly unsupported: true
+  readonly reason: string
+}
+
+/** Declare an optional turn capability unsupported, with a renderable reason. */
+export function declaredUnsupported(reason: string): DeclaredUnsupported {
+  return { unsupported: true, reason }
+}
+
+/** Narrow an optional sink edge to its declared-unsupported sentinel. */
+export function isDeclaredUnsupported(value: unknown): value is DeclaredUnsupported {
+  return typeof value === "object" && value !== null && (value as { unsupported?: unknown }).unsupported === true
+}
+
+/**
  * The host edges a turn runs against — what persona-agent used to hand the loop
  * as raw closures. Only the commit path is mandatory; a minimal host (no trace,
  * no interjection) supplies just `commitMessage`.
@@ -56,8 +79,13 @@ export interface TurnSink {
   commitMessage: (commit: TurnCommit) => Promise<TurnCommitReceipt>
   /** Event sink — trace projection, digest collection, OTEL. */
   observers?: AgentObserver[]
-  /** Mid-turn interjection (new-message awareness). Omitted → the host can't see mid-turn messages. */
-  newMessages?: NewMessageAwareness
+  /**
+   * Mid-turn interjection (new-message awareness). A real provider lets the loop
+   * reconsider on messages that land mid-turn; `declaredUnsupported(reason)` says
+   * the host structurally can't (the enclave reads sealed history once — UX-12);
+   * omitted means the host simply didn't wire it.
+   */
+  newMessages?: NewMessageAwareness | DeclaredUnsupported
   /** Hard cancellation: a returned reason aborts the turn (externally deleted/superseded sessions). */
   shouldAbort?: () => Promise<string | null>
   /** Cooperative per-tool cancellation (graceful partial results, not session failure). */
@@ -97,6 +125,39 @@ export interface TurnDriver {
 }
 
 /**
+ * Map a request + sink onto the loop's own constructor shape and run it. Shared
+ * by every in-process-style driver — the companion in plaintext and the enclave
+ * behind its sealing sink — which differ only by `delivery`, never by how the
+ * request and sink reach `AgentRuntime`.
+ */
+function runTurnOnAgentRuntime(ai: AgentRuntimeAI, request: TurnRequest, sink: TurnSink): Promise<TurnResult> {
+  const runtime = new AgentRuntime({
+    ai,
+    model: request.model,
+    modelString: request.modelString,
+    systemPrompt: request.systemPrompt,
+    messages: request.messages,
+    tools: request.tools,
+    maxTokens: request.maxTokens,
+    temperature: request.temperature,
+    maxIterations: request.maxIterations,
+    initialContext: request.initialContext,
+    telemetry: request.telemetry,
+    costContext: request.costContext,
+    allowNoMessageOutput: request.allowNoMessageOutput,
+    validateFinalResponse: request.validateFinalResponse,
+    sendMessage: sink.commitMessage,
+    observers: sink.observers,
+    // A declared-unsupported interjection edge is a real "no provider" to the
+    // loop; the reason rides the seam for rendering, never into the loop.
+    newMessages: isDeclaredUnsupported(sink.newMessages) ? undefined : sink.newMessages,
+    shouldAbort: sink.shouldAbort,
+    toolSignalProvider: sink.toolSignalProvider,
+  })
+  return runtime.run()
+}
+
+/**
  * The plaintext driver: runs `AgentRuntime` in-process (the companion path).
  * Long-lived — construct once with the host's AI; each turn passes its own
  * request and sink.
@@ -110,28 +171,26 @@ export class InProcessTurnDriver implements TurnDriver {
     if (request.delivery !== this.delivery) {
       throw new Error(`InProcessTurnDriver serves "${this.delivery}" turns; got "${request.delivery}"`)
     }
+    return runTurnOnAgentRuntime(this.deps.ai, request, sink)
+  }
+}
 
-    const runtime = new AgentRuntime({
-      ai: this.deps.ai,
-      model: request.model,
-      modelString: request.modelString,
-      systemPrompt: request.systemPrompt,
-      messages: request.messages,
-      tools: request.tools,
-      maxTokens: request.maxTokens,
-      temperature: request.temperature,
-      maxIterations: request.maxIterations,
-      initialContext: request.initialContext,
-      telemetry: request.telemetry,
-      costContext: request.costContext,
-      allowNoMessageOutput: request.allowNoMessageOutput,
-      validateFinalResponse: request.validateFinalResponse,
-      sendMessage: sink.commitMessage,
-      observers: sink.observers,
-      newMessages: sink.newMessages,
-      shouldAbort: sink.shouldAbort,
-      toolSignalProvider: sink.toolSignalProvider,
-    })
-    return runtime.run()
+/**
+ * The sealed driver: runs the SAME `AgentRuntime` loop, but inside the enclave
+ * next to decrypted plaintext, with a sealing sink (its commit and trace edges
+ * seal under the stream SSK before crossing the HTTP callbacks). Constructed per
+ * turn because the enclave's `AgentRuntimeAI` is itself per turn — it accumulates
+ * that turn's token usage — unlike the companion's process-long-lived AI.
+ */
+export class EnclaveTurnDriver implements TurnDriver {
+  readonly delivery: TurnDelivery = TurnDeliveries.SEALED
+
+  constructor(private readonly deps: { ai: AgentRuntimeAI }) {}
+
+  async runTurn(request: TurnRequest, sink: TurnSink): Promise<TurnResult> {
+    if (request.delivery !== this.delivery) {
+      throw new Error(`EnclaveTurnDriver serves "${this.delivery}" turns; got "${request.delivery}"`)
+    }
+    return runTurnOnAgentRuntime(this.deps.ai, request, sink)
   }
 }


### PR DESCRIPTION
## Problem

Phase 2.1 (#848) defined the turn contract's structural spine — `TurnDriver`/`TurnSink`/`TurnRequest(delivery)` — and wrapped the companion as `InProcessTurnDriver`. The handoff for that phase deliberately left the enclave path untouched: the provider-free enclave barrel did **not** export the driver, because "2.2 decides how the enclave path wraps." Today the enclave still constructs `AgentRuntime` inline in `run-turn.ts` with a ~55-line config literal, and its one real parity gap — **no mid-turn interjection (UX-12)** — is a *silently omitted* `newMessages` field, not a declared decision (`docs/plans/agent-runtimes-unification-redesign.md` §2.2/§2.3/§2.4, drift matrix row UX-12).

## Solution

Phase 2.2 of the agent-runtimes unification plan (§2.4): wrap the enclave loop as `EnclaveTurnDriver` over the existing HTTP callbacks, and close UX-12 by **declaration**. No wire change, no behavior change.

### How it works

```
TurnRequest { delivery: "sealed", model, prompt, history, toolset, sampling }
        │
        ▼
EnclaveTurnDriver (readonly delivery="sealed"; wrong-delivery fails loudly, INV-11)
        │  ── same runTurnOnAgentRuntime mapping the plaintext driver uses ──
        ▼
TurnSink { commitMessage → seals reply under the stream SSK,
           observers → seal each trace step,
           newMessages: declaredUnsupported("…encrypted scratchpads"),
           toolSignalProvider → research cancel }
```

`run-turn.ts` now mirrors the companion's seam exactly: it builds a `TurnRequest` (delivery `"sealed"`) and a sealing `TurnSink`, then hands both to an `EnclaveTurnDriver`. The existing sealed HTTP callbacks (`onMessage`, the trace observers) *are* the sink — the transport is untouched.

### Key design decisions

**1. `EnclaveTurnDriver` wraps the in-enclave `AgentRuntime`, not the backend transport.** The §2.4 row is "over the existing HTTP callbacks" — so the driver runs the loop in-enclave behind its sealing sink (§2.3: "it runs `AgentRuntime` … with the sealing sink"), exactly as 2.1 wrapped the companion. The push→pull transport inversion (§2.7) is explicitly a separate, later concern; nothing here touches the assignment forward or the callback routes.

**2. The two drivers share one mapping (INV-35).** Extracted `runTurnOnAgentRuntime(ai, request, sink)`; `InProcessTurnDriver` and `EnclaveTurnDriver` differ only by `delivery` and the loud wrong-delivery guard, never by how request + sink reach `AgentRuntime`. `InProcessTurnDriver`'s behavior and error message are unchanged.

**3. Interjection is declared, not implemented (UX-12, §2.2.4 / Open-Q1).** The plan recommends "declare … decide on implementation after the contract lands." New `declaredUnsupported(reason)` / `DeclaredUnsupported` / `isDeclaredUnsupported` on the seam; `TurnSink.newMessages` becomes `NewMessageAwareness | DeclaredUnsupported`. The enclave passes `declaredUnsupported("Ariadne can't see mid-turn messages in encrypted scratchpads")` instead of omitting the field — the gap is now a named, renderable product decision. Drivers fold the sentinel to "no provider" for the loop while the reason stays available to telemetry/UI. The sealed mid-turn pull (§2.7) is the deferred "implement" alternative.

**4. Constructed per turn, deliberately.** Unlike the companion's process-long-lived `InProcessTurnDriver`, `EnclaveTurnDriver` is built per turn because the enclave's `AgentRuntimeAI` is per turn — it accumulates that turn's token usage. Documented at the construction site.

**5. The curated barrel now exports the sealed driver + seam, provider-free.** `EnclaveTurnDriver`, `TurnDeliveries`, `declaredUnsupported`, and the seam types are added to `enclave-runtime.ts` (no `createAI`, no OTEL). `InProcessTurnDriver` stays out — the enclave only ever serves `"sealed"`.

## Modified files

| File | Change |
| --- | --- |
| `packages/agent-runtime/src/runtime/turn-driver.ts` | Add `EnclaveTurnDriver`; extract shared `runTurnOnAgentRuntime`; add `declaredUnsupported`/`DeclaredUnsupported`/`isDeclaredUnsupported`; `TurnSink.newMessages` accepts the sentinel |
| `apps/enclave/src/agent/run-turn.ts` | Build a `TurnRequest` + sealing `TurnSink` and run via `EnclaveTurnDriver` instead of inlining `AgentRuntime`; declare interjection unsupported |
| `packages/agent-runtime/src/{index,runtime/index,runtime/enclave-runtime}.ts` | Export the sealed driver + sentinel + seam types from the `.`, internal `./runtime`, and curated enclave barrels |
| `packages/agent-runtime/src/runtime/turn-driver.test.ts` | 4 new tests: sealed end-to-end commit, loud wrong-delivery rejection, `declaredUnsupported` sentinel behavior |
| `docs/features/architecture/agent-runtime.md` | Document the sealed turn driver in the enclave section |

## Test plan

- [x] `packages/agent-runtime`: 188 pass (4 new in `turn-driver.test.ts`)
- [x] enclave (vitest): 68 pass — the enclave path is rewired but behavior is byte-identical
- [x] backend agents + enclave-runtimes: 371 pass
- [x] `bun run typecheck` + `bun run lint` clean; OpenAPI spec unchanged (`--check` passes); no wire change anywhere

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2.2 of `docs/plans/agent-runtimes-unification-redesign.md` §2.4: wrap the enclave loop as `EnclaveTurnDriver` over the existing HTTP callbacks, and close UX-12 by declaring interjection unsupported (the plan's Open-Q1 recommendation). No wire change. `ExternalTurnDriver` (2.3) builds on the same seam.

## What Was Built

1. **`EnclaveTurnDriver`** (`turn-driver.ts`): a `TurnDriver` with `readonly delivery = "sealed"` that maps a `TurnRequest` + `TurnSink` onto `AgentRuntime` and throws on a mismatched delivery before any model call (INV-11). Mirror of `InProcessTurnDriver`.
2. **Shared mapping** (`runTurnOnAgentRuntime`): the ~18-line request+sink → `AgentRuntimeConfig` mapping is extracted; both drivers delegate to it, so they differ only by delivery (INV-35). `InProcessTurnDriver` behavior + error message unchanged.
3. **`declaredUnsupported` sentinel** (§2.2.4): `declaredUnsupported(reason)`, `DeclaredUnsupported`, `isDeclaredUnsupported`. `TurnSink.newMessages: NewMessageAwareness | DeclaredUnsupported`. Drivers fold the sentinel to `undefined` for the loop (genuinely no interjection) while the reason rides the seam for rendering/telemetry.
4. **Enclave carve** (`run-turn.ts`): the inline `new AgentRuntime({...})` becomes a `TurnRequest` (delivery `"sealed"`, model/prompt/history/toolset/sampling/initialContext) + a sealing `TurnSink` (`commitMessage` = the sealing `onMessage` closure unchanged, `observers` = `[traceObserver, digestCollector]`, `toolSignalProvider` for research cancel, `newMessages` = `declaredUnsupported(...)`), run via a per-turn `EnclaveTurnDriver`. `AgentRuntime` import dropped from the file.
5. **Barrels**: export the sealed driver + sentinel + seam from `.`, internal `./runtime`, and the curated provider-free `enclave-runtime.ts` (which had no driver exports before).
6. **Docs**: a paragraph in `agent-runtime.md`'s enclave section.

## Design Decisions

- **In-enclave wrap, not backend transport** — §2.4 says "over the existing HTTP callbacks"; the transport (assignment forward + callback routes) is untouched. §2.7 push→pull inversion is later.
- **Declare, don't implement, interjection** — Open-Q1 recommends declaring first; keeps 2.2 minimal and host-agnostic. Sealed mid-turn pull (§2.7) is the forward path; the seam already accepts a real `NewMessageAwareness` for it.
- **Per-turn driver** — the enclave's AI is per turn (usage accumulator), so the driver that wraps it is too; honest about INV-13's "construct once" applying to genuinely long-lived collaborators.
- **`InProcessTurnDriver` untouched in behavior** — only refactored to share the mapping; its test (delivery, wrong-delivery message, control edges) stays green.

## What's NOT Included (later phases)

- Sealed mid-turn message pull / actual interjection (§2.7) — the "implement" arm of implement-or-declare.
- User-facing render of the declared-unsupported reason (trace chip) — frontend follow-up.
- `ExternalTurnDriver`, `bot:hello` manifest, context handle, reject-undeclared (2.3).
- Trust-tier rule in `negotiateCapabilities`; transport inversion / claim protocol (2.4 / §2.7).
- `TurnDispatch` itself — dispatch still lives in the worker/run-turn wiring.

## Status

Complete. Gauntlet green: agent-runtime 188 (+4); enclave vitest 68; backend agents + enclave-runtimes 371; monorepo typecheck + lint; OpenAPI unchanged.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01HHnyt3m5Txon9FUPxf6wsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHnyt3m5Txon9FUPxf6wsR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804432&installation_id=129946197&pr_number=853&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F853&signature=d11deb31cd7a712e0f6f7a61123c0409614005451aa5272bb679c919bcd66af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->