### PR TITLE
feat: put conversations and memos on the sync-v2 catch-up path

### DIFF
--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type ReactNode } from "react"
+import type { Socket } from "socket.io-client"
+import type { ConversationWithStaleness } from "@threa/types"
+import * as contextsModule from "@/contexts"
+import * as syncEngineModule from "@/sync/sync-engine"
+import { SocketEventGate } from "@/sync/socket-event-gate"
+import { useConversations, conversationKeys } from "./use-conversations"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_1"
+
+function createTestSocket() {
+  const handlers = new Map<string, Set<(payload: unknown) => void>>()
+
+  const socket = {
+    on(event: string, handler: (payload: unknown) => void) {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return this
+    },
+    off(event: string, handler: (payload: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+      return this
+    },
+  } as unknown as Socket
+
+  return {
+    socket,
+    emit(event: string, payload: unknown) {
+      handlers.get(event)?.forEach((handler) => handler(payload))
+    },
+  }
+}
+
+function makeConversation(id: string): ConversationWithStaleness {
+  return { id } as unknown as ConversationWithStaleness
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  return { queryClient, wrapper }
+}
+
+function listKey() {
+  return conversationKeys.list(WORKSPACE_ID, STREAM_ID, { status: undefined, limit: undefined })
+}
+
+describe("useConversations event registration", () => {
+  let reconnectCount: number
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    reconnectCount = 0
+    vi.spyOn(contextsModule, "useConversationService").mockReturnValue({
+      listByStream: vi.fn().mockResolvedValue([]),
+    } as unknown as contextsModule.ConversationService)
+    vi.spyOn(contextsModule, "useSocketReconnectCount").mockImplementation(() => reconnectCount)
+  })
+
+  it("receives catch-up entries dispatched through the engine's event gate", async () => {
+    const { socket } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+
+    const gate = new SocketEventGate(WORKSPACE_ID)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue({
+      getLiveEventSource: () => gate,
+    } as unknown as syncEngineModule.SyncEngine)
+
+    const { queryClient, wrapper } = createWrapper()
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await waitFor(() => expect(queryClient.getQueryData(listKey())).toEqual([]))
+
+    // Catch-up replay path: the engine pages the sync log and hands each
+    // entry to gate.dispatch — never to the raw socket.
+    await act(async () => {
+      await gate.dispatch("conversation:created", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        conversation: makeConversation("conv_1"),
+      })
+    })
+
+    expect(queryClient.getQueryData(listKey())).toEqual([makeConversation("conv_1")])
+
+    gate.dispose()
+  })
+
+  it("falls back to raw socket registration without a sync engine", async () => {
+    const { socket, emit } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(null)
+
+    const { queryClient, wrapper } = createWrapper()
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await waitFor(() => expect(queryClient.getQueryData(listKey())).toEqual([]))
+
+    act(() => {
+      emit("conversation:created", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        conversation: makeConversation("conv_1"),
+      })
+    })
+
+    expect(queryClient.getQueryData(listKey())).toEqual([makeConversation("conv_1")])
+  })
+
+  it("still invalidates the list on socket reconnect (INV-53 healing untouched)", async () => {
+    const { socket } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(null)
+
+    const { queryClient, wrapper } = createWrapper()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    reconnectCount = 1
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: listKey() }))
+  })
+})

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useConversationService, useSocket, useSocketReconnectCount } from "@/contexts"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import type { ConversationWithStaleness, ConversationStatus } from "@threa/types"
 
 export const conversationKeys = {
@@ -61,6 +62,8 @@ export function useConversations(workspaceId: string, streamId: string, options?
   const queryClient = useQueryClient()
   const socket = useSocket()
   const reconnectCount = useSocketReconnectCount()
+  // Optional: conversation overlays can mount outside the workspace SyncEngine provider.
+  const syncEngine = useOptionalSyncEngine()
 
   const {
     data: conversations = [],
@@ -140,18 +143,24 @@ export function useConversations(workspaceId: string, streamId: string, options?
       queryClient.invalidateQueries({ queryKey: conversationKeys.messages(payload.toConversationId) })
     }
 
-    socket.on("conversation:created", handleCreated)
-    socket.on("conversation:updated", handleUpdated)
-    socket.on("conversation:message_assigned", handleMessageAssigned)
-    socket.on("conversation:message_reassigned", handleMessageReassigned)
+    // In active sync-v2 mode, register through the engine's event gate so
+    // these handlers receive catch-up replays and respect buffer-and-splice
+    // ordering exactly like engine-owned handlers — conversation events are
+    // stream-scoped sync-log entries, and a raw-socket registration would
+    // never see them replayed after a gap.
+    const eventSource = syncEngine?.getLiveEventSource() ?? socket
+    eventSource.on("conversation:created", handleCreated)
+    eventSource.on("conversation:updated", handleUpdated)
+    eventSource.on("conversation:message_assigned", handleMessageAssigned)
+    eventSource.on("conversation:message_reassigned", handleMessageReassigned)
 
     return () => {
-      socket.off("conversation:created", handleCreated)
-      socket.off("conversation:updated", handleUpdated)
-      socket.off("conversation:message_assigned", handleMessageAssigned)
-      socket.off("conversation:message_reassigned", handleMessageReassigned)
+      eventSource.off("conversation:created", handleCreated)
+      eventSource.off("conversation:updated", handleUpdated)
+      eventSource.off("conversation:message_assigned", handleMessageAssigned)
+      eventSource.off("conversation:message_reassigned", handleMessageReassigned)
     }
-  }, [socket, workspaceId, streamId, status, limit, enabled, queryClient])
+  }, [socket, syncEngine, workspaceId, streamId, status, limit, enabled, queryClient])
 
   return {
     conversations,

--- a/apps/frontend/src/hooks/use-memos.ts
+++ b/apps/frontend/src/hooks/use-memos.ts
@@ -3,8 +3,10 @@ import { getMemo, searchMemos, type MemoSearchRequest } from "@/api"
 
 export const memoKeys = {
   all: ["memos"] as const,
-  search: (workspaceId: string, request: MemoSearchRequest) =>
-    [...memoKeys.all, "search", workspaceId, request] as const,
+  /** Prefix for every search query in one workspace — the invalidation target
+   *  when a `memo:created` event lands (workspace-sync). */
+  searches: (workspaceId: string) => [...memoKeys.all, "search", workspaceId] as const,
+  search: (workspaceId: string, request: MemoSearchRequest) => [...memoKeys.searches(workspaceId), request] as const,
   detail: (workspaceId: string, memoId: string) => [...memoKeys.all, "detail", workspaceId, memoId] as const,
 }
 

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -10,6 +10,7 @@ import {
 import { readMirroredSyncV2Mode } from "./sync-v2-mode"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
+import { memoKeys } from "@/hooks/use-memos"
 import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_QUICK_LINKS,
@@ -702,6 +703,31 @@ describe("registerWorkspaceSocketHandlers", () => {
       cleanup()
     }
   )
+
+  it("invalidates the memo search queries when a memo:created event lands", () => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, "active")
+
+    emit("memo:created", { workspaceId: "ws_1", memoId: "memo_1" })
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })
+    cleanup()
+  })
+
+  it("ignores memo:created events from other workspaces", () => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, "active")
+
+    emit("memo:created", { workspaceId: "ws_other", memoId: "memo_1" })
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_other") })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })
+    cleanup()
+  })
 
   it("subscribes the creator when a new stream is created at runtime", async () => {
     const queryClient = new QueryClient()

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -33,6 +33,7 @@ import type {
   LabelUnassignedPayload,
 } from "@threa/types"
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
+import { memoKeys } from "@/hooks/use-memos"
 import { persistScheduledRows, removeScheduledRow, scheduledKeys } from "@/hooks/use-scheduled"
 import { assignmentToCached, assignmentId } from "@/hooks/use-labels"
 import {
@@ -1437,6 +1438,17 @@ export function registerWorkspaceSocketHandlers(
     queryClient.invalidateQueries({ queryKey: ["activity", workspaceId] })
   }
 
+  // GAM memo extraction: surface new memos in the memory explorer without a
+  // manual refresh. memo:created is workspace-group routed (sync log + emit),
+  // so registering here puts memos on the sync-v2 catch-up path like every
+  // other workspace-level event — a reconnect replay invalidates the same
+  // queries a live emit does. The in-situ timeline row rides the separate
+  // stream:memos_captured event (stream-sync).
+  const handleMemoCreated = (payload: { workspaceId: string; memoId: string }) => {
+    if (payload.workspaceId !== workspaceId) return
+    queryClient.invalidateQueries({ queryKey: memoKeys.searches(workspaceId) })
+  }
+
   // Handle attachment transcoded (video processing completed or failed)
   const handleAttachmentTranscoded = async (payload: {
     workspaceId: string
@@ -1769,6 +1781,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("bot:created", handleBotCreated)
   socket.on("bot:updated", handleBotUpdated)
   socket.on("activity:created", handleActivityCreated)
+  socket.on("memo:created", handleMemoCreated)
   socket.on("saved:upserted", handleSavedUpserted)
   socket.on("saved:deleted", handleSavedDeleted)
   socket.on("saved_reminder:fired", handleSavedReminderFired)
@@ -1809,6 +1822,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("bot:created", handleBotCreated)
     socket.off("bot:updated", handleBotUpdated)
     socket.off("activity:created", handleActivityCreated)
+    socket.off("memo:created", handleMemoCreated)
     socket.off("saved:upserted", handleSavedUpserted)
     socket.off("saved:deleted", handleSavedDeleted)
     socket.off("saved_reminder:fired", handleSavedReminderFired)

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -1,0 +1,127 @@
+# Sync v2 PR E+ — healing-path inventory and deletion verdicts
+
+Survey of every remaining client-side healing path (blanket reconnect
+invalidations, bootstrap refetches, INV-53 redundancy) now that the workspace
+sync cursor is the default (`sync-v2-cursor: active`, #884) and the
+saved/scheduled reconnect refetch is gated (#885). Ground rules carried from
+the rollout sessions:
+
+- **One healing deletion per PR**, each with a test proving the cursor covers
+  what the deleted healing covered.
+- **Never delete healing that covers dropped live emits** until a socket
+  heartbeat exists.
+- Coverage proof method (established in #885): event type → scoping list in
+  `apps/backend/src/lib/outbox/repository.ts` → delivery group
+  (`delivery-groups.ts`, single source of truth for log + emit) → `sync_log`
+  (`features/sync/repository.ts:listEntriesForUser`) → `gate.dispatch` through
+  the registered live handlers.
+
+## Two mechanics that decide every verdict
+
+**1. The log is populated independently of emit success.** The
+BroadcastHandler persists delivery groups to `sync_log` and derives the
+Socket.io rooms from the same groups, so a dropped live emit still has a log
+entry, the client cursor stays behind it (the cursor only advances by applied
+events), and the _next_ catch-up trigger (reconnect, resume, online flip)
+replays it. What's missing is _detection between the drop and the next
+trigger_ — that's the heartbeat gap. Consequence: healing that fires on the
+same triggers as catch-up adds no dropped-emit coverage; only healing with
+_extra_ triggers (or continuous detection, like timeline contiguity) does.
+
+**2. Catch-up replay reaches only gate-registered handlers.**
+`SocketEventGate.dispatch` invokes handlers registered _on the gate_
+(`sync-engine.ts:getLiveEventSource`). Registered on the gate today:
+`registerWorkspaceSocketHandlers` (workspace-sync), engine-owned
+`registerStreamSocketHandlers` per member stream (stream-sync), and
+`useStreamSocket`. Registered on the **raw socket** (replay never reaches
+them): `use-conversations`, `use-agent-activity`, `use-agent-trace`,
+`use-link-preview-dismissals`, `use-voice-dictation`.
+
+## Deletion candidates (in recommended order)
+
+### PR E — `use-conversations` reconnect invalidation
+
+`apps/frontend/src/hooks/use-conversations.ts:82-87`: invalidates the
+conversation list on every socket reconnect.
+
+- All four conversation events are stream-scoped in the log
+  (`conversation:created`/`updated`/`message_assigned` also fan out to the
+  parent stream group), and `listEntriesForUser` returns them for member
+  streams including threads (INV-62 rule mirrored in the SQL).
+- **Blocker inside the same PR:** the hook registers its handlers on the raw
+  socket (`use-conversations.ts:143-146`), so replay currently no-ops. Migrate
+  it to `syncEngine?.getLiveEventSource() ?? socket` (the `useStreamSocket`
+  pattern) first, then gate the invalidation on `mode !== "active"`.
+- Unmounted-during-catch-up is safe: the query uses default staleness, so the
+  next mount refetches anyway. The invalidation only ever fired on reconnect,
+  so dropped-emit coverage is unchanged.
+- Test: replay `conversation:created` through the gate and assert the list
+  cache updates; pin that `off` and `shadow` keep the invalidation.
+
+**Verdict: covered once the hook is gate-registered. Smallest, cleanest next
+deletion.**
+
+### PR F — `refetchOnReconnect: true` on saved + scheduled lists
+
+`use-saved.ts:150`, `use-scheduled.ts:203`. Kept by #885 to cover the pure
+browser online/offline flip (no socket.io reconnect cycle).
+
+- The same flip already triggers `refreshAfterConnectivityResume()`
+  (workspace-layout.tsx isOnline effect) → `runCatchUp("resume")` → replays
+  the user-scoped saved/scheduled entries through the gate-registered
+  workspace-sync handlers — the exact PR-B proof chain, on the exact same
+  trigger.
+- Needs the hooks to read the engine mode (engine context) to set the option
+  per mode; keep `true` in off/shadow.
+
+**Verdict: covered in active mode. Same shape and risk profile as #885.**
+
+### PR G — `refetchOnReconnect: true` on `useLabelsSync`
+
+`use-labels.ts:194`. All seven `label:*` events have delivery groups and
+gate-registered handlers in workspace-sync, so the reconnect gap is replayed
+in active mode.
+
+- **One open edge:** public-label `label:assigned`/`unassigned` on a _stream_
+  resource is stream-group-scoped. Catch-up only returns stream groups for
+  member streams, but a non-member can be viewing a public stream live (live
+  emit reaches the room; catch-up won't return it). The labels query has
+  `staleTime: Infinity`, so without `refetchOnReconnect` that viewer's
+  assignment state stays stale until a reload or another invalidation.
+
+**Verdict: mostly covered; resolve or accept the non-member public-stream
+edge before deleting.**
+
+## Not deletable / keep as-is
+
+- **`usePageResumeRefresh`** (workspace + visible-stream bootstrap
+  invalidation on ≥5s resume): overlaps `SyncEngine.handlePageResume` (≥10s
+  away → probe → full reconnect bootstrap + catch-up), and on a ≥10s resume
+  the two run _duplicate_ full bootstrap fetches in every mode — but it is the
+  only healing in the 5–10s window and the only blanket cover for
+  "socket-healthy but tab-throttled" gaps below the probe threshold. Any
+  change here is a redesign (threshold alignment / engine-owned resume
+  catch-up), not a one-line deletion. Owner decision; not next.
+- **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): blocked.
+  Bootstrap is still the authority for legacy unread-counter entries (until
+  sync_log retention ships and `isLegacyUnreadCounterEntry` dies), heals the
+  accepted #874 drift, and active-mode seeding is read-before-stamp _against
+  this fetch_.
+- **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
+  this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
+- **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**
+  (INV-61): the only healing with in-band dropped-emit _detection_ (a gap is
+  visible the moment the next event arrives). Keep until a heartbeat exists.
+- **Ephemeral raw-socket handlers** (`agent_session:activity_started`,
+  `:progress`, `:step:*`, voice, `bot_runtime:presence`,
+  `pointer:invalidated`): not outbox-routed, never in the log; no healing
+  attached. Nothing to do. (`agent_session:started/completed/failed/deleted`
+  _are_ logged and replay through gate-registered stream-sync handlers.)
+- **`use-memos`**: default TanStack refetch behavior only; `memo:created` is
+  workspace-group-logged but has no gate handler — and no INV-53-style healing
+  exists to delete. In-situ capture rides `stream:memos_captured` through
+  stream-sync.
+- **`refetchOnMount: true`** on saved/scheduled/labels/activity: mount-time
+  freshness, not reconnect healing. Out of scope.
+- **`useBackgroundBootstrapSync`** (SW prefetch) and **`useAppUpdate`**
+  (version check on reconnect): not sync healing.

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -33,13 +33,31 @@ _extra_ triggers (or continuous detection, like timeline contiguity) does.
 (`sync-engine.ts:getLiveEventSource`). Registered on the gate today:
 `registerWorkspaceSocketHandlers` (workspace-sync), engine-owned
 `registerStreamSocketHandlers` per member stream (stream-sync), and
-`useStreamSocket`. Registered on the **raw socket** (replay never reaches
-them): `use-conversations`, `use-agent-activity`, `use-agent-trace`,
-`use-link-preview-dismissals`, `use-voice-dictation`.
+`useStreamSocket`, and (since the additive PR) `use-conversations`. Registered
+on the **raw socket** (replay never reaches them): `use-agent-activity`,
+`use-agent-trace`, `use-link-preview-dismissals`, `use-voice-dictation` — all
+ephemeral-event consumers except `use-link-preview-dismissals` (logged,
+author-scoped; migrate if dismissal staleness is ever reported).
 
-## Deletion candidates (in recommended order)
+## Decision (2026-06-12): additive first
 
-### PR E — `use-conversations` reconnect invalidation
+The rollout isn't complete (no heartbeat, no sync_log retention), so the owner
+chose to finish wiring consumers into the sync system before deleting any more
+healing. PR E therefore ships the **additive** halves only:
+
+- `use-conversations` registers through the engine's event gate (catch-up
+  replay now reaches it); its reconnect invalidation **stays**.
+- `memo:created` gets a gate-registered handler in workspace-sync (it was
+  logged but had no listener at all) — memos now ride the system.
+
+The deletions below follow afterwards, one per PR as before. The
+`usePageResumeRefresh` redesign is agreed as a follow-up: once retention ships
+and the resume path no longer needs the blanket bootstrap fetch, resume becomes
+"cursor catch-up only" and the 5s hook is deleted rather than redesigned.
+
+## Deletion candidates (in agreed order, after the additive PR)
+
+### `use-conversations` reconnect invalidation
 
 `apps/frontend/src/hooks/use-conversations.ts:82-87`: invalidates the
 conversation list on every socket reconnect.
@@ -48,10 +66,10 @@ conversation list on every socket reconnect.
   (`conversation:created`/`updated`/`message_assigned` also fan out to the
   parent stream group), and `listEntriesForUser` returns them for member
   streams including threads (INV-62 rule mirrored in the SQL).
-- **Blocker inside the same PR:** the hook registers its handlers on the raw
-  socket (`use-conversations.ts:143-146`), so replay currently no-ops. Migrate
-  it to `syncEngine?.getLiveEventSource() ?? socket` (the `useStreamSocket`
-  pattern) first, then gate the invalidation on `mode !== "active"`.
+- ~~Blocker:~~ **done in the additive PR** — the hook now registers through
+  `syncEngine?.getLiveEventSource() ?? socket` (the `useStreamSocket` pattern),
+  so replay reaches it. The remaining change is gating the invalidation on
+  `mode !== "active"`.
 - Unmounted-during-catch-up is safe: the query uses default staleness, so the
   next mount refetches anyway. The invalidation only ever fired on reconnect,
   so dropped-emit coverage is unchanged.
@@ -61,7 +79,7 @@ conversation list on every socket reconnect.
 **Verdict: covered once the hook is gate-registered. Smallest, cleanest next
 deletion.**
 
-### PR F — `refetchOnReconnect: true` on saved + scheduled lists
+### `refetchOnReconnect: true` on saved + scheduled lists
 
 `use-saved.ts:150`, `use-scheduled.ts:203`. Kept by #885 to cover the pure
 browser online/offline flip (no socket.io reconnect cycle).
@@ -76,7 +94,7 @@ browser online/offline flip (no socket.io reconnect cycle).
 
 **Verdict: covered in active mode. Same shape and risk profile as #885.**
 
-### PR G — `refetchOnReconnect: true` on `useLabelsSync`
+### `refetchOnReconnect: true` on `useLabelsSync`
 
 `use-labels.ts:194`. All seven `label:*` events have delivery groups and
 gate-registered handlers in workspace-sync, so the reconnect gap is replayed
@@ -104,9 +122,9 @@ edge before deleting.**
   catch-up), not a one-line deletion. Owner decision; not next.
 - **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): blocked.
   Bootstrap is still the authority for legacy unread-counter entries (until
-  sync_log retention ships and `isLegacyUnreadCounterEntry` dies), heals the
-  accepted #874 drift, and active-mode seeding is read-before-stamp _against
-  this fetch_.
+  sync*log retention ships and `isLegacyUnreadCounterEntry` dies), heals the
+  accepted #874 drift, and active-mode seeding is read-before-stamp \_against
+  this fetch*.
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**
@@ -117,10 +135,11 @@ edge before deleting.**
   `pointer:invalidated`): not outbox-routed, never in the log; no healing
   attached. Nothing to do. (`agent_session:started/completed/failed/deleted`
   _are_ logged and replay through gate-registered stream-sync handlers.)
-- **`use-memos`**: default TanStack refetch behavior only; `memo:created` is
-  workspace-group-logged but has no gate handler — and no INV-53-style healing
-  exists to delete. In-situ capture rides `stream:memos_captured` through
-  stream-sync.
+- **`use-memos`**: `memo:created` was workspace-group-logged but had no
+  frontend listener at all — fixed in the additive PR with a gate-registered
+  handler in workspace-sync that invalidates the memory-explorer search
+  queries, so live emits and catch-up replays both heal it now. In-situ
+  capture rides `stream:memos_captured` through stream-sync.
 - **`refetchOnMount: true`** on saved/scheduled/labels/activity: mount-time
   freshness, not reconnect healing. Out of scope.
 - **`useBackgroundBootstrapSync`** (SW prefetch) and **`useAppUpdate`**

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -122,9 +122,9 @@ edge before deleting.**
   catch-up), not a one-line deletion. Owner decision; not next.
 - **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): blocked.
   Bootstrap is still the authority for legacy unread-counter entries (until
-  sync*log retention ships and `isLegacyUnreadCounterEntry` dies), heals the
-  accepted #874 drift, and active-mode seeding is read-before-stamp \_against
-  this fetch*.
+  `sync_log` retention ships and `isLegacyUnreadCounterEntry` dies), heals the
+  accepted #874 drift, and active-mode seeding is read-before-stamp against
+  this very fetch.
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**


### PR DESCRIPTION
## Problem

With the sync-v2 workspace cursor now the default (#884) and the first healing deletion landed (#885), the next step was supposed to be deleting more legacy healing. A survey of every remaining healing path (committed here as `docs/plans/sync-v2-healing-deletion-inventory.md`) found that the rollout itself isn't complete: catch-up replay only reaches handlers registered on the `SocketEventGate`, and two domains weren't on it.

- **Conversations**: `use-conversations` registered its four `conversation:*` handlers on the raw socket, so catch-up replay after a gap never reached them — the events are in the sync log, but the only thing healing the conversation list was its blanket reconnect invalidation.
- **Memos**: `memo:created` is written to the sync log (workspace group) but had **no frontend listener at all** — the memory explorer only refreshed via default TanStack staleness.

Per the owner decision recorded in the inventory doc: finish wiring consumers into the sync system first (this PR, additive only), resume one-deletion-per-PR afterwards.

## Solution

Register both domains through the engine's event gate so live emits and catch-up replays flow through the same handlers. **No healing is removed** — the `use-conversations` INV-53 reconnect invalidation is untouched.

### Key design decisions

**1. `use-conversations` uses the `useStreamSocket` pattern.** Handlers register on `syncEngine?.getLiveEventSource() ?? socket` via `useOptionalSyncEngine()`, keeping the raw-socket fallback for mounts outside the workspace SyncEngine provider. In active mode the gate is the registration surface, so the handlers also respect buffer-and-splice ordering during catch-up windows.

**2. Memo invalidation lives in `registerWorkspaceSocketHandlers`.** `memo:created` is workspace-group routed, so the workspace-level handler set is its natural home (same as `activity:created`). The handler invalidates the memory-explorer search queries via a new `memoKeys.searches(workspaceId)` prefix — the key shape is unchanged (`["memos", "search", workspaceId, request]`), so no cache migration.

**3. In-situ memo capture is untouched.** The timeline row still rides `stream:memos_captured` through stream-sync (INV-62); this PR only adds the explorer-refresh path for the workspace-group event.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/hooks/use-conversations.ts` | Register handlers through the engine event gate (raw-socket fallback kept); reconnect invalidation unchanged |
| `apps/frontend/src/hooks/use-memos.ts` | New `memoKeys.searches(workspaceId)` prefix; `search` builds on it (same key shape) |
| `apps/frontend/src/sync/workspace-sync.ts` | New `handleMemoCreated` → invalidates `memoKeys.searches` for the matching workspace |
| `apps/frontend/src/sync/workspace-sync.test.ts` | `memo:created` invalidates matching workspace only |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Full healing-path inventory, coverage verdicts, and the additive-first sequencing decision |

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/hooks/use-conversations.test.tsx` | Gate-dispatched `conversation:created` updates the list cache (the catch-up path); raw-socket fallback without an engine; reconnect invalidation still fires |

## Test plan

- [x] `bunx vitest run src/sync src/hooks` — 56 files, 581 tests passed
- [x] `bun run typecheck` — clean across the monorepo
- [x] New tests pin the replay path, the no-engine fallback, the untouched INV-53 healing, and the memo workspace guard

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Complete the sync-v2 rollout surface before deleting more legacy healing — every logged event type should reach a gate-registered handler so catch-up replay heals it.

**What was built:**
1. Healing-path inventory (`docs/plans/sync-v2-healing-deletion-inventory.md`): every remaining reconnect invalidation / bootstrap refetch, each with a cursor-coverage verdict built on the #885 proof chain (event type → delivery group → sync_log → `listEntriesForUser` → `gate.dispatch`).
2. `use-conversations` gate migration (additive — its reconnect invalidation stays).
3. `memo:created` workspace-sync handler (event was logged with no listener).

**Design decisions:** see prose above.

**What's NOT included (sequenced for later, per the inventory doc):**
- The three healing deletions (conversations invalidation → saved/scheduled `refetchOnReconnect` → labels), one per PR with coverage tests.
- Socket heartbeat (dropped-emit detection between catch-up triggers).
- sync_log retention, which unblocks the reconnect-bootstrap and `usePageResumeRefresh` cleanups (resume becomes cursor catch-up only).
- `use-link-preview-dismissals` gate migration (logged but raw-socket; cosmetic, migrate if staleness is reported).

**Status:** complete; all tests green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01JSqtGjiUdyisJA21jRgE6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSqtGjiUdyisJA21jRgE6x)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783881039&installation_id=129946197&pr_number=891&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F891&signature=ca052bc1dd675da819cd1ceb99d48a27372a308416aff655bf0c0b589b0b9f50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->