### PR TITLE
feat: ExternalTurnDriver + synchronous/dispatched turn-driver split (Phase 2.3c)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/external-turn-driver.test.ts
+++ b/apps/backend/src/features/bot-runtimes/external-turn-driver.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, mock } from "bun:test"
+import {
+  TurnDeliveries,
+  isDeclaredUnsupported,
+  type SynchronousTurnDriver,
+  type TurnDispatchBinding,
+} from "@threa/agent-runtime"
+import { ExternalTurnDriver } from "./external-turn-driver"
+import type { BotRuntimeService } from "./service"
+
+const binding: TurnDispatchBinding = {
+  workspaceId: "ws_1",
+  actorId: "bot_alice",
+  rootStreamId: "stream_root",
+  activeStreamId: "stream_active",
+  responseStreamId: "stream_resp",
+  sourceMessageId: "msg_src",
+  authorUserId: "usr_owner",
+  trigger: "mention",
+  requiredCapability: "mentionable",
+  mentionedActorSlugs: ["alice"],
+  targetInstanceId: null,
+  targetRuntimeSessionId: null,
+  metadata: {},
+}
+
+function makeDriver(result: { wasNewlyInserted: boolean }) {
+  const createInvocation = mock(async (_params: unknown) => ({
+    invocation: { id: "inv_1" },
+    wasNewlyInserted: result.wasNewlyInserted,
+  }))
+  const driver = new ExternalTurnDriver({ service: { createInvocation } as unknown as BotRuntimeService })
+  return { driver, createInvocation }
+}
+
+const externalRequest = (content: string) => ({
+  delivery: TurnDeliveries.EXTERNAL,
+  messages: [{ role: "user" as const, content }],
+})
+
+describe("ExternalTurnDriver", () => {
+  it("maps the binding onto createInvocation exactly and returns a dispatched receipt", async () => {
+    const { driver, createInvocation } = makeDriver({ wasNewlyInserted: true })
+
+    const receipt = await driver.dispatchTurn(externalRequest("hello @alice"), binding)
+
+    expect(createInvocation.mock.calls[0]?.[0]).toEqual({
+      workspaceId: "ws_1",
+      rootStreamId: "stream_root",
+      activeStreamId: "stream_active",
+      sourceMessageId: "msg_src",
+      responseStreamId: "stream_resp",
+      actorId: "bot_alice",
+      trigger: "mention",
+      requiredCapability: "mentionable",
+      promptMarkdown: "hello @alice",
+      authorUserId: "usr_owner",
+      mentionedActorSlugs: ["alice"],
+      targetInstanceId: null,
+      targetRuntimeSessionId: null,
+      metadata: {},
+    })
+    expect(receipt).toEqual({ invocationId: "inv_1", status: "dispatched" })
+  })
+
+  it("returns a deduplicated receipt on an idempotent re-dispatch", async () => {
+    const { driver } = makeDriver({ wasNewlyInserted: false })
+
+    const receipt = await driver.dispatchTurn(externalRequest("hello again"), binding)
+
+    expect(receipt).toEqual({ invocationId: "inv_1", status: "deduplicated" })
+  })
+
+  it("refuses a non-external delivery before any dispatch", async () => {
+    const { driver, createInvocation } = makeDriver({ wasNewlyInserted: true })
+
+    await expect(
+      driver.dispatchTurn({ ...externalRequest("hi"), delivery: TurnDeliveries.PLAINTEXT }, binding)
+    ).rejects.toThrow('serves "external" turns')
+    expect(createInvocation).not.toHaveBeenCalled()
+  })
+
+  it("rejects a request that ships loop history instead of the single trigger prompt", async () => {
+    const { driver, createInvocation } = makeDriver({ wasNewlyInserted: true })
+
+    await expect(
+      driver.dispatchTurn(
+        {
+          delivery: TurnDeliveries.EXTERNAL,
+          messages: [
+            { role: "user", content: "earlier history" },
+            { role: "user", content: "the prompt" },
+          ],
+        },
+        binding
+      )
+    ).rejects.toThrow("single plain-text user prompt")
+    expect(createInvocation).not.toHaveBeenCalled()
+  })
+
+  it("declares its sink edges: durable verbs for commit and trace, loud gaps for the rest", () => {
+    const { driver } = makeDriver({ wasNewlyInserted: true })
+
+    const declaredGaps = Object.fromEntries(
+      Object.entries(driver.sinkResolution).map(([edge, resolution]) => [edge, isDeclaredUnsupported(resolution)])
+    )
+    expect(declaredGaps).toEqual({
+      commitMessage: false,
+      observers: false,
+      newMessages: true,
+      shouldAbort: true,
+      toolSignalProvider: true,
+    })
+  })
+
+  it("is not a synchronous driver — there is no runTurn to await", () => {
+    const { driver } = makeDriver({ wasNewlyInserted: true })
+
+    // @ts-expect-error — ExternalTurnDriver cannot resolve a TurnResult in one call; the turn completes in a later request.
+    const synchronous: SynchronousTurnDriver = driver
+    expect("runTurn" in synchronous).toBe(false)
+  })
+})

--- a/apps/backend/src/features/bot-runtimes/external-turn-driver.ts
+++ b/apps/backend/src/features/bot-runtimes/external-turn-driver.ts
@@ -1,0 +1,75 @@
+import {
+  TurnDeliveries,
+  declaredUnsupported,
+  type DispatchedTurnDriver,
+  type DispatchedTurnRequest,
+  type TurnDelivery,
+  type TurnDispatchBinding,
+  type TurnDispatchReceipt,
+  type TurnSinkResolution,
+} from "@threa/agent-runtime"
+import type { BotRuntimeService } from "./service"
+
+/**
+ * The external driver: hands the turn to a third-party harness over the bot
+ * wire. `dispatchTurn` is a thin wrapper over `BotRuntimeService.createInvocation`
+ * — it returns once the `bot_invocations` row exists and
+ * `bot_invocation:available` is on the outbox. The harness claims the row,
+ * streams `/steps`, and `/complete`s in later, separate requests, so the sink
+ * edges are realized by those durable verb handlers, never inside this call.
+ * Long-lived — construct once with the feature's service.
+ */
+export class ExternalTurnDriver implements DispatchedTurnDriver {
+  readonly delivery: TurnDelivery = TurnDeliveries.EXTERNAL
+
+  // How the TurnSink vocabulary lands on the external wire: commit and trace
+  // resolve through the durable verbs; the rest are structural gaps of the
+  // pull-based transport, declared with renderable reasons instead of omitted.
+  readonly sinkResolution: TurnSinkResolution = {
+    commitMessage: { realizedBy: "completeBotInvocation (POST .../bot-invocations/{invocationId}/complete)" },
+    observers: { realizedBy: "recordBotInvocationStep (POST .../bot-invocations/{invocationId}/steps)" },
+    shouldAbort: declaredUnsupported("cancellation toward an external runner has no carrier yet"),
+    toolSignalProvider: declaredUnsupported("the harness drives its own tools"),
+    newMessages: declaredUnsupported("third-party harnesses don't receive mid-turn messages"),
+  }
+
+  constructor(private readonly deps: { service: BotRuntimeService }) {}
+
+  async dispatchTurn(request: DispatchedTurnRequest, binding: TurnDispatchBinding): Promise<TurnDispatchReceipt> {
+    if (request.delivery !== this.delivery) {
+      throw new Error(`ExternalTurnDriver serves "${this.delivery}" turns; got "${request.delivery}"`)
+    }
+    const { invocation, wasNewlyInserted } = await this.deps.service.createInvocation({
+      workspaceId: binding.workspaceId,
+      rootStreamId: binding.rootStreamId,
+      activeStreamId: binding.activeStreamId,
+      sourceMessageId: binding.sourceMessageId,
+      responseStreamId: binding.responseStreamId,
+      actorId: binding.actorId,
+      trigger: binding.trigger,
+      requiredCapability: binding.requiredCapability,
+      promptMarkdown: extractPromptMarkdown(request),
+      authorUserId: binding.authorUserId,
+      mentionedActorSlugs: binding.mentionedActorSlugs,
+      targetInstanceId: binding.targetInstanceId,
+      targetRuntimeSessionId: binding.targetRuntimeSessionId,
+      metadata: binding.metadata,
+    })
+    return { invocationId: invocation.id, status: wasNewlyInserted ? "dispatched" : "deduplicated" }
+  }
+}
+
+/**
+ * A dispatched request carries exactly the trigger prompt: the harness brings
+ * its own model and tools, and history reaches it via the claim payload. More
+ * than one message — or non-plain-text content — means a caller tried to ship
+ * loop inputs across the wire, which must fail loudly (INV-11) rather than be
+ * silently flattened into `promptMarkdown`.
+ */
+function extractPromptMarkdown(request: DispatchedTurnRequest): string {
+  const [prompt, ...rest] = request.messages
+  if (!prompt || rest.length > 0 || prompt.role !== "user" || typeof prompt.content !== "string") {
+    throw new Error("external dispatch carries a single plain-text user prompt; history rides the claim payload")
+  }
+  return prompt.content
+}

--- a/apps/backend/src/features/bot-runtimes/index.ts
+++ b/apps/backend/src/features/bot-runtimes/index.ts
@@ -18,3 +18,4 @@ export {
 } from "./socket-handler"
 export { createBotSocketAuthMiddleware, type BotSocketData } from "./socket-auth"
 export { assertManifestAllows } from "./assert-manifest-allows"
+export { ExternalTurnDriver } from "./external-turn-driver"

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -74,9 +74,10 @@ describe("BotInvocationOutboxHandler E2E short-circuit", () => {
       rootStreamId: null,
       e2eEnabled: true,
     } as never)
-    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
-      undefined as never
-    )
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
+      invocation: { id: "inv_1" },
+      wasNewlyInserted: true,
+    } as never)
 
     await runProcessMessageCreated({})
 
@@ -102,9 +103,10 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
       { id: "bot_1", slug: "аріадна", name: "Аріадна", archivedAt: null, traits: ["mentionable"] },
     ] as never)
     spyOn(PersonaRepository, "findBySlug").mockResolvedValue(null as never)
-    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
-      undefined as never
-    )
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
+      invocation: { id: "inv_1" },
+      wasNewlyInserted: true,
+    } as never)
 
     // The retired ASCII regex could never match this mention; the node can.
     await runProcessMessageCreated(
@@ -124,9 +126,10 @@ describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => 
   it("ignores @-shaped plain text that has no mention node", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(channelStream as never)
     const findVisibleBySlugs = spyOn(BotRepository, "findVisibleBySlugs").mockResolvedValue([] as never)
-    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
-      undefined as never
-    )
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
+      invocation: { id: "inv_1" },
+      wasNewlyInserted: true,
+    } as never)
 
     await runProcessMessageCreated(
       userMessagePayload({ contentMarkdown: "ping @scout", contentJson: docWithText("ping @scout") })
@@ -171,9 +174,10 @@ describe("BotInvocationOutboxHandler active-scratchpad session-link policy", () 
     spyOn(BotRuntimeInstanceRepository, "findLatestForBots").mockResolvedValue(
       (params.instance ? new Map([["bot_1", params.instance]]) : new Map()) as never
     )
-    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue(
-      undefined as never
-    )
+    const createInvocation = spyOn(BotRuntimeService.prototype, "createInvocation").mockResolvedValue({
+      invocation: { id: "inv_1" },
+      wasNewlyInserted: true,
+    } as never)
     const createMessage = spyOn(EventService.prototype, "createMessage").mockResolvedValue(undefined as never)
     return { createInvocation, createMessage }
   }

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -1,5 +1,6 @@
 import type { Pool } from "pg"
 import { AuthorTypes, StreamTypes, botHasCapability } from "@threa/types"
+import { TurnDeliveries } from "@threa/agent-runtime"
 import { collectMentionSlugs, parseMarkdown } from "@threa/prosemirror"
 import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
 import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../lib/outbox"
@@ -7,6 +8,7 @@ import { logger } from "../../lib/logger"
 import { StreamRepository } from "../streams"
 import { BotRepository } from "../public-api/bot-repository"
 import { BotRuntimeService } from "./service"
+import { ExternalTurnDriver } from "./external-turn-driver"
 import {
   BotRuntimeInstanceRepository,
   BotRuntimeSessionLinkRepository,
@@ -33,11 +35,13 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
   private readonly cursorLock: CursorLock
   private readonly debouncer: DebounceWithMaxWait
   private readonly service: BotRuntimeService
+  private readonly turnDriver: ExternalTurnDriver
   private readonly eventService: EventService
 
   constructor(pool: Pool, eventService = new EventService(pool)) {
     this.pool = pool
     this.service = new BotRuntimeService({ pool })
+    this.turnDriver = new ExternalTurnDriver({ service: this.service })
     this.eventService = eventService
     this.cursorLock = new CursorLock({
       pool,
@@ -126,20 +130,25 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const hasMentionedPersona = mentionedPersonas.some(Boolean)
 
     for (const mentionedBot of mentionableBots) {
-      await this.service.createInvocation({
-        workspaceId: message.workspaceId,
-        rootStreamId: invocationRootStreamId,
-        activeStreamId: stream.id,
-        sourceMessageId: message.event.payload.messageId,
-        responseStreamId: stream.id,
-        actorId: mentionedBot.id,
-        trigger: "mention",
-        requiredCapability: "mentionable",
-        promptMarkdown: message.event.payload.contentMarkdown,
-        authorUserId: message.event.actorId,
-        mentionedActorSlugs: mentionedSlugs,
-        metadata: {},
-      })
+      await this.turnDriver.dispatchTurn(
+        {
+          delivery: TurnDeliveries.EXTERNAL,
+          messages: [{ role: "user", content: message.event.payload.contentMarkdown }],
+        },
+        {
+          workspaceId: message.workspaceId,
+          actorId: mentionedBot.id,
+          rootStreamId: invocationRootStreamId,
+          activeStreamId: stream.id,
+          responseStreamId: stream.id,
+          sourceMessageId: message.event.payload.messageId,
+          authorUserId: message.event.actorId,
+          trigger: "mention",
+          requiredCapability: "mentionable",
+          mentionedActorSlugs: mentionedSlugs,
+          metadata: {},
+        }
+      )
     }
 
     if (!rootStream || rootStream.type !== StreamTypes.SCRATCHPAD || rootStream.archivedAt) return
@@ -186,29 +195,35 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
       }
     }
 
-    await this.service.createInvocation({
-      workspaceId: message.workspaceId,
-      rootStreamId: rootStream.id,
-      activeStreamId: stream.id,
-      sourceMessageId: message.event.payload.messageId,
-      responseStreamId: stream.id,
-      actorId: bot.id,
-      trigger: "active-scratchpad",
-      requiredCapability: "active-scratchpad",
-      promptMarkdown: isUserAuthored
-        ? message.event.payload.contentMarkdown
-        : [
-            "A non-user message was posted in your active Threa scratchpad.",
-            "Use the stream context to decide whether a reply is useful. If no reply is needed, respond exactly: THREA_NO_RESPONSE",
-            "",
-            message.event.payload.contentMarkdown,
-          ].join("\n"),
-      authorUserId: message.event.actorId,
-      mentionedActorSlugs: mentionedSlugs,
-      targetInstanceId: link?.instanceId ?? null,
-      targetRuntimeSessionId: link?.runtimeSessionId ?? null,
-      metadata: {},
-    })
+    const promptMarkdown = isUserAuthored
+      ? message.event.payload.contentMarkdown
+      : [
+          "A non-user message was posted in your active Threa scratchpad.",
+          "Use the stream context to decide whether a reply is useful. If no reply is needed, respond exactly: THREA_NO_RESPONSE",
+          "",
+          message.event.payload.contentMarkdown,
+        ].join("\n")
+    await this.turnDriver.dispatchTurn(
+      {
+        delivery: TurnDeliveries.EXTERNAL,
+        messages: [{ role: "user", content: promptMarkdown }],
+      },
+      {
+        workspaceId: message.workspaceId,
+        actorId: bot.id,
+        rootStreamId: rootStream.id,
+        activeStreamId: stream.id,
+        responseStreamId: stream.id,
+        sourceMessageId: message.event.payload.messageId,
+        authorUserId: message.event.actorId,
+        trigger: "active-scratchpad",
+        requiredCapability: "active-scratchpad",
+        mentionedActorSlugs: mentionedSlugs,
+        targetInstanceId: link?.instanceId ?? null,
+        targetRuntimeSessionId: link?.runtimeSessionId ?? null,
+        metadata: {},
+      }
+    )
   }
 
   private async createMissingLinkNotice(params: {

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -301,15 +301,16 @@ export class BotRuntimeService {
     targetInstanceId?: string | null
     targetRuntimeSessionId?: string | null
     metadata?: Record<string, unknown>
-  }): Promise<BotInvocation> {
+  }): Promise<{ invocation: BotInvocation; wasNewlyInserted: boolean }> {
     return withTransaction(this.pool, (db) => this.createInvocationInTransaction(db, params))
   }
 
   /**
    * Inserts a `bot_invocations` row and emits `bot_invocation:available` in the
    * same tx — but only when the insert actually created a new row. The idempotent
-   * conflict path returns the existing invocation untouched so we do not re-push
-   * duplicates to listeners after a retried HTTP call.
+   * conflict path returns the existing invocation untouched (`wasNewlyInserted:
+   * false`) so we do not re-push duplicates to listeners after a retried HTTP
+   * call, and so dispatch can report the turn as deduplicated.
    */
   async createInvocationInTransaction(
     db: Querier,
@@ -329,7 +330,7 @@ export class BotRuntimeService {
       targetRuntimeSessionId?: string | null
       metadata?: Record<string, unknown>
     }
-  ): Promise<BotInvocation> {
+  ): Promise<{ invocation: BotInvocation; wasNewlyInserted: boolean }> {
     const { invocation, wasNewlyInserted } = await BotInvocationRepository.insertIdempotent(db, {
       id: botInvocationId(),
       workspaceId: params.workspaceId,
@@ -359,7 +360,7 @@ export class BotRuntimeService {
         createdAt: invocation.createdAt.toISOString(),
       })
     }
-    return invocation
+    return { invocation, wasNewlyInserted }
   }
 
   /**

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -16,13 +16,22 @@ export {
   isDeclaredUnsupported,
 } from "./runtime/turn-driver"
 export type {
+  AnyTurnDriver,
+  BaseTurnDriver,
+  DispatchedTurnDriver,
+  DispatchedTurnRequest,
+  SynchronousTurnDriver,
   TurnCommit,
   TurnCommitReceipt,
   TurnDelivery,
+  TurnDispatchBinding,
+  TurnDispatchReceipt,
   TurnDriver,
   TurnRequest,
   TurnResult,
   TurnSink,
+  TurnSinkResolution,
+  TurnTrigger,
   DeclaredUnsupported,
 } from "./runtime/turn-driver"
 export {

--- a/packages/agent-runtime/src/runtime/index.ts
+++ b/packages/agent-runtime/src/runtime/index.ts
@@ -17,13 +17,22 @@ export {
   isDeclaredUnsupported,
 } from "./turn-driver"
 export type {
+  AnyTurnDriver,
+  BaseTurnDriver,
+  DispatchedTurnDriver,
+  DispatchedTurnRequest,
+  SynchronousTurnDriver,
   TurnCommit,
   TurnCommitReceipt,
   TurnDelivery,
+  TurnDispatchBinding,
+  TurnDispatchReceipt,
   TurnDriver,
   TurnRequest,
   TurnResult,
   TurnSink,
+  TurnSinkResolution,
+  TurnTrigger,
   DeclaredUnsupported,
 } from "./turn-driver"
 export {

--- a/packages/agent-runtime/src/runtime/turn-driver.test.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.test.ts
@@ -7,6 +7,9 @@ import {
   TurnDeliveries,
   declaredUnsupported,
   isDeclaredUnsupported,
+  type AnyTurnDriver,
+  type DispatchedTurnDriver,
+  type SynchronousTurnDriver,
   type TurnCommit,
   type TurnRequest,
 } from "./turn-driver"
@@ -138,6 +141,19 @@ describe("EnclaveTurnDriver", () => {
     ).rejects.toThrow('serves "sealed" turns')
     expect(generateTextWithTools).not.toHaveBeenCalled()
     expect(commitMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe("turn driver families", () => {
+  it("keeps the synchronous and dispatched families structurally distinct", () => {
+    const driver = new InProcessTurnDriver({ ai: commitOnceAI("unused") })
+    // `TurnDriver` aliases the synchronous contract, so today's call sites and
+    // the union the dispatch layer routes over both accept the driver as-is.
+    const synchronous: SynchronousTurnDriver = driver
+    const anyDriver: AnyTurnDriver = driver
+    // @ts-expect-error — a synchronous driver is not a dispatcher: it resolves the turn in one call instead of durably enqueueing it.
+    const dispatched: DispatchedTurnDriver = driver
+    expect([synchronous, anyDriver, dispatched]).toEqual([driver, driver, driver])
   })
 })
 

--- a/packages/agent-runtime/src/runtime/turn-driver.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel, ModelMessage } from "ai"
-import type { SourceItem } from "@threa/types"
+import type { BotInvocationCapability, BotInvocationTrigger, SourceItem } from "@threa/types"
 import type { CostContext } from "../ai/ai"
 import {
   AgentRuntime,
@@ -118,11 +118,95 @@ export interface TurnRequest {
 
 export type TurnResult = AgentRuntimeResult
 
-export interface TurnDriver {
-  /** The single delivery this driver serves; dispatch routes requests by it. */
+/** Shared by every driver: the single delivery it serves. Dispatch routes by `delivery` only — never `instanceof`. */
+export interface BaseTurnDriver {
   readonly delivery: TurnDelivery
+}
+
+/**
+ * A driver that runs the loop in-process (or behind a sealed HTTP callback the
+ * backend awaits) and resolves the whole turn within one call — it holds the
+ * `TurnResult` in the same stack frame. The companion and the enclave.
+ */
+export interface SynchronousTurnDriver extends BaseTurnDriver {
   runTurn(request: TurnRequest, sink: TurnSink): Promise<TurnResult>
 }
+
+/** Today's name for the synchronous contract, kept so existing call sites compile unchanged. */
+export type TurnDriver = SynchronousTurnDriver
+
+/**
+ * The trigger identity a dispatched turn carries instead of the loop inputs —
+ * the seam-level name for the bot wire's invocation-trigger vocabulary.
+ */
+export type TurnTrigger = BotInvocationTrigger
+
+/**
+ * The slice of a `TurnRequest` that survives dispatch to a runner the backend
+ * does not control. The mapping is deliberately lossy AND declared: the harness
+ * brings its own model, system prompt, and tools, so a full `TurnRequest` is
+ * assignable here and everything outside this slice is structurally dropped.
+ * `messages` carries exactly the trigger prompt — history reaches the runner
+ * through the claim payload, never through the loop's message array.
+ */
+export type DispatchedTurnRequest = Pick<TurnRequest, "delivery" | "messages">
+
+/**
+ * What dispatch knows at hand-off that the LATER verb handlers need to resolve
+ * the turn's sink edges. The durable analogue of `TurnSink`: instead of
+ * closures invoked in one stack frame, it names the rows the verb handlers
+ * read when the runner reports back.
+ */
+export interface TurnDispatchBinding {
+  workspaceId: string
+  /** The bot actor the turn is dispatched to. */
+  actorId: string
+  rootStreamId: string
+  activeStreamId: string
+  responseStreamId: string
+  sourceMessageId: string
+  authorUserId: string
+  trigger: TurnTrigger
+  requiredCapability: BotInvocationCapability
+  mentionedActorSlugs?: string[]
+  targetInstanceId?: string | null
+  targetRuntimeSessionId?: string | null
+  metadata?: Record<string, unknown>
+}
+
+/** Returned once the turn's work item is durably enqueued. */
+export interface TurnDispatchReceipt {
+  invocationId: string
+  /** `deduplicated`: the durable queue already held this work item (idempotent re-dispatch), nothing new was enqueued. */
+  status: "dispatched" | "deduplicated"
+}
+
+/**
+ * How a dispatched turn realizes each `TurnSink` edge. The synchronous drivers
+ * get live closures resolved in one stack frame; a dispatched turn's edges are
+ * realized later, by durable verb handlers, against the same projection layer.
+ * Each edge names its realizing verb or declares itself unsupported with a
+ * renderable reason — keyed off `TurnSink` so a new sink edge forces every
+ * dispatched driver to take a position on it.
+ */
+export type TurnSinkResolution = {
+  readonly [Edge in keyof Required<TurnSink>]: { readonly realizedBy: string } | DeclaredUnsupported
+}
+
+/**
+ * A driver that hands the turn to a runner it does not control and returns
+ * once the work item is durably enqueued. The turn's sink edges are realized
+ * LATER by the verb handlers — never within this call, so there is no
+ * `TurnResult` to return: at dispatch time the model has not run and no
+ * message exists. The external bot path; later, the pulled enclave.
+ */
+export interface DispatchedTurnDriver extends BaseTurnDriver {
+  readonly sinkResolution: TurnSinkResolution
+  dispatchTurn(request: DispatchedTurnRequest, binding: TurnDispatchBinding): Promise<TurnDispatchReceipt>
+}
+
+/** Any driver. Dispatch narrows by `delivery`. */
+export type AnyTurnDriver = SynchronousTurnDriver | DispatchedTurnDriver
 
 /**
  * Map a request + sink onto the loop's own constructor shape and run it. Shared


### PR DESCRIPTION
## Problem

The external bot path is the last delivery without a driver behind the turn contract. The in-process drivers (`InProcessTurnDriver`, `EnclaveTurnDriver`) run `AgentRuntime` and `await runTurn(...)` to a `TurnResult` in one stack frame — but the external wire is pull-based and durable: a harness claims an invocation in one HTTP request, POSTs `/steps` over time, and `/complete`s in a later, separate request, surviving runner restarts via claim/renew/park. A blocking `runTurn` structurally cannot fit: returning `sentMessageIds: []` at dispatch time is indistinguishable from a genuine no-response turn (an INV-11 silent fallback), and blocking until `/complete` would couple a backend request's lifetime to the bot's wall-clock, defeating the durable claim machinery.

Meanwhile the invocation outbox handler calls `BotRuntimeService.createInvocation` directly at two sites — there is no typed seam, so the "one vocabulary, three drivers" shape (redesign §2.2) has a hole where external delivery should be.

## Solution

Per the approved design (`docs/plans/agent-runtimes-phase-2-3-external-turn-driver.md` §1.3), split the turn-driver contract into a base plus two sub-interfaces, and add `ExternalTurnDriver` as the first dispatched driver:

- **`BaseTurnDriver`** — just `delivery`; dispatch routes by it (never `instanceof`).
- **`SynchronousTurnDriver`** — today's contract (`runTurn`); `TurnDriver` is retained as an alias, so the two existing blocking call sites (`persona-agent.ts`, `run-turn.ts`) compile unchanged.
- **`DispatchedTurnDriver`** — `dispatchTurn(request, binding): Promise<TurnDispatchReceipt>`, returning once the work item is durably enqueued. Sink edges are realized later by the durable verb handlers, documented per-edge via `TurnSinkResolution`.

`ExternalTurnDriver` (in the `bot-runtimes` feature) implements `DispatchedTurnDriver` as a thin wrapper over the existing `BotRuntimeService.createInvocation` — claim/renew/park semantics untouched. The two direct `createInvocation` calls in the invocation outbox handler become one `dispatchTurn` mapping.

### How it works

```
message:created (outbox) ─▶ BotInvocationOutboxHandler
                              └─ ExternalTurnDriver.dispatchTurn(request, binding)
                                   └─ BotRuntimeService.createInvocation
                                        ├─ bot_invocations row (idempotent insert)
                                        └─ bot_invocation:available (same tx)
                                   ◀─ TurnDispatchReceipt { invocationId, "dispatched" | "deduplicated" }

later, separate requests (the harness):   claim → /steps* → /complete | /fail
                                          (these realize the turn's sink edges)
```

### Key design decisions

**1. Dispatcher, not uniform blocking `runTurn`** (design §1.1–1.2, decided pre-implementation). The type split makes the asymmetry a compile-time fact: synchronous drivers hold the `TurnResult` in the same stack frame; a dispatcher cannot — at dispatch time the model hasn't run and no message exists. Type-level tests (`@ts-expect-error`, enforced by `tsc`) prove the families are not structurally interchangeable in either direction. When the enclave inverts to pull (§2.7), it migrates by changing which sub-interface it implements.

**2. The prompt rides the request; identity rides the binding.** The design's `TurnDispatchBinding` deliberately omits `promptMarkdown` (it's turn content, not durable identity), so the dispatch request carries it: `DispatchedTurnRequest = Pick<TurnRequest, "delivery" | "messages">`. A full `TurnRequest` stays assignable, and everything outside the slice (model, systemPrompt, tools, sampling — the harness brings its own) is structurally dropped, making the design-§3 "lossy and declared" mapping a compile-time property. `messages` must be exactly one plain-text user message (the trigger prompt); anything else throws loudly (INV-11) instead of being silently flattened — history reaches the runner via the claim payload (2.3d), never the loop's message array.

**3. Sink edges as a declared resolution, not closures.** `TurnSinkResolution` is keyed off `keyof Required<TurnSink>` (INV-31: a new sink edge forces every dispatched driver to take a position). External resolves `commitMessage` ← `/complete` and `observers` ← `/steps` → `TraceProjector`; `shouldAbort` / `toolSignalProvider` / `newMessages` reuse the existing `declaredUnsupported(...)` sentinel with renderable reasons.

**4. Interfaces in the package, class in the feature** (INV-51/52). The vocabulary lives in `packages/agent-runtime/src/runtime/turn-driver.ts` next to its synchronous siblings; `ExternalTurnDriver` imports `BotRuntimeService` and therefore lives in `apps/backend/src/features/bot-runtimes/`, exported via the feature barrel. The package stays free of backend imports.

**5. `createInvocation` now returns `{ invocation, wasNewlyInserted }`** so the receipt can report `"deduplicated"` on the idempotent re-insert path (the `xmax = 0` marker the repo already computed). All existing callers ignored the return value, so this is non-breaking; the `bot_invocation:available` emit-once behavior is unchanged.

No wire change anywhere in this PR — OpenAPI is untouched.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/features/bot-runtimes/external-turn-driver.ts` | `ExternalTurnDriver implements DispatchedTurnDriver`; constructed once with `{ service }` (INV-13); wraps `createInvocation` (INV-35) |
| `apps/backend/src/features/bot-runtimes/external-turn-driver.test.ts` | Binding→`createInvocation` exact mapping, deduplicated receipt, delivery guard, single-prompt guard, sink-edge declaration, `@ts-expect-error` not-synchronous proof |

## Modified files

| File | Change |
| --- | --- |
| `packages/agent-runtime/src/runtime/turn-driver.ts` | `BaseTurnDriver` / `SynchronousTurnDriver` / `DispatchedTurnDriver` split; `TurnDriver` aliased; `DispatchedTurnRequest`, `TurnDispatchBinding`, `TurnDispatchReceipt`, `TurnTrigger`, `TurnSinkResolution`, `AnyTurnDriver`. Existing driver classes untouched |
| `packages/agent-runtime/src/runtime/turn-driver.test.ts` | Family-distinctness test (alias + union accept the in-process driver; `@ts-expect-error` it is not a dispatcher) |
| `packages/agent-runtime/src/index.ts`, `src/runtime/index.ts` | Barrel-export the new types (INV-52) |
| `apps/backend/src/features/bot-runtimes/service.ts` | `createInvocation` / `createInvocationInTransaction` return `{ invocation, wasNewlyInserted }` |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | The two direct `createInvocation` calls replaced with one constructed-once `dispatchTurn` path; mention extraction and session-link policy unchanged |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts` | `createInvocation` spy resolutions updated to the new return shape |
| `apps/backend/src/features/bot-runtimes/index.ts` | Export `ExternalTurnDriver` |

## Test plan

- [x] `packages/agent-runtime`: 189 pass (incl. new family-distinctness test)
- [x] `apps/backend` bot-runtimes + commands suites: 66 pass (incl. 6 new `ExternalTurnDriver` tests)
- [x] Monorepo `bun run typecheck` + `bun run lint` clean (the `@ts-expect-error` proofs are enforced both ways by `tsc`)
- [x] `generate-api-docs --check`: spec unchanged (no wire delta in this PR)

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Phase 2.3c of the agent-runtimes unification (`docs/plans/agent-runtimes-unification-redesign.md` §2.4 row 2.3): the structural seam for external turn delivery, per the approved design doc `docs/plans/agent-runtimes-phase-2-3-external-turn-driver.md` (landed via #861). Follows 2.3a (`/complete` sources, #861) and 2.3b (`bot:hello` output manifest + reject-undeclared, #865).

**What was built.**

1. Interface split in `packages/agent-runtime/src/runtime/turn-driver.ts` (design §1.3): `BaseTurnDriver` + `SynchronousTurnDriver` (with `TurnDriver` as alias — no edits to the blocking call sites) + `DispatchedTurnDriver`; `AnyTurnDriver` union for the future dispatch layer.
2. Dispatch vocabulary: `TurnDispatchBinding` (durable identity the verb handlers re-derive sink edges from), `TurnDispatchReceipt` (`dispatched` | `deduplicated`), `TurnTrigger` (seam name for `BotInvocationTrigger`), `DispatchedTurnRequest` (declared-lossy `Pick` of `TurnRequest`), `TurnSinkResolution` (per-edge realization or `declaredUnsupported`).
3. `ExternalTurnDriver` in the bot-runtimes feature (design §1.4): one mapping over `createInvocation`; service create methods now surface `wasNewlyInserted`.
4. Outbox handler dispatches through the driver (design §3 consequence); mention path and active-scratchpad path converge on one mapping.

**Design evolution vs. the doc.**

- `promptMarkdown` placement was unspecified (the binding omits it by design): resolved as the single-user-message convention on `DispatchedTurnRequest` with a loud guard, keeping content on the request and identity on the binding.
- `ExternalContextHandle` / `contextHandle` on the binding: deferred to 2.3d, which builds the claim-response wire shape it types — avoids speculative shape churn (INV-36).

**What's NOT included (later sub-PRs / deferred per design §6):** context handle inline-last-N (2.3d); `supportedCapabilities`→`manifest.triggers` rename (possible 2.3e); sealed/pulled-enclave migration to `DispatchedTurnDriver` (§2.7); in-loop cancellation carrier (N-3); external usage/cost reporting; `taipVersion`.

**Status:** complete; all suites green; no schema or wire changes.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_017AZS7Bb3VvFnyJPrqVrguL

---
_Generated by [Claude Code](https://claude.ai/code/session_017AZS7Bb3VvFnyJPrqVrguL)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783839858&installation_id=129946197&pr_number=870&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F870&signature=65471ee3fdde2f5f826727f221a981297a006b9539510816486f1a947cb32cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->