### PR TITLE
feat(public-site): dark mode, defaulting to the system preference

### DIFF
--- a/apps/public-site/src/components/BaseHead.astro
+++ b/apps/public-site/src/components/BaseHead.astro
@@ -9,6 +9,30 @@ const { title, description } = Astro.props
 
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<script is:inline>
+  /* Theme bootstrap — must run before first paint (hence inline in <head>).
+     No stored choice → follow the system; a stored choice wins. The toggle
+     (ThemeToggle.astro) writes the choice; here we only resolve it. */
+  ;(() => {
+    let stored = null
+    try {
+      stored = localStorage.getItem("threa:theme")
+    } catch {
+      /* storage blocked — fall through to system */
+    }
+    const dark = stored === "dark" || (stored !== "light" && matchMedia("(prefers-color-scheme: dark)").matches)
+    document.documentElement.dataset.theme = dark ? "dark" : "light"
+    /* Live-follow OS changes while the user hasn't chosen explicitly. */
+    matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+      try {
+        if (localStorage.getItem("threa:theme")) return
+      } catch {
+        /* no storage — always follow the system */
+      }
+      document.documentElement.dataset.theme = e.matches ? "dark" : "light"
+    })
+  })()
+</script>
 <meta name="description" content={description} />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <!-- Agent entry points: a markdown index of the developer docs and the full

--- a/apps/public-site/src/components/ThemeToggle.astro
+++ b/apps/public-site/src/components/ThemeToggle.astro
@@ -1,0 +1,36 @@
+---
+/*
+ * Light/dark toggle. The head bootstrap (BaseHead.astro) resolves the initial
+ * theme (stored choice, else system); clicking here stores an explicit choice
+ * and flips `data-theme` on <html>. Both icons ship in the markup and CSS
+ * shows the one for the mode a click switches TO (moon in light, sun in dark),
+ * so there's no icon swap script and no layout shift.
+ */
+---
+
+<button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light and dark mode">
+  <svg class="tt-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+  <svg class="tt-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+  </svg>
+</button>
+
+<script is:inline>
+  /* One listener for every toggle on the page (nav + drawer can both have one). */
+  if (!window.__threaThemeToggleBound) {
+    window.__threaThemeToggleBound = true
+    document.addEventListener("click", (e) => {
+      if (!e.target.closest("[data-theme-toggle]")) return
+      const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark"
+      document.documentElement.dataset.theme = next
+      try {
+        localStorage.setItem("threa:theme", next)
+      } catch {
+        /* storage blocked — the flip still applies for this page view */
+      }
+    })
+  }
+</script>

--- a/apps/public-site/src/layouts/DocsLayout.astro
+++ b/apps/public-site/src/layouts/DocsLayout.astro
@@ -3,6 +3,7 @@ import "../styles/global.css"
 import "../styles/docs.css"
 import BaseHead from "../components/BaseHead.astro"
 import SvgDefs from "../components/SvgDefs.astro"
+import ThemeToggle from "../components/ThemeToggle.astro"
 
 interface Props {
   title?: string
@@ -101,6 +102,7 @@ for (const s of sections) {
           <a href="/llms.txt">llms.txt</a>
           <a class="home" href="/">↩ threa.io</a>
         </nav>
+        <ThemeToggle />
         <button type="button" class="pg-toggle" id="pg-toggle" aria-expanded="false" aria-controls="pg-panel">
           <span class="pg-dot" id="pg-dot" data-state="idle"></span>
           <span id="pg-toggle-label">Credentials</span>

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro"
 import SvgDefs from "../components/SvgDefs.astro"
+import ThemeToggle from "../components/ThemeToggle.astro"
 ---
 
 <Layout
@@ -26,6 +27,7 @@ import SvgDefs from "../components/SvgDefs.astro"
             <a href="/developers">Developer</a>
             <a href="/about" aria-current="page">About</a>
           </nav>
+          <ThemeToggle />
         </div>
 
         <div class="about-hero">

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro"
 import SvgDefs from "../components/SvgDefs.astro"
+import ThemeToggle from "../components/ThemeToggle.astro"
 
 // Where the waitlist form POSTs. The marketing site is a separate origin from
 // the API, so this is a cross-origin call to the workspace-router, which proxies
@@ -22,6 +23,7 @@ const apiBase = import.meta.env.PUBLIC_API_BASE ?? "https://app.threa.io"
         <nav class="nav-links">
           <a href="/" aria-current="page">Product</a><a href="/developers">Developer</a><a href="/about">About</a>
         </nav>
+        <ThemeToggle />
       </div>
       <div class="hero-stage">
         <div>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -1304,3 +1304,38 @@ a {
     grid-template-columns: 1fr;
   }
 }
+
+/* ---------- DARK MODE OVERRIDES ----------
+   Tokens flip in global.css; these are the docs-local hardcoded values.
+   The code surfaces (.pg-pre) are always dark and need nothing here. */
+[data-theme="dark"] .ep-method.get {
+  background: hsl(205 35% 22%);
+  color: hsl(205 50% 72%);
+}
+[data-theme="dark"] .ep-method.patch {
+  background: hsl(38 40% 22%);
+}
+[data-theme="dark"] .ep-method.delete {
+  background: hsl(8 40% 22%);
+  color: hsl(8 60% 70%);
+}
+[data-theme="dark"] .api-method.m-patch {
+  color: hsl(28 60% 65%);
+}
+[data-theme="dark"] .api-method.m-delete {
+  color: hsl(8 65% 68%);
+}
+[data-theme="dark"] .pg-output[data-kind="err"] {
+  color: hsl(8 60% 64%);
+}
+[data-theme="dark"] .pg-status[data-state="bad"],
+[data-theme="dark"] .pg-status[data-state="cors"] {
+  color: hsl(8 65% 64%);
+  border-color: hsl(8 65% 64% / 0.4);
+}
+[data-theme="dark"] .api-req {
+  color: hsl(8 60% 64%);
+}
+[data-theme="dark"] .note.warn {
+  border-left-color: hsl(8 55% 55%);
+}

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -36,6 +36,33 @@
 
   /* total animation cycle for the chat widget */
   --cycle: 22s;
+
+  color-scheme: light;
+}
+
+/* ---------- DARK THEME TOKENS ----------
+   data-theme is resolved before first paint by the head bootstrap in
+   BaseHead.astro: a stored choice wins, otherwise the system preference.
+   Same warm hue family inverted — espresso canvas, parchment ink, gold
+   lifted for contrast. The always-dark surfaces (--night terminals/code)
+   drop BELOW the canvas so they still read as sunk panels. */
+:root[data-theme="dark"] {
+  --gold: 40 62% 56%;
+  --gold-soft: 42 70% 68%;
+  --gold-dim: 38 35% 58%;
+  --paper: 26 12% 13%;
+  --paper-warm: 26 14% 11%;
+  --paper-sunk: 26 15% 9%;
+  --ink: 38 16% 90%;
+  --ink-soft: 35 11% 74%;
+  --night: 26 16% 7%;
+  --night-soft: 26 12% 15%;
+  --line: 26 8% 24%;
+  --muted: 32 7% 57%;
+  --emerald: 142 45% 52%;
+  --emerald-soft: 142 28% 16%;
+
+  color-scheme: dark;
 }
 
 * {
@@ -2244,4 +2271,93 @@ body::after {
     width: 100%;
     justify-content: center;
   }
+}
+
+/* ---------- THEME TOGGLE ---------- */
+.theme-toggle {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: hsl(var(--muted));
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+.theme-toggle:hover {
+  color: hsl(var(--ink));
+  border-color: hsl(var(--line));
+  background: hsl(var(--paper));
+}
+/* Show the icon of the mode a click switches TO. */
+.theme-toggle .tt-sun {
+  display: none;
+}
+[data-theme="dark"] .theme-toggle .tt-sun {
+  display: block;
+}
+[data-theme="dark"] .theme-toggle .tt-moon {
+  display: none;
+}
+/* Marketing nav-row gains a third child; keep the links hugging the toggle
+   on the right instead of letting space-between spread all three apart. */
+.nav-row .nav-links {
+  margin-left: auto;
+}
+.nav-row .theme-toggle {
+  margin-left: 20px;
+}
+
+/* ---------- DARK MODE OVERRIDES ----------
+   Everything token-based flips automatically; these are the hardcoded
+   light-surface values that need explicit dark counterparts. */
+
+/* Multiplied noise is invisible on a dark canvas — switch to screen so the
+   grain lightens instead, at lower strength. */
+[data-theme="dark"] body::after {
+  mix-blend-mode: screen;
+  opacity: 0.4;
+}
+
+/* Chat-demo avatar pastels: same hues, inverted value. */
+[data-theme="dark"] .tl-avatar.av-alex,
+[data-theme="dark"] .capture-row .c-avatar.av-sam {
+  background: hsl(28 18% 26%);
+  color: hsl(28 28% 80%);
+}
+[data-theme="dark"] .tl-avatar.av-jordan,
+[data-theme="dark"] .capture-row .c-avatar.av-jordan {
+  background: hsl(200 20% 27%);
+  color: hsl(200 30% 80%);
+}
+[data-theme="dark"] .tl-avatar.av-maya,
+[data-theme="dark"] .capture-row .c-avatar.av-maya,
+[data-theme="dark"] .recall-row .r-avatar.av-maya {
+  background: hsl(20 22% 27%);
+  color: hsl(20 30% 80%);
+}
+
+/* Floating composer: dark border, black-based shadows (an ink-derived shadow
+   would glow white on the inverted palette). */
+[data-theme="dark"] .composer {
+  border-color: hsl(26 10% 26%);
+  box-shadow:
+    0 1px 0 hsl(26 12% 17%) inset,
+    0 8px 24px -14px hsl(0 0% 0% / 0.55),
+    0 2px 6px -2px hsl(0 0% 0% / 0.3);
+}
+[data-theme="dark"] .trace-card {
+  background: hsl(26 10% 17%);
+}
+[data-theme="dark"] .memory-card {
+  box-shadow: 0 6px 20px -10px hsl(0 0% 0% / 0.55);
+}
+/* Terminal borders lift a step so the sunk panel still has an edge against
+   the dark canvas. */
+[data-theme="dark"] .os-terminal {
+  border-color: hsl(26 12% 26%);
 }


### PR DESCRIPTION
## Problem

The public site and developer docs are light-only. The site should respect the reader's system preference and offer an explicit choice.

## Solution

### Key design decisions

**1. System default, explicit override**

An inline script in `<head>` (before any paint) resolves `data-theme` on `<html>`: a stored `localStorage` choice wins; otherwise the system `prefers-color-scheme` applies, and the page live-follows OS changes until the user picks explicitly. No flash of wrong theme on load.

**2. One dark token set, same hue family**

Dark mode inverts the existing warm palette rather than introducing a new one: espresso canvas (`26 14% 11%`), parchment ink, gold lifted two steps for contrast, `color-scheme` set for native form controls. The always-dark code/terminal surfaces (`--night`) drop *below* the canvas (7% vs 11%) so they still read as sunk panels in dark mode. Everything built on tokens flips automatically; an audited set of hardcoded light values (chat-demo avatar pastels, composer shadows, trace card, HTTP method pills, error reds) gets explicit dark counterparts, and the paper grain switches from multiply to screen so it stays visible.

**3. Sun/moon toggle**

A small ghost button in the marketing nav and the docs nav. Both icons ship in the markup; CSS shows the one for the mode a click switches to, so there's no icon-swap script and no layout shift (INV-21). One delegated click listener, guarded against double-binding.

## New files

| File | Purpose |
| ---- | ------- |
| `src/components/ThemeToggle.astro` | Toggle button + click handler |

## Modified files

| File | Change |
| ---- | ------ |
| `src/components/BaseHead.astro` | Pre-paint theme bootstrap script |
| `src/styles/global.css` | Dark token set, toggle styles, dark overrides for hardcoded values |
| `src/styles/docs.css` | Docs-local dark overrides (method pills, error states) |
| `src/layouts/DocsLayout.astro`, `src/pages/index.astro`, `src/pages/about.astro` | Toggle placement |

## Test plan

- [x] `astro check` + full build green
- [x] Both modes verified in browser at 1440px: homepage (hero, memory flow, terminals, night band), reference, recipes
- [x] Toggle round-trips and persists; reload in dark shows no light flash
- [x] 390px: nav fits with toggle, dark renders cleanly
- [x] Light mode pixel-identical to before (tokens unchanged)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783835896&installation_id=129946197&pr_number=864&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F864&signature=8a9897e5ea11d10f61c9c8c581ca3f9bef3e518483a54930a6f054f6a19b41b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->