### PR TITLE
feat: add /handover skill for end-of-session handover docs

### DIFF
--- a/.agents/skills/handover/SKILL.md
+++ b/.agents/skills/handover/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: handover
+description: Write a session handover doc for the next agent picking up this line of work. Use when asked to "write a handover", "hand over", "handoff doc", or at the end of a session whose work continues in a future session.
+---
+
+# Session Handover Doc
+
+Produce a dense, self-contained handover document that lets a fresh agent — with none of this session's context — continue the work without re-deriving anything. Output it in a single markdown code block in chat (so the user can paste it into the next session's opening prompt). Do not commit it to the repo unless explicitly asked.
+
+## Core principle
+
+The reader knows the codebase conventions (CLAUDE.md) but knows NOTHING about this session: not what shipped, not what was decided, not what broke, not the user's standing preferences expressed along the way. Every sentence should either (a) save the next agent a search, (b) prevent it from redoing or undoing something, or (c) prevent it from re-asking the user something already settled. Cut anything that does none of those.
+
+## Gather before writing
+
+1. `git log origin/main --oneline -15` and the session's PR(s) — what actually merged, PR numbers, final commit SHAs.
+2. The branch state: designated branch name, whether it was reset/merged/deleted, anything unpushed (unpushed work MUST be called out loudly — the container is ephemeral).
+3. Re-read the session start: what the task was, which plan/design docs are binding.
+4. Scan the conversation for: user decisions (especially AskUserQuestion answers and mid-session reversals), deliberate deviations from plans/docs, review rounds and their dispositions, environment quirks discovered the hard way.
+
+## Structure (adapt, don't pad — omit empty sections)
+
+```markdown
+# Handover: <workstream> — <state in five words>, next is <X>
+
+One-line orientation: what this session shipped (PR #s + merge SHAs), where
+the designated branch stands. Then **First moves:** numbered, concrete
+commands/reads the next agent should do before anything else (reset branch
+onto main, read the binding design doc §X, ask the user Y).
+
+## Where we are / What <PR> did
+Per merged change: what it does, the load-bearing file paths (path:symbol,
+not prose descriptions), and the invariant/finding anchors (INV-x, E2EE-x).
+
+## Decision history (don't relitigate)
+Numbered. Every user ruling with its rationale, including reversals
+("shipped as A, user then chose B mid-PR — B is what's in main"). Mark
+deliberate deviations from design docs so the next agent doesn't "fix" them.
+
+## Open follow-ups (in priority order)
+Numbered, each with: what, where (file/section), size, and whether it's
+blocked on a user decision (say "ask before doing").
+
+## Review/babysit notes
+Reviewer findings + dispositions, rate-limit workarounds, how replies/thread
+resolution were done, anything the reviewer "learned" that affects future PRs.
+
+## Workflow notes (re-verified this session)
+Only environment facts that were actually confirmed or newly discovered this
+session: tooling availability (gh CLI, MCP tools), test-runner quirks per
+package, pre-commit duration, monitor/background-task lifetimes, container
+restart behavior, expected-vs-real failures (e.g. ECONNREFUSED = no local
+DB, environmental). Inherited notes that still held can be carried forward;
+drop ones proven stale.
+```
+
+## Style rules
+
+- Dense over polished: fragments and inline enumerations are fine here (this doc is for an agent, not prose for a human). Bold the load-bearing words (MERGED, NOT implemented, ASK before coding, NEVER).
+- Always cite anchors the next agent can jump to: file paths with symbols, doc sections (§4.2), PR/issue numbers, commit SHAs, invariant IDs.
+- State negatives explicitly: things that look wrong but are deliberate, things that were considered and rejected, questions the user left unanswered.
+- Calibrate length to session complexity: a one-PR bugfix session needs ~20 lines; a multi-PR phase of a long workstream needs the full structure.
+- Never include secrets, tokens, or model identifiers.
+
+## Example
+
+The handover that seeded this skill followed this exact shape; see the "Handover: Agent Runtimes Unification" docs passed between sessions on the agent-runtimes workstream for the target density and tone.


### PR DESCRIPTION
## Problem

Long workstreams (e.g. agent-runtimes unification) span many agent sessions, with continuity carried by hand-written handover docs pasted into the next session's prompt. The structure and density rules that make those docs work lived only in the docs themselves — each session reinvented the shape.

## Solution

A `/handover` skill (`.agents/skills/handover/SKILL.md`, shared via the `.claude/skills` symlink) that codifies the format:

- **Gather first:** merged PRs/SHAs, branch state (unpushed work flagged loudly — containers are ephemeral), binding design docs, and a conversation scan for user rulings, reversals, and environment quirks.
- **Structure:** orientation + "First moves" → what shipped with `path:symbol` and invariant/finding anchors → decision history ("don't relitigate", including mid-PR reversals) → prioritized follow-ups with "ask before doing" markers → review notes → workflow facts re-verified in-session.
- **Style:** dense over polished, explicit negatives (deliberate deviations marked so they don't get "fixed"), length calibrated to session complexity, output as a pasteable code block in chat — never committed unless asked, never includes secrets.

## Files changed

| File | Change |
| ---- | ------ |
| `.agents/skills/handover/SKILL.md` | New skill |

## Test plan

- [x] Skill file follows the existing frontmatter format (`name` + trigger-phrase `description`); picked up by the harness skill list after creation
- [x] Docs-only change — pre-commit lint/typecheck/api-docs all green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01QjaEnrRw2YSCYVvcJAJvSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjaEnrRw2YSCYVvcJAJvSo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882718&installation_id=129946197&pr_number=898&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F898&signature=9ae768b3ee3144631e604eb458189f6212367d49a796303d5b44a878c3797e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->