### PR TITLE
feat(public-site): world-class developer docs — highlighting, examples, two-column reference

### DIFF
--- a/apps/public-site/package.json
+++ b/apps/public-site/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
     "@types/turndown": "^5.0.6",
+    "shiki": "^3.21.0",
     "turndown": "^7.2.4",
     "typescript": "^5.9.3"
   }

--- a/apps/public-site/scripts/build-llms.ts
+++ b/apps/public-site/scripts/build-llms.ts
@@ -259,11 +259,12 @@ function rewriteLinks(markdown: string): string {
 
 function pageToMarkdown(page: Page): string {
   const html = readFileSync(dist(page.html), "utf8")
-  // The wrapper comes from DocsLayout.astro's <article class="docs-article">;
-  // this extraction is what breaks if that layout renames or re-nests it.
-  const article = html.match(/<article class="docs-article">([\s\S]*?)<\/article>/)?.[1]
+  // The wrapper comes from DocsLayout.astro's <article class="docs-article">
+  // (plus variant classes like is-wide); this extraction is what breaks if
+  // that layout renames or re-nests it.
+  const article = html.match(/<article class="docs-article[^"]*">([\s\S]*?)<\/article>/)?.[1]
   if (!article) {
-    throw new Error(`No <article class="docs-article"> in ${page.html} — did DocsLayout.astro change its wrapper?`)
+    throw new Error(`No <article class="docs-article…"> in ${page.html} — did DocsLayout.astro change its wrapper?`)
   }
 
   let md = createConverter().turndown(article)

--- a/apps/public-site/src/components/ApiEndpoint.astro
+++ b/apps/public-site/src/components/ApiEndpoint.astro
@@ -11,6 +11,7 @@ import {
   buildSchemaTree,
   jsonSchemaOf,
   exampleBody,
+  exampleResponse,
   typeLabel,
   constraintNote,
   type JsonSchema,
@@ -49,8 +50,10 @@ interface Props {
   anchor: string
   op: Operation
   run?: RunConfig
+  /** Entity noun for synthesized ids in the example response (e.g. "stream"). */
+  hint?: string
 }
-const { method, path, anchor, op, run } = Astro.props
+const { method, path, anchor, op, run, hint = "" } = Astro.props
 const verb = method.toUpperCase()
 
 // Required scopes come straight from the spec's per-operation security. An empty
@@ -126,6 +129,11 @@ if (method === "get") {
     curl += ` \\\n  -H "Content-Type: application/json" \\\n  -d '${exampleBodyStr}'`
   }
 }
+
+// Synthesized example response (the schema beside it stays the contract).
+const responseExample = successSchema?.properties
+  ? JSON.stringify(exampleResponse(successSchema, hint), null, 2)
+  : null
 ---
 
 <section class="api-op" id={anchor}>
@@ -134,52 +142,59 @@ if (method === "get") {
     <code class="api-path">{path}</code>
   </div>
   {op.summary && <h3 class="api-op-title">{op.summary}</h3>}
-  {op.description && <p class="api-op-desc">{op.description}</p>}
 
-  <p class="api-scopes">
-    <span class="api-scopes-label">Scope</span>
-    {scopes.length > 0 ? (
-      scopes.map((s) => <code class="api-scope">{s}</code>)
-    ) : (
-      <span class="api-scope-none">none — any valid key</span>
-    )}
-  </p>
+  <div class="api-op-cols">
+    <div class="api-op-main">
+      {op.description && <p class="api-op-desc">{op.description}</p>}
 
-  {pathParams.length > 0 && (
-    <>
-      <h4 class="api-sub">Path parameters</h4>
-      <SchemaTable nodes={pathParams.map(paramNode)} />
-    </>
-  )}
+      <p class="api-scopes">
+        <span class="api-scopes-label">Scope</span>
+        {scopes.length > 0 ? (
+          scopes.map((s) => <code class="api-scope">{s}</code>)
+        ) : (
+          <span class="api-scope-none">none — any valid key</span>
+        )}
+      </p>
 
-  {queryParams.length > 0 && (
-    <>
-      <h4 class="api-sub">Query parameters</h4>
-      <SchemaTable nodes={queryParams.map(paramNode)} />
-    </>
-  )}
+      {pathParams.length > 0 && (
+        <>
+          <h4 class="api-sub">Path parameters</h4>
+          <SchemaTable nodes={pathParams.map(paramNode)} />
+        </>
+      )}
 
-  {bodyNodes.length > 0 && (
-    <>
-      <h4 class="api-sub">Request body</h4>
-      <SchemaTable nodes={bodyNodes} />
-    </>
-  )}
+      {queryParams.length > 0 && (
+        <>
+          <h4 class="api-sub">Query parameters</h4>
+          <SchemaTable nodes={queryParams.map(paramNode)} />
+        </>
+      )}
 
-  <h4 class="api-sub">Example</h4>
-  <CodeBlock lang="bash" label={`${verb} ${path.replace("/api/v1/workspaces/{workspaceId}", "")}`} code={curl} run={run} />
+      {bodyNodes.length > 0 && (
+        <>
+          <h4 class="api-sub">Request body</h4>
+          <SchemaTable nodes={bodyNodes} />
+        </>
+      )}
 
-  {successNodes.length > 0 && (
-    <>
-      <h4 class="api-sub">Response {successCode}</h4>
-      <SchemaTable nodes={successNodes} />
-    </>
-  )}
+      {successNodes.length > 0 && (
+        <>
+          <h4 class="api-sub">Response {successCode}</h4>
+          <SchemaTable nodes={successNodes} />
+        </>
+      )}
 
-  <h4 class="api-sub">Status codes</h4>
-  <ul class="api-status">
-    {responseEntries.map(([code, r]) => (
-      <li><code>{code}</code> {r.description}</li>
-    ))}
-  </ul>
+      <h4 class="api-sub">Status codes</h4>
+      <ul class="api-status">
+        {responseEntries.map(([code, r]) => (
+          <li><code>{code}</code> {r.description}</li>
+        ))}
+      </ul>
+    </div>
+
+    <aside class="api-op-side">
+      <CodeBlock lang="bash" label={`${verb} ${path.replace("/api/v1/workspaces/{workspaceId}", "")}`} code={curl} run={run} />
+      {responseExample && <CodeBlock lang="json" label={`Response ${successCode} · example`} code={responseExample} />}
+    </aside>
+  </div>
 </section>

--- a/apps/public-site/src/components/BaseHead.astro
+++ b/apps/public-site/src/components/BaseHead.astro
@@ -11,6 +11,10 @@ const { title, description } = Astro.props
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="description" content={description} />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<!-- Agent entry points: a markdown index of the developer docs and the full
+     API contract, discoverable from every page (robots.txt names them too). -->
+<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt — markdown index of the developer docs" />
+<link rel="alternate" type="application/json" href="/openapi.json" title="OpenAPI 3.1 contract for the Threa API" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/apps/public-site/src/components/CodeBlock.astro
+++ b/apps/public-site/src/components/CodeBlock.astro
@@ -6,6 +6,8 @@
  * provided, a Run button fires the call against the reader's base URL and
  * prints the response under the block.
  */
+import { highlightCode, type CodeLang } from "../lib/highlight"
+
 interface RunConfig {
   method: string
   path: string
@@ -14,32 +16,15 @@ interface RunConfig {
 }
 interface Props {
   code: string
-  lang?: string
+  lang?: CodeLang
   label?: string
   run?: RunConfig
 }
 const { code, lang = "bash", label, run } = Astro.props
 
-const TOKEN_RE = /\{\{(baseUrl|workspaceId|apiKey)\}\}/g
-
-function escapeHtml(s: string): string {
-  return s
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-}
-
-// Turn the raw template into HTML: escaped literal segments with token chips
-// spliced in. The chips are filled by the playground runtime at load.
-let html = ""
-let last = 0
-let m: RegExpExecArray | null
-while ((m = TOKEN_RE.exec(code)) !== null) {
-  html += escapeHtml(code.slice(last, m.index))
-  html += `<span class="pg-var is-unset" data-var="${m[1]}"></span>`
-  last = m.index + m[0].length
-}
-html += escapeHtml(code.slice(last))
+// Build-time Shiki pass: colored token spans with the {{var}} chips spliced
+// in. The chips are filled by the playground runtime at load, same as before.
+const html = await highlightCode(code, lang)
 ---
 
 <div class="pg-block">

--- a/apps/public-site/src/layouts/DocsLayout.astro
+++ b/apps/public-site/src/layouts/DocsLayout.astro
@@ -9,12 +9,15 @@ interface Props {
   description?: string
   current?: string
   sections?: { id: string; label: string; group?: string }[]
+  /** Full-width article (the API reference's two-column endpoint layout). */
+  wide?: boolean
 }
 const {
   title = "Threa Developers",
   description = "Build on Threa: a public REST API over your workspace covering messages, streams, memos, search, and a bot runtime for connecting your own agent.",
   current = "",
   sections = [],
+  wide = false,
 } = Astro.props
 
 const nav = [
@@ -95,6 +98,7 @@ for (const s of sections) {
           <a href="/developers/reference">Reference</a>
           <a href="/developers/recipes">Recipes</a>
           <a href="/openapi.json">OpenAPI</a>
+          <a href="/llms.txt">llms.txt</a>
           <a class="home" href="/">↩ threa.io</a>
         </nav>
         <button type="button" class="pg-toggle" id="pg-toggle" aria-expanded="false" aria-controls="pg-panel">
@@ -196,7 +200,7 @@ for (const s of sections) {
       </aside>
 
       <main class="docs-main">
-        <article class="docs-article">
+        <article class={`docs-article${wide ? " is-wide" : ""}`}>
           <slot />
         </article>
 
@@ -209,6 +213,8 @@ for (const s of sections) {
                 &nbsp;·&nbsp;
               </>
             )}
+            <a href="/llms.txt">llms.txt</a>
+            &nbsp;·&nbsp;
             <a href="/developers/feature-requests">Request a feature</a>
             &nbsp;·&nbsp;
             <a href="/">threa.io</a>

--- a/apps/public-site/src/lib/highlight.ts
+++ b/apps/public-site/src/lib/highlight.ts
@@ -1,0 +1,123 @@
+/*
+ * Build-time syntax highlighting for docs code samples.
+ *
+ * Wraps Shiki with a custom theme on the site's palette — warm charcoal
+ * surface, gold for keywords and JSON keys (the thread in the dark),
+ * parchment strings, muted comments. The highlighter is a module singleton so
+ * the ~26 blocks on the reference page share one instance per build.
+ *
+ * The {{baseUrl}} / {{workspaceId}} / {{apiKey}} playground tokens must
+ * survive tokenization as single units (the grammar would otherwise split the
+ * braces from the name). highlight() swaps them for identifier-shaped
+ * sentinels before tokenizing and swaps chip markup back in afterwards; the
+ * chips are then hydrated client-side by scripts/playground.ts, same as before.
+ */
+
+import { createHighlighter, type BundledLanguage, type Highlighter, type ThemeRegistration } from "shiki"
+
+export type CodeLang = "bash" | "ts" | "json" | "text"
+
+const SHIKI_LANG: Record<Exclude<CodeLang, "text">, BundledLanguage> = {
+  bash: "bash",
+  ts: "typescript",
+  json: "json",
+}
+
+/* Warm-dark theme derived from the site tokens (see styles/global.css :root).
+   Background is owned by CSS (--code surface); only token colors live here. */
+const threaDusk: ThemeRegistration = {
+  name: "threa-dusk",
+  type: "dark",
+  colors: {
+    "editor.background": "#201a13",
+    "editor.foreground": "#e6ded2",
+  },
+  settings: [
+    { settings: { foreground: "#e6ded2" } },
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#8c8273", fontStyle: "italic" },
+    },
+    {
+      scope: ["string", "string.template", "punctuation.definition.string"],
+      settings: { foreground: "#c8b080" },
+    },
+    {
+      scope: ["constant.numeric", "constant.language", "constant.other"],
+      settings: { foreground: "#dfa567" },
+    },
+    {
+      scope: ["keyword", "storage.type", "storage.modifier", "keyword.control"],
+      settings: { foreground: "#e2a554" },
+    },
+    {
+      scope: ["keyword.operator"],
+      settings: { foreground: "#c9bca8" },
+    },
+    {
+      scope: ["entity.name.function", "support.function", "meta.function-call.generic"],
+      settings: { foreground: "#efe6d4" },
+    },
+    {
+      scope: ["variable", "variable.other", "variable.parameter"],
+      settings: { foreground: "#e6ded2" },
+    },
+    {
+      // JSON keys — gold, so payload shape pops the way the brand does.
+      scope: ["support.type.property-name", "meta.object-literal.key"],
+      settings: { foreground: "#e2a554" },
+    },
+    {
+      scope: ["punctuation", "meta.brace"],
+      settings: { foreground: "#a1968a" },
+    },
+  ],
+}
+
+const VAR_NAMES = ["baseUrl", "workspaceId", "apiKey"] as const
+const sentinel = (name: string) => `__PGVAR_${name}__`
+
+let highlighterPromise: Promise<Highlighter> | null = null
+function getHighlighter(): Promise<Highlighter> {
+  highlighterPromise ??= createHighlighter({
+    themes: [threaDusk],
+    langs: Object.values(SHIKI_LANG),
+  })
+  return highlighterPromise
+}
+
+function escapeHtml(s: string): string {
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}
+
+/* Highlight a code template into inner-<code> HTML: colored spans per token,
+   with each {{var}} replaced by an (empty) chip span the playground fills. */
+export async function highlightCode(code: string, lang: CodeLang): Promise<string> {
+  let prepared = code
+  for (const name of VAR_NAMES) {
+    prepared = prepared.replaceAll(`{{${name}}}`, sentinel(name))
+  }
+
+  // Plain text (e.g. the agent prompt block): no grammar, just escape + chips.
+  if (lang === "text") {
+    return escapeHtml(prepared).replace(/__PGVAR_(baseUrl|workspaceId|apiKey)__/g, (_, name: string) => {
+      return `<span class="pg-var is-unset" data-var="${name}"></span>`
+    })
+  }
+
+  const hl = await getHighlighter()
+  const { tokens } = hl.codeToTokens(prepared, {
+    lang: SHIKI_LANG[lang],
+    theme: "threa-dusk",
+  })
+
+  const html = tokens
+    .map((line) =>
+      line.map((t) => `<span style="color:${t.color ?? "#e6ded2"}">${escapeHtml(t.content)}</span>`).join("")
+    )
+    .join("\n")
+
+  return html.replace(/__PGVAR_(baseUrl|workspaceId|apiKey)__/g, (_, name: string) => {
+    return `<span class="pg-var is-unset" data-var="${name}"></span>`
+  })
+}

--- a/apps/public-site/src/lib/openapi.ts
+++ b/apps/public-site/src/lib/openapi.ts
@@ -138,3 +138,114 @@ export function exampleBody(schema: JsonSchema | undefined): Record<string, unkn
   }
   return out
 }
+
+/* ---------- Example responses ----------
+   The spec carries no example values, so the reference synthesizes realistic
+   ones from field names: prefixed-ULID ids, ISO timestamps, and content drawn
+   from the same auth-refactor story the marketing pages tell. Illustrative,
+   not contractual — the schema tables beside them stay the contract. */
+
+const ULID = "01jd2q4z8kxw9v7r3m5t8n"
+
+function prefixedId(noun: string): string {
+  const n = noun.toLowerCase()
+  if (n.includes("stream") || n.includes("channel")) return `stream_${ULID}`
+  if (n.includes("message")) return `msg_${ULID}`
+  if (n.includes("memo")) return `memo_${ULID}`
+  if (n.includes("user") || n.includes("author") || n.includes("member") || n.includes("owner")) return `usr_${ULID}`
+  if (n.includes("workspace")) return `ws_${ULID}`
+  if (n.includes("attachment") || n.includes("file")) return `attach_${ULID}`
+  if (n.includes("invocation")) return `inv_${ULID}`
+  if (n.includes("bot")) return `bot_${ULID}`
+  return `${n || "id"}_${ULID}`
+}
+
+function exampleString(name: string, schema: JsonSchema, hint: string): string {
+  if (schema.enum && schema.enum.length) return String(schema.enum[0])
+  if (schema.format === "date-time") return "2026-03-12T11:42:00.000Z"
+  const n = name.toLowerCase()
+  if (n === "id") return prefixedId(hint)
+  if (n.endsWith("id")) {
+    if (n.startsWith("client")) return "ci-deploy-2.4.1"
+    if (n.startsWith("instance")) return "my-laptop-1"
+    // sourceMessageId / parentStreamId / rootStreamId → the bare entity noun.
+    return prefixedId(n.slice(0, -2).replace(/^(source|parent|root)/, ""))
+  }
+  if (n.includes("email")) return "maya@acme.dev"
+  if (n.includes("slug")) return "api-v3"
+  if (n.includes("displayname") || n === "name") {
+    if (n.includes("author") || n.includes("user") || hint.includes("user") || hint.includes("bot")) {
+      return "Maya Reyes"
+    }
+    return "api-v3"
+  }
+  if (n.includes("sequence")) return "412"
+  if (n.includes("title")) return "Auth refactor held pending token-rotation review"
+  if (n.includes("abstract") || n.includes("summary") || n.includes("description")) {
+    return "Jordan asked to pause the v3 auth boundary until the rotation flow is reviewed."
+  }
+  if (n.includes("content") || n.includes("markdown") || n.includes("prompt") || n.includes("text")) {
+    return "Picking the auth refactor back up next sprint."
+  }
+  if (n.includes("query")) return "auth refactor"
+  if (n.includes("url")) return "https://files.threa.io/attachments/rotation-flow.png"
+  if (n.includes("token")) return "clm_7f3kq9w2…"
+  if (n.includes("filename")) return "rotation-flow.png"
+  if (n.includes("mime")) return "image/png"
+  if (n.includes("tag")) return "api-v3"
+  if (n.includes("knowledgetype")) return "decision"
+  if (n.includes("role")) return "member"
+  if (n.includes("kind")) return "user"
+  if (n.includes("visibility")) return "open"
+  if (n.includes("status") || n.includes("state")) return "available"
+  return "…"
+}
+
+function exampleNumber(name: string): number {
+  const n = name.toLowerCase()
+  if (n.includes("limit")) return 20
+  if (n.includes("count") || n.includes("total")) return 2
+  if (n.includes("sequence")) return 412
+  if (n.includes("size") || n.includes("bytes")) return 48213
+  if (n.includes("score") || n.includes("similarity")) return 0.87
+  if (n.includes("ttl") || n.includes("seconds")) return 120
+  if (n.includes("ms") || n.includes("duration")) return 1240
+  return 1
+}
+
+function exampleResponseValue(name: string, schema: JsonSchema, hint: string, depth: number): unknown {
+  const variants = schema.anyOf ?? schema.oneOf
+  if (variants && variants.length) {
+    // Nullable cursors read most naturally as their resting state.
+    if (name.toLowerCase().includes("cursor")) return null
+    const nonNull = variants.find((v) => v.type !== "null") ?? variants[0]
+    return exampleResponseValue(name, nonNull, hint, depth)
+  }
+  switch (schema.type) {
+    case "string":
+      return exampleString(name, schema, hint)
+    case "integer":
+    case "number":
+      return exampleNumber(name)
+    case "boolean":
+      return schema.default !== undefined ? schema.default : name.toLowerCase() === "hasmore" ? false : true
+    case "array":
+      return schema.items ? [exampleResponseValue(name, schema.items, hint, depth)] : []
+    case "object":
+      return exampleResponse(schema, hint, depth + 1)
+    default:
+      return null
+  }
+}
+
+/* A full example object for a response schema: every property, arrays as one
+   item, nested objects to a sane depth. `hint` names the entity (from the
+   endpoint path) so bare `id` fields get the right prefix. */
+export function exampleResponse(schema: JsonSchema | undefined, hint = "", depth = 0): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (!schema?.properties || depth > 4) return out
+  for (const [name, prop] of Object.entries(schema.properties)) {
+    out[name] = exampleResponseValue(name, prop, hint, depth)
+  }
+  return out
+}

--- a/apps/public-site/src/lib/openapi.ts
+++ b/apps/public-site/src/lib/openapi.ts
@@ -228,7 +228,8 @@ function exampleResponseValue(name: string, schema: JsonSchema, hint: string, de
     case "number":
       return exampleNumber(name)
     case "boolean":
-      return schema.default !== undefined ? schema.default : name.toLowerCase() === "hasmore" ? false : true
+      if (schema.default !== undefined) return schema.default
+      return name.toLowerCase() !== "hasmore"
     case "array":
       return schema.items ? [exampleResponseValue(name, schema.items, hint, depth)] : []
     case "object":

--- a/apps/public-site/src/pages/developers/reference.astro
+++ b/apps/public-site/src/pages/developers/reference.astro
@@ -14,6 +14,10 @@ const specPath = fileURLToPath(new URL("../../../../../docs/public-api/openapi.j
 const spec = JSON.parse(readFileSync(specPath, "utf8"))
 
 const WORKSPACE_PREFIX = "/api/v1/workspaces/{workspaceId}"
+// Run configs use the playground's {{token}} form, NOT the spec's single-brace
+// {workspaceId}: the playground only substitutes {{…}}, so a single-brace path
+// would fire a literal "/workspaces/{workspaceId}/…" request.
+const RUN_PREFIX = "/api/v1/workspaces/{{workspaceId}}"
 
 // Tag order and descriptions. The spec declares only the first five; the bot and
 // identity tags are described here so the reference reads in a sensible order.
@@ -45,23 +49,23 @@ const TAG_DESC: Record<string, string> = {
 // id). Everything else shows a copyable curl without a Run button, so the docs
 // never fire a state-changing call.
 const RUNS: Record<string, { method: string; path: string; body?: string }> = {
-  getMe: { method: "GET", path: `{{baseUrl}}${WORKSPACE_PREFIX}/me` },
-  listMyBots: { method: "GET", path: `{{baseUrl}}${WORKSPACE_PREFIX}/me/bots` },
-  listStreams: { method: "GET", path: `{{baseUrl}}${WORKSPACE_PREFIX}/streams?type=channel&limit=20` },
-  listUsers: { method: "GET", path: `{{baseUrl}}${WORKSPACE_PREFIX}/users?limit=20` },
+  getMe: { method: "GET", path: `{{baseUrl}}${RUN_PREFIX}/me` },
+  listMyBots: { method: "GET", path: `{{baseUrl}}${RUN_PREFIX}/me/bots` },
+  listStreams: { method: "GET", path: `{{baseUrl}}${RUN_PREFIX}/streams?type=channel&limit=20` },
+  listUsers: { method: "GET", path: `{{baseUrl}}${RUN_PREFIX}/users?limit=20` },
   searchMessages: {
     method: "POST",
-    path: `{{baseUrl}}${WORKSPACE_PREFIX}/messages/search`,
+    path: `{{baseUrl}}${RUN_PREFIX}/messages/search`,
     body: JSON.stringify({ query: "auth", semantic: true, exact: false, limit: 5 }),
   },
   searchMemos: {
     method: "POST",
-    path: `{{baseUrl}}${WORKSPACE_PREFIX}/memos/search`,
+    path: `{{baseUrl}}${RUN_PREFIX}/memos/search`,
     body: JSON.stringify({ query: "auth", limit: 5 }),
   },
   searchAttachments: {
     method: "POST",
-    path: `{{baseUrl}}${WORKSPACE_PREFIX}/attachments/search`,
+    path: `{{baseUrl}}${RUN_PREFIX}/attachments/search`,
     body: JSON.stringify({ query: "auth", limit: 5 }),
   },
 }
@@ -92,6 +96,33 @@ const groups = TAG_ORDER.map((tag) => ({
   ops: ops.filter((o) => o.tag === tag),
 })).filter((g) => g.ops.length > 0)
 
+// Worked examples that use each group's endpoints. The reference describes
+// the wire; the recipe shows the task — link them so a reader who lands on
+// an endpoint finds the "how would I actually use this" path immediately.
+const TAG_RECIPES: Record<string, { href: string; label: string }[]> = {
+  Streams: [{ href: "/developers/recipes#ci-notify", label: "Notify a stream from CI" }],
+  Messages: [
+    { href: "/developers/recipes#ci-notify", label: "Notify a stream from CI" },
+    { href: "/developers/recipes#mirror-search", label: "Mirror a search into your own tool" },
+  ],
+  Memos: [{ href: "/developers/recipes#decisions", label: "Find out what was decided, and why" }],
+  "Bot runtimes": [{ href: "/developers/recipes#local-agent", label: "Connect your local agent" }],
+  "Bot invocations": [{ href: "/developers/recipes#local-agent", label: "Connect your local agent" }],
+}
+
+// Entity noun per tag, used to synthesize correctly-prefixed ids in example
+// responses (a bare `id` under Streams renders as stream_…).
+const TAG_HINT: Record<string, string> = {
+  Identity: "user",
+  Streams: "stream",
+  Messages: "message",
+  Memos: "memo",
+  Attachments: "attachment",
+  Users: "user",
+  "Bot runtimes": "bot",
+  "Bot invocations": "invocation",
+}
+
 const shortPath = (p: string) => p.replace(WORKSPACE_PREFIX, "") || "/"
 const sections = groups.flatMap((g) =>
   g.ops.map((o) => ({
@@ -102,7 +133,7 @@ const sections = groups.flatMap((g) =>
 )
 ---
 
-<DocsLayout title="API reference · Threa Developers" current="reference" sections={sections}>
+<DocsLayout title="API reference · Threa Developers" current="reference" sections={sections} wide>
   <p class="eyebrow">Reference</p>
   <h1>API <span class="accent">reference</span>.</h1>
   <p class="lead">
@@ -122,6 +153,14 @@ const sections = groups.flatMap((g) =>
     <section class="api-group">
       <h2 id={g.slug}>{g.tag}</h2>
       {g.desc && <p class="api-group-desc">{g.desc}</p>}
+      {TAG_RECIPES[g.tag] && (
+        <p class="api-recipes">
+          <span class="api-recipes-label">Recipes</span>
+          {TAG_RECIPES[g.tag].map((r) => (
+            <a href={r.href}>{r.label} →</a>
+          ))}
+        </p>
+      )}
       {g.ops.map((o) => (
         <ApiEndpoint
           method={o.method}
@@ -129,6 +168,7 @@ const sections = groups.flatMap((g) =>
           anchor={o.anchor}
           op={o.op}
           run={o.op.operationId ? RUNS[o.op.operationId] : undefined}
+          hint={TAG_HINT[g.tag]}
         />
       ))}
     </section>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -947,10 +947,83 @@ a {
 }
 
 /* ---------- API REFERENCE (hand-rendered from the spec) ---------- */
+/* The reference runs full width: each operation is a two-column band — the
+   contract (params, body, response shape) on the left, the wire (example
+   request + example response) sticky on the right. Lead prose stays at
+   reading width. */
+.docs-article.is-wide {
+  max-width: none;
+}
+.docs-article.is-wide > p {
+  max-width: 760px;
+}
+.api-op-cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 440px);
+  gap: 36px;
+  align-items: start;
+  margin-top: 6px;
+}
+.api-op-main {
+  min-width: 0;
+}
+.api-op-side {
+  min-width: 0;
+  position: sticky;
+  top: 64px;
+}
+.api-op-side .pg-block {
+  margin: 0 0 14px;
+}
+/* The side column is narrow; wrap long request lines instead of clipping
+   them behind a scrollbar (copy still uses the raw template, so display
+   wrapping is safe), and cap very long response examples. */
+.api-op-side .pg-pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 520px;
+  overflow-y: auto;
+}
+@media (max-width: 1120px) {
+  .api-op-cols {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .api-op-side {
+    position: static;
+  }
+}
+
 .api-group-desc {
   color: hsl(var(--muted));
   margin: -4px 0 10px;
   font-size: 14px;
+}
+/* Recipe links under a group heading — the task-shaped path into the group. */
+.api-recipes {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 7px 16px;
+  margin: 0 0 8px;
+}
+.api-recipes-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: hsl(var(--muted));
+}
+.api-recipes a {
+  font-size: 13.5px;
+  color: hsl(var(--gold-dim));
+  text-decoration: none;
+  border-bottom: 1px solid hsl(var(--gold) / 0.35);
+  padding-bottom: 1px;
+}
+.api-recipes a:hover {
+  border-bottom-color: hsl(var(--gold));
+  color: hsl(var(--gold));
 }
 .api-op {
   scroll-margin-top: 64px;

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -18,8 +18,11 @@
   --paper-sunk: 40 14% 93%; /* page canvas, just below cards */
   --ink: 30 10% 12%; /* === app --foreground */
   --ink-soft: 30 9% 26%;
-  --night: 222 25% 8%;
-  --night-soft: 222 18% 14%;
+  /* Warm dark — the night surfaces share the page's hue family (espresso
+     ink, not blue-black) so terminals and the closing band sit IN the warm
+     paper world instead of beside it. */
+  --night: 26 16% 10%;
+  --night-soft: 26 12% 16%;
   --line: 35 15% 88%; /* === app --border */
   --muted: 30 8% 45%; /* === app --muted-foreground */
   --emerald: 142 64% 38%;
@@ -1694,7 +1697,7 @@ body::after {
    instead of another gray box. Prompt stays gold: the thread in the dark. */
 .os-terminal {
   background: hsl(var(--night));
-  border: 1px solid hsl(222 16% 18%);
+  border: 1px solid hsl(26 12% 20%);
   border-radius: 6px;
   padding: 18px 22px;
   font-family: var(--font-mono);
@@ -1703,7 +1706,7 @@ body::after {
   color: hsl(35 12% 72%);
   margin-top: 4px;
   overflow-x: auto;
-  box-shadow: 0 16px 44px -24px hsl(222 30% 8% / 0.6);
+  box-shadow: 0 16px 44px -24px hsl(26 30% 6% / 0.55);
 }
 .os-terminal .row {
   display: block;
@@ -1973,17 +1976,17 @@ body::after {
 }
 .frame.night .cta-shell input {
   background: hsl(var(--night-soft));
-  border-color: hsl(222 14% 24%);
+  border-color: hsl(26 10% 24%);
   color: hsl(38 16% 92%);
 }
 .frame.night .cta-shell input::placeholder {
-  color: hsl(222 10% 46%);
+  color: hsl(28 8% 48%);
 }
 .frame.night .cta-shell input:focus {
   border-color: hsl(var(--gold) / 0.6);
 }
 .frame.night .quiet {
-  color: hsl(222 10% 52%);
+  color: hsl(28 7% 52%);
 }
 .frame.night #wl-status.is-ok {
   color: hsl(142 50% 56%);

--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
         "@types/turndown": "^5.0.6",
+        "shiki": "^3.21.0",
         "turndown": "^7.2.4",
         "typescript": "^5.9.3",
       },


### PR DESCRIPTION
## Problem

The developer docs were functional but flat and harder to use than they should be: no syntax highlighting anywhere (the TypeScript recipe read as a wall of monochrome), the dark code surfaces were a cold blue-black that sat oddly on the warm site, the API reference showed attribute lists with no example of what actually comes over the wire, and nothing connected the reference ("the wire") to the recipes ("the task"). Also one real bug: the reference page's Run buttons built URLs with single-brace `{workspaceId}`, which the playground never substitutes — Run fired a literal `/workspaces/{workspaceId}/…` request.

## Solution

### Key design decisions

**1. Build-time Shiki with a custom `threa-dusk` theme**

All docs code blocks (bash/TypeScript/JSON) are highlighted at build time with a theme derived from the site palette: gold keywords and JSON keys, parchment strings, muted italic comments on warm charcoal. Zero client-side JS added. The `{{baseUrl}}`/`{{workspaceId}}`/`{{apiKey}}` playground chips survive tokenization by being swapped to identifier-shaped sentinels before the grammar runs and swapped back to chip markup after — the client-side hydration in `playground.ts` is untouched.

**2. Warm night surfaces**

`--night` moves from cold blue-black (`hsl(222 25% 8%)`) to espresso ink (`hsl(26 16% 10%)`), slightly lifted. Terminals, code blocks, and the homepage closing band now share the page's hue family instead of sitting beside it.

**3. Stripe-style two-column reference**

Each endpoint renders as a two-column band: the contract (description, scope, params, body, response schema, status codes) on the left; the wire (example request + example response) sticky on the right. The reference page uses a new full-width article variant; below 1120px it collapses to one column. Long request lines wrap in the narrow column (copy uses the raw template, so display wrapping is safe).

**4. Synthesized example responses**

The spec carries no example values, so `exampleResponse()` builds realistic ones from field names: correctly-prefixed ULIDs (`stream_…`, `msg_…`, `memo_…`, verified against backend id generation), ISO timestamps, and content drawn from the same auth-refactor story the marketing pages tell. Labeled "example" beside the schema tables, which remain the contract.

**5. Recipes as the integration path**

Reference groups link to the worked examples that use them ("Recipes: Notify a stream from CI →"). The docs guide integration rather than trying to be the integration surface.

**6. Agent legibility**

`llms.txt` joins the docs top nav and footer; every page advertises `llms.txt` and `openapi.json` via `link rel=alternate`. The markdown mirrors regenerate with the new content (example responses included for free, since mirrors read each block's raw template).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/public-site/src/lib/highlight.ts` | Shiki singleton + `threa-dusk` theme + chip-preserving token rendering |

## Modified files

| File | Change |
| ---- | ------ |
| `src/components/CodeBlock.astro` | Escape-and-splice replaced by `highlightCode()` |
| `src/components/ApiEndpoint.astro` | Two-column structure; synthesized response example |
| `src/lib/openapi.ts` | `exampleResponse()` with name-aware value heuristics |
| `src/pages/developers/reference.astro` | Recipe links, entity hints, wide layout, **RUNS `{{workspaceId}}` fix** |
| `src/layouts/DocsLayout.astro` | `wide` prop; llms.txt nav/footer links |
| `src/components/BaseHead.astro` | Agent entry points as `link rel=alternate` |
| `src/styles/docs.css` | Two-column band, recipe links, dark-block chip tuning |
| `src/styles/global.css` | Warm `--night` family |
| `scripts/build-llms.ts` | Tolerate variant classes on the article wrapper |
| `package.json`, `bun.lock` | `shiki` dev dependency |

## Test plan

- [x] `astro check` clean; full `bun run build` green including markdown-mirror generation (69 KB llms-full.txt)
- [x] Verified in browser at 1440px: reference (Identity, Messages, Memos endpoints), recipes (TS block highlighting), overview, homepage night surfaces
- [x] Verified at 390px: reference collapses to one column, drawer nav intact
- [x] Markdown mirror of the reference inspected — examples and curls render with literal placeholders

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783808085&installation_id=129946197&pr_number=862&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F862&signature=2ac5169fd5c8867787e3f7d74f60e5963a46f49b0bb36134acf06e90d4560ba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->