### PR TITLE
fix(frontend): widen the split-button chevron on touch viewports

### DIFF
--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -228,15 +228,18 @@ export function ConversationOverlayRow({
           // it adds no height (INV-21) — toggling the overlay must not move
           // a single message. Purely informational (focus/corrections live
           // in the panel and the rail swatch); fades on row hover to hand
-          // the corner to the message hover toolbar. Desktop-only: on
-          // mobile's dense header line the chip covers the timestamp, and
-          // the rails + panel already carry the grouping there.
+          // the corner to the message hover toolbar. Wide-desktop-only
+          // (≥1120px: the 800px timeline column + the w-64 panel + margins
+          // genuinely fit side by side): below that the top-right panel
+          // overlaps the top rows' chip corner, and on mobile's dense header
+          // line the chip covers the timestamp — in both cases the rails +
+          // panel already carry the grouping.
           <span
             data-testid="conversation-block-chip"
             title={conversation.topicSummary ?? undefined}
             className={cn(
-              "pointer-events-none absolute right-3 top-1.5 z-[5] sm:right-4",
-              "hidden max-w-[40%] items-center gap-1.5 rounded-full border px-2 py-0.5 sm:inline-flex",
+              "pointer-events-none absolute right-4 top-1.5 z-[5]",
+              "hidden max-w-[40%] items-center gap-1.5 rounded-full border px-2 py-0.5 min-[1120px]:inline-flex",
               "bg-background/85 text-[10px] font-medium leading-4 shadow-sm backdrop-blur-sm",
               "transition-opacity group-hover/convrow:opacity-0"
             )}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -478,7 +478,9 @@ export function StreamPage() {
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-8 w-5 rounded-l-none border-l border-border/50 px-0"
+                    // Wider on touch viewports — a 20px chevron is fiddly with
+                    // a finger; desktop keeps the compact split-button look.
+                    className="h-8 w-7 rounded-l-none border-l border-border/50 px-0 sm:w-5"
                     aria-label="Other conversation views"
                   >
                     <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />


### PR DESCRIPTION
Stacked on #856. Closes item 4 of #849.

## Problem

The chevron half of the header split button (`pages/stream.tsx`) was `h-8 w-5` — a 20px-wide touch target, fine for a mouse, fiddly with a finger.

## Change

`h-8 w-7 sm:w-5`: 28px wide below the `sm` breakpoint, unchanged compact 20px on desktop. The primary segment is untouched and the dropdown keeps `align="end"`, so it still right-aligns to the trigger.

## Verification

Playwright run at a 390×844 viewport, both overlay states:
- chevron bounding box ≥ 27px wide with overlay on and off, at the same header y (no layout shift, INV-21 mindset)
- dropdown opens and its right edge stays inside the viewport (right-aligned)
- desktop (1400px) chevron measured back at 20px

Frontend suite 2425 pass / 0 fail; `tsc --noEmit` clean.

https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783805730&installation_id=129946197&pr_number=858&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F858&signature=291f0665b06d50598b312815a878b749f1cf70208e6a95d3105d9bb53e5b764e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->