### PR TITLE
feat(public-site): thread spine, night terminals, and closing band

### DIFF
--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -632,7 +632,7 @@ const apiBase = import.meta.env.PUBLIC_API_BASE ?? "https://app.threa.io"
 <!-- ============================================================
      WAITLIST CTA
      ============================================================ -->
-<div class="frame warm" id="waitlist">
+<div class="frame night" id="waitlist">
   <div class="cta-shell">
     <div>
       <h3>Workplace chat that <span class="accent">remembers</span>.<br/>Get on the list.</h3>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -452,6 +452,17 @@ a {
   color: hsl(var(--gold));
   margin: 0 0 12px;
 }
+/* Thread bead — the same diamond node the marketing sections carry. */
+.docs-article .eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 10px;
+  transform: rotate(45deg);
+  background: hsl(var(--gold));
+  vertical-align: 1px;
+}
 .docs-article h1 {
   font-family: var(--font-display);
   font-weight: 300;
@@ -602,6 +613,8 @@ a {
   border-color: hsl(var(--gold));
   color: hsl(var(--gold-dim));
 }
+/* Code goes night — the samples are the substance of these pages, so they
+   carry the contrast. Light header above, dark body, light output below. */
 .pg-pre {
   margin: 0;
   padding: 14px 16px;
@@ -609,9 +622,13 @@ a {
   font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.6;
-  color: hsl(var(--ink));
+  background: hsl(var(--night));
+  color: hsl(38 14% 86%);
   white-space: pre;
   tab-size: 2;
+}
+.pg-pre:last-child {
+  border-radius: 0 0 5px 5px;
 }
 .pg-pre code {
   font-family: inherit;
@@ -630,19 +647,20 @@ a {
   position: relative;
   transition: background 0.15s;
 }
+/* Chip colors tuned for the night code surface: gold lifts instead of dims. */
 .pg-var.is-set {
-  background: hsl(var(--gold) / 0.16);
-  color: hsl(var(--gold-dim));
-  box-shadow: inset 0 -1px 0 hsl(var(--gold) / 0.5);
+  background: hsl(var(--gold) / 0.22);
+  color: hsl(var(--gold-soft));
+  box-shadow: inset 0 -1px 0 hsl(var(--gold) / 0.6);
 }
 .pg-var.is-unset {
-  background: hsl(var(--gold) / 0.06);
-  color: hsl(var(--gold-dim) / 0.85);
-  box-shadow: inset 0 0 0 1px hsl(var(--gold) / 0.35);
+  background: hsl(var(--gold) / 0.1);
+  color: hsl(var(--gold-soft) / 0.9);
+  box-shadow: inset 0 0 0 1px hsl(var(--gold) / 0.45);
   cursor: pointer;
 }
 .pg-var.is-unset:hover {
-  background: hsl(var(--gold) / 0.14);
+  background: hsl(var(--gold) / 0.2);
 }
 /* explain-on-hover tooltip. A single fixed element (positioned in JS) instead
    of a ::after, so it escapes the code block's overflow clipping and can flip

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -51,6 +51,24 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Paper grain — a fixed film of fractal noise over the whole page, multiply
+   so it darkens both the light bands and the night surfaces uniformly. At
+   this opacity it reads as paper tooth, not texture; pointer-events none so
+   it never intercepts anything. */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+  mix-blend-mode: multiply;
+}
+
+::selection {
+  background: hsl(var(--gold) / 0.3);
+}
+
 /* ---------- PAGE FRAME (seamless bands) ----------
      Each section is a full-bleed band that touches its neighbours with no
      gap; the tint alternates paper / paper-warm so the page reads as one
@@ -65,6 +83,61 @@ body {
 }
 .frame.warm {
   background: hsl(var(--paper-warm));
+}
+/* Night band — the closing register. Terminal surfaces and the final CTA
+   share this deep ink so the page ends with weight instead of one more
+   beige strip. */
+.frame.night {
+  background: hsl(var(--night));
+  color: hsl(35 12% 80%);
+}
+
+/* ---------- THREAD SPINE ----------
+   The golden thread, literally: a 1px gold line running down the left
+   margin of every section shell, with a small diamond bead marking each
+   section's start. Shells touch vertically, so per-shell lines read as one
+   continuous thread from the memory section to the closing band. */
+.memo-shell::before,
+.cta-shell::before {
+  content: "";
+  position: absolute;
+  left: calc(var(--pad-x) / 2);
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: hsl(var(--gold) / 0.18);
+  pointer-events: none;
+}
+.memo-shell::after,
+.cta-shell::after {
+  content: "";
+  position: absolute;
+  left: calc(var(--pad-x) / 2);
+  top: 84px;
+  width: 7px;
+  height: 7px;
+  transform: translateX(-3.5px) rotate(45deg);
+  background: hsl(var(--paper));
+  border: 1px solid hsl(var(--gold));
+  pointer-events: none;
+}
+/* The first section fades the thread in; the closing band fades it out. */
+.memo-shell.is-centerpiece::before {
+  background: linear-gradient(180deg, hsl(var(--gold) / 0) 0, hsl(var(--gold) / 0.18) 140px);
+}
+.frame.night .cta-shell::before {
+  background: linear-gradient(180deg, hsl(var(--gold) / 0.3), hsl(var(--gold) / 0) 88%);
+}
+.frame.night .cta-shell::after {
+  background: hsl(var(--night));
+}
+@media (max-width: 880px) {
+  .memo-shell::before,
+  .memo-shell::after,
+  .cta-shell::before,
+  .cta-shell::after {
+    display: none;
+  }
 }
 .section-meta {
   display: flex;
@@ -157,6 +230,11 @@ body {
   content: "→";
   font-family: var(--font-display);
   font-weight: 400;
+  display: inline-block;
+  transition: transform 0.2s ease-out;
+}
+.cta:hover::after {
+  transform: translateX(3px);
 }
 .quiet {
   font-family: var(--font-mono);
@@ -1116,6 +1194,18 @@ body {
   overflow: hidden;
   position: relative;
 }
+/* Warm atmosphere behind the conversation — a soft gold wash so the hero
+   reads as lit paper instead of a flat white field. */
+.hero-shell::before {
+  content: "";
+  position: absolute;
+  top: -160px;
+  right: -180px;
+  width: 760px;
+  height: 760px;
+  background: radial-gradient(closest-side, hsl(var(--gold) / 0.09), transparent 72%);
+  pointer-events: none;
+}
 .hero-inner {
   padding: 64px var(--pad-x) 72px;
   position: relative;
@@ -1599,40 +1689,44 @@ body {
   max-width: 320px;
 }
 
+/* Terminal goes night — the one deep-ink surface in each band, so the
+   dev-credible artifacts (real commands, real output) carry the contrast
+   instead of another gray box. Prompt stays gold: the thread in the dark. */
 .os-terminal {
-  background: hsl(var(--paper-warm));
-  border: 1px solid hsl(var(--line));
+  background: hsl(var(--night));
+  border: 1px solid hsl(222 16% 18%);
   border-radius: 6px;
   padding: 18px 22px;
   font-family: var(--font-mono);
   font-size: 12.5px;
   line-height: 1.8;
-  color: hsl(var(--ink-soft));
+  color: hsl(35 12% 72%);
   margin-top: 4px;
   overflow-x: auto;
+  box-shadow: 0 16px 44px -24px hsl(222 30% 8% / 0.6);
 }
 .os-terminal .row {
   display: block;
   white-space: pre;
 }
 .os-terminal .prompt {
-  color: hsl(var(--gold));
+  color: hsl(var(--gold-soft));
   margin-right: 10px;
   user-select: none;
 }
 .os-terminal .cmd {
-  color: hsl(var(--ink));
+  color: hsl(38 18% 92%);
 }
 .os-terminal .arg {
-  color: hsl(var(--ink-soft));
+  color: hsl(35 12% 70%);
 }
 .os-terminal .out {
-  color: hsl(var(--muted));
+  color: hsl(35 8% 52%);
   padding-left: 20px;
   display: block;
 }
 .os-terminal .cmt {
-  color: hsl(var(--muted));
+  color: hsl(35 8% 50%);
   font-style: italic;
   padding-left: 4px;
 }
@@ -1689,24 +1783,26 @@ body {
 .patch-example .patch-body .md-li {
   color: hsl(var(--ink-soft));
 }
+/* The run line is a terminal, so it gets the night strip — the file above
+   stays paper (it's a document), the command below goes dark (it's a shell). */
 .patch-example .patch-run {
   padding: 11px 14px 13px;
-  border-top: 1px dashed hsl(var(--line));
+  background: hsl(var(--night));
   font-family: var(--font-mono);
   font-size: 12px;
-  color: hsl(var(--ink-soft));
+  color: hsl(35 12% 70%);
   white-space: pre;
   overflow-x: auto;
 }
 .patch-example .patch-run .prompt {
-  color: hsl(var(--gold));
+  color: hsl(var(--gold-soft));
   margin-right: 10px;
 }
 .patch-example .patch-run .cmd {
-  color: hsl(var(--ink));
+  color: hsl(38 18% 92%);
 }
 .patch-example .patch-run .arg {
-  color: hsl(var(--muted));
+  color: hsl(35 10% 60%);
 }
 
 .os-cta {
@@ -1822,6 +1918,7 @@ body {
   max-width: 1240px;
   margin: 0 auto;
   padding: 80px var(--pad-x);
+  position: relative;
   display: grid;
   grid-template-columns: 1.1fr 0.9fr;
   gap: 48px;
@@ -1861,6 +1958,38 @@ body {
 .cta-shell .quiet {
   margin-top: 12px;
   display: block;
+}
+/* Night variant — the closing band. Gold becomes the button color (ink-on-ink
+   would vanish), the input sinks into the dark, the accent word stays gold. */
+.frame.night .cta-shell h3 {
+  color: hsl(38 16% 94%);
+}
+.frame.night .cta-shell h3 .accent {
+  color: hsl(var(--gold-soft));
+}
+.frame.night .cta {
+  background: hsl(var(--gold));
+  color: hsl(var(--night));
+}
+.frame.night .cta-shell input {
+  background: hsl(var(--night-soft));
+  border-color: hsl(222 14% 24%);
+  color: hsl(38 16% 92%);
+}
+.frame.night .cta-shell input::placeholder {
+  color: hsl(222 10% 46%);
+}
+.frame.night .cta-shell input:focus {
+  border-color: hsl(var(--gold) / 0.6);
+}
+.frame.night .quiet {
+  color: hsl(222 10% 52%);
+}
+.frame.night #wl-status.is-ok {
+  color: hsl(142 50% 56%);
+}
+.frame.night #wl-status.is-err {
+  color: hsl(0 60% 62%);
 }
 /* Honeypot — kept in the layout for bots but pulled off-screen for humans and
    assistive tech (aria-hidden on the element). */


### PR DESCRIPTION
## Problem

The marketing site and developer docs are competently laid out but visually flat. Everything sits on near-identical near-white bands, the gold accent only appears as heading tints, code/terminal surfaces are gray placeholder boxes, and the page trails off into one more beige strip. The golden thread — literally the brand (Ariadne) — appears exactly once, in the hero animation, then vanishes.

## Solution

Use the existing design language (warm paper, gold, Space Grotesk + JetBrains Mono) with more conviction instead of adding anything foreign. Pure CSS plus one class swap; no layout, typography, or copy changes.

### Key design decisions

**1. The golden thread as page structure**

A 1px gold line runs down the left margin of every section shell with a small gold diamond bead at each section start. It fades in at the first section and fades out into the closing band. Per-shell pseudo-elements align across touching bands, so it reads as one continuous thread. The about page inherits it automatically. Hidden below 880px.

**2. Terminal and code surfaces go night**

The homepage clone-and-run terminal, the `patch.md` run strip, and all docs code blocks render on deep ink (`--night`) with gold prompts and warm-white commands. The `patch.md` figure body stays paper (it's a document); only the shell line goes dark. In the docs, the live variable chips are retuned so gold lifts off the dark surface instead of dimming into it.

**3. Dark closing band**

The waitlist CTA becomes a night band with a gold button, so the page ends with weight. Input, placeholder, status, and quiet text get dark-surface variants.

**4. Atmosphere**

A barely-there fixed fractal-noise grain over the whole site (multiply blend, reads as paper tooth), a soft gold radial wash behind the hero, gold text selection, a CTA arrow hover nudge, and matching diamond beads on docs page eyebrows.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/public-site/src/styles/global.css` | Grain, selection, hero glow, thread spine + beads, night terminal/patch-run/waitlist-band styles, CTA hover |
| `apps/public-site/src/styles/docs.css` | Code blocks go night, variable chips retuned for dark surface, eyebrow bead |
| `apps/public-site/src/pages/index.astro` | Waitlist band `frame warm` → `frame night` |

## Test plan

- [x] `astro check` clean (0 errors/warnings/hints)
- [x] Verified in browser at 1440px: homepage (full scroll), open-source band, waitlist band, about page, developers overview
- [x] Verified at 390px: spine hidden, no horizontal overflow, night bands render cleanly
- [x] Docs variable chips legible in both set/unset states on dark blocks

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783806640&installation_id=129946197&pr_number=860&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F860&signature=b93e3ad0ea67eb80dc524a51b0acb1e93ad1433f86a0df997c8629a7fe4e3b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->