### PR TITLE
fix(frontend): hide topic chips where the in-view panel overlaps them

### DIFF
--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -228,15 +228,18 @@ export function ConversationOverlayRow({
           // it adds no height (INV-21) — toggling the overlay must not move
           // a single message. Purely informational (focus/corrections live
           // in the panel and the rail swatch); fades on row hover to hand
-          // the corner to the message hover toolbar. Desktop-only: on
-          // mobile's dense header line the chip covers the timestamp, and
-          // the rails + panel already carry the grouping there.
+          // the corner to the message hover toolbar. Wide-desktop-only
+          // (≥1120px: the 800px timeline column + the w-64 panel + margins
+          // genuinely fit side by side): below that the top-right panel
+          // overlaps the top rows' chip corner, and on mobile's dense header
+          // line the chip covers the timestamp — in both cases the rails +
+          // panel already carry the grouping.
           <span
             data-testid="conversation-block-chip"
             title={conversation.topicSummary ?? undefined}
             className={cn(
-              "pointer-events-none absolute right-3 top-1.5 z-[5] sm:right-4",
-              "hidden max-w-[40%] items-center gap-1.5 rounded-full border px-2 py-0.5 sm:inline-flex",
+              "pointer-events-none absolute right-4 top-1.5 z-[5]",
+              "hidden max-w-[40%] items-center gap-1.5 rounded-full border px-2 py-0.5 min-[1120px]:inline-flex",
               "bg-background/85 text-[10px] font-medium leading-4 shadow-sm backdrop-blur-sm",
               "transition-opacity group-hover/convrow:opacity-0"
             )}


### PR DESCRIPTION
Stacked on #858. Closes item 5 of #849. Last PR of the stack — once everything is merged, #849 can be closed.

## Problem

The "Conversations in view" panel anchors top-right of the stream body on desktop; the per-row topic chips sit at the top-right of the centered 800px timeline column. Between ~640–1100px viewport width the panel constantly overlapped the chips of the topmost rows.

## Change

Chips gate at `min-[1120px]:inline-flex` instead of `sm:inline-flex` (column 800px + panel `w-64` + margins). Below that, rails, washes, and the panel carry the grouping — same rationale as the existing mobile behavior; the chip's comment block is updated accordingly. The old `right-3`/`sm:right-4` offset split became dead styling (the chip never renders below `sm` anymore) and collapses to `right-4`.

## Verification

- `tests/browser/conversation-overlay.spec.ts` (asserts chip visibility at the default 1280px viewport, which is above the 1120px gate): **passed**.
- Screenshot run at 900px: chips hidden, panel clean over the column. At 1400px: chips visible.
- Known residual (pre-existing, called out in #849): on wide viewports the chips of the few rows directly beneath the expanded panel can still tuck under it, since the panel floats at a higher z-index — it resolves on scroll/collapse. The 1120px gate removes the constant-overlap band, it doesn't re-anchor the panel.
- Frontend suite 2425 pass / 0 fail; `tsc --noEmit` clean.

https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdLNS7gX8Za142XJruk4x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783805747&installation_id=129946197&pr_number=859&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F859&signature=f6bdae29ec2dbf401904728f3e11435326ee03cf29f4d04ca23b183160dbf795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->