### PR TITLE
feat: inline context handle on the bot invocation claim response (Phase 2.3d)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/external-turn-driver.test.ts
+++ b/apps/backend/src/features/bot-runtimes/external-turn-driver.test.ts
@@ -98,6 +98,18 @@ describe("ExternalTurnDriver", () => {
     expect(createInvocation).not.toHaveBeenCalled()
   })
 
+  it("rejects a pre-resolved context handle — external context is hydrated at claim time", async () => {
+    const { driver, createInvocation } = makeDriver({ wasNewlyInserted: true })
+
+    await expect(
+      driver.dispatchTurn(externalRequest("hi"), {
+        ...binding,
+        contextHandle: { kind: "inline", messages: [] },
+      })
+    ).rejects.toThrow("hydrated at claim time")
+    expect(createInvocation).not.toHaveBeenCalled()
+  })
+
   it("declares its sink edges: durable verbs for commit and trace, loud gaps for the rest", () => {
     const { driver } = makeDriver({ wasNewlyInserted: true })
 

--- a/apps/backend/src/features/bot-runtimes/external-turn-driver.ts
+++ b/apps/backend/src/features/bot-runtimes/external-turn-driver.ts
@@ -39,6 +39,13 @@ export class ExternalTurnDriver implements DispatchedTurnDriver {
     if (request.delivery !== this.delivery) {
       throw new Error(`ExternalTurnDriver serves "${this.delivery}" turns; got "${request.delivery}"`)
     }
+    // Context on this wire is hydrated by the claim handler when the runner
+    // picks the turn up (fresh history, nothing double-stored on the
+    // invocation row — INV-57). A pre-resolved handle has no carrier here, so
+    // accepting one would silently drop it (INV-11).
+    if (binding.contextHandle) {
+      throw new Error("external context is hydrated at claim time; a pre-resolved context handle has no carrier")
+    }
     const { invocation, wasNewlyInserted } = await this.deps.service.createInvocation({
       workspaceId: binding.workspaceId,
       rootStreamId: binding.rootStreamId,

--- a/apps/backend/src/features/public-api/claim-context.test.ts
+++ b/apps/backend/src/features/public-api/claim-context.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { BotRepository } from "./bot-repository"
+import { BotChannelAccessRepository } from "../api-keys"
+import { MessageRepository, type EventService, type Message } from "../messaging"
+import { StreamMemberRepository, StreamRepository, type Stream } from "../streams"
+import { UserRepository } from "../workspaces"
+import { PersonaRepository, AgentSessionRepository } from "../agents"
+import * as dbModule from "../../db"
+
+// Phase 2.3d (N-4): the claim response carries an inline context handle — the
+// last messages preceding the trigger from the invocation's own stream, so an
+// external runner gets the conversation it was invoked into without a second
+// round-trip. Scoping is per-location (INV-62): the invocation's stream IS the
+// grant, with thread access resolving through the root — never the bot's
+// standing channel grants and never a direct stream_members filter.
+
+function createResponse() {
+  const payloads: unknown[] = []
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock((body: unknown) => {
+    payloads.push(body)
+    return res
+  }) as unknown as Response["json"]
+  return { res, payloads }
+}
+
+function historyMessage(overrides: Partial<Message>): Message {
+  return {
+    id: "msg_x",
+    streamId: "stream_thread",
+    sequence: 1n,
+    authorId: "usr_1",
+    authorType: "user",
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "hello",
+    replyCount: 0,
+    clientMessageId: null,
+    sentVia: null,
+    reactions: {},
+    metadata: {},
+    editedAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-06-12T08:00:00.000Z"),
+    ciphertext: null,
+    envelope: null,
+    e2eVersion: null,
+    ...overrides,
+  } as Message
+}
+
+function arrangeClaim(params: { stream: Stream | null; surrounding?: Message[] }) {
+  // The invocation lands in a thread; access resolves through the root channel.
+  const invocation = {
+    id: "binv_1",
+    workspaceId: "ws_1",
+    rootStreamId: "stream_channel",
+    activeStreamId: "stream_thread",
+    sourceMessageId: "msg_trigger",
+    responseStreamId: "stream_thread",
+    actorType: "bot" as const,
+    actorId: "bot_1",
+    trigger: "mention",
+    requiredCapability: "mentionable",
+    promptMarkdown: "@pi what's the tide tomorrow?",
+    authorUserId: "usr_1",
+    mentionedActorSlugs: ["pi"],
+    status: "claimed",
+    targetInstanceId: null,
+    targetRuntimeSessionId: null,
+    claimedByInstanceId: "inst_1",
+    claimToken: "tok_1",
+    claimExpiresAt: new Date("2026-06-12T09:01:00.000Z"),
+    attempts: 1,
+    errorMessage: null,
+    metadata: {},
+    createdAt: new Date("2026-06-12T09:00:00.000Z"),
+    updatedAt: new Date("2026-06-12T09:00:00.000Z"),
+    completedAt: null,
+  }
+
+  // Presence fan-out no-ops (no granted streams) so the claim path stays focused.
+  spyOn(BotChannelAccessRepository, "getGrantedStreamIds").mockResolvedValue([])
+  spyOn(BotRepository, "findById").mockResolvedValue({
+    id: "bot_1",
+    slug: "pi",
+    name: "Pi",
+    archivedAt: null,
+  } as never)
+  spyOn(dbModule, "withTransaction").mockImplementation(((_pool: unknown, fn: (c: unknown) => unknown) =>
+    fn({})) as never)
+  spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue(null as never)
+
+  const findStream = spyOn(StreamRepository, "findById").mockResolvedValue(params.stream as never)
+  const findSurrounding = spyOn(MessageRepository, "findSurrounding").mockResolvedValue(
+    (params.surrounding ?? []) as never
+  )
+  const isMember = spyOn(StreamMemberRepository, "isMember").mockResolvedValue(false as never)
+  spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_1", name: "Kris" }] as never)
+  spyOn(BotRepository, "findByIds").mockResolvedValue([
+    { id: "bot_1", name: "Pi" },
+    { id: "bot_2", name: "Crab" },
+  ] as never)
+  spyOn(PersonaRepository, "findByIds").mockResolvedValue([] as never)
+
+  const botRuntimeService = {
+    claimNextInvocation: mock(() => Promise.resolve(invocation)),
+    upsertPresenceFromBotKey: mock(() => Promise.resolve(null)),
+  } as unknown as PublicApiDeps["botRuntimeService"]
+  const isStreamAccessibleForBot = mock(() => Promise.resolve(true))
+  const botChannelService = {
+    isStreamAccessibleForBot,
+  } as unknown as PublicApiDeps["botChannelService"]
+  const eventService = {
+    getLatestSequence: mock(() => Promise.resolve(7n)),
+  } as unknown as EventService
+
+  const handlers = createPublicApiHandlers({
+    eventService,
+    streamService: {} as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService,
+    botRuntimeService,
+    pool: {} as PublicApiDeps["pool"],
+    io: {} as PublicApiDeps["io"],
+  })
+
+  const req = {
+    workspaceId: "ws_1",
+    botApiKey: { botId: "bot_1" },
+    body: { runtimeKind: "pi-local", instanceId: "inst_1", supportedCapabilities: ["mentionable"] },
+  } as unknown as Request
+
+  return { handlers, req, findStream, findSurrounding, isMember, isStreamAccessibleForBot }
+}
+
+const threadStream = {
+  id: "stream_thread",
+  workspaceId: "ws_1",
+  type: "thread",
+  rootStreamId: "stream_channel",
+  visibility: "private",
+} as unknown as Stream
+
+describe("claimBotInvocation context handle", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("inlines prior messages oldest→newest with the trigger excluded and own-bot rows as assistant", async () => {
+    const { handlers, req, findSurrounding } = arrangeClaim({
+      stream: threadStream,
+      surrounding: [
+        historyMessage({
+          id: "msg_1",
+          sequence: 1n,
+          authorId: "usr_1",
+          authorType: "user",
+          contentMarkdown: "when's high tide?",
+          createdAt: new Date("2026-06-12T08:00:00.000Z"),
+        }),
+        historyMessage({
+          id: "msg_2",
+          sequence: 2n,
+          authorId: "bot_1",
+          authorType: "bot",
+          contentMarkdown: "Around 14:00, checking.",
+          createdAt: new Date("2026-06-12T08:01:00.000Z"),
+        }),
+        historyMessage({
+          id: "msg_3",
+          sequence: 3n,
+          authorId: "bot_2",
+          authorType: "bot",
+          contentMarkdown: "I posted the charts.",
+          createdAt: new Date("2026-06-12T08:02:00.000Z"),
+        }),
+        historyMessage({ id: "msg_trigger", sequence: 4n, contentMarkdown: "@pi what's the tide tomorrow?" }),
+      ],
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.claimBotInvocation(req, res)
+
+    // The window mirrors the enclave's assignment cap (30 before the trigger).
+    expect(findSurrounding.mock.calls[0]?.slice(1)).toEqual(["msg_trigger", "stream_thread", 30, 0])
+    const data = (payloads[0] as { data: Record<string, unknown> }).data
+    expect(data.context).toEqual({
+      kind: "inline",
+      messages: [
+        {
+          messageId: "msg_1",
+          role: "user",
+          authorId: "usr_1",
+          authorType: "user",
+          authorDisplayName: "Kris",
+          contentMarkdown: "when's high tide?",
+          createdAt: "2026-06-12T08:00:00.000Z",
+        },
+        {
+          messageId: "msg_2",
+          role: "assistant",
+          authorId: "bot_1",
+          authorType: "bot",
+          authorDisplayName: "Pi",
+          contentMarkdown: "Around 14:00, checking.",
+          createdAt: "2026-06-12T08:01:00.000Z",
+        },
+        {
+          // Another bot's message is conversational input, not this runner's own output.
+          messageId: "msg_3",
+          role: "user",
+          authorId: "bot_2",
+          authorType: "bot",
+          authorDisplayName: "Crab",
+          contentMarkdown: "I posted the charts.",
+          createdAt: "2026-06-12T08:02:00.000Z",
+        },
+      ],
+    })
+  })
+
+  it("hydrates a non-member thread inside a member channel without touching membership or standing grants (INV-62)", async () => {
+    const { handlers, req, isMember, isStreamAccessibleForBot } = arrangeClaim({
+      stream: threadStream,
+      surrounding: [
+        historyMessage({ id: "msg_1", contentMarkdown: "thread chatter" }),
+        historyMessage({ id: "msg_trigger", sequence: 2n }),
+      ],
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.claimBotInvocation(req, res)
+
+    const data = (payloads[0] as { data: Record<string, unknown> }).data
+    const context = data.context as { messages: { messageId: string }[] }
+    expect(context.messages.map((m) => m.messageId)).toEqual(["msg_1"])
+    // The location is the grant: a stream_members or bot-channel-grant filter
+    // would silently drop thread context (membership ≠ access).
+    expect(isMember).not.toHaveBeenCalled()
+    expect(isStreamAccessibleForBot).not.toHaveBeenCalled()
+  })
+
+  it("ships an explicitly empty inline handle when the trigger opens the conversation", async () => {
+    const { handlers, req } = arrangeClaim({
+      stream: threadStream,
+      surrounding: [historyMessage({ id: "msg_trigger" })],
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.claimBotInvocation(req, res)
+
+    const data = (payloads[0] as { data: Record<string, unknown> }).data
+    // Empty is a real answer ("nothing came before"), distinct from the
+    // withheld/omitted field — the same dispatched-vs-empty distinction §1.1
+    // demands of the receipt.
+    expect(data.context).toEqual({ kind: "inline", messages: [] })
+  })
+
+  it("withholds context entirely for an E2E stream — no plaintext history leaves the enclave path", async () => {
+    const { handlers, req, findSurrounding } = arrangeClaim({
+      stream: { ...threadStream, e2eEnabled: true } as unknown as Stream,
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.claimBotInvocation(req, res)
+
+    const data = (payloads[0] as { data: Record<string, unknown> }).data
+    expect(data.id).toBe("binv_1")
+    expect("context" in data).toBe(false)
+    expect(findSurrounding).not.toHaveBeenCalled()
+  })
+
+  it("withholds context when the stream row is gone or belongs to another workspace (INV-8)", async () => {
+    const { handlers, req, findSurrounding } = arrangeClaim({
+      stream: { ...threadStream, workspaceId: "ws_other" } as unknown as Stream,
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.claimBotInvocation(req, res)
+
+    const data = (payloads[0] as { data: Record<string, unknown> }).data
+    expect("context" in data).toBe(false)
+    expect(findSurrounding).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -5,7 +5,8 @@ import type { Server } from "socket.io"
 import type { SearchFilters, SearchService } from "../search"
 import { serializeSearchResult, resolveUserAccessibleStreamIds } from "../search"
 import { BotChannelAccessRepository, type BotChannelService } from "../api-keys"
-import type { EventService } from "../messaging"
+import { MessageRepository, type EventService } from "../messaging"
+import type { ExternalContextHandle } from "@threa/agent-runtime"
 import {
   StreamRepository,
   StreamEventRepository,
@@ -354,6 +355,65 @@ async function resolveAuthorDisplayNames(
 
   await Promise.all(fetches)
   return nameMap
+}
+
+/** Mirrors the enclave assignment's history cap (`MAX_HISTORY_MESSAGES`, enclave-invoke-worker). */
+const CLAIM_CONTEXT_MAX_MESSAGES = 30
+
+/**
+ * Hydrate the inline context handle for a freshly claimed invocation (N-4):
+ * the last messages preceding the trigger, from the invocation's own stream,
+ * oldest → newest. The trigger itself already travels as `promptMarkdown`.
+ *
+ * Scoping is per-location (INV-62): the invocation's location is the grant —
+ * an agent's access derives from WHERE it was invoked, and every surface's
+ * access spec includes the surface itself. So no `stream_members` or
+ * bot-channel-grant filter applies here: either would silently drop thread
+ * context (threads carry no membership of their own; access resolves through
+ * the root), and standing grants are the wrong axis anyway.
+ *
+ * Returns `undefined` when context is WITHHELD (stream gone, cross-workspace,
+ * or E2E — plaintext history never leaves the enclave path). An empty
+ * conversation instead yields an explicit empty inline handle, so the runner
+ * can tell "nothing came before" from "context unavailable".
+ */
+async function buildClaimContext(
+  pool: Pool,
+  invocation: { workspaceId: string; activeStreamId: string; sourceMessageId: string; actorId: string }
+): Promise<ExternalContextHandle | undefined> {
+  const stream = await StreamRepository.findById(pool, invocation.activeStreamId)
+  if (!stream || stream.workspaceId !== invocation.workspaceId) return undefined
+  // External dispatch into E2E streams is already blocked upstream
+  // (invocation-outbox-handler); this guards invocations that predate a later
+  // E2E enablement of the stream.
+  if (stream.e2eEnabled === true) return undefined
+
+  const surrounding = await MessageRepository.findSurrounding(
+    pool,
+    invocation.sourceMessageId,
+    invocation.activeStreamId,
+    CLAIM_CONTEXT_MAX_MESSAGES,
+    0
+  )
+  const prior = surrounding.filter((m) => m.id !== invocation.sourceMessageId)
+  const authorNames = await resolveAuthorDisplayNames(pool, invocation.workspaceId, prior)
+  return {
+    kind: "inline",
+    messages: prior.map((m) => {
+      const authorDisplayName = authorNames.get(m.authorId)
+      return {
+        messageId: m.id,
+        // "assistant" = this runner's own prior replies; other bots and
+        // personas are conversational input like any other participant.
+        role: m.authorType === AuthorTypes.BOT && m.authorId === invocation.actorId ? "assistant" : "user",
+        authorId: m.authorId,
+        authorType: m.authorType,
+        ...(authorDisplayName != null && { authorDisplayName }),
+        contentMarkdown: m.contentMarkdown,
+        createdAt: m.createdAt.toISOString(),
+      }
+    }),
+  }
 }
 
 export interface PublicApiDeps {
@@ -935,6 +995,7 @@ export function createPublicApiHandlers({
           })
         })
       }
+      const context = await buildClaimContext(pool, invocation)
       res.json({
         data: {
           id: invocation.id,
@@ -953,6 +1014,7 @@ export function createPublicApiHandlers({
           claimExpiresAt: invocation.claimExpiresAt!.toISOString(),
           runtimeSessionId: invocation.targetRuntimeSessionId,
           metadata: invocation.metadata,
+          ...(context && { context }),
         },
       })
     },

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -298,6 +298,26 @@ const botRuntimePresenceSchema = z.object({
   updatedAt: z.string().datetime(),
 })
 
+const externalHistoryMessageSchema = z.object({
+  messageId: z.string(),
+  role: z.enum(["user", "assistant"]),
+  authorId: z.string(),
+  authorType: z.enum(AUTHOR_TYPES),
+  authorDisplayName: z.string().optional(),
+  contentMarkdown: z.string(),
+  createdAt: z.string().datetime(),
+})
+
+// Wire shape of `ExternalContextHandle` (@threa/agent-runtime): recent
+// conversation from the invocation's own stream, oldest → newest, trigger
+// excluded (it travels as `promptMarkdown`). Discriminated on `kind` so a
+// fetch-back `ref` variant can be added later without a wire break; only the
+// inline variant exists today.
+const externalContextHandleSchema = z.object({
+  kind: z.literal("inline"),
+  messages: z.array(externalHistoryMessageSchema),
+})
+
 const claimedInvocationSchema = z.object({
   id: z.string(),
   workspaceId: z.string(),
@@ -315,6 +335,9 @@ const claimedInvocationSchema = z.object({
   claimExpiresAt: z.string().datetime(),
   runtimeSessionId: z.string().nullable(),
   metadata: z.record(z.string(), z.unknown()),
+  // Omitted when context is withheld (E2E or unresolvable stream); an empty
+  // conversation is an explicit `{ kind: "inline", messages: [] }` instead.
+  context: externalContextHandleSchema.optional(),
 })
 
 const runtimeSessionLinkSchema = z.object({

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1290,6 +1290,38 @@
                               "type": "object",
                               "propertyNames": { "type": "string" },
                               "additionalProperties": {}
+                            },
+                            "context": {
+                              "type": "object",
+                              "properties": {
+                                "kind": { "type": "string", "const": "inline" },
+                                "messages": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "messageId": { "type": "string" },
+                                      "role": { "type": "string", "enum": ["user", "assistant"] },
+                                      "authorId": { "type": "string" },
+                                      "authorType": { "type": "string", "enum": ["user", "persona", "system", "bot"] },
+                                      "authorDisplayName": { "type": "string" },
+                                      "contentMarkdown": { "type": "string" },
+                                      "createdAt": { "type": "string", "format": "date-time" }
+                                    },
+                                    "required": [
+                                      "messageId",
+                                      "role",
+                                      "authorId",
+                                      "authorType",
+                                      "contentMarkdown",
+                                      "createdAt"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "required": ["kind", "messages"],
+                              "additionalProperties": false
                             }
                           },
                           "required": [

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -20,6 +20,8 @@ export type {
   BaseTurnDriver,
   DispatchedTurnDriver,
   DispatchedTurnRequest,
+  ExternalContextHandle,
+  ExternalHistoryMessage,
   SynchronousTurnDriver,
   TurnCommit,
   TurnCommitReceipt,

--- a/packages/agent-runtime/src/runtime/index.ts
+++ b/packages/agent-runtime/src/runtime/index.ts
@@ -21,6 +21,8 @@ export type {
   BaseTurnDriver,
   DispatchedTurnDriver,
   DispatchedTurnRequest,
+  ExternalContextHandle,
+  ExternalHistoryMessage,
   SynchronousTurnDriver,
   TurnCommit,
   TurnCommitReceipt,

--- a/packages/agent-runtime/src/runtime/turn-driver.ts
+++ b/packages/agent-runtime/src/runtime/turn-driver.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel, ModelMessage } from "ai"
-import type { BotInvocationCapability, BotInvocationTrigger, SourceItem } from "@threa/types"
+import type { AuthorType, BotInvocationCapability, BotInvocationTrigger, SourceItem } from "@threa/types"
 import type { CostContext } from "../ai/ai"
 import {
   AgentRuntime,
@@ -152,6 +152,34 @@ export type TurnTrigger = BotInvocationTrigger
 export type DispatchedTurnRequest = Pick<TurnRequest, "delivery" | "messages">
 
 /**
+ * One prior conversation message shipped to a dispatched runner. The runner
+ * brings its own model and prompt assembly, so this is wire-shaped (ISO
+ * timestamps, markdown content), not the loop's `ModelMessage`.
+ */
+export interface ExternalHistoryMessage {
+  messageId: string
+  /** `assistant` = authored by the claiming bot itself; everything else — users, other bots, personas — is conversational input. */
+  role: "user" | "assistant"
+  authorId: string
+  authorType: AuthorType
+  authorDisplayName?: string
+  contentMarkdown: string
+  createdAt: string
+}
+
+/**
+ * Recent, location-scoped conversation context for a dispatched turn,
+ * discriminated on `kind` so a fetch-back `ref` variant can be added later
+ * without a wire break. Only the inline variant exists today: the last N
+ * messages preceding the trigger, oldest → newest, trigger excluded (it
+ * already travels as the invocation's prompt).
+ */
+export interface ExternalContextHandle {
+  kind: "inline"
+  messages: ExternalHistoryMessage[]
+}
+
+/**
  * What dispatch knows at hand-off that the LATER verb handlers need to resolve
  * the turn's sink edges. The durable analogue of `TurnSink`: instead of
  * closures invoked in one stack frame, it names the rows the verb handlers
@@ -171,6 +199,14 @@ export interface TurnDispatchBinding {
   mentionedActorSlugs?: string[]
   targetInstanceId?: string | null
   targetRuntimeSessionId?: string | null
+  /**
+   * Forward-compat slot for a transport that resolves context AT dispatch. The
+   * external bot path does not: it hydrates context at claim time, so history
+   * is fresh when the runner picks the turn up and is never double-stored on
+   * the invocation row (INV-57) — `ExternalTurnDriver` rejects a pre-resolved
+   * handle loudly rather than dropping it.
+   */
+  contextHandle?: ExternalContextHandle
   metadata?: Record<string, unknown>
 }
 


### PR DESCRIPTION
## Problem

An external bot claims an invocation and receives only the trigger prompt (`promptMarkdown`). To respond well it needs the conversation it was invoked into, but the wire offers no way to get it: history is deliberately barred from riding `messages` on dispatch (the 2.3c single-prompt convention), and making the runner fetch messages itself would route context through the bot's standing API scopes — the wrong access axis for an invocation-scoped turn.

This is delta N-4 of the Phase 2.3 design (`docs/plans/agent-runtimes-phase-2-3-external-turn-driver.md` §4.2), the last 2.3 sub-PR after #861 (sources), #865 (manifest), #870 (driver split).

## Solution

The claim response gains an optional `context` field: an **inline context handle** carrying the last 30 messages preceding the trigger from the invocation's own stream, oldest → newest, trigger excluded. Hydration happens **at claim time** — fresh history when the runner actually picks the turn up, nothing double-stored on the invocation row (INV-57). The cap and shape mirror the enclave assignment's history hydration (`MAX_HISTORY_MESSAGES` in `enclave-invoke-worker.ts`).

### Key design decisions

**1. Per-location access scoping, not standing scopes (INV-62).** The invocation's location is the grant: an agent's access derives from *where* it was invoked, and every surface's access spec includes the surface itself (`computeAgentAccessSpec`). So hydration serves only the invocation's own stream and applies **no** `stream_members` or bot-channel-grant filter — either would silently drop thread context (threads carry no membership of their own; access resolves thread → root). A test pins the non-member-thread-inside-a-member-channel case and asserts membership/grant paths are never consulted.

**2. Withheld ≠ empty.** A stream that is E2E, missing, or cross-workspace (INV-8) withholds the field entirely; a conversation with nothing before the trigger ships an explicit `{ kind: "inline", messages: [] }`. The runner can always tell "nothing came before" from "context unavailable" — the same dispatched-vs-empty distinction the design's §1.1 demands of the receipt.

**3. Discriminated handle, inline-only.** `ExternalContextHandle` is discriminated on `kind` so the deferred fetch-back `ref` variant can land later without a wire break. Only the inline variant is typed and built (INV-36).

**4. `role` means "this runner's own output".** Prior replies by the claiming bot map to `assistant`; users, personas, and *other* bots are conversational input (`user`), with `authorId`/`authorType`/`authorDisplayName` carried for rendering. The enclave's persona→assistant mapping expresses the same "me vs not me" rule for its single-persona world.

**5. The binding slot is forward-compat only.** `TurnDispatchBinding.contextHandle` (the design's §1.4 slot) is typed for a future transport that resolves context at dispatch; `ExternalTurnDriver` rejects a pre-resolved handle loudly rather than silently dropping it (INV-11), since this wire hydrates at claim time.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/public-api/claim-context.test.ts` | Claim-context behavior: ordering/role mapping, INV-62 thread case, withheld-vs-empty, E2E exclusion regression |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/agent-runtime/src/runtime/turn-driver.ts` | `ExternalHistoryMessage` + `ExternalContextHandle` seam types; `contextHandle?` forward-compat slot on `TurnDispatchBinding` |
| `packages/agent-runtime/src/{index,runtime/index}.ts` | Barrel exports |
| `apps/backend/src/features/bot-runtimes/external-turn-driver.ts` | Loud rejection of a pre-resolved context handle (+ test) |
| `apps/backend/src/features/public-api/handlers.ts` | `buildClaimContext` hydration; claim response includes `context` |
| `apps/backend/src/features/public-api/routes.ts` | Wire schema for the claim response's `context` field |
| `docs/public-api/openapi.json` | Regenerated (additive optional field only) |

## Test plan

- [x] New `claim-context.test.ts` — 5 tests covering inline shape, INV-62 thread hydration, explicit-empty, E2E withhold, cross-workspace withhold
- [x] `external-turn-driver.test.ts` — new pre-resolved-handle rejection test (7 pass)
- [x] Full `public-api` + `bot-runtimes` suites: 105 pass
- [x] `packages/agent-runtime` suite: 189 pass
- [x] `bun run typecheck`, `bun run lint`, `generate-api-docs --check` all green (also enforced by pre-commit)

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Phase 2.3d of the agent-runtimes unification (`docs/plans/agent-runtimes-unification-redesign.md` §2.4 row 2.3; detailed design `docs/plans/agent-runtimes-phase-2-3-external-turn-driver.md` §4.2, N-4, Open-Q2): ship recent, access-scoped conversation history inline on the bot-invocation claim response.

**What was built:**

1. Seam types in `@threa/agent-runtime` (`turn-driver.ts`): `ExternalHistoryMessage` (wire-shaped: ISO timestamps, markdown), `ExternalContextHandle` (`kind: "inline"`; `ref` variant deferred per Open-Q2/INV-36), `TurnDispatchBinding.contextHandle?` forward-compat slot (§1.4).
2. `ExternalTurnDriver` rejects a binding carrying a pre-resolved handle (INV-11) — claim-time hydration is the live path, so the slot has no carrier on this wire.
3. `buildClaimContext` in `public-api/handlers.ts`: resolves the invocation's stream, withholds for missing/cross-workspace/E2E streams, fetches `MessageRepository.findSurrounding(pool, sourceMessageId, activeStreamId, 30, 0)` (the enclave's cap), excludes the trigger, resolves author display names via the existing `resolveAuthorDisplayNames`, maps own-bot rows to `role: "assistant"`.
4. Claim handler spreads `...(context && { context })` into the response; `routes.ts` adds the matching zod wire schema; OpenAPI regenerated.

**Design decisions (bound upstream, not relitigated here):** claim-time hydration over dispatch-time (design leans claim-time; INV-57 forbids storing history on the invocation row); per-location access spec over bot standing scopes (INV-62); single-user-message dispatch convention from 2.3c retained (history never rides `messages`).

**What's NOT included:** the `ref` fetch-back variant (typed direction only, not built), cancellation (N-3), `manifest.triggers` rename (possible 2.3e), trust-tier rule in `negotiateCapabilities` (Phase 2.4).

**Status:** complete; all suites green; wire change additive and optional — existing Pi/OpenClaw harnesses unaffected.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01CMUX97JCydDMjcHpvfF15f

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMUX97JCydDMjcHpvfF15f)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783842945&installation_id=129946197&pr_number=871&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F871&signature=074c3874ea5c1330006b69c3fbbaf2fdab37d21378136a7734987a0635b1d532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->