### PR TITLE
refactor(backend): extract DebouncedOutboxHandler base for feature outbox handlers

### DIFF
--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -1,5 +1,4 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { StreamRepository } from "../streams"
 import { resolveDeliveryVerdict, TrustTiers } from "@threa/agent-runtime"
 import { resolveSealingContext } from "../e2e-streams"
@@ -10,28 +9,9 @@ import { AuthorTypes, CompanionModes, StreamTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 
-export interface CompanionHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type CompanionHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that dispatches agentic jobs for messages in streams
@@ -46,211 +26,135 @@ const DEFAULT_CONFIG = {
  * Uses time-based cursor locking for exclusive access without
  * holding database connections during processing.
  */
-export class CompanionHandler implements OutboxHandler {
-  readonly listenerId = "companion"
-
-  private readonly db: Pool
+export class CompanionHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: CompanionHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "companion", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+  }
 
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "message:created") {
+      return
+    }
+
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      logger.debug({ eventId: event.id.toString() }, "CompanionHandler: malformed event, skipping")
+      return
+    }
+
+    const { streamId, workspaceId, event: messageEvent } = payload
+
+    // The companion is an in-process plaintext driver: it only takes
+    // turns the delivery verdict says may be minted plaintext. E2E
+    // streams come back denied (no grant by construction — Ariadne
+    // can't see ciphertext) and route through the enclave instead.
+    const sealing = await resolveSealingContext(this.db, {
+      workspaceId,
+      streamId,
+      actor: { kind: "companion" },
     })
+    const verdict = resolveDeliveryVerdict({ trust: TrustTiers.FIRST_PARTY_INPROC, sealing })
+    if (verdict.delivery !== "plaintext") {
+      return
+    }
 
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "CompanionHandler debouncer error")
-    )
-  }
+    // Ignore persona messages (avoid infinite loops)
+    if (messageEvent.actorType !== AuthorTypes.USER) {
+      return
+    }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+    if (!messageEvent.actorId) {
+      logger.warn({ streamId }, "CompanionHandler: MEMBER message has no actorId, skipping")
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const triggeredBy = messageEvent.actorId
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    const stream = await StreamRepository.findById(this.db, streamId)
+    if (!stream) {
+      logger.warn({ streamId }, "CompanionHandler: stream not found")
+      return
+    }
 
-      if (events.length === 0) {
-        return { status: "no_events" }
+    // Resolve companion settings: for threads rooted in a scratchpad,
+    // inherit the root scratchpad's companion mode and persona so
+    // Ariadna responds in nested threads the same way she responds
+    // in the scratchpad itself.
+    let companionSource = stream
+    if (stream.companionMode !== CompanionModes.ON && stream.rootStreamId) {
+      const rootStream = await StreamRepository.findById(this.db, stream.rootStreamId)
+      if (rootStream && rootStream.type === StreamTypes.SCRATCHPAD && rootStream.companionMode === CompanionModes.ON) {
+        companionSource = rootStream
       }
+    }
 
-      const seen: bigint[] = []
+    if (companionSource.companionMode !== CompanionModes.ON) {
+      return
+    }
 
-      try {
-        for (const event of events) {
-          if (event.eventType !== "message:created") {
-            seen.push(event.id)
-            continue
-          }
+    let persona = companionSource.companionPersonaId
+      ? await PersonaRepository.findById(this.db, companionSource.companionPersonaId!, companionSource.workspaceId)
+      : null
 
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            logger.debug({ eventId: event.id.toString() }, "CompanionHandler: malformed event, skipping")
-            seen.push(event.id)
-            continue
-          }
+    if (!persona || persona.status !== "active") {
+      persona = await PersonaRepository.getSystemDefault(this.db, companionSource.workspaceId)
+    }
 
-          const { streamId, workspaceId, event: messageEvent } = payload
+    if (!persona) {
+      logger.warn({ streamId }, "Companion mode on but no active persona available")
+      return
+    }
 
-          // The companion is an in-process plaintext driver: it only takes
-          // turns the delivery verdict says may be minted plaintext. E2E
-          // streams come back denied (no grant by construction — Ariadne
-          // can't see ciphertext) and route through the enclave instead.
-          const sealing = await resolveSealingContext(this.db, {
-            workspaceId,
-            streamId,
-            actor: { kind: "companion" },
-          })
-          const verdict = resolveDeliveryVerdict({ trust: TrustTiers.FIRST_PARTY_INPROC, sealing })
-          if (verdict.delivery !== "plaintext") {
-            seen.push(event.id)
-            continue
-          }
+    const lastSession = await AgentSessionRepository.findLatestByStream(this.db, streamId)
 
-          // Ignore persona messages (avoid infinite loops)
-          if (messageEvent.actorType !== AuthorTypes.USER) {
-            seen.push(event.id)
-            continue
-          }
+    if (lastSession) {
+      const messageSequence = BigInt(messageEvent.sequence)
 
-          if (!messageEvent.actorId) {
-            logger.warn({ streamId }, "CompanionHandler: MEMBER message has no actorId, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          const triggeredBy = messageEvent.actorId
-
-          const stream = await StreamRepository.findById(this.db, streamId)
-          if (!stream) {
-            logger.warn({ streamId }, "CompanionHandler: stream not found")
-            seen.push(event.id)
-            continue
-          }
-
-          // Resolve companion settings: for threads rooted in a scratchpad,
-          // inherit the root scratchpad's companion mode and persona so
-          // Ariadna responds in nested threads the same way she responds
-          // in the scratchpad itself.
-          let companionSource = stream
-          if (stream.companionMode !== CompanionModes.ON && stream.rootStreamId) {
-            const rootStream = await StreamRepository.findById(this.db, stream.rootStreamId)
-            if (
-              rootStream &&
-              rootStream.type === StreamTypes.SCRATCHPAD &&
-              rootStream.companionMode === CompanionModes.ON
-            ) {
-              companionSource = rootStream
-            }
-          }
-
-          if (companionSource.companionMode !== CompanionModes.ON) {
-            seen.push(event.id)
-            continue
-          }
-
-          let persona = companionSource.companionPersonaId
-            ? await PersonaRepository.findById(
-                this.db,
-                companionSource.companionPersonaId!,
-                companionSource.workspaceId
-              )
-            : null
-
-          if (!persona || persona.status !== "active") {
-            persona = await PersonaRepository.getSystemDefault(this.db, companionSource.workspaceId)
-          }
-
-          if (!persona) {
-            logger.warn({ streamId }, "Companion mode on but no active persona available")
-            seen.push(event.id)
-            continue
-          }
-
-          const lastSession = await AgentSessionRepository.findLatestByStream(this.db, streamId)
-
-          if (lastSession) {
-            const messageSequence = BigInt(messageEvent.sequence)
-
-            // If a session is still running or pending, it will pick up new messages
-            // via check_new_messages node in the graph — don't dispatch duplicate jobs
-            if (lastSession.status === SessionStatuses.PENDING || lastSession.status === SessionStatuses.RUNNING) {
-              logger.debug(
-                {
-                  streamId,
-                  messageId: messageEvent.payload.messageId,
-                  sessionId: lastSession.id,
-                  sessionStatus: lastSession.status,
-                },
-                "Session already active for stream, new message will be handled in-flight"
-              )
-              seen.push(event.id)
-              continue
-            }
-
-            if (lastSession.status === SessionStatuses.COMPLETED && lastSession.lastSeenSequence) {
-              if (messageSequence <= lastSession.lastSeenSequence) {
-                logger.debug(
-                  {
-                    streamId,
-                    messageId: messageEvent.payload.messageId,
-                    messageSequence: messageSequence.toString(),
-                    lastSeenSequence: lastSession.lastSeenSequence.toString(),
-                  },
-                  "Message already seen by previous session, skipping"
-                )
-                seen.push(event.id)
-                continue
-              }
-            }
-          }
-
-          logger.info(
-            { streamId, messageId: messageEvent.payload.messageId, personaId: persona.id },
-            "Persona agent job dispatched (companion mode)"
-          )
-
-          await this.jobQueue.send(JobQueues.PERSONA_AGENT, {
-            workspaceId: stream.workspaceId,
+      // If a session is still running or pending, it will pick up new messages
+      // via check_new_messages node in the graph — don't dispatch duplicate jobs
+      if (lastSession.status === SessionStatuses.PENDING || lastSession.status === SessionStatuses.RUNNING) {
+        logger.debug(
+          {
             streamId,
             messageId: messageEvent.payload.messageId,
-            personaId: persona.id,
-            triggeredBy,
-          })
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
+            sessionId: lastSession.id,
+            sessionStatus: lastSession.status,
+          },
+          "Session already active for stream, new message will be handled in-flight"
+        )
+        return
       }
+
+      if (lastSession.status === SessionStatuses.COMPLETED && lastSession.lastSeenSequence) {
+        if (messageSequence <= lastSession.lastSeenSequence) {
+          logger.debug(
+            {
+              streamId,
+              messageId: messageEvent.payload.messageId,
+              messageSequence: messageSequence.toString(),
+              lastSeenSequence: lastSession.lastSeenSequence.toString(),
+            },
+            "Message already seen by previous session, skipping"
+          )
+          return
+        }
+      }
+    }
+
+    logger.info(
+      { streamId, messageId: messageEvent.payload.messageId, personaId: persona.id },
+      "Persona agent job dispatched (companion mode)"
+    )
+
+    await this.jobQueue.send(JobQueues.PERSONA_AGENT, {
+      workspaceId: stream.workspaceId,
+      streamId,
+      messageId: messageEvent.payload.messageId,
+      personaId: persona.id,
+      triggeredBy,
     })
   }
 }

--- a/apps/backend/src/features/agents/context-bag-precompute-handler.ts
+++ b/apps/backend/src/features/agents/context-bag-precompute-handler.ts
@@ -1,33 +1,21 @@
 import type { Pool } from "pg"
-import type { OutboxHandler } from "../../lib/outbox"
-import { OutboxRepository, isOneOfOutboxEventType } from "../../lib/outbox"
+import { isOneOfOutboxEventType } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import type { QueueManager, ContextBagPrecomputeJobData } from "../../lib/queue"
 import { JobQueues, type JobHandler } from "../../lib/queue"
 import type { AI } from "@threa/agent-runtime"
 import { CompanionModes, StreamTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
 import { StreamRepository } from "../streams"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import { ContextBagRepository, persistSnapshot, resolveBagForStream } from "./context-bag"
 
-export interface ContextBagPrecomputeHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
+export type ContextBagPrecomputeHandlerConfig = DebouncedOutboxHandlerConfig
 
-const DEFAULT_CONFIG = {
+// Smaller batch + slightly longer max-wait than the canonical defaults:
+// stream:created bursts are bursty and each event does a stream lookup.
+const HANDLER_CONFIG: DebouncedOutboxHandlerConfig = {
   batchSize: 50,
-  debounceMs: 50,
   maxWaitMs: 250,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
 }
 
 export const CONTEXT_BAG_PRECOMPUTE_QUEUE = JobQueues.CONTEXT_BAG_PRECOMPUTE
@@ -40,92 +28,38 @@ export const CONTEXT_BAG_PRECOMPUTE_QUEUE = JobQueues.CONTEXT_BAG_PRECOMPUTE
  * diff is correctly anchored. No kickoff message is posted — Ariadne stays
  * silent until the user sends their first message.
  */
-export class ContextBagPrecomputeHandler implements OutboxHandler {
-  readonly listenerId = "context-bag-precompute"
-
-  private readonly db: Pool
+export class ContextBagPrecomputeHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: ContextBagPrecomputeHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "context-bag-precompute", ...HANDLER_CONFIG, ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+  }
 
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (!isOneOfOutboxEventType(event, ["stream:created"])) {
+      return
+    }
+
+    const { workspaceId, streamId, stream } = event.payload
+    if (stream.type !== StreamTypes.SCRATCHPAD) {
+      return
+    }
+    if (stream.companionMode !== CompanionModes.ON) {
+      return
+    }
+
+    const bag = await ContextBagRepository.findByStream(this.db, workspaceId, streamId)
+    if (!bag) {
+      return
+    }
+
+    await this.jobQueue.send(CONTEXT_BAG_PRECOMPUTE_QUEUE, {
+      workspaceId,
+      streamId,
+      bagId: bag.id,
     })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "ContextBagPrecomputeHandler debouncer error")
-    )
-  }
-
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-      if (events.length === 0) return { status: "no_events" }
-
-      const seen: bigint[] = []
-      try {
-        for (const event of events) {
-          if (!isOneOfOutboxEventType(event, ["stream:created"])) {
-            seen.push(event.id)
-            continue
-          }
-
-          const { workspaceId, streamId, stream } = event.payload
-          if (stream.type !== StreamTypes.SCRATCHPAD) {
-            seen.push(event.id)
-            continue
-          }
-          if (stream.companionMode !== CompanionModes.ON) {
-            seen.push(event.id)
-            continue
-          }
-
-          const bag = await ContextBagRepository.findByStream(this.db, workspaceId, streamId)
-          if (!bag) {
-            seen.push(event.id)
-            continue
-          }
-
-          await this.jobQueue.send(CONTEXT_BAG_PRECOMPUTE_QUEUE, {
-            workspaceId,
-            streamId,
-            bagId: bag.id,
-          })
-          logger.info({ streamId, bagId: bag.id }, "context-bag precompute job dispatched")
-          seen.push(event.id)
-        }
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-        return { status: "error", error }
-      }
-    })
+    logger.info({ streamId, bagId: bag.id }, "context-bag precompute job dispatched")
   }
 }
 

--- a/apps/backend/src/features/agents/mention-invoke-outbox-handler.ts
+++ b/apps/backend/src/features/agents/mention-invoke-outbox-handler.ts
@@ -1,5 +1,4 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { PersonaRepository } from "./persona-repository"
 import { parseMessagePayload } from "../../lib/outbox"
@@ -8,28 +7,9 @@ import { extractMentionSlugs } from "./mention-extractor"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 
-export interface MentionInvokeHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type MentionInvokeHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that invokes personas when @mentioned in messages.
@@ -42,139 +22,75 @@ const DEFAULT_CONFIG = {
  *
  * Note: Thread creation for channels is handled by the PersonaAgent, not this handler.
  */
-export class MentionInvokeHandler implements OutboxHandler {
-  readonly listenerId = "mention-invoke"
-
-  private readonly db: Pool
+export class MentionInvokeHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: MentionInvokeHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "mention-invoke", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "MentionInvokeHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "message:created") {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      logger.debug({ eventId: event.id.toString() }, "MentionInvokeHandler: malformed event, skipping")
+      return
+    }
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    const { streamId, workspaceId, event: messageEvent } = payload
 
-      if (events.length === 0) {
-        return { status: "no_events" }
+    // E2E streams: persona mentions in ciphertext are invisible to the
+    // backend, and Phase 1 doesn't allow agent recipients anyway.
+    if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
+      return
+    }
+
+    // Ignore persona messages (avoid infinite loops)
+    if (messageEvent.actorType !== AuthorTypes.USER) {
+      return
+    }
+
+    if (!messageEvent.actorId) {
+      logger.warn({ streamId }, "MentionInvokeHandler: MEMBER message has no actorId, skipping")
+      return
+    }
+
+    const triggeredBy = messageEvent.actorId
+
+    const mentionSlugs = extractMentionSlugs(messageEvent.payload.contentMarkdown)
+    if (mentionSlugs.length === 0) {
+      return
+    }
+
+    for (const slug of mentionSlugs) {
+      const persona = await PersonaRepository.findBySlug(this.db, slug, workspaceId)
+
+      if (!persona || persona.status !== "active") {
+        continue
       }
 
-      const seen: bigint[] = []
+      logger.info(
+        {
+          streamId,
+          messageId: messageEvent.payload.messageId,
+          personaId: persona.id,
+          personaSlug: persona.slug,
+        },
+        "Persona agent job dispatched (mention trigger)"
+      )
 
-      try {
-        for (const event of events) {
-          if (event.eventType !== "message:created") {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            logger.debug({ eventId: event.id.toString() }, "MentionInvokeHandler: malformed event, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          const { streamId, workspaceId, event: messageEvent } = payload
-
-          // E2E streams: persona mentions in ciphertext are invisible to the
-          // backend, and Phase 1 doesn't allow agent recipients anyway.
-          if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
-            seen.push(event.id)
-            continue
-          }
-
-          // Ignore persona messages (avoid infinite loops)
-          if (messageEvent.actorType !== AuthorTypes.USER) {
-            seen.push(event.id)
-            continue
-          }
-
-          if (!messageEvent.actorId) {
-            logger.warn({ streamId }, "MentionInvokeHandler: MEMBER message has no actorId, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          const triggeredBy = messageEvent.actorId
-
-          const mentionSlugs = extractMentionSlugs(messageEvent.payload.contentMarkdown)
-          if (mentionSlugs.length === 0) {
-            seen.push(event.id)
-            continue
-          }
-
-          for (const slug of mentionSlugs) {
-            const persona = await PersonaRepository.findBySlug(this.db, slug, workspaceId)
-
-            if (!persona || persona.status !== "active") {
-              continue
-            }
-
-            logger.info(
-              {
-                streamId,
-                messageId: messageEvent.payload.messageId,
-                personaId: persona.id,
-                personaSlug: persona.slug,
-              },
-              "Persona agent job dispatched (mention trigger)"
-            )
-
-            await this.jobQueue.send(JobQueues.PERSONA_AGENT, {
-              workspaceId,
-              streamId,
-              messageId: messageEvent.payload.messageId,
-              personaId: persona.id,
-              triggeredBy,
-              trigger: AgentTriggers.MENTION,
-            })
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+      await this.jobQueue.send(JobQueues.PERSONA_AGENT, {
+        workspaceId,
+        streamId,
+        messageId: messageEvent.payload.messageId,
+        personaId: persona.id,
+        triggeredBy,
+        trigger: AgentTriggers.MENTION,
+      })
+    }
   }
 }

--- a/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
+++ b/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
@@ -3,15 +3,9 @@ import { AuthorTypes, type AgentSessionRerunContext } from "@threa/types"
 import { withTransaction } from "../../db"
 import { eventId } from "../../lib/id"
 import { logger } from "../../lib/logger"
-import {
-  CursorLock,
-  ensureListenerFromLatest,
-  DebounceWithMaxWait,
-  serializeBigInt,
-  type ProcessResult,
-} from "@threa/backend-common"
+import { serializeBigInt } from "@threa/backend-common"
 import { OutboxRepository } from "../../lib/outbox"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { JobQueues, type QueueManager } from "../../lib/queue"
 import type { EventService } from "../messaging"
 import { MessageVersionRepository } from "../messaging"
@@ -19,25 +13,7 @@ import { StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { AgentSessionRepository, SessionStatuses, type AgentSession } from "./session-repository"
 
-export interface AgentMessageMutationHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type AgentMessageMutationHandlerConfig = DebouncedOutboxHandlerConfig
 
 function rerunQueueMessageId(sessionId: string): string {
   return `queue_rerun_${sessionId}`
@@ -128,15 +104,9 @@ function parseMessageDeletedPayload(payload: unknown): NormalizedMessageDeletedP
  *   The rerun reconciles prior sent messages (edit/delete) on completion.
  * - In-flight edit/delete reconsideration is handled by runtime context polling (no extra dispatch here).
  */
-export class AgentMessageMutationHandler implements OutboxHandler {
-  readonly listenerId = "agent-message-mutations"
-
-  private readonly db: Pool
+export class AgentMessageMutationHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
   private readonly eventService: EventService
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(
     db: Pool,
@@ -144,85 +114,32 @@ export class AgentMessageMutationHandler implements OutboxHandler {
     eventService: EventService,
     config?: AgentMessageMutationHandlerConfig
   ) {
-    this.db = db
+    super(db, { listenerId: "agent-message-mutations", ...config })
     this.jobQueue = jobQueue
     this.eventService = eventService
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "AgentMessageMutationHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (event.eventType === "message:edited") {
-            const payload = parseMessageEditedPayload(event.payload)
-            if (payload) {
-              // E2E streams: Phase 1 doesn't allow agent recipients, so there
-              // are no sessions to rerun. Ciphertext edits are also invisible
-              // to the backend, so skip without inspecting the message.
-              if (await E2eStreamsRepository.isE2eStream(this.db, payload.workspaceId, payload.streamId)) {
-                seen.push(event.id)
-                continue
-              }
-              await this.handleInvokingMessageEdited(payload, event.createdAt)
-            }
-          } else if (event.eventType === "message:deleted") {
-            const payload = parseMessageDeletedPayload(event.payload)
-            if (payload) {
-              // E2E streams: no agent sessions exist for E2E streams in Phase 1
-              // (agents not allowed), so the session lookup is a natural no-op.
-              // We still call through; the repository returns no rows.
-              await this.handleInvokingMessageDeleted(payload)
-            }
-          }
-
-          seen.push(event.id)
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType === "message:edited") {
+      const payload = parseMessageEditedPayload(event.payload)
+      if (payload) {
+        // E2E streams: Phase 1 doesn't allow agent recipients, so there
+        // are no sessions to rerun. Ciphertext edits are also invisible
+        // to the backend, so skip without inspecting the message.
+        if (await E2eStreamsRepository.isE2eStream(this.db, payload.workspaceId, payload.streamId)) {
+          return
         }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
+        await this.handleInvokingMessageEdited(payload, event.createdAt)
       }
-    })
+    } else if (event.eventType === "message:deleted") {
+      const payload = parseMessageDeletedPayload(event.payload)
+      if (payload) {
+        // E2E streams: no agent sessions exist for E2E streams in Phase 1
+        // (agents not allowed), so the session lookup is a natural no-op.
+        // We still call through; the repository returns no rows.
+        await this.handleInvokingMessageDeleted(payload)
+      }
+    }
   }
 
   private async handleInvokingMessageEdited(payload: NormalizedMessageEditedPayload, occurredAt: Date): Promise<void> {

--- a/apps/backend/src/features/attachments/embedding-outbox-handler.ts
+++ b/apps/backend/src/features/attachments/embedding-outbox-handler.ts
@@ -3,32 +3,14 @@ import { logger } from "../../lib/logger"
 import { JobQueues, type QueueManager } from "../../lib/queue"
 import {
   isOutboxEventType,
-  OutboxRepository,
-  type OutboxHandler,
+  DebouncedOutboxHandler,
+  type DebouncedOutboxHandlerConfig,
+  type OutboxEvent,
   type AttachmentExtractionCompletedOutboxPayload,
 } from "../../lib/outbox"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import { isContentTypeEmbeddable } from "./embedding-config"
 
-export interface AttachmentEmbeddingHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type AttachmentEmbeddingHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Watches the outbox for `attachment:extraction_completed` events and
@@ -40,92 +22,32 @@ const DEFAULT_CONFIG = {
  * the same eligibility against the freshly-fetched extraction as a defence
  * against reprocessed content.
  */
-export class AttachmentEmbeddingHandler implements OutboxHandler {
-  readonly listenerId = "attachment-embedding"
-
-  private readonly db: Pool
+export class AttachmentEmbeddingHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: AttachmentEmbeddingHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "attachment-embedding", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "AttachmentEmbeddingHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (!isOutboxEventType(event, "attachment:extraction_completed")) {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const payload: AttachmentExtractionCompletedOutboxPayload = event.payload
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    if (!isContentTypeEmbeddable(payload.contentType)) {
+      logger.debug(
+        { attachmentId: payload.attachmentId, contentType: payload.contentType },
+        "Skipping embedding job for ineligible content type"
+      )
+      return
+    }
 
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (!isOutboxEventType(event, "attachment:extraction_completed")) {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload: AttachmentExtractionCompletedOutboxPayload = event.payload
-
-          if (!isContentTypeEmbeddable(payload.contentType)) {
-            logger.debug(
-              { attachmentId: payload.attachmentId, contentType: payload.contentType },
-              "Skipping embedding job for ineligible content type"
-            )
-            seen.push(event.id)
-            continue
-          }
-
-          await this.jobQueue.send(JobQueues.ATTACHMENT_EMBED, {
-            attachmentId: payload.attachmentId,
-            workspaceId: payload.workspaceId,
-          })
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
+    await this.jobQueue.send(JobQueues.ATTACHMENT_EMBED, {
+      attachmentId: payload.attachmentId,
+      workspaceId: payload.workspaceId,
     })
   }
 }

--- a/apps/backend/src/features/attachments/uploaded-outbox-handler.ts
+++ b/apps/backend/src/features/attachments/uploaded-outbox-handler.ts
@@ -1,35 +1,16 @@
 import type { Pool } from "pg"
-import { OutboxRepository, isOutboxEventType } from "../../lib/outbox"
+import { isOutboxEventType } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { isImageAttachment } from "./image-caption"
 import { isPdfAttachment } from "./pdf"
 import { isWordAttachment } from "./word"
 import { isExcelAttachment } from "./excel"
 import { isVideoAttachment } from "./video"
 
-export interface AttachmentUploadedHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type AttachmentUploadedHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that processes attachment:uploaded events.
@@ -38,148 +19,89 @@ const DEFAULT_CONFIG = {
  * For PDFs: enqueues PDF_PREPARE job for document extraction
  * For others: enqueues TEXT_PROCESS job (binary detection decides skip vs process)
  */
-export class AttachmentUploadedHandler implements OutboxHandler {
-  readonly listenerId = "attachment-uploaded"
-
-  private readonly db: Pool
+export class AttachmentUploadedHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: AttachmentUploadedHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "attachment-uploaded", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "AttachmentUploadedHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (!isOutboxEventType(event, "attachment:uploaded")) {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const { attachmentId, workspaceId, filename, mimeType, storagePath } = event.payload
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    switch (true) {
+      case isImageAttachment(mimeType, filename):
+        await this.jobQueue.send(JobQueues.IMAGE_CAPTION, {
+          attachmentId,
+          workspaceId,
+          filename,
+          mimeType,
+          storagePath,
+        })
+        await this.jobQueue.send(JobQueues.IMAGE_THUMBNAIL, {
+          attachmentId,
+          workspaceId,
+          filename,
+          mimeType,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "Image caption + thumbnail jobs dispatched")
+        break
 
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
+      case isPdfAttachment(mimeType, filename):
+        await this.jobQueue.send(JobQueues.PDF_PREPARE, {
+          attachmentId,
+          workspaceId,
+          filename,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "PDF prepare job dispatched")
+        break
 
-      const seen: bigint[] = []
+      case isWordAttachment(mimeType, filename):
+        await this.jobQueue.send(JobQueues.WORD_PROCESS, {
+          attachmentId,
+          workspaceId,
+          filename,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "Word processing job dispatched")
+        break
 
-      try {
-        for (const event of events) {
-          if (!isOutboxEventType(event, "attachment:uploaded")) {
-            seen.push(event.id)
-            continue
-          }
+      case isExcelAttachment(mimeType, filename):
+        await this.jobQueue.send(JobQueues.EXCEL_PROCESS, {
+          attachmentId,
+          workspaceId,
+          filename,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "Excel processing job dispatched")
+        break
 
-          const { attachmentId, workspaceId, filename, mimeType, storagePath } = event.payload
+      case isVideoAttachment(mimeType, filename):
+        await this.jobQueue.send(JobQueues.VIDEO_TRANSCODE_SUBMIT, {
+          attachmentId,
+          workspaceId,
+          filename,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "Video transcode submit job dispatched")
+        break
 
-          switch (true) {
-            case isImageAttachment(mimeType, filename):
-              await this.jobQueue.send(JobQueues.IMAGE_CAPTION, {
-                attachmentId,
-                workspaceId,
-                filename,
-                mimeType,
-                storagePath,
-              })
-              await this.jobQueue.send(JobQueues.IMAGE_THUMBNAIL, {
-                attachmentId,
-                workspaceId,
-                filename,
-                mimeType,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "Image caption + thumbnail jobs dispatched")
-              break
-
-            case isPdfAttachment(mimeType, filename):
-              await this.jobQueue.send(JobQueues.PDF_PREPARE, {
-                attachmentId,
-                workspaceId,
-                filename,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "PDF prepare job dispatched")
-              break
-
-            case isWordAttachment(mimeType, filename):
-              await this.jobQueue.send(JobQueues.WORD_PROCESS, {
-                attachmentId,
-                workspaceId,
-                filename,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "Word processing job dispatched")
-              break
-
-            case isExcelAttachment(mimeType, filename):
-              await this.jobQueue.send(JobQueues.EXCEL_PROCESS, {
-                attachmentId,
-                workspaceId,
-                filename,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "Excel processing job dispatched")
-              break
-
-            case isVideoAttachment(mimeType, filename):
-              await this.jobQueue.send(JobQueues.VIDEO_TRANSCODE_SUBMIT, {
-                attachmentId,
-                workspaceId,
-                filename,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "Video transcode submit job dispatched")
-              break
-
-            default:
-              // Route everything else to text processing — binary detection decides skip vs process
-              await this.jobQueue.send(JobQueues.TEXT_PROCESS, {
-                attachmentId,
-                workspaceId,
-                filename,
-                storagePath,
-              })
-              logger.info({ attachmentId, filename, mimeType }, "Text processing job dispatched")
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+      default:
+        // Route everything else to text processing — binary detection decides skip vs process
+        await this.jobQueue.send(JobQueues.TEXT_PROCESS, {
+          attachmentId,
+          workspaceId,
+          filename,
+          storagePath,
+        })
+        logger.info({ attachmentId, filename, mimeType }, "Text processing job dispatched")
+    }
   }
 }

--- a/apps/backend/src/features/commands/outbox-handler.ts
+++ b/apps/backend/src/features/commands/outbox-handler.ts
@@ -1,12 +1,10 @@
 import type { Pool } from "pg"
 import { CommandKinds } from "@threa/types"
-import { OutboxRepository } from "../../lib/outbox"
 import type { CommandDispatchedOutboxPayload } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 
 interface CommandDispatchedEventPayload {
   commandId: string
@@ -16,123 +14,45 @@ interface CommandDispatchedEventPayload {
   executionKind?: string
 }
 
-export interface CommandHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type CommandHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that dispatches command execution jobs when
  * `command:dispatched` events appear in the outbox.
  */
-export class CommandHandler implements OutboxHandler {
-  readonly listenerId = "command"
-
-  private readonly db: Pool
+export class CommandHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: CommandHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "command", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+  }
 
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "command:dispatched") {
+      return
+    }
 
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "CommandHandler debouncer error")
+    const payload = event.payload as CommandDispatchedOutboxPayload
+    const { event: commandEvent, workspaceId, streamId, authorId } = payload
+    const eventPayload = commandEvent.payload as CommandDispatchedEventPayload
+
+    if (eventPayload.executionKind && eventPayload.executionKind !== CommandKinds.SERVER) {
+      return
+    }
+
+    logger.info(
+      { commandId: eventPayload.commandId, commandName: eventPayload.name, streamId },
+      "Command job dispatched"
     )
-  }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (event.eventType !== "command:dispatched") {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload = event.payload as CommandDispatchedOutboxPayload
-          const { event: commandEvent, workspaceId, streamId, authorId } = payload
-          const eventPayload = commandEvent.payload as CommandDispatchedEventPayload
-
-          if (eventPayload.executionKind && eventPayload.executionKind !== CommandKinds.SERVER) {
-            seen.push(event.id)
-            continue
-          }
-
-          logger.info(
-            { commandId: eventPayload.commandId, commandName: eventPayload.name, streamId },
-            "Command job dispatched"
-          )
-
-          await this.jobQueue.send(JobQueues.COMMAND_EXECUTE, {
-            commandId: eventPayload.commandId,
-            commandName: eventPayload.name,
-            args: eventPayload.args,
-            workspaceId,
-            streamId,
-            userId: authorId,
-          })
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
+    await this.jobQueue.send(JobQueues.COMMAND_EXECUTE, {
+      commandId: eventPayload.commandId,
+      commandName: eventPayload.name,
+      args: eventPayload.args,
+      workspaceId,
+      streamId,
+      userId: authorId,
     })
   }
 }

--- a/apps/backend/src/features/conversations/boundary-extraction-outbox-handler.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-outbox-handler.ts
@@ -1,33 +1,13 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { parseMessagePayload } from "../../lib/outbox"
 import { AuthorTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 
-export interface BoundaryExtractionHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type BoundaryExtractionHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that dispatches jobs for messages to detect conversational boundaries.
@@ -37,105 +17,43 @@ const DEFAULT_CONFIG = {
  * 2. Check if it's a user message (persona messages can be added later)
  * 3. Dispatch queue job for LLM processing
  */
-export class BoundaryExtractionHandler implements OutboxHandler {
-  readonly listenerId = "boundary-extraction"
-
-  private readonly db: Pool
+export class BoundaryExtractionHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: BoundaryExtractionHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "boundary-extraction", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "BoundaryExtractionHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "message:created") {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      logger.debug({ eventId: event.id.toString() }, "BoundaryExtractionHandler: malformed event, skipping")
+      return
+    }
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    const { streamId, workspaceId, event: messageEvent } = payload
 
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
+    // E2E streams: boundary extraction inspects message content, which
+    // is ciphertext on E2E streams and useless to the LLM.
+    if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
+      return
+    }
 
-      const seen: bigint[] = []
+    if (messageEvent.actorType !== AuthorTypes.USER) {
+      return
+    }
 
-      try {
-        for (const event of events) {
-          if (event.eventType !== "message:created") {
-            seen.push(event.id)
-            continue
-          }
+    logger.debug({ streamId, messageId: messageEvent.payload.messageId }, "Boundary extraction job dispatched")
 
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            logger.debug({ eventId: event.id.toString() }, "BoundaryExtractionHandler: malformed event, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          const { streamId, workspaceId, event: messageEvent } = payload
-
-          // E2E streams: boundary extraction inspects message content, which
-          // is ciphertext on E2E streams and useless to the LLM.
-          if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
-            seen.push(event.id)
-            continue
-          }
-
-          if (messageEvent.actorType !== AuthorTypes.USER) {
-            seen.push(event.id)
-            continue
-          }
-
-          logger.debug({ streamId, messageId: messageEvent.payload.messageId }, "Boundary extraction job dispatched")
-
-          await this.jobQueue.send(JobQueues.BOUNDARY_EXTRACT, {
-            messageId: messageEvent.payload.messageId,
-            streamId,
-            workspaceId,
-          })
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
+    await this.jobQueue.send(JobQueues.BOUNDARY_EXTRACT, {
+      messageId: messageEvent.payload.messageId,
+      streamId,
+      workspaceId,
     })
   }
 }

--- a/apps/backend/src/features/emoji/usage-outbox-handler.ts
+++ b/apps/backend/src/features/emoji/usage-outbox-handler.ts
@@ -1,34 +1,15 @@
 import type { Pool } from "pg"
-import { OutboxRepository, type ReactionOutboxPayload } from "../../lib/outbox"
+import { type ReactionOutboxPayload } from "../../lib/outbox"
 import { EmojiUsageRepository } from "./usage-repository"
 import { parseMessagePayload } from "../../lib/outbox"
 import { AuthorTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
 import { emojiUsageId } from "../../lib/id"
 import { isValidShortcode } from "./emoji"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 
-export interface EmojiUsageHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type EmojiUsageHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Extract shortcodes from normalized message content.
@@ -68,76 +49,17 @@ function stripColons(shortcode: string): string {
  * 2. Extract emoji shortcodes from content or reaction
  * 3. Insert usage records for personalized emoji ordering
  */
-export class EmojiUsageHandler implements OutboxHandler {
-  readonly listenerId = "emoji-usage"
-
-  private readonly db: Pool
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
-
+export class EmojiUsageHandler extends DebouncedOutboxHandler {
   constructor(db: Pool, config?: EmojiUsageHandlerConfig) {
-    this.db = db
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "EmojiUsageHandler debouncer error")
-    )
+    super(db, { listenerId: "emoji-usage", ...config })
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (event.eventType === "message:created") {
-            await this.handleMessageCreated(event)
-          } else if (event.eventType === "reaction:added") {
-            await this.handleReactionAdded(event)
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType === "message:created") {
+      await this.handleMessageCreated(event)
+    } else if (event.eventType === "reaction:added") {
+      await this.handleReactionAdded(event)
+    }
   }
 
   private async handleMessageCreated(outboxEvent: { id: bigint; payload: unknown }): Promise<void> {

--- a/apps/backend/src/features/invitations/shadow-sync-outbox-handler.ts
+++ b/apps/backend/src/features/invitations/shadow-sync-outbox-handler.ts
@@ -1,155 +1,83 @@
 import type { Pool } from "pg"
-import { OutboxRepository, isOneOfOutboxEventType, isOutboxEventType } from "../../lib/outbox"
+import { isOneOfOutboxEventType, isOutboxEventType } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type OutboxEvent } from "../../lib/outbox"
 import type { ControlPlaneClient } from "../../lib/control-plane-client"
 import { InvitationRepository } from "./repository"
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
 
 /**
  * Syncs invitation lifecycle events to the control-plane as shadows.
  * Handles invitation:sent (create shadow) and invitation:revoked (revoke shadow).
  */
-export class InvitationShadowSyncHandler implements OutboxHandler {
-  readonly listenerId = "invitation-shadow-sync"
-
-  private readonly db: Pool
+export class InvitationShadowSyncHandler extends DebouncedOutboxHandler {
   private readonly controlPlaneClient: ControlPlaneClient
   private readonly region: string
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, controlPlaneClient: ControlPlaneClient, region: string) {
-    this.db = db
+    super(db, { listenerId: "invitation-shadow-sync" })
     this.controlPlaneClient = controlPlaneClient
     this.region = region
-    this.batchSize = DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      DEFAULT_CONFIG.debounceMs,
-      DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "InvitationShadowSyncHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (
+      !isOneOfOutboxEventType(event, [
+        "invitation:sent",
+        "invitation:link-created",
+        "invitation:link-claimed",
+        "invitation:revoked",
+      ])
+    ) {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
+    if (isOutboxEventType(event, "invitation:sent")) {
+      const { invitationId, workspaceId, email, role, inviterWorkosUserId } = event.payload
+      const invitation = await InvitationRepository.findById(this.db, invitationId)
+      if (!invitation) {
+        logger.warn({ invitationId }, "Invitation not found for shadow sync, skipping")
+        return
       }
 
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (
-            !isOneOfOutboxEventType(event, [
-              "invitation:sent",
-              "invitation:link-created",
-              "invitation:link-claimed",
-              "invitation:revoked",
-            ])
-          ) {
-            seen.push(event.id)
-            continue
-          }
-
-          if (isOutboxEventType(event, "invitation:sent")) {
-            const { invitationId, workspaceId, email, role, inviterWorkosUserId } = event.payload
-            const invitation = await InvitationRepository.findById(this.db, invitationId)
-            if (!invitation) {
-              logger.warn({ invitationId }, "Invitation not found for shadow sync, skipping")
-              seen.push(event.id)
-              continue
-            }
-
-            await this.controlPlaneClient.createInvitationShadow({
-              id: invitation.id,
-              workspaceId,
-              region: this.region,
-              kind: "email",
-              email,
-              tokenHash: null,
-              roleSlug: role,
-              expiresAt: invitation.expiresAt,
-              inviterWorkosUserId,
-            })
-          } else if (isOutboxEventType(event, "invitation:link-created")) {
-            const { invitationId, workspaceId, tokenHash, role } = event.payload
-            const invitation = await InvitationRepository.findById(this.db, invitationId)
-            if (!invitation) {
-              logger.warn({ invitationId }, "Link invitation not found for shadow sync, skipping")
-              seen.push(event.id)
-              continue
-            }
-
-            await this.controlPlaneClient.createInvitationShadow({
-              id: invitation.id,
-              workspaceId,
-              region: this.region,
-              kind: "link",
-              email: null,
-              tokenHash,
-              roleSlug: role,
-              expiresAt: invitation.expiresAt,
-            })
-          } else if (isOutboxEventType(event, "invitation:link-claimed")) {
-            const { invitationId, email, inviterWorkosUserId } = event.payload
-            await this.controlPlaneClient.notifyInvitationLinkClaimed({
-              id: invitationId,
-              email,
-              inviterWorkosUserId,
-            })
-          } else if (event.eventType === "invitation:revoked") {
-            const { invitationId } = event.payload
-            await this.controlPlaneClient.revokeInvitationShadow(invitationId)
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
+      await this.controlPlaneClient.createInvitationShadow({
+        id: invitation.id,
+        workspaceId,
+        region: this.region,
+        kind: "email",
+        email,
+        tokenHash: null,
+        roleSlug: role,
+        expiresAt: invitation.expiresAt,
+        inviterWorkosUserId,
+      })
+    } else if (isOutboxEventType(event, "invitation:link-created")) {
+      const { invitationId, workspaceId, tokenHash, role } = event.payload
+      const invitation = await InvitationRepository.findById(this.db, invitationId)
+      if (!invitation) {
+        logger.warn({ invitationId }, "Link invitation not found for shadow sync, skipping")
+        return
       }
-    })
+
+      await this.controlPlaneClient.createInvitationShadow({
+        id: invitation.id,
+        workspaceId,
+        region: this.region,
+        kind: "link",
+        email: null,
+        tokenHash,
+        roleSlug: role,
+        expiresAt: invitation.expiresAt,
+      })
+    } else if (isOutboxEventType(event, "invitation:link-claimed")) {
+      const { invitationId, email, inviterWorkosUserId } = event.payload
+      await this.controlPlaneClient.notifyInvitationLinkClaimed({
+        id: invitationId,
+        email,
+        inviterWorkosUserId,
+      })
+    } else if (event.eventType === "invitation:revoked") {
+      const { invitationId } = event.payload
+      await this.controlPlaneClient.revokeInvitationShadow(invitationId)
+    }
   }
 }

--- a/apps/backend/src/features/link-previews/outbox-handler.ts
+++ b/apps/backend/src/features/link-previews/outbox-handler.ts
@@ -1,139 +1,61 @@
 import type { Pool } from "pg"
-import { OutboxRepository, parseMessagePayload } from "../../lib/outbox"
+import { parseMessagePayload } from "../../lib/outbox"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import { logger } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 
 const LINK_PREVIEW_EVENT_TYPES = new Set(["message:created", "message:edited"])
 
-export interface LinkPreviewHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type LinkPreviewHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Outbox handler that dispatches link preview extraction jobs
  * when messages are created or edited.
  */
-export class LinkPreviewOutboxHandler implements OutboxHandler {
-  readonly listenerId = "link_preview"
-
-  private readonly db: Pool
+export class LinkPreviewOutboxHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: LinkPreviewHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "link_preview", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+  }
 
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (!LINK_PREVIEW_EVENT_TYPES.has(event.eventType)) {
+      return
+    }
+
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      return
+    }
+
+    const isEdit = event.eventType === "message:edited"
+    const { workspaceId, streamId, event: messageEvent } = payload
+    const { messageId, contentMarkdown } = messageEvent.payload
+
+    // E2E streams: contentMarkdown is ciphertext, so the URL scanner
+    // would find nothing useful. Skip without inspecting the message.
+    if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
+      return
+    }
+
+    // For creates, skip if no content. For edits, always enqueue
+    // so stale previews are cleared even when all URLs are removed.
+    if (!isEdit && !contentMarkdown) {
+      return
+    }
+
+    await this.jobQueue.send(JobQueues.LINK_PREVIEW_EXTRACT, {
+      workspaceId,
+      streamId,
+      messageId,
+      contentMarkdown,
+      isEdit,
     })
 
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "LinkPreviewOutboxHandler debouncer error")
-    )
-  }
-
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (!LINK_PREVIEW_EVENT_TYPES.has(event.eventType)) {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            seen.push(event.id)
-            continue
-          }
-
-          const isEdit = event.eventType === "message:edited"
-          const { workspaceId, streamId, event: messageEvent } = payload
-          const { messageId, contentMarkdown } = messageEvent.payload
-
-          // E2E streams: contentMarkdown is ciphertext, so the URL scanner
-          // would find nothing useful. Skip without inspecting the message.
-          if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
-            seen.push(event.id)
-            continue
-          }
-
-          // For creates, skip if no content. For edits, always enqueue
-          // so stale previews are cleared even when all URLs are removed.
-          if (!isEdit && !contentMarkdown) {
-            seen.push(event.id)
-            continue
-          }
-
-          await this.jobQueue.send(JobQueues.LINK_PREVIEW_EXTRACT, {
-            workspaceId,
-            streamId,
-            messageId,
-            contentMarkdown,
-            isEdit,
-          })
-
-          logger.debug({ messageId, isEdit }, "Link preview extraction job dispatched")
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-        return { status: "error", error }
-      }
-    })
+    logger.debug({ messageId, isEdit }, "Link preview extraction job dispatched")
   }
 }

--- a/apps/backend/src/features/memos/accumulator-outbox-handler.ts
+++ b/apps/backend/src/features/memos/accumulator-outbox-handler.ts
@@ -1,34 +1,14 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { StreamStateRepository, StreamRepository } from "../streams"
 import { PendingItemRepository } from "./pending-item-repository"
 import { pendingItemId } from "../../lib/id"
 import { StreamTypes } from "@threa/types"
 import { logger } from "../../lib/logger"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { withClient } from "../../db"
 import { E2eStreamsRepository } from "../e2e-streams"
 
-export interface MemoAccumulatorHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type MemoAccumulatorHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that queues conversations for batch memo processing.
@@ -46,77 +26,18 @@ const DEFAULT_CONFIG = {
  * creates/updates conversations on every message, and the conversation events
  * trigger memo processing via the conversation path only.
  */
-export class MemoAccumulatorHandler implements OutboxHandler {
-  readonly listenerId = "memo-accumulator"
-
-  private readonly db: Pool
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
-
+export class MemoAccumulatorHandler extends DebouncedOutboxHandler {
   constructor(db: Pool, config?: MemoAccumulatorHandlerConfig) {
-    this.db = db
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "MemoAccumulatorHandler debouncer error")
-    )
+    super(db, { listenerId: "memo-accumulator", ...config })
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          switch (event.eventType) {
-            case "conversation:created":
-            case "conversation:updated":
-              await this.handleConversationEvent(event)
-              break
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    switch (event.eventType) {
+      case "conversation:created":
+      case "conversation:updated":
+        await this.handleConversationEvent(event)
+        break
+    }
   }
 
   private async handleConversationEvent(outboxEvent: { id: bigint; payload: unknown }): Promise<void> {

--- a/apps/backend/src/features/memos/embedding-outbox-handler.ts
+++ b/apps/backend/src/features/memos/embedding-outbox-handler.ts
@@ -1,32 +1,12 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { parseMessagePayload } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 
-export interface EmbeddingHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type EmbeddingHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that dispatches embedding generation jobs for new messages.
@@ -34,102 +14,40 @@ const DEFAULT_CONFIG = {
  * Embedding generation runs async - messages are immediately searchable via
  * keyword search, and become semantically searchable once the embedding is ready.
  */
-export class EmbeddingHandler implements OutboxHandler {
-  readonly listenerId = "embedding"
-
-  private readonly db: Pool
+export class EmbeddingHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: EmbeddingHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "embedding", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "EmbeddingHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "message:created") {
+      return
+    }
 
-  handle(): void {
-    this.debouncer.trigger()
-  }
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      logger.debug({ eventId: event.id.toString() }, "EmbeddingHandler: malformed event, skipping")
+      return
+    }
 
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+    // E2E streams: contentMarkdown is ciphertext, so an embedding of it
+    // is meaningless. Skip without inspecting the message.
+    if (await E2eStreamsRepository.isE2eStream(this.db, payload.workspaceId, payload.streamId)) {
+      return
+    }
 
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
+    if (payload.event.actorType === "system") {
+      return
+    }
 
-      const seen: bigint[] = []
+    logger.debug({ messageId: payload.event.payload.messageId }, "Embedding job dispatched")
 
-      try {
-        for (const event of events) {
-          if (event.eventType !== "message:created") {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            logger.debug({ eventId: event.id.toString() }, "EmbeddingHandler: malformed event, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          // E2E streams: contentMarkdown is ciphertext, so an embedding of it
-          // is meaningless. Skip without inspecting the message.
-          if (await E2eStreamsRepository.isE2eStream(this.db, payload.workspaceId, payload.streamId)) {
-            seen.push(event.id)
-            continue
-          }
-
-          if (payload.event.actorType === "system") {
-            seen.push(event.id)
-            continue
-          }
-
-          logger.debug({ messageId: payload.event.payload.messageId }, "Embedding job dispatched")
-
-          await this.jobQueue.send(JobQueues.EMBEDDING_GENERATE, {
-            messageId: payload.event.payload.messageId,
-            workspaceId: payload.workspaceId,
-          })
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
+    await this.jobQueue.send(JobQueues.EMBEDDING_GENERATE, {
+      messageId: payload.event.payload.messageId,
+      workspaceId: payload.workspaceId,
     })
   }
 }

--- a/apps/backend/src/features/push/outbox-handler.ts
+++ b/apps/backend/src/features/push/outbox-handler.ts
@@ -1,6 +1,5 @@
 import type { Pool } from "pg"
 import {
-  OutboxRepository,
   type ActivityCreatedOutboxPayload,
   type OutboxEvent,
   type StreamReadOutboxPayload,
@@ -9,19 +8,12 @@ import {
 } from "../../lib/outbox"
 import type { PushService } from "./service"
 import { logger } from "../../lib/logger"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig } from "../../lib/outbox"
 
-const DEFAULT_CONFIG = {
-  // Smaller batch than other outbox handlers: each event triggers external HTTP calls
-  // (webpush.sendNotification) that hold the cursor lock during network I/O.
+// Smaller batch than other outbox handlers: each event triggers external HTTP
+// calls (webpush.sendNotification) that hold the cursor lock during network I/O.
+const HANDLER_CONFIG: DebouncedOutboxHandlerConfig = {
   batchSize: 10,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
 }
 
 interface PushNotificationHandlerDeps {
@@ -34,89 +26,29 @@ interface PushNotificationHandlerDeps {
  * Handles activity:created (show notification) and stream:read (clear notifications).
  * Infrastructure-only: cursor management, batching, and error handling (INV-34).
  */
-export class PushNotificationHandler implements OutboxHandler {
-  readonly listenerId = "push-notifications"
-
-  private readonly db: Pool
+export class PushNotificationHandler extends DebouncedOutboxHandler {
   private readonly pushService: PushService
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(deps: PushNotificationHandlerDeps) {
-    this.db = deps.pool
+    super(deps.pool, { listenerId: "push-notifications", ...HANDLER_CONFIG })
     this.pushService = deps.pushService
-    this.batchSize = DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: deps.pool,
-      listenerId: this.listenerId,
-      lockDurationMs: DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      DEFAULT_CONFIG.debounceMs,
-      DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "PushNotificationHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      // Sequential delivery within the batch. Parallel delivery is tempting but
-      // unsafe with CursorLock's sliding-window compaction: if event 8 fails but
-      // events 9-10 succeed and are added to processedIds, the gap window can
-      // expire during retry backoff, causing the cursor to jump past event 8 and
-      // permanently lose it. Sequential stops at the first failure, ensuring the
-      // cursor never advances past un-delivered events.
-      //
-      // Push events are low-volume (activity:created, stream:read) so sequential
-      // within a batch of 10 has negligible latency impact — the real throughput
-      // win is the dedicated realtime pool isolating push from background workers.
-      //
-      // Per-device webpush failures are handled inside PushService (stale
-      // subscription eviction) and don't escape as thrown errors here.
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          await this.deliverEvent(event)
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
-  }
-
-  private async deliverEvent(event: OutboxEvent): Promise<void> {
+  // Delivery is sequential within the batch (the base loops events in order and
+  // stops at the first throw). Parallel delivery is tempting but unsafe with
+  // CursorLock's sliding-window compaction: if event 8 fails but events 9-10
+  // succeed and are added to processedIds, the gap window can expire during
+  // retry backoff, causing the cursor to jump past event 8 and permanently lose
+  // it. Sequential stops at the first failure, ensuring the cursor never
+  // advances past un-delivered events.
+  //
+  // Push events are low-volume (activity:created, stream:read) so sequential
+  // within a batch of 10 has negligible latency impact — the real throughput
+  // win is the dedicated realtime pool isolating push from background workers.
+  //
+  // Per-device webpush failures are handled inside PushService (stale
+  // subscription eviction) and don't escape as thrown errors here.
+  protected async processEvent(event: OutboxEvent): Promise<void> {
     if (event.eventType === "activity:created") {
       const payload = event.payload as ActivityCreatedOutboxPayload
       if (!payload?.workspaceId || !payload?.targetUserId || !payload?.activity) {

--- a/apps/backend/src/features/streams/naming-outbox-handler.ts
+++ b/apps/backend/src/features/streams/naming-outbox-handler.ts
@@ -1,5 +1,4 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import { StreamRepository } from "./repository"
 import { parseMessagePayload } from "../../lib/outbox"
 import { needsAutoNaming } from "./display-name"
@@ -7,29 +6,10 @@ import { logger } from "../../lib/logger"
 import { AuthorTypes } from "@threa/types"
 import { JobQueues } from "../../lib/queue"
 import type { QueueManager } from "../../lib/queue"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig, type OutboxEvent } from "../../lib/outbox"
 import { E2eStreamsRepository } from "../e2e-streams"
 
-export interface NamingHandlerConfig {
-  batchSize?: number
-  debounceMs?: number
-  maxWaitMs?: number
-  lockDurationMs?: number
-  refreshIntervalMs?: number
-  maxRetries?: number
-  baseBackoffMs?: number
-}
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
+export type NamingHandlerConfig = DebouncedOutboxHandlerConfig
 
 /**
  * Handler that dispatches auto-naming jobs for messages in streams
@@ -42,120 +22,50 @@ const DEFAULT_CONFIG = {
  * Uses time-based cursor locking for exclusive access without
  * holding database connections during processing.
  */
-export class NamingHandler implements OutboxHandler {
-  readonly listenerId = "naming"
-
-  private readonly db: Pool
+export class NamingHandler extends DebouncedOutboxHandler {
   private readonly jobQueue: QueueManager
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, jobQueue: QueueManager, config?: NamingHandlerConfig) {
-    this.db = db
+    super(db, { listenerId: "naming", ...config })
     this.jobQueue = jobQueue
-    this.batchSize = config?.batchSize ?? DEFAULT_CONFIG.batchSize
+  }
 
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: config?.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: config?.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: config?.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: config?.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType !== "message:created") {
+      return
+    }
+
+    const payload = parseMessagePayload(event.payload)
+    if (!payload) {
+      logger.debug({ eventId: event.id.toString() }, "NamingHandler: malformed event, skipping")
+      return
+    }
+
+    const { streamId, workspaceId, event: messageEvent } = payload
+    const isAgentMessage = messageEvent.actorType !== AuthorTypes.USER
+
+    // E2E streams: auto-naming reads message content which is ciphertext
+    // on E2E streams. The client picks a name locally instead.
+    if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
+      return
+    }
+
+    const stream = await StreamRepository.findById(this.db, streamId)
+    if (!stream) {
+      logger.warn({ streamId }, "NamingHandler: stream not found")
+      return
+    }
+
+    if (!needsAutoNaming(stream)) {
+      return
+    }
+
+    await this.jobQueue.send(JobQueues.NAMING_GENERATE, {
+      workspaceId: stream.workspaceId,
+      streamId,
+      requireName: isAgentMessage,
     })
 
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      config?.debounceMs ?? DEFAULT_CONFIG.debounceMs,
-      config?.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "NamingHandler debouncer error")
-    )
-  }
-
-  /**
-   * Ensures the listener exists in the database.
-   * Call this during startup before registering with the dispatcher.
-   */
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  /**
-   * Called by OutboxDispatcher on notification.
-   * Debounces rapid notifications and processes events.
-   */
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (event.eventType !== "message:created") {
-            seen.push(event.id)
-            continue
-          }
-
-          const payload = parseMessagePayload(event.payload)
-          if (!payload) {
-            logger.debug({ eventId: event.id.toString() }, "NamingHandler: malformed event, skipping")
-            seen.push(event.id)
-            continue
-          }
-
-          const { streamId, workspaceId, event: messageEvent } = payload
-          const isAgentMessage = messageEvent.actorType !== AuthorTypes.USER
-
-          // E2E streams: auto-naming reads message content which is ciphertext
-          // on E2E streams. The client picks a name locally instead.
-          if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, streamId)) {
-            seen.push(event.id)
-            continue
-          }
-
-          const stream = await StreamRepository.findById(this.db, streamId)
-          if (!stream) {
-            logger.warn({ streamId }, "NamingHandler: stream not found")
-            seen.push(event.id)
-            continue
-          }
-
-          if (!needsAutoNaming(stream)) {
-            seen.push(event.id)
-            continue
-          }
-
-          await this.jobQueue.send(JobQueues.NAMING_GENERATE, {
-            workspaceId: stream.workspaceId,
-            streamId,
-            requireName: isAgentMessage,
-          })
-
-          logger.info({ streamId, requireName: isAgentMessage }, "Naming job dispatched")
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+    logger.info({ streamId, requireName: isAgentMessage }, "Naming job dispatched")
   }
 }

--- a/apps/backend/src/features/system-messages/outbox-handler.ts
+++ b/apps/backend/src/features/system-messages/outbox-handler.ts
@@ -1,97 +1,27 @@
 import type { Pool } from "pg"
-import { OutboxRepository } from "../../lib/outbox"
 import type { BudgetAlertOutboxPayload, InvitationAcceptedOutboxPayload } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
-import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
-import type { OutboxHandler } from "../../lib/outbox"
+import { DebouncedOutboxHandler, type OutboxEvent } from "../../lib/outbox"
 import type { SystemMessageService } from "./service"
-
-const DEFAULT_CONFIG = {
-  batchSize: 100,
-  debounceMs: 50,
-  maxWaitMs: 200,
-  lockDurationMs: 10_000,
-  refreshIntervalMs: 5_000,
-  maxRetries: 5,
-  baseBackoffMs: 1_000,
-}
 
 /**
  * Converts outbox events into system messages posted to each user's system stream.
  * Listens for events like budget:alert and formats them as messages.
  */
-export class SystemMessageOutboxHandler implements OutboxHandler {
-  readonly listenerId = "system-messages"
-
-  private readonly db: Pool
+export class SystemMessageOutboxHandler extends DebouncedOutboxHandler {
   private readonly systemMessageService: SystemMessageService
-  private readonly cursorLock: CursorLock
-  private readonly debouncer: DebounceWithMaxWait
-  private readonly batchSize: number
 
   constructor(db: Pool, systemMessageService: SystemMessageService) {
-    this.db = db
+    super(db, { listenerId: "system-messages" })
     this.systemMessageService = systemMessageService
-    this.batchSize = DEFAULT_CONFIG.batchSize
-
-    this.cursorLock = new CursorLock({
-      pool: db,
-      listenerId: this.listenerId,
-      lockDurationMs: DEFAULT_CONFIG.lockDurationMs,
-      refreshIntervalMs: DEFAULT_CONFIG.refreshIntervalMs,
-      maxRetries: DEFAULT_CONFIG.maxRetries,
-      baseBackoffMs: DEFAULT_CONFIG.baseBackoffMs,
-      batchSize: this.batchSize,
-    })
-
-    this.debouncer = new DebounceWithMaxWait(
-      () => this.processEvents(),
-      DEFAULT_CONFIG.debounceMs,
-      DEFAULT_CONFIG.maxWaitMs,
-      (err) => logger.error({ err, listenerId: this.listenerId }, "SystemMessageOutboxHandler debouncer error")
-    )
   }
 
-  async ensureListener(): Promise<void> {
-    await ensureListenerFromLatest(this.db, this.listenerId)
-  }
-
-  handle(): void {
-    this.debouncer.trigger()
-  }
-
-  private async processEvents(): Promise<void> {
-    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
-      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
-
-      if (events.length === 0) {
-        return { status: "no_events" }
-      }
-
-      const seen: bigint[] = []
-
-      try {
-        for (const event of events) {
-          if (event.eventType === "budget:alert") {
-            await this.handleBudgetAlert(event.payload as BudgetAlertOutboxPayload)
-          } else if (event.eventType === "invitation:accepted") {
-            await this.handleInvitationAccepted(event.payload as InvitationAcceptedOutboxPayload)
-          }
-
-          seen.push(event.id)
-        }
-
-        return { status: "processed", processedIds: seen }
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-
-        if (seen.length > 0) {
-          return { status: "error", error, processedIds: seen }
-        }
-
-        return { status: "error", error }
-      }
-    })
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (event.eventType === "budget:alert") {
+      await this.handleBudgetAlert(event.payload as BudgetAlertOutboxPayload)
+    } else if (event.eventType === "invitation:accepted") {
+      await this.handleInvitationAccepted(event.payload as InvitationAcceptedOutboxPayload)
+    }
   }
 
   private async handleBudgetAlert(payload: BudgetAlertOutboxPayload): Promise<void> {

--- a/apps/backend/src/lib/outbox/debounced-handler.test.ts
+++ b/apps/backend/src/lib/outbox/debounced-handler.test.ts
@@ -6,15 +6,21 @@ import type { OutboxEvent } from "./repository"
 import { DebouncedOutboxHandler } from "./debounced-handler"
 
 // Replace CursorLock.run with a fake that invokes the processor once with
-// cursor 0 and no in-flight ids, then hands the result back to the test. This
-// exercises the real processEvents/processEvent path without a database.
-function mockCursorLock(onRun?: (result: ProcessResult) => void) {
+// cursor 0 and no in-flight ids. This exercises the real
+// processEvents/processEvent path without a database. The returned promise
+// resolves with the ProcessResult when the batch completes, so tests await
+// actual completion instead of sleeping through real debounce timers.
+function mockCursorLock(): Promise<ProcessResult> {
+  let resolve: (result: ProcessResult) => void
+  const completed = new Promise<ProcessResult>((r) => {
+    resolve = r
+  })
   ;(spyOn(cursorLockModule, "CursorLock") as any).mockImplementation(() => ({
     run: mock(async (processor: (cursor: bigint, processedIds: bigint[]) => Promise<ProcessResult>) => {
-      const result = await processor(0n, [])
-      onRun?.(result)
+      resolve(await processor(0n, []))
     }),
   }))
+  return completed
 }
 
 function makeEvent(id: bigint, eventType: string): OutboxEvent {
@@ -23,12 +29,13 @@ function makeEvent(id: bigint, eventType: string): OutboxEvent {
 
 // Minimal concrete subclass: records the events it was handed and optionally
 // throws on a designated id, so we can observe per-event dispatch and the
-// partial-progress error path.
+// partial-progress error path. Zero debounce so handle() fires on the next
+// tick — the tests await batch completion, not wall-clock time.
 class TestHandler extends DebouncedOutboxHandler {
   readonly handled: bigint[] = []
 
   constructor(private readonly throwOnId?: bigint) {
-    super({} as any, { listenerId: "test-handler" })
+    super({} as any, { listenerId: "test-handler", debounceMs: 0, maxWaitMs: 0 })
   }
 
   protected async processEvent(event: OutboxEvent): Promise<void> {
@@ -50,15 +57,11 @@ describe("DebouncedOutboxHandler", () => {
       makeEvent(2n, "message:created"),
       makeEvent(3n, "reaction:added"),
     ])
-
-    let result: ProcessResult | undefined
-    mockCursorLock((r) => {
-      result = r
-    })
+    const completed = mockCursorLock()
 
     const handler = new TestHandler()
     handler.handle()
-    await new Promise((r) => setTimeout(r, 300))
+    const result = await completed
 
     expect(handler.handled).toEqual([1n, 2n, 3n])
     expect(result).toEqual({ status: "processed", processedIds: [1n, 2n, 3n] })
@@ -70,22 +73,18 @@ describe("DebouncedOutboxHandler", () => {
       makeEvent(2n, "message:created"),
       makeEvent(3n, "message:created"),
     ])
-
-    let result: ProcessResult | undefined
-    mockCursorLock((r) => {
-      result = r
-    })
+    const completed = mockCursorLock()
 
     // Event 1 and 2 succeed, event 3 throws — the batch must report the two it
     // already handled so the cursor advances over them and only 3 is retried.
     const handler = new TestHandler(3n)
     handler.handle()
-    await new Promise((r) => setTimeout(r, 300))
+    const result = await completed
 
     expect(handler.handled).toEqual([1n, 2n])
-    expect(result?.status).toBe("error")
+    expect(result.status).toBe("error")
     expect(result).toMatchObject({ status: "error", processedIds: [1n, 2n] })
-    if (result?.status === "error") {
+    if (result.status === "error") {
       expect(result.error.message).toBe("boom on 3")
     }
   })
@@ -95,19 +94,15 @@ describe("DebouncedOutboxHandler", () => {
       makeEvent(1n, "message:created"),
       makeEvent(2n, "message:created"),
     ])
-
-    let result: ProcessResult | undefined
-    mockCursorLock((r) => {
-      result = r
-    })
+    const completed = mockCursorLock()
 
     const handler = new TestHandler(1n)
     handler.handle()
-    await new Promise((r) => setTimeout(r, 300))
+    const result = await completed
 
     expect(handler.handled).toEqual([])
-    expect(result?.status).toBe("error")
-    if (result?.status === "error") {
+    expect(result.status).toBe("error")
+    if (result.status === "error") {
       expect(result.processedIds).toBeUndefined()
       expect(result.error.message).toBe("boom on 1")
     }
@@ -115,15 +110,11 @@ describe("DebouncedOutboxHandler", () => {
 
   it("reports no_events for an empty batch without invoking processEvent", async () => {
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([])
-
-    let result: ProcessResult | undefined
-    mockCursorLock((r) => {
-      result = r
-    })
+    const completed = mockCursorLock()
 
     const handler = new TestHandler()
     handler.handle()
-    await new Promise((r) => setTimeout(r, 300))
+    const result = await completed
 
     expect(handler.handled).toEqual([])
     expect(result).toEqual({ status: "no_events" })

--- a/apps/backend/src/lib/outbox/debounced-handler.test.ts
+++ b/apps/backend/src/lib/outbox/debounced-handler.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import * as cursorLockModule from "@threa/backend-common"
+import type { ProcessResult } from "@threa/backend-common"
+import { OutboxRepository } from "./repository"
+import type { OutboxEvent } from "./repository"
+import { DebouncedOutboxHandler } from "./debounced-handler"
+
+// Replace CursorLock.run with a fake that invokes the processor once with
+// cursor 0 and no in-flight ids, then hands the result back to the test. This
+// exercises the real processEvents/processEvent path without a database.
+function mockCursorLock(onRun?: (result: ProcessResult) => void) {
+  ;(spyOn(cursorLockModule, "CursorLock") as any).mockImplementation(() => ({
+    run: mock(async (processor: (cursor: bigint, processedIds: bigint[]) => Promise<ProcessResult>) => {
+      const result = await processor(0n, [])
+      onRun?.(result)
+    }),
+  }))
+}
+
+function makeEvent(id: bigint, eventType: string): OutboxEvent {
+  return { id, eventType, payload: {}, createdAt: new Date() } as unknown as OutboxEvent
+}
+
+// Minimal concrete subclass: records the events it was handed and optionally
+// throws on a designated id, so we can observe per-event dispatch and the
+// partial-progress error path.
+class TestHandler extends DebouncedOutboxHandler {
+  readonly handled: bigint[] = []
+
+  constructor(private readonly throwOnId?: bigint) {
+    super({} as any, { listenerId: "test-handler" })
+  }
+
+  protected async processEvent(event: OutboxEvent): Promise<void> {
+    if (this.throwOnId !== undefined && event.id === this.throwOnId) {
+      throw new Error(`boom on ${event.id}`)
+    }
+    this.handled.push(event.id)
+  }
+}
+
+describe("DebouncedOutboxHandler", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("processes every event in the batch and reports them as processed", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([
+      makeEvent(1n, "message:created"),
+      makeEvent(2n, "message:created"),
+      makeEvent(3n, "reaction:added"),
+    ])
+
+    let result: ProcessResult | undefined
+    mockCursorLock((r) => {
+      result = r
+    })
+
+    const handler = new TestHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(handler.handled).toEqual([1n, 2n, 3n])
+    expect(result).toEqual({ status: "processed", processedIds: [1n, 2n, 3n] })
+  })
+
+  it("returns an error carrying the ids processed before the throw (partial progress)", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([
+      makeEvent(1n, "message:created"),
+      makeEvent(2n, "message:created"),
+      makeEvent(3n, "message:created"),
+    ])
+
+    let result: ProcessResult | undefined
+    mockCursorLock((r) => {
+      result = r
+    })
+
+    // Event 1 and 2 succeed, event 3 throws — the batch must report the two it
+    // already handled so the cursor advances over them and only 3 is retried.
+    const handler = new TestHandler(3n)
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(handler.handled).toEqual([1n, 2n])
+    expect(result?.status).toBe("error")
+    expect(result).toMatchObject({ status: "error", processedIds: [1n, 2n] })
+    if (result?.status === "error") {
+      expect(result.error.message).toBe("boom on 3")
+    }
+  })
+
+  it("returns an error with no processedIds when the first event throws", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([
+      makeEvent(1n, "message:created"),
+      makeEvent(2n, "message:created"),
+    ])
+
+    let result: ProcessResult | undefined
+    mockCursorLock((r) => {
+      result = r
+    })
+
+    const handler = new TestHandler(1n)
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(handler.handled).toEqual([])
+    expect(result?.status).toBe("error")
+    if (result?.status === "error") {
+      expect(result.processedIds).toBeUndefined()
+      expect(result.error.message).toBe("boom on 1")
+    }
+  })
+
+  it("reports no_events for an empty batch without invoking processEvent", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([])
+
+    let result: ProcessResult | undefined
+    mockCursorLock((r) => {
+      result = r
+    })
+
+    const handler = new TestHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(handler.handled).toEqual([])
+    expect(result).toEqual({ status: "no_events" })
+  })
+})

--- a/apps/backend/src/lib/outbox/debounced-handler.ts
+++ b/apps/backend/src/lib/outbox/debounced-handler.ts
@@ -1,0 +1,132 @@
+import type { Pool } from "pg"
+import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
+import { logger } from "../logger"
+import { OutboxRepository, type OutboxEvent } from "./repository"
+import type { OutboxHandler } from "@threa/backend-common"
+
+/**
+ * Tunables shared by every debounced outbox handler. All optional — omitted
+ * fields fall back to the canonical defaults below.
+ */
+export interface DebouncedOutboxHandlerConfig {
+  batchSize?: number
+  debounceMs?: number
+  maxWaitMs?: number
+  lockDurationMs?: number
+  refreshIntervalMs?: number
+  maxRetries?: number
+  baseBackoffMs?: number
+}
+
+/**
+ * Canonical defaults copied across every feature outbox handler before this
+ * base class existed. Handlers that need different values pass overrides in
+ * super() rather than redefining the whole block.
+ */
+const DEFAULT_CONFIG = {
+  batchSize: 100,
+  debounceMs: 50,
+  maxWaitMs: 200,
+  lockDurationMs: 10_000,
+  refreshIntervalMs: 5_000,
+  maxRetries: 5,
+  baseBackoffMs: 1_000,
+}
+
+/**
+ * Base class for outbox handlers that debounce notifications and process
+ * events one batch at a time under a {@link CursorLock}.
+ *
+ * It owns the scaffolding every feature handler used to copy verbatim:
+ * - canonical {@link DEFAULT_CONFIG} merged with per-handler overrides,
+ * - {@link CursorLock} + {@link DebounceWithMaxWait} construction,
+ * - `ensureListener()` / `handle()` wiring,
+ * - the `processEvents()` batch loop with seen-tracking and the
+ *   partial-progress error path.
+ *
+ * Subclasses implement {@link processEvent} with their event-dispatch and
+ * domain logic. The base catches per-batch errors and returns them with the
+ * ids processed so far, so an event that throws mid-batch retries without
+ * losing the events already handled.
+ *
+ * `processEvents` is `protected` (not private) so a rare handler that needs a
+ * different batch shape (pre-filtering, batch-level grouping) can override it
+ * while still reusing the construction and wiring above.
+ */
+export abstract class DebouncedOutboxHandler implements OutboxHandler {
+  readonly listenerId: string
+
+  protected readonly db: Pool
+  protected readonly batchSize: number
+  private readonly cursorLock: CursorLock
+  private readonly debouncer: DebounceWithMaxWait
+
+  constructor(db: Pool, opts: { listenerId: string } & DebouncedOutboxHandlerConfig) {
+    this.db = db
+    this.listenerId = opts.listenerId
+    this.batchSize = opts.batchSize ?? DEFAULT_CONFIG.batchSize
+
+    this.cursorLock = new CursorLock({
+      pool: db,
+      listenerId: this.listenerId,
+      lockDurationMs: opts.lockDurationMs ?? DEFAULT_CONFIG.lockDurationMs,
+      refreshIntervalMs: opts.refreshIntervalMs ?? DEFAULT_CONFIG.refreshIntervalMs,
+      maxRetries: opts.maxRetries ?? DEFAULT_CONFIG.maxRetries,
+      baseBackoffMs: opts.baseBackoffMs ?? DEFAULT_CONFIG.baseBackoffMs,
+      batchSize: this.batchSize,
+    })
+
+    this.debouncer = new DebounceWithMaxWait(
+      () => this.processEvents(),
+      opts.debounceMs ?? DEFAULT_CONFIG.debounceMs,
+      opts.maxWaitMs ?? DEFAULT_CONFIG.maxWaitMs,
+      (err) => logger.error({ err, listenerId: this.listenerId }, "DebouncedOutboxHandler debouncer error")
+    )
+  }
+
+  async ensureListener(): Promise<void> {
+    await ensureListenerFromLatest(this.db, this.listenerId)
+  }
+
+  handle(): void {
+    this.debouncer.trigger()
+  }
+
+  protected async processEvents(): Promise<void> {
+    await this.cursorLock.run(async (cursor, processedIds): Promise<ProcessResult> => {
+      const events = await OutboxRepository.fetchAfterId(this.db, cursor, this.batchSize, processedIds)
+
+      if (events.length === 0) {
+        return { status: "no_events" }
+      }
+
+      const seen: bigint[] = []
+
+      try {
+        for (const event of events) {
+          await this.processEvent(event)
+          seen.push(event.id)
+        }
+
+        return { status: "processed", processedIds: seen }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+
+        if (seen.length > 0) {
+          return { status: "error", error, processedIds: seen }
+        }
+
+        return { status: "error", error }
+      }
+    })
+  }
+
+  /**
+   * Handle a single outbox event. Implementations filter on `event.eventType`
+   * and skip-and-return for events they don't care about; the base marks every
+   * event as processed once this resolves. Throwing aborts the batch at this
+   * event — the events already processed are persisted, this one and the rest
+   * are retried.
+   */
+  protected abstract processEvent(event: OutboxEvent): Promise<void>
+}

--- a/apps/backend/src/lib/outbox/debounced-handler.ts
+++ b/apps/backend/src/lib/outbox/debounced-handler.ts
@@ -19,9 +19,9 @@ export interface DebouncedOutboxHandlerConfig {
 }
 
 /**
- * Canonical defaults copied across every feature outbox handler before this
- * base class existed. Handlers that need different values pass overrides in
- * super() rather than redefining the whole block.
+ * Canonical tunables shared by every feature outbox handler. Handlers that
+ * need different values pass overrides in super() rather than redefining the
+ * whole block.
  */
 const DEFAULT_CONFIG = {
   batchSize: 100,
@@ -37,7 +37,7 @@ const DEFAULT_CONFIG = {
  * Base class for outbox handlers that debounce notifications and process
  * events one batch at a time under a {@link CursorLock}.
  *
- * It owns the scaffolding every feature handler used to copy verbatim:
+ * It owns the scaffolding every feature handler shares:
  * - canonical {@link DEFAULT_CONFIG} merged with per-handler overrides,
  * - {@link CursorLock} + {@link DebounceWithMaxWait} construction,
  * - `ensureListener()` / `handle()` wiring,

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -3,6 +3,7 @@ export { OutboxDispatcher, type OutboxHandler, type OutboxDispatcherConfig } fro
 export { OutboxRetentionWorker, type OutboxRetentionWorkerConfig } from "@threa/backend-common"
 
 // Domain-specific outbox code
+export { DebouncedOutboxHandler, type DebouncedOutboxHandlerConfig } from "./debounced-handler"
 export { BroadcastHandler, type BroadcastHandlerConfig } from "./broadcast-handler"
 export {
   resolveDeliveryGroups,


### PR DESCRIPTION
## Summary

Audit finding #6 (`docs/codebase-audit-2026-06-12.md`, P1): every feature outbox handler copy-pasted the same ~60-line scaffold — a 7-field `DEFAULT_CONFIG`, CursorLock + DebounceWithMaxWait wiring, `ensureListener()`/`handle()`, and the `fetchAfterId` batch loop with seen-tracking and the partial-progress error path.

This extracts one abstract `DebouncedOutboxHandler` base class in `lib/outbox/` and migrates 16 handlers onto it. Handlers keep only their event dispatch and domain logic; per-handler config deviations ride through `super()` overrides (e.g. push keeps `batchSize: 10` with its lock-during-network-I/O rationale comment).

**Net: −1,000 lines** (854 insertions, 1,854 deletions).

## Design decisions

- `processEvents()` is `protected` (not private) so a rare handler needing a different batch shape can override it while reusing construction/wiring. None of the 16 migrated handlers needed to.
- `processEvent(event)` is the single abstract method — implementations filter on `event.eventType` and skip-and-return, exactly like the bodies of the old per-handler loops. Throwing aborts the batch at that event with partial progress preserved (same semantics as every old copy).
- Constructor signatures of all migrated handlers are unchanged, so `server.ts` needed no edits.

## Deliberately not migrated

- `activity/outbox-handler.ts` — owned by in-transit #886
- `enclave-runtimes/dispatch/enclave-dispatch-handler.ts` — active enclave work (#889 area)
- `bot-runtimes/invocation-outbox-handler.ts` — agent-session adjacent, deviant shape
- `lib/outbox/broadcast-handler.ts` — deviant batch shape: it sequences and routes the whole batch (`sequenceEvents()`) before per-event handling, so the per-event `processEvent` contract doesn't fit

These migrate trivially once their PRs land.

## Verification

- `bun run typecheck` clean
- New base-class unit test (per-event processing, partial-progress error path, empty batch)
- Backend unit suite: 1,746 pass / 0 fail
- Integration suite: parity with main (3 pre-existing env-dependent security-regression failures, identical on untouched main)
- E2E suite: 308 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783881557&installation_id=129946197&pr_number=892&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F892&signature=35e73945daeb1b94c44f5203ac90fa876d11f884cfb5f5ff7ab4e1a037963db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
