### PR TITLE
feat: absolute unread-counter payloads for sync-v2 catch-up (phase 2c backend)

### DIFF
--- a/apps/backend/src/db/migrations/20260612082009_add_stream_events_message_seq_index.sql
+++ b/apps/backend/src/db/migrations/20260612082009_add_stream_events_message_seq_index.sql
@@ -1,0 +1,11 @@
+-- Partial index for message-ordinal counts (sync-v2 phase 2c).
+-- countMessagesThrough / getMessageOrdinalForEvent / countUnreadByStreamBatch
+-- count message_created rows by (stream_id, sequence) range. The generic
+-- idx_stream_events_stream_seq covers (stream_id, sequence) but not the
+-- event_type filter, so every count would post-filter non-message events.
+-- The partial index makes the count an index-only range scan, which matters
+-- because countMessagesThrough runs inside every message-send transaction.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stream_events_message_seq
+  ON stream_events (stream_id, sequence)
+  WHERE event_type = 'message_created';

--- a/apps/backend/src/features/activity/outbox-handler.test.ts
+++ b/apps/backend/src/features/activity/outbox-handler.test.ts
@@ -4,6 +4,7 @@ import * as cursorLockModule from "@threa/backend-common"
 import * as dbModule from "../../db"
 import { ActivityFeedHandler } from "./outbox-handler"
 import type { ActivityService } from "./service"
+import { ActivityRepository } from "./repository"
 import type { ProcessResult } from "@threa/backend-common"
 import { AuthorTypes } from "@threa/types"
 import { E2eStreamsRepository } from "../e2e-streams"
@@ -247,6 +248,9 @@ describe("ActivityFeedHandler", () => {
 
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event] as any)
     const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const countsSpy = spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([["usr_alice:stream_test", { mentionCount: 3, totalCount: 5 }]])
+    )
 
     // Mock withTransaction to just call the callback directly
     spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => {
@@ -260,9 +264,11 @@ describe("ActivityFeedHandler", () => {
 
     await new Promise((r) => setTimeout(r, 300))
 
+    expect(countsSpy).toHaveBeenCalledWith({}, "ws_test", [{ userId: "usr_alice", streamId: "stream_test" }])
     expect(insertSpy).toHaveBeenCalledWith({}, "activity:created", {
       workspaceId: "ws_test",
       targetUserId: "usr_alice",
+      counts: { mentionCount: 3, activityCount: 5 },
       activity: {
         id: "activity_test123",
         activityType: "mention",
@@ -324,6 +330,9 @@ describe("ActivityFeedHandler", () => {
 
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event] as any)
     const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([["usr_bob:stream_test", { mentionCount: 1, totalCount: 1 }]])
+    )
 
     spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => {
       return callback({} as any)
@@ -339,6 +348,7 @@ describe("ActivityFeedHandler", () => {
     const want = {
       workspaceId: "ws_test",
       targetUserId: "usr_bob",
+      counts: { mentionCount: 1, activityCount: 1 },
       activity: {
         id: "activity_existing",
         activityType: "mention",

--- a/apps/backend/src/features/activity/outbox-handler.ts
+++ b/apps/backend/src/features/activity/outbox-handler.ts
@@ -11,7 +11,7 @@ import { logger } from "../../lib/logger"
 import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import type { OutboxHandler } from "../../lib/outbox"
 import type { ActivityService } from "./service"
-import type { Activity } from "./repository"
+import { ActivityRepository, type Activity } from "./repository"
 import { withTransaction } from "../../db"
 import { E2eStreamsRepository } from "../e2e-streams"
 
@@ -302,27 +302,56 @@ export class ActivityFeedHandler implements OutboxHandler {
   /**
    * Publish an activity:created outbox event for each activity row. Grouped in
    * one transaction per call to keep outbox writes batched.
+   *
+   * Each payload carries the target user's absolute unread counts for the
+   * stream (sync-v2 phase 2c): clients set counters from these instead of
+   * incrementing, so replayed/duplicated events converge. The activity rows
+   * are committed before this runs, so the counts include them; rows sharing
+   * a (user, stream) pair carry identical final counts, which is correct
+   * under absolute semantics.
    */
   private async publishActivityCreated(activities: Activity[]): Promise<void> {
     if (activities.length === 0) return
 
     await withTransaction(this.db, async (client) => {
+      // Activities from one source event share a workspace, but group
+      // defensively rather than assume it.
+      const byWorkspace = new Map<string, Activity[]>()
       for (const activity of activities) {
-        await OutboxRepository.insert(client, "activity:created", {
-          workspaceId: activity.workspaceId,
-          targetUserId: activity.userId,
-          activity: {
-            id: activity.id,
-            activityType: activity.activityType,
-            streamId: activity.streamId,
-            messageId: activity.messageId,
-            actorId: activity.actorId,
-            actorType: activity.actorType,
-            context: activity.context,
-            createdAt: activity.createdAt.toISOString(),
-            isSelf: activity.isSelf,
-          },
-        })
+        const group = byWorkspace.get(activity.workspaceId) ?? []
+        group.push(activity)
+        byWorkspace.set(activity.workspaceId, group)
+      }
+
+      for (const [workspaceId, group] of byWorkspace) {
+        const counts = await ActivityRepository.countUnreadForPairs(
+          client,
+          workspaceId,
+          group.map((a) => ({ userId: a.userId, streamId: a.streamId }))
+        )
+
+        for (const activity of group) {
+          const pairCounts = counts.get(`${activity.userId}:${activity.streamId}`)
+          await OutboxRepository.insert(client, "activity:created", {
+            workspaceId: activity.workspaceId,
+            targetUserId: activity.userId,
+            counts: {
+              mentionCount: pairCounts?.mentionCount ?? 0,
+              activityCount: pairCounts?.totalCount ?? 0,
+            },
+            activity: {
+              id: activity.id,
+              activityType: activity.activityType,
+              streamId: activity.streamId,
+              messageId: activity.messageId,
+              actorId: activity.actorId,
+              actorType: activity.actorType,
+              context: activity.context,
+              createdAt: activity.createdAt.toISOString(),
+              isSelf: activity.isSelf,
+            },
+          })
+        }
       }
     })
   }

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -259,6 +259,51 @@ export const ActivityRepository = {
     return { mentionsByStream, totalByStream, total }
   },
 
+  /**
+   * Unread counts for a batch of (user, stream) pairs in one set-based query
+   * (INV-56). Keyed `${userId}:${streamId}`; pairs with no unread rows map to
+   * zeros. Used to stamp absolute counts onto activity:created payloads.
+   */
+  async countUnreadForPairs(
+    db: Querier,
+    workspaceId: string,
+    pairs: Array<{ userId: string; streamId: string }>
+  ): Promise<Map<string, { mentionCount: number; totalCount: number }>> {
+    if (pairs.length === 0) return new Map()
+
+    const userIds = pairs.map((p) => p.userId)
+    const streamIds = pairs.map((p) => p.streamId)
+    const result = await db.query<{ user_id: string; stream_id: string; mention_count: string; total_count: string }>(
+      sql`
+      SELECT
+        p.user_id,
+        p.stream_id,
+        COUNT(ua.id) FILTER (WHERE ua.activity_type = 'mention')::text AS mention_count,
+        COUNT(ua.id)::text AS total_count
+      FROM (
+        SELECT DISTINCT user_id, stream_id
+        FROM unnest(${userIds}::text[], ${streamIds}::text[]) AS pair(user_id, stream_id)
+      ) p
+      LEFT JOIN user_activity ua
+        ON ua.user_id = p.user_id
+        AND ua.stream_id = p.stream_id
+        AND ua.workspace_id = ${workspaceId}
+        AND ua.read_at IS NULL
+        AND ua.is_self = FALSE
+      GROUP BY p.user_id, p.stream_id
+    `
+    )
+
+    const map = new Map<string, { mentionCount: number; totalCount: number }>()
+    for (const row of result.rows) {
+      map.set(`${row.user_id}:${row.stream_id}`, {
+        mentionCount: Number(row.mention_count),
+        totalCount: Number(row.total_count),
+      })
+    }
+    return map
+  },
+
   async countUnreadForStream(
     db: Querier,
     userId: string,

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -19,6 +19,7 @@ describe("EventService attachment safety checks", () => {
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", type: "scratchpad" } as any)
     spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
     spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
     spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
   })
 
@@ -692,6 +693,7 @@ describe("EventService.createMessage metadata propagation", () => {
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", type: "scratchpad" } as any)
     spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
     spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
     spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
     spyOn(StreamMemberRepository, "update").mockResolvedValue(undefined as any)
     spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -667,13 +667,20 @@ export class EventService {
       event: serializeBigInt(event),
     })
 
-    // 9. Publish unread increment for sidebar updates
+    // 9. Publish stream activity for sidebar updates
     // Stream-scoped: only members of this stream receive the preview content.
-    // Frontend excludes the author's own messages from unread count.
+    // sequence/messageOrdinal are absolute stream facts (sync-v2 phase 2c):
+    // clients derive unread as latestOrdinal - lastReadOrdinal instead of
+    // incrementing, so replayed/duplicated events converge. Exact under
+    // concurrency: the sequence allocator's row lock serializes message
+    // inserts per stream until commit.
+    const messageOrdinal = await StreamEventRepository.countMessagesThrough(client, params.streamId, event.sequence)
     await OutboxRepository.insert(client, "stream:activity", {
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       authorId: params.authorId,
+      sequence: event.sequence.toString(),
+      messageOrdinal,
       lastMessagePreview: {
         authorId: params.authorId,
         authorType: params.authorType,

--- a/apps/backend/src/features/push/service.test.ts
+++ b/apps/backend/src/features/push/service.test.ts
@@ -12,6 +12,7 @@ function makeActivityPayload(): ActivityCreatedOutboxPayload {
   return {
     workspaceId: "ws_1",
     targetUserId: "usr_1",
+    counts: { mentionCount: 1, activityCount: 1 },
     activity: {
       id: "act_1",
       activityType: ActivityTypes.MESSAGE,

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -643,20 +643,23 @@ export const StreamEventRepository = {
   },
 
   /**
-   * Count unread message_created events per stream for a user.
+   * Count unread and total message_created events per stream for a user.
    * Unread = events with sequence > lastReadEventId's sequence.
    * If lastReadEventId is null, all messages in that stream are unread.
+   * Total is the stream's message ordinal at read time — clients derive
+   * unread as latestOrdinal - lastReadOrdinal from absolute counter payloads,
+   * and this total seeds that baseline at bootstrap.
    */
   async countUnreadByStreamBatch(
     db: Querier,
     memberships: Array<{ streamId: string; lastReadEventId: string | null }>
-  ): Promise<Map<string, number>> {
+  ): Promise<Map<string, { unreadCount: number; totalCount: number }>> {
     if (memberships.length === 0) return new Map()
 
     const streamIds = memberships.map((m) => m.streamId)
     const lastReadEventIds = memberships.map((m) => m.lastReadEventId)
 
-    const result = await db.query<{ stream_id: string; unread_count: string }>(
+    const result = await db.query<{ stream_id: string; unread_count: string; total_count: string }>(
       `
       WITH memberships AS (
         SELECT
@@ -669,7 +672,8 @@ export const StreamEventRepository = {
       )
       SELECT
         m.stream_id,
-        COUNT(*) FILTER (WHERE e.sequence > m.last_read_seq)::text as unread_count
+        COUNT(*) FILTER (WHERE e.sequence > m.last_read_seq)::text as unread_count,
+        COUNT(e.id)::text as total_count
       FROM memberships m
       LEFT JOIN stream_events e ON e.stream_id = m.stream_id AND e.event_type = 'message_created'
       GROUP BY m.stream_id
@@ -677,11 +681,61 @@ export const StreamEventRepository = {
       [streamIds, lastReadEventIds]
     )
 
-    const map = new Map<string, number>()
+    const map = new Map<string, { unreadCount: number; totalCount: number }>()
     for (const row of result.rows) {
-      map.set(row.stream_id, parseInt(row.unread_count, 10))
+      map.set(row.stream_id, {
+        unreadCount: parseInt(row.unread_count, 10),
+        totalCount: parseInt(row.total_count, 10),
+      })
     }
     return map
+  },
+
+  /**
+   * Count message_created events at or below a sequence — the message's
+   * ordinal position in its stream. Exact under concurrency: the stream's
+   * sequence allocator row lock serializes message inserts per stream until
+   * commit, so every lower-sequence message is committed and visible.
+   */
+  async countMessagesThrough(db: Querier, streamId: string, sequence: bigint): Promise<number> {
+    const result = await db.query<{ count: string }>(sql`
+      SELECT COUNT(*)::text AS count
+      FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type = 'message_created'
+        AND sequence <= ${sequence.toString()}
+    `)
+    return parseInt(result.rows[0].count, 10)
+  },
+
+  /**
+   * An event's sequence plus the stream's message ordinal at that position
+   * (count of message_created events with sequence ≤ the event's). Returns
+   * null when the event doesn't exist in the stream — callers mirror the
+   * unread query's COALESCE(sequence, 0) convention for missing events.
+   */
+  async getMessageOrdinalForEvent(
+    db: Querier,
+    streamId: string,
+    eventId: string
+  ): Promise<{ sequence: bigint; messageOrdinal: number } | null> {
+    const result = await db.query<{ sequence: string; message_ordinal: string }>(sql`
+      SELECT
+        se.sequence,
+        (
+          SELECT COUNT(*)
+          FROM stream_events e
+          WHERE e.stream_id = se.stream_id
+            AND e.event_type = 'message_created'
+            AND e.sequence <= se.sequence
+        )::text AS message_ordinal
+      FROM stream_events se
+      WHERE se.id = ${eventId}
+        AND se.stream_id = ${streamId}
+    `)
+    const row = result.rows[0]
+    if (!row) return null
+    return { sequence: BigInt(row.sequence), messageOrdinal: parseInt(row.message_ordinal, 10) }
   },
 
   /**

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1011,3 +1011,115 @@ describe("StreamService.createScratchpad (E2E)", () => {
     )
   })
 })
+
+// The stream:read / stream:read_all payloads carry absolute read positions
+// (sync-v2 phase 2c): clients derive unread as latestOrdinal - lastReadOrdinal,
+// so these events must say where the read lands in message-ordinal space.
+describe("StreamService.markAsRead", () => {
+  let service: StreamService
+  const mockMemberUpdate = spyOn(StreamMemberRepository, "update")
+  const mockGetMessageOrdinalForEvent = spyOn(StreamEventRepository, "getMessageOrdinalForEvent")
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockMemberUpdate.mockReset()
+    mockGetMessageOrdinalForEvent.mockReset()
+    mockInsertOutbox.mockReset()
+    mockInsertOutbox.mockResolvedValue({} as never)
+  })
+
+  test("emits stream:read with the absolute read position", async () => {
+    mockMemberUpdate.mockResolvedValue({ streamId: "stream_1", memberId: "usr_1" } as never)
+    mockGetMessageOrdinalForEvent.mockResolvedValue({ sequence: 42n, messageOrdinal: 7 })
+
+    await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
+
+    expect(mockGetMessageOrdinalForEvent).toHaveBeenCalledWith({}, "stream_1", "evt_9")
+    expect(mockInsertOutbox).toHaveBeenCalledWith({}, "stream:read", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_9",
+      lastReadSequence: "42",
+      lastReadOrdinal: 7,
+    })
+  })
+
+  test("mirrors the unread query's zero convention when the read event is missing", async () => {
+    mockMemberUpdate.mockResolvedValue({ streamId: "stream_1", memberId: "usr_1" } as never)
+    mockGetMessageOrdinalForEvent.mockResolvedValue(null)
+
+    await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_gone")
+
+    expect(mockInsertOutbox).toHaveBeenCalledWith(
+      {},
+      "stream:read",
+      expect.objectContaining({ lastReadSequence: "0", lastReadOrdinal: 0 })
+    )
+  })
+
+  test("emits nothing for a non-member", async () => {
+    mockMemberUpdate.mockResolvedValue(null)
+
+    await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
+
+    expect(mockInsertOutbox).not.toHaveBeenCalled()
+  })
+})
+
+describe("StreamService.markAllAsRead", () => {
+  let service: StreamService
+  const mockMemberList = spyOn(StreamMemberRepository, "list")
+  const mockStreamList = spyOn(StreamRepository, "list")
+  const mockLatestEventIds = spyOn(StreamEventRepository, "getLatestEventIdByStreamBatch")
+  const mockBatchUpdate = spyOn(StreamMemberRepository, "batchUpdateLastReadEventId")
+  const mockCountMessages = spyOn(StreamEventRepository, "countMessagesByStreamBatch")
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockMemberList.mockReset()
+    mockStreamList.mockReset()
+    mockLatestEventIds.mockReset()
+    mockBatchUpdate.mockReset()
+    mockCountMessages.mockReset()
+    mockInsertOutbox.mockReset()
+    mockInsertOutbox.mockResolvedValue({} as never)
+  })
+
+  test("emits stream:read_all with per-stream absolute read positions", async () => {
+    mockMemberList.mockResolvedValue([
+      { streamId: "stream_1", memberId: "usr_1", lastReadEventId: null },
+      { streamId: "stream_2", memberId: "usr_1", lastReadEventId: "evt_old" },
+    ] as never)
+    mockStreamList.mockResolvedValue([{ id: "stream_1" }, { id: "stream_2" }] as never)
+    mockLatestEventIds.mockResolvedValue(
+      new Map([
+        ["stream_1", "evt_a"],
+        ["stream_2", "evt_b"],
+      ])
+    )
+    mockBatchUpdate.mockResolvedValue(undefined as never)
+    // Read-all pins each membership to the stream's latest event, so the
+    // absolute position per stream is its total message count.
+    mockCountMessages.mockResolvedValue(
+      new Map([
+        ["stream_1", 12],
+        ["stream_2", 3],
+      ])
+    )
+
+    const updated = await service.markAllAsRead("ws_1", "usr_1")
+
+    expect(updated).toEqual(["stream_1", "stream_2"])
+    expect(mockCountMessages).toHaveBeenCalledWith({}, ["stream_1", "stream_2"])
+    expect(mockInsertOutbox).toHaveBeenCalledWith({}, "stream:read_all", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamIds: ["stream_1", "stream_2"],
+      reads: [
+        { streamId: "stream_1", lastReadOrdinal: 12 },
+        { streamId: "stream_2", lastReadOrdinal: 3 },
+      ],
+    })
+  })
+})

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1550,11 +1550,18 @@ export class StreamService {
     return withTransaction(this.pool, async (client) => {
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
       if (membership) {
+        // Absolute read position (sync-v2 phase 2c): clients derive unread as
+        // latestOrdinal - lastReadOrdinal, so the event carries where this
+        // read lands in message-ordinal space. A missing event mirrors the
+        // unread query's COALESCE(sequence, 0) convention.
+        const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
         await OutboxRepository.insert(client, "stream:read", {
           workspaceId,
           authorId: memberId,
           streamId,
           lastReadEventId: eventId,
+          lastReadSequence: (position?.sequence ?? 0n).toString(),
+          lastReadOrdinal: position?.messageOrdinal ?? 0,
         })
       }
       return membership
@@ -1596,10 +1603,18 @@ export class StreamService {
       const updatedStreamIds = Array.from(updatesToApply.keys())
 
       if (updatedStreamIds.length > 0) {
+        // Read-all sets each membership to its stream's latest event, so the
+        // absolute read position per stream is the stream's total message
+        // count (sync-v2 phase 2c).
+        const messageCounts = await StreamEventRepository.countMessagesByStreamBatch(client, updatedStreamIds)
         await OutboxRepository.insert(client, "stream:read_all", {
           workspaceId,
           authorId: memberId,
           streamIds: updatedStreamIds,
+          reads: updatedStreamIds.map((streamId) => ({
+            streamId,
+            lastReadOrdinal: messageCounts.get(streamId) ?? 0,
+          })),
         })
       }
 
@@ -1609,13 +1624,13 @@ export class StreamService {
 
   async getUnreadCounts(
     memberships: Array<{ streamId: string; lastReadEventId: string | null }>
-  ): Promise<Map<string, number>> {
+  ): Promise<Map<string, { unreadCount: number; totalCount: number }>> {
     return StreamEventRepository.countUnreadByStreamBatch(this.pool, memberships)
   }
 
   async getUnreadCount(streamId: string, lastReadEventId: string | null): Promise<number> {
     const unreadCounts = await this.getUnreadCounts([{ streamId, lastReadEventId }])
-    return unreadCounts.get(streamId) ?? 0
+    return unreadCounts.get(streamId)?.unreadCount ?? 0
   }
 
   /**

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -186,8 +186,10 @@ export function createWorkspaceHandlers({
         activityService?.getUnreadCounts(userId, workspaceId),
       ])
       const unreadCounts: Record<string, number> = {}
-      for (const [streamId, count] of unreadCountsMap) {
-        unreadCounts[streamId] = count
+      const messageCounts: Record<string, number> = {}
+      for (const [streamId, counts] of unreadCountsMap) {
+        unreadCounts[streamId] = counts.unreadCount
+        messageCounts[streamId] = counts.totalCount
       }
 
       const mentionCounts: Record<string, number> = {}
@@ -240,6 +242,7 @@ export function createWorkspaceHandlers({
           emojiWeights,
           commands,
           unreadCounts,
+          messageCounts,
           mentionCounts,
           activityCounts: activityCountsPerStream,
           unreadActivityCount: activityCounts?.total ?? 0,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -343,6 +343,14 @@ export interface WorkspaceUserUpdatedOutboxPayload extends WorkspaceScopedPayloa
  *  Only members of the stream receive preview content. */
 export interface StreamActivityOutboxPayload extends StreamScopedPayload {
   authorId: string
+  /** The message event's per-stream sequence (bigint as string). */
+  sequence: string
+  /**
+   * Count of message_created events with sequence ≤ this one — an absolute,
+   * recipient-independent stream fact (sync-v2 phase 2c). Clients derive
+   * unread as latestOrdinal - lastReadOrdinal instead of incrementing.
+   */
+  messageOrdinal: number
   lastMessagePreview: LastMessagePreview
 }
 
@@ -432,11 +440,25 @@ export interface StreamReadOutboxPayload extends WorkspaceScopedPayload {
   authorId: string
   streamId: string
   lastReadEventId: string
+  /** The read event's per-stream sequence (bigint as string; "0" when the event is missing). */
+  lastReadSequence: string
+  /**
+   * Message ordinal of the read position (sync-v2 phase 2c): count of
+   * message_created events with sequence ≤ the read event's. Clients derive
+   * unread as latestOrdinal - lastReadOrdinal.
+   */
+  lastReadOrdinal: number
 }
 
 export interface StreamsReadAllOutboxPayload extends WorkspaceScopedPayload {
   authorId: string
   streamIds: string[]
+  /**
+   * Absolute read position per updated stream (sync-v2 phase 2c). Read-all
+   * pins each membership to its stream's latest event, so the ordinal is the
+   * stream's total message count at read time.
+   */
+  reads: Array<{ streamId: string; lastReadOrdinal: number }>
 }
 
 // User preferences event payload (author-scoped - only visible to the user who updated)
@@ -493,6 +515,15 @@ export interface InvitationRevokedOutboxPayload extends WorkspaceScopedPayload {
 // User-scoped event payloads (delivered to a specific target user)
 export interface ActivityCreatedOutboxPayload extends WorkspaceScopedPayload {
   targetUserId: string
+  /**
+   * The target user's absolute unread counts for the activity's stream,
+   * computed after the row was inserted (sync-v2 phase 2c). Clients set
+   * counters from these — never increment — so replays converge.
+   */
+  counts: {
+    mentionCount: number
+    activityCount: number
+  }
   activity: {
     id: string
     activityType: string

--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -63,7 +63,7 @@ describe("Unread Counts", () => {
       // Count unreads with lastReadEventId = latest event
       const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: lastEventId }])
 
-      expect(counts.get(testStreamId)).toBe(0)
+      expect(counts.get(testStreamId)).toEqual({ unreadCount: 0, totalCount: 1 })
     })
 
     test("should return correct unread count when messages exist after lastReadEventId", async () => {
@@ -111,7 +111,7 @@ describe("Unread Counts", () => {
       // Should have 2 unread (messages 2 and 3)
       const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: firstEventId }])
 
-      expect(counts.get(testStreamId)).toBe(2)
+      expect(counts.get(testStreamId)).toEqual({ unreadCount: 2, totalCount: 3 })
     })
 
     test("should return all messages as unread when lastReadEventId is null", async () => {
@@ -141,7 +141,7 @@ describe("Unread Counts", () => {
       // Count with null lastReadEventId (never read)
       const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: null }])
 
-      expect(counts.get(testStreamId)).toBe(3)
+      expect(counts.get(testStreamId)).toEqual({ unreadCount: 3, totalCount: 3 })
     })
 
     test("should not count user's own message as unread", async () => {
@@ -177,7 +177,7 @@ describe("Unread Counts", () => {
       const authorCounts = await streamService.getUnreadCounts([
         { streamId: testStreamId, lastReadEventId: authorMembership!.lastReadEventId },
       ])
-      expect(authorCounts.get(testStreamId)).toBe(0)
+      expect(authorCounts.get(testStreamId)).toEqual({ unreadCount: 0, totalCount: 1 })
 
       // Other user should have 1 unread (their lastReadEventId is still null)
       const otherMembership = await streamService.getMembership(testStreamId, otherUserId)
@@ -186,7 +186,7 @@ describe("Unread Counts", () => {
       const otherCounts = await streamService.getUnreadCounts([
         { streamId: testStreamId, lastReadEventId: otherMembership!.lastReadEventId },
       ])
-      expect(otherCounts.get(testStreamId)).toBe(1)
+      expect(otherCounts.get(testStreamId)).toEqual({ unreadCount: 1, totalCount: 1 })
     })
 
     test("should handle multiple streams in batch", async () => {
@@ -244,8 +244,8 @@ describe("Unread Counts", () => {
         { streamId: stream2, lastReadEventId: events2[2].id }, // Read all 3, unread 0
       ])
 
-      expect(counts.get(stream1)).toBe(1)
-      expect(counts.get(stream2)).toBe(0)
+      expect(counts.get(stream1)).toEqual({ unreadCount: 1, totalCount: 2 })
+      expect(counts.get(stream2)).toEqual({ unreadCount: 0, totalCount: 3 })
     })
   })
 
@@ -308,8 +308,8 @@ describe("Unread Counts", () => {
         { streamId: stream2, lastReadEventId: membership2!.lastReadEventId },
       ])
 
-      expect(counts.get(stream1)).toBe(0)
-      expect(counts.get(stream2)).toBe(0)
+      expect(counts.get(stream1)).toEqual({ unreadCount: 0, totalCount: 1 })
+      expect(counts.get(stream2)).toEqual({ unreadCount: 0, totalCount: 1 })
     })
 
     test("should only update streams that have unread messages", async () => {
@@ -453,6 +453,145 @@ describe("Unread Counts", () => {
       expect(m1?.lastReadEventId).toBe(eventIds[0])
       expect(m2?.lastReadEventId).toBe(eventIds[1])
       expect(m3?.lastReadEventId).toBe(eventIds[2])
+    })
+  })
+
+  // Sync-v2 phase 2c: the unread counter events carry absolute values so
+  // replayed/duplicated sync-log entries converge instead of compounding.
+  // Clients derive unread = latestOrdinal - lastReadOrdinal; these tests pin
+  // the ordinal payloads end-to-end through the real write paths.
+  describe("absolute counter payloads", () => {
+    async function setupStreamWithMembers(): Promise<{
+      testStreamId: string
+      testWorkspaceId: string
+      authorId: string
+      readerId: string
+    }> {
+      const testStreamId = streamId()
+      const testWorkspaceId = workspaceId()
+      const authorId = userId()
+      const readerId = userId()
+
+      await withTransaction(pool, async (client) => {
+        await client.query(
+          `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+          [testStreamId, testWorkspaceId, authorId]
+        )
+        await StreamMemberRepository.insert(client, testStreamId, authorId)
+        await StreamMemberRepository.insert(client, testStreamId, readerId)
+      })
+
+      return { testStreamId, testWorkspaceId, authorId, readerId }
+    }
+
+    async function listOutboxPayloads(eventType: string, streamIdValue: string): Promise<Array<Record<string, any>>> {
+      const result = await pool.query(
+        `SELECT payload FROM outbox WHERE event_type = $1 AND payload->>'streamId' = $2 ORDER BY id`,
+        [eventType, streamIdValue]
+      )
+      return result.rows.map((row) => row.payload)
+    }
+
+    test("stream:activity carries the message's sequence and ordinal", async () => {
+      const { testStreamId, testWorkspaceId, authorId } = await setupStreamWithMembers()
+
+      for (let i = 1; i <= 3; i++) {
+        await eventService.createMessage({
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          authorId,
+          authorType: "user",
+          ...testMessageContent(`Message ${i}`),
+        })
+      }
+
+      const payloads = await listOutboxPayloads("stream:activity", testStreamId)
+      expect(payloads).toHaveLength(3)
+      expect(payloads.map((p) => p.messageOrdinal)).toEqual([1, 2, 3])
+
+      // Sequences are the events' per-stream sequences, in order.
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      expect(payloads.map((p) => p.sequence)).toEqual(events.map((e) => e.sequence.toString()))
+    })
+
+    test("stream:read carries the read position in message-ordinal space", async () => {
+      const { testStreamId, testWorkspaceId, authorId, readerId } = await setupStreamWithMembers()
+
+      for (let i = 1; i <= 3; i++) {
+        await eventService.createMessage({
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          authorId,
+          authorType: "user",
+          ...testMessageContent(`Message ${i}`),
+        })
+      }
+
+      // Read up to the second message: ordinal 2 of 3.
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      await streamService.markAsRead(testWorkspaceId, testStreamId, readerId, events[1].id)
+
+      const payloads = await listOutboxPayloads("stream:read", testStreamId)
+      expect(payloads).toHaveLength(1)
+      expect(payloads[0]).toEqual({
+        workspaceId: testWorkspaceId,
+        authorId: readerId,
+        streamId: testStreamId,
+        lastReadEventId: events[1].id,
+        lastReadSequence: events[1].sequence.toString(),
+        lastReadOrdinal: 2,
+      })
+
+      // The derived unread matches the authoritative count: 3 - 2 = 1.
+      const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: events[1].id }])
+      expect(counts.get(testStreamId)).toEqual({ unreadCount: 1, totalCount: 3 })
+    })
+
+    test("stream:read_all carries per-stream absolute read positions", async () => {
+      const { testStreamId, testWorkspaceId, authorId, readerId } = await setupStreamWithMembers()
+
+      await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId,
+        authorType: "user",
+        ...testMessageContent("Only message"),
+      })
+
+      await streamService.markAllAsRead(testWorkspaceId, readerId)
+
+      const result = await pool.query(
+        `SELECT payload FROM outbox WHERE event_type = 'stream:read_all' AND payload->>'authorId' = $1 ORDER BY id`,
+        [readerId]
+      )
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0].payload).toEqual({
+        workspaceId: testWorkspaceId,
+        authorId: readerId,
+        streamIds: [testStreamId],
+        reads: [{ streamId: testStreamId, lastReadOrdinal: 1 }],
+      })
+    })
+
+    test("getMessageOrdinalForEvent counts only messages at or below the event's sequence", async () => {
+      const { testStreamId, testWorkspaceId, authorId } = await setupStreamWithMembers()
+
+      for (let i = 1; i <= 2; i++) {
+        await eventService.createMessage({
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          authorId,
+          authorType: "user",
+          ...testMessageContent(`Message ${i}`),
+        })
+      }
+
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      const first = await StreamEventRepository.getMessageOrdinalForEvent(pool, testStreamId, events[0].id)
+      expect(first).toEqual({ sequence: events[0].sequence, messageOrdinal: 1 })
+
+      expect(await StreamEventRepository.getMessageOrdinalForEvent(pool, testStreamId, "evt_missing")).toBeNull()
+      expect(await StreamEventRepository.countMessagesThrough(pool, testStreamId, events[1].sequence)).toBe(2)
     })
   })
 })

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1002,6 +1002,13 @@ export interface WorkspaceBootstrap {
   emojiWeights: Record<string, number>
   commands: CommandInfo[]
   unreadCounts: Record<string, number>
+  /**
+   * Per-stream total message count (message ordinal) at snapshot time —
+   * the baseline for deriving unread from absolute counter payloads
+   * (sync-v2 phase 2c): lastReadOrdinal = messageCounts - unreadCounts.
+   * Optional during rollout: snapshots cached before the field shipped lack it.
+   */
+  messageCounts?: Record<string, number>
   mentionCounts: Record<string, number>
   activityCounts: Record<string, number>
   unreadActivityCount: number
@@ -1131,6 +1138,17 @@ export interface Activity {
 export interface ActivityCreatedPayload {
   workspaceId: string
   targetUserId: string
+  /**
+   * The target user's absolute unread counts for the activity's stream
+   * (sync-v2 phase 2c). Clients set counters from these — never increment —
+   * so replayed/duplicated events converge. Optional: sync-log entries
+   * persisted before the field shipped lack it; consumers must fall back to
+   * legacy increment-or-skip handling for those.
+   */
+  counts?: {
+    mentionCount: number
+    activityCount: number
+  }
   activity: {
     id: string
     activityType: string


### PR DESCRIPTION
## Problem

Phase 2b (#851) left exactly one unsafe surface in active catch-up: the unread counter family. `stream:activity`, `activity:created`, `stream:read`, and `stream:read_all` carry **increments** (or zeroing that races skipped increments), so replaying them from the sync log would compound — they sit in `CATCHUP_SKIPPED_UNREAD_EVENT_TYPES` and the workspace bootstrap stays the sole counter authority (INV-53). That blocks phase 2c's goal of narrowing INV-53: counters can't heal through the log until their payloads are safe to re-apply.

The hard case is `stream:activity`: it's stream-scoped (one payload for every member) while unread counts are per-member, so the payload can't simply carry "your new unread count".

## Solution

Make all four payloads carry **absolute values** so clients can set counters instead of incrementing. For the per-member problem, ship recipient-independent **message ordinals**: `stream:activity` carries the message's ordinal position (count of messages at or below its sequence), read events carry the read position in the same ordinal space, and each client derives `unread = latestOrdinal − lastReadOrdinal` — every apply becomes a max-merge, idempotent and order-independent.

Per event:

- **`stream:activity`** + `sequence` (the event's per-stream sequence, bigint as string) and `messageOrdinal`, computed in the message-create transaction. Exact under concurrency: the stream's sequence-allocator row lock serializes message inserts per stream until commit.
- **`stream:read`** + `lastReadSequence` / `lastReadOrdinal` via new `StreamEventRepository.getMessageOrdinalForEvent`. A missing read event falls back to `"0"` / `0`, mirroring the unread query's `COALESCE(sequence, 0)` convention.
- **`stream:read_all`** + `reads: [{streamId, lastReadOrdinal}]`. Read-all pins each membership to its stream's latest event, so the ordinal is the stream's total message count (existing `countMessagesByStreamBatch`, batched in the same transaction).
- **`activity:created`** + `counts: {mentionCount, activityCount}` — the target user's absolute unread counts for the stream, via new set-based `ActivityRepository.countUnreadForPairs` (INV-56), computed in `publishActivityCreated`'s transaction after the rows are committed. The workspace total needs no field: `unreadActivityCount ≡ Σ activityCounts` (verified against `countUnreadGrouped`).
- **Workspace bootstrap** + `messageCounts` per stream — free, from a `COUNT(e.id)` column added to the same `countUnreadByStreamBatch` scan that produces `unreadCounts`. Clients seed `lastReadOrdinal = messageCounts − unreadCounts`.
- **New partial index** `idx_stream_events_message_seq ON stream_events (stream_id, sequence) WHERE event_type = 'message_created'` — the ordinal count runs inside every message-send transaction; the generic `(stream_id, sequence)` index doesn't cover the `event_type` filter (same shape as the existing `idx_stream_events_message_id` precedent).

### Key design decisions

**1. Ordinals over per-member fan-out or an applied-id ledger.** Per-member absolute unread on a stream-scoped event would require N user-scoped emits per message; an applied-id ledger was already rejected in 2b (INV-36). Ordinals are recipient-independent absolutes that make the client computation a pure max-merge — duplicates and out-of-order delivery (sweep-rescued late sync ids) converge without new client bookkeeping beyond two numbers per stream.

**2. Ordinals are COUNT-derived, not a denormalized counter.** The ordinal is defined by the same query family the bootstrap uses (`countUnreadByStreamBatch`), so live-derived and bootstrap-derived values can't drift by construction. A denormalized counter would be cheaper per send but can diverge after `messages:moved` (vacated slots). Known accepted drift: a move shrinks the source stream's true ordinal below a client's max-merged value → transient overcount that heals at bootstrap.

**3. Backend payload fields are required; wire types are optional.** Every emit site provides the new fields, but sync-log entries persisted before this deploys will replay without them forever (no log retention yet). `packages/types` marks `counts?` / `messageCounts?` optional so the frontend conversion (next PR) must implement a missing-fields fallback (keep skip-set behavior for legacy entries).

**4. Activity counts are LWW-set, not max-merged.** Reaction removal deletes activity rows without a compensating event, so absolute counts can legitimately decrease between consecutive `activity:created` events. The frontend will apply them as plain sets in delivery order.

**5. Purely additive.** No client behavior changes in this PR — frontend handlers are untouched until the conversion PR. The bootstrap response only gains a field; the changed `countUnreadByStreamBatch` return shape is internal to the backend.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/db/migrations/20260612082009_add_stream_events_message_seq_index.sql` | Partial index backing the message-ordinal counts |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/features/streams/event-repository.ts` | `countUnreadByStreamBatch` returns `{unreadCount, totalCount}` (same scan); new `countMessagesThrough`, `getMessageOrdinalForEvent` |
| `apps/backend/src/features/streams/service.ts` | `markAsRead` / `markAllAsRead` emit absolute read positions; `getUnreadCounts` richer return; `getUnreadCount` adapted |
| `apps/backend/src/features/messaging/event-service.ts` | `stream:activity` carries `sequence` + `messageOrdinal` |
| `apps/backend/src/features/activity/repository.ts` | New set-based `countUnreadForPairs` |
| `apps/backend/src/features/activity/outbox-handler.ts` | `publishActivityCreated` stamps absolute `counts` per payload |
| `apps/backend/src/features/workspaces/handlers.ts` | Bootstrap ships `messageCounts` |
| `apps/backend/src/lib/outbox/repository.ts` | Payload interface additions (required) |
| `packages/types/src/api.ts` | `WorkspaceBootstrap.messageCounts?`, `ActivityCreatedPayload.counts?` (optional, rollout-aware) |
| `apps/backend/src/features/streams/service.test.ts` | New `markAsRead` / `markAllAsRead` payload tests |
| `apps/backend/src/features/activity/outbox-handler.test.ts` | `counts` expectations + `countUnreadForPairs` spy |
| `apps/backend/src/features/messaging/event-service.test.ts` | `countMessagesThrough` spies in create-path suites |
| `apps/backend/src/features/push/service.test.ts` | Fixture gains required `counts` |
| `apps/backend/tests/integration/unread-counts.test.ts` | Updated to richer count shape + 4 new end-to-end ordinal payload tests |

## Test plan

- [x] Backend unit: 1704 pass (includes new `markAsRead`/`markAllAsRead`/`activity:created` payload tests)
- [x] Backend integration: 484 pass — includes 4 new tests pinning ordinal payloads through the real write paths (`stream:activity` ordinals 1..3, `stream:read` position + derived-unread identity `3−2=1` vs the authoritative count, `stream:read_all` reads array, `getMessageOrdinalForEvent`/`countMessagesThrough` semantics incl. missing-event null)
- [x] Backend e2e: 308 pass
- [x] Migration applied through the real boot path (test server) and index verified in `pg_indexes`
- [x] Monorepo typecheck + lint + prettier + OpenAPI check (pre-commit)
- [x] Multi-perspective review (3 reviewers): spec/CLAUDE.md clean, correctness/security clean, design found the missing partial index → fixed in `635ead2`

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2c of sync-engine v2, first implementable unit (PR C of the agreed plan): convert the four unread-counter event payloads from increments to absolute values so the frontend can later apply them idempotently from the sync log and `CATCHUP_SKIPPED_UNREAD_EVENT_TYPES` can be narrowed to a legacy-entry fallback.

## Phase 2c sequencing (agreed with owner)

1. **(Owner gates, still open)** Prod shadow-log verification — `fetched > 0` only after disconnects; reload/fresh-boot `trigger: connect` small fetches within ~1s of last event are benign; the bug signature is `fetched > 0` on `reconnect`/`resume` while healthy. Then flip staging → prod to `VITE_SYNC_V2_CURSOR=active`.
2. **PR A** — flip the flag default `shadow` → `active` once prod proves out.
3. **PR B** — gate the `savedKeys`/`scheduledKeys` reconnect invalidations in `registerWorkspaceSocketHandlers` on non-active mode (`if (mode !== "active") invalidate`). Gate, don't delete: `off` is the kill switch and must re-enable INV-53 healing.
4. **PR C (this PR)** — backend absolutes + types. Purely additive, safe to land before any flips.
5. **PR D** — frontend conversion: rewrite the four handlers (max-merge ordinals for stream unread, LWW set for activity counts), derive `unreadActivityCount = Σ activityCounts`, seed ordinal baselines from bootstrap `messageCounts`, multi-tab-safe read-max-write IDB transactions for `unreadState`, demote the skip set to a missing-fields fallback. Keep the own-message suppression (mirror the server's author auto-advance by setting `lastReadOrdinal = messageOrdinal` on own `stream:activity`) and the viewing suppression (optimistically pin `lastReadOrdinal = latestOrdinal` while viewing).
6. **PR E+** — further INV-53 narrowing, one deletion per PR with a test.

## What Was Built (this PR)

- Ordinal space: `messageOrdinal(S) = COUNT(message_created WHERE sequence ≤ S)` per stream; unread is exactly `ordinal(head) − ordinal(lastRead)` per the bootstrap's `countUnreadByStreamBatch` definition.
- `stream:activity` + `sequence`/`messageOrdinal` (send transaction; allocator row lock makes the count exact).
- `stream:read` + `lastReadSequence`/`lastReadOrdinal`; missing event → zeros (mirrors `COALESCE(sequence,0)`).
- `stream:read_all` + `reads[]` (ordinal = total message count, batched).
- `activity:created` + `counts {mentionCount, activityCount}` via set-based `countUnreadForPairs`, computed post-insert; rows sharing a (user, stream) pair carry identical final counts (correct under absolute semantics).
- Bootstrap `messageCounts` from a `COUNT(e.id)` column on the existing unread scan.
- Partial index `idx_stream_events_message_seq` for the ordinal count pattern (review finding).

## Design Decisions

1. Ordinals (recipient-independent absolutes) over per-member fan-out / applied-id ledger — max-merge convergence, no new client ledger.
2. COUNT-derived ordinals over a denormalized counter — single definition shared with bootstrap; `messages:moved` drift is transient and heals at bootstrap.
3. Required backend payload fields, optional wire types — pre-deploy sync-log entries replay without the fields forever (no retention); frontend must keep a legacy fallback.
4. Activity counts are LWW (can decrease: reaction removal deletes rows with no compensating event); stream ordinals are max-merge (monotonic).
5. `markStreamActivityAsRead` stays a separate call after `markAsRead`'s transaction (INV-6/INV-51 boundary) — the stale-count window is identical to today's and self-heals under absolutes.

## What's NOT Included (deliberate)

- No frontend handler changes, no skip-set narrowing (PR D).
- No INV-53 invalidation gating/deletions (PR B / E+).
- No flag default change (PR A, gated on prod shadow verification).
- No `sync_log` retention (still the open phase-1 deferral; also the trigger for removing the legacy-entry fallback later).

## Status

- Phase 2b: merged and runtime-verified (#851). Prod still in shadow mode.
- This PR: phase 2c backend half. Frontend conversion (PR D) follows after this merges.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01MXuq8RHzH4ENXJmb1ZAQsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXuq8RHzH4ENXJmb1ZAQsr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783844752&installation_id=129946197&pr_number=872&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F872&signature=16f71c47efe1aad938ceb95b824483c8e17b26ccbc6af7c52f69843197bf688a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->