### PR TITLE
fix(frontend): replace history entry on overlay toggle from the header

### DIFF
--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -112,15 +112,22 @@ export function StreamPage() {
   const isConversationOverlayOn = searchParams.get("convOverlay") === "on"
 
   const setConversationOverlayOn = (on: boolean) => {
-    setSearchParams((prev) => {
-      const newParams = new URLSearchParams(prev)
-      if (on) {
-        newParams.set("convOverlay", "on")
-      } else {
-        newParams.delete("convOverlay")
-      }
-      return newParams
-    })
+    setSearchParams(
+      (prev) => {
+        const newParams = new URLSearchParams(prev)
+        if (on) {
+          newParams.set("convOverlay", "on")
+        } else {
+          newParams.delete("convOverlay")
+        }
+        return newParams
+      },
+      // The overlay is ephemeral view chrome, not navigation: every toggle
+      // path replaces (the panel's X in stream-content.tsx does too), so Back
+      // leaves the stream instead of silently toggling chrome. The URL still
+      // updates for refresh/share (INV-59).
+      { replace: true }
+    )
   }
 
   const { openUserProfile } = useUserProfile()


### PR DESCRIPTION
Stacked on #855. Closes item 3 of #849.

## Problem

The header split button (`setConversationOverlayOn` in `pages/stream.tsx`) pushed a history entry on every overlay toggle, while the panel's X (`closeConversationOverlay` in `stream-content.tsx`) used `{ replace: true }`. Back-button behavior differed depending on how the overlay was closed.

## Change

Standardize on `{ replace: true }` for both paths: the overlay is ephemeral view chrome, not navigation — Back should leave the stream, not silently toggle chrome. A comment at the toggle states the rule. URL persistence per INV-59 is unaffected; replace still updates the URL for refresh/share.

## Tests

Frontend suite: 2425 pass / 0 fail; `tsc --noEmit` clean. The e2e overlay spec (URL assertions on toggle) ran green on the stacked branches.

https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804931&installation_id=129946197&pr_number=856&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F856&signature=e2fa754650d9155fb99cc09e567b50a499d523a59e07847f15e21d89091403b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->