### PR TITLE
refactor(backend): shared validateRequest helper + messaging HttpError unification (INV-32, INV-55)

### DIFF
--- a/apps/backend/src/features/agents/context-bag/handlers.test.ts
+++ b/apps/backend/src/features/agents/context-bag/handlers.test.ts
@@ -83,32 +83,33 @@ describe("createContextBagHandlers.precompute", () => {
     )
   })
 
-  it("returns 400 when the body is missing required fields", async () => {
+  it("throws a 400 VALIDATION_ERROR when the body is missing required fields", async () => {
     const precomputeSpy = spyOn(precomputeService, "precomputeRefSummaries")
 
     const handlers = createContextBagHandlers({ pool: {} as any, ai: {} as any })
     const req = mockReq({ intent: ContextIntents.DISCUSS_THREAD })
     const res = mockRes() as any
-    await handlers.precompute(req, res)
 
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toMatchObject({ error: "Validation failed" })
+    await expect(handlers.precompute(req, res)).rejects.toMatchObject({
+      status: 400,
+      code: "VALIDATION_ERROR",
+      message: "Validation failed",
+    })
     expect(precomputeSpy).not.toHaveBeenCalled()
   })
 
-  it("returns 400 when refs is empty", async () => {
+  it("throws a 400 VALIDATION_ERROR when refs is empty", async () => {
     const precomputeSpy = spyOn(precomputeService, "precomputeRefSummaries")
 
     const handlers = createContextBagHandlers({ pool: {} as any, ai: {} as any })
     const req = mockReq({ intent: ContextIntents.DISCUSS_THREAD, refs: [] })
     const res = mockRes() as any
-    await handlers.precompute(req, res)
 
-    expect(res.statusCode).toBe(400)
+    await expect(handlers.precompute(req, res)).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" })
     expect(precomputeSpy).not.toHaveBeenCalled()
   })
 
-  it("returns 400 when a ref has an unknown kind", async () => {
+  it("throws a 400 VALIDATION_ERROR when a ref has an unknown kind", async () => {
     const precomputeSpy = spyOn(precomputeService, "precomputeRefSummaries")
 
     const handlers = createContextBagHandlers({ pool: {} as any, ai: {} as any })
@@ -117,9 +118,8 @@ describe("createContextBagHandlers.precompute", () => {
       refs: [{ kind: "memo", memoId: "memo_1" }],
     })
     const res = mockRes() as any
-    await handlers.precompute(req, res)
 
-    expect(res.statusCode).toBe(400)
+    await expect(handlers.precompute(req, res)).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" })
     expect(precomputeSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/agents/context-bag/handlers.ts
+++ b/apps/backend/src/features/agents/context-bag/handlers.ts
@@ -1,9 +1,9 @@
 import type { Request, Response } from "express"
 import type { Pool } from "pg"
-import { z } from "zod"
 import type { AI } from "@threa/agent-runtime"
 import type { ContextIntent } from "@threa/types"
 import { withClient } from "../../../db"
+import { validateRequest } from "../../../lib/validation"
 import {
   fetchStreamBag,
   type ContextRefSource,
@@ -45,15 +45,7 @@ export function createContextBagHandlers({ pool, ai }: Dependencies) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const parsed = precomputeSchema.safeParse(req.body)
-      if (!parsed.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(parsed.error).fieldErrors,
-        })
-      }
-
-      const { intent, refs } = parsed.data
+      const { intent, refs } = validateRequest(precomputeSchema, req.body)
       const results = await precomputeService.precomputeRefSummaries(
         { pool, ai },
         { workspaceId, userId, intent: intent as ContextIntent, refs }

--- a/apps/backend/src/features/ai-usage/handlers.ts
+++ b/apps/backend/src/features/ai-usage/handlers.ts
@@ -5,6 +5,7 @@ import { withClient } from "../../db"
 import { AIUsageRepository } from "./usage-repository"
 import { AIBudgetRepository } from "./budget-repository"
 import { aiBudgetId } from "../../lib/id"
+import { validateRequest } from "../../lib/validation"
 
 const updateBudgetSchema = z.object({
   monthlyBudgetUsd: z.number().min(0).optional(),
@@ -166,15 +167,7 @@ export function createAIUsageHandlers({ pool }: Dependencies) {
     async updateBudget(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = updateBudgetSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const updates = result.data
+      const updates = validateRequest(updateBudgetSchema, req.body)
       const { start, end } = getCurrentMonthRange()
 
       const [budget, usage] = await withClient(pool, async (client) => {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express"
 import type { ConversationService } from "./service"
 import type { StreamService } from "../streams"
 import { CONVERSATION_STATUSES } from "@threa/types"
+import { validateRequest } from "../../lib/validation"
 
 const listConversationsSchema = z.object({
   status: z.enum(CONVERSATION_STATUSES).optional(),
@@ -26,18 +27,12 @@ export function createConversationHandlers({ conversationService, streamService 
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = listConversationsSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const query = validateRequest(listConversationsSchema, req.query)
 
       // validateStreamAccess handles public visibility + thread root membership
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const conversations = await conversationService.listByStream(streamId, result.data)
+      const conversations = await conversationService.listByStream(streamId, query)
       res.json({ conversations })
     },
 
@@ -83,14 +78,7 @@ export function createConversationHandlers({ conversationService, streamService 
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const paramsResult = reassignMessageParamsSchema.safeParse(req.params)
-      if (!paramsResult.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(paramsResult.error).fieldErrors,
-        })
-      }
-      const { conversationId, messageId } = paramsResult.data
+      const { conversationId, messageId } = validateRequest(reassignMessageParamsSchema, req.params)
 
       const conversation = await conversationService.getById(conversationId)
       if (!conversation || conversation.workspaceId !== workspaceId) {

--- a/apps/backend/src/features/invitations/handlers.ts
+++ b/apps/backend/src/features/invitations/handlers.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import { WORKSPACE_INVITABLE_ROLES, WORKSPACE_ROLE_SLUGS } from "@threa/types"
 import { HttpError } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import type { Invitation } from "./repository"
 import type { InvitationService, InvitationLinkErrorCode } from "./service"
 import { InvitationLinkError } from "./service"
@@ -53,15 +54,7 @@ export function createInvitationHandlers({ invitationService }: Dependencies) {
       const workspaceId = req.workspaceId!
       const userId = req.user!.id
 
-      const result = sendInvitationsSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { emails, role } = result.data
+      const { emails, role } = validateRequest(sendInvitationsSchema, req.body)
 
       const sendResult = await invitationService.sendInvitations({
         workspaceId,
@@ -118,19 +111,13 @@ export function createInvitationHandlers({ invitationService }: Dependencies) {
       const workspaceId = req.workspaceId!
       const userId = req.user!.id
 
-      const result = createLinkSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(createLinkSchema, req.body)
 
       const { invitation, token } = await invitationService.createLink({
         workspaceId,
         invitedBy: userId,
-        role: result.data.role,
-        note: result.data.note?.trim() || null,
+        role: data.role,
+        note: data.note?.trim() || null,
       })
 
       // Token returned exactly once. Frontend constructs the join URL from

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -9,7 +9,9 @@ import { StreamEventRepository } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
 import type { CommandRegistry } from "../commands"
 import { type CommandDispatchedPayload, E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
-import { serializeBigInt } from "@threa/backend-common"
+import { serializeBigInt, HttpError } from "@threa/backend-common"
+import { MessageNotFoundError } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import { eventId, commandId as generateCommandId } from "../../lib/id"
 import { toShortcode, normalizeMessage, toEmoji } from "../emoji"
 import { collectAttachmentReferenceIds, parseMarkdown } from "@threa/prosemirror"
@@ -264,15 +266,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = createMessageSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const data = result.data
+      const data = validateRequest(createMessageSchema, req.body)
 
       const stream = await streamService.resolveWritableMessageStream({
         workspaceId,
@@ -290,12 +284,12 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const isE2eStream = stream.e2eEnabled === true
       const isE2eRequest = "ciphertext" in data
       if (isE2eStream !== isE2eRequest) {
-        return res.status(400).json({
-          error: isE2eStream
+        throw new HttpError(
+          isE2eStream
             ? "Stream is end-to-end encrypted; send ciphertext, envelope, and e2eVersion"
             : "Stream is not end-to-end encrypted; send plaintext content",
-          code: isE2eStream ? "E2E_STREAM_REQUIRES_CIPHERTEXT" : "E2E_PAYLOAD_REQUIRES_E2E_STREAM",
-        })
+          { status: 400, code: isE2eStream ? "E2E_STREAM_REQUIRES_CIPHERTEXT" : "E2E_PAYLOAD_REQUIRES_E2E_STREAM" }
+        )
       }
 
       if ("ciphertext" in data) {
@@ -405,17 +399,11 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const workspaceId = req.workspaceId!
       const { messageId } = req.params
 
-      const result = updateMessageSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateMessageSchema, req.body)
 
       const existing = await eventService.getMessageById(messageId)
       if (!existing) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       // Read-access gate (visibility + workspace + thread inheritance), not
@@ -424,15 +412,15 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       // restriction below still enforces "edit your own".
       const accessibleStream = await streamService.tryAccess(existing.streamId, workspaceId, userId)
       if (!accessibleStream) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       if (existing.authorId !== userId) {
-        return res.status(403).json({ error: "Can only edit your own messages" })
+        throw new HttpError("Can only edit your own messages", { status: 403, code: "FORBIDDEN" })
       }
 
       // Normalize to both JSON and markdown formats
-      const { contentJson, contentMarkdown } = normalizeContent(result.data)
+      const { contentJson, contentMarkdown } = normalizeContent(data)
 
       // Derive inline attachment ids from the new contentJson so event-service
       // can refresh the `attachment_references` projection in sync (INV-7).
@@ -448,11 +436,11 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         contentMarkdown,
         actorId: userId,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        confirmedPrivacyWarning: result.data.confirmedPrivacyWarning,
+        confirmedPrivacyWarning: data.confirmedPrivacyWarning,
       })
 
       if (!message) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       res.json({ message: serializeMessage(message) })
@@ -462,27 +450,21 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = moveMessagesToThreadSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(moveMessagesToThreadSchema, req.body)
 
       await streamService.resolveWritableMessageStream({
         workspaceId,
         userId,
-        target: { streamId: result.data.sourceStreamId },
+        target: { streamId: data.sourceStreamId },
       })
 
       const moveResult = await eventService.moveMessagesToThread({
         workspaceId,
-        sourceStreamId: result.data.sourceStreamId,
-        targetMessageId: result.data.targetMessageId,
-        messageIds: result.data.messageIds,
+        sourceStreamId: data.sourceStreamId,
+        targetMessageId: data.targetMessageId,
+        messageIds: data.messageIds,
         actorId: userId,
-        leaseKey: result.data.leaseKey,
+        leaseKey: data.leaseKey,
       })
 
       res.json({
@@ -501,25 +483,19 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = validateMoveMessagesToThreadSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(validateMoveMessagesToThreadSchema, req.body)
 
       await streamService.resolveWritableMessageStream({
         workspaceId,
         userId,
-        target: { streamId: result.data.sourceStreamId },
+        target: { streamId: data.sourceStreamId },
       })
 
       const validation = await eventService.validateMoveMessagesToThread({
         workspaceId,
-        sourceStreamId: result.data.sourceStreamId,
-        targetMessageId: result.data.targetMessageId,
-        messageIds: result.data.messageIds,
+        sourceStreamId: data.sourceStreamId,
+        targetMessageId: data.targetMessageId,
+        messageIds: data.messageIds,
         actorId: userId,
       })
 
@@ -533,18 +509,18 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
 
       const existing = await eventService.getMessageById(messageId)
       if (!existing) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       // Same read-access reasoning as `update`: gate on tryAccess (visibility
       // + workspace + thread inheritance), then enforce author-only below.
       const accessibleStream = await streamService.tryAccess(existing.streamId, workspaceId, userId)
       if (!accessibleStream) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       if (existing.authorId !== userId) {
-        return res.status(403).json({ error: "Can only delete your own messages" })
+        throw new HttpError("Can only delete your own messages", { status: 403, code: "FORBIDDEN" })
       }
 
       await eventService.deleteMessage({
@@ -562,22 +538,16 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const workspaceId = req.workspaceId!
       const { messageId } = req.params
 
-      const result = addReactionSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(addReactionSchema, req.body)
 
-      const shortcode = toShortcode(result.data.emoji)
+      const shortcode = toShortcode(data.emoji)
       if (!shortcode) {
-        return res.status(400).json({ error: "Invalid emoji" })
+        throw new HttpError("Invalid emoji", { status: 400, code: "INVALID_EMOJI" })
       }
 
       const existing = await eventService.getMessageById(messageId)
       if (!existing) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       // Reactions are participation by anyone who can read the message.
@@ -586,7 +556,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       // inheritance — neither is the intent.
       const accessibleStream = await streamService.tryAccess(existing.streamId, workspaceId, userId)
       if (!accessibleStream) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       const message = await eventService.addReaction({
@@ -598,7 +568,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       })
 
       if (!message) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       res.json({ message: serializeMessage(message) })
@@ -611,12 +581,12 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
 
       const shortcode = toShortcode(emoji)
       if (!shortcode) {
-        return res.status(400).json({ error: "Invalid emoji" })
+        throw new HttpError("Invalid emoji", { status: 400, code: "INVALID_EMOJI" })
       }
 
       const existing = await eventService.getMessageById(messageId)
       if (!existing) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       // Mirror addReaction: read-access gate so users can un-react in any
@@ -624,7 +594,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       // thread access.
       const accessibleStream = await streamService.tryAccess(existing.streamId, workspaceId, userId)
       if (!accessibleStream) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       const message = await eventService.removeReaction({
@@ -636,7 +606,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       })
 
       if (!message) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       res.json({ message: serializeMessage(message) })
@@ -649,7 +619,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
 
       const existing = await eventService.getMessageById(messageId)
       if (!existing || existing.deletedAt) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       // Edit-history is a pure read of a message the viewer can see.
@@ -657,7 +627,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       // tryAccess, not bare membership.
       const accessibleStream = await streamService.tryAccess(existing.streamId, workspaceId, userId)
       if (!accessibleStream) {
-        return res.status(404).json({ error: "Message not found" })
+        throw new MessageNotFoundError()
       }
 
       const versions = await eventService.getMessageVersions(messageId)

--- a/apps/backend/src/features/public-api/bot-handlers.ts
+++ b/apps/backend/src/features/public-api/bot-handlers.ts
@@ -101,7 +101,14 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
     async create(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const { type, name, description, avatarEmoji, traits, slug: slugInput } = validateRequest(createBotSchema, req.body)
+      const {
+        type,
+        name,
+        description,
+        avatarEmoji,
+        traits,
+        slug: slugInput,
+      } = validateRequest(createBotSchema, req.body)
 
       // Gate depends on the `type` field in the request body, which isn't
       // known at route registration time, so the check lives in the handler.
@@ -133,8 +140,9 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
 
       const slug = generateSlug(slugInput)
       if (!slug) {
-        return res.status(400).json({
-          error: "Validation failed",
+        throw new HttpError("Validation failed", {
+          status: 400,
+          code: "VALIDATION_ERROR",
           details: { slug: ["Slug cannot be empty after normalization"] },
         })
       }
@@ -183,8 +191,9 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
       if (fields.slug) {
         fields.slug = generateSlug(fields.slug)
         if (!fields.slug) {
-          return res.status(400).json({
-            error: "Validation failed",
+          throw new HttpError("Validation failed", {
+            status: 400,
+            code: "VALIDATION_ERROR",
             details: { slug: ["Slug cannot be empty after normalization"] },
           })
         }

--- a/apps/backend/src/features/public-api/bot-handlers.ts
+++ b/apps/backend/src/features/public-api/bot-handlers.ts
@@ -15,6 +15,7 @@ import { sql, withTransaction } from "../../db"
 import { OutboxRepository } from "../../lib/outbox"
 import { HttpError } from "@threa/backend-common"
 import { isUniqueViolation } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import {
   API_KEY_ELIGIBLE_SCOPES,
   BOT_TRAITS,
@@ -100,15 +101,7 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
     async create(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = createBotSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { type, name, description, avatarEmoji, traits } = result.data
+      const { type, name, description, avatarEmoji, traits, slug: slugInput } = validateRequest(createBotSchema, req.body)
 
       // Gate depends on the `type` field in the request body, which isn't
       // known at route registration time, so the check lives in the handler.
@@ -138,7 +131,7 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
       }
       const ownerUserId = type === BotTypes.PERSONAL ? actorId : null
 
-      const slug = generateSlug(result.data.slug)
+      const slug = generateSlug(slugInput)
       if (!slug) {
         return res.status(400).json({
           error: "Validation failed",
@@ -184,15 +177,9 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
       const { botId: id } = req.params
       // req.bot set by requireBotManagement middleware
 
-      const result = updateBotSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateBotSchema, req.body)
 
-      const fields = { ...result.data }
+      const fields = { ...data }
       if (fields.slug) {
         fields.slug = generateSlug(fields.slug)
         if (!fields.slug) {
@@ -339,20 +326,14 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
         throw new HttpError("Bot is archived", { status: 409, code: "BOT_ARCHIVED" })
       }
 
-      const result = createBotKeySchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(createBotKeySchema, req.body)
 
       const { row, value } = await botApiKeyService.createKey({
         workspaceId,
         botId: id,
-        name: result.data.name,
-        scopes: result.data.scopes as WorkspacePermissionSlug[],
-        expiresAt: result.data.expiresAt ? new Date(result.data.expiresAt) : null,
+        name: data.name,
+        scopes: data.scopes as WorkspacePermissionSlug[],
+        expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
       })
 
       res.status(201).json({ key: serializeBotKey(row), value })
@@ -362,18 +343,12 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
     async updateKey(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
       const { botId: id, keyId } = req.params
-      const result = updateBotKeySchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateBotKeySchema, req.body)
       const row = await botApiKeyService.updateScopes({
         workspaceId,
         botId: id,
         keyId,
-        scopes: result.data.scopes as WorkspacePermissionSlug[],
+        scopes: data.scopes as WorkspacePermissionSlug[],
       })
       res.json({ data: serializeBotKey(row) })
     },

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -53,6 +53,7 @@ import {
 } from "../commands"
 import type { BotRuntimeKind, BotRuntimeStatus } from "@threa/types"
 import { HttpError } from "@threa/backend-common"
+import { validateRequest } from "../../lib/validation"
 import { normalizeMessage, toEmoji } from "../emoji"
 import { collectAttachmentReferenceIds, parseMarkdown } from "@threa/prosemirror"
 import { randomUUID } from "crypto"
@@ -790,25 +791,22 @@ export function createPublicApiHandlers({
 
     async upsertBotRuntimePresence(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = upsertPresenceSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(upsertPresenceSchema, req.body)
       const presence = await botRuntimeService.upsertPresenceFromBotKey({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        runtimeKind: result.data.runtimeKind,
-        instanceId: result.data.instanceId,
-        displayName: result.data.displayName,
-        status: result.data.status,
-        acceptingInvocations: result.data.acceptingInvocations,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        displayName: data.displayName,
+        status: data.status,
+        acceptingInvocations: data.acceptingInvocations,
         capabilities: {
-          ...result.data.capabilities,
-          ...(result.data.runtimeSessionId && { runtimeSessionId: result.data.runtimeSessionId }),
+          ...data.capabilities,
+          ...(data.runtimeSessionId && { runtimeSessionId: data.runtimeSessionId }),
         },
-        statusText: sanitizeStatusText(result.data.statusText),
-        publicKey: result.data.publicKey,
-        publicKeyId: result.data.publicKeyId,
+        statusText: sanitizeStatusText(data.statusText),
+        publicKey: data.publicKey,
+        publicKeyId: data.publicKeyId,
       })
       await broadcastBotPresence(req.workspaceId!, req.botApiKey.botId, presence)
       res.json({
@@ -823,10 +821,7 @@ export function createPublicApiHandlers({
 
     async createBotRuntimeSession(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = createRuntimeSessionSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(createRuntimeSessionSchema, req.body)
       const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
       if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
       if (bot.type !== "personal") {
@@ -841,8 +836,8 @@ export function createPublicApiHandlers({
       const existingLink = await botRuntimeService.findActivePiRemoteSession({
         workspaceId: req.workspaceId!,
         botId: bot.id,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: result.data.runtimeSessionId,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
       })
       if (existingLink) {
         await withTransaction(pool, (client) =>
@@ -865,7 +860,7 @@ export function createPublicApiHandlers({
 
       const stream = await streamService.createScratchpad({
         workspaceId: req.workspaceId!,
-        displayName: result.data.displayName,
+        displayName: data.displayName,
         createdBy: bot.ownerUserId,
       })
       await streamService.addBotToStream(stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
@@ -878,12 +873,12 @@ export function createPublicApiHandlers({
         return botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: bot.id,
-          instanceId: result.data.instanceId,
-          runtimeSessionId: result.data.runtimeSessionId,
+          instanceId: data.instanceId,
+          runtimeSessionId: data.runtimeSessionId,
           rootStreamId: stream.id,
           activeStreamId: stream.id,
           linkedBy: bot.ownerUserId,
-          metadata: { displayName: result.data.displayName, localCwd: result.data.localCwd ?? null },
+          metadata: { displayName: data.displayName, localCwd: data.localCwd ?? null },
         })
       })
 
@@ -900,20 +895,17 @@ export function createPublicApiHandlers({
 
     async renameBotRuntimeSession(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = renameRuntimeSessionSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(renameRuntimeSessionSchema, req.body)
       const link = await botRuntimeService.findActivePiRemoteSession({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: result.data.runtimeSessionId,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
       })
       if (!link) {
         throw new HttpError("No active runtime session link found", { status: 404, code: "NOT_FOUND" })
       }
-      const updated = await streamService.updateStream(link.activeStreamId, { displayName: result.data.displayName })
+      const updated = await streamService.updateStream(link.activeStreamId, { displayName: data.displayName })
       if (!updated) {
         throw new HttpError("Linked stream not found", { status: 404, code: "NOT_FOUND" })
       }
@@ -924,46 +916,43 @@ export function createPublicApiHandlers({
           activeStreamId: link.activeStreamId,
           runtimeSessionId: link.runtimeSessionId,
           streamUrlPath: `/w/${req.workspaceId!}/s/${link.activeStreamId}`,
-          displayName: updated.displayName ?? result.data.displayName,
+          displayName: updated.displayName ?? data.displayName,
         },
       })
     },
 
     async claimBotInvocation(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = claimInvocationSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(claimInvocationSchema, req.body)
       // Claim doubles as a heartbeat: refresh presence as "available" on every
       // poll so Pi does not need a separate /presence call per tick. If a claim
       // lands we'll overwrite to "busy" right after.
       await touchAndBroadcastPresence({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        runtimeKind: result.data.runtimeKind,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: result.data.runtimeSessionId,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
         status: "available",
         acceptingInvocations: true,
       })
       const invocation = await botRuntimeService.claimNextInvocation({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        runtimeKind: result.data.runtimeKind,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: result.data.runtimeSessionId,
-        supportedCapabilities: result.data.supportedCapabilities,
-        claimTtlSeconds: result.data.claimTtlSeconds,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
+        supportedCapabilities: data.supportedCapabilities,
+        claimTtlSeconds: data.claimTtlSeconds,
         claimToken: randomUUID(),
       })
       if (!invocation) return res.json({ data: null })
       await touchAndBroadcastPresence({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
-        runtimeKind: result.data.runtimeKind,
-        instanceId: result.data.instanceId,
-        runtimeSessionId: invocation.targetRuntimeSessionId ?? result.data.runtimeSessionId,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        runtimeSessionId: invocation.targetRuntimeSessionId ?? data.runtimeSessionId,
         status: "busy",
         acceptingInvocations: false,
       })
@@ -1028,17 +1017,14 @@ export function createPublicApiHandlers({
 
     async renewBotInvocationClaim(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = renewInvocationClaimSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(renewInvocationClaimSchema, req.body)
       const renewed = await botRuntimeService.renewInvocationClaim({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
         invocationId: req.params.invocationId,
-        instanceId: result.data.instanceId,
-        claimToken: result.data.claimToken,
-        claimTtlSeconds: result.data.claimTtlSeconds,
+        instanceId: data.instanceId,
+        claimToken: data.claimToken,
+        claimTtlSeconds: data.claimTtlSeconds,
       })
       if (!renewed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
       res.json({
@@ -1052,16 +1038,13 @@ export function createPublicApiHandlers({
 
     async recordBotInvocationStep(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = recordInvocationStepSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(recordInvocationStepSchema, req.body)
       const claim = await botRuntimeService.findActiveClaim({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
         invocationId: req.params.invocationId,
-        instanceId: result.data.instanceId,
-        claimToken: result.data.claimToken,
+        instanceId: data.instanceId,
+        claimToken: data.claimToken,
       })
       if (!claim) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
       await assertStreamAccessible(req, claim.responseStreamId)
@@ -1070,7 +1053,7 @@ export function createPublicApiHandlers({
         botRuntimeService.findPresenceByInstance({
           workspaceId: req.workspaceId!,
           botId: req.botApiKey.botId,
-          instanceId: result.data.instanceId,
+          instanceId: data.instanceId,
         }),
       ])
       // Reject-undeclared (INV-11): a runtime that declared a manifest without
@@ -1090,8 +1073,8 @@ export function createPublicApiHandlers({
         personaName: bot?.name ?? "",
       })
       for (const event of botInvocationStepEvents({
-        stepType: result.data.stepType,
-        content: sanitizeInvocationStepContent(result.data.content),
+        stepType: data.stepType,
+        content: sanitizeInvocationStepContent(data.content),
       })) {
         await projector.handle(event)
       }
@@ -1112,39 +1095,34 @@ export function createPublicApiHandlers({
         workspaceId: req.workspaceId!,
         botId: req.botApiKey.botId,
         runtimeKind: runtimePresence?.runtimeKind ?? BotRuntimeKinds.PI_LOCAL,
-        instanceId: result.data.instanceId,
+        instanceId: data.instanceId,
         runtimeSessionId: claim.targetRuntimeSessionId ?? persistedRuntimeSessionId,
         status: "busy",
         acceptingInvocations: false,
-        statusText: sanitizeStatusText(result.data.statusText),
+        statusText: sanitizeStatusText(data.statusText),
       })
       res.json({ data: { invocationId: claim.id, sessionId: claim.id, stepId: step.id } })
     },
 
     async completeBotInvocation(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = completeInvocationSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(completeInvocationSchema, req.body)
       const [bot, runtimePresence] = await Promise.all([
         BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId),
         botRuntimeService.findPresenceByInstance({
           workspaceId: req.workspaceId!,
           botId: req.botApiKey.botId,
-          instanceId: result.data.instanceId,
+          instanceId: data.instanceId,
         }),
       ])
       if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
       const contentMarkdown =
-        result.data.noResponse === true || !result.data.finalMessageMarkdown
-          ? null
-          : normalizeMessage(result.data.finalMessageMarkdown)
+        data.noResponse === true || !data.finalMessageMarkdown ? null : normalizeMessage(data.finalMessageMarkdown)
       // Reject-undeclared (INV-11): a runtime that declared a manifest may only
       // emit what it declared. Unenforced for legacy (null-manifest) runtimes.
       const manifest = runtimePresence?.manifest ?? null
       if (contentMarkdown) assertManifestAllows(manifest, "reply")
-      if (result.data.sources && result.data.sources.length > 0) assertManifestAllows(manifest, "sources")
+      if (data.sources && data.sources.length > 0) assertManifestAllows(manifest, "sources")
       const contentJson = contentMarkdown ? parseMarkdown(contentMarkdown, undefined, toEmoji) : null
       const attachmentIds = contentJson ? collectAttachmentReferenceIds(contentJson) : []
       const { completed, message, sessionFinalized, synthesizedSteps } = await withTransaction(pool, async (client) => {
@@ -1152,8 +1130,8 @@ export function createPublicApiHandlers({
           workspaceId: req.workspaceId!,
           botId: req.botApiKey!.botId,
           invocationId: req.params.invocationId,
-          instanceId: result.data.instanceId,
-          claimToken: result.data.claimToken,
+          instanceId: data.instanceId,
+          claimToken: data.claimToken,
         })
         if (!claim) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
         await assertStreamAccessible(req, claim.responseStreamId)
@@ -1174,16 +1152,16 @@ export function createPublicApiHandlers({
               contentMarkdown,
               attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
               clientMessageId: `bot-invocation:${claim.id}`,
-              sources: result.data.sources,
-              metadata: result.data.metadata,
+              sources: data.sources,
+              metadata: data.metadata,
             })
           : null
         const completed = await botRuntimeService.completeInvocationInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: req.botApiKey!.botId,
           invocationId: req.params.invocationId,
-          instanceId: result.data.instanceId,
-          claimToken: result.data.claimToken,
+          instanceId: data.instanceId,
+          claimToken: data.claimToken,
         })
         if (!completed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
         const runtimeCommand = parseRuntimeCommandInvocationMetadata(completed.metadata)
@@ -1283,18 +1261,15 @@ export function createPublicApiHandlers({
 
     async failBotInvocation(req: Request, res: Response) {
       if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
-      const result = failInvocationSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({ error: "Validation failed", details: z.flattenError(result.error).fieldErrors })
-      }
+      const data = validateRequest(failInvocationSchema, req.body)
       const failed = await withTransaction(pool, async (client) => {
         const failed = await botRuntimeService.failInvocationInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: req.botApiKey!.botId,
           invocationId: req.params.invocationId,
-          instanceId: result.data.instanceId,
-          claimToken: result.data.claimToken,
-          errorMessage: result.data.errorMessage,
+          instanceId: data.instanceId,
+          claimToken: data.claimToken,
+          errorMessage: data.errorMessage,
         })
         if (!failed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
 
@@ -1305,7 +1280,7 @@ export function createPublicApiHandlers({
             streamId: failed.responseStreamId,
             userId: failed.authorUserId,
             commandId: runtimeCommand.id,
-            error: result.data.errorMessage,
+            error: data.errorMessage,
           })
         }
 
@@ -1322,15 +1297,10 @@ export function createPublicApiHandlers({
     async searchMessages(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = publicSearchSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { query, semantic, exact, streams, from, type, before, after, limit } = result.data
+      const { query, semantic, exact, streams, from, type, before, after, limit } = validateRequest(
+        publicSearchSchema,
+        req.body
+      )
 
       const accessibleStreamIds = await getAccessibleStreamIds(req)
 
@@ -1375,15 +1345,10 @@ export function createPublicApiHandlers({
     async searchMemos(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = searchMemosSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { query, exact, streams, memoType, knowledgeType, tags, before, after, limit } = result.data
+      const { query, exact, streams, memoType, knowledgeType, tags, before, after, limit } = validateRequest(
+        searchMemosSchema,
+        req.body
+      )
       const normalized = normalizeMemoSearchMode(query, exact)
       const accessibleStreamIds = await getAccessibleStreamIds(req, {
         archiveStatus: ["active", "archived"],
@@ -1440,15 +1405,7 @@ export function createPublicApiHandlers({
     async searchAttachments(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = searchAttachmentsSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { query, streams, contentTypes, limit } = result.data
+      const { query, streams, contentTypes, limit } = validateRequest(searchAttachmentsSchema, req.body)
       const accessibleStreamIds = await getAccessibleStreamIds(req)
       if (accessibleStreamIds.length === 0) {
         return res.json({ data: [] })
@@ -1507,15 +1464,7 @@ export function createPublicApiHandlers({
      * GET /api/v1/workspaces/:workspaceId/streams
      */
     async listStreams(req: Request, res: Response) {
-      const result = listStreamsSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { type, query, after: afterCursor, limit } = result.data
+      const { type, query, after: afterCursor, limit } = validateRequest(listStreamsSchema, req.query)
       const accessibleStreamIds = await getAccessibleStreamIds(req)
 
       if (accessibleStreamIds.length === 0) {
@@ -1584,15 +1533,7 @@ export function createPublicApiHandlers({
       const streamId = req.params.streamId
       const workspaceId = req.workspaceId!
 
-      const result = listMembersSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { after: afterCursor, limit } = result.data
+      const { after: afterCursor, limit } = validateRequest(listMembersSchema, req.query)
 
       await assertStreamAccessible(req, streamId)
 
@@ -1699,15 +1640,7 @@ export function createPublicApiHandlers({
     async findMessagesByMetadata(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = findMessagesByMetadataSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { metadata, streamId, limit } = result.data
+      const { metadata, streamId, limit } = validateRequest(findMessagesByMetadataSchema, req.body)
 
       const accessibleStreamIds = await getAccessibleStreamIds(req)
       if (accessibleStreamIds.length === 0) {
@@ -1742,15 +1675,7 @@ export function createPublicApiHandlers({
       const workspaceId = req.workspaceId!
       const streamId = req.params.streamId
 
-      const result = sendMessageSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { content, clientMessageId, metadata } = result.data
+      const { content, clientMessageId, metadata } = validateRequest(sendMessageSchema, req.body)
 
       // Verify stream access
       await assertStreamAccessible(req, streamId)
@@ -1902,15 +1827,7 @@ export function createPublicApiHandlers({
     async listUsers(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = listUsersSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { query, after: afterCursor, limit } = result.data
+      const { query, after: afterCursor, limit } = validateRequest(listUsersSchema, req.query)
 
       // Cursor pagination disabled when query is provided (relevance ordering)
       const cursor = !query && afterCursor ? decodeCursor(afterCursor) : undefined
@@ -1996,14 +1913,8 @@ export function createPublicApiHandlers({
       const workspaceId = req.workspaceId!
       const userId = req.user!.id
 
-      const result = listMyBotsSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-      const traits = result.data.traits ? [result.data.traits] : []
+      const query = validateRequest(listMyBotsSchema, req.query)
+      const traits = query.traits ? [query.traits] : []
 
       const bots = await BotRepository.listByOwner(pool, workspaceId, userId, { traits })
       res.json({ data: bots.map(serializeBot) })

--- a/apps/backend/src/features/push/handlers.ts
+++ b/apps/backend/src/features/push/handlers.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express"
 import { z } from "zod"
 import { HttpError } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import type { PushService } from "./service"
 
 /**
@@ -62,16 +63,12 @@ export function createPushHandlers({ pushService }: Dependencies) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const parsed = subscribeSchema.safeParse(req.body)
-      if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: z.flattenError(parsed.error).fieldErrors })
-        return
-      }
+      const data = validateRequest(subscribeSchema, req.body)
 
       const subscription = await pushService.subscribe({
         workspaceId,
         userId,
-        ...parsed.data,
+        ...data,
       })
 
       res.json({ subscription: { id: subscription.id } })
@@ -84,13 +81,9 @@ export function createPushHandlers({ pushService }: Dependencies) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const parsed = unsubscribeSchema.safeParse(req.body)
-      if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: z.flattenError(parsed.error).fieldErrors })
-        return
-      }
+      const { endpoint } = validateRequest(unsubscribeSchema, req.body)
 
-      await pushService.unsubscribe(workspaceId, userId, parsed.data.endpoint)
+      await pushService.unsubscribe(workspaceId, userId, endpoint)
       res.json({ ok: true })
     },
 
@@ -100,13 +93,9 @@ export function createPushHandlers({ pushService }: Dependencies) {
      * Not workspace-scoped — uses auth-only middleware.
      */
     async cleanupEndpoint(req: Request, res: Response) {
-      const parsed = unsubscribeSchema.safeParse(req.body)
-      if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: z.flattenError(parsed.error).fieldErrors })
-        return
-      }
+      const { endpoint } = validateRequest(unsubscribeSchema, req.body)
 
-      await pushService.unsubscribeAllWorkspaces(parsed.data.endpoint, req.workosUserId!)
+      await pushService.unsubscribeAllWorkspaces(endpoint, req.workosUserId!)
       res.json({ ok: true })
     },
 

--- a/apps/backend/src/features/search/handlers.ts
+++ b/apps/backend/src/features/search/handlers.ts
@@ -4,6 +4,7 @@ import type { Pool } from "pg"
 import type { SearchService } from "./service"
 import type { SearchResult } from "./repository"
 import { resolveUserAccessibleStreamIds } from "./access"
+import { validateRequest } from "../../lib/validation"
 import { STREAM_TYPES } from "@threa/types"
 
 const ARCHIVE_STATUSES = ["active", "archived"] as const
@@ -65,13 +66,7 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = searchQuerySchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(searchQuerySchema, req.body)
 
       const {
         query,
@@ -84,7 +79,7 @@ export function createSearchHandlers({ pool, searchService }: Dependencies) {
         after,
         exact,
         limit,
-      } = result.data
+      } = data
 
       const filters = {
         authorId: from,

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -21,6 +21,7 @@ import type { Pool } from "pg"
 import { PersonaRepository, getResolver, fetchStreamBag, contextBagSchema } from "../agents"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
 import { HttpError } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import { streamTypeSchema, visibilitySchema, companionModeSchema, notificationLevelSchema } from "../../lib/schemas"
 
 const createStreamSchema = z
@@ -462,13 +463,7 @@ export function createStreamHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = createStreamSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(createStreamSchema, req.body)
 
       const {
         type,
@@ -484,7 +479,7 @@ export function createStreamHandlers({
         contextBag,
         e2eEnabled,
         e2eOwnerKeyId,
-      } = result.data
+      } = data
 
       // Verify the caller owns the referenced E2E key BEFORE we hand off to
       // the service. Phase 1 invariant: the stream's `owner_user_key_id`
@@ -592,15 +587,9 @@ export function createStreamHandlers({
         throw new HttpError("Cannot update this stream type", { status: 403, code: "STREAM_IMMUTABLE" })
       }
 
-      const result = schema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(schema, req.body)
 
-      const { displayName, slug, description, visibility, sealedNameCiphertext, sealedNameEnvelope } = result.data
+      const { displayName, slug, description, visibility, sealedNameCiphertext, sealedNameEnvelope } = data
 
       // Schema guarantees one of: both set, both null (clear), or both omitted.
       let sealedName: { ciphertext: string; envelope: unknown } | null | undefined
@@ -625,14 +614,7 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = listEventsQuerySchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-      const { type, limit, after, before } = result.data
+      const { type, limit, after, before } = validateRequest(listEventsQuerySchema, req.query)
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
@@ -657,14 +639,7 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const parsed = listEventsAroundQuerySchema.safeParse(req.query)
-      if (!parsed.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(parsed.error).fieldErrors,
-        })
-      }
-      const { eventId, messageId, limit } = parsed.data
+      const { eventId, messageId, limit } = validateRequest(listEventsAroundQuerySchema, req.query)
       const targetId = (eventId ?? messageId)!
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
@@ -697,15 +672,7 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = updateCompanionModeSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
-
-      const { companionMode, companionPersonaId } = result.data
+      const { companionMode, companionPersonaId } = validateRequest(updateCompanionModeSchema, req.body)
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
@@ -724,17 +691,11 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = setNotificationLevelSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(setNotificationLevelSchema, req.body)
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const membership = await streamService.setNotificationLevel(streamId, userId, result.data.notificationLevel)
+      const membership = await streamService.setNotificationLevel(streamId, userId, data.notificationLevel)
       if (!membership) {
         return res.status(404).json({ error: "Not a member of this stream" })
       }
@@ -747,17 +708,11 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = markAsReadSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(markAsReadSchema, req.body)
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const membership = await streamService.markAsRead(workspaceId, streamId, userId, result.data.lastEventId)
+      const membership = await streamService.markAsRead(workspaceId, streamId, userId, data.lastEventId)
       if (!membership) {
         return res.status(404).json({ error: "Not a member of this stream" })
       }
@@ -811,14 +766,8 @@ export function createStreamHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
-      const parsed = streamBootstrapQuerySchema.safeParse(req.query)
-      if (!parsed.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(parsed.error).fieldErrors,
-        })
-      }
-      const afterSequence = parsed.data.after ? BigInt(parsed.data.after) : undefined
+      const query = validateRequest(streamBootstrapQuerySchema, req.query)
+      const afterSequence = query.after ? BigInt(query.after) : undefined
 
       const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
@@ -932,15 +881,9 @@ export function createStreamHandlers({
     async checkSlugAvailable(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = checkSlugAvailableSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const query = validateRequest(checkSlugAvailableSchema, req.query)
 
-      const available = await streamService.checkSlugAvailable(workspaceId, result.data.slug, result.data.exclude)
+      const available = await streamService.checkSlugAvailable(workspaceId, query.slug, query.exclude)
       res.json({ available })
     },
 
@@ -949,13 +892,7 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const result = addMemberSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(addMemberSchema, req.body)
 
       const stream = await streamService.validateStreamAccess(streamId, workspaceId, actorId)
 
@@ -963,7 +900,7 @@ export function createStreamHandlers({
         throw new HttpError("Cannot add members to this stream type", { status: 400, code: "ADD_MEMBER_NOT_ALLOWED" })
       }
 
-      const membership = await streamService.addMember(streamId, result.data.memberId, workspaceId, actorId)
+      const membership = await streamService.addMember(streamId, data.memberId, workspaceId, actorId)
       res.status(201).json({ membership })
     },
 

--- a/apps/backend/src/features/user-api-keys/handlers.ts
+++ b/apps/backend/src/features/user-api-keys/handlers.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
+import { validateRequest } from "../../lib/validation"
 import type { UserApiKeyService } from "./service"
 import type { UserApiKeyRow } from "./repository"
 import { API_KEY_ELIGIBLE_SCOPES, type WorkspacePermissionSlug, type UserApiKey } from "@threa/types"
@@ -56,20 +57,14 @@ export function createUserApiKeyHandlers({ userApiKeyService }: Dependencies) {
       const workspaceId = req.workspaceId!
       const userId = req.user!.id
 
-      const result = createKeySchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(createKeySchema, req.body)
 
       const { row, value } = await userApiKeyService.createKey({
         workspaceId,
         userId,
-        name: result.data.name,
-        scopes: result.data.scopes as WorkspacePermissionSlug[],
-        expiresAt: result.data.expiresAt ? new Date(result.data.expiresAt) : null,
+        name: data.name,
+        scopes: data.scopes as WorkspacePermissionSlug[],
+        expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
       })
 
       res.status(201).json({ key: serializeKey(row), value })
@@ -80,19 +75,13 @@ export function createUserApiKeyHandlers({ userApiKeyService }: Dependencies) {
       const userId = req.user!.id
       const { keyId } = req.params
 
-      const result = updateKeySchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateKeySchema, req.body)
 
       const row = await userApiKeyService.updateScopes({
         workspaceId,
         userId,
         keyId,
-        scopes: result.data.scopes as WorkspacePermissionSlug[],
+        scopes: data.scopes as WorkspacePermissionSlug[],
       })
       res.json({ key: serializeKey(row) })
     },

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -19,6 +19,7 @@ import {
   BLOCKQUOTE_COLLAPSE_THRESHOLD_MAX,
 } from "@threa/types"
 import { workScheduleSchema, statusPresetsSchema } from "../../lib/schemas"
+import { validateRequest } from "../../lib/validation"
 
 const updatePreferencesSchema = z.object({
   theme: z.enum(THEME_OPTIONS).optional(),
@@ -85,15 +86,9 @@ export function createUserPreferencesHandlers({ userPreferencesService }: Depend
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = updatePreferencesSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updatePreferencesSchema, req.body)
 
-      const preferences = await userPreferencesService.updatePreferences(workspaceId, userId, result.data)
+      const preferences = await userPreferencesService.updatePreferences(workspaceId, userId, data)
       res.json({ preferences })
     },
   }

--- a/apps/backend/src/features/workspace-integrations/handlers.ts
+++ b/apps/backend/src/features/workspace-integrations/handlers.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { WorkspaceIntegrationProvider } from "@threa/types"
 import { WorkspaceIntegrationService } from "./service"
+import { validateRequest } from "../../lib/validation"
 
 const githubCallbackSchema = z.object({
   installation_id: z.string().min(1, "installation_id is required"),
@@ -91,18 +92,12 @@ export function createWorkspaceIntegrationHandlers({
     },
 
     async githubCallback(req: Request, res: Response) {
-      const parsed = githubCallbackSchema.safeParse(req.query)
-      if (!parsed.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(parsed.error).fieldErrors,
-        })
-      }
+      const query = validateRequest(githubCallbackSchema, req.query)
 
       const workosUserId = req.workosUserId!
       const { workspaceId } = await workspaceIntegrationService.handleGithubCallback({
-        state: parsed.data.state,
-        installationId: parsed.data.installation_id,
+        state: query.state,
+        installationId: query.installation_id,
         workosUserId,
         viewerPermissions: req.authUser?.permissions ?? null,
       })
@@ -132,18 +127,12 @@ export function createWorkspaceIntegrationHandlers({
     },
 
     async linearCallback(req: Request, res: Response) {
-      const parsed = linearCallbackSchema.safeParse(req.query)
-      if (!parsed.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(parsed.error).fieldErrors,
-        })
-      }
+      const query = validateRequest(linearCallbackSchema, req.query)
 
       const workosUserId = req.workosUserId!
       const { workspaceId } = await workspaceIntegrationService.handleLinearCallback({
-        state: parsed.data.state,
-        code: parsed.data.code,
+        state: query.state,
+        code: query.code,
         workosUserId,
       })
 

--- a/apps/backend/src/features/workspace-settings/handlers.ts
+++ b/apps/backend/src/features/workspace-settings/handlers.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { WorkspaceSettingsService } from "./service"
 import { workScheduleSchema, statusPresetsSchema } from "../../lib/schemas"
+import { validateRequest } from "../../lib/validation"
 
 const updateWorkspaceSettingsSchema = z.object({
   defaultWorkSchedule: workScheduleSchema.optional(),
@@ -26,15 +27,9 @@ export function createWorkspaceSettingsHandlers({ workspaceSettingsService }: De
     async update(req: Request, res: Response) {
       const workspaceId = req.workspaceId!
 
-      const result = updateWorkspaceSettingsSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateWorkspaceSettingsSchema, req.body)
 
-      const settings = await workspaceSettingsService.updateSettings(workspaceId, result.data)
+      const settings = await workspaceSettingsService.updateSettings(workspaceId, data)
       res.json({ settings })
     },
   }

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -17,6 +17,7 @@ import { getEffectiveLevel } from "../streams"
 import { BotRepository, serializeBot } from "../public-api"
 import { displayNameFromWorkos, type WorkosOrgService } from "@threa/backend-common"
 import { HttpError } from "../../lib/errors"
+import { validateRequest } from "../../lib/validation"
 import { setStatusSchema, setNotificationPauseSchema } from "../../lib/schemas"
 import {
   parseJwtPermissions,
@@ -109,13 +110,7 @@ export function createWorkspaceHandlers({
       const workosUserId = req.workosUserId!
       const authUser = req.authUser
 
-      const result = createWorkspaceSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(createWorkspaceSchema, req.body)
 
       if (!authUser) {
         throw new HttpError("Not authenticated", { status: 401, code: "NOT_AUTHENTICATED" })
@@ -123,7 +118,7 @@ export function createWorkspaceHandlers({
 
       const userName = displayNameFromWorkos(authUser)
       const workspace = await workspaceService.createWorkspace({
-        name: result.data.name,
+        name: data.name,
         workosUserId,
         email: authUser.email,
         userName,
@@ -288,15 +283,9 @@ export function createWorkspaceHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = completeUserSetupSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(completeUserSetupSchema, req.body)
 
-      const user = await workspaceService.completeUserSetup(userId, workspaceId, result.data)
+      const user = await workspaceService.completeUserSetup(userId, workspaceId, data)
 
       res.json({ user })
     },
@@ -305,15 +294,9 @@ export function createWorkspaceHandlers({
       const workspaceId = req.workspaceId!
       const userId = req.user!.id
 
-      const result = checkSlugAvailableSchema.safeParse(req.query)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const query = validateRequest(checkSlugAvailableSchema, req.query)
 
-      const available = await workspaceService.isSlugAvailable(workspaceId, result.data.slug, userId)
+      const available = await workspaceService.isSlugAvailable(workspaceId, query.slug, userId)
       res.json({ available })
     },
 
@@ -321,15 +304,9 @@ export function createWorkspaceHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = updateProfileSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(updateProfileSchema, req.body)
 
-      const user = await workspaceService.updateUserProfile(userId, workspaceId, result.data)
+      const user = await workspaceService.updateUserProfile(userId, workspaceId, data)
       res.json({ user })
     },
 
@@ -337,19 +314,13 @@ export function createWorkspaceHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = setStatusSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(setStatusSchema, req.body)
 
       const user = await workspaceService.setUserStatus(userId, workspaceId, {
-        statusEmoji: result.data.emoji,
-        statusText: result.data.text,
-        statusExpiresAt: result.data.expiresAt ? new Date(result.data.expiresAt) : null,
-        statusPausesNotifications: result.data.pausesNotifications,
+        statusEmoji: data.emoji,
+        statusText: data.text,
+        statusExpiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
+        statusPausesNotifications: data.pausesNotifications,
       })
       res.json({ user })
     },
@@ -371,16 +342,10 @@ export function createWorkspaceHandlers({
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const result = setNotificationPauseSchema.safeParse(req.body)
-      if (!result.success) {
-        return res.status(400).json({
-          error: "Validation failed",
-          details: z.flattenError(result.error).fieldErrors,
-        })
-      }
+      const data = validateRequest(setNotificationPauseSchema, req.body)
 
       const user = await workspaceService.setNotificationPause(userId, workspaceId, {
-        until: result.data.until ? new Date(result.data.until) : null,
+        until: data.until ? new Date(data.until) : null,
       })
       res.json({ user })
     },

--- a/apps/backend/src/lib/validation.test.ts
+++ b/apps/backend/src/lib/validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test"
+import { HttpError } from "@threa/backend-common"
+import { z } from "zod"
+import { validateRequest } from "./validation"
+
+const schema = z.object({
+  name: z.string().min(1),
+  age: z.number().int(),
+})
+
+describe("validateRequest", () => {
+  it("returns the parsed, typed data on success", () => {
+    expect(validateRequest(schema, { name: "ada", age: 36 })).toEqual({ name: "ada", age: 36 })
+  })
+
+  it("throws an HttpError carrying status 400, code, and flattened field errors", () => {
+    let thrown: unknown
+    try {
+      validateRequest(schema, { name: "", age: "old" })
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(HttpError)
+    const err = thrown as HttpError
+    expect({ message: err.message, status: err.status, code: err.code, details: err.details }).toEqual({
+      message: "Validation failed",
+      status: 400,
+      code: "VALIDATION_ERROR",
+      details: {
+        name: ["Too small: expected string to have >=1 characters"],
+        age: ["Invalid input: expected number, received string"],
+      },
+    })
+  })
+})

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -1,0 +1,21 @@
+import { HttpError } from "@threa/backend-common"
+import { z } from "zod"
+
+/**
+ * Parse `value` against `schema`, returning the typed data on success. On
+ * failure, throws an `HttpError` (status 400, `VALIDATION_ERROR`) carrying the
+ * flattened field errors as `details`. Express 5 surfaces the throw to the
+ * shared error middleware, which formats `{ error, code, details }` (INV-32) —
+ * replacing the hand-rolled `safeParse` + `res.status(400).json(...)` blocks.
+ */
+export function validateRequest<Schema extends z.ZodType>(schema: Schema, value: unknown): z.infer<Schema> {
+  const result = schema.safeParse(value)
+  if (!result.success) {
+    throw new HttpError("Validation failed", {
+      status: 400,
+      code: "VALIDATION_ERROR",
+      details: z.flattenError(result.error).fieldErrors,
+    })
+  }
+  return result.data
+}

--- a/packages/backend-common/src/errors.ts
+++ b/packages/backend-common/src/errors.ts
@@ -2,16 +2,19 @@ interface HttpErrorOptions {
   status: number
   code?: string
   cause?: Error
+  details?: unknown
 }
 
 export class HttpError extends Error {
   readonly status: number
   readonly code?: string
+  readonly details?: unknown
 
-  constructor(message: string, { status, code, cause }: HttpErrorOptions) {
+  constructor(message: string, { status, code, cause, details }: HttpErrorOptions) {
     super(message, { cause })
     this.status = status
     this.code = code
+    this.details = details
     this.name = "HttpError"
   }
 }

--- a/packages/backend-common/src/middleware/error-handler.test.ts
+++ b/packages/backend-common/src/middleware/error-handler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import type { NextFunction, Request, Response } from "express"
+import { HttpError } from "../errors"
+import { errorHandler } from "./error-handler"
+
+function makeRes(): Response & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(body: unknown) {
+      this.body = body
+      return this
+    },
+  }
+  return res as unknown as Response & { statusCode: number; body: unknown }
+}
+
+const req = { path: "/x", method: "GET" } as unknown as Request
+const next = (() => {}) as unknown as NextFunction
+
+describe("errorHandler", () => {
+  test("formats an HttpError with status, message, code, and details", () => {
+    const res = makeRes()
+    errorHandler(
+      new HttpError("Validation failed", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+        details: { name: ["Required"] },
+      }),
+      req,
+      res,
+      next
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      error: "Validation failed",
+      code: "VALIDATION_ERROR",
+      details: { name: ["Required"] },
+    })
+  })
+
+  test("omits code and details when not provided", () => {
+    const res = makeRes()
+    errorHandler(new HttpError("Nope", { status: 404 }), req, res, next)
+
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toEqual({ error: "Nope" })
+  })
+
+  test("surfaces unknown errors as a 500", () => {
+    const res = makeRes()
+    errorHandler(new Error("boom"), req, res, next)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ error: "Internal server error", code: "INTERNAL_ERROR" })
+  })
+})

--- a/packages/backend-common/src/middleware/error-handler.ts
+++ b/packages/backend-common/src/middleware/error-handler.ts
@@ -10,7 +10,11 @@ import { logger } from "../logger"
  */
 export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction): void {
   if (err instanceof HttpError) {
-    res.status(err.status).json({ error: err.message, ...(err.code && { code: err.code }) })
+    res.status(err.status).json({
+      error: err.message,
+      ...(err.code && { code: err.code }),
+      ...(err.details !== undefined && { details: err.details }),
+    })
     return
   }
 


### PR DESCRIPTION
## Summary

Audit findings #7 and #9 (`docs/codebase-audit-2026-06-12.md`, P1): ~62 handler sites hand-rolled the same `safeParse` → `res.status(400).json({ error: "Validation failed", details })` block, and `messaging/handlers.ts` returned ad-hoc error bodies while its service layer throws typed `HttpError`s — the same logical error had two wire shapes depending on path.

Three commits:

1. **feat(backend-common):** `HttpError` gains optional `details`; the shared error middleware includes it when present. New `validateRequest(schema, value)` helper in `apps/backend/src/lib/validation.ts` — throws `HttpError` 400 `VALIDATION_ERROR` with flattened field errors as details.
2. **refactor(backend):** migrates the standard-shape validation blocks across 16 handler files (public-api, streams, workspaces, push, search, invitations, ai-usage, conversations, user-api-keys, user-preferences, workspace-settings, workspace-integrations, context-bag, bot-handlers, …).
3. **refactor(messaging):** all error responses now throw — 404s via `MessageNotFoundError`, author-only 403s and invalid-emoji 400s via `HttpError` with codes, the E2E mismatch 400 keeps its exact message + codes, validation via `validateRequest`.

## Wire-shape impact

Additive only: validation responses gain `code: "VALIDATION_ERROR"`; previously code-less messaging bodies gain `MESSAGE_NOT_FOUND` / `FORBIDDEN` / `INVALID_EMOJI`. Messages and `details` shapes are unchanged. Frontend `ApiError` parsing already handles `code`.

## Deliberately not migrated

- `saved-messages/handlers.ts`, `enclave-runtimes/session-handlers.ts`, `routes.ts` — owned by in-transit #886/#889
- public-api `listMessages` — uses `formErrors[0]` as the message (different shape)
- `commands/handlers.ts` dispatch — body carries `success: false`
- `bot-runtimes/socket-handler.ts` — socket ack, not HTTP middleware

## Verification

- `bun run typecheck` clean; backend-common tests pass
- Backend unit suite: 1,744 pass / 0 fail (context-bag handler tests updated to assert the thrown HttpError)
- Integration suite: parity with main (3 pre-existing env-dependent failures, identical on untouched main)
- E2E suite: 308 pass / 0 fail — exercises the messaging error paths end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783881578&installation_id=129946197&pr_number=893&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F893&signature=cf28c23f10472e9138136066e336c30e7276440effb725d594b32e641f692928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->