### PR TITLE
feat: rank suggestion matches by where the query hit (label vs alias)

### DIFF
--- a/apps/frontend/src/components/editor/triggers/command-placement.test.ts
+++ b/apps/frontend/src/components/editor/triggers/command-placement.test.ts
@@ -80,6 +80,16 @@ describe("filterCommands placement gating", () => {
     expect(names(filterCommands(ALL, "mem", editor))).toEqual(["memo"])
   })
 
+  it("ranks name matches above description-only matches", () => {
+    const editor = makeEditor()
+    typeText(editor, "/invite")
+    // SHOUT matches "invite" only in its description and is defined first;
+    // INVITE matches on its visible name and must rank above it.
+    const SHOUT: CommandItem = { name: "shout", description: "Invite everyone loudly" }
+    const items = filterCommands([SHOUT, INVITE], "invite", editor)
+    expect(items.map((i) => i.name)).toEqual(["invite", "shout"])
+  })
+
   it("returns whole-message commands when no editor context is available", () => {
     // Defensive fallback: without an editor we can't tell where the slash is, so
     // we don't hide message-level commands (the prior behavior).

--- a/apps/frontend/src/components/editor/triggers/use-channel-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-channel-suggestion.tsx
@@ -3,20 +3,15 @@ import { useParams } from "react-router-dom"
 import type { ChannelItem } from "./types"
 import { ChannelList } from "./channel-list"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { rankMatches } from "@/lib/match-score"
 import { useSuggestion } from "./use-suggestion"
 
 /**
- * Filter channels by query string.
- * Matches against slug and name, case-insensitive.
+ * Filter and rank channels by query string: exact/prefix matches on slug or
+ * name rank above mid-word substring hits.
  */
 function filterChannels(items: ChannelItem[], query: string): ChannelItem[] {
-  if (!query) return items
-
-  const lowerQuery = query.toLowerCase()
-  return items.filter(
-    (item) =>
-      item.slug.toLowerCase().includes(lowerQuery) || (item.name && item.name.toLowerCase().includes(lowerQuery))
-  )
+  return rankMatches(items, query, (item) => ({ labels: item.name ? [item.slug, item.name] : [item.slug] }))
 }
 
 /**

--- a/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
@@ -7,6 +7,7 @@ import type { CommandItem } from "./types"
 import { CommandList } from "./command-list"
 import { MEMO_SEARCH_SLASH_ACTION, GIPHY_SLASH_ACTION } from "./command-extension"
 import { useWorkspaceMetadata } from "@/stores/workspace-store"
+import { rankMatches } from "@/lib/match-score"
 import { streamKeys } from "@/hooks/use-streams"
 import type { CachedStreamBootstrap } from "@/sync/stream-sync"
 import { useSuggestion } from "./use-suggestion"
@@ -25,17 +26,15 @@ function slashOpensMessage(editor: Editor | undefined, query: string): boolean {
 /**
  * Filter commands by query string and cursor context.
  *
- * Matches name/description case-insensitively, and drops whole-message commands
- * (anything not `placement: "inline"`) unless the slash opens the message.
+ * Drops whole-message commands (anything not `placement: "inline"`) unless the
+ * slash opens the message, then ranks by match location: the command name is
+ * the visible label, the description a hidden alias a tier below, so
+ * name matches always sort above description-only matches.
  */
 export function filterCommands(items: CommandItem[], query: string, editor?: Editor): CommandItem[] {
   const opensMessage = slashOpensMessage(editor, query)
-  const lowerQuery = query.toLowerCase()
-  return items.filter((item) => {
-    if (item.placement !== "inline" && !opensMessage) return false
-    if (!lowerQuery) return true
-    return item.name.toLowerCase().includes(lowerQuery) || item.description.toLowerCase().includes(lowerQuery)
-  })
+  const placed = items.filter((item) => item.placement === "inline" || opensMessage)
+  return rankMatches(placed, query, (item) => ({ labels: [item.name], keywords: [item.description] }))
 }
 
 export function resolveEffectiveCommandInfos(

--- a/apps/frontend/src/components/editor/triggers/use-filter-type-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-filter-type-suggestion.tsx
@@ -1,21 +1,19 @@
 import { useCallback } from "react"
+import { rankMatches } from "@/lib/match-score"
 import { useSuggestion } from "./use-suggestion"
 import { FilterTypeList } from "./filter-type-list"
 import { FILTER_TYPE_OPTIONS, type FilterTypeItem } from "./filter-type-extension"
 
 /**
- * Filters stream type options by query string.
+ * Filters and ranks stream type options by query string. Label and inserted
+ * value are both visible match targets; the description is a hidden alias
+ * scored a tier below.
  */
 export function filterFilterTypes(items: FilterTypeItem[], query: string): FilterTypeItem[] {
-  if (!query) return items
-
-  const lowerQuery = query.toLowerCase()
-  return items.filter(
-    (item) =>
-      item.value.toLowerCase().startsWith(lowerQuery) ||
-      item.label.toLowerCase().includes(lowerQuery) ||
-      item.description.toLowerCase().includes(lowerQuery)
-  )
+  return rankMatches(items, query, (item) => ({
+    labels: [item.label, item.value],
+    keywords: [item.description],
+  }))
 }
 
 /**

--- a/apps/frontend/src/components/editor/triggers/use-in-channel-filter-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-in-channel-filter-suggestion.tsx
@@ -3,18 +3,15 @@ import { useParams } from "react-router-dom"
 import type { ChannelItem } from "./types"
 import { ChannelList } from "./channel-list"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { rankMatches } from "@/lib/match-score"
 import { useSuggestion } from "./use-suggestion"
 
 /**
- * Filter channels by query string.
+ * Filter and rank channels by query string: exact/prefix matches on slug or
+ * name rank above mid-word substring hits.
  */
 function filterChannels(items: ChannelItem[], query: string): ChannelItem[] {
-  if (!query) return items
-  const lowerQuery = query.toLowerCase()
-  return items.filter(
-    (item) =>
-      item.slug.toLowerCase().includes(lowerQuery) || (item.name && item.name.toLowerCase().includes(lowerQuery))
-  )
+  return rankMatches(items, query, (item) => ({ labels: item.name ? [item.slug, item.name] : [item.slug] }))
 }
 
 /**

--- a/apps/frontend/src/components/editor/triggers/use-status-filter-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-status-filter-suggestion.tsx
@@ -1,21 +1,19 @@
 import { useCallback } from "react"
+import { rankMatches } from "@/lib/match-score"
 import { useSuggestion } from "./use-suggestion"
 import { StatusFilterList } from "./status-filter-list"
 import { STATUS_FILTER_OPTIONS, type StatusFilterItem } from "./status-filter-extension"
 
 /**
- * Filters status options by query string.
+ * Filters and ranks status options by query string. Label and inserted value
+ * are both visible match targets; the description is a hidden alias scored a
+ * tier below.
  */
 export function filterStatusOptions(items: StatusFilterItem[], query: string): StatusFilterItem[] {
-  if (!query) return items
-
-  const lowerQuery = query.toLowerCase()
-  return items.filter(
-    (item) =>
-      item.value.toLowerCase().startsWith(lowerQuery) ||
-      item.label.toLowerCase().includes(lowerQuery) ||
-      item.description.toLowerCase().includes(lowerQuery)
-  )
+  return rankMatches(items, query, (item) => ({
+    labels: [item.label, item.value],
+    keywords: [item.description],
+  }))
 }
 
 /**

--- a/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { FileText } from "lucide-react"
+import { commands, type Command } from "./commands"
+import { rankCommands } from "./use-command-items"
+
+function makeCommand(overrides: Partial<Command> & Pick<Command, "id" | "label">): Command {
+  return { icon: FileText, action: () => {}, ...overrides }
+}
+
+describe("rankCommands", () => {
+  it("returns all commands in curated order for an empty query", () => {
+    expect(rankCommands(commands, "")).toEqual(commands)
+  })
+
+  it("ranks a label match above an earlier-defined keyword-only match", () => {
+    // "Add To-do" matches "saved" only via its hidden alias; "View Saved"
+    // matches on its visible label. Label must win despite definition order.
+    const todo = makeCommand({ id: "add-todo", label: "Add To-do", keywords: ["saved", "task"] })
+    const saved = makeCommand({ id: "view-saved", label: "View Saved", keywords: ["bookmark"] })
+    const ranked = rankCommands([todo, saved], "saved")
+    expect(ranked.map((c) => c.id)).toEqual(["view-saved", "add-todo"])
+  })
+
+  it("ranks real palette commands by where the match landed", () => {
+    // "New Scratchpad" carries the keyword "note" and is defined before
+    // "New Quick Note", whose visible label matches.
+    const ranked = rankCommands(commands, "note")
+    const quickNoteIndex = ranked.findIndex((c) => c.id === "new-quick-note")
+    const scratchpadIndex = ranked.findIndex((c) => c.id === "new-scratchpad")
+    expect(quickNoteIndex).toBeGreaterThanOrEqual(0)
+    expect(scratchpadIndex).toBeGreaterThanOrEqual(0)
+    expect(quickNoteIndex).toBeLessThan(scratchpadIndex)
+  })
+
+  it("still matches on hidden keywords and ids", () => {
+    const ranked = rankCommands(commands, "bookmark")
+    expect(ranked.map((c) => c.id)).toContain("view-saved")
+  })
+
+  it("drops non-matching commands", () => {
+    const ranked = rankCommands(commands, "zzz-no-such-command")
+    expect(ranked).toEqual([])
+  })
+})

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { isDraftId } from "@/hooks"
+import { rankMatches } from "@/lib/match-score"
 import { commands, type Command, type CommandContext } from "./commands"
 import { draftStreamCommands, streamCommands } from "./stream-commands"
 import type { ModeResult, QuickSwitcherItem } from "./types"
@@ -9,16 +10,23 @@ interface UseCommandItemsParams {
   commandContext: CommandContext
 }
 
+/**
+ * Filter and rank palette commands for a query. The visible label is the
+ * primary match target; id and keywords are hidden aliases scored a tier
+ * below, so a command whose label matches always outranks one that only
+ * matches on an alias, regardless of definition order. Ties keep the curated
+ * array order.
+ */
+export function rankCommands(candidates: Command[], query: string): Command[] {
+  return rankMatches(candidates, query, (command) => ({
+    labels: [command.label],
+    keywords: [command.id, ...(command.keywords ?? [])],
+  }))
+}
+
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {
   const items = useMemo(() => {
     const { currentStreamId, currentStreamName } = commandContext
-    const lowerQuery = query.toLowerCase()
-
-    const matchesQuery = (command: Command) => {
-      if (!query) return true
-      const searchValue = [command.id, command.label, ...(command.keywords ?? [])].join(" ").toLowerCase()
-      return searchValue.includes(lowerQuery)
-    }
 
     const toItem = (command: Command, group: string): QuickSwitcherItem => ({
       id: command.id,
@@ -39,9 +47,11 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
       contextualCommands = isDraftId(currentStreamId) ? draftStreamCommands : streamCommands
     }
     const contextualGroup = currentStreamName ? `This stream — ${currentStreamName}` : "This stream"
-    const contextualItems = contextualCommands.filter(matchesQuery).map((c) => toItem(c, contextualGroup))
+    // Each group is ranked independently — the list renders grouped, so
+    // cross-group ordering is the section order, not match quality.
+    const contextualItems = rankCommands(contextualCommands, query).map((c) => toItem(c, contextualGroup))
 
-    const globalItems = commands.filter(matchesQuery).map((c) => toItem(c, "Commands"))
+    const globalItems = rankCommands(commands, query).map((c) => toItem(c, "Commands"))
 
     return [...contextualItems, ...globalItems]
   }, [query, commandContext])

--- a/apps/frontend/src/hooks/use-mentionables.test.ts
+++ b/apps/frontend/src/hooks/use-mentionables.test.ts
@@ -85,6 +85,16 @@ describe("filterMentionables", () => {
     // Matches: alice (slug), Ariadne (slug/name), Channel (name)
     expect(result.length).toBeGreaterThanOrEqual(2)
   })
+
+  it("should rank prefix matches above mid-word substring matches", () => {
+    const withMidWordMatch: Mentionable[] = [
+      // Defined first and matches "ali" only mid-word; the prefix match must win.
+      { id: "usr_9", slug: "natalie", name: "Natalie Doe", type: "user" },
+      { id: "usr_1", slug: "alice", name: "Alice Smith", type: "user" },
+    ]
+    const result = filterMentionables(withMidWordMatch, "ali")
+    expect(result.map((item) => item.slug)).toEqual(["alice", "natalie"])
+  })
 })
 
 describe("filterBroadcastMentions", () => {

--- a/apps/frontend/src/hooks/use-mentionables.ts
+++ b/apps/frontend/src/hooks/use-mentionables.ts
@@ -8,6 +8,7 @@ import {
 } from "@/stores/workspace-store"
 import { useParams } from "react-router-dom"
 import { useUser } from "@/auth"
+import { rankMatches } from "@/lib/match-score"
 import { useStreamBootstrap } from "./use-streams"
 import { useWorkspaceEmoji } from "./use-workspace-emoji"
 import { StreamTypes, type StreamType } from "@threa/types"
@@ -228,24 +229,22 @@ export function useMentionables(streamContext?: MentionStreamContext) {
 }
 
 /**
- * Filter mentionables by query string.
- * Matches against slug and name, case-insensitive.
+ * Filter and rank mentionables by query string.
+ * Matches against slug and name (both visible in the row), case-insensitive;
+ * exact/prefix matches rank above mid-word substring hits, ties keep input
+ * order (current user stays first among equals).
  * Special case: "me" matches the current user.
  */
 export function filterMentionables(items: Mentionable[], query: string): Mentionable[] {
   if (!query) return items
 
-  const lowerQuery = query.toLowerCase()
-
   // Special case: "me" should match the current user
-  if (lowerQuery === "me") {
+  if (query.toLowerCase() === "me") {
     const currentUser = items.find((item) => item.isCurrentUser)
     if (currentUser) return [currentUser]
   }
 
-  return items.filter(
-    (item) => item.slug.toLowerCase().includes(lowerQuery) || item.name.toLowerCase().includes(lowerQuery)
-  )
+  return rankMatches(items, query, (item) => ({ labels: [item.slug, item.name] }))
 }
 
 /**

--- a/apps/frontend/src/lib/emoji-picker.test.ts
+++ b/apps/frontend/src/lib/emoji-picker.test.ts
@@ -76,6 +76,12 @@ describe("filterBySearch", () => {
     const matches = filterBySearch([smile, poop], "HANKEY")
     expect(matches.map((e) => e.shortcode)).toEqual(["poop"])
   })
+
+  it("ranks visible shortcode matches above hidden alias matches regardless of input order", () => {
+    const happy = make("happy_face", "people", 1, ["happy_face", "smile_alt"])
+    const matches = filterBySearch([happy, smile], "smile")
+    expect(matches.map((e) => e.shortcode)).toEqual(["smile", "happy_face"])
+  })
 })
 
 describe("indexToCoord", () => {

--- a/apps/frontend/src/lib/emoji-picker.ts
+++ b/apps/frontend/src/lib/emoji-picker.ts
@@ -119,9 +119,15 @@ export function buildQuickEmojis(
  * primary match target; other aliases score a tier below, so `:smile:` ranks
  * above an emoji that merely lists "smile" as a hidden alias. Ties keep input
  * order (default order for the grid, weight order for recents).
+ *
+ * `aliases` includes the primary shortcode (see EmojiEntry), so it is
+ * excluded from the keyword band to keep the tier intent explicit.
  */
 export function filterBySearch(emojis: EmojiEntry[], query: string): EmojiEntry[] {
-  return rankMatches(emojis, query, (e) => ({ labels: [e.shortcode], keywords: e.aliases }))
+  return rankMatches(emojis, query, (e) => ({
+    labels: [e.shortcode],
+    keywords: e.aliases.filter((alias) => alias !== e.shortcode),
+  }))
 }
 
 export type Section = "recent" | "all"

--- a/apps/frontend/src/lib/emoji-picker.ts
+++ b/apps/frontend/src/lib/emoji-picker.ts
@@ -1,4 +1,5 @@
 import type { EmojiEntry } from "@threa/types"
+import { rankMatches } from "@/lib/match-score"
 
 export const EMOJI_GROUP_ORDER = [
   "smileys",
@@ -113,10 +114,14 @@ export function buildQuickEmojis(
   return result
 }
 
+/**
+ * Filter and rank emojis for a search query. The canonical shortcode is the
+ * primary match target; other aliases score a tier below, so `:smile:` ranks
+ * above an emoji that merely lists "smile" as a hidden alias. Ties keep input
+ * order (default order for the grid, weight order for recents).
+ */
 export function filterBySearch(emojis: EmojiEntry[], query: string): EmojiEntry[] {
-  if (!query) return emojis
-  const q = query.toLowerCase()
-  return emojis.filter((e) => e.aliases.some((a) => a.includes(q)))
+  return rankMatches(emojis, query, (e) => ({ labels: [e.shortcode], keywords: e.aliases }))
 }
 
 export type Section = "recent" | "all"

--- a/apps/frontend/src/lib/match-score.test.ts
+++ b/apps/frontend/src/lib/match-score.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import { scoreMatch, rankMatches } from "./match-score"
+
+describe("scoreMatch", () => {
+  it("returns 0 for an empty query (no scoring required)", () => {
+    expect(scoreMatch("", ["View Saved"], ["bookmark"])).toBe(0)
+  })
+
+  it("tiers label matches: exact < prefix < contains", () => {
+    expect(scoreMatch("view saved", ["View Saved"])).toBe(0)
+    expect(scoreMatch("view", ["View Saved"])).toBe(1)
+    expect(scoreMatch("saved", ["View Saved"])).toBe(2)
+  })
+
+  it("tiers keyword matches a whole band below label matches", () => {
+    expect(scoreMatch("saved", ["Add To-do"], ["saved"])).toBe(3)
+    expect(scoreMatch("sav", ["Add To-do"], ["saved"])).toBe(4)
+    expect(scoreMatch("ave", ["Add To-do"], ["saved"])).toBe(5)
+  })
+
+  it("ranks any label match above any keyword match", () => {
+    const labelContains = scoreMatch("saved", ["View Saved"], [])
+    const keywordExact = scoreMatch("saved", ["Add To-do"], ["saved"])
+    expect(labelContains).toBeLessThan(keywordExact)
+  })
+
+  it("takes the best score across multiple labels", () => {
+    expect(scoreMatch("alice", ["Alice Smith", "alice"])).toBe(0)
+  })
+
+  it("returns Infinity when nothing matches", () => {
+    expect(scoreMatch("zzz", ["View Saved"], ["bookmark"])).toBe(Infinity)
+  })
+
+  it("is case-insensitive on both sides", () => {
+    expect(scoreMatch("SAVED", ["view saved"])).toBe(2)
+    expect(scoreMatch("saved", ["VIEW SAVED"])).toBe(2)
+  })
+})
+
+describe("rankMatches", () => {
+  interface Item {
+    label: string
+    keywords?: string[]
+  }
+  const text = (item: Item) => ({ labels: [item.label], keywords: item.keywords })
+
+  it("returns the input unchanged for an empty query", () => {
+    const items: Item[] = [{ label: "b" }, { label: "a" }]
+    expect(rankMatches(items, "", text)).toEqual(items)
+  })
+
+  it("drops non-matches", () => {
+    const items: Item[] = [{ label: "View Saved" }, { label: "Open Memory" }]
+    expect(rankMatches(items, "saved", text)).toEqual([{ label: "View Saved" }])
+  })
+
+  it("ranks a label match above an earlier-defined keyword-only match", () => {
+    const todo: Item = { label: "Add To-do", keywords: ["saved"] }
+    const saved: Item = { label: "View Saved", keywords: ["bookmark"] }
+    expect(rankMatches([todo, saved], "saved", text)).toEqual([saved, todo])
+  })
+
+  it("preserves input order within a tier (stable)", () => {
+    const items: Item[] = [{ label: "saver" }, { label: "saved" }]
+    // Both are label-prefix matches for "save"; definition order decides.
+    expect(rankMatches(items, "save", text)).toEqual(items)
+  })
+})

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -1,0 +1,61 @@
+/**
+ * Tiered relevance scoring shared by suggestion surfaces (command palette,
+ * slash commands, mention/channel triggers, emoji search).
+ *
+ * The problem this solves: pickers used to flat-filter with a boolean
+ * substring test over "label + keywords", so an item matching only on a
+ * hidden alias ranked identically to one whose visible label matched, and
+ * definition order decided. Tiers encode WHERE the match landed: any visible
+ * label match sorts above any hidden keyword match, and exact beats prefix
+ * beats substring within each band. Mirrors the heuristic `scoreStreamMatch`
+ * (lib/stream-sort.ts) already applies to streams.
+ *
+ * Lower score = better match; Infinity = no match.
+ */
+
+/** exact (0) < prefix (1) < contains (2), Infinity for no match. */
+function scoreText(text: string, lowerQuery: string): number {
+  const lower = text.toLowerCase()
+  if (lower === lowerQuery) return 0
+  if (lower.startsWith(lowerQuery)) return 1
+  if (lower.includes(lowerQuery)) return 2
+  return Infinity
+}
+
+/** Keyword tiers sit one whole band below label tiers (3/4/5 vs 0/1/2). */
+const KEYWORD_TIER_OFFSET = 3
+
+export function scoreMatch(query: string, labels: readonly string[], keywords: readonly string[] = []): number {
+  if (!query) return 0
+  const lowerQuery = query.toLowerCase()
+  let best = Infinity
+  for (const label of labels) {
+    best = Math.min(best, scoreText(label, lowerQuery))
+  }
+  if (best === 0) return best
+  for (const keyword of keywords) {
+    best = Math.min(best, KEYWORD_TIER_OFFSET + scoreText(keyword, lowerQuery))
+  }
+  return best
+}
+
+/**
+ * Filter and rank items by `scoreMatch`. Non-matches are dropped; ties keep
+ * input order (sort is stable), so each surface's curated ordering still
+ * breaks ties within a tier. An empty query returns the input unchanged.
+ */
+export function rankMatches<T>(
+  items: readonly T[],
+  query: string,
+  getText: (item: T) => { labels: readonly string[]; keywords?: readonly string[] }
+): T[] {
+  if (!query) return [...items]
+  return items
+    .map((item) => {
+      const { labels, keywords } = getText(item)
+      return { item, score: scoreMatch(query, labels, keywords) }
+    })
+    .filter((entry) => entry.score !== Infinity)
+    .sort((a, b) => a.score - b.score)
+    .map((entry) => entry.item)
+}


### PR DESCRIPTION
## Problem

Suggestion surfaces filtered with flat boolean substring tests over "label + keywords", so an item that matched only on a *hidden* alias ranked identically to one whose *visible* label matched — definition order decided the winner. Concrete case: typing `> saved` in the command palette ranked "Add To-do" (alias-only match) above "View Saved" (label match). The same flat-filter pattern existed in seven other pickers; only the stream switcher (`scoreStreamMatch`) had tiering.

## Solution

A shared tiered scorer, `apps/frontend/src/lib/match-score.ts`, generalizing the existing `scoreStreamMatch` heuristic:

```
label exact (0) < label prefix (1) < label contains (2)
  < keyword exact (3) < keyword prefix (4) < keyword contains (5)
```

`rankMatches()` filters non-matches and stable-sorts by tier, so each surface's curated source order still breaks ties within a tier. Any visible-label match now outranks any hidden-alias match, on every surface.

### Adopted by

| Surface | Labels (visible) | Keywords (hidden, one band below) |
| --- | --- | --- |
| Command palette | command label | id + keywords |
| Editor `/` commands | name | description |
| `is:` + `status:` filters | label, inserted value | description |
| `@` mentions | slug, name | — |
| `in:#` + inline `#channel` | slug, name | — |
| Emoji search | canonical shortcode | non-primary aliases |

### Key design decisions

**1. Rank within groups, not across them.** The palette renders contextual ("This stream") and global ("Commands") sections; each is ranked independently so section structure is preserved.

**2. `scoreStreamMatch` left as-is.** It already tiers correctly, has a stream-specific id tier, and its tests assert exact score values; folding it in would churn behavior for no user-visible gain.

**3. `SearchableSelect` left as-is.** It delegates to cmdk's internal fuzzy filter; replacing that is a different, larger change.

**4. Behavior-preserving special cases kept:** the `@me` shortcut, current-user-first tiebreak in mentions, weight-order recents in emoji search, and slash-command placement gating all survive (ties are stable).

## New files

| File | Purpose |
| --- | --- |
| `apps/frontend/src/lib/match-score.ts` | Shared tiered scorer + `rankMatches` |
| `apps/frontend/src/lib/match-score.test.ts` | Tier semantics + stability tests |
| `apps/frontend/src/components/quick-switcher/use-command-items.test.ts` | Palette ranking regression (the `> saved` case) |

## Modified files

| File | Change |
| --- | --- |
| `quick-switcher/use-command-items.ts` | Extracted `rankCommands`; ranks per group |
| `editor/triggers/use-command-suggestion.tsx` | `/` commands: name above description-only matches |
| `editor/triggers/use-filter-type-suggestion.tsx` | `is:` filter ranked |
| `editor/triggers/use-status-filter-suggestion.tsx` | `status:` filter ranked (self-review catch) |
| `editor/triggers/use-in-channel-filter-suggestion.tsx` | `in:#` ranked |
| `editor/triggers/use-channel-suggestion.tsx` | inline `#channel` ranked (self-review catch) |
| `hooks/use-mentionables.ts` | mentions ranked; `me` special case kept |
| `lib/emoji-picker.ts` | emoji search ranked; primary shortcode excluded from keyword band |
| 3 test files | ordering regression tests added |

## Test plan

- [x] New unit tests for the scorer (11) and palette ranking (5)
- [x] Ordering regressions added to emoji, mentions, and slash-command suites
- [x] Full frontend suite: 2582 passed, 0 failed
- [x] Monorepo typecheck + lint (pre-commit hook)
- [ ] Manual spot-check of palette/mention/emoji ranking in the running app

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** When two suggestions both match a query but one matches its displayed text and the other only a hidden alias/keyword/description, the displayed-text match must rank first — on every suggestion surface, not just streams.

**What Was Built:**
- `lib/match-score.ts`: `scoreMatch(query, labels, keywords)` returning tier 0–5 or Infinity; `rankMatches(items, query, getText)` filtering + stable-sorting. Mirrors `scoreStreamMatch` (lib/stream-sort.ts).
- Adoption in eight call sites: quick-switcher command palette (per group), editor slash commands, `is:` and `status:` filter triggers, `@` mentions (incl. `in:@` and search-mention variants via the shared `filterMentionables`), `in:#` and inline `#channel` triggers, emoji search (grid + recents + reaction picker via shared `filterBySearch`).

**Design Decisions:**
- Keyword tiers sit a whole band below label tiers, so keyword-exact never beats label-contains.
- Stable sort preserves curated source order within a tier (palette array order, weight order for emoji recents, current-user-first for mentions).
- `scoreStreamMatch` and cmdk-backed `SearchableSelect` deliberately untouched (already tiered / third-party filter).

**Design Evolution (self-review findings, second commit):**
- Inline `#channel` trigger and `status:` filter had their own flat filters the first sweep missed — adopted.
- `EmojiEntry.aliases` includes the primary shortcode; excluded from the keyword band so the tier intent is explicit.

**What's NOT Included:** word-boundary tier (e.g. "saved" word-prefix in "View Saved" vs mid-word), usage/frecency weighting, cross-group ranking in the palette, `SearchableSelect`/cmdk rework.

**Status:** Complete; all checks green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_016S35npxYekZAg4SRr6twK1

---
_Generated by [Claude Code](https://claude.ai/code/session_016S35npxYekZAg4SRr6twK1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882520&installation_id=129946197&pr_number=897&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F897&signature=09c0c216173d61b263faf82a644d8d37214f2019a4916c2847030436888ef4fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->