### PR TITLE
feat: drop the inert reconnect refetch on the labels sync query

### DIFF
--- a/apps/frontend/src/hooks/use-labels.test.ts
+++ b/apps/frontend/src/hooks/use-labels.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query"
+import { createElement, type ReactNode } from "react"
 import { LabelableResourceTypes, type Label, type LabelAssignment, type LabelMember } from "@threa/types"
 import { db } from "@/db"
-import { reconcileLabels, selectLabelStreams, type CachedLabelAssignment } from "./use-labels"
+import * as contextsModule from "@/contexts"
+import { labelKeys, reconcileLabels, selectLabelStreams, useLabelsSync, type CachedLabelAssignment } from "./use-labels"
 import type { CachedStream } from "@/db"
 
 const WORKSPACE_ID = "ws_test"
@@ -235,5 +239,49 @@ describe("selectLabelStreams", () => {
     expect(
       selectLabelStreams([cachedAssignment("label_a", "stream_1")], [cachedStream("stream_1")], "label_z")
     ).toEqual([])
+  })
+})
+
+describe("useLabelsSync refetchOnReconnect", () => {
+  let listFn: ReturnType<typeof vi.fn>
+  const response = { labels: [], memberships: [], assignments: [] }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    onlineManager.setOnline(true)
+    await Promise.all([db.labels.clear(), db.labelMemberships.clear(), db.labelAssignments.clear()])
+    listFn = vi.fn().mockResolvedValue(response)
+    vi.spyOn(contextsModule, "useLabelService").mockReturnValue({
+      list: listFn,
+    } as unknown as contextsModule.LabelService)
+  })
+
+  it("does not refetch on the online flip even when invalidated while offline", async () => {
+    // With staleTime Infinity, a reconnect refetch only ever fires for an
+    // invalidated query, so invalidated-while-offline is the one state where
+    // `refetchOnReconnect: true` and `false` behave differently on the online
+    // flip. Pin that the flip does not refetch: reconnect healing for labels
+    // is the engine's bootstrap reconcile plus catch-up replay through the
+    // gate-registered workspace-sync handlers, not this query.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+    renderHook(() => useLabelsSync(WORKSPACE_ID), { wrapper })
+    // Wait for the fetch to SETTLE (not just for listFn to be called) — a
+    // success landing after the invalidation would reset isInvalidated and
+    // make the assertion pass for the wrong reason.
+    await waitFor(() => expect(queryClient.getQueryData(labelKeys.list(WORKSPACE_ID))).toEqual(response))
+
+    await act(async () => {
+      onlineManager.setOnline(false)
+      await queryClient.invalidateQueries({ queryKey: labelKeys.list(WORKSPACE_ID), refetchType: "none" })
+    })
+
+    await act(async () => {
+      onlineManager.setOnline(true)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(listFn).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -191,7 +191,15 @@ export function useLabelsSync(workspaceId: string) {
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
+    // Explicit false (the v5 default is true): with staleTime Infinity a
+    // reconnect refetch only ever fires for a query invalidated while
+    // offline, and the only invalidators of this key are the label mutations
+    // below — which can't run offline. Reconnect healing lives elsewhere: the
+    // engine's reconnect workspace bootstrap reconciles labels/memberships/
+    // assignments into IDB (the render source), and active-mode catch-up
+    // replays `label:*` events through the gate-registered workspace-sync
+    // handlers.
+    refetchOnReconnect: false,
     enabled: !!workspaceId,
   })
 }

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -17,11 +17,13 @@ import {
   DEFAULT_QUICK_LINKS,
   SIDEBAR_CONFIG_VERSION,
   defaultFeatureFlags,
+  type LabelAssignment,
   type SavedMessageView,
   type ScheduledMessageView,
   type StreamBootstrap,
   type WorkspaceBootstrap,
 } from "@threa/types"
+import { assignmentId } from "@/hooks/use-labels"
 import type { Socket } from "socket.io-client"
 
 function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
@@ -763,6 +765,48 @@ describe("registerWorkspaceSocketHandlers", () => {
     await vi.waitFor(async () => {
       expect(await db.savedMessages.get("saved_replay")).toBeTruthy()
       expect(await db.scheduledMessages.get("sched_replay")).toBeTruthy()
+    })
+
+    cleanup()
+    gate.dispose()
+  })
+
+  it("applies gate-dispatched label assignment catch-up replays to IDB", async () => {
+    // The coverage labels' dropped `refetchOnReconnect` is traded for in
+    // active mode: the label handlers register on the engine's event gate, so
+    // a catch-up replay (gate.dispatch, never the raw socket) lands assignment
+    // rows in IDB through the same code path as a live emit.
+    await db.labelAssignments.clear()
+    const queryClient = new QueryClient()
+    const gate = new SocketEventGate("ws_1")
+    const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs, "active")
+
+    const assignment: LabelAssignment = {
+      workspaceId: "ws_1",
+      labelId: "label_1",
+      resourceType: "stream",
+      resourceId: "stream_1",
+      userId: "member_1",
+      assignedAt: new Date().toISOString(),
+    }
+    const rowId = assignmentId("ws_1", "stream", "stream_1", "label_1", "member_1")
+
+    await gate.dispatch("label:assigned", { workspaceId: "ws_1", targetUserId: null, assignment })
+    // The handlers persist fire-and-forget, so poll IDB for the row.
+    await vi.waitFor(async () => {
+      expect(await db.labelAssignments.get(rowId)).toBeTruthy()
+    })
+
+    await gate.dispatch("label:unassigned", {
+      workspaceId: "ws_1",
+      targetUserId: null,
+      labelId: "label_1",
+      resourceType: "stream",
+      resourceId: "stream_1",
+      userId: "member_1",
+    })
+    await vi.waitFor(async () => {
+      expect(await db.labelAssignments.get(rowId)).toBeUndefined()
     })
 
     cleanup()

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -79,36 +79,69 @@ following #891): the invalidation now skips when
 
 **Verdict: covered; deleted.**
 
-### `refetchOnReconnect: true` on saved + scheduled lists
+### `refetchOnReconnect: true` on saved + scheduled lists — DONE
 
-`use-saved.ts:150`, `use-scheduled.ts:203`. Kept by #885 to cover the pure
-browser online/offline flip (no socket.io reconnect cycle).
+`use-saved.ts:useSavedList`, `use-scheduled.ts:useScheduledList`. Kept by #885
+to cover the pure browser online/offline flip (no socket.io reconnect cycle).
+**Gated on active mode (#900):** both hooks read the engine via
+`useOptionalSyncEngine()` and set
+`refetchOnReconnect: syncEngine?.syncCursorMode !== "active"` (null engine →
+`true`), so off/shadow/no-engine mounts keep the refetch.
 
 - The same flip already triggers `refreshAfterConnectivityResume()`
   (workspace-layout.tsx isOnline effect) → `runCatchUp("resume")` → replays
   the user-scoped saved/scheduled entries through the gate-registered
   workspace-sync handlers — the exact PR-B proof chain, on the exact same
   trigger.
-- Needs the hooks to read the engine mode (engine context) to set the option
-  per mode; keep `true` in off/shadow.
+- Tests pin the mode matrix (an invalidated-while-offline query refetches on
+  the flip in off/shadow/no-engine, not in active) and the replacement path
+  (`gate.dispatch("saved:upserted"/"scheduled_message:upserted")` lands rows
+  in IDB).
 
-**Verdict: covered in active mode. Same shape and risk profile as #885.**
+**Verdict: covered; gated (#900).**
 
-### `refetchOnReconnect: true` on `useLabelsSync`
+### `refetchOnReconnect: true` on `useLabelsSync` — DONE
 
-`use-labels.ts:194`. All seven `label:*` events have delivery groups and
+`use-labels.ts`. All seven `label:*` events have delivery groups and
 gate-registered handlers in workspace-sync, so the reconnect gap is replayed
-in active mode.
+in active mode. **Removed outright (explicit `refetchOnReconnect: false`, not
+mode-gated — owner decision)** after investigation showed the flag was inert
+in every mode:
 
-- **One open edge:** public-label `label:assigned`/`unassigned` on a _stream_
-  resource is stream-group-scoped. Catch-up only returns stream groups for
-  member streams, but a non-member can be viewing a public stream live (live
-  emit reaches the room; catch-up won't return it). The labels query has
-  `staleTime: Infinity`, so without `refetchOnReconnect` that viewer's
-  assignment state stays stale until a reload or another invalidation.
+- With `staleTime: Infinity`, `refetchOnReconnect: true` only fires on the
+  online flip for an invalidated query (mechanic 3 below), and the only
+  invalidators of `labelKeys.list` are the label mutation hooks themselves —
+  which cannot run while offline. The flag could never fire, in any mode.
+- The non-member public-stream edge flagged earlier is real for catch-up
+  (`listEntriesForUser` builds `visible_streams` from `stream_members` only,
+  so a stream-group-scoped public `label:assigned` never replays to a
+  non-member viewing the public stream) — but it is already healed by a kept
+  mechanism: the engine's reconnect workspace bootstrap fetches
+  `labelAssignmentService.listForViewer` (public rows gated through
+  `listAccessibleStreamIds`, which includes non-member public streams per
+  INV-62) and the frontend reconciles labels/memberships/assignments into IDB
+  (bulkPut + stale-delete). IDB is the render source; the `useLabelsSync`
+  query data is only read for `isFetched`.
+- The hook mounts only on the labels catalog and label-detail pages, so there
+  was no workspace-wide query for the flag to heal in the first place.
+- Tests pin both sides: the hook does not refetch on the online flip even
+  when invalidated while offline, and a gate-dispatched
+  `label:assigned`/`unassigned` replay lands/removes the assignment row in
+  IDB.
 
-**Verdict: mostly covered; resolve or accept the non-member public-stream
-edge before deleting.**
+**Verdict: inert healing; deleted. The catch-up gap for non-member public
+streams is owned by the reconnect bootstrap reconcile (kept, see below).**
+
+### Mechanic 3 (added with the labels deletion): when `refetchOnReconnect` can fire
+
+TanStack v5 (5.99.0, verified in source): on the online flip,
+`shouldFetchOnReconnect` → `shouldFetchOn` → `isStale` → `query.isStaleByTime`
+(`shouldFetchOn` also returns false outright for `staleTime: "static"`). With
+`staleTime: Infinity` and data present, `isStaleByTime` is true only when
+`state.isInvalidated` — and a fetch success resets `isInvalidated`. So for an
+Infinity-staleTime query, `refetchOnReconnect: true` is only live if something
+invalidates the query while offline. Audit that invalidator set before
+treating such a flag as real healing — it may be dead code (labels was).
 
 ## Not deletable / keep as-is
 


### PR DESCRIPTION
## Problem

Sync v2 healing-deletion rollout, deletion 3 of the inventory (`docs/plans/sync-v2-healing-deletion-inventory.md`). `useLabelsSync` carried `refetchOnReconnect: true` as blanket reconnect healing for the labels catalog/memberships/assignments. The inventory flagged an open edge before deleting it: a public `label:assigned` on a public stream is stream-group-scoped, catch-up (`listEntriesForUser`) only replays member streams, so a non-member viewing the public stream live would seemingly rely on this refetch to heal.

## Solution

Investigation (full chain in the details block) showed the flag is **inert in every sync mode**, so per owner decision it is removed outright — an explicit `refetchOnReconnect: false` (the TanStack v5 default is `true`, so deleting the line would change nothing) — rather than mode-gated like #885/#895/#900.

### Key findings

**1. The flag could never fire.** With `staleTime: Infinity`, a reconnect refetch only fires on the online flip for an *invalidated* query (TanStack 5.99.0: `shouldFetchOn` → `isStaleByTime` → `state.isInvalidated`, verified in source). The only invalidators of `labelKeys.list` are the label mutation hooks in the same file — which cannot run while offline. No other code path invalidates that key, and the app never touches `onlineManager`.

**2. The catch-up edge is real but already owned by a kept mechanism.** `listEntriesForUser` builds `visible_streams` from `stream_members` only, so the non-member public-stream replay gap exists — but the engine's reconnect workspace bootstrap (on the inventory's "not deletable" list) fetches `labelAssignmentService.listForViewer`, whose public rows are gated through `listAccessibleStreamIds` (which includes non-member public streams per INV-62), and the frontend reconciles labels/memberships/assignments into IDB (bulkPut + stale-delete). IDB is the render source (`useWorkspaceLabelAssignments`); the `useLabelsSync` query data is only read for `isFetched`.

**3. The hook only mounts on label pages.** The labels catalog and label-detail pages are the only consumers, so there was no workspace-wide query for the flag to heal in the first place.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-labels.ts` | `refetchOnReconnect: true` → explicit `false`, with a comment stating why and where reconnect healing actually lives |
| `apps/frontend/src/hooks/use-labels.test.ts` | New suite: an invalidated-while-offline query does not refetch on the online flip (the one state where `true` vs `false` differ) |
| `apps/frontend/src/sync/workspace-sync.test.ts` | New replacement-path test: gate-dispatched `label:assigned`/`label:unassigned` catch-up replays land/remove the assignment row in IDB |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Saved/scheduled section marked DONE (#900, missed in that PR); labels section rewritten with the corrected analysis and verdict; new "mechanic 3" documenting when `refetchOnReconnect` can fire under `staleTime: Infinity` |

## Test plan

- [x] `bunx vitest run src/sync src/hooks` — 595/595 pass
- [x] `tsc --noEmit` (frontend) clean; full pre-commit lint + typecheck + OpenAPI check green

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Deletion 3 of the sync-v2 healing inventory: remove the labels `refetchOnReconnect` healing, resolving the flagged non-member public-stream edge first.

**Coverage proof chain (established method):** event type → scoping in `apps/backend/src/lib/outbox/repository.ts` → delivery group (`delivery-groups.ts`) → `sync_log` (`features/sync/repository.ts:listEntriesForUser`) → `gate.dispatch` through registered handlers. All seven `label:*` events have delivery groups and gate-registered workspace-sync handlers; private-label and membership events are user-group-scoped, public label upserts/deletes are workspace-group-scoped — all replay in active mode. Public assignments on streams are stream-group-scoped and replay for member streams.

**Edge investigation:** the non-member public-stream gap is real for catch-up but (a) the deleted flag never covered it — with `staleTime: Infinity` it only fires for a query invalidated while offline, and nothing can invalidate `labelKeys.list` offline (verified against TanStack 5.99.0 source: `shouldFetchOnReconnect` → `shouldFetchOn` → `isStaleByTime` → `state.isInvalidated`); and (b) the reconnect workspace bootstrap reconcile (kept healing) fully reconciles `db.labelAssignments` from `listForViewer`, which includes non-member public streams via `listAccessibleStreamIds`.

**Decision:** owner chose outright removal (explicit `false` in all modes) over the #900-style mode gate, since the flag is dead code regardless of mode.

**What's NOT included:** no change to delivery-group scoping (a workspace-group re-scope of public-stream assignments would make catch-up congruent with live, but is unnecessary while the bootstrap reconcile owns the edge); no change to the reconnect bootstrap, per-stream delta, or contiguity healing (all on the keep list until heartbeat/retention ship).

**Status:** complete; next inventory items are the heartbeat design and sync_log retention.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01VpW25WQLuVXr2jsn6E3KAG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpW25WQLuVXr2jsn6E3KAG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783888238&installation_id=129946197&pr_number=901&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F901&signature=5b4af98a534715f4300b6e547683eb399ee027022401a5a3c7b6c4da60bfad1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->