### PR TITLE
fix: refocus sidebar search input when the search shortcut fires while the panel is open

### DIFF
--- a/apps/frontend/src/components/search/search-panel-context.tsx
+++ b/apps/frontend/src/components/search/search-panel-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react"
 import { useNavigate } from "react-router-dom"
 import { useSidebar } from "@/contexts/sidebar-context"
 
@@ -23,6 +23,12 @@ interface SearchPanelContextValue {
   openSearch: (options?: OpenSearchOptions) => void
   /** Leave search mode and return the sidebar to the stream list. */
   closeSearch: () => void
+  /**
+   * The mounted panel registers how to focus its input so `openSearch` can
+   * refocus it when the panel is already open (mod+shift+f after focus
+   * wandered elsewhere). Pass null on unmount.
+   */
+  registerFocusHandler: (handler: (() => void) | null) => void
 }
 
 const SearchPanelContext = createContext<SearchPanelContextValue | null>(null)
@@ -33,6 +39,11 @@ export function SearchPanelProvider({ workspaceId, children }: { workspaceId: st
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [activeResultId, setActiveResultId] = useState<string | null>(null)
+
+  const focusInputRef = useRef<(() => void) | null>(null)
+  const registerFocusHandler = useCallback((handler: (() => void) | null) => {
+    focusInputRef.current = handler
+  }, [])
 
   const openSearch = useCallback(
     (options?: OpenSearchOptions) => {
@@ -57,6 +68,9 @@ export function SearchPanelProvider({ workspaceId, children }: { workspaceId: st
       if (state !== "pinned") {
         togglePinned()
       }
+      // Already-open panel: refocus the input (first open is handled by the
+      // panel's own autoFocus — no handler is registered yet at that point).
+      focusInputRef.current?.()
     },
     [isMobile, collapse, navigate, workspaceId, state, togglePinned]
   )
@@ -66,8 +80,17 @@ export function SearchPanelProvider({ workspaceId, children }: { workspaceId: st
   }, [])
 
   const value = useMemo(
-    () => ({ isOpen, query, setQuery, activeResultId, setActiveResultId, openSearch, closeSearch }),
-    [isOpen, query, activeResultId, openSearch, closeSearch]
+    () => ({
+      isOpen,
+      query,
+      setQuery,
+      activeResultId,
+      setActiveResultId,
+      openSearch,
+      closeSearch,
+      registerFocusHandler,
+    }),
+    [isOpen, query, activeResultId, openSearch, closeSearch, registerFocusHandler]
   )
 
   return <SearchPanelContext.Provider value={value}>{children}</SearchPanelContext.Provider>

--- a/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
@@ -89,8 +89,14 @@ function RouterWrapper({ children }: { children: React.ReactNode }) {
 
 /** Exposes provider state so tests can assert open/close transitions. */
 function SearchPanelProbe() {
-  const { isOpen, query } = useSearchPanel()
-  return <div data-testid="search-panel-probe" data-open={String(isOpen)} data-query={query} />
+  const { isOpen, query, openSearch } = useSearchPanel()
+  return (
+    <>
+      <div data-testid="search-panel-probe" data-open={String(isOpen)} data-query={query} />
+      {/* Stands in for the global mod+shift+f handler, which calls openSearch() */}
+      <button onClick={() => openSearch()}>Trigger open search</button>
+    </>
+  )
 }
 
 /** Opens the panel on mount so `closeSearch` transitions are observable. */
@@ -209,6 +215,27 @@ describe("SidebarSearchPanel Integration Tests", () => {
       await user.click(screen.getByRole("button", { name: /back to streams/i }))
 
       expect(screen.getByTestId("search-panel-probe")).toHaveAttribute("data-open", "false")
+    })
+
+    it("refocuses the search input when openSearch fires while the panel is already open", async () => {
+      const user = userEvent.setup()
+      renderPanel()
+
+      const editor = screen.getByLabelText("Search messages")
+      await user.click(editor)
+      expect(editor).toHaveFocus()
+
+      // Focus wanders elsewhere (the user tabbed out, clicked another control...)
+      const trigger = screen.getByRole("button", { name: /trigger open search/i })
+      trigger.focus()
+      expect(editor).not.toHaveFocus()
+
+      // mod+shift+f calls openSearch() again — the input regains focus
+      await user.click(trigger)
+
+      expect(screen.getByTestId("search-panel-probe")).toHaveAttribute("data-open", "true")
+      // TipTap defers focus to the next animation frame
+      await waitFor(() => expect(editor).toHaveFocus())
     })
 
     it("closes the panel with Escape when no popover is open", async () => {

--- a/apps/frontend/src/components/search/sidebar-search-panel.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 import { useNavigate } from "react-router-dom"
 import { ArrowLeft, Search as SearchIcon } from "lucide-react"
 import { SidebarShell } from "@/components/layout/sidebar/sidebar-shell"
@@ -23,13 +23,19 @@ import { SearchResults } from "./search-results"
  */
 export function SidebarSearchPanel({ workspaceId }: { workspaceId: string }) {
   const navigate = useNavigate()
-  const { query, setQuery, activeResultId, setActiveResultId, closeSearch } = useSearchPanel()
+  const { query, setQuery, activeResultId, setActiveResultId, closeSearch, registerFocusHandler } = useSearchPanel()
   const { results, isLoading, error, parsedFilters, searchText, hasQuery } = useMessageSearch(workspaceId, query)
   const { preferences } = usePreferences()
 
   const inputRef = useRef<RichInputRef>(null)
   const resultsRef = useRef<HTMLDivElement>(null)
   const isPopoverActiveRef = useRef(false)
+
+  // Lets mod+shift+f refocus the input while the panel is already open.
+  useEffect(() => {
+    registerFocusHandler(() => inputRef.current?.focus())
+    return () => registerFocusHandler(null)
+  }, [registerFocusHandler])
 
   const terms = useMemo(() => extractSearchTerms(searchText), [searchText])
   const streamCount = useMemo(() => new Set(results.map((r) => r.streamId)).size, [results])


### PR DESCRIPTION
## Problem

Once the sidebar search panel is open, pressing the workspace search shortcut (`mod+shift+f`) again does nothing. The global handler calls `openSearch()`, which only sets `isOpen` — already true — so if focus has wandered (tabbing out, clicking a message, typing in the composer), there is no way to get back to the search input from the keyboard. The in-stream search (`mod+f`) already handles this: `openOrFocusSearch` in `stream-content.tsx` refocuses the input when the bar is already open.

## Solution

Mirror the in-stream pattern through the existing `SearchPanelContext`:

- The context gains `registerFocusHandler`. The mounted `SidebarSearchPanel` registers `inputRef.current?.focus()` and unregisters on unmount.
- `openSearch` invokes the registered handler after opening. Since every entry point (keyboard shortcut, sidebar header button, quick switcher command) goes through `openSearch`, they all get the refocus behavior.

### Key design decisions

**1. Ref-registration instead of a focus-request counter.** The handler lives in a ref on the provider, so re-invoking the shortcut doesn't re-render context consumers. First open still relies on the input's `autoFocus` — no handler is registered yet at that moment, so there's no double-focus path.

**2. Mobile untouched.** On mobile, `openSearch` navigates to the full-page search view; the shortcut-refocus scenario is a desktop sidebar concern.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/search/search-panel-context.tsx` | Add `registerFocusHandler` to the context; `openSearch` invokes the registered handler |
| `apps/frontend/src/components/search/sidebar-search-panel.tsx` | Register the input-focus handler on mount, unregister on unmount |
| `apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx` | New test: focus wanders elsewhere, `openSearch()` fires again, input regains focus |

## Test plan

- [x] New integration test fails with the focus call removed, passes with it
- [x] All 36 search component tests pass (`bun run test -- src/components/search/`)
- [x] Monorepo typecheck clean
- [ ] Manual: open sidebar search, click into the timeline, press `mod+shift+f`, input is focused again

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01CCB4YTS7WCGF9Ajv6idY6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCB4YTS7WCGF9Ajv6idY6v)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880993&installation_id=129946197&pr_number=890&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F890&signature=9d43418adf26223fbda31118e1283dbd74e71128c5aa2038c0845537bddff708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->