### PR TITLE
feat: skip the saved/scheduled online-flip refetch in active sync-v2 mode

### DIFF
--- a/apps/frontend/src/hooks/use-saved.test.ts
+++ b/apps/frontend/src/hooks/use-saved.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query"
+import { createElement, type ReactNode } from "react"
 import type { SavedMessageView } from "@threa/types"
 import { db } from "@/db"
-import { persistSavedRows, replaceSavedPage } from "./use-saved"
+import * as contextsModule from "@/contexts"
+import * as syncEngineModule from "@/sync/sync-engine"
+import { persistSavedRows, replaceSavedPage, savedKeys, useSavedList } from "./use-saved"
 
 const WORKSPACE_ID = "ws_test"
 
@@ -191,6 +196,87 @@ describe("replaceSavedPage", () => {
 
     const remaining = await db.savedMessages.toArray()
     expect(remaining.map((r) => r.id).sort()).toEqual(["saved_page1", "saved_page2"])
+  })
+})
+
+describe("useSavedList refetchOnReconnect (sync-v2 mode gate)", () => {
+  let listFn: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    onlineManager.setOnline(true)
+    await db.savedMessages.clear()
+    listFn = vi.fn().mockResolvedValue({ saved: [], nextCursor: null })
+    vi.spyOn(contextsModule, "useSavedService").mockReturnValue({
+      list: listFn,
+    } as unknown as contextsModule.SavedService)
+  })
+
+  function mockEngine(mode: "off" | "shadow" | "active" | null) {
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(
+      mode === null ? null : ({ syncCursorMode: mode } as unknown as syncEngineModule.SyncEngine)
+    )
+  }
+
+  /**
+   * Mounts the list, lets the initial fetch land, then marks the query
+   * invalidated while the browser is offline. `staleTime: Infinity` means the
+   * reconnect refetch only ever fires for an invalidated query, so this is
+   * the state that distinguishes `refetchOnReconnect` true from false on the
+   * online flip.
+   */
+  async function mountInvalidatedOffline() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+    renderHook(() => useSavedList(WORKSPACE_ID, "saved"), { wrapper })
+    // Wait for the fetch to SETTLE (not just for listFn to be called) — a
+    // success landing after the invalidation would reset isInvalidated and
+    // neutralise the reconnect refetch in every mode.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(savedKeys.list(WORKSPACE_ID, "saved"))).toEqual({ saved: [], nextCursor: null })
+    )
+    await act(async () => {
+      onlineManager.setOnline(false)
+      await queryClient.invalidateQueries({
+        queryKey: savedKeys.list(WORKSPACE_ID, "saved"),
+        refetchType: "none",
+      })
+    })
+  }
+
+  it("skips the reconnect refetch in active sync-v2 mode (resume catch-up covers the online flip)", async () => {
+    mockEngine("active")
+    await mountInvalidatedOffline()
+
+    await act(async () => {
+      onlineManager.setOnline(true)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(listFn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(["off", "shadow"] as const)("keeps the reconnect refetch in %s sync-v2 mode", async (mode) => {
+    mockEngine(mode)
+    await mountInvalidatedOffline()
+
+    act(() => {
+      onlineManager.setOnline(true)
+    })
+
+    await waitFor(() => expect(listFn).toHaveBeenCalledTimes(2))
+  })
+
+  it("keeps the reconnect refetch without a sync engine", async () => {
+    mockEngine(null)
+    await mountInvalidatedOffline()
+
+    act(() => {
+      onlineManager.setOnline(true)
+    })
+
+    await waitFor(() => expect(listFn).toHaveBeenCalledTimes(2))
   })
 })
 

--- a/apps/frontend/src/hooks/use-saved.ts
+++ b/apps/frontend/src/hooks/use-saved.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useSavedService } from "@/contexts"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { db, type CachedSavedMessage } from "@/db"
 import type {
   SavedMessageView,
@@ -131,6 +132,9 @@ export async function replaceSavedPage(
  */
 export function useSavedList(workspaceId: string, status: SavedStatus) {
   const savedService = useSavedService()
+  // Optional: the Saved view normally mounts inside the workspace SyncEngine
+  // provider, but the hook must stay safe (and keep its healing) without one.
+  const syncEngine = useOptionalSyncEngine()
 
   const serverQuery = useQuery({
     queryKey: savedKeys.list(workspaceId, status),
@@ -147,13 +151,20 @@ export function useSavedList(workspaceId: string, status: SavedStatus) {
     // INV-53: socket reconnects close their own event gap by invalidating
     // `savedKeys.all` at the top of `registerWorkspaceSocketHandlers` (in
     // active sync-v2 mode the catch-up cursor replays the missed events
-    // instead); `refetchOnReconnect: true` then catches the pure browser
-    // online/offline case. `refetchOnMount: true` plus `staleTime: Infinity`
-    // makes the invalidation land on the next render.
+    // instead); `refetchOnReconnect` then catches the pure browser
+    // online/offline case. In active mode that same online flip already runs
+    // `refreshAfterConnectivityResume()` → catch-up (workspace-layout's
+    // isOnline effect), replaying the user-scoped saved entries through the
+    // gate-registered workspace-sync handlers, so active skips the blanket
+    // refetch — "off" (kill switch), "shadow", and mounts without an engine
+    // keep it. The mode is fixed per engine lifetime; a flag flip recreates
+    // the engine and re-renders with the new option. `refetchOnMount: true`
+    // plus `staleTime: Infinity` makes the invalidation land on the next
+    // render.
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
+    refetchOnReconnect: syncEngine?.syncCursorMode !== "active",
     enabled: !!workspaceId,
   })
 

--- a/apps/frontend/src/hooks/use-scheduled.test.ts
+++ b/apps/frontend/src/hooks/use-scheduled.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query"
+import { createElement, type ReactNode } from "react"
+import { db } from "@/db"
+import * as contextsModule from "@/contexts"
+import * as syncEngineModule from "@/sync/sync-engine"
+import { scheduledKeys, useScheduledList } from "./use-scheduled"
+
+const WORKSPACE_ID = "ws_test"
+
+describe("useScheduledList refetchOnReconnect (sync-v2 mode gate)", () => {
+  let listFn: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    onlineManager.setOnline(true)
+    await db.scheduledMessages.clear()
+    listFn = vi.fn().mockResolvedValue({ scheduled: [], nextCursor: null })
+    vi.spyOn(contextsModule, "useScheduledService").mockReturnValue({
+      list: listFn,
+    } as unknown as contextsModule.ScheduledService)
+  })
+
+  function mockEngine(mode: "off" | "shadow" | "active" | null) {
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(
+      mode === null ? null : ({ syncCursorMode: mode } as unknown as syncEngineModule.SyncEngine)
+    )
+  }
+
+  /**
+   * Mounts the list, lets the initial fetch land, then marks the query
+   * invalidated while the browser is offline. `staleTime: Infinity` means the
+   * reconnect refetch only ever fires for an invalidated query, so this is
+   * the state that distinguishes `refetchOnReconnect` true from false on the
+   * online flip.
+   */
+  async function mountInvalidatedOffline() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+    renderHook(() => useScheduledList(WORKSPACE_ID, "pending"), { wrapper })
+    // Wait for the fetch to SETTLE (not just for listFn to be called) — a
+    // success landing after the invalidation would reset isInvalidated and
+    // neutralise the reconnect refetch in every mode.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(scheduledKeys.list(WORKSPACE_ID, "pending"))).toEqual({
+        scheduled: [],
+        nextCursor: null,
+      })
+    )
+    await act(async () => {
+      onlineManager.setOnline(false)
+      await queryClient.invalidateQueries({
+        queryKey: scheduledKeys.list(WORKSPACE_ID, "pending"),
+        refetchType: "none",
+      })
+    })
+  }
+
+  it("skips the reconnect refetch in active sync-v2 mode (resume catch-up covers the online flip)", async () => {
+    mockEngine("active")
+    await mountInvalidatedOffline()
+
+    await act(async () => {
+      onlineManager.setOnline(true)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(listFn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(["off", "shadow"] as const)("keeps the reconnect refetch in %s sync-v2 mode", async (mode) => {
+    mockEngine(mode)
+    await mountInvalidatedOffline()
+
+    act(() => {
+      onlineManager.setOnline(true)
+    })
+
+    await waitFor(() => expect(listFn).toHaveBeenCalledTimes(2))
+  })
+
+  it("keeps the reconnect refetch without a sync engine", async () => {
+    mockEngine(null)
+    await mountInvalidatedOffline()
+
+    act(() => {
+      onlineManager.setOnline(true)
+    })
+
+    await waitFor(() => expect(listFn).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/frontend/src/hooks/use-scheduled.ts
+++ b/apps/frontend/src/hooks/use-scheduled.ts
@@ -3,7 +3,7 @@ import { useLiveQuery } from "dexie-react-hooks"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { useScheduledService } from "@/contexts"
-import { useSyncEngine } from "@/sync/sync-engine"
+import { useSyncEngine, useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useUser } from "@/auth"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { db, type CachedScheduledMessage } from "@/db"
@@ -183,6 +183,10 @@ export async function replaceScheduledPage(
  */
 export function useScheduledList(workspaceId: string, status: ScheduledMessageStatus, streamId?: string) {
   const scheduledService = useScheduledService()
+  // Optional: the Scheduled views normally mount inside the workspace
+  // SyncEngine provider, but the hook must stay safe (and keep its healing)
+  // without one.
+  const syncEngine = useOptionalSyncEngine()
 
   const serverQuery = useQuery({
     queryKey: scheduledKeys.list(workspaceId, status, streamId),
@@ -195,12 +199,19 @@ export function useScheduledList(workspaceId: string, status: ScheduledMessageSt
     // INV-53: workspace-sync invalidates `scheduledKeys.all` on reconnect at
     // the top of `registerWorkspaceSocketHandlers` (in active sync-v2 mode
     // the catch-up cursor replays the missed events instead);
-    // refetchOnReconnect catches the pure online/offline case; refetchOnMount
-    // + staleTime: Infinity makes the invalidation actually fire on next render.
+    // refetchOnReconnect catches the pure online/offline case. In active mode
+    // that same online flip already runs `refreshAfterConnectivityResume()` →
+    // catch-up (workspace-layout's isOnline effect), replaying the user-scoped
+    // scheduled entries through the gate-registered workspace-sync handlers,
+    // so active skips the blanket refetch — "off" (kill switch), "shadow",
+    // and mounts without an engine keep it. The mode is fixed per engine
+    // lifetime; a flag flip recreates the engine and re-renders with the new
+    // option. refetchOnMount + staleTime: Infinity makes the invalidation
+    // actually fire on next render.
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
+    refetchOnReconnect: syncEngine?.syncCursorMode !== "active",
     enabled: !!workspaceId,
   })
 

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -8,6 +8,7 @@ import {
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import { readMirroredSyncV2Mode } from "./sync-v2-mode"
+import { SocketEventGate } from "./socket-event-gate"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
 import { memoKeys } from "@/hooks/use-memos"
@@ -16,6 +17,8 @@ import {
   DEFAULT_QUICK_LINKS,
   SIDEBAR_CONFIG_VERSION,
   defaultFeatureFlags,
+  type SavedMessageView,
+  type ScheduledMessageView,
   type StreamBootstrap,
   type WorkspaceBootstrap,
 } from "@threa/types"
@@ -703,6 +706,68 @@ describe("registerWorkspaceSocketHandlers", () => {
       cleanup()
     }
   )
+
+  it("applies gate-dispatched saved/scheduled catch-up replays to IDB in active mode", async () => {
+    // The coverage the mode-gated `refetchOnReconnect` is traded for: in
+    // active mode these handlers register on the engine's event gate, so a
+    // catch-up replay (gate.dispatch, never the raw socket) writes the rows
+    // through the same code path as a live emit.
+    await Promise.all([db.savedMessages.clear(), db.scheduledMessages.clear()])
+    const queryClient = new QueryClient()
+    const gate = new SocketEventGate("ws_1")
+    const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs, "active")
+
+    const now = new Date().toISOString()
+    const saved: SavedMessageView = {
+      id: "saved_replay",
+      workspaceId: "ws_1",
+      userId: "member_1",
+      messageId: "msg_1",
+      streamId: "stream_1",
+      status: "saved",
+      title: null,
+      note: null,
+      remindAt: null,
+      reminderSentAt: null,
+      savedAt: now,
+      statusChangedAt: now,
+      message: null,
+      unavailableReason: null,
+    }
+    const scheduled: ScheduledMessageView = {
+      id: "sched_replay",
+      workspaceId: "ws_1",
+      userId: "member_1",
+      streamId: "stream_1",
+      parentMessageId: null,
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "hello",
+      attachmentIds: [],
+      metadata: null,
+      scheduledFor: now,
+      status: "pending",
+      sentMessageId: null,
+      lastError: null,
+      editActiveUntil: null,
+      clientMessageId: null,
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+      statusChangedAt: now,
+    }
+
+    await gate.dispatch("saved:upserted", { workspaceId: "ws_1", saved })
+    await gate.dispatch("scheduled_message:upserted", { workspaceId: "ws_1", scheduled })
+
+    // The handlers persist fire-and-forget, so poll IDB for the rows.
+    await vi.waitFor(async () => {
+      expect(await db.savedMessages.get("saved_replay")).toBeTruthy()
+      expect(await db.scheduledMessages.get("sched_replay")).toBeTruthy()
+    })
+
+    cleanup()
+    gate.dispose()
+  })
 
   it("invalidates the memo search queries when a memo:created event lands", () => {
     const queryClient = new QueryClient()


### PR DESCRIPTION
## Problem

Sync v2 healing-deletion series, deletion 2 of 3 (after #895; inventory: `docs/plans/sync-v2-healing-deletion-inventory.md`). The saved and scheduled list hooks set `refetchOnReconnect: true`, kept by #885 to cover the pure browser online/offline flip — the one reconnect-shaped trigger that doesn't go through `registerWorkspaceSocketHandlers` (whose blanket invalidations were already mode-gated in #885).

In active sync-v2 mode this is redundant: the same `navigator.onLine` flip runs the workspace-layout `isOnline` effect → `refreshAfterConnectivityResume()` → `runCatchUp("resume")`, which replays the user-scoped `saved:*` / `scheduled_message:*` sync-log entries through the gate-registered workspace-sync handlers — the exact #885 proof chain (event type → scoping → delivery group → sync_log → `gate.dispatch`), on the exact same trigger.

## Solution

`useSavedList` and `useScheduledList` read the engine mode via `useOptionalSyncEngine()` and set `refetchOnReconnect: syncEngine?.syncCursorMode !== "active"`. The blanket refetch stays for `off` (runtime kill switch), `shadow` (applies nothing), and mounts outside the SyncEngine provider — the same gating shape as #885 (`workspace-sync.ts`) and #895 (`use-conversations`).

### Key design decisions

**1. Option per mode, no effect.** These are TanStack query options, not invalidation effects, so the gate is just the computed option value. The mode is fixed per engine lifetime (a flag flip recreates the engine and re-renders with the new option), so there is no option churn mid-lifetime.

**2. `useOptionalSyncEngine`, not `useSyncEngine`.** A mount without an engine keeps `refetchOnReconnect: true` — no provider, no replacement coverage, keep the healing (same rule as #895).

**3. What the tests pin (behavioral, not option introspection).** With `staleTime: Infinity`, the reconnect refetch only ever fires for an *invalidated* query, so the tests invalidate with `refetchType: "none"` while offline and flip `onlineManager` — in active mode the list service is not called again; in `off`/`shadow`/no-engine it is. The traded-for coverage is pinned in `workspace-sync.test.ts`: `saved:upserted` / `scheduled_message:upserted` dispatched through a `SocketEventGate` (the catch-up replay path, never the raw socket) land in IDB through the same registered handlers.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-saved.ts` | `useSavedList` reads the engine mode; `refetchOnReconnect` skips in active mode |
| `apps/frontend/src/hooks/use-scheduled.ts` | Same for `useScheduledList` |
| `apps/frontend/src/hooks/use-saved.test.ts` | Mode-gate tests: active skips the online-flip refetch; off/shadow/no-engine keep it |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Coverage proof: gate-dispatched saved/scheduled replays land in IDB in active mode |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-scheduled.test.ts` | Same mode-gate matrix for the scheduled list |

## Test plan

- [x] `bunx vitest run src/sync src/hooks` — 593 tests pass
- [x] `bun run typecheck` — clean
- [x] Rebased on main after #886 (saved items title/note) and re-verified: 45 affected tests + frontend typecheck green
- [ ] Staging: with `sync-v2-cursor: active`, toggle airplane mode with the Saved view open; rows still reconcile (via resume catch-up) without the list refetch

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Deletion PR 2 of the sync-v2 healing-deletion series — remove the redundant saved/scheduled `refetchOnReconnect` healing in active cursor mode, one deletion per PR with a coverage-proof test.

**Coverage proof (established method):** all `saved:*` and `scheduled_message:*` events are user-scoped in the outbox scoping list → delivery groups (`delivery-groups.ts`, single source for sync_log + emit, so the log is populated independently of emit success) → `listEntriesForUser` returns them → catch-up pages the log and applies entries via `SocketEventGate.dispatch` → `registerWorkspaceSocketHandlers` is gate-registered in active mode, so the replay reaches the same `persistSavedRows`/`persistScheduledRows` write-through as a live emit. The pure browser online flip — the only trigger this option covered — fires `refreshAfterConnectivityResume()` → `runCatchUp("resume")` on the same signal (workspace-layout `isOnline` effect).

**What was built:**
- Both list hooks read `useOptionalSyncEngine()?.syncCursorMode` and compute `refetchOnReconnect: mode !== "active"`.
- Hook tests prove the option behaviorally: invalidated-while-offline query + `onlineManager` flip → no refetch in active, refetch in off/shadow/no-engine. (A fetch success resets `isInvalidated`, so the tests wait for the initial fetch to settle before invalidating.)
- `workspace-sync.test.ts` pins the replacement path: handlers registered on a `SocketEventGate`, `gate.dispatch` of `saved:upserted` / `scheduled_message:upserted` writes the rows to IDB.

**Design evolution:** an interim commit added `.agents/skills/handover/SKILL.md`, then #898 landed the same skill on main independently — the rebase dropped the duplicate, so this PR is back to exactly one deletion.

**What's NOT included (sequenced behind this, per the inventory):**
- Labels `refetchOnReconnect` (deletion PR 3) — blocked on the non-member public-stream `label:assigned` edge.
- Heartbeat (dropped-emit detection between drop and next trigger) and sync_log retention — rollout incomplete until both ship.
- `usePageResumeRefresh` — deleted only after retention, not redesigned.

**Status:** complete; one deletion, coverage-proven, kill switch intact.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01RWfizgeefz5bWNCCfJyG9p