### PR TITLE
feat: skeleton rows while fetching older timeline pages

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -10,6 +10,8 @@ import {
   injectGapItems,
   timelineItemEqual,
   timelineRowPropsEqual,
+  OLDER_SKELETON_COUNT,
+  OLDER_SKELETON_ITEMS,
   type TimelineItem,
   type TimelineItemRenderContext,
 } from "./event-list"
@@ -465,6 +467,25 @@ describe("injectGapItems", () => {
   })
 })
 
+describe("OLDER_SKELETON_ITEMS (older-page skeleton rows)", () => {
+  it("provides the configured number of skeleton items with stable, distinct keys", () => {
+    expect(OLDER_SKELETON_ITEMS).toHaveLength(OLDER_SKELETON_COUNT)
+    const keys = OLDER_SKELETON_ITEMS.map(getTimelineItemKey)
+    expect(new Set(keys).size).toBe(OLDER_SKELETON_COUNT)
+    expect(keys[0]).toBe("skeleton:older:0")
+  })
+
+  it("skeleton keys never collide with event, group, or gap keys", () => {
+    const eventKey = getTimelineItemKey({
+      type: "event",
+      event: createEvent({ id: "evt_1", sequence: "1", eventType: "message_created", payload: {} }),
+    })
+    const gapKey = getTimelineItemKey({ type: "gap", afterEventId: "evt_1", missingCount: 1 })
+    expect(OLDER_SKELETON_ITEMS.map(getTimelineItemKey)).not.toContain(eventKey)
+    expect(OLDER_SKELETON_ITEMS.map(getTimelineItemKey)).not.toContain(gapKey)
+  })
+})
+
 describe("timelineRowPropsEqual (memoized row comparator)", () => {
   function makeCtx(overrides: Partial<TimelineItemRenderContext> = {}): TimelineItemRenderContext {
     return {
@@ -597,5 +618,20 @@ describe("timelineRowPropsEqual (memoized row comparator)", () => {
     expect(timelineItemEqual(a, { type: "event", event: msgA })).toBe(true)
     expect(timelineItemEqual(a, { type: "event", event: msgA, groupContinuation: true })).toBe(false)
     expect(timelineItemEqual(a, { type: "event", event: { ...msgA } })).toBe(false)
+  })
+
+  it("timelineItemEqual: skeleton items compare by index, never equal another item type", () => {
+    expect(timelineItemEqual({ type: "skeleton", index: 0 }, { type: "skeleton", index: 0 })).toBe(true)
+    expect(timelineItemEqual({ type: "skeleton", index: 0 }, { type: "skeleton", index: 1 })).toBe(false)
+    expect(
+      timelineItemEqual({ type: "skeleton", index: 0 }, { type: "gap", afterEventId: "evt_1", missingCount: 1 })
+    ).toBe(false)
+  })
+
+  it("skeleton rows stay equal when ctx is rebuilt with fresh containers (no churn while fetching)", () => {
+    const item = OLDER_SKELETON_ITEMS[0]
+    const prev = { item, ctx: makeCtx({ newMessageIds: new Set(["evt_x"]) }), deferSecondaryHydration: false }
+    const next = { item, ctx: makeCtx({ newMessageIds: new Set(["evt_y"]) }), deferSecondaryHydration: false }
+    expect(timelineRowPropsEqual(prev, next)).toBe(true)
   })
 })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -130,6 +130,15 @@ export type TimelineItem =
    * place — a missed message never pops in above rows already on screen.
    */
   | { type: "gap"; afterEventId: string; missingCount: number }
+  /**
+   * A placeholder row prepended at the head of the timeline while an older
+   * page is in flight (infinite scroll), so the space the page will fill
+   * reads as loading instead of blank. Visually similar to `gap` but
+   * semantically different — a gap is known-missing events (INV-61
+   * contiguity), a skeleton is just a page fetch in flight — so they stay
+   * separate item types.
+   */
+  | { type: "skeleton"; index: number }
 
 /** Event types that participate in author-grouping (render as message bodies). */
 const MESSAGE_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["message_created", "companion_response"])
@@ -276,10 +285,26 @@ export function getTimelineItemKey(item: TimelineItem): string {
       return item.sessionId
     case "gap":
       return `gap:${item.afterEventId}`
+    case "skeleton":
+      return `skeleton:older:${item.index}`
     default:
       return item.event.id
   }
 }
+
+/** Number of skeleton placeholder rows prepended while an older page is in flight. */
+export const OLDER_SKELETON_COUNT = 4
+
+/**
+ * The skeleton placeholder items, as a module-level constant so both the item
+ * identities and their keys are stable across renders while a fetch is in
+ * flight — otherwise the row memo comparator and virtua's measurement cache
+ * churn every frame.
+ */
+export const OLDER_SKELETON_ITEMS: readonly TimelineItem[] = Array.from(
+  { length: OLDER_SKELETON_COUNT },
+  (_, index) => ({ type: "skeleton" as const, index })
+)
 
 /** Whether a timeline item renders (or contains) the given event id. */
 function itemContainsEvent(item: TimelineItem, eventId: string): boolean {
@@ -288,6 +313,7 @@ function itemContainsEvent(item: TimelineItem, eventId: string): boolean {
     case "session_group":
       return item.events.some((event) => event.id === eventId)
     case "gap":
+    case "skeleton":
       return false
     default:
       return item.event.id === eventId
@@ -450,7 +476,7 @@ export interface TimelineItemRenderContext {
 
 function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean {
   if (!firstUnreadEventId) return false
-  if (item.type === "gap") return false
+  if (item.type === "gap" || item.type === "skeleton") return false
   if (item.type === "command_group" || item.type === "session_group") {
     return item.events[0]?.id === firstUnreadEventId
   }
@@ -524,6 +550,20 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
           <span>Loading {item.missingCount === 1 ? "a missed message" : `${item.missingCount} missed messages`}…</span>
         </div>
       )}
+      {item.type === "skeleton" && (
+        // Fixed-height placeholder while an older page is in flight. The
+        // floating "Loading older messages..." pill carries the announcement;
+        // these rows are purely visual (aria-hidden) and are swapped for the
+        // real rows in the same render the page lands.
+        <div aria-hidden data-testid="older-skeleton-row" className="flex gap-3 px-4 py-3 sm:px-6">
+          <Skeleton className="h-9 w-9 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      )}
       {item.type === "session_group" && !ctx.hideSessionCards && (
         <div className="px-3 sm:px-6">
           <AgentSessionEvent
@@ -590,6 +630,10 @@ export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
     case "gap": {
       const other = b as Extract<TimelineItem, { type: "gap" }>
       return a.afterEventId === other.afterEventId && a.missingCount === other.missingCount
+    }
+    case "skeleton": {
+      const other = b as Extract<TimelineItem, { type: "skeleton" }>
+      return a.index === other.index
     }
   }
 }

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -4,6 +4,7 @@ import {
   shouldStartHighlightClear,
   computeScrollEdges,
   shouldPrefetchOlderHistory,
+  shouldShowOlderSkeletons,
 } from "./stream-content"
 
 const DEADLINE = 4000
@@ -239,5 +240,61 @@ describe("shouldPrefetchOlderHistory", () => {
 
   it("does not stack a second fetch while one is already in flight", () => {
     expect(shouldPrefetchOlderHistory({ ...base, isFetchingOlder: true })).toBe(false)
+  })
+})
+
+describe("shouldShowOlderSkeletons", () => {
+  it("shows skeletons while the tracked fetch is in flight and the appear delay has elapsed", () => {
+    expect(
+      shouldShowOlderSkeletons({
+        trackedOldestEventId: "evt_1",
+        currentOldestEventId: "evt_1",
+        appearDelayElapsed: true,
+      })
+    ).toBe(true)
+  })
+
+  it("does not flash skeletons before the appear delay elapses (fast responses stay skeleton-free)", () => {
+    expect(
+      shouldShowOlderSkeletons({
+        trackedOldestEventId: "evt_1",
+        currentOldestEventId: "evt_1",
+        appearDelayElapsed: false,
+      })
+    ).toBe(false)
+  })
+
+  it("never shows skeletons when no fetch is tracked — at top of history no fetch ever starts", () => {
+    expect(
+      shouldShowOlderSkeletons({
+        trackedOldestEventId: null,
+        currentOldestEventId: "evt_1",
+        appearDelayElapsed: true,
+      })
+    ).toBe(false)
+  })
+
+  it("removes skeletons in the same render the prepend lands (oldest id changed)", () => {
+    // The load-bearing property (INV-21): removal keys off the rendered oldest
+    // id, not isFetchingOlder — the flag flips false a render or two before
+    // the IDB live query re-emits with the new page, and dropping skeletons
+    // on the flag would leave an intermediate frame N rows shorter.
+    expect(
+      shouldShowOlderSkeletons({
+        trackedOldestEventId: "evt_2",
+        currentOldestEventId: "evt_1",
+        appearDelayElapsed: true,
+      })
+    ).toBe(false)
+  })
+
+  it("hides skeletons when the window empties mid-fetch (stream switch)", () => {
+    expect(
+      shouldShowOlderSkeletons({
+        trackedOldestEventId: "evt_1",
+        currentOldestEventId: null,
+        appearDelayElapsed: true,
+      })
+    ).toBe(false)
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -61,6 +61,7 @@ import {
   findMessageItemIndex,
   getTimelineItemKey,
   filterVisibleItems,
+  OLDER_SKELETON_ITEMS,
   type TimelineItem,
   type TimelineItemRenderContext,
   type BatchTimelineState,
@@ -209,6 +210,38 @@ export function shouldPrefetchOlderHistory(args: {
 }): boolean {
   if (!args.hasOlderEvents || args.isFetchingOlder) return false
   return !(args.followingLiveTail && args.scrollerScrollable)
+}
+
+/** How long an older-page fetch must be in flight before skeleton rows render,
+ *  so a fast response never flashes them. */
+export const OLDER_SKELETON_APPEAR_DELAY_MS = 150
+
+/** Grace period after the fetch settles for the prepend to land (IDB live-query
+ *  propagation runs a couple of renders behind the query). Past it the tracker
+ *  clears so a failed or empty page can't leave skeletons hanging. */
+export const OLDER_SKELETON_SETTLE_GRACE_MS = 1000
+
+/**
+ * Whether skeleton placeholder rows render at the head of the timeline while
+ * an older page is in flight.
+ *
+ * `trackedOldestEventId` is the oldest rendered event id captured when the
+ * fetch started (null = no fetch tracked, which also covers top-of-history:
+ * with `hasOlderEvents` false no fetch ever starts, so nothing is tracked).
+ * Comparing it against the CURRENT oldest id — instead of `isFetchingOlder`,
+ * which flips false a render or two before the IDB live query re-emits with
+ * the new page — makes removal land in the same render as the prepend: the
+ * skeletons leave and the real rows arrive in one items-array swap, one
+ * `shift` computation, with no intermediate frame where the list is N rows
+ * shorter (INV-21).
+ */
+export function shouldShowOlderSkeletons(args: {
+  trackedOldestEventId: string | null
+  currentOldestEventId: string | null
+  appearDelayElapsed: boolean
+}): boolean {
+  if (args.trackedOldestEventId === null || !args.appearDelayElapsed) return false
+  return args.currentOldestEventId === args.trackedOldestEventId
 }
 
 interface StreamContentProps {
@@ -802,13 +835,75 @@ export function StreamContent({
   // Use virtualized scroll for non-thread views, plain scroll for threads
   const useVirtualized = !isThread
 
+  // --- Skeleton rows while an older page is in flight ---
+  // A fast scroll can reach the top of the loaded window before the older
+  // page lands; without placeholders that space is plain blank and reads as
+  // broken. Track each older fetch from its start: capture the oldest
+  // rendered event id, show skeletons once the fetch outlives the appear
+  // delay, and hide them the moment the oldest id changes — i.e. in the same
+  // render the prepend lands (see shouldShowOlderSkeletons). Virtualized
+  // streams only: threads load all history up front and render their own
+  // inline loading row. Deep-link jumps (jumpToEvent) never set
+  // isFetchingOlder, so a programmatic jump's window fetch can't trigger this.
+  const oldestEventId = events.length > 0 ? events[0].id : null
+  const oldestEventIdRef = useRef(oldestEventId)
+  oldestEventIdRef.current = oldestEventId
+  const [olderSkeletonTrackedId, setOlderSkeletonTrackedId] = useState<string | null>(null)
+  const [olderSkeletonReady, setOlderSkeletonReady] = useState(false)
+
+  useEffect(() => {
+    if (!isFetchingOlder || !useVirtualized) return
+    setOlderSkeletonTrackedId(oldestEventIdRef.current)
+  }, [isFetchingOlder, useVirtualized])
+
+  // Appear delay: commit to skeletons only once the fetch has been in flight
+  // long enough that they won't flash for a fast response.
+  useEffect(() => {
+    if (olderSkeletonTrackedId === null) {
+      setOlderSkeletonReady(false)
+      return
+    }
+    const timer = window.setTimeout(() => setOlderSkeletonReady(true), OLDER_SKELETON_APPEAR_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [olderSkeletonTrackedId])
+
+  // The prepend landed (or the stream switched): visibility already dropped in
+  // that same render via shouldShowOlderSkeletons; this just retires the
+  // tracker so the next fetch starts clean.
+  const olderPrependLanded = olderSkeletonTrackedId !== null && oldestEventId !== olderSkeletonTrackedId
+  useEffect(() => {
+    if (olderPrependLanded) setOlderSkeletonTrackedId(null)
+  }, [olderPrependLanded])
+
+  // Fetch settled without a prepend (failed request, or the final page was
+  // empty): give the IDB live query a grace window, then clear so skeletons
+  // can't hang. A new fetch re-arms via the rising-edge effect above.
+  useEffect(() => {
+    if (olderSkeletonTrackedId === null || isFetchingOlder) return
+    const timer = window.setTimeout(() => setOlderSkeletonTrackedId(null), OLDER_SKELETON_SETTLE_GRACE_MS)
+    return () => window.clearTimeout(timer)
+  }, [olderSkeletonTrackedId, isFetchingOlder])
+
+  const showOlderSkeletons =
+    useVirtualized &&
+    shouldShowOlderSkeletons({
+      trackedOldestEventId: olderSkeletonTrackedId,
+      currentOldestEventId: oldestEventId,
+      appearDelayElapsed: olderSkeletonReady,
+    })
+
   // Filter out zero-height items (reactions, hidden session cards) for the virtualizer.
   // Without this, items that render as empty wrappers get measured as 0px, causing
   // subsequent items to overlap at the same Y position.
-  const visibleItems = useMemo(
-    () => (useVirtualized ? filterVisibleItems(timelineItems, isChannel) : timelineItems),
-    [timelineItems, useVirtualized, isChannel]
-  )
+  //
+  // Skeleton rows are prepended here — inside the array the shift computation
+  // reads — so adding them changes the first item's key and useTimelineScroll
+  // passes `shift` to virtua for that render, holding the viewport exactly
+  // like a real older-page prepend (INV-21).
+  const visibleItems = useMemo(() => {
+    const base = useVirtualized ? filterVisibleItems(timelineItems, isChannel) : timelineItems
+    return showOlderSkeletons ? [...OLDER_SKELETON_ITEMS, ...base] : base
+  }, [timelineItems, useVirtualized, isChannel, showOlderSkeletons])
 
   // Mirror of `visibleItems` for the long-lived scrollToMessage retry loop:
   // its closure is created once per scroll but runs for up to ~1.2s, during

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -851,10 +851,19 @@ export function StreamContent({
   const [olderSkeletonTrackedId, setOlderSkeletonTrackedId] = useState<string | null>(null)
   const [olderSkeletonReady, setOlderSkeletonReady] = useState(false)
 
+  // Arm the tracker whenever a fetch is in flight and nothing is tracked.
+  // Gated on the tracker being empty (not just the isFetchingOlder rising
+  // edge) so it self-re-arms when a prepend lands mid-fetch: with
+  // back-to-back pages, fetch N+1 can start before fetch N's rows have
+  // propagated out of IDB, so a rising-edge capture would record the stale
+  // pre-page-N head — page N landing would then retire the tracker and leave
+  // fetch N+1 with no skeleton coverage. Instead the landed cleanup below
+  // clears the tracker and this effect immediately re-arms it against the
+  // new head while the fetch is still in flight.
   useEffect(() => {
-    if (!isFetchingOlder || !useVirtualized) return
+    if (!isFetchingOlder || !useVirtualized || olderSkeletonTrackedId !== null) return
     setOlderSkeletonTrackedId(oldestEventIdRef.current)
-  }, [isFetchingOlder, useVirtualized])
+  }, [isFetchingOlder, useVirtualized, olderSkeletonTrackedId])
 
   // Appear delay: commit to skeletons only once the fetch has been in flight
   // long enough that they won't flash for a fast response.

--- a/tests/browser/infinite-scroll.spec.ts
+++ b/tests/browser/infinite-scroll.spec.ts
@@ -199,6 +199,101 @@ test.describe("Infinite Scroll", () => {
       .toBeGreaterThan(0)
   })
 
+  test("should show skeleton rows while the older page is in flight and hold the viewport when it lands", async ({
+    page,
+  }) => {
+    // Same short-viewport setup as the scroll-older test: forces genuine
+    // virtualization so reaching the top is a real boundary crossing.
+    await page.setViewportSize({ width: 1024, height: 400 })
+
+    const PAGED_MESSAGE_COUNT = 51
+    const channelName = `scroll-skeleton-${testId}`
+    await createChannel(page, channelName)
+
+    const { workspaceId, streamId } = extractIds(page)
+    const prefix = `[${testId}]`
+
+    // Seed from another route, then reload for a cold bootstrap window with
+    // hasOlderEvents: true — see the scroll-older test for why.
+    await page.goto(`/w/${workspaceId}/drafts`)
+    await expect(page).toHaveURL(new RegExp(`/w/${workspaceId}/drafts`))
+    await seedMessages(page, workspaceId, streamId, PAGED_MESSAGE_COUNT, prefix)
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 20000 })
+    await page.reload()
+    await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 20000 })
+
+    // Gate the older-page request so the fetch deterministically stays in
+    // flight (well past the skeleton appear delay) until we release it.
+    let releaseOlderPage = () => {}
+    const olderPageGate = new Promise<void>((resolve) => {
+      releaseOlderPage = resolve
+    })
+    await page.route(
+      (url) => url.pathname.endsWith("/events") && url.searchParams.has("before"),
+      async (route) => {
+        await olderPageGate
+        await route.continue()
+      }
+    )
+
+    // Scroll to the top until the older fetch arms and the skeleton rows
+    // render at the head of the timeline.
+    const skeletonRows = page.getByTestId("older-skeleton-row")
+    await expect
+      .poll(
+        async () => {
+          await scrollToTop(page)
+          return await skeletonRows.count()
+        },
+        { timeout: 30000, message: "should render skeleton rows while the older page is in flight" }
+      )
+      .toBeGreaterThan(0)
+
+    // The blank space above the loaded window must read as loading: wheel into
+    // the skeleton zone and confirm the rows are actually on screen.
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const box = await scroller.boundingBox()
+    if (box) await page.mouse.move(box.x + box.width / 2, box.y + 24)
+    for (let i = 0; i < 2; i++) {
+      await page.mouse.wheel(0, -2000)
+      await page.waitForTimeout(50)
+    }
+    await expect(skeletonRows.first()).toBeVisible()
+
+    // Park the viewport just below the skeleton block — the INV-21 guarantee
+    // is for content the user is reading below the in-flight zone (a viewport
+    // pinned *inside* the skeletons necessarily morphs as they become real
+    // rows of different heights).
+    await page.evaluate(() => {
+      const container = document.querySelector("[data-suppress-pull-refresh]")
+      const skeletons = document.querySelectorAll('[data-testid="older-skeleton-row"]')
+      const last = skeletons[skeletons.length - 1]
+      if (container instanceof HTMLElement && last instanceof HTMLElement) {
+        container.scrollTop += last.getBoundingClientRect().bottom - container.getBoundingClientRect().top
+      }
+    })
+
+    // Anchor on the oldest message of the bootstrap window, sitting at the
+    // viewport top directly under the skeleton block.
+    const anchor = messageLocator(page, prefix, 2)
+    const before = await anchor.boundingBox()
+    expect(before).not.toBeNull()
+
+    releaseOlderPage()
+
+    // The page lands: skeletons leave and the older message arrives in one
+    // swap...
+    const oldestMessage = messageLocator(page, prefix, 1)
+    await expect(oldestMessage).toBeAttached({ timeout: 15000 })
+    await expect(skeletonRows).toHaveCount(0)
+
+    // ...and the anchored message must not move on screen (INV-21).
+    const after = await anchor.boundingBox()
+    expect(after).not.toBeNull()
+    expect(Math.abs(after!.y - before!.y)).toBeLessThanOrEqual(5)
+  })
+
   test("should show 'Jump to latest' when scrolled far from bottom and hide when scrolled back", async ({ page }) => {
     // The "Jump to latest" affordance keys off Virtuoso's rendered range
     // (`distFromEnd > 10` items), so it only appears once the bottom of the list
@@ -280,5 +375,9 @@ test.describe("Infinite Scroll", () => {
 
     // No pagination requests should have been made
     expect(eventRequests.length).toBe(0)
+
+    // And with no fetch in flight at the top of history, no skeleton rows
+    // may render either.
+    await expect(page.getByTestId("older-skeleton-row")).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## Problem

When a fast scroll reaches the top of the loaded event window before the older page lands, the only affordance is the floating "Loading older messages..." pill — the space where messages will appear is plain blank, which reads as broken. This is the deferred fetch-bound half of Symptom 3 from the stream-timeline perceived-performance exploration (#828); the render-bound half landed in #834–#837.

## Solution

While an older page is in flight, prepend a few fixed-height skeleton rows (avatar + lines) at the head of the virtualized timeline, following the `gap` item precedent from #824: a new `TimelineItem` variant injected into the items array and rendered by `TimelineItemContent`, so virtua measures them as ordinary rows. Insertion and removal both change the first item's key, which drives the existing `shift` prepend-hold in `use-timeline-scroll.ts` — the viewport never moves for a user reading below the skeletons (INV-21).

### Key design decisions

**1. Separate `skeleton` type, not an overload of `gap`**

A gap is known-missing events (INV-61 contiguity machinery); a skeleton is just a page fetch in flight. Keeping them distinct item types keeps the contiguity semantics clean.

**2. Removal keys off the rendered oldest event id, not `isFetchingOlder`**

In normal mode the events flow through an IndexedDB live query that re-emits one or more renders *after* the fetch flag flips false. Dropping skeletons on the flag would leave an intermediate frame where the list is N rows shorter. Instead, visibility is derived per render as `currentOldestId === trackedOldestId` (`shouldShowOlderSkeletons`, pure + tested), so the skeletons leave and the page arrives in one items-array swap, one `shift` computation. Jump mode lands same-render anyway and is covered by the same rule.

**3. Tracker arms whenever a fetch is in flight and nothing is tracked**

Rather than capturing on the `isFetchingOlder` rising edge: with back-to-back pages, fetch N+1 can start before fetch N's rows propagate out of IDB, so a rising-edge capture would record a stale head and page N's landing would retire the tracker mid-fetch. The empty-tracker gate makes it self-re-arm against the new head. (Found in self-review.)

**4. 150ms appear delay, 1s settle grace**

Fast responses never flash skeletons; a failed request or empty final page can't leave them hanging. Skeletons never appear at top-of-history because no fetch ever starts there, and deep-link jumps (`jumpToEvent`) don't set `isFetchingOlder`, so programmatic jumps are unaffected. Scoped to virtualized streams — threads (`loadAll`) keep their inline loading row.

**5. Stable identities via module constant**

`OLDER_SKELETON_ITEMS` is a module-level constant, so item identities and keys (`skeleton:older:0..3`) are stable across renders — neither the row memo comparator (#835 discipline) nor virtua's measurement cache churns while fetching.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/event-list.tsx` | `skeleton` TimelineItem variant, `OLDER_SKELETON_COUNT/ITEMS`, key/comparator/`itemContainsEvent`/`isFirstUnread` cases, fixed-height skeleton row renderer |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `shouldShowOlderSkeletons` + timing constants; tracker state machine (arm / appear delay / landed retire / settle grace); skeleton prepend inside the `visibleItems` memo so `shift` covers it |
| `apps/frontend/src/components/timeline/event-list.test.ts` | Comparator + key cases for the new variant |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | Pure-function coverage: presence while fetching, no-flash before delay, absence at top-of-history, same-render removal |
| `tests/browser/infinite-scroll.spec.ts` | New spec gating `/events?before=`: skeletons render + are visible mid-fetch, viewport anchor holds within 5px on page land; skeleton-absence assertion in the no-pagination test |

## Test plan

- [x] Frontend unit suite: 2454 passed, 0 failed (includes new decision-function and comparator tests)
- [x] Monorepo typecheck + lint (pre-commit hooks)
- [x] Self-review: 3-perspective review (spec/correctness/design); the one surviving finding (back-to-back-fetch tracker race) fixed in 80e0871
- [ ] Playwright `browser/infinite-scroll` — written but **not executed**: the dev sandbox has no Docker for the Postgres/MinIO test containers; needs CI or a local run
- [ ] Manual Slow-3G fling per the handover doc (`bun run dev:test`, `#scroll-pinning` seed): blank top reads as skeletons; a watched message must not move when the page lands

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Deferred half of item 5 in the stream-timeline perceived-performance doc (exploration #828): skeleton placeholder rows in the space where older messages will appear during infinite-scroll fetches, without ever shifting content the user is reading (INV-21 adjacent).

**What was built:**
- `{ type: "skeleton"; index }` TimelineItem variant following the `gap` precedent — injected into the items array, never DOM outside the virtualizer. Rendered aria-hidden (the floating pill carries the announcement) with `data-testid="older-skeleton-row"` for the browser spec.
- Prepend happens inside the `visibleItems` memo in `StreamContent`, the same array `useTimelineScroll`'s first-key prepend detection reads, so both insertion and removal produce `shift={true}` renders and virtua maintains scroll from the end.
- Tracker state machine in `StreamContent`: `olderSkeletonTrackedId` (oldest rendered event id at arm time) + `olderSkeletonReady` (150ms appear delay). Four effects: arm while fetch in flight and tracker empty (self-re-arms after a mid-fetch land); appear-delay timer; retire on prepend land; 1s settle grace after the fetch settles without a land (failure / empty final page).
- Visibility is a pure function (`shouldShowOlderSkeletons`) evaluated in render: tracked id non-null ∧ delay elapsed ∧ current oldest id === tracked id. The id comparison is what makes removal land in the same commit as the prepend despite the IDB live-query lag.

**Design decisions:** separate type from `gap` (INV-61 semantics); removal keyed off data, not the fetch flag; module-constant items for stable identity/keys; scoped to virtualized streams; no skeletons for deep-link jump fetches (they never set `isFetchingOlder`); no `hasOlderEvents` gate on *removal* (the final page lands events one render after the flag flips false — gating would reintroduce the shorter-list frame; the start gate is implicit since no fetch starts without older history).

**What's NOT included:** the doc's optional adaptive-prefetch-lead piece (trigger older fetch on estimated rows-remaining / raise `EDGE_PREFETCH_PX`) — deliberately skipped pending measurement, per the doc's "measure before changing".

**Status:** complete; Playwright spec written but unexecuted in the sandbox (no Docker) — verify in CI.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01LCDWNSqDWbcnT9AkKuh8s7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCDWNSqDWbcnT9AkKuh8s7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783836581&installation_id=129946197&pr_number=867&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F867&signature=8f5189609e7e65d4538240c608a73a9123859ac6f4785e56a061a18ee03e02ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->