### PR TITLE
fix(public-site): theme-aware send button in the chat demo

### DIFF
--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -37,6 +37,15 @@
   /* total animation cycle for the chat widget */
   --cycle: 22s;
 
+  /* Chat-demo send button. Tokens rather than literals because the armed/idle
+     swap lives in @keyframes (send-arm), which a [data-theme] selector cannot
+     reach — the vars resolve per-theme inside the keyframes instead. Idle is
+     the app's disabled-primary; armed is full primary. */
+  --send-idle-bg: 38 50% 75%;
+  --send-idle-fg: 42 55% 97%;
+  --send-armed-bg: 38 62% 53%;
+  --send-armed-fg: 42 40% 98%;
+
   color-scheme: light;
 }
 
@@ -61,6 +70,13 @@
   --muted: 32 7% 57%;
   --emerald: 142 45% 52%;
   --emerald-soft: 142 28% 16%;
+
+  /* Dark disabled-primary: dimmed olive-gold with a light arrow, matching
+     the real app's dark composer. */
+  --send-idle-bg: 44 32% 35%;
+  --send-idle-fg: 44 40% 90%;
+  --send-armed-bg: 40 62% 56%;
+  --send-armed-fg: 26 16% 10%;
 
   color-scheme: dark;
 }
@@ -682,8 +698,8 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: hsl(38 50% 75%);
-  color: hsl(42 55% 97%);
+  background: hsl(var(--send-idle-bg));
+  color: hsl(var(--send-idle-fg));
   border: none;
   margin-left: 4px;
   flex-shrink: 0;
@@ -1099,18 +1115,18 @@ body::after {
        button), arms to full gold while content is typed. */
   0%,
   29.9% {
-    background: hsl(38 50% 75%);
-    color: hsl(42 55% 97%);
+    background: hsl(var(--send-idle-bg));
+    color: hsl(var(--send-idle-fg));
   }
   30%,
   48.9% {
-    background: hsl(38 62% 53%);
-    color: hsl(42 40% 98%);
+    background: hsl(var(--send-armed-bg));
+    color: hsl(var(--send-armed-fg));
   }
   49%,
   100% {
-    background: hsl(38 50% 75%);
-    color: hsl(42 55% 97%);
+    background: hsl(var(--send-idle-bg));
+    color: hsl(var(--send-idle-fg));
   }
 }
 


### PR DESCRIPTION
## Problem

In dark mode the chat demo's send button rendered the light theme's disabled-primary beige instead of the dark composer's dimmed olive-gold.

## Solution

The idle/armed colors were literals inside the `send-arm` `@keyframes`, which a `[data-theme="dark"]` selector cannot reach — keyframes are global. Routed through four `--send-*` tokens defined per theme; the keyframes reference the vars and resolve correctly in both modes. Light mode resolves to the exact previous values (verified via computed style: `rgb(223,200,159)`); dark idle is now `hsl(44 32% 35%)` with a light arrow, matching the real app's dark composer.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/public-site/src/styles/global.css` | `--send-idle/armed-bg/fg` tokens in both theme blocks; literals replaced in `.composer-send` + `send-arm` keyframes |

## Test plan

- [x] `astro check` clean
- [x] Both modes verified in browser: dark idle matches the reference (`rgb(118,103,61)`), light unchanged

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783837853&installation_id=129946197&pr_number=868&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F868&signature=cfeaa719a0132aac86017f3ed25dbbb27ed4491666425a4d6f7c3a88c138a35a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->