### PR TITLE
feat: require the dispatch-minted callback token on enclave session callbacks (Phase 2.4b flip, E2EE-21)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -36,7 +36,16 @@ function fakeRes(): Response & { statusCode: number; jsonBody?: unknown } {
   return res as unknown as Response & { statusCode: number; jsonBody?: unknown }
 }
 
-function req(id: string | undefined, body: unknown, headers: Record<string, string> = {}): Request {
+// Callbacks are token-bound (Phase 2.4b, reject-if-absent): the default
+// request carries the session's token so handler tests exercise the
+// authenticated path. Binding tests override `headers` ({} = absent token).
+const CB_TOKEN = "cbtok_good"
+
+function req(
+  id: string | undefined,
+  body: unknown,
+  headers: Record<string, string> = { [ENCLAVE_CALLBACK_TOKEN_HEADER]: CB_TOKEN }
+): Request {
   return {
     params: { id },
     body,
@@ -51,6 +60,7 @@ const SESSION = {
   status: SessionStatuses.RUNNING,
   lastSeenSequence: null,
   triggerMessageId: "msg_trigger",
+  callbackTokenHash: hashCallbackToken(CB_TOKEN),
   createdAt: new Date("2026-05-30T00:00:00.000Z"),
 } as unknown as Awaited<ReturnType<typeof AgentSessionRepository.findById>>
 
@@ -707,7 +717,6 @@ describe("createEnclaveSessionHandlers callback binding (Phase 2.4b)", () => {
   // The row stores only the digest; the runner echoes the cleartext.
   const BOUND_SESSION = {
     ...SESSION!,
-    callbackTokenHash: hashCallbackToken("cbtok_good"),
     replyKeyGeneration: 0,
   } as typeof SESSION
 
@@ -723,7 +732,10 @@ describe("createEnclaveSessionHandlers callback binding (Phase 2.4b)", () => {
   })
 
   it("403s a presented token when the session row carries none", async () => {
-    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({
+      ...SESSION!,
+      callbackTokenHash: null,
+    } as typeof SESSION)
     const { handlers } = makeHandlers()
     await expect(
       handlers.message(req("session_1", MESSAGE_BODY, tokenHeader("cbtok_any")), fakeRes())
@@ -740,13 +752,14 @@ describe("createEnclaveSessionHandlers callback binding (Phase 2.4b)", () => {
     expect(createMessage).toHaveBeenCalled()
   })
 
-  it("tolerates an absent token on a token-bearing session — rollout phase 1, in-flight sessions drain", async () => {
+  it("403s an absent token without writing anything — rollout tolerance is over", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(BOUND_SESSION)
-    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
-    const { handlers } = makeHandlers()
-    const res = fakeRes()
-    await handlers.message(req("session_1", MESSAGE_BODY), res)
-    expect(res.statusCode).toBe(204)
+    const { handlers, createMessage } = makeHandlers()
+    await expect(handlers.message(req("session_1", MESSAGE_BODY, {}), fakeRes())).rejects.toMatchObject({
+      status: 403,
+      code: "CALLBACK_TOKEN_MISSING",
+    })
+    expect(createMessage).not.toHaveBeenCalled()
   })
 
   it("rejects a wrong-generation seal loudly instead of persisting an undecryptable reply", async () => {
@@ -762,17 +775,17 @@ describe("createEnclaveSessionHandlers callback binding (Phase 2.4b)", () => {
     expect(createMessage).not.toHaveBeenCalled()
   })
 
-  it("passes any generation for sessions dispatched before the column shipped (NULL)", async () => {
+  it("403s pre-2.4b sessions (NULL hash) called without a token — no caller can satisfy them", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue({
       ...SESSION!,
       callbackTokenHash: null,
       replyKeyGeneration: null,
     } as typeof SESSION)
-    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
     const { handlers } = makeHandlers()
-    const res = fakeRes()
-    await handlers.message(req("session_1", MESSAGE_BODY), res)
-    expect(res.statusCode).toBe(204)
+    await expect(handlers.message(req("session_1", MESSAGE_BODY, {}), fakeRes())).rejects.toMatchObject({
+      status: 403,
+      code: "CALLBACK_TOKEN_MISSING",
+    })
   })
 
   it("binds the heartbeat too — wrong token never refreshes", async () => {

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -157,14 +157,16 @@ interface Dependencies {
  * the runner this session was assigned to (a stronger binding than a
  * self-reported keyId, which any internal-key holder could copy). The row
  * holds only the sha256 digest, so the presented value is hashed before the
- * timing-safe compare (both sides are fixed-length hex). Rollout phase 1: a
- * presented token must match; an absent token is tolerated so sessions in
- * flight across the deploy boundary drain cleanly. The reject-if-absent flip
- * (for rows that carry a hash) is the later one-liner.
+ * timing-safe compare (both sides are fixed-length hex). The token is
+ * mandatory: the rollout-phase tolerance for tokenless in-flight sessions has
+ * drained (all pre-2.4b rows are terminal), so an absent token — like a NULL
+ * row hash, which no token can match — is rejected outright.
  */
 function assertCallbackBound(session: AgentSession, req: Request): void {
   const presented = req.header(ENCLAVE_CALLBACK_TOKEN_HEADER)
-  if (!presented) return
+  if (!presented) {
+    throw new HttpError("Missing callback token", { status: 403, code: "CALLBACK_TOKEN_MISSING" })
+  }
   const expected = session.callbackTokenHash
   const presentedHash = Buffer.from(hashCallbackToken(presented))
   if (!expected || !timingSafeEqual(presentedHash, Buffer.from(expected))) {


### PR DESCRIPTION
## Problem

Phase 2.4b (#882) bound enclave session callbacks to a dispatch-minted token, but shipped in rollout phase 1: `assertCallbackBound` tolerated an **absent** token so sessions in flight across the deploy boundary could drain cleanly. That tolerance means any holder of the enclave internal key could still drive a session's callbacks without proving it is the runner the session was assigned to — the planned reject-if-absent flip was deferred until old sessions drained.

The drain is over, verified in prod before this change:

- Every pre-2.4b session (`callback_token_hash IS NULL`) is terminal — zero running/pending rows.
- The post-#889 deploy round-trip works end to end: session `session_01KTYM2Y9AJHDX780REEA287BR` (19:14 UTC today) was created with a token hash, sealed under the prescribed generation, and completed cleanly.
- The enclave threads the assignment's `callbackToken` into every callback header (`createBackendCallbacks`), so no legitimate caller is tokenless.

## Solution

Flip `assertCallbackBound` to reject an absent token with `403 CALLBACK_TOKEN_MISSING` (distinct from `CALLBACK_TOKEN_MISMATCH` so a misconfigured runner is diagnosable from the error code alone). All eleven callback routes share the chokepoint, so the flip covers message/steps/complete/fail/heartbeat/etc. in one place. Pre-2.4b rows (NULL hash) are now unreachable by any caller: no token can match a NULL hash, and no token at all is rejected outright.

### Key design decisions

**1. Distinct `CALLBACK_TOKEN_MISSING` code.** A runner that fails to send the header is a different failure (config/version skew) than one sending the wrong value (cross-session confusion or replay); one code per cause keeps prod triage one log line.

**2. Test fixtures default to the authenticated path.** The shared `req()` helper now sends the session's token by default and the base `SESSION` fixture carries the matching hash, so the ~40 handler tests exercise the world as it now is; binding tests override `headers` explicitly (`{}` = absent token).

**3. `assertReplyGeneration`'s NULL exemption left untouched.** Its NULL-generation branch now only triggers behind the token gate; removing it is not needed for correctness and stays out of this minimal flip.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | `assertCallbackBound` rejects absent tokens; doc comment updated to the post-flip truth |
| `apps/backend/src/features/enclave-runtimes/session-handlers.test.ts` | Tolerance test flipped to a 403 assertion; NULL-hash test asserts unreachability; fixtures token-bound by default |

## Test plan

- [x] `bun test src/features/enclave-runtimes/` — 87 pass, 0 fail
- [x] Full monorepo typecheck + lint (pre-commit)
- [x] Prod precondition verified read-only: no live tokenless sessions; post-deploy round-trip carries the token

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01P128AFuKG2zRYG9W9g9JQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01P128AFuKG2zRYG9W9g9JQw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783884134&installation_id=129946197&pr_number=899&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F899&signature=52f120a205511460813c6f0bb755334dcaa7acd74a25e0795cad147c3651522c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->