### PR TITLE
feat: Add To-do command in the quick switcher (stacked on #886)

### DIFF
--- a/apps/frontend/src/components/quick-switcher/commands.test.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.test.ts
@@ -99,6 +99,7 @@ describe("commands", () => {
         openStreamSettings: vi.fn(),
         requestArchiveStream: vi.fn(),
         openLabelPicker: vi.fn(),
+        createSavedTodo: vi.fn(async () => {}),
       } as unknown as CommandContext
       return { context, navigate, openExplorer }
     }
@@ -122,6 +123,62 @@ describe("commands", () => {
         command.action(harness.context)
       }
       reachability[key](harness)
+    })
+  })
+
+  // "Add To-do" switches the palette into its inline input mode and saves the
+  // typed title as a standalone saved item.
+  describe("add-todo", () => {
+    function runAddTodo() {
+      const cmd = commands.find((c) => c.id === "add-todo")!
+      const requestInput = vi.fn()
+      const closeDialog = vi.fn()
+      const createSavedTodo = vi.fn(async () => {})
+      cmd.action({ requestInput, closeDialog, createSavedTodo } as unknown as CommandContext)
+      const request = requestInput.mock.calls[0]![0] as {
+        placeholder: string
+        hint: string
+        onSubmit: (value: string) => Promise<void>
+      }
+      return { request, closeDialog, createSavedTodo }
+    }
+
+    it("requests inline input rather than acting immediately", () => {
+      const { request, closeDialog, createSavedTodo } = runAddTodo()
+      expect(request.placeholder).toBeTruthy()
+      expect(request.hint).toBeTruthy()
+      expect(createSavedTodo).not.toHaveBeenCalled()
+      expect(closeDialog).not.toHaveBeenCalled()
+    })
+
+    it("creates the saved item with the trimmed title and closes the palette", async () => {
+      const { request, closeDialog, createSavedTodo } = runAddTodo()
+      await request.onSubmit("  Call the landlord  ")
+      expect(createSavedTodo).toHaveBeenCalledWith("Call the landlord")
+      expect(closeDialog).toHaveBeenCalled()
+    })
+
+    it("ignores empty submissions", async () => {
+      const { request, closeDialog, createSavedTodo } = runAddTodo()
+      await request.onSubmit("   ")
+      expect(createSavedTodo).not.toHaveBeenCalled()
+      expect(closeDialog).not.toHaveBeenCalled()
+    })
+
+    it("keeps the palette open when the create fails", async () => {
+      const cmd = commands.find((c) => c.id === "add-todo")!
+      const requestInput = vi.fn()
+      const closeDialog = vi.fn()
+      const createSavedTodo = vi.fn(async () => {
+        throw new Error("offline")
+      })
+      cmd.action({ requestInput, closeDialog, createSavedTodo } as unknown as CommandContext)
+      const request = requestInput.mock.calls[0]![0] as { onSubmit: (value: string) => Promise<void> }
+
+      await request.onSubmit("Buy milk")
+
+      expect(createSavedTodo).toHaveBeenCalled()
+      expect(closeDialog).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -6,6 +6,7 @@ import {
   CalendarClock,
   FileText,
   Hash,
+  ListTodo,
   Paperclip,
   Search,
   FileEdit,
@@ -69,6 +70,12 @@ export interface CommandContext {
   requestArchiveStream: (streamId: string) => void
   /** Open the label picker for a stream. */
   openLabelPicker: (streamId: string) => void
+  /**
+   * Create a standalone saved item (to-do) titled `title`. Backed by the same
+   * mutation as the Saved page's quick-add, so the new item lands in the
+   * Saved tab and the offline cache immediately.
+   */
+  createSavedTodo: (title: string) => Promise<void>
 }
 
 export interface Command {
@@ -156,6 +163,34 @@ export const commands: Command[] = [
         const message = error instanceof Error ? error.message : "Failed to create encrypted quick note"
         toast.error(message)
       }
+    },
+  },
+  {
+    id: "add-todo",
+    label: "Add To-do",
+    icon: ListTodo,
+    keywords: ["todo", "task", "saved", "remember", "capture", "quick add", "later"],
+    // Switches the palette into its inline input mode: type the title, Enter
+    // saves it as a standalone saved item. Deliberately not called a "note" —
+    // Quick Notes are scratchpads; this lands in Saved.
+    action: ({ requestInput, createSavedTodo, closeDialog }) => {
+      requestInput({
+        icon: ListTodo,
+        placeholder: "What needs doing?",
+        hint: "Press Enter to add this to-do to Saved",
+        onSubmit: async (value) => {
+          const title = value.trim()
+          if (!title) return
+          try {
+            await createSavedTodo(title)
+            closeDialog()
+            toast.success("To-do added to Saved")
+          } catch (error) {
+            console.error("Failed to add to-do:", error)
+            toast.error("Could not add to-do")
+          }
+        },
+      })
     },
   },
   {

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -171,6 +171,13 @@ function installSpies() {
     mutate: vi.fn(),
     isPending: false,
   } as unknown as ReturnType<typeof hooksModule.useArchiveStream>)
+  // `useSaveMessage` (backs the Add To-do command) resolves the saved service
+  // from ServicesProvider, which this harness doesn't mount — stub the hook.
+  vi.spyOn(hooksModule, "useSaveMessage").mockReturnValue({
+    mutateAsync: vi.fn(async () => ({})),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof hooksModule.useSaveMessage>)
   vi.spyOn(streamSettingsModule, "useStreamSettings").mockReturnValue({
     openStreamSettings: mockOpenStreamSettings,
   } as unknown as ReturnType<typeof streamSettingsModule.useStreamSettings>)

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -14,7 +14,7 @@ import {
   ResponsiveAlertDialogHeader,
   ResponsiveAlertDialogTitle,
 } from "@/components/ui/responsive-alert-dialog"
-import { useDraftScratchpads, useArchiveStream, useStreamName, isDraftId } from "@/hooks"
+import { useDraftScratchpads, useArchiveStream, useSaveMessage, useStreamName, isDraftId } from "@/hooks"
 import {
   useWorkspaceUsers,
   useWorkspaceStreams,
@@ -191,6 +191,17 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
     setInputValue("")
   }, [])
 
+  // "Add To-do" creates a standalone saved item via the same mutation as the
+  // Saved page's quick-add, so IDB and the list caches update identically.
+  const saveMutation = useSaveMessage(workspaceId)
+  const { mutateAsync: saveTodoAsync } = saveMutation
+  const createSavedTodo = useCallback(
+    async (title: string): Promise<void> => {
+      await saveTodoAsync({ title })
+    },
+    [saveTodoAsync]
+  )
+
   // Contextual stream actions close the palette first, then open their own
   // surface (settings dialog, confirm modal, label picker), which render as
   // siblings so they survive the palette unmounting its content.
@@ -266,6 +277,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       openStreamSettings: handleOpenStreamSettings,
       requestArchiveStream,
       openLabelPicker,
+      createSavedTodo,
     }),
     [
       workspaceId,
@@ -285,6 +297,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       handleOpenStreamSettings,
       requestArchiveStream,
       openLabelPicker,
+      createSavedTodo,
     ]
   )
 

--- a/apps/frontend/src/components/saved/saved-edit-dialog.test.tsx
+++ b/apps/frontend/src/components/saved/saved-edit-dialog.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { E2E_PLACEHOLDER_CONTENT_MARKDOWN, type SavedMessageView } from "@threa/types"
+import { SavedEditDialog } from "./saved-edit-dialog"
+import { ServicesProvider } from "@/contexts"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as contextsModule from "@/contexts"
+import * as useMobileModule from "@/hooks/use-mobile"
+
+const WORKSPACE_ID = "ws_1"
+
+function makeView(overrides: Partial<SavedMessageView> = {}): SavedMessageView {
+  const now = "2026-01-01T00:00:00.000Z"
+  return {
+    id: "saved_1",
+    workspaceId: WORKSPACE_ID,
+    userId: "usr_me",
+    messageId: "msg_1",
+    streamId: "stream_ch",
+    status: "saved",
+    title: null,
+    note: null,
+    remindAt: null,
+    reminderSentAt: null,
+    savedAt: now,
+    statusChangedAt: now,
+    unavailableReason: null,
+    message: {
+      authorId: "usr_peer",
+      authorType: "user",
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "**ship** the Q3 invoice",
+      createdAt: now,
+      editedAt: null,
+      streamName: null,
+    },
+    ...overrides,
+  }
+}
+
+function mount(saved: SavedMessageView) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ServicesProvider>
+        <SavedEditDialog open onOpenChange={() => {}} workspaceId={WORKSPACE_ID} saved={saved} />
+      </ServicesProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+    { id: "stream_ch", type: "channel", slug: "general", displayName: null },
+  ] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([
+    { id: "usr_peer", name: "Ada Lovelace" },
+  ] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("SavedEditDialog source message preview", () => {
+  it("shows author, stream, and markdown-stripped content for message-anchored items", () => {
+    mount(makeView())
+
+    expect(screen.getByText("Ada Lovelace")).toBeTruthy()
+    expect(screen.getByText("in #general")).toBeTruthy()
+    // INV-60: literal **bold** syntax must never reach the preview.
+    expect(screen.getByText("ship the Q3 invoice")).toBeTruthy()
+    expect(screen.queryByText("**ship** the Q3 invoice")).toBeNull()
+  })
+
+  it("shows the deleted fallback when the message is gone", () => {
+    mount(makeView({ message: null, unavailableReason: "deleted" }))
+    expect(screen.getByText("Original message was deleted")).toBeTruthy()
+  })
+
+  it("shows the encrypted placeholder for E2E messages", () => {
+    mount(makeView({ message: { ...makeView().message!, contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN } }))
+    expect(screen.getByText("🔒 Encrypted message")).toBeTruthy()
+  })
+
+  it("renders no preview block for standalone items, but does render the title field", () => {
+    mount(makeView({ messageId: null, streamId: null, message: null, title: "Call the landlord" }))
+    expect(screen.queryByText(/^in /)).toBeNull()
+    expect(screen.getByLabelText("Title")).toBeTruthy()
+  })
+})

--- a/apps/frontend/src/components/saved/saved-edit-dialog.tsx
+++ b/apps/frontend/src/components/saved/saved-edit-dialog.tsx
@@ -75,10 +75,16 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
   }
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+    // disableSnapPoints: this dialog is a keyboard form. The default
+    // snap-point drawer is forced to h-[100dvh]; when the on-screen keyboard
+    // opens on a focused input, the drawer is pushed up and its top — header
+    // and first field — slides off-screen under the status bar. A content-
+    // height, bottom-anchored drawer rides above the keyboard instead
+    // (matches PassphraseSetupModal, the reference for input drawers).
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
       <ResponsiveDialogContent
         desktopClassName="max-w-[480px] gap-0 p-0 overflow-hidden"
-        drawerClassName="gap-0 p-0 overflow-hidden"
+        drawerClassName="flex max-h-[92dvh] flex-col gap-0 p-0 overflow-hidden"
         aria-describedby={undefined}
       >
         <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4">
@@ -103,7 +109,10 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
 
         <div className="border-t border-border" />
 
-        <div className="px-4 sm:px-6 py-5 space-y-5">
+        {/* Scrollable so a shrunken visual viewport (keyboard) can never trap
+            fields off-screen — the body scrolls within whatever height the
+            drawer has left. */}
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 sm:px-6 py-5 space-y-5">
           {isStandalone && (
             <div className="space-y-2">
               <div className="flex items-baseline justify-between">
@@ -144,7 +153,9 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
           </div>
         </div>
 
-        <div className="border-t border-border px-4 sm:px-6 py-4 flex items-center justify-end gap-2 bg-muted/30">
+        {/* pb-[max(...)] keeps the buttons above the home indicator on mobile;
+            resolves to the same 16px as py-4 on desktop. */}
+        <div className="border-t border-border px-4 sm:px-6 pt-4 pb-[max(16px,env(safe-area-inset-bottom))] flex items-center justify-end gap-2 bg-muted/30">
           <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/apps/frontend/src/components/saved/saved-edit-dialog.tsx
+++ b/apps/frontend/src/components/saved/saved-edit-dialog.tsx
@@ -13,7 +13,12 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
+import { cn } from "@/lib/utils"
 import { useUpdateSaved } from "@/hooks/use-saved"
+import { useActors } from "@/hooks/use-actors"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { RelativeTime } from "@/components/relative-time"
+import { resolveSavedPreview } from "./saved-item"
 
 const TITLE_MAX = 300
 const NOTE_MAX = 4000
@@ -113,6 +118,7 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
             fields off-screen — the body scrolls within whatever height the
             drawer has left. */}
         <div className="flex-1 min-h-0 overflow-y-auto px-4 sm:px-6 py-5 space-y-5">
+          {!isStandalone && <SourceMessagePreview workspaceId={workspaceId} saved={saved} />}
           {isStandalone && (
             <div className="space-y-2">
               <div className="flex items-baseline justify-between">
@@ -172,5 +178,39 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
         </div>
       </ResponsiveDialogContent>
     </ResponsiveDialog>
+  )
+}
+
+interface SourceMessagePreviewProps {
+  workspaceId: string
+  saved: SavedMessageView
+}
+
+/**
+ * Quoted preview of the message this saved item is anchored to, so the note
+ * is written with its subject in view. Read-only context — the row itself is
+ * the navigation surface. Preview text goes through `resolveSavedPreview`
+ * (markdown stripped per INV-60; deleted/access-lost/encrypted fallbacks
+ * shared with the saved row).
+ */
+function SourceMessagePreview({ workspaceId, saved }: SourceMessagePreviewProps) {
+  const { getActorName } = useActors(workspaceId)
+  const streamLabel = useStreamName(workspaceId, saved.streamId ?? "") ?? saved.message?.streamName ?? "Unknown"
+  const isUnavailable = saved.unavailableReason !== null
+  const authorName = saved.message ? getActorName(saved.message.authorId, saved.message.authorType) : null
+
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 border-l-2 border-l-primary/40">
+      <div className="flex items-baseline gap-1.5 text-xs text-muted-foreground">
+        {authorName && <span className="font-medium text-foreground/80">{authorName}</span>}
+        <span className="truncate">in {streamLabel}</span>
+        {saved.message && <RelativeTime date={saved.message.createdAt} className="shrink-0 text-muted-foreground/60" />}
+      </div>
+      <p
+        className={cn("mt-1 text-sm text-foreground/80 line-clamp-3", isUnavailable && "italic text-muted-foreground")}
+      >
+        {resolveSavedPreview(saved)}
+      </p>
+    </div>
   )
 }

--- a/apps/frontend/src/components/saved/saved-item.tsx
+++ b/apps/frontend/src/components/saved/saved-item.tsx
@@ -33,7 +33,7 @@ export function SavedItem({ saved, workspaceId, onMarkDone, onArchive, onRestore
   const isUnavailable = saved.unavailableReason !== null
   const linkable = !isUnavailable && saved.message !== null
   const href = `/w/${workspaceId}/s/${saved.streamId}?m=${saved.messageId}`
-  const previewText = resolvePreview(saved)
+  const previewText = resolveSavedPreview(saved)
   // The backend snapshot's `streamName` is null for DMs (viewer-specific names
   // aren't persisted on the stream row), so resolve from the workspace caches.
   // The persisted snapshot is the last-resort fallback for rows whose stream
@@ -230,7 +230,12 @@ function SavedRowActions({ workspaceId, saved, onMarkDone, onArchive, onRestore,
   )
 }
 
-function resolvePreview(saved: SavedMessageView): string {
+/**
+ * Single-line plain-text preview of a saved item's source message, including
+ * the deleted / access-lost / encrypted fallbacks. Shared with
+ * `SavedEditDialog`'s message context block so the two surfaces can't drift.
+ */
+export function resolveSavedPreview(saved: SavedMessageView): string {
   if (saved.message) {
     // E2E messages store a zero-width placeholder on the wire and ship no
     // ciphertext to the Saved surface, so there's nothing to decrypt here —

--- a/apps/frontend/src/components/ui/responsive-dialog.tsx
+++ b/apps/frontend/src/components/ui/responsive-dialog.tsx
@@ -47,6 +47,14 @@ interface ResponsiveDialogProps {
    * drawer (matches `MessageEditForm`'s pattern). Use this when the dialog
    * is designed to take the whole viewport on mobile and the partial-snap
    * UX would obscure the action bar / trailing buttons.
+   *
+   * ALWAYS set this for dialogs containing text inputs. The snap-point
+   * drawer is forced to h-[100dvh]; when the on-screen keyboard opens, the
+   * drawer is pushed up and its top (header + first fields) slides off-screen
+   * under the status bar. A content-height drawer rides above the keyboard
+   * instead. Pair with a scrollable body (`flex-1 min-h-0 overflow-y-auto`)
+   * so a small visual viewport can never trap fields off-screen. Reference
+   * implementations: `PassphraseSetupModal`, `SavedEditDialog`.
    */
   disableSnapPoints?: boolean
 }


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #886** (saved items — optional message anchor). Merge that first; this PR's base is its branch, so GitHub will retarget to `main` automatically when #886 lands.

## Problem

Standalone to-dos (from #886) can only be created from the Saved page's quick-add input. Capture should cost one keystroke from anywhere: thought → palette → typed → saved, without leaving whatever you were doing.

## Solution

A new **Add To-do** palette command. Selecting it flips the quick switcher into its inline input mode (the `requestInput` infrastructure already existed in `commands.ts`/`quick-switcher.tsx` but had no callers); you type the title and Enter saves it as a standalone saved item via the same `useSaveMessage` mutation as the Saved page quick-add — so the item lands in the Saved tab, the offline cache, and other devices identically.

### Key design decisions

**1. Reuse the palette's dormant input mode, not a new dialog.** `InputRequest` (icon, placeholder, hint, onSubmit) was already designed and rendered by the palette — this is its first caller. Escape returns to the command list; Enter submits.

**2. Named "Add To-do", not anything with "note".** Quick Notes already exist (companion-off scratchpads); this lands in Saved. Keywords (`todo`, `task`, `capture`, `remember`, `later`) make it findable either way.

**3. Failure keeps the palette open.** A failed create (offline, server error) toasts but doesn't close or clear, so the typed title isn't lost. Empty submissions are ignored.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/components/quick-switcher/commands.ts` | `add-todo` command; `createSavedTodo` on `CommandContext` |
| `apps/frontend/src/components/quick-switcher/quick-switcher.tsx` | Wire `createSavedTodo` through `useSaveMessage` |
| `apps/frontend/src/components/quick-switcher/commands.test.ts` | Input-flow coverage: trim, empty submit, failure keeps palette open |
| `apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx` | Stub `useSaveMessage` (harness mounts no `ServicesProvider`) |

## Test plan

- [x] Quick-switcher suite: 330 pass (incl. 4 new `add-todo` cases)
- [x] Full frontend suite: 2569 pass
- [x] Monorepo typecheck clean
- [ ] Manual: `Cmd+K` → "add" → type a to-do → Enter → appears in `/saved`

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01JbXE8UPYHDi7tDH2wMqFeF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbXE8UPYHDi7tDH2wMqFeF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783877202&installation_id=129946197&pr_number=888&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F888&signature=9be3cd8784cceb8b7239d76d7cbca55a1bf49783cfe2d97a5603f04bef8754a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->