### PR TITLE
feat: sync platform-admin access to regions and link the backoffice from the app

### DIFF
--- a/apps/backend/src/db/migrations/20260612113940_platform_admin_access.sql
+++ b/apps/backend/src/db/migrations/20260612113940_platform_admin_access.sql
@@ -1,0 +1,14 @@
+-- Regional mirror of control-plane platform-admin grants (platform_roles).
+-- Presence of a row = this workspace user is a platform admin and may see
+-- links into the backoffice (admin.threa.io). Keyed by workos_user_id rather
+-- than the regional users.id so a sync can land independently of regional
+-- user provisioning order. Populated only by the control-plane fan-out via
+-- POST /internal/platform-admin; never written by regional product code.
+
+CREATE TABLE IF NOT EXISTS platform_admin_access (
+    workspace_id TEXT NOT NULL,
+    workos_user_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, workos_user_id)
+);

--- a/apps/backend/src/features/platform-admin/handlers.ts
+++ b/apps/backend/src/features/platform-admin/handlers.ts
@@ -1,0 +1,34 @@
+import type { NextFunction, Request, Response } from "express"
+import { z } from "zod"
+import { HttpError } from "../../lib/errors"
+import type { PlatformAdminService } from "./service"
+
+const syncSchema = z.object({
+  workspaceId: z.string().min(1),
+  workosUserId: z.string().min(1),
+  isPlatformAdmin: z.boolean(),
+})
+
+interface Dependencies {
+  platformAdminService: PlatformAdminService
+}
+
+export function createPlatformAdminHandlers({ platformAdminService }: Dependencies) {
+  return {
+    /**
+     * POST /internal/platform-admin
+     * CP fan-out endpoint: replace one workspace user's platform-admin mirror
+     * row in this region (grant upserts, revoke deletes — idempotent).
+     */
+    async sync(req: Request, res: Response, next: NextFunction) {
+      const result = syncSchema.safeParse(req.body)
+      if (!result.success) {
+        next(new HttpError("Invalid request body", { status: 400, code: "VALIDATION_ERROR" }))
+        return
+      }
+
+      await platformAdminService.applySync(result.data)
+      res.status(204).end()
+    },
+  }
+}

--- a/apps/backend/src/features/platform-admin/index.ts
+++ b/apps/backend/src/features/platform-admin/index.ts
@@ -1,0 +1,3 @@
+export { createPlatformAdminHandlers } from "./handlers"
+export { PlatformAdminService, type ApplyPlatformAdminSyncInput } from "./service"
+export { PlatformAdminAccessRepository } from "./repository"

--- a/apps/backend/src/features/platform-admin/repository.ts
+++ b/apps/backend/src/features/platform-admin/repository.ts
@@ -1,0 +1,37 @@
+import { sql, type Querier } from "../../db"
+
+/**
+ * Regional mirror of control-plane platform-admin grants. Presence of a row
+ * means the workspace user is a platform admin. Rows are written only by the
+ * control-plane fan-out (`POST /internal/platform-admin`); regional product
+ * code reads them at bootstrap time.
+ */
+export const PlatformAdminAccessRepository = {
+  async hasAccess(db: Querier, workspaceId: string, workosUserId: string): Promise<boolean> {
+    const result = await db.query(sql`
+      SELECT 1 FROM platform_admin_access
+      WHERE workspace_id = ${workspaceId} AND workos_user_id = ${workosUserId}
+    `)
+    return result.rows.length > 0
+  },
+
+  /**
+   * Apply a control-plane snapshot for one workspace user: grant inserts the
+   * row, revoke deletes it. Both branches are single race-safe statements
+   * (INV-20) — concurrent syncs converge on the last writer.
+   */
+  async setAccess(db: Querier, workspaceId: string, workosUserId: string, isPlatformAdmin: boolean): Promise<void> {
+    if (isPlatformAdmin) {
+      await db.query(sql`
+        INSERT INTO platform_admin_access (workspace_id, workos_user_id)
+        VALUES (${workspaceId}, ${workosUserId})
+        ON CONFLICT (workspace_id, workos_user_id) DO UPDATE SET updated_at = NOW()
+      `)
+    } else {
+      await db.query(sql`
+        DELETE FROM platform_admin_access
+        WHERE workspace_id = ${workspaceId} AND workos_user_id = ${workosUserId}
+      `)
+    }
+  },
+}

--- a/apps/backend/src/features/platform-admin/service.test.ts
+++ b/apps/backend/src/features/platform-admin/service.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { PlatformAdminService } from "./service"
+import { PlatformAdminAccessRepository } from "./repository"
+
+const WORKSPACE_ID = "ws_1"
+const WORKOS_USER_ID = "workos_user_1"
+
+describe("PlatformAdminService.applySync", () => {
+  afterEach(() => mock.restore())
+
+  it("forwards a grant snapshot to the mirror row", async () => {
+    const setAccess = spyOn(PlatformAdminAccessRepository, "setAccess").mockResolvedValue()
+    const service = new PlatformAdminService({} as any)
+
+    await service.applySync({ workspaceId: WORKSPACE_ID, workosUserId: WORKOS_USER_ID, isPlatformAdmin: true })
+
+    expect(setAccess).toHaveBeenCalledWith({}, WORKSPACE_ID, WORKOS_USER_ID, true)
+  })
+
+  it("forwards a revoke snapshot so the mirror row is deleted", async () => {
+    const setAccess = spyOn(PlatformAdminAccessRepository, "setAccess").mockResolvedValue()
+    const service = new PlatformAdminService({} as any)
+
+    await service.applySync({ workspaceId: WORKSPACE_ID, workosUserId: WORKOS_USER_ID, isPlatformAdmin: false })
+
+    expect(setAccess).toHaveBeenCalledWith({}, WORKSPACE_ID, WORKOS_USER_ID, false)
+  })
+})
+
+describe("PlatformAdminService.hasAccess", () => {
+  afterEach(() => mock.restore())
+
+  it("reads the mirror row for the workspace user", async () => {
+    spyOn(PlatformAdminAccessRepository, "hasAccess").mockResolvedValue(true)
+    const service = new PlatformAdminService({} as any)
+
+    expect(await service.hasAccess(WORKSPACE_ID, WORKOS_USER_ID)).toBe(true)
+  })
+})

--- a/apps/backend/src/features/platform-admin/service.ts
+++ b/apps/backend/src/features/platform-admin/service.ts
@@ -1,0 +1,34 @@
+import type { Pool } from "pg"
+import { PlatformAdminAccessRepository } from "./repository"
+
+export interface ApplyPlatformAdminSyncInput {
+  workspaceId: string
+  workosUserId: string
+  /** Snapshot from the control plane — grants insert the mirror row, revokes delete it. */
+  isPlatformAdmin: boolean
+}
+
+/**
+ * Regional read/write surface for platform-admin access. The control plane
+ * owns the data (`platform_roles`) and pushes per-workspace snapshots through
+ * `applySync`; the bootstrap reads `hasAccess` so the frontend can gate links
+ * into the backoffice. There is no live broadcast — grants are rare operator
+ * actions, so the change takes effect on the viewer's next bootstrap.
+ */
+export class PlatformAdminService {
+  constructor(private pool: Pool) {}
+
+  async hasAccess(workspaceId: string, workosUserId: string): Promise<boolean> {
+    // Single query, INV-30
+    return PlatformAdminAccessRepository.hasAccess(this.pool, workspaceId, workosUserId)
+  }
+
+  async applySync(input: ApplyPlatformAdminSyncInput): Promise<void> {
+    await PlatformAdminAccessRepository.setAccess(
+      this.pool,
+      input.workspaceId,
+      input.workosUserId,
+      input.isPlatformAdmin
+    )
+  }
+}

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -5,6 +5,7 @@ import type { StreamService } from "../streams"
 import type { UserPreferencesService } from "../user-preferences"
 import type { WorkspaceSettingsService } from "../workspace-settings"
 import type { FeatureFlagService } from "../feature-flags"
+import type { PlatformAdminService } from "../platform-admin"
 import type { SidebarConfigService } from "../sidebar-config"
 import type { InvitationService } from "../invitations"
 import type { ActivityService } from "../activity"
@@ -55,6 +56,7 @@ interface Dependencies {
   userPreferencesService: UserPreferencesService
   workspaceSettingsService: WorkspaceSettingsService
   featureFlagService: FeatureFlagService
+  platformAdminService: PlatformAdminService
   sidebarConfigService: SidebarConfigService
   invitationService: InvitationService
   activityService?: ActivityService
@@ -72,6 +74,7 @@ export function createWorkspaceHandlers({
   userPreferencesService,
   workspaceSettingsService,
   featureFlagService,
+  platformAdminService,
   sidebarConfigService,
   invitationService,
   activityService,
@@ -149,6 +152,7 @@ export function createWorkspaceHandlers({
         userPreferences,
         workspaceSettings,
         featureFlags,
+        viewerIsPlatformAdmin,
         sidebarConfig,
         dmPeers,
         labels,
@@ -164,6 +168,7 @@ export function createWorkspaceHandlers({
         userPreferencesService.getPreferences(workspaceId, userId),
         workspaceSettingsService.getSettings(workspaceId),
         featureFlagService.getFlags(workspaceId, userId),
+        platformAdminService.hasAccess(workspaceId, req.user!.workosUserId),
         sidebarConfigService.getConfig(workspaceId, userId),
         streamService.listDmPeers(workspaceId, userId),
         labelService.listVisibleTo(workspaceId, userId),
@@ -262,6 +267,7 @@ export function createWorkspaceHandlers({
           labelAssignments,
           invitations,
           viewerPermissions,
+          viewerIsPlatformAdmin,
         },
       })
     },

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -10,6 +10,7 @@ import { createRequireBotManagement } from "./middleware/bot-management"
 import { createRequireWorkspacePermission } from "./middleware/workspace-permission"
 import { createWorkspaceAuthzHandlers, WorkspaceAuthzService } from "./features/workspace-authz"
 import { createFeatureFlagHandlers, type FeatureFlagService } from "./features/feature-flags"
+import { createPlatformAdminHandlers, type PlatformAdminService } from "./features/platform-admin"
 import { createAuthHandlers } from "./auth/handlers"
 import { createWorkspaceHandlers, WorkspaceRepository } from "./features/workspaces"
 import { createWorkspaceMemberManagementHandlers } from "./features/workspace-members"
@@ -108,6 +109,7 @@ interface Dependencies {
   userPreferencesService: UserPreferencesService
   workspaceSettingsService: WorkspaceSettingsService
   featureFlagService: FeatureFlagService
+  platformAdminService: PlatformAdminService
   sidebarConfigService: SidebarConfigService
   userE2eKeysService: UserE2eKeysService
   invitationService: InvitationService
@@ -160,6 +162,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     userPreferencesService,
     workspaceSettingsService,
     featureFlagService,
+    platformAdminService,
     sidebarConfigService,
     userE2eKeysService,
     invitationService,
@@ -204,6 +207,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const requireWorkspacePermission = createRequireWorkspacePermission()
   const workspaceAuthz = createWorkspaceAuthzHandlers({ workspaceAuthzService })
   const featureFlags = createFeatureFlagHandlers({ featureFlagService })
+  const platformAdmin = createPlatformAdminHandlers({ platformAdminService })
 
   const rateLimits = createRateLimiters(rateLimiterConfig)
   const opsAccess = createOpsAccessMiddleware()
@@ -217,6 +221,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     userPreferencesService,
     workspaceSettingsService,
     featureFlagService,
+    platformAdminService,
     sidebarConfigService,
     invitationService,
     activityService,
@@ -289,6 +294,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app.post("/internal/invitations/claim-link", internalAuth, invitation.claimLink)
     app.post("/internal/authz/memberships", internalAuth, workspaceAuthz.syncMembership)
     app.post("/internal/feature-flags", internalAuth, featureFlags.sync)
+    app.post("/internal/platform-admin", internalAuth, platformAdmin.sync)
 
     // Enclave runtime registry — each enclave instance authenticates with the
     // same shared internal secret to register/refresh/retire its EIK.

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -77,6 +77,7 @@ import {
 import { UserPreferencesService } from "./features/user-preferences"
 import { WorkspaceSettingsService } from "./features/workspace-settings"
 import { FeatureFlagService } from "./features/feature-flags"
+import { PlatformAdminService } from "./features/platform-admin"
 import { SidebarConfigService } from "./features/sidebar-config"
 import { UserE2eKeysService } from "./features/user-e2e-keys"
 import { createS3Storage } from "./lib/storage/s3-client"
@@ -270,6 +271,7 @@ export async function startServer(): Promise<ServerInstance> {
   const userPreferencesService = new UserPreferencesService(pool)
   const workspaceSettingsService = new WorkspaceSettingsService(pool)
   const featureFlagService = new FeatureFlagService(pool)
+  const platformAdminService = new PlatformAdminService(pool)
   const sidebarConfigService = new SidebarConfigService(pool)
   const userE2eKeysService = new UserE2eKeysService(pool)
 
@@ -616,6 +618,7 @@ export async function startServer(): Promise<ServerInstance> {
     userPreferencesService,
     workspaceSettingsService,
     featureFlagService,
+    platformAdminService,
     sidebarConfigService,
     userE2eKeysService,
     invitationService,

--- a/apps/control-plane/src/features/invitation-shadows/service.ts
+++ b/apps/control-plane/src/features/invitation-shadows/service.ts
@@ -12,6 +12,8 @@ import { InvitationShadowRepository } from "./repository"
 import { WorkspaceRegistryRepository } from "../workspaces"
 import { RegionalClaimError, type RegionalClient } from "../../lib/regional-client"
 import type { InvitationLinkLookupResponse, PendingInvitation, WorkspaceInvitableRole } from "@threa/types"
+// Type-only to avoid a runtime module cycle; injected by the composition root.
+import type { PlatformAdminSyncService } from "../platform-admin"
 
 function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex")
@@ -32,17 +34,20 @@ interface Dependencies {
   pool: Pool
   regionalClient: RegionalClient
   workosOrgService: WorkosOrgService
+  platformAdminSync: PlatformAdminSyncService
 }
 
 export class InvitationShadowService {
   private pool: Pool
   private regionalClient: RegionalClient
   private workosOrgService: WorkosOrgService
+  private platformAdminSync: PlatformAdminSyncService
 
-  constructor({ pool, regionalClient, workosOrgService }: Dependencies) {
+  constructor({ pool, regionalClient, workosOrgService, platformAdminSync }: Dependencies) {
     this.pool = pool
     this.regionalClient = regionalClient
     this.workosOrgService = workosOrgService
+    this.platformAdminSync = platformAdminSync
   }
 
   private resolveDisplayName(user: ShadowUser): string {
@@ -108,6 +113,9 @@ export class InvitationShadowService {
 
       // Regional call succeeded — commit membership alongside the claim
       await WorkspaceRegistryRepository.insertMembership(client, shadow.workspace_id, user.id)
+      // An invited platform admin should see backoffice links in the joined
+      // workspace without waiting for the next control-plane restart.
+      await this.platformAdminSync.enqueueIfAdmin(client, user.id)
       return { workspaceId: shadow.workspace_id }
     })
 

--- a/apps/control-plane/src/features/platform-admin/index.ts
+++ b/apps/control-plane/src/features/platform-admin/index.ts
@@ -1,0 +1,1 @@
+export { PlatformAdminSyncService, OUTBOX_PLATFORM_ADMIN_SYNC, type PlatformAdminSyncPayload } from "./sync"

--- a/apps/control-plane/src/features/platform-admin/sync.ts
+++ b/apps/control-plane/src/features/platform-admin/sync.ts
@@ -1,0 +1,106 @@
+import type { Pool } from "pg"
+import { logger, OutboxRepository, type Querier } from "@threa/backend-common"
+import { PlatformRoleRepository } from "../backoffice"
+import { WorkspaceRegistryRepository } from "../workspaces"
+import type { RegionalClient } from "../../lib/regional-client"
+
+export const OUTBOX_PLATFORM_ADMIN_SYNC = "platform_admin_sync"
+
+/**
+ * Outbox payload for the regional fan-out. Carries only identity — the
+ * handler re-reads the grant and the user's memberships at delivery time and
+ * pushes a full snapshot, so rapid changes collapse to the latest state and
+ * replays are idempotent (same shape as the feature-flags sync).
+ */
+export interface PlatformAdminSyncPayload extends Record<string, unknown> {
+  workosUserId: string
+}
+
+interface Dependencies {
+  pool: Pool
+  regionalClient: RegionalClient
+}
+
+/**
+ * Pushes control-plane platform-admin grants (`platform_roles`) to the
+ * regional `platform_admin_access` mirrors so the product app can gate links
+ * into the backoffice. The control plane stays the authorization source of
+ * truth — the mirror is cosmetic (UI gating only); the backoffice re-checks
+ * `requirePlatformAdmin` on every request regardless.
+ *
+ * Emission points:
+ * - startup seeding (`seedPlatformAdmins` callers) — re-emits every boot,
+ *   which doubles as self-heal for any membership created while an emit was
+ *   missed or a region was unreachable;
+ * - membership creation (workspace create, invitation accept) via
+ *   `enqueueIfAdmin`, so an admin's brand-new workspace shows the link
+ *   without waiting for the next control-plane restart.
+ */
+export class PlatformAdminSyncService {
+  private pool: Pool
+  private regionalClient: RegionalClient
+
+  constructor({ pool, regionalClient }: Dependencies) {
+    this.pool = pool
+    this.regionalClient = regionalClient
+  }
+
+  /** Enqueue a fan-out for one user. Pass the transaction client to commit atomically (INV-7). */
+  async enqueue(db: Querier, workosUserId: string): Promise<void> {
+    await OutboxRepository.insert(db, OUTBOX_PLATFORM_ADMIN_SYNC, {
+      workosUserId,
+    } satisfies PlatformAdminSyncPayload)
+  }
+
+  /**
+   * Enqueue only when the user actually holds a platform-admin grant — the
+   * membership-creation hook. Non-admins (the overwhelmingly common case)
+   * cost one indexed read and no event; their regional default is already
+   * "no access".
+   */
+  async enqueueIfAdmin(db: Querier, workosUserId: string): Promise<void> {
+    const row = await PlatformRoleRepository.findByWorkosUserId(db, workosUserId)
+    if (row?.role === "admin") {
+      await this.enqueue(db, workosUserId)
+    }
+  }
+
+  /**
+   * Outbox handler: re-read the grant and fan the snapshot out to every
+   * workspace the user belongs to, in parallel. Partial failures are
+   * aggregated and rethrown so the outbox retries (successful regions just
+   * re-apply an idempotent snapshot).
+   */
+  async syncToRegions(payload: PlatformAdminSyncPayload): Promise<void> {
+    const role = await PlatformRoleRepository.findByWorkosUserId(this.pool, payload.workosUserId)
+    const isPlatformAdmin = role?.role === "admin"
+    const workspaces = await WorkspaceRegistryRepository.listByUser(this.pool, payload.workosUserId)
+    if (workspaces.length === 0) return
+
+    const results = await Promise.allSettled(
+      workspaces.map((ws) =>
+        this.regionalClient.syncPlatformAdminAccess(ws.region, {
+          workspaceId: ws.id,
+          workosUserId: payload.workosUserId,
+          isPlatformAdmin,
+        })
+      )
+    )
+
+    const errors: unknown[] = []
+    results.forEach((result, idx) => {
+      if (result.status === "rejected") {
+        const ws = workspaces[idx]
+        logger.error(
+          { err: result.reason, region: ws.region, workspaceId: ws.id, workosUserId: payload.workosUserId },
+          "Regional platform-admin sync failed for workspace"
+        )
+        errors.push(result.reason)
+      }
+    })
+
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Regional platform-admin sync failed for one or more workspaces")
+    }
+  }
+}

--- a/apps/control-plane/src/features/platform-admin/sync.ts
+++ b/apps/control-plane/src/features/platform-admin/sync.ts
@@ -45,11 +45,19 @@ export class PlatformAdminSyncService {
     this.regionalClient = regionalClient
   }
 
-  /** Enqueue a fan-out for one user. Pass the transaction client to commit atomically (INV-7). */
-  async enqueue(db: Querier, workosUserId: string): Promise<void> {
-    await OutboxRepository.insert(db, OUTBOX_PLATFORM_ADMIN_SYNC, {
-      workosUserId,
-    } satisfies PlatformAdminSyncPayload)
+  /**
+   * Enqueue fan-outs for a batch of users in one round-trip (INV-56) — the
+   * startup-seeding path. Pass the transaction client to commit atomically
+   * with surrounding writes (INV-7).
+   */
+  async enqueueMany(db: Querier, workosUserIds: string[]): Promise<void> {
+    await OutboxRepository.insertMany(
+      db,
+      workosUserIds.map((workosUserId) => ({
+        eventType: OUTBOX_PLATFORM_ADMIN_SYNC,
+        payload: { workosUserId } satisfies PlatformAdminSyncPayload,
+      }))
+    )
   }
 
   /**
@@ -61,7 +69,9 @@ export class PlatformAdminSyncService {
   async enqueueIfAdmin(db: Querier, workosUserId: string): Promise<void> {
     const row = await PlatformRoleRepository.findByWorkosUserId(db, workosUserId)
     if (row?.role === "admin") {
-      await this.enqueue(db, workosUserId)
+      await OutboxRepository.insert(db, OUTBOX_PLATFORM_ADMIN_SYNC, {
+        workosUserId,
+      } satisfies PlatformAdminSyncPayload)
     }
   }
 

--- a/apps/control-plane/src/features/workspaces/service.ts
+++ b/apps/control-plane/src/features/workspaces/service.ts
@@ -14,6 +14,10 @@ import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
 import { WorkspaceRegistryRepository } from "./repository"
 import type { RegionalClient } from "../../lib/regional-client"
 import type { KvClient } from "../../lib/cloudflare-kv-client"
+// Type-only: the platform-admin feature imports this feature's repository, so
+// a value import here would create a runtime module cycle. The instance is
+// injected by the composition root instead.
+import type { PlatformAdminSyncService } from "../platform-admin"
 
 export const OUTBOX_KV_SYNC = "kv_sync"
 export const OUTBOX_REGIONAL_CREATE = "regional_create"
@@ -23,6 +27,7 @@ interface Dependencies {
   regionalClient: RegionalClient
   workosOrgService: WorkosOrgService
   kvClient: KvClient
+  platformAdminSync: PlatformAdminSyncService
   availableRegions: string[]
   requireWorkspaceCreationInvite: boolean
 }
@@ -32,6 +37,7 @@ export class ControlPlaneWorkspaceService {
   private regionalClient: RegionalClient
   private workosOrgService: WorkosOrgService
   private kvClient: KvClient
+  private platformAdminSync: PlatformAdminSyncService
   private availableRegions: Set<string>
   private requireInvite: boolean
 
@@ -40,6 +46,7 @@ export class ControlPlaneWorkspaceService {
     this.regionalClient = deps.regionalClient
     this.workosOrgService = deps.workosOrgService
     this.kvClient = deps.kvClient
+    this.platformAdminSync = deps.platformAdminSync
     this.availableRegions = new Set(deps.availableRegions)
     this.requireInvite = deps.requireWorkspaceCreationInvite
   }
@@ -140,6 +147,10 @@ export class ControlPlaneWorkspaceService {
             ownerName: displayName,
           })
           await OutboxRepository.insert(client, OUTBOX_KV_SYNC, { workspaceId: id, region })
+
+          // A platform admin's new workspace should show backoffice links
+          // without waiting for the next control-plane restart to re-seed.
+          await this.platformAdminSync.enqueueIfAdmin(client, workosUserId)
 
           return ws
         })

--- a/apps/control-plane/src/lib/regional-client.ts
+++ b/apps/control-plane/src/lib/regional-client.ts
@@ -100,14 +100,19 @@ export class RegionalClient {
       lastEventAt: Date
     }
   ): Promise<void> {
-    await this.postToAuthzMemberships(region, "sync", {
-      kind: "upsert",
-      workspaceId: data.workspaceId,
-      workosUserId: data.workosUserId,
-      roleSlugs: data.roleSlugs,
-      status: data.status,
-      lastEventAt: data.lastEventAt.toISOString(),
-    })
+    await this.postInternal(
+      region,
+      "/internal/authz/memberships",
+      {
+        kind: "upsert",
+        workspaceId: data.workspaceId,
+        workosUserId: data.workosUserId,
+        roleSlugs: data.roleSlugs,
+        status: data.status,
+        lastEventAt: data.lastEventAt.toISOString(),
+      },
+      "Regional authz membership sync"
+    )
   }
 
   /**
@@ -119,25 +124,31 @@ export class RegionalClient {
     region: string,
     data: { workspaceId: string; workosUserId: string; eventCreatedAt: Date }
   ): Promise<void> {
-    await this.postToAuthzMemberships(region, "removal", {
-      kind: "remove",
-      workspaceId: data.workspaceId,
-      workosUserId: data.workosUserId,
-      eventCreatedAt: data.eventCreatedAt.toISOString(),
-    })
+    await this.postInternal(
+      region,
+      "/internal/authz/memberships",
+      {
+        kind: "remove",
+        workspaceId: data.workspaceId,
+        workosUserId: data.workosUserId,
+        eventCreatedAt: data.eventCreatedAt.toISOString(),
+      },
+      "Regional authz membership removal"
+    )
   }
 
   /**
-   * Shared transport for `POST /internal/authz/memberships`. The two callers
-   * differ only in the discriminated-union body and the log verb, so headers,
-   * timeout, error normalization, and HTTP plumbing live here once.
+   * Shared transport for fire-and-forget internal POSTs (no response body
+   * needed). Headers, timeout, error normalization, and HTTP plumbing live
+   * here once; callers differ only in path, body, and the log label.
    */
-  private async postToAuthzMemberships(
+  private async postInternal(
     region: string,
-    op: "sync" | "removal",
-    body: Record<string, unknown>
+    path: string,
+    body: Record<string, unknown>,
+    logContext: string
   ): Promise<void> {
-    const url = `${this.getRegionUrl(region)}/internal/authz/memberships`
+    const url = `${this.getRegionUrl(region)}${path}`
     let res: Response
     try {
       res = await fetch(url, {
@@ -150,13 +161,13 @@ export class RegionalClient {
         signal: AbortSignal.timeout(REGIONAL_REQUEST_TIMEOUT_MS),
       })
     } catch (err) {
-      logger.error({ err, region, url }, `Regional authz membership ${op} request failed`)
+      logger.error({ err, region, url }, `${logContext} request failed`)
       throw err
     }
 
     if (!res.ok) {
       const responseBody = await res.text().catch(() => "")
-      logger.error({ region, status: res.status, body: responseBody }, `Regional authz membership ${op} failed`)
+      logger.error({ region, status: res.status, body: responseBody }, `${logContext} failed`)
       throw new Error(`Regional backend returned ${res.status}: ${responseBody}`)
     }
   }
@@ -170,28 +181,7 @@ export class RegionalClient {
     region: string,
     data: { workspaceId: string; workosUserId: string; flags: Record<string, string> }
   ): Promise<void> {
-    const url = `${this.getRegionUrl(region)}/internal/feature-flags`
-    let res: Response
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          [INTERNAL_API_KEY_HEADER]: this.internalApiKey,
-        },
-        body: JSON.stringify(data),
-        signal: AbortSignal.timeout(REGIONAL_REQUEST_TIMEOUT_MS),
-      })
-    } catch (err) {
-      logger.error({ err, region, url }, "Regional feature flag sync request failed")
-      throw err
-    }
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "")
-      logger.error({ region, status: res.status, body }, "Regional feature flag sync failed")
-      throw new Error(`Regional backend returned ${res.status}: ${body}`)
-    }
+    await this.postInternal(region, "/internal/feature-flags", data, "Regional feature flag sync")
   }
 
   /**
@@ -203,28 +193,7 @@ export class RegionalClient {
     region: string,
     data: { workspaceId: string; workosUserId: string; isPlatformAdmin: boolean }
   ): Promise<void> {
-    const url = `${this.getRegionUrl(region)}/internal/platform-admin`
-    let res: Response
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          [INTERNAL_API_KEY_HEADER]: this.internalApiKey,
-        },
-        body: JSON.stringify(data),
-        signal: AbortSignal.timeout(REGIONAL_REQUEST_TIMEOUT_MS),
-      })
-    } catch (err) {
-      logger.error({ err, region, url }, "Regional platform-admin sync request failed")
-      throw err
-    }
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "")
-      logger.error({ region, status: res.status, body }, "Regional platform-admin sync failed")
-      throw new Error(`Regional backend returned ${res.status}: ${body}`)
-    }
+    await this.postInternal(region, "/internal/platform-admin", data, "Regional platform-admin sync")
   }
 
   /**

--- a/apps/control-plane/src/lib/regional-client.ts
+++ b/apps/control-plane/src/lib/regional-client.ts
@@ -195,6 +195,39 @@ export class RegionalClient {
   }
 
   /**
+   * Push one workspace user's platform-admin grant to the regional
+   * `platform_admin_access` mirror. Snapshot semantics keep the call
+   * idempotent and replay-safe — a grant upserts the row, a revoke deletes it.
+   */
+  async syncPlatformAdminAccess(
+    region: string,
+    data: { workspaceId: string; workosUserId: string; isPlatformAdmin: boolean }
+  ): Promise<void> {
+    const url = `${this.getRegionUrl(region)}/internal/platform-admin`
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [INTERNAL_API_KEY_HEADER]: this.internalApiKey,
+        },
+        body: JSON.stringify(data),
+        signal: AbortSignal.timeout(REGIONAL_REQUEST_TIMEOUT_MS),
+      })
+    } catch (err) {
+      logger.error({ err, region, url }, "Regional platform-admin sync request failed")
+      throw err
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      logger.error({ region, status: res.status, body }, "Regional platform-admin sync failed")
+      throw new Error(`Regional backend returned ${res.status}: ${body}`)
+    }
+  }
+
+  /**
    * Forward a link-invitation claim from CP to the regional backend that owns
    * the row. Regional performs the atomic claim (INV-20). On 4xx, surfaces the
    * upstream error code so CP can map it to an HTTP status without parsing.

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -49,6 +49,11 @@ import {
   OUTBOX_FEATURE_FLAGS_SYNC,
   type FeatureFlagsSyncPayload,
 } from "./features/feature-flags"
+import {
+  PlatformAdminSyncService,
+  OUTBOX_PLATFORM_ADMIN_SYNC,
+  type PlatformAdminSyncPayload,
+} from "./features/platform-admin"
 import { WorkosEventPollerLock } from "./lib/workos-event-poller-lock"
 import { CONTROL_PLANE_LISTENER_ID } from "./lib/outbox-listeners"
 
@@ -78,21 +83,29 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   const kvClient: KvClient = config.cloudflareKv ? new CloudflareKvClient(config.cloudflareKv) : new NoopKvClient()
 
   const availableRegions = Object.keys(config.regions)
+  const platformAdminSync = new PlatformAdminSyncService({ pool, regionalClient })
   const workspaceService = new ControlPlaneWorkspaceService({
     pool,
     regionalClient,
     workosOrgService,
     kvClient,
+    platformAdminSync,
     availableRegions,
     requireWorkspaceCreationInvite: config.workspaceCreationRequiresInvite,
   })
-  const shadowService = new InvitationShadowService({ pool, regionalClient, workosOrgService })
+  const shadowService = new InvitationShadowService({ pool, regionalClient, workosOrgService, platformAdminSync })
   const waitlistEmailSender = config.waitlist.resendApiKey
     ? new ResendWaitlistEmailSender({ apiKey: config.waitlist.resendApiKey, from: config.waitlist.fromEmail })
     : new StubWaitlistEmailSender()
   const waitlistService = new WaitlistService({ pool, emailSender: waitlistEmailSender })
   const workosAuthzAdminService = new WorkosAuthzAdminService({ pool, workosOrgService })
   await seedPlatformAdmins(pool, config.platformAdminWorkosUserIds)
+  // Re-emitting the fan-out for every seeded admin on each boot is the
+  // self-heal path: idempotent snapshots, tiny N, and it converges regions
+  // that missed a membership-time emit or were unreachable during one.
+  for (const workosUserId of config.platformAdminWorkosUserIds) {
+    await platformAdminSync.enqueue(pool, workosUserId)
+  }
 
   // Outbox — single handler for all control-plane events (no sharding needed)
   const cursorLock = new CursorLock({
@@ -117,7 +130,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
       let lastError: Error | undefined
       for (const event of events) {
         try {
-          await dispatchEvent(event, { workspaceService, authzFanOut, featureFlagService })
+          await dispatchEvent(event, { workspaceService, authzFanOut, featureFlagService, platformAdminSync })
           seen.push(event.id)
         } catch (err) {
           lastError = err instanceof Error ? err : new Error(String(err))
@@ -280,6 +293,7 @@ async function dispatchEvent(
     workspaceService: ControlPlaneWorkspaceService
     authzFanOut: RegionalAuthzFanOut
     featureFlagService: ControlPlaneFeatureFlagService
+    platformAdminSync: PlatformAdminSyncService
   }
 ): Promise<void> {
   const payload = event.payload as unknown
@@ -298,6 +312,9 @@ async function dispatchEvent(
       break
     case OUTBOX_FEATURE_FLAGS_SYNC:
       await deps.featureFlagService.syncToRegion(payload as FeatureFlagsSyncPayload)
+      break
+    case OUTBOX_PLATFORM_ADMIN_SYNC:
+      await deps.platformAdminSync.syncToRegions(payload as PlatformAdminSyncPayload)
       break
     default:
       logger.warn({ eventType: event.eventType }, "Unknown outbox event type")

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -103,9 +103,7 @@ export async function startServer(): Promise<ControlPlaneInstance> {
   // Re-emitting the fan-out for every seeded admin on each boot is the
   // self-heal path: idempotent snapshots, tiny N, and it converges regions
   // that missed a membership-time emit or were unreachable during one.
-  for (const workosUserId of config.platformAdminWorkosUserIds) {
-    await platformAdminSync.enqueue(pool, workosUserId)
-  }
+  await platformAdminSync.enqueueMany(pool, config.platformAdminWorkosUserIds)
 
   // Outbox — single handler for all control-plane events (no sharding needed)
   const cursorLock = new CursorLock({

--- a/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
+++ b/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
@@ -3,6 +3,7 @@ import type { Pool } from "pg"
 import { StubWorkosOrgService } from "@threa/backend-common"
 import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
 import { InvitationShadowRepository, InvitationShadowService } from "../../src/features/invitation-shadows"
+import type { PlatformAdminSyncService } from "../../src/features/platform-admin"
 import type { RegionalClient } from "../../src/lib/regional-client"
 import { setupTestDatabase } from "./setup"
 
@@ -40,7 +41,13 @@ describe("InvitationShadowService role_slug propagation", () => {
     // suite doesn't exercise. A bare object satisfies the type without binding
     // to a live region map.
     regional = {} as RegionalClient
-    service = new InvitationShadowService({ pool, regionalClient: regional, workosOrgService: workos })
+    service = new InvitationShadowService({
+      pool,
+      regionalClient: regional,
+      workosOrgService: workos,
+      // The accept path isn't exercised here, so the sync hook never runs.
+      platformAdminSync: {} as PlatformAdminSyncService,
+    })
 
     await pool.query(
       `INSERT INTO workspace_registry (id, name, slug, region, created_by_workos_user_id, workos_organization_id)

--- a/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
+++ b/apps/control-plane/tests/integration/invitation-shadow-role-slug.test.ts
@@ -3,7 +3,7 @@ import type { Pool } from "pg"
 import { StubWorkosOrgService } from "@threa/backend-common"
 import { WORKSPACE_ROLE_SLUGS } from "@threa/types"
 import { InvitationShadowRepository, InvitationShadowService } from "../../src/features/invitation-shadows"
-import type { PlatformAdminSyncService } from "../../src/features/platform-admin"
+import { PlatformAdminSyncService } from "../../src/features/platform-admin"
 import type { RegionalClient } from "../../src/lib/regional-client"
 import { setupTestDatabase } from "./setup"
 
@@ -45,8 +45,10 @@ describe("InvitationShadowService role_slug propagation", () => {
       pool,
       regionalClient: regional,
       workosOrgService: workos,
-      // The accept path isn't exercised here, so the sync hook never runs.
-      platformAdminSync: {} as PlatformAdminSyncService,
+      // Real service: acceptShadow calls enqueueIfAdmin, which only reads
+      // platform_roles and writes the outbox — the invitee holds no grant in
+      // this suite, so it never reaches the regional client.
+      platformAdminSync: new PlatformAdminSyncService({ pool, regionalClient: regional }),
     })
 
     await pool.query(

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
@@ -25,6 +25,8 @@ export interface SidebarActionItem {
   /** Optional muted second line under the label (e.g. "Clears in 2 hours"). */
   description?: string | null
   href?: string
+  /** Render `href` as a plain anchor opening in a new tab (cross-origin destinations). */
+  external?: boolean
   onSelect?: () => void | Promise<void>
   variant?: "default" | "destructive"
   separatorBefore?: boolean
@@ -92,31 +94,54 @@ function SidebarActionContent({ action, iconClassName }: { action: SidebarAction
 function SidebarActionMenuEntry({ action }: { action: SidebarActionItem }) {
   const isDestructive = action.variant === "destructive"
   const content = <SidebarActionContent action={action} iconClassName="mr-2 h-4 w-4" />
+  const itemClassName = cn(isDestructive && "text-destructive focus:text-destructive")
 
-  return (
-    <div>
-      {action.separatorBefore && <DropdownMenuSeparator />}
-      {action.href ? (
-        <DropdownMenuItem asChild className={cn(isDestructive && "text-destructive focus:text-destructive")}>
-          <Link
-            to={action.href}
-            onClick={() => {
-              void runSidebarAction(action)
-            }}
-          >
-            {content}
-          </Link>
-        </DropdownMenuItem>
-      ) : (
-        <DropdownMenuItem
-          className={cn(isDestructive && "text-destructive focus:text-destructive")}
-          onSelect={() => {
+  let item: ReactNode
+  if (action.href && action.external) {
+    item = (
+      <DropdownMenuItem asChild className={itemClassName}>
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
             void runSidebarAction(action)
           }}
         >
           {content}
-        </DropdownMenuItem>
-      )}
+        </a>
+      </DropdownMenuItem>
+    )
+  } else if (action.href) {
+    item = (
+      <DropdownMenuItem asChild className={itemClassName}>
+        <Link
+          to={action.href}
+          onClick={() => {
+            void runSidebarAction(action)
+          }}
+        >
+          {content}
+        </Link>
+      </DropdownMenuItem>
+    )
+  } else {
+    item = (
+      <DropdownMenuItem
+        className={itemClassName}
+        onSelect={() => {
+          void runSidebarAction(action)
+        }}
+      >
+        {content}
+      </DropdownMenuItem>
+    )
+  }
+
+  return (
+    <div>
+      {action.separatorBefore && <DropdownMenuSeparator />}
+      {item}
     </div>
   )
 }
@@ -250,32 +275,36 @@ function SidebarActionDrawerEntry({ action, onClose }: { action: SidebarActionIt
     />
   )
 
+  const handleClick = () => {
+    onClose()
+    void runSidebarAction(action)
+  }
+
+  let item: ReactNode
+  if (action.href && action.external) {
+    item = (
+      <a href={action.href} target="_blank" rel="noreferrer" className={className} onClick={handleClick}>
+        {content}
+      </a>
+    )
+  } else if (action.href) {
+    item = (
+      <Link to={action.href} className={className} onClick={handleClick}>
+        {content}
+      </Link>
+    )
+  } else {
+    item = (
+      <button type="button" className={className} onClick={handleClick}>
+        {content}
+      </button>
+    )
+  }
+
   return (
     <div>
       {action.separatorBefore && <Divider />}
-      {action.href ? (
-        <Link
-          to={action.href}
-          className={className}
-          onClick={() => {
-            onClose()
-            void runSidebarAction(action)
-          }}
-        >
-          {content}
-        </Link>
-      ) : (
-        <button
-          type="button"
-          className={className}
-          onClick={() => {
-            onClose()
-            void runSidebarAction(action)
-          }}
-        >
-          {content}
-        </button>
-      )}
+      {item}
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.test.tsx
@@ -3,7 +3,9 @@ import { User as UserIcon } from "lucide-react"
 import { describe, expect, it, beforeEach, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { WorkspaceBootstrap } from "@threa/types"
 import { render, screen, userEvent, spyOnExport } from "@/test"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { SidebarFooter } from "./sidebar-footer"
 import * as authModule from "@/auth"
 import * as contextsModule from "@/contexts"
@@ -16,10 +18,10 @@ const openSettings = vi.fn()
 const collapseOnMobile = vi.fn()
 const isMobile = { value: true }
 
-function renderWithRouter(ui: React.ReactElement) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+function renderWithRouter(ui: React.ReactElement, queryClient?: QueryClient) {
+  const client = queryClient ?? new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       <MemoryRouter>{ui}</MemoryRouter>
     </QueryClientProvider>
   )
@@ -319,6 +321,95 @@ describe("SidebarFooter", () => {
     expect(screen.getAllByText(/Notifications paused/i).length).toBeGreaterThan(0)
     // While paused, the menu offers a one-tap resume rather than a pause entry.
     expect(screen.getByText("Resume notifications")).toBeInTheDocument()
+  })
+
+  it("links platform admins to the admin portal in a new tab", async () => {
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(workspaceKeys.bootstrap("workspace_1"), {
+      viewerIsPlatformAdmin: true,
+    } as WorkspaceBootstrap)
+
+    renderWithRouter(
+      <SidebarFooter
+        workspaceId="workspace_1"
+        onCreateScratchpad={vi.fn()}
+        onCreateChannel={vi.fn()}
+        currentUser={{
+          id: "user_1",
+          workspaceId: "workspace_1",
+          workosUserId: "workos_user_1",
+          email: "kris@example.com",
+          role: "member",
+          slug: "kris",
+          name: "Kris",
+          description: null,
+          avatarUrl: null,
+          timezone: "Europe/Stockholm",
+          locale: "en-SE",
+          pronouns: null,
+          phone: null,
+          githubUsername: null,
+          statusEmoji: null,
+          statusText: null,
+          statusExpiresAt: null,
+          statusPausesNotifications: false,
+          notificationsPausedUntil: null,
+          notificationsPausedIndefinitely: false,
+          setupCompleted: true,
+          joinedAt: "2026-03-03T10:00:00Z",
+        }}
+      />,
+      queryClient
+    )
+
+    await user.click(screen.getByRole("button", { name: /kris/i }))
+
+    const link = screen.getByRole("link", { name: "Admin Portal" })
+    // The dev/test fallback of getAdminPortalUrl (vitest runs with DEV=true).
+    expect(link).toHaveAttribute("href", "http://localhost:3004")
+    expect(link).toHaveAttribute("target", "_blank")
+  })
+
+  it("hides the admin portal entry from non-admins", async () => {
+    const user = userEvent.setup()
+
+    // No viewerIsPlatformAdmin in the bootstrap cache (the common case).
+    renderWithRouter(
+      <SidebarFooter
+        workspaceId="workspace_1"
+        onCreateScratchpad={vi.fn()}
+        onCreateChannel={vi.fn()}
+        currentUser={{
+          id: "user_1",
+          workspaceId: "workspace_1",
+          workosUserId: "workos_user_1",
+          email: "pierre@example.com",
+          role: "member",
+          slug: "pierre",
+          name: "Pierre",
+          description: null,
+          avatarUrl: null,
+          timezone: "Europe/Stockholm",
+          locale: "en-SE",
+          pronouns: null,
+          phone: null,
+          githubUsername: null,
+          statusEmoji: null,
+          statusText: null,
+          statusExpiresAt: null,
+          statusPausesNotifications: false,
+          notificationsPausedUntil: null,
+          notificationsPausedIndefinitely: false,
+          setupCompleted: true,
+          joinedAt: "2026-03-03T10:00:00Z",
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /pierre/i }))
+
+    expect(screen.queryByText("Admin Portal")).not.toBeInTheDocument()
   })
 
   it("offers a pause-notifications entry in the account menu when not paused", async () => {

--- a/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx
@@ -12,6 +12,7 @@ import {
   Moon,
   Plus,
   Settings,
+  ShieldCheck,
 } from "lucide-react"
 import { useSearchParams } from "react-router-dom"
 import { useQueryClient } from "@tanstack/react-query"
@@ -21,6 +22,8 @@ import { useAuth } from "@/auth"
 import { LOGOUT_CONFIRM_PARAM } from "@/components/account-switcher/logout-scope-dialog"
 import { useSettings, useSidebar } from "@/contexts"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { getAdminPortalUrl } from "@/lib/admin-url"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { getInitials } from "@/lib/initials"
@@ -229,6 +232,12 @@ export function SidebarFooter({
   const resumeNotifications = useResumeNotifications(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
 
+  // Synced from the control plane's platform_roles via the regional mirror;
+  // only platform admins get a link into the backoffice. The URL is
+  // hostname-derived and null on unknown hosts, which also hides the entry.
+  const isPlatformAdmin = useCachedWorkspaceBootstrap(workspaceId)?.viewerIsPlatformAdmin ?? false
+  const adminPortalUrl = getAdminPortalUrl()
+
   const status = useMemo<FooterStatus | null>(() => {
     if (!currentUser) return null
     const active = resolveActiveStatus({
@@ -405,6 +414,20 @@ export function SidebarFooter({
         onSelect: collapseOnMobile,
         separatorBefore: true,
       },
+      // Backoffice entry — platform admins only. Cosmetic gating: the
+      // backoffice re-checks the platform-admin grant server-side.
+      ...(isPlatformAdmin && adminPortalUrl
+        ? [
+            {
+              id: "admin-portal",
+              label: "Admin Portal",
+              icon: ShieldCheck,
+              href: adminPortalUrl,
+              external: true,
+              onSelect: collapseOnMobile,
+            } satisfies SidebarActionItem,
+          ]
+        : []),
       {
         id: "switch-account",
         label: "Switch account",
@@ -431,6 +454,8 @@ export function SidebarFooter({
       collapseOnMobile,
       handleLogout,
       workspaceId,
+      isPlatformAdmin,
+      adminPortalUrl,
     ]
   )
 

--- a/apps/frontend/src/lib/admin-url.ts
+++ b/apps/frontend/src/lib/admin-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the backoffice (admin portal) URL for the environment the app is
+ * running in. The frontend ships a single build for prod and staging (the
+ * deploy workflow sets no VITE_ vars), so this must be derived at runtime
+ * from the page's hostname rather than baked in at build time.
+ *
+ * Hosts map 1:1 to the backoffice-router routes in
+ * `apps/backoffice-router/wrangler.{production,staging}.toml`; the dev
+ * fallback is the backoffice Vite dev server port (`apps/backoffice/vite.config.ts`).
+ * Unknown hosts (e.g. PR previews) return null — callers hide the link rather
+ * than guess an environment.
+ */
+const ADMIN_URL_BY_HOST: Record<string, string> = {
+  "app.threa.io": "https://admin.threa.io",
+  "staging.threa.io": "https://admin-staging.threa.io",
+}
+
+export function getAdminPortalUrl(): string | null {
+  const mapped = ADMIN_URL_BY_HOST[window.location.hostname]
+  if (mapped) return mapped
+  if (import.meta.env.DEV) return "http://localhost:3004"
+  return null
+}

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -246,6 +246,9 @@ WebSocket connections bypass the router entirely. The frontend fetches `/api/wor
 
 - `POST /internal/workspaces` — provision a new workspace in this region
 - `POST /internal/invitations/:id/accept` — accept an invitation
+- `POST /internal/authz/memberships` — sync the `workspace_user_permissions` mirror (WorkOS membership fan-out)
+- `POST /internal/feature-flags` — replace one user's feature-flag snapshot
+- `POST /internal/platform-admin` — replace one user's platform-admin mirror row (gates backoffice links in the app)
 
 **Key subsystems:**
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1051,6 +1051,14 @@ export interface WorkspaceBootstrap {
    * per-user overrides). Kept live by the `feature_flags:updated` socket event.
    */
   featureFlags: FeatureFlags
+  /**
+   * True when the viewer holds a control-plane platform-admin grant (synced
+   * to the regional `platform_admin_access` mirror). Gates UI links into the
+   * backoffice. Optional because bootstraps cached before this field shipped
+   * lack it — absent reads as false. No live broadcast: grants are rare
+   * operator actions and take effect on the next bootstrap.
+   */
+  viewerIsPlatformAdmin?: boolean
 }
 
 // ============================================================================

--- a/scripts/grant-platform-role.ts
+++ b/scripts/grant-platform-role.ts
@@ -17,8 +17,9 @@
  */
 
 import { readFileSync, existsSync } from "fs"
-import { createDatabasePool } from "../packages/backend-common/src"
+import { createDatabasePool, withTransaction, OutboxRepository } from "../packages/backend-common/src"
 import { PlatformRoleRepository, isValidPlatformRole } from "../apps/control-plane/src/features/backoffice"
+import { OUTBOX_PLATFORM_ADMIN_SYNC } from "../apps/control-plane/src/features/platform-admin"
 
 function loadEnvFile(filePath: string): Record<string, string> {
   const env: Record<string, string> = {}
@@ -67,7 +68,13 @@ async function main() {
   const databaseUrl = resolveDatabaseUrl()
   const pool = createDatabasePool(databaseUrl, { max: 1 })
   try {
-    const row = await PlatformRoleRepository.upsert(pool, userIdArg, role)
+    // Grant and regional fan-out commit atomically (INV-7) so a running
+    // control-plane pushes the new admin's mirror rows without a restart.
+    const row = await withTransaction(pool, async (client) => {
+      const granted = await PlatformRoleRepository.upsert(client, userIdArg, role)
+      await OutboxRepository.insert(client, OUTBOX_PLATFORM_ADMIN_SYNC, { workosUserId: userIdArg })
+      return granted
+    })
     console.log(`granted platform role "${row.role}" to ${row.workos_user_id}`)
   } finally {
     await pool.end()


### PR DESCRIPTION
## Problem

Platform admins (currently just the control-plane `platform_roles` table, gated by `requirePlatformAdmin`) have no way to reach the backoffice from the product app — and the app has no way to know who is an admin, so it can't even show a link. Non-admin users must never see the entry.

This is also the second real consumer of the control-plane → regional sync need (after feature flags), so the implementation deliberately establishes the feature-flags shape as the canonical template rather than inventing a new mechanism or a generic framework.

## Solution

Sync the platform-admin grant control-plane → regional backends using the same pattern as the feature-flags sync: **identity-only outbox event → re-read state at delivery → idempotent per-workspace snapshot push** over the existing `RegionalClient` / `X-Internal-API-Key` transport. The regional backend stores a tiny mirror table, the workspace bootstrap exposes `viewerIsPlatformAdmin`, and the sidebar account menu shows an "Admin Portal" external link (new tab) only for admins.

### How it works

```
platform_roles change (seed / script / membership creation)
  └─ outbox: platform_admin_sync { workosUserId }            (control-plane)
       └─ handler re-reads grant + workspace_memberships
            └─ POST /internal/platform-admin per workspace's region
                 └─ platform_admin_access mirror row (upsert / delete)
                      └─ bootstrap → viewerIsPlatformAdmin
                           └─ sidebar "Admin Portal" link → admin.threa.io
```

Emission points:
- **Startup seeding** — re-emits for every `PLATFORM_ADMIN_WORKOS_USER_IDS` entry on each boot (single batched `insertMany`); doubles as the self-heal path for missed emits or unreachable regions.
- **Membership creation** — workspace create and invitation accept call `enqueueIfAdmin` inside their existing transactions, so an admin's new workspace shows the link immediately.
- **`scripts/grant-platform-role.ts`** — grant + fan-out event commit atomically.

### Key design decisions

**1. Mirror keyed by `(workspace_id, workos_user_id)`, not the regional user id**

Unlike `user_feature_flags`, the mirror doesn't reference `users.id`, so a sync can land before/independently of regional user provisioning — no ordering hazard between `regional_create` and `platform_admin_sync` events.

**2. Cosmetic gating only**

The regional mirror gates UI affordances; the backoffice re-checks `requirePlatformAdmin` server-side on every request. A stale mirror can never grant access.

**3. No live broadcast**

Grants are rare operator actions; the flag applies on the next bootstrap (page load). This keeps the patch free of socket/IDB plumbing.

**4. Runtime hostname-derived admin URL**

The frontend ships one build for prod and staging (deploy workflow sets no `VITE_` vars), so the backoffice URL can't be baked in. `getAdminPortalUrl()` maps `app.threa.io → admin.threa.io`, `staging.threa.io → admin-staging.threa.io`, dev → `localhost:3004`; unknown hosts (PR previews) hide the link.

**5. Type-only imports to keep the module graph acyclic**

`platform-admin` (CP) imports the `backoffice` and `workspaces` barrels; the reverse edges (workspaces/invitation-shadows → platform-admin) are `import type` + constructor injection from the composition root.

## New files

| File | Purpose |
| --- | --- |
| `apps/backend/src/db/migrations/20260612113940_platform_admin_access.sql` | Regional mirror table |
| `apps/backend/src/features/platform-admin/*` | Repository / service / handlers / barrel / tests for the regional mirror |
| `apps/control-plane/src/features/platform-admin/*` | Outbox event, payload, fan-out service, barrel |
| `apps/frontend/src/lib/admin-url.ts` | Runtime hostname → backoffice URL mapping |

## Modified files

| File | Change |
| --- | --- |
| `apps/backend/src/routes.ts`, `server.ts` | Wire `PlatformAdminService` + `POST /internal/platform-admin` behind `internalAuth` |
| `apps/backend/src/features/workspaces/handlers.ts` | Bootstrap computes and returns `viewerIsPlatformAdmin` |
| `apps/control-plane/src/server.ts` | Construct/wire sync service, dispatch case, batched seed emission |
| `apps/control-plane/src/features/workspaces/service.ts` | `enqueueIfAdmin` on workspace creation (same transaction) |
| `apps/control-plane/src/features/invitation-shadows/service.ts` | `enqueueIfAdmin` on invitation acceptance (same transaction) |
| `apps/control-plane/src/lib/regional-client.ts` | `syncPlatformAdminAccess`; collapsed 3 duplicated transport bodies into one `postInternal` helper |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx` | `SidebarActionItem.external` → plain anchor, new tab |
| `apps/frontend/src/components/layout/sidebar/sidebar-footer.tsx` | Gated "Admin Portal" menu entry |
| `packages/types/src/api.ts` | `WorkspaceBootstrap.viewerIsPlatformAdmin?` (optional: pre-deploy cached bootstraps lack it) |
| `scripts/grant-platform-role.ts` | Emit fan-out event atomically with the grant |
| `docs/system-overview.md` | Document the regional internal sync endpoints (incl. the two that were missing) |

## Test plan

- [x] Full monorepo typecheck (14 workspaces)
- [x] Backend unit tests: `features/platform-admin`, `features/feature-flags`, `features/workspaces` (19 pass)
- [x] Frontend sidebar tests incl. two new ones: admin link shown for admins (href + `target="_blank"`), hidden for non-admins (14 pass)
- [x] Self-review: 3 parallel reviewer agents (spec/correctness/design); both surviving findings fixed in `decf51e` (INV-56 batch seed emission, RegionalClient transport dedupe)
- [ ] DB-backed integration suites run in CI (no Postgres/Docker in the authoring environment)
- [ ] Manual: grant via `scripts/grant-platform-role.ts` on staging, reload app, confirm Admin Portal entry opens admin-staging.threa.io; confirm absent for a non-admin user

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Let platform admins open the backoffice (admin.threa.io) from the app sidebar; non-admins must not see the entry. Establish the feature-flags sync shape as the canonical control-plane → regional sync template (second consumer).

**What was built:**
- CP `platform_admin_sync` outbox event (identity-only payload `{ workosUserId }`); `PlatformAdminSyncService.syncToRegions` re-reads `platform_roles` + `workspace_memberships` at delivery and fans out per-workspace snapshots in parallel (`Promise.allSettled`, aggregated errors rethrown for outbox retry).
- Regional `platform_admin_access` table (presence = admin), `POST /internal/platform-admin` (zod-validated, internalAuth), single-statement upsert/delete (INV-20).
- Bootstrap field `viewerIsPlatformAdmin`; frontend reads it via the cache-only bootstrap observer and renders a gated external link in the account menu.

**Design evolution:**
- Initial recommendation was *no sync at all* (put `isPlatformAdmin` on the control-plane's `/api/auth/me`); user chose the regional sync so the bit lives in the regional backend/app and seeds the unified-sync direction.
- Considered modeling it as a feature flag — rejected: flags are manually-set workspace-scoped overrides; admin status is global, derived state.
- Considered a generic sync framework — rejected (INV-36): the existing differences between feature-flags (re-read snapshot) and authz (timestamp-guarded events) semantics are load-bearing; this PR reuses the snapshot shape instead.

**Schema changes:** one append-only backend migration (`platform_admin_access`). No CP migration (reuses `platform_roles`).

**What's NOT included:** live broadcast of grant changes (next-bootstrap semantics); a backoffice UI for granting platform roles (seed env var + script remain the grant surfaces); cleanup of mirror rows when a user leaves a workspace (row is inert and unreadable without membership).

**Status:** complete; integration suites deferred to CI.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01LPJMLpnmWYDtAy3qdtoQRk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPJMLpnmWYDtAy3qdtoQRk)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783858206&installation_id=129946197&pr_number=880&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F880&signature=4f7f90a5ca459dbae2945a40ef2e7d708d8d10bd550e3a48f5872637ad21832e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->