### PR TITLE
fix: reflect existing browser push subscription immediately on app start

### DIFF
--- a/apps/frontend/src/hooks/use-push-notifications.test.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { usePushNotifications } from "./use-push-notifications"
+import { api } from "@/api/client"
+
+const swDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
+const notificationDescriptor = Object.getOwnPropertyDescriptor(window, "Notification")
+
+function fakeSubscription(endpoint = "https://push.example/sub-1") {
+  return {
+    endpoint,
+    options: { applicationServerKey: new Uint8Array([1, 2, 3]).buffer },
+    toJSON: () => ({ endpoint, keys: { p256dh: "p256dh-key", auth: "auth-key" } }),
+    unsubscribe: vi.fn().mockResolvedValue(true),
+  }
+}
+
+/** Stubs the browser push surface: granted permission, ready SW, given existing subscription. */
+function installBrowserPush(existingSubscription: ReturnType<typeof fakeSubscription> | null) {
+  const pushManager = {
+    getSubscription: vi.fn().mockResolvedValue(existingSubscription),
+    subscribe: vi.fn().mockResolvedValue(fakeSubscription()),
+  }
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: { ready: Promise.resolve({ pushManager }) },
+  })
+  Object.defineProperty(window, "Notification", {
+    configurable: true,
+    value: { permission: "granted", requestPermission: vi.fn() },
+  })
+  return pushManager
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+  if (swDescriptor) {
+    Object.defineProperty(navigator, "serviceWorker", swDescriptor)
+  } else {
+    delete (navigator as { serviceWorker?: unknown }).serviceWorker
+  }
+  if (notificationDescriptor) {
+    Object.defineProperty(window, "Notification", notificationDescriptor)
+  } else {
+    delete (window as { Notification?: unknown }).Notification
+  }
+})
+
+describe("usePushNotifications", () => {
+  it("reflects an existing browser subscription before the backend handshake completes", async () => {
+    installBrowserPush(fakeSubscription())
+    // Hold the VAPID config fetch open — the regression was isSubscribed
+    // staying false (unchecked checklist task) for the seconds this
+    // round-trip takes on app start.
+    vi.spyOn(api, "get").mockReturnValue(new Promise(() => {}))
+    const post = vi.spyOn(api, "post").mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => usePushNotifications("ws_1"))
+
+    await waitFor(() => expect(result.current.isSubscribed).toBe(true))
+    // The handshake is still in flight — the early flip didn't come from it.
+    expect(result.current.status).toBe("subscribing")
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it("stays unsubscribed until the handshake completes when the browser holds no subscription", async () => {
+    installBrowserPush(null)
+    vi.spyOn(api, "get").mockResolvedValue({ vapidPublicKey: "dGVzdGtleQ", enabled: true })
+    const post = vi.spyOn(api, "post").mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => usePushNotifications("ws_1"))
+
+    await waitFor(() => expect(result.current.status).toBe("subscribed"))
+    expect(result.current.isSubscribed).toBe(true)
+    expect(post).toHaveBeenCalledWith(
+      "/api/workspaces/ws_1/push/subscribe",
+      expect.objectContaining({ endpoint: "https://push.example/sub-1" }),
+      expect.anything()
+    )
+  })
+
+  it("drops the optimistic subscribed state when the handshake fails", async () => {
+    installBrowserPush(fakeSubscription())
+    vi.spyOn(api, "get").mockRejectedValue(new Error("network down"))
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { result } = renderHook(() => usePushNotifications("ws_1"))
+
+    await waitFor(() => expect(result.current.status).toBe("error"))
+    expect(result.current.isSubscribed).toBe(false)
+  })
+})

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -272,6 +272,14 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
             throw new Error("Service workers are not available in this browser")
           }
           const registration = await navigator.serviceWorker.ready
+          // A browser-held subscription means this device already receives
+          // push — reflect it immediately instead of leaving the UI "off"
+          // (unchecked getting-started task, "Disabled" settings badge) for
+          // the seconds the backend handshake's network round-trips take on
+          // app start. The handshake's terminal state still wins: a failure
+          // flips this back to false in the catch below.
+          const existing = await registration.pushManager.getSubscription()
+          if (existing && isLatest()) setIsSubscribed(true)
           return runSubscribeFlow(workspaceId, registration, vapidCacheRef, controller.signal)
         })(),
         timeoutPromise,


### PR DESCRIPTION
## Problem

The getting-started "Turn on notifications" task showed as unchecked for a couple of seconds on every app start, even on devices that already had push notifications enabled. The same flash affected the notifications settings badge ("Disabled" → "Enabled").

The checklist derives its checked state from `isSubscribed` in `usePushNotifications`, which started as `false` and only flipped to `true` after the full backend re-registration handshake completed on mount: wait for the service worker, GET the VAPID key, POST to `/push/subscribe`. Those network round-trips are the visible flash window.

## Solution

`subscribe()` now probes the browser-held push subscription (`pushManager.getSubscription()` — a fast, local check) right after the service worker is ready, and flips `isSubscribed` immediately when one exists. The idempotent backend handshake still runs unchanged and its terminal state remains authoritative: a failed handshake resets the state to unsubscribed and surfaces the error exactly as before.

### Key design decisions

**1. Derive from the browser subscription, not a persisted flag**

A localStorage "was subscribed" hint would also kill the flash, but the checklist's philosophy (per the `useGettingStarted` docs) is that completion is *derived from real state, never tracked*. The browser's own subscription record is the real state, and reading it costs no network round-trip.

**2. Optimistic flip lives inside `subscribe()`, gated by the attempt generation**

The probe runs inside the existing per-attempt generation guard (`isLatest()`), so a superseded attempt can't write stale state, and a handshake failure in the same attempt deterministically wins by resetting `isSubscribed` in the catch path.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-push-notifications.ts` | Probe the existing browser subscription after SW ready and set `isSubscribed` immediately |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-push-notifications.test.ts` | Regression coverage: early flip while handshake is in flight, no false positive without a browser subscription, rollback on handshake failure |

## Test plan

- [x] New hook tests (3) pass: `bunx vitest run src/hooks/use-push-notifications.test.ts`
- [x] Related suites pass (getting-started, sidebar-footer, settings-dialog — 16 tests)
- [x] Frontend typecheck clean (`tsc --noEmit`), pre-commit monorepo lint + typecheck green
- [ ] Manual: reload the app on a subscribed device — the "Turn on notifications" task renders checked with no flash

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01NCbYA2J7JFZH9GpJ6N6Rto

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCbYA2J7JFZH9GpJ6N6Rto)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783854817&installation_id=129946197&pr_number=876&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F876&signature=1caf0d74eddc412611a1d4571c6731c8283385a2dacd037bcecb81281482f172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->