### PR TITLE
docs(features): re-sweep inventory, reconcile landed docs, defer in-flux surfaces

### DIFF
--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -3,7 +3,10 @@
 A catalog of what exists in the codebase today, bucketed the way this tree is organized,
 so backfill can proceed deliberately instead of ad hoc. Compiled from a code sweep on
 2026-06-02: backend feature folders (`apps/backend/src/features/*`), frontend routes and
-components, the CLAUDE.md invariants, and the packages and services.
+components, the CLAUDE.md invariants, and the packages and services. Re-swept 2026-06-11:
+added rows the first sweep missed (messages-and-timeline, user-status, giphy, onboarding),
+reconciled rows whose docs had landed without a checkmark, and recorded which surfaces are
+currently in flux (see "In flux right now").
 
 Two rules for using it:
 
@@ -15,36 +18,40 @@ Two rules for using it:
 
 ## Public features
 
-| Doc                                                                  | Covers                                                                           | Where to look                                                       |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [configurable-sidebar](public/configurable-sidebar.md) ✅ (building) | Sections, presets, quick links, label sections                                   | done                                                                |
-| scratchpads                                                          | The solo-first entry point: personal streams, AI companion on/off, auto-naming   | `features/streams`, `docs/core-concepts.md`                         |
-| channels-and-dms                                                     | Channels (public/private), DMs (lazy creation), archive, rename                  | `features/streams`                                                  |
-| threads-and-conversations                                            | Nested threads, breadcrumbs, conversation grouping, thread unreads               | `components/thread/`, `features/conversations`                      |
-| message-composer                                                     | Rich text, mentions, emoji, formatting toolbar, fullscreen document mode         | `components/composer/message-composer.tsx`                          |
-| voice-dictation                                                      | Recording, live transcript, polished vs raw chunks                               | `hooks/use-voice-dictation.ts`, `features/voice-transcription`      |
-| reactions                                                            | Emoji reactions, reactor details                                                 | `components/timeline/message-reactions.tsx`                         |
-| message-sharing                                                      | Share a message into another stream, quote replies                               | `components/share/`, `quote-reply-extension.ts`                     |
-| slash-commands                                                       | Command registry, stream-scoped commands, routing to bots                        | `features/commands`                                                 |
-| search                                                               | Global search with filters, in-stream search, quick switcher                     | `features/search`, `components/quick-switcher/`                     |
-| saved-messages                                                       | Save for later, done/archived lifecycle, reminders                               | `features/saved-messages`, `pages/saved.tsx`                        |
-| scheduled-messages                                                   | Compose now, send later; edit and send-now                                       | `features/scheduled-messages`                                       |
-| drafts                                                               | Autosave, stashing, drafts page                                                  | `stores/draft-store.ts`, `pages/drafts.tsx`                         |
-| labels                                                               | Create/join, color and emoji, assign to streams, public/private                  | `features/labels`, `pages/labels.tsx`                               |
-| memory-explorer                                                      | Browse and search memos, tags, knowledge types, memo embeds in messages          | `features/memos`, `pages/memory.tsx`                                |
-| activity-feed                                                        | All/unread/me filters, mark read                                                 | `features/activity`, `pages/activity.tsx`                           |
-| notifications                                                        | Web push, per-stream notification levels, device-aware suppression               | `features/push`                                                     |
-| attachments-and-files                                                | Uploads, extraction-backed previews, files page, gallery, per-stream explorer    | `features/attachments`, `pages/files.tsx`                           |
-| link-previews                                                        | URL preview cards on messages                                                    | `features/link-previews`                                            |
-| e2e-encrypted-scratchpads                                            | Passphrase setup/unlock, inviting actors, encrypted AI companion via the enclave | `components/encryption/`, `features/e2e-streams`                    |
-| invitations                                                          | Invite links, claiming, joining a workspace                                      | `features/invitations`, `pages/join.tsx`                            |
-| multi-account                                                        | Account switcher, add account, scoped logout                                     | `components/account-switcher/`                                      |
-| user-settings                                                        | Appearance, keyboard shortcuts, notification prefs, date/time, accessibility     | `components/settings/`                                              |
-| workspace-settings                                                   | Members and roles, bots, GitHub/Linear integrations, AI usage dashboard          | `components/workspace-settings/`, `features/workspace-integrations` |
-| public-api                                                           | REST API for integrations, user API keys                                         | `features/public-api`, `docs/public-api/openapi.json`               |
-| share-target                                                         | OS-level share into a workspace (PWA), destination picker                        | `pages/share-target.tsx`                                            |
-| offline                                                              | Composing offline, queued operations, connection status                          | `sw.ts`, `sync/operation-queue.ts`                                  |
-| [ai-companions](public/ai-companions.md) ✅                          | Personas, companion mode, mentions, in-timeline activity card, agent traces      | `features/agents`, `docs/core-concepts.md`                          |
+| Doc                                                                            | Covers                                                                                                                                  | Where to look                                                                |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [configurable-sidebar](public/configurable-sidebar.md) ✅ (building)           | Sections, presets, quick links, label sections                                                                                          | done                                                                         |
+| scratchpads                                                                    | The solo-first entry point: personal streams, AI companion on/off, auto-naming                                                          | `features/streams`, `docs/core-concepts.md`                                  |
+| channels-and-dms                                                               | Channels (public/private), DMs (lazy creation), archive, rename                                                                         | `features/streams`                                                           |
+| threads-and-conversations                                                      | Nested threads, breadcrumbs, conversation grouping, thread unreads                                                                      | `components/thread/`, `features/conversations`                               |
+| messages-and-timeline                                                          | Message lifecycle: edit/delete, edited indicator, context menu and action drawer, system membership events, unread badges and mark-read | `components/timeline/`, `features/messaging`, `features/system-messages`     |
+| message-composer                                                               | Rich text, mentions, emoji, formatting toolbar, fullscreen document mode                                                                | `components/composer/message-composer.tsx`                                   |
+| giphy                                                                          | GIF search and picker, GIF previews on messages (may fold into message-composer at writing time)                                        | `features/giphy`, `components/giphy/`                                        |
+| voice-dictation                                                                | Recording, live transcript, polished vs raw chunks                                                                                      | `hooks/use-voice-dictation.ts`, `features/voice-transcription`               |
+| reactions                                                                      | Emoji reactions, reactor details                                                                                                        | `components/timeline/message-reactions.tsx`                                  |
+| message-sharing                                                                | Share a message into another stream, quote replies                                                                                      | `components/share/`, `quote-reply-extension.ts`                              |
+| slash-commands                                                                 | Command registry, stream-scoped commands, routing to bots                                                                               | `features/commands`                                                          |
+| search                                                                         | Global search with filters, in-stream search, quick switcher                                                                            | `features/search`, `components/quick-switcher/`                              |
+| saved-messages                                                                 | Save for later, done/archived lifecycle, reminders                                                                                      | `features/saved-messages`, `pages/saved.tsx`                                 |
+| scheduled-messages                                                             | Compose now, send later; edit and send-now                                                                                              | `features/scheduled-messages`                                                |
+| drafts                                                                         | Autosave, stashing, drafts page                                                                                                         | `stores/draft-store.ts`, `pages/drafts.tsx`                                  |
+| labels                                                                         | Create/join, color and emoji, assign to streams, public/private                                                                         | `features/labels`, `pages/labels.tsx`                                        |
+| memory-explorer                                                                | Browse and search memos, tags, knowledge types, memo embeds in messages                                                                 | `features/memos`, `pages/memory.tsx`                                         |
+| activity-feed                                                                  | All/unread/me filters, mark read                                                                                                        | `features/activity`, `pages/activity.tsx`                                    |
+| notifications                                                                  | Web push, per-stream notification levels, device-aware suppression                                                                      | `features/push`                                                              |
+| attachments-and-files                                                          | Uploads, extraction-backed previews, files page, gallery, per-stream explorer                                                           | `features/attachments`, `pages/files.tsx`                                    |
+| link-previews                                                                  | URL preview cards on messages                                                                                                           | `features/link-previews`                                                     |
+| [e2e-encrypted-scratchpads](public/e2e-encrypted-scratchpads.md) ✅ (building) | Passphrase setup/unlock, inviting actors, encrypted AI companion via the enclave                                                        | done                                                                         |
+| invitations                                                                    | Invite links, claiming, joining a workspace                                                                                             | `features/invitations`, `pages/join.tsx`                                     |
+| onboarding-and-workspace-creation                                              | Sign-up flow, user setup, creating and selecting a workspace                                                                            | `pages/user-setup.tsx`, `pages/workspace-select.tsx`, `apps/control-plane/`  |
+| multi-account                                                                  | Account switcher, add account, scoped logout                                                                                            | `components/account-switcher/`                                               |
+| user-settings                                                                  | Appearance, keyboard shortcuts, notification prefs, date/time, accessibility                                                            | `components/settings/`                                                       |
+| user-status                                                                    | Status text/emoji, presets, expiry, notification pausing, work schedule                                                                 | `components/status/`, `features/workspaces` (status fields), `lib/status.ts` |
+| workspace-settings                                                             | Members and roles, bots, GitHub/Linear integrations, AI usage dashboard                                                                 | `components/workspace-settings/`, `features/workspace-integrations`          |
+| public-api                                                                     | REST API for integrations, user API keys                                                                                                | `features/public-api`, `docs/public-api/openapi.json`                        |
+| share-target                                                                   | OS-level share into a workspace (PWA), destination picker                                                                               | `pages/share-target.tsx`                                                     |
+| offline                                                                        | Composing offline, queued operations, connection status                                                                                 | `sw.ts`, `sync/operation-queue.ts`                                           |
+| [ai-companions](public/ai-companions.md) ✅                                    | Personas, companion mode, mentions, in-timeline activity card, agent traces                                                             | `features/agents`, `docs/core-concepts.md`                                   |
 
 ## Concepts
 
@@ -71,21 +78,21 @@ this tree. See Decisions below.
 
 ## Architecture
 
-| Doc                                                           | Covers                                                                                               | Where to look                                               |
-| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [outbox-pattern](architecture/outbox-pattern.md) ✅           | Transactional events, dispatcher, gap-safe cursors                                                   | done                                                        |
-| [sync-engine](architecture/sync-engine.md) ✅                 | Client sync lifecycle, reconnect, IDB reconciliation                                                 | done                                                        |
-| [coordinated-loading](architecture/coordinated-loading.md) ✅ | First-paint gate: reveal app shell + stream content together (resolved names/avatars) off cached IDB | done                                                        |
-| job-queue                                                     | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                        | `apps/backend/src/lib/queue/`                               |
-| ai-wrapper                                                    | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets        | `packages/agent-runtime/src/ai/`                            |
-| socket-rooms                                                  | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                          | `apps/backend/src/socket.ts`                                |
-| [agent-runtime](architecture/agent-runtime.md) ✅             | Persona sessions, tool execution, traces, per-persona tool enablement and access scope               | `packages/agent-runtime/`, `features/agents`                |
-| bot-runtimes                                                  | External bot runtime connections and session links                                                   | `features/bot-runtimes`                                     |
-| e2e-encryption                                                | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                           | `packages/crypto/`, `features/e2e-streams`, `apps/enclave/` |
-| push-pipeline                                                 | Subscriptions, device/session suppression logic, outbox-driven delivery                              | `features/push`                                             |
-| attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                                   | `features/attachments`, `lib/storage/`                      |
-| search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                                 | `features/search`                                           |
-| memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                            | `features/memos` and its outbox handlers                    |
+| Doc                                                           | Covers                                                                                               | Where to look                                                                                   |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [outbox-pattern](architecture/outbox-pattern.md) ✅           | Transactional events, dispatcher, gap-safe cursors                                                   | done                                                                                            |
+| [sync-engine](architecture/sync-engine.md) ✅                 | Client sync lifecycle, reconnect, IDB reconciliation                                                 | done                                                                                            |
+| [coordinated-loading](architecture/coordinated-loading.md) ✅ | First-paint gate: reveal app shell + stream content together (resolved names/avatars) off cached IDB | done                                                                                            |
+| job-queue                                                     | PG-backed queue: fair-share scheduling, priorities, DLQ, the job-type catalog                        | `apps/backend/src/lib/queue/`                                                                   |
+| ai-wrapper                                                    | `createAI` over the AI SDK and OpenRouter, Langfuse/OTEL telemetry, cost tracking and budgets        | `packages/agent-runtime/src/ai/`                                                                |
+| socket-rooms                                                  | Room naming (`ws:*`), cookie auth, user socket registry, connection metrics                          | `apps/backend/src/socket.ts`                                                                    |
+| [agent-runtime](architecture/agent-runtime.md) ✅ (drifting)  | Persona sessions, tool execution, traces, per-persona tool enablement and access scope               | doc predates the Turn Contract redesign (PR #817 onward); refresh after the unification settles |
+| bot-runtimes                                                  | External bot runtime connections and session links                                                   | `features/bot-runtimes`                                                                         |
+| [e2e-enclave](architecture/e2e-enclave.md) ✅ (building)      | SSK wraps, enclave instance keys, HPKE, the sealed AI loop                                           | done                                                                                            |
+| push-pipeline                                                 | Subscriptions, device/session suppression logic, outbox-driven delivery                              | `features/push`                                                                                 |
+| attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                                   | `features/attachments`, `lib/storage/`                                                          |
+| search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                                 | `features/search`                                                                               |
+| memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                            | `features/memos` and its outbox handlers                                                        |
 
 ## Probably skip, or covered elsewhere
 
@@ -96,8 +103,27 @@ this tree. See Decisions below.
   would just restate them.
 - **Solo-first philosophy**: belongs in the scratchpads public doc and CLAUDE.md, not a
   standalone concept.
-- **Minor infra** (operation-leases, observability/metrics wiring, emoji): document
-  inline in whichever doc touches them, or not at all.
+- **Minor infra** (operation-leases, observability/metrics wiring, emoji data and
+  usage tracking, user profile cards, bot channel access grants in `features/api-keys`):
+  document inline in whichever doc touches them, or not at all.
+
+## In flux right now
+
+Surfaces under active redesign as of 2026-06-11. Don't backfill these; a doc written
+mid-redesign churns with every phase PR. For the ones that already have a doc, the doc
+stays (it was accurate when written) but gets a refresh pass once the work settles
+rather than per-phase edits.
+
+- **agent-runtime**: the Turn Contract unification (PR #817 design; phases landing in
+  #838, #841, #845, #847, #848: TraceProjector, per-stream tool policy via
+  `stream_policies`, TurnDriver/TurnSink spine). `architecture/agent-runtime.md` predates
+  it and is marked drifting above.
+- **e2e scratchpads + enclave**: still `building` and actively changing (e.g. #794
+  enclave auto-titles). Both docs exist with `status: building`; refresh when it ships.
+- **sync-v2**: client cursor in shadow mode (#832, #833, #846). Parts of
+  `architecture/sync-engine.md` will need updating when it leaves shadow mode.
+- **conversation overlay**: conversation grouping overlay with user corrections (#842)
+  is new; fold into threads-and-conversations once it stabilizes.
 
 ## Decisions
 
@@ -105,13 +131,15 @@ this tree. See Decisions below.
    and personas sections each become a `concepts/` doc through normal document-feature
    runs. Whichever run lands the last of the three also reduces core-concepts.md to a
    short pointer into this tree, so external references keep working.
+2. **Backfill order: stable surfaces first** (decided 2026-06-11, reversing the earlier
+   suggestion to start with surfaces under active change, which produced docs that
+   drifted within weeks, e.g. agent-runtime). Prefer rows whose code hasn't moved
+   recently and the concepts that prevent recurring bugs; defer everything in
+   "In flux right now" until the work settles.
 
 ## Open questions
 
-1. **Backfill order.** Suggested: start where docs pay rent fastest. That's the surfaces
-   under active change (e2e-encrypted-scratchpads, ai-companions, agent-runtime) and the
-   concepts that prevent recurring bugs (optimistic-then-reconcile,
-   content-canonical-form, race-safe-writes).
-2. **Granularity calls** to make at writing time: split user-settings from
+1. **Granularity calls** to make at writing time: split user-settings from
    workspace-settings or merge; whether public-api belongs in `public/` (developer
-   audience) or its own bucket.
+   audience) or its own bucket; whether giphy folds into message-composer; whether
+   messages-and-timeline is one doc or splits (lifecycle vs. unreads).


### PR DESCRIPTION
## Problem

The feature-doc inventory (`docs/features/INVENTORY.md`) drifted from reality in three ways since the 2026-06-02 sweep:

1. **Missing rows.** The sweep missed four user-facing surfaces that exist in the code today.
2. **Stale bookkeeping.** The e2e scratchpad docs (`public/e2e-encrypted-scratchpads.md`, `architecture/e2e-enclave.md`) landed without their inventory rows being checked off, and `architecture/agent-runtime.md` (written at #762) predates the Turn Contract redesign (#817 onward) but still reads as current.
3. **Backwards backfill guidance.** The open-questions section recommended documenting surfaces *under active change* first. That's exactly what produced the agent-runtime drift within weeks.

## Solution

A re-sweep of `apps/backend/src/features/*`, frontend pages/components, and recent main history (verified against the code, not just the old sweep):

- **New rows:** `messages-and-timeline` (edit/delete, edited indicator, context menu, system membership events, unreads/mark-read — the core of the product had no row), `user-status` (presets, expiry, notification pausing, work schedule), `giphy`, and `onboarding-and-workspace-creation` (invitations covered joining, nothing covered sign-up/creation).
- **Reconciled rows:** checked off both e2e docs as ✅ (building); marked `agent-runtime` ✅ (drifting) with a pointer to the redesign PRs.
- **New "In flux right now" section:** agent-runtime (Turn Contract phases #838–#848), e2e enclave, sync-v2 shadow mode (#832/#833/#846), conversation overlay (#842). Backfill defers these; existing docs for them get one refresh pass when the work settles.
- **Reversed decision (recorded under Decisions):** backfill stable surfaces first, not active ones.
- Folded `features/api-keys` (bot channel access) and user profile cards into the minor-infra skip bullet.

## Modified files

| File                         | Change                                                  |
| ---------------------------- | ------------------------------------------------------- |
| `docs/features/INVENTORY.md` | Re-sweep: 4 new rows, reconciliation, in-flux deferrals |

## Test plan

- [x] Docs-only change; pre-commit prettier/lint/typecheck passed
- [x] All "where to look" pointers verified to exist in the tree

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01SUQU15T4RwAVkeeC9BNKzP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUQU15T4RwAVkeeC9BNKzP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804560&installation_id=129946197&pr_number=854&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F854&signature=4f99d22d0691b24919f911590a21375565bf05ab6833fc374d0c2e4c1afd0f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->