### PR TITLE
feat: apply absolute unread-counter payloads on the frontend (phase 2c PR D)

### DIFF
--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -356,6 +356,13 @@ export interface CachedUnreadState {
   mentionCounts: Record<string, number>
   activityCounts: Record<string, number>
   unreadActivityCount: number
+  /**
+   * Latest message ordinal per stream (sync-v2 phase 2c) — seeded from
+   * bootstrap `messageCounts`, max-merged from `stream:activity`. The read
+   * position is implicit: latestOrdinals[s] − unreadCounts[s]. Absent for
+   * rows cached before the field shipped; see sync/unread-counters.ts.
+   */
+  latestOrdinals?: Record<string, number>
   mutedStreamIds: string[]
   _cachedAt: number
 }

--- a/apps/frontend/src/hooks/use-activity.ts
+++ b/apps/frontend/src/hooks/use-activity.ts
@@ -44,17 +44,43 @@ export function useMarkActivityRead(workspaceId: string) {
       // Optimistic update: mark as read in cache
       await queryClient.cancelQueries({ queryKey: activityKeys.list(workspaceId) })
 
+      let target: Activity | undefined
       queryClient.setQueriesData<Activity[]>({ queryKey: activityKeys.list(workspaceId) }, (old) => {
         if (!old) return old
-        return old.map((a) => (a.id === activityId ? { ...a, readAt: new Date().toISOString() } : a))
+        return old.map((a) => {
+          if (a.id !== activityId) return a
+          target ??= a
+          return { ...a, readAt: new Date().toISOString() }
+        })
       })
 
-      // Decrement unreadActivityCount
+      // Decrement the per-stream counts together with the workspace total:
+      // absolute counter events rederive the total as Σ activityCounts
+      // (sync-v2 phase 2c), so a total-only decrement would resurrect on the
+      // next apply. Rows already read (or self rows) never counted. When the
+      // row isn't in any cached list we can't resolve its stream — decrement
+      // the total alone and let the next absolute apply settle it.
+      const wasUnread = target ? !target.readAt && !target.isSelf : true
+      const streamId = target?.streamId
+      const isMention = target?.activityType === "mention"
+      if (!wasUnread) return { previousUnreadState: undefined }
+
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
         return {
           ...old,
           unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - 1),
+          ...(streamId
+            ? {
+                activityCounts: {
+                  ...old.activityCounts,
+                  [streamId]: Math.max(0, (old.activityCounts[streamId] ?? 0) - 1),
+                },
+                mentionCounts: isMention
+                  ? { ...old.mentionCounts, [streamId]: Math.max(0, (old.mentionCounts[streamId] ?? 0) - 1) }
+                  : old.mentionCounts,
+              }
+            : {}),
         }
       })
 
@@ -63,6 +89,20 @@ export function useMarkActivityRead(workspaceId: string) {
         await db.unreadState.put({
           ...previousUnreadState,
           unreadActivityCount: Math.max(0, previousUnreadState.unreadActivityCount - 1),
+          ...(streamId
+            ? {
+                activityCounts: {
+                  ...previousUnreadState.activityCounts,
+                  [streamId]: Math.max(0, (previousUnreadState.activityCounts[streamId] ?? 0) - 1),
+                },
+                mentionCounts: isMention
+                  ? {
+                      ...previousUnreadState.mentionCounts,
+                      [streamId]: Math.max(0, (previousUnreadState.mentionCounts[streamId] ?? 0) - 1),
+                    }
+                  : previousUnreadState.mentionCounts,
+              }
+            : {}),
           _cachedAt: Date.now(),
         })
       }

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -163,44 +163,12 @@ export function useUnreadCounts(workspaceId: string) {
     markAllAsReadMutation.mutate()
   }, [markAllAsReadMutation])
 
-  const incrementUnread = useCallback(
-    (streamId: string) => {
-      // Update TanStack cache (bridge)
-      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-        if (!old) return old
-        return {
-          ...old,
-          unreadCounts: {
-            ...old.unreadCounts,
-            [streamId]: (old.unreadCounts[streamId] ?? 0) + 1,
-          },
-        }
-      })
-
-      // Update IDB
-      db.transaction("rw", [db.unreadState], async () => {
-        const state = await db.unreadState.get(workspaceId)
-        if (!state) return
-        await db.unreadState.put({
-          ...state,
-          unreadCounts: {
-            ...state.unreadCounts,
-            [streamId]: (state.unreadCounts[streamId] ?? 0) + 1,
-          },
-          _cachedAt: Date.now(),
-        })
-      })
-    },
-    [queryClient, workspaceId]
-  )
-
   return {
     unreadCounts,
     getUnreadCount,
     getTotalUnreadCount,
     markAsRead,
     markAllAsRead,
-    incrementUnread,
     isMarkingAsRead: markAsReadMutation.isPending,
     isMarkingAllAsRead: markAllAsReadMutation.isPending,
   }

--- a/apps/frontend/src/sync/socket-event-gate.ts
+++ b/apps/frontend/src/sync/socket-event-gate.ts
@@ -143,7 +143,7 @@ export class SocketEventGate implements SyncEventSource {
    * splice from there. Reopening here would let live events flow into the
    * new cycle's bootstrap window.
    */
-  async resume(applyIf: (eventType: string, syncId: bigint) => boolean): Promise<void> {
+  async resume(applyIf: (eventType: string, syncId: bigint, payload: unknown) => boolean): Promise<void> {
     const epoch = this.pauseEpoch
     while (this.buffer.length > 0) {
       if (this.disposed) return
@@ -161,7 +161,7 @@ export class SocketEventGate implements SyncEventSource {
           return
         }
         const event = batch[i]
-        if (!applyIf(event.eventType, event.syncId)) continue
+        if (!applyIf(event.eventType, event.syncId, event.payload)) continue
         await this.dispatch(event.eventType, event.payload)
         this.opts.onApplied?.(event.syncId.toString())
       }

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1084,7 +1084,7 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     engine.destroy()
   })
 
-  it("skips unread-counter entries from the log but still advances the cursor past them", async () => {
+  it("skips LEGACY unread-counter entries (no absolute fields) but still advances the cursor past them", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     const catchUp = vi
       .fn()
@@ -1144,7 +1144,7 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     engine.destroy()
   })
 
-  it("applies buffered counter events at the splice even when at or below the catch-up position", async () => {
+  it("applies buffered LEGACY counter events at the splice even when at or below the catch-up position", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
     const catchUp = vi
@@ -1166,8 +1166,9 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     }
     socket.trigger("activity:created", activityPayload)
 
-    // The same event is also in the log (duplicate by design) — catch-up
-    // skips it there; the buffered live copy applies exactly once at splice.
+    // The same legacy event is also in the log (duplicate by design) —
+    // catch-up skips it there; the buffered live copy applies exactly once
+    // at splice.
     resolveFirstPage!({
       entries: [
         {
@@ -1184,6 +1185,167 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     await vi.waitFor(async () => {
       expect((await db.unreadState.get("ws_1"))?.unreadActivityCount).toBe(1)
     })
+    expect((await db.unreadState.get("ws_1"))?.activityCounts["stream_x"]).toBe(1)
+    engine.destroy()
+  })
+
+  /** Active deps whose bootstrap carries counter baselines for stream_x:
+   *  5 messages, 1 unread (implied read position 4), 1 activity, plus a
+   *  membership so the live handlers' IDB writes pass the member check. */
+  function makeCounterDeps(catchUp: ReturnType<typeof vi.fn>) {
+    const deps = makeActiveDeps(catchUp)
+    deps.workspaceService.bootstrap = vi.fn(async () => ({
+      ...makeWorkspaceBootstrap(),
+      streamMemberships: [
+        {
+          streamId: "stream_x",
+          memberId: "member_1",
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: new Date().toISOString(),
+        },
+      ],
+      unreadCounts: { stream_x: 1 },
+      mentionCounts: { stream_x: 0 },
+      activityCounts: { stream_x: 1 },
+      unreadActivityCount: 1,
+      messageCounts: { stream_x: 5 },
+    }))
+    return deps
+  }
+
+  function streamActivityEntry(syncId: string, messageOrdinal: number): SyncCatchUpResponse["entries"][number] {
+    return {
+      syncId,
+      eventType: "stream:activity",
+      payload: {
+        workspaceId: "ws_1",
+        streamId: "stream_x",
+        authorId: "member_other",
+        sequence: String(messageOrdinal),
+        messageOrdinal,
+        lastMessagePreview: {
+          authorId: "member_other",
+          authorType: "user",
+          content: "hi",
+          createdAt: new Date().toISOString(),
+        },
+      },
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  function activityCountsEntry(
+    syncId: string,
+    counts: { mentionCount: number; activityCount: number }
+  ): SyncCatchUpResponse["entries"][number] {
+    return {
+      syncId,
+      eventType: "activity:created",
+      payload: {
+        workspaceId: "ws_1",
+        targetUserId: "member_1",
+        counts,
+        activity: { id: `act_${syncId}`, streamId: "stream_x", activityType: "mention", isSelf: false },
+      },
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  it("applies absolute counter entries from the log without double-counting the bootstrap snapshot", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi
+      .fn()
+      // Entry 11 (ordinal 5) is already reflected in the snapshot — the safe
+      // duplicate side of read-before-stamp; entry 12 (ordinal 6) is new.
+      .mockResolvedValueOnce({ entries: [streamActivityEntry("11", 5), streamActivityEntry("12", 6)], head: "12" })
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeCounterDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(async () => {
+      const unread = await db.unreadState.get("ws_1")
+      expect(unread?.unreadCounts["stream_x"]).toBe(2)
+      expect(unread?.latestOrdinals?.["stream_x"]).toBe(6)
+    })
+    expect(engine.getSyncCursor()).toBe("12")
+    engine.destroy()
+  })
+
+  it("replays a read-zero between two absolute activity entries in log order", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi
+      .fn()
+      .mockResolvedValueOnce({
+        entries: [
+          activityCountsEntry("11", { mentionCount: 2, activityCount: 2 }),
+          {
+            syncId: "12",
+            eventType: "stream:read",
+            payload: {
+              workspaceId: "ws_1",
+              authorId: "member_1",
+              streamId: "stream_x",
+              lastReadEventId: "evt_5",
+              lastReadSequence: "5",
+              lastReadOrdinal: 5,
+            },
+            createdAt: new Date().toISOString(),
+          },
+          activityCountsEntry("13", { mentionCount: 0, activityCount: 1 }),
+        ],
+        head: "13",
+      })
+      .mockResolvedValue(emptyPage("13"))
+    const engine = new SyncEngine(makeCounterDeps(catchUp))
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    await vi.waitFor(async () => {
+      const unread = await db.unreadState.get("ws_1")
+      // Log order: counts set to 2, read zeroes them, counts set to 1.
+      expect(unread?.activityCounts["stream_x"]).toBe(1)
+      expect(unread?.mentionCounts["stream_x"]).toBe(0)
+      expect(unread?.unreadActivityCount).toBe(1)
+      // The read position covers all 5 snapshot messages.
+      expect(unread?.unreadCounts["stream_x"]).toBe(0)
+    })
+    expect(engine.getSyncCursor()).toBe("13")
+    engine.destroy()
+  })
+
+  it("does not re-apply a buffered ABSOLUTE counter duplicate at or below the catch-up position", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
+      .mockResolvedValue(emptyPage("12"))
+    const engine = new SyncEngine(makeCounterDeps(catchUp))
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
+
+    // Live duplicate of log entry 11 lands during the pause window. Its log
+    // copy applies below; re-applying the buffered copy AFTER entry 12 would
+    // regress the LWW activity counts back to 2.
+    const duplicate = activityCountsEntry("11", { mentionCount: 0, activityCount: 2 })
+    socket.trigger("activity:created", { ...(duplicate.payload as object), syncId: "11" })
+
+    resolveFirstPage!({
+      entries: [duplicate, activityCountsEntry("12", { mentionCount: 0, activityCount: 1 })],
+      head: "12",
+    })
+
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.activityCounts["stream_x"]).toBe(1)
+    })
+    expect(engine.getSyncCursor()).toBe("12")
+    // Give any stray (incorrect) splice apply a chance to land before re-checking.
+    await new Promise((resolve) => setTimeout(resolve, 10))
     expect((await db.unreadState.get("ws_1"))?.activityCounts["stream_x"]).toBe(1)
     engine.destroy()
   })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -20,6 +20,7 @@ import {
 import { processOperationQueue } from "./operation-queue"
 import { waitForInitialReveal } from "./reveal-gate"
 import { SyncLogCursor, SYNC_V2_CURSOR_MODE, type SyncV2CursorMode } from "./sync-log-cursor"
+import { isLegacyUnreadCounterEntry } from "./unread-counters"
 import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
@@ -69,27 +70,13 @@ interface SyncEngineDeps {
 const MAX_CATCHUP_PAGES = 20
 const CATCHUP_PAGE_LIMIT = 500
 
-/**
- * Unread/read-state event types that active catch-up SKIPS (the cursor still
- * advances past them). Their handlers are the only duplicate-unsafe ones in
- * the apply surface: `stream:activity` and `activity:created` increment
- * counters, so replaying a log entry already reflected in the bootstrap's
- * absolute counts double-counts; and replaying `stream:read`/`stream:read_all`
- * would zero counts whose causing increments were skipped. In phase 2b the
- * workspace bootstrap stays the sole authority for unread state (INV-53
- * healing is untouched), and live delivery of these types — including events
- * buffered while catch-up pages — keeps applying exactly as today. A dropped
- * live emit of these types heals on the next bootstrap, the same loss mode
- * as before the log existed. Phase 2c can lift them into the log properly by
- * converting their payloads to absolute values (LWW), at which point they
- * leave this set.
- */
-const CATCHUP_SKIPPED_UNREAD_EVENT_TYPES = new Set([
-  "stream:activity",
-  "activity:created",
-  "stream:read",
-  "stream:read_all",
-])
+// Unread counter events replay from the log like any other event since their
+// payloads went absolute (phase 2c) — EXCEPT legacy entries persisted before
+// the backend shipped the absolute fields, which still carry increments and
+// must be skipped (the cursor advances past them; the bootstrap remains their
+// authority, INV-53). `isLegacyUnreadCounterEntry` is that per-entry check;
+// it replaces the phase-2b CATCHUP_SKIPPED_UNREAD_EVENT_TYPES set and dies
+// when sync-log retention ships and pre-field entries age out.
 
 /**
  * Owns the full sync lifecycle for a workspace:
@@ -923,14 +910,19 @@ export class SyncEngine {
    * order, awaiting each entry so applies cannot interleave. Duplicates are
    * by design (sweep + dispatcher can both emit; snapshot/log overlap is the
    * safe side of read-before-stamp) and are absorbed by the handlers'
-   * idempotency — except the unread counter family, which is skipped (see
-   * CATCHUP_SKIPPED_UNREAD_EVENT_TYPES).
+   * idempotency — including the unread counter family, whose absolute
+   * payloads max-merge/LWW-set (phase 2c). Only LEGACY counter entries
+   * (pre-field payloads, still increments) are skipped; see
+   * isLegacyUnreadCounterEntry.
    *
    * While catch-up pages, the gate buffers live syncId-bearing events; the
    * finally-splice applies buffered events above the catch-up position (plus
-   * skipped-type events at any position, since catch-up never applies those)
-   * and reopens live flow. The cursor advances only past entries that were
-   * handed to handlers (or policy-skipped), never by jumping to head.
+   * legacy counter events at any position, since catch-up never applies
+   * those) and reopens live flow. A buffered ABSOLUTE counter event at or
+   * below the position must NOT re-apply: its log copy already applied, and
+   * activity counts are LWW — re-applying it after a newer log entry would
+   * regress them. The cursor advances only past entries that were handed to
+   * handlers (or policy-skipped), never by jumping to head.
    */
   private async performActiveCatchUp(trigger: string, signal: AbortSignal, cycle: number): Promise<void> {
     const syncService = this.deps.syncService!
@@ -981,7 +973,7 @@ export class SyncEngine {
         for (const entry of response.entries) {
           if (this.isDestroyed) return
           byEventType[entry.eventType] = (byEventType[entry.eventType] ?? 0) + 1
-          if (CATCHUP_SKIPPED_UNREAD_EVENT_TYPES.has(entry.eventType)) {
+          if (isLegacyUnreadCounterEntry(entry.eventType, entry.payload)) {
             skipped += 1
           } else {
             // Mirror the live wire shape exactly: emits carry the syncId
@@ -1019,14 +1011,14 @@ export class SyncEngine {
       // this run was in flight, its bootstrap window is still open; leave the
       // gate paused and let that cycle's own run (chained by runCatchUp) do
       // the splice. Buffered events at or below the applied position were
-      // already applied from the log — except skipped-type events, which
+      // already applied from the log — except legacy counter events, which
       // only ever apply via live delivery and so splice regardless of
       // position.
       if (!this.isDestroyed && this.catchUpCycle === cycle) {
         const through = appliedThrough
         await gate.resume(
-          (eventType, syncId) =>
-            through === null || syncId > through || CATCHUP_SKIPPED_UNREAD_EVENT_TYPES.has(eventType)
+          (eventType, syncId, payload) =>
+            through === null || syncId > through || isLegacyUnreadCounterEntry(eventType, payload)
         )
       }
     }

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest"
+import {
+  applyStreamActivityOrdinal,
+  applyStreamReadOrdinal,
+  applyStreamsReadAllOrdinals,
+  applyActivityCounts,
+  isLegacyUnreadCounterEntry,
+  type UnreadCounterState,
+} from "./unread-counters"
+
+function makeState(overrides: Partial<UnreadCounterState> = {}): UnreadCounterState {
+  return {
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    latestOrdinals: {},
+    ...overrides,
+  }
+}
+
+describe("applyStreamActivityOrdinal", () => {
+  // Bootstrap seeded: 5 messages total, 1 unread → implied read position 4.
+  const seeded = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 5 } })
+
+  it("sets unread from the ordinal delta for others' messages", () => {
+    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+    expect(next.unreadCounts.s1).toBe(2)
+    expect(next.latestOrdinals?.s1).toBe(6)
+  })
+
+  it("converges on duplicate apply", () => {
+    const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+    const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false, isViewing: false })
+    expect(twice).toEqual(once)
+  })
+
+  it("converges on out-of-order apply (sweep-rescued late sync ids)", () => {
+    const inOrder = applyStreamActivityOrdinal(
+      applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false }),
+      "s1",
+      7,
+      { isOwnMessage: false, isViewing: false }
+    )
+    const outOfOrder = applyStreamActivityOrdinal(
+      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false }),
+      "s1",
+      6,
+      { isOwnMessage: false, isViewing: false }
+    )
+    expect(outOfOrder).toEqual(inOrder)
+    expect(outOfOrder.unreadCounts.s1).toBe(3)
+  })
+
+  it("advances the read position to the message for own sends (server auto-advance mirror)", () => {
+    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: true, isViewing: false })
+    expect(next.unreadCounts.s1).toBe(0)
+    expect(next.latestOrdinals?.s1).toBe(6)
+  })
+
+  it("keeps newer messages unread when an own send applies out of order", () => {
+    // Someone else's message 7 already applied, then own message 6 arrives late:
+    // read advances to 6, message 7 stays unread.
+    const other = applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false })
+    const own = applyStreamActivityOrdinal(other, "s1", 6, { isOwnMessage: true, isViewing: false })
+    expect(own.unreadCounts.s1).toBe(1)
+    expect(own.latestOrdinals?.s1).toBe(7)
+  })
+
+  it("pins the read position to latest while viewing", () => {
+    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: true })
+    expect(next.unreadCounts.s1).toBe(0)
+  })
+
+  it("seeds a baseline as the legacy increment when none exists", () => {
+    const noBaseline = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: undefined })
+    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: false, isViewing: false })
+    expect(next.unreadCounts.s1).toBe(3)
+    expect(next.latestOrdinals?.s1).toBe(9)
+    // The seeded baseline makes the SAME event idempotent from here on.
+    const again = applyStreamActivityOrdinal(next, "s1", 9, { isOwnMessage: false, isViewing: false })
+    expect(again.unreadCounts.s1).toBe(3)
+  })
+
+  it("seeds a zero-unread baseline for own sends without a baseline", () => {
+    const noBaseline = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: undefined })
+    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: true, isViewing: false })
+    expect(next.unreadCounts.s1).toBe(0)
+  })
+})
+
+describe("applyStreamReadOrdinal", () => {
+  const seeded = makeState({
+    unreadCounts: { s1: 3 },
+    mentionCounts: { s1: 2 },
+    activityCounts: { s1: 2, s2: 1 },
+    unreadActivityCount: 3,
+    latestOrdinals: { s1: 8 },
+  })
+
+  it("leaves messages past the read position unread", () => {
+    // Read up to ordinal 6 of 8: two messages remain unread.
+    const next = applyStreamReadOrdinal(seeded, "s1", 6)
+    expect(next.unreadCounts.s1).toBe(2)
+  })
+
+  it("zeroes mention/activity counts and rederives the workspace total", () => {
+    const next = applyStreamReadOrdinal(seeded, "s1", 8)
+    expect(next.unreadCounts.s1).toBe(0)
+    expect(next.mentionCounts.s1).toBe(0)
+    expect(next.activityCounts.s1).toBe(0)
+    expect(next.unreadActivityCount).toBe(1) // s2's count survives
+  })
+
+  it("never regresses the read position on a stale read event", () => {
+    const read = applyStreamReadOrdinal(seeded, "s1", 8)
+    const stale = applyStreamReadOrdinal(read, "s1", 5)
+    expect(stale.unreadCounts.s1).toBe(0)
+  })
+
+  it("treats a read position ahead of the known latest as a lower bound on latest", () => {
+    const next = applyStreamReadOrdinal(seeded, "s1", 12)
+    expect(next.latestOrdinals?.s1).toBe(12)
+    expect(next.unreadCounts.s1).toBe(0)
+  })
+
+  it("zeroes unread when no baseline exists (legacy-equivalent)", () => {
+    const noBaseline = makeState({ unreadCounts: { s1: 4 }, latestOrdinals: undefined })
+    const next = applyStreamReadOrdinal(noBaseline, "s1", 7)
+    expect(next.unreadCounts.s1).toBe(0)
+    expect(next.latestOrdinals?.s1).toBe(7)
+  })
+
+  it("lands in log order between two absolute activity applies", () => {
+    // activity counts 2 → read zeroes → activity counts 1: final state is the
+    // last entry's absolute value, exactly as the log orders them.
+    let state = makeState()
+    state = applyActivityCounts(state, "s1", { mentionCount: 1, activityCount: 2 })
+    state = applyStreamReadOrdinal(state, "s1", 5)
+    expect(state.activityCounts.s1).toBe(0)
+    state = applyActivityCounts(state, "s1", { mentionCount: 0, activityCount: 1 })
+    expect(state.mentionCounts.s1).toBe(0)
+    expect(state.activityCounts.s1).toBe(1)
+    expect(state.unreadActivityCount).toBe(1)
+  })
+})
+
+describe("applyStreamsReadAllOrdinals", () => {
+  it("applies each stream's absolute read position", () => {
+    const state = makeState({
+      unreadCounts: { s1: 2, s2: 5 },
+      activityCounts: { s1: 1, s2: 2 },
+      unreadActivityCount: 3,
+      latestOrdinals: { s1: 4, s2: 10 },
+    })
+    const next = applyStreamsReadAllOrdinals(state, [
+      { streamId: "s1", lastReadOrdinal: 4 },
+      { streamId: "s2", lastReadOrdinal: 10 },
+    ])
+    expect(next.unreadCounts).toEqual({ s1: 0, s2: 0 })
+    expect(next.activityCounts).toEqual({ s1: 0, s2: 0 })
+    expect(next.unreadActivityCount).toBe(0)
+  })
+})
+
+describe("applyActivityCounts", () => {
+  it("sets absolute counts and derives the total as Σ activityCounts", () => {
+    const state = makeState({ activityCounts: { s1: 1, s2: 4 }, unreadActivityCount: 5 })
+    const next = applyActivityCounts(state, "s1", { mentionCount: 2, activityCount: 3 })
+    expect(next.mentionCounts.s1).toBe(2)
+    expect(next.activityCounts).toEqual({ s1: 3, s2: 4 })
+    expect(next.unreadActivityCount).toBe(7)
+  })
+
+  it("converges on duplicate apply and allows decreases (LWW)", () => {
+    const state = makeState({ activityCounts: { s1: 5 }, unreadActivityCount: 5 })
+    const once = applyActivityCounts(state, "s1", { mentionCount: 0, activityCount: 2 })
+    expect(applyActivityCounts(once, "s1", { mentionCount: 0, activityCount: 2 })).toEqual(once)
+    expect(once.unreadActivityCount).toBe(2)
+  })
+})
+
+describe("isLegacyUnreadCounterEntry", () => {
+  it("detects missing absolute fields per counter event type", () => {
+    expect(isLegacyUnreadCounterEntry("stream:activity", { streamId: "s1" })).toBe(true)
+    expect(isLegacyUnreadCounterEntry("stream:activity", { streamId: "s1", messageOrdinal: 3 })).toBe(false)
+    expect(isLegacyUnreadCounterEntry("stream:read", { streamId: "s1" })).toBe(true)
+    expect(isLegacyUnreadCounterEntry("stream:read", { streamId: "s1", lastReadOrdinal: 0 })).toBe(false)
+    expect(isLegacyUnreadCounterEntry("stream:read_all", { streamIds: [] })).toBe(true)
+    expect(isLegacyUnreadCounterEntry("stream:read_all", { streamIds: [], reads: [] })).toBe(false)
+    expect(isLegacyUnreadCounterEntry("activity:created", { activity: {} })).toBe(true)
+    expect(isLegacyUnreadCounterEntry("activity:created", { counts: { mentionCount: 1, activityCount: 2 } })).toBe(
+      false
+    )
+  })
+
+  it("never marks non-counter events legacy", () => {
+    expect(isLegacyUnreadCounterEntry("message:created", {})).toBe(false)
+    expect(isLegacyUnreadCounterEntry("workspace_user:added", undefined)).toBe(false)
+  })
+})

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -1,0 +1,196 @@
+import type { WorkspaceBootstrap } from "@threa/types"
+
+/**
+ * Pure state math for the unread counter family (sync-v2 phase 2c).
+ *
+ * The four counter events (`stream:activity`, `stream:read`,
+ * `stream:read_all`, `activity:created`) carry ABSOLUTE values so clients set
+ * counters instead of incrementing — replayed and duplicated events converge.
+ * Per stream the client keeps one number pair: the latest message ordinal
+ * (`latestOrdinals`, the stream's total message count) and the unread count.
+ * The read position is implicit — `lastReadOrdinal = latestOrdinal − unread`
+ * — so every pre-existing code path that "zeroes the unread count" (local
+ * mark-as-read, legacy event fallbacks) stays coherent for free: zeroing
+ * unread IS advancing the read position to latest.
+ *
+ * Merge disciplines (PR #872 design decisions):
+ * - Stream ordinals MAX-MERGE. They are monotonic stream facts, so duplicate
+ *   and out-of-order applies (sweep-rescued late sync ids) converge without
+ *   extra bookkeeping.
+ * - Activity/mention counts LWW-SET in delivery order. They can legitimately
+ *   DECREASE (reaction removal deletes activity rows and emits no
+ *   compensating event), so a plain set is the only safe apply.
+ * - `unreadActivityCount` is never on the wire: it is derived as
+ *   Σ activityCounts whenever an absolute apply touches activity counts.
+ *
+ * Events missing the absolute fields are legacy: sync-log entries persisted
+ * before the backend shipped the fields replay without them forever (no log
+ * retention exists). `isLegacyUnreadCounterEntry` detects them so catch-up
+ * can skip them (bootstrap stays their authority) while live handlers fall
+ * back to the old increment/zero behavior.
+ */
+
+export interface UnreadCounterState {
+  unreadCounts: Record<string, number>
+  mentionCounts: Record<string, number>
+  activityCounts: Record<string, number>
+  unreadActivityCount: number
+  /**
+   * Latest message ordinal per stream, seeded from bootstrap `messageCounts`
+   * and max-merged from `stream:activity.messageOrdinal`. A missing entry
+   * means no baseline yet (snapshot predates the field); appliers seed it
+   * from the first absolute event they see.
+   */
+  latestOrdinals?: Record<string, number>
+}
+
+function sumCounts(counts: Record<string, number>): number {
+  return Object.values(counts).reduce((sum, count) => sum + count, 0)
+}
+
+/**
+ * Apply a `stream:activity` message ordinal. Latest max-merges; the implied
+ * read position advances to the message for the author's own sends (the
+ * server auto-advances the author's read pointer in the send transaction
+ * without emitting `stream:read`) and pins to latest while the user is
+ * viewing the stream (optimistic — auto-mark-read confirms server-side).
+ *
+ * Without a baseline the event seeds one: others' messages land as the
+ * legacy increment would have; own/viewing land read = latest.
+ */
+export function applyStreamActivityOrdinal(
+  state: UnreadCounterState,
+  streamId: string,
+  messageOrdinal: number,
+  opts: { isOwnMessage: boolean; isViewing: boolean }
+): UnreadCounterState {
+  const prevLatest = state.latestOrdinals?.[streamId]
+  let latest: number
+  let read: number
+  if (prevLatest === undefined) {
+    latest = messageOrdinal
+    read = opts.isOwnMessage || opts.isViewing ? latest : Math.max(0, latest - (state.unreadCounts[streamId] ?? 0) - 1)
+  } else {
+    const prevRead = Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0))
+    latest = Math.max(prevLatest, messageOrdinal)
+    read = opts.isOwnMessage ? Math.max(prevRead, messageOrdinal) : prevRead
+    if (opts.isViewing) read = latest
+  }
+  return {
+    ...state,
+    latestOrdinals: { ...state.latestOrdinals, [streamId]: latest },
+    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, latest - read) },
+  }
+}
+
+/**
+ * Apply a `stream:read` absolute read position. The read position max-merges
+ * (a stale read event can never regress unread); a read position ahead of
+ * the locally-known latest is itself a lower bound on latest. Messages that
+ * arrived after the read position stay unread — strictly better than the
+ * legacy unconditional zero, which over-cleared when a message raced the
+ * read event. Mention/activity counts zero in delivery order (the backend
+ * clears the stream's activity rows on mark-as-read), LWW like all activity
+ * counts.
+ */
+export function applyStreamReadOrdinal(
+  state: UnreadCounterState,
+  streamId: string,
+  lastReadOrdinal: number
+): UnreadCounterState {
+  const prevLatest = state.latestOrdinals?.[streamId]
+  const latest = Math.max(prevLatest ?? 0, lastReadOrdinal)
+  const prevRead =
+    prevLatest === undefined ? lastReadOrdinal : Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0))
+  const read = Math.max(prevRead, lastReadOrdinal)
+  const activityCounts = { ...state.activityCounts, [streamId]: 0 }
+  return {
+    ...state,
+    latestOrdinals: { ...state.latestOrdinals, [streamId]: latest },
+    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, latest - read) },
+    mentionCounts: { ...state.mentionCounts, [streamId]: 0 },
+    activityCounts,
+    unreadActivityCount: sumCounts(activityCounts),
+  }
+}
+
+/** Apply a `stream:read_all` reads array — per-stream `applyStreamReadOrdinal`. */
+export function applyStreamsReadAllOrdinals(
+  state: UnreadCounterState,
+  reads: Array<{ streamId: string; lastReadOrdinal: number }>
+): UnreadCounterState {
+  let next = state
+  for (const read of reads) {
+    next = applyStreamReadOrdinal(next, read.streamId, read.lastReadOrdinal)
+  }
+  return next
+}
+
+/**
+ * Apply an `activity:created` absolute count pair for the target user's
+ * stream (LWW set), rederiving the workspace total as Σ activityCounts.
+ */
+export function applyActivityCounts(
+  state: UnreadCounterState,
+  streamId: string,
+  counts: { mentionCount: number; activityCount: number }
+): UnreadCounterState {
+  const activityCounts = { ...state.activityCounts, [streamId]: counts.activityCount }
+  return {
+    ...state,
+    mentionCounts: { ...state.mentionCounts, [streamId]: counts.mentionCount },
+    activityCounts,
+    unreadActivityCount: sumCounts(activityCounts),
+  }
+}
+
+/** The counter slice of a workspace bootstrap (`messageCounts` are the latest ordinals). */
+export function toCounterState(bootstrap: WorkspaceBootstrap): UnreadCounterState {
+  return {
+    unreadCounts: bootstrap.unreadCounts,
+    mentionCounts: bootstrap.mentionCounts,
+    activityCounts: bootstrap.activityCounts,
+    unreadActivityCount: bootstrap.unreadActivityCount,
+    latestOrdinals: bootstrap.messageCounts,
+  }
+}
+
+/** Write a counter slice back onto a workspace bootstrap object. */
+export function withCounterState(bootstrap: WorkspaceBootstrap, state: UnreadCounterState): WorkspaceBootstrap {
+  return {
+    ...bootstrap,
+    unreadCounts: state.unreadCounts,
+    mentionCounts: state.mentionCounts,
+    activityCounts: state.activityCounts,
+    unreadActivityCount: state.unreadActivityCount,
+    messageCounts: state.latestOrdinals,
+  }
+}
+
+/**
+ * True when this is one of the four unread counter events AND its payload
+ * lacks the absolute fields — a sync-log entry persisted before the backend
+ * shipped them (or a live emit from a not-yet-upgraded backend). Catch-up
+ * skips these (the cursor still advances past them; the bootstrap remains
+ * their authority, INV-53) and the gate splice applies their buffered live
+ * copies regardless of position, exactly as the phase-2b skip set did.
+ * Non-counter event types are never legacy. This fallback dies when sync-log
+ * retention ships and pre-field entries age out.
+ */
+export function isLegacyUnreadCounterEntry(eventType: string, payload: unknown): boolean {
+  const p = payload as Record<string, unknown> | null | undefined
+  switch (eventType) {
+    case "stream:activity":
+      return typeof p?.messageOrdinal !== "number"
+    case "stream:read":
+      return typeof p?.lastReadOrdinal !== "number"
+    case "stream:read_all":
+      return !Array.isArray(p?.reads)
+    case "activity:created": {
+      const counts = p?.counts as Record<string, unknown> | null | undefined
+      return typeof counts?.mentionCount !== "number" || typeof counts?.activityCount !== "number"
+    }
+    default:
+      return false
+  }
+}

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -962,3 +962,350 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 })
+
+describe("unread counter events (absolute payloads, sync-v2 phase 2c)", () => {
+  const preview = {
+    authorId: "member_2",
+    authorType: "user" as const,
+    content: "hello",
+    createdAt: new Date().toISOString(),
+  }
+
+  function membership(streamId: string) {
+    return {
+      streamId,
+      memberId: "member_1",
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+    }
+  }
+
+  /**
+   * Fixture: stream_1 has 5 messages, 1 unread (implied read position 4),
+   * 1 mention + 1 activity; stream_2 contributes 1 activity to the total.
+   */
+  async function seedCounterFixture(queryClient: QueryClient) {
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({
+        users: [makeWorkspaceUser()],
+        streamMemberships: [membership("stream_1"), membership("stream_2")],
+        unreadCounts: { stream_1: 1 },
+        mentionCounts: { stream_1: 1 },
+        activityCounts: { stream_1: 1, stream_2: 1 },
+        unreadActivityCount: 2,
+        messageCounts: { stream_1: 5 },
+      })
+    )
+
+    const now = Date.now()
+    await db.workspaceUsers.put({ ...makeWorkspaceUser(), _cachedAt: now })
+    await db.streamMemberships.bulkPut(
+      ["stream_1", "stream_2"].map((streamId) => ({
+        ...membership(streamId),
+        id: `ws_1:${streamId}`,
+        workspaceId: "ws_1",
+        _cachedAt: now,
+      }))
+    )
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 1 },
+      mentionCounts: { stream_1: 1 },
+      activityCounts: { stream_1: 1, stream_2: 1 },
+      unreadActivityCount: 2,
+      latestOrdinals: { stream_1: 5 },
+      mutedStreamIds: [],
+      _cachedAt: now,
+    })
+  }
+
+  function register(queryClient: QueryClient, currentStreamId?: string) {
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => currentStreamId,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+    })
+    return { emit, cleanup }
+  }
+
+  beforeEach(async () => {
+    await Promise.all([
+      db.streams.clear(),
+      db.streamMemberships.clear(),
+      db.workspaceUsers.clear(),
+      db.unreadState.clear(),
+    ])
+  })
+
+  it("applies stream:activity ordinals as absolutes — duplicates converge", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    const payload = {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_2",
+      sequence: "9",
+      messageOrdinal: 6,
+      lastMessagePreview: preview,
+    }
+    emit("stream:activity", payload)
+    emit("stream:activity", payload)
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(2)
+    expect(bootstrap?.messageCounts?.stream_1).toBe(6)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadCounts.stream_1).toBe(2)
+      expect(state?.latestOrdinals?.stream_1).toBe(6)
+    })
+
+    cleanup()
+  })
+
+  it("advances the read position for own messages instead of skipping the event", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    emit("stream:activity", {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_1",
+      sequence: "9",
+      messageOrdinal: 6,
+      lastMessagePreview: preview,
+    })
+
+    // The server auto-advances the author's read pointer in the send
+    // transaction, so the prior unread message clears too.
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(0)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadCounts.stream_1).toBe(0)
+      expect(state?.latestOrdinals?.stream_1).toBe(6)
+    })
+
+    cleanup()
+  })
+
+  it("pins the read position to latest while viewing the stream", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient, "stream_1")
+
+    emit("stream:activity", {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_2",
+      sequence: "9",
+      messageOrdinal: 6,
+      lastMessagePreview: preview,
+    })
+
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(0)
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(0)
+    })
+
+    cleanup()
+  })
+
+  it("falls back to the legacy increment when stream:activity lacks an ordinal", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    emit("stream:activity", {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_2",
+      lastMessagePreview: preview,
+    })
+
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(2)
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(2)
+    })
+
+    cleanup()
+  })
+
+  it("applies stream:read absolute positions — newer messages stay unread", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    // 7 messages now exist; the read position covers 6 of them.
+    emit("stream:activity", {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_2",
+      sequence: "10",
+      messageOrdinal: 7,
+      lastMessagePreview: preview,
+    })
+    emit("stream:read", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      lastReadEventId: "event_6",
+      lastReadSequence: "8",
+      lastReadOrdinal: 6,
+    })
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(1)
+    expect(bootstrap?.mentionCounts.stream_1).toBe(0)
+    expect(bootstrap?.activityCounts.stream_1).toBe(0)
+    // Σ activityCounts: stream_2's activity survives.
+    expect(bootstrap?.unreadActivityCount).toBe(1)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadCounts.stream_1).toBe(1)
+      expect(state?.unreadActivityCount).toBe(1)
+    })
+
+    cleanup()
+  })
+
+  it("applies stream:read_all reads as absolute positions", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    emit("stream:read_all", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamIds: ["stream_1", "stream_2"],
+      reads: [
+        { streamId: "stream_1", lastReadOrdinal: 5 },
+        { streamId: "stream_2", lastReadOrdinal: 3 },
+      ],
+    })
+
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(0)
+    expect(bootstrap?.activityCounts).toEqual({ stream_1: 0, stream_2: 0 })
+    expect(bootstrap?.unreadActivityCount).toBe(0)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadCounts.stream_1).toBe(0)
+      expect(state?.unreadActivityCount).toBe(0)
+    })
+
+    cleanup()
+  })
+
+  it("sets activity:created counts as absolutes — duplicates converge, decreases apply", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient)
+
+    const payload = {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      counts: { mentionCount: 2, activityCount: 3 },
+      activity: {
+        id: "act_1",
+        activityType: "mention",
+        streamId: "stream_1",
+        messageId: "msg_1",
+        actorId: "member_2",
+        actorType: "user",
+        context: {},
+        createdAt: new Date().toISOString(),
+        isSelf: false,
+        emoji: null,
+      },
+    }
+    emit("activity:created", payload)
+    emit("activity:created", payload)
+
+    let bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.mentionCounts.stream_1).toBe(2)
+    expect(bootstrap?.activityCounts.stream_1).toBe(3)
+    expect(bootstrap?.unreadActivityCount).toBe(4) // 3 + stream_2's 1
+
+    // A lower absolute (reaction removal raced an insert) applies as-is (LWW).
+    emit("activity:created", {
+      ...payload,
+      counts: { mentionCount: 1, activityCount: 1 },
+      activity: { ...payload.activity, id: "act_2" },
+    })
+    bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.activityCounts.stream_1).toBe(1)
+    expect(bootstrap?.unreadActivityCount).toBe(2)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.activityCounts.stream_1).toBe(1)
+      expect(state?.unreadActivityCount).toBe(2)
+    })
+
+    cleanup()
+  })
+})
+
+describe("latest ordinal seeding and reconnect merge (sync-v2 phase 2c)", () => {
+  beforeEach(async () => {
+    await db.unreadState.clear()
+  })
+
+  it("applyWorkspaceBootstrap seeds latestOrdinals from messageCounts", async () => {
+    await applyWorkspaceBootstrap(
+      "ws_1",
+      makeBootstrap({
+        unreadCounts: { stream_1: 2 },
+        messageCounts: { stream_1: 7 },
+      })
+    )
+
+    expect((await db.unreadState.get("ws_1"))?.latestOrdinals).toEqual({ stream_1: 7 })
+  })
+
+  it("mergeReconnectWorkspaceBootstrap keeps each stream's ordinal paired with its winning unread source", () => {
+    const fetchStartedAt = Date.now() - 1000
+    const merged = mergeReconnectWorkspaceBootstrap({
+      workspaceBootstrap: makeBootstrap({
+        unreadCounts: { stream_fresh: 9, stream_stale: 9, stream_gone: 9 },
+        messageCounts: { stream_fresh: 9, stream_stale: 9, stream_gone: 9 },
+      }),
+      successfulStreamBootstraps: new Map(),
+      staleStreamIds: new Set(["stream_stale"]),
+      terminalStreamIds: new Set(["stream_gone"]),
+      localStreams: [],
+      localMemberships: [],
+      localUnreadState: {
+        id: "ws_1",
+        workspaceId: "ws_1",
+        // Fresher than the fetch: stream_fresh's local pair wins; stream_stale
+        // has a local unread but NO local ordinal — its baseline must drop
+        // rather than pair the server ordinal with the local unread.
+        unreadCounts: { stream_fresh: 2, stream_stale: 1 },
+        mentionCounts: {},
+        activityCounts: {},
+        unreadActivityCount: 0,
+        latestOrdinals: { stream_fresh: 11 },
+        mutedStreamIds: [],
+        _cachedAt: fetchStartedAt + 500,
+      },
+      fetchStartedAt,
+    })
+
+    expect(merged.unreadCounts).toEqual({ stream_fresh: 2, stream_stale: 1 })
+    expect(merged.messageCounts).toEqual({ stream_fresh: 11 })
+  })
+})

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -42,6 +42,14 @@ import {
   normalizeSidebarConfig,
 } from "@threa/types"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
+import {
+  applyActivityCounts,
+  applyStreamActivityOrdinal,
+  applyStreamReadOrdinal,
+  applyStreamsReadAllOrdinals,
+  toCounterState,
+  withCounterState,
+} from "./unread-counters"
 
 // ============================================================================
 // Workspace socket handler payload types
@@ -95,23 +103,37 @@ interface WorkspaceUserUpdatedPayload {
   user: WorkspaceUserPayload
 }
 
+// The unread counter payloads carry absolute fields (sync-v2 phase 2c).
+// They are optional on the wire: sync-log entries persisted before the
+// backend shipped them replay without them forever, and handlers fall back
+// to the legacy increment/zero behavior (see sync/unread-counters.ts).
 interface StreamReadPayload {
   workspaceId: string
   authorId: string
   streamId: string
   lastReadEventId: string
+  /** The read event's per-stream sequence (bigint as string). */
+  lastReadSequence?: string
+  /** Message ordinal of the read position. */
+  lastReadOrdinal?: number
 }
 
 interface StreamsReadAllPayload {
   workspaceId: string
   authorId: string
   streamIds: string[]
+  /** Absolute read position per updated stream. */
+  reads?: Array<{ streamId: string; lastReadOrdinal: number }>
 }
 
 interface StreamActivityPayload {
   workspaceId: string
   streamId: string
   authorId: string
+  /** The message event's per-stream sequence (bigint as string). */
+  sequence?: string
+  /** Count of message_created events with sequence ≤ this one. */
+  messageOrdinal?: number
   lastMessagePreview: LastMessagePreview
 }
 
@@ -280,6 +302,13 @@ export function mergeReconnectWorkspaceBootstrap({
   const unreadCounts = { ...workspaceBootstrap.unreadCounts }
   const mentionCounts = { ...workspaceBootstrap.mentionCounts }
   const activityCounts = { ...workspaceBootstrap.activityCounts }
+  // The latest message ordinals (sync-v2 phase 2c). A stream's ordinal must
+  // stay paired with whichever unreadCounts source wins for it — the implied
+  // read position is latestOrdinal − unreadCount, so mixing a local unread
+  // with the server ordinal (or vice versa) would shift it. Streams whose
+  // local unread state wins but that have no local ordinal lose their
+  // baseline (handlers re-seed from the next absolute event).
+  const messageCounts = { ...workspaceBootstrap.messageCounts }
   const mutedStreamIds = new Set(workspaceBootstrap.mutedStreamIds)
   const localStreamById = new Map(localStreams.map((stream) => [stream.id, stream]))
   const localMembershipByStreamId = new Map(localMemberships.map((membership) => [membership.streamId, membership]))
@@ -301,6 +330,12 @@ export function mergeReconnectWorkspaceBootstrap({
       for (const [streamId, count] of Object.entries(localUnreadState.unreadCounts)) {
         if (successfulStreamIds.has(streamId)) continue
         unreadCounts[streamId] = count
+        const localOrdinal = localUnreadState.latestOrdinals?.[streamId]
+        if (localOrdinal !== undefined) {
+          messageCounts[streamId] = localOrdinal
+        } else {
+          delete messageCounts[streamId]
+        }
       }
       for (const [streamId, count] of Object.entries(localUnreadState.mentionCounts)) {
         if (successfulStreamIds.has(streamId)) continue
@@ -332,6 +367,12 @@ export function mergeReconnectWorkspaceBootstrap({
       unreadCounts[streamId] = localUnreadState.unreadCounts[streamId] ?? 0
       mentionCounts[streamId] = localUnreadState.mentionCounts[streamId] ?? 0
       activityCounts[streamId] = localUnreadState.activityCounts[streamId] ?? 0
+      const localOrdinal = localUnreadState.latestOrdinals?.[streamId]
+      if (localOrdinal !== undefined) {
+        messageCounts[streamId] = localOrdinal
+      } else {
+        delete messageCounts[streamId]
+      }
       if (localUnreadState.mutedStreamIds.includes(streamId)) {
         mutedStreamIds.add(streamId)
       } else {
@@ -369,6 +410,7 @@ export function mergeReconnectWorkspaceBootstrap({
     delete unreadCounts[streamId]
     delete mentionCounts[streamId]
     delete activityCounts[streamId]
+    delete messageCounts[streamId]
     mutedStreamIds.delete(streamId)
   }
 
@@ -380,6 +422,7 @@ export function mergeReconnectWorkspaceBootstrap({
     mentionCounts,
     activityCounts,
     unreadActivityCount: sumActivityCounts(activityCounts),
+    messageCounts,
     mutedStreamIds: Array.from(mutedStreamIds),
   }
 }
@@ -734,12 +777,28 @@ export function registerWorkspaceSocketHandlers(
 
     const current = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
     const hadActivity = (current?.activityCounts[payload.streamId] ?? 0) > 0
+    // Absolute read position (sync-v2 phase 2c); null on legacy payloads.
+    const readOrdinal = typeof payload.lastReadOrdinal === "number" ? payload.lastReadOrdinal : null
 
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
+      const withMembership = {
+        ...old,
+        streamMemberships: old.streamMemberships.map((membership) =>
+          membership.streamId === payload.streamId
+            ? { ...membership, lastReadEventId: payload.lastReadEventId }
+            : membership
+        ),
+      }
+      if (readOrdinal !== null) {
+        return withCounterState(
+          withMembership,
+          applyStreamReadOrdinal(toCounterState(old), payload.streamId, readOrdinal)
+        )
+      }
       const clearedActivity = old.activityCounts[payload.streamId] ?? 0
       return {
-        ...old,
+        ...withMembership,
         unreadCounts: {
           ...old.unreadCounts,
           [payload.streamId]: 0,
@@ -753,11 +812,6 @@ export function registerWorkspaceSocketHandlers(
           [payload.streamId]: 0,
         },
         unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - clearedActivity),
-        streamMemberships: old.streamMemberships.map((membership) =>
-          membership.streamId === payload.streamId
-            ? { ...membership, lastReadEventId: payload.lastReadEventId }
-            : membership
-        ),
       }
     })
 
@@ -778,15 +832,25 @@ export function registerWorkspaceSocketHandlers(
       const now = Date.now()
       const state = await db.unreadState.get(workspaceId)
       if (state) {
-        const clearedActivity = state.activityCounts[payload.streamId] ?? 0
-        await db.unreadState.put({
-          ...state,
-          unreadCounts: { ...state.unreadCounts, [payload.streamId]: 0 },
-          mentionCounts: { ...state.mentionCounts, [payload.streamId]: 0 },
-          activityCounts: { ...state.activityCounts, [payload.streamId]: 0 },
-          unreadActivityCount: Math.max(0, state.unreadActivityCount - clearedActivity),
-          _cachedAt: now,
-        })
+        if (readOrdinal !== null) {
+          // Read-merge-write inside one transaction so concurrent tabs
+          // max-merge instead of clobbering each other (INV-20 analogue).
+          await db.unreadState.put({
+            ...state,
+            ...applyStreamReadOrdinal(state, payload.streamId, readOrdinal),
+            _cachedAt: now,
+          })
+        } else {
+          const clearedActivity = state.activityCounts[payload.streamId] ?? 0
+          await db.unreadState.put({
+            ...state,
+            unreadCounts: { ...state.unreadCounts, [payload.streamId]: 0 },
+            mentionCounts: { ...state.mentionCounts, [payload.streamId]: 0 },
+            activityCounts: { ...state.activityCounts, [payload.streamId]: 0 },
+            unreadActivityCount: Math.max(0, state.unreadActivityCount - clearedActivity),
+            _cachedAt: now,
+          })
+        }
       }
 
       await db.streams.update(payload.streamId, { lastReadEventId: payload.lastReadEventId, _cachedAt: now })
@@ -819,8 +883,15 @@ export function registerWorkspaceSocketHandlers(
   const handleStreamReadAll = (payload: StreamsReadAllPayload) => {
     if (payload.workspaceId !== workspaceId) return
 
+    // Absolute read positions (sync-v2 phase 2c); null on legacy payloads.
+    const reads = Array.isArray(payload.reads) ? payload.reads : null
+
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
+
+      if (reads !== null) {
+        return withCounterState(old, applyStreamsReadAllOrdinals(toCounterState(old), reads))
+      }
 
       const newUnreadCounts = { ...old.unreadCounts }
       const newMentionCounts = { ...old.mentionCounts }
@@ -845,6 +916,14 @@ export function registerWorkspaceSocketHandlers(
     db.transaction("rw", [db.unreadState], async () => {
       const state = await db.unreadState.get(workspaceId)
       if (!state) return
+      if (reads !== null) {
+        await db.unreadState.put({
+          ...state,
+          ...applyStreamsReadAllOrdinals(state, reads),
+          _cachedAt: Date.now(),
+        })
+        return
+      }
       const updated = { ...state, _cachedAt: Date.now() }
       const newUnread = { ...state.unreadCounts }
       const newMention = { ...state.mentionCounts }
@@ -893,6 +972,9 @@ export function registerWorkspaceSocketHandlers(
       })
     }
 
+    // Absolute message ordinal (sync-v2 phase 2c); null on legacy payloads.
+    const messageOrdinal = typeof payload.messageOrdinal === "number" ? payload.messageOrdinal : null
+
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
 
@@ -900,28 +982,42 @@ export function registerWorkspaceSocketHandlers(
       const isMember = old.streamMemberships.some((m: StreamMember) => m.streamId === payload.streamId)
       if (!isMember) return old
 
-      // Determine if we should increment unread count:
-      // - Not for own messages (authorId is a userId — match via user.workosUserId)
-      // - Not when currently viewing the stream
+      // Own messages never raise unread (authorId is a userId — match via
+      // user.workosUserId): the server auto-advances the author's read
+      // pointer in the send transaction without emitting stream:read.
       const currentUser = refs.getCurrentUser()
       const currentMember = currentUser && getWorkspaceUsers(old).find((u) => u.workosUserId === currentUser.id)
-      const isOwnMessage = currentMember && payload.authorId === currentMember.id
-      const shouldIncrementUnread = !isOwnMessage && !isViewingStream
+      const isOwnMessage = Boolean(currentMember && payload.authorId === currentMember.id)
 
-      return {
+      // Always update stream's lastMessagePreview for sidebar display
+      const withPreview = {
         ...old,
-        // Only increment unread count for others' messages when not viewing
-        unreadCounts: shouldIncrementUnread
-          ? {
-              ...old.unreadCounts,
-              [payload.streamId]: (old.unreadCounts[payload.streamId] ?? 0) + 1,
-            }
-          : old.unreadCounts,
-        // Always update stream's lastMessagePreview for sidebar display
         streams: old.streams.map((stream) =>
           stream.id === payload.streamId ? { ...stream, lastMessagePreview: payload.lastMessagePreview } : stream
         ),
       }
+
+      if (messageOrdinal !== null) {
+        return withCounterState(
+          withPreview,
+          applyStreamActivityOrdinal(toCounterState(old), payload.streamId, messageOrdinal, {
+            isOwnMessage,
+            isViewing: isViewingStream,
+          })
+        )
+      }
+
+      // Legacy payload: increment unread for others' messages when not viewing.
+      const shouldIncrementUnread = !isOwnMessage && !isViewingStream
+      return shouldIncrementUnread
+        ? {
+            ...withPreview,
+            unreadCounts: {
+              ...withPreview.unreadCounts,
+              [payload.streamId]: (withPreview.unreadCounts[payload.streamId] ?? 0) + 1,
+            },
+          }
+        : withPreview
     })
 
     // Always persist lastMessagePreview to IDB so the cached sort order
@@ -931,36 +1027,50 @@ export function registerWorkspaceSocketHandlers(
       _cachedAt: Date.now(),
     })
 
-    // Update IDB: increment unread count for others' messages when not viewing.
-    // We check membership via IDB to avoid dependency on the TanStack closure.
-    if (!isViewingStream) {
-      void (async () => {
-        const membership = await db.streamMemberships.get(`${workspaceId}:${payload.streamId}`)
-        if (!membership) return
-        const currentUser = refs.getCurrentUser()
-        const currentMember = currentUser
-          ? await db.workspaceUsers
-              .where("workspaceId")
-              .equals(workspaceId)
-              .filter((u) => u.workosUserId === currentUser.id)
-              .first()
-          : null
-        if (currentMember && payload.authorId === currentMember.id) return
+    // Update IDB unread state. We check membership via IDB to avoid dependency
+    // on the TanStack closure. Unlike the legacy increment (skipped for own
+    // messages and while viewing), the absolute path always writes: own sends
+    // advance the implied read position and viewing pins it to latest.
+    void (async () => {
+      const membership = await db.streamMemberships.get(`${workspaceId}:${payload.streamId}`)
+      if (!membership) return
+      const currentUser = refs.getCurrentUser()
+      const currentMember = currentUser
+        ? await db.workspaceUsers
+            .where("workspaceId")
+            .equals(workspaceId)
+            .filter((u) => u.workosUserId === currentUser.id)
+            .first()
+        : null
+      const isOwnMessage = Boolean(currentMember && payload.authorId === currentMember.id)
+      if (messageOrdinal === null && (isOwnMessage || isViewingStream)) return
 
-        await db.transaction("rw", [db.unreadState], async () => {
-          const state = await db.unreadState.get(workspaceId)
-          if (!state) return
+      await db.transaction("rw", [db.unreadState], async () => {
+        const state = await db.unreadState.get(workspaceId)
+        if (!state) return
+        if (messageOrdinal !== null) {
+          // Read-merge-write inside one transaction so concurrent tabs
+          // max-merge instead of clobbering each other (INV-20 analogue).
           await db.unreadState.put({
             ...state,
-            unreadCounts: {
-              ...state.unreadCounts,
-              [payload.streamId]: (state.unreadCounts[payload.streamId] ?? 0) + 1,
-            },
+            ...applyStreamActivityOrdinal(state, payload.streamId, messageOrdinal, {
+              isOwnMessage,
+              isViewing: isViewingStream,
+            }),
             _cachedAt: Date.now(),
           })
+          return
+        }
+        await db.unreadState.put({
+          ...state,
+          unreadCounts: {
+            ...state.unreadCounts,
+            [payload.streamId]: (state.unreadCounts[payload.streamId] ?? 0) + 1,
+          },
+          _cachedAt: Date.now(),
         })
-      })()
-    }
+      })
+    })()
   }
 
   // Handle stream display name updated (from auto-naming service)
@@ -1235,10 +1345,30 @@ export function registerWorkspaceSocketHandlers(
     if (payload.workspaceId !== workspaceId) return
 
     const { streamId, activityType, isSelf } = payload.activity
+    // Absolute per-stream counts for the target user (sync-v2 phase 2c);
+    // undefined on legacy payloads.
+    const counts = payload.counts
 
-    // Self rows (the user's own message or reaction) show in the feed but must
-    // not inflate unread counts. The backend inserts them already read.
-    if (!isSelf) {
+    if (counts) {
+      // Absolute counts apply for self rows too — the backend inserts those
+      // already read, so the counts simply restate the unchanged truth (LWW).
+      updateBootstrapOrInvalidate(queryClient, workspaceId, (old) =>
+        withCounterState(old, applyActivityCounts(toCounterState(old), streamId, counts))
+      )
+
+      db.transaction("rw", [db.unreadState], async () => {
+        const state = await db.unreadState.get(workspaceId)
+        if (!state) return
+        await db.unreadState.put({
+          ...state,
+          ...applyActivityCounts(state, streamId, counts),
+          _cachedAt: Date.now(),
+        })
+      })
+    } else if (!isSelf) {
+      // Legacy payload. Self rows (the user's own message or reaction) show in
+      // the feed but must not inflate unread counts — the backend inserts them
+      // already read.
       updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => ({
         ...old,
         mentionCounts:
@@ -1765,6 +1895,7 @@ export async function applyWorkspaceBootstrap(
           mentionCounts: bootstrap.mentionCounts,
           activityCounts: bootstrap.activityCounts,
           unreadActivityCount: bootstrap.unreadActivityCount,
+          latestOrdinals: bootstrap.messageCounts,
           mutedStreamIds: bootstrap.mutedStreamIds,
           _cachedAt: now,
         })
@@ -1859,6 +1990,7 @@ export async function applyWorkspaceBootstrap(
       mentionCounts: bootstrap.mentionCounts,
       activityCounts: bootstrap.activityCounts,
       unreadActivityCount: bootstrap.unreadActivityCount,
+      latestOrdinals: bootstrap.messageCounts,
       mutedStreamIds: bootstrap.mutedStreamIds,
       _cachedAt: now,
     },
@@ -2000,6 +2132,7 @@ export async function applyReconnectBootstrapBatch(
           mentionCounts: finalBootstrap.mentionCounts,
           activityCounts: finalBootstrap.activityCounts,
           unreadActivityCount: finalBootstrap.unreadActivityCount,
+          latestOrdinals: finalBootstrap.messageCounts,
           mutedStreamIds: finalBootstrap.mutedStreamIds,
           _cachedAt: now,
         }),
@@ -2092,6 +2225,7 @@ export async function applyReconnectBootstrapBatch(
       mentionCounts: finalBootstrap.mentionCounts,
       activityCounts: finalBootstrap.activityCounts,
       unreadActivityCount: finalBootstrap.unreadActivityCount,
+      latestOrdinals: finalBootstrap.messageCounts,
       mutedStreamIds: finalBootstrap.mutedStreamIds,
       _cachedAt: now,
     },


### PR DESCRIPTION
## Problem

PR C (#872) made the four unread-counter payloads absolute on the backend, but the frontend still treats the whole family as duplicate-unsafe: `CATCHUP_SKIPPED_UNREAD_EVENT_TYPES` skips every counter entry during active catch-up, the live handlers increment/zero, and the workspace bootstrap remains the sole counter authority (INV-53). A counter event missed during a disconnect can only heal via a full bootstrap.

## Solution

Convert the frontend to absolute counter semantics so the counter family replays safely from the sync log, and demote the skip set to a per-entry missing-fields fallback for legacy log entries.

### How it works

Per stream the client keeps one number pair: the **latest message ordinal** (new `CachedUnreadState.latestOrdinals`, seeded from bootstrap `messageCounts`) and the **unread count**. The read position is implicit — `lastReadOrdinal = latestOrdinal − unreadCount` — so every pre-existing code path that "zeroes the unread count" (local mark-as-read, legacy fallbacks) stays coherent without modification: zeroing unread IS advancing the read position to latest. The pure merge math lives in `sync/unread-counters.ts` and is shared by the IDB writes and the TanStack bootstrap-cache writes (where `messageCounts` plays the latest-ordinal role).

Per event:

- **`stream:activity`** — max-merge `latestOrdinal` with `messageOrdinal`; `unread = latest − impliedRead`. Own messages advance the implied read position to the message (mirrors the server auto-advancing the author's read pointer in the send transaction, replacing the old own-message increment skip); viewing pins it to latest (optimistic — auto-mark-read confirms server-side).
- **`stream:read`** — the read position max-merges, so a stale read event can never regress unread, and messages that arrived after the read position **stay unread** (strictly better than the legacy unconditional zero). Mention/activity counts zero in delivery order.
- **`stream:read_all`** — per-stream `reads[].lastReadOrdinal`, same math.
- **`activity:created`** — `counts` LWW-set per stream (they can legitimately decrease: reaction removal deletes activity rows with no compensating event); `unreadActivityCount` is derived as Σ activityCounts.

Events missing the absolute fields fall back to the legacy increment/zero handling live, and are skipped during catch-up (`isLegacyUnreadCounterEntry`) — pre-deploy sync-log entries replay without the fields forever since no log retention exists.

### Key design decisions

**1. One stored field, implicit read position.** Storing `(latestOrdinal, unreadCount)` instead of an explicit `lastReadOrdinal` keeps every existing unreadState writer (markAsRead/markAllAsRead mutations, activity clears — all of which spread `...state`) coherent with zero changes, and makes bootstrap seeding trivial (`latestOrdinals = messageCounts`).

**2. The splice no longer re-applies absolute counter duplicates at or below the catch-up position.** Their log copies already applied, and activity counts are LWW — re-applying a buffered duplicate after a newer log entry would regress them (pinned by a test that fails under the old predicate). Legacy counter events still splice regardless of position since catch-up never applies those. `SocketEventGate.resume`'s predicate now receives the payload to tell the two apart.

**3. Reconnect merge keeps each stream's ordinal paired with its winning unread source.** `mergeReconnectWorkspaceBootstrap` carries `messageCounts` per stream from whichever side (server snapshot vs fresher/stale local state) supplied the unread count; a stream whose local unread wins without a local ordinal drops its baseline rather than pairing mismatched numbers (handlers re-seed from the next absolute event).

**4. Optimistic single-activity mark-read decrements per-stream counts.** With the total derived as Σ activityCounts, the old total-only decrement would resurrect on the next absolute apply; decrementing the matching per-stream count keeps the optimistic state consistent with what the server will report.

**5. Dead `incrementUnread` removed** (INV-38 — no callers).

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/sync/unread-counters.ts` | Pure merge math (max-merge ordinals, LWW counts, Σ derivation) + legacy-payload detection |
| `apps/frontend/src/sync/unread-counters.test.ts` | Pure-function coverage: idempotence, out-of-order convergence, baselines, LWW |

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/sync/workspace-sync.ts` | Four handlers apply absolutes with legacy fallbacks; bootstrap/reconnect seeding of `latestOrdinals`; reconnect merge pairs `messageCounts` |
| `apps/frontend/src/sync/sync-engine.ts` | Skip set → `isLegacyUnreadCounterEntry` per-entry check in catch-up and the splice predicate |
| `apps/frontend/src/sync/socket-event-gate.ts` | `resume` predicate gains the buffered event's payload |
| `apps/frontend/src/db/database.ts` | `CachedUnreadState.latestOrdinals?` (non-indexed, no schema version bump) |
| `apps/frontend/src/hooks/use-activity.ts` | Optimistic mark-read decrements per-stream counts; skips rows that never counted |
| `apps/frontend/src/hooks/use-unread-counts.ts` | Remove dead `incrementUnread` |
| `apps/frontend/src/sync/workspace-sync.test.ts` | 9 new handler/seeding/merge tests |
| `apps/frontend/src/sync/sync-engine.test.ts` | 3 new catch-up/splice tests; 2 renamed to mark legacy scope |

## Test plan

- [x] New pure tests: duplicate apply converges, out-of-order (sweep-rescued late sync ids) converges, own-message/viewing read advance, baseline seeding, stale-read no-regress, LWW decreases, read-zero-between-activity-entries log order
- [x] New handler tests: absolute apply + duplicate convergence in both IDB and the bootstrap cache, legacy fallbacks, partial-read leaves newer messages unread, Σ derivation
- [x] New engine tests: bootstrap+catch-up overlap doesn't double-count (snapshot-covered ordinal is a no-op), read-zero replayed between two activity entries lands in log order, buffered ABSOLUTE duplicate at/below the position is not re-applied (verified the test FAILS under the old splice predicate)
- [x] Full frontend suite: 2554 pass (225 files)
- [x] Monorepo typecheck + lint + prettier + OpenAPI check (pre-commit)
- [ ] Backend suites untouched by this PR (frontend-only change) — CI runs them

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Phase 2c of sync-engine v2, second implementable unit (PR D of the agreed plan): consume the absolute unread-counter payloads PR C (#872) added, so the counter family applies idempotently from the sync log and `CATCHUP_SKIPPED_UNREAD_EVENT_TYPES` narrows to a legacy-entry fallback.

## Phase 2c sequencing (agreed with owner)

1. **(Owner gates, still open)** Prod shadow-log verification — bug signature is `fetched > 0` on `reconnect`/`resume` while healthy; small `connect` fetches ~1s after the last event are benign. Then flip staging → prod to `VITE_SYNC_V2_CURSOR=active`.
2. **PR A** — flip the flag default `shadow` → `active` once prod proves out.
3. **PR B** — gate the `savedKeys`/`scheduledKeys` reconnect invalidations in `registerWorkspaceSocketHandlers` on non-active mode. Gate, don't delete: `off` is the kill switch and must re-enable INV-53 healing.
4. **PR C (#872, merged)** — backend absolute payloads + types + partial index.
5. **PR D (this PR)** — frontend conversion: max-merge ordinals for stream unread, LWW set for activity counts, `unreadActivityCount = Σ activityCounts`, ordinal baselines from bootstrap `messageCounts`, read-merge-write IDB transactions for `unreadState`, skip set demoted to a missing-fields fallback. Own-message suppression mirrors the server's author auto-advance; viewing suppression pins the read position optimistically.
6. **PR E+** — further INV-53 narrowing, one deletion per PR with a test.

## What Was Built (this PR)

- `sync/unread-counters.ts`: pure counter math over `(latestOrdinal, unreadCount)` per stream, read position implicit. Shared by IDB unreadState writes and TanStack bootstrap-cache writes.
- Handler conversion with rollout-aware fallbacks: absolute fields optional on the local payload types, legacy path preserved verbatim.
- Bootstrap seeding: `latestOrdinals = messageCounts` in `applyWorkspaceBootstrap`, `applyReconnectBootstrapBatch`, `seedWorkspaceCache`; reconnect merge pairs ordinals with their winning unread source.
- Catch-up: `isLegacyUnreadCounterEntry(eventType, payload)` replaces the static skip set; the cursor still advances past skipped legacy entries.
- Splice: absolute counter duplicates at/below `appliedThrough` are dropped (LWW regression guard); legacy counter events splice regardless of position as before.
- Multi-tab: every unreadState write reads, merges (max/LWW), and puts inside one IDB `rw` transaction.

## Design Decisions

1. Implicit read position (`latest − unread`) over a second stored record — all existing writers spread `...state` and stay coherent; zeroing unread is advancing the read position.
2. Splice predicate is payload-aware — re-applying an absolute LWW duplicate after a newer log entry would regress counts; max-merge fields would tolerate it, activity counts would not.
3. `stream:read` improves on legacy: max-merged read position means a racing message no longer gets over-cleared; a `lastReadOrdinal` of 0 (missing read event) is a no-op for ordinals while still zeroing activity.
4. Optimistic single-activity mark-read decrements per-stream counts so Σ derivation doesn't resurrect the total.

## Known accepted drift

- `messages:moved` vacates source-stream message events → a max-merged `latestOrdinal` can exceed truth → transient overcount that heals at bootstrap (flagged in the phase plan; a recomputed-ordinals payload on the moved event remains a possible follow-up).
- Catch-up LWW replay can momentarily restate activity counts as of the last logged activity entry, missing non-logged changes (single-activity reads, reaction removals) that the snapshot already reflected — heals on the next activity event or bootstrap, same loss mode as today's skip-set behavior.

## What's NOT Included (deliberate)

- No INV-53 invalidation gating/deletions (PR B / E+).
- No flag default change (PR A, gated on prod shadow verification).
- No `sync_log` retention (open phase-1 deferral; also the trigger for deleting the legacy fallback).

## Status

- PR C (#872): merged.
- This PR: phase 2c frontend half. Prod still in shadow mode.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01JJMKLMVL5hRvxProNXtw1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJMKLMVL5hRvxProNXtw1n)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783847897&installation_id=129946197&pr_number=874&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F874&signature=6a78f40fb354a2a0e0f7e0a6e8aa49e14ca5f840017fe060c1cd6421b07739a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->