### PR TITLE
feat: dedicated enclave credential + wrap-eligibility boundary (Phase 2.4c, E2EE-22)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/forwarder.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/forwarder.test.ts
@@ -29,7 +29,7 @@ describe("EnclaveForwarder.assignSession", () => {
       return new Response(null, { status: 202 })
     }) as unknown as typeof fetch
 
-    const forwarder = new EnclaveForwarder({ internalApiKey: "shared-secret" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "shared-secret" })
     await forwarder.assignSession("https://enclave-1.internal/", ASSIGNMENT)
 
     expect(captured.url).toBe("https://enclave-1.internal/sessions")
@@ -40,7 +40,7 @@ describe("EnclaveForwarder.assignSession", () => {
   it("throws EnclaveForwardError with the status when the enclave does not ack 202", async () => {
     // 200 (not 202) is a failed handoff — the enclave didn't take ownership.
     globalThis.fetch = mock(async () => new Response(null, { status: 200 })) as unknown as typeof fetch
-    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "s" })
 
     const err = await forwarder.assignSession("https://enclave-1.internal", ASSIGNMENT).catch((e) => e)
     expect(err).toBeInstanceOf(EnclaveForwardError)
@@ -49,7 +49,7 @@ describe("EnclaveForwarder.assignSession", () => {
 
   it("throws EnclaveForwardError on a 5xx", async () => {
     globalThis.fetch = mock(async () => new Response(null, { status: 503 })) as unknown as typeof fetch
-    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "s" })
 
     const err = await forwarder.assignSession("https://enclave-1.internal", ASSIGNMENT).catch((e) => e)
     expect(err).toBeInstanceOf(EnclaveForwardError)
@@ -60,7 +60,7 @@ describe("EnclaveForwarder.assignSession", () => {
     globalThis.fetch = mock(async () => {
       throw new Error("ECONNREFUSED")
     }) as unknown as typeof fetch
-    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "s" })
 
     const err = await forwarder.assignSession("https://enclave-1.internal", ASSIGNMENT).catch((e) => e)
     expect(err).toBeInstanceOf(EnclaveForwardError)
@@ -83,7 +83,7 @@ describe("EnclaveForwarder.cancelSession", () => {
       return new Response(null, { status: 202 })
     }) as unknown as typeof fetch
 
-    const forwarder = new EnclaveForwarder({ internalApiKey: "shared-secret" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "shared-secret" })
     const ok = await forwarder.cancelSession("https://enclave-1.internal/", "session_1")
 
     expect(ok).toBe(true)
@@ -94,7 +94,7 @@ describe("EnclaveForwarder.cancelSession", () => {
 
   it("returns false (not throw) on a non-202 — the turn may have already finished", async () => {
     globalThis.fetch = mock(async () => new Response(null, { status: 404 })) as unknown as typeof fetch
-    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "s" })
     expect(await forwarder.cancelSession("https://enclave-1.internal", "session_1")).toBe(false)
   })
 
@@ -102,7 +102,7 @@ describe("EnclaveForwarder.cancelSession", () => {
     globalThis.fetch = mock(async () => {
       throw new Error("ECONNREFUSED")
     }) as unknown as typeof fetch
-    const forwarder = new EnclaveForwarder({ internalApiKey: "s" })
+    const forwarder = new EnclaveForwarder({ enclaveInternalApiKey: "s" })
     expect(await forwarder.cancelSession("https://enclave-1.internal", "session_1")).toBe(false)
   })
 })

--- a/apps/backend/src/features/enclave-runtimes/forwarder.ts
+++ b/apps/backend/src/features/enclave-runtimes/forwarder.ts
@@ -8,8 +8,9 @@ import { INTERNAL_API_KEY_HEADER, type EnclaveSessionAssignment } from "@threa/t
  * session callbacks (heartbeat / complete). The backend never sees plaintext —
  * only opaque envelopes cross this boundary.
  *
- * Authenticated with the shared internal-API-key header (the same secret the
- * enclave uses to call `/internal/enclave-runtimes/*`). The `instanceUrl` is
+ * Authenticated with the dedicated enclave-channel secret on the internal-API-key
+ * header (the same credential the enclave uses to call
+ * `/internal/enclave-runtimes/*`; Phase 2.4c, E2EE-22). The `instanceUrl` is
  * the address the enclave registered, already SSRF-validated at registration.
  */
 
@@ -26,11 +27,11 @@ export class EnclaveForwardError extends Error {
 }
 
 export class EnclaveForwarder {
-  private readonly internalApiKey: string
+  private readonly enclaveInternalApiKey: string
   private readonly timeoutMs: number
 
-  constructor(deps: { internalApiKey: string; timeoutMs?: number }) {
-    this.internalApiKey = deps.internalApiKey
+  constructor(deps: { enclaveInternalApiKey: string; timeoutMs?: number }) {
+    this.enclaveInternalApiKey = deps.enclaveInternalApiKey
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
   }
 
@@ -43,7 +44,7 @@ export class EnclaveForwarder {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          [INTERNAL_API_KEY_HEADER]: this.internalApiKey,
+          [INTERNAL_API_KEY_HEADER]: this.enclaveInternalApiKey,
         },
         body: JSON.stringify(assignment),
         signal: AbortSignal.timeout(this.timeoutMs),
@@ -71,7 +72,7 @@ export class EnclaveForwarder {
     try {
       const res = await fetch(url, {
         method: "POST",
-        headers: { [INTERNAL_API_KEY_HEADER]: this.internalApiKey },
+        headers: { [INTERNAL_API_KEY_HEADER]: this.enclaveInternalApiKey },
         signal: AbortSignal.timeout(this.timeoutMs),
       })
       return res.status === 202

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -33,9 +33,9 @@ import { parseModelId } from "@threa/agent-runtime"
 
 /**
  * Session callbacks the enclave calls while it owns an assigned turn. The enclave
- * authenticates with the shared internal-api-key (same gate as register/heartbeat),
- * and everything it sends is ciphertext — the backend writes sealed replies but
- * never sees plaintext (INV-E7).
+ * authenticates with the dedicated enclave credential (same gate as
+ * register/heartbeat; Phase 2.4c, E2EE-22), and everything it sends is ciphertext
+ * — the backend writes sealed replies but never sees plaintext (INV-E7).
  *
  *   POST /internal/enclave-runtimes/sessions/:id/heartbeat  — liveness refresh
  *   POST /internal/enclave-runtimes/sessions/:id/messages   — one sealed reply, streamed

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -894,6 +894,11 @@ export class StreamService {
 
     for (const actor of actors) {
       if (actor.kind === "enclave") {
+        // Wrap eligibility inherits the registration boundary (Phase 2.4c,
+        // E2EE-22): enclave_runtimes rows are only creatable through the
+        // /internal/enclave-runtimes routes, gated by the dedicated enclave
+        // credential — so "every live EIK" means every key registered by an
+        // enclave-credential holder, not by any internal-key holder.
         const eiks = await EnclaveRuntimesRepository.listLive(db, ENCLAVE_RUNTIME_STALENESS_MS)
         for (const eik of eiks) {
           recipients.push({

--- a/apps/backend/src/lib/env.test.ts
+++ b/apps/backend/src/lib/env.test.ts
@@ -17,6 +17,8 @@ function setBaseEnv() {
   delete process.env.MEDIACONVERT_ENABLED
   delete process.env.MEDIACONVERT_ROLE_ARN
   delete process.env.MEDIACONVERT_ENDPOINT
+  delete process.env.INTERNAL_API_KEY
+  delete process.env.ENCLAVE_INTERNAL_API_KEY
 }
 
 afterEach(() => {
@@ -188,5 +190,46 @@ describe("loadConfig MediaConvert configuration", () => {
     const config = loadConfig()
     expect(config.mediaConvert.enabled).toBe(true)
     expect(config.mediaConvert.roleArn).toBe("arn:aws:iam::123456789012:role/threa-mediaconvert-dev")
+  })
+})
+
+describe("loadConfig enclave credential separation (Phase 2.4c, E2EE-22)", () => {
+  test("prefers ENCLAVE_INTERNAL_API_KEY when both keys are set, without warning", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.INTERNAL_API_KEY = "shared-key"
+    process.env.ENCLAVE_INTERNAL_API_KEY = "enclave-key"
+
+    const warnSpy = spyOn(logger, "warn")
+    const config = loadConfig()
+
+    expect(config.internalApiKey).toBe("shared-key")
+    expect(config.enclaveInternalApiKey).toBe("enclave-key")
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("ENCLAVE_INTERNAL_API_KEY"))).toBe(false)
+    warnSpy.mockRestore()
+  })
+
+  test("falls back to INTERNAL_API_KEY with a warning when the dedicated key is absent", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+    process.env.INTERNAL_API_KEY = "shared-key"
+
+    const warnSpy = spyOn(logger, "warn")
+    const config = loadConfig()
+
+    expect(config.enclaveInternalApiKey).toBe("shared-key")
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("ENCLAVE_INTERNAL_API_KEY"))).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  test("is null when neither key is set", () => {
+    setBaseEnv()
+    process.env.NODE_ENV = "development"
+    process.env.USE_STUB_AUTH = "true"
+
+    const config = loadConfig()
+    expect(config.enclaveInternalApiKey).toBeNull()
   })
 })

--- a/apps/backend/src/lib/env.test.ts
+++ b/apps/backend/src/lib/env.test.ts
@@ -19,6 +19,8 @@ function setBaseEnv() {
   delete process.env.MEDIACONVERT_ENDPOINT
   delete process.env.INTERNAL_API_KEY
   delete process.env.ENCLAVE_INTERNAL_API_KEY
+  delete process.env.CONTROL_PLANE_URL
+  delete process.env.REGION
 }
 
 afterEach(() => {
@@ -194,42 +196,36 @@ describe("loadConfig MediaConvert configuration", () => {
 })
 
 describe("loadConfig enclave credential separation (Phase 2.4c, E2EE-22)", () => {
-  test("prefers ENCLAVE_INTERNAL_API_KEY when both keys are set, without warning", () => {
+  test("reads the dedicated key and never falls back to INTERNAL_API_KEY", () => {
     setBaseEnv()
     process.env.NODE_ENV = "development"
     process.env.USE_STUB_AUTH = "true"
     process.env.INTERNAL_API_KEY = "shared-key"
     process.env.ENCLAVE_INTERNAL_API_KEY = "enclave-key"
 
-    const warnSpy = spyOn(logger, "warn")
     const config = loadConfig()
-
     expect(config.internalApiKey).toBe("shared-key")
     expect(config.enclaveInternalApiKey).toBe("enclave-key")
-    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("ENCLAVE_INTERNAL_API_KEY"))).toBe(false)
-    warnSpy.mockRestore()
   })
 
-  test("falls back to INTERNAL_API_KEY with a warning when the dedicated key is absent", () => {
+  test("stays null when only the shared key is set — the enclave channel is then off", () => {
     setBaseEnv()
     process.env.NODE_ENV = "development"
     process.env.USE_STUB_AUTH = "true"
     process.env.INTERNAL_API_KEY = "shared-key"
 
-    const warnSpy = spyOn(logger, "warn")
     const config = loadConfig()
-
-    expect(config.enclaveInternalApiKey).toBe("shared-key")
-    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("ENCLAVE_INTERNAL_API_KEY"))).toBe(true)
-    warnSpy.mockRestore()
+    expect(config.enclaveInternalApiKey).toBeNull()
   })
 
-  test("is null when neither key is set", () => {
+  test("throws when CONTROL_PLANE_URL is set without the dedicated key (INV-11)", () => {
     setBaseEnv()
     process.env.NODE_ENV = "development"
     process.env.USE_STUB_AUTH = "true"
+    process.env.CONTROL_PLANE_URL = "http://localhost:3003"
+    process.env.REGION = "local"
+    process.env.INTERNAL_API_KEY = "shared-key"
 
-    const config = loadConfig()
-    expect(config.enclaveInternalApiKey).toBeNull()
+    expect(() => loadConfig()).toThrow("ENCLAVE_INTERNAL_API_KEY is required when CONTROL_PLANE_URL is set")
   })
 })

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -103,6 +103,15 @@ export interface Config {
   controlPlaneUrl: string | null
   /** Shared secret for authenticating internal API calls from the control-plane */
   internalApiKey: string | null
+  /**
+   * Dedicated secret for the enclave↔backend channel — enclave registration,
+   * session callbacks, and the backend's assignment calls (Phase 2.4c,
+   * E2EE-22). Resolved here with a transitional fallback to INTERNAL_API_KEY
+   * so a deploy never bricks before the var is provisioned; the fallback
+   * warns at boot, and separation activates the moment the var is set on
+   * both the backend and enclave services.
+   */
+  enclaveInternalApiKey: string | null
   /** This instance's region name (e.g., "eu-north-1") */
   region: string | null
   /** URL prefixes an enclave instance may register; empty disables the prefix check */
@@ -221,6 +230,7 @@ export function loadConfig(): Config {
     },
     controlPlaneUrl: process.env.CONTROL_PLANE_URL || null,
     internalApiKey: process.env.INTERNAL_API_KEY || null,
+    enclaveInternalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY || process.env.INTERNAL_API_KEY || null,
     region: process.env.REGION || null,
     enclaveInstanceUrlAllowedPrefixes:
       process.env.ENCLAVE_INSTANCE_URL_ALLOWED_PREFIXES?.split(",")
@@ -283,6 +293,16 @@ export function loadConfig(): Config {
   if (config.controlPlaneUrl && !config.internalApiKey) {
     throw new Error(
       "INTERNAL_API_KEY is required when CONTROL_PLANE_URL is set — inter-service calls need authentication"
+    )
+  }
+
+  // Phase 2.4c (E2EE-22): the enclave channel should run on its own credential
+  // so an INTERNAL_API_KEY holder (e.g. the bot-runtime) cannot register an EIK
+  // and become an SSK wrap recipient. Warn-and-fall-back rather than fail so the
+  // cutover is a config-only event, not a coordinated deploy.
+  if (process.env.INTERNAL_API_KEY && !process.env.ENCLAVE_INTERNAL_API_KEY) {
+    logger.warn(
+      "ENCLAVE_INTERNAL_API_KEY is not set — enclave registration and session callbacks fall back to the shared INTERNAL_API_KEY. Set a dedicated key on both the backend and enclave services to complete credential separation."
     )
   }
 

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -106,10 +106,10 @@ export interface Config {
   /**
    * Dedicated secret for the enclave↔backend channel — enclave registration,
    * session callbacks, and the backend's assignment calls (Phase 2.4c,
-   * E2EE-22). Resolved here with a transitional fallback to INTERNAL_API_KEY
-   * so a deploy never bricks before the var is provisioned; the fallback
-   * warns at boot, and separation activates the moment the var is set on
-   * both the backend and enclave services.
+   * E2EE-22). Deliberately distinct from INTERNAL_API_KEY so a shared-key
+   * holder (e.g. the bot-runtime) cannot register an EIK and become an SSK
+   * wrap recipient. Absent ⇒ the enclave channel is off; required when
+   * CONTROL_PLANE_URL is set (INV-11), same as INTERNAL_API_KEY.
    */
   enclaveInternalApiKey: string | null
   /** This instance's region name (e.g., "eu-north-1") */
@@ -230,7 +230,7 @@ export function loadConfig(): Config {
     },
     controlPlaneUrl: process.env.CONTROL_PLANE_URL || null,
     internalApiKey: process.env.INTERNAL_API_KEY || null,
-    enclaveInternalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY || process.env.INTERNAL_API_KEY || null,
+    enclaveInternalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY || null,
     region: process.env.REGION || null,
     enclaveInstanceUrlAllowedPrefixes:
       process.env.ENCLAVE_INSTANCE_URL_ALLOWED_PREFIXES?.split(",")
@@ -296,13 +296,12 @@ export function loadConfig(): Config {
     )
   }
 
-  // Phase 2.4c (E2EE-22): the enclave channel should run on its own credential
-  // so an INTERNAL_API_KEY holder (e.g. the bot-runtime) cannot register an EIK
-  // and become an SSK wrap recipient. Warn-and-fall-back rather than fail so the
-  // cutover is a config-only event, not a coordinated deploy.
-  if (process.env.INTERNAL_API_KEY && !process.env.ENCLAVE_INTERNAL_API_KEY) {
-    logger.warn(
-      "ENCLAVE_INTERNAL_API_KEY is not set — enclave registration and session callbacks fall back to the shared INTERNAL_API_KEY. Set a dedicated key on both the backend and enclave services to complete credential separation."
+  // Phase 2.4c (E2EE-22): a prod-shaped backend must carry the dedicated
+  // enclave credential — silently booting without it would unmount the enclave
+  // routes and break registration/heartbeats without a loud signal (INV-11).
+  if (config.controlPlaneUrl && !config.enclaveInternalApiKey) {
+    throw new Error(
+      "ENCLAVE_INTERNAL_API_KEY is required when CONTROL_PLANE_URL is set — the enclave channel runs on its own credential, distinct from INTERNAL_API_KEY"
     )
   }
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -298,14 +298,18 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app.post("/internal/authz/memberships", internalAuth, workspaceAuthz.syncMembership)
     app.post("/internal/feature-flags", internalAuth, featureFlags.sync)
     app.post("/internal/platform-admin", internalAuth, platformAdmin.sync)
+  }
 
-    // Enclave runtime registry — gated by the dedicated enclave credential
-    // (ENCLAVE_INTERNAL_API_KEY; transitional fallback to the shared key is
-    // resolved in env.ts). A separate middleware instance means a shared
-    // INTERNAL_API_KEY holder (e.g. the bot-runtime) can no longer register an
-    // EIK and become an SSK wrap recipient once the dedicated key is
-    // provisioned (Phase 2.4c, E2EE-22).
-    const enclaveAuth = createInternalAuthMiddleware(enclaveInternalApiKey ?? internalApiKey)
+  // Enclave runtime registry — gated by the dedicated enclave credential
+  // (ENCLAVE_INTERNAL_API_KEY; env.ts resolves a transitional fallback to the
+  // shared key, so this is non-null whenever either secret is set). Mounted
+  // independently of the control-plane block above so the enclave channel
+  // doesn't require INTERNAL_API_KEY. A separate middleware instance means a
+  // shared INTERNAL_API_KEY holder (e.g. the bot-runtime) can no longer
+  // register an EIK and become an SSK wrap recipient once the dedicated key
+  // is provisioned (Phase 2.4c, E2EE-22).
+  if (enclaveInternalApiKey) {
+    const enclaveAuth = createInternalAuthMiddleware(enclaveInternalApiKey)
     app.post("/internal/enclave-runtimes/register-key", enclaveAuth, enclave.registerKey)
     app.post("/internal/enclave-runtimes/heartbeat", enclaveAuth, enclave.heartbeat)
     app.post("/internal/enclave-runtimes/revoke", enclaveAuth, enclave.revoke)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -127,7 +127,7 @@ interface Dependencies {
   corsAllowedOrigins: string[]
   allowDevAuthRoutes: boolean
   internalApiKey: string | null
-  /** Dedicated enclave-channel secret (already fallback-resolved in env.ts; Phase 2.4c, E2EE-22). */
+  /** Dedicated enclave-channel secret, distinct from internalApiKey (Phase 2.4c, E2EE-22). */
   enclaveInternalApiKey: string | null
   apiKeyService: ApiKeyService
   botChannelService: BotChannelService
@@ -301,13 +301,11 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   }
 
   // Enclave runtime registry — gated by the dedicated enclave credential
-  // (ENCLAVE_INTERNAL_API_KEY; env.ts resolves a transitional fallback to the
-  // shared key, so this is non-null whenever either secret is set). Mounted
-  // independently of the control-plane block above so the enclave channel
-  // doesn't require INTERNAL_API_KEY. A separate middleware instance means a
-  // shared INTERNAL_API_KEY holder (e.g. the bot-runtime) can no longer
-  // register an EIK and become an SSK wrap recipient once the dedicated key
-  // is provisioned (Phase 2.4c, E2EE-22).
+  // (ENCLAVE_INTERNAL_API_KEY), mounted independently of the control-plane
+  // block above so the enclave channel doesn't require INTERNAL_API_KEY. A
+  // separate middleware instance means a shared INTERNAL_API_KEY holder
+  // (e.g. the bot-runtime) cannot register an EIK and become an SSK wrap
+  // recipient (Phase 2.4c, E2EE-22).
   if (enclaveInternalApiKey) {
     const enclaveAuth = createInternalAuthMiddleware(enclaveInternalApiKey)
     app.post("/internal/enclave-runtimes/register-key", enclaveAuth, enclave.registerKey)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -127,6 +127,8 @@ interface Dependencies {
   corsAllowedOrigins: string[]
   allowDevAuthRoutes: boolean
   internalApiKey: string | null
+  /** Dedicated enclave-channel secret (already fallback-resolved in env.ts; Phase 2.4c, E2EE-22). */
+  enclaveInternalApiKey: string | null
   apiKeyService: ApiKeyService
   botChannelService: BotChannelService
   linkPreviewService: LinkPreviewService
@@ -180,6 +182,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     corsAllowedOrigins,
     allowDevAuthRoutes,
     internalApiKey,
+    enclaveInternalApiKey,
     apiKeyService,
     botChannelService,
     linkPreviewService,
@@ -296,14 +299,19 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     app.post("/internal/feature-flags", internalAuth, featureFlags.sync)
     app.post("/internal/platform-admin", internalAuth, platformAdmin.sync)
 
-    // Enclave runtime registry — each enclave instance authenticates with the
-    // same shared internal secret to register/refresh/retire its EIK.
-    app.post("/internal/enclave-runtimes/register-key", internalAuth, enclave.registerKey)
-    app.post("/internal/enclave-runtimes/heartbeat", internalAuth, enclave.heartbeat)
-    app.post("/internal/enclave-runtimes/revoke", internalAuth, enclave.revoke)
+    // Enclave runtime registry — gated by the dedicated enclave credential
+    // (ENCLAVE_INTERNAL_API_KEY; transitional fallback to the shared key is
+    // resolved in env.ts). A separate middleware instance means a shared
+    // INTERNAL_API_KEY holder (e.g. the bot-runtime) can no longer register an
+    // EIK and become an SSK wrap recipient once the dedicated key is
+    // provisioned (Phase 2.4c, E2EE-22).
+    const enclaveAuth = createInternalAuthMiddleware(enclaveInternalApiKey ?? internalApiKey)
+    app.post("/internal/enclave-runtimes/register-key", enclaveAuth, enclave.registerKey)
+    app.post("/internal/enclave-runtimes/heartbeat", enclaveAuth, enclave.heartbeat)
+    app.post("/internal/enclave-runtimes/revoke", enclaveAuth, enclave.revoke)
 
     // Session callbacks: a live enclave drives an assigned turn over these
-    // (liveness refresh + sealed replies on completion). Same shared-secret gate.
+    // (liveness refresh + sealed replies on completion). Same enclave-credential gate.
     const enclaveSession = createEnclaveSessionHandlers({
       pool,
       eventService,
@@ -311,14 +319,14 @@ export function registerRoutes(app: Express, deps: Dependencies) {
       jobQueue: deps.jobQueue,
       costService: deps.costService,
     })
-    app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", internalAuth, enclaveSession.heartbeat)
-    app.post("/internal/enclave-runtimes/sessions/:id/messages", internalAuth, enclaveSession.message)
-    app.post("/internal/enclave-runtimes/sessions/:id/sealed-name", internalAuth, enclaveSession.sealedName)
-    app.post("/internal/enclave-runtimes/sessions/:id/steps/started", internalAuth, enclaveSession.stepStarted)
-    app.post("/internal/enclave-runtimes/sessions/:id/steps", internalAuth, enclaveSession.steps)
-    app.post("/internal/enclave-runtimes/sessions/:id/substeps", internalAuth, enclaveSession.substep)
-    app.post("/internal/enclave-runtimes/sessions/:id/complete", internalAuth, enclaveSession.complete)
-    app.post("/internal/enclave-runtimes/sessions/:id/fail", internalAuth, enclaveSession.fail)
+    app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", enclaveAuth, enclaveSession.heartbeat)
+    app.post("/internal/enclave-runtimes/sessions/:id/messages", enclaveAuth, enclaveSession.message)
+    app.post("/internal/enclave-runtimes/sessions/:id/sealed-name", enclaveAuth, enclaveSession.sealedName)
+    app.post("/internal/enclave-runtimes/sessions/:id/steps/started", enclaveAuth, enclaveSession.stepStarted)
+    app.post("/internal/enclave-runtimes/sessions/:id/steps", enclaveAuth, enclaveSession.steps)
+    app.post("/internal/enclave-runtimes/sessions/:id/substeps", enclaveAuth, enclaveSession.substep)
+    app.post("/internal/enclave-runtimes/sessions/:id/complete", enclaveAuth, enclaveSession.complete)
+    app.post("/internal/enclave-runtimes/sessions/:id/fail", enclaveAuth, enclaveSession.fail)
   }
 
   // Global baseline rate limit

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -636,6 +636,7 @@ export async function startServer(): Promise<ServerInstance> {
     corsAllowedOrigins: config.corsAllowedOrigins,
     allowDevAuthRoutes: config.useStubAuth && !isProduction,
     internalApiKey: config.internalApiKey,
+    enclaveInternalApiKey: config.enclaveInternalApiKey,
     apiKeyService,
     botChannelService,
     linkPreviewService,
@@ -681,9 +682,9 @@ export async function startServer(): Promise<ServerInstance> {
 
   // Built once here so both the socket layer (forwarding a user "Stop research"
   // to the enclave that owns an E2E session) and the enclave-invoke worker below
-  // share it. Null when no internal key — enclave dispatch/cancel are then off.
-  const enclaveForwarder = config.internalApiKey
-    ? new EnclaveForwarder({ internalApiKey: config.internalApiKey })
+  // share it. Null when no enclave credential — enclave dispatch/cancel are then off.
+  const enclaveForwarder = config.enclaveInternalApiKey
+    ? new EnclaveForwarder({ enclaveInternalApiKey: config.enclaveInternalApiKey })
     : undefined
 
   registerSocketHandlers(io, {

--- a/apps/enclave/README.md
+++ b/apps/enclave/README.md
@@ -58,16 +58,15 @@ What the enclave does not do:
 
 ## Environment
 
-| Variable                        | Required                                   | Purpose                                                                                                                                                       |
-| ------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                          | no (default `3011`)                        | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                                                           |
-| `ENCLAVE_SELF_URL`              | yes                                        | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                                                          |
-| `BACKEND_BASE_URL`              | yes                                        | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks.                                         |
-| `ENCLAVE_INTERNAL_API_KEY`      | recommended (required for full separation) | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*` + inbound `/sessions`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY`. |
-| `INTERNAL_API_KEY`              | no (transitional)                          | Fallback when `ENCLAVE_INTERNAL_API_KEY` is unset (warns at boot). Will be dropped once separation is enforced.                                               |
-| `OPENROUTER_API_KEY`            | yes                                        | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                     |
-| `OPENROUTER_BASE_URL`           | no                                         | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                        |
-| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`)                       | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                               |
+| Variable                        | Required             | Purpose                                                                                                                                                                                                        |
+| ------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                          | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                                                                                                            |
+| `ENCLAVE_SELF_URL`              | yes                  | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                                                                                                           |
+| `BACKEND_BASE_URL`              | yes                  | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks.                                                                                          |
+| `ENCLAVE_INTERNAL_API_KEY`      | yes                  | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*` + inbound `/sessions`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY` and must NOT equal the shared `INTERNAL_API_KEY`. |
+| `OPENROUTER_API_KEY`            | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                                                                      |
+| `OPENROUTER_BASE_URL`           | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                                                                         |
+| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                                                                                |
 
 ## Egress allow-list (operational)
 

--- a/apps/enclave/README.md
+++ b/apps/enclave/README.md
@@ -58,15 +58,16 @@ What the enclave does not do:
 
 ## Environment
 
-| Variable                        | Required             | Purpose                                                                                                               |
-| ------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                          | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                   |
-| `ENCLAVE_SELF_URL`              | yes                  | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                  |
-| `BACKEND_BASE_URL`              | yes                  | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks. |
-| `INTERNAL_API_KEY`              | yes                  | Shared bearer secret guarding the enclave's calls to `/internal/enclave-runtimes/*`.                                  |
-| `OPENROUTER_API_KEY`            | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                             |
-| `OPENROUTER_BASE_URL`           | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                |
-| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                       |
+| Variable                        | Required             | Purpose                                                                                                                                                       |
+| ------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                          | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                                                           |
+| `ENCLAVE_SELF_URL`              | yes                  | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                                                          |
+| `BACKEND_BASE_URL`              | yes                  | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks.                                         |
+| `ENCLAVE_INTERNAL_API_KEY`      | yes                  | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*` + inbound `/sessions`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY`. |
+| `INTERNAL_API_KEY`              | no (transitional)    | Fallback when `ENCLAVE_INTERNAL_API_KEY` is unset (warns at boot). Will be dropped once separation is enforced.                                               |
+| `OPENROUTER_API_KEY`            | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                     |
+| `OPENROUTER_BASE_URL`           | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                        |
+| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                               |
 
 ## Egress allow-list (operational)
 
@@ -85,7 +86,7 @@ No other outbound traffic is required.
 ```sh
 ENCLAVE_SELF_URL=http://localhost:3011 \
 BACKEND_BASE_URL=http://localhost:3001 \
-INTERNAL_API_KEY=$INTERNAL_API_KEY \
+ENCLAVE_INTERNAL_API_KEY=$ENCLAVE_INTERNAL_API_KEY \
 OPENROUTER_API_KEY=$OPENROUTER_API_KEY \
 bun run dev
 ```
@@ -112,12 +113,13 @@ All Railway services listen on the injected `PORT` (8080); internal URLs use
 # 1. Create the service in the existing project and point it at the repo.
 railway add --service enclave
 
-# 2. Set its variables. INTERNAL_API_KEY must MATCH the backend's — read it with
-#    `railway variables --service backend` and reuse the same value. OPENROUTER_API_KEY
-#    is your zero-retention OpenRouter key (billing-attached, so set it yourself).
+# 2. Set its variables. ENCLAVE_INTERNAL_API_KEY must MATCH the backend's — set the
+#    same fresh secret on both services (it is dedicated to the enclave channel and
+#    must NOT equal the shared INTERNAL_API_KEY). OPENROUTER_API_KEY is your
+#    zero-retention OpenRouter key (billing-attached, so set it yourself).
 railway variables --service enclave \
   --set "BACKEND_BASE_URL=http://backend.railway.internal:8080" \
-  --set "INTERNAL_API_KEY=<same value as backend>" \
+  --set "ENCLAVE_INTERNAL_API_KEY=<same value as backend's ENCLAVE_INTERNAL_API_KEY>" \
   --set "OPENROUTER_API_KEY=<your openrouter key>" \
   --set "ENCLAVE_SELF_URL=http://enclave.railway.internal:8080"
 

--- a/apps/enclave/README.md
+++ b/apps/enclave/README.md
@@ -58,16 +58,16 @@ What the enclave does not do:
 
 ## Environment
 
-| Variable                        | Required             | Purpose                                                                                                                                                       |
-| ------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                          | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                                                           |
-| `ENCLAVE_SELF_URL`              | yes                  | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                                                          |
-| `BACKEND_BASE_URL`              | yes                  | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks.                                         |
-| `ENCLAVE_INTERNAL_API_KEY`      | yes                  | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*` + inbound `/sessions`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY`. |
-| `INTERNAL_API_KEY`              | no (transitional)    | Fallback when `ENCLAVE_INTERNAL_API_KEY` is unset (warns at boot). Will be dropped once separation is enforced.                                               |
-| `OPENROUTER_API_KEY`            | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                     |
-| `OPENROUTER_BASE_URL`           | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                        |
-| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                               |
+| Variable                        | Required                                   | Purpose                                                                                                                                                       |
+| ------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                          | no (default `3011`)                        | Listen port for `/pubkey`, `/healthz`, `/attestation`, `/sessions`.                                                                                           |
+| `ENCLAVE_SELF_URL`              | yes                                        | URL the backend stores as this instance's reachable address (e.g. `https://enclave-eu-1.threa.dev`).                                                          |
+| `BACKEND_BASE_URL`              | yes                                        | Regional backend base URL — target for register/heartbeat/revoke + per-session heartbeat/messages/complete callbacks.                                         |
+| `ENCLAVE_INTERNAL_API_KEY`      | recommended (required for full separation) | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*` + inbound `/sessions`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY`. |
+| `INTERNAL_API_KEY`              | no (transitional)                          | Fallback when `ENCLAVE_INTERNAL_API_KEY` is unset (warns at boot). Will be dropped once separation is enforced.                                               |
+| `OPENROUTER_API_KEY`            | yes                                        | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                     |
+| `OPENROUTER_BASE_URL`           | no                                         | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                        |
+| `ENCLAVE_HEARTBEAT_INTERVAL_MS` | no (default `30000`)                       | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                               |
 
 ## Egress allow-list (operational)
 

--- a/apps/enclave/src/config.test.ts
+++ b/apps/enclave/src/config.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 })
 
 describe("loadEnclaveConfig credential resolution (Phase 2.4c, E2EE-22)", () => {
-  it("prefers ENCLAVE_INTERNAL_API_KEY over the shared key", () => {
+  it("reads ENCLAVE_INTERNAL_API_KEY, ignoring the backend's shared key", () => {
     setBaseEnv()
     process.env.ENCLAVE_INTERNAL_API_KEY = "enclave-key"
     process.env.INTERNAL_API_KEY = "shared-key"
@@ -24,15 +24,9 @@ describe("loadEnclaveConfig credential resolution (Phase 2.4c, E2EE-22)", () => 
     expect(loadEnclaveConfig().internalApiKey).toBe("enclave-key")
   })
 
-  it("falls back to INTERNAL_API_KEY when the dedicated key is absent (rollout phase)", () => {
+  it("throws when the dedicated key is absent — the shared key is not a fallback", () => {
     setBaseEnv()
     process.env.INTERNAL_API_KEY = "shared-key"
-
-    expect(loadEnclaveConfig().internalApiKey).toBe("shared-key")
-  })
-
-  it("throws when neither key is set", () => {
-    setBaseEnv()
 
     expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_INTERNAL_API_KEY")
   })

--- a/apps/enclave/src/config.test.ts
+++ b/apps/enclave/src/config.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { loadEnclaveConfig } from "./config"
+
+const ORIGINAL_ENV = { ...process.env }
+
+function setBaseEnv() {
+  process.env.BACKEND_BASE_URL = "https://backend.internal"
+  process.env.ENCLAVE_SELF_URL = "https://enclave.internal"
+  process.env.OPENROUTER_API_KEY = "sk-test"
+  delete process.env.INTERNAL_API_KEY
+  delete process.env.ENCLAVE_INTERNAL_API_KEY
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe("loadEnclaveConfig credential resolution (Phase 2.4c, E2EE-22)", () => {
+  it("prefers ENCLAVE_INTERNAL_API_KEY over the shared key", () => {
+    setBaseEnv()
+    process.env.ENCLAVE_INTERNAL_API_KEY = "enclave-key"
+    process.env.INTERNAL_API_KEY = "shared-key"
+
+    expect(loadEnclaveConfig().internalApiKey).toBe("enclave-key")
+  })
+
+  it("falls back to INTERNAL_API_KEY when the dedicated key is absent (rollout phase)", () => {
+    setBaseEnv()
+    process.env.INTERNAL_API_KEY = "shared-key"
+
+    expect(loadEnclaveConfig().internalApiKey).toBe("shared-key")
+  })
+
+  it("throws when neither key is set", () => {
+    setBaseEnv()
+
+    expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_INTERNAL_API_KEY")
+  })
+})

--- a/apps/enclave/src/config.ts
+++ b/apps/enclave/src/config.ts
@@ -1,5 +1,3 @@
-import { logger } from "@threa/agent-runtime/logger"
-
 export interface EnclaveConfig {
   port: number
   /** URL the backend stores as this instance's reachable address (registration `instanceUrl`). */
@@ -7,10 +5,10 @@ export interface EnclaveConfig {
   /** Backend base URL — target for register/heartbeat/revoke. */
   backendBaseUrl: string
   /**
-   * Secret for the enclave↔backend channel — the enclave's calls to
+   * Dedicated secret for the enclave↔backend channel — the enclave's calls to
    * /internal/enclave-runtimes/* and the gate on the backend's inbound
-   * /sessions assignment. ENCLAVE_INTERNAL_API_KEY (dedicated, Phase 2.4c /
-   * E2EE-22) with a transitional fallback to the shared INTERNAL_API_KEY.
+   * /sessions assignment (ENCLAVE_INTERNAL_API_KEY; Phase 2.4c, E2EE-22).
+   * Deliberately distinct from the backend's shared INTERNAL_API_KEY.
    */
   internalApiKey: string
   /** Heartbeat interval. Backend's staleness window is 2min, so 30s keeps us with 3 retries of grace. */
@@ -32,26 +30,17 @@ export interface EnclaveConfig {
 }
 
 export function loadEnclaveConfig(): EnclaveConfig {
-  const required = ["BACKEND_BASE_URL", "ENCLAVE_SELF_URL", "OPENROUTER_API_KEY"]
+  const required = ["ENCLAVE_INTERNAL_API_KEY", "BACKEND_BASE_URL", "ENCLAVE_SELF_URL", "OPENROUTER_API_KEY"]
   const missing = required.filter((k) => !process.env[k])
-  const internalApiKey = process.env.ENCLAVE_INTERNAL_API_KEY || process.env.INTERNAL_API_KEY
-  if (!internalApiKey) {
-    missing.push("ENCLAVE_INTERNAL_API_KEY")
-  }
   if (missing.length > 0) {
     throw new Error(`Missing required environment variables: ${missing.join(", ")}`)
-  }
-  if (!process.env.ENCLAVE_INTERNAL_API_KEY) {
-    logger.warn(
-      "ENCLAVE_INTERNAL_API_KEY is not set — falling back to the shared INTERNAL_API_KEY. Set the dedicated key here and on the backend to complete credential separation (Phase 2.4c, E2EE-22)."
-    )
   }
 
   return {
     port: Number(process.env.PORT) || 3011,
     selfUrl: process.env.ENCLAVE_SELF_URL!,
     backendBaseUrl: process.env.BACKEND_BASE_URL!.replace(/\/$/, ""),
-    internalApiKey: internalApiKey!,
+    internalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY!,
     heartbeatIntervalMs: Number(process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS) || 30_000,
     sourceCommitSha: process.env.GIT_SHA || "unknown",
     buildHash: process.env.BUILD_HASH || "unknown",

--- a/apps/enclave/src/config.ts
+++ b/apps/enclave/src/config.ts
@@ -1,10 +1,17 @@
+import { logger } from "@threa/agent-runtime/logger"
+
 export interface EnclaveConfig {
   port: number
   /** URL the backend stores as this instance's reachable address (registration `instanceUrl`). */
   selfUrl: string
   /** Backend base URL — target for register/heartbeat/revoke. */
   backendBaseUrl: string
-  /** Shared secret for the enclave's calls to /internal/enclave-runtimes/*. */
+  /**
+   * Secret for the enclave↔backend channel — the enclave's calls to
+   * /internal/enclave-runtimes/* and the gate on the backend's inbound
+   * /sessions assignment. ENCLAVE_INTERNAL_API_KEY (dedicated, Phase 2.4c /
+   * E2EE-22) with a transitional fallback to the shared INTERNAL_API_KEY.
+   */
   internalApiKey: string
   /** Heartbeat interval. Backend's staleness window is 2min, so 30s keeps us with 3 retries of grace. */
   heartbeatIntervalMs: number
@@ -25,17 +32,26 @@ export interface EnclaveConfig {
 }
 
 export function loadEnclaveConfig(): EnclaveConfig {
-  const required = ["INTERNAL_API_KEY", "BACKEND_BASE_URL", "ENCLAVE_SELF_URL", "OPENROUTER_API_KEY"]
+  const required = ["BACKEND_BASE_URL", "ENCLAVE_SELF_URL", "OPENROUTER_API_KEY"]
   const missing = required.filter((k) => !process.env[k])
+  const internalApiKey = process.env.ENCLAVE_INTERNAL_API_KEY || process.env.INTERNAL_API_KEY
+  if (!internalApiKey) {
+    missing.push("ENCLAVE_INTERNAL_API_KEY")
+  }
   if (missing.length > 0) {
     throw new Error(`Missing required environment variables: ${missing.join(", ")}`)
+  }
+  if (!process.env.ENCLAVE_INTERNAL_API_KEY) {
+    logger.warn(
+      "ENCLAVE_INTERNAL_API_KEY is not set — falling back to the shared INTERNAL_API_KEY. Set the dedicated key here and on the backend to complete credential separation (Phase 2.4c, E2EE-22)."
+    )
   }
 
   return {
     port: Number(process.env.PORT) || 3011,
     selfUrl: process.env.ENCLAVE_SELF_URL!,
     backendBaseUrl: process.env.BACKEND_BASE_URL!.replace(/\/$/, ""),
-    internalApiKey: process.env.INTERNAL_API_KEY!,
+    internalApiKey: internalApiKey!,
     heartbeatIntervalMs: Number(process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS) || 30_000,
     sourceCommitSha: process.env.GIT_SHA || "unknown",
     buildHash: process.env.BUILD_HASH || "unknown",

--- a/docs/features/architecture/e2e-enclave.md
+++ b/docs/features/architecture/e2e-enclave.md
@@ -113,7 +113,7 @@ sub-loop returns partial findings and the turn still replies. For in-process
   wires it to a deploy target (`Dockerfile.enclave`, `healthcheckPath = "/healthz"`),
   matching every other service. Bringing up an instance is then just: create the
   Railway service and set the four required env vars (`ENCLAVE_SELF_URL`,
-  `BACKEND_BASE_URL`, `INTERNAL_API_KEY`, `OPENROUTER_API_KEY` — see
+  `BACKEND_BASE_URL`, `ENCLAVE_INTERNAL_API_KEY`, `OPENROUTER_API_KEY` — see
   `apps/enclave/README.md`); the enclave self-registers with the backend over
   `BACKEND_BASE_URL`, so no backend config change is needed. Pin the egress
   allow-list to the backend and OpenRouter only.
@@ -124,6 +124,23 @@ sub-loop returns partial findings and the turn still replies. For in-process
   the enclave is operationally separated, not yet a hardware TEE. Migrating to a
   real TEE (Nitro / Confidential VM / Confidential Space) is a deployment-shape
   change, not a protocol change — the sealed envelope is portable.
+- **Identity posture (Phase 2.4c, E2EE-22).** Enclave identity rests on
+  **`ENCLAVE_INTERNAL_API_KEY` secrecy plus the registration path** — a dedicated
+  credential, distinct from the `INTERNAL_API_KEY` other internal consumers hold,
+  gates `/internal/enclave-runtimes/*` (registration, heartbeat, revoke, session
+  callbacks) and the backend's assignment/cancel calls to the enclave. This is
+  what makes the `first-party-attested` trust tier honest: a bot-runtime or any
+  other shared-key holder can no longer register an EIK and become an SSK wrap
+  recipient. Wrap eligibility inherits the boundary without a schema change —
+  owner clients wrap to every live `enclave_runtimes` row, and only
+  enclave-credential holders can create rows. Rollout: while
+  `ENCLAVE_INTERNAL_API_KEY` is unset, both services fall back to the shared key
+  with a boot warning, so separation activates as a config-only event (set the
+  var on backend and enclave together). The `/attestation` endpoint remains
+  informational; real TEE evidence (e.g. a Nitro/TDX document binding the EIK
+  public key) slots into the registration handler when the infrastructure
+  exists — there is deliberately **no verifier seam or `attestation_status`
+  column** ahead of that day (INV-36): the registration handler is the seam.
 
 ## Invariants
 

--- a/docs/features/architecture/e2e-enclave.md
+++ b/docs/features/architecture/e2e-enclave.md
@@ -133,10 +133,10 @@ sub-loop returns partial findings and the turn still replies. For in-process
   other shared-key holder can no longer register an EIK and become an SSK wrap
   recipient. Wrap eligibility inherits the boundary without a schema change —
   owner clients wrap to every live `enclave_runtimes` row, and only
-  enclave-credential holders can create rows. Rollout: while
-  `ENCLAVE_INTERNAL_API_KEY` is unset, both services fall back to the shared key
-  with a boot warning, so separation activates as a config-only event (set the
-  var on backend and enclave together). The `/attestation` endpoint remains
+  enclave-credential holders can create rows. There is no fallback: the enclave
+  refuses to boot without the var, and a prod-shaped backend (CONTROL_PLANE_URL
+  set) does the same — set the same fresh secret on both services, distinct
+  from `INTERNAL_API_KEY`. The `/attestation` endpoint remains
   informational; real TEE evidence (e.g. a Nitro/TDX document binding the EIK
   public key) slots into the registration handler when the infrastructure
   exists — there is deliberately **no verifier seam or `attestation_status`

--- a/packages/agent-runtime/src/runtime/negotiate-capabilities.ts
+++ b/packages/agent-runtime/src/runtime/negotiate-capabilities.ts
@@ -9,9 +9,12 @@ import type { AgentTool } from "./agent-tool"
  * a runner-supplied manifest: a manifest is the runner's claim, and the tier
  * gates key material.
  *
- * `FIRST_PARTY_ATTESTED` is operational, not adversarial, until E2EE-21/22
- * close (Phase 2.4b/c): enclave identity currently rests on internal-key
- * secrecy, not verified attestation.
+ * `FIRST_PARTY_ATTESTED` means "authenticated as the enclave", not "hardware
+ * attested": session callbacks are token-bound (Phase 2.4b, E2EE-21) and
+ * registration runs on a dedicated credential distinct from the shared
+ * internal key (Phase 2.4c, E2EE-22), so the tier rests on
+ * ENCLAVE_INTERNAL_API_KEY secrecy. Real TEE evidence is a documented
+ * upgrade path — see docs/features/architecture/e2e-enclave.md.
  */
 export const TrustTiers = {
   /** First-party persona constructed in-process (the companion). */

--- a/packages/backend-common/src/middleware/internal-auth.test.ts
+++ b/packages/backend-common/src/middleware/internal-auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import type { NextFunction, Request, Response } from "express"
+import { INTERNAL_API_KEY_HEADER } from "@threa/types"
+import { HttpError } from "../errors"
+import { createInternalAuthMiddleware } from "./internal-auth"
+
+/** Run the middleware against a request presenting `key` (or no header) and return what it passed to next(). */
+function run(middleware: ReturnType<typeof createInternalAuthMiddleware>, key?: string): unknown {
+  let passed: unknown = "next-not-called"
+  const headers = key === undefined ? {} : { [INTERNAL_API_KEY_HEADER.toLowerCase()]: key }
+  middleware(
+    { headers } as Request,
+    {} as Response,
+    ((err?: unknown) => {
+      passed = err
+    }) as NextFunction
+  )
+  return passed
+}
+
+describe("createInternalAuthMiddleware", () => {
+  test("accepts the configured key", () => {
+    const middleware = createInternalAuthMiddleware("secret-a")
+    expect(run(middleware, "secret-a")).toBeUndefined()
+  })
+
+  test("rejects a missing header with 401", () => {
+    const middleware = createInternalAuthMiddleware("secret-a")
+    const err = run(middleware)
+    expect(err).toBeInstanceOf(HttpError)
+    expect((err as HttpError).status).toBe(401)
+  })
+
+  test("rejects a wrong key with 401", () => {
+    const middleware = createInternalAuthMiddleware("secret-a")
+    const err = run(middleware, "secret-b")
+    expect(err).toBeInstanceOf(HttpError)
+    expect((err as HttpError).status).toBe(401)
+  })
+
+  // Phase 2.4c (E2EE-22): credential separation is two middleware instances
+  // with different secrets — the shared INTERNAL_API_KEY must not open the
+  // enclave routes, and the enclave credential must not open the other
+  // internal routes. Same-length keys so only the value differs.
+  test("instances with different secrets reject each other's keys", () => {
+    const internalAuth = createInternalAuthMiddleware("internal-key-1")
+    const enclaveAuth = createInternalAuthMiddleware("enclaved-key-1")
+
+    expect(run(internalAuth, "internal-key-1")).toBeUndefined()
+    expect(run(enclaveAuth, "enclaved-key-1")).toBeUndefined()
+    expect((run(internalAuth, "enclaved-key-1") as HttpError).status).toBe(401)
+    expect((run(enclaveAuth, "internal-key-1") as HttpError).status).toBe(401)
+  })
+})

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -132,6 +132,7 @@ async function main() {
       CORS_ALLOWED_ORIGINS: corsOrigins,
       CONTROL_PLANE_URL: `http://localhost:${controlPlanePort}`,
       INTERNAL_API_KEY: backendEnv.INTERNAL_API_KEY ?? "dev-internal-key",
+      ENCLAVE_INTERNAL_API_KEY: backendEnv.ENCLAVE_INTERNAL_API_KEY ?? "dev-enclave-internal-key",
       REGION: "local",
     }
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -342,8 +342,8 @@ async function main() {
 
   // Shared internal secret. The backend mounts /internal/* only when this is
   // set. The enclave channel runs on its own dedicated secret (Phase 2.4c,
-  // E2EE-22) — distinct values in dev so local runs exercise the separated
-  // path, never the transitional fallback.
+  // E2EE-22) — distinct values in dev so local runs exercise the real
+  // credential boundary.
   const internalApiKey = backendEnv.INTERNAL_API_KEY ?? "dev-internal-key"
   const enclaveInternalApiKey = backendEnv.ENCLAVE_INTERNAL_API_KEY ?? "dev-enclave-internal-key"
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -340,10 +340,12 @@ async function main() {
   const dbBase = backendEnv.DATABASE_URL ?? process.env.DATABASE_URL ?? "postgresql://threa:threa@localhost:5454/threa"
   const useStubAuth = backendEnv.USE_STUB_AUTH ?? process.env.USE_STUB_AUTH ?? "false"
 
-  // Shared internal secret. The backend mounts /internal/enclave-runtimes/* only
-  // when this is set, and the enclave must present the same value — so they
-  // resolve from one source to avoid drift.
+  // Shared internal secret. The backend mounts /internal/* only when this is
+  // set. The enclave channel runs on its own dedicated secret (Phase 2.4c,
+  // E2EE-22) — distinct values in dev so local runs exercise the separated
+  // path, never the transitional fallback.
   const internalApiKey = backendEnv.INTERNAL_API_KEY ?? "dev-internal-key"
+  const enclaveInternalApiKey = backendEnv.ENCLAVE_INTERNAL_API_KEY ?? "dev-enclave-internal-key"
 
   // Derive control-plane DB URL from the backend's DATABASE_URL by appending _cp
   const cpDbUrl = dbBase.replace(/\/([^/?]+)(\?.*)?$/, "/$1_cp$2")
@@ -439,6 +441,7 @@ async function main() {
       USE_STUB_AUTH: useStubAuth,
       CONTROL_PLANE_URL: "http://localhost:3003",
       INTERNAL_API_KEY: internalApiKey,
+      ENCLAVE_INTERNAL_API_KEY: enclaveInternalApiKey,
       CORS_ALLOWED_ORIGINS: corsOrigins.join(","),
       REGION: "local",
     },
@@ -510,7 +513,7 @@ async function main() {
       PORT: "3011",
       ENCLAVE_SELF_URL: "http://localhost:3011",
       BACKEND_BASE_URL: "http://localhost:3002",
-      INTERNAL_API_KEY: internalApiKey,
+      ENCLAVE_INTERNAL_API_KEY: enclaveInternalApiKey,
       // Dev only: persist the EIK across `node --watch` restarts so a code
       // change doesn't mint a fresh key and silently break every E2E stream's
       // wraps. Prod never sets this — the key stays ephemeral.

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -485,7 +485,8 @@ async function main() {
   // lacks X25519 `deriveBits`, which the enclave needs to unwrap the per-stream
   // key. Bun only bundles it. Build once up front so `node --watch` has a file
   // to load, then run a rebuild-watcher beside the Node process. It registers
-  // with the backend at :3002 (not the :3001 router) using the shared key.
+  // with the backend at :3002 (not the :3001 router) using the dedicated
+  // ENCLAVE_INTERNAL_API_KEY.
   const enclaveDir = path.join(process.cwd(), "apps/enclave")
   console.log("Building enclave bundle...")
   await $`bun build src/index.ts --target=node --format=esm --outfile dist/index.mjs`.cwd(enclaveDir).quiet()


### PR DESCRIPTION
## Problem

The enclave's entire identity rests on `INTERNAL_API_KEY` — a secret shared with every internal consumer. The audit's words (E2EE-22): *"Any internal-key holder (e.g. the bot-runtime, which holds the same key) can register a key and become an SSK recipient."* Concretely: anyone holding the shared key could register an EIK via `/internal/enclave-runtimes/register-key`, and because owner clients wrap the stream key to **every live `enclave_runtimes` row** (`resolveActorRecipients`), that registered key would start receiving SSK wraps for encrypted streams. The `first-party-attested` trust tier introduced in Phase 2.4a is policy theater until this is closed.

This is the third and final sub-PR of Phase 2.4 (design doc: `docs/plans/agent-runtimes-phase-2-4-trust-tiers.md`, §4.2). 2.4a (verdict gate) and 2.4b (session-bound callbacks, E2EE-21) merged in #882.

## Solution

The enclave↔backend channel runs on a dedicated secret, `ENCLAVE_INTERNAL_API_KEY`, distinct from the shared `INTERNAL_API_KEY`:

- **Backend inbound:** all 11 `/internal/enclave-runtimes/*` routes (register/heartbeat/revoke + the 8 session callbacks) are gated by a **separate middleware instance** keyed by the enclave credential, mounted independently of the control-plane internal block. The shared key does not open these routes — and the enclave credential opens nothing else.
- **Backend outbound:** `EnclaveForwarder` (assignment + cancel) presents the enclave credential; the enclave's inbound `requireInternalKey` gate validates the same value.
- **Enclave:** requires `ENCLAVE_INTERNAL_API_KEY` at boot; `INTERNAL_API_KEY` is no longer read.
- **Wrap eligibility inherits the boundary with no schema change:** owner clients still wrap to every live `enclave_runtimes` row — but rows can now only be created by enclave-credential holders, so "every live EIK" means "every key registered through the enclave registration path."
- **Attestation posture documented** (the finding's "document explicitly" arm): enclave identity rests on `ENCLAVE_INTERNAL_API_KEY` secrecy plus the registration path. Deliberately **no verifier seam, no `attestation_status` column** (INV-36) — the registration handler is the seam where real TEE evidence slots in when the infrastructure exists.

### Key design decisions

**1. No fallback — the dedicated credential is required** *(Kris's call; the var is provisioned on both services in prod + staging)*

The PR originally shipped a transitional warn-and-fall-back to `INTERNAL_API_KEY`; once Kris provisioned `ENCLAVE_INTERNAL_API_KEY` on both Railway services, the fallback was dropped in the same PR (4b11206). A prod-shaped backend (`CONTROL_PLANE_URL` set) now refuses to boot without the var — mirroring the existing `INTERNAL_API_KEY` co-presence rule (INV-11) so a missed provisioning fails loudly instead of silently unmounting the enclave routes. In dev-shape, absence simply leaves the enclave channel off. The enclave requires the var unconditionally.

**2. The boundary is two middleware instances, not new auth machinery**

`createInternalAuthMiddleware` already does timing-safe comparison; credential separation is literally the same factory constructed twice with different secrets. A new test pins the property that matters: instances with different secrets reject each other's keys. The enclave route block mounts under its own `if (enclaveInternalApiKey)` so an enclave-credential-only config serves the channel (CodeRabbit review fix, 85ab1e2).

**3. Dev runs the separated path**

`scripts/dev.ts` and `scripts/dev-test.ts` feed distinct keys (`dev-internal-key` / `dev-enclave-internal-key`) to the backend and enclave, so local development and E2E runs exercise the real credential boundary.

**4. The tier caveat is retired, accurately**

The Phase 2.4a `TrustTiers` comment said `FIRST_PARTY_ATTESTED` was "operational, not adversarial, until E2EE-21/22 close." Both are now closed (21 in #882, 22's actionable half here), so the comment now states what the tier actually means: "authenticated as the enclave" via a dedicated credential — not hardware-attested, with TEE evidence as the documented upgrade path.

## Deployment note

`ENCLAVE_INTERNAL_API_KEY` is already set on the `backend` and `enclave` Railway services (prod + staging) — distinct per environment and from `INTERNAL_API_KEY`. Staging PR environments inherit it automatically (staging-pr.ts copies env vars from the main staging backend). Local dev needs nothing; the dev scripts default it.

## New files

| File | Purpose |
| ---- | ------- |
| `packages/backend-common/src/middleware/internal-auth.test.ts` | Middleware accept/reject matrix + the cross-credential rejection property |
| `apps/enclave/src/config.test.ts` | Dedicated key read; throws without it (shared key is not a fallback) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/env.ts` | `enclaveInternalApiKey` config field; required when `CONTROL_PLANE_URL` is set (INV-11) |
| `apps/backend/src/lib/env.test.ts` | Dedicated-key read, no-fallback, and prod-shape co-presence throw cases |
| `apps/backend/src/routes.ts` | Separate `enclaveAuth` middleware on all 11 enclave routes, mounted under its own conditional |
| `apps/backend/src/server.ts` | Pass the credential to routes; forwarder constructed from it |
| `apps/backend/src/features/enclave-runtimes/forwarder.ts` | Presents the enclave credential (dep renamed to match, INV-10) |
| `apps/backend/src/features/enclave-runtimes/forwarder.test.ts` | Renamed constructor dep |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | Doc comment: callbacks ride the enclave-credential gate |
| `apps/backend/src/features/streams/service.ts` | Comment: wrap eligibility inherits the registration boundary |
| `packages/agent-runtime/src/runtime/negotiate-capabilities.ts` | `FIRST_PARTY_ATTESTED` caveat replaced with the post-2.4b/c posture |
| `apps/enclave/src/config.ts` | `ENCLAVE_INTERNAL_API_KEY` required; shared key no longer read |
| `scripts/dev.ts`, `scripts/dev-test.ts` | Distinct dev keys for backend + enclave |
| `apps/enclave/README.md` | Env table, local-run and Railway instructions |
| `docs/features/architecture/e2e-enclave.md` | Identity-posture section (the E2EE-22 documentation arm); env var list |

## Test plan

- [x] `internal-auth.test.ts` — accepts configured key; 401 on missing/wrong; **instances with different secrets reject each other's keys** (the separation property from design doc §6)
- [x] `env.test.ts` — dedicated key read; null when only the shared key is set (no fallback); prod-shape boot throw without it
- [x] `config.test.ts` (enclave, vitest) — dedicated key read; throws without it even when `INTERNAL_API_KEY` is set
- [x] `forwarder.test.ts` — header carries the dedicated credential
- [x] Full `enclave-runtimes` backend suite (87 tests), full enclave vitest suite (75 tests), monorepo typecheck + lint + API-docs check (pre-commit) — all green
- [ ] Post-deploy smoke (staging): enclave registers/heartbeats under the dedicated key; an E2E scratchpad turn round-trips

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Close E2EE-22's actionable half — Phase 2.4c of the agent-runtimes unification (binding design: `docs/plans/agent-runtimes-phase-2-4-trust-tiers.md` §4.2, committed in-repo).

**What was built** (the design's three moves):
1. **Credential separation** — dedicated `ENCLAVE_INTERNAL_API_KEY` for enclave registration + session callbacks (and the backend's outbound assignment/cancel, since the channel is bidirectional on one secret), validated by the same middleware factory with a different value (design §4.2.1).
2. **Wrap eligibility inherits the boundary** — `resolveActorRecipients`' enclave branch unchanged; only enclave-credential holders can create `enclave_runtimes` rows, so eligibility follows without a schema change (design §4.2.2).
3. **Documented attestation posture** — in `docs/features/architecture/e2e-enclave.md` and beside the tier derivation; no verifier seam or `attestation_status` column ahead of real TEE infrastructure (INV-36; design §4.2.3).

**Decisions resolved with Kris during the PR:**
- Boot behavior: shipped first as warn + fallback to keep deploys safe; after Kris provisioned the var on both services (prod + staging), the fallback was dropped in-PR (4b11206) — backend requires it in prod-shape (`CONTROL_PLANE_URL` co-presence, INV-11), enclave requires it unconditionally.
- Provisioning: done by Kris before the fallback drop, so no deploy window ever lacked the credential.
- PR shape: all of 2.4c in this one PR.

**Review:** CodeRabbit round 1 — 3 findings, all accepted and fixed in 85ab1e2 (independent enclave-route mounting, stale dev.ts comment, README wording).

**Deliberately out of scope** (design §4.3): TEE integration; flipping `externalSealedDelivery`; sealed bot wire variants; consent/revocation UX; E2EE-7; the §2.7 pull transport. Also pending separately: the 2.4b reject-if-absent callback-token flip once a release has drained.

**Status:** Complete pending review + post-deploy smoke. With this, Phase 2.4 (a+b+c) is done.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01QjaEnrRw2YSCYVvcJAJvSo
