### PR TITLE
refactor(backend): single canonical stream-access SQL predicate (INV-62)

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,5 +1,6 @@
 export {
   sql,
+  composeSql,
   createDatabasePool,
   createDatabasePools,
   withTransaction,

--- a/apps/backend/src/features/attachments/repository.ts
+++ b/apps/backend/src/features/attachments/repository.ts
@@ -1,9 +1,9 @@
-import { sql, type Querier } from "../../db"
+import { sql, composeSql, type Querier } from "../../db"
+import { streamAccessPredicateSql } from "../streams"
 import {
   AttachmentSafetyStatuses,
   SHAREABLE_SAFETY_STATUSES,
   ProcessingStatuses,
-  Visibilities,
   mimePrefixesForCategory,
   type StorageProvider,
   type ProcessingStatus,
@@ -464,8 +464,9 @@ export const AttachmentRepository = {
 
   /**
    * Explorer search. One round trip combining:
-   *   - readable-stream gating for `userId` (mirrors `listAccessibleStreamIds`
-   *     so the predicate stays consistent with `checkStreamAccess`)
+   *   - readable-stream gating for `userId` via the canonical
+   *     `streamAccessPredicateSql` (the single thread → root access
+   *     definition shared with `listAccessibleStreamIds` / `checkStreamAccess`)
    *   - thread-descendant expansion when `streamIds` is supplied (callers
    *     pass channel/DM ids and the repo finds files in those streams *and*
    *     their threads via `root_stream_id`)
@@ -512,29 +513,12 @@ export const AttachmentRepository = {
     const cursorCreatedAt = cursor?.createdAt ?? null
     const cursorId = cursor?.id ?? ""
 
-    const result = await client.query<AttachmentSearchRowDb>(sql`
+    const result = await client.query<AttachmentSearchRowDb>(composeSql`
       WITH accessible_streams AS (
         SELECT s.id
         FROM streams s
-        LEFT JOIN streams root ON root.id = s.root_stream_id
         WHERE s.workspace_id = ${workspaceId}
-          AND (
-            (s.root_stream_id IS NULL AND (
-              s.visibility = ${Visibilities.PUBLIC}
-              OR EXISTS (
-                SELECT 1 FROM stream_members
-                WHERE stream_id = s.id AND member_id = ${userId}
-              )
-            ))
-            OR
-            (s.root_stream_id IS NOT NULL AND root.id IS NOT NULL AND (
-              root.visibility = ${Visibilities.PUBLIC}
-              OR EXISTS (
-                SELECT 1 FROM stream_members
-                WHERE stream_id = s.root_stream_id AND member_id = ${userId}
-              )
-            ))
-          )
+          AND ${streamAccessPredicateSql(workspaceId, userId, "s.id")}
       ),
       scoped_streams AS (
         SELECT acc.id

--- a/apps/backend/src/features/search/repository.ts
+++ b/apps/backend/src/features/search/repository.ts
@@ -1,7 +1,8 @@
 import type { Querier } from "../../db"
-import { sql } from "../../db"
+import { sql, composeSql } from "../../db"
 import { DM_PARTICIPANT_COUNT, Visibilities, type AuthorType, type StreamType } from "@threa/types"
 import { parseArchiveStatusFilter, type ArchiveStatus } from "../../lib/sql-filters"
+import { streamAccessPredicateSql } from "../streams"
 import type { AgentAccessSpec } from "../agents"
 
 export interface GetAccessibleStreamsParams {
@@ -124,18 +125,11 @@ export const SearchRepository = {
 
     // If no participant filter, simpler query
     if (!hasParticipantFilter) {
-      const result = await db.query<{ id: string }>(sql`
-        SELECT DISTINCT s.id
+      const result = await db.query<{ id: string }>(composeSql`
+        SELECT s.id
         FROM streams s
-        LEFT JOIN stream_members sm ON s.id = sm.stream_id AND sm.member_id = ${userId}
-        LEFT JOIN streams root ON s.root_stream_id = root.id
-        LEFT JOIN stream_members root_sm ON root.id = root_sm.stream_id AND root_sm.member_id = ${userId}
         WHERE s.workspace_id = ${workspaceId}
-          AND (
-            sm.member_id IS NOT NULL
-            OR s.visibility = ${Visibilities.PUBLIC}
-            OR (s.root_stream_id IS NOT NULL AND (root_sm.member_id IS NOT NULL OR root.visibility = ${Visibilities.PUBLIC}))
-          )
+          AND ${streamAccessPredicateSql(workspaceId, userId, "s.id")}
           AND (${!hasTypeFilter} OR s.type = ANY(${streamTypes ?? []}))
           AND (${filterAll} OR (${includeArchived} AND s.archived_at IS NOT NULL) OR (${!includeArchived} AND s.archived_at IS NULL))
       `)
@@ -143,19 +137,12 @@ export const SearchRepository = {
     }
 
     // With participant filter: combined query using UNION for users + personas
-    const result = await db.query<{ id: string }>(sql`
+    const result = await db.query<{ id: string }>(composeSql`
       WITH accessible AS (
-        SELECT DISTINCT s.id
+        SELECT s.id
         FROM streams s
-        LEFT JOIN stream_members sm ON s.id = sm.stream_id AND sm.member_id = ${userId}
-        LEFT JOIN streams root ON s.root_stream_id = root.id
-        LEFT JOIN stream_members root_sm ON root.id = root_sm.stream_id AND root_sm.member_id = ${userId}
         WHERE s.workspace_id = ${workspaceId}
-          AND (
-            sm.member_id IS NOT NULL
-            OR s.visibility = ${Visibilities.PUBLIC}
-            OR (s.root_stream_id IS NOT NULL AND (root_sm.member_id IS NOT NULL OR root.visibility = ${Visibilities.PUBLIC}))
-          )
+          AND ${streamAccessPredicateSql(workspaceId, userId, "s.id")}
           AND (${!hasTypeFilter} OR s.type = ANY(${streamTypes ?? []}))
           AND (${filterAll} OR (${includeArchived} AND s.archived_at IS NOT NULL) OR (${!includeArchived} AND s.archived_at IS NULL))
       ),

--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -1,5 +1,6 @@
+import type { QueryConfig } from "pg"
 import type { Querier } from "../../db"
-import { sql } from "../../db"
+import { sql, composeSql } from "../../db"
 import { Visibilities } from "@threa/types"
 import { StreamRepository, type Stream } from "./repository"
 import { StreamMemberRepository } from "./member-repository"
@@ -92,15 +93,69 @@ export async function checkStreamAccess(
 }
 
 /**
+ * Canonical SQL predicate for the "thread → root" stream-access rule
+ * (INV-62), as a reusable `EXISTS` fragment correlated to a stream-id
+ * column. This is the single source of truth for the *set-based* form of
+ * the same three rules `checkStreamAccess` enforces per-id (workspace
+ * boundary, public root grants read without a `stream_members` row, threads
+ * inherit from their root). When the thread→root resolution rule changes,
+ * this fragment and the per-id helpers update together.
+ *
+ * The returned `QueryConfig` is spliced into a larger query via
+ * {@link composeSql} (squid's own `sql` tag cannot nest fragments — it would
+ * parametrize the whole object). Any row source can gate on stream access by
+ * dropping this into its WHERE:
+ *
+ * ```ts
+ * composeSql`... WHERE ${streamAccessPredicateSql(ws, user, "a.stream_id")}`
+ * ```
+ *
+ * `streamIdColumn` is injected raw (squid `raw`) because it is a SQL column
+ * reference, not a value — so it MUST be a trusted constant column ref
+ * supplied by call-site code (e.g. `"a.stream_id"`, `"s.id"`), NEVER derived
+ * from user input. The fragment is fully self-contained: it re-checks the
+ * workspace boundary inside the EXISTS, so it is correct even when the outer
+ * query does not otherwise constrain the stream's workspace.
+ */
+export function streamAccessPredicateSql(
+  workspaceId: string,
+  userId: string,
+  streamIdColumn: string
+): QueryConfig {
+  return sql`EXISTS (
+    SELECT 1
+    FROM streams eff_s
+    LEFT JOIN streams eff_root ON eff_root.id = eff_s.root_stream_id
+    WHERE eff_s.id = ${sql.raw(streamIdColumn)}
+      AND eff_s.workspace_id = ${workspaceId}
+      AND (
+        (eff_s.root_stream_id IS NULL AND (
+          eff_s.visibility = ${Visibilities.PUBLIC}
+          OR EXISTS (
+            SELECT 1 FROM stream_members
+            WHERE stream_id = eff_s.id AND member_id = ${userId}
+          )
+        ))
+        OR
+        (eff_s.root_stream_id IS NOT NULL AND eff_root.id IS NOT NULL AND (
+          eff_root.visibility = ${Visibilities.PUBLIC}
+          OR EXISTS (
+            SELECT 1 FROM stream_members
+            WHERE stream_id = eff_s.root_stream_id AND member_id = ${userId}
+          )
+        ))
+      )
+  )`
+}
+
+/**
  * Batched equivalent of {@link checkStreamAccess}. Given a candidate set
  * of stream ids in a workspace, returns the subset the viewer can read.
  *
- * Encodes the same three rules as `checkStreamAccess` /
- * {@link resolveEffectiveAccessStream} in one SQL round-trip so
- * cross-cutting features (pointer hydration, search, activity feeds) can
- * filter many stream ids at once without an N+1. Keep the predicate in
- * sync with the per-id helpers — when the rule for thread → root
- * resolution changes, both code paths update together.
+ * Routes through {@link streamAccessPredicateSql} so the thread → root
+ * access rule has exactly one definition shared with the cross-cutting
+ * features (search, attachments) that filter many stream ids at once
+ * without an N+1.
  *
  * Empty input → empty Set; missing/cross-workspace ids are silently dropped
  * exactly like the per-id helper returning `null`.
@@ -112,29 +167,12 @@ export async function listAccessibleStreamIds(
   candidateStreamIds: readonly string[]
 ): Promise<Set<string>> {
   if (candidateStreamIds.length === 0) return new Set()
-  const result = await db.query<{ id: string }>(sql`
+  const result = await db.query<{ id: string }>(composeSql`
     SELECT s.id
     FROM streams s
-    LEFT JOIN streams root ON root.id = s.root_stream_id
     WHERE s.workspace_id = ${workspaceId}
       AND s.id = ANY(${candidateStreamIds as string[]})
-      AND (
-        (s.root_stream_id IS NULL AND (
-          s.visibility = ${Visibilities.PUBLIC}
-          OR EXISTS (
-            SELECT 1 FROM stream_members
-            WHERE stream_id = s.id AND member_id = ${userId}
-          )
-        ))
-        OR
-        (s.root_stream_id IS NOT NULL AND root.id IS NOT NULL AND (
-          root.visibility = ${Visibilities.PUBLIC}
-          OR EXISTS (
-            SELECT 1 FROM stream_members
-            WHERE stream_id = s.root_stream_id AND member_id = ${userId}
-          )
-        ))
-      )
+      AND ${streamAccessPredicateSql(workspaceId, userId, "s.id")}
   `)
   return new Set(result.rows.map((r) => r.id))
 }

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -6,7 +6,12 @@ export { StreamService } from "./service"
 export type { CreateScratchpadParams, CreateChannelParams, CreateThreadParams } from "./service"
 
 // Access (canonical "can this user read this stream?" check — INV-8)
-export { checkStreamAccess, listAccessibleStreamIds, resolveEffectiveAccessStream } from "./access"
+export {
+  checkStreamAccess,
+  listAccessibleStreamIds,
+  resolveEffectiveAccessStream,
+  streamAccessPredicateSql,
+} from "./access"
 
 // Naming
 export { StreamNamingService } from "./naming-service"

--- a/apps/backend/tests/integration/access-control.test.ts
+++ b/apps/backend/tests/integration/access-control.test.ts
@@ -13,12 +13,14 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
 import { withTransaction, addTestMember } from "./setup"
 import { WorkspaceRepository, WorkspaceService } from "../../src/features/workspaces"
-import { StreamEventRepository, StreamService } from "../../src/features/streams"
+import { StreamEventRepository, StreamService, listAccessibleStreamIds } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
+import { SearchRepository } from "../../src/features/search"
+import { AttachmentRepository } from "../../src/features/attachments"
 import { StreamNotFoundError } from "../../src/lib/errors"
 import { setupTestDatabase, testMessageContent } from "./setup"
-import { userId, workspaceId, eventId, commandId } from "../../src/lib/id"
-import { StreamTypes, Visibilities } from "@threa/types"
+import { userId, workspaceId, eventId, commandId, attachmentId } from "../../src/lib/id"
+import { StreamTypes, Visibilities, AttachmentSafetyStatuses } from "@threa/types"
 
 describe("Access Control", () => {
   let pool: Pool
@@ -884,6 +886,177 @@ describe("Access Control", () => {
       const userBEventTypes = userBEvents.map((e) => e.eventType)
       expect(userBEventTypes).not.toContain("command_dispatched")
       expect(userBEventTypes).not.toContain("command_failed")
+    })
+  })
+
+  /**
+   * INV-62: stream access is inherited via thread → root, and membership ≠
+   * access. These cases pin the SQL-side predicate
+   * (`streamAccessPredicateSql`, now the single definition shared by
+   * `listAccessibleStreamIds`, the search repo, and the attachment explorer
+   * search) against the three scenarios the inlined copies used to get
+   * wrong, on each cross-cutting surface:
+   *   (a) a thread inside a channel the viewer is a member of (but not a
+   *       member of the thread itself) IS visible;
+   *   (b) a public channel the viewer is NOT a member of IS visible;
+   *   (c) a private channel the viewer is NOT a member of is NOT visible.
+   */
+  describe("Thread → root SQL access predicate (INV-62)", () => {
+    /**
+     * Builds one workspace containing, for a viewer who is ONLY a member of
+     * `memberPrivateChannel`:
+     *   - memberThread: a thread inside that private channel (viewer is NOT a
+     *     thread member) → must be visible via root inheritance
+     *   - publicChannel: a public channel the viewer is not a member of →
+     *     visible
+     *   - otherPrivateChannel: a private channel the viewer is not a member of
+     *     → not visible
+     */
+    async function buildFixture() {
+      const ownerId = userId()
+      const wsId = workspaceId()
+      let viewerId = ""
+
+      await withTransaction(pool, async (client) => {
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "INV-62 Predicate Workspace",
+          slug: `inv62-ws-${wsId}`,
+          createdBy: ownerId,
+        })
+        viewerId = (await addTestMember(client, wsId, userId())).id
+      })
+
+      const memberPrivateChannel = await streamService.createChannel({
+        workspaceId: wsId,
+        slug: `inv62-member-private-${Date.now()}`,
+        displayName: "Member Private Channel",
+        createdBy: ownerId,
+        visibility: Visibilities.PRIVATE,
+      })
+      await streamService.addMember(memberPrivateChannel.id, viewerId, wsId)
+
+      // Thread inside the member channel; viewer is NOT added to the thread.
+      const parentMessage = await eventService.createMessage({
+        workspaceId: wsId,
+        streamId: memberPrivateChannel.id,
+        authorId: ownerId,
+        authorType: "user",
+        ...testMessageContent("Parent message spawning a thread"),
+      })
+      const memberThread = await streamService.createThread({
+        workspaceId: wsId,
+        parentStreamId: memberPrivateChannel.id,
+        parentMessageId: parentMessage.id,
+        createdBy: ownerId,
+      })
+
+      const publicChannel = await streamService.createChannel({
+        workspaceId: wsId,
+        slug: `inv62-public-${Date.now()}`,
+        displayName: "Public Channel",
+        createdBy: ownerId,
+        visibility: Visibilities.PUBLIC,
+      })
+
+      const otherPrivateChannel = await streamService.createChannel({
+        workspaceId: wsId,
+        slug: `inv62-other-private-${Date.now()}`,
+        displayName: "Other Private Channel",
+        createdBy: ownerId,
+        visibility: Visibilities.PRIVATE,
+      })
+
+      return {
+        wsId,
+        viewerId,
+        memberThread,
+        publicChannel,
+        otherPrivateChannel,
+      }
+    }
+
+    test("listAccessibleStreamIds resolves all three cases through the shared predicate", async () => {
+      const { wsId, viewerId, memberThread, publicChannel, otherPrivateChannel } = await buildFixture()
+
+      const accessible = await listAccessibleStreamIds(pool, wsId, viewerId, [
+        memberThread.id,
+        publicChannel.id,
+        otherPrivateChannel.id,
+      ])
+
+      expect(accessible.has(memberThread.id)).toBe(true)
+      expect(accessible.has(publicChannel.id)).toBe(true)
+      expect(accessible.has(otherPrivateChannel.id)).toBe(false)
+    })
+
+    test("search accessible-stream gating resolves all three cases", async () => {
+      const { wsId, viewerId, memberThread, publicChannel, otherPrivateChannel } = await buildFixture()
+
+      const accessibleIds = await SearchRepository.getAccessibleStreamsWithMembers(pool, {
+        workspaceId: wsId,
+        userId: viewerId,
+      })
+      const accessible = new Set(accessibleIds)
+
+      expect(accessible.has(memberThread.id)).toBe(true)
+      expect(accessible.has(publicChannel.id)).toBe(true)
+      expect(accessible.has(otherPrivateChannel.id)).toBe(false)
+    })
+
+    test("attachment explorer search returns uploads from a thread inside a member channel and from a public channel, never from a private non-member channel", async () => {
+      const { wsId, viewerId, memberThread, publicChannel, otherPrivateChannel } = await buildFixture()
+      const ownerId = userId()
+
+      // One clean, message-linked attachment per stream. They share a common
+      // filename token so a single name-substring search would surface every
+      // accessible one; gating, not text matching, is what's under test.
+      const nameToken = `inv62token${Date.now()}`
+      const seedAttachment = async (streamIdValue: string, tag: string): Promise<string> => {
+        const attId = attachmentId()
+        await withTransaction(pool, async (client) => {
+          // The explorer search requires message_id IS NOT NULL; create a
+          // message in the stream and point the attachment at it.
+          const message = await eventService.createMessageInTransaction(client, {
+            workspaceId: wsId,
+            streamId: streamIdValue,
+            authorId: ownerId,
+            authorType: "user",
+            ...testMessageContent(`attachment carrier ${tag}`),
+          })
+          await AttachmentRepository.insert(client, {
+            id: attId,
+            workspaceId: wsId,
+            streamId: streamIdValue,
+            uploadedBy: ownerId,
+            filename: `${nameToken}-${tag}.pdf`,
+            mimeType: "application/pdf",
+            sizeBytes: 1024,
+            storagePath: `/test/${nameToken}-${tag}`,
+            safetyStatus: AttachmentSafetyStatuses.CLEAN,
+          })
+          await client.query(`UPDATE attachments SET message_id = $1 WHERE id = $2`, [message.id, attId])
+        })
+        return attId
+      }
+
+      const threadAttachmentId = await seedAttachment(memberThread.id, "thread")
+      const publicAttachmentId = await seedAttachment(publicChannel.id, "public")
+      const privateAttachmentId = await seedAttachment(otherPrivateChannel.id, "private")
+
+      const results = await withTransaction(pool, (client) =>
+        AttachmentRepository.search(client, {
+          workspaceId: wsId,
+          userId: viewerId,
+          nameSubstring: nameToken,
+          limit: 50,
+        })
+      )
+      const foundIds = new Set(results.map((r) => r.id))
+
+      expect(foundIds.has(threadAttachmentId)).toBe(true)
+      expect(foundIds.has(publicAttachmentId)).toBe(true)
+      expect(foundIds.has(privateAttachmentId)).toBe(false)
     })
   })
 })

--- a/packages/backend-common/src/db/compose.test.ts
+++ b/packages/backend-common/src/db/compose.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { sql } from "squid/pg"
+import { composeSql } from "./compose"
+
+describe("composeSql", () => {
+  test("plain values only behave exactly like sql``", () => {
+    const query = composeSql`SELECT * FROM users WHERE id = ${"u_1"} AND age > ${30}`
+    expect(query).toEqual({
+      text: "SELECT * FROM users WHERE id = $1 AND age > $2",
+      values: ["u_1", 30],
+    })
+  })
+
+  test("no interpolations returns the static text with empty values", () => {
+    const query = composeSql`SELECT 1`
+    expect(query).toEqual({ text: "SELECT 1", values: [] })
+  })
+
+  test("splices a single fragment inline and merges its values", () => {
+    const fragment = sql`status = ${"active"} AND deleted_at IS NULL`
+    const query = composeSql`SELECT * FROM streams WHERE workspace_id = ${"ws_1"} AND (${fragment})`
+    expect(query).toEqual({
+      text: "SELECT * FROM streams WHERE workspace_id = $1 AND (status = $2 AND deleted_at IS NULL)",
+      values: ["ws_1", "active"],
+    })
+  })
+
+  test("renumbers multiple fragments so placeholders never collide", () => {
+    // Both fragments use $1 internally; composing must renumber each to a
+    // distinct outer placeholder.
+    const first = sql`a = ${"A"}`
+    const second = sql`b = ${"B"}`
+    const query = composeSql`WHERE ${first} OR ${second} OR c = ${"C"}`
+    expect(query).toEqual({
+      text: "WHERE a = $1 OR b = $2 OR c = $3",
+      values: ["A", "B", "C"],
+    })
+  })
+
+  test("renumbers a fragment that holds multiple placeholders, including multi-digit offsets", () => {
+    // Outer query first emits 9 plain values, then a fragment whose own
+    // placeholders are $1 and $2 — they must shift to $10 and $11.
+    const fragment = sql`x = ${"X"} AND y = ${"Y"}`
+    const query = composeSql`SELECT ${1}, ${2}, ${3}, ${4}, ${5}, ${6}, ${7}, ${8}, ${9} WHERE ${fragment}`
+    expect(query).toEqual({
+      text: "SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9 WHERE x = $10 AND y = $11",
+      values: [1, 2, 3, 4, 5, 6, 7, 8, 9, "X", "Y"],
+    })
+  })
+
+  test("handles a fragment with no values (raw-only)", () => {
+    const fragment = sql`s.archived_at IS NULL`
+    const query = composeSql`SELECT * FROM streams WHERE workspace_id = ${"ws_1"} AND ${fragment} AND id = ${"s_1"}`
+    expect(query).toEqual({
+      text: "SELECT * FROM streams WHERE workspace_id = $1 AND s.archived_at IS NULL AND id = $2",
+      values: ["ws_1", "s_1"],
+    })
+  })
+
+  test("handles fragments adjacent to plain values on both sides", () => {
+    const fragment = sql`role = ${"admin"}`
+    const query = composeSql`WHERE w = ${"ws"} AND ${fragment} AND tier = ${"gold"}`
+    expect(query).toEqual({
+      text: "WHERE w = $1 AND role = $2 AND tier = $3",
+      values: ["ws", "admin", "gold"],
+    })
+  })
+
+  test("preserves parameter ordering when a fragment precedes plain values", () => {
+    const predicate = sql`(visibility = ${"public"} OR owner = ${"u_1"})`
+    const query = composeSql`SELECT id FROM s WHERE ${predicate} AND workspace_id = ${"ws_1"}`
+    expect(query).toEqual({
+      text: "SELECT id FROM s WHERE (visibility = $1 OR owner = $2) AND workspace_id = $3",
+      values: ["public", "u_1", "ws_1"],
+    })
+  })
+
+  test("a composed fragment can itself be re-composed (nested composition)", () => {
+    // composeSql output is QueryConfig-shaped, so it splices into another
+    // composeSql call exactly like a squid fragment does.
+    const inner = composeSql`id = ${"s_1"}`
+    const outer = composeSql`SELECT 1 WHERE ws = ${"ws_1"} AND ${inner} AND tier = ${"gold"}`
+    expect(outer).toEqual({
+      text: "SELECT 1 WHERE ws = $1 AND id = $2 AND tier = $3",
+      values: ["ws_1", "s_1", "gold"],
+    })
+  })
+})

--- a/packages/backend-common/src/db/compose.ts
+++ b/packages/backend-common/src/db/compose.ts
@@ -1,0 +1,59 @@
+import type { QueryConfig } from "pg"
+
+/** A `QueryConfig` fragment with `values` guaranteed present (squid always emits it). */
+type SqlFragment = { text: string; values: unknown[] }
+
+/**
+ * Type guard for a squid/pg `QueryConfig`-shaped fragment: `{ text, values }`.
+ * Used to decide whether an interpolated value is spliced inline (a nested
+ * fragment) or parametrized as an ordinary value.
+ */
+function isQueryConfig(value: unknown): value is SqlFragment {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { text?: unknown }).text === "string" &&
+    Array.isArray((value as { values?: unknown }).values)
+  )
+}
+
+/**
+ * `sql`-compatible tagged template that additionally splices nested
+ * `QueryConfig` fragments inline.
+ *
+ * squid's own `sql` tag cannot nest one `sql`` fragment inside another:
+ * interpolating a `QueryConfig` parametrizes the whole object as a single
+ * value. `composeSql` behaves exactly like `sql` for plain values (each is
+ * emitted as `$n` and collected into `values`), but when an interpolated
+ * value is `QueryConfig`-shaped its `text` is inlined with every `$k`
+ * placeholder renumbered to follow the outer query's parameters, and its
+ * `values` are appended in order. This lets a single canonical predicate
+ * fragment be shared across queries without copy-pasting the SQL.
+ *
+ * Fragment placeholders are assumed to be the standard `$1..$k` produced by
+ * squid `sql`` (1-indexed, contiguous), which is the only kind of fragment we
+ * compose here.
+ */
+export function composeSql(texts: TemplateStringsArray, ...values: unknown[]): QueryConfig {
+  let text = ""
+  const outValues: unknown[] = []
+
+  for (let i = 0; i < texts.length; i++) {
+    text += texts[i]
+    if (i >= values.length) continue
+
+    const value = values[i]
+    if (isQueryConfig(value)) {
+      // Renumber the fragment's $k placeholders to continue after the
+      // parameters already accumulated, then append its values in order.
+      const offset = outValues.length
+      text += value.text.replace(/\$(\d+)/g, (_match, n: string) => `$${Number(n) + offset}`)
+      outValues.push(...value.values)
+    } else {
+      outValues.push(value)
+      text += `$${outValues.length}`
+    }
+  }
+
+  return { text, values: outValues }
+}

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -31,6 +31,7 @@ export type { WorkosConfig } from "./auth/types"
 // Database
 export { sql, createDatabasePool, createDatabasePools, withTransaction, withClient, warmPool } from "./db/index"
 export type { Querier, DatabasePools } from "./db/index"
+export { composeSql } from "./db/compose"
 export { createMigrator, runMigrations } from "./db/migrations"
 
 // Errors


### PR DESCRIPTION
## Summary

Audit finding #8 (`docs/codebase-audit-2026-06-12.md`, P1): the thread→root access rule had three SQL copies — `listAccessibleStreamIds` (EXISTS form), the attachment explorer search (a hand-mirrored EXISTS copy whose own comment admitted it must stay manually in sync), and the search repo's accessible-streams queries (a LEFT JOIN form that was only coincidentally equivalent). Each copy was a drift surface for the exact footgun INV-62 documents.

- **`composeSql`** (packages/backend-common): squid's `sql` tag cannot nest fragments — interpolating a QueryConfig parameterizes it as a value. This ~40-line tagged template behaves like `sql` but splices QueryConfig-shaped values inline with placeholders renumbered. Unit-tested (renumbering, multiple fragments, adjacency).
- **`streamAccessPredicateSql(workspaceId, userId, streamIdColumn)`** (streams/access.ts): the single EXISTS-form definition, self-contained (re-checks the workspace boundary internally). `listAccessibleStreamIds` itself now routes through it, so the predicate has exactly one home. `streamIdColumn` is injected via `sql.raw` and documented as trusted-constant-only.
- attachments explorer search + 2 of 3 search-repo sites compose the canonical fragment. The third search site (participant intersection) correlates access per `requested_users.member_id` — a column, not a value — which the fragment cannot express; left unchanged with the existing LEFT JOIN form.
- The outer `s.workspace_id` filters are retained alongside the fragment so the planner keeps its index-narrowing scan (the fragment's internal workspace check is the correctness backstop, not the access path).

## Tests (INV-62 pairing requirement)

`access-control.test.ts` gains a fixture pinning the three scenarios the inlined copies historically got wrong, against each converted surface (`listAccessibleStreamIds`, `SearchRepository`, `AttachmentRepository`):
- a thread inside a member channel (viewer NOT a thread member) IS visible
- a public channel the viewer is not a member of IS visible
- a private channel the viewer is not a member of is NOT visible

## Out of scope (deliberate)

saved-messages' app-side re-derivations (`ensureStreamAccess`, `computeAccessibleStreams`) are drop-in replaceable by the canonical helpers, but #886 owns that feature — deferred until it lands. sync catch-up's membership-only CTE is a separate audit item (P0 #1) pending a behavior decision.

## Verification

- backend-common tests: 24 pass (incl. new composeSql suite)
- `bun run typecheck` clean
- access-control: 22 pass (incl. new INV-62 cases); trigram-search 16 pass; attachment-repository + search-streams-tool-dm 15 pass
- Backend unit suite: 1,742 pass / 0 fail; E2E: 308 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783881605&installation_id=129946197&pr_number=894&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F894&signature=6c0a8ab5569551c21888c88e7d288b3e7074d396b869997b5dd34b7b64c5ef61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->