### PR TITLE
refactor: refine the sidebar New button (original anatomy, cleaner finish)

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -495,27 +495,33 @@ export function SidebarFooter({
   )
 }
 
-// Shared face for the create control. A gold "thread" chip carries the emphasis
-// (per the design system, --primary is the single accent that signals primary
-// actions), the label sits left-aligned so the control reads as a sidebar row
-// rather than a form button, and the trailing chevron telegraphs the upward
-// menu — rhyming with the account row beneath it. The whole face reacts to the
-// trigger's `data-state` so hover and open share one warm treatment; both the
-// Radix desktop trigger and the manual mobile button expose that attribute.
+// Shared face for the create control. This is the sidebar's one deliberate
+// golden-thread moment: a centered, bordered gold pill (the accent token pair
+// keeps the label legible on the tint in both modes) so it reads as the app's
+// primary creation action rather than another list row. The plus rotates into
+// an × while the menu is open — the face reacts to the trigger's `data-state`,
+// which both the Radix desktop trigger and the manual mobile button expose.
 function SidebarCreateButtonFace() {
   return (
     <>
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary transition-colors group-hover/new:bg-primary/25 group-data-[state=open]/new:bg-primary/25">
-        <Plus className="h-4 w-4" />
-      </span>
-      <span className="flex-1 text-left font-medium">New</span>
-      <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/new:rotate-180" />
+      <Plus className="h-4 w-4 shrink-0 transition-transform duration-200 group-data-[state=open]/new:rotate-45" />
+      <span className="font-medium">New</span>
     </>
   )
 }
 
-const CREATE_BUTTON_CLASS =
-  "group/new w-full justify-start gap-2.5 px-3 bg-primary/[0.04] hover:bg-primary/10 hover:text-foreground data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
+// Hover and open share one warm treatment: deeper border, warmer gradient, and
+// a soft golden glow (the design system's "key moment" cue). Border and sizing
+// are constant across states, so nothing shifts (INV-21).
+const CREATE_BUTTON_CLASS = cn(
+  "group/new w-full justify-center gap-1.5 rounded-lg border border-primary/25",
+  "bg-gradient-to-b from-primary/15 to-primary/5 text-accent-foreground shadow-sm",
+  "transition-all duration-200",
+  "hover:border-primary/50 hover:from-primary/20 hover:to-primary/10 hover:text-accent-foreground",
+  "hover:shadow-[0_0_14px_hsl(var(--primary)/0.25)]",
+  "data-[state=open]:border-primary/50 data-[state=open]:from-primary/20 data-[state=open]:to-primary/10",
+  "data-[state=open]:text-accent-foreground data-[state=open]:shadow-[0_0_14px_hsl(var(--primary)/0.25)]"
+)
 
 /**
  * The always-visible "New" control at the bottom of the sidebar. Opens a menu of

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -495,32 +495,28 @@ export function SidebarFooter({
   )
 }
 
-// Shared face for the create control. This is the sidebar's one deliberate
-// golden-thread moment: a centered, bordered gold pill (the accent token pair
-// keeps the label legible on the tint in both modes) so it reads as the app's
-// primary creation action rather than another list row. The plus rotates into
-// an × while the menu is open — the face reacts to the trigger's `data-state`,
+// Shared face for the create control. Quiet and structural: it borrows the
+// bordered-neutral language of the header's quick-action pills so top and
+// bottom of the sidebar bookend each other, and the gold is confined to the
+// plus glyph — the golden thread used sparingly. The plus rotates into an ×
+// while the menu is open — the face reacts to the trigger's `data-state`,
 // which both the Radix desktop trigger and the manual mobile button expose.
 function SidebarCreateButtonFace() {
   return (
     <>
-      <Plus className="h-4 w-4 shrink-0 transition-transform duration-200 group-data-[state=open]/new:rotate-45" />
+      <Plus className="h-4 w-4 shrink-0 text-primary transition-transform duration-200 group-data-[state=open]/new:rotate-45" />
       <span className="font-medium">New</span>
     </>
   )
 }
 
-// Hover and open share one warm treatment: deeper border, warmer gradient, and
-// a soft golden glow (the design system's "key moment" cue). Border and sizing
-// are constant across states, so nothing shifts (INV-21).
+// Hover and open share the same quiet treatment as the quick-action pills:
+// the surface deepens to muted, nothing else changes. Border and sizing are
+// constant across states, so nothing shifts (INV-21).
 const CREATE_BUTTON_CLASS = cn(
-  "group/new w-full justify-center gap-1.5 rounded-lg border border-primary/25",
-  "bg-gradient-to-b from-primary/15 to-primary/5 text-accent-foreground shadow-sm",
-  "transition-all duration-200",
-  "hover:border-primary/50 hover:from-primary/20 hover:to-primary/10 hover:text-accent-foreground",
-  "hover:shadow-[0_0_14px_hsl(var(--primary)/0.25)]",
-  "data-[state=open]:border-primary/50 data-[state=open]:from-primary/20 data-[state=open]:to-primary/10",
-  "data-[state=open]:text-accent-foreground data-[state=open]:shadow-[0_0_14px_hsl(var(--primary)/0.25)]"
+  "group/new w-full justify-center gap-1.5 rounded-lg border border-border bg-background text-foreground",
+  "transition-colors hover:bg-muted/60 hover:text-foreground",
+  "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground"
 )
 
 /**

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -495,28 +495,32 @@ export function SidebarFooter({
   )
 }
 
-// Shared face for the create control. Quiet and structural: it borrows the
-// bordered-neutral language of the header's quick-action pills so top and
-// bottom of the sidebar bookend each other, and the gold is confined to the
-// plus glyph — the golden thread used sparingly. The plus rotates into an ×
-// while the menu is open — the face reacts to the trigger's `data-state`,
-// which both the Radix desktop trigger and the manual mobile button expose.
+// Shared face for the create control. Same anatomy as the account row beneath
+// it (left-aligned label, trailing chevron) so the footer reads as one stack;
+// the gold plus chip is the only accent and carries the create affordance.
+// The chevron flips while the menu is open — the face reacts to the trigger's
+// `data-state`, which both the Radix desktop trigger and the manual mobile
+// button expose.
 function SidebarCreateButtonFace() {
   return (
     <>
-      <Plus className="h-4 w-4 shrink-0 text-primary transition-transform duration-200 group-data-[state=open]/new:rotate-45" />
-      <span className="font-medium">New</span>
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/20 text-primary transition-colors group-hover/new:bg-primary/30 group-data-[state=open]/new:bg-primary/30">
+        <Plus className="h-4 w-4" />
+      </span>
+      <span className="flex-1 text-left font-medium">New</span>
+      <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/new:rotate-180" />
     </>
   )
 }
 
-// Hover and open share the same quiet treatment as the quick-action pills:
-// the surface deepens to muted, nothing else changes. Border and sizing are
-// constant across states, so nothing shifts (INV-21).
+// No resting wash — the row sits flush like its neighbors until interaction.
+// Hover/open use the account row's own bg-muted/50 so the two footer rows
+// behave identically; the chip warming is the only gold response (INV-21:
+// constant sizing, nothing shifts).
 const CREATE_BUTTON_CLASS = cn(
-  "group/new w-full justify-center gap-1.5 rounded-lg border border-border bg-background text-foreground",
-  "transition-colors hover:bg-muted/60 hover:text-foreground",
-  "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground"
+  "group/new w-full justify-start gap-2.5 px-3",
+  "hover:bg-muted/50 hover:text-foreground",
+  "data-[state=open]:bg-muted/50 data-[state=open]:text-foreground"
 )
 
 /**


### PR DESCRIPTION
## Problem

The "New" create control at the bottom of the sidebar had a few rough edges: a barely-there `bg-primary/[0.04]` resting wash that read as a smudge rather than a surface, a slightly timid plus chip, and a gold-tinted hover that didn't match how the account row directly beneath it behaves.

## Solution

Keep the original anatomy — left-aligned row, gold plus chip, `New` label, trailing chevron that flips while the menu is open — and refine the finish in `SidebarCreateButtonFace` / `CREATE_BUTTON_CLASS` (`sidebar-footer.tsx`):

- **No resting wash.** The row sits flush like its neighbors until interaction.
- **Slightly stronger chip** — `bg-primary/20`, warming to `/30` on hover/open, so the one gold accent reads intentional.
- **Neutral hover/open** — `bg-muted/50`, the same treatment as the account row below, so the footer reads as one coherent stack.

No behavior changes: same menu/drawer, same actions, same accessible name ("New").

### Design history

Two louder directions were tried on staging and rejected: a gold gradient pill with border and glow (cheesy), and a centered bordered-neutral control echoing the header's quick-action pills (worse — generic). The original row anatomy was right all along; only the finish needed work.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | Refined `SidebarCreateButtonFace` and `CREATE_BUTTON_CLASS`; no API or behavior changes |

## Test plan

- [x] `sidebar-footer.test.tsx` (6/6 pass) — including "opens the create drawer from the New button and exposes every stream flavor"
- [x] Frontend typecheck clean
- [x] Visually verified light + dark, rest/hover/open states by rendering the real component face through the app's Vite/Tailwind pipeline and screenshotting in Chromium (full app stack not runnable in this sandbox — no Docker)
- [ ] Eyeball on the per-PR staging environment (label applied)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GjPwdLdRKqWKkheaeAbh5v