### PR TITLE
feat: read-only feature flags tab in workspace settings

### DIFF
--- a/apps/frontend/src/components/workspace-settings/feature-flags-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/feature-flags-tab.tsx
@@ -1,0 +1,43 @@
+import { Badge } from "@/components/ui/badge"
+import { useOverriddenFeatureFlags } from "@/hooks/use-feature-flags"
+
+interface FeatureFlagsTabProps {
+  workspaceId: string
+}
+
+/**
+ * Read-only view of the viewer's feature flags that differ from the default.
+ * Flags at their default value are intentionally not listed, and the tab
+ * itself is hidden by the dialog when this list is empty — flag state never
+ * leaks beyond what is actually enabled for the viewer.
+ */
+export function FeatureFlagsTab({ workspaceId }: FeatureFlagsTabProps) {
+  const flags = useOverriddenFeatureFlags(workspaceId)
+
+  return (
+    <div className="space-y-4 p-1">
+      <p className="text-sm text-muted-foreground">
+        These flags are set to a non-default value for your account. They are managed by Threa and cannot be changed
+        here.
+      </p>
+
+      {flags.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No flags are set on your account.</p>
+      ) : (
+        <ul className="space-y-3">
+          {flags.map(({ key, value, defaultValue }) => (
+            <li key={key} className="flex items-center justify-between gap-3">
+              <div>
+                <div className="font-mono text-sm">{key}</div>
+                <div className="text-xs text-muted-foreground">Default: {defaultValue}</div>
+              </div>
+              <Badge variant="secondary" className="font-mono">
+                {value}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/workspace-settings/tab-config.ts
+++ b/apps/frontend/src/components/workspace-settings/tab-config.ts
@@ -9,6 +9,7 @@ export const WORKSPACE_SETTINGS_TABS = [
   "integrations",
   "bots",
   "api-keys",
+  "feature-flags",
 ] as const
 export type WorkspaceSettingsTab = (typeof WORKSPACE_SETTINGS_TABS)[number]
 
@@ -20,4 +21,5 @@ export const WORKSPACE_SETTINGS_TAB_CONFIG: Record<WorkspaceSettingsTab, { label
   integrations: { label: "Integrations", description: "Shared third-party connections" },
   bots: { label: "Bots", description: "Workspace automation accounts" },
   "api-keys": { label: "API Keys", description: "Create and revoke access keys" },
+  "feature-flags": { label: "Feature flags", description: "Rollout flags set on your account" },
 }

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { WorkspaceBootstrap } from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { WorkspaceSettingsDialog } from "./workspace-settings-dialog"
 import * as generalTabModule from "./general-tab"
 import * as usersTabModule from "./users-tab"
@@ -22,6 +25,22 @@ function WorkspaceSettingsRoute() {
   )
 }
 
+function renderDialog(initialEntry: string, queryClient = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<WorkspaceSettingsRoute />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function seedBootstrapFlags(queryClient: QueryClient, featureFlags: WorkspaceBootstrap["featureFlags"]) {
+  queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), { featureFlags } as WorkspaceBootstrap)
+}
+
 describe("WorkspaceSettingsDialog", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -34,13 +53,7 @@ describe("WorkspaceSettingsDialog", () => {
   it("uses the sidebar navigation and keeps URL tab state in sync", async () => {
     const user = userEvent.setup()
 
-    render(
-      <MemoryRouter initialEntries={["/w/ws_1?ws-settings=general"]}>
-        <Routes>
-          <Route path="/w/:workspaceId" element={<WorkspaceSettingsRoute />} />
-        </Routes>
-      </MemoryRouter>
-    )
+    renderDialog("/w/ws_1?ws-settings=general")
 
     expect(await screen.findByText("Workspace identity and region")).toBeInTheDocument()
     expect(screen.getByText("General panel")).toBeVisible()
@@ -62,5 +75,41 @@ describe("WorkspaceSettingsDialog", () => {
     })
     expect(screen.getByText("Bots panel")).toBeVisible()
     expect(screen.getByText("Members and pending invites")).toBeInTheDocument()
+  })
+
+  describe("feature flags tab", () => {
+    it("shows the tab with the viewer's non-default flags only", async () => {
+      const user = userEvent.setup()
+      const queryClient = new QueryClient()
+      seedBootstrapFlags(queryClient, { "sync-v2-cursor": "active" })
+
+      renderDialog("/w/ws_1?ws-settings=general", queryClient)
+
+      await user.click(await screen.findByRole("button", { name: /Feature flags/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search")).toHaveTextContent("?ws-settings=feature-flags")
+      })
+      expect(screen.getByText("sync-v2-cursor")).toBeVisible()
+      expect(screen.getByText("active")).toBeVisible()
+    })
+
+    it("hides the tab when every flag is at its default", async () => {
+      const queryClient = new QueryClient()
+      seedBootstrapFlags(queryClient, { "sync-v2-cursor": "shadow" })
+
+      renderDialog("/w/ws_1?ws-settings=general", queryClient)
+
+      expect(await screen.findByText("Workspace identity and region")).toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: /Feature flags/i })).not.toBeInTheDocument()
+    })
+
+    it("falls back to the general tab when deep-linked without any overridden flags", async () => {
+      renderDialog("/w/ws_1?ws-settings=feature-flags")
+
+      expect(await screen.findByText("General panel")).toBeVisible()
+      expect(screen.queryByRole("button", { name: /Feature flags/i })).not.toBeInTheDocument()
+      expect(screen.queryByText("sync-v2-cursor")).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
+++ b/apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx
@@ -15,7 +15,9 @@ import {
   WS_SETTINGS_PARAM,
   type WorkspaceSettingsTab,
 } from "./tab-config"
+import { useOverriddenFeatureFlags } from "@/hooks/use-feature-flags"
 import { GeneralTab } from "./general-tab"
+import { FeatureFlagsTab } from "./feature-flags-tab"
 import { UsersTab } from "./users-tab"
 import { ApiKeysTab } from "./api-keys-tab"
 import { BotsTab } from "./bots-tab"
@@ -31,11 +33,18 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
   const [searchParams, setSearchParams] = useSearchParams()
   const [mounted, setMounted] = useState(false)
 
+  // The feature flags view is read-only and deliberately absent (including via
+  // deep link) when the viewer has no non-default flags, so flag state is
+  // never surfaced beyond what is actually set for them.
+  const overriddenFlags = useOverriddenFeatureFlags(workspaceId)
+  const visibleTabs: readonly WorkspaceSettingsTab[] =
+    overriddenFlags.length > 0 ? WORKSPACE_SETTINGS_TABS : WORKSPACE_SETTINGS_TABS.filter((t) => t !== "feature-flags")
+
   const settingsParam = searchParams.get(WS_SETTINGS_PARAM)
   const normalizedSettingsParam = settingsParam === "members" ? "users" : settingsParam
   const isOpen = settingsParam !== null
   const activeTab: WorkspaceSettingsTab =
-    normalizedSettingsParam && WORKSPACE_SETTINGS_TABS.includes(normalizedSettingsParam as WorkspaceSettingsTab)
+    normalizedSettingsParam && visibleTabs.includes(normalizedSettingsParam as WorkspaceSettingsTab)
       ? (normalizedSettingsParam as WorkspaceSettingsTab)
       : "general"
 
@@ -79,7 +88,7 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
         >
           <div data-slot="settings-panels" className={SETTINGS_DIALOG_LAYOUT_CLASSNAMES.panels}>
             <ResponsiveSettingsNav
-              tabs={WORKSPACE_SETTINGS_TABS}
+              tabs={visibleTabs}
               items={WORKSPACE_SETTINGS_TAB_CONFIG}
               value={activeTab}
               onValueChange={setTab}
@@ -106,6 +115,9 @@ export function WorkspaceSettingsDialog({ workspaceId }: WorkspaceSettingsDialog
               </TabsContent>
               <TabsContent value="api-keys" className="mt-0">
                 <ApiKeysTab workspaceId={workspaceId} />
+              </TabsContent>
+              <TabsContent value="feature-flags" className="mt-0">
+                <FeatureFlagsTab workspaceId={workspaceId} />
               </TabsContent>
             </div>
           </div>

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -1,7 +1,10 @@
+import { useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   defaultFeatureFlagValue,
+  FEATURE_FLAG_KEYS,
   type FeatureFlagKey,
+  type FeatureFlags,
   type FeatureFlagValue,
   type WorkspaceBootstrap,
 } from "@threa/types"
@@ -41,4 +44,37 @@ export function useFeatureFlagWhenKnown<K extends FeatureFlagKey>(
  */
 export function useFeatureFlag<K extends FeatureFlagKey>(workspaceId: string, key: K): FeatureFlagValue<K> {
   return useFeatureFlagWhenKnown(workspaceId, key) ?? defaultFeatureFlagValue(key)
+}
+
+export interface OverriddenFeatureFlag {
+  key: FeatureFlagKey
+  value: FeatureFlagValue
+  defaultValue: FeatureFlagValue
+}
+
+/**
+ * The viewer's feature flags that are set to a non-default value, for the
+ * read-only flags view. Until the bootstrap is cached this returns `[]` —
+ * same "unknown renders as default" stance as {@link useFeatureFlag}, which
+ * here means showing nothing rather than leaking flag state.
+ */
+export function useOverriddenFeatureFlags(workspaceId: string): OverriddenFeatureFlag[] {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: workspaceKeys.bootstrap(workspaceId),
+    queryFn: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+    select: (bootstrap) => bootstrap?.featureFlags ?? null,
+  })
+  return useMemo(() => listOverriddenFlags(data), [data])
+}
+
+function listOverriddenFlags(flags: FeatureFlags | null | undefined): OverriddenFeatureFlag[] {
+  if (!flags) return []
+  return FEATURE_FLAG_KEYS.flatMap((key) => {
+    const value = flags[key]
+    const defaultValue = defaultFeatureFlagValue(key)
+    return value !== undefined && value !== defaultValue ? [{ key, value, defaultValue }] : []
+  })
 }


### PR DESCRIPTION
## Problem

Feature flags shipped with a backoffice UI for platform admins (#873), but there is no in-app surface where a user can see which flags are set on their own account. When support flips a flag for someone, the user has no way to confirm what's active for them.

The view must not leak flag state: disabled/unset flags (and the existence of the flags surface itself) should not be visible to users who have nothing set.

## Solution

A read-only **Feature flags** tab in the workspace settings dialog that lists only the viewer's flags set to a **non-default** value. When every flag is at its default, the tab does not exist: it's absent from the settings nav, and a deep link to `?ws-settings=feature-flags` falls back to the General tab.

### How it works

No new data crosses the wire. The viewer's resolved flag map already rides `WorkspaceBootstrap.featureFlags` and stays live via the `feature_flags:updated` socket event. A new `useOverriddenFeatureFlags(workspaceId)` hook reads the bootstrap cache (same cache-only observer pattern as `useFeatureFlag`) and filters to flags whose value differs from the registry default (first declared value). If the backoffice flips a flag while the dialog is open, the tab appears/disappears live.

### Key design decisions

**1. Workspace settings tab, not a new page**

The settings dialog is already the "findable if you know to look" surface, drives its active tab from the URL (INV-59), and has an established tab pattern. A dedicated route would be more surface area for a view that's usually empty.

**2. Hide the tab entirely when nothing is overridden**

Rather than showing an empty tab, the tab is filtered out of the nav and the deep-link falls back to General. "Only contains anything if flags are set for me" becomes "only exists if flags are set for me" — nothing about the flags surface leaks to users at defaults.

**3. Filter client-side against the shared registry**

The full resolved map (including defaults) is already in the client bundle and bootstrap payload by design, so "don't leak" is a presentation rule. Comparing against `defaultFeatureFlagValue(key)` from `@threa/types` keeps the default semantics in one place.

**4. Quick switcher untouched**

Verified its settings commands are hand-written per tab (general, users only), not derived from the tab config — so the new tab cannot leak through command search.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/workspace-settings/feature-flags-tab.tsx` | Read-only list of the viewer's non-default flags (key, value, default) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-feature-flags.ts` | Added `useOverriddenFeatureFlags` hook filtering bootstrap flags to non-default values |
| `apps/frontend/src/components/workspace-settings/tab-config.ts` | Registered the `feature-flags` tab |
| `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.tsx` | Conditional tab visibility + deep-link fallback to General when no overrides |
| `apps/frontend/src/components/workspace-settings/workspace-settings-dialog.test.tsx` | QueryClient wrapper + three new tests for the flag tab behavior |

## Test plan

- [x] Tab visible and lists the overridden flag when bootstrap has a non-default value
- [x] Tab hidden when every flag is at its default
- [x] Deep link `?ws-settings=feature-flags` falls back to General with no overrides
- [x] Full frontend suite passes (2,557 tests)
- [x] Monorepo typecheck + lint clean (pre-commit pipeline)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_018VwXFYYdnpD2XbMf6eysi6

---
_Generated by [Claude Code](https://claude.ai/code/session_018VwXFYYdnpD2XbMf6eysi6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783857644&installation_id=129946197&pr_number=879&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F879&signature=3afddfab08f8eff1ec3d47ab28b4b464e762828d80bccf535f71ada4c30c91f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->