### PR TITLE
fix(frontend): track conversation correction pending state per message

### DIFF
--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -191,12 +191,12 @@ export function ConversationOverlayRow({
   messageId: string
   children: ReactNode
 }) {
-  const { model, focusedConversationId, onReassignMessage, pendingMessageId, observeRow } = overlay
+  const { model, focusedConversationId, onReassignMessage, pendingMessageIds, observeRow } = overlay
   const conversation = annotation.conversationId ? model.conversationsById.get(annotation.conversationId) : undefined
   const conversationId = conversation?.id ?? null
   const colorIndex = conversation ? (model.colorIndexById.get(conversation.id) ?? 0) : null
   const isDimmed = focusedConversationId != null && annotation.conversationId !== focusedConversationId
-  const isPending = pendingMessageId === messageId
+  const isPending = pendingMessageIds.has(messageId)
 
   // React 19 ref-callback cleanup: registration is undone when the row
   // unmounts or its conversation changes (reassignment). MUST be memoized —
@@ -334,11 +334,11 @@ export function ConversationPickerDrawer({
   annotation: ConversationRowAnnotation
   messageId: string
 }) {
-  const { model, onReassignMessage, pendingMessageId } = overlay
+  const { model, onReassignMessage, pendingMessageIds } = overlay
   // Mirror the rail swatch menu: ignore picks while this message's
   // reassignment is already in flight, so rapid taps can't enqueue
   // duplicate corrections.
-  const isPending = pendingMessageId === messageId
+  const isPending = pendingMessageIds.has(messageId)
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent>

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -76,8 +76,12 @@ export interface ConversationOverlayContext {
   onToggleFocus: (conversationId: string) => void
   /** User correction: move a message's primary membership. */
   onReassignMessage: (messageId: string, toConversationId: string) => void
-  /** messageId of an in-flight correction, for pending affordance state. */
-  pendingMessageId: string | null
+  /**
+   * messageIds with an in-flight correction, for pending affordance state.
+   * A set rather than the latest mutation's variables: two rapid corrections
+   * on different messages each keep their own pending affordance.
+   */
+  pendingMessageIds: ReadonlySet<string>
   /**
    * Viewport tracking for the in-view panel: rows register their DOM node +
    * conversation on mount and return the IntersectionObserver cleanup (React

--- a/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-overlay.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-overlay.ts
@@ -114,27 +114,39 @@ export function useConversationOverlay({
     setFocusedConversationId((previous) => (previous === conversationId ? null : conversationId))
   }, [])
 
+  // One entry per in-flight correction, keyed by messageId. React state (not
+  // a ref) on purpose: each change gives `context` a new identity, which is
+  // what `timelineRowPropsEqual` (event-list.tsx) compares to repaint the
+  // decorated rows' pending affordances.
+  const [pendingMessageIds, setPendingMessageIds] = useState<ReadonlySet<string>>(() => new Set())
+
   const { mutate } = reassign
   const onReassignMessage = useCallback(
     (messageId: string, toConversationId: string) => {
+      setPendingMessageIds((previous) => new Set(previous).add(messageId))
       mutate(
         { messageId, toConversationId },
         {
           onError: () => toast.error("Couldn't move the message to that conversation"),
+          onSettled: () => {
+            setPendingMessageIds((previous) => {
+              const next = new Set(previous)
+              next.delete(messageId)
+              return next
+            })
+          },
         }
       )
     },
     [mutate]
   )
 
-  const pendingMessageId = reassign.isPending ? (reassign.variables?.messageId ?? null) : null
-
   const context = useMemo(
     () =>
       enabled
-        ? { model, focusedConversationId, onToggleFocus, onReassignMessage, pendingMessageId, observeRow }
+        ? { model, focusedConversationId, onToggleFocus, onReassignMessage, pendingMessageIds, observeRow }
         : undefined,
-    [enabled, model, focusedConversationId, onToggleFocus, onReassignMessage, pendingMessageId, observeRow]
+    [enabled, model, focusedConversationId, onToggleFocus, onReassignMessage, pendingMessageIds, observeRow]
   )
 
   const inViewConversations = useMemo(


### PR DESCRIPTION
Stacked on #852. Closes item 2 of #849.

## Problem

`use-conversation-overlay.ts` derived `pendingMessageId` from the single TanStack mutation's `variables`, so two rapid corrections on different messages showed the pending spinner only on the latest one.

## Change

- `ConversationOverlayContext.pendingMessageId: string | null` → `pendingMessageIds: ReadonlySet<string>` (`model.ts`).
- `useConversationOverlay` maintains the set in React state: the id is added when the correction's `mutate` fires and removed in that call's `onSettled`. State (not a ref) on purpose — each change gives the memoized context a new identity, which is exactly what `timelineRowPropsEqual` (`event-list.tsx`) compares to repaint decorated rows.
- Consumers updated to `pendingMessageIds.has(messageId)`: the rail swatch + its disabled menu items (`ConversationOverlayRow`) and `ConversationPickerDrawer`'s in-flight guard.

## Tests

- Frontend suite: 2425 pass / 0 fail; `tsc --noEmit` clean.
- `tests/browser/conversation-overlay.spec.ts` (single-correction path incl. swatch menu + picker drawer): 1 passed.

https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804637&installation_id=129946197&pr_number=855&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F855&signature=58a15ca14e3a00bde847197fc135644cfed01fb4c9451507afbc972aca3f0738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->