### PR TITLE
feat: skip the saved/scheduled reconnect refetch in active sync-v2 mode

### DIFF
--- a/apps/frontend/src/hooks/use-saved.ts
+++ b/apps/frontend/src/hooks/use-saved.ts
@@ -139,10 +139,11 @@ export function useSavedList(workspaceId: string, status: SavedStatus) {
       return res
     },
     // INV-53: socket reconnects close their own event gap by invalidating
-    // `savedKeys.all` at the top of `registerWorkspaceSocketHandlers`;
-    // `refetchOnReconnect: true` then catches the pure browser online/offline
-    // case. `refetchOnMount: true` plus `staleTime: Infinity` makes the
-    // invalidation land on the next render.
+    // `savedKeys.all` at the top of `registerWorkspaceSocketHandlers` (in
+    // active sync-v2 mode the catch-up cursor replays the missed events
+    // instead); `refetchOnReconnect: true` then catches the pure browser
+    // online/offline case. `refetchOnMount: true` plus `staleTime: Infinity`
+    // makes the invalidation land on the next render.
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,

--- a/apps/frontend/src/hooks/use-scheduled.ts
+++ b/apps/frontend/src/hooks/use-scheduled.ts
@@ -193,9 +193,10 @@ export function useScheduledList(workspaceId: string, status: ScheduledMessageSt
       return res
     },
     // INV-53: workspace-sync invalidates `scheduledKeys.all` on reconnect at
-    // the top of `registerWorkspaceSocketHandlers`; refetchOnReconnect catches
-    // the pure online/offline case; refetchOnMount + staleTime: Infinity makes
-    // the invalidation actually fire on next render.
+    // the top of `registerWorkspaceSocketHandlers` (in active sync-v2 mode
+    // the catch-up cursor replays the missed events instead);
+    // refetchOnReconnect catches the pure online/offline case; refetchOnMount
+    // + staleTime: Infinity makes the invalidation actually fire on next render.
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -211,7 +211,8 @@ export class SyncEngine {
         getCurrentStreamId: () => this.currentStreamId,
         getCurrentUser: () => this.currentUser,
         subscribeStream: (streamId: string) => void this.subscribeStream(streamId),
-      }
+      },
+      this.syncCursorMode
     )
 
     await this.runBootstrap(isReconnect)

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -8,6 +8,8 @@ import {
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import { readMirroredSyncV2Mode } from "./sync-v2-mode"
+import { savedKeys } from "@/hooks/use-saved"
+import { scheduledKeys } from "@/hooks/use-scheduled"
 import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_QUICK_LINKS,
@@ -668,6 +670,39 @@ describe("registerWorkspaceSocketHandlers", () => {
     await Promise.all([db.streams.clear(), db.streamMemberships.clear(), db.dmPeers.clear(), db.unreadState.clear()])
   })
 
+  const handlerRefs = {
+    getCurrentStreamId: () => undefined,
+    getCurrentUser: () => ({ id: "workos_1" }),
+    subscribeStream: vi.fn(),
+  }
+
+  it("skips the INV-53 saved/scheduled reconnect invalidations in active sync-v2 mode", () => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket } = createTestSocket()
+
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, "active")
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: savedKeys.all })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: scheduledKeys.all })
+    cleanup()
+  })
+
+  it.each(["off", "shadow"] as const)(
+    "runs the INV-53 saved/scheduled reconnect invalidations in %s mode (kill switch restores healing)",
+    (mode) => {
+      const queryClient = new QueryClient()
+      const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+      const { socket } = createTestSocket()
+
+      const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, mode)
+
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: savedKeys.all })
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: scheduledKeys.all })
+      cleanup()
+    }
+  )
+
   it("subscribes the creator when a new stream is created at runtime", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(
@@ -681,11 +716,17 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     const subscribeStream = vi.fn()
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => undefined,
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream,
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => undefined,
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream,
+      },
+      "off"
+    )
 
     emit("stream:created", {
       workspaceId: "ws_1",
@@ -724,11 +765,17 @@ describe("registerWorkspaceSocketHandlers", () => {
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
 
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => undefined,
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream: vi.fn(),
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => undefined,
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream: vi.fn(),
+      },
+      "off"
+    )
 
     emit("feature_flags:updated", {
       workspaceId: "ws_1",
@@ -783,11 +830,17 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     const subscribeStream = vi.fn()
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => undefined,
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream,
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => undefined,
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream,
+      },
+      "off"
+    )
 
     emit("stream:created", {
       workspaceId: "ws_1",
@@ -851,11 +904,17 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     const subscribeStream = vi.fn()
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => undefined,
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream,
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => undefined,
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream,
+      },
+      "off"
+    )
 
     emit("stream:member_added", {
       workspaceId: "ws_1",
@@ -976,11 +1035,17 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     const subscribeStream = vi.fn()
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => "stream_1",
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream,
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => "stream_1",
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream,
+      },
+      "off"
+    )
 
     emit("stream:read", {
       workspaceId: "ws_1",
@@ -1064,11 +1129,17 @@ describe("unread counter events (absolute payloads, sync-v2 phase 2c)", () => {
 
   function register(queryClient: QueryClient, currentStreamId?: string) {
     const { socket, emit } = createTestSocket()
-    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
-      getCurrentStreamId: () => currentStreamId,
-      getCurrentUser: () => ({ id: "workos_1" }),
-      subscribeStream: vi.fn(),
-    })
+    const cleanup = registerWorkspaceSocketHandlers(
+      socket,
+      "ws_1",
+      queryClient,
+      {
+        getCurrentStreamId: () => currentStreamId,
+        getCurrentUser: () => ({ id: "workos_1" }),
+        subscribeStream: vi.fn(),
+      },
+      "off"
+    )
     return { emit, cleanup }
   }
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -43,7 +43,7 @@ import {
   normalizeSidebarConfig,
 } from "@threa/types"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
-import { mirrorSyncV2Mode } from "./sync-v2-mode"
+import { mirrorSyncV2Mode, type SyncV2CursorMode } from "./sync-v2-mode"
 import {
   applyActivityCounts,
   applyStreamActivityOrdinal,
@@ -459,7 +459,8 @@ export function registerWorkspaceSocketHandlers(
     getCurrentStreamId: () => string | undefined
     getCurrentUser: () => { id: string } | null
     subscribeStream: (streamId: string) => void
-  }
+  },
+  syncCursorMode: SyncV2CursorMode
 ): () => void {
   const abortController = new AbortController()
 
@@ -468,8 +469,17 @@ export function registerWorkspaceSocketHandlers(
   // and rehydrates IDB with any rows whose upsert/delete events we missed
   // during the disconnect. `refetchOnReconnect: true` alone only covers
   // browser network online/offline, not socket.io reconnects.
-  queryClient.invalidateQueries({ queryKey: savedKeys.all })
-  queryClient.invalidateQueries({ queryKey: scheduledKeys.all })
+  //
+  // In active sync-v2 mode the workspace catch-up cursor replays the missed
+  // saved/scheduled events (user-scoped sync-log entries) through these same
+  // handlers, so the blanket refetch is redundant there — but "off" is the
+  // runtime kill switch and "shadow" applies nothing, so both must keep this
+  // healing. The mode is fixed per SyncEngine lifetime; a flag flip recreates
+  // the engine and re-registers these handlers with the new mode.
+  if (syncCursorMode !== "active") {
+    queryClient.invalidateQueries({ queryKey: savedKeys.all })
+    queryClient.invalidateQueries({ queryKey: scheduledKeys.all })
+  }
 
   // Handle stream created
   const handleStreamCreated = (payload: StreamPayload) => {


### PR DESCRIPTION
## Problem

With `active` now the default sync-v2 cursor mode (#884), the workspace catch-up cursor already replays every missed saved/scheduled event on reconnect — yet `registerWorkspaceSocketHandlers` still fires the blanket INV-53 invalidations (`savedKeys.all`, `scheduledKeys.all`) on every socket re-registration, refetching whole list pages the cursor just healed row-by-row.

## Solution

This is **PR B** of the rollout sequence: gate the two invalidations on `syncCursorMode !== "active"` — **gate, not delete**. `off` is the runtime kill switch and `shadow` applies nothing, so both must keep the blanket-refetch healing.

### How it works

`SyncEngine.onConnect` passes its `syncCursorMode` (fixed per engine lifetime) into `registerWorkspaceSocketHandlers` as an explicit parameter. A backoffice flag flip destroys and recreates the engine, which re-registers the handlers with the new mode — so flipping a user to `off` restores the INV-53 healing on their very next connect, with no reload.

### Why the cursor covers what the refetch covered

`saved:*` / `scheduled_message:*` are `USER_SCOPED_EVENTS` (`apps/backend/src/lib/outbox/repository.ts:888`): the BroadcastHandler persists them to `sync_log` under the user's delivery group, the catch-up read returns them, and `gate.dispatch` routes them through the **same registered live handlers** (`handleSavedUpserted` etc.) that write IDB and invalidate the affected lists. The healing isn't removed; it's replaced by a finer-grained replay of the exact missed events.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/workspace-sync.ts` | New required `syncCursorMode` param; invalidations gated on `!== "active"` |
| `apps/frontend/src/sync/sync-engine.ts` | Pass `this.syncCursorMode` at the registration call site |
| `apps/frontend/src/sync/workspace-sync.test.ts` | New tests pinning both directions; existing call sites pass `"off"` |
| `apps/frontend/src/hooks/use-saved.ts` | INV-53 comment notes the active-mode replacement |
| `apps/frontend/src/hooks/use-scheduled.ts` | Same comment update |

## Test plan

- [x] New: invalidations **skipped** when the engine registers in `active` mode
- [x] New (each): invalidations **restored** in `off` and `shadow` (kill switch re-enables healing)
- [x] Existing INV-53 reconnect-gap cursor tests unchanged and green
- [x] Frontend `src/sync` + `src/hooks`: 576 passed (55 files)
- [x] Full monorepo typecheck + lint via pre-commit hooks

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Step 3 of the sync-v2 rollout (owner canary → PR A #884 → **PR B** → PR E+): stop double-healing saved/scheduled state on reconnect now that active mode is the default, while keeping the blanket refetch reachable through the kill switch.

**What was built:** `registerWorkspaceSocketHandlers` takes the engine's `syncCursorMode` explicitly (the engine fixes mode per lifetime, so the constructed mode is safe to pass; mode changes arrive only via engine recreation, which re-registers handlers). The two reconnect invalidations run only when mode is not `active`.

**Coverage proof:** saved/scheduled outbox events are user-scoped → logged to `sync_log` under `user:<id>` → returned by the user's catch-up read → dispatched through the same live handlers. Verified before gating.

**What's NOT included (PR E+):** further INV-53 narrowing, one deletion per PR, each with a test proving cursor coverage. Healing that covers dropped live emits stays until a socket heartbeat exists (live cursor advance is optimistic).

**Status:** Complete; single commit `7ee3981`.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01PmXQFyvqogGe5ZkNfMnTi3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmXQFyvqogGe5ZkNfMnTi3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783866632&installation_id=129946197&pr_number=885&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F885&signature=6be07c2997af091fcb345f685f573cec725b12d29d1dc7b919e7fe921e3165d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->