### PR TITLE
feat: skip the conversations reconnect invalidation in active sync-v2 mode

### DIFF
--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -111,7 +111,7 @@ describe("useConversations event registration", () => {
     expect(queryClient.getQueryData(listKey())).toEqual([makeConversation("conv_1")])
   })
 
-  it("still invalidates the list on socket reconnect (INV-53 healing untouched)", async () => {
+  it("still invalidates the list on socket reconnect without a sync engine", async () => {
     const { socket } = createTestSocket()
     vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
     vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(null)
@@ -123,5 +123,59 @@ describe("useConversations event registration", () => {
     renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: listKey() }))
+  })
+
+  it.each(["off", "shadow"] as const)("keeps the reconnect invalidation in %s sync-v2 mode", async (mode) => {
+    const { socket } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+
+    const gate = new SocketEventGate(WORKSPACE_ID)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue({
+      getLiveEventSource: () => gate,
+      syncCursorMode: mode,
+    } as unknown as syncEngineModule.SyncEngine)
+
+    const { queryClient, wrapper } = createWrapper()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    reconnectCount = 1
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: listKey() }))
+
+    gate.dispose()
+  })
+
+  it("skips the reconnect invalidation in active sync-v2 mode (catch-up replay covers the gap)", async () => {
+    const { socket } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+
+    const gate = new SocketEventGate(WORKSPACE_ID)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue({
+      getLiveEventSource: () => gate,
+      syncCursorMode: "active",
+    } as unknown as syncEngineModule.SyncEngine)
+
+    const { queryClient, wrapper } = createWrapper()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    reconnectCount = 1
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await waitFor(() => expect(queryClient.getQueryData(listKey())).toEqual([]))
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: listKey() })
+
+    // The replay path the deleted healing is traded for: a gate-dispatched
+    // catch-up entry still lands in the list cache.
+    await act(async () => {
+      await gate.dispatch("conversation:created", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        conversation: makeConversation("conv_1"),
+      })
+    })
+    expect(queryClient.getQueryData(listKey())).toEqual([makeConversation("conv_1")])
+
+    gate.dispose()
   })
 })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -84,10 +84,19 @@ export function useConversations(workspaceId: string, streamId: string, options?
 
   // INV-53: invalidate bootstrap on resubscribe (reconnect) so any events
   // missed during the disconnect are reconciled from the server.
+  //
+  // In active sync-v2 mode the workspace catch-up cursor replays the missed
+  // conversation events (stream-scoped sync-log entries) through the
+  // gate-registered handlers below, so the blanket invalidation is redundant
+  // there — but "off" is the runtime kill switch and "shadow" applies
+  // nothing, so both keep this healing, as do mounts outside the SyncEngine
+  // provider. The mode is fixed per engine lifetime; a flag flip recreates
+  // the engine and re-runs this effect with the new mode.
   useEffect(() => {
     if (reconnectCount === 0 || !workspaceId || !streamId || !enabled) return
+    if (syncEngine?.syncCursorMode === "active") return
     queryClient.invalidateQueries({ queryKey: conversationKeys.list(workspaceId, streamId, { status, limit }) })
-  }, [reconnectCount, workspaceId, streamId, status, limit, enabled, queryClient])
+  }, [reconnectCount, workspaceId, streamId, status, limit, enabled, queryClient, syncEngine])
 
   // Handle real-time conversation events
   useEffect(() => {

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -57,27 +57,27 @@ and the resume path no longer needs the blanket bootstrap fetch, resume becomes
 
 ## Deletion candidates (in agreed order, after the additive PR)
 
-### `use-conversations` reconnect invalidation
+### `use-conversations` reconnect invalidation — DONE
 
-`apps/frontend/src/hooks/use-conversations.ts:82-87`: invalidates the
-conversation list on every socket reconnect.
+`apps/frontend/src/hooks/use-conversations.ts`: invalidated the conversation
+list on every socket reconnect. **Gated on active mode** (the deletion PR
+following #891): the invalidation now skips when
+`syncEngine?.syncCursorMode === "active"`.
 
 - All four conversation events are stream-scoped in the log
   (`conversation:created`/`updated`/`message_assigned` also fan out to the
   parent stream group), and `listEntriesForUser` returns them for member
   streams including threads (INV-62 rule mirrored in the SQL).
-- ~~Blocker:~~ **done in the additive PR** — the hook now registers through
+- ~~Blocker:~~ **done in the additive PR (#891)** — the hook registers through
   `syncEngine?.getLiveEventSource() ?? socket` (the `useStreamSocket` pattern),
-  so replay reaches it. The remaining change is gating the invalidation on
-  `mode !== "active"`.
+  so replay reaches it.
 - Unmounted-during-catch-up is safe: the query uses default staleness, so the
   next mount refetches anyway. The invalidation only ever fired on reconnect,
   so dropped-emit coverage is unchanged.
-- Test: replay `conversation:created` through the gate and assert the list
-  cache updates; pin that `off` and `shadow` keep the invalidation.
+- Tests pin: gate-dispatched replay updates the list cache in active mode with
+  no invalidation; `off`/`shadow`/no-engine keep the invalidation.
 
-**Verdict: covered once the hook is gate-registered. Smallest, cleanest next
-deletion.**
+**Verdict: covered; deleted.**
 
 ### `refetchOnReconnect: true` on saved + scheduled lists
 


### PR DESCRIPTION
## Problem

#891 put `use-conversations` on the sync-v2 catch-up path: its four `conversation:*` handlers register through the engine's event gate, so catch-up replay after a gap reaches them. That left its blanket INV-53 reconnect invalidation redundant in active mode — the workspace cursor replays the missed conversation events through those same handlers, on the same reconnect trigger, so every reconnect fired a duplicate list refetch on top of the replay.

This is the first of the planned healing deletions from `docs/plans/sync-v2-healing-deletion-inventory.md` (one per PR, each with a coverage-proof test).

## Solution

Gate the reconnect invalidation on the engine mode, exactly like #885 did for saved/scheduled in `registerWorkspaceSocketHandlers`:

- `syncCursorMode === "active"` → skip the invalidation; the catch-up cursor owns the gap.
- `off` (runtime kill switch), `shadow` (applies nothing), and mounts outside the SyncEngine provider (no engine) → keep the invalidation unchanged.

The mode is fixed per engine lifetime; a flag flip recreates the engine, the hook re-renders with the new instance, and the effect re-runs with the new mode.

### Coverage proof (the #885 chain)

All four conversation events are stream-scoped sync-log entries (`conversation:created`/`updated`/`message_assigned` also fan out to the parent stream group), `listEntriesForUser` returns them for member streams including threads, and `gate.dispatch` reaches the hook's handlers since #891. Dropped-emit coverage is unchanged: the deleted invalidation only ever fired on reconnect — the same trigger as catch-up — so it never added detection between a drop and the next trigger.

## Modified files

| File | Change |
| --- | --- |
| `apps/frontend/src/hooks/use-conversations.ts` | Reconnect invalidation skips when `syncEngine?.syncCursorMode === "active"` |
| `apps/frontend/src/hooks/use-conversations.test.tsx` | Pins all three behaviors: active skips the invalidation but applies a gate-dispatched replay to the list cache; `off`/`shadow` keep it; no-engine keeps it |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Conversations deletion marked done |

## Test plan

- [x] `bunx vitest run src/sync src/hooks` — 56 files, 584 tests passed
- [x] `bun run typecheck` — clean across the monorepo

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** First healing deletion after the additive #891 — remove the redundant blanket reconnect invalidation in `use-conversations` for active sync-v2 mode, keeping it everywhere the cursor doesn't cover.

**What was built:** A mode gate on the INV-53 reconnect effect (`syncEngine?.syncCursorMode === "active"` → skip), plus tests pinning the skip, the off/shadow keep, the no-engine keep, and the replacement replay path (gate-dispatched `conversation:created` updates the list cache).

**Design decisions:** Same gating shape as #885 (`syncCursorMode !== "active"` keeps healing). The hook already held the optional engine from the #891 gate migration, so the gate reads `syncCursorMode` off it — no new context or prop threading.

**What's NOT included (sequenced per the inventory doc):**
- Deletion PR 2: saved/scheduled `refetchOnReconnect: true` → mode-gated (online flip already triggers resume catch-up).
- Deletion PR 3: labels `refetchOnReconnect` (resolve the non-member public-stream edge first).
- Socket heartbeat (dropped-emit detection between catch-up triggers), then sync_log retention, which unblocks the reconnect-bootstrap slimming and the `usePageResumeRefresh` deletion.

**Status:** complete; all tests green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_019yecLnbhTcZ8SvMvQhGeCm

---
_Generated by [Claude Code](https://claude.ai/code/session_019yecLnbhTcZ8SvMvQhGeCm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882257&installation_id=129946197&pr_number=895&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F895&signature=8f90be65126552676fdc0784e2eb26bca97c915814a61394a01a621b267e5daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->