### PR TITLE
feat: bot:hello output manifest + reject-undeclared at the verb boundary (Phase 2.3b)

### DIFF
--- a/apps/backend/src/db/migrations/20260612053541_add_bot_runtime_instance_manifest.sql
+++ b/apps/backend/src/db/migrations/20260612053541_add_bot_runtime_instance_manifest.sql
@@ -1,0 +1,8 @@
+-- Add a declared-output manifest to bot runtime instances.
+-- Populated from the optional `manifest` block on bot:hello; null means the
+-- runtime declared none and is treated as the legacy default output profile
+-- (reply + trace, no sources). The verb-boundary reject-undeclared check
+-- (Phase 2.3b) reads it per claiming instance.
+
+ALTER TABLE bot_runtime_instances
+ADD COLUMN IF NOT EXISTS manifest JSONB;

--- a/apps/backend/src/features/bot-runtimes/assert-manifest-allows.test.ts
+++ b/apps/backend/src/features/bot-runtimes/assert-manifest-allows.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { HttpError } from "@threa/backend-common"
+import { assertManifestAllows } from "./assert-manifest-allows"
+
+describe("assertManifestAllows", () => {
+  it("leaves a legacy null manifest unenforced", () => {
+    expect(() => assertManifestAllows(null, "sources")).not.toThrow()
+  })
+
+  it("passes when the declared manifest allows the output", () => {
+    const manifest = { output: { reply: true, trace: true, sources: true } }
+    expect(() => assertManifestAllows(manifest, "sources")).not.toThrow()
+  })
+
+  it("rejects loudly when the declared manifest omits the output", () => {
+    const manifest = { output: { reply: true, trace: true, sources: false } }
+    let caught: unknown
+    try {
+      assertManifestAllows(manifest, "sources")
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(HttpError)
+    expect(caught).toMatchObject({ status: 400, code: "CAPABILITY_NOT_DECLARED" })
+  })
+})

--- a/apps/backend/src/features/bot-runtimes/assert-manifest-allows.ts
+++ b/apps/backend/src/features/bot-runtimes/assert-manifest-allows.ts
@@ -1,0 +1,21 @@
+import type { BotOutputManifest, BotRuntimeManifest } from "@threa/types"
+import { HttpError } from "@threa/backend-common"
+
+/**
+ * Reject-undeclared at the verb boundary (Phase 2.3b, INV-11). A runtime that
+ * declared a manifest may only emit what it declared; using an output it left
+ * off is a loud `400`, never a silent drop.
+ *
+ * A null manifest is the legacy default profile (a runtime that predates the
+ * manifest, or one that opted out): unenforced, so existing Pi/OpenClaw
+ * harnesses keep working. Enforcement turns on only once a runtime declares.
+ */
+export function assertManifestAllows(manifest: BotRuntimeManifest | null, output: keyof BotOutputManifest): void {
+  if (!manifest) return
+  if (!manifest.output[output]) {
+    throw new HttpError(`Bot runtime did not declare the "${output}" output capability`, {
+      status: 400,
+      code: "CAPABILITY_NOT_DECLARED",
+    })
+  }
+}

--- a/apps/backend/src/features/bot-runtimes/index.ts
+++ b/apps/backend/src/features/bot-runtimes/index.ts
@@ -17,3 +17,4 @@ export {
   type SerializedBotInvocation,
 } from "./socket-handler"
 export { createBotSocketAuthMiddleware, type BotSocketData } from "./socket-auth"
+export { assertManifestAllows } from "./assert-manifest-allows"

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -9,6 +9,7 @@ import {
   type BotInvocationStatus,
   type BotInvocationTrigger,
   type BotRuntimeKind,
+  type BotRuntimeManifest,
   type BotRuntimeSessionLinkStatus,
   type BotRuntimeStatus,
 } from "@threa/types"
@@ -54,6 +55,9 @@ export interface BotRuntimeInstance {
   status: BotRuntimeStatus
   acceptingInvocations: boolean
   capabilities: Record<string, unknown>
+  // Declared-output manifest from bot:hello; null = legacy default profile,
+  // which the reject-undeclared boundary leaves unenforced (Phase 2.3b).
+  manifest: BotRuntimeManifest | null
   statusText: string | null
   // BIK — the runtime's per-session X25519 public key (base64) and the short id
   // used as `recipient_key_id` when wrapping a stream's SSK to this bot. Null
@@ -131,6 +135,7 @@ interface BotRuntimeInstanceRow {
   status: string
   accepting_invocations: boolean
   capabilities: Record<string, unknown>
+  manifest: BotRuntimeManifest | null
   status_text: string | null
   public_key: string | null
   public_key_id: string | null
@@ -227,6 +232,7 @@ function mapRuntimeInstance(row: BotRuntimeInstanceRow): BotRuntimeInstance {
     status: row.status as BotRuntimeStatus,
     acceptingInvocations: row.accepting_invocations,
     capabilities: row.capabilities,
+    manifest: row.manifest,
     statusText: row.status_text,
     publicKey: row.public_key,
     publicKeyId: row.public_key_id,
@@ -399,6 +405,7 @@ export const BotRuntimeInstanceRepository = {
       status: BotRuntimeStatus
       acceptingInvocations: boolean
       capabilities: Record<string, unknown>
+      manifest?: BotRuntimeManifest | null
       statusText?: string | null
       publicKey?: string | null
       publicKeyId?: string | null
@@ -421,9 +428,9 @@ export const BotRuntimeInstanceRepository = {
       ? "public_key = COALESCE(EXCLUDED.public_key, bot_runtime_instances.public_key), public_key_id = COALESCE(EXCLUDED.public_key_id, bot_runtime_instances.public_key_id)"
       : "public_key = EXCLUDED.public_key, public_key_id = EXCLUDED.public_key_id"
     const result =
-      await db.query<BotRuntimeInstanceRow>(sql`INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, runtime_kind, instance_id, display_name, status, accepting_invocations, capabilities, status_text, public_key, public_key_id)
-      VALUES (${params.id}, ${params.workspaceId}, ${params.botId}, ${params.runtimeKind}, ${params.instanceId}, ${params.displayName ?? null}, ${params.status}, ${params.acceptingInvocations}, ${params.capabilities}, ${params.statusText ?? null}, ${publicKey}, ${publicKeyId})
-      ON CONFLICT (workspace_id, bot_id, instance_id) DO UPDATE SET runtime_kind = EXCLUDED.runtime_kind, display_name = EXCLUDED.display_name, status = EXCLUDED.status, accepting_invocations = EXCLUDED.accepting_invocations, ${sql.raw(capabilitiesSet)}, status_text = EXCLUDED.status_text, ${sql.raw(bikSet)}, last_seen_at = NOW(), updated_at = NOW()
+      await db.query<BotRuntimeInstanceRow>(sql`INSERT INTO bot_runtime_instances (id, workspace_id, bot_id, runtime_kind, instance_id, display_name, status, accepting_invocations, capabilities, manifest, status_text, public_key, public_key_id)
+      VALUES (${params.id}, ${params.workspaceId}, ${params.botId}, ${params.runtimeKind}, ${params.instanceId}, ${params.displayName ?? null}, ${params.status}, ${params.acceptingInvocations}, ${params.capabilities}, ${params.manifest ?? null}, ${params.statusText ?? null}, ${publicKey}, ${publicKeyId})
+      ON CONFLICT (workspace_id, bot_id, instance_id) DO UPDATE SET runtime_kind = EXCLUDED.runtime_kind, display_name = EXCLUDED.display_name, status = EXCLUDED.status, accepting_invocations = EXCLUDED.accepting_invocations, ${sql.raw(capabilitiesSet)}, manifest = COALESCE(EXCLUDED.manifest, bot_runtime_instances.manifest), status_text = EXCLUDED.status_text, ${sql.raw(bikSet)}, last_seen_at = NOW(), updated_at = NOW()
       RETURNING *`)
     return mapRuntimeInstance(result.rows[0]!)
   },

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -4,6 +4,7 @@ import type {
   BotInvocationCapability,
   BotInvocationTrigger,
   BotRuntimeKind,
+  BotRuntimeManifest,
   BotRuntimeStatus,
   BotTrait,
 } from "@threa/types"
@@ -81,6 +82,7 @@ export class BotRuntimeService {
     status: BotRuntimeStatus
     acceptingInvocations: boolean
     capabilities?: Record<string, unknown>
+    manifest?: BotRuntimeManifest | null
     statusText?: string | null
     publicKey?: string | null
     publicKeyId?: string | null
@@ -97,6 +99,7 @@ export class BotRuntimeService {
       status: params.status,
       acceptingInvocations: params.acceptingInvocations,
       capabilities: params.capabilities ?? {},
+      manifest: params.manifest,
       statusText: params.statusText,
       publicKey: params.publicKey,
       publicKeyId: params.publicKeyId,

--- a/apps/backend/src/features/bot-runtimes/socket-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/socket-handler.ts
@@ -31,6 +31,20 @@ const helloSchema = z
     displayName: z.string().max(256).optional().nullable(),
     capabilities: z.record(z.string(), z.unknown()).optional(),
     supportedCapabilities: z.array(z.enum(BOT_INVOCATION_CAPABILITIES)).min(1),
+    // Declared-output manifest (Phase 2.3b). Optional and additive — a runtime
+    // that sends none keeps the legacy default profile and stays unenforced.
+    // Once present, the verb boundary rejects any output it didn't declare. The
+    // `output` object's fields default (reply+trace on, sources off), so sending
+    // `manifest: { output: {} }` opts into enforcement at the default profile.
+    manifest: z
+      .object({
+        output: z.object({
+          reply: z.boolean().optional().default(true),
+          trace: z.boolean().optional().default(true),
+          sources: z.boolean().optional().default(false),
+        }),
+      })
+      .optional(),
     // ISO timestamp — server echoes the next cursor in the ack and the runtime
     // sends it back on the following hello so we only replay events the
     // runtime hasn't already seen.
@@ -179,6 +193,7 @@ export function attachBotNamespace(deps: BotSocketHandlerDeps): void {
             ...(data.capabilities ?? {}),
             ...(runtimeSessionId ? { runtimeSessionId } : {}),
           },
+          manifest: data.manifest ?? null,
           publicKey: data.publicKey,
           publicKeyId: data.publicKeyId,
         })

--- a/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
+++ b/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
@@ -23,7 +23,7 @@ function createResponse(): Response {
   return res
 }
 
-function arrangeCompletion(params: { existingSteps: unknown[] }) {
+function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknown }) {
   spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
   spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Pi", archivedAt: null } as never)
   spyOn(dbModule, "withTransaction").mockImplementation(((_pool: unknown, fn: (c: unknown) => unknown) =>
@@ -90,6 +90,7 @@ function arrangeCompletion(params: { existingSteps: unknown[] }) {
   } as unknown as EventService
   const botRuntimeService = {
     findActiveClaimForUpdate: mock(() => Promise.resolve({ id: "binv_1", responseStreamId: "stream_1" })),
+    findPresenceByInstance: mock(() => Promise.resolve({ manifest: params.manifest ?? null })),
     completeInvocationInTransaction: mock(() =>
       Promise.resolve({
         id: "binv_1",
@@ -210,5 +211,59 @@ describe("completeBotInvocation sources", () => {
     await handlers.completeBotInvocation(req, createResponse())
 
     expect(createMessageInTransaction.mock.calls[0]?.[1].sources).toBeUndefined()
+  })
+})
+
+describe("completeBotInvocation manifest enforcement", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  const sources = [{ type: "web", title: "Tide tables", url: "https://tides.example/today" }]
+
+  it("rejects sources a declared manifest did not allow (INV-11)", async () => {
+    const { handlers, req } = arrangeCompletion({
+      existingSteps: [],
+      manifest: { output: { reply: true, trace: true, sources: false } },
+    })
+    req.body = { ...(req.body as Record<string, unknown>), sources }
+
+    await expect(handlers.completeBotInvocation(req, createResponse())).rejects.toMatchObject({
+      status: 400,
+      code: "CAPABILITY_NOT_DECLARED",
+    })
+  })
+
+  it("allows sources when the declared manifest permits them", async () => {
+    const { handlers, req, createMessageInTransaction } = arrangeCompletion({
+      existingSteps: [],
+      manifest: { output: { reply: true, trace: true, sources: true } },
+    })
+    req.body = { ...(req.body as Record<string, unknown>), sources }
+
+    await handlers.completeBotInvocation(req, createResponse())
+
+    expect(createMessageInTransaction.mock.calls[0]?.[1]).toMatchObject({ sources })
+  })
+
+  it("rejects a reply a declared manifest did not allow", async () => {
+    const { handlers, req } = arrangeCompletion({
+      existingSteps: [],
+      manifest: { output: { reply: false, trace: true, sources: false } },
+    })
+
+    await expect(handlers.completeBotInvocation(req, createResponse())).rejects.toMatchObject({
+      status: 400,
+      code: "CAPABILITY_NOT_DECLARED",
+    })
+  })
+
+  it("leaves a legacy null-manifest completion unenforced", async () => {
+    const { handlers, req, createMessageInTransaction } = arrangeCompletion({ existingSteps: [], manifest: null })
+    req.body = { ...(req.body as Record<string, unknown>), sources }
+
+    await handlers.completeBotInvocation(req, createResponse())
+
+    expect(createMessageInTransaction.mock.calls[0]?.[1]).toMatchObject({ sources })
   })
 })

--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -109,6 +109,7 @@ describe("public API E2E-stream plaintext gate", () => {
       fn({})) as never)
     const botRuntimeService = {
       findActiveClaimForUpdate: mock(() => Promise.resolve({ id: "claim_1", responseStreamId: "stream_1" })),
+      findPresenceByInstance: mock(() => Promise.resolve({ manifest: null })),
       completeInvocationInTransaction: mock(() => Promise.resolve({ id: "inv_1" })),
     } as unknown as PublicApiDeps["botRuntimeService"]
     const botChannelService = {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -44,7 +44,7 @@ import {
   type AuthorType,
   type PiToolTraceSectionLabel,
 } from "@threa/types"
-import { BotRuntimeService, type BotRuntimeInstance } from "../bot-runtimes"
+import { BotRuntimeService, assertManifestAllows, type BotRuntimeInstance } from "../bot-runtimes"
 import {
   insertCommandCompletedEvent,
   insertCommandFailedEvent,
@@ -1004,6 +1004,9 @@ export function createPublicApiHandlers({
           instanceId: result.data.instanceId,
         }),
       ])
+      // Reject-undeclared (INV-11): a runtime that declared a manifest without
+      // trace can't post /steps. Unenforced for legacy (null-manifest) runtimes.
+      assertManifestAllows(runtimePresence?.manifest ?? null, "trace")
       // Normalize the wire frame into AgentEvents and run them through the
       // shared TraceProjector — the same event → step state machine the
       // in-process companion and the enclave project through; only the sink
@@ -1055,12 +1058,24 @@ export function createPublicApiHandlers({
       if (!result.success) {
         return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
       }
-      const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
+      const [bot, runtimePresence] = await Promise.all([
+        BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId),
+        botRuntimeService.findPresenceByInstance({
+          workspaceId: req.workspaceId!,
+          botId: req.botApiKey.botId,
+          instanceId: result.data.instanceId,
+        }),
+      ])
       if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
       const contentMarkdown =
         result.data.noResponse === true || !result.data.finalMessageMarkdown
           ? null
           : normalizeMessage(result.data.finalMessageMarkdown)
+      // Reject-undeclared (INV-11): a runtime that declared a manifest may only
+      // emit what it declared. Unenforced for legacy (null-manifest) runtimes.
+      const manifest = runtimePresence?.manifest ?? null
+      if (contentMarkdown) assertManifestAllows(manifest, "reply")
+      if (result.data.sources && result.data.sources.length > 0) assertManifestAllows(manifest, "sources")
       const contentJson = contentMarkdown ? parseMarkdown(contentMarkdown, undefined, toEmoji) : null
       const attachmentIds = contentJson ? collectAttachmentReferenceIds(contentJson) : []
       const { completed, message, sessionFinalized, synthesizedSteps } = await withTransaction(pool, async (client) => {

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -317,6 +317,26 @@ export interface StreamMember {
 }
 
 /**
+ * What a bot runtime declares it can emit, sent in the optional `manifest` block
+ * on `bot:hello` and persisted per instance. A null/absent manifest is the
+ * legacy default output profile (reply + trace, no sources) and is NOT enforced;
+ * once a runtime declares a manifest, the verb boundary loudly rejects anything
+ * it didn't declare (Phase 2.3b reject-undeclared).
+ */
+export interface BotOutputManifest {
+  /** Emits a final reply message via `/complete`. */
+  reply: boolean
+  /** POSTs `/steps` trace frames. */
+  trace: boolean
+  /** Attaches citation sources on `/complete`. */
+  sources: boolean
+}
+
+export interface BotRuntimeManifest {
+  output: BotOutputManifest
+}
+
+/**
  * User-defined organizational label. Private labels (`visibility: "private"`)
  * are only visible to the creator. Public labels (`visibility: "public"`) are
  * discoverable workspace-wide; workspace users join via `LabelMember` rows to

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -246,6 +246,8 @@ export type {
   BotRuntimeInstance,
   BotRuntimeSessionLink,
   BotInvocation,
+  BotOutputManifest,
+  BotRuntimeManifest,
   StreamMember,
   Label,
   LabelMember,


### PR DESCRIPTION
## Problem

Phase 2.3a gave external bots a `/complete` `sources` field, but **ungated** — any harness could attach citations whether or not it declared it could. More broadly, the external wire has no declared-output contract: the backend can't tell a reply-only harness from a full-trace one, so it can't honor §2.3's "reject undeclared capabilities loudly at the boundary" (INV-11). This is the §2.4 row 2.3 deltas "bot:hello manifest" + "reject-undeclared at boundary".

## Solution

**Phase 2.3b — declared-output manifest + reject-undeclared.**

A runtime can now declare, at `bot:hello`, what it emits; the verb handlers reject anything it didn't declare. Backward-compatible by construction: a runtime that declares nothing keeps the legacy default profile and is **not** enforced, so existing Pi/OpenClaw harnesses (and 2.3a's ungated sources) keep working untouched. Enforcement turns on only once a runtime opts in by declaring.

### How it works

```
bot:hello { manifest: { output: { reply, trace, sources } } }   (optional)
        │  reply+trace default true, sources default false
        ▼
bot_runtime_instances.manifest (jsonb, nullable, per instance)
        │  retained via COALESCE on the internal presence-touch path
        ▼
verb boundary: assertManifestAllows(instance.manifest, output)
   /complete → reply (when a reply is sent), sources (when sources present)
   /steps    → trace
   null manifest ⇒ unenforced (legacy);  declared-but-omitted ⇒ 400 CAPABILITY_NOT_DECLARED
```

### Key design decisions

**1. Column on the instance row, not a tracking table.** The manifest is per-instance connection config declared at `bot:hello`, already where presence is upserted and already read by the verb handlers via the claiming `instanceId`. A presence row is infra, not a core domain entity, so INV-57 doesn't pull toward a tracking table; the read-path simplicity (no extra join on every boundary check) wins.

**2. Retain-on-absent (COALESCE), not overwrite.** The internal presence-touch path (session links, `/steps` heartbeat) calls `upsertPresence` without a manifest. `manifest = COALESCE(EXCLUDED.manifest, …)` keeps a hello-declared manifest from being clobbered by those writes, mirroring the BIK retain pattern.

**3. Null manifest is unenforced (opt-in enforcement).** Reject-undeclared only fires once a runtime declares a manifest. A null/legacy manifest is the default profile and passes — this is what keeps 2.3a's ungated sources and existing harnesses working.

**4. Output flags trimmed to what's enforced (INV-36).** Only `reply`/`trace`/`sources` — the three outputs with an enforcement point today. `multimodal`/`interjection` from the design doc are deferred, not added as speculative config.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/db/migrations/…_add_bot_runtime_instance_manifest.sql` | Nullable `manifest jsonb` on `bot_runtime_instances` |
| `apps/backend/src/features/bot-runtimes/assert-manifest-allows.ts` | The reject-undeclared chokepoint (one function, INV-35) |
| `apps/backend/src/features/bot-runtimes/assert-manifest-allows.test.ts` | Unit: null unenforced; declared-true passes; declared-false ⇒ 400 |

## Modified files

| File | Change |
| --- | --- |
| `packages/types/src/{domain,index}.ts` | `BotOutputManifest` + `BotRuntimeManifest` |
| `bot-runtimes/socket-handler.ts` | Optional `manifest.output` on `bot:hello`; persist it |
| `bot-runtimes/service.ts` | Thread `manifest` through `upsertPresenceFromBotKey` |
| `bot-runtimes/repository.ts` | Map the column; `upsertPresence` retains via COALESCE |
| `bot-runtimes/index.ts` | Export `assertManifestAllows` |
| `public-api/handlers.ts` | `assertManifestAllows` at `/complete` (reply, sources) and `/steps` (trace) |
| `public-api/complete-invocation-floor.test.ts` | `findPresenceByInstance` mock + 4 manifest cases |
| `public-api/e2e-stream-gate.test.ts` | Add the `findPresenceByInstance` mock (INV-22) |

## Test plan

- [x] `assert-manifest-allows.test.ts`: null unenforced; declared-true passes; declared-false ⇒ `400 CAPABILITY_NOT_DECLARED`
- [x] `/complete`: sources rejected when undeclared; allowed when declared; reply rejected when undeclared; legacy null-manifest unenforced
- [x] bot-runtimes + public-api: 93 pass
- [x] Monorepo typecheck + lint clean; OpenAPI unchanged (`bot:hello` is a socket schema, not an HTTP route)
- [x] Backward-compatible: no-manifest runtimes byte-identical to today

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2.3b of `docs/plans/agent-runtimes-unification-redesign.md` §2.4 row 2.3 — the `bot:hello` manifest + reject-undeclared boundary. Follows 2.3a (`/complete` sources, #861) and the `ExternalTurnDriver` design doc (also landed in #861).

## What Was Built

- Optional `manifest.output` (`reply`/`trace`/`sources`) on `bot:hello`, persisted per instance in a new nullable `manifest jsonb` column (retained via COALESCE on the internal touch path).
- `BotOutputManifest`/`BotRuntimeManifest` in `@threa/types`.
- `assertManifestAllows` reject-undeclared chokepoint (INV-11), wired at `/complete` (reply, sources) and `/steps` (trace). Null manifest unenforced (legacy).

## Design Decisions

- Column on the instance/presence row (per-instance config, already read by handlers); retain-on-absent so the touch path can't clobber; opt-in enforcement (null ⇒ unenforced) for back-compat; output flags trimmed to the enforced three (INV-36).

## What's NOT Included (later 2.3 PRs)

- **2.3c** — `ExternalTurnDriver` + the `Synchronous`/`Dispatched` interface split (design doc in #861).
- **2.3d** — context handle (N-4, inline-first).
- Triggers rename (`supportedCapabilities` → `manifest.triggers`) — deferred; the existing field stays authoritative.

## Status

Complete for 2.3b. Gauntlet green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_016EBD7RTpDaFBsa4dhVX8dS

---
_Generated by [Claude Code](https://claude.ai/code/session_016EBD7RTpDaFBsa4dhVX8dS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783835944&installation_id=129946197&pr_number=865&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F865&signature=180c814709cf7abf5c009d70b0e21cf58d997a660a12c0840ac93baef8216033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->