### PR TITLE
feat: serve attachments via stable content URLs for cross-session caching

### DIFF
--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -399,6 +399,9 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       getObjectStream: async () => {
         throw new Error("Not implemented in stub")
       },
+      getObjectContent: async () => {
+        throw new Error("Not implemented in stub")
+      },
       putObject: async () => {},
       delete: async () => {},
     }

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -123,6 +123,9 @@ function createMockStorage(images: Map<string, Buffer>): StorageProvider {
     async getObjectStream(): Promise<never> {
       throw new Error("Not implemented in mock")
     },
+    async getObjectContent(): Promise<never> {
+      throw new Error("Not implemented in mock")
+    },
     async putObject(): Promise<void> {
       // No-op for mock
     },

--- a/apps/backend/src/features/attachments/handlers.test.ts
+++ b/apps/backend/src/features/attachments/handlers.test.ts
@@ -279,6 +279,41 @@ describe("attachment handlers safety gating", () => {
     expect(res.body).toEqual({ url: "https://download", expiresIn: 900 })
   })
 
+  it("presigns the generated thumbnail with a filename matching the served webp bytes", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
+      thumbnailStoragePath: "ws_1/attach_1/thumbnail.webp",
+    }
+    const attachmentService = {
+      getById: mock(() => Promise.resolve(attachment)),
+      getDownloadUrl: mock(() => Promise.resolve("https://download")),
+      getSharingBlockReason: mock(() => null),
+    } as any
+    const storage = {
+      getSignedDownloadUrl: mock(() => Promise.resolve("https://thumbnail")),
+    } as any
+
+    const handlers = createAttachmentHandlers({ attachmentService, streamService: {} as any, storage, pool: {} as any })
+    const res = createResponse()
+
+    await handlers.getDownloadUrl(
+      {
+        user: { id: "usr_1" },
+        workspaceId: "ws_1",
+        params: { attachmentId: "attach_1" },
+        query: { download: "true", variant: "thumbnail" },
+      } as any,
+      res
+    )
+
+    expect(storage.getSignedDownloadUrl).toHaveBeenCalledWith("ws_1/attach_1/thumbnail.webp", {
+      // The original is test.png, but the thumbnail bytes are webp.
+      responseContentDisposition: expect.stringContaining('filename="test.webp"'),
+    })
+    expect(res.body).toEqual({ url: "https://thumbnail", expiresIn: 900 })
+    expect(attachmentService.getDownloadUrl).not.toHaveBeenCalled()
+  })
+
   it("denies download when user has no direct stream access nor share grant nor inline reference", async () => {
     const attachment = {
       ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
@@ -628,10 +663,13 @@ function createStreamingResponse() {
   const res: any = new Writable({
     write(chunk, _encoding, callback) {
       chunks.push(Buffer.from(chunk))
+      // Mirror http.ServerResponse: the first body write flushes the headers.
+      res.headersSent = true
       callback()
     },
   })
   res.statusCode = 200
+  res.headersSent = false
   res.headers = {} as Record<string, string>
   res.set = mock((name: string, value: string) => {
     res.headers[name.toLowerCase()] = value
@@ -899,5 +937,36 @@ describe("attachment content handler", () => {
 
     expect(res.statusCode).toBe(400)
     expect(storage.getObjectContent).not.toHaveBeenCalled()
+  })
+
+  it("aborts the response when the object stream errors mid-transfer", async () => {
+    // A truncated body must surface as a failed transfer (socket abort), never
+    // as a cleanly-terminated 200 the client would treat as complete.
+    async function* failingBytes() {
+      yield Buffer.from("partial-")
+      throw new Error("S3 connection reset")
+    }
+    const storage = {
+      getObjectContent: mock(async () => ({
+        stream: Readable.from(failingBytes()),
+        contentLength: 100,
+        contentRange: undefined,
+      })),
+    } as any
+    const { handlers } = makeHandlers({ storage })
+    const res = createStreamingResponse()
+    const resErrors: Error[] = []
+    res.on("error", (err: Error) => resErrors.push(err))
+    const closed = new Promise<void>((resolve) => res.on("close", resolve))
+
+    await handlers.getContent(contentRequest(), res)
+    await closed
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/test.png", { range: undefined })
+    expect(res.sentBytes().toString()).toBe("partial-")
+    expect(res.destroyed).toBe(true)
+    // Headers were already flushed when the stream failed — the handler must
+    // abort rather than rewrite the status to 500.
+    expect(res.statusCode).toBe(200)
   })
 })

--- a/apps/backend/src/features/attachments/handlers.test.ts
+++ b/apps/backend/src/features/attachments/handlers.test.ts
@@ -1,9 +1,13 @@
+import { createHash } from "node:crypto"
+import { once } from "node:events"
+import { Readable, Writable } from "node:stream"
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { AttachmentSafetyStatuses } from "@threa/types"
 import { createAttachmentHandlers } from "./handlers"
 import { SharedMessageRepository } from "../messaging"
 import { AttachmentReferenceRepository } from "./reference-repository"
 import { AttachmentRepository, type AttachmentSearchRow } from "./repository"
+import { VideoTranscodeJobRepository } from "./video"
 
 function createResponse() {
   const res: any = {}
@@ -612,5 +616,288 @@ describe("attachment search handler", () => {
       referenceCount: 3,
     })
     expect(res.body.items[0].extraction).not.toHaveProperty("fullText")
+  })
+})
+
+/**
+ * Response double for the streaming content handler: a real Writable so
+ * `stream.pipe(res)` works, with the Express helpers the handler touches.
+ */
+function createStreamingResponse() {
+  const chunks: Buffer[] = []
+  const res: any = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk))
+      callback()
+    },
+  })
+  res.statusCode = 200
+  res.headers = {} as Record<string, string>
+  res.set = mock((name: string, value: string) => {
+    res.headers[name.toLowerCase()] = value
+    return res
+  })
+  res.status = mock((code: number) => {
+    res.statusCode = code
+    return res
+  })
+  res.json = mock((body: unknown) => {
+    res.body = body
+    return res
+  })
+  res.sentBytes = () => Buffer.concat(chunks)
+  return res
+}
+
+function pathEtag(storagePath: string): string {
+  return `"${createHash("sha256").update(storagePath).digest("hex")}"`
+}
+
+function buildContentStorage(content = "image-bytes") {
+  return {
+    getObjectContent: mock(async (_key: string, options?: { range?: string }) => ({
+      stream: Readable.from([Buffer.from(content)]),
+      contentLength: content.length,
+      contentRange: options?.range ? `bytes 0-${content.length - 1}/${content.length}` : undefined,
+    })),
+  } as any
+}
+
+function contentRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    user: { id: "usr_1" },
+    workspaceId: "ws_1",
+    params: { attachmentId: "attach_1" },
+    query: {},
+    headers: {},
+    ...overrides,
+  } as any
+}
+
+describe("attachment content handler", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  function makeHandlers({
+    attachment = buildAttachment(AttachmentSafetyStatuses.CLEAN),
+    storage = buildContentStorage(),
+    streamService = { tryAccess: mock(() => Promise.resolve({ id: "str_1" })) } as any,
+  }: { attachment?: any; storage?: any; streamService?: any } = {}) {
+    const attachmentService = {
+      getById: mock(() => Promise.resolve(attachment)),
+      getSharingBlockReason: mock(() => null),
+    } as any
+    return {
+      handlers: createAttachmentHandlers({ attachmentService, streamService, storage, pool: {} as any }),
+      storage,
+    }
+  }
+
+  it("streams the raw object with immutable caching and document-execution hardening", async () => {
+    const attachment = buildAttachment(AttachmentSafetyStatuses.CLEAN)
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest(), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/test.png", { range: undefined })
+    expect(res.sentBytes().toString()).toBe("image-bytes")
+    expect(res.headers).toMatchObject({
+      "content-type": "image/png",
+      "cache-control": "private, max-age=31536000, immutable",
+      etag: pathEtag("ws_1/attach_1/test.png"),
+      "x-content-type-options": "nosniff",
+      "content-security-policy": "sandbox",
+      "accept-ranges": "bytes",
+      "content-length": "11",
+    })
+  })
+
+  it("returns 304 without fetching the object when If-None-Match matches", async () => {
+    const { handlers, storage } = makeHandlers()
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ headers: { "if-none-match": pathEtag("ws_1/attach_1/test.png") } }), res)
+
+    expect(res.statusCode).toBe(304)
+    expect(storage.getObjectContent).not.toHaveBeenCalled()
+  })
+
+  it("serves the sharp thumbnail variant as webp when generated", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
+      thumbnailStoragePath: "ws_1/attach_1/thumbnail.webp",
+    }
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ query: { variant: "thumbnail" } }), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/thumbnail.webp", { range: undefined })
+    expect(res.headers).toMatchObject({
+      "content-type": "image/webp",
+      "cache-control": "private, max-age=31536000, immutable",
+      etag: pathEtag("ws_1/attach_1/thumbnail.webp"),
+    })
+  })
+
+  it("serves the raw fall-through with no-store and no ETag while the thumbnail is not ready", async () => {
+    // Caching the fallback under the variant URL would pin the raw bytes
+    // forever ("immutable") and the real thumbnail would never appear.
+    const { handlers, storage } = makeHandlers()
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ query: { variant: "thumbnail" } }), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/test.png", { range: undefined })
+    expect(res.headers["cache-control"]).toBe("private, no-store")
+    expect(res.headers).not.toHaveProperty("etag")
+  })
+
+  it("serves the processed video variant from the completed transcode job", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
+      mimeType: "video/quicktime",
+      filename: "clip.mov",
+      storagePath: "ws_1/attach_1/clip.mov",
+    }
+    spyOn(VideoTranscodeJobRepository, "findByAttachmentId").mockResolvedValue({
+      status: "completed",
+      processedStoragePath: "ws_1/attach_1/processed.mp4",
+      thumbnailStoragePath: "ws_1/attach_1/thumbnail.0000000.jpg",
+    } as any)
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ query: { variant: "processed" } }), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/processed.mp4", { range: undefined })
+    expect(res.headers).toMatchObject({
+      "content-type": "video/mp4",
+      "cache-control": "private, max-age=31536000, immutable",
+    })
+  })
+
+  it("falls through to the raw video with no-store while the transcode is incomplete", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
+      mimeType: "video/quicktime",
+      filename: "clip.mov",
+      storagePath: "ws_1/attach_1/clip.mov",
+    }
+    spyOn(VideoTranscodeJobRepository, "findByAttachmentId").mockResolvedValue({
+      status: "submitted",
+      processedStoragePath: null,
+      thumbnailStoragePath: null,
+    } as any)
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ query: { variant: "processed" } }), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/clip.mov", { range: undefined })
+    expect(res.headers["cache-control"]).toBe("private, no-store")
+    expect(res.headers["content-type"]).toBe("video/quicktime")
+  })
+
+  it("passes a Range request through and responds 206 with Content-Range", async () => {
+    const { handlers, storage } = makeHandlers()
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ headers: { range: "bytes=0-10" } }), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/test.png", { range: "bytes=0-10" })
+    expect(res.statusCode).toBe(206)
+    expect(res.headers["content-range"]).toBe("bytes 0-10/11")
+  })
+
+  it("returns 404 for an attachment in another workspace", async () => {
+    const attachment = { ...buildAttachment(AttachmentSafetyStatuses.CLEAN), workspaceId: "ws_other" }
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest(), res)
+
+    expect(res.statusCode).toBe(404)
+    expect(storage.getObjectContent).not.toHaveBeenCalled()
+  })
+
+  it("blocks content while the malware scan is pending", async () => {
+    const attachmentService = {
+      getById: mock(() => Promise.resolve(buildAttachment(AttachmentSafetyStatuses.PENDING_SCAN))),
+      getSharingBlockReason: mock(() => "Attachment is pending malware scan"),
+    } as any
+    const storage = buildContentStorage()
+    const handlers = createAttachmentHandlers({
+      attachmentService,
+      streamService: {} as any,
+      storage,
+      pool: {} as any,
+    })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest(), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({ error: "Attachment is pending malware scan" })
+    expect(storage.getObjectContent).not.toHaveBeenCalled()
+  })
+
+  it("denies content when there is no stream access, share grant, or inline reference", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.CLEAN),
+      streamId: "str_source",
+      messageId: "msg_source",
+    }
+    spyOn(SharedMessageRepository, "listSourcesGrantedToViewer").mockResolvedValue(new Set())
+    spyOn(AttachmentReferenceRepository, "hasViewerAccessByReference").mockResolvedValue(false)
+    const { handlers, storage } = makeHandlers({
+      attachment,
+      streamService: { tryAccess: mock(() => Promise.resolve(null)) } as any,
+    })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest(), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({ error: "Access denied" })
+    expect(storage.getObjectContent).not.toHaveBeenCalled()
+  })
+
+  it("serves E2E ciphertext with its placeholder mime type", async () => {
+    const attachment = {
+      ...buildAttachment(AttachmentSafetyStatuses.E2E_UNSCANNED),
+      filename: "encrypted",
+      mimeType: "application/octet-stream",
+      storagePath: "ws_1/attach_1/encrypted",
+    }
+    const { handlers, storage } = makeHandlers({ attachment })
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest(), res)
+    await once(res, "finish")
+
+    expect(storage.getObjectContent).toHaveBeenCalledWith("ws_1/attach_1/encrypted", { range: undefined })
+    expect(res.headers).toMatchObject({
+      "content-type": "application/octet-stream",
+      "cache-control": "private, max-age=31536000, immutable",
+    })
+  })
+
+  it("rejects an unknown variant", async () => {
+    const { handlers, storage } = makeHandlers()
+    const res = createStreamingResponse()
+
+    await handlers.getContent(contentRequest({ query: { variant: "original" } }), res)
+
+    expect(res.statusCode).toBe(400)
+    expect(storage.getObjectContent).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -4,7 +4,12 @@ import { z } from "zod"
 import type { Pool } from "pg"
 import { buildContentDisposition, buildUploadParams, parseE2eUploadFlag, type AttachmentService } from "./service"
 import { isAttachmentReadableViaShareOrReference } from "./access"
-import { AttachmentRepository, type AttachmentSearchCursor, type AttachmentSearchRow } from "./repository"
+import {
+  AttachmentRepository,
+  type Attachment,
+  type AttachmentSearchCursor,
+  type AttachmentSearchRow,
+} from "./repository"
 import { AttachmentExtractionRepository } from "./extraction-repository"
 import type { StreamService } from "../streams"
 import { VideoTranscodeJobRepository } from "./video"
@@ -114,31 +119,13 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       if (!parsed.success) return res.status(400).json({ error: "Invalid query parameters" })
       const { download, variant } = parsed.data
 
-      // Image thumbnail: serve the sharp-generated WebP variant when ready.
-      // Generated asynchronously by the IMAGE_THUMBNAIL worker; if not yet
-      // available, fall through to the raw original.
-      if (variant === "thumbnail" && isImageAttachment(attachment.mimeType, attachment.filename)) {
-        if (attachment.thumbnailStoragePath) {
-          const responseContentDisposition =
-            download === "true" ? buildContentDisposition(attachment.filename) : undefined
-          const url = await storage.getSignedDownloadUrl(attachment.thumbnailStoragePath, {
-            responseContentDisposition,
-          })
-          return res.json({ url, expiresIn: 900 })
-        }
-        // Thumbnail not generated yet — fall through to raw original.
-      } else if (variant === "processed" || variant === "thumbnail") {
-        // For video variants (processed/thumbnail), look up the transcode job
-        const job = await VideoTranscodeJobRepository.findByAttachmentId(pool, attachmentId)
-        const path = variant === "processed" ? job?.processedStoragePath : job?.thumbnailStoragePath
-        if (job?.status === "completed" && path) {
-          const filename =
-            variant === "processed" ? attachment.filename.replace(/\.[^.]+$/, ".mp4") : attachment.filename
-          const responseContentDisposition = download === "true" ? buildContentDisposition(filename) : undefined
-          const url = await storage.getSignedDownloadUrl(path, { responseContentDisposition })
-          return res.json({ url, expiresIn: 900 })
-        }
-        // Fall through to raw file if variant not available
+      // A generated variant resolved to its own object → presign it. Raw
+      // requests and not-ready fall-throughs presign the original below.
+      const resolved = await resolveAttachmentVariant(pool, attachment, variant)
+      if (resolved.ready && resolved.storagePath !== attachment.storagePath) {
+        const responseContentDisposition = download === "true" ? buildContentDisposition(resolved.filename) : undefined
+        const url = await storage.getSignedDownloadUrl(resolved.storagePath, { responseContentDisposition })
+        return res.json({ url, expiresIn: 900 })
       }
 
       const url = await attachmentService.getDownloadUrl(attachment, { download: download === "true" })
@@ -194,52 +181,30 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
       if (!parsed.success) return res.status(400).json({ error: "Invalid query parameters" })
       const { variant } = parsed.data
 
-      // Resolve the variant to a stored object, mirroring getDownloadUrl's
-      // thumbnail → raw and transcode-job fall-throughs.
-      let storagePath = attachment.storagePath
-      let contentType = attachment.mimeType
-      let variantReady = true
-
-      if (variant === "thumbnail" && isImageAttachment(attachment.mimeType, attachment.filename)) {
-        if (attachment.thumbnailStoragePath) {
-          storagePath = attachment.thumbnailStoragePath
-          contentType = "image/webp"
-        } else {
-          variantReady = false
-        }
-      } else if (variant === "processed" || variant === "thumbnail") {
-        const job = await VideoTranscodeJobRepository.findByAttachmentId(pool, attachmentId)
-        const path = variant === "processed" ? job?.processedStoragePath : job?.thumbnailStoragePath
-        if (job?.status === "completed" && path) {
-          storagePath = path
-          contentType = variant === "processed" ? "video/mp4" : "image/jpeg"
-        } else {
-          variantReady = false
-        }
-      }
+      const resolved = await resolveAttachmentVariant(pool, attachment, variant)
 
       // The storage path uniquely identifies the served bytes (objects are
       // written once), so a path-derived ETag is a valid validator. The
       // fall-through gets no validator — a 304 must never extend the life of
       // fallback bytes under the variant URL.
-      const etag = `"${createHash("sha256").update(storagePath).digest("hex")}"`
-      const cacheControl = variantReady ? "private, max-age=31536000, immutable" : "private, no-store"
+      const etag = `"${createHash("sha256").update(resolved.storagePath).digest("hex")}"`
+      const cacheControl = resolved.ready ? "private, max-age=31536000, immutable" : "private, no-store"
 
       res.set("Cache-Control", cacheControl)
       res.set("X-Content-Type-Options", "nosniff")
       // User-authored bytes served from the app origin must never execute as a
       // document (HTML/SVG navigated to directly).
       res.set("Content-Security-Policy", "sandbox")
-      if (variantReady) res.set("ETag", etag)
+      if (resolved.ready) res.set("ETag", etag)
 
-      if (variantReady && req.headers["if-none-match"] === etag) {
+      if (resolved.ready && req.headers["if-none-match"] === etag) {
         return res.status(304).end()
       }
 
       const range = typeof req.headers.range === "string" ? req.headers.range : undefined
-      const object = await storage.getObjectContent(storagePath, { range })
+      const object = await storage.getObjectContent(resolved.storagePath, { range })
 
-      res.set("Content-Type", contentType)
+      res.set("Content-Type", resolved.contentType)
       res.set("Accept-Ranges", "bytes")
       if (object.contentLength !== undefined) res.set("Content-Length", String(object.contentLength))
       if (object.contentRange) {
@@ -247,11 +212,14 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
         res.set("Content-Range", object.contentRange)
       }
 
-      object.stream.on("error", () => {
+      object.stream.on("error", (err) => {
         if (!res.headersSent) {
           res.status(500).end()
         } else {
-          res.end()
+          // Headers (including Content-Length) are already on the wire — abort
+          // the socket so the client sees a failed transfer instead of a
+          // cleanly-terminated truncated 200 it would treat as complete.
+          res.destroy(err)
         }
       })
       object.stream.pipe(res)
@@ -377,6 +345,72 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
         nextCursor,
       })
     },
+  }
+}
+
+interface ResolvedAttachmentVariant {
+  storagePath: string
+  contentType: string
+  /** Filename for content-disposition downloads (processed video renames to .mp4). */
+  filename: string
+  /**
+   * False when a generated variant was requested but isn't available yet —
+   * callers serve the raw original instead and must NOT let it be cached
+   * under the variant URL.
+   */
+  ready: boolean
+}
+
+/**
+ * Resolve which stored object a (attachment, variant) pair maps to — the one
+ * rule shared by `getDownloadUrl` (presign) and `getContent` (streaming).
+ *
+ * Image thumbnails are sharp-generated WebP, produced asynchronously by the
+ * IMAGE_THUMBNAIL worker; video processed/thumbnail variants come from the
+ * MediaConvert transcode job. Either may not exist yet, in which case the
+ * raw original is the fall-through with `ready: false`.
+ */
+async function resolveAttachmentVariant(
+  pool: Pool,
+  attachment: Attachment,
+  variant: "raw" | "processed" | "thumbnail" | undefined
+): Promise<ResolvedAttachmentVariant> {
+  if (variant === "thumbnail" && isImageAttachment(attachment.mimeType, attachment.filename)) {
+    if (attachment.thumbnailStoragePath) {
+      return {
+        storagePath: attachment.thumbnailStoragePath,
+        contentType: "image/webp",
+        filename: attachment.filename,
+        ready: true,
+      }
+    }
+  } else if (variant === "processed" || variant === "thumbnail") {
+    const job = await VideoTranscodeJobRepository.findByAttachmentId(pool, attachment.id)
+    const path = variant === "processed" ? job?.processedStoragePath : job?.thumbnailStoragePath
+    if (job?.status === "completed" && path) {
+      return {
+        storagePath: path,
+        contentType: variant === "processed" ? "video/mp4" : "image/jpeg",
+        filename: variant === "processed" ? attachment.filename.replace(/\.[^.]+$/, ".mp4") : attachment.filename,
+        ready: true,
+      }
+    }
+  } else {
+    // Raw (or no variant) requested — the original is always available.
+    return {
+      storagePath: attachment.storagePath,
+      contentType: attachment.mimeType,
+      filename: attachment.filename,
+      ready: true,
+    }
+  }
+
+  // Requested variant not generated yet — raw fall-through.
+  return {
+    storagePath: attachment.storagePath,
+    contentType: attachment.mimeType,
+    filename: attachment.filename,
+    ready: false,
   }
 }
 

--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import type { Request, Response } from "express"
 import { z } from "zod"
 import type { Pool } from "pg"
@@ -142,6 +143,118 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
 
       const url = await attachmentService.getDownloadUrl(attachment, { download: download === "true" })
       res.json({ url, expiresIn: 900 })
+    },
+
+    /**
+     * Serve attachment bytes through the backend at a deterministic URL per
+     * (attachment, variant), so the browser HTTP cache works across sessions —
+     * unlike presigned URLs from `getDownloadUrl`, whose fresh signature
+     * defeats cache keying and forces a re-download every cold open.
+     *
+     * Same ACL chain as `getDownloadUrl`: workspace scoping, sharing-safety
+     * gate, direct stream access with the share-grant/inline-reference
+     * fallback.
+     *
+     * The stored object for a given (attachment, variant) never changes after
+     * processing completes, so ready variants are served `immutable`. The
+     * not-ready fall-through (thumbnail/processed not generated yet) serves
+     * the raw original with `no-store` — caching fallback bytes under the
+     * variant URL would pin them and the real variant would never appear.
+     */
+    async getContent(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { attachmentId } = req.params
+
+      const attachment = await attachmentService.getById(attachmentId)
+      if (!attachment || attachment.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Attachment not found" })
+      }
+
+      const sharingBlockReason = attachmentService.getSharingBlockReason(attachment)
+      if (sharingBlockReason) {
+        return res.status(403).json({ error: sharingBlockReason })
+      }
+
+      if (attachment.streamId) {
+        const accessible = await streamService.tryAccess(attachment.streamId, workspaceId, userId)
+        if (!accessible) {
+          const granted = await isAttachmentReadableViaShareOrReference(pool, attachment, workspaceId, userId)
+          if (!granted) {
+            return res.status(403).json({ error: "Access denied" })
+          }
+        }
+      }
+
+      const parsed = z
+        .object({
+          variant: z.enum(["raw", "processed", "thumbnail"]).optional(),
+        })
+        .safeParse(req.query)
+      if (!parsed.success) return res.status(400).json({ error: "Invalid query parameters" })
+      const { variant } = parsed.data
+
+      // Resolve the variant to a stored object, mirroring getDownloadUrl's
+      // thumbnail → raw and transcode-job fall-throughs.
+      let storagePath = attachment.storagePath
+      let contentType = attachment.mimeType
+      let variantReady = true
+
+      if (variant === "thumbnail" && isImageAttachment(attachment.mimeType, attachment.filename)) {
+        if (attachment.thumbnailStoragePath) {
+          storagePath = attachment.thumbnailStoragePath
+          contentType = "image/webp"
+        } else {
+          variantReady = false
+        }
+      } else if (variant === "processed" || variant === "thumbnail") {
+        const job = await VideoTranscodeJobRepository.findByAttachmentId(pool, attachmentId)
+        const path = variant === "processed" ? job?.processedStoragePath : job?.thumbnailStoragePath
+        if (job?.status === "completed" && path) {
+          storagePath = path
+          contentType = variant === "processed" ? "video/mp4" : "image/jpeg"
+        } else {
+          variantReady = false
+        }
+      }
+
+      // The storage path uniquely identifies the served bytes (objects are
+      // written once), so a path-derived ETag is a valid validator. The
+      // fall-through gets no validator — a 304 must never extend the life of
+      // fallback bytes under the variant URL.
+      const etag = `"${createHash("sha256").update(storagePath).digest("hex")}"`
+      const cacheControl = variantReady ? "private, max-age=31536000, immutable" : "private, no-store"
+
+      res.set("Cache-Control", cacheControl)
+      res.set("X-Content-Type-Options", "nosniff")
+      // User-authored bytes served from the app origin must never execute as a
+      // document (HTML/SVG navigated to directly).
+      res.set("Content-Security-Policy", "sandbox")
+      if (variantReady) res.set("ETag", etag)
+
+      if (variantReady && req.headers["if-none-match"] === etag) {
+        return res.status(304).end()
+      }
+
+      const range = typeof req.headers.range === "string" ? req.headers.range : undefined
+      const object = await storage.getObjectContent(storagePath, { range })
+
+      res.set("Content-Type", contentType)
+      res.set("Accept-Ranges", "bytes")
+      if (object.contentLength !== undefined) res.set("Content-Length", String(object.contentLength))
+      if (object.contentRange) {
+        res.status(206)
+        res.set("Content-Range", object.contentRange)
+      }
+
+      object.stream.on("error", () => {
+        if (!res.headersSent) {
+          res.status(500).end()
+        } else {
+          res.end()
+        }
+      })
+      object.stream.pipe(res)
     },
 
     /**

--- a/apps/backend/src/features/attachments/handlers.ts
+++ b/apps/backend/src/features/attachments/handlers.ts
@@ -351,7 +351,11 @@ export function createAttachmentHandlers({ attachmentService, streamService, sto
 interface ResolvedAttachmentVariant {
   storagePath: string
   contentType: string
-  /** Filename for content-disposition downloads (processed video renames to .mp4). */
+  /**
+   * Filename for content-disposition downloads, with its extension matching
+   * the served bytes (.webp/.jpg thumbnails, .mp4 processed video) rather
+   * than the original upload's.
+   */
   filename: string
   /**
    * False when a generated variant was requested but isn't available yet —
@@ -380,7 +384,7 @@ async function resolveAttachmentVariant(
       return {
         storagePath: attachment.thumbnailStoragePath,
         contentType: "image/webp",
-        filename: attachment.filename,
+        filename: attachment.filename.replace(/\.[^.]+$/, ".webp"),
         ready: true,
       }
     }
@@ -391,7 +395,7 @@ async function resolveAttachmentVariant(
       return {
         storagePath: path,
         contentType: variant === "processed" ? "video/mp4" : "image/jpeg",
-        filename: variant === "processed" ? attachment.filename.replace(/\.[^.]+$/, ".mp4") : attachment.filename,
+        filename: attachment.filename.replace(/\.[^.]+$/, variant === "processed" ? ".mp4" : ".jpg"),
         ready: true,
       }
     }

--- a/apps/backend/src/lib/storage/s3-client.ts
+++ b/apps/backend/src/lib/storage/s3-client.ts
@@ -14,6 +14,13 @@ export interface SignedDownloadUrlOptions {
   responseContentDisposition?: string
 }
 
+export interface ObjectContent {
+  stream: Readable
+  contentLength?: number
+  /** Set when the request carried a Range header — the S3 Content-Range of the partial response. */
+  contentRange?: string
+}
+
 export interface StorageProvider {
   getObjectSize(key: string): Promise<number>
   getSignedDownloadUrl(key: string, options?: SignedDownloadUrlOptions): Promise<string>
@@ -21,6 +28,8 @@ export interface StorageProvider {
   /** Fetch first N bytes of an object using HTTP Range header */
   getObjectRange(key: string, start: number, end: number): Promise<Buffer>
   getObjectStream(key: string): Promise<Readable>
+  /** Stream an object with the metadata needed to proxy it over HTTP (optionally a Range slice). */
+  getObjectContent(key: string, options?: { range?: string }): Promise<ObjectContent>
   putObject(key: string, body: Buffer, contentType: string): Promise<void>
   delete(key: string): Promise<void>
 }
@@ -120,6 +129,25 @@ export function createS3Storage(config: S3Config): StorageProvider {
       }
 
       return response.Body as Readable
+    },
+
+    async getObjectContent(key: string, options?: { range?: string }): Promise<ObjectContent> {
+      const command = new GetObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        ...(options?.range && { Range: options.range }),
+      })
+      const response = await client.send(command)
+
+      if (!response.Body) {
+        throw new Error(`No body in S3 response for key: ${key}`)
+      }
+
+      return {
+        stream: response.Body as Readable,
+        contentLength: response.ContentLength,
+        contentRange: response.ContentRange,
+      }
     },
 
     async putObject(key: string, body: Buffer, contentType: string): Promise<void> {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -436,6 +436,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/attachments", ...authed, rateLimits.upload, upload, attachment.upload)
   app.post("/api/workspaces/:workspaceId/attachments/search", ...authed, rateLimits.search, attachment.search)
   app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/url", ...authed, attachment.getDownloadUrl)
+  app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/content", ...authed, attachment.getContent)
   app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/extraction", ...authed, attachment.getExtraction)
   app.delete("/api/workspaces/:workspaceId/attachments/:attachmentId", ...authed, attachment.delete)
 

--- a/apps/frontend/src/api/attachments.test.ts
+++ b/apps/frontend/src/api/attachments.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { api } from "./client"
+import { api, API_BASE } from "./client"
 import { attachmentContentUrl, attachmentsApi, resetAttachmentUrlCache } from "./attachments"
 
 describe("attachmentContentUrl", () => {
-  it("builds a deterministic same-origin content URL per (attachment, variant)", () => {
-    expect(attachmentContentUrl("ws_1", "attach_1")).toBe("/api/workspaces/ws_1/attachments/attach_1/content")
+  it("builds a deterministic content URL on the API origin per (attachment, variant)", () => {
+    expect(attachmentContentUrl("ws_1", "attach_1")).toBe(
+      `${API_BASE}/api/workspaces/ws_1/attachments/attach_1/content`
+    )
     expect(attachmentContentUrl("ws_1", "attach_1", { variant: "thumbnail" })).toBe(
-      "/api/workspaces/ws_1/attachments/attach_1/content?variant=thumbnail"
+      `${API_BASE}/api/workspaces/ws_1/attachments/attach_1/content?variant=thumbnail`
     )
   })
 })

--- a/apps/frontend/src/api/attachments.test.ts
+++ b/apps/frontend/src/api/attachments.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { api } from "./client"
-import { attachmentsApi, resetAttachmentUrlCache } from "./attachments"
+import { attachmentContentUrl, attachmentsApi, resetAttachmentUrlCache } from "./attachments"
+
+describe("attachmentContentUrl", () => {
+  it("builds a deterministic same-origin content URL per (attachment, variant)", () => {
+    expect(attachmentContentUrl("ws_1", "attach_1")).toBe("/api/workspaces/ws_1/attachments/attach_1/content")
+    expect(attachmentContentUrl("ws_1", "attach_1", { variant: "thumbnail" })).toBe(
+      "/api/workspaces/ws_1/attachments/attach_1/content?variant=thumbnail"
+    )
+  })
+})
 
 describe("attachmentsApi.getDownloadUrl", () => {
   beforeEach(() => {

--- a/apps/frontend/src/api/attachments.ts
+++ b/apps/frontend/src/api/attachments.ts
@@ -49,20 +49,20 @@ export function resetAttachmentUrlCache(): void {
 }
 
 /**
- * Synchronous peek at an already-resolved download URL. Lets remounting
- * components (virtualized rows) seed their initial state with the cached URL
- * instead of rendering a skeleton for the frame(s) the async `getDownloadUrl`
- * resolution takes, even on a warm cache.
+ * Deterministic, cookie-authenticated URL for an attachment's bytes. Stable
+ * across sessions — unlike presigned URLs from `getDownloadUrl`, whose fresh
+ * signature changes the cache key — so the browser HTTP cache serves warm
+ * opens with zero presign round trips and zero media bytes. Synchronous: safe
+ * to use directly as an `<img src>` in render. The backend serves ready
+ * variants with long-lived immutable caching.
  */
-export function peekDownloadUrl(
+export function attachmentContentUrl(
   workspaceId: string,
   attachmentId: string,
-  options?: { download?: boolean; variant?: "raw" | "processed" | "thumbnail" }
-): string | null {
-  const key = `${workspaceId}:${attachmentId}:${options?.download ? "download" : "inline"}:${options?.variant ?? "raw"}`
-  const cached = resolvedDownloadUrlCache.get(key)
-  if (cached && cached.expiresAt > Date.now()) return cached.url
-  return null
+  options?: { variant?: "raw" | "processed" | "thumbnail" }
+): string {
+  const params = options?.variant ? `?variant=${options.variant}` : ""
+  return `${API_BASE}/api/workspaces/${workspaceId}/attachments/${attachmentId}/content${params}`
 }
 
 export const attachmentsApi = {

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -4,7 +4,7 @@ export { workspacesApi, type WorkspaceBootstrap } from "./workspaces"
 export { streamsApi, type StreamBootstrap, type CreateStreamInput, type UpdateStreamInput } from "./streams"
 export { e2eKeyWrapsApi } from "./e2e-key-wraps"
 export { messagesApi, type CreateMessageInput, type UpdateMessageInput } from "./messages"
-export { attachmentsApi, peekDownloadUrl } from "./attachments"
+export { attachmentsApi, attachmentContentUrl } from "./attachments"
 export {
   commandsApi,
   type DispatchCommandInput,

--- a/apps/frontend/src/components/timeline/attachment-list.test.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.test.tsx
@@ -71,7 +71,7 @@ describe("AttachmentList", () => {
       expect(screen.getByText("file2.txt")).toBeInTheDocument()
     })
 
-    it("should render image attachments as thumbnails", async () => {
+    it("should render image attachments as thumbnails", () => {
       const attachment = createAttachment({
         id: "img_1",
         filename: "photo.png",
@@ -79,16 +79,14 @@ describe("AttachmentList", () => {
       })
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
-      // Inline view requests the small thumbnail variant, not the original
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).toHaveBeenCalledWith(workspaceId, "img_1", { variant: "thumbnail" })
-      })
-
-      // Image should be present with alt text for accessibility
-      expect(screen.getByAltText("photo.png")).toBeInTheDocument()
+      // Inline view renders the stable thumbnail-variant content URL
+      // synchronously — no presign request before the <img> has a src.
+      const image = screen.getByAltText("photo.png")
+      expect(image).toHaveAttribute("src", `/api/workspaces/${workspaceId}/attachments/img_1/content?variant=thumbnail`)
+      expect(mockGetDownloadUrl).not.toHaveBeenCalled()
     })
 
-    it("should defer image URL hydration when requested", async () => {
+    it("should defer image hydration when requested", () => {
       const attachment = createAttachment({
         id: "img_1",
         filename: "photo.png",
@@ -99,15 +97,11 @@ describe("AttachmentList", () => {
         renderOpts
       )
 
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).not.toHaveBeenCalled()
-      })
+      expect(screen.queryByAltText("photo.png")).not.toBeInTheDocument()
 
       rerender(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} deferHydration={false} />)
 
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).toHaveBeenCalledWith(workspaceId, "img_1", { variant: "thumbnail" })
-      })
+      expect(screen.getByAltText("photo.png")).toBeInTheDocument()
     })
 
     it("should separate images and files into different groups", async () => {
@@ -124,7 +118,7 @@ describe("AttachmentList", () => {
       expect(screen.getByText("doc.pdf")).toBeInTheDocument()
     })
 
-    it("should not fetch thumbnails while videos are processing", async () => {
+    it("should not render a thumbnail while videos are processing", () => {
       const attachment = createAttachment({
         id: "video_1",
         filename: "clip.mov",
@@ -134,12 +128,10 @@ describe("AttachmentList", () => {
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
       expect(screen.getByText("Processing...")).toBeInTheDocument()
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).not.toHaveBeenCalled()
-      })
+      expect(screen.queryByAltText("clip.mov")).not.toBeInTheDocument()
     })
 
-    it("should render skipped videos without requesting a missing thumbnail", async () => {
+    it("should render skipped videos without a thumbnail src", () => {
       const attachment = createAttachment({
         id: "video_1",
         filename: "clip.mov",
@@ -149,12 +141,12 @@ describe("AttachmentList", () => {
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
       expect(screen.getByRole("button", { name: "clip.mov" })).toBeInTheDocument()
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).not.toHaveBeenCalled()
-      })
+      // A skipped transcode has no thumbnail object — the variant URL would
+      // fall through to raw video bytes, which an <img> can't render.
+      expect(screen.getByAltText("clip.mov")).not.toHaveAttribute("src")
     })
 
-    it("should fetch thumbnail URL for completed videos", async () => {
+    it("should render the thumbnail content URL for completed videos", () => {
       const attachment = createAttachment({
         id: "video_1",
         filename: "clip.mov",
@@ -163,9 +155,10 @@ describe("AttachmentList", () => {
       })
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
-      await waitFor(() => {
-        expect(mockGetDownloadUrl).toHaveBeenCalledWith(workspaceId, "video_1", { variant: "thumbnail" })
-      })
+      expect(screen.getByAltText("clip.mov")).toHaveAttribute(
+        "src",
+        `/api/workspaces/${workspaceId}/attachments/video_1/content?variant=thumbnail`
+      )
     })
   })
 
@@ -309,8 +302,6 @@ describe("AttachmentList", () => {
 
   describe("error handling", () => {
     it("should show error state when image fails to load", async () => {
-      mockGetDownloadUrl.mockRejectedValue(new Error("Failed to load"))
-
       const attachment = createAttachment({
         id: "img_1",
         filename: "broken.png",
@@ -318,7 +309,8 @@ describe("AttachmentList", () => {
       })
       render(<AttachmentList attachments={[attachment]} workspaceId={workspaceId} />, renderOpts)
 
-      // Wait for error state to appear
+      fireEvent.error(screen.getByAltText("broken.png"))
+
       expect(await screen.findByText("Failed to load image")).toBeInTheDocument()
     })
   })

--- a/apps/frontend/src/components/timeline/attachment-list.test.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { MediaGalleryProvider } from "@/contexts"
 import { attachmentsApi } from "@/api"
+import { API_BASE } from "@/api/client"
 import { AttachmentList } from "./attachment-list"
 import type { AttachmentSummary } from "@threa/types"
 
@@ -82,7 +83,10 @@ describe("AttachmentList", () => {
       // Inline view renders the stable thumbnail-variant content URL
       // synchronously — no presign request before the <img> has a src.
       const image = screen.getByAltText("photo.png")
-      expect(image).toHaveAttribute("src", `/api/workspaces/${workspaceId}/attachments/img_1/content?variant=thumbnail`)
+      expect(image).toHaveAttribute(
+        "src",
+        `${API_BASE}/api/workspaces/${workspaceId}/attachments/img_1/content?variant=thumbnail`
+      )
       expect(mockGetDownloadUrl).not.toHaveBeenCalled()
     })
 
@@ -157,7 +161,7 @@ describe("AttachmentList", () => {
 
       expect(screen.getByAltText("clip.mov")).toHaveAttribute(
         "src",
-        `/api/workspaces/${workspaceId}/attachments/video_1/content?variant=thumbnail`
+        `${API_BASE}/api/workspaces/${workspaceId}/attachments/video_1/content?variant=thumbnail`
       )
     })
   })

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { Skeleton } from "@/components/ui/skeleton"
-import { attachmentsApi, peekDownloadUrl } from "@/api"
+import { attachmentsApi, attachmentContentUrl } from "@/api"
 import { cn } from "@/lib/utils"
 import { downloadImage, copyImage, triggerDownload } from "@/lib/image-utils"
 import { formatFileSize } from "@/lib/file-size"
@@ -27,10 +27,6 @@ interface AttachmentItemProps {
   attachment: AttachmentSummary
   workspaceId: string
   onImageClick?: (attachmentId: string) => void
-  /** Image variant: surface the resolved thumbnail URL to the parent so the
-   *  gallery sidebar can render the same small image instead of waiting for the
-   *  full-resolution variant to lazy-fetch on open. */
-  onThumbnailLoaded?: (attachmentId: string, thumbnailUrl: string) => void
   isHighlighted?: boolean
   deferHydration?: boolean
 }
@@ -39,7 +35,6 @@ interface VideoAttachmentItemProps {
   attachment: AttachmentSummary
   workspaceId: string
   onVideoClick?: (attachmentId: string) => void
-  onThumbnailLoaded?: (attachmentId: string, thumbnailUrl: string) => void
   isHighlighted?: boolean
   deferHydration?: boolean
 }
@@ -131,48 +126,21 @@ function ImageAttachment({
   attachment,
   workspaceId,
   onImageClick,
-  onThumbnailLoaded,
   isHighlighted,
   deferHydration = false,
 }: AttachmentItemProps) {
-  // Seed from the resolved-presign cache so a warm remount (virtua
-  // unmount/remount, bootstrap rewrite) renders the <img> on the very first
-  // frame instead of replaying skeleton → async presign → fade.
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(() =>
-    peekDownloadUrl(workspaceId, attachment.id, { variant: "thumbnail" })
-  )
+  // Deterministic content URL — no presign round trip before the <img> has a
+  // src, and the browser HTTP cache keys on it across sessions, so a warm
+  // open paints from disk cache without re-downloading.
+  const thumbnailUrl = deferHydration
+    ? null
+    : attachmentContentUrl(workspaceId, attachment.id, { variant: "thumbnail" })
   const [imgDecoded, setImgDecoded] = useState(false)
   const [error, setError] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const isMobile = useIsMobile()
 
   const box = inlineImageBox(attachment.width, attachment.height)
-
-  useEffect(() => {
-    if (deferHydration) return
-
-    let mounted = true
-
-    async function loadImage() {
-      try {
-        const url = await attachmentsApi.getDownloadUrl(workspaceId, attachment.id, { variant: "thumbnail" })
-        if (mounted) {
-          setThumbnailUrl(url)
-          onThumbnailLoaded?.(attachment.id, url)
-        }
-      } catch {
-        if (mounted) {
-          setError(true)
-        }
-      }
-    }
-
-    loadImage()
-
-    return () => {
-      mounted = false
-    }
-  }, [workspaceId, attachment.id, deferHydration, onThumbnailLoaded])
 
   // The box is interactable as soon as it mounts — the gallery fetches the
   // full-resolution image itself, so opening it never depends on the inline
@@ -334,56 +302,23 @@ function VideoAttachment({
   attachment,
   workspaceId,
   onVideoClick,
-  onThumbnailLoaded,
   isHighlighted,
   deferHydration = false,
 }: VideoAttachmentItemProps) {
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(false)
 
   const isProcessing = attachment.processingStatus === "pending" || attachment.processingStatus === "processing"
   const isFailed = attachment.processingStatus === "failed"
   const isSkipped = attachment.processingStatus === "skipped"
 
-  useEffect(() => {
-    if (deferHydration || isFailed || isProcessing) return
-
-    if (isSkipped) {
-      setThumbnailUrl(null)
-      setIsLoading(false)
-      setError(false)
-      return
-    }
-
-    let mounted = true
-
-    async function loadThumbnail() {
-      try {
-        setIsLoading(true)
-        setError(false)
-        const url = await attachmentsApi.getDownloadUrl(workspaceId, attachment.id, { variant: "thumbnail" })
-        if (mounted) {
-          setThumbnailUrl(url)
-          onThumbnailLoaded?.(attachment.id, url)
-        }
-      } catch {
-        if (mounted) {
-          setError(true)
-        }
-      } finally {
-        if (mounted) {
-          setIsLoading(false)
-        }
-      }
-    }
-
-    loadThumbnail()
-
-    return () => {
-      mounted = false
-    }
-  }, [workspaceId, attachment.id, onThumbnailLoaded, deferHydration, isFailed, isProcessing, isSkipped])
+  // Deterministic content URL (see ImageAttachment). Skipped transcodes have
+  // no thumbnail object — the variant would fall through to raw video bytes,
+  // which an <img> can't render, so they keep a null src.
+  const thumbnailUrl =
+    deferHydration || isProcessing || isFailed || isSkipped
+      ? null
+      : attachmentContentUrl(workspaceId, attachment.id, { variant: "thumbnail" })
+  const isLoading = deferHydration
 
   const handleClick = useCallback(() => {
     if (!isProcessing && !isFailed) {
@@ -493,8 +428,6 @@ function FileAttachment({ attachment, workspaceId, isHighlighted }: AttachmentIt
 }
 
 export function AttachmentList({ attachments, workspaceId, className, deferHydration = false }: AttachmentListProps) {
-  const [loadedFullImageUrls, setLoadedFullImageUrls] = useState<Map<string, string>>(new Map())
-  const [loadedThumbnails, setLoadedThumbnails] = useState<Map<string, string>>(new Map())
   const [loadedVideoUrls, setLoadedVideoUrls] = useState<Map<string, string>>(new Map())
   // Markdown, HTML, and PDF attachments share a single URL cache: each viewer
   // just needs a presigned URL (the markdown viewer fetches text from it, the
@@ -552,15 +485,17 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     [attachments]
   )
 
-  // Build gallery items — images + completed videos. Image items exist for
-  // every image attachment (url empty until the full-resolution variant is
-  // fetched on open) so the gallery can open instantly and show a loader,
-  // mirroring the video lazy-fetch path.
+  // Build gallery items — images + completed videos. Image URLs are
+  // deterministic content URLs (no presign), so they're set synchronously;
+  // the gallery only loads the current item's full-resolution bytes, and the
+  // sidebar reuses the inline thumbnail variant straight from browser cache.
+  // Video playback keeps the lazy presigned URL (bytes stream straight from
+  // S3 with native Range support).
   const galleryItems: GalleryItem[] = useMemo(() => {
     const imageItems: GalleryItem[] = imageAttachments.map((a) => ({
       type: "image" as const,
-      url: loadedFullImageUrls.get(a.id) ?? "",
-      thumbnailUrl: loadedThumbnails.get(a.id) ?? "",
+      url: attachmentContentUrl(workspaceId, a.id),
+      thumbnailUrl: attachmentContentUrl(workspaceId, a.id, { variant: "thumbnail" }),
       filename: a.filename,
       attachmentId: a.id,
     }))
@@ -569,7 +504,10 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
       .filter((a) => a.processingStatus === "completed" || a.processingStatus === "skipped")
       .map((a) => {
         const videoUrl = loadedVideoUrls.get(a.id) ?? ""
-        const thumbnailUrl = loadedThumbnails.get(a.id) ?? ""
+        // Skipped transcodes have no thumbnail object; the variant URL would
+        // fall through to raw video bytes, which an <img> can't render.
+        const thumbnailUrl =
+          a.processingStatus === "completed" ? attachmentContentUrl(workspaceId, a.id, { variant: "thumbnail" }) : ""
         return {
           type: "video" as const,
           url: videoUrl,
@@ -602,26 +540,15 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
 
     return [...imageItems, ...videoItems, ...markdownItems, ...htmlItems, ...pdfItems]
   }, [
+    workspaceId,
     imageAttachments,
     videoAttachments,
     markdownAttachments,
     htmlAttachments,
     pdfAttachments,
-    loadedFullImageUrls,
-    loadedThumbnails,
     loadedVideoUrls,
     loadedTextUrls,
   ])
-
-  // Called by VideoAttachment children when their thumbnail loads
-  const registerThumbnailUrl = useCallback((attachmentId: string, thumbnailUrl: string) => {
-    setLoadedThumbnails((prev) => {
-      if (prev.get(attachmentId) === thumbnailUrl) return prev
-      const next = new Map(prev)
-      next.set(attachmentId, thumbnailUrl)
-      return next
-    })
-  }, [])
 
   // Track selected item by ID — derived index stays correct even as galleryItems grows
   const galleryIndex = selectedAttachmentId
@@ -689,35 +616,6 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     }
   }, [selectedAttachmentId, videoAttachments, loadedVideoUrls, workspaceId])
 
-  // Lazily fetch the full-resolution original when an image is opened in the
-  // gallery. The inline view only ever loads the small thumbnail variant, so
-  // the lightbox must fetch the original itself on demand.
-  useEffect(() => {
-    if (!selectedAttachmentId) return
-    const isImage = imageAttachments.some((a) => a.id === selectedAttachmentId)
-    if (!isImage || loadedFullImageUrls.has(selectedAttachmentId)) return
-
-    let mounted = true
-    async function fetchFullImage() {
-      try {
-        const url = await attachmentsApi.getDownloadUrl(workspaceId, selectedAttachmentId!)
-        if (mounted) {
-          setLoadedFullImageUrls((prev) => {
-            const next = new Map(prev)
-            next.set(selectedAttachmentId!, url)
-            return next
-          })
-        }
-      } catch {
-        console.error("Failed to get image URL")
-      }
-    }
-    fetchFullImage()
-    return () => {
-      mounted = false
-    }
-  }, [selectedAttachmentId, imageAttachments, loadedFullImageUrls, workspaceId])
-
   // Lazy-fetch presigned URLs for markdown/html/pdf attachments when opened.
   useEffect(() => {
     if (!selectedAttachmentId) return
@@ -765,7 +663,6 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
                 attachment={attachment}
                 workspaceId={workspaceId}
                 onImageClick={handleImageClick}
-                onThumbnailLoaded={registerThumbnailUrl}
                 isHighlighted={attachment.id === hoveredAttachmentId}
                 deferHydration={deferHydration}
               />
@@ -776,7 +673,6 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
                 attachment={attachment}
                 workspaceId={workspaceId}
                 onVideoClick={handleVideoClick}
-                onThumbnailLoaded={registerThumbnailUrl}
                 isHighlighted={attachment.id === hoveredAttachmentId}
                 deferHydration={deferHydration}
               />

--- a/tests/browser/attachment-stable-urls.spec.ts
+++ b/tests/browser/attachment-stable-urls.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test"
+import { createChannel, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * Stable attachment content URLs.
+ *
+ * Inline timeline media must render from the deterministic
+ * `/attachments/:id/content?variant=…` endpoint — never from per-session
+ * presigned URLs behind a `/attachments/:id/url` round trip. The URL being
+ * identical across sessions plus the `immutable` Cache-Control is what lets
+ * a warm open serve every image from the browser HTTP cache with zero
+ * presign requests and zero media bytes.
+ */
+
+// 1x1 red PNG
+const TEST_PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+  0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49,
+  0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xfe, 0xd4,
+  0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+])
+
+const PRESIGN_URL_PATTERN = /\/attachments\/[^/]+\/url(\?|$)/
+
+test.describe("Stable attachment content URLs", () => {
+  test("timeline image renders from the deterministic content URL with no presign round trip", async ({ page }) => {
+    const presignRequests: string[] = []
+    page.on("request", (request) => {
+      if (PRESIGN_URL_PATTERN.test(request.url())) presignRequests.push(request.url())
+    })
+
+    const testId = Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
+    await loginAndCreateWorkspace(page, "media-cache")
+    await createChannel(page, `media-${testId}`)
+
+    // Paste an image into the composer and send it.
+    const editor = page.locator("[contenteditable='true']")
+    await editor.click()
+    await page.evaluate(async (imageData) => {
+      const editorEl = document.querySelector("[contenteditable='true']")
+      if (!editorEl) throw new Error("Editor not found")
+      const blob = new Blob([new Uint8Array(imageData)], { type: "image/png" })
+      const file = new File([blob], "photo.png", { type: "image/png" })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(file)
+      editorEl.dispatchEvent(
+        new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: dataTransfer })
+      )
+    }, Array.from(TEST_PNG))
+    await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
+    await editor.press("Enter")
+
+    // The timeline <img> src must be the deterministic content URL, present
+    // synchronously — no async presign before the image can start loading.
+    const timelineImg = page.locator("img[src*='/content?variant=thumbnail']").first()
+    await expect(timelineImg).toBeVisible({ timeout: 15000 })
+    const src = await timelineImg.getAttribute("src")
+    expect(src).toContain("/api/workspaces/")
+    expect(src).toMatch(/\/attachments\/[^/]+\/content\?variant=thumbnail$/)
+
+    // The raw object (always ready, unlike the async thumbnail variant) is
+    // served with long-lived immutable caching over the session cookie.
+    const rawResponse = await page.request.get(src!.replace("?variant=thumbnail", ""))
+    expect(rawResponse.status()).toBe(200)
+    expect(rawResponse.headers()["cache-control"]).toBe("private, max-age=31536000, immutable")
+    expect(rawResponse.headers()["content-type"]).toBe("image/png")
+
+    // A warm open renders the image again from the same URL — still without a
+    // single presign request anywhere in the flow.
+    await page.reload()
+    await expect(page.locator("img[src*='/content?variant=thumbnail']").first()).toBeVisible({ timeout: 15000 })
+    expect(presignRequests).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

Attachment bytes are served via presigned S3/MinIO URLs that carry a fresh signature each session. The browser HTTP cache keys on the full URL, so every cold open of the app re-downloads every visible image and GIF — each behind a per-attachment presign round trip (`GET /attachments/:id/url`) before the `<img>` even has a `src`. On a phone this was the single biggest remaining "media loads in again" cost (item 3 of the stream-timeline perceived-performance work; exploration PR #828, frontend render fixes in #834–#837).

## Solution

Give the browser a **deterministic URL per (attachment, variant)**: a new `GET /api/workspaces/:wsId/attachments/:attachmentId/content?variant=raw|processed|thumbnail` endpoint that streams the S3 object through the backend with `Cache-Control: private, max-age=31536000, immutable`. The frontend builds this URL synchronously in render — no presign in the render path at all. A warm open serves every inline image from disk cache: zero presign requests, zero media bytes.

### How it works

- **ACL:** identical chain to the existing `/url` handler — workspace scoping → `getSharingBlockReason` → `streamService.tryAccess` fast path with the share-grant/inline-reference fallback.
- **Variant resolution:** a shared `resolveAttachmentVariant` helper (used by both `/url` and `/content`) maps (attachment, variant) → stored object: sharp WebP thumbnail for images, MediaConvert outputs for video `processed`/`thumbnail`, raw original otherwise.
- **Caching:** ready variants are written once and never change, so `immutable` is honest, with a path-derived `ETag` (`If-None-Match` → 304) and `Range` passthrough (206 + `Content-Range`). Auth rides the session cookie — the app is same-origin with `/api/*`, so plain `<img src>` works (verified in dev via the Vite proxy and in the browser test).
- **Frontend:** `attachmentContentUrl()` replaces the async presign for inline image thumbnails, video thumbnails, and gallery full-res images. Presign stays where it's the right tool: explicit downloads (`content-disposition`), gallery video playback (bytes stream from S3 with native Range), markdown/HTML/PDF viewers, E2E decrypt fetch.

### Key design decisions

**1. Stream through the backend rather than 302 → presigned URL.** A redirect only removes the presign round trip within the TTL window; it cannot make the cache key stable across sessions, which is the actual goal. Cost is backend bandwidth for media; in exchange the browser cache does all the work on warm opens.

**2. Not-ready variants fall through to the raw original with `no-store`.** If the fall-through were served `immutable` under the variant URL, the raw bytes would be pinned in cache and the real thumbnail would never appear. The fall-through also gets no `ETag`, so a 304 can never extend its life.

**3. Origin-safety hardening.** User-uploaded bytes now ride the app origin, so the endpoint sets `X-Content-Type-Options: nosniff` and `Content-Security-Policy: sandbox` — uploaded HTML/SVG navigated to directly can never execute as a document.

**4. No ACL memo cache yet.** Per-request ACL is two indexed queries; the handover says measure first. Deliberately not added (INV-36).

**5. Dead code deleted (INV-38).** `peekDownloadUrl` (added in #836 to soften the presign latency) and the `onThumbnailLoaded`/`loadedThumbnails`/`loadedFullImageUrls` plumbing are obsolete once URLs are deterministic. The `img.complete` warm-remount fast path stays.

## New files

| File | Purpose |
| ---- | ------- |
| `tests/browser/attachment-stable-urls.spec.ts` | Browser-level proof: timeline `<img>` uses the deterministic content URL, response carries immutable headers, zero presign requests across send + reload |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/attachments/handlers.ts` | New `getContent` streaming handler; shared `resolveAttachmentVariant` now backs both `/url` and `/content` |
| `apps/backend/src/lib/storage/s3-client.ts` | `getObjectContent(key, { range })` — stream + length/range metadata for HTTP proxying |
| `apps/backend/src/routes.ts` | Register `GET …/attachments/:attachmentId/content` |
| `apps/backend/evals/suites/{companion,multimodal-vision}/suite.ts` | Storage stubs implement the new interface method |
| `apps/frontend/src/api/attachments.ts` | Add sync `attachmentContentUrl()`; remove dead `peekDownloadUrl` |
| `apps/frontend/src/components/timeline/attachment-list.tsx` | Image/video thumbnails + gallery image URLs built synchronously; presign removed from render path; dead thumbnail-registration plumbing deleted |
| `apps/backend/src/features/attachments/handlers.test.ts` | 12 new `getContent` tests (headers, 304, both fall-throughs, Range, 403/404 parity, E2E ciphertext) |
| `apps/frontend/src/components/timeline/attachment-list.test.tsx`, `apps/frontend/src/api/attachments.test.ts`, `apps/frontend/src/api/index.ts` | Tests updated for sync URLs; barrel export swap |

## Test plan

- [x] Backend unit: 1689 pass (`bun run test:unit`)
- [x] Backend e2e: 308 pass against Postgres + MinIO (`bun run test:e2e`)
- [x] Frontend: 2446 pass
- [x] Monorepo typecheck clean
- [x] Browser (Playwright): new `attachment-stable-urls` spec + existing `inline-file-upload` and `user-journey` specs pass
- [x] Self-review (3 parallel reviewers); both surviving findings fixed in d28049a (shared variant resolver, `res.destroy` on mid-stream error)

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** A warm app open downloads zero media bytes and makes zero presign requests, by giving the browser a deterministic, long-lived-cacheable URL per (attachment, variant).

**What Was Built**
- `GET /api/workspaces/:wsId/attachments/:attachmentId/content?variant=raw|processed|thumbnail` in `features/attachments/` (INV-51), Zod-validated query (INV-55), workspace-scoped (INV-8), same response style as the sibling handler (INV-32 local style).
- Exact ACL parity with `/url`: workspace check → sharing-safety gate → stream access fast path → share-grant/inline-reference fallback.
- Streaming via new `StorageProvider.getObjectContent` (stream + ContentLength + ContentRange); `Range` and `If-None-Match` passthrough; `ETag` derived from the storage path (objects are write-once).
- Ready variants: `Cache-Control: private, max-age=31536000, immutable`. Not-ready fall-through: raw original with `no-store`, no ETag.
- E2E attachments: served as opaque `application/octet-stream` ciphertext, immutable (bytes never change); decrypt flow untouched.
- Frontend: `attachmentContentUrl(workspaceId, attachmentId, { variant })` used by `ImageAttachment`, `VideoAttachment`, and gallery image items; `deferHydration` still gates when the `<img>` gets its src. Skipped video transcodes get no thumbnail src (variant would fall through to raw video bytes an `<img>` can't render).

**Design Decisions**
- Option 1 (backend streaming) over option 2 (302 to presign): only option 1 achieves cross-session caching.
- `CSP: sandbox` + `nosniff` because user bytes now ride the app origin.
- Per-call-site presign retention: downloads, gallery video playback, markdown/HTML/PDF viewers, E2E decrypt.
- No short-TTL ACL memo yet — measure first (INV-36).

**What's NOT Included**
- Attachment-explorer thumbnails still presign per open (candidate follow-up).
- ACL memo cache for the hot path (only if measurement shows need).
- No removal of the `/url` endpoint — other clients/tests rely on it.

**Status:** Complete; all suites green; self-review findings addressed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EynZ7B2BRHM81kZhPFQh2w

---
_Generated by [Claude Code](https://claude.ai/code/session_01EynZ7B2BRHM81kZhPFQh2w)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783833958&installation_id=129946197&pr_number=863&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F863&signature=5f4b31d5dbeeb02bd3e51ef8ebfcb93349867460733e9857818378d1defa3357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->